### PR TITLE
Separate circleci steps *package_deliverable 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,14 @@ references:
   attach_workspace: &attach_workspace
     attach_workspace:
       at: *workspace_root
+  package_deliverable: &package_deliverable
+    run:
+      name: Generating mirror-node.tgz
+      working_directory: /tmp/workspace/
+      command: |
+        _tagged_dir=mirror-node-${CIRCLE_TAG:-b$CIRCLE_BUILD_NUM}
+        mv mirror-node "${_tagged_dir}"
+        tar -czf /tmp/workspace/mirror-node.tgz "${_tagged_dir}"
 
 workflows:
   version: 2
@@ -63,22 +71,17 @@ jobs:
             mv target/lib /tmp/workspace/mirror-node/
             mv systemd /tmp/workspace/mirror-node/
             mv scripts /tmp/workspace/mirror-node/
+            mv rest-api /tmp/workspace/mirror-node/
       - persist_to_workspace:
           root: *workspace_root
           paths:
             - mirror-node
-  
+
 
   release_artifacts:
     <<: *defaults
     steps:
       - *attach_workspace
-      - run:
-          name: Generating mirror-node.tgz
-          working_directory: /tmp/workspace/
-          command: |
-            _tagged_dir=mirror-node-${CIRCLE_TAG}
-            mv mirror-node "${_tagged_dir}"
-            tar -czf /tmp/mirror-node.tgz "${_tagged_dir}"
+      - *package_deliverable
       - store_artifacts:
-          path: /tmp/mirror-node.tgz
+          path: /tmp/workspace/mirror-node.tgz

--- a/scripts/deploy-mirror-node.sh
+++ b/scripts/deploy-mirror-node.sh
@@ -2,7 +2,7 @@
 
 # CD to parent directory containing scripts, lib, mirror-node.jar, etc.
 cd "$(dirname $0)/.."
-version=$(ls -1 -d "../"mirror-node-v* | tr '\n' '\0' | xargs -0 -n 1 basename | tail -1 | sed -e "s/mirror-node-//")
+version=$(ls -1 -d "../"mirror-node-[vb]* | tr '\n' '\0' | xargs -0 -n 1 basename | tail -1 | sed -e "s/mirror-node-//")
 if [ -z "${version}" ]; then
     echo "Can't find mirror-node-v* versioned parent directory. Unrecognized layout. Aborting"
     exit 1


### PR DESCRIPTION
**Detailed description**:

- creates a separate set of steps (yaml reference) `package_deliverable` that creates the tarball.
- release_artifacts to use this step before publishing artifact
- this means the perf_test step can use the same reference to run the same steps and have access to /tmp/workspace/mirror-node.tgz - to push that to the perf test host
- include rest-api in the tarball (unbuild and untested)
- Inside the tarball (since we're not just building for tagged releases) the inner directory will be either mirror-node-b789 (circleci build number) or mirror-node-v0.2.0 (git version tag).

**Which issue(s) this PR fixes**:
Fixes #206 

**Special notes for your reviewer**:

The script inside the tarball (scripts/deploy-mirror-node.sh) should deploy the mirror node (java side), but not currently do anything with the rest-api side.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

