### PR TITLE
Add hcs fake data generation for load testing grpc api

### DIFF
--- a/hedera-mirror-faker/faker/load_data.sql
+++ b/hedera-mirror-faker/faker/load_data.sql
@@ -33,6 +33,11 @@ SELECT drop_constraints_and_indexes();
 \copy t_file_data FROM '%%TMP_DIR%%/t_file_data' WITH CSV HEADER;
 
 \echo ------------------------------
+\echo COPY data to topic_message from %%TMP_DIR%%/topic_message
+\echo ------------------------------
+\copy topic_message FROM '%%TMP_DIR%%/topic_message' WITH CSV HEADER;
+
+\echo ------------------------------
 \echo COPY data to account_balances from %%TMP_DIR%%/account_balances
 \echo ------------------------------
 \copy account_balances FROM '%%TMP_DIR%%/account_balances' WITH CSV HEADER;

--- a/hedera-mirror-faker/src/main/java/com/hedera/faker/common/EntityManager.java
+++ b/hedera-mirror-faker/src/main/java/com/hedera/faker/common/EntityManager.java
@@ -23,7 +23,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.Set;
 import javax.inject.Named;
 
@@ -46,6 +45,9 @@ public class EntityManager {
     @Getter
     private final EntitySet files;
 
+    @Getter
+    private final EntitySet topics;
+
     // Keeps track of entities' balances.
     @Getter
     private final Map<Long, Long> balances;
@@ -56,6 +58,7 @@ public class EntityManager {
     public EntityManager() {
         accounts = new EntitySet(0L);  // Account entities start from 0
         files = new EntitySet(100_000_000L);
+        topics = new EntitySet(200_000_000L);
         balances = new HashMap<>();
 
         // Create one node account with id = 0.

--- a/hedera-mirror-faker/src/main/java/com/hedera/faker/common/TopicTransactionProperties.java
+++ b/hedera-mirror-faker/src/main/java/com/hedera/faker/common/TopicTransactionProperties.java
@@ -1,0 +1,50 @@
+package com.hedera.faker.common;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Named;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import com.hedera.faker.sampling.NumberDistributionConfig;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+@Named
+@ConfigurationProperties("faker.transaction.topic")
+public class TopicTransactionProperties {
+
+    private final NumberDistributionConfig messageSize = new NumberDistributionConfig();
+
+    /**
+     * Relative frequency of CONSENSUSCREATETOPIC transactions
+     */
+    private int createsFrequency;
+
+    /**
+     * Relative frequency of CONSENSUSDELETETOPIC transactions
+     */
+    private int deletesFrequency;
+
+    /**
+     * Relative frequency of CONSENSUSUPDATETOPIC transactions
+     */
+    private int updatesFrequency;
+
+    /**
+     * Relative frequency of CONSENSUSSUBMITMESSAGE transactions
+     */
+    private int submitMessageFrequency;
+
+    /**
+     * When generating transactions, first 'numSeedTopics' number of transactions will be of type CONSENSUSCREATETOPIC
+     * only. This is to seed the system with some topics for deletes/updates/submitMessage.
+     */
+    private int numSeedTopics;
+
+    @PostConstruct
+    void initDistributions() {
+        messageSize.initDistribution();
+    }
+}

--- a/hedera-mirror-faker/src/main/java/com/hedera/faker/common/TransactionGeneratorProperties.java
+++ b/hedera-mirror-faker/src/main/java/com/hedera/faker/common/TransactionGeneratorProperties.java
@@ -30,4 +30,5 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class TransactionGeneratorProperties {
     private int cryptoTransactionsFrequency;
     private int fileTransactionsFrequency;
+    private int topicTransactionsFrequency;
 }

--- a/hedera-mirror-faker/src/main/java/com/hedera/faker/domain/generators/entity/EntityGenerator.java
+++ b/hedera-mirror-faker/src/main/java/com/hedera/faker/domain/generators/entity/EntityGenerator.java
@@ -60,6 +60,7 @@ public class EntityGenerator {
         Stopwatch stopwatch = Stopwatch.createStarted();
         generateAndWriteEntityType(entityManager.getAccounts(), domainWriter, this::generateAccountEntity, "account");
         generateAndWriteEntityType(entityManager.getFiles(), domainWriter, this::generateFileEntity, "file");
+        generateAndWriteEntityType(entityManager.getTopics(), domainWriter, this::generateTopicEntity, "topic");
         log.info("Generated all entities in {}", stopwatch);
     }
 
@@ -101,6 +102,12 @@ public class EntityGenerator {
     private Entities generateFileEntity(long id) {
         Entities entity = createBaseEntity(id);
         entity.setEntityTypeId(3); // 3 = file
+        return entity;
+    }
+
+    private Entities generateTopicEntity(long id) {
+        Entities entity = createBaseEntity(id);
+        entity.setEntityTypeId(4); // 4 = topic
         return entity;
     }
 }

--- a/hedera-mirror-faker/src/main/java/com/hedera/faker/domain/generators/transaction/DomainTransactionGenerator.java
+++ b/hedera-mirror-faker/src/main/java/com/hedera/faker/domain/generators/transaction/DomainTransactionGenerator.java
@@ -36,10 +36,11 @@ public class DomainTransactionGenerator {
 
     public DomainTransactionGenerator(
             TransactionGeneratorProperties properties, CryptoTransactionGenerator cryptoTransactionGenerator,
-            FileTransactionGenerator fileTransactionGenerator) {
+            FileTransactionGenerator fileTransactionGenerator, TopicTransactionGenerator topicTransactionGenerator) {
         mixedTransactionGenerator = new FrequencyDistribution<>(Map.of(
                 cryptoTransactionGenerator, properties.getCryptoTransactionsFrequency(),
-                fileTransactionGenerator, properties.getFileTransactionsFrequency()
+                fileTransactionGenerator, properties.getFileTransactionsFrequency(),
+                topicTransactionGenerator, properties.getTopicTransactionsFrequency()
         ));
     }
 

--- a/hedera-mirror-faker/src/main/java/com/hedera/faker/domain/generators/transaction/TopicTransactionGenerator.java
+++ b/hedera-mirror-faker/src/main/java/com/hedera/faker/domain/generators/transaction/TopicTransactionGenerator.java
@@ -1,0 +1,102 @@
+package com.hedera.faker.domain.generators.transaction;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import java.util.function.Consumer;
+import javax.inject.Named;
+
+import lombok.Getter;
+import lombok.extern.log4j.Log4j2;
+
+import com.hedera.faker.common.EntityManager;
+import com.hedera.faker.common.TopicTransactionProperties;
+import com.hedera.faker.common.TransactionGenerator;
+import com.hedera.faker.domain.writer.DomainWriter;
+import com.hedera.faker.sampling.Distribution;
+import com.hedera.faker.sampling.FrequencyDistribution;
+import com.hedera.mirror.importer.domain.TopicMessage;
+import com.hedera.mirror.importer.domain.Transaction;
+
+/**
+ * Generates topic transactions (CONSENSUSCREATETOPIC, CONSENSUSUPDATETOPIC, CONSENSUSDELETETOPIC,
+ * CONSENSUSSUBMITMESSAGE)
+ */
+@Log4j2
+@Named
+public class TopicTransactionGenerator extends TransactionGenerator {
+
+    private final TopicTransactionProperties properties;
+    @Getter
+    private final Distribution<Consumer<Transaction>> transactionDistribution;
+    private final byte[] runningHash;
+    private Map<Long, Integer> topicToNextSequenceNumber;
+
+    public TopicTransactionGenerator(
+            TopicTransactionProperties properties, EntityManager entityManager, DomainWriter domainWriter) {
+        super(entityManager, domainWriter, properties.getNumSeedTopics());
+        this.properties = properties;
+        transactionDistribution = new FrequencyDistribution<>(Map.of(
+                this::createTopic, this.properties.getCreatesFrequency(),
+                this::deleteTopic, this.properties.getDeletesFrequency(),
+                this::updateTopic, this.properties.getUpdatesFrequency(),
+                this::submitMessage, this.properties.getSubmitMessageFrequency()
+        ));
+        runningHash = new byte[32]; // Size = 32bytes. TODO: what's correct size here?
+        Arrays.fill(runningHash, (byte) 0x01);
+        topicToNextSequenceNumber = new HashMap<>();
+    }
+
+    @Override
+    protected void seedEntity(Transaction transaction) {
+        createTopic(transaction);
+    }
+
+    private void createTopic(Transaction transaction) {
+        transaction.setType(24);  // 24 = CONSENSUSCREATETOPIC
+        Long newTopicId = entityManager.getTopics().newEntity();
+        transaction.setEntityId(newTopicId);
+        topicToNextSequenceNumber.put(newTopicId, 0);
+        log.trace("CONSENSUSCREATETOPIC transaction: topicId {}", newTopicId);
+    }
+
+    private void deleteTopic(Transaction transaction) {
+        transaction.setType(26);  // 26 = CONSENSUSDELETETOPIC
+        Long topicId = entityManager.getTopics().getRandom();
+        entityManager.getTopics().delete(topicId);
+        transaction.setEntityId(topicId);
+        log.trace("CONSENSUSDELETETOPIC transaction: topicId {}", topicId);
+    }
+
+    private void updateTopic(Transaction transaction) {
+        transaction.setType(25);  // 25 = CONSENSUSUPDATETOPIC
+        Long topicId = entityManager.getTopics().getRandom();
+        transaction.setEntityId(topicId);
+        log.trace("CONSENSUSUPDATETOPIC transaction: topicId {}", topicId);
+    }
+
+    private void submitMessage(Transaction transaction) {
+        transaction.setType(27);  // 27 = CONSENSUSSUBMITMESSAGE
+        Long topicId = entityManager.getTopics().getRandom();
+        transaction.setEntityId(topicId);
+        createTopicMessage(transaction.getConsensusNs(), topicId);
+        log.trace("CONSENSUSSUBMITMESSAGE transaction: topicId {}", topicId);
+    }
+
+    private void createTopicMessage(long consensusNs, long topicId) {
+        TopicMessage topicMessage = new TopicMessage();
+        topicMessage.setConsensusTimestamp(consensusNs);
+        topicMessage.setRealmNum(0);
+        topicMessage.setTopicNum((int) topicId);
+        topicMessage.setRunningHash(runningHash);
+        int sequenceNumber = topicToNextSequenceNumber.get(topicId);
+        topicMessage.setSequenceNumber(sequenceNumber);
+        topicToNextSequenceNumber.put(topicId, sequenceNumber + 1);
+        long messageSize = properties.getMessageSize().sample();
+        byte[] messageBytes = new byte[(int) messageSize];
+        new Random().nextBytes(messageBytes);
+        topicMessage.setMessage(messageBytes);
+        domainWriter.addTopicMessage(topicMessage);
+    }
+}

--- a/hedera-mirror-faker/src/main/java/com/hedera/faker/domain/writer/DomainWriter.java
+++ b/hedera-mirror-faker/src/main/java/com/hedera/faker/domain/writer/DomainWriter.java
@@ -22,6 +22,7 @@ package com.hedera.faker.domain.writer;
 import com.hedera.mirror.importer.domain.CryptoTransfer;
 import com.hedera.mirror.importer.domain.Entities;
 import com.hedera.mirror.importer.domain.FileData;
+import com.hedera.mirror.importer.domain.TopicMessage;
 import com.hedera.mirror.importer.domain.Transaction;
 
 public interface DomainWriter {
@@ -32,6 +33,8 @@ public interface DomainWriter {
     void addCryptoTransfer(CryptoTransfer cryptoTransfer);
 
     void addFileData(FileData fileData);
+
+    void addTopicMessage(TopicMessage topicMessage);
 
     void addAccountBalances(long consensusNs, long balance, long accountNum);
 

--- a/hedera-mirror-faker/src/main/resources/application.yml
+++ b/hedera-mirror-faker/src/main/resources/application.yml
@@ -4,8 +4,9 @@ faker:
     rangeMin: 3
     rangeMax: 8
   transaction:
-    cryptoTransactionsFrequency: 990
+    cryptoTransactionsFrequency: 490
     fileTransactionsFrequency: 10
+    topicTransactionsFrequency: 500
     crypto:
       createsFrequency: 10
       transfersFrequency: 988
@@ -24,6 +25,15 @@ faker:
       fileDataSize:
         rangeMin: 0
         rangeMax: 5000
+    topic:
+      createsFrequency: 1
+      updatesFrequency: 1
+      deletesFrequency: 1
+      submitMessageFrequency: 997
+      numSeedTopics: 10
+      messageSize:
+        rangeMin: 0
+        rangeMax: 3000
 
 logging:
   level:

--- a/hedera-mirror-importer/src/main/resources/db/migration/V1.19__topic_message.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/V1.19__topic_message.sql
@@ -1,0 +1,76 @@
+CREATE OR REPLACE FUNCTION drop_constraints_and_indexes() RETURNS void AS
+$$
+DECLARE
+BEGIN
+    -- Drop order is roughly determined by foreign key constraints. If foreign key A.fk_id references B.id, then
+    -- foreign key constraint on A.fk_id needs to be dropped before dropping any indexes/primary_key on B.id.
+    PERFORM drop_t_cryptotransferlists_constraints_and_indexes();
+    PERFORM drop_t_file_data_constraints_and_indexes();
+    PERFORM drop_t_livehashes_constraints_and_indexes();
+    PERFORM drop_t_contract_result_constraints_and_indexes();
+    PERFORM drop_topic_message_constraints_and_indexes();
+    PERFORM drop_t_transactions_constraints_and_indexes();
+    PERFORM drop_t_entities_constraints_and_indexes();
+    PERFORM drop_account_balances_constraints_and_indexes();
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION create_constraints_and_indexes() RETURNS void AS
+$$
+DECLARE
+BEGIN
+    -- Creates should be in reverse order of drops above. If foreign key A.fk_id references B.id, then
+    -- foreign key constraint on A.fk_id should be created after creating index/primary_key on B.id.
+    PERFORM create_account_balances_constraints_and_indexes();
+    PERFORM create_t_entities_constraints_and_indexes();
+    PERFORM create_t_transactions_constraints_and_indexes();
+    PERFORM create_topic_message_constraints_and_indexes();
+    PERFORM create_t_contract_result_constraints_and_indexes();
+    PERFORM create_t_livehashes_constraints_and_indexes();
+    PERFORM create_t_file_data_constraints_and_indexes();
+    PERFORM create_t_cryptotransferlists_constraints_and_indexes();
+END;
+$$ LANGUAGE plpgsql;
+
+
+CREATE OR REPLACE FUNCTION drop_topic_message_constraints_and_indexes() RETURNS void AS
+$$
+DECLARE
+BEGIN
+    ALTER TABLE topic_message
+        DROP CONSTRAINT topic_message_pkey;
+    DROP INDEX topic_message__realm_num_timestamp;
+    DROP TRIGGER topic_message_trigger ON topic_message; -- TODO : verify
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION create_topic_message_constraints_and_indexes() RETURNS void AS
+$$
+DECLARE
+BEGIN
+    CREATE UNIQUE INDEX topic_message_pkey ON topic_message (consensus_timestamp);
+    ALTER TABLE topic_message
+        ADD PRIMARY KEY USING INDEX topic_message_pkey;
+    CREATE INDEX topic_message__realm_num_timestamp ON topic_message (realm_num, topic_num, consensus_timestamp);
+    CREATE TRIGGER topic_message_trigger
+        AFTER INSERT ON topic_message FOR EACH ROW EXECUTE PROCEDURE topic_message_notifier('topic_message');
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION cleanup() RETURNS void AS
+$$
+DECLARE
+BEGIN
+    TRUNCATE TABLE account_balance_sets RESTART IDENTITY CASCADE;
+    TRUNCATE TABLE account_balances RESTART IDENTITY CASCADE;
+    TRUNCATE TABLE t_contract_result RESTART IDENTITY CASCADE;
+    TRUNCATE TABLE t_cryptotransferlists RESTART IDENTITY CASCADE;
+    TRUNCATE TABLE t_file_data RESTART IDENTITY CASCADE;
+    TRUNCATE TABLE t_livehashes RESTART IDENTITY CASCADE;
+    TRUNCATE TABLE t_record_files RESTART IDENTITY CASCADE;
+    TRUNCATE TABLE t_entities RESTART IDENTITY CASCADE;
+    TRUNCATE TABLE t_transactions RESTART IDENTITY CASCADE;
+    TRUNCATE TABLE topic_message RESTART IDENTITY CASCADE;
+    UPDATE t_application_status SET status_value = NULL;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
Signed-off-by: Apekshit Sharma <apekshit.sharma@hedera.com>

**Detailed description**:
Fake data generation part for GRPC perf testing.
This covers static data generation and loading into DB, which can then be queried using grpc server.
In phase two, we should add "live data" functionality to faker to be able to perf test 'notify' aspect of grpc server.

This depends on PR #396 being merged into master first.

**Which issue(s) this PR fixes**:
Partially fixes #422 

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

