### PR TITLE
Fix address book not copied from classpath

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>com.hedera</groupId>
     <artifactId>mirror-node</artifactId>
-    <version>0.4.0-SNAPSHOT</version>
+    <version>0.4.0-rc3</version>
     <name>Hedera Mirror Node</name>
     <description>Hedera Mirror Node mirrors data from Hedera nodes and serves it via an API</description>
     <ciManagement>

--- a/rest-api/package.json
+++ b/rest-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rest-api",
-  "version": "0.4.0-SNAPSHOT",
+  "version": "0.4.0-rc3",
   "description": "REST API for Hedera Mirror Node",
   "main": "server.js",
   "scripts": {

--- a/scripts/deploy-mirror-node.sh
+++ b/scripts/deploy-mirror-node.sh
@@ -31,6 +31,11 @@ if [ -f "${usrlib}/mirror-node.jar" ]; then
 
     # Handle the migration from config.json to application.yml
     if [ -f "${usretc}/config.json" ] && [ ! -f  "${usretc}/application.yml" ]; then
+        network="MAINNET"
+        if (grep "bucketName.*testnet" "${usretc}/config.json"); then
+            network="TESTNET"
+        fi
+
         apiPassword=$(grep -oP '"apiPassword": "\K[^"]+' "${usretc}/config.json")
         bucketName=$(grep -oP '"bucketName": "\K[^"]+' "${usretc}/config.json")
         dbHost=$(grep -oP '"dbUrl": "jdbc:postgresql://\K[^:]+' "${usretc}/config.json")
@@ -46,6 +51,7 @@ hedera:
       password: ${dbPassword}
     downloader:
       bucketName: ${bucketName}
+    network: ${network}
 EOF
     fi
 else

--- a/scripts/deploy-mirror-node.sh
+++ b/scripts/deploy-mirror-node.sh
@@ -8,15 +8,14 @@ if [ -z "${version}" ]; then
     exit 1
 fi
 
-usrlib=/usr/lib/mirror-node/
-usretc=/usr/etc/mirror-node/
+usretc=/usr/etc/mirror-node
+usrlib=/usr/lib/mirror-node
+varlib=/var/lib/mirror-node
 ts=$(date -u +%s)
-upgrade=0
 
-mkdir -p "${usretc}" "${usrlib}" /var/lib/mirror-node
+mkdir -p "${usretc}" "${usrlib}" "${varlib}"
 
 if [ -f "${usrlib}/mirror-node.jar" ]; then
-    upgrade=1
     echo "Upgrading to ${version}"
 
     # Stop the service
@@ -25,6 +24,10 @@ if [ -f "${usrlib}/mirror-node.jar" ]; then
 
     echo "Backing up binary"
     mv "${usrlib}/mirror-node.jar" "${usrlib}/mirror-node.jar.${ts}.old"
+
+    if [ -f "${usretc}/0.0.102" ] && [ ! -f "${varlib}/addressbook.bin" ]; then
+      cp "${usretc}/0.0.102" "${varlib}/addressbook.bin"
+    fi
 
     # Handle the migration from config.json to application.yml
     if [ -f "${usretc}/config.json" ] && [ ! -f  "${usretc}/application.yml" ]; then
@@ -51,7 +54,7 @@ else
     cat > "${usretc}/application.yml" <<EOF
 hedera:
   mirror:
-    dataPath: /var/lib/mirror-node
+    dataPath: ${varlib}
     db:
       apiPassword:
       host:

--- a/src/main/java/com/hedera/mirror/addressbook/NetworkAddressBook.java
+++ b/src/main/java/com/hedera/mirror/addressbook/NetworkAddressBook.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableList;
 import com.hederahashgraph.api.proto.java.NodeAddressBook;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -33,6 +34,7 @@ import java.util.Collection;
 import javax.inject.Named;
 
 import lombok.extern.log4j.Log4j2;
+import org.apache.commons.io.IOUtils;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 
@@ -59,11 +61,10 @@ public class NetworkAddressBook {
             File addressBookFile = path.toFile();
             if (!addressBookFile.exists() || !addressBookFile.canRead()) {
                 HederaNetwork hederaNetwork = mirrorProperties.getNetwork();
-                Resource resource = new ClassPathResource(String
-                        .format("addressbook/%s", hederaNetwork.name().toLowerCase()));
-                Path defaultAddressBook = resource.getFile().toPath();
+                String resourcePath = String.format("/addressbook/%s", hederaNetwork.name().toLowerCase());
+                Resource resource = new ClassPathResource(resourcePath, getClass());
                 Utility.ensureDirectory(path.getParent());
-                Files.copy(defaultAddressBook, path, StandardCopyOption.REPLACE_EXISTING);
+                IOUtils.copy(resource.getInputStream(), new FileOutputStream(addressBookFile));
                 log.info("Copied default address book {} to {}", resource, path);
             }
         } catch (Exception e) {


### PR DESCRIPTION
**Detailed description**:
- This is a v0.4.0 blocker.
- Bump version in pom.xml & package.json
- Fix deploy script to copy older `/usr/etc/mirror-node/0.0.102` to new path `/var/lib/mirror-node/addressbook.bin` instead of address book from classpath
- Fix deploy script not setting network
- Fix copying address book from classpath

**Which issue(s) this PR fixes**:
Fixes #389 

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

