### PR TITLE
Expose ed25519 key explicitly and remove admin_key in t_entities

### DIFF
--- a/rest-api/accounts.js
+++ b/rest-api/accounts.js
@@ -36,7 +36,6 @@ const processRow = function (row) {
     accRecord.balance.balance = (row.account_balance === null) ? null : Number(row.account_balance);
     accRecord.expiry_timestamp = (row.exp_time_ns === null) ? null : utils.nsToSecNs(row.exp_time_ns);
     accRecord.auto_renew_period = (row.auto_renew_period=== null) ? null : Number(row.auto_renew_period);
-    accRecord.admin_key = (row.admin_key === null) ? null : utils.encodeKey(row.admin_key);
     accRecord.key = (row.key === null) ? null : utils.encodeKey(row.key);
     accRecord.deleted = row.deleted;
     accRecord.entity_type = row.entity_type;
@@ -53,7 +52,6 @@ const getAccountQueryPrefix = function() {
         "    , coalesce(ab.account_num, e.entity_num) as entity_num\n" +
         "    , e.exp_time_ns\n" +
         "    , e.auto_renew_period\n" +
-        "    , e.admin_key\n" +
         "    , e.key\n" +
         "    , e.deleted\n" +
         "    , et.name as entity_type\n" +
@@ -100,7 +98,7 @@ const getAccounts = function (req) {
         ['ab.balance']);
 
     let [pubKeyQuery, pubKeyParams] = utils.parseParams(req, 'account.publickey',
-        ['e.key'], 'hexstring');
+        ['e.ed25519_public_key_hex'], null, (s) => {return s.toLowerCase();});
 
     const { limitQuery, limitParams, order, limit } =
         utils.parseLimitAndOrderParams(req, 'asc');

--- a/rest-api/balances.js
+++ b/rest-api/balances.js
@@ -58,7 +58,7 @@ const getBalances = function (req) {
         ['ab.balance']);
 
     let [pubKeyQuery, pubKeyParams] = utils.parseParams(req, 'account.publickey',
-        ['e.key'], 'hexstring');
+        ['e.ed25519_public_key_hex'], null, (s) => {return s.toLowerCase();});
     let joinEntities = ('' !== pubKeyQuery); // Only need to join t_entites if we're selecting on publickey.
 
     const { limitQuery, limitParams, order, limit } =

--- a/src/main/java/com/hedera/recordFileLogger/Entities.java
+++ b/src/main/java/com/hedera/recordFileLogger/Entities.java
@@ -62,8 +62,7 @@ public class Entities {
     }
 
 	private static Connection connect = null;
