### PR TITLE
Downloader: Replace AWS SDKv1 by SDKv2.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,6 @@
 	</scm>
 	<url>https://github.com/hashgraph/hedera-mirror-node</url>
 	<properties>
-		<aws.version>1.11.327</aws.version>
 		<commons-io.version>2.6</commons-io.version>
 		<disruptor.version>3.4.2</disruptor.version>
 		<hedera-protobuf.version>0.3.5</hedera-protobuf.version>
@@ -130,11 +129,14 @@
 			<artifactId>commons-io</artifactId>
 			<version>${commons-io.version}</version>
 		</dependency>
-		<dependency>
-			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk-s3</artifactId>
-			<version>${aws.version}</version>
-		</dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>netty-nio-client</artifactId>
+        </dependency>
 		<dependency>
 			<groupId>javax.inject</groupId>
 			<artifactId>javax.inject</artifactId>
@@ -188,6 +190,17 @@
 			</exclusions>
 		</dependency>
 	</dependencies>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>bom</artifactId>
+                <version>2.10.6</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 	<build>
 		<plugins>
 			<plugin>

--- a/src/main/java/com/hedera/mirror/config/MirrorNodeConfiguration.java
+++ b/src/main/java/com/hedera/mirror/config/MirrorNodeConfiguration.java
@@ -20,34 +20,17 @@ package com.hedera.mirror.config;
  * ‍
  */
 
-import com.amazonaws.ClientConfiguration;
-import com.amazonaws.Request;
-
-import com.amazonaws.Response;
-
-import com.amazonaws.auth.AWSCredentials;
-
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.AnonymousAWSCredentials;
-
-import com.amazonaws.auth.BasicAWSCredentials;
-
-import com.amazonaws.client.builder.AwsClientBuilder;
-import com.amazonaws.handlers.RequestHandler2;
-import com.amazonaws.retry.PredefinedRetryPolicies;
-import com.amazonaws.retry.RetryPolicy;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3Client;
-import com.amazonaws.services.s3.AmazonS3ClientBuilder;
-
-import com.amazonaws.services.s3.transfer.TransferManager;
-import com.amazonaws.services.s3.transfer.TransferManagerBuilder;
-
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
+import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
 import com.hedera.mirror.downloader.CommonDownloaderProperties;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.flywaydb.core.api.configuration.FluentConfiguration;
 import org.flywaydb.core.api.migration.JavaMigration;
 import org.flywaydb.core.api.resolver.*;
@@ -64,12 +47,11 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+import java.net.URI;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 
 @Configuration
 @EnableAsync
@@ -109,47 +91,26 @@ public class MirrorNodeConfiguration {
     }
 
     @Bean
