### PR TITLE
Fix REST config loading incorrect values for env variables

### DIFF
--- a/rest-api/__tests__/config.test.js
+++ b/rest-api/__tests__/config.test.js
@@ -89,9 +89,10 @@ describe('Load YAML configuration:', () => {
 
 describe('Load environment configuration:', () => {
   test('Number', () => {
-    process.env = {HEDERA_MIRROR_SHARD: '2'};
+    process.env = {HEDERA_MIRROR_SHARD: '2', HEDERA_MIRROR_API_PORT: '5552'};
     const config = require('../config');
     expect(config.shard).toBe(2);
+    expect(config.api.port).toBe(5552);
   });
 
   test('String', () => {

--- a/rest-api/config.js
+++ b/rest-api/config.js
@@ -58,11 +58,8 @@ function loadYaml(configFile) {
 }
 
 function loadEnvironment() {
-  let keys = Object.keys(process.env);
-  let values = Object.values(process.env);
-
-  for (i in keys) {
-    setConfigValue(keys[i], values[i]);
+  for (const [key, value] of Object.entries(process.env)) {
+    setConfigValue(key, value);
   }
 }
 
@@ -89,6 +86,7 @@ function setConfigValue(propertyPath, value) {
           break;
         } else {
           current[k] = convertType(value);
+          console.log(`Override config with environment variable ${propertyPath}=${value}`);
           return;
         }
       }

--- a/rest-api/pm2.json
+++ b/rest-api/pm2.json
@@ -1,0 +1,94 @@
+{
+  "apps": [
+    {
+      "exec_mode": "fork_mode",
+      "script": "./server.js",
+      "name": "6551",
+      "env": {
+        "HEDERA_MIRROR_API_PORT": 6551,
+        "NODE_ENV": "production"
+      }
+    },
+    {
+      "exec_mode": "fork_mode",
+      "script": "./server.js",
+      "name": "6552",
+      "env": {
+        "HEDERA_MIRROR_API_PORT": 6552,
+        "NODE_ENV": "production"
+      }
+    },
+    {
+      "exec_mode": "fork_mode",
+      "script": "./server.js",
+      "name": "6553",
+      "env": {
+        "HEDERA_MIRROR_API_PORT": 6553,
+        "NODE_ENV": "production"
+      }
+    },
+    {
+      "exec_mode": "fork_mode",
+      "script": "./server.js",
+      "name": "6554",
+      "env": {
+        "HEDERA_MIRROR_API_PORT": 6554,
+        "NODE_ENV": "production"
+      }
+    },
+    {
+      "exec_mode": "fork_mode",
+      "script": "./server.js",
+      "name": "6555",
+      "env": {
+        "HEDERA_MIRROR_API_PORT": 6555,
+        "NODE_ENV": "production"
+      }
+    },
+    {
+      "exec_mode": "fork_mode",
+      "script": "./server.js",
+      "name": "6556",
+      "env": {
+        "HEDERA_MIRROR_API_PORT": 6556,
+        "NODE_ENV": "production"
+      }
+    },
+    {
+      "exec_mode": "fork_mode",
+      "script": "./server.js",
+      "name": "6557",
+      "env": {
+        "HEDERA_MIRROR_API_PORT": 6557,
+        "NODE_ENV": "production"
+      }
+    },
+    {
+      "exec_mode": "fork_mode",
+      "script": "./server.js",
+      "name": "6558",
+      "env": {
+        "HEDERA_MIRROR_API_PORT": 6558,
+        "NODE_ENV": "production"
+      }
+    },
+    {
+      "exec_mode": "fork_mode",
+      "script": "./server.js",
+      "name": "6559",
+      "env": {
+        "HEDERA_MIRROR_API_PORT": 6559,
+        "NODE_ENV": "production"
+      }
+    },
+    {
+      "exec_mode": "fork_mode",
+      "script": "./server.js",
+      "name": "6560",
+      "env": {
+        "HEDERA_MIRROR_API_PORT": 6560,
+        "NODE_ENV": "production"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
**Detailed description**:
This is a blocker for v0.4.0. The REST API config loading was not properly associating keys with values from `process.env` leading to incorrect config property values being set.

Additionally, this provides a `pm2.json` to [declaratively](https://futurestud.io/tutorials/pm2-start-multiple-apps-with-a-single-process-file-json-js-yaml) configure the startup of 10 node process with ports 6551-6560 with a single command `pm2 start ./pm2.json`.

**Which issue(s) this PR fixes**:
Fixes #387 

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated

