### PR TITLE
HCS fix deploy script and service files. Update version to 0.1.0-rc1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /^v.*/
+              only: /^.*\/v.*/
 
 jobs:
   build_maven:
@@ -70,7 +70,8 @@ jobs:
       - run:
           name: Collecting assets for hedera-mirror-grpc
           command: |
-            NAME=hedera-mirror-grpc-${CIRCLE_TAG:-b$CIRCLE_BUILD_NUM}
+            VERSION_TAG=${CIRCLE_TAG/*\//}
+            NAME=hedera-mirror-grpc-hcs-${VERSION_TAG:-b$CIRCLE_BUILD_NUM}
             WORKSPACE=/tmp/workspace
             mkdir -p ${WORKSPACE}/${NAME}
             mv hedera-mirror-grpc/target/hedera-mirror-grpc-*.jar ${WORKSPACE}/${NAME}
@@ -80,7 +81,8 @@ jobs:
       - run:
           name: Collecting assets for hedera-mirror-importer
           command: |
-            NAME=hedera-mirror-importer-${CIRCLE_TAG:-b$CIRCLE_BUILD_NUM}
+            VERSION_TAG=${CIRCLE_TAG/*\//}
+            NAME=hedera-mirror-importer-hcs-${VERSION_TAG:-b$CIRCLE_BUILD_NUM}
             WORKSPACE=/tmp/workspace
             mkdir -p ${WORKSPACE}/${NAME}
             mv hedera-mirror-importer/target/hedera-mirror-importer-*.jar ${WORKSPACE}/${NAME}
@@ -130,7 +132,8 @@ jobs:
           working_directory: "hedera-mirror-rest"
           name: Collecting assets
           command: |
-            NAME=hedera-mirror-rest-${CIRCLE_TAG:-b$CIRCLE_BUILD_NUM}
+            VERSION_TAG=${CIRCLE_TAG/*\//}
+            NAME=hedera-mirror-rest-hcs-${VERSION_TAG:-b$CIRCLE_BUILD_NUM}
             npm pack
             mkdir -p /tmp/workspace/artifacts
             mv hedera-mirror-rest*.tgz /tmp/workspace/artifacts/${NAME}.tgz

--- a/hedera-mirror-coverage/pom.xml
+++ b/hedera-mirror-coverage/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node-hcs</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0-rc1</version>
     </parent>
 
     <dependencies>

--- a/hedera-mirror-grpc/pom.xml
+++ b/hedera-mirror-grpc/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node-hcs</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0-rc1</version>
     </parent>
 
     <dependencies>

--- a/hedera-mirror-grpc/scripts/deploy.sh
+++ b/hedera-mirror-grpc/scripts/deploy.sh
@@ -1,14 +1,22 @@
 #!/bin/sh -ex
 
+artifactname=hedera-mirror-grpc-hcs
+
+# name of the service and directories
 name=hedera-mirror-grpc
 usretc="/usr/etc/${name}"
 usrlib="/usr/lib/${name}"
 
 # CD to parent directory
 cd "$(dirname $0)/.."
-version=$(ls -1 -d "../"${name}-[vb]* | tr '\n' '\0' | xargs -0 -n 1 basename | tail -1 | sed -e "s/${name}-//")
+version=$(ls -1 -d "../"${artifactname}-[vb]* | tr '\n' '\0' | xargs -0 -n 1 basename | tail -1 | sed -e "s/${artifactname}-//")
 if [ -z "${version}" ]; then
-    echo "Can't find ${name}-v* versioned parent directory. Unrecognized layout. Aborting"
+    echo "Can't find ${artifactname}-[vb]* versioned parent directory. Unrecognized layout. Aborting"
+    exit 1
+fi
+jarname="${artifactname}-${version:1}.jar"
+if [ ! -f "${jarname}" ]; then
+    echo "Can't find ${jarname}. Aborting"
     exit 1
 fi
 
@@ -31,8 +39,8 @@ fi
 
 echo "Copying new binary"
 rm -f "${usrlib}/${name}.jar"
-cp "${name}-${version}.jar" "${usrlib}"
-ln -s "${usrlib}/${name}-${version}.jar" "${usrlib}/${name}.jar"
+cp "${jarname}" "${usrlib}"
+ln -s "${usrlib}/${jarname}" "${usrlib}/${name}.jar"
 
 echo "Setting up ${name} systemd service"
 cp "scripts/${name}.service" /etc/systemd/system

--- a/hedera-mirror-importer/pom.xml
+++ b/hedera-mirror-importer/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node-hcs</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0-rc1</version>
     </parent>
 
     <properties>

--- a/hedera-mirror-importer/scripts/deploy.sh
+++ b/hedera-mirror-importer/scripts/deploy.sh
@@ -1,5 +1,8 @@
 #!/bin/sh -ex
 
+artifactname=hedera-mirror-importer-hcs
+
+# name of the service and directories
 name=hedera-mirror-importer
 usretc="/usr/etc/${name}"
 usrlib="/usr/lib/${name}"
@@ -7,9 +10,14 @@ varlib="/var/lib/${name}"
 
 # CD to parent directory
 cd "$(dirname $0)/.."
-version=$(ls -1 -d "../"${name}-[vb]* | tr '\n' '\0' | xargs -0 -n 1 basename | tail -1 | sed -e "s/${name}-//")
+version=$(ls -1 -d "../"${artifactname}-[vb]* | tr '\n' '\0' | xargs -0 -n 1 basename | tail -1 | sed -e "s/${artifactname}-//")
 if [ -z "${version}" ]; then
-    echo "Can't find ${name}-v* versioned parent directory. Unrecognized layout. Aborting"
+    echo "Can't find ${artifactname}-[vb]* versioned parent directory. Unrecognized layout. Aborting"
+    exit 1
+fi
+jarname="${artifactname}-${version:1}.jar"
+if [ ! -f "${jarname}" ]; then
+    echo "Can't find ${jarname}. Aborting"
     exit 1
 fi
 
@@ -82,8 +90,8 @@ fi
 
 echo "Copying new binary"
 rm -f "${usrlib}/${name}.jar"
-cp "${name}-${version}.jar" "${usrlib}"
-ln -s "${usrlib}/${name}-${version}.jar" "${usrlib}/${name}.jar"
+cp "${jarname}" "${usrlib}"
+ln -s "${usrlib}/${jarname}" "${usrlib}/${name}.jar"
 
 echo "Setting up ${name} systemd service"
 cp "scripts/${name}.service" /etc/systemd/system

--- a/hedera-mirror-importer/scripts/hedera-mirror-importer.service
+++ b/hedera-mirror-importer/scripts/hedera-mirror-importer.service
@@ -4,6 +4,7 @@ Description=Hedera Mirror Importer
 
 [Service]
 ExecStart=/usr/bin/java -jar hedera-mirror-importer.jar -Djavax.net.ssl.trustStorePassword=changeit -DLog4jContextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector --spring.config.additional-location=file:/usr/etc/hedera-mirror-importer/
+
 LimitNOFILE=65536
 Restart=on-failure
 RestartSec=1

--- a/hedera-mirror-protobuf/pom.xml
+++ b/hedera-mirror-protobuf/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node-hcs</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0-rc1</version>
     </parent>
 
     <properties>

--- a/hedera-mirror-rest/package-lock.json
+++ b/hedera-mirror-rest/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-mirror-rest-hcs",
-  "version": "0.1.0-SNAPSHOT",
+  "version": "0.1.0-rc1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hedera-mirror-rest/package.json
+++ b/hedera-mirror-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-mirror-rest-hcs",
-  "version": "0.1.0-SNAPSHOT",
+  "version": "0.1.0-rc1",
   "description": "Hedera Mirror Node REST API (HCS)",
   "main": "server.js",
   "scripts": {

--- a/hedera-mirror-rest/pom.xml
+++ b/hedera-mirror-rest/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node-hcs</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0-rc1</version>
     </parent>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.hedera</groupId>
     <artifactId>hedera-mirror-node-hcs</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.1.0-rc1</version>
     <description>Hedera Mirror Node mirrors data from Hedera nodes and serves it via an API</description>
     <inceptionYear>2019</inceptionYear>
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
**Detailed description**:
- Update versions from 0.1.0-SNAPSHOT to 0.1.0-rc1
- Make service name match artifact (-hcs suffix)
- Adjust deploy script for new service name.
- Fix bug in deploy script introduced in #400. jar name is "-0.1.0", directory is "-v0.1.0". Links at the end of deploy script fail.
- Change to CircleCI - version tags for HCS will be `hcs/v0.1.0` style.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
