### PR TITLE
Fix install/upgrade to use of application.yml for DB config (instead of config.json)

### DIFF
--- a/scripts/deploy-mirror-node.sh
+++ b/scripts/deploy-mirror-node.sh
@@ -13,60 +13,60 @@ usretc=/usr/etc/mirror-node/
 ts=$(date -u +%s)
 upgrade=0
 
-sudo mkdir -p "${usretc}" "${usrlib}" /var/lib/mirror-node
+mkdir -p "${usretc}" "${usrlib}" /var/lib/mirror-node
 
 if [ -f "${usrlib}/mirror-node.jar" ]; then
     upgrade=1
     echo "Upgrading to ${version}"
 
     echo "Stopping services"
-    sudo touch "${usrlib}/stop"
+    touch "${usrlib}/stop"
     sleep 5
 
     # Optionally stop these since some of these might not exist
-    sudo systemctl stop mirror-balance-downloader.service || true
-    sudo systemctl stop mirror-balance-parser.service || true
-    sudo systemctl stop mirror-record-downloader.service || true
-    sudo systemctl stop mirror-record-parser.service || true
-    sudo systemctl stop mirror-node.service || true
-    sudo rm -f /etc/systemd/systemd/mirror-*.service
+    systemctl stop mirror-balance-downloader.service || true
+    systemctl stop mirror-balance-parser.service || true
+    systemctl stop mirror-record-downloader.service || true
+    systemctl stop mirror-record-parser.service || true
+    systemctl stop mirror-node.service || true
+    rm -f /etc/systemd/systemd/mirror-*.service
 
     echo "Backing up binaries"
-    sudo rm -rf "${usrlib}/lib"* "${usrlib}/logs" "${usrlib}/mirror-node.jar."*
-    sudo mv "${usrlib}/mirror-node.jar" "${usrlib}/mirror-node.jar.${ts}.old"
+    rm -rf "${usrlib}/lib"* "${usrlib}/logs" "${usrlib}/mirror-node.jar."*
+    mv "${usrlib}/mirror-node.jar" "${usrlib}/mirror-node.jar.${ts}.old"
 
     # Handle the upgrade from config.json database params to application.yml database params
     appyml="${usretc}/application.yml"
     if [ -f "${usretc}/config.json" ] && [ ! -f  "${appyml}" ]; then
-        sudo echo -e "hedera:\n  mirror:\n    db:" > "${appyml}"
-        sudo cat "${usretc}/config.json" | awk -F: '{gsub(/ |\"/, "", $0); gsub(/,$/, "", $0); print}' | grep -E "^(api|db)" | \
+        echo -e "hedera:\n  mirror:\n    db:" > "${appyml}"
+        cat "${usretc}/config.json" | awk -F: '{gsub(/ |\"/, "", $0); gsub(/,$/, "", $0); print}' | grep -E "^(api|db)" | \
           sed -e "s/apiUsername:/api-username: /" -e "s/apiPassword:/api-password: /" -e "s/dbName:/name: /" \
             -e "s/dbUsername:/username: /" -e "s/dbPassword:/password: /" | grep -v dbUrl | \
-            sudo sed -e "s/^/      /" >> "${appyml}"
-        dbUrl=$(sudo grep "dbUrl" "${usretc}/config.json" | sed -e "s#.*//##" -e "s#/.*##")
+            sed -e "s/^/      /" >> "${appyml}"
+        dbUrl=$(grep "dbUrl" "${usretc}/config.json" | sed -e "s#.*//##" -e "s#/.*##")
         dbhost=$(echo ${dbUrl} | sed -e "s#:.*##")
         dbport=$(echo ${dbUrl} | grep ':' | sed -e "s#.*:##")
         if [ -n "${dbhost}" ]; then
-            sudo echo "      host: ${dbhost}" >> "${appyml}"
+            echo "      host: ${dbhost}" >> "${appyml}"
         fi
         if [ -n "${dbport}" ]; then
-            sudo echo "      port: ${dbport}" >> "${appyml}"
+            echo "      port: ${dbport}" >> "${appyml}"
         fi
-        sudo sed -ie '/apiPassword/d;/apiUsername/d;/dbName/d;/dbUsername/d;/dbPassword/d;/dbUrl/d' "${usretc}/config.json"
+        sed -ie '/apiPassword/d;/apiUsername/d;/dbName/d;/dbUsername/d;/dbPassword/d;/dbUrl/d' "${usretc}/config.json"
     fi
 else
     echo "Fresh install of ${version}"
     echo "Copying config (will need to be edited)"
