### PR TITLE
Force anonymous AWS credentials to be used by downloader when so configured

### DIFF
--- a/src/main/java/com/hedera/downloader/Downloader.java
+++ b/src/main/java/com/hedera/downloader/Downloader.java
@@ -444,6 +444,7 @@ public abstract class Downloader {
 				s3Client = AmazonS3ClientBuilder.standard()
 						.withRegion(ConfigLoader.getClientRegion())
 						.withClientConfiguration(clientConfiguration)
+						.withCredentials(new AWSStaticCredentialsProvider(new AnonymousAWSCredentials()))
 						.build();
 			} else {
 				s3Client = AmazonS3ClientBuilder.standard()
@@ -461,6 +462,7 @@ public abstract class Downloader {
 								new AwsClientBuilder.EndpointConfiguration(
 										"https://storage.googleapis.com", ConfigLoader.getClientRegion()))
 						.withClientConfiguration(clientConfiguration)
+						.withCredentials(new AWSStaticCredentialsProvider(new AnonymousAWSCredentials()))
 						.build();
 			} else {
 				s3Client = AmazonS3ClientBuilder.standard()


### PR DESCRIPTION
**Detailed description**:

When config.json has "accessKey" and "secretKey" set to empty - force anonymous credentials to be used. Prior to this change, the downloader would pick up those keys from either the environment or user profile (~/.aws) - which would cause errors like "The AWS Access Key Id you provided does not exist in our records" when trying to run the downloader (as the hedera buckets would reject non-hedera keys or even keys for other hedera buckets).

**Which issue(s) this PR fixes**:
Fixes #127

**Special notes for your reviewer**:

You can test this if you like by:
- `brew install awscli`
- `aws configure`
- use an access key for mainnet
- try to run either downloader process against the testnet bucket

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

