### PR TITLE
CryptoCreate initial balance transfer not visible in REST API

### DIFF
--- a/src/main/java/com/hedera/recordFileLogger/RecordFileLogger.java
+++ b/src/main/java/com/hedera/recordFileLogger/RecordFileLogger.java
@@ -648,7 +648,7 @@ public class RecordFileLogger {
 			sqlInsertTransferList.setLong(F_TRANSFERLIST.AMOUNT.ordinal(), amount);
 			sqlInsertTransferList.addBatch();
 			
-        	if ((initialBalance == Math.abs(aa.getAmount())) && ((account == payerAccountNum) || (account == createdAccountNum))) {
+        	if (addInitialBalance && (initialBalance == aa.getAmount()) && (account == createdAccountNum)) {
         		addInitialBalance = false;
         	}
 		}
@@ -658,6 +658,8 @@ public class RecordFileLogger {
             sqlInsertTransferList.setLong(F_TRANSFERLIST.ACCOUNT_ID.ordinal(), payerAccountId);
             sqlInsertTransferList.setLong(F_TRANSFERLIST.AMOUNT.ordinal(), -initialBalance);
 
+            sqlInsertTransferList.addBatch();
+            
             sqlInsertTransferList.setLong(F_TRANSFERLIST.CONSENSUS_TIMESTAMP.ordinal(), consensusTimestamp);
             sqlInsertTransferList.setLong(F_TRANSFERLIST.ACCOUNT_ID.ordinal(), createdAccountId);
             sqlInsertTransferList.setLong(F_TRANSFERLIST.AMOUNT.ordinal(), initialBalance);

--- a/src/main/java/com/hedera/recordFileLogger/RecordFileLogger.java
+++ b/src/main/java/com/hedera/recordFileLogger/RecordFileLogger.java
@@ -552,7 +552,7 @@ public class RecordFileLogger {
 
                 try {
                     if (ConfigLoader.getPersistCryptoTransferAmounts()) {
-                    	boolean bAddInitialBalance = false;
+                    	boolean bAddInitialBalance = (body.hasCryptoCreateAccount() && txRecord.getReceipt().getStatus() == ResponseCodeEnum.SUCCESS);
 	                    for (int i = 0; i < pTransfer.getAccountAmountsCount(); i++) {
 	                        // insert
 	                    	long amount = pTransfer.getAccountAmounts(i).getAmount();
@@ -561,11 +561,11 @@ public class RecordFileLogger {
 	                        sqlInsertTransferList.setLong(F_TRANSFERLIST.ACCOUNT_ID.ordinal(), xferAccountId);
 	                        sqlInsertTransferList.setLong(F_TRANSFERLIST.AMOUNT.ordinal(), amount);
 	                        
-	                        if (body.hasCryptoCreateAccount()) {
+	                        if (body.hasCryptoCreateAccount() && txRecord.getReceipt().getStatus() == ResponseCodeEnum.SUCCESS) {
 	                        	if ((initialBalance == Math.abs(amount)) && ((xferAccountId == fkPayerAccountId) || (xferAccountId == createdAccountId))) {
 	                        		bAddInitialBalance = false;
 	                        	}
-	                        }
+	                        } 
 
 	                        sqlInsertTransferList.addBatch();
 	                    }


### PR DESCRIPTION
**Detailed description**:
Some record files are missing items in their transfer list. This occurs on CryptoCreate transactions.
The parser adds the missing data if it is missing, indeed, later files include the correct and full information. This only happens on Successful CryptoCreate transactions that are missing the data.

**Which issue(s) this PR fixes**:
Fixes #229 

**Special notes for your reviewer**:
Note: This fix will conflict with another PR in progress #236, merging will require additional work.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated