### PR TITLE
Updates support for protobuf to match pending network upgrades

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 
 	<properties>
 		<flyway.version>5.2.4</flyway.version>
-		<hedera.protobuf.version>0.3.3</hedera.protobuf.version>
+		<hedera.protobuf.version>0.3.4</hedera.protobuf.version>
 		<hedera.sdk.version>0.5.0</hedera.sdk.version>
 		<junit.jupiter.version>5.5.1</junit.jupiter.version>
 		<junit.jupiter.platform.version>1.5.1</junit.jupiter.platform.version>

--- a/src/main/java/com/hedera/recordFileLogger/RecordFileLogger.java
+++ b/src/main/java/com/hedera/recordFileLogger/RecordFileLogger.java
@@ -34,7 +34,6 @@ import lombok.extern.log4j.Log4j2;
 import com.hedera.addressBook.NetworkAddressBook;
 import com.hedera.configLoader.ConfigLoader;
 import com.hedera.databaseUtilities.DatabaseUtilities;
-import com.hedera.hashgraph.sdk.proto.ResponseCodeEnum;
 import com.hedera.utilities.Utility;
 import com.hederahashgraph.api.proto.java.ContractCreateTransactionBody;
 import com.hederahashgraph.api.proto.java.ContractUpdateTransactionBody;
@@ -43,6 +42,7 @@ import com.hederahashgraph.api.proto.java.CryptoUpdateTransactionBody;
 import com.hederahashgraph.api.proto.java.FileCreateTransactionBody;
 import com.hederahashgraph.api.proto.java.FileID;
 import com.hederahashgraph.api.proto.java.FileUpdateTransactionBody;
+import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.Transaction;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionID;
@@ -328,7 +328,13 @@ public class RecordFileLogger {
 			sqlInsertTransaction.setLong(F_TRANSACTION.FK_PAYER_ACCOUNT_ID.ordinal(), fkPayerAccountId);
 
 			long fk_result_id = -1;
-			String responseCode = ResponseCodeEnum.forNumber(txRecord.getReceipt().getStatus().getNumber()).getValueDescriptor().getName();
+			String responseCode = "";
+			try {
+				responseCode = ResponseCodeEnum.forNumber(txRecord.getReceipt().getStatus().getNumber()).getValueDescriptor().getName();
+			} catch (Exception e) {
+				log.error("Unknown response code, com.hederahashgraph.api library likely out of date. Exception {}", e );
+ 				throw e;
+			}
 
 			fk_result_id = transactionResults.get(responseCode);
 

--- a/src/main/resources/db/migration/V1.10.2__response_codes.sql
+++ b/src/main/resources/db/migration/V1.10.2__response_codes.sql
@@ -1,0 +1,17 @@
+INSERT INTO t_transaction_results (proto_id, result) values (89,'PAYER_ACCOUNT_UNAUTHORIZED');
+INSERT INTO t_transaction_results (proto_id, result) values (90,'INVALID_FREEZE_TRANSACTION_BODY');
+INSERT INTO t_transaction_results (proto_id, result) values (91,'FREEZE_TRANSACTION_BODY_NOT_FOUND');
+INSERT INTO t_transaction_results (proto_id, result) values (92,'TRANSFER_LIST_SIZE_LIMIT_EXCEEDED');
+INSERT INTO t_transaction_results (proto_id, result) values (93,'RESULT_SIZE_LIMIT_EXCEEDED');
+INSERT INTO t_transaction_results (proto_id, result) values (94,'NOT_SPECIAL_ACCOUNT');
+INSERT INTO t_transaction_results (proto_id, result) values (95,'CONTRACT_NEGATIVE_GAS');
+INSERT INTO t_transaction_results (proto_id, result) values (96,'CONTRACT_NEGATIVE_VALUE');
+INSERT INTO t_transaction_results (proto_id, result) values (97,'INVALID_FEE_FILE');
+INSERT INTO t_transaction_results (proto_id, result) values (98,'INVALID_EXCHANGE_RATE_FILE');
+INSERT INTO t_transaction_results (proto_id, result) values (99,'INSUFFICIENT_LOCAL_CALL_GAS');
+INSERT INTO t_transaction_results (proto_id, result) values (100,'ENTITY_NOT_ALLOWED_TO_DELETE');
+INSERT INTO t_transaction_results (proto_id, result) values (101,'AUTHORIZATION_FAILED');
+INSERT INTO t_transaction_results (proto_id, result) values (102,'FILE_UPLOADED_PROTO_INVALID');
+INSERT INTO t_transaction_results (proto_id, result) values (103,'FILE_UPLOADED_PROTO_NOT_SAVED_TO_DISK');
+INSERT INTO t_transaction_results (proto_id, result) values (104,'FEE_SCHEDULE_FILE_PART_UPLOADED');
+INSERT INTO t_transaction_results (proto_id, result) values (105,'EXCHANGE_RATE_CHANGE_LIMIT_EXCEEDED');


### PR DESCRIPTION
**Detailed description:**
Updates the protobuf library used by mirror node to match testnet/mainnet upgrade version.
-A number of new ResponseCodes are added with the upgrade, mirror node needs to support them.
-Added error handling around unknown response codes to avoid NPE

**Which issue(s) this PR fixes:**
Fixes #138

**Checklist**
- [ ] Documentation added
- [X] Tests updated