-    final private Utility utility = new Utility();
-	
+
 	public Entities(Connection connect) throws SQLException {
 		Entities.connect = connect;
 		if (Entities.connect != null) {
@@ -159,7 +158,7 @@ public class Entities {
 			fieldCount += 1;
 			String ed25519PublicKeyHex = null;
 			try {
-				ed25519PublicKeyHex = utility.protobufKeyToHexIfEd25519OrNull(key);
+				ed25519PublicKeyHex = Utility.protobufKeyToHexIfEd25519OrNull(key);
 			} catch (InvalidProtocolBufferException e) {
 				log.error("Invalid ED25519 key could not be translated to hex text for entity {}.{}.{}. Column will be nulled. {}",
 						shard, realm, num, e);
@@ -349,7 +348,7 @@ public class Entities {
     	} else {
 			String ed25519PublicKeyHex = null;
 			try {
-				ed25519PublicKeyHex = utility.protobufKeyToHexIfEd25519OrNull(key);
+				ed25519PublicKeyHex = Utility.protobufKeyToHexIfEd25519OrNull(key);
 			} catch (InvalidProtocolBufferException e) {
 				log.error("Invalid ED25519 key could not be translated to hex text for entity {}.{}.{}. Column will be nulled. {}",
 						shard, realm, num, e);

--- a/src/main/java/com/hedera/recordFileLogger/Entities.java
+++ b/src/main/java/com/hedera/recordFileLogger/Entities.java
@@ -29,11 +29,15 @@ import java.sql.Types;
 import java.time.Instant;
 import java.util.HashMap;
 
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.utilities.Utility;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ContractID;
 import com.hederahashgraph.api.proto.java.FileID;
 import lombok.extern.log4j.Log4j2;
+
+import static java.sql.Types.VARBINARY;
+import static java.sql.Types.VARCHAR;
 
 @Log4j2
 public class Entities {
@@ -52,12 +56,13 @@ public class Entities {
     	,EXP_TIME_NANOS
     	,EXP_TIME_NS
     	,AUTO_RENEW
-    	,ADMIN_KEY
+    	,ED25519_PUBLIC_KEY_HEX
     	,KEY
     	,FK_PROXY_ACCOUNT_ID
     }
 
 	private static Connection connect = null;
+    final private Utility utility = new Utility();
 	
 	public Entities(Connection connect) throws SQLException {
 		Entities.connect = connect;
@@ -77,10 +82,9 @@ public class Entities {
 	            resultSet.close();      
 			}
 		}
-    }       
+    }
 
-	private long updateEntity(int fk_entity_type, long shard, long realm, long num, long exp_time_seconds, long exp_time_nanos, long auto_renew_period, byte[] admin_key, byte[] key, long fk_proxy_account_id) throws SQLException {
-		
+	private long updateEntity(int fk_entity_type, long shard, long realm, long num, long exp_time_seconds, long exp_time_nanos, long auto_renew_period, byte[] key, long fk_proxy_account_id) throws SQLException {
 		long entityId = 0;
 		
 	    if (shard + realm + num == 0 ) {
@@ -89,7 +93,7 @@ public class Entities {
 
 	    entityId = createOrGetEntity(shard, realm, num, fk_entity_type);
 	    
-	    if ((exp_time_nanos == 0) && (exp_time_seconds == 0) && (auto_renew_period == 0) && (fk_proxy_account_id == 0) && (admin_key == null) && (key == null)) {
+	    if ((exp_time_nanos == 0) && (exp_time_seconds == 0) && (auto_renew_period == 0) && (fk_proxy_account_id == 0) && (key == null)) {
 	    	// nothing to update
 	    	return entityId;
 	    }
@@ -112,13 +116,12 @@ public class Entities {
 	    	bDoComma = true;
 	    }
 	    
-	    if (admin_key != null) {
-	    	if (bDoComma) sqlUpdate += ",";
-	    	sqlUpdate += "admin_key = ?";
-	    	bDoComma = true;
-	    }
-
 	    if (key != null) {
+	    	// The key has been specified, thus update this field either to null for non-ED25519 key or the hex value.
+			if (bDoComma) sqlUpdate += ",";
+			sqlUpdate += "ed25519_public_key_hex = ?";
+			bDoComma = true;
+
 	    	if (bDoComma) sqlUpdate += ",";
 	    	sqlUpdate += "key = ?";
 	    	bDoComma = true;
@@ -151,13 +154,22 @@ public class Entities {
 	    	fieldCount += 1;
 	    	updateEntity.setLong(fieldCount, auto_renew_period);
 	    }
-	    
-	    if (admin_key != null) {
-	    	fieldCount += 1;
-    		updateEntity.setBytes(fieldCount, admin_key);
-	    }
 
 	    if (key != null) {
+			fieldCount += 1;
+			String ed25519PublicKeyHex = null;
+			try {
+				ed25519PublicKeyHex = utility.protobufKeyToHexIfEd25519OrNull(key);
+			} catch (InvalidProtocolBufferException e) {
+				log.error("Invalid ED25519 key could not be translated to hex text for entity {}.{}.{}. Column will be nulled. {}",
+						shard, realm, num, e);
+			}
+			if (null != ed25519PublicKeyHex) {
+				updateEntity.setString(fieldCount, ed25519PublicKeyHex);
+			} else {
+				updateEntity.setNull(fieldCount, VARCHAR);
+			}
+
 	    	fieldCount += 1;
     		updateEntity.setBytes(fieldCount, key);
 	    }
@@ -193,14 +205,14 @@ public class Entities {
 	    
 	}
 
-	public long updateEntity(FileID fileId, long exp_time_seconds, long exp_time_nanos, long auto_renew_period, byte[] admin_key, byte[] key, long fk_proxy_account_id) throws SQLException {
-		return updateEntity(FK_FILE, fileId.getShardNum(),fileId.getRealmNum(), fileId.getFileNum(), exp_time_seconds, exp_time_nanos, auto_renew_period, admin_key, key, fk_proxy_account_id);
+	public long updateEntity(FileID fileId, long exp_time_seconds, long exp_time_nanos, long auto_renew_period, byte[] key, long fk_proxy_account_id) throws SQLException {
+		return updateEntity(FK_FILE, fileId.getShardNum(),fileId.getRealmNum(), fileId.getFileNum(), exp_time_seconds, exp_time_nanos, auto_renew_period, key, fk_proxy_account_id);
 	}
-	public long updateEntity(ContractID contractId, long exp_time_seconds, long exp_time_nanos, long auto_renew_period, byte[] admin_key, byte[] key, long fk_proxy_account_id) throws SQLException {
-		return updateEntity(FK_CONTRACT, contractId.getShardNum(),contractId.getRealmNum(), contractId.getContractNum(), exp_time_seconds, exp_time_nanos, auto_renew_period, admin_key, key, fk_proxy_account_id);
+	public long updateEntity(ContractID contractId, long exp_time_seconds, long exp_time_nanos, long auto_renew_period, byte[] key, long fk_proxy_account_id) throws SQLException {
+		return updateEntity(FK_CONTRACT, contractId.getShardNum(),contractId.getRealmNum(), contractId.getContractNum(), exp_time_seconds, exp_time_nanos, auto_renew_period, key, fk_proxy_account_id);
 	}
-	public long updateEntity(AccountID accountId, long exp_time_seconds, long exp_time_nanos, long auto_renew_period, byte[] admin_key, byte[] key, long fk_proxy_account_id) throws SQLException {
-		return updateEntity(FK_ACCOUNT, accountId.getShardNum(),accountId.getRealmNum(), accountId.getAccountNum(), exp_time_seconds, exp_time_nanos, auto_renew_period, admin_key, key, fk_proxy_account_id);
+	public long updateEntity(AccountID accountId, long exp_time_seconds, long exp_time_nanos, long auto_renew_period, byte[] key, long fk_proxy_account_id) throws SQLException {
+		return updateEntity(FK_ACCOUNT, accountId.getShardNum(),accountId.getRealmNum(), accountId.getAccountNum(), exp_time_seconds, exp_time_nanos, auto_renew_period, key, fk_proxy_account_id);
 	}
 
 	private long deleteEntity(int fk_entity_type, long shard, long realm, long num) throws SQLException {
@@ -308,7 +320,9 @@ public class Entities {
 		return unDeleteEntity(FK_ACCOUNT, accountId.getShardNum(),accountId.getRealmNum(), accountId.getAccountNum());
 	}
 
-	private long createEntity(long shard, long realm, long num, long exp_time_seconds, long exp_time_nanos, long auto_renew_period, byte[] admin_key, byte[] key, long fk_proxy_account_id, int fk_entity_type) throws SQLException {
+	private long createEntity(long shard, long realm, long num, long exp_time_seconds, long exp_time_nanos,
+							  long auto_renew_period, byte[] key, long fk_proxy_account_id, int fk_entity_type)
+			throws SQLException {
 
 		long entityId = getCachedEntityId(shard, realm, num, fk_entity_type);
 		if (entityId != -1) {
@@ -329,15 +343,22 @@ public class Entities {
     	entityCreate.setLong(8, Utility.convertInstantToNanos(expiryTime));
 		entityCreate.setLong(9, auto_renew_period);
 
-		if (admin_key == null) {
-    		entityCreate.setBytes(10, new byte[0]);
-    	} else {
-    		entityCreate.setBytes(10, admin_key);
-    	}
-
     	if (key == null) {
-    		entityCreate.setBytes(11, new byte[0]);
+			entityCreate.setNull(10, VARCHAR);
+			entityCreate.setNull(11, VARBINARY);
     	} else {
+			String ed25519PublicKeyHex = null;
+			try {
+				ed25519PublicKeyHex = utility.protobufKeyToHexIfEd25519OrNull(key);
+			} catch (InvalidProtocolBufferException e) {
+				log.error("Invalid ED25519 key could not be translated to hex text for entity {}.{}.{}. Column will be nulled. {}",
+						shard, realm, num, e);
+			}
+			if (null != ed25519PublicKeyHex) {
+				entityCreate.setString(10, ed25519PublicKeyHex);
+			} else {
+				entityCreate.setNull(10, VARCHAR);
+			}
     		entityCreate.setBytes(11, key);
     	}
 
@@ -352,14 +373,14 @@ public class Entities {
 	    
 	}
 
-	public long createEntity(FileID fileId, long exp_time_seconds, long exp_time_nanos, long auto_renew_period, byte[] admin_key, byte[] key, long fk_proxy_account_id) throws SQLException {
-		return createEntity(fileId.getShardNum(),fileId.getRealmNum(), fileId.getFileNum(), exp_time_seconds, exp_time_nanos, auto_renew_period, admin_key, key, fk_proxy_account_id, FK_FILE);
+	public long createEntity(FileID fileId, long exp_time_seconds, long exp_time_nanos, long auto_renew_period, byte[] key, long fk_proxy_account_id) throws SQLException {
+		return createEntity(fileId.getShardNum(),fileId.getRealmNum(), fileId.getFileNum(), exp_time_seconds, exp_time_nanos, auto_renew_period, key, fk_proxy_account_id, FK_FILE);
 	}
-	public long createEntity(ContractID contractId, long exp_time_seconds, long exp_time_nanos, long auto_renew_period, byte[] admin_key, byte[] key, long fk_proxy_account_id) throws SQLException {
-		return createEntity(contractId.getShardNum(),contractId.getRealmNum(), contractId.getContractNum(), exp_time_seconds, exp_time_nanos, auto_renew_period, admin_key, key, fk_proxy_account_id, FK_CONTRACT);
+	public long createEntity(ContractID contractId, long exp_time_seconds, long exp_time_nanos, long auto_renew_period, byte[] key, long fk_proxy_account_id) throws SQLException {
+		return createEntity(contractId.getShardNum(),contractId.getRealmNum(), contractId.getContractNum(), exp_time_seconds, exp_time_nanos, auto_renew_period, key, fk_proxy_account_id, FK_CONTRACT);
 	}
-	public long createEntity(AccountID accountId, long exp_time_seconds, long exp_time_nanos, long auto_renew_period, byte[] admin_key, byte[] key, long fk_proxy_account_id) throws SQLException {
-		return createEntity(accountId.getShardNum(),accountId.getRealmNum(), accountId.getAccountNum(), exp_time_seconds, exp_time_nanos, auto_renew_period, admin_key, key, fk_proxy_account_id, FK_ACCOUNT);
+	public long createEntity(AccountID accountId, long exp_time_seconds, long exp_time_nanos, long auto_renew_period, byte[] key, long fk_proxy_account_id) throws SQLException {
+		return createEntity(accountId.getShardNum(),accountId.getRealmNum(), accountId.getAccountNum(), exp_time_seconds, exp_time_nanos, auto_renew_period, key, fk_proxy_account_id, FK_ACCOUNT);
 	}
 	private long createOrGetEntity(long shard, long realm, long num, int fk_entity_type) throws SQLException {
 		
@@ -378,8 +399,8 @@ public class Entities {
 		entityCreate.setLong(7, 0);
     	entityCreate.setLong(8, 0);
 		entityCreate.setLong(9, 0);
-		entityCreate.setBytes(10, new byte[0]);
-		entityCreate.setBytes(11, new byte[0]);
+		entityCreate.setNull(10, VARCHAR);
+		entityCreate.setNull(11, VARBINARY);
 		entityCreate.setLong(12, 0);
 		
 		entityCreate.execute();

--- a/src/main/java/com/hedera/recordFileLogger/RecordFileLogger.java
+++ b/src/main/java/com/hedera/recordFileLogger/RecordFileLogger.java
@@ -366,13 +366,12 @@ public class RecordFileLogger {
 	            	if (txMessage.hasAutoRenewPeriod()) {
 	            		auto_renew_period = txMessage.getAutoRenewPeriod().getSeconds();
 	            	}
-	            	byte[] admin_key = null;
-	            	if (txMessage.hasAdminKey()) {
-	            		admin_key = txMessage.getAdminKey().toByteArray();
-	            	}
 	            	byte[] key = null;
+	            	if (txMessage.hasAdminKey()) {
+	            		key = txMessage.getAdminKey().toByteArray();
+	            	}
 	            	long proxy_account_id = entities.createOrGetEntity(txMessage.getProxyAccountID());
-	            	entityId = entities.createEntity(txRecord.getReceipt().getContractID(), expiration_time_sec, expiration_time_nanos, auto_renew_period, admin_key, key, proxy_account_id);
+	            	entityId = entities.createEntity(txRecord.getReceipt().getContractID(), expiration_time_sec, expiration_time_nanos, auto_renew_period, key, proxy_account_id);
             	}
 
                 initialBalance = body.getContractCreateInstance().getInitialBalance();
@@ -394,15 +393,14 @@ public class RecordFileLogger {
             		auto_renew_period = txMessage.getAutoRenewPeriod().getSeconds();
             	}
 
-            	byte[] admin_key = null;
+            	byte[] key = null;
             	if (txMessage.hasAdminKey()) {
-            		admin_key = txMessage.getAdminKey().toByteArray();
+            		key = txMessage.getAdminKey().toByteArray();
             	}
 
-            	byte[] key = null;
             	long proxy_account_id = entities.createOrGetEntity(txMessage.getProxyAccountID());
 
-            	entityId = entities.updateEntity(txMessage.getContractID(), expiration_time_sec, expiration_time_nanos, auto_renew_period, admin_key, key, proxy_account_id);
+            	entityId = entities.updateEntity(txMessage.getContractID(), expiration_time_sec, expiration_time_nanos, auto_renew_period, key, proxy_account_id);
             } else if (body.hasCryptoAddClaim()) {
                 if (body.getCryptoAddClaim().hasClaim()) {
                     if (body.getCryptoAddClaim().getClaim().hasAccountID()) {
@@ -418,13 +416,12 @@ public class RecordFileLogger {
 	            	if (txMessage.hasAutoRenewPeriod()) {
 	            		auto_renew_period = txMessage.getAutoRenewPeriod().getSeconds();
 	            	}
-	            	byte[] admin_key = null;
 	            	byte[] key = null;
 	            	if (txMessage.hasKey()) {
 	            		key = txMessage.getKey().toByteArray();
 	            	}
 	            	long proxy_account_id = entities.createOrGetEntity(txMessage.getProxyAccountID());
-	            	entityId = entities.createEntity(txRecord.getReceipt().getAccountID(), expiration_time_sec, expiration_time_nanos, auto_renew_period, admin_key, key, proxy_account_id);
+	            	entityId = entities.createEntity(txRecord.getReceipt().getAccountID(), expiration_time_sec, expiration_time_nanos, auto_renew_period, key, proxy_account_id);
             	}
 
             	initialBalance = body.getCryptoCreateAccount().getInitialBalance();
@@ -452,8 +449,6 @@ public class RecordFileLogger {
             		auto_renew_period = txMessage.getAutoRenewPeriod().getSeconds();
             	}
 
-            	byte[] admin_key = null;
-
             	byte[] key = null;
             	if (txMessage.hasKey()) {
             		key = txMessage.getKey().toByteArray();
@@ -461,7 +456,7 @@ public class RecordFileLogger {
 
             	long proxy_account_id = entities.createOrGetEntity(txMessage.getProxyAccountID());
 
-            	entityId = entities.updateEntity(body.getCryptoUpdateAccount().getAccountIDToUpdate(), expiration_time_sec, expiration_time_nanos, auto_renew_period, admin_key, key, proxy_account_id);
+            	entityId = entities.updateEntity(body.getCryptoUpdateAccount().getAccountIDToUpdate(), expiration_time_sec, expiration_time_nanos, auto_renew_period, key, proxy_account_id);
             } else if (body.hasFileCreate()) {
             	if (txRecord.getReceipt().hasFileID()) {
             		FileCreateTransactionBody txMessage = body.getFileCreate();
@@ -472,13 +467,12 @@ public class RecordFileLogger {
 	            		expiration_time_nanos = txMessage.getExpirationTime().getNanos();
 	            	}
 	            	long auto_renew_period = 0;
-	            	byte[] admin_key = null;
 	            	byte[] key = null;
 	            	if (txMessage.hasKeys()) {
 	            		key = txMessage.getKeys().toByteArray();
 	            	}
 	            	long proxy_account_id = 0;
-	            	entityId = entities.createEntity(txRecord.getReceipt().getFileID(), expiration_time_sec, expiration_time_nanos, auto_renew_period, admin_key, key, proxy_account_id);
+	            	entityId = entities.createEntity(txRecord.getReceipt().getFileID(), expiration_time_sec, expiration_time_nanos, auto_renew_period, key, proxy_account_id);
             	}
             } else if (body.hasFileAppend()) {
                 if (body.getFileAppend().hasFileID()) {
@@ -499,8 +493,6 @@ public class RecordFileLogger {
             	}
             	long auto_renew_period = 0;
 
-            	byte[] admin_key = null;
-
             	byte[] key = null;
             	if (txMessage.hasKeys()) {
             		key = txMessage.getKeys().toByteArray();
@@ -508,7 +500,7 @@ public class RecordFileLogger {
 
             	long proxy_account_id = 0;
 
-            	entityId = entities.updateEntity(txMessage.getFileID(), expiration_time_sec, expiration_time_nanos, auto_renew_period, admin_key, key, proxy_account_id);
+            	entityId = entities.updateEntity(txMessage.getFileID(), expiration_time_sec, expiration_time_nanos, auto_renew_period, key, proxy_account_id);
 
 			} else if (body.hasFreeze()) {
 				//TODO:

--- a/src/main/java/com/hedera/utilities/Utility.java
+++ b/src/main/java/com/hedera/utilities/Utility.java
@@ -32,6 +32,7 @@ import com.google.protobuf.TextFormat;
 import com.hedera.downloader.Downloader;
 import com.hedera.filedelimiters.FileDelimiter;
 import com.hederahashgraph.api.proto.java.AccountID;
+import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.Transaction;
 import com.hederahashgraph.api.proto.java.TransactionBody;
@@ -42,6 +43,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.lang3.tuple.Triple;
 
+import javax.annotation.Nullable;
 import java.io.DataInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -58,6 +60,8 @@ import java.time.format.DateTimeParseException;
 import java.util.Arrays;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import static com.hederahashgraph.api.proto.java.Key.KeyCase.ED25519;
 
 @Log4j2
 public class Utility {
@@ -744,5 +748,21 @@ public class Utility {
 		} catch (Exception e) {
 			throw new RuntimeException(e);
 		}
+	}
+
+	/**
+	 * If the protobuf encoding of a Key is a single ED25519 key, return the key as a String with lowercase hex encoding.
+	 * @param protobufKey
+	 * @return ED25519 public key as a String in hex encoding, or null
+	 * @throws InvalidProtocolBufferException if the protobufKey is not a valid protobuf encoding of a Key (BasicTypes.proto)
+	 */
+	public @Nullable String protobufKeyToHexIfEd25519OrNull(@Nullable final byte[] protobufKey)
+			throws InvalidProtocolBufferException {
+		if ((null == protobufKey) || (0 == protobufKey.length)) return null;
+
+		final var parsedKey = Key.parseFrom(protobufKey);
+		if (ED25519 != parsedKey.getKeyCase()) return null;
+
+		return Hex.encodeHexString(parsedKey.getEd25519().toByteArray(), true);
 	}
 }

--- a/src/main/java/com/hedera/utilities/Utility.java
+++ b/src/main/java/com/hedera/utilities/Utility.java
@@ -756,7 +756,7 @@ public class Utility {
 	 * @return ED25519 public key as a String in hex encoding, or null
 	 * @throws InvalidProtocolBufferException if the protobufKey is not a valid protobuf encoding of a Key (BasicTypes.proto)
 	 */
-	public @Nullable String protobufKeyToHexIfEd25519OrNull(@Nullable final byte[] protobufKey)
+	public static @Nullable String protobufKeyToHexIfEd25519OrNull(@Nullable final byte[] protobufKey)
 			throws InvalidProtocolBufferException {
 		if ((null == protobufKey) || (0 == protobufKey.length)) return null;
 

--- a/src/main/resources/db/migration/V1.11.0__entity_key.sql
+++ b/src/main/resources/db/migration/V1.11.0__entity_key.sql
@@ -1,0 +1,102 @@
+-- Fix bad data where empty string was used instead of null for keys.
+update t_entities
+    set key = null
+    where length(key) = 0;
+update t_entities
+    set admin_key = null
+    where length(admin_key) = 0;
+
+-- Consolidate the key and admin_key fields as they cannot both be present for the same entities.
+update t_entities
+    set key = admin_key
+    where admin_key is not null
+    and key is null;
+alter table t_entities
+    rename column admin_key to admin_key__deprecated;
+
+-- Add a plaintext hex (lowercase) representation of ED25519 public key
+alter table t_entities
+    add column ed25519_public_key_hex varchar null;
+-- Enforce lowercase hex representation by constraint rather than making indexes on lower(ed25519).
+alter table t_entities
+    add constraint c__t_entities__lower_ed25519
+    check (ed25519_public_key_hex = lower(ed25519_public_key_hex));
+create index idx__t_entities__ed25519_public_key_hex_natural_id
+    on t_entities (ed25519_public_key_hex, fk_entity_type_id, entity_shard, entity_realm, entity_num);
+
+-- Fill in the ed25519_public_key_hex from the raw 'key' column.
+-- From BasicTypes.proto, message Key, extract the ED25519 key as hex.
+-- This will convert conformant keys (protobuf option #2, length = 32 bytes)
+-- NOTE: if the DB has many entities, this may need to be broken up into batches.
+update t_entities
+    set ed25519_public_key_hex = substring(encode(key::bytea, 'hex'), 4) -- This is where the key data starts in the protobuf
+    where key is not null
+        and encode(key::bytea, 'hex') like '1220%'; -- This indicates it's a single ED25519 key of proper length.
+
+--
+-- Update affected functions.
+--
+
+-- Full list of parameters required in `drop function` prior to postgresql 10.
+drop function if exists f_entity_create(bigint, bigint, bigint, integer,
+    bigint, bigint, bigint, bigint, bytea, bytea, bigint);
+
+CREATE FUNCTION f_entity_create (
+    _shard t_entities.entity_shard%TYPE
+    ,_realm t_entities.entity_realm%TYPE
+    ,_num t_entities.entity_num%TYPE
+    ,_type_id t_entities.fk_entity_type_id%TYPE
+    ,_exp_time_sec t_entities.exp_time_seconds%TYPE
+    ,_exp_time_nanos t_entities.exp_time_nanos%TYPE
+    ,_exp_time_ns t_entities.exp_time_ns%TYPE
+    ,_auto_renew t_entities.auto_renew_period%TYPE
+    ,_ed25519_public_key_hex t_entities.ed25519_public_key_hex%type
+    ,_key t_entities.key%type
+    ,_proxy_acc_id t_entities.fk_prox_acc_id%TYPE
+) RETURNS BIGINT AS $$
+DECLARE
+    entity_id BIGINT;
+BEGIN
+
+    SELECT id
+    INTO entity_id
+    FROM t_entities
+    WHERE entity_shard = _shard
+      AND   entity_realm = _realm
+      AND   entity_num = _num
+      AND   fk_entity_type_id = _type_id;
+
+    IF NOT FOUND THEN
+        INSERT INTO t_entities (
+                                 entity_shard
+                               , entity_realm
+                               , entity_num
+                               , fk_entity_type_id
+                               , exp_time_seconds
+                               , exp_time_nanos
+                               , exp_time_ns
+                               , auto_renew_period
+                               , ed25519_public_key_hex
+                               , key
+                               , fk_prox_acc_id
+        )
+        SELECT
+            _shard
+             ,_realm
+             ,_num
+             ,_type_id
+             ,CASE WHEN _exp_time_sec = 0 THEN NULL ELSE _exp_time_sec END
+             ,CASE WHEN _exp_time_nanos = 0 THEN NULL ELSE _exp_time_nanos END
+             ,CASE WHEN _exp_time_ns = 0 THEN NULL ELSE _exp_time_ns END
+             ,CASE WHEN _auto_renew = 0 THEN NULL ELSE _auto_renew END
+             ,_ed25519_public_key_hex
+             ,_key
+             ,CASE WHEN _proxy_acc_id = 0 THEN NULL ELSE _proxy_acc_id END
+
+            RETURNING id INTO entity_id;
+    END IF;
+
+    RETURN entity_id;
+END
+$$ LANGUAGE plpgsql
+;

--- a/src/test/java/com/hedera/utilities/UtilityTest.java
+++ b/src/test/java/com/hedera/utilities/UtilityTest.java
@@ -134,7 +134,7 @@ public class UtilityTest {
 	private Utility getCut() throws SQLException { return new Utility(); }
 
 	@Test
-	@DisplayName("null")
+	@DisplayName("protobufKeyToHexIfEd25519OrNull null key")
 	public void protobufKeyToHexIfEd25519OrNull_Null() throws InvalidProtocolBufferException, SQLException {
 		final var result = getCut().protobufKeyToHexIfEd25519OrNull(null);
 
@@ -142,7 +142,7 @@ public class UtilityTest {
 	}
 
 	@Test
-	@DisplayName("valid")
+	@DisplayName("protobufKeyToHexIfEd25519OrNull valid ED25519 key")
 	public void protobufKeyToHexIfEd25519OrNull_Valid() throws InvalidProtocolBufferException, SQLException {
 		final var instr = "0011223344556677889900aabbccddeeff0011223344556677889900aabbccddeeff";
 		final var input = Key.newBuilder().setEd25519(ByteString.copyFrom(Hex.decode(instr))).build();
@@ -153,7 +153,7 @@ public class UtilityTest {
 	}
 
 	@Test
-	@DisplayName("threshold key (null)")
+	@DisplayName("protobufKeyToHexIfEd25519OrNull threshold key")
 	public void protobufKeyToHexIfEd25519OrNull_ThresholdKey() throws InvalidProtocolBufferException, SQLException {
 		final var ks = "0011223344556677889900aabbccddeeff0011223344556677889900aabbccddeeff";
 		final var key = Key.newBuilder().setEd25519(ByteString.copyFrom(Hex.decode(ks))).build();

--- a/src/test/java/com/hedera/utilities/UtilityTest.java
+++ b/src/test/java/com/hedera/utilities/UtilityTest.java
@@ -20,17 +20,24 @@ package com.hedera.utilities;
  * ‍
  */
 
+import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.hederahashgraph.api.proto.java.AccountID;
 
+import com.hederahashgraph.api.proto.java.Key;
+import com.hederahashgraph.api.proto.java.KeyList;
+import com.hederahashgraph.api.proto.java.ThresholdKey;
 import org.apache.commons.lang3.tuple.Triple;
 import static org.assertj.core.api.Assertions.*;
 
+import org.bouncycastle.util.encoders.Hex;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.nio.file.*;
+import java.sql.SQLException;
 import java.time.Instant;
 
 public class UtilityTest {
@@ -122,5 +129,40 @@ public class UtilityTest {
 	void getResource() {
 		assertThat(Utility.getResource("log4j2.xml")).exists().canRead();
 		assertThat(Utility.getResource("log4j2-test.xml")).exists().canRead();
+	}
+
+	private Utility getCut() throws SQLException { return new Utility(); }
+
+	@Test
+	@DisplayName("null")
+	public void protobufKeyToHexIfEd25519OrNull_Null() throws InvalidProtocolBufferException, SQLException {
+		final var result = getCut().protobufKeyToHexIfEd25519OrNull(null);
+
+		assertThat(result).isNull();
+	}
+
+	@Test
+	@DisplayName("valid")
+	public void protobufKeyToHexIfEd25519OrNull_Valid() throws InvalidProtocolBufferException, SQLException {
+		final var instr = "0011223344556677889900aabbccddeeff0011223344556677889900aabbccddeeff";
+		final var input = Key.newBuilder().setEd25519(ByteString.copyFrom(Hex.decode(instr))).build();
+
+		final var result = getCut().protobufKeyToHexIfEd25519OrNull(input.toByteArray());
+
+		assertThat(result).isEqualTo(instr);
+	}
+
+	@Test
+	@DisplayName("threshold key (null)")
+	public void protobufKeyToHexIfEd25519OrNull_ThresholdKey() throws InvalidProtocolBufferException, SQLException {
+		final var ks = "0011223344556677889900aabbccddeeff0011223344556677889900aabbccddeeff";
+		final var key = Key.newBuilder().setEd25519(ByteString.copyFrom(Hex.decode(ks))).build();
+		final var keyList = KeyList.newBuilder().addKeys(key).build();
+		final var tk = ThresholdKey.newBuilder().setThreshold(1).setKeys(keyList).build();
+		final var input = Key.newBuilder().setThresholdKey(tk).build();
+
+		final var result = getCut().protobufKeyToHexIfEd25519OrNull(input.toByteArray());
+
+		assertThat(result).isNull();
 	}
 }


### PR DESCRIPTION
**Detailed description**:

key column will now be used in place of admin_key where admin_key was used in the past. No entity had both

- copied data from t_entities.admin_key to t_entities.key if present
- deprecated t_entities.admin_key
- added t_entities.ed25519_public_key_hex (lowercase hex string if the key)
- updated java, sql function, and rest-api for this change
- rest-api will no longer be returning admin_key publicly (didn't make sense on accounts anyway)

**Which issue(s) this PR fixes**:
Fixes #56 

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [X] Tests updated