-    AmazonS3 s3Client(CommonDownloaderProperties downloaderProperties) {
-        RetryPolicy retryPolicy = PredefinedRetryPolicies.getDefaultRetryPolicyWithCustomMaxRetries(5);
-        ClientConfiguration clientConfiguration = new ClientConfiguration();
-        clientConfiguration.setRetryPolicy(retryPolicy);
-        clientConfiguration.setMaxConnections(downloaderProperties.getMaxConnections());
+    public S3AsyncClient s3AsyncClient(CommonDownloaderProperties downloaderProperties) {
+        SdkAsyncHttpClient httpClient = NettyNioAsyncHttpClient.builder()
+                .maxConcurrency(downloaderProperties.getMaxConcurrency())
+                .maxPendingConnectionAcquires(downloaderProperties.getMaxPendingAcquires())
+                .connectionMaxIdleTime(Duration.ofSeconds(5))  // https://github.com/aws/aws-sdk-java-v2/issues/1122
+                .build();
 
-        RequestHandler2 errorHandler = new RequestHandler2() {
-            private Logger logger = LogManager.getLogger(AmazonS3Client.class);
-
-            @Override
-            public void afterError(Request<?> request, Response<?> response, Exception e) {
-                logger.error("Error calling {} {}", request.getHttpMethod(), request.getEndpoint(), e);
-            }
-        };
-
-        AWSCredentials awsCredentials = new AnonymousAWSCredentials();
+        AwsCredentialsProvider awsCredentials = AnonymousCredentialsProvider.create();
 
         if (StringUtils.isNotBlank(downloaderProperties.getAccessKey()) &&
                 StringUtils.isNotBlank(downloaderProperties.getSecretKey())) {
-            awsCredentials = new BasicAWSCredentials(downloaderProperties.getAccessKey(), downloaderProperties
-                    .getSecretKey());
+            awsCredentials = StaticCredentialsProvider.create(
+                    AwsBasicCredentials.create(downloaderProperties.getAccessKey(), downloaderProperties.getSecretKey()));
         }
 
-        return AmazonS3ClientBuilder.standard()
-                .withClientConfiguration(clientConfiguration)
-                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
-                .withEndpointConfiguration(
-                        new AwsClientBuilder.EndpointConfiguration(downloaderProperties.getCloudProvider().getEndpoint(), downloaderProperties.getRegion()))
-                .withRequestHandlers(errorHandler)
+        return S3AsyncClient.builder()
+                .credentialsProvider(awsCredentials)
+                .endpointOverride(URI.create(downloaderProperties.getCloudProvider().getEndpoint()))
+                .region(Region.of(downloaderProperties.getRegion()))
+                .httpClient(httpClient)
                 .build();
-    }
-
-    @Bean
-    public TransferManager transferManager(CommonDownloaderProperties downloaderProperties) {
-        TransferManager transferManager = TransferManagerBuilder.standard()
-                .withExecutorFactory(() -> new ThreadPoolExecutor(downloaderProperties.getMinThreads(), downloaderProperties
-                        .getMaxThreads(),
-                        120, TimeUnit.SECONDS, new ArrayBlockingQueue<>(downloaderProperties.getMaxQueued())))
-                .withS3Client(s3Client(downloaderProperties))
-                .build();
-        Runtime.getRuntime().addShutdownHook(new Thread(transferManager::shutdownNow));
-        return transferManager;
     }
 }

