### PR TITLE
Bug/exp overflow master

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -63,6 +63,7 @@ issues are resolvable by updating the application configuration and restarting t
 These should be investigated by Hedera, but require no immediate escalation unless they are occurring frequently (more than 1/min).
 
 -   `Transaction type .* not known to mirror node`
+-   `Long overflow when converting time to nanos timestamp`
 
 ## Known Issues
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/Entities.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/Entities.java
@@ -20,9 +20,6 @@ package com.hedera.mirror.importer.parser.record;
  * ‍
  */
 
-import static java.sql.Types.VARBINARY;
-import static java.sql.Types.VARCHAR;
-
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ContractID;
@@ -35,11 +32,14 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Types;
+import java.time.DateTimeException;
 import java.util.HashMap;
 
 import lombok.extern.log4j.Log4j2;
 
 import com.hedera.mirror.importer.util.Utility;
+
+import static java.sql.Types.*;
 
 @Log4j2
 public class Entities {
@@ -139,7 +139,7 @@ public class Entities {
             if ((exp_time_seconds != 0) || (exp_time_nanos != 0)) {
                 updateEntity.setLong(1, exp_time_seconds);
                 updateEntity.setLong(2, exp_time_nanos);
-                updateEntity.setLong(3, Utility.convertToNanos(exp_time_seconds, exp_time_nanos));
+                updateEntity.setLong(3, Utility.convertToNanosMax(exp_time_seconds, exp_time_nanos));
                 fieldCount = 3;
             }
 
@@ -332,8 +332,7 @@ public class Entities {
             entityCreate.setInt(5, fk_entity_type);
             entityCreate.setLong(6, exp_time_seconds);
             entityCreate.setLong(7, exp_time_nanos);
-
-            entityCreate.setLong(8, Utility.convertToNanos(exp_time_seconds, exp_time_nanos));
+            entityCreate.setLong(8, Utility.convertToNanosMax(exp_time_seconds, exp_time_nanos));
             entityCreate.setLong(9, auto_renew_period);
 
             if (key == null) {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileLoggerCryptoTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileLoggerCryptoTest.java
@@ -536,7 +536,8 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
         updateTransactionBody.setAccountIDToUpdate(accountId);
 
         // *** THIS IS THE OVERFLOW WE WANT TO TEST ***
-        // This should result in the entity having a NULL expiration
+        // This should result in the entity having a Long.MAX_VALUE or Long.MIN_VALUE expirations (the results of
+        // overflows).
         updateTransactionBody.setExpirationTime(Timestamp.newBuilder().setSeconds(seconds));
 
         var transactionBody = defaultTransactionBodyBuilder(memo);

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileLoggerCryptoTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileLoggerCryptoTest.java
@@ -50,7 +50,10 @@ import org.apache.commons.codec.binary.Hex;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.test.context.jdbc.Sql;
 
 import com.hedera.mirror.importer.domain.CryptoTransfer;
@@ -508,6 +511,51 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
 
         // Crypto transfer list
         verifyRepoCryptoTransferList(record);
+    }
+
+    @DisplayName("update account such that expiration timestamp overflows nanos_timestamp")
+    @ParameterizedTest(name = "with seconds {0} and expectedNanosTimestamp {1}")
+    @CsvSource({
+            "9223372036854775807, 9223372036854775807",
+            "31556889864403199, 9223372036854775807",
+            "-9223372036854775808, -9223372036854775808",
+            "-1000000000000000000, -9223372036854775808"
+    })
+    void cryptoUpdateExpirationOverflow(long seconds, long expectedNanosTimestamp) throws Exception {
+
+        // first create the account
+        var createTransaction = cryptoCreateTransaction();
+        var createTransactionBody = TransactionBody.parseFrom(createTransaction.getBodyBytes());
+        var createRecord = transactionRecordSuccess(createTransactionBody);
+
+        RecordFileLogger.storeRecord(createTransaction, createRecord);
+
+        // now update
+        var updateTransaction = Transaction.newBuilder();
+        var updateTransactionBody = CryptoUpdateTransactionBody.newBuilder();
+        updateTransactionBody.setAccountIDToUpdate(accountId);
+
+        // *** THIS IS THE OVERFLOW WE WANT TO TEST ***
+        // This should result in the entity having a NULL expiration
+        updateTransactionBody.setExpirationTime(Timestamp.newBuilder().setSeconds(seconds));
+
+        var transactionBody = defaultTransactionBodyBuilder(memo);
+        transactionBody.setCryptoUpdateAccount(updateTransactionBody.build());
+        updateTransaction.setBodyBytes(transactionBody.build().toByteString());
+        var rec = transactionRecordSuccess(transactionBody.build());
+
+        RecordFileLogger.storeRecord(updateTransaction.build(), rec);
+        RecordFileLogger.completeFile("", "");
+
+        var dbTransaction = transactionRepository
+                .findById(Utility.timeStampInNanos(rec.getConsensusTimestamp())).get();
+        var dbAccountEntity = entityRepository.findById(dbTransaction.getEntityId()).get();
+
+        assertAll(
+                () -> assertEquals(1, recordFileRepository.count()),
+                () -> assertEquals(2, transactionRepository.count()),
+                () -> assertEquals(expectedNanosTimestamp, dbAccountEntity.getExpiryTimeNs())
+        );
     }
 
     @Test

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileLoggerFileTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileLoggerFileTest.java
@@ -20,13 +20,11 @@ package com.hedera.mirror.importer.parser.record;
  * ‍
  */
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.google.protobuf.ByteString;
 import com.hederahashgraph.api.proto.java.AccountAmount;
 import com.hederahashgraph.api.proto.java.AccountID;
-import com.hederahashgraph.api.proto.java.CryptoUpdateTransactionBody;
 import com.hederahashgraph.api.proto.java.FileAppendTransactionBody;
 import com.hederahashgraph.api.proto.java.FileCreateTransactionBody;
 import com.hederahashgraph.api.proto.java.FileDeleteTransactionBody;
@@ -55,7 +53,6 @@ import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/util/UtilityTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/util/UtilityTest.java
@@ -229,12 +229,31 @@ public class UtilityTest {
         );
     }
 
-    @Test
-    @DisplayName("converting illegal instant to nanos")
-    void convertInstantToNanosIllegalInput() {
-        assertThrows(ArithmeticException.class, () -> {
-            Utility.convertToNanos(1568376750538L, 0L);
-        });
+    @ParameterizedTest(name = "with seconds {0} and nanos {1}")
+    @CsvSource({
+            "1568376750538, 0",
+            "9223372036854775807, 0",
+            "-9223372036854775808, 0",
+            "9223372036, 854775808",
+            "-9223372036, -854775809"
+    })
+    void convertInstantToNanosThrows(long seconds, int nanos) {
+        assertThrows(ArithmeticException.class, () -> Utility.convertToNanos(seconds, nanos));
+    }
+
+    @ParameterizedTest(name = "with seconds {0} and nanos {1}")
+    @CsvSource({
+            "0, 0, 0",
+            "1574880387, 0, 1574880387000000000",
+            "1574880387, 999999999, 1574880387999999999",
+            "1568376750538, 0, 9223372036854775807",
+            "9223372036854775807, 0, 9223372036854775807",
+            "-9223372036854775808, 0, -9223372036854775808",
+            "9223372036, 854775808, 9223372036854775807",
+            "-9223372036, -854775809, -9223372036854775808"
+    })
+    void convertInstantToNanosMax(long seconds, int nanos, long expected) {
+        assertThat(Utility.convertToNanosMax(seconds, nanos)).isEqualTo(expected);
     }
 
     @ParameterizedTest(name = "with seconds {0} and nanos {1}")

--- a/hedera-mirror-rest/__tests__/integration.test.js
+++ b/hedera-mirror-rest/__tests__/integration.test.js
@@ -26,6 +26,15 @@
  * Tests instantiate the database schema via a flywaydb wrapper using the flyway CLI to clean and migrate the
  * schema (using sql files in the ../src/resources/db/migration directory).
  *
+ * Test data is created by:
+ * 1) reading account id, balance, expiration and crypto transfer information from integration_test_data.json
+ * 2) storing those accounts in integration DB
+ * 3) creating 3 balances records per account at timestamp 1000, 2000, 3000 in the integration DB
+ * 4) apply transfers (from integration_test_data.json) to the integration DB
+ *
+ * Tests are then run in code below (find TESTS all caps) and by comparing requests/responses from the server to data
+ * in the specs/ dir.
+ *
  * environment variables used:
  * TEST_DB_HOST (default: use testcontainers, examples: localhost, dbhost, 10.0.0.75)
  * TEST_DB_PORT (default: 5432)
