### PR TITLE
148 bug freeze transaction missing

### DIFF
--- a/src/main/java/com/hedera/recordFileLogger/RecordFileLogger.java
+++ b/src/main/java/com/hedera/recordFileLogger/RecordFileLogger.java
@@ -712,7 +712,8 @@ public class RecordFileLogger {
 		if (transactionTypes.containsKey(transactionName)) {
 			return transactionTypes.get(transactionName);
 		} else {
-			return transactionTypes.get("unknown");
+			log.error("Transaction type {} not known to mirror node, storing 'UNKNOWN'", transactionName);
+			return transactionTypes.get("UNKNOWN");
 		}
 	}
 

--- a/src/main/resources/db/migration/V1.10.1__freeze_transaction.sql
+++ b/src/main/resources/db/migration/V1.10.1__freeze_transaction.sql
@@ -1,0 +1,18 @@
+INSERT INTO t_transaction_types (proto_id, name) values (23,'FREEZE');
+
+UPDATE t_transaction_types set proto_id = 14 WHERE name = 'CRYPTOTRANSFER';
+UPDATE t_transaction_types set proto_id = 15 WHERE name = 'CRYPTOUPDATEACCOUNT';
+UPDATE t_transaction_types set proto_id = 12 WHERE name = 'CRYPTODELETE';
+UPDATE t_transaction_types set proto_id = 10 WHERE name = 'CRYPTOADDCLAIM';
+UPDATE t_transaction_types set proto_id = 13 WHERE name = 'CRYPTODELETECLAIM';
+UPDATE t_transaction_types set proto_id = 7  WHERE name = 'CONTRACTCALL';
+UPDATE t_transaction_types set proto_id = 8  WHERE name = 'CONTRACTCREATEINSTANCE';
+UPDATE t_transaction_types set proto_id = 9  WHERE name = 'CONTRACTUPDATEINSTANCE';
+UPDATE t_transaction_types set proto_id = 17 WHERE name = 'FILECREATE';
+UPDATE t_transaction_types set proto_id = 16 WHERE name = 'FILEAPPEND';
+UPDATE t_transaction_types set proto_id = 19 WHERE name = 'FILEUPDATE';
+UPDATE t_transaction_types set proto_id = 18 WHERE name = 'FILEDELETE';
+UPDATE t_transaction_types set proto_id = 11 WHERE name = 'CRYPTOCREATEACCOUNT';
+UPDATE t_transaction_types set proto_id = 20 WHERE name = 'SYSTEMDELETE';
+UPDATE t_transaction_types set proto_id = 21 WHERE name = 'SYSTEMUNDELETE';
+UPDATE t_transaction_types set proto_id = 22 WHERE name = 'CONTRACTDELETEINSTANCE';


### PR DESCRIPTION
**Detailed description**:
Corrects a number of issues with transaction types:
-When a transaction type is unknown to mirror node, an NPE occurred while attempting to fetch an "unknown" key from a hash map instead of "UNKNOWN"
-The freeze transaction type was missing from the database
-The proto_id for transaction types was incorrect. It was pulled from the `HederaFunctionality` enum in `BasicTypes.proto` instead of the `oneof data` in `TransactionBody.proto`

**Which issue(s) this PR fixes**:
Fixes #148

**Checklist**
- [ ] Documentation added
- [x] Tested working with a Freeze transaction in a record file.
