### PR TITLE
Adopt insert instead of update for v1.16 db migration. Avoids temp_fi…

### DIFF
--- a/hedera-mirror-importer/scripts/deploy.sh
+++ b/hedera-mirror-importer/scripts/deploy.sh
@@ -12,7 +12,7 @@ if [ -z "${version}" ]; then
     echo "Can't find ${name}-[vb]* versioned parent directory. Unrecognized layout. Aborting"
     exit 1
 fi
-jarname="${name}-${version:1}.jar"
+jarname="${name}-${version:-1}.jar"
 if [ ! -f "${jarname}" ]; then
     echo "Can't find ${jarname}. Aborting"
     exit 1

--- a/hedera-mirror-importer/scripts/deploy.sh
+++ b/hedera-mirror-importer/scripts/deploy.sh
@@ -12,7 +12,7 @@ if [ -z "${version}" ]; then
     echo "Can't find ${name}-[vb]* versioned parent directory. Unrecognized layout. Aborting"
     exit 1
 fi
-jarname="${name}-${version:-1}.jar"
+jarname="${name}-${version:1}.jar"
 if [ ! -f "${jarname}" ]; then
     echo "Can't find ${jarname}. Aborting"
     exit 1

--- a/hedera-mirror-importer/src/main/resources/db/migration/V1.16__cryptotransferlist_realm_num.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/V1.16__cryptotransferlist_realm_num.sql
@@ -29,6 +29,9 @@ create index if not exists idx__t_cryptotransferlist_amount ON t_cryptotransferl
 create index if not exists idx__t_cryptotransferlists__consensus_and_realm_and_num
     on t_cryptotransferlists (consensus_timestamp, realm_num, entity_num);
 
+create index if not exists idx__t_cryptotransferlists__realm_and_num_and_consensus
+    on t_cryptotransferlists (realm_num, entity_num, consensus_timestamp);
+
 -- add foreign key
 alter table t_cryptotransferlists
     add constraint fk__t_transactions foreign key (consensus_timestamp) references t_transactions (consensus_ns);

--- a/hedera-mirror-importer/src/main/resources/db/migration/V1.16__cryptotransferlist_realm_num.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/V1.16__cryptotransferlist_realm_num.sql
@@ -9,35 +9,36 @@ drop index if exists
 drop index if exists
     idx__t_cryptotransferlists__consensus_and_account;
 
--- add realm_num and entity_num
-alter table t_cryptotransferlists
-    add column if not exists realm_num entity_realm_num null;
-
-alter table t_cryptotransferlists
-    add column if not exists entity_num entity_num null;
-
 -- populate realm_num and entity_num from t_entities table
-with dupe_entities as (
-        select id, entity_realm, entity_num from t_entities
-)
-update t_cryptotransferlists c set realm_num = de.entity_realm, entity_num = de.entity_num from dupe_entities de where c.account_id = de.id;
+-- instead of in place update insert into a new table without index overhead for optimal performance
+create table t_cryptotransferlists_migrate
+(
+    consensus_timestamp nanos_timestamp not null,
+    realm_num           entity_num      not null,
+    entity_num          entity_num      not null,
+    amount              hbar_tinybars   not null
+);
 
-alter table t_cryptotransferlists
-    alter column realm_num set not null;
+insert into t_cryptotransferlists_migrate (consensus_timestamp, realm_num, entity_num, amount)
+select ctl.consensus_timestamp, ent.entity_realm, ent.entity_num, ctl.amount
+from t_cryptotransferlists ctl
+         join t_entities ent
+              on ctl.account_id = ent.id;
 
-alter table t_cryptotransferlists
-    alter column entity_num set not null;
-
--- add additional indexes
-create index if not exists idx__t_cryptotransferlists__consensus_and_realm_and_num
-    on t_cryptotransferlists (consensus_timestamp, realm_num, entity_num);
+-- add indexes
+create index if not exists idx__t_cryptotransferlist_amount ON t_cryptotransferlists_migrate (amount);
 
 create index if not exists idx__t_cryptotransferlists__ts_then_acct
-    on t_cryptotransferlists (consensus_timestamp, realm_num, entity_num);
+    on t_cryptotransferlists_migrate (consensus_timestamp, entity_num);
 