@@ -153,14 +162,14 @@ const flywayMigrate = function() {
 
 //
 // TEST DATA
-// shard 0, realm 15, accounts 1-50
+// shard 0, realm 15, accounts 1-10
 // 3 balances per account
 // several transactions
 //
 const shard = 0;
 const realm = 15;
 const accountEntityIds = {};
-const addAccount = async function(accountId, exp_tm_nanosecs = 4223372036854775807) {
+const addAccount = async function(accountId, exp_tm_nanosecs = null) {
   let e = accountEntityIds[accountId];
   if (e) {
     return e;
@@ -243,39 +252,34 @@ const addCryptoTransferTransaction = async function(
 /**
  * Setup test data in the postgres instance.
  */
-const accountCount = 10;
-const minExpiryAccountId = accountCount - 1;
-const maxExpiryAccountId = accountCount;
+const testDataPath = path.join(__dirname, 'integration_test_data.json');
+const testData = fs.readFileSync(testDataPath);
+const testDataJson = JSON.parse(testData);
+
 const setupData = async function() {
   let res = await sqlConnection.query('insert into t_record_files (name) values ($1) returning id;', ['test']);
   let fileId = res.rows[0]['id'];
   console.log(`Record file id is ${fileId}`);
 
   const balancePerAccountCount = 3;
-  console.log(`Adding ${accountCount} accounts with ${balancePerAccountCount} balances per account`);
-  for (var i = 1; i <= accountCount; ++i) {
-    if (i == maxExpiryAccountId) {
-      // set max expiry time for account accountCount
-      await addAccount(i, '9223372036854775807');
-    } else if (i == minExpiryAccountId) {
-      // set min expiry time for account accountCount - 1
-      await addAccount(i, '-9223372036854775808');
-    } else {
-      await addAccount(i);
-    }
+  const testAccounts = testDataJson['accounts'];
+  console.log(`Adding ${testAccounts.length} accounts with ${balancePerAccountCount} balances per account`);
+  for (let account of testAccounts) {
+    await addAccount(account.id, account.expiration_ns);
+
     // Add 3 balances for each account.
     for (var ts = 0; ts < balancePerAccountCount; ++ts) {
       await sqlConnection.query(
         'insert into account_balances (consensus_timestamp, account_realm_num, account_num, balance) values ($1, $2, $3, $4);',
-        [ts * 1000, realm, i, i * 10]
+        [ts * 1000, realm, account.id, account.balance]
       );
     }
   }
 
   console.log('Adding crypto transfer transactions');
-  await addCryptoTransferTransaction(1050, fileId, 10, 9, 10);
-  await addCryptoTransferTransaction(1051, fileId, 10, 9, 20);
-  await addCryptoTransferTransaction(1052, fileId, 8, 9, 30);
+  for (let transfer of testDataJson['transfers']) {
+    await addCryptoTransferTransaction(transfer.time, fileId, transfer.from, transfer.to, transfer.amount);
+  }
 
   console.log('Finished initializing DB data');
 };

--- a/hedera-mirror-rest/__tests__/integration_test_data.json
+++ b/hedera-mirror-rest/__tests__/integration_test_data.json
@@ -1,0 +1,74 @@
+{
+  "accounts": [
+    {
+      "id": 1,
+      "balance": 10,
+      "expiration_ns": null
+    },
+    {
+      "id": 2,
+      "balance": 20,
+      "expiration_ns": null
+    },
+    {
+      "id": 3,
+      "balance": 30,
+      "expiration_ns": null
+    },
+    {
+      "id": 4,
+      "balance": 40,
+      "expiration_ns": null
+    },
+    {
+      "id": 5,
+      "balance": 50,
+      "expiration_ns": null
+    },
+    {
+      "id": 6,
+      "balance": 60,
+      "expiration_ns": null
+    },
+    {
+      "id": 7,
+      "balance": 70,
+      "expiration_ns": null
+    },
+    {
+      "id": 8,
+      "balance": 80,
+      "expiration_ns": null
+    },
+    {
+      "id": 9,
+      "balance": 90,
+      "expiration_ns": "-9223372036854775808"
+    },
+    {
+      "id": 10,
+      "balance": 100,
+      "expiration_ns": "9223372036854775807"
+    }
+  ],
+  "transfers": [
+    {
+      "time": 1050,
+      "from": 10,
+      "to": 9,
+      "amount": 10
+    },
+    {
+      "time": 1051,
+      "from": 10,
+      "to": 9,
+      "amount": 20
+    },
+    {
+      "time": 1052,
+      "from": 8,
+      "to": 9,
+      "amount": 30
+    }
+  ]
+}

--- a/hedera-mirror-rest/__tests__/specs/accounts-01-no-args.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/accounts-01-no-args.spec.json
@@ -9,7 +9,7 @@
           "balance": 10
         },
         "account": "0.15.1",
-        "expiry_timestamp": "4223372036.854776000",
+        "expiry_timestamp": null,
         "auto_renew_period": null,
         "key": null,
         "deleted": false
@@ -20,7 +20,7 @@
           "balance": 20
         },
         "account": "0.15.2",
-        "expiry_timestamp": "4223372036.854776000",
+        "expiry_timestamp": null,
         "auto_renew_period": null,
         "key": null,
         "deleted": false
@@ -31,7 +31,7 @@
           "balance": 30
         },
         "account": "0.15.3",
-        "expiry_timestamp": "4223372036.854776000",
+        "expiry_timestamp": null,
         "auto_renew_period": null,
         "key": null,
         "deleted": false
@@ -42,7 +42,7 @@
           "balance": 40
         },
         "account": "0.15.4",
-        "expiry_timestamp": "4223372036.854776000",
+        "expiry_timestamp": null,
         "auto_renew_period": null,
         "key": null,
         "deleted": false
@@ -53,7 +53,7 @@
           "balance": 50
         },
         "account": "0.15.5",
-        "expiry_timestamp": "4223372036.854776000",
+        "expiry_timestamp": null,
         "auto_renew_period": null,
         "key": null,
         "deleted": false
@@ -64,7 +64,7 @@
           "balance": 60
         },
         "account": "0.15.6",
