### PR TITLE
Fix long overflow during missing entities migration

### DIFF
--- a/src/main/java/com/hedera/mirror/migration/V1_11_6__Missing_Entities.java
+++ b/src/main/java/com/hedera/mirror/migration/V1_11_6__Missing_Entities.java
@@ -105,7 +105,11 @@ public class V1_11_6__Missing_Entities extends BaseJavaMigration {
         Entities entity = entityExists.orElseGet(() -> toEntity(accountID));
 
         if (entity.getExpiryTimeNs() == null && accountInfo.hasExpirationTime()) {
-            entity.setExpiryTimeNs(Utility.timeStampInNanos(accountInfo.getExpirationTime()));
+            try {
+                entity.setExpiryTimeNs(Utility.timeStampInNanos(accountInfo.getExpirationTime()));
+            } catch (ArithmeticException e) {
+                log.warn("Invalid expiration time for account {}: {}", accountID.getAccountNum(), StringUtils.trim(e.getMessage()));
+            }
         }
 
         if (entity.getAutoRenewPeriod() == null && accountInfo.hasAutoRenewPeriod()) {

--- a/src/main/java/com/hedera/mirror/util/Utility.java
+++ b/src/main/java/com/hedera/mirror/util/Utility.java
@@ -613,8 +613,7 @@ public class Utility {
         try {
             return Math.addExact(Math.multiplyExact(timestamp.getSeconds(), SCALAR), timestamp.getNanos());
         } catch (ArithmeticException e) {
-            log.error("Long overflow when converting Timestamp to nanos timestamp : {}", timestamp, e);
-            throw e;
+            throw new ArithmeticException("Long overflow when converting Timestamp to nanos timestamp: " + timestamp);
         }
     }
 


### PR DESCRIPTION
**Detailed description**:
Apparently system accounts (<1000) set an expiration time of `12/31/1000000000 @ 11:59pm (UTC)`. Since our seconds + nanos bigint can't handle that, we overflow. This PR catches the exception and just puts null to indicate it never expires.

**Which issue(s) this PR fixes**:
Fixes #384

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated

