### PR TITLE
Fix circleCI Test Summary

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,18 +35,10 @@ workflows:
               only: /.*/
             tags:
               only: /.*/
-      - build: # required since `release_artifacts` has tag filters AND requires `this`
+      - release_artifacts:
           requires:
             - build_mirror_node
             - build_rest_api
-          filters:
-            branches:
-              only: /.*/
-            tags:
-              only: /.*/
-      - release_artifacts:
-          requires:
-            - build
           filters:
             branches:
               ignore: /.*/
@@ -128,16 +120,6 @@ jobs:
           paths:
             - rest-api.tgz
             - test-results/rest-api
-
-  build:
-    <<: *defaults
-    steps:
-      - *attach_workspace
-      - store_test_results:
-          path: /tmp/workspace/test-results/
-      - run:
-          name: Success
-          command: echo "Build successful"
 
   release_artifacts:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,12 +70,16 @@ jobs:
           key: maven-v1-{{ .Branch }}-{{ checksum "pom.xml" }}
           paths:
           - ~/.m2
+      - store_test_results:
+          path: target/surefire-reports
       - run:
           name: Upload Code Coverage
           command: bash <(curl -s https://codecov.io/bash)
       - run:
           name: Collecting mirror-node assets
           command: |
+            mkdir -p /tmp/workspace/test-results/mirror-node/
+            cp -R target/surefire-reports/* /tmp/workspace/test-results/mirror-node/
             mkdir -p /tmp/workspace/mirror-node/
             mv target/mirror-node-*.jar /tmp/workspace/mirror-node/mirror-node.jar
             mv config /tmp/workspace/mirror-node/
@@ -84,6 +88,7 @@ jobs:
           root: *workspace_root
           paths:
             - mirror-node
+            - test-results/mirror-node
 
   build_rest_api:
     docker:
@@ -113,6 +118,8 @@ jobs:
           working_directory: 'rest-api'
           name: Collecting rest-api assets
           command: |
+            mkdir -p /tmp/workspace/test-results/rest-api/
+            cp -R target/jest-junit/* /tmp/workspace/test-results/rest-api/
             npm pack
             mkdir -p /tmp/workspace/
             mv rest-api*.tgz /tmp/workspace/rest-api.tgz
@@ -120,10 +127,14 @@ jobs:
           root: *workspace_root
           paths:
             - rest-api.tgz
+            - test-results/rest-api
 
   build:
     <<: *defaults
     steps:
+      - *attach_workspace
+      - store_test_results:
+          path: /tmp/workspace/test-results/
       - run:
           name: Success
           command: echo "Build successful"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,8 +70,6 @@ jobs:
       - run:
           name: Collecting mirror-node assets
           command: |
-            mkdir -p /tmp/workspace/test-results/mirror-node/
-            cp -R target/surefire-reports/* /tmp/workspace/test-results/mirror-node/
             mkdir -p /tmp/workspace/mirror-node/
             mv target/mirror-node-*.jar /tmp/workspace/mirror-node/mirror-node.jar
             mv config /tmp/workspace/mirror-node/
@@ -80,7 +78,6 @@ jobs:
           root: *workspace_root
           paths:
             - mirror-node
-            - test-results/mirror-node
 
   build_rest_api:
     docker:
@@ -110,8 +107,6 @@ jobs:
           working_directory: 'rest-api'
           name: Collecting rest-api assets
           command: |
-            mkdir -p /tmp/workspace/test-results/rest-api/
-            cp -R target/jest-junit/* /tmp/workspace/test-results/rest-api/
             npm pack
             mkdir -p /tmp/workspace/
             mv rest-api*.tgz /tmp/workspace/rest-api.tgz
@@ -119,7 +114,6 @@ jobs:
           root: *workspace_root
           paths:
             - rest-api.tgz
-            - test-results/rest-api
 
   release_artifacts:
     <<: *defaults

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.hedera</groupId>
 	<artifactId>mirror-node</artifactId>
-	<version>0.3-SNAPSHOT</version>
+	<version>0.3.0-SNAPSHOT</version>
 	<name>Hedera Mirror Node</name>
 	<description>Hedera Mirror Node mirrors data from Hedera nodes and serves it via an API</description>
 	<ciManagement>

--- a/rest-api/package-lock.json
+++ b/rest-api/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "backend",
-  "version": "0.3.0",
+  "name": "rest-api",
+  "version": "0.3.0-SNAPSHOT",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/rest-api/package.json
+++ b/rest-api/package.json
@@ -20,8 +20,17 @@
     "node-cache": "^4.2.1",
     "pg": "^7.11.0"
   },
-  "bundledDependencies": ["body-parser", "compression", "cors", "dotenv", "express", "log4js", "mathjs", "node-cache",
-    "pg"],
+  "bundledDependencies": [
+    "body-parser",
+    "compression",
+    "cors",
+    "dotenv",
+    "express",
+    "log4js",
+    "mathjs",
+    "node-cache",
+    "pg"
+  ],
   "devDependencies": {
     "jest": "^24.8.0",
     "jest-junit": "^8.0.0",


### PR DESCRIPTION
The CirlceCI Test Summary for "build" and "build_mirror_node" weren't showing anything in the Test Summary tab.

- Store surefire test results in "build_mirror_node"
- Save off test results in "build_mirror_node" and "build_rest_api" for the "build" step to save as test results (combined report) for the Test Summary tab.
- package*.json reformatted and using 0.3.0-SNAPSHOT
- Also updated the pom version to 0.3.0-SNAPSHOT
- Remove circleci build job