### PR TITLE
Fix /transactions query performance

### DIFF
--- a/config/flyway.conf.sample
+++ b/config/flyway.conf.sample
@@ -1,0 +1,9 @@
+# From ../ - run "flyway -c config/flyway.conf.sample migrate"
+flyway.url=jdbc:postgresql://localhost:5432/mirror_node
+flyway.schemas=public
+flyway.placeholders.db-name=mirror_node
+flyway.placeholders.db-user=mirror_node
+flyway.placeholders.api-user=mirror_api
+flyway.placeholders.api-password=mirror_api_pass
+flyway.ignoreMissingMigrations=true
+flyway.locations=filesystem:src/main/resources/db/migration/

--- a/rest-api/__tests__/transactionsTest.test.js
+++ b/rest-api/__tests__/transactionsTest.test.js
@@ -1,0 +1,88 @@
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+'use strict';
+
+const transactions = require('../transactions.js');
+
+function normalizeSql(str) {
+    return str.replace(/\s+/g, ' ').replace(/,\s*/g, ',').replace(/\s*,/g, ',').replace(/\s+$/, '');
+}
+
+test('transactions by timestamp gte', () => {
+    let sql = transactions.reqToSql({query: {timestamp: 'gte:1234'}});
+    let expected = normalizeSql(`select etrans.entity_shard,etrans.entity_realm,etrans.entity_num
+        ,t.memo,t.consensus_ns,valid_start_ns,ttr.result,t.fk_trans_type_id,ttt.name,t.fk_node_acc_id
+        ,enode.entity_shard as node_shard,enode.entity_realm as node_realm,enode.entity_num as node_num
+        ,account_id,eaccount.entity_shard as account_shard,eaccount.entity_realm as account_realm
+        ,eaccount.entity_num as account_num,amount,t.charged_tx_fee
+from t_transactions t
+join t_transaction_results ttr on ttr.id = t.fk_result_id
+join t_entities enode on enode.id = t.fk_node_acc_id
+join t_entities etrans on etrans.id = t.fk_payer_acc_id
+join t_transaction_types ttt on ttt.id = t.fk_trans_type_id
+left outer join t_cryptotransferlists ctl on ctl.consensus_timestamp = t.consensus_ns
+join t_entities eaccount on eaccount.id = ctl.account_id
+where 1=1
+and ((t.consensus_ns >= $1) ) and 1=1 order by t.consensus_ns desc
+limit $2`);
+    expect(normalizeSql(sql.query)).toEqual(expected);
+    expect(sql.params).toEqual(["1234000000000", 1000]);
+});
+
+test('transactions by timestamp eq', () => {
+    let sql = transactions.reqToSql({query: {timestamp: 'eq:123'}});
+    let expected = normalizeSql(`select etrans.entity_shard,etrans.entity_realm,etrans.entity_num
+        ,t.memo,t.consensus_ns,valid_start_ns,ttr.result,t.fk_trans_type_id,ttt.name,t.fk_node_acc_id
+        ,enode.entity_shard as node_shard,enode.entity_realm as node_realm,enode.entity_num as node_num
+        ,account_id,eaccount.entity_shard as account_shard,eaccount.entity_realm as account_realm
+        ,eaccount.entity_num as account_num,amount,t.charged_tx_fee
+from t_transactions t
+join t_transaction_results ttr on ttr.id = t.fk_result_id
+join t_entities enode on enode.id = t.fk_node_acc_id
+join t_entities etrans on etrans.id = t.fk_payer_acc_id
+join t_transaction_types ttt on ttt.id = t.fk_trans_type_id
+left outer join t_cryptotransferlists ctl on ctl.consensus_timestamp = t.consensus_ns
+join t_entities eaccount on eaccount.id = ctl.account_id
+where 1=1
+and ((t.consensus_ns = $1) ) and 1=1 order by t.consensus_ns desc
+limit $2`);
+expect(normalizeSql(sql.query)).toEqual(expected);
+expect(sql.params).toEqual(["123000000000", 1000]);
+});
+
+test('transactions by account eq', () => {
+    let sql = transactions.reqToSql({query: {'account.id': '0.1.123'}});
+let expected = normalizeSql(`select etrans.entity_shard,etrans.entity_realm,etrans.entity_num
+        ,t.memo,t.consensus_ns,valid_start_ns,ttr.result,t.fk_trans_type_id,ttt.name,t.fk_node_acc_id
+        ,enode.entity_shard as node_shard,enode.entity_realm as node_realm,enode.entity_num as node_num
+        ,account_id,eaccount.entity_shard as account_shard,eaccount.entity_realm as account_realm
+        ,eaccount.entity_num as account_num,amount,t.charged_tx_fee
+from t_transactions t
+join t_transaction_results ttr on ttr.id = t.fk_result_id
+join t_entities enode on enode.id = t.fk_node_acc_id
+join t_entities etrans on etrans.id = t.fk_payer_acc_id
+join t_transaction_types ttt on ttt.id = t.fk_trans_type_id
+left outer join t_cryptotransferlists ctl on ctl.consensus_timestamp = t.consensus_ns
+join t_entities eaccount on eaccount.id = ctl.account_id
+where ctl.account_id in (select id from t_entities where ((entity_shard = $1 and entity_realm = $2 and entity_num = $3 )) and fk_entity_type_id = 1 limit 1000) and 1=1 and 1=1 order by t.consensus_ns desc
+limit $4`);
+expect(normalizeSql(sql.query)).toEqual(expected);
+expect(sql.params).toEqual(["0", "1", "123", 1000]);
+});

