### PR TITLE
[Downloader] Common sig verifier and data download code

### DIFF
--- a/src/main/java/com/hedera/mirror/downloader/Downloader.java
+++ b/src/main/java/com/hedera/mirror/downloader/Downloader.java
@@ -141,7 +141,7 @@ public abstract class Downloader {
 		 */
 		for (String nodeAccountId : nodeAccountIds) {
 			tasks.add(Executors.callable(() -> {
-				log.debug("Downloading {} signature files for node {} created after file {}", getType(), nodeAccountId, lastValidFileName);
+				log.debug("Downloading signature files for node {} created after file {}", nodeAccountId, lastValidFileName);
 				// Get a list of objects in the bucket, 100 at a time
 				String prefix = s3Prefix + nodeAccountId + "/";
 				int downloadCount = 0;
@@ -215,10 +215,10 @@ public abstract class Downloader {
 						}
 					});
 					if (ref.count > 0) {
-						log.info("Downloaded {} {} signatures for node {} in {}", ref.count, getType(), nodeAccountId, stopwatch);
+						log.info("Downloaded {} signatures for node {} in {}", ref.count, nodeAccountId, stopwatch);
 					}
 				} catch (Exception e) {
-					log.error("Error downloading {} signature files for node {} after {}", getType(), nodeAccountId, stopwatch, e);
+					log.error("Error downloading signature files for node {} after {}", nodeAccountId, stopwatch, e);
 				}
 			}));
 		}
@@ -378,7 +378,7 @@ public abstract class Downloader {
     }
 
     protected Pair<Boolean, File> downloadFile(File sigFile) {
-		String fileName = getDataFileName(sigFile.getName());
+		String fileName = sigFile.getName().replace("_sig", "");
         String s3Prefix = downloaderProperties.getPrefix();
 
 		String nodeAccountId = Utility.getAccountIDStringFromFilePath(sigFile.getPath());
@@ -395,14 +395,15 @@ public abstract class Downloader {
 		}
 	}
 
-    protected abstract DownloadType getType();
+    private boolean isNeededSigFile(String s3ObjectKey) {
+        return s3ObjectKey.endsWith("_sig");
+    }
+
     protected abstract ApplicationStatusCode getLastValidDownloadedFileKey();
     // Only used if shouldVerifyHashChain() return true
     protected abstract ApplicationStatusCode getLastValidDownloadedFileHashKey();
     // Only used if shouldVerifyHashChain() return true
     protected abstract ApplicationStatusCode getBypassHashKey();
-    protected abstract String getDataFileName(String sigFileName);
-    protected abstract boolean isNeededSigFile(String s3ObjectKey);
     protected abstract boolean shouldVerifyHashChain();
     protected abstract String getPrevFileHash(String filePath);
 }

