### PR TITLE
Upgrade to Spring Boot 2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.1.8.RELEASE</version>
+        <version>2.2.1.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.hedera</groupId>
@@ -47,8 +47,7 @@
         <hedera-sdk.version>0.6.1</hedera-sdk.version>
         <jacoco.version>0.8.4</jacoco.version>
         <java.version>11</java.version>
-        <jib.version>1.5.1</jib.version>
-        <junit-jupiter.version>5.5.2</junit-jupiter.version>
+        <jib.version>1.8.0</jib.version>
         <testcontainers.version>1.12.1</testcontainers.version>
     </properties>
     <dependencies>
@@ -163,30 +162,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-params</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-junit-jupiter</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.springframework.boot</groupId>
-                    <artifactId>spring-boot-starter-logging</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
     </dependencies>
     <dependencyManagement>

--- a/src/main/java/com/hedera/mirror/MirrorNodeApplication.java
+++ b/src/main/java/com/hedera/mirror/MirrorNodeApplication.java
@@ -22,7 +22,9 @@ package com.hedera.mirror;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
+@ConfigurationPropertiesScan
 @SpringBootApplication
 public class MirrorNodeApplication {
 

--- a/src/main/java/com/hedera/mirror/MirrorProperties.java
+++ b/src/main/java/com/hedera/mirror/MirrorProperties.java
@@ -22,7 +22,6 @@ package com.hedera.mirror;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import javax.inject.Named;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
@@ -34,7 +33,6 @@ import com.hedera.mirror.domain.HederaNetwork;
 import com.hedera.mirror.util.Utility;
 
 @Data
-@Named
 @Validated
 @ConfigurationProperties("hedera.mirror")
 public class MirrorProperties {

--- a/src/main/java/com/hedera/mirror/config/MirrorNodeConfiguration.java
+++ b/src/main/java/com/hedera/mirror/config/MirrorNodeConfiguration.java
@@ -22,24 +22,11 @@ package com.hedera.mirror.config;
 
 import java.net.URI;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.StringUtils;
-import org.flywaydb.core.api.configuration.FluentConfiguration;
-import org.flywaydb.core.api.migration.JavaMigration;
-import org.flywaydb.core.api.resolver.Context;
-import org.flywaydb.core.api.resolver.ResolvedMigration;
-import org.flywaydb.core.internal.configuration.ConfigUtils;
-import org.flywaydb.core.internal.resolver.ResolvedMigrationComparator;
-import org.flywaydb.core.internal.resolver.ResolvedMigrationImpl;
-import org.flywaydb.core.internal.resolver.java.JavaMigrationResolver;
-import org.flywaydb.core.internal.util.ClassUtils;
-import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.autoconfigure.flyway.FlywayConfigurationCustomizer;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;
@@ -59,33 +46,6 @@ import com.hedera.mirror.downloader.CommonDownloaderProperties;
 @EnableAsync
 @Log4j2
 public class MirrorNodeConfiguration {
-
-    // TODO: Remove in Spring Boot 2.2
-    @Bean
-    FlywayConfigurationCustomizer flywayCustomizer(ObjectProvider<JavaMigration> javaMigrations) {
-        return new FlywayConfigurationCustomizer() {
-            @Override
-            public void customize(FluentConfiguration configuration) {
-                configuration.resolvers(new JavaMigrationResolver(null, null) {
-                    @Override
-                    public List<ResolvedMigration> resolveMigrations(Context context) {
-                        List<ResolvedMigration> resolvedMigrations = new ArrayList<>();
-
-                        for (JavaMigration migration : javaMigrations) {
-                            ConfigUtils.injectFlywayConfiguration(migration, configuration);
-                            ResolvedMigrationImpl resolvedMigration = extractMigrationInfo(migration);
-                            resolvedMigration.setPhysicalLocation(ClassUtils.getLocationOnDisk(migration.getClass()));
-                            resolvedMigration.setExecutor(createExecutor(migration));
-                            resolvedMigrations.add(resolvedMigration);
-                        }
-
-                        Collections.sort(resolvedMigrations, new ResolvedMigrationComparator());
-                        return resolvedMigrations;
-                    }
-                });
-            }
-        };
-    }
 
     @Bean
     public S3AsyncClient s3AsyncClient(CommonDownloaderProperties downloaderProperties) {

--- a/src/main/java/com/hedera/mirror/downloader/CommonDownloaderProperties.java
+++ b/src/main/java/com/hedera/mirror/downloader/CommonDownloaderProperties.java
@@ -20,7 +20,6 @@ package com.hedera.mirror.downloader;
  * ‍
  */
 
-import javax.inject.Named;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
@@ -32,7 +31,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
 @Data
-@Named
 @Validated
 @ConfigurationProperties("hedera.mirror.downloader")
 public class CommonDownloaderProperties {

--- a/src/main/java/com/hedera/mirror/downloader/balance/BalanceDownloaderProperties.java
+++ b/src/main/java/com/hedera/mirror/downloader/balance/BalanceDownloaderProperties.java
@@ -22,7 +22,6 @@ package com.hedera.mirror.downloader.balance;
 
 import java.nio.file.Path;
 import java.time.Duration;
-import javax.inject.Named;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
@@ -37,7 +36,6 @@ import com.hedera.mirror.downloader.CommonDownloaderProperties;
 import com.hedera.mirror.downloader.DownloaderProperties;
 
 @Data
-@Named
 @Validated
 @ConfigurationProperties("hedera.mirror.downloader.balance")
 public class BalanceDownloaderProperties implements DownloaderProperties {

--- a/src/main/java/com/hedera/mirror/downloader/event/EventDownloaderProperties.java
+++ b/src/main/java/com/hedera/mirror/downloader/event/EventDownloaderProperties.java
@@ -22,7 +22,6 @@ package com.hedera.mirror.downloader.event;
 
 import java.nio.file.Path;
 import java.time.Duration;
-import javax.inject.Named;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
@@ -37,7 +36,6 @@ import com.hedera.mirror.downloader.CommonDownloaderProperties;
 import com.hedera.mirror.downloader.DownloaderProperties;
 
 @Data
-@Named
 @Validated
 @ConfigurationProperties("hedera.mirror.downloader.event")
 public class EventDownloaderProperties implements DownloaderProperties {

--- a/src/main/java/com/hedera/mirror/downloader/record/RecordDownloaderProperties.java
+++ b/src/main/java/com/hedera/mirror/downloader/record/RecordDownloaderProperties.java
@@ -22,7 +22,6 @@ package com.hedera.mirror.downloader.record;
 
 import java.nio.file.Path;
 import java.time.Duration;
-import javax.inject.Named;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
@@ -37,7 +36,6 @@ import com.hedera.mirror.downloader.CommonDownloaderProperties;
 import com.hedera.mirror.downloader.DownloaderProperties;
 
 @Data
-@Named
 @Validated
 @ConfigurationProperties("hedera.mirror.downloader.record")
 public class RecordDownloaderProperties implements DownloaderProperties {

--- a/src/main/java/com/hedera/mirror/parser/balance/BalanceParserProperties.java
+++ b/src/main/java/com/hedera/mirror/parser/balance/BalanceParserProperties.java
@@ -21,7 +21,6 @@ package com.hedera.mirror.parser.balance;
  */
 
 import java.nio.file.Path;
-import javax.inject.Named;
 import javax.validation.constraints.Min;
 
 import lombok.Data;
@@ -33,7 +32,6 @@ import com.hedera.mirror.domain.StreamType;
 import com.hedera.mirror.parser.ParserProperties;
 
 @Data
-@Named
 @Validated
 @ConfigurationProperties("hedera.mirror.parser.balance")
 public class BalanceParserProperties implements ParserProperties {

--- a/src/main/java/com/hedera/mirror/parser/event/EventParserProperties.java
+++ b/src/main/java/com/hedera/mirror/parser/event/EventParserProperties.java
@@ -22,7 +22,6 @@ package com.hedera.mirror.parser.event;
 
 import java.nio.file.Path;
 import java.time.Duration;
-import javax.inject.Named;
 import javax.validation.constraints.NotNull;
 
 import lombok.Data;
@@ -34,7 +33,6 @@ import com.hedera.mirror.domain.StreamType;
 import com.hedera.mirror.parser.ParserProperties;
 
 @Data
-@Named
 @Validated
 @ConfigurationProperties("hedera.mirror.parser.event")
 public class EventParserProperties implements ParserProperties {

--- a/src/main/java/com/hedera/mirror/parser/record/RecordParserProperties.java
+++ b/src/main/java/com/hedera/mirror/parser/record/RecordParserProperties.java
@@ -22,7 +22,6 @@ package com.hedera.mirror.parser.record;
 
 import java.nio.file.Path;
 import java.time.Duration;
-import javax.inject.Named;
 import javax.validation.constraints.NotNull;
 
 import lombok.Data;
@@ -34,7 +33,6 @@ import com.hedera.mirror.domain.StreamType;
 import com.hedera.mirror.parser.ParserProperties;
 
 @Data
-@Named
 @Validated
 @ConfigurationProperties("hedera.mirror.parser.record")
 public class RecordParserProperties implements ParserProperties {

--- a/src/main/java/com/hedera/mirror/util/DatabaseUtilities.java
+++ b/src/main/java/com/hedera/mirror/util/DatabaseUtilities.java
@@ -22,9 +22,11 @@ package com.hedera.mirror.util;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.concurrent.TimeUnit;
 import javax.inject.Named;
 import javax.sql.DataSource;
 
+import com.google.common.util.concurrent.Uninterruptibles;
 import lombok.extern.log4j.Log4j2;
 
 /**
@@ -52,6 +54,7 @@ public class DatabaseUtilities {
                 return dataSource.getConnection();
             } catch (Exception e) {
                 log.warn("Unable to connect to database: {}", e.getMessage());
+                Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
             }
         }
     }

--- a/src/main/java/com/hedera/mirror/util/DatabaseUtilities.java
+++ b/src/main/java/com/hedera/mirror/util/DatabaseUtilities.java
@@ -20,13 +20,14 @@ package com.hedera.mirror.util;
  * ‍
  */
 
+import com.google.common.util.concurrent.Uninterruptibles;
+
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.concurrent.TimeUnit;
 import javax.inject.Named;
 import javax.sql.DataSource;
 
-import com.google.common.util.concurrent.Uninterruptibles;
 import lombok.extern.log4j.Log4j2;
 
 /**
@@ -54,6 +55,7 @@ public class DatabaseUtilities {
                 return dataSource.getConnection();
             } catch (Exception e) {
                 log.warn("Unable to connect to database: {}", e.getMessage());
+                // Don't use 100% CPU if DataSource is null or can't connect
                 Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
             }
         }

--- a/src/test/resources/application-default.yml
+++ b/src/test/resources/application-default.yml
@@ -4,6 +4,9 @@ hedera:
       bucketName: test
       cloudProvider: LOCAL
     network: TESTNET
+    parser:
+      balance:
+        enabled: false
 spring:
   task:
     scheduling:


### PR DESCRIPTION
**Detailed description**:
- Upgrades Spring Boot to 2.2
- Fixes circular dependency in DB migration
- Rework JUnit dependencies
- Component scan `@ConfigurationProperties`
- Lazy initialization broke things so didn't enable it

**Which issue(s) this PR fixes**:
Fixes #329 

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated

