### PR TITLE
Fixed the SQL query for /balances?account.publickey api

### DIFF
--- a/rest-api/__tests__/accounts.test.js
+++ b/rest-api/__tests__/accounts.test.js
@@ -71,6 +71,12 @@ const singletests = {
             {field: 'balance', operator: '<', value: 5432100},
         ]
     },
+    accountpublickey_equal: {
+        urlparam: 'account.publickey=6bd7b31fd59fc1b51314ac90253dfdbffa18eec48c00051e92635fe964a08c9b',
+        checks: [
+            {field: 'ed25519_public_key_hex', operator: '=', value: '6bd7b31fd59fc1b51314ac90253dfdbffa18eec48c00051e92635fe964a08c9b'}
+        ]
+    },
     limit: {
         urlparam: 'limit=99',
         checks: [

--- a/rest-api/__tests__/balances.test.js
+++ b/rest-api/__tests__/balances.test.js
@@ -89,6 +89,12 @@ const singletests = {
             {field: 'balance', operator: '<', value: 5432100},
         ]
     },
+    accountpublickey_equal: {
+        urlparam: 'account.publickey=6bd7b31fd59fc1b51314ac90253dfdbffa18eec48c00051e92635fe964a08c9b',
+        checks: [
+            {field: 'ed25519_public_key_hex', operator: '=', value: '6bd7b31fd59fc1b51314ac90253dfdbffa18eec48c00051e92635fe964a08c9b'}
+        ]
+    },
     limit: {
         urlparam: 'limit=99',
         checks: [

--- a/rest-api/balances.js
+++ b/rest-api/balances.js
@@ -79,7 +79,7 @@ const getBalances = function (req) {
         sqlQuery += " join t_entities e\n" +
             " on e.entity_realm = ab.account_realm_num\n" +
             " and e.entity_num = ab.account_num\n" +
-            " and e.entity_shard = process.env.SHARD_NUM\n" +
+            " and e.entity_shard = " + process.env.SHARD_NUM + "\n" +
             " and e.fk_entity_type_id < " + utils.ENTITY_TYPE_FILE + "\n";
     }
     sqlQuery += " where " +


### PR DESCRIPTION
Signed-off-by: Atul Mahamuni <atulmahamuni@hedera.com>

**Detailed description**:
/balances/accounts.publickey api was broken because of incorrect inclusion of process.env.SHARD_NUM in the query string.

**Which issue(s) this PR fixes**:
Fixes #271 

**Special notes for your reviewer**:
This is needed for exchanges. We might have to include this in v0.2.0-rc4.

**Checklist**
- [ ] Documentation added
- [x] Tests updated

