### PR TITLE
Improve download performance [master]

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,6 @@ Note: Changes to this file while downloading or processing is taking place may b
 | dbPassword | `"mirror_node_pass"` | The password to access the database |
 | apiUsername | `"mirror_api"` | The database user for the REST API |
 | apiPassword | `"mirror_api_pass"` | The password for the REST API user |
-| maxDownloadItems | `0` | The maximum number of new files to download at a time, set to `0` in production, change to `10` or other low number for testing or catching up with a large number of files. |
 | persistClaims | `false` | Determines whether claim data is persisted to the database or not |
 | persistFiles | `"ALL"` | Determines whether file data is persisted to the database or not, can be set to `ALL`, `NONE` or `SYSTEM`. `SYSTEM` means only files with a file number lower than `1000` will be persisted |
 | persistContracts | `true` | Determines whether contract data is persisted to the database or not |

--- a/src/main/java/com/hedera/configLoader/ConfigLoader.java
+++ b/src/main/java/com/hedera/configLoader/ConfigLoader.java
@@ -73,6 +73,12 @@ public class ConfigLoader {
 	private static final boolean DEFAULT_ACCOUNT_BALANCES_USE_TRANSACTION = false;
 	private static boolean accountBalancesUseTransaction = DEFAULT_ACCOUNT_BALANCES_USE_TRANSACTION;
 
+	private static final int DEFAULT_TRANSFER_MANAGER_MAX_THREADS = 60;
+	private static int transferManagerMaxThreads = DEFAULT_TRANSFER_MANAGER_MAX_THREADS;
+
+	private static final int DEFAULT_DOWNLOADER_MAX_THREADS = 13;
+	private static int downloaderMaxThreads = DEFAULT_DOWNLOADER_MAX_THREADS;
+
 	// location of account balances on S3
 	private static String accountBalanceS3Location = "accountBalances/balance";
 
@@ -180,6 +186,18 @@ public class ConfigLoader {
 			}
 			if (configJsonObject.has("accountBalancesUseTransaction")) {
 				accountBalancesUseTransaction = configJsonObject.get("accountBalancesUseTransaction").getAsBoolean();
+			}
+			if (configJsonObject.has("transferManagerMaxThreads")) {
+				var i = configJsonObject.get("transferManagerMaxThreads").getAsInt();
+				if (i > 0) {
+					transferManagerMaxThreads = i;
+				}
+			}
+			if (configJsonObject.has("downloaderMaxThreads")) {
+				var i = configJsonObject.get("downloaderMaxThreads").getAsInt();
+				if (i > 0) {
+					downloaderMaxThreads = i;
+				}
 			}
 			if (configJsonObject.has("systemShardNum")) {
 				systemShardNum = configJsonObject.get("systemShardNum").getAsLong();
@@ -339,6 +357,13 @@ public class ConfigLoader {
 
 	public static String getAccountBalanceS3Location() {
 		return accountBalanceS3Location;
+	}
+
+	public static int getTransferManagerMaxThreads() {
+		return transferManagerMaxThreads;
+	}
+	public static int getDownloaderMaxThreads() {
+		return downloaderMaxThreads;
 	}
 
 	public static long getSystemShardNum() {

--- a/src/main/java/com/hedera/configLoader/ConfigLoader.java
+++ b/src/main/java/com/hedera/configLoader/ConfigLoader.java
@@ -73,12 +73,6 @@ public class ConfigLoader {
 	private static final boolean DEFAULT_ACCOUNT_BALANCES_USE_TRANSACTION = false;
 	private static boolean accountBalancesUseTransaction = DEFAULT_ACCOUNT_BALANCES_USE_TRANSACTION;
 
-	private static final int DEFAULT_TRANSFER_MANAGER_MAX_THREADS = 60;
-	private static int transferManagerMaxThreads = DEFAULT_TRANSFER_MANAGER_MAX_THREADS;
-
-	private static final int DEFAULT_DOWNLOADER_MAX_THREADS = 13;
-	private static int downloaderMaxThreads = DEFAULT_DOWNLOADER_MAX_THREADS;
-
 	// location of account balances on S3
 	private static String accountBalanceS3Location = "accountBalances/balance";
 
@@ -110,8 +104,6 @@ public class ConfigLoader {
     private static String dbUserName = "";
     // database password
     private static String dbPassword = "";
-    // max download items for testing
-    private static int maxDownloadItems = 0;
 
     private static Dotenv dotEnv = Dotenv.configure().ignoreIfMissing().load();
 
@@ -187,18 +179,6 @@ public class ConfigLoader {
 			if (configJsonObject.has("accountBalancesUseTransaction")) {
 				accountBalancesUseTransaction = configJsonObject.get("accountBalancesUseTransaction").getAsBoolean();
 			}
-			if (configJsonObject.has("transferManagerMaxThreads")) {
-				var i = configJsonObject.get("transferManagerMaxThreads").getAsInt();
-				if (i > 0) {
-					transferManagerMaxThreads = i;
-				}
-			}
-			if (configJsonObject.has("downloaderMaxThreads")) {
-				var i = configJsonObject.get("downloaderMaxThreads").getAsInt();
-				if (i > 0) {
-					downloaderMaxThreads = i;
-				}
-			}
 			if (configJsonObject.has("systemShardNum")) {
 				systemShardNum = configJsonObject.get("systemShardNum").getAsLong();
 			}
@@ -247,10 +227,7 @@ public class ConfigLoader {
 					dbPassword = configJsonObject.get("dbPassword").getAsString();
 				}
 			}
-			if (configJsonObject.has("maxDownloadItems")) {
-				maxDownloadItems = configJsonObject.get("maxDownloadItems").getAsInt();
-			}
-			
+
 			if (configJsonObject.has("persistClaims")) {
 				persistClaims = configJsonObject.get("persistClaims").getAsBoolean();
 			}
@@ -359,13 +336,6 @@ public class ConfigLoader {
 		return accountBalanceS3Location;
 	}
 
-	public static int getTransferManagerMaxThreads() {
-		return transferManagerMaxThreads;
-	}
-	public static int getDownloaderMaxThreads() {
-		return downloaderMaxThreads;
-	}
-
 	public static long getSystemShardNum() {
 		return systemShardNum;
 	}
@@ -395,14 +365,6 @@ public class ConfigLoader {
 	}
 	public static String getDBPassword() {
 		return dbPassword;
-	}
-
-	public static int getMaxDownloadItems() {
-		return maxDownloadItems;
-	}
-
-	public static void setMaxDownloadItems(int maxDownloadItems) {
-		ConfigLoader.maxDownloadItems = maxDownloadItems;
 	}
 
 	public static boolean getPersistClaims() {

--- a/src/main/java/com/hedera/downloader/AccountBalancesDownloader.java
+++ b/src/main/java/com/hedera/downloader/AccountBalancesDownloader.java
@@ -48,6 +48,7 @@ public class AccountBalancesDownloader extends Downloader {
 	private final BalanceProperties balanceProperties;
 
 	public AccountBalancesDownloader(BalanceProperties balanceProperties) {
+		super(balanceProperties.getDownloader());
 		this.balanceProperties = balanceProperties;
 		Utility.ensureDirectory(validDir);
 		Utility.ensureDirectory(tmpDir);

--- a/src/main/java/com/hedera/downloader/AccountBalancesDownloader.java
+++ b/src/main/java/com/hedera/downloader/AccountBalancesDownloader.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.hedera.mirror.config.BalanceProperties;
+import com.hedera.mirror.config.DownloaderProperties;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.tuple.Pair;
 
@@ -47,8 +48,8 @@ public class AccountBalancesDownloader extends Downloader {
 
 	private final BalanceProperties balanceProperties;
 
-	public AccountBalancesDownloader(BalanceProperties balanceProperties) {
-		super(balanceProperties.getDownloader());
+	public AccountBalancesDownloader(BalanceProperties balanceProperties, DownloaderProperties downloaderProperties) {
+		super(balanceProperties.getDownloader(), downloaderProperties);
 		this.balanceProperties = balanceProperties;
 		Utility.ensureDirectory(validDir);
 		Utility.ensureDirectory(tmpDir);

--- a/src/main/java/com/hedera/downloader/AccountBalancesDownloader.java
+++ b/src/main/java/com/hedera/downloader/AccountBalancesDownloader.java
@@ -67,7 +67,7 @@ public class AccountBalancesDownloader extends Downloader {
 			}
 
 			// balance files with sig verification
-			Map<String, List<File>> sigFilesMap = downloadSigFiles(DownloadType.BALANCE);
+			final var sigFilesMap = downloadSigFiles(DownloadType.BALANCE);
 
 			// Verify signature files and download corresponding files of valid signature files
 			verifySigsAndDownloadBalanceFiles(sigFilesMap);

--- a/src/main/java/com/hedera/downloader/Downloader.java
+++ b/src/main/java/com/hedera/downloader/Downloader.java
@@ -360,18 +360,16 @@ public abstract class Downloader {
 	}
 
 	void shutdown() {
+		log.info("Shutting down");
 		if (signatureDownloadThreadPool != null) {
 			signatureDownloadThreadPool.shutdown();
 			signatureDownloadThreadPool = null;
 		}
-		log.info("Shutting down");
-		shutdownTransferManager();
-	}
-
-	static synchronized void shutdownTransferManager() {
-		if (xfer_mgr != null) {
-			xfer_mgr.shutdownNow();
-			xfer_mgr = null;
+		synchronized (Downloader.class) {
+			if (xfer_mgr != null) {
+				xfer_mgr.shutdownNow();
+				xfer_mgr = null;
+			}
 		}
 	}
 

--- a/src/main/java/com/hedera/downloader/EventStreamFileDownloader.java
+++ b/src/main/java/com/hedera/downloader/EventStreamFileDownloader.java
@@ -22,6 +22,7 @@ package com.hedera.downloader;
 
 import com.hedera.configLoader.ConfigLoader;
 import com.hedera.configLoader.ConfigLoader.OPERATION_TYPE;
+import com.hedera.mirror.config.DownloaderProperties;
 import com.hedera.mirror.config.EventProperties;
 import com.hedera.parser.EventStreamFileParser;
 import com.hedera.signatureVerifier.NodeSignatureVerifier;
@@ -48,8 +49,8 @@ public class EventStreamFileDownloader extends Downloader {
 	private final String tmpDir = ConfigLoader.getDefaultTmpDir(OPERATION_TYPE.EVENTS);
 	private final EventProperties eventProperties;
 
-	public EventStreamFileDownloader(EventProperties eventProperties) {
-		super(eventProperties.getDownloader());
+	public EventStreamFileDownloader(EventProperties eventProperties, DownloaderProperties downloaderProperties) {
+		super(eventProperties.getDownloader(), downloaderProperties);
 		this.eventProperties = eventProperties;
 		Utility.ensureDirectory(validDir);
 		Utility.ensureDirectory(tmpDir);

--- a/src/main/java/com/hedera/downloader/EventStreamFileDownloader.java
+++ b/src/main/java/com/hedera/downloader/EventStreamFileDownloader.java
@@ -67,13 +67,13 @@ public class EventStreamFileDownloader extends Downloader {
 		}
 
 		try {
-			Map<String, List<File>> sigFilesMap = downloadSigFiles(DownloadType.EVENT);
-
 			if (Utility.checkStopFile()) {
 				log.info("Stop file found, exiting");
 				return;
 			}
-			
+
+			final var sigFilesMap = downloadSigFiles(DownloadType.EVENT);
+
 			// Verify signature files and download .evts files of valid signature files
 			verifySigsAndDownloadEventStreamFiles(sigFilesMap);
 			verifyValidFiles();

--- a/src/main/java/com/hedera/downloader/EventStreamFileDownloader.java
+++ b/src/main/java/com/hedera/downloader/EventStreamFileDownloader.java
@@ -49,6 +49,7 @@ public class EventStreamFileDownloader extends Downloader {
 	private final EventProperties eventProperties;
 
 	public EventStreamFileDownloader(EventProperties eventProperties) {
+		super(eventProperties.getDownloader());
 		this.eventProperties = eventProperties;
 		Utility.ensureDirectory(validDir);
 		Utility.ensureDirectory(tmpDir);

--- a/src/main/java/com/hedera/downloader/PendingDownload.java
+++ b/src/main/java/com/hedera/downloader/PendingDownload.java
@@ -1,0 +1,84 @@
+package com.hedera.downloader;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.amazonaws.services.s3.transfer.Download;
+import com.google.common.base.Stopwatch;
+import lombok.ToString;
+import lombok.Value;
+import lombok.experimental.NonFinal;
+import lombok.extern.log4j.Log4j2;
+
+import java.io.File;
+
+import static com.amazonaws.services.s3.transfer.Transfer.TransferState.Completed;
+
+/**
+ * The results of a pending download from the AWS TransferManager.
+ * Call waitForCompletion() to wait for the transfer to complete and get the status of whether it was successful
+ * or not.
+ */
+@Log4j2
+@Value
+public class PendingDownload {
+	Download download;
+	Stopwatch stopwatch;
+	File file; // Destination file
+	String s3key; // Source S3 key
+	@NonFinal boolean alreadyWaited = false; // has waitForCompletion been called
+	@NonFinal boolean downloadSuccessful;
+
+	public PendingDownload(final Download download, final File file, final String s3key) {
+		this.download = download;
+		this.stopwatch = Stopwatch.createStarted();
+		this.file = file;
+		this.s3key = s3key;
+	}
+
+	/**
+	 * @return true if the download was successful.
+	 * @throws InterruptedException
+	 */
+	public boolean waitForCompletion() throws InterruptedException {
+		if (alreadyWaited) {
+			return downloadSuccessful;
+		}
+		alreadyWaited = true;
+		try {
+			download.waitForCompletion();
+			if (download.isDone() && (Completed == download.getState())) {
+				log.debug("Finished downloading {} in {}", s3key, stopwatch);
+				downloadSuccessful = true;
+			} else {
+				log.error("Failed downloading {} after {}", s3key, stopwatch);
+				downloadSuccessful = false;
+			}
+		} catch (InterruptedException e) {
+			log.error("Failed downloading {} after {}", s3key, stopwatch, e);
+			downloadSuccessful = false;
+			throw e;
+		} catch (Exception ex) {
+			log.error("Failed downloading {} after {}", s3key, stopwatch, ex);
+			downloadSuccessful = false;
+		}
+		return downloadSuccessful;
+	}
+}

--- a/src/main/java/com/hedera/downloader/RecordFileDownloader.java
+++ b/src/main/java/com/hedera/downloader/RecordFileDownloader.java
@@ -22,6 +22,7 @@ package com.hedera.downloader;
 
 import com.hedera.configLoader.ConfigLoader;
 import com.hedera.configLoader.ConfigLoader.OPERATION_TYPE;
+import com.hedera.mirror.config.DownloaderProperties;
 import com.hedera.mirror.config.RecordProperties;
 import com.hedera.parser.RecordFileParser;
 import com.hedera.signatureVerifier.NodeSignatureVerifier;
@@ -50,8 +51,8 @@ public class RecordFileDownloader extends Downloader {
 
 	private final RecordProperties recordProperties;
 
-	public RecordFileDownloader(RecordProperties recordProperties) {
-		super(recordProperties.getDownloader());
+	public RecordFileDownloader(RecordProperties recordProperties, DownloaderProperties downloaderProperties) {
+		super(recordProperties.getDownloader(), downloaderProperties);
 		this.recordProperties = recordProperties;
 		Utility.ensureDirectory(validDir);
 		Utility.ensureDirectory(tmpDir);

--- a/src/main/java/com/hedera/downloader/RecordFileDownloader.java
+++ b/src/main/java/com/hedera/downloader/RecordFileDownloader.java
@@ -51,6 +51,7 @@ public class RecordFileDownloader extends Downloader {
 	private final RecordProperties recordProperties;
 
 	public RecordFileDownloader(RecordProperties recordProperties) {
+		super(recordProperties.getDownloader());
 		this.recordProperties = recordProperties;
 		Utility.ensureDirectory(validDir);
 		Utility.ensureDirectory(tmpDir);

--- a/src/main/java/com/hedera/downloader/RecordFileDownloader.java
+++ b/src/main/java/com/hedera/downloader/RecordFileDownloader.java
@@ -69,7 +69,7 @@ public class RecordFileDownloader extends Downloader {
 				return;
 			}
 
-			Map<String, List<File>> sigFilesMap = downloadSigFiles(DownloadType.RCD);
+			final var sigFilesMap = downloadSigFiles(DownloadType.RCD);
 			verifySigsAndDownloadRecordFiles(sigFilesMap);
 		} catch (Exception e) {
 			log.error("Error downloading and verifying new record files", e);
@@ -117,11 +117,11 @@ public class RecordFileDownloader extends Downloader {
 
 		Collections.sort(fileNames);
 
+		if (Utility.checkStopFile()) {
+			log.info("Stop file found, stopping");
+			return;
+		}
 		for (String fileName : fileNames) {
-			if (Utility.checkStopFile()) {
-				log.info("Stop file found, stopping");
-				break;
-			}
 			boolean valid = false;
 			List<File> sigFiles = sigFilesMap.get(fileName);
 

--- a/src/main/java/com/hedera/mirror/config/BalanceProperties.java
+++ b/src/main/java/com/hedera/mirror/config/BalanceProperties.java
@@ -25,12 +25,10 @@ public class BalanceProperties {
         @Min(0)
         private int coreThreads = 5;
         @Min(1)
-        private int maxThreads = 5;
+        private int maxThreads = 13;
         @Min(1)
         private int taskQueueSize = 50;
         @Min(1)
-        private int listObjectsMaxKeys = 100;
-        @Min(1)
-        private int maxDownloadItems = 5;
+        private int batchSize = 15;
     }
 }

--- a/src/main/java/com/hedera/mirror/config/BalanceProperties.java
+++ b/src/main/java/com/hedera/mirror/config/BalanceProperties.java
@@ -22,7 +22,7 @@ public class BalanceProperties {
     public class BalanceDownloaderProperties implements CommonDownloaderProperties {
         private Duration frequency = Duration.ofMillis(100L);
 
-        @Min(1)
+        @Min(0)
         private int coreThreads = 5;
         @Min(1)
         private int maxThreads = 5;

--- a/src/main/java/com/hedera/mirror/config/BalanceProperties.java
+++ b/src/main/java/com/hedera/mirror/config/BalanceProperties.java
@@ -4,6 +4,7 @@ import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import javax.inject.Named;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import java.time.Duration;
 
@@ -18,7 +19,18 @@ public class BalanceProperties {
     private BalanceDownloaderProperties downloader = new BalanceDownloaderProperties();
 
     @Data
-    public class BalanceDownloaderProperties {
+    public class BalanceDownloaderProperties implements CommonDownloaderProperties {
         private Duration frequency = Duration.ofMillis(100L);
+
+        @Min(1)
+        private int coreThreads = 5;
+        @Min(1)
+        private int maxThreads = 5;
+        @Min(1)
+        private int taskQueueSize = 50;
+        @Min(1)
+        private int listObjectsMaxKeys = 100;
+        @Min(1)
+        private int maxDownloadItems = 5;
     }
 }

--- a/src/main/java/com/hedera/mirror/config/CommonDownloaderProperties.java
+++ b/src/main/java/com/hedera/mirror/config/CommonDownloaderProperties.java
@@ -1,0 +1,9 @@
+package com.hedera.mirror.config;
+
+public interface CommonDownloaderProperties {
+    int getMaxThreads();
+    int getTaskQueueSize();
+    int getListObjectsMaxKeys();
+    int getMaxDownloadItems();
+    int getCoreThreads();
+}

--- a/src/main/java/com/hedera/mirror/config/CommonDownloaderProperties.java
+++ b/src/main/java/com/hedera/mirror/config/CommonDownloaderProperties.java
@@ -3,7 +3,6 @@ package com.hedera.mirror.config;
 public interface CommonDownloaderProperties {
     int getMaxThreads();
     int getTaskQueueSize();
-    int getListObjectsMaxKeys();
-    int getMaxDownloadItems();
+    int getBatchSize();
     int getCoreThreads();
 }

--- a/src/main/java/com/hedera/mirror/config/DownloaderProperties.java
+++ b/src/main/java/com/hedera/mirror/config/DownloaderProperties.java
@@ -1,0 +1,22 @@
+package com.hedera.mirror.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import javax.inject.Named;
+import javax.validation.constraints.Min;
+
+@Data
+@Named
+@ConfigurationProperties("hedera.mirror.downloader")
+public class DownloaderProperties {
+    @Min(0)
+    private int maxConnections = 500;
+
+    @Min(1)
+    private int coreThreads = 20;
+    @Min(0)
+    private int maxThreads = 60;
+    @Min(1)
+    private int taskQueueSize = 500;
+}

--- a/src/main/java/com/hedera/mirror/config/DownloaderProperties.java
+++ b/src/main/java/com/hedera/mirror/config/DownloaderProperties.java
@@ -13,7 +13,7 @@ public class DownloaderProperties {
     @Min(0)
     private int maxConnections = 500;
 
-    @Min(1)
+    @Min(0)
     private int coreThreads = 20;
     @Min(0)
     private int maxThreads = 60;

--- a/src/main/java/com/hedera/mirror/config/EventProperties.java
+++ b/src/main/java/com/hedera/mirror/config/EventProperties.java
@@ -28,13 +28,11 @@ public class EventProperties {
         @Min(0)
         private int coreThreads = 5;
         @Min(1)
-        private int maxThreads = 5;
+        private int maxThreads = 13;
         @Min(1)
         private int taskQueueSize = 50;
         @Min(1)
-        private int listObjectsMaxKeys = 100;
-        @Min(1)
-        private int maxDownloadItems = 10;
+        private int batchSize = 15;
     }
 
     @Data

--- a/src/main/java/com/hedera/mirror/config/EventProperties.java
+++ b/src/main/java/com/hedera/mirror/config/EventProperties.java
@@ -4,6 +4,7 @@ import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import javax.inject.Named;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import java.time.Duration;
 
@@ -21,8 +22,19 @@ public class EventProperties {
     private EventParserProperties parser = new EventParserProperties();
 
     @Data
-    public class EventDownloaderProperties {
+    public class EventDownloaderProperties implements CommonDownloaderProperties {
         private Duration frequency = Duration.ofMillis(100L);
+
+        @Min(1)
+        private int coreThreads = 5;
+        @Min(1)
+        private int maxThreads = 5;
+        @Min(1)
+        private int taskQueueSize = 50;
+        @Min(1)
+        private int listObjectsMaxKeys = 100;
+        @Min(1)
+        private int maxDownloadItems = 10;
     }
 
     @Data

--- a/src/main/java/com/hedera/mirror/config/EventProperties.java
+++ b/src/main/java/com/hedera/mirror/config/EventProperties.java
@@ -25,7 +25,7 @@ public class EventProperties {
     public class EventDownloaderProperties implements CommonDownloaderProperties {
         private Duration frequency = Duration.ofMillis(100L);
 
-        @Min(1)
+        @Min(0)
         private int coreThreads = 5;
         @Min(1)
         private int maxThreads = 5;

--- a/src/main/java/com/hedera/mirror/config/RecordProperties.java
+++ b/src/main/java/com/hedera/mirror/config/RecordProperties.java
@@ -25,7 +25,7 @@ public class RecordProperties {
     public class RecordDownloaderProperties implements CommonDownloaderProperties {
         private Duration frequency = Duration.ofMillis(100L);
 
-        @Min(1)
+        @Min(0)
         private int coreThreads = 5;
         @Min(1)
         private int maxThreads = 5;

--- a/src/main/java/com/hedera/mirror/config/RecordProperties.java
+++ b/src/main/java/com/hedera/mirror/config/RecordProperties.java
@@ -28,13 +28,11 @@ public class RecordProperties {
         @Min(0)
         private int coreThreads = 5;
         @Min(1)
-        private int maxThreads = 5;
+        private int maxThreads = 13;
         @Min(1)
         private int taskQueueSize = 50;
         @Min(1)
-        private int listObjectsMaxKeys = 100;
-        @Min(1)
-        private int maxDownloadItems = 40;
+        private int batchSize = 40;
     }
 
     @Data

--- a/src/main/java/com/hedera/mirror/config/RecordProperties.java
+++ b/src/main/java/com/hedera/mirror/config/RecordProperties.java
@@ -4,6 +4,7 @@ import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import javax.inject.Named;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import java.time.Duration;
 
@@ -21,8 +22,19 @@ public class RecordProperties {
     private RecordParserProperties parser = new RecordParserProperties();
 
     @Data
-    public class RecordDownloaderProperties {
+    public class RecordDownloaderProperties implements CommonDownloaderProperties {
         private Duration frequency = Duration.ofMillis(100L);
+
+        @Min(1)
+        private int coreThreads = 5;
+        @Min(1)
+        private int maxThreads = 5;
+        @Min(1)
+        private int taskQueueSize = 50;
+        @Min(1)
+        private int listObjectsMaxKeys = 100;
+        @Min(1)
+        private int maxDownloadItems = 40;
     }
 
     @Data

--- a/src/test/java/com/hedera/downloader/RecordFileDownloaderTest.java
+++ b/src/test/java/com/hedera/downloader/RecordFileDownloaderTest.java
@@ -23,6 +23,7 @@ package com.hedera.downloader;
 import com.hedera.FileCopier;
 import com.hedera.configLoader.ConfigLoader;
 import com.hedera.databaseUtilities.ApplicationStatus;
+import com.hedera.mirror.config.DownloaderProperties;
 import com.hedera.mirror.config.RecordProperties;
 import com.hedera.utilities.Utility;
 import io.findify.s3mock.S3Mock;
@@ -61,9 +62,9 @@ public class RecordFileDownloaderTest {
     void before() throws Exception {
         ConfigLoader.setAddressBookFile("./config/0.0.102-testnet");
         ConfigLoader.setDownloadToDir(dataPath.toAbsolutePath().toString());
-        properties.getDownloader().setMaxDownloadItems(100);
+        properties.getDownloader().setBatchSize(100);
 
-        downloader = new RecordFileDownloader(properties);
+        downloader = new RecordFileDownloader(properties, new DownloaderProperties());
         downloader.applicationStatus = applicationStatus;
 
         validPath = Paths.get(ConfigLoader.getDefaultParseDir(ConfigLoader.OPERATION_TYPE.RECORDS));
@@ -130,20 +131,15 @@ public class RecordFileDownloaderTest {
     @Test
     @DisplayName("Max download items reached")
     void maxDownloadItemsReached() throws Exception {
-        var pre = properties.getDownloader().getMaxDownloadItems();
-        try {
-            properties.getDownloader().setMaxDownloadItems(1);
-            fileCopier.copy();
-            downloader.download();
-            assertThat(Files.walk(validPath))
-                    .filteredOn(p -> !p.toFile().isDirectory())
-                    .hasSize(1)
-                    .allMatch(p -> Utility.isRecordFile(p.toString()))
-                    .extracting(Path::getFileName)
-                    .contains(Paths.get("2019-08-30T18_10_00.419072Z.rcd"));
-        } finally {
-            properties.getDownloader().setMaxDownloadItems(pre);
-        }
+        properties.getDownloader().setBatchSize(1);
+        fileCopier.copy();
+        downloader.download();
+        assertThat(Files.walk(validPath))
+                .filteredOn(p -> !p.toFile().isDirectory())
+                .hasSize(1)
+                .allMatch(p -> Utility.isRecordFile(p.toString()))
+                .extracting(Path::getFileName)
+                .contains(Paths.get("2019-08-30T18_10_00.419072Z.rcd"));
     }
 
     @Test


### PR DESCRIPTION
**Detailed description**:

In the download process spawn separate threads for each node to:
- call S3 ListObjects looking for a batch of signature files
- begin downloading each of those files
- wait for all the download for this node to complete

Moved some "stop file checks" outside of the loops so we're only checking that file at the beginning of batches.

Then move on to processing the actual record files one at a time after a large batch of signatures has been downloaded.

New configuration properties `hedera.mirror.downloader`:
- maxConnections 500 (tcp client connections to s3)
- coreThreads 20 (threads to at least keep alive in processing requests)
- maxThreads 60 (max thread pool size for the aws xfer_mgr
- taskQueueSize 500 (backlog that this task queue can have)

Configuration properties for balance, event, and record have been updated:
- coreThreads varies
- maxThreads varies
- taskQueueSize 50
- listObjectsMaxKeys 100
- maxDownloadItems varies

Also fixed new Downloader to only create 1 xfer_manager (was doing 1 per stream) and handle shutdown properly.

And the log message about "Downloaded 0" that was spamming the logs is gone.

_There's some issue where if coreThreads is 0 performance is terrible - haven't found it yet_

**Which issue(s) this PR fixes**:
Addresses #74 for now
Fixes #231 

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [X] Tests updated
