### PR TITLE
Fix record parser continuing to next file after exception

### DIFF
--- a/src/main/java/com/hedera/parser/RecordFileParser.java
+++ b/src/main/java/com/hedera/parser/RecordFileParser.java
@@ -140,17 +140,12 @@ public class RecordFileParser implements FileParser {
 								dis.readFully(rawBytes);
 
 								TransactionRecord txRecord = TransactionRecord.parseFrom(rawBytes);
+								RecordFileLogger.storeRecord(transaction, txRecord);
 
-								boolean bStored = RecordFileLogger.storeRecord(transaction, txRecord);
-								if (bStored) {
-									if (log.isTraceEnabled()) {
-										log.trace("Transaction = {}, Record = {}", Utility.printTransaction(transaction), TextFormat.shortDebugString(txRecord));
-									} else {
-										log.debug("Stored transaction with consensus timestamp {}", txRecord.getConsensusTimestamp());
-									}
+								if (log.isTraceEnabled()) {
+									log.trace("Transaction = {}, Record = {}", Utility.printTransaction(transaction), TextFormat.shortDebugString(txRecord));
 								} else {
-									RecordFileLogger.rollback();
-									return false;
+									log.debug("Stored transaction with consensus timestamp {}", txRecord.getConsensusTimestamp());
 								}
 								break;
 							case FileDelimiter.RECORD_TYPE_SIGNATURE:


### PR DESCRIPTION
**Detailed description**:
- Removes try/catch and boolean return value in `RecordFileLogger.completeFile()`and lets `RecordFileParser` handle rollback and halting processing
- Also removes try/catch and boolean return for `RecordFileLogger.storeRecord()` to avoid double rollback.

**Which issue(s) this PR fixes**:
Fixes #260 

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

