### PR TITLE
Downloader: Better polling

### DIFF
--- a/src/main/java/com/hedera/mirror/downloader/Downloader.java
+++ b/src/main/java/com/hedera/mirror/downloader/Downloader.java
@@ -46,6 +46,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -88,13 +89,13 @@ public abstract class Downloader {
             if (downloaderProperties.isEnabled()) {
                 newFilesFound = download();
             }
-            // If no new files were found, do not sleep, keep processing. This is the usual case when mirror node is
-            // catching up.
+            // If new files were found, do not sleep, keep processing.
+            // During catchup, newFilesFound=true will be the usual case.
             if (!newFilesFound) {
                 try {
-                    log.debug("No new files found or downloaded is disabled, sleeping for {}",
-                            downloaderProperties.getSteadyStatePollDelay());
-                    Thread.sleep(downloaderProperties.getSteadyStatePollDelay().toMillis());
+                    Duration delay = downloaderProperties.getSteadyStatePollDelay();
+                    log.debug("No new files found or downloaded is disabled, sleeping for {}", delay);
+                    Thread.sleep(delay.toMillis());
                 } catch(InterruptedException e) {
                     log.info("Interrupted when downloader was sleeping", e);
                 }

--- a/src/main/java/com/hedera/mirror/downloader/DownloaderInitializer.java
+++ b/src/main/java/com/hedera/mirror/downloader/DownloaderInitializer.java
@@ -1,0 +1,33 @@
+package com.hedera.mirror.downloader;
+
+import com.hedera.mirror.downloader.balance.AccountBalancesDownloader;
+import com.hedera.mirror.downloader.event.EventStreamFileDownloader;
+
+import com.hedera.mirror.downloader.record.RecordFileDownloader;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Named;
+
+// This pattern to kick off downloaders using separate initializer class is based on example here:
+// https://docs.spring.io/spring/docs/5.2.x/spring-framework-reference/integration.html#scheduling-annotation-support-async
+@Named
+public class DownloaderInitializer {
+    private final AccountBalancesDownloader accountBalancesDownloader;
+    private final RecordFileDownloader recordFileDownloader;
+    private final EventStreamFileDownloader eventStreamFileDownloader;
+
+    public DownloaderInitializer(AccountBalancesDownloader accountBalancesDownloader,
+                                 RecordFileDownloader recordFileDownloader,
+                                 EventStreamFileDownloader eventStreamFileDownloader) {
+        this.accountBalancesDownloader = accountBalancesDownloader;
+        this.recordFileDownloader = recordFileDownloader;
+        this.eventStreamFileDownloader = eventStreamFileDownloader;
+    }
+
+    @PostConstruct
+    public void initialize() {
+        accountBalancesDownloader.run();
+        recordFileDownloader.run();
+        eventStreamFileDownloader.run();
+    }
+}

--- a/src/main/java/com/hedera/mirror/downloader/DownloaderProperties.java
+++ b/src/main/java/com/hedera/mirror/downloader/DownloaderProperties.java
@@ -25,6 +25,7 @@ import com.hedera.utilities.Utility;
 
 import javax.annotation.PostConstruct;
 import java.nio.file.Path;
+import java.time.Duration;
 
 public interface DownloaderProperties {
 
@@ -36,6 +37,8 @@ public interface DownloaderProperties {
      * The number of current mainnet nodes used to download signatures in parallel. Should be adjusted when nodes change
      */
     int getThreads();
+
+    Duration getSteadyStatePollDelay();
 
     String getPrefix();
 

--- a/src/main/java/com/hedera/mirror/downloader/balance/AccountBalancesDownloader.java
+++ b/src/main/java/com/hedera/mirror/downloader/balance/AccountBalancesDownloader.java
@@ -42,11 +42,6 @@ public class AccountBalancesDownloader extends Downloader {
         super(s3Client, applicationStatusRepository, networkAddressBook, downloaderProperties);
     }
 
-    @Scheduled(fixedRateString = "${hedera.mirror.downloader.balance.frequency:500}")
-    public void download() {
-        downloadNextBatch();
-    }
-
     @Override
     protected boolean verifyHashChain(File file) {
         return true;

--- a/src/main/java/com/hedera/mirror/downloader/balance/BalanceDownloaderProperties.java
+++ b/src/main/java/com/hedera/mirror/downloader/balance/BalanceDownloaderProperties.java
@@ -51,8 +51,9 @@ public class BalanceDownloaderProperties implements DownloaderProperties {
 
     private boolean enabled = true;
 
+    // If no new file is found, check again in 1 min. Balances files are generated every 15 min.
     @NotNull
-    private Duration frequency = Duration.ofMillis(500L);
+    private Duration steadyStatePollDelay = Duration.ofMinutes(1);
 
     @NotBlank
     private String prefix = "accountBalances/balance";

--- a/src/main/java/com/hedera/mirror/downloader/event/EventDownloaderProperties.java
+++ b/src/main/java/com/hedera/mirror/downloader/event/EventDownloaderProperties.java
@@ -51,8 +51,8 @@ public class EventDownloaderProperties implements DownloaderProperties {
 
     private boolean enabled = false;
 
-    // If no new file is found, check again in 1 min. Record files are generated every 5 sec, but there is no urgency
-    // to process them, hence the longer wait.
+    // If no new file is found, check again in 1 min. Event files are generated every 5 sec, but there is no urgency
+    // to process them since there is no real data in them right now, hence the longer wait.
     @NotNull
     private Duration steadyStatePollDelay = Duration.ofMinutes(1);
 

--- a/src/main/java/com/hedera/mirror/downloader/event/EventDownloaderProperties.java
+++ b/src/main/java/com/hedera/mirror/downloader/event/EventDownloaderProperties.java
@@ -51,8 +51,10 @@ public class EventDownloaderProperties implements DownloaderProperties {
 
     private boolean enabled = false;
 
+    // If no new file is found, check again in 1 min. Record files are generated every 5 sec, but there is no urgency
+    // to process them, hence the longer wait.
     @NotNull
-    private Duration frequency = Duration.ofMinutes(1L);
+    private Duration steadyStatePollDelay = Duration.ofMinutes(1);
 
     @NotBlank
     private String prefix = "eventsStreams/events_";

--- a/src/main/java/com/hedera/mirror/downloader/event/EventStreamFileDownloader.java
+++ b/src/main/java/com/hedera/mirror/downloader/event/EventStreamFileDownloader.java
@@ -42,11 +42,6 @@ public class EventStreamFileDownloader extends Downloader {
         super(s3Client, applicationStatusRepository, networkAddressBook, downloaderProperties);
     }
 
-    @Scheduled(fixedRateString = "${hedera.mirror.downloader.event.frequency:60000}")
-    public void download() {
-        downloadNextBatch();
-    }
-
     protected ApplicationStatusCode getLastValidDownloadedFileKey() {
         return ApplicationStatusCode.LAST_VALID_DOWNLOADED_EVENT_FILE;
     }

--- a/src/main/java/com/hedera/mirror/downloader/record/RecordDownloaderProperties.java
+++ b/src/main/java/com/hedera/mirror/downloader/record/RecordDownloaderProperties.java
@@ -49,8 +49,9 @@ public class RecordDownloaderProperties implements DownloaderProperties {
 
     private boolean enabled = true;
 
+    // If no new file is found, check again in 3 sec. Record files are generated every 5 sec.
     @NotNull
-    private Duration frequency = Duration.ofMillis(500L);
+    private Duration steadyStatePollDelay = Duration.ofSeconds(3);
 
     @NotBlank
     private String prefix = "recordstreams/record";

--- a/src/main/java/com/hedera/mirror/downloader/record/RecordFileDownloader.java
+++ b/src/main/java/com/hedera/mirror/downloader/record/RecordFileDownloader.java
@@ -42,11 +42,6 @@ public class RecordFileDownloader extends Downloader {
         super(s3Client, applicationStatusRepository, networkAddressBook, downloaderProperties);
     }
 
-    @Scheduled(fixedRateString = "${hedera.mirror.downloader.record.frequency:500}")
-    public void download() {
-        downloadNextBatch();
-    }
-
     protected ApplicationStatusCode getLastValidDownloadedFileKey() {
         return ApplicationStatusCode.LAST_VALID_DOWNLOADED_RECORD_FILE;
     }

--- a/src/test/java/com/hedera/mirror/downloader/balance/AccountBalancesDownloaderTest.java
+++ b/src/test/java/com/hedera/mirror/downloader/balance/AccountBalancesDownloaderTest.java
@@ -195,6 +195,15 @@ public class AccountBalancesDownloaderTest {
         assertThat(downloaderProperties.getValidPath()).doesNotExist();
     }
 
+    @Test
+    @DisplayName("no new files found")
+    void noNewFilesFound() {
+        fileCopier.copy();
+        doReturn("2019-08-30T18_30_00.010147001Z_Balances.csv").when(applicationStatusRepository).findByStatusCode(ApplicationStatusCode.LAST_VALID_DOWNLOADED_BALANCE_FILE);
+        boolean newFilesFound = downloader.download();
+        assertThat(newFilesFound).isFalse();
+    }
+
     private static void corruptFile(Path p) {
         try {
             File file = p.toFile();

--- a/src/test/java/com/hedera/mirror/downloader/record/RecordFileDownloaderTest.java
+++ b/src/test/java/com/hedera/mirror/downloader/record/RecordFileDownloaderTest.java
@@ -252,6 +252,15 @@ public class RecordFileDownloaderTest {
         assertThat(downloaderProperties.getValidPath()).doesNotExist();
     }
 
+    @Test
+    @DisplayName("no new files found")
+    void noNewFilesFound() {
+        fileCopier.copy();
+        doReturn("2019-08-30T18_10_05.249678Z.rcd").when(applicationStatusRepository).findByStatusCode(ApplicationStatusCode.LAST_VALID_DOWNLOADED_RECORD_FILE);
+        boolean newFilesFound = downloader.download();
+        assertThat(newFilesFound).isFalse();
+    }
+
     private static void corruptFile(Path p) {
         try {
             File file = p.toFile();


### PR DESCRIPTION
Current:
We use spring fixedRateDelay to calls FooDownloader.download(). https://stackoverflow.com/a/44340260

Therefore,
- Optimizing for steady state will require setting delay based
  on how frequently new files are produced in the stream
  (record: ~5s, event: ~5s, balance: ~15min)
- But we can't make it too large (~min), otherwise catchup will suffer.
  For eg. we can't set it to ~1min for balance downloader.

Our current values are:
Balance delay: 500ms
Record delay: 500ms
Event delay: 1min // since we don't care about events currently

So basically, we are spamming S3 a lot in steady state.

Proposed fix:
Manage download() invocation smartly.
- If new files are found, call next download() immediately without
  wait. This optimizes catchup.
- If no new files are found, wait for 'delay' time. This optimizes
  steady state.

Signed-off-by: Apekshit Sharma <apekshit.sharma@hedera.com>

**Detailed description**:

**Which issue(s) this PR fixes**:
#314 - Downloader performance improvements

**Special notes for your reviewer**:
If this looks good to you guys, i'll try it *close to current mainnet head* to test manually too.

**Checklist**
- [ ] Documentation added
- [x] Tests updated

