### PR TITLE
Remove deprecated tables and columns from v0.1.

### DIFF
--- a/src/main/resources/db/migration/V1.11.0__remove_deprecated.sql
+++ b/src/main/resources/db/migration/V1.11.0__remove_deprecated.sql
@@ -1,0 +1,9 @@
+drop table if exists t_account_balances__deprecated cascade;
+drop table if exists t_account_balance_history__deprecated;
+drop table if exists t_account_balance_refresh_time__deprecated;
+
+alter table account_balances
+    drop column if exists account_id__deprecated;
+-- OPS NOTE: either a vacuum analyze or vacuum full (careful) should be done on the table after this removal.
+
+drop type if exists entity_id;


### PR DESCRIPTION
**Detailed description**:

- removing 3 __deprecated tables (the old account balance tables from pre-0.1 which were marked as deprecated in 0.1 - were no longer used at that point or now, and are now safe to officially remove).
- removing entity_id type and account_balances.account_id - was temporarily used pre-0.1 and deprecated in favor of using separate fields in account_balances for realm_num, account_num.

**Which issue(s) this PR fixes**:
Fixes #115 

**Special notes for your reviewer**:

Operations-wise - a `vacuum full` or at least a `vacuum analyze` should be run on the account_balances table afterwords to reclaim space. if there is time when traffic is low, stop the mirror-node, run `vacuum full account_balances`, then restart the mirror-node. it will probably take a minute. If no time for that, just `vacuum analyze account_balances`

I'll test the `vacuum full` time on a large dataset, locally.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

