### PR TITLE
Fix coverage & license badge links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![CircleCI](https://circleci.com/gh/hashgraph/hedera-mirror-node/tree/master.svg?style=shield)](https://circleci.com/gh/hashgraph/hedera-mirror-node/tree/master)
-![Coveralls github branch](https://img.shields.io/coveralls/github/hashgraph/hedera-mirror-node/master)
-![GitHub](https://img.shields.io/github/license/hashgraph/hedera-mirror-node)
+[![Coveralls github branch](https://img.shields.io/coveralls/github/hashgraph/hedera-mirror-node/master)](https://coveralls.io/github/hashgraph/hedera-mirror-node?branch=master)
+[![GitHub](https://img.shields.io/github/license/hashgraph/hedera-mirror-node)](LICENSE)
 
 # Beta Mirror Node
 


### PR DESCRIPTION
**Detailed description**:
Coverage and license badge links in README previously just opened image. Now they forward to the coveralls site and to the LICENSE file.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [x] Documentation added
- [ ] Tests updated