-        "expiry_timestamp": "4223372036.854776000",
+        "expiry_timestamp": null,
         "auto_renew_period": null,
         "key": null,
         "deleted": false
@@ -75,7 +75,7 @@
           "balance": 70
         },
         "account": "0.15.7",
-        "expiry_timestamp": "4223372036.854776000",
+        "expiry_timestamp": null,
         "auto_renew_period": null,
         "key": null,
         "deleted": false
@@ -86,7 +86,7 @@
           "balance": 80
         },
         "account": "0.15.8",
-        "expiry_timestamp": "4223372036.854776000",
+        "expiry_timestamp": null,
         "auto_renew_period": null,
         "key": null,
         "deleted": false

--- a/hedera-mirror-rest/__tests__/specs/accounts-01-no-args.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/accounts-01-no-args.spec.json
@@ -9,7 +9,7 @@
           "balance": 10
         },
         "account": "0.15.1",
-        "expiry_timestamp": null,
+        "expiry_timestamp": "4223372036.854776000",
         "auto_renew_period": null,
         "key": null,
         "deleted": false
@@ -20,7 +20,7 @@
           "balance": 20
         },
         "account": "0.15.2",
-        "expiry_timestamp": null,
+        "expiry_timestamp": "4223372036.854776000",
         "auto_renew_period": null,
         "key": null,
         "deleted": false
