### PR TITLE
NetworkAddressBook improvements

### DIFF
--- a/src/main/java/com/hedera/mirror/downloader/NodeSignatureVerifier.java
+++ b/src/main/java/com/hedera/mirror/downloader/NodeSignatureVerifier.java
@@ -21,14 +21,12 @@ package com.hedera.mirror.downloader;
  */
 
 import com.hedera.mirror.addressbook.NetworkAddressBook;
-import com.hedera.mirror.domain.NodeAddress;
 import com.hedera.utilities.Utility;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.lang3.tuple.Pair;
 
-import javax.persistence.Tuple;
 import java.io.File;
 import java.security.PublicKey;
 import java.security.Signature;
@@ -38,19 +36,15 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 @Log4j2
-public class NodeSignatureVerifier {
+class NodeSignatureVerifier {
 
-	private final Map<String, PublicKey> nodeIDPubKeyMap;
+    private final Map<String, PublicKey> nodeIDPubKeyMap;
 
-	public NodeSignatureVerifier(NetworkAddressBook networkAddressBook) {
-		nodeIDPubKeyMap = networkAddressBook
-                .load()
-                .stream()
-                .collect(Collectors.toMap(NodeAddress::getId, NodeAddress::getPublicKeyAsObject));
-	}
+    NodeSignatureVerifier(NetworkAddressBook networkAddressBook) {
+        nodeIDPubKeyMap = networkAddressBook.getNodeIDPubKeyMap();
+    }
 
     /**
      * Verifies that the signature files are signed by corresponding node's PublicKey. For valid signature files, we
@@ -62,7 +56,7 @@ public class NodeSignatureVerifier {
      *     agreed by super-majority nodes.
      *     If validity of signatures can not be established, then returns <null, empty list>.
      */
-    public Pair<byte[], List<File>> verifySignatureFiles(List<File> sigFiles) {
+    Pair<byte[], List<File>> verifySignatureFiles(List<File> sigFiles) {
         // If a signature is valid, we put the Hash in its content and its File to the map, to see if more than 2/3
         // valid signatures have the same Hash
         Map<String, Set<File>> hashToSigFiles = new HashMap<>();

--- a/src/main/java/com/hedera/mirror/parser/record/RecordFileParser.java
+++ b/src/main/java/com/hedera/mirror/parser/record/RecordFileParser.java
@@ -31,6 +31,8 @@ import java.util.stream.Collectors;
 
 import com.google.common.base.Stopwatch;
 import com.google.protobuf.TextFormat;
+
+import com.hedera.mirror.addressbook.NetworkAddressBook;
 import com.hedera.mirror.domain.ApplicationStatusCode;
 import com.hedera.mirror.repository.ApplicationStatusRepository;
 import com.hedera.filedelimiters.FileDelimiter;
@@ -56,10 +58,12 @@ public class RecordFileParser implements FileParser {
 	private final ApplicationStatusRepository applicationStatusRepository;
 	private final RecordParserProperties parserProperties;
 
-	public RecordFileParser(ApplicationStatusRepository applicationStatusRepository, RecordParserProperties parserProperties) {
+	public RecordFileParser(ApplicationStatusRepository applicationStatusRepository,
+                            NetworkAddressBook networkAddressBook, RecordParserProperties parserProperties) {
 		this.applicationStatusRepository = applicationStatusRepository;
 		this.parserProperties = parserProperties;
 		RecordFileLogger.parserProperties = parserProperties;
+        RecordFileLogger.networkAddressBook = networkAddressBook;
 	}
 
 	/**

--- a/src/main/java/com/hedera/recordFileLogger/RecordFileLogger.java
+++ b/src/main/java/com/hedera/recordFileLogger/RecordFileLogger.java
@@ -27,7 +27,6 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
-import java.time.Instant;
 import java.util.HashMap;
 
 import com.hedera.databaseUtilities.DatabaseUtilities;
@@ -40,7 +39,6 @@ import com.hederahashgraph.api.proto.java.ContractUpdateTransactionBody;
 import com.hederahashgraph.api.proto.java.CryptoAddClaimTransactionBody;
 import com.hederahashgraph.api.proto.java.CryptoCreateTransactionBody;
 import com.hederahashgraph.api.proto.java.CryptoUpdateTransactionBody;
-import com.hederahashgraph.api.proto.java.Duration;
 import com.hederahashgraph.api.proto.java.FileAppendTransactionBody;
 import com.hederahashgraph.api.proto.java.FileCreateTransactionBody;
 import com.hederahashgraph.api.proto.java.FileID;
@@ -59,6 +57,7 @@ public class RecordFileLogger {
     public static Connection connect = null;
 	private static Entities entities = null;
 	public static RecordParserProperties parserProperties = null;
+    public static NetworkAddressBook networkAddressBook = null;
 
 	private static HashMap<String, Integer> transactionResults = null;
 	private static HashMap<String, Integer> transactionTypes = null;
@@ -627,7 +626,7 @@ public class RecordFileLogger {
 			// update the local address book
 			if (isFileAddressBook(transactionBody.getFileID())) {
 				// we have an address book update, refresh the local file
-				NetworkAddressBook.append(contents);
+				networkAddressBook.append(contents);
 			}
 		}
 	}
@@ -757,7 +756,7 @@ public class RecordFileLogger {
 		// update the local address book
 		if (isFileAddressBook(fileId)) {
 			// we have an address book update, refresh the local file
-			NetworkAddressBook.update(transactionBody.getContents().toByteArray());
+			networkAddressBook.update(transactionBody.getContents().toByteArray());
 		}
 	}
 

--- a/src/test/java/com/hedera/mirror/downloader/balance/AccountBalancesDownloaderTest.java
+++ b/src/test/java/com/hedera/mirror/downloader/balance/AccountBalancesDownloaderTest.java
@@ -111,17 +111,6 @@ public class AccountBalancesDownloaderTest {
     }
 
     @Test
-    @DisplayName("Missing address book")
-    void missingAddressBook() throws Exception {
-        Files.delete(mirrorProperties.getAddressBookPath());
-        fileCopier.copy();
-        downloader.download();
-        assertThat(Files.walk(downloaderProperties.getValidPath()))
-                .filteredOn(p -> !p.toFile().isDirectory())
-                .hasSize(0);
-    }
-
-    @Test
     @DisplayName("Max download items reached")
     void maxDownloadItemsReached() throws Exception {
         downloaderProperties.setBatchSize(1);


### PR DESCRIPTION
Main change:
Not read NAB from disk from about 10 different places.

Currently, all downloaders read NAB twice during each batch.
Once when downloading sig files, second time when creating
NodeSignatureVerifier (which does the read in its own ctor).

NetworkAddressBook class is a collection of static fns
for writing and a regular instance-based fn for reading.

Simplifying everything so that all reads are served from
in-memory bytes/datastructures and all writes update
in-memory copy when being persisted to disk.

Using synchronized for mutually exclusive reads/writes
also removes race condition which exists when
reading/writing directly from/to filesystem.

Signed-off-by: Apekshit Sharma <apekshit.sharma@hedera.com>


**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated

