### PR TITLE
Fix record file mismatch race condition

### DIFF
--- a/src/main/java/com/hedera/downloader/RecordFileDownloader.java
+++ b/src/main/java/com/hedera/downloader/RecordFileDownloader.java
@@ -141,13 +141,14 @@ public class RecordFileDownloader extends Downloader {
 					if (rcdFile != null && Utility.hashMatch(validSigFile, rcdFile)) {
 						if (verifyHashChain(rcdFile)) {
 							// move the file to the valid directory
-							File validFile = Paths.get(validDir, rcdFile.getName()).toFile();
+							String name = rcdFile.getName();
+							String hash = Utility.bytesToHex(Utility.getFileHash(rcdFile.getAbsolutePath()));
+							File validFile = Paths.get(validDir, name).toFile();
 
 							if (moveFile(rcdFile, validFile)) {
 								log.debug("Verified signature file matches at least 2/3 of nodes: {}", fileName);
-								String hash = Utility.bytesToHex(Utility.getFileHash(validFile.getAbsolutePath()));
 								applicationStatus.updateLastValidDownloadedRecordFileHash(hash);
-								applicationStatus.updateLastValidDownloadedRecordFileName(validFile.getName());
+								applicationStatus.updateLastValidDownloadedRecordFileName(name);
 								valid = true;
 								break;
 							}

--- a/src/main/java/com/hedera/downloader/RecordFileDownloader.java
+++ b/src/main/java/com/hedera/downloader/RecordFileDownloader.java
@@ -119,24 +119,23 @@ public class RecordFileDownloader extends Downloader {
 				break;
 			}
 			boolean valid = false;
+			List<File> sigFiles = sigFilesMap.get(fileName);
 
-			try {
-				List<File> sigFiles = sigFilesMap.get(fileName);
+			// If the number of sigFiles is not greater than 2/3 of number of nodes, we don't need to verify them
+			if (sigFiles == null || !Utility.greaterThanSuperMajorityNum(sigFiles.size(), nodeAccountIds.size())) {
+				log.warn("Signature file count for {} does not exceed 2/3 of nodes", fileName);
+				continue;
+			}
 
-				// If the number of sigFiles is not greater than 2/3 of number of nodes, we don't need to verify them
-				if (sigFiles == null || !Utility.greaterThanSuperMajorityNum(sigFiles.size(), nodeAccountIds.size())) {
-					log.warn("Signature file count for {} does not exceed 2/3 of nodes", fileName);
-					continue;
+			// validSigFiles are signed by node key and contains the same hash which has been agreed by more than 2/3 nodes
+			List<File> validSigFiles = verifier.verifySignatureFiles(sigFiles);
+			for (File validSigFile : validSigFiles) {
+				if (Utility.checkStopFile()) {
+					log.info("Stop file found, stopping");
+					break;
 				}
 
-				// validSigFiles are signed by node key and contains the same hash which has been agreed by more than 2/3 nodes
-				List<File> validSigFiles = verifier.verifySignatureFiles(sigFiles);
-				for (File validSigFile : validSigFiles) {
-					if (Utility.checkStopFile()) {
-						log.info("Stop file found, stopping");
-						break;
-					}
-
+				try {
 					Pair<Boolean, File> rcdFileResult = downloadFile(DownloadType.RCD, validSigFile, tmpDir);
 					File rcdFile = rcdFileResult.getRight();
 					if (rcdFile != null && Utility.hashMatch(validSigFile, rcdFile)) {
@@ -154,11 +153,11 @@ public class RecordFileDownloader extends Downloader {
 							}
 						}
 					} else if (rcdFile != null) {
-						log.warn("Hash of {} doesn't match the hash contained in the signature file. Will try to download a record file with same timestamp from other nodes", rcdFile);
+						log.warn("Hash of {} doesn't match the hash contained in the signature file. Will try to download a record file with same timestamp from other nodes", validSigFile);
 					}
+				} catch (Exception e) {
+					log.error("Unable to verify signature {}", validSigFile, e);
 				}
-			} catch (Exception e) {
-				log.error("Unable to verify signature {}", fileName, e);
 			}
 
 			if (!valid) {

--- a/src/test/java/com/hedera/downloader/RecordFileDownloaderTestV1.java
+++ b/src/test/java/com/hedera/downloader/RecordFileDownloaderTestV1.java
@@ -72,9 +72,6 @@ public class RecordFileDownloaderTestV1 {
 
         s3 = S3Mock.create(8001, s3Path.toString());
         s3.start();
-
-        when(applicationStatus.getLastValidDownloadedRecordFileName()).thenReturn("");
-        when(applicationStatus.getLastValidDownloadedRecordFileHash()).thenReturn("");
     }
 
     @AfterEach
@@ -163,13 +160,11 @@ public class RecordFileDownloaderTestV1 {
     void hashMismatchWithPrevious() throws Exception {
         when(applicationStatus.getLastValidDownloadedRecordFileName()).thenReturn("2019-07-01T14:12:00.000000Z.rcd");
         when(applicationStatus.getLastValidDownloadedRecordFileHash()).thenReturn("123");
-        when(applicationStatus.getBypassRecordHashMismatchUntilAfter()).thenReturn("");
         fileCopier.copy();
         downloader.download();
         assertThat(Files.walk(validPath))
                 .filteredOn(p -> !p.toFile().isDirectory())
-                .hasSize(2)
-                .allMatch(p -> Utility.isRecordFile(p.toString()));
+                .hasSize(0);
     }
 
     @Test

--- a/src/test/java/com/hedera/downloader/RecordFileDownloaderTestV2.java
+++ b/src/test/java/com/hedera/downloader/RecordFileDownloaderTestV2.java
@@ -72,9 +72,6 @@ public class RecordFileDownloaderTestV2 {
 
         s3 = S3Mock.create(8001, s3Path.toString());
         s3.start();
-
-        when(applicationStatus.getLastValidDownloadedRecordFileName()).thenReturn("");
-        when(applicationStatus.getLastValidDownloadedRecordFileHash()).thenReturn("");
     }
 
     @AfterEach


### PR DESCRIPTION
**Detailed description**:
Ensures that signature is validated by 2/3 of nodes _and_ the hash chain is validated before moving to valid folder and updating the db. This fixes the race condition with parser processing files that hadn't had their hash chain confirmed.

**Which issue(s) this PR fixes**:
Fixes #195

**Special notes for your reviewer**:
Note this is merging into the release branch `release/0.1` for a `v0.1.1` release. I will cherry pick it to master after.

**Checklist**
- [ ] Documentation added
- [x] Tests updated