-    cp -n config/* "#{usretc}"
+    cp -n config/* "${usretc}"
 fi
 
 echo "Copying binaries"
-sudo cp mirror-node.jar "${usrlib}"
+cp mirror-node.jar "${usrlib}"
 
 echo "Setting up systemd services"
-sudo cp scripts/*mirror*.service /etc/systemd/system
-sudo systemctl daemon-reload
-sudo systemctl enable mirror-node.service
+cp scripts/*mirror*.service /etc/systemd/system
+systemctl daemon-reload
+systemctl enable mirror-node.service
 
 echo "Starting services"
-sudo systemctl start mirror-node.service
+systemctl start mirror-node.service

--- a/scripts/deploy-mirror-node.sh
+++ b/scripts/deploy-mirror-node.sh
@@ -19,20 +19,11 @@ if [ -f "${usrlib}/mirror-node.jar" ]; then
     upgrade=1
     echo "Upgrading to ${version}"
 
-    echo "Stopping services"
-    touch "${usrlib}/stop"
-    sleep 5
-
-    # Optionally stop these since some of these might not exist
-    systemctl stop mirror-balance-downloader.service || true
-    systemctl stop mirror-balance-parser.service || true
-    systemctl stop mirror-record-downloader.service || true
-    systemctl stop mirror-record-parser.service || true
+    # Stop the service
+    echo "Stopping mirror-node service"
     systemctl stop mirror-node.service || true
-    rm -f /etc/systemd/systemd/mirror-*.service
 
-    echo "Backing up binaries"
-    rm -rf "${usrlib}/lib"* "${usrlib}/logs" "${usrlib}/mirror-node.jar."*
+    echo "Backing up binary"
     mv "${usrlib}/mirror-node.jar" "${usrlib}/mirror-node.jar.${ts}.old"
 
     # Handle the upgrade from config.json database params to application.yml database params
@@ -60,13 +51,13 @@ else
     cp -n config/* "${usretc}"
 fi
 
-echo "Copying binaries"
+echo "Copying new binary"
 cp mirror-node.jar "${usrlib}"
 
-echo "Setting up systemd services"
-cp scripts/*mirror*.service /etc/systemd/system
+echo "Setting up mirror-node systemd service"
+cp scripts/mirror-node.service /etc/systemd/system
 systemctl daemon-reload
 systemctl enable mirror-node.service
 
-echo "Starting services"
+echo "Starting mirror-node service"
 systemctl start mirror-node.service

--- a/scripts/deploy-mirror-node.sh
+++ b/scripts/deploy-mirror-node.sh
@@ -38,21 +38,21 @@ if [ -f "${usrlib}/mirror-node.jar" ]; then
     # Handle the upgrade from config.json database params to application.yml database params
     appyml="${usretc}/application.yml"
     if [ -f "${usretc}/config.json" ] && [ ! -f  "${appyml}" ]; then
-        echo -e "hedera:\n  mirror:\n    db:" > "${appyml}"
-        cat "${usretc}/config.json" | awk -F: '{gsub(/ |\"/, "", $0); gsub(/,$/, "", $0); print}' | grep -E "^(api|db)" | \
+        sudo echo -e "hedera:\n  mirror:\n    db:" > "${appyml}"
+        sudo cat "${usretc}/config.json" | awk -F: '{gsub(/ |\"/, "", $0); gsub(/,$/, "", $0); print}' | grep -E "^(api|db)" | \
           sed -e "s/apiUsername:/api-username: /" -e "s/apiPassword:/api-password: /" -e "s/dbName:/name: /" \
             -e "s/dbUsername:/username: /" -e "s/dbPassword:/password: /" | grep -v dbUrl | \
-            sed -e "s/^/      /" >> "${appyml}"
-        dbUrl=$(grep "dbUrl" "${usretc}/config.json" | sed -e "s#.*//##" -e "s#/.*##")
+            sudo sed -e "s/^/      /" >> "${appyml}"
+        dbUrl=$(sudo grep "dbUrl" "${usretc}/config.json" | sed -e "s#.*//##" -e "s#/.*##")
         dbhost=$(echo ${dbUrl} | sed -e "s#:.*##")
         dbport=$(echo ${dbUrl} | grep ':' | sed -e "s#.*:##")
         if [ -n "${dbhost}" ]; then
-            echo "      host: ${dbhost}" >> "${appyml}"
+            sudo echo "      host: ${dbhost}" >> "${appyml}"
         fi
         if [ -n "${dbport}" ]; then
-            echo "      port: ${dbport}" >> "${appyml}"
+            sudo echo "      port: ${dbport}" >> "${appyml}"
         fi
-        sed -ie '/apiPassword/d;/apiUsername/d;/dbName/d;/dbUsername/d;/dbPassword/d;/dbUrl/d' "${usretc}/config.json"
+        sudo sed -ie '/apiPassword/d;/apiUsername/d;/dbName/d;/dbUsername/d;/dbPassword/d;/dbUrl/d' "${usretc}/config.json"
     fi
 else
     echo "Fresh install of ${version}"

--- a/scripts/mirror-node.service
+++ b/scripts/mirror-node.service
@@ -4,7 +4,7 @@ Description=Hedera Mirror Node
 
 [Service]
 Environment=HEDERA_MIRROR_CONFIG_PATH=/usr/etc/mirror-node/config.json
-ExecStart=/usr/bin/java -jar mirror-node.jar -Djavax.net.ssl.trustStorePassword=changeit -DLog4jContextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector
+ExecStart=/usr/bin/java -jar mirror-node.jar -Djavax.net.ssl.trustStorePassword=changeit -DLog4jContextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector --spring.config.additional-location=file:/usr/etc/mirror-node/application.yml
 LimitNOFILE=65536
 Restart=on-failure
 RestartSec=1

--- a/scripts/mirror-node.service
+++ b/scripts/mirror-node.service
@@ -4,7 +4,7 @@ Description=Hedera Mirror Node
 
 [Service]
 Environment=HEDERA_MIRROR_CONFIG_PATH=/usr/etc/mirror-node/config.json
-ExecStart=/usr/bin/java -jar mirror-node.jar -Djavax.net.ssl.trustStorePassword=changeit -DLog4jContextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector --spring.config.additional-location=file:/usr/etc/mirror-node/application.yml
+ExecStart=/usr/bin/java -jar mirror-node.jar -Djavax.net.ssl.trustStorePassword=changeit -DLog4jContextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector --spring.config.additional-location=file:/usr/etc/mirror-node/
 LimitNOFILE=65536
 Restart=on-failure
 RestartSec=1


### PR DESCRIPTION
**Detailed description**:
- Update the mirror-node.service system config to add `--spring.config.additional-location=file:/usr/etc/mirror-node/application.yml` (application.yml config file will be read from /usr/etc/mirror-node
- `scripts/deploy-mirror-node.sh` to create an application.yml for db params from config.json and remove those params from config.json

**Which issue(s) this PR fixes**:
Fixes #309

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

