### PR TITLE
Fix table name on insert to be t_livehashes

### DIFF
--- a/src/main/java/com/hedera/recordFileLogger/RecordFileLogger.java
+++ b/src/main/java/com/hedera/recordFileLogger/RecordFileLogger.java
@@ -174,7 +174,7 @@ public class RecordFileLogger {
 					+ " (consensus_timestamp, function_params, gas_supplied, call_result, gas_used)"
 					+ " VALUES (?, ?, ?, ?, ?)");
 
-			sqlInsertClaimData = connect.prepareStatement("INSERT INTO t_livehash_data"
+			sqlInsertClaimData = connect.prepareStatement("INSERT INTO t_livehashes"
 					+ " (consensus_timstamp, livehash)"
 					+ " VALUES (?, ?)");
 			


### PR DESCRIPTION
**Detailed description**:
Wrong database name on record stream insert causes the record set to not get inserted.

**Which issue(s) this PR fixes**:
Fixes #257 

**Special notes for your reviewer**:

Table name fixed, insert params look correct in insertCryptoAddClaim. Should be good. 

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

