### PR TITLE
Fix sporadic circle CI integration test failures

### DIFF
--- a/src/test/java/com/hedera/mirror/dataset/AccountBalancesFileLoaderIT.java
+++ b/src/test/java/com/hedera/mirror/dataset/AccountBalancesFileLoaderIT.java
@@ -22,6 +22,7 @@ package com.hedera.mirror.dataset;
 
 import com.hedera.mirror.exception.InvalidDatasetException;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.context.jdbc.Sql;
 
 import java.io.FileNotFoundException;
 import java.net.URISyntaxException;
@@ -30,6 +31,7 @@ import java.sql.SQLException;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+@Sql(executionPhase= Sql.ExecutionPhase.AFTER_TEST_METHOD, scripts="classpath:db/scripts/cleanup.sql") // Class manually commits so have to manually cleanup tables
 public class AccountBalancesFileLoaderIT {
     @Test
     public void positiveSmallFile() throws FileNotFoundException, InvalidDatasetException, URISyntaxException, SQLException {

--- a/src/test/java/com/hedera/mirror/repository/EntityRepositoryTest.java
+++ b/src/test/java/com/hedera/mirror/repository/EntityRepositoryTest.java
@@ -22,9 +22,12 @@ package com.hedera.mirror.repository;
 
 import com.hedera.mirror.domain.Entities;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.context.jdbc.Sql;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+
+@Sql("classpath:db/scripts/cleanup.sql") // Some test class isn't cleaning up
 public class EntityRepositoryTest extends AbstractRepositoryTest {
 
     @Test
@@ -42,9 +45,9 @@ public class EntityRepositoryTest extends AbstractRepositoryTest {
     	entity.setAutoRenewPeriod(100L);
     	entity.setDeleted(true);
     	entity.setEd25519PublicKeyHex("ed25519publickeyhex");
-    	entity.setEntityNum(3L);
-    	entity.setEntityRealm(2L);
-    	entity.setEntityShard(1L);
+        entity.setEntityNum(5L);
+        entity.setEntityRealm(4L);
+        entity.setEntityShard(3L);
     	entity.setEntityTypeId(entityTypeId);
     	entity.setExpiryTimeNanos(200L);
     	entity.setExpiryTimeNs(300L);
@@ -52,7 +55,7 @@ public class EntityRepositoryTest extends AbstractRepositoryTest {
     	entity.setKey("key".getBytes());
     	entity.setProxyAccountId(proxyEntity.getId());
     	entity = entityRepository.save(entity);
-    	
+
     	assertThat(entityRepository.findByPrimaryKey(entity.getEntityShard(), entity.getEntityRealm(), entity.getEntityNum()).get())
 			.isNotNull()
 			.isEqualTo(entity);

--- a/src/test/java/com/hedera/mirror/repository/EntityRepositoryTest.java
+++ b/src/test/java/com/hedera/mirror/repository/EntityRepositoryTest.java
@@ -27,7 +27,7 @@ import org.springframework.test.context.jdbc.Sql;
 import static org.assertj.core.api.Assertions.assertThat;
 
 
-@Sql("classpath:db/scripts/cleanup.sql") // Some test class isn't cleaning up
+@Sql(executionPhase= Sql.ExecutionPhase.AFTER_TEST_METHOD, scripts="classpath:db/scripts/cleanup.sql") // Class manually commits so have to manually cleanup tables
 public class EntityRepositoryTest extends AbstractRepositoryTest {
 
     @Test

--- a/src/test/java/com/hedera/mirror/repository/FileDataRepositoryTest.java
+++ b/src/test/java/com/hedera/mirror/repository/FileDataRepositoryTest.java
@@ -25,9 +25,11 @@ import com.hedera.mirror.domain.FileData;
 import com.hedera.mirror.domain.RecordFile;
 import com.hedera.mirror.domain.Transaction;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.context.jdbc.Sql;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Sql(executionPhase= Sql.ExecutionPhase.AFTER_TEST_METHOD, scripts="classpath:db/scripts/cleanup.sql") // Class manually commits so have to manually cleanup tables
 public class FileDataRepositoryTest extends AbstractRepositoryTest {
 
     @Test
@@ -40,9 +42,9 @@ public class FileDataRepositoryTest extends AbstractRepositoryTest {
     	fileData.setConsensusTimestamp(transaction.getConsensusNs());
     	fileData.setFileData("some file data".getBytes());
     	fileData = fileDataRepository.save(fileData);
-    	
+
     	assertThat(fileDataRepository.findById(transaction.getConsensusNs()).get())
 			.isNotNull()
-			.isEqualTo(fileData);    
+			.isEqualTo(fileData);
     }
 }

--- a/src/test/java/com/hedera/mirror/repository/LiveHashRepositoryTest.java
+++ b/src/test/java/com/hedera/mirror/repository/LiveHashRepositoryTest.java
@@ -25,9 +25,11 @@ import com.hedera.mirror.domain.LiveHash;
 import com.hedera.mirror.domain.RecordFile;
 import com.hedera.mirror.domain.Transaction;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.context.jdbc.Sql;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Sql(executionPhase= Sql.ExecutionPhase.AFTER_TEST_METHOD, scripts="classpath:db/scripts/cleanup.sql") // Class manually commits so have to manually cleanup tables
 public class LiveHashRepositoryTest extends AbstractRepositoryTest {
 
     @Test
@@ -40,10 +42,10 @@ public class LiveHashRepositoryTest extends AbstractRepositoryTest {
     	liveHash.setConsensusTimestamp(transaction.getConsensusNs());
     	liveHash.setLivehash("some live hash".getBytes());
     	liveHash = liveHashRepository.save(liveHash);
-    	
+
     	assertThat(liveHashRepository.findById(transaction.getConsensusNs()).get())
 			.isNotNull()
 			.isEqualTo(liveHash);
-    	
+
     }
 }

--- a/src/test/java/com/hedera/mirror/repository/RecordFileRepositoryTest.java
+++ b/src/test/java/com/hedera/mirror/repository/RecordFileRepositoryTest.java
@@ -22,9 +22,11 @@ package com.hedera.mirror.repository;
 
 import com.hedera.mirror.domain.RecordFile;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.context.jdbc.Sql;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Sql(executionPhase= Sql.ExecutionPhase.AFTER_TEST_METHOD, scripts="classpath:db/scripts/cleanup.sql") // Class manually commits so have to manually cleanup tables
 public class RecordFileRepositoryTest extends AbstractRepositoryTest {
 
     @Test
@@ -35,9 +37,9 @@ public class RecordFileRepositoryTest extends AbstractRepositoryTest {
 		recordFile.setLoadEnd(20L);
 		recordFile.setLoadStart(30L);
 		recordFile.setPreviousHash("previousHash");
-		
+
 		recordFile = recordFileRepository.save(recordFile);
-    	
+
     	assertThat(recordFileRepository.findById(recordFile.getId()).get())
     		.isNotNull()
 			.isEqualTo(recordFile);

--- a/src/test/java/com/hedera/mirror/repository/TransactionRepositoryTest.java
+++ b/src/test/java/com/hedera/mirror/repository/TransactionRepositoryTest.java
@@ -22,9 +22,11 @@ package com.hedera.mirror.repository;
 
 import com.hedera.mirror.domain.Transaction;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.context.jdbc.Sql;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Sql(executionPhase= Sql.ExecutionPhase.AFTER_TEST_METHOD, scripts="classpath:db/scripts/cleanup.sql") // Class manually commits so have to manually cleanup tables
 public class TransactionRepositoryTest extends AbstractRepositoryTest {
 
     @Test

--- a/src/test/java/com/hedera/parser/RecordFileParserTest.java
+++ b/src/test/java/com/hedera/parser/RecordFileParserTest.java
@@ -42,7 +42,7 @@ import java.nio.file.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@Sql("classpath:db/scripts/cleanup.sql") // Class manually commits so have to manually cleanup tables
+@Sql(executionPhase= Sql.ExecutionPhase.AFTER_TEST_METHOD, scripts="classpath:db/scripts/cleanup.sql") // Class manually commits so have to manually cleanup tables
 public class RecordFileParserTest extends IntegrationTest {
 
     @Resource

--- a/src/test/java/com/hedera/recordLogger/RecordFileLoggerCryptoTest.java
+++ b/src/test/java/com/hedera/recordLogger/RecordFileLoggerCryptoTest.java
@@ -62,7 +62,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-@Sql("classpath:db/scripts/cleanup.sql") // Class manually commits so have to manually cleanup tables
+@Sql(executionPhase= Sql.ExecutionPhase.AFTER_TEST_METHOD, scripts="classpath:db/scripts/cleanup.sql") // Class manually commits so have to manually cleanup tables
 public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
 
 	//TODO: These transaction data items are not saved to the database

--- a/src/test/java/com/hedera/recordLogger/RecordFileLoggerFileTest.java
+++ b/src/test/java/com/hedera/recordLogger/RecordFileLoggerFileTest.java
@@ -60,7 +60,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-@Sql("classpath:db/scripts/cleanup.sql") // Class manually commits so have to manually cleanup tables
+@Sql(executionPhase= Sql.ExecutionPhase.AFTER_TEST_METHOD, scripts="classpath:db/scripts/cleanup.sql") // Class manually commits so have to manually cleanup tables
 public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
 
 	//TODO: The following are not yet saved to the mirror node database


### PR DESCRIPTION
**Detailed description**:
RecordFileLoggerCryptoTest was creating an entity 1.2.3 which was conflicting with the EntityRepositoryTest's use of entity 1.2.3 if DB cleanup wasn't performed in between the 2 (which depended on the random ordering of unit test classes being called).

- Changed EntityRepositoryTest to use 3.4.5 instead of 1.2.3
- Added @Sql annotation to classes that write to tables that are cleanup up by the "cleanup.sql" script - to call that script _after_ their tests are run in order to clean up the data they've written.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [X] Tests updated

