### PR TITLE
Refactor Downloader

### DIFF
--- a/src/main/java/com/hedera/mirror/downloader/balance/AccountBalancesDownloader.java
+++ b/src/main/java/com/hedera/mirror/downloader/balance/AccountBalancesDownloader.java
@@ -20,13 +20,6 @@ package com.hedera.mirror.downloader.balance;
  * ‍
  */
 
-import java.io.File;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-
 import com.amazonaws.services.s3.transfer.TransferManager;
 
 import com.hedera.mirror.addressbook.NetworkAddressBook;
@@ -34,9 +27,7 @@ import com.hedera.mirror.domain.ApplicationStatusCode;
 import com.hedera.mirror.downloader.Downloader;
 import com.hedera.mirror.repository.ApplicationStatusRepository;
 import lombok.extern.log4j.Log4j2;
-import org.apache.commons.lang3.tuple.Pair;
 
-import com.hedera.mirror.downloader.NodeSignatureVerifier;
 import com.hedera.utilities.Utility;
 import org.springframework.scheduling.annotation.Scheduled;
 

--- a/src/main/java/com/hedera/mirror/downloader/balance/AccountBalancesDownloader.java
+++ b/src/main/java/com/hedera/mirror/downloader/balance/AccountBalancesDownloader.java
@@ -32,6 +32,7 @@ import com.hedera.utilities.Utility;
 import org.springframework.scheduling.annotation.Scheduled;
 
 import javax.inject.Named;
+import java.io.File;
 
 @Log4j2
 @Named
@@ -63,6 +64,11 @@ public class AccountBalancesDownloader extends Downloader {
 		}
 	}
 
+    @Override
+    protected boolean verifyHashChain(File file) {
+        return true;
+    }
+
     protected ApplicationStatusCode getLastValidDownloadedFileKey() {
         return ApplicationStatusCode.LAST_VALID_DOWNLOADED_BALANCE_FILE;
     }
