### PR TITLE
Fix duplicate entities

### DIFF
--- a/src/main/java/com/hedera/recordFileLogger/Entities.java
+++ b/src/main/java/com/hedera/recordFileLogger/Entities.java
@@ -135,7 +135,6 @@ public class Entities {
 	    sqlUpdate += " WHERE entity_shard = ?";
 	    sqlUpdate += " AND entity_realm = ?";
 	    sqlUpdate += " AND entity_num = ?";
-	    sqlUpdate += " AND fk_entity_type_id = ?";
 	    sqlUpdate += " RETURNING id";
 	    
 	    // inserts or returns an existing entity
@@ -184,8 +183,6 @@ public class Entities {
         updateEntity.setLong(fieldCount, realm);
     	fieldCount += 1;
         updateEntity.setLong(fieldCount, num);
-    	fieldCount += 1;
-        updateEntity.setLong(fieldCount, fk_entity_type);
 
         updateEntity.execute();
         
@@ -229,7 +226,6 @@ public class Entities {
 	    sqlDelete += " WHERE entity_shard = ?";
 	    sqlDelete += " AND entity_realm = ?";
 	    sqlDelete += " AND entity_num = ?";
-	    sqlDelete += " AND fk_entity_type_id = ?";
 	    sqlDelete += " RETURNING id";
 
 	    // inserts or returns an existing entity
@@ -238,7 +234,6 @@ public class Entities {
 	    deleteEntity.setLong(1, shard);
         deleteEntity.setLong(2, realm);
         deleteEntity.setLong(3, num);
-        deleteEntity.setLong(4, fk_entity_type);
 
         deleteEntity.execute();
         
@@ -282,7 +277,6 @@ public class Entities {
 	    sqlDelete += " WHERE entity_shard = ?";
 	    sqlDelete += " AND entity_realm = ?";
 	    sqlDelete += " AND entity_num = ?";
-	    sqlDelete += " AND fk_entity_type_id = ?";
 	    sqlDelete += " RETURNING id";
 
 	    // inserts or returns an existing entity
@@ -291,7 +285,6 @@ public class Entities {
 	    deleteEntity.setLong(1, shard);
         deleteEntity.setLong(2, realm);
         deleteEntity.setLong(3, num);
-        deleteEntity.setLong(4, fk_entity_type);
 
         deleteEntity.execute();
         
@@ -323,7 +316,7 @@ public class Entities {
 							  long auto_renew_period, byte[] key, long fk_proxy_account_id, int fk_entity_type)
 			throws SQLException {
 
-		long entityId = getCachedEntityId(shard, realm, num, fk_entity_type);
+		long entityId = getCachedEntityId(shard, realm, num);
 		if (entityId != -1) {
 			return entityId;
 		}
@@ -383,7 +376,7 @@ public class Entities {
 	}
 	private long createOrGetEntity(long shard, long realm, long num, int fk_entity_type) throws SQLException {
 		
-		long entityId = getCachedEntityId(shard, realm, num, fk_entity_type);
+		long entityId = getCachedEntityId(shard, realm, num);
 		if (entityId != -1) {
 			return entityId;
 		}
@@ -406,7 +399,7 @@ public class Entities {
 		entityId = entityCreate.getLong(1);
 		entityCreate.close();
 
-        String entity = shard + "-" + realm + "-" + num + "-" + fk_entity_type;
+        String entity = shard + "-" + realm + "-" + num;
         entities.put(entity, entityId);
         return entityId;
 	}
@@ -421,8 +414,8 @@ public class Entities {
         return createOrGetEntity(accountId.getShardNum(), accountId.getRealmNum(), accountId.getAccountNum(), FK_ACCOUNT);
     }
 
-    private long getCachedEntityId(long shard, long realm, long num, int fk_entity_type) {
-        String entity = shard + "-" + realm + "-" + num + "-" + fk_entity_type;
+    private long getCachedEntityId(long shard, long realm, long num) {
+        String entity = shard + "-" + realm + "-" + num;
     	
         if (shard + realm + num == 0 ) {
             return 0;

--- a/src/main/resources/db/migration/V1.11.4__duplicate_entities.sql
+++ b/src/main/resources/db/migration/V1.11.4__duplicate_entities.sql
@@ -1,0 +1,22 @@
+DROP INDEX IF EXISTS idx_t_entities_unq;
+
+WITH dupe_entities AS (
+    SELECT * FROM (
+        select id, min(id) OVER (PARTITION BY entity_shard, entity_realm, entity_num) AS newId FROM t_entities
+    ) dupes WHERE id <> newId
+),
+update_cryptotransferlists AS (
+    UPDATE t_cryptotransferlists c SET account_id = de.newId FROM dupe_entities de WHERE c.account_id = de.id
+),
+update_transactions_cud AS (
+    UPDATE t_transactions t SET fk_cud_entity_id = de.newId FROM dupe_entities de WHERE t.fk_cud_entity_id = de.id
+),
+update_transactions_node AS (
+    UPDATE t_transactions t SET fk_node_acc_id = de.newId FROM dupe_entities de WHERE t.fk_node_acc_id = de.id
+),
+update_transactions_payer AS (
+    UPDATE t_transactions t SET fk_payer_acc_id = de.newId FROM dupe_entities de WHERE t.fk_payer_acc_id = de.id
+)
+DELETE FROM t_entities e USING dupe_entities de WHERE e.id = de.id;
+
+CREATE UNIQUE INDEX idx_t_entities_unq ON t_entities (entity_shard, entity_realm, entity_num);


### PR DESCRIPTION
**Detailed description**:
- Changes unique index and lookup criteria for t_entities to be (entity_shard, entity_realm, entity_num)
- Migrates duplicate entities that have both account and contract to use the contract entity

**Which issue(s) this PR fixes**:
Fixes #251 

**Special notes for your reviewer**:
The contract is always created first for these dupes, hence why min(id) chooses the contract entity in the migration

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