--- drop constraint and acount_id
-alter table t_cryptotransferlists
-   drop constraint if exists fk_ctl_account_id;
+create index if not exists idx__t_cryptotransferlists__consensus_and_realm_and_num
+    on t_cryptotransferlists_migrate (consensus_timestamp, realm_num, entity_num);
 
-alter table t_cryptotransferlists
-    drop column if exists account_id;
+-- add foreign key
+alter table t_cryptotransferlists_migrate
+    add constraint fk__t_transactions foreign key (consensus_timestamp) references t_transactions (consensus_ns);
+
+-- swap tables
+drop table t_cryptotransferlists;
+alter table t_cryptotransferlists_migrate
+    rename to t_cryptotransferlists;

--- a/hedera-mirror-importer/src/main/resources/db/migration/V1.16__cryptotransferlist_realm_num.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/V1.16__cryptotransferlist_realm_num.sql
@@ -25,20 +25,20 @@ from t_cryptotransferlists ctl
          join t_entities ent
               on ctl.account_id = ent.id;
 
--- add indexes
-create index if not exists idx__t_cryptotransferlist_amount ON t_cryptotransferlists_migrate (amount);
-
-create index if not exists idx__t_cryptotransferlists__ts_then_acct
-    on t_cryptotransferlists_migrate (consensus_timestamp, entity_num);
-
-create index if not exists idx__t_cryptotransferlists__consensus_and_realm_and_num
-    on t_cryptotransferlists_migrate (consensus_timestamp, realm_num, entity_num);
-
--- add foreign key
-alter table t_cryptotransferlists_migrate
-    add constraint fk__t_transactions foreign key (consensus_timestamp) references t_transactions (consensus_ns);
-
 -- swap tables
 drop table t_cryptotransferlists;
 alter table t_cryptotransferlists_migrate
     rename to t_cryptotransferlists;
+
+    -- add indexes
+create index if not exists idx__t_cryptotransferlist_amount ON t_cryptotransferlists (amount);
+
+create index if not exists idx__t_cryptotransferlists__ts_then_acct
+    on t_cryptotransferlists (consensus_timestamp, entity_num);
+
+create index if not exists idx__t_cryptotransferlists__consensus_and_realm_and_num
+    on t_cryptotransferlists (consensus_timestamp, realm_num, entity_num);
+
+-- add foreign key
+alter table t_cryptotransferlists
+    add constraint fk__t_transactions foreign key (consensus_timestamp) references t_transactions (consensus_ns);


### PR DESCRIPTION
**Detailed description**:
During v0.5 deployment testing on dev Migration V1.16__cryptotransferlist_realm_num.sql failed with ERROR: temporary file size exceeds temp_file_limit (1025563kB)
This is likely due to the demand on temp file size the db created to manage in the inlace update of the t_cryptotransferlists table using the Postgres common table expression format.
A more efficient strategy inserts into a new db table thus avoiding the overhead the db goes through due to the presence of indexes.
All indexes and constraints are created on the new table and rename is performed to swap the tables.

-- V1.16__cryptotransferlist_realm_num.sql was updated to inserts into a new table, then create indexes and do a rename and remove to swap tables thus creating the desired updated t_cryptotransferlists table

**Which issue(s) this PR fixes**:
Fixes #448 

**Special notes for your reviewer**:
Ran on dev machine where Mike had hit the above issue. Output is as follows
```
Dec 16 21:14:36 mirrornode-dev-1 java[26321]: 2019-12-16 21:14:36,515 INFO  [main ] o.f.c.i.c.DbMigrate Successfully applied 2 migrations to schema "public" (execution time 01:08.708s)
Dec 16 21:14:36 mirrornode-dev-1 java[26321]: 2019-12-16 21:14:36,487 INFO  [main ] o.f.c.i.c.DbMigrate Migrating schema "public" to version 1.17 - transaction bytes
Dec 16 21:13:27 mirrornode-dev-1 java[26321]: 2019-12-16 21:13:27,943 INFO  [main ] o.f.c.i.c.DbMigrate Migrating schema "public" to version 1.16 - cryptotransferlist realm num
Dec 16 21:13:27 mirrornode-dev-1 java[26321]: 2019-12-16 21:13:27,827 INFO  [main ] o.f.c.i.c.DbMigrate Current version of schema "public": 1.15
```

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