@@ -73,10 +79,6 @@ public class AccountBalancesDownloader extends Downloader {
 
     protected ApplicationStatusCode getBypassHashKey() {
         return null; // Not used since shouldVerifyHashChain returns false;
-    }
-
-    protected boolean shouldVerifyHashChain() {
-        return false;
     }
 
     protected String getPrevFileHash(String filePath) {

--- a/src/main/java/com/hedera/mirror/downloader/event/EventStreamFileDownloader.java
+++ b/src/main/java/com/hedera/mirror/downloader/event/EventStreamFileDownloader.java
@@ -27,21 +27,12 @@ import com.hedera.mirror.domain.ApplicationStatusCode;
 import com.hedera.mirror.downloader.Downloader;
 import com.hedera.mirror.repository.ApplicationStatusRepository;
 import com.hedera.mirror.parser.event.EventStreamFileParser;
-import com.hedera.mirror.downloader.NodeSignatureVerifier;
 import com.hedera.utilities.Utility;
 
 import lombok.extern.log4j.Log4j2;
-import org.apache.commons.codec.binary.Hex;
-import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.scheduling.annotation.Scheduled;
 
 import javax.inject.Named;
-import java.io.File;
-import java.nio.file.*;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @Log4j2
 @Named

--- a/src/main/java/com/hedera/mirror/downloader/event/EventStreamFileDownloader.java
+++ b/src/main/java/com/hedera/mirror/downloader/event/EventStreamFileDownloader.java
@@ -63,123 +63,32 @@ public class EventStreamFileDownloader extends Downloader {
 		}
 
 		try {
-			if (Utility.checkStopFile()) {
-				log.info("Stop file found, exiting");
-				return;
-			}
-
 			final var sigFilesMap = downloadSigFiles();
 
 			// Verify signature files and download .evts files of valid signature files
-			verifySigsAndDownloadEventStreamFiles(sigFilesMap);
-			verifyValidFiles();
+			verifySigsAndDownloadDataFiles(sigFilesMap);
 		} catch (Exception e) {
 			log.error("Error downloading and verifying new event files", e);
 		}
 	}
 
-	/**
-	 * Check if there is any missing .evts file:
-	 * (1) Sort .evts files by timestamp,
-	 * (2) Verify the .evts files to see if the file Hash matches prevFileHash
-	 *
-	 * @throws Exception
-	 */
-	private void verifyValidFiles() {
-		String lastValidEventFileName = applicationStatusRepository.findByStatusCode(ApplicationStatusCode.LAST_VALID_DOWNLOADED_EVENT_FILE);
-		String lastValidEventFileHash = applicationStatusRepository.findByStatusCode(ApplicationStatusCode.LAST_VALID_DOWNLOADED_EVENT_FILE_HASH);
-        Path validDir = downloaderProperties.getValidPath();
-		try (Stream<Path> pathStream = Files.walk(validDir)) {
-			List<String> fileNames = pathStream.filter(p -> Utility.isEventStreamFile(p.toString()))
-					.filter(p -> lastValidEventFileName.isEmpty() ||
-							fileNameComparator.compare(p.toFile().getName(), lastValidEventFileName) > 0)
-					.sorted(pathComparator)
-					.map(p -> p.toString()).collect(Collectors.toList());
-
-			String newLastValidEventFileName = lastValidEventFileName;
-			String newLastValidEventFileHash = lastValidEventFileHash;
-
-			for (String fileName : fileNames) {
-				String prevFileHash = EventStreamFileParser.readPrevFileHash(fileName);
-				if (prevFileHash == null) {
-					log.info("{} doesn't contain valid prevFileHash", fileName);
-					break;
-				}
-				if (newLastValidEventFileHash.isEmpty() ||
-						newLastValidEventFileHash.equals(prevFileHash) ||
-						prevFileHash.equals(Hex.encodeHexString(new byte[48]))) {
-					newLastValidEventFileHash = Utility.bytesToHex(Utility.getFileHash(fileName));
-					newLastValidEventFileName = new File(fileName).getName();
-				} else {
-					break;
-				}
-			}
-
-			if (!newLastValidEventFileName.equals(lastValidEventFileName)) {
-				applicationStatusRepository.updateStatusValue(ApplicationStatusCode.LAST_VALID_DOWNLOADED_EVENT_FILE_HASH, newLastValidEventFileHash);
-				applicationStatusRepository.updateStatusValue(ApplicationStatusCode.LAST_VALID_DOWNLOADED_EVENT_FILE, newLastValidEventFileName);
-			}
-
-		} catch (Exception ex) {
-			log.error("Failed to verify event files in {}", validDir, ex);
-		}
-	}
-
-	/**
-	 * For each group of signature Files with the same file name:
-	 * (1) verify that the signature files are signed by corresponding node's PublicKey;
-	 * (2) For valid signature files, we compare their Hashes to see if more than 2/3 Hashes matches.
-	 * If more than 2/3 Hashes matches, we download the corresponding .evts file from a node folder which has valid
-	 * signature file.
-	 * (3) compare the Hash of .evts file with Hash which has been agreed on by valid signatures, if match, move the
-	 * .evts file into `valid` directory; else download .evts file from other valid node folder, and compare the Hash
-	 * until find a match one
-	 * return the name of directory which contains valid .evts files
-	 *
-	 * @param sigFilesMap
-	 */
-	private void verifySigsAndDownloadEventStreamFiles(Map<String, List<File>> sigFilesMap) {
-		NodeSignatureVerifier verifier = new NodeSignatureVerifier(networkAddressBook);
-        Path validDir = downloaderProperties.getValidPath();
-
-		for (String fileName : sigFilesMap.keySet()) {
-			boolean valid = false;
-			List<File> sigFiles = sigFilesMap.get(fileName);
-
-			// If the number of sigFiles is not greater than 2/3 of number of nodes, we don't need to verify them
-			if (sigFiles == null || !Utility.greaterThanSuperMajorityNum(sigFiles.size(), nodeAccountIds.size())) {
-				log.warn("Signature file count does not exceed 2/3 of nodes");
-				continue;
-			}
-
-			// validSigFiles are signed by node key and contains the same hash which has been agreed by more than 2/3
-            final var hashAndvalidSigFiles  = verifier.verifySignatureFiles(sigFiles);
-            final byte[] validHash = hashAndvalidSigFiles.getLeft();
-			for (File validSigFile : hashAndvalidSigFiles.getRight()) {
-				Pair<Boolean, File> fileResult = downloadFile(validSigFile);
-				File file = fileResult.getRight();
-				if (file != null &&	Utility.hashMatch(validHash, file)) {
-					log.debug("Verified signature file matches at least 2/3 of nodes: {}", fileName);
-					// move the file to the valid directory
-					File destination = validDir.resolve(file.getName()).toFile();
-
-					if (moveFile(file, destination)) {
-						log.debug("Verified signature file matches at least 2/3 of nodes: {}", fileName);
-						valid = true;
-						break;
-					}
-				} else if (file != null) {
-					log.warn("Hash of {} doesn't match the hash contained in the signature file. Will try to download a event file with same timestamp from other nodes", file);
-				}
-			}
-
-			if (!valid) {
-				log.error("File could not be verified by at least 2/3 of nodes: {}", fileName);
-			}
-		}
-	}
-
     protected ApplicationStatusCode getLastValidDownloadedFileKey() {
         return ApplicationStatusCode.LAST_VALID_DOWNLOADED_EVENT_FILE;
+    }
+
+    protected ApplicationStatusCode getLastValidDownloadedFileHashKey() {
+        return ApplicationStatusCode.LAST_VALID_DOWNLOADED_EVENT_FILE_HASH;
+    }
+
+    protected ApplicationStatusCode getBypassHashKey() {
+        return ApplicationStatusCode.EVENT_HASH_MISMATCH_BYPASS_UNTIL_AFTER;
+    }
+
+    protected boolean shouldVerifyHashChain() {
+        return true;
+    }
+
+    protected String getPrevFileHash(String filePath) {
+        return EventStreamFileParser.readPrevFileHash(filePath);
     }
 }