--- a/src/main/java/com/hedera/mirror/downloader/CommonDownloaderProperties.java
+++ b/src/main/java/com/hedera/mirror/downloader/CommonDownloaderProperties.java
@@ -39,6 +39,8 @@ public class CommonDownloaderProperties {
 
     private String accessKey;
 
+    private String secretKey;
+
     @NotBlank
     private String bucketName;
 
@@ -52,9 +54,6 @@ public class CommonDownloaderProperties {
     private int maxPendingAcquires = 10000; // aws sdk default = 10,000
 
     private String region = "us-east-1";
-
-    private String secretKey;
-
 
     @Getter
     @RequiredArgsConstructor

--- a/src/main/java/com/hedera/mirror/downloader/CommonDownloaderProperties.java
+++ b/src/main/java/com/hedera/mirror/downloader/CommonDownloaderProperties.java
@@ -46,16 +46,10 @@ public class CommonDownloaderProperties {
     private CloudProvider cloudProvider = CloudProvider.S3;
 
     @Min(0)
-    private int maxConnections = 500;
-
-    @Min(1)
-    private int maxQueued = 500;
-
-    @Min(1)
-    private int maxThreads = 60;
+    private int maxConcurrency = 1000; // aws sdk default = 50
 
     @Min(0)
-    private int minThreads = 20;
+    private int maxPendingAcquires = 10000; // aws sdk default = 10,000
 
     private String region = "us-east-1";
 

--- a/src/main/java/com/hedera/mirror/downloader/Downloader.java
+++ b/src/main/java/com/hedera/mirror/downloader/Downloader.java
@@ -35,13 +35,9 @@ import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
-import software.amazon.awssdk.services.s3.model.GetObjectResponse;
-import software.amazon.awssdk.services.s3.model.ListObjectsResponse;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
 import software.amazon.awssdk.services.s3.model.S3Object;
-import software.amazon.awssdk.services.s3.paginators.ListObjectsV2Iterable;
-import software.amazon.awssdk.services.s3.paginators.ListObjectsV2Publisher;
 
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
@@ -49,11 +45,8 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -196,9 +189,7 @@ public abstract class Downloader {
 		Stopwatch stopwatch = Stopwatch.createStarted();
 		signatureDownloadThreadPool.invokeAll(tasks);
 		if (totalDownloads.get() > 0) {
-			double rate = stopwatch.elapsed(TimeUnit.MILLISECONDS);
-			if (0 == rate) rate = 1;
-			rate = 1000.0 * totalDownloads.get() / rate;
+			var rate = (int)(1000000.0 * totalDownloads.get() / stopwatch.elapsed(TimeUnit.MICROSECONDS));
 			log.info("Downloaded {} signatures in {} ({}/s)", totalDownloads, stopwatch, rate);
 		}
 		return sigFilesMap;

--- a/src/main/java/com/hedera/mirror/downloader/Downloader.java
+++ b/src/main/java/com/hedera/mirror/downloader/Downloader.java
@@ -20,12 +20,6 @@ package com.hedera.mirror.downloader;
  * ‍
  */
 
-import com.amazonaws.services.s3.model.ListObjectsRequest;
-import com.amazonaws.services.s3.model.ObjectListing;
-import com.amazonaws.services.s3.model.S3ObjectSummary;
-import com.amazonaws.services.s3.transfer.Download;
-import com.amazonaws.services.s3.transfer.TransferManager;
-
 import com.google.common.base.Stopwatch;
 
 import com.hedera.mirror.addressbook.NetworkAddressBook;
@@ -38,6 +32,16 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.ListObjectsResponse;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.S3Object;
+import software.amazon.awssdk.services.s3.paginators.ListObjectsV2Iterable;
+import software.amazon.awssdk.services.s3.paginators.ListObjectsV2Publisher;
 
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
@@ -53,6 +57,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -63,7 +68,7 @@ import java.util.stream.Collectors;
 public abstract class Downloader {
 	protected final Logger log = LogManager.getLogger(getClass());
 
-	private final TransferManager transferManager;
+	private final S3AsyncClient s3Client;
 	private List<String> nodeAccountIds;
 	private final ApplicationStatusRepository applicationStatusRepository;
     private final NetworkAddressBook networkAddressBook;
@@ -71,25 +76,15 @@ public abstract class Downloader {
     // Thread pool used one per node during the download process for signatures.
 	private final ExecutorService signatureDownloadThreadPool;
 
-    private final Comparator<String> s3KeyComparator;
-
-    public Downloader(TransferManager transferManager, ApplicationStatusRepository applicationStatusRepository,
+    public Downloader(S3AsyncClient s3Client, ApplicationStatusRepository applicationStatusRepository,
                       NetworkAddressBook networkAddressBook, DownloaderProperties downloaderProperties) {
-	    this.transferManager = transferManager;
+	    this.s3Client = s3Client;
 		this.applicationStatusRepository = applicationStatusRepository;
 		this.networkAddressBook = networkAddressBook;
 		this.downloaderProperties = downloaderProperties;
 		signatureDownloadThreadPool = Executors.newFixedThreadPool(downloaderProperties.getThreads());
 		nodeAccountIds = networkAddressBook.load().stream().map(NodeAddress::getId).collect(Collectors.toList());
         Runtime.getRuntime().addShutdownHook(new Thread(signatureDownloadThreadPool::shutdown));
-
-        s3KeyComparator = (String o1, String o2) -> {
-            Instant o1TimeStamp = Utility.parseToInstant(Utility.parseS3SummaryKey(o1).getMiddle());
-            Instant o2TimeStamp = Utility.parseToInstant(Utility.parseS3SummaryKey(o2).getMiddle());
-            if (o1TimeStamp == null) return -1;
-            if (o2TimeStamp == null) return 1;
-            return o1TimeStamp.compareTo(o2TimeStamp);
-        };
 	}
 
 	protected void downloadNextBatch() {
@@ -118,11 +113,13 @@ public abstract class Downloader {
      *  @return
      *      key: sig file name
      *      value: a list of sig files with the same name and from different nodes folder;
-     * @throws Exception
      */
 	private Map<String, List<File>> downloadSigFiles() throws InterruptedException {
 		String s3Prefix = downloaderProperties.getPrefix();
 		String lastValidFileName = applicationStatusRepository.findByStatusCode(getLastValidDownloadedFileKey());
+        // foo.rcd < foo.rcd_sig. If we read foo.rcd from application stats, we have to start listing from
+        // next to 'foo.rcd_sig'.
+        String lastValidSigFileName = lastValidFileName.isEmpty() ? "" : lastValidFileName + "_sig";
 
 		final var sigFilesMap = new ConcurrentHashMap<String, List<File>>();
 
@@ -136,57 +133,33 @@ public abstract class Downloader {
 		 */
 		for (String nodeAccountId : nodeAccountIds) {
 			tasks.add(Executors.callable(() -> {
-				log.debug("Downloading signature files for node {} created after file {}", nodeAccountId, lastValidFileName);
+				log.debug("Downloading signature files for node {} created after file {}", nodeAccountId, lastValidSigFileName);
 				// Get a list of objects in the bucket, 100 at a time
 				String prefix = s3Prefix + nodeAccountId + "/";
-				int downloadCount = 0;
-				int downloadMax = downloaderProperties.getBatchSize();
 				Stopwatch stopwatch = Stopwatch.createStarted();
 
-				try {
-					// batchSize (number of items we plan do download in a single batch) times 2 for file + sig
-					// + 5 for any other files we may skip
-					final var listSize = (downloaderProperties.getBatchSize() * 2) + 5;
-					ListObjectsRequest listRequest = new ListObjectsRequest()
-							.withBucketName(downloaderProperties.getCommon().getBucketName())
-							.withPrefix(prefix)
-							.withDelimiter("/")
-							.withMarker(prefix + lastValidFileName)
-							.withMaxKeys(listSize);
-					ObjectListing objects = transferManager.getAmazonS3Client().listObjects(listRequest);
-					var pendingDownloads = new LinkedList<PendingDownload>();
-					// Loop through the list of remote files beginning a download for each relevant sig file.
-
-					while (downloadCount <= downloadMax) {
-						List<S3ObjectSummary> summaries = objects.getObjectSummaries();
-						for (S3ObjectSummary summary : summaries) {
-							if (downloadCount >= downloadMax) {
-								break;
-							}
-
-							String s3ObjectKey = summary.getKey();
-
-							if (s3ObjectKey.endsWith("_sig") &&
-									(s3KeyComparator.compare(s3ObjectKey, prefix + lastValidFileName) > 0 || lastValidFileName.isEmpty())) {
-								Path saveTarget = downloaderProperties.getStreamPath().getParent().resolve(s3ObjectKey);
-								try {
-									pendingDownloads.add(saveToLocalAsync(s3ObjectKey, saveTarget));
-                                    downloadCount++;
-                                    totalDownloads.incrementAndGet();
-								} catch (Exception ex) {
-									log.error("Failed downloading {}", s3ObjectKey, ex);
-									return;
-								}
-							}
-						}
-						if (downloadCount >= downloadMax) {
-							break;
-						} else if (objects.isTruncated()) {
-							objects = transferManager.getAmazonS3Client().listNextBatchOfObjects(objects);
-						} else {
-							break;
-						}
-					}
+                try {
+                    // batchSize (number of items we plan do download in a single batch) times 2 for file + sig
+                    final var listSize = (downloaderProperties.getBatchSize() * 2);
+                    ListObjectsV2Request listRequest = ListObjectsV2Request.builder()
+                            .bucket(downloaderProperties.getCommon().getBucketName())
+                            .prefix(prefix)
+                            .delimiter("/")
+                            .startAfter(prefix + lastValidSigFileName)
+                            .maxKeys(listSize)
+                            .build();
+                    CompletableFuture<ListObjectsV2Response> response = s3Client.listObjectsV2(listRequest);
+                    var pendingDownloads = new ArrayList<PendingDownload>(downloaderProperties.getBatchSize());
+                    // Loop through the list of remote files beginning a download for each relevant sig file.
+                    for (S3Object content : response.get().contents()) {
+                        String s3ObjectKey = content.key();
+                        if (s3ObjectKey.endsWith("_sig")) {
+                            Path saveTarget = downloaderProperties.getStreamPath().getParent().resolve(s3ObjectKey);
+                            Utility.ensureDirectory(saveTarget.getParent());
+                            pendingDownloads.add(saveToLocalAsync(s3ObjectKey, saveTarget));
+                            totalDownloads.incrementAndGet();
+                        }
+                    }
 
 					/*
 					 * With the list of pending downloads - wait for them to complete and add them to the list
@@ -238,11 +211,20 @@ public abstract class Downloader {
 	 * @param localFile
 	 * @return
 	 */
-	private PendingDownload saveToLocalAsync(String s3ObjectKey, Path localFile) {
+    private PendingDownload saveToLocalAsync(String s3ObjectKey, Path localFile) {
         File file = localFile.toFile();
-		Download download = transferManager.download(downloaderProperties.getCommon().getBucketName(), s3ObjectKey, file);
-		return new PendingDownload(download, file, s3ObjectKey);
-	}
+        // If process stops abruptly and is restarted, it's possible we try to re-download some of the files which
+        // already exist on disk because lastValidFileName wasn't updated. AsyncFileResponseTransformer throws
+        // exceptions if a file already exists, rather then silently overwrite it. So following check and short-circuit
+        // are to avoid log spam of java.nio.file.FileAlreadyExistsException, not for optimization purpose.
+        if (file.exists()) {
+            return new PendingDownload(CompletableFuture.completedFuture(null), file, s3ObjectKey);
+        }
+        var future = s3Client.getObject(
+                GetObjectRequest.builder().bucket(downloaderProperties.getCommon().getBucketName()).key(s3ObjectKey).build(),
+                AsyncResponseTransformer.toFile(file));
+        return new PendingDownload(future, file, s3ObjectKey);
+    }
 
 	/**
 	 * Moves a file from one location to another

--- a/src/main/java/com/hedera/mirror/downloader/PendingDownload.java
+++ b/src/main/java/com/hedera/mirror/downloader/PendingDownload.java
@@ -24,7 +24,6 @@ import com.google.common.base.Stopwatch;
 import lombok.Value;
 import lombok.experimental.NonFinal;
 import lombok.extern.log4j.Log4j2;
-import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 
 import java.io.File;
 import java.util.concurrent.CompletableFuture;

--- a/src/main/java/com/hedera/mirror/downloader/balance/AccountBalancesDownloader.java
+++ b/src/main/java/com/hedera/mirror/downloader/balance/AccountBalancesDownloader.java
@@ -20,8 +20,6 @@ package com.hedera.mirror.downloader.balance;
  * ‍
  */
 
-import com.amazonaws.services.s3.transfer.TransferManager;
-
 import com.hedera.mirror.addressbook.NetworkAddressBook;
 import com.hedera.mirror.domain.ApplicationStatusCode;
 import com.hedera.mirror.downloader.Downloader;
@@ -29,6 +27,7 @@ import com.hedera.mirror.repository.ApplicationStatusRepository;
 import lombok.extern.log4j.Log4j2;
 
 import org.springframework.scheduling.annotation.Scheduled;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
 
 import javax.inject.Named;
 import java.io.File;
@@ -38,9 +37,9 @@ import java.io.File;
 public class AccountBalancesDownloader extends Downloader {
 
     public AccountBalancesDownloader(
-            TransferManager transferManager, ApplicationStatusRepository applicationStatusRepository,
+            S3AsyncClient s3Client, ApplicationStatusRepository applicationStatusRepository,
             NetworkAddressBook networkAddressBook, BalanceDownloaderProperties downloaderProperties) {
-        super(transferManager, applicationStatusRepository, networkAddressBook, downloaderProperties);
+        super(s3Client, applicationStatusRepository, networkAddressBook, downloaderProperties);
     }
 
     @Scheduled(fixedRateString = "${hedera.mirror.downloader.balance.frequency:500}")

--- a/src/main/java/com/hedera/mirror/downloader/event/EventStreamFileDownloader.java
+++ b/src/main/java/com/hedera/mirror/downloader/event/EventStreamFileDownloader.java
@@ -20,8 +20,6 @@ package com.hedera.mirror.downloader.event;
  * ‍
  */
 
-import com.amazonaws.services.s3.transfer.TransferManager;
-
 import com.hedera.mirror.addressbook.NetworkAddressBook;
 import com.hedera.mirror.domain.ApplicationStatusCode;
 import com.hedera.mirror.downloader.Downloader;
@@ -30,6 +28,7 @@ import com.hedera.mirror.parser.event.EventStreamFileParser;
 
 import lombok.extern.log4j.Log4j2;
 import org.springframework.scheduling.annotation.Scheduled;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
 
 import javax.inject.Named;
 
@@ -38,9 +37,9 @@ import javax.inject.Named;
 public class EventStreamFileDownloader extends Downloader {
 
     public EventStreamFileDownloader(
-            TransferManager transferManager, ApplicationStatusRepository applicationStatusRepository,
+            S3AsyncClient s3Client, ApplicationStatusRepository applicationStatusRepository,
             NetworkAddressBook networkAddressBook, EventDownloaderProperties downloaderProperties) {
-        super(transferManager, applicationStatusRepository, networkAddressBook, downloaderProperties);
+        super(s3Client, applicationStatusRepository, networkAddressBook, downloaderProperties);
     }
 
     @Scheduled(fixedRateString = "${hedera.mirror.downloader.event.frequency:60000}")

--- a/src/main/java/com/hedera/mirror/downloader/record/RecordFileDownloader.java
+++ b/src/main/java/com/hedera/mirror/downloader/record/RecordFileDownloader.java
@@ -20,8 +20,6 @@ package com.hedera.mirror.downloader.record;
  * ‍
  */
 
-import com.amazonaws.services.s3.transfer.TransferManager;
-
 import com.hedera.mirror.addressbook.NetworkAddressBook;
 import com.hedera.mirror.downloader.Downloader;
 import com.hedera.mirror.domain.ApplicationStatusCode;
@@ -30,6 +28,7 @@ import com.hedera.mirror.parser.record.RecordFileParser;
 
 import lombok.extern.log4j.Log4j2;
 import org.springframework.scheduling.annotation.Scheduled;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
 
 import javax.inject.Named;
 
@@ -38,9 +37,9 @@ import javax.inject.Named;
 public class RecordFileDownloader extends Downloader {
 
     public RecordFileDownloader(
-            TransferManager transferManager, ApplicationStatusRepository applicationStatusRepository,
+            S3AsyncClient s3Client, ApplicationStatusRepository applicationStatusRepository,
             NetworkAddressBook networkAddressBook, RecordDownloaderProperties downloaderProperties) {
-        super(transferManager, applicationStatusRepository, networkAddressBook, downloaderProperties);
+        super(s3Client, applicationStatusRepository, networkAddressBook, downloaderProperties);
     }
 
     @Scheduled(fixedRateString = "${hedera.mirror.downloader.record.frequency:500}")

--- a/src/test/java/com/hedera/mirror/downloader/balance/AccountBalancesDownloaderTest.java
+++ b/src/test/java/com/hedera/mirror/downloader/balance/AccountBalancesDownloaderTest.java
@@ -65,7 +65,7 @@ public class AccountBalancesDownloaderTest {
     private BalanceDownloaderProperties downloaderProperties;
 
     @BeforeEach
-    void before() throws Exception {
+    void before() {
         mirrorProperties = new MirrorProperties();
         mirrorProperties.setDataPath(dataPath);
         mirrorProperties.setNetwork(HederaNetwork.TESTNET);

--- a/src/test/java/com/hedera/mirror/downloader/balance/AccountBalancesDownloaderTest.java
+++ b/src/test/java/com/hedera/mirror/downloader/balance/AccountBalancesDownloaderTest.java
@@ -76,9 +76,9 @@ public class AccountBalancesDownloaderTest {
         downloaderProperties = new BalanceDownloaderProperties(mirrorProperties, commonDownloaderProperties);
         downloaderProperties.init();
         networkAddressBook = new NetworkAddressBook(mirrorProperties);
-        TransferManager transferManager = new MirrorNodeConfiguration().transferManager(commonDownloaderProperties);
+        var s3AsyncClient = (new MirrorNodeConfiguration()).s3AsyncClient(commonDownloaderProperties);
 
-        downloader = new AccountBalancesDownloader(transferManager, applicationStatusRepository, networkAddressBook, downloaderProperties);
+        downloader = new AccountBalancesDownloader(s3AsyncClient, applicationStatusRepository, networkAddressBook, downloaderProperties);
 
         fileCopier = FileCopier.create(Utility.getResource("data").toPath(), s3Path)
                 .from(downloaderProperties.getStreamType().getPath())

--- a/src/test/java/com/hedera/mirror/downloader/balance/AccountBalancesDownloaderTest.java
+++ b/src/test/java/com/hedera/mirror/downloader/balance/AccountBalancesDownloaderTest.java
@@ -20,8 +20,6 @@ package com.hedera.mirror.downloader.balance;
  * ‍
  */
 
-import com.amazonaws.services.s3.transfer.TransferManager;
-
 import com.hedera.FileCopier;
 import com.hedera.mirror.addressbook.NetworkAddressBook;
 import com.hedera.mirror.MirrorProperties;
@@ -36,6 +34,7 @@ import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -48,7 +47,7 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 public class AccountBalancesDownloaderTest {
 
-    @Mock
+    @Mock(answer = Answers.RETURNS_SMART_NULLS)
     private ApplicationStatusRepository applicationStatusRepository;
 
     @TempDir
@@ -73,6 +72,8 @@ public class AccountBalancesDownloaderTest {
         commonDownloaderProperties = new CommonDownloaderProperties();
         commonDownloaderProperties.setBucketName("test");
         commonDownloaderProperties.setCloudProvider(CommonDownloaderProperties.CloudProvider.LOCAL);
+        commonDownloaderProperties.setAccessKey("x"); // https://github.com/findify/s3mock/issues/147
+        commonDownloaderProperties.setSecretKey("x");
         downloaderProperties = new BalanceDownloaderProperties(mirrorProperties, commonDownloaderProperties);
         downloaderProperties.init();
         networkAddressBook = new NetworkAddressBook(mirrorProperties);
@@ -86,8 +87,6 @@ public class AccountBalancesDownloaderTest {
 
         s3 = S3Mock.create(8001, s3Path.toString());
         s3.start();
-
-        when(applicationStatusRepository.findByStatusCode(ApplicationStatusCode.LAST_VALID_DOWNLOADED_BALANCE_FILE)).thenReturn("");
     }
 
     @AfterEach

--- a/src/test/java/com/hedera/mirror/downloader/record/RecordFileDownloaderTest.java
+++ b/src/test/java/com/hedera/mirror/downloader/record/RecordFileDownloaderTest.java
@@ -78,9 +78,9 @@ public class RecordFileDownloaderTest {
         downloaderProperties = new RecordDownloaderProperties(mirrorProperties, commonDownloaderProperties);
         downloaderProperties.init();
         networkAddressBook = new NetworkAddressBook(mirrorProperties);
-        TransferManager transferManager = new MirrorNodeConfiguration().transferManager(commonDownloaderProperties);
+        var s3AsyncClient = (new MirrorNodeConfiguration()).s3AsyncClient(commonDownloaderProperties);
 
-        downloader = new RecordFileDownloader(transferManager, applicationStatusRepository, networkAddressBook, downloaderProperties);
+        downloader = new RecordFileDownloader(s3AsyncClient, applicationStatusRepository, networkAddressBook, downloaderProperties);
 
         fileCopier = FileCopier.create(Utility.getResource("data").toPath(), s3Path)
                 .from(downloaderProperties.getStreamType().getPath(), "v2")

--- a/src/test/java/com/hedera/mirror/downloader/record/RecordFileDownloaderTest.java
+++ b/src/test/java/com/hedera/mirror/downloader/record/RecordFileDownloaderTest.java
@@ -20,8 +20,6 @@ package com.hedera.mirror.downloader.record;
  * ‍
  */
 
-import com.amazonaws.services.s3.transfer.TransferManager;
-
 import com.hedera.FileCopier;
 import com.hedera.mirror.addressbook.NetworkAddressBook;
 import com.hedera.mirror.MirrorProperties;
@@ -75,6 +73,8 @@ public class RecordFileDownloaderTest {
         commonDownloaderProperties = new CommonDownloaderProperties();
         commonDownloaderProperties.setBucketName("test");
         commonDownloaderProperties.setCloudProvider(CommonDownloaderProperties.CloudProvider.LOCAL);
+        commonDownloaderProperties.setAccessKey("x"); // https://github.com/findify/s3mock/issues/147
+        commonDownloaderProperties.setSecretKey("x");
         downloaderProperties = new RecordDownloaderProperties(mirrorProperties, commonDownloaderProperties);
         downloaderProperties.init();
         networkAddressBook = new NetworkAddressBook(mirrorProperties);


### PR DESCRIPTION
**Detailed description**:
- Removed TransferManager
- Removed configs for threads.
- SDKv2 has AsyncResponseTransformer.toBytes() to download object data direcly in memory i.e. without downloading it to a file first.

Signed-off-by: Apekshit Sharma <apekshit.sharma@hedera.com>

**Which issue(s) this PR fixes**:
#314 

**Checklist**
- [ ] Documentation added
- [x] Tests updated

----

### Compare download speed of SDKv1 and SDKv2

Testing methodology:
- Tested with record downloader only. Disabled other parts: Removed `@Scheduled` from balance downloader, events downloader+parser, and records parser.

#### SDKv2
maxConcurrency: 1000
batchSize
*= 20*
`2019-11-02 12:41:42,577 INFO  [scheduling-2] c.h.m.d.r.RecordFileDownloader Downloaded 200 signatures in 1.702 s (117.50881316098707/s)`
`2019-11-02 12:41:48,249 INFO  [scheduling-1] c.h.m.d.r.RecordFileDownloader Downloaded 200 signatures in 2.886 s (69.32409012131716/s)`
`2019-11-02 12:41:52,413 INFO  [scheduling-3] c.h.m.d.r.RecordFileDownloader Downloaded 200 signatures in 1.467 s (136.332651670075/s)`
`2019-11-02 12:41:55,589 INFO  [scheduling-2] c.h.m.d.r.RecordFileDownloader Downloaded 200 signatures in 473.6 ms (422.8329809725159/s)`
 
*= 50*
`2019-11-02 12:40:49,849 INFO  [scheduling-1] c.h.m.d.r.RecordFileDownloader Downloaded 500 signatures in 2.116 s (236.29489603024575/s)`
`2019-11-02 12:40:59,264 INFO  [scheduling-2] c.h.m.d.r.RecordFileDownloader Downloaded 500 signatures in 2.543 s (196.6955153422502/s)`
`2019-11-02 12:41:08,534 INFO  [scheduling-1] c.h.m.d.r.RecordFileDownloader Downloaded 500 signatures in 2.663 s (187.75816748028538/s)`

*= 100*
`2019-11-02 12:39:43,396 INFO  [scheduling-1] c.h.m.d.r.RecordFileDownloader Downloaded 1000 signatures in 4.385 s (228.1021897810219/s)`
`2019-11-02 12:40:02,000 INFO  [scheduling-1] c.h.m.d.r.RecordFileDownloader Downloaded 1000 signatures in 4.568 s (218.96211955331728/s)`
`2019-11-02 12:40:22,508 INFO  [scheduling-2] c.h.m.d.r.RecordFileDownloader Downloaded 1000 signatures in 5.148 s (194.25019425019426/s)`

#### SDKv1
maxConnections=1000.  Others default(minThreads=20, maxThreads=60, maxQueued = 500)
batchSize
*= 20*
`2019-11-02 13:01:04,457 INFO  [scheduling-1] c.h.m.d.r.RecordFileDownloader Downloaded 200 signatures in 5.151 s (38.83495145631068/s)`
`2019-11-02 13:01:15,425 INFO  [scheduling-2] c.h.m.d.r.RecordFileDownloader Downloaded 200 signatures in 4.796 s (41.70141784820684/s)`
`2019-11-02 13:01:26,696 INFO  [scheduling-1] c.h.m.d.r.RecordFileDownloader Downloaded 200 signatures in 4.586 s (43.61098996947231/s)`

*= 50*
`2019-11-02 12:51:33,750 INFO  [scheduling-1] c.h.m.d.r.RecordFileDownloader Downloaded 500 signatures in 10.14 s (49.333991119881595/s)`
`2019-11-02 12:52:01,091 INFO  [scheduling-1] c.h.m.d.r.RecordFileDownloader Downloaded 500 signatures in 10.33 s (48.4214603912454/s)`
`2019-11-02 12:52:26,086 INFO  [scheduling-2] c.h.m.d.r.RecordFileDownloader Downloaded 500 signatures in 9.876 s (50.63291139240506/s)`

*= 100*
`2019-11-02 12:57:33,557 INFO  [scheduling-2] c.h.m.d.r.RecordFileDownloader Downloaded 1000 signatures in 19.54 s (51.174453712706615/s)`
`2019-11-02 12:58:25,339 INFO  [scheduling-2] c.h.m.d.r.RecordFileDownloader Downloaded 1000 signatures in 19.76 s (50.60216577269507/s)`
`2019-11-02 12:59:16,428 INFO  [scheduling-2] c.h.m.d.r.RecordFileDownloader Downloaded 1000 signatures in 20.27 s (49.33885928557332/s)`
