### PR TITLE
Updated protobuf library to include new HAPI response codes.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.hedera</groupId>
 	<artifactId>mirror-node</artifactId>
-	<version>0.2.0-rc3</version>
+	<version>0.2.1</version>
 	<name>Hedera Mirror Node</name>
 	<description>Hedera Mirror Node mirrors data from Hedera nodes and serves it via an API</description>
 	<ciManagement>
@@ -45,7 +45,7 @@
 		<commons-io.version>2.6</commons-io.version>
 		<coveralls.version>4.3.0</coveralls.version>
 		<disruptor.version>3.4.2</disruptor.version>
-		<hedera-protobuf.version>0.3.4</hedera-protobuf.version>
+		<hedera-protobuf.version>0.3.5</hedera-protobuf.version>
 		<hedera-sdk.version>0.5.0</hedera-sdk.version>
 		<jacoco.version>0.8.4</jacoco.version>
 		<java.version>11</java.version>

--- a/rest-api/package.json
+++ b/rest-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "1.0.0",
+  "version": "0.2.1",
   "description": "REST API for Hedera mirror node",
   "main": "server.js",
   "scripts": {

--- a/src/main/resources/db/migration/V1.11.5.1__response_codes.sql
+++ b/src/main/resources/db/migration/V1.11.5.1__response_codes.sql
@@ -1,0 +1,3 @@
+insert into t_transaction_results (proto_id, result)
+    values (106, 'MAX_CONTRACT_STORAGE_EXCEEDED')
+    on conflict do nothing;


### PR DESCRIPTION
Updated protobuf library to include new HAPI response codes.
Update reference data in DB - new ResultCode.

Processing by the mirror-node stopped once it encountered a new result code on testnet in file 2019-10-09T16_57_55.013935Z.rcd.

You can verify the fix by pointing at the testnet S3 bucket and with the following SQL:
```
update t_application_status set status_value = '2019-10-09T16_56_51.826934Z.rcd' where status_code = 'LAST_VALID_DOWNLOADED_RECORD_FILE';
update t_application_status set status_value = null where status_code = 'LAST_PROCESSED_RECORD_HASH';
update t_application_status set status_value = null where status_code = 'LAST_VALID_DOWNLOADED_RECORD_FILE_HASH';
```

**Detailed description**:

**Which issue(s) this PR fixes**:
Fixes #310 

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