--- a/src/main/java/com/hedera/mirror/downloader/event/EventStreamFileDownloader.java
+++ b/src/main/java/com/hedera/mirror/downloader/event/EventStreamFileDownloader.java
@@ -75,10 +75,6 @@ public class EventStreamFileDownloader extends Downloader {
         return ApplicationStatusCode.EVENT_HASH_MISMATCH_BYPASS_UNTIL_AFTER;
     }
 
-    protected boolean shouldVerifyHashChain() {
-        return true;
-    }
-
     protected String getPrevFileHash(String filePath) {
         return EventStreamFileParser.readPrevFileHash(filePath);
     }

--- a/src/main/java/com/hedera/mirror/downloader/record/RecordFileDownloader.java
+++ b/src/main/java/com/hedera/mirror/downloader/record/RecordFileDownloader.java
@@ -27,18 +27,12 @@ import com.hedera.mirror.downloader.Downloader;
 import com.hedera.mirror.domain.ApplicationStatusCode;
 import com.hedera.mirror.repository.ApplicationStatusRepository;
 import com.hedera.mirror.parser.record.RecordFileParser;
-import com.hedera.mirror.downloader.NodeSignatureVerifier;
 import com.hedera.utilities.Utility;
 
 import lombok.extern.log4j.Log4j2;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.scheduling.annotation.Scheduled;
 
 import javax.inject.Named;
-import java.io.File;
-import java.nio.file.*;
-import java.util.*;
 
 @Log4j2
 @Named

--- a/src/main/java/com/hedera/mirror/downloader/record/RecordFileDownloader.java
+++ b/src/main/java/com/hedera/mirror/downloader/record/RecordFileDownloader.java
@@ -61,110 +61,29 @@ public class RecordFileDownloader extends Downloader {
 			}
 
 			final var sigFilesMap = downloadSigFiles();
-			verifySigsAndDownloadRecordFiles(sigFilesMap);
+			verifySigsAndDownloadDataFiles(sigFilesMap);
 		} catch (Exception e) {
 			log.error("Error downloading and verifying new record files", e);
 		}
 	}
 