@@ -31,7 +31,7 @@
           "balance": 30
         },
         "account": "0.15.3",
-        "expiry_timestamp": null,
+        "expiry_timestamp": "4223372036.854776000",
         "auto_renew_period": null,
         "key": null,
         "deleted": false
@@ -42,7 +42,7 @@
           "balance": 40
         },
         "account": "0.15.4",
-        "expiry_timestamp": null,
+        "expiry_timestamp": "4223372036.854776000",
         "auto_renew_period": null,
         "key": null,
         "deleted": false
@@ -53,7 +53,7 @@
           "balance": 50
         },
         "account": "0.15.5",
-        "expiry_timestamp": null,
+        "expiry_timestamp": "4223372036.854776000",
         "auto_renew_period": null,
         "key": null,
         "deleted": false
@@ -64,7 +64,7 @@
           "balance": 60
         },
         "account": "0.15.6",
-        "expiry_timestamp": null,
+        "expiry_timestamp": "4223372036.854776000",
         "auto_renew_period": null,
         "key": null,
         "deleted": false
@@ -75,7 +75,7 @@
           "balance": 70
         },
         "account": "0.15.7",
-        "expiry_timestamp": null,
+        "expiry_timestamp": "4223372036.854776000",
         "auto_renew_period": null,
         "key": null,
         "deleted": false