--- a/rest-api/accounts.js
+++ b/rest-api/accounts.js
@@ -222,7 +222,7 @@ const getOneAccount = function (req, res) {
     '      select distinct t.consensus_ns\n' +
     '       from t_transactions t\n' +
     '       join t_transaction_results tr on t.fk_result_id = tr.id\n' +
-    '       join t_cryptotransferlists ctl on t.id = ctl.fk_trans_id\n' +
+    '       join t_cryptotransferlists ctl on t.consensus_ns = ctl.consensus_timestamp\n' +
     '       join t_entities eaccount on eaccount.id = ctl.account_id\n' +
     '       where ' +
             [accountQuery, tsQuery, resultTypeQuery].map(q => q === '' ? '1=1' : q).join(' and ') +

--- a/src/main/java/com/hedera/parser/RecordFileParser.java
+++ b/src/main/java/com/hedera/parser/RecordFileParser.java
@@ -141,7 +141,7 @@ public class RecordFileParser implements FileParser {
 
 								TransactionRecord txRecord = TransactionRecord.parseFrom(rawBytes);
 
-								boolean bStored = RecordFileLogger.storeRecord(counter, Utility.convertToInstant(txRecord.getConsensusTimestamp()), transaction, txRecord);
+								boolean bStored = RecordFileLogger.storeRecord(transaction, txRecord);
 								if (bStored) {
 									if (log.isTraceEnabled()) {
 										log.trace("Transaction = {}, Record = {}", Utility.printTransaction(transaction), TextFormat.shortDebugString(txRecord));
@@ -158,9 +158,7 @@ public class RecordFileParser implements FileParser {
 								byte[] sigBytes = new byte[sigLength];
 								dis.readFully(sigBytes);
 								log.trace("File {} has signature {}", fileName, Hex.encodeHexString(sigBytes));
-								if (RecordFileLogger.storeSignature(Hex.encodeHexString(sigBytes))) {
-									break;
-								}
+								break;
 
 							default:
 								log.error("Unknown record file delimiter {} for file {}", typeDelimiter, file);

--- a/src/main/java/com/hedera/recordFileLogger/RecordFileLogger.java
+++ b/src/main/java/com/hedera/recordFileLogger/RecordFileLogger.java
@@ -20,6 +20,7 @@ package com.hedera.recordFileLogger;
  * ‍
  */
 
+import java.io.IOException;
 import java.sql.CallableStatement;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -29,30 +30,17 @@ import java.sql.Types;
 import java.time.Instant;
 import java.util.HashMap;
 
+import com.hederahashgraph.api.proto.java.*;
 import lombok.extern.log4j.Log4j2;
 
 import com.hedera.addressBook.NetworkAddressBook;
 import com.hedera.configLoader.ConfigLoader;
 import com.hedera.databaseUtilities.DatabaseUtilities;
 import com.hedera.utilities.Utility;
-import com.hederahashgraph.api.proto.java.ContractCreateTransactionBody;
-import com.hederahashgraph.api.proto.java.ContractUpdateTransactionBody;
-import com.hederahashgraph.api.proto.java.CryptoCreateTransactionBody;
-import com.hederahashgraph.api.proto.java.CryptoUpdateTransactionBody;
-import com.hederahashgraph.api.proto.java.FileCreateTransactionBody;
-import com.hederahashgraph.api.proto.java.FileID;
-import com.hederahashgraph.api.proto.java.FileUpdateTransactionBody;
-import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
-import com.hederahashgraph.api.proto.java.Transaction;
-import com.hederahashgraph.api.proto.java.TransactionBody;
-import com.hederahashgraph.api.proto.java.TransactionID;
-import com.hederahashgraph.api.proto.java.TransactionRecord;
-import com.hederahashgraph.api.proto.java.TransferList;
 
 @Log4j2
 public class RecordFileLogger {
-
-	public static Connection connect = null;
+    public static Connection connect = null;
 	private static Entities entities = null;
 
 	private static HashMap<String, Integer> transactionResults = null;
@@ -75,15 +63,12 @@ public class RecordFileLogger {
 	}
     enum F_TRANSACTION {
         ZERO // column indices start at 1, this creates the necessary offset
-        ,ID
         ,FK_NODE_ACCOUNT_ID
         ,MEMO
         ,VALID_START_NS
         ,FK_TRANS_TYPE_ID
         ,FK_PAYER_ACCOUNT_ID
         ,FK_RESULT
-        ,CONSENSUS_SECONDS
-        ,CONSENSUS_NANOS
         ,CONSENSUS_NS
         ,CUD_ENTITY_ID
         ,CHARGED_TX_FEE
@@ -93,7 +78,7 @@ public class RecordFileLogger {
 
     enum F_TRANSFERLIST {
         ZERO // column indices start at 1, this creates the necessary offset
-        ,TXID
+        ,CONSENSUS_TIMESTAMP
         ,ACCOUNT_ID
         ,AMOUNT
         ,TYPE_ID
@@ -101,13 +86,13 @@ public class RecordFileLogger {
 
     enum F_FILE_DATA {
     	ZERO
-    	,FK_TRANS_ID
+        ,CONSENSUS_TIMESTAMP
     	,FILE_DATA
     }
 
     enum F_CONTRACT_CALL {
     	ZERO
-    	,FK_TRANS_ID
+        ,CONSENSUS_TIMESTAMP
     	,FUNCTION_PARAMS
     	,GAS_SUPPLIED
     	,CALL_RESULT
@@ -116,11 +101,9 @@ public class RecordFileLogger {
 
     enum F_LIVEHASH_DATA {
     	ZERO
-    	,FK_TRANS_ID
+        ,CONSENSUS_TIMESTAMP
     	,LIVEHASH
     }
-    
-    private static boolean bSkip = false;
 
 	public static boolean start() {
 		batch_count = 0;
@@ -175,25 +158,24 @@ public class RecordFileLogger {
         }
 		try {
 			sqlInsertTransaction = connect.prepareStatement("INSERT INTO t_transactions"
-					+ " (id, fk_node_acc_id, memo, valid_start_ns, fk_trans_type_id, fk_payer_acc_id"
-					+ ", fk_result_id, consensus_seconds, consensus_nanos, consensus_ns, fk_cud_entity_id, charged_tx_fee"
+					+ " (fk_node_acc_id, memo, valid_start_ns, fk_trans_type_id, fk_payer_acc_id"
+					+ ", fk_result_id, consensus_ns, fk_cud_entity_id, charged_tx_fee"
 					+ ", initial_balance, fk_rec_file_id)"
-					+ " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
-					+ " RETURNING id");
+					+ " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
 			sqlInsertTransferList = connect.prepareStatement("INSERT INTO t_cryptotransferlists"
-					+ " (fk_trans_id, account_id, amount)"
+					+ " (consensus_timestamp, account_id, amount)"
 					+ " VALUES (?, ?, ?)");
 		
 			sqlInsertFileData = connect.prepareStatement("INSERT INTO t_file_data"
-					+ " (fk_trans_id, file_data)"
+					+ " (consensus_timestamp, file_data)"
 					+ " VALUES (?, ?)");
 		
 			sqlInsertContractCall = connect.prepareStatement("INSERT INTO t_contract_result"
-					+ " (fk_trans_id, function_params, gas_supplied, call_result, gas_used)"
+					+ " (consensus_timestamp, function_params, gas_supplied, call_result, gas_used)"
 					+ " VALUES (?, ?, ?, ?, ?)");
 
 			sqlInsertClaimData = connect.prepareStatement("INSERT INTO t_livehash_data"
-					+ " (fk_trans_id, livehash)"
+					+ " (consensus_timstamp, livehash)"
 					+ " VALUES (?, ?)");
 			
 		} catch (SQLException e) {
@@ -220,8 +202,6 @@ public class RecordFileLogger {
 	}
 
 	public static INIT_RESULT initFile(String fileName) {
-		if (bSkip) { fileId = 0; return INIT_RESULT.OK;}
-
 		try {
 			fileId = 0;
 
@@ -247,8 +227,6 @@ public class RecordFileLogger {
 	}
 		
 	public static boolean completeFile(String fileHash, String previousHash) {
-		if (bSkip) { return true;}
-
 		try {
 			// execute any remaining batches
 	    	executeBatches();
@@ -282,31 +260,16 @@ public class RecordFileLogger {
 		return true;
 	}
 	public static void rollback() {
-		if (bSkip) { return;}
 		try {
 			connect.rollback();
 		} catch (SQLException e) {
 			log.error("Exception while rolling transaction back", e);
 		}
 	}
-	public static boolean storeRecord(long counter, Instant consensusTimeStamp, Transaction transaction, TransactionRecord txRecord) throws Exception {
+	public static boolean storeRecord(Transaction transaction, TransactionRecord txRecord) throws Exception {
 
 		try {
-
-			long fkTransactionId = 0;
-			
-            ResultSet resultSet;
-			try {
-				resultSet = connect.createStatement().executeQuery("SELECT nextval('s_transactions_seq')");
-				resultSet.next();
-            	fkTransactionId = resultSet.getLong(1);
-	            resultSet.close();
-			} catch (SQLException e) {
-	            log.error("Unable to fetch new transaction id", e);
-				return false;
-			}
-			
-			TransactionBody body = null;
+			TransactionBody body;
 			if (transaction.hasBody()) {
 				body = transaction.getBody();
 			} else {
@@ -314,11 +277,12 @@ public class RecordFileLogger {
 			}
 			long fkNodeAccountId = entities.createOrGetEntity(body.getNodeAccountID());
 			TransactionID transactionID = body.getTransactionID();
-			long seconds = transactionID.getTransactionValidStart().getSeconds();
-			long nanos = transactionID.getTransactionValidStart().getNanos();
-			long validStartNs = Utility.convertInstantToNanos(Instant.ofEpochSecond(seconds, nanos));
 
-			sqlInsertTransaction.setLong(F_TRANSACTION.ID.ordinal(), fkTransactionId);
+			final var vs = transactionID.getTransactionValidStart();
+			final long validStartNs = Utility.convertInstantToNanos(Instant.ofEpochSecond(vs.getSeconds(), vs.getNanos()));
+			final var c = txRecord.getConsensusTimestamp();
+			final long consensusNs = Utility.convertInstantToNanos(Instant.ofEpochSecond(c.getSeconds(), c.getNanos()));
+
 			sqlInsertTransaction.setLong(F_TRANSACTION.FK_NODE_ACCOUNT_ID.ordinal(), fkNodeAccountId);
 			sqlInsertTransaction.setBytes(F_TRANSACTION.MEMO.ordinal(), body.getMemo().getBytes());
 			sqlInsertTransaction.setLong(F_TRANSACTION.VALID_START_NS.ordinal(), validStartNs);
@@ -340,13 +304,7 @@ public class RecordFileLogger {
 
 			fk_result_id = transactionResults.get(responseCode);
 
-			seconds = txRecord.getConsensusTimestamp().getSeconds();
-			nanos = txRecord.getConsensusTimestamp().getNanos();
-			long consensusNs = Utility.convertInstantToNanos(Instant.ofEpochSecond(seconds, nanos));
-			
 			sqlInsertTransaction.setLong(F_TRANSACTION.FK_RESULT.ordinal(), fk_result_id);
-			sqlInsertTransaction.setLong(F_TRANSACTION.CONSENSUS_SECONDS.ordinal(), seconds);
-			sqlInsertTransaction.setLong(F_TRANSACTION.CONSENSUS_NANOS.ordinal(), nanos);
 			sqlInsertTransaction.setLong(F_TRANSACTION.CONSENSUS_NS.ordinal(), consensusNs);
 			sqlInsertTransaction.setLong(F_TRANSACTION.CHARGED_TX_FEE.ordinal(), txRecord.getTransactionFee());
 			
@@ -377,7 +335,7 @@ public class RecordFileLogger {
                 initialBalance = body.getContractCreateInstance().getInitialBalance();
             } else if (body.hasContractDeleteInstance()) {
                 if (body.getContractDeleteInstance().hasContractID()) {
-                    entityId = entities.createOrGetEntity(body.getContractDeleteInstance().getContractID());
+                    entities.createOrGetEntity(body.getContractDeleteInstance().getContractID());
                     entityId = entities.deleteEntity(body.getContractDeleteInstance().getContractID());
                 }
             } else if (body.hasContractUpdateInstance()) {
@@ -427,15 +385,13 @@ public class RecordFileLogger {
             	initialBalance = body.getCryptoCreateAccount().getInitialBalance();
             } else if (body.hasCryptoDelete()) {
                 if (body.getCryptoDelete().hasDeleteAccountID()) {
-                    entityId = entities.createOrGetEntity(body.getCryptoDelete().getDeleteAccountID());
+                    entities.createOrGetEntity(body.getCryptoDelete().getDeleteAccountID());
                     entityId = entities.deleteEntity(body.getCryptoDelete().getDeleteAccountID());
                 }
             } else if (body.hasCryptoDeleteClaim()) {
                 if (body.getCryptoDeleteClaim().hasAccountIDToDeleteFrom()) {
                     entityId = entities.createOrGetEntity(body.getCryptoDeleteClaim().getAccountIDToDeleteFrom());
                 }
-            } else if (body.hasCryptoTransfer()) {
-            	// do nothing
             } else if (body.hasCryptoUpdateAccount()) {
         		CryptoUpdateTransactionBody txMessage = body.getCryptoUpdateAccount();
             	long expiration_time_sec = 0;
@@ -480,7 +436,7 @@ public class RecordFileLogger {
                 }
             } else if (body.hasFileDelete()) {
                 if (body.getFileDelete().hasFileID()) {
-                    entityId = entities.createOrGetEntity(body.getFileDelete().getFileID());
+                    entities.createOrGetEntity(body.getFileDelete().getFileID());
                     entityId = entities.deleteEntity(body.getFileDelete().getFileID());
                 }
             } else if (body.hasFileUpdate()) {
@@ -502,22 +458,20 @@ public class RecordFileLogger {
 
             	entityId = entities.updateEntity(txMessage.getFileID(), expiration_time_sec, expiration_time_nanos, auto_renew_period, key, proxy_account_id);
 
-			} else if (body.hasFreeze()) {
-				//TODO:
 			} else if (body.hasSystemDelete()) {
 				if (body.getSystemDelete().hasContractID()) {
-					entityId = entities.createOrGetEntity(body.getSystemDelete().getContractID());
+					entities.createOrGetEntity(body.getSystemDelete().getContractID());
                     entityId = entities.deleteEntity(body.getSystemDelete().getContractID());
 				} else if (body.getSystemDelete().hasFileID()) {
-					entityId = entities.createOrGetEntity(body.getSystemDelete().getFileID());
+					entities.createOrGetEntity(body.getSystemDelete().getFileID());
                     entityId = entities.deleteEntity(body.getSystemDelete().getFileID());
 				}
 			} else if (body.hasSystemUndelete()) {
 				if (body.getSystemUndelete().hasContractID()) {
-					entityId = entities.createOrGetEntity(body.getSystemUndelete().getContractID());
+					entities.createOrGetEntity(body.getSystemUndelete().getContractID());
                     entityId = entities.unDeleteEntity(body.getSystemDelete().getContractID());
 				} else if (body.getSystemDelete().hasFileID()) {
-					entityId = entities.createOrGetEntity(body.getSystemUndelete().getFileID());
+					entities.createOrGetEntity(body.getSystemUndelete().getFileID());
                     entityId = entities.unDeleteEntity(body.getSystemDelete().getFileID());
 				}
 			}
@@ -530,161 +484,27 @@ public class RecordFileLogger {
 
             }
             sqlInsertTransaction.setLong(F_TRANSACTION.INITIAL_BALANCE.ordinal(), initialBalance);
-
-			try {
-//                fkTransactionId = insertTransaction(sqlInsertTransaction);
-				sqlInsertTransaction.addBatch();
-			} catch (SQLException e) {
-			    if (e.getSQLState().contentEquals("23505")) {
-                    // duplicate transaction id, rollback and exit
-                	rollback();
-                	return false;
-			    } else {
-			        // Other SQL Exception
-			        throw e;
-			    }
-			}
+			sqlInsertTransaction.addBatch();
 
 			if (txRecord.hasTransferList()) {
-	            TransferList pTransfer = txRecord.getTransferList();
-
-                try {
-                    if (ConfigLoader.getPersistCryptoTransferAmounts()) {
-	                    for (int i = 0; i < pTransfer.getAccountAmountsCount(); i++) {
-	                        // insert
-	                        sqlInsertTransferList.setLong(F_TRANSFERLIST.TXID.ordinal(), fkTransactionId);
-	                        long xferAccountId = entities.createOrGetEntity(pTransfer.getAccountAmounts(i).getAccountID());
-	                        sqlInsertTransferList.setLong(F_TRANSFERLIST.ACCOUNT_ID.ordinal(), xferAccountId);
-	                        sqlInsertTransferList.setLong(F_TRANSFERLIST.AMOUNT.ordinal(), pTransfer.getAccountAmounts(i).getAmount());
-
-	                        sqlInsertTransferList.addBatch();
-	                    }
-//	                    if ( ! bSkip) {
-//	                    	sqlInsertTransferList.executeBatch();
-//	                    }
-                    }
-                } catch (SQLException e) {
-                    if (e.getSQLState().contentEquals("23505")) {
-                        // duplicate transaction id, rollback and exit
-                    	rollback();
-                    	return false;
-                    } else {
-                        // Other SQL Exception
-                    	rollback();
-                        log.error("Exception {}", e);
-                        Exception e2 = e.getNextException();
-                        throw e2;
-                    }
-                }
+				insertTransferList(consensusNs, txRecord.getTransferList());
 			}
 
-			// now deal with transaction specifics
+            // TransactionBody-specific handlers.
+            // If so-configured, each will update the SQL prepared statements via addBatch().
             if (body.hasContractCall()) {
-            	if (ConfigLoader.getPersistContracts()) {
-	            	byte[] functionParams = body.getContractCall().getFunctionParameters().toByteArray();
-	            	long gasSupplied = body.getContractCall().getGas();
-	            	byte[] callResult = new byte[0];
-	            	long gasUsed = 0;
-	            	if (txRecord.hasContractCallResult()) {
-	            		callResult = txRecord.getContractCallResult().toByteArray();
-	            		gasUsed = txRecord.getContractCallResult().getGasUsed();
-	            	}
-
-	            	insertContractResults(sqlInsertContractCall, fkTransactionId, functionParams, gasSupplied, callResult, gasUsed);
-            	}
+                insertContractCall(consensusNs, body.getContractCall(), txRecord);
             } else if (body.hasContractCreateInstance()) {
-            	if (ConfigLoader.getPersistContracts()) {
-	            	byte[] functionParams = body.getContractCreateInstance().getConstructorParameters().toByteArray();
-	            	long gasSupplied = body.getContractCreateInstance().getGas();
-	            	byte[] callResult = new byte[0];
-	            	long gasUsed = 0;
-	            	if (txRecord.hasContractCreateResult()) {
-	            		callResult = txRecord.getContractCreateResult().toByteArray();
-	            		gasUsed = txRecord.getContractCreateResult().getGasUsed();
-	            	}
-
-	            	insertContractResults(sqlInsertContractCall, fkTransactionId, functionParams, gasSupplied, callResult, gasUsed);
-            	}
-            } else if (body.hasContractDeleteInstance()) {
-            	// Do nothing
-            } else if (body.hasContractUpdateInstance()) {
-            	// Do nothing
+                insertContractCreateInstance(consensusNs, body.getContractCreateInstance(), txRecord);
             } else if (body.hasCryptoAddClaim()) {
-            	if (ConfigLoader.getPersistClaims()) {
-	            	byte[] claim = body.getCryptoAddClaim().getClaim().getHash().toByteArray();
-
-	    			sqlInsertClaimData.setLong(F_LIVEHASH_DATA.FK_TRANS_ID.ordinal(), fkTransactionId);
-	            	sqlInsertClaimData.setBytes(F_LIVEHASH_DATA.LIVEHASH.ordinal(), claim);
-                    if ( ! bSkip) {
-                    	sqlInsertClaimData.addBatch();
-                    }
-            	}
-            } else if (body.hasCryptoDeleteClaim()) {
-            	// Do nothing
-            } else if (body.hasCryptoCreateAccount()) {
-            	// Do nothing
-            } else if (body.hasCryptoDelete()) {
-            	// Do nothing
-            } else if (body.hasCryptoTransfer()) {
-            	// Do nothing
-            } else if (body.hasCryptoUpdateAccount()) {
-            	// Do nothing
+                insertCryptoAddClaim(consensusNs, body.getCryptoAddClaim());
             } else if (body.hasFileAppend()) {
-            	if (ConfigLoader.getPersistFiles().contentEquals("ALL") || (ConfigLoader.getPersistFiles().contentEquals("SYSTEM") && body.getFileAppend().getFileID().getFileNum() < 1000)) {
-	            	byte[] contents = body.getFileAppend().getContents().toByteArray();
-	            	sqlInsertFileData.setLong(F_FILE_DATA.FK_TRANS_ID.ordinal(), fkTransactionId);
-	            	sqlInsertFileData.setBytes(F_FILE_DATA.FILE_DATA.ordinal(), contents);
-                    if ( ! bSkip) {
-                    	sqlInsertFileData.addBatch();
-                    }
-                    
-                	// update the local address book
-                	FileID updatedFile = body.getFileAppend().getFileID();
-
-                	if ((updatedFile.getFileNum() == 102) && (updatedFile.getShardNum() == 0) && (updatedFile.getRealmNum() == 0)) {
-                		// we have an address book update, refresh the local file
-                		NetworkAddressBook.append(contents);
-                	}
-                    
-            	}
+                insertFileAppend(consensusNs, body.getFileAppend());
             } else if (body.hasFileCreate()) {
-            	if (ConfigLoader.getPersistFiles().contentEquals("ALL") || (ConfigLoader.getPersistFiles().contentEquals("SYSTEM") && txRecord.getReceipt().getFileID().getFileNum() < 1000)) {
-	            	byte[] contents = body.getFileCreate().getContents().toByteArray();
-	            	sqlInsertFileData.setLong(F_FILE_DATA.FK_TRANS_ID.ordinal(), fkTransactionId);
-	            	sqlInsertFileData.setBytes(F_FILE_DATA.FILE_DATA.ordinal(), contents);
-                    if ( ! bSkip) {
-                    	sqlInsertFileData.addBatch();
-                    }
-            	}
-            	//TODO:Address book + proxy amounts for nodes
-            } else if (body.hasFileDelete()) {
-            	// Do nothing
+                insertFileCreate(consensusNs, body.getFileCreate(), txRecord);
             } else if (body.hasFileUpdate()) {
-            	if (ConfigLoader.getPersistFiles().contentEquals("ALL") || (ConfigLoader.getPersistFiles().contentEquals("SYSTEM") && body.getFileUpdate().getFileID().getFileNum() < 1000)) {
-	            	byte[] contents = body.getFileUpdate().getContents().toByteArray();
-	            	sqlInsertFileData.setLong(F_FILE_DATA.FK_TRANS_ID.ordinal(), fkTransactionId);
-	            	sqlInsertFileData.setBytes(F_FILE_DATA.FILE_DATA.ordinal(), contents);
-                    if ( ! bSkip) {
-                    	sqlInsertFileData.addBatch();
-                    }
-            	}
-
-            	// update the local address book
-            	FileID updatedFile = body.getFileUpdate().getFileID();
-
-            	if ((updatedFile.getFileNum() == 102) && (updatedFile.getShardNum() == 0) && (updatedFile.getRealmNum() == 0)) {
-            		// we have an address book update, refresh the local file
-            		NetworkAddressBook.update(body.getFileUpdate().getContents().toByteArray());
-            	}
-
-            } else if (body.hasFreeze()) {
-            	// Do nothing
-            } else if (body.hasSystemDelete()) {
-            	// Do nothing
-            } else if (body.hasSystemUndelete()) {
-            	// Do nothing
-            }
-
+                insertFileUpdate(consensusNs, body.getFileUpdate());
+			}
 		} catch (Exception e) {
 			log.error("Error storing record", e);
 			rollback();
@@ -702,17 +522,117 @@ public class RecordFileLogger {
 		return true;
 	}
 
-	public static boolean storeSignature(String signature) {
-//		try {
-//			fw.write("SIGNATURE\n");
-//			fw.write(signature);
-//			fw.write("\n");
-//		} catch (IOException e) {
-//			// TODO Auto-generated catch block
-//			e.printStackTrace();
-//		}
+	private static void insertFileCreate(final long consensusTimestamp, final FileCreateTransactionBody transactionBody,
+										 final TransactionRecord transactionRecord) throws SQLException {
+		if (ConfigLoader.getPersistFiles().contentEquals("ALL") ||
+				(ConfigLoader.getPersistFiles().contentEquals("SYSTEM") &&
+						transactionRecord.getReceipt().getFileID().getFileNum() < 1000)) {
+			byte[] contents = transactionBody.getContents().toByteArray();
+			sqlInsertFileData.setLong(F_FILE_DATA.CONSENSUS_TIMESTAMP.ordinal(), consensusTimestamp);
+			sqlInsertFileData.setBytes(F_FILE_DATA.FILE_DATA.ordinal(), contents);
+			sqlInsertFileData.addBatch();
+		}
+	}
 
-		return true;
+	private static void insertFileAppend(final long consensusTimestamp, final FileAppendTransactionBody transactionBody)
+			throws SQLException, IOException {
+		if (ConfigLoader.getPersistFiles().contentEquals("ALL") ||
+				(ConfigLoader.getPersistFiles().contentEquals("SYSTEM") &&
+						transactionBody.getFileID().getFileNum() < 1000)) {
+			byte[] contents = transactionBody.getContents().toByteArray();
+			sqlInsertFileData.setLong(F_FILE_DATA.CONSENSUS_TIMESTAMP.ordinal(), consensusTimestamp);
+			sqlInsertFileData.setBytes(F_FILE_DATA.FILE_DATA.ordinal(), contents);
+			sqlInsertFileData.addBatch();
+
+			// update the local address book
+			if (isFileAddressBook(transactionBody.getFileID())) {
+				// we have an address book update, refresh the local file
+				NetworkAddressBook.append(contents);
+			}
+		}
+	}
+
+	private static void insertCryptoAddClaim(final long consensusTimestamp,
+											 final CryptoAddClaimTransactionBody transactionBody) throws SQLException {
+		if (ConfigLoader.getPersistClaims()) {
+			byte[] claim = transactionBody.getClaim().getHash().toByteArray();
+
+			sqlInsertClaimData.setLong(F_LIVEHASH_DATA.CONSENSUS_TIMESTAMP.ordinal(), consensusTimestamp);
+			sqlInsertClaimData.setBytes(F_LIVEHASH_DATA.LIVEHASH.ordinal(), claim);
+			sqlInsertClaimData.addBatch();
+		}
+	}
+
+	private static void insertContractCall(final long consensusTimestamp,
+										   final ContractCallTransactionBody transactionBody,
+										   final TransactionRecord transactionRecord) throws SQLException {
+		if (ConfigLoader.getPersistContracts()) {
+			byte[] functionParams = transactionBody.getFunctionParameters().toByteArray();
+			long gasSupplied = transactionBody.getGas();
+			byte[] callResult = new byte[0];
+			long gasUsed = 0;
+			if (transactionRecord.hasContractCallResult()) {
+				callResult = transactionRecord.getContractCallResult().toByteArray();
+				gasUsed = transactionRecord.getContractCallResult().getGasUsed();
+			}
+
+			insertContractResults(sqlInsertContractCall, consensusTimestamp, functionParams, gasSupplied, callResult,
+					gasUsed);
+		}
+	}
+
+	private static void insertContractCreateInstance(final long consensusTimestamp,
+													 final ContractCreateTransactionBody transactionBody,
+													 final TransactionRecord transactionRecord) throws SQLException {
+		if (ConfigLoader.getPersistContracts()) {
+			byte[] functionParams = transactionBody.getConstructorParameters().toByteArray();
+			long gasSupplied = transactionBody.getGas();
+			byte[] callResult = new byte[0];
+			long gasUsed = 0;
+			if (transactionRecord.hasContractCreateResult()) {
+				callResult = transactionRecord.getContractCreateResult().toByteArray();
+				gasUsed = transactionRecord.getContractCreateResult().getGasUsed();
+			}
+
+			insertContractResults(sqlInsertContractCall, consensusTimestamp, functionParams, gasSupplied, callResult,
+					gasUsed);
+		}
+	}
+
+	private static void insertTransferList(final long consensusTimestamp, final TransferList transactionBody)
+			throws SQLException {
+		if (ConfigLoader.getPersistCryptoTransferAmounts()) {
+			for (int i = 0; i < transactionBody.getAccountAmountsCount(); ++i) {
+				sqlInsertTransferList.setLong(F_TRANSFERLIST.CONSENSUS_TIMESTAMP.ordinal(), consensusTimestamp);
+				var aa = transactionBody.getAccountAmounts(i);
+				sqlInsertTransferList.setLong(F_TRANSFERLIST.ACCOUNT_ID.ordinal(),
+						entities.createOrGetEntity(aa.getAccountID()));
+				sqlInsertTransferList.setLong(F_TRANSFERLIST.AMOUNT.ordinal(), aa.getAmount());
+				sqlInsertTransferList.addBatch();
+			}
+		}
+	}
+
+	private static boolean isFileAddressBook(final FileID fileId) {
+		return (fileId.getFileNum() == 102) && (fileId.getShardNum() == 0) && (fileId.getRealmNum() == 0);
+	}
+
+	private static void insertFileUpdate(final long consensusTimestamp, final FileUpdateTransactionBody transactionBody)
+			throws SQLException, IOException {
+		FileID fileId = transactionBody.getFileID();
+		if (ConfigLoader.getPersistFiles().contentEquals("ALL") ||
+				(ConfigLoader.getPersistFiles().contentEquals("SYSTEM") && fileId.getFileNum() < 1000)) {
+			byte[] contents = transactionBody.getContents().toByteArray();
+			sqlInsertFileData.setLong(F_FILE_DATA.CONSENSUS_TIMESTAMP.ordinal(), consensusTimestamp);
+			sqlInsertFileData.setBytes(F_FILE_DATA.FILE_DATA.ordinal(), contents);
+			sqlInsertFileData.addBatch();
+		}
+
+		// update the local address book
+		if (isFileAddressBook(fileId)) {
+			// we have an address book update, refresh the local file
+			NetworkAddressBook.update(transactionBody.getContents().toByteArray());
+		}
 	}
 
 	private static int getTransactionTypeId (TransactionBody body) {
@@ -726,30 +646,16 @@ public class RecordFileLogger {
 		}
 	}
 
-//	private static long insertTransaction(PreparedStatement insertTransaction) throws SQLException {
-//        if ( bSkip) { return 0;}
-//        
-//		insertTransaction.execute();
-//
-//        ResultSet newId = insertTransaction.getResultSet();
-//        newId.next();
-//        Long txId = newId.getLong(1);
-//        newId.close();
-//
-//        return txId;
-//	}
-
-	public static void insertContractResults(PreparedStatement insert, long fkTxId, byte[] functionParams, long gasSupplied, byte[] callResult, long gasUsed) throws SQLException {
-        if ( bSkip) { return;}
-
-		insert.setLong(F_CONTRACT_CALL.FK_TRANS_ID.ordinal(), fkTxId);
+	public static void insertContractResults(final PreparedStatement insert, final long consensusTimestamp,
+											 final byte[] functionParams, final long gasSupplied,
+											 final byte[] callResult, final long gasUsed) throws SQLException {
+		insert.setLong(F_CONTRACT_CALL.CONSENSUS_TIMESTAMP.ordinal(), consensusTimestamp);
 		insert.setBytes(F_CONTRACT_CALL.FUNCTION_PARAMS.ordinal(), functionParams);
 		insert.setLong(F_CONTRACT_CALL.GAS_SUPPLIED.ordinal(), gasSupplied);
 		insert.setBytes(F_CONTRACT_CALL.CALL_RESULT.ordinal(), callResult);
 		insert.setLong(F_CONTRACT_CALL.GAS_USED.ordinal(), gasUsed);
 
 		insert.addBatch();
-
 	}
 	
 	private static void executeBatches() throws SQLException {

--- a/src/main/resources/db/migration/V1.11.2__transactions_pk.sql
+++ b/src/main/resources/db/migration/V1.11.2__transactions_pk.sql
@@ -1,0 +1,161 @@
+-- Move to using t_transactions.consensus_ns instead of id.
+
+--
+-- t_livehashes
+--
+
+-- Migrate t_livehashes to that new PK column (consensus_ns)
+alter table t_livehashes
+    add column if not exists consensus_timestamp nanos_timestamp null;
+drop index if exists idx_livehash_tx_id;
+alter table t_livehashes
+    drop constraint if exists fk_cd_tx_id;
+
+-- Migrate the data into t_livehashes.
+update t_livehashes
+    set consensus_timestamp = t_transactions.consensus_ns
+    from t_transactions
+    where t_transactions.id = fk_trans_id
+    and consensus_timestamp is null;
+alter table t_livehashes
+    alter column consensus_timestamp set not null;
+
+-- Drop the column.
+alter table t_livehashes
+    drop column if exists fk_trans_id;
+
+create index if not exists idx__t_livehashes__consensus
+    on t_livehashes (consensus_timestamp desc);
+
+--
+-- t_contract_result
+--
+
+-- Migrate t_contract_result to that new PK column (consensus_ns)
+alter table t_contract_result
+    add column if not exists consensus_timestamp nanos_timestamp null;
+drop index if exists idx_contract_result_tx_id;
+alter table t_contract_result
+    drop constraint if exists fk_cr_tx_id;
+
+-- Migrate the data into t_contract_result.
+update t_contract_result
+    set consensus_timestamp = t_transactions.consensus_ns
+    from t_transactions
+    where t_transactions.id = fk_trans_id
+    and consensus_timestamp is null;
+alter table t_contract_result
+    alter column consensus_timestamp set not null;
+
+-- Drop the column.
+alter table t_contract_result
+    drop column if exists fk_trans_id;
+
+create index if not exists idx__t_contract_result__consensus
+    on t_contract_result (consensus_timestamp desc);
+
+--
+-- t_file_data
+--
+
+-- Migrate t_file_data to that new PK column (consensus_ns)
+alter table t_file_data
+    add column if not exists consensus_timestamp nanos_timestamp null;
+drop index if exists idx_file_data_tx_id;
+alter table t_file_data
+    drop constraint if exists fk_fd_tx_id;
+
+-- Migrate the data into t_file_data.
+update t_file_data
+    set consensus_timestamp = t_transactions.consensus_ns
+    from t_transactions
+    where t_transactions.id = fk_trans_id
+    and consensus_timestamp is null;
+alter table t_file_data
+    alter column consensus_timestamp set not null;
+
+-- Drop the column.
+alter table t_file_data
+    drop column if exists fk_trans_id;
+
+create index if not exists idx__t_file_data__consensus
+    on t_file_data (consensus_timestamp desc);
+
+--
+-- t_cryptotransferlists
+--
+
+-- Remove duplicate foreign key constraint (there were 2 on the same field)
+alter table t_cryptotransferlists
+    drop constraint if exists fk_ctl_acc_id;
+
+-- Migrate t_cryptotransferlists to the new PK column (consensus_ns)
+alter table t_cryptotransferlists
+    add column if not exists consensus_timestamp nanos_timestamp null;
+drop index if exists idx_cryptotransferslist_tx_id;
+drop index if exists idx_t_cryptotransferlist_tx_id_account;
+drop index if exists idx_cryptotransferlist_account; -- too general
+alter table t_cryptotransferlists
+    drop constraint if exists fk_ctl_tx_id;
+
+-- Migrate the data into t_cryptotransferlists. Long step.
+update t_cryptotransferlists
+    set consensus_timestamp = t_transactions.consensus_ns
+    from t_transactions
+    where t_transactions.id = fk_trans_id
+    and consensus_timestamp is null;
+alter table t_cryptotransferlists
+    alter column consensus_timestamp set not null;
+
+-- Drop the column.
+alter table t_cryptotransferlists
+    drop column if exists fk_trans_id;
+
+create index if not exists idx__t_cryptotransferlists__consensus_and_account
+    on t_cryptotransferlists (consensus_timestamp desc, account_id);
+create index if not exists idx__t_cryptotransferlists__account_and_consensus
+    on t_cryptotransferlists (account_id, consensus_timestamp desc);
+
+--
+-- t_transactions
+--
+
+drop index if exists idx__t_transactions__consensus_ns__id;
+drop index if exists idx_t_transactions_cs_ns;
+drop index if exists idx_t_transactions_crud_entity; -- unused
+
+alter table t_transactions
+    drop constraint if exists t_transactions_pkey;
+alter table t_transactions
+    drop column if exists id;
+-- Other columns that are deprecated and should be dropped.
+alter table t_transactions
+    drop column if exists consensus_seconds;
+alter table t_transactions
+    drop column if exists consensus_nanos;
+
+drop sequence if exists s_transactions_seq;
+alter table t_transactions
+    add constraint pk__t_transactions__consensus_ns primary key (consensus_ns);
+
+drop index if exists idx_t_transactions_id;
+
+--
+-- Add back in the foreign key constraints
+--
+alter table t_cryptotransferlists
+    add constraint fk__t_transactions foreign key (consensus_timestamp) references t_transactions (consensus_ns);
+alter table t_livehashes
+    add constraint fk__t_transactions foreign key (consensus_timestamp) references t_transactions (consensus_ns);
+alter table t_contract_result
+    add constraint fk__t_transactions foreign key (consensus_timestamp) references t_transactions (consensus_ns);
+alter table t_file_data
+    add constraint fk__t_transactions foreign key (consensus_timestamp) references t_transactions (consensus_ns);
+
+--
+-- Other redundant indexes
+--
+drop index if exists idx_t_entities_id; -- Duplicate
+drop index if exists idx_t_entities_id_num; -- Covered by idx_t_entities_id_num_id
+drop index if exists idx_t_entities_exp_t_ns; -- unused
+drop index if exists idx_t_rec_file; -- unused


### PR DESCRIPTION
**Detailed description**:

- Remove t_transactions.id as a primary key, in favor of consensus_ns
- Update related tables that had foreign keys on that (to now use consensus_timestamp)
- Update java code that writes all those records
- Update rest-api queries to use
- Removed redundant indexes

**Which issue(s) this PR fixes**:
Fixes #220 
Fixes #219 

**Special notes for your reviewer**:

- `vacuum full` should be performed on all the affected tables(`t_transactions`, `t_livehashes`, `t_cryptotransferlists`, `t_contract_result`, `t_file_data`), post install, and while we're at it - account_balances - when there is downtime.

**Checklist**
- [ ] Documentation added
- [X] Tests updated