-	/**
-	 * Verify the .rcd files to see if the file Hash matches prevFileHash
-	 * @throws Exception
-	 */
-	private boolean verifyHashChain(File recordFile) throws Exception {
-		String recordPath = recordFile.getAbsolutePath();
-		String lastValidRecordFileHash = applicationStatusRepository.findByStatusCode(ApplicationStatusCode.LAST_VALID_DOWNLOADED_RECORD_FILE_HASH);
-		String bypassMismatch = applicationStatusRepository.findByStatusCode(ApplicationStatusCode.RECORD_HASH_MISMATCH_BYPASS_UNTIL_AFTER);
-		String prevFileHash = RecordFileParser.readPrevFileHash(recordPath);
-
-		if (prevFileHash == null) {
-			log.warn("Doesn't contain valid previous file hash: {}", recordPath);
-			return false;
-		}
-
-		if (StringUtils.isBlank(lastValidRecordFileHash) || lastValidRecordFileHash.equals(prevFileHash) ||
-				Utility.hashIsEmpty(prevFileHash) || bypassMismatch.compareTo(recordFile.getName()) > 0) {
-			return true;
-		}
-
-		log.warn("File Hash Mismatch with previous: {}, expected {}, got {}", recordFile.getName(), lastValidRecordFileHash, prevFileHash);
-		return false;
-	}
-
-	/**
-	 *  For each group of signature Files with the same file name:
-	 *  (1) verify that the signature files are signed by corresponding node's PublicKey;
-	 *  (2) For valid signature files, we compare their Hashes to see if more than 2/3 Hashes matches.
-	 *  If more than 2/3 Hashes matches, we download the corresponding .rcd file from a node folder which has valid signature file.
-	 *  (3) compare the Hash of .rcd file with Hash which has been agreed on by valid signatures, if match, move the .rcd file into `valid` directory; else download .rcd file from other valid node folder, and compare the Hash until find a match one
-	 *  return the name of directory which contains valid .rcd files
-	 * @param sigFilesMap
-	 */
-	private void verifySigsAndDownloadRecordFiles(Map<String, List<File>> sigFilesMap) {
-		// reload address book and keys
-		NodeSignatureVerifier verifier = new NodeSignatureVerifier(networkAddressBook);
-        Path validDir = downloaderProperties.getValidPath();
-
-		List<String> fileNames = new ArrayList<String>(sigFilesMap.keySet());
-
-		Collections.sort(fileNames);
-
-		if (Utility.checkStopFile()) {
-			log.info("Stop file found, stopping");
-			return;
-		}
-		for (String fileName : fileNames) {
-			boolean valid = false;
-			List<File> sigFiles = sigFilesMap.get(fileName);
-
-			// If the number of sigFiles is not greater than 2/3 of number of nodes, we don't need to verify them
-			if (sigFiles == null || !Utility.greaterThanSuperMajorityNum(sigFiles.size(), nodeAccountIds.size())) {
-				log.warn("Signature file count for {} does not exceed 2/3 of nodes", fileName);
-				continue;
-			}
-
-			// validSigFiles are signed by node key and contains the same hash which has been agreed by more than 2/3 nodes
-            final var hashAndvalidSigFiles = verifier.verifySignatureFiles(sigFiles);
-			final byte[] validHash = hashAndvalidSigFiles.getLeft();
-			for (File validSigFile : hashAndvalidSigFiles.getRight()) {
-				if (Utility.checkStopFile()) {
-					log.info("Stop file found, stopping");
-					break;
-				}
-
-				try {
-					Pair<Boolean, File> rcdFileResult = downloadFile(validSigFile);
-					File rcdFile = rcdFileResult.getRight();
-					if (rcdFile != null && Utility.hashMatch(validHash, rcdFile)) {
-						if (verifyHashChain(rcdFile)) {
-							// move the file to the valid directory
-							String name = rcdFile.getName();
-							String hash = Utility.bytesToHex(Utility.getFileHash(rcdFile.getAbsolutePath()));
-							File validFile = validDir.resolve(name).toFile();
-
-							if (moveFile(rcdFile, validFile)) {
-								log.debug("Verified signature file matches at least 2/3 of nodes: {}", fileName);
-								applicationStatusRepository.updateStatusValue(ApplicationStatusCode.LAST_VALID_DOWNLOADED_RECORD_FILE_HASH, hash);
-								applicationStatusRepository.updateStatusValue(ApplicationStatusCode.LAST_VALID_DOWNLOADED_RECORD_FILE, name);
-								valid = true;
-								break;
-							}
-						}
-					} else if (rcdFile != null) {
-						log.warn("Hash of {} doesn't match the hash contained in the signature file. Will try to download a record file with same timestamp from other nodes", rcdFile);
-					}
-				} catch (Exception e) {
-					log.error("Unable to verify signature {}", validSigFile, e);
-				}
-			}
-
-			if (!valid) {
-				log.error("File could not be verified by at least 2/3 of nodes: {}", fileName);
-			}
-		}
-	}
-
     protected ApplicationStatusCode getLastValidDownloadedFileKey() {
         return ApplicationStatusCode.LAST_VALID_DOWNLOADED_RECORD_FILE;
+    }
+
+    protected ApplicationStatusCode getLastValidDownloadedFileHashKey() {
+        return ApplicationStatusCode.LAST_VALID_DOWNLOADED_RECORD_FILE_HASH;
+    }
+
+    protected ApplicationStatusCode getBypassHashKey() {
+        return ApplicationStatusCode.RECORD_HASH_MISMATCH_BYPASS_UNTIL_AFTER;
+    }
+
+   protected boolean shouldVerifyHashChain() {
+        return true;
+    }
+
+    protected String getPrevFileHash(String filePath) {
+        return RecordFileParser.readPrevFileHash(filePath);
     }
 }

