### PR TITLE
AccountBalancesFileLoader improvements (Issues #297, #117)

### DIFF
--- a/src/main/java/com/hedera/configLoader/ConfigLoader.java
+++ b/src/main/java/com/hedera/configLoader/ConfigLoader.java
@@ -9,9 +9,9 @@ package com.hedera.configLoader;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -73,9 +73,6 @@ public class ConfigLoader {
 	private static final int DEFAULT_ACCOUNT_BALANCES_FILE_BUFFER_SIZE = 200_000;
 	private static int accountBalancesFileBufferSize = DEFAULT_ACCOUNT_BALANCES_FILE_BUFFER_SIZE;
 
-	private static final boolean DEFAULT_ACCOUNT_BALANCES_USE_TRANSACTION = false;
-	private static boolean accountBalancesUseTransaction = DEFAULT_ACCOUNT_BALANCES_USE_TRANSACTION;
-
 	// location of account balances on S3
 	private static String accountBalanceS3Location = "accountBalances/balance";
 
@@ -99,9 +96,9 @@ public class ConfigLoader {
     private static Dotenv dotEnv = Dotenv.configure().ignoreIfMissing().load();
 
 	private static String configSavePath = "./config/config.json";
-	
+
 	private static JsonObject configJsonObject;
-	
+
 	public static enum OPERATION_TYPE {
                BALANCE
                ,RECORDS
@@ -166,9 +163,6 @@ public class ConfigLoader {
 				if (i > 0) {
 					accountBalancesFileBufferSize = i;
 				}
-			}
-			if (configJsonObject.has("accountBalancesUseTransaction")) {
-				accountBalancesUseTransaction = configJsonObject.get("accountBalancesUseTransaction").getAsBoolean();
 			}
 			if (configJsonObject.has("systemShardNum")) {
 				systemShardNum = configJsonObject.get("systemShardNum").getAsLong();
@@ -280,10 +274,6 @@ public class ConfigLoader {
 
 	public static int getAccountBalancesFileBufferSize() {
 		return accountBalancesFileBufferSize;
-	}
-
-	public static boolean getAccountBalancesUseTransaction() {
-		return accountBalancesUseTransaction;
 	}
 
 	public static String getAccountBalanceS3Location() {

--- a/src/test/java/com/hedera/mirror/dataset/AccountBalancesFileLoaderIT.java
+++ b/src/test/java/com/hedera/mirror/dataset/AccountBalancesFileLoaderIT.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.dataset;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -37,10 +37,10 @@ public class AccountBalancesFileLoaderIT {
         final var fileName = "2019-08-20T21_30_00.147998006Z_Balances.csv";
         final var path = getClass().getResource(Paths.get("/account_balances", fileName).toString());
         final var cut = new AccountBalancesFileLoader(Paths.get(path.toURI()));
-        cut.loadAccountBalances();
+        boolean success = cut.loadAccountBalances();
         assertAll(
                 () -> assertEquals(2, cut.getValidRowCount())
-                ,() -> assertFalse(cut.isInsertErrors())
+                ,() -> assertTrue(success)
         );
         // TODO assert the rows actually added to the database.
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
-->

**Detailed description**:
- Removed accountBalancesUseTransaction. Logs below show no perf difference,
  so keeping it simple by removing db transaction option.
- There was partial error handling in processRecordStreamWithoutDatabaseTransaction.
  Errors in last batch  would have propagated up and skipped remaining logic
  in loadAccountBalances(). Fixed.
- insertError (only needed in test) didn't need to be state variable.
  Just passing it as return value was enough. One less state variable.
- Minor logging improvement

**Which issue(s) this PR fixes**:
Fixes #297
Fixes #117

**Special notes for your reviewer**:
Comparing performance (running locally on laptop):

_Without Database txn_
2019-10-04 16:23:10,697 INFO  [task-1] … balances file ./MirrorNodeData/accountBalances/valid/2019-10-04T12_00_00.040026Z_Balances.csv with 53667 records in 25.17 s
2019-10-04 16:23:35,648 INFO  [task-1] …balances file ./MirrorNodeData/accountBalances/valid/2019-10-04T12_45_00.036906001Z_Balances.csv with 53669 records in 24.95 s
2019-10-04 16:24:09,066 INFO  [task-1]… balances file ./MirrorNodeData/accountBalances/valid/2019-10-04T08_00_00.033413001Z_Balances.csv with 53634 records in 33.44 s
2019-10-04 16:24:36,983 INFO  [task-1] … balances file ./MirrorNodeData/accountBalances/valid/2019-10-04T18_15_00.015393Z_Balances.csv with 53883 records in 27.92 s
2019-10-04 16:25:02,511 INFO  [task-1] … balances file ./MirrorNodeData/accountBalances/valid/2019-10-04T08_45_00.017710Z_Balances.csv with 53644 records in 25.52 s
2019-10-04 16:25:05,825 INFO  [task-1] … balances file ./MirrorNodeData/accountBalances/valid/2019-10-04T02_30_00.029959Z_Balances.csv with 53511 records in 3.312 s
2019-10-04 16:25:29,676 INFO  [task-1] … balances file ./MirrorNodeData/accountBalances/valid/2019-10-04T15_15_00.023209001Z_Balances.csv with 53693 records in 23.85 s

_With database txn_
2019-10-04 16:28:50,700 INFO  [task-1] … balances file ./MirrorNodeData/accountBalances/valid/2019-10-04T23_15_00.042208001Z_Balances.csv with 54053 records in 21.31 s
2019-10-04 16:29:11,515 INFO  [task-1] … balances file ./MirrorNodeData/accountBalances/valid/2019-10-04T21_45_00.032315Z_Balances.csv with 54053 records in 20.81 s
2019-10-04 16:29:14,652 INFO  [task-1] … balances file ./MirrorNodeData/accountBalances/valid/2019-10-04T11_45_00.012213Z_Balances.csv with 53667 records in 3.135 s
2019-10-04 16:29:38,843 INFO  [task-1] … balances file ./MirrorNodeData/accountBalances/valid/2019-10-04T22_00_00.055866Z_Balances.csv with 54053 records in 24.19 s
2019-10-04 16:30:08,299 INFO  [task-1] … balances file ./MirrorNodeData/accountBalances/valid/2019-10-03T23_30_00.015795001Z_Balances.csv with 53511 records in 29.45 s
