### PR TITLE
Fix CircleCI failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,13 @@ BUCKET_NAME=<your-bucket-name> docker-compose up
 
 ## Contributing
 
-See the [contributing](CONTRIBUTING.md) guide
+Contributions are welcome. Please see the [contributing](CONTRIBUTING.md) guide to see how you can get
+involved.
+
+## Code of Conduct
+
+This project is governed by the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are
+expected to uphold this code of conduct. Please report unacceptable behavior to [oss@hedera.com](mailto:oss@hedera.com)
 
 ## License
 

--- a/src/main/java/com/hedera/mirror/addressbook/NetworkAddressBook.java
+++ b/src/main/java/com/hedera/mirror/addressbook/NetworkAddressBook.java
@@ -46,8 +46,8 @@ import javax.inject.Named;
 @Named
 public class NetworkAddressBook {
 
-    private static MirrorProperties mirrorProperties;
-    static byte[] addressBookBytes = new byte[0];
+    private MirrorProperties mirrorProperties;
+    private byte[] addressBookBytes = new byte[0];
 
     public NetworkAddressBook(MirrorProperties mirrorProperties) {
         this.mirrorProperties = mirrorProperties;
@@ -71,19 +71,19 @@ public class NetworkAddressBook {
         }
     }
 
-    public static void update(byte[] newContents) throws IOException {
+    public void update(byte[] newContents) throws IOException {
     	addressBookBytes = newContents;
 		saveToDisk();
     }
 
-    public static void append(byte[] extraContents) throws IOException {
+    public void append(byte[] extraContents) throws IOException {
     	byte[] newAddressBook = Arrays.copyOf(addressBookBytes, addressBookBytes.length + extraContents.length);
     	System.arraycopy(extraContents, 0, newAddressBook, addressBookBytes.length, extraContents.length);
     	addressBookBytes = newAddressBook;
 		saveToDisk();
     }
 
-    private static void saveToDisk() throws IOException {
+    private void saveToDisk() throws IOException {
         Path path = mirrorProperties.getAddressBookPath();
         Files.write(path, addressBookBytes);
 		log.info("New address book successfully saved to {}", path);

--- a/src/main/java/com/hedera/mirror/parser/record/RecordFileParser.java
+++ b/src/main/java/com/hedera/mirror/parser/record/RecordFileParser.java
@@ -60,7 +60,6 @@ public class RecordFileParser implements FileParser {
 	public RecordFileParser(ApplicationStatusRepository applicationStatusRepository, RecordParserProperties parserProperties) {
 		this.applicationStatusRepository = applicationStatusRepository;
 		this.parserProperties = parserProperties;
-		RecordFileLogger.parserProperties = parserProperties;
 	}
 
 	/**

--- a/src/main/java/com/hedera/recordFileLogger/RecordFileLogger.java
+++ b/src/main/java/com/hedera/recordFileLogger/RecordFileLogger.java
@@ -53,12 +53,15 @@ import com.hederahashgraph.api.proto.java.TransactionRecord;
 import com.hederahashgraph.api.proto.java.TransferList;
 
 import lombok.extern.log4j.Log4j2;
+import javax.inject.Named;
 
 @Log4j2
+@Named
 public class RecordFileLogger {
     public static Connection connect = null;
 	private static Entities entities = null;
-	public static RecordParserProperties parserProperties = null;
+	private static RecordParserProperties parserProperties = null;
+	private static NetworkAddressBook networkAddressBook = null;
 
 	private static HashMap<String, Integer> transactionResults = null;
 	private static HashMap<String, Integer> transactionTypes = null;
@@ -130,6 +133,11 @@ public class RecordFileLogger {
     }
     static void setBatchSize(long batchSize) {
     	BATCH_SIZE = batchSize;
+    }
+
+    public RecordFileLogger(RecordParserProperties parserProperties, NetworkAddressBook networkAddressBook) {
+        RecordFileLogger.parserProperties = parserProperties;
+        RecordFileLogger.networkAddressBook = networkAddressBook;
     }
 
 	public static boolean start() {
@@ -630,7 +638,7 @@ public class RecordFileLogger {
 			// update the local address book
 			if (isFileAddressBook(transactionBody.getFileID())) {
 				// we have an address book update, refresh the local file
-				NetworkAddressBook.append(contents);
+				networkAddressBook.append(contents);
 			}
 		}
 	}
@@ -760,7 +768,7 @@ public class RecordFileLogger {
 		// update the local address book
 		if (isFileAddressBook(fileId)) {
 			// we have an address book update, refresh the local file
-			NetworkAddressBook.update(transactionBody.getContents().toByteArray());
+			networkAddressBook.update(transactionBody.getContents().toByteArray());
 		}
 	}
 

--- a/src/test/java/com/hedera/recordFileLogger/RecordFileLoggerCryptoTest.java
+++ b/src/test/java/com/hedera/recordFileLogger/RecordFileLoggerCryptoTest.java
@@ -652,7 +652,7 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
 
 	@Test
 	void cryptoAddClaimDoNotPersist() throws Exception {
-	    RecordFileLogger.parserProperties.setPersistClaims(false);
+	    parserProperties.setPersistClaims(false);
 		// first create the account
 		final Transaction createTransaction = cryptoCreateTransaction();
 		final TransactionBody createTransactionBody = TransactionBody.parseFrom(createTransaction.getBodyBytes());
@@ -754,7 +754,7 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
 
 	@Test
 	void cryptoTransferWithPersistence() throws Exception {
-	    RecordFileLogger.parserProperties.setPersistCryptoTransferAmounts(true);
+	    parserProperties.setPersistCryptoTransferAmounts(true);
 		// make the transfers
 		final Transaction transaction = cryptoTransferTransaction();
 		final TransactionBody transactionBody = TransactionBody.parseFrom(transaction.getBodyBytes());
@@ -788,7 +788,7 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
 
 	@Test
 	void cryptoTransferWithoutPersistence() throws Exception {
-	    RecordFileLogger.parserProperties.setPersistCryptoTransferAmounts(false);
+	    parserProperties.setPersistCryptoTransferAmounts(false);
 		// make the transfers
 		final Transaction transaction = cryptoTransferTransaction();
 		final TransactionBody transactionBody = TransactionBody.parseFrom(transaction.getBodyBytes());

--- a/src/test/java/com/hedera/recordFileLogger/RecordFileLoggerFileTest.java
+++ b/src/test/java/com/hedera/recordFileLogger/RecordFileLoggerFileTest.java
@@ -89,12 +89,16 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
     @Resource
     private MirrorProperties mirrorProperties;
 
+    @Resource
+    private NetworkAddressBook networkAddressBook;
+
     @BeforeEach
     void before() throws Exception {
         mirrorProperties.setDataPath(dataPath);
         parserProperties.setPersistFiles(true);
         parserProperties.setPersistSystemFiles(true);
         parserProperties.setPersistCryptoTransferAmounts(true);
+        parserProperties.init();
 
 		assertTrue(RecordFileLogger.start());
 		assertEquals(INIT_RESULT.OK, RecordFileLogger.initFile("TestFile"));
@@ -160,8 +164,8 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
 
     @Test
     void fileCreateDoNotPersist() throws Exception {
-        RecordFileLogger.parserProperties.setPersistFiles(false);
-        RecordFileLogger.parserProperties.setPersistSystemFiles(false);
+        parserProperties.setPersistFiles(false);
+        parserProperties.setPersistSystemFiles(false);
     	final Transaction transaction = fileCreateTransaction();
     	final TransactionBody transactionBody = TransactionBody.parseFrom(transaction.getBodyBytes());
     	final TransactionRecord record = transactionRecord(transactionBody);
@@ -198,7 +202,7 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
 
     @Test
     void fileCreatePersistSystemPositive() throws Exception {
-        RecordFileLogger.parserProperties.setPersistFiles(false);
+        parserProperties.setPersistFiles(false);
     	final Transaction transaction = fileCreateTransaction();
     	final TransactionBody transactionBody = TransactionBody.parseFrom(transaction.getBodyBytes());
     	final FileCreateTransactionBody fileCreateTransactionBody = transactionBody.getFileCreate();
@@ -251,7 +255,7 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
 
     @Test
     void fileCreatePersistSystemNegative() throws Exception {
-        RecordFileLogger.parserProperties.setPersistFiles(false);
+        parserProperties.setPersistFiles(false);
     	final Transaction transaction = fileCreateTransaction();
     	final TransactionBody transactionBody = TransactionBody.parseFrom(transaction.getBodyBytes());
     	final FileCreateTransactionBody fileCreateTransactionBody = transactionBody.getFileCreate();
@@ -416,8 +420,8 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
     	final FileAppendTransactionBody fileAppendTransactionBody = transactionBody.getFileAppend();
     	final TransactionRecord record = transactionRecord(transactionBody, FileID.newBuilder().setShardNum(0).setRealmNum(0).setFileNum(10).build());
 
-    	RecordFileLogger.parserProperties.setPersistFiles(true);
-    	RecordFileLogger.parserProperties.setPersistSystemFiles(true);
+    	parserProperties.setPersistFiles(true);
+    	parserProperties.setPersistSystemFiles(true);
 
     	RecordFileLogger.storeRecord(transaction, record);
 
@@ -585,10 +589,10 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
     @Test
     void fileAppendToAddressBook() throws Exception {
 
-        NetworkAddressBook.update(new byte[0]);
+        networkAddressBook.update(new byte[0]);
 
-        RecordFileLogger.parserProperties.setPersistFiles(true);
-        RecordFileLogger.parserProperties.setPersistSystemFiles(true);
+        parserProperties.setPersistFiles(true);
+        parserProperties.setPersistSystemFiles(true);
 
 		final Transaction transaction = fileAppendTransaction(FileID.newBuilder().setShardNum(0).setRealmNum(0).setFileNum(102).build());
     	final TransactionBody transactionBody = TransactionBody.parseFrom(transaction.getBodyBytes());
@@ -1040,8 +1044,8 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
     	final FileUpdateTransactionBody fileUpdateTransactionBody = transactionBody.getFileUpdate();
     	final TransactionRecord record = transactionRecord(transactionBody, FileID.newBuilder().setShardNum(0).setRealmNum(0).setFileNum(10).build());
 
-    	RecordFileLogger.parserProperties.setPersistFiles(true);
-    	RecordFileLogger.parserProperties.setPersistSystemFiles(true);
+    	parserProperties.setPersistFiles(true);
+    	parserProperties.setPersistSystemFiles(true);
 
     	RecordFileLogger.storeRecord(transaction, record);
 
@@ -1097,8 +1101,8 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
     	final FileUpdateTransactionBody fileUpdateTransactionBody = transactionBody.getFileUpdate();
     	final TransactionRecord record = transactionRecord(transactionBody, FileID.newBuilder().setShardNum(0).setRealmNum(0).setFileNum(102).build());
 
-        RecordFileLogger.parserProperties.setPersistFiles(true);
-        RecordFileLogger.parserProperties.setPersistSystemFiles(true);
+        parserProperties.setPersistFiles(true);
+        parserProperties.setPersistSystemFiles(true);
 
     	RecordFileLogger.storeRecord(transaction, record);
 


### PR DESCRIPTION
**Detailed description**:
CircleCI has been failing every other build and causing PRs to not pass. The issue was due to `NetworkAddressBook` having references to an older `MirrorProperties` and the tests in `RecordFileLoggerFileTest` that were specifically checking for the address book were failing. Fixed by making methods in `NetworkAddressBook` non-static. Also made `RecordFileLogger` a bean and rely upon spring initialization to assign the static addressbook in its class.

Also update the README to add Code of Conduct and a blurb about contributing.

**Which issue(s) this PR fixes**:
Fixes #375

**Special notes for your reviewer**:
Don't use static variables for mutable data. Ever.

**Checklist**
- [ ] Documentation added
- [x] Tests updated