--- a/src/main/java/com/hedera/mirror/downloader/record/RecordFileDownloader.java
+++ b/src/main/java/com/hedera/mirror/downloader/record/RecordFileDownloader.java
@@ -73,10 +73,6 @@ public class RecordFileDownloader extends Downloader {
         return ApplicationStatusCode.RECORD_HASH_MISMATCH_BYPASS_UNTIL_AFTER;
     }
 
-   protected boolean shouldVerifyHashChain() {
-        return true;
-    }
-
     protected String getPrevFileHash(String filePath) {
         return RecordFileParser.readPrevFileHash(filePath);
     }

--- a/src/test/java/com/hedera/mirror/downloader/record/RecordFileDownloaderTest.java
+++ b/src/test/java/com/hedera/mirror/downloader/record/RecordFileDownloaderTest.java
@@ -91,10 +91,8 @@ public class RecordFileDownloaderTest {
     }
 
     @AfterEach
-    void after(TestInfo testInfo) {
+    void after() {
         s3.shutdown();
-        System.out.println("After test: " + testInfo.getTestMethod().get().getName());
-        System.out.println("##########################################\n");
     }
 
     @Test

--- a/src/test/java/com/hedera/mirror/downloader/record/RecordFileDownloaderTest.java
+++ b/src/test/java/com/hedera/mirror/downloader/record/RecordFileDownloaderTest.java
@@ -32,13 +32,10 @@ import com.hedera.mirror.downloader.CommonDownloaderProperties;
 import com.hedera.mirror.repository.ApplicationStatusRepository;
 import com.hedera.utilities.Utility;
 import io.findify.s3mock.S3Mock;
-import lombok.extern.log4j.Log4j2;
 import org.apache.commons.io.FileUtils;
-import org.junit.Rule;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
-import org.junit.rules.TestName;
 import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.util.ResourceUtils;
@@ -60,9 +57,6 @@ public class RecordFileDownloaderTest {
 
     @TempDir
     Path s3Path;
-
-    @Rule
-    public TestName name = new TestName();
 
     private S3Mock s3;
     private FileCopier fileCopier;


### PR DESCRIPTION
**Detailed description**:
This change builds on the last change (PR #330) to replace 3
verifySigsAndDownload<Type>Files() fns by a single function
Downloader.verifySigsAndDownloadDataFiles(), therefore removing
3 copies of mostly similar code with one. This will make further
changes to Downloader code easier.

(Note D = Downloader)
Notable changes:
- RecordD and eventsD didn't check for newFileName > oldFileName (since prevFileHash check was enough).
  The common function always checks for newFileName > oldFileName condition.
  It's needed for balances file and acts as extra validity check for record & event files.
- Earlier, eventsD was not sorting sigFiles before iterating on them, which led to more complicated
  verification logic.
  EventsD was first moving all files (after verifying sig) to valid dir and then checking for validity of
  prevFilehash in verifyValidFiles() fn. In contrast, recordD was checking for both, sigs and prevFileHash,
  before moving to vaild dir. And the logic was simpler and better too. So
  Downloader.verifySigsAndDownloadDataFiles() follows the latter one i.e. check sigs and hash-linking
  before moving to valid dir.
- Unlike RecordsD, EventD wasn't respecting bypass parameter (EVENT_HASH_MISMATCH_BYPASS_UNTIL_AFTER).
  Now it does. If that's not the expected behavior, please let me know.

Signed-off-by: Apekshit Sharma <apekshit.sharma@hedera.com>

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:
Following diffs might help in reviewing:
Account Balances: https://www.textcompare.org/index.html?id=5db353729c87f20017a3d4b7
Record : https://www.textcompare.org/index.html?id=5db354ef9c87f20017a3d4b8
EventStream: https://www.textcompare.org/index.html?id=5db355949c87f20017a3d4b9

**Checklist**
- [ ] Documentation added
- [x] Tests updated

