### PR TITLE
Fix java integration tests not running in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,5 @@
 version: 2
 
-defaults: &defaults
-  docker:
-    - image: adoptopenjdk:11-jdk-hotspot
-
 references:
   workspace_root: &workspace_root
     /tmp/workspace
@@ -47,7 +43,13 @@ workflows:
 
 jobs:
   build_mirror_node:
-    <<: *defaults
+    docker:
+      - image: adoptopenjdk:11-jdk-hotspot
+      - image: postgres:9.6-alpine
+        environment:
+          POSTGRES_DB: mirror_node
+          POSTGRES_PASSWORD: mirror_node_pass
+          POSTGRES_USER: mirror_node
     steps:
       - checkout
       - restore_cache:
@@ -116,7 +118,8 @@ jobs:
             - rest-api.tgz
 
   release_artifacts:
-    <<: *defaults
+    docker:
+      - image: adoptopenjdk:11-jdk-hotspot
     steps:
       - *attach_workspace
       - *package_mirror_node

--- a/pom.xml
+++ b/pom.xml
@@ -165,12 +165,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.testcontainers</groupId>
-			<artifactId>junit-jupiter</artifactId>
-			<version>${testcontainers.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>io.findify</groupId>
 			<artifactId>s3mock_2.12</artifactId>
 			<version>0.2.5</version>

--- a/src/test/java/com/hedera/IntegrationTest.java
+++ b/src/test/java/com/hedera/IntegrationTest.java
@@ -20,39 +20,68 @@ package com.hedera;
  * ‍
  */
 
+import lombok.extern.log4j.Log4j2;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.*;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.context.*;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
+
+import javax.annotation.*;
 
 @AutoConfigureDataJpa
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @AutoConfigureTestEntityManager
-@ContextConfiguration(initializers = IntegrationTest.Initializer.class)
+@ContextConfiguration(initializers = IntegrationTest.TestDatabaseConfiguration.class)
 @SpringBootTest
-@Testcontainers(disabledWithoutDocker = true)
 @TestPropertySource(properties = "spring.task.scheduling.enabled=false")
 public abstract class IntegrationTest {
 
-    @Container
-    private static final PostgreSQLContainer postgres = new PostgreSQLContainer<>("postgres:9.6-alpine");
+    /**
+     *  First try to use a Testcontainer. If Docker is not running or it fails to connect to the Testcontainer,
+     *  fallback to a database running on localhost.
+     */
+    @Log4j2
+    @TestConfiguration
+    static class TestDatabaseConfiguration implements ApplicationContextInitializer<ConfigurableApplicationContext> {
 
-    static class Initializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+        private static PostgreSQLContainer postgresql;
+
+        static {
+            System.setProperty("testcontainers.environmentprovider.timeout", "1");
+            System.setProperty("testcontainers.npipesocketprovider.timeout", "1");
+            System.setProperty("testcontainers.unixsocketprovider.timeout", "1");
+            System.setProperty("testcontainers.windowsprovider.timeout", "1");
+        }
 
         @Override
         public void initialize(ConfigurableApplicationContext applicationContext) {
-            TestPropertyValues
-                    .of("hedera.mirror.db.name=" + postgres.getDatabaseName())
-                    .and("hedera.mirror.db.password=" + postgres.getPassword())
-                    .and("hedera.mirror.db.username=" + postgres.getUsername())
-                    .and("spring.datasource.url=" + postgres.getJdbcUrl())
-                    .applyTo(applicationContext);
+            try {
+                log.info("Starting PostgreSQL");
+                postgresql = new PostgreSQLContainer<>("postgres:9.6-alpine");
+                postgresql.start();
+
+                TestPropertyValues
+                        .of("hedera.mirror.db.name=" + postgresql.getDatabaseName())
+                        .and("hedera.mirror.db.password=" + postgresql.getPassword())
+                        .and("hedera.mirror.db.username=" + postgresql.getUsername())
+                        .and("spring.datasource.url=" + postgresql.getJdbcUrl())
+                        .applyTo(applicationContext);
+            } catch (Throwable ex) {
+                log.warn(ex.getMessage());
+            }
+        }
+
+        @PreDestroy
+        public void stop() {
+            if (postgresql != null && postgresql.isRunning()) {
+                log.info("Stopping PostgreSQL");
+                postgresql.stop();
+            }
         }
     }
 }

--- a/src/test/java/com/hedera/mirror/repository/ApplicationStatusRepositoryTest.java
+++ b/src/test/java/com/hedera/mirror/repository/ApplicationStatusRepositoryTest.java
@@ -23,14 +23,11 @@ package com.hedera.mirror.repository;
 import com.hedera.IntegrationTest;
 import com.hedera.mirror.domain.ApplicationStatusCode;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 import javax.annotation.Resource;
-import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.*;
 
-@Testcontainers(disabledWithoutDocker = true)
 public class ApplicationStatusRepositoryTest extends IntegrationTest {
 
     @Resource

--- a/src/test/java/com/hedera/parser/RecordFileParserTest.java
+++ b/src/test/java/com/hedera/parser/RecordFileParserTest.java
@@ -35,7 +35,6 @@ import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.io.TempDir;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.test.context.jdbc.Sql;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 import javax.annotation.Resource;
 import java.io.File;
@@ -44,7 +43,6 @@ import java.nio.file.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Sql("classpath:db/scripts/cleanup.sql") // Class manually commits so have to manually cleanup tables
-@Testcontainers(disabledWithoutDocker = true)
 public class RecordFileParserTest extends IntegrationTest {
 
     @Resource


### PR DESCRIPTION
**Detailed description**:
CircleCI doesn't [support](https://circleci.com/docs/2.0/building-docker-images/#separation-of-environments) connecting from the job container to a remote docker container (at least not ones that CircleCI doesn't start themselves). To workaround this, switched to manually [starting](https://circleci.com/docs/2.0/databases/#postgresql-database-testing-example) a PostgreSQL container in CircleCI.

Had to remove Testcontainer's JUnit annotation support since it could only either fail tests or skip tests if testcontainer couldn't start/connect. Replaced with having Spring manage the lifecycle of the container and conditionally use testcontainer if it's supported and fallback to localhost container if not. This has the advantage that the database will now start once for all test classes versus the previous once per class previously.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated

