### PR TITLE
Bug/livehashes sql on 0.1 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>com.hedera</groupId>
 	<artifactId>mirror-node</artifactId>
-	<version>0.1-SNAPSHOT</version>
+	<version>0.1.2</version>
 	<name>Hedera Mirror Node</name>
 	<description>Hedera Mirror Node mirrors data from Hedera nodes and serves it via an API</description>
 	<ciManagement>

--- a/src/main/java/com/hedera/recordFileLogger/RecordFileLogger.java
+++ b/src/main/java/com/hedera/recordFileLogger/RecordFileLogger.java
@@ -192,7 +192,7 @@ public class RecordFileLogger {
 					+ " (fk_trans_id, function_params, gas_supplied, call_result, gas_used)"
 					+ " VALUES (?, ?, ?, ?, ?)");
 
-			sqlInsertClaimData = connect.prepareStatement("INSERT INTO t_livehash_data"
+			sqlInsertClaimData = connect.prepareStatement("INSERT INTO t_livehashes"
 					+ " (fk_trans_id, livehash)"
 					+ " VALUES (?, ?)");
 			


### PR DESCRIPTION
**Detailed description**:
Fix a bug where a wrong tablename (t_livehash_data vs t_livehashes) was breaking record processing whenever we encountered those types of transactions (which are happening in testnet).

v0.1.2 also includes downloader performance improvements (changes on release/0.1 since 0.1.1).

**Which issue(s) this PR fixes**:
Fixes #257

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

