### PR TITLE
Fix balances query performance with related schema changes

### DIFF
--- a/rest-api/balances.js
+++ b/rest-api/balances.js
@@ -78,7 +78,7 @@ const getBalances = function (req) {
     sqlQuery += " where " +
         [tsQuery, accountQuery, pubKeyQuery, balanceQuery].map(q => q === '' ? '1=1' : q).join(' and ') +
         " order by consensus_timestamp desc, " +
-        ['entity_type_id', 'realm_num', 'entity_num'].map(q => q + ' ' + order).join(',') +
+        ['account_realm_num', 'account_num'].map(q => q + ' ' + order).join(',') +
         " " + limitQuery;
 
     let sqlParams = tsParams

--- a/rest-api/balances.js
+++ b/rest-api/balances.js
@@ -33,7 +33,7 @@ const getBalances = function (req) {
     // timestamp and pagination
     let [accountQuery, accountParams] =
         utils.parseParams(req, 'account.id',
-            [{ shard: '0', realm: '(ab.account_id).realm_num', num: '(ab.account_id).num' }],
+            [{ shard: '0', realm: 'ab.account_realm_num', num: 'ab.account_num' }],
             'entityId');
 
     // if the request has a timestamp=xxxx or timestamp=eq:xxxxx, then 
@@ -66,13 +66,13 @@ const getBalances = function (req) {
 
     // Use the inner query to find the latest snapshot timestamp from the balance history table
     let sqlQuery =
-        "select ab.consensus_timestamp, (ab.account_id).type_id as entity_type_id,\n" +
-        "(ab.account_id).realm_num as realm_num, (ab.account_id).num as entity_num, ab.balance\n" +
+        "select ab.consensus_timestamp,\n" +
+        "ab.account_realm_num as realm_num, ab.account_num as entity_num, ab.balance\n" +
         " from account_balances ab\n";
     if (joinEntities) {
         sqlQuery += " join t_entities e\n" +
-            " on e.entity_realm = (ab.account_id).realm_num\n" +
-            " and e.entity_num = (ab.account_id).num\n" +
+            " on e.entity_realm = ab.account_realm_num\n" +
+            " and e.entity_num = ab.account_num\n" +
             " and e.entity_shard = 0 and e.fk_entity_type_id = 1\n";
     }
     sqlQuery += " where " +

--- a/src/main/java/com/hedera/mirror/dataset/AccountBalancesFileLoader.java
+++ b/src/main/java/com/hedera/mirror/dataset/AccountBalancesFileLoader.java
@@ -197,7 +197,7 @@ public final class AccountBalancesFileLoader implements AutoCloseable {
 				final var insertSet = conn.prepareStatement(
 						"insert into account_balance_sets (consensus_timestamp) values (?) on conflict do nothing returning is_complete, processing_start_timestamp;");
 				final var insertBalance = conn.prepareStatement(
-						"insert into account_balances (consensus_timestamp, account_id, balance) values (?, ('a', ?, ?), ?) on conflict do nothing;");
+						"insert into account_balances (consensus_timestamp, account_realm_num, account_num, balance) values (?, ?, ?, ?) on conflict do nothing;");
 				final var updateSet = conn.prepareStatement(
 						"update account_balance_sets set is_complete = true, processing_end_timestamp = now() at time zone 'utc' where consensus_timestamp = ? and is_complete = false;");
 

--- a/src/main/resources/db/migration/V1.10.3__account_balances.sql
+++ b/src/main/resources/db/migration/V1.10.3__account_balances.sql
@@ -1,0 +1,46 @@
+--
+-- Migrate off account_id as entity_id to separate columns for realm/num instead of user defined type.
+--
+-- 1. Remove indexes and PK on account_balances.
+-- 2. Add new (nullable) columns for account_realm_num and account_num.
+-- 3. Migrate data from account_id to account_realm_num, account_num.
+-- 4. Make account_id nullable and rename to deprecated, to be removed in subsequent release (along with entity_id UDT)
+-- 5. Make new columns non-nullable.
+-- 6. Re-add PK and indexes.
+--
+alter table account_balances
+    drop constraint pk__account_balances;
+drop index idx__account_balances__account_then_timestamp;
+
+alter table account_balances
+    add column account_realm_num entity_realm_num null;
+alter table account_balances
+    add column account_num entity_num null;
+
+update account_balances
+    set account_realm_num = (account_id).realm_num,
+        account_num = (account_id).num;
+
+alter table account_balances
+    alter column account_id drop not null;
+
+alter table account_balances
+    rename column account_id to account_id__deprecated;
+
+alter table account_balances
+    alter column account_realm_num set not null;
+alter table account_balances
+    alter column account_num set not null;
+
+alter table account_balances
+    add constraint pk__account_balances primary key (consensus_timestamp, account_realm_num, account_num);
+create index idx__account_balances__account_then_timestamp
+    on account_balances (account_realm_num desc, account_num desc, consensus_timestamp desc);
+
+-- Mark old account balances tables as deprecated
+alter table t_account_balances
+    rename to t_account_balances__deprecated;
+alter table t_account_balance_refresh_time
+    rename to t_account_balance_refresh_time__deprecated;
+alter table t_account_balance_history
+    rename to t_account_balance_history__deprecated;


### PR DESCRIPTION
**Detailed description**:

The balances query on account_balances was doing a table scan because the account_id, as a user defined type `entity_id` couldn't be indexed by postgres' btree indexer.

It can be, if additional operators and an operator class are defined, but that requires superuser privilege.

So - the entity_id type is deprecated, and in its place account_balances has account_realm_num and account_num columns.

- Database upgrade script will migrate _all_ data from the former account_id field to account_realm_num and account_num columns
- Change deprecated table and column names to suffix __deprecated (remove them in next release via #175 )
- Update balances.js query to use new columns.

**Which issue(s) this PR fixes**:
Fixes #173

**Special notes for your reviewer**:

I manually tested the upgrade from the prior database version with 2.5M rows already in account balances.

I ran a local performance test of inserts and query before and after the upgrade.
Before:
- insert 1M rows - 25sec
- query against 2.5M rows - 0.5sec
After:
- query against 2.5M rows : 0.5ms (milliseconds)
- clear DB and insert 1M rows again : 19sec

here is the query plan after upgrade (see that it uses index):
```
explain analyze select consensus_timestamp, account_realm_num, account_num from account_balances where account_realm_num = 0 and account_num = 0 order by consensus_timestamp desc, account_realm_num desc, account_num desc;

 Sort  (cost=493.03..493.34 rows=125 width=51) (actual time=0.397..0.399 rows=25 loops=1)
   Sort Key: consensus_timestamp DESC
   Sort Method: quicksort  Memory: 28kB
   ->  Bitmap Heap Scan on account_balances  (cost=5.71..488.68 rows=125 width=51) (actual time=0.088..0.350 rows=25 loops=1)
         Recheck Cond: (((account_realm_num)::smallint = 0) AND ((account_num)::integer = 0))
         Heap Blocks: exact=25
         ->  Bitmap Index Scan on idx__account_balances__account_then_timestamp  (cost=0.00..5.68 rows=125 width=0) (actual time=0.072..0.072 rows=25 loops=1)
               Index Cond: (((account_realm_num)::smallint = 0) AND ((account_num)::integer = 0))
 Planning time: 0.778 ms
 Execution time: 0.470 ms
```

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

Tests not updated as still awaiting integration/performance tooling setup.