--- a/src/main/java/com/hedera/mirror/downloader/Downloader.java
+++ b/src/main/java/com/hedera/mirror/downloader/Downloader.java
@@ -34,6 +34,7 @@ import com.hedera.mirror.domain.NodeAddress;
 import com.hedera.mirror.repository.ApplicationStatusRepository;
 import com.hedera.utilities.Utility;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -44,6 +45,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -123,7 +125,7 @@ public abstract class Downloader {
      *      value: a list of sig files with the same name and from different nodes folder;
      * @throws Exception
      */
-	protected Map<String, List<File>> downloadSigFiles() throws Exception {
+	protected Map<String, List<File>> downloadSigFiles() throws InterruptedException {
 		String s3Prefix = downloaderProperties.getPrefix();
 		String lastValidFileName = applicationStatusRepository.findByStatusCode(getLastValidDownloadedFileKey());
 
@@ -270,7 +272,112 @@ public abstract class Downloader {
 		}
 	}
 
-	protected Pair<Boolean, File> downloadFile(File sigFile) {
+    /**
+     *  For each group of signature Files with the same file name:
+     *  (1) verify that the signature files are signed by corresponding node's PublicKey;
+     *  (2) For valid signature files, we compare their Hashes to see if more than 2/3 Hashes matches.
+     *  If more than 2/3 Hashes matches, we download the corresponding data file from a node folder which has valid
+     *  signature file.
+     *  (3) compare the Hash of data file with Hash which has been agreed on by valid signatures, if match, move the
+     *  data file into `valid` directory; else download the data file from other valid node folder, and compare the
+     *  Hash until find a match one
+     * @param sigFilesMap
+     */
+    protected void verifySigsAndDownloadDataFiles(Map<String, List<File>> sigFilesMap) {
+        String lastValidFileName =
+                applicationStatusRepository.findByStatusCode(getLastValidDownloadedFileKey());
+
+        // reload address book and keys
+        NodeSignatureVerifier verifier = new NodeSignatureVerifier(networkAddressBook);
+
+        List<String> sigFileNames = new ArrayList<>(sigFilesMap.keySet());
+        Collections.sort(sigFileNames);
+
+        for (String sigFileName : sigFileNames) {
+            if (Utility.checkStopFile()) {
+                log.info("Stop file found, stopping");
+                return;
+            }
+
+            List<File> sigFiles = sigFilesMap.get(sigFileName);
+            boolean valid = false;
+
+            // If the number of sigFiles is not greater than 2/3 of number of nodes, we don't need to verify them
+            if (sigFiles == null || !Utility.greaterThanSuperMajorityNum(sigFiles.size(), nodeAccountIds.size())) {
+                log.warn("Signature file count does not exceed 2/3 of nodes");
+                continue;
+            }
+
+            // validSigFiles are signed by node'key and contains the same Hash which has been agreed by more than 2/3 nodes
+            Pair<byte[], List<File>> hashAndvalidSigFiles = verifier.verifySignatureFiles(sigFiles);
+            final byte[] validHash = hashAndvalidSigFiles.getLeft();
+            for (File validSigFile : hashAndvalidSigFiles.getRight()) {
+                if (Utility.checkStopFile()) {
+                    log.info("Stop file found, stopping");
+                    return;
+                }
+
+                Pair<Boolean, File> fileResult = downloadFile(validSigFile);
+                File file = fileResult.getRight();
+                if (file != null && Utility.hashMatch(validHash, file)) {
+                    log.debug("Verified signature file matches at least 2/3 of nodes: {}", sigFileName);
+                    // Check that file is newer than last valid downloaded file.
+                    // Additionally, if the file type uses prevFileHash based linking, verify that new file is next in
+                    // the sequence.
+                    // TODO(reviewers): Requesting extra careful look at this condition. Thanks
+                    if ((lastValidFileName.isEmpty()
+                            || fileNameComparator.compare(lastValidFileName, file.getName()) < 0)
+                            && (!shouldVerifyHashChain() || verifyHashChain(file))) {
+                        // move the file to the valid directory
+                        File destination = downloaderProperties.getValidPath().resolve(file.getName()).toFile();
+                        if (moveFile(file, destination)) {
+                            log.debug("Successfully moved file from {} to {}", file, destination);
+                            if (shouldVerifyHashChain()) {
+                                String hash = Utility.bytesToHex(Utility.getFileHash(destination.getAbsolutePath()));
+                                applicationStatusRepository.updateStatusValue(getLastValidDownloadedFileHashKey(), hash);
+                            }
+                            applicationStatusRepository.updateStatusValue(getLastValidDownloadedFileKey(), destination.getName());
+                            valid = true;
+                            break;
+                        }
+                    }
+                } else if (file != null) {
+                    log.warn("Hash doesn't match the hash contained in valid signature file. Will try to download a file with same timestamp from other nodes and check the Hash: {}", file);
+                }
+            }
+
+            if (!valid) {
+                log.error("File could not be verified by at least 2/3 of nodes: {}", sigFileName);
+            }
+        }
+    }
+
+
+    /**
+     * Verifies that prevFileHash in given {@code file} matches that in application repository.
+     * @throws Exception
+     */
+    private boolean verifyHashChain(File file) {
+        String filePath = file.getAbsolutePath();
+        String lastValidFileHash = applicationStatusRepository.findByStatusCode(getLastValidDownloadedFileHashKey()); // todo
+        String bypassMismatch = applicationStatusRepository.findByStatusCode(getBypassHashKey());
+        String prevFileHash = getPrevFileHash(filePath);
+
+        if (prevFileHash == null) {
+            log.warn("Doesn't contain valid previous file hash: {}", filePath);
+            return false;
+        }
+
+        if (StringUtils.isBlank(lastValidFileHash) || lastValidFileHash.equals(prevFileHash) ||
+                Utility.hashIsEmpty(prevFileHash) || bypassMismatch.compareTo(file.getName()) > 0) {
+            return true;
+        }
+
+        log.warn("File Hash Mismatch with previous: {}, expected {}, got {}", file.getName(), lastValidFileHash, prevFileHash);
+        return false;
+    }
+
+    protected Pair<Boolean, File> downloadFile(File sigFile) {
 		String fileName = getDataFileName(sigFile.getName());
         String s3Prefix = downloaderProperties.getPrefix();
 
@@ -290,6 +397,12 @@ public abstract class Downloader {
 
     protected abstract DownloadType getType();
     protected abstract ApplicationStatusCode getLastValidDownloadedFileKey();
+    // Only used if shouldVerifyHashChain() return true
+    protected abstract ApplicationStatusCode getLastValidDownloadedFileHashKey();
+    // Only used if shouldVerifyHashChain() return true
+    protected abstract ApplicationStatusCode getBypassHashKey();
     protected abstract String getDataFileName(String sigFileName);
     protected abstract boolean isNeededSigFile(String s3ObjectKey);
+    protected abstract boolean shouldVerifyHashChain();
+    protected abstract String getPrevFileHash(String filePath);
 }

--- a/src/main/java/com/hedera/mirror/downloader/DownloaderProperties.java
+++ b/src/main/java/com/hedera/mirror/downloader/DownloaderProperties.java
@@ -27,6 +27,7 @@ import javax.annotation.PostConstruct;
 import java.nio.file.Path;
 
 public interface DownloaderProperties {
+
     int getBatchSize();
 
     CommonDownloaderProperties getCommon();

--- a/src/main/java/com/hedera/mirror/downloader/NodeSignatureVerifier.java
+++ b/src/main/java/com/hedera/mirror/downloader/NodeSignatureVerifier.java
@@ -53,16 +53,18 @@ public class NodeSignatureVerifier {
 	}
 
     /**
-     * Input: a list of a sig files which has the same timestamp
-     * Output: a list of valid sig files - being valid means the signature is valid and the Hash is agreed by super-majority nodes.
-     * 1. Verify that the signature files are signed by corresponding node's PublicKey;
-     * For invalid signature files, we will log them;
-     * 2. For valid signature files, we compare their Hashes to see if more than 2/3 Hashes matches. If more than 2/3 Hashes matches, we return a List of Files which contains this Hash
-     * @param sigFiles
-     * @return
+     * Verifies that the signature files are signed by corresponding node's PublicKey. For valid signature files, we
+     * compare their Hashes to see if more than 2/3 Hashes match. If more than 2/3 Hashes match, we return a List of
+     * Files which contains this Hash.
+     * @param sigFiles a list of a sig files which have the same timestamp
+     * @return Pair of
+     *     <hash of valid data file, list of valid sig files>. Valid means the signature is valid and the Hash is
+     *     agreed by super-majority nodes.
+     *     If validity of signatures can not be established, then returns <null, empty list>.
      */
     public Pair<byte[], List<File>> verifySignatureFiles(List<File> sigFiles) {
-        // If a signature is valid, we put the Hash in its content and its File to the map, to see if more than 2/3 valid signatures have the same Hash
+        // If a signature is valid, we put the Hash in its content and its File to the map, to see if more than 2/3
+        // valid signatures have the same Hash
         Map<String, Set<File>> hashToSigFiles = new HashMap<>();
         for (File sigFile : sigFiles) {
             Pair<byte[], byte[]> hashAndSig = Utility.extractHashAndSigFromFile(sigFile);

--- a/src/main/java/com/hedera/mirror/downloader/balance/AccountBalancesDownloader.java
+++ b/src/main/java/com/hedera/mirror/downloader/balance/AccountBalancesDownloader.java
@@ -72,10 +72,6 @@ public class AccountBalancesDownloader extends Downloader {
 		}
 	}
 
-    protected DownloadType getType() {
-        return DownloadType.BALANCE;
-    }
-
     protected ApplicationStatusCode getLastValidDownloadedFileKey() {
         return ApplicationStatusCode.LAST_VALID_DOWNLOADED_BALANCE_FILE;
     }
@@ -86,14 +82,6 @@ public class AccountBalancesDownloader extends Downloader {
 
     protected ApplicationStatusCode getBypassHashKey() {
         return null; // Not used since shouldVerifyHashChain returns false;
-    }
-
-    protected String getDataFileName(String sigFileName) {
-        return sigFileName.replace("_Balances.csv_sig", "_Balances.csv");
-    }
-
-    protected boolean isNeededSigFile(String s3ObjectKey) {
-        return Utility.isBalanceSigFile(s3ObjectKey);
     }
 
     protected boolean shouldVerifyHashChain() {

--- a/src/main/java/com/hedera/mirror/downloader/balance/AccountBalancesDownloader.java
+++ b/src/main/java/com/hedera/mirror/downloader/balance/AccountBalancesDownloader.java
@@ -66,82 +66,9 @@ public class AccountBalancesDownloader extends Downloader {
 			final var sigFilesMap = downloadSigFiles();
 
 			// Verify signature files and download corresponding files of valid signature files
-			verifySigsAndDownloadBalanceFiles(sigFilesMap);
+			verifySigsAndDownloadDataFiles(sigFilesMap);
 		} catch (Exception e) {
 			log.error("Error downloading balance files", e);
-		}
-	}
-
-	/**
-	 *  For each group of signature Files with the same file name:
-	 *  (1) verify that the signature files are signed by corresponding node's PublicKey;
-	 *  (2) For valid signature files, we compare their Hashes to see if more than 2/3 Hashes matches.
-	 *  If more than 2/3 Hashes matches, we download the corresponding _Balances.csv file from a node folder which has valid signature file.
-	 *  (3) compare the Hash of _Balances.csv file with Hash which has been agreed on by valid signatures, if match, move the _Balances.csv file into `valid` directory; else download _Balances.csv file from other valid node folder, and compare the Hash until find a match one
-	 *  return the name of directory which contains valid _Balances.csv files
-	 * @param sigFilesMap
-	 * @throws Exception
-	 */
-	private void verifySigsAndDownloadBalanceFiles(Map<String, List<File>> sigFilesMap) throws Exception {
-		String lastValidBalanceFileName = applicationStatusRepository.findByStatusCode(ApplicationStatusCode.LAST_VALID_DOWNLOADED_BALANCE_FILE);
-		String newLastValidBalanceFileName = lastValidBalanceFileName;
-
-		// reload address book and keys
-		NodeSignatureVerifier verifier = new NodeSignatureVerifier(networkAddressBook);
-        Path tmpDir = downloaderProperties.getTempPath();
-        Path validDir = downloaderProperties.getValidPath();
-
-		List<String> fileNames = new ArrayList<String>(sigFilesMap.keySet());
-		Collections.sort(fileNames);
-
-		for (String fileName : fileNames) {
-			if (Utility.checkStopFile()) {
-				log.info("Stop file found, stopping");
-				break;
-			}
-
-			List<File> sigFiles = sigFilesMap.get(fileName);
-			boolean valid = false;
-
-			// If the number of sigFiles is not greater than 2/3 of number of nodes, we don't need to verify them
-			if (sigFiles == null || !Utility.greaterThanSuperMajorityNum(sigFiles.size(), nodeAccountIds.size())) {
-				log.warn("Signature file count does not exceed 2/3 of nodes");
-				continue;
-			}
-
-			// validSigFiles are signed by node'key and contains the same Hash which has been agreed by more than 2/3 nodes
-			final var hashAndvalidSigFiles = verifier.verifySignatureFiles(sigFiles);
-            final byte[] validHash = hashAndvalidSigFiles.getLeft();
-			for (File validSigFile : hashAndvalidSigFiles.getRight()) {
-				if (Utility.checkStopFile()) {
-					log.info("Stop file found, stopping");
-					break;
-				}
-
-				Pair<Boolean, File> fileResult = downloadFile(validSigFile);
-				File file = fileResult.getRight();
-				if (file != null && Utility.hashMatch(validHash, file)) {
-				    File destination = validDir.resolve(file.getName()).toFile();
-					if (moveFile(file, destination)) {
-						if (newLastValidBalanceFileName.isEmpty() ||
-								fileNameComparator.compare(newLastValidBalanceFileName, file.getName()) < 0) {
-							newLastValidBalanceFileName = file.getName();
-							log.debug("Verified signature file matches at least 2/3 of nodes: {}", fileName);
-						}
-						valid = true;
-						break;
-					}
-				} else if (file != null) {
-					log.warn("Hash doesn't match the hash contained in valid signature file. Will try to download a balance file with same timestamp from other nodes and check the Hash: {}", file);
-				}
-			}
-
-			if (!valid) {
-				log.error("File could not be verified by at least 2/3 of nodes: {}", fileName);
-			}
-		}
-		if (!newLastValidBalanceFileName.equals(lastValidBalanceFileName)) {
-			applicationStatusRepository.updateStatusValue(ApplicationStatusCode.LAST_VALID_DOWNLOADED_BALANCE_FILE, newLastValidBalanceFileName);
 		}
 	}
 
@@ -153,11 +80,27 @@ public class AccountBalancesDownloader extends Downloader {
         return ApplicationStatusCode.LAST_VALID_DOWNLOADED_BALANCE_FILE;
     }
 
+    protected ApplicationStatusCode getLastValidDownloadedFileHashKey() {
+        return null; // Not used since shouldVerifyHashChain returns false;
+    }
+
+    protected ApplicationStatusCode getBypassHashKey() {
+        return null; // Not used since shouldVerifyHashChain returns false;
+    }
+
     protected String getDataFileName(String sigFileName) {
         return sigFileName.replace("_Balances.csv_sig", "_Balances.csv");
     }
 
     protected boolean isNeededSigFile(String s3ObjectKey) {
         return Utility.isBalanceSigFile(s3ObjectKey);
+    }
+
+    protected boolean shouldVerifyHashChain() {
+        return false;
+    }
+
+    protected String getPrevFileHash(String filePath) {
+        return null;  // Only used if verifyHashChain() return true
     }
 }

--- a/src/main/java/com/hedera/mirror/downloader/balance/BalanceDownloaderProperties.java
+++ b/src/main/java/com/hedera/mirror/downloader/balance/BalanceDownloaderProperties.java
@@ -23,7 +23,6 @@ package com.hedera.mirror.downloader.balance;
 import com.hedera.mirror.MirrorProperties;
 import com.hedera.mirror.domain.StreamType;
 import com.hedera.mirror.downloader.CommonDownloaderProperties;
-import com.hedera.mirror.downloader.Downloader;
 import com.hedera.mirror.downloader.DownloaderProperties;
 
 import java.nio.file.Path;

--- a/src/main/java/com/hedera/mirror/downloader/event/EventDownloaderProperties.java
+++ b/src/main/java/com/hedera/mirror/downloader/event/EventDownloaderProperties.java
@@ -23,7 +23,6 @@ package com.hedera.mirror.downloader.event;
 import com.hedera.mirror.MirrorProperties;
 import com.hedera.mirror.domain.StreamType;
 import com.hedera.mirror.downloader.CommonDownloaderProperties;
-import com.hedera.mirror.downloader.Downloader;
 import com.hedera.mirror.downloader.DownloaderProperties;
 
 import java.nio.file.Path;

--- a/src/main/java/com/hedera/mirror/downloader/event/EventStreamFileDownloader.java
+++ b/src/main/java/com/hedera/mirror/downloader/event/EventStreamFileDownloader.java
@@ -72,10 +72,6 @@ public class EventStreamFileDownloader extends Downloader {
 		}
 	}
 
-    protected DownloadType getType() {
-        return DownloadType.EVENT;
-    }
-
     protected ApplicationStatusCode getLastValidDownloadedFileKey() {
         return ApplicationStatusCode.LAST_VALID_DOWNLOADED_EVENT_FILE;
     }
@@ -86,14 +82,6 @@ public class EventStreamFileDownloader extends Downloader {
 
     protected ApplicationStatusCode getBypassHashKey() {
         return ApplicationStatusCode.EVENT_HASH_MISMATCH_BYPASS_UNTIL_AFTER;
-    }
-
-    protected String getDataFileName(String sigFileName) {
-        return sigFileName.replace(".evts_sig", ".evts");
-    }
-
-    protected boolean isNeededSigFile(String s3ObjectKey) {
-        return Utility.isEventStreamSigFile(s3ObjectKey);
     }
 
     protected boolean shouldVerifyHashChain() {

--- a/src/main/java/com/hedera/mirror/downloader/event/EventStreamFileDownloader.java
+++ b/src/main/java/com/hedera/mirror/downloader/event/EventStreamFileDownloader.java
@@ -63,119 +63,12 @@ public class EventStreamFileDownloader extends Downloader {
 		}
 
 		try {
-			if (Utility.checkStopFile()) {
-				log.info("Stop file found, exiting");
-				return;
-			}
-
 			final var sigFilesMap = downloadSigFiles();
 
 			// Verify signature files and download .evts files of valid signature files
-			verifySigsAndDownloadEventStreamFiles(sigFilesMap);
-			verifyValidFiles();
+			verifySigsAndDownloadDataFiles(sigFilesMap);
 		} catch (Exception e) {
 			log.error("Error downloading and verifying new event files", e);
-		}
-	}
-
-	/**
-	 * Check if there is any missing .evts file:
-	 * (1) Sort .evts files by timestamp,
-	 * (2) Verify the .evts files to see if the file Hash matches prevFileHash
-	 *
-	 * @throws Exception
-	 */
-	private void verifyValidFiles() {
-		String lastValidEventFileName = applicationStatusRepository.findByStatusCode(ApplicationStatusCode.LAST_VALID_DOWNLOADED_EVENT_FILE);
-		String lastValidEventFileHash = applicationStatusRepository.findByStatusCode(ApplicationStatusCode.LAST_VALID_DOWNLOADED_EVENT_FILE_HASH);
-        Path validDir = downloaderProperties.getValidPath();
-		try (Stream<Path> pathStream = Files.walk(validDir)) {
-			List<String> fileNames = pathStream.filter(p -> Utility.isEventStreamFile(p.toString()))
-					.filter(p -> lastValidEventFileName.isEmpty() ||
-							fileNameComparator.compare(p.toFile().getName(), lastValidEventFileName) > 0)
-					.sorted(pathComparator)
-					.map(p -> p.toString()).collect(Collectors.toList());
-
-			String newLastValidEventFileName = lastValidEventFileName;
-			String newLastValidEventFileHash = lastValidEventFileHash;
-
-			for (String fileName : fileNames) {
-				String prevFileHash = EventStreamFileParser.readPrevFileHash(fileName);
-				if (prevFileHash == null) {
-					log.info("{} doesn't contain valid prevFileHash", fileName);
-					break;
-				}
-				if (newLastValidEventFileHash.isEmpty() ||
-						newLastValidEventFileHash.equals(prevFileHash) ||
-						prevFileHash.equals(Hex.encodeHexString(new byte[48]))) {
-					newLastValidEventFileHash = Utility.bytesToHex(Utility.getFileHash(fileName));
-					newLastValidEventFileName = new File(fileName).getName();
-				} else {
-					break;
-				}
-			}
-
-			if (!newLastValidEventFileName.equals(lastValidEventFileName)) {
-				applicationStatusRepository.updateStatusValue(ApplicationStatusCode.LAST_VALID_DOWNLOADED_EVENT_FILE_HASH, newLastValidEventFileHash);
-				applicationStatusRepository.updateStatusValue(ApplicationStatusCode.LAST_VALID_DOWNLOADED_EVENT_FILE, newLastValidEventFileName);
-			}
-
-		} catch (Exception ex) {
-			log.error("Failed to verify event files in {}", validDir, ex);
-		}
-	}
-
-	/**
-	 * For each group of signature Files with the same file name:
-	 * (1) verify that the signature files are signed by corresponding node's PublicKey;
-	 * (2) For valid signature files, we compare their Hashes to see if more than 2/3 Hashes matches.
-	 * If more than 2/3 Hashes matches, we download the corresponding .evts file from a node folder which has valid
-	 * signature file.
-	 * (3) compare the Hash of .evts file with Hash which has been agreed on by valid signatures, if match, move the
-	 * .evts file into `valid` directory; else download .evts file from other valid node folder, and compare the Hash
-	 * until find a match one
-	 * return the name of directory which contains valid .evts files
-	 *
-	 * @param sigFilesMap
-	 */
-	private void verifySigsAndDownloadEventStreamFiles(Map<String, List<File>> sigFilesMap) {
-		NodeSignatureVerifier verifier = new NodeSignatureVerifier(networkAddressBook);
-        Path validDir = downloaderProperties.getValidPath();
-
-		for (String fileName : sigFilesMap.keySet()) {
-			boolean valid = false;
-			List<File> sigFiles = sigFilesMap.get(fileName);
-
-			// If the number of sigFiles is not greater than 2/3 of number of nodes, we don't need to verify them
-			if (sigFiles == null || !Utility.greaterThanSuperMajorityNum(sigFiles.size(), nodeAccountIds.size())) {
-				log.warn("Signature file count does not exceed 2/3 of nodes");
-				continue;
-			}
-
-			// validSigFiles are signed by node key and contains the same hash which has been agreed by more than 2/3
-            final var hashAndvalidSigFiles  = verifier.verifySignatureFiles(sigFiles);
-            final byte[] validHash = hashAndvalidSigFiles.getLeft();
-			for (File validSigFile : hashAndvalidSigFiles.getRight()) {
-				Pair<Boolean, File> fileResult = downloadFile(validSigFile);
-				File file = fileResult.getRight();
-				if (file != null &&	Utility.hashMatch(validHash, file)) {
-					log.debug("Verified signature file matches at least 2/3 of nodes: {}", fileName);
-					// move the file to the valid directory
-					File destination = validDir.resolve(file.getName()).toFile();
-
-					if (moveFile(file, destination)) {
-						log.debug("Verified signature file matches at least 2/3 of nodes: {}", fileName);
-						valid = true;
-						break;
-					}
-				} else if (file != null) {
-					log.warn("Hash of {} doesn't match the hash contained in the signature file. Will try to download a event file with same timestamp from other nodes", file);
-				}
-			}
-
-			if (!valid) {
-				log.error("File could not be verified by at least 2/3 of nodes: {}", fileName);
-			}
 		}
 	}
 
@@ -187,11 +80,27 @@ public class EventStreamFileDownloader extends Downloader {
         return ApplicationStatusCode.LAST_VALID_DOWNLOADED_EVENT_FILE;
     }
 
+    protected ApplicationStatusCode getLastValidDownloadedFileHashKey() {
+        return ApplicationStatusCode.LAST_VALID_DOWNLOADED_EVENT_FILE_HASH;
+    }
+
+    protected ApplicationStatusCode getBypassHashKey() {
+        return ApplicationStatusCode.EVENT_HASH_MISMATCH_BYPASS_UNTIL_AFTER;
+    }
+
     protected String getDataFileName(String sigFileName) {
         return sigFileName.replace(".evts_sig", ".evts");
     }
 
     protected boolean isNeededSigFile(String s3ObjectKey) {
         return Utility.isEventStreamSigFile(s3ObjectKey);
+    }
+
+    protected boolean shouldVerifyHashChain() {
+        return true;
+    }
+
+    protected String getPrevFileHash(String filePath) {
+        return EventStreamFileParser.readPrevFileHash(filePath);
     }
 }

--- a/src/main/java/com/hedera/mirror/downloader/record/RecordDownloaderProperties.java
+++ b/src/main/java/com/hedera/mirror/downloader/record/RecordDownloaderProperties.java
@@ -21,7 +21,6 @@ package com.hedera.mirror.downloader.record;
  */
 
 import com.hedera.mirror.domain.StreamType;
-import com.hedera.mirror.downloader.Downloader;
 import com.hedera.mirror.downloader.DownloaderProperties;
 import com.hedera.mirror.MirrorProperties;
 import com.hedera.mirror.downloader.CommonDownloaderProperties;

--- a/src/main/java/com/hedera/mirror/downloader/record/RecordFileDownloader.java
+++ b/src/main/java/com/hedera/mirror/downloader/record/RecordFileDownloader.java
@@ -67,10 +67,6 @@ public class RecordFileDownloader extends Downloader {
 		}
 	}
 
-    protected DownloadType getType() {
-        return DownloadType.RCD;
-    }
-
     protected ApplicationStatusCode getLastValidDownloadedFileKey() {
         return ApplicationStatusCode.LAST_VALID_DOWNLOADED_RECORD_FILE;
     }
@@ -81,14 +77,6 @@ public class RecordFileDownloader extends Downloader {
 
     protected ApplicationStatusCode getBypassHashKey() {
         return ApplicationStatusCode.RECORD_HASH_MISMATCH_BYPASS_UNTIL_AFTER;
-    }
-
-    protected String getDataFileName(String sigFileName) {
-        return sigFileName.replace(".rcd_sig", ".rcd");
-    }
-
-    protected boolean isNeededSigFile(String s3ObjectKey) {
-        return Utility.isRecordSigFile(s3ObjectKey);
     }
 
     protected boolean shouldVerifyHashChain() {

--- a/src/main/java/com/hedera/mirror/downloader/record/RecordFileDownloader.java
+++ b/src/main/java/com/hedera/mirror/downloader/record/RecordFileDownloader.java
@@ -61,106 +61,9 @@ public class RecordFileDownloader extends Downloader {
 			}
 
 			final var sigFilesMap = downloadSigFiles();
-			verifySigsAndDownloadRecordFiles(sigFilesMap);
+			verifySigsAndDownloadDataFiles(sigFilesMap);
 		} catch (Exception e) {
 			log.error("Error downloading and verifying new record files", e);
-		}
-	}
-
-	/**
-	 * Verify the .rcd files to see if the file Hash matches prevFileHash
-	 * @throws Exception
-	 */
-	private boolean verifyHashChain(File recordFile) throws Exception {
-		String recordPath = recordFile.getAbsolutePath();
-		String lastValidRecordFileHash = applicationStatusRepository.findByStatusCode(ApplicationStatusCode.LAST_VALID_DOWNLOADED_RECORD_FILE_HASH);
-		String bypassMismatch = applicationStatusRepository.findByStatusCode(ApplicationStatusCode.RECORD_HASH_MISMATCH_BYPASS_UNTIL_AFTER);
-		String prevFileHash = RecordFileParser.readPrevFileHash(recordPath);
-
-		if (prevFileHash == null) {
-			log.warn("Doesn't contain valid previous file hash: {}", recordPath);
-			return false;
-		}
-
-		if (StringUtils.isBlank(lastValidRecordFileHash) || lastValidRecordFileHash.equals(prevFileHash) ||
-				Utility.hashIsEmpty(prevFileHash) || bypassMismatch.compareTo(recordFile.getName()) > 0) {
-			return true;
-		}
-
-		log.warn("File Hash Mismatch with previous: {}, expected {}, got {}", recordFile.getName(), lastValidRecordFileHash, prevFileHash);
-		return false;
-	}
-
-	/**
-	 *  For each group of signature Files with the same file name:
-	 *  (1) verify that the signature files are signed by corresponding node's PublicKey;
-	 *  (2) For valid signature files, we compare their Hashes to see if more than 2/3 Hashes matches.
-	 *  If more than 2/3 Hashes matches, we download the corresponding .rcd file from a node folder which has valid signature file.
-	 *  (3) compare the Hash of .rcd file with Hash which has been agreed on by valid signatures, if match, move the .rcd file into `valid` directory; else download .rcd file from other valid node folder, and compare the Hash until find a match one
-	 *  return the name of directory which contains valid .rcd files
-	 * @param sigFilesMap
-	 */
-	private void verifySigsAndDownloadRecordFiles(Map<String, List<File>> sigFilesMap) {
-		// reload address book and keys
-		NodeSignatureVerifier verifier = new NodeSignatureVerifier(networkAddressBook);
-        Path validDir = downloaderProperties.getValidPath();
-
-		List<String> fileNames = new ArrayList<String>(sigFilesMap.keySet());
-
-		Collections.sort(fileNames);
-
-		if (Utility.checkStopFile()) {
-			log.info("Stop file found, stopping");
-			return;
-		}
-		for (String fileName : fileNames) {
-			boolean valid = false;
-			List<File> sigFiles = sigFilesMap.get(fileName);
-
-			// If the number of sigFiles is not greater than 2/3 of number of nodes, we don't need to verify them
-			if (sigFiles == null || !Utility.greaterThanSuperMajorityNum(sigFiles.size(), nodeAccountIds.size())) {
-				log.warn("Signature file count for {} does not exceed 2/3 of nodes", fileName);
-				continue;
-			}
-
-			// validSigFiles are signed by node key and contains the same hash which has been agreed by more than 2/3 nodes
-            final var hashAndvalidSigFiles = verifier.verifySignatureFiles(sigFiles);
-			final byte[] validHash = hashAndvalidSigFiles.getLeft();
-			for (File validSigFile : hashAndvalidSigFiles.getRight()) {
-				if (Utility.checkStopFile()) {
-					log.info("Stop file found, stopping");
-					break;
-				}
-
-				try {
-					Pair<Boolean, File> rcdFileResult = downloadFile(validSigFile);
-					File rcdFile = rcdFileResult.getRight();
-					if (rcdFile != null && Utility.hashMatch(validHash, rcdFile)) {
-						if (verifyHashChain(rcdFile)) {
-							// move the file to the valid directory
-							String name = rcdFile.getName();
-							String hash = Utility.bytesToHex(Utility.getFileHash(rcdFile.getAbsolutePath()));
-							File validFile = validDir.resolve(name).toFile();
-
-							if (moveFile(rcdFile, validFile)) {
-								log.debug("Verified signature file matches at least 2/3 of nodes: {}", fileName);
-								applicationStatusRepository.updateStatusValue(ApplicationStatusCode.LAST_VALID_DOWNLOADED_RECORD_FILE_HASH, hash);
-								applicationStatusRepository.updateStatusValue(ApplicationStatusCode.LAST_VALID_DOWNLOADED_RECORD_FILE, name);
-								valid = true;
-								break;
-							}
-						}
-					} else if (rcdFile != null) {
-						log.warn("Hash of {} doesn't match the hash contained in the signature file. Will try to download a record file with same timestamp from other nodes", rcdFile);
-					}
-				} catch (Exception e) {
-					log.error("Unable to verify signature {}", validSigFile, e);
-				}
-			}
-
-			if (!valid) {
-				log.error("File could not be verified by at least 2/3 of nodes: {}", fileName);
-			}
 		}
 	}
 
@@ -172,11 +75,27 @@ public class RecordFileDownloader extends Downloader {
         return ApplicationStatusCode.LAST_VALID_DOWNLOADED_RECORD_FILE;
     }
 
+    protected ApplicationStatusCode getLastValidDownloadedFileHashKey() {
+        return ApplicationStatusCode.LAST_VALID_DOWNLOADED_RECORD_FILE_HASH;
+    }
+
+    protected ApplicationStatusCode getBypassHashKey() {
+        return ApplicationStatusCode.RECORD_HASH_MISMATCH_BYPASS_UNTIL_AFTER;
+    }
+
     protected String getDataFileName(String sigFileName) {
         return sigFileName.replace(".rcd_sig", ".rcd");
     }
 
     protected boolean isNeededSigFile(String s3ObjectKey) {
         return Utility.isRecordSigFile(s3ObjectKey);
+    }
+
+    protected boolean shouldVerifyHashChain() {
+        return true;
+    }
+
+    protected String getPrevFileHash(String filePath) {
+        return RecordFileParser.readPrevFileHash(filePath);
     }
 }

--- a/src/main/java/com/hedera/utilities/Utility.java
+++ b/src/main/java/com/hedera/utilities/Utility.java
@@ -518,20 +518,10 @@ public class Utility {
 	}
 
 	public static String getAccountIDStringFromFilePath(String path) {
-		if (isRecordFile(path) || isRecordSigFile(path)) {
-			return getAccountIDStringFromFilePath(path, Downloader.DownloadType.RCD);
-		} else if (isEventStreamFile(path) || isEventStreamSigFile(path)) {
-			return getAccountIDStringFromFilePath(path, Downloader.DownloadType.EVENT);
-		} else {
-			return getAccountIDStringFromFilePath(path, Downloader.DownloadType.BALANCE);
-		}
-	}
-
-	public static String getAccountIDStringFromFilePath(String path, Downloader.DownloadType type) {
 		String regex;
-		if (type == Downloader.DownloadType.RCD) {
+        if (isRecordFile(path) || isRecordSigFile(path)) {
 			regex = "record([\\d]+[.][\\d]+[.][\\d]+)";
-		} else if (type == Downloader.DownloadType.EVENT) {
+        } else if (isEventStreamFile(path) || isEventStreamSigFile(path)) {
 			regex = "events_([\\d]+[.][\\d]+[.][\\d]+)";
 		} else {
 			//account balance


### PR DESCRIPTION
This change builds on the last change (PR #330) to replace 3
verifySigsAndDownload<Type>Files() fns by a single function
Downloader.verifySigsAndDownloadDataFiles(), therefore removing
3 copies of mostly similar code with one. This will make further
changes to Downloader code easier.

(Note D = Downloader)
Notable changes:
- RecordD and eventsD didn't check for newFileName > oldFileName (since prevFileHash check was enough).
  The common function always checks for newFileName > oldFileName condition.
  It's needed for balances file and acts as extra validity check for record & event files.
- Earlier, eventsD was not sorting sigFiles before iterating on them, which led to more complicated
  verification logic.
  EventsD was first moving all files (after verifying sig) to valid dir and then checking for validity of
  prevFilehash in verifyValidFiles() fn. In contrast, recordD was checking for both, sigs and prevFileHash,
  before moving to vaild dir. And the logic was simpler and better too. So
  Downloader.verifySigsAndDownloadDataFiles() follows the latter one i.e. check sigs and hash-linking
  before moving to valid dir.
- Unlike RecordsD, EventD wasn't respecting bypass parameter (EVENT_HASH_MISMATCH_BYPASS_UNTIL_AFTER).
  Now it does. If that's not the expected behavior, please let me know.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated

