### PR TITLE
WIP: Support for genesis record file

### DIFF
--- a/src/main/java/com/hedera/databaseUtilities/ApplicationStatus.java
+++ b/src/main/java/com/hedera/databaseUtilities/ApplicationStatus.java
@@ -20,6 +20,8 @@ public class ApplicationStatus {
 		,RECORD_HASH_MISMATCH_BYPASS_UNTIL_AFTER
 		,LAST_PROCESSED_EVENT_HASH
 		,LAST_PROCESSED_RECORD_HASH
+		,AWAIT_RECORD_GENESIS_EVENT
+		,AWAIT_EVENT_GENESIS_EVENT
 	}
 	
 	private static ConcurrentHashMap<ApplicationStatusCode, String> applicationStatusMap = new ConcurrentHashMap<ApplicationStatusCode, String>();
@@ -144,6 +146,21 @@ public class ApplicationStatus {
 	}
 	public String getLastProcessedRcdHash() throws Exception {
 		return getStatus(ApplicationStatusCode.LAST_PROCESSED_RECORD_HASH);
+	}
+
+	public void setAwaitRecordGenesisEvent() throws Exception {
+		updateStatus(ApplicationStatusCode.AWAIT_RECORD_GENESIS_EVENT, "false");
+	}
+	public boolean getAwaitRecordGenesisEvent() throws Exception {
+		String await = getStatus(ApplicationStatusCode.AWAIT_RECORD_GENESIS_EVENT);
+		return (await.contentEquals("true") ? true : false);
+	}
+	public void setAwaitEventGenesisEvent() throws Exception {
+		updateStatus(ApplicationStatusCode.AWAIT_EVENT_GENESIS_EVENT, "false");
+	}
+	public boolean getAwaitEventGenesisEvent() throws Exception {
+		String await = getStatus(ApplicationStatusCode.AWAIT_EVENT_GENESIS_EVENT);
+		return (await.contentEquals("true") ? true : false);
 	}
 
 	public void updateLastProcessedRcdHash(String hash) throws Exception {

--- a/src/main/java/com/hedera/parser/RecordFileParser.java
+++ b/src/main/java/com/hedera/parser/RecordFileParser.java
@@ -102,6 +102,9 @@ public class RecordFileParser {
 										// last file for which mismatch is allowed is in the past
 										log.error("Hash mismatch for file {}. Previous = {}, Current = {}", fileName, previousFileHash, newFileHash);
 										return false;
+									} else if (applicationStatus.getAwaitRecordGenesisEvent() && Utility.hashIsGenesis(newFileHash)) {
+										log.info("Genesis event found for file {}.", fileName);
+										applicationStatus.setAwaitRecordGenesisEvent();
 									}
 								}
 								break;

--- a/src/main/java/com/hedera/utilities/Utility.java
+++ b/src/main/java/com/hedera/utilities/Utility.java
@@ -479,6 +479,10 @@ public class Utility {
 		return (hash.isEmpty() || hash.contentEquals("000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"));
 	}
 	
+	public static boolean hashIsGenesis(String hash) {
+		return hash.contentEquals("000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
+	}
+
 	public static void moveFileToParsedDir(String fileName, String subDir) {
 		File sourceFile = new File(fileName);
 		String pathToSaveTo = sourceFile.getParentFile().getParentFile().getPath() + subDir;

--- a/src/main/resources/db/migration/V1.10__app_status_genesis
+++ b/src/main/resources/db/migration/V1.10__app_status_genesis
@@ -1,0 +1,2 @@
+INSERT INTO t_application_status (status_name, status_code, status_value) VALUES ('Await record genesis event', 'AWAIT_RECORD_GENESIS_EVENT','true');
+INSERT INTO t_application_status (status_name, status_code, status_value) VALUES ('Await event genesis event', 'AWAIT_EVENT_GENESIS_EVENT','true');


### PR DESCRIPTION
**Detailed description**:
Accepts one hash mismatch based on `prevHash` in a record file being equal to a `new byte[48]`.
This is controlled via a parameter which exists in the database. If the parameter is false, one occurrence of such a `prevHash` will be accepted, all others will result in a failure to match previous hash.

**Which issue(s) this PR fixes**:
Fixes #119 

**Special notes for your reviewer**:
Do not merge at this stage, still needs testing, created PR for initial review

**Checklist**
- [X] Documentation added
- [ ] Tests updated
