### PR TITLE
Fix deploy script bug. Update version to 0.5.0-rc1

### DIFF
--- a/hedera-mirror-coverage/pom.xml
+++ b/hedera-mirror-coverage/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.5.0-SNAPSHOT</version>
+        <version>0.5.0-rc1</version>
     </parent>
 
     <dependencies>

--- a/hedera-mirror-importer/pom.xml
+++ b/hedera-mirror-importer/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.5.0-SNAPSHOT</version>
+        <version>0.5.0-rc1</version>
     </parent>
 
     <properties>

--- a/hedera-mirror-importer/scripts/deploy.sh
+++ b/hedera-mirror-importer/scripts/deploy.sh
@@ -9,7 +9,12 @@ varlib="/var/lib/${name}"
 cd "$(dirname $0)/.."
 version=$(ls -1 -d "../"${name}-[vb]* | tr '\n' '\0' | xargs -0 -n 1 basename | tail -1 | sed -e "s/${name}-//")
 if [ -z "${version}" ]; then
-    echo "Can't find ${name}-v* versioned parent directory. Unrecognized layout. Aborting"
+    echo "Can't find ${name}-[vb]* versioned parent directory. Unrecognized layout. Aborting"
+    exit 1
+fi
+jarname="${name}-${version:1}.jar"
+if [ ! -f "${jarname}" ]; then
+    echo "Can't find ${jarname}. Aborting"
     exit 1
 fi
 
@@ -82,8 +87,8 @@ fi
 
 echo "Copying new binary"
 rm -f "${usrlib}/${name}.jar"
-cp "${name}-${version}.jar" "${usrlib}"
-ln -s "${usrlib}/${name}-${version}.jar" "${usrlib}/${name}.jar"
+cp "${jarname}" "${usrlib}"
+ln -s "${usrlib}/${jarname}" "${usrlib}/${name}.jar"
 
 echo "Setting up ${name} systemd service"
 cp "scripts/${name}.service" /etc/systemd/system

--- a/hedera-mirror-rest/package-lock.json
+++ b/hedera-mirror-rest/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-mirror-rest",
-  "version": "0.5.0-SNAPSHOT",
+  "version": "0.5.0-rc1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hedera-mirror-rest/package.json
+++ b/hedera-mirror-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-mirror-rest",
-  "version": "0.5.0-SNAPSHOT",
+  "version": "0.5.0-rc1",
   "description": "Hedera Mirror Node REST API",
   "main": "server.js",
   "scripts": {

--- a/hedera-mirror-rest/pom.xml
+++ b/hedera-mirror-rest/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.5.0-SNAPSHOT</version>
+        <version>0.5.0-rc1</version>
     </parent>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.hedera</groupId>
     <artifactId>hedera-mirror-node</artifactId>
-    <version>0.5.0-SNAPSHOT</version>
+    <version>0.5.0-rc1</version>
     <description>Hedera Mirror Node mirrors data from Hedera nodes and serves it via an API</description>
     <inceptionYear>2019</inceptionYear>
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
**Detailed description**:
- Update versions from 0.5.0-SNAPSHOT to 0.5.0-rc1
- Fix bug in deploy script introduced in #400. jar name is "-0.5.0", directory is "-v0.5.0". Links at the end of deploy script fail.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

