### PR TITLE
Fixes mirror node breaks when large address book is updated

### DIFF
--- a/src/main/java/com/hedera/addressBook/NetworkAddressBook.java
+++ b/src/main/java/com/hedera/addressBook/NetworkAddressBook.java
@@ -22,6 +22,7 @@ package com.hedera.addressBook;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Map;
 
 import com.hedera.configLoader.ConfigLoader;
@@ -33,6 +34,7 @@ import com.hedera.hashgraph.sdk.HederaNetworkException;
 import com.hedera.hashgraph.sdk.account.AccountId;
 import com.hedera.hashgraph.sdk.crypto.ed25519.Ed25519PrivateKey;
 import com.hedera.hashgraph.sdk.file.FileId;
+import com.hederahashgraph.api.proto.java.NodeAddressBook;
 
 import io.github.cdimascio.dotenv.Dotenv;
 
@@ -50,6 +52,7 @@ public class NetworkAddressBook {
 
 	static Client client;
 	static Dotenv dotenv = Dotenv.configure().ignoreIfMissing().load();
+    static byte[] addressBookBytes = new byte[0];
     
     public static void main(String[] args) {
 
@@ -62,7 +65,7 @@ public class NetworkAddressBook {
                     .setFileId(new FileId(0, 0, 102))
                     .execute();
 
-            writeFile(contents.getFileContents().getContents().toByteArray());
+            update(contents.getFileContents().getContents().toByteArray());
 			log.info("New address book successfully saved to {}", addressBookFile);
         } catch (FileNotFoundException e) {
     		log.error("Address book file {} not found.", addressBookFile);
@@ -75,9 +78,34 @@ public class NetworkAddressBook {
 		}
 	}
 
-    public static void writeFile(byte[] newContents) throws IOException {
+    public static void update(byte[] newContents) throws IOException {
+    	addressBookBytes = newContents;
+    	try {
+    		NodeAddressBook nodeAddressBook = NodeAddressBook.parseFrom(addressBookBytes);
+    		savetoDisk();
+    		
+    	} catch (Exception e) {
+    		log.warn("Unable to parse incomplete address book");
+    	}
+    }
+
+    public static void append(byte[] extraContents) throws IOException {
+    	byte[] newAddressBook = Arrays.copyOf(addressBookBytes, addressBookBytes.length + extraContents.length);
+    	System.arraycopy(extraContents, 0, addressBookBytes, addressBookBytes.length, extraContents.length);
+    	
+    	try {
+    		NodeAddressBook nodeAddressBook = NodeAddressBook.parseFrom(newAddressBook);
+    		addressBookBytes = newAddressBook;
+    		savetoDisk();
+    		
+    	} catch (Exception e) {
+    		log.warn("Unable to parse incomplete address book");
+    	}
+    }
+
+    private static void savetoDisk() throws IOException {
         FileOutputStream fos = new FileOutputStream(addressBookFile);
-        fos.write(newContents);
+        fos.write(addressBookBytes);
         fos.close();
     }
     

--- a/src/main/java/com/hedera/addressBook/NetworkAddressBook.java
+++ b/src/main/java/com/hedera/addressBook/NetworkAddressBook.java
@@ -66,7 +66,6 @@ public class NetworkAddressBook {
                     .execute();
 
             update(contents.getFileContents().getContents().toByteArray());
-			log.info("New address book successfully saved to {}", addressBookFile);
         } catch (FileNotFoundException e) {
     		log.error("Address book file {} not found.", addressBookFile);
         } catch (IOException e) {
@@ -80,33 +79,21 @@ public class NetworkAddressBook {
 
     public static void update(byte[] newContents) throws IOException {
     	addressBookBytes = newContents;
-    	try {
-    		NodeAddressBook nodeAddressBook = NodeAddressBook.parseFrom(addressBookBytes);
-    		savetoDisk();
-    		
-    	} catch (Exception e) {
-    		log.warn("Unable to parse incomplete address book");
-    	}
+		savetoDisk();
     }
 
     public static void append(byte[] extraContents) throws IOException {
     	byte[] newAddressBook = Arrays.copyOf(addressBookBytes, addressBookBytes.length + extraContents.length);
-    	System.arraycopy(extraContents, 0, addressBookBytes, addressBookBytes.length, extraContents.length);
-    	
-    	try {
-    		NodeAddressBook nodeAddressBook = NodeAddressBook.parseFrom(newAddressBook);
-    		addressBookBytes = newAddressBook;
-    		savetoDisk();
-    		
-    	} catch (Exception e) {
-    		log.warn("Unable to parse incomplete address book");
-    	}
+    	System.arraycopy(extraContents, 0, newAddressBook, addressBookBytes.length, extraContents.length);
+    	addressBookBytes = newAddressBook;
+		savetoDisk();
     }
 
     private static void savetoDisk() throws IOException {
         FileOutputStream fos = new FileOutputStream(addressBookFile);
         fos.write(addressBookBytes);
         fos.close();
+		log.info("New address book successfully saved to {}", addressBookFile);
     }
     
 	private static Client createHederaClient() {

--- a/src/main/java/com/hedera/recordFileLogger/RecordFileLogger.java
+++ b/src/main/java/com/hedera/recordFileLogger/RecordFileLogger.java
@@ -645,6 +645,15 @@ public class RecordFileLogger {
                     if ( ! bSkip) {
                     	sqlInsertFileData.addBatch();
                     }
+                    
+                	// update the local address book
+                	FileID updatedFile = body.getFileAppend().getFileID();
+
+                	if ((updatedFile.getFileNum() == 102) && (updatedFile.getShardNum() == 0) && (updatedFile.getRealmNum() == 0)) {
+                		// we have an address book update, refresh the local file
+                		NetworkAddressBook.append(contents);
+                	}
+                    
             	}
             } else if (body.hasFileCreate()) {
             	if (ConfigLoader.getPersistFiles().contentEquals("ALL") || (ConfigLoader.getPersistFiles().contentEquals("SYSTEM") && txRecord.getReceipt().getFileID().getFileNum() < 1000)) {
@@ -673,7 +682,7 @@ public class RecordFileLogger {
 
             	if ((updatedFile.getFileNum() == 102) && (updatedFile.getShardNum() == 0) && (updatedFile.getRealmNum() == 0)) {
             		// we have an address book update, refresh the local file
-            		NetworkAddressBook.writeFile(body.getFileUpdate().getContents().toByteArray());
+            		NetworkAddressBook.update(body.getFileUpdate().getContents().toByteArray());
             	}
 
             } else if (body.hasFreeze()) {


### PR DESCRIPTION
**Detailed description**:
Address book updates in multi-parts (fileUpdate + fileAppend) would result in a truncated address book file on disk.

**Which issue(s) this PR fixes**:
Fixes #192 

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
