### PR TITLE
Fix CircleCI caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,11 +16,15 @@ jobs:
     steps:
     - checkout
     - restore_cache:
-        key: maven
+        keys:
+          - maven-v1-{{ .Branch }}-{{ checksum "pom.xml" }}
+          - maven-v1-{{ .Branch }}
+          - maven-v1-
     - run: ./mvnw install
     - store_test_results:
         path: target/surefire-reports
     - save_cache:
-        key: maven
+        key: maven-v1-{{ .Branch }}-{{ checksum "pom.xml" }}
         paths:
         - ~/.m2
+


### PR DESCRIPTION
**Detailed description**:
Fix Maven caching to check pom.xml checksum so cache is updated on changes. Previously `save_cache` staged said `Skipping cache generation, cache already exists for key: maven` despite there showing downloads in mvn install.

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:
The 3 cache keys are for the same cache and help reduce build conflicts between branches

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