@@ -86,7 +86,7 @@
           "balance": 80
         },
         "account": "0.15.8",
-        "expiry_timestamp": null,
+        "expiry_timestamp": "4223372036.854776000",
         "auto_renew_period": null,
         "key": null,
         "deleted": false
@@ -97,7 +97,7 @@
           "balance": 90
         },
         "account": "0.15.9",
-        "expiry_timestamp": null,
+        "expiry_timestamp": "-9223372036.854775808",
         "auto_renew_period": null,
         "key": null,
         "deleted": false
@@ -108,7 +108,7 @@
           "balance": 100
         },
         "account": "0.15.10",
-        "expiry_timestamp": null,
+        "expiry_timestamp": "9223372036.854775807",
         "auto_renew_period": null,
         "key": null,
         "deleted": false

--- a/hedera-mirror-rest/__tests__/utils.test.js
+++ b/hedera-mirror-rest/__tests__/utils.test.js
@@ -20,7 +20,6 @@
 'use strict';
 
 const request = require('supertest');
-const math = require('mathjs');
 const utils = require('../utils.js');
 
 describe('Utils getNullableNumber tests', () => {


### PR DESCRIPTION
**Detailed description**:

Applying bug fix from #409 to master.

From the original PR:
- In Entities.create/update, handle overflows during conversion of (seconds,nanos) to a long nanos timestamp and set the database values accordingly.
- Utilities.convertToNanos changed due to its implementation adding an additional runtime exception possibility (DateTimeException), rather than just the expected ArithmeticException.
- Tested update via RecordFileLoggerCryptoTest and RecordFileLoggerFileTest

Additions in this change that were not on the release/0.4 branch:
- Correcting a comment in RecordFileLoggerCryptoTest (on numeric overflow of expiration_ns, long max and min values are used, not null which indicates the value is unknown).
- Readding rest-api test data that includes a null expiration timestamp result as well as still testing the new max and min long values that represent the overflow case.
- Refactoring the rest integration test data setup which added confusion during the bug fix. json file integration_test_data.json along with comments at the top of integration.test.js should hopefully make this a bit more clear.

**Which issue(s) this PR fixes**:
Fixes #386 

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [X] Tests updated
