### PR TITLE
Log nodes that don't reach consensus

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -272,12 +272,13 @@ Response: Requires human action at some point.
 | `Error reading previous file hash`                                       | LOW              |                                 |
 | `Failed to verify`                                                       | LOW              |                                 |
 | `Input parameter is not a folder`                                        | LOW              |                                 |
-| `Invalid signature in file`                                              | LOW              |                                 |
+| `Failed to verify signature with public key`                             | LOW              |                                 |
 | `Missing signature for file`                                             | LOW              |                                 |
 | `Error saving file in database`                                          | NONE             | HIGH (if 30 entries in 1 min)   |
 | `Failed downloading`                                                     | NONE             | HIGH (if 30 entries in 1 min)   |
 | `File could not be verified by more than 2/3 of nodes`                   | NONE             | HIGH (if 30 entries in 1 min)   |
 | `File watching events may have been lost or discarded`                   | NONE             | HIGH (if 30 entries in 1 min)   |
+| `Signature verification failed`                                          | NONE             | HIGH (if 30 entries in 1 min)   |
 | `Unable to connect to database`                                          | NONE             | HIGH (if 30 entries in 1 min)   |
 | `Unable to fetch entity types`                                           | NONE             | HIGH (if 30 entries in 1 min)   |
 | `Unable to prepare SQL statements`                                       | NONE             | HIGH (if 30 entries in 1 min)   |

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/FileStreamSignature.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/FileStreamSignature.java
@@ -26,20 +26,27 @@ import lombok.Data;
 import com.hedera.mirror.importer.util.Utility;
 
 @Data
-public class SignatureStream implements Comparable<SignatureStream> {
+public class FileStreamSignature implements Comparable<FileStreamSignature> {
 
     private File file;
     private byte[] hash;
     private String node;
     private byte[] signature;
-    private boolean valid;
+    private SignatureStatus status = SignatureStatus.DOWNLOADED;
 
     @Override
-    public int compareTo(SignatureStream other) {
+    public int compareTo(FileStreamSignature other) {
         return file.compareTo(other.getFile());
     }
 
     public String getHashAsHex() {
         return Utility.bytesToHex(hash);
+    }
+
+    public enum SignatureStatus {
+        DOWNLOADED,        // Signature has been downloaded but not verified
+        PARSED,            // Extracted hash and signature data from file
+        VERIFIED,          // Signature has been verified against the node's public key
+        CONSENSUS_REACHED; // More than 2/3 of all nodes have been verified
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/SignatureStream.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/SignatureStream.java
@@ -1,4 +1,4 @@
-package com.hedera.mirror.importer.exception;
+package com.hedera.mirror.importer.domain;
 
 /*-
  * ‌
@@ -20,22 +20,26 @@ package com.hedera.mirror.importer.exception;
  * ‍
  */
 
-/**
- * Invalid dataset such as an account balances dataset.
- */
-public class InvalidDatasetException extends ImporterException {
+import java.io.File;
+import lombok.Data;
 
-    private static final long serialVersionUID = 3679395824341309905L;
+import com.hedera.mirror.importer.util.Utility;
 
-    public InvalidDatasetException(String message) {
-        super(message);
+@Data
+public class SignatureStream implements Comparable<SignatureStream> {
+
+    private File file;
+    private byte[] hash;
+    private String node;
+    private byte[] signature;
+    private boolean valid;
+
+    @Override
+    public int compareTo(SignatureStream other) {
+        return file.compareTo(other.getFile());
     }
 
-    public InvalidDatasetException(Throwable throwable) {
-        super(throwable);
-    }
-
-    public InvalidDatasetException(String message, Throwable throwable) {
-        super(message, throwable);
+    public String getHashAsHex() {
+        return Utility.bytesToHex(hash);
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/Downloader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/Downloader.java
@@ -23,26 +23,25 @@ package com.hedera.mirror.importer.downloader;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
 import com.google.common.base.Stopwatch;
-
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+import com.google.common.collect.TreeMultimap;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Collection;
 import java.util.List;
-import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
-
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
@@ -55,6 +54,8 @@ import software.amazon.awssdk.services.s3.model.S3Object;
 import com.hedera.mirror.importer.addressbook.NetworkAddressBook;
 import com.hedera.mirror.importer.domain.ApplicationStatusCode;
 import com.hedera.mirror.importer.domain.NodeAddress;
+import com.hedera.mirror.importer.domain.SignatureStream;
+import com.hedera.mirror.importer.exception.SignatureVerificationException;
 import com.hedera.mirror.importer.repository.ApplicationStatusRepository;
 import com.hedera.mirror.importer.util.ShutdownHelper;
 import com.hedera.mirror.importer.util.Utility;
@@ -68,7 +69,7 @@ public abstract class Downloader {
     private final DownloaderProperties downloaderProperties;
     // Thread pool used one per node during the download process for signatures.
     private final ExecutorService signatureDownloadThreadPool;
-    private List<String> nodeAccountIds;
+    private Set<String> nodeAccountIds;
 
     public Downloader(S3AsyncClient s3Client, ApplicationStatusRepository applicationStatusRepository,
                       NetworkAddressBook networkAddressBook, DownloaderProperties downloaderProperties) {
@@ -77,7 +78,7 @@ public abstract class Downloader {
         this.networkAddressBook = networkAddressBook;
         this.downloaderProperties = downloaderProperties;
         signatureDownloadThreadPool = Executors.newFixedThreadPool(downloaderProperties.getThreads());
-        nodeAccountIds = networkAddressBook.load().stream().map(NodeAddress::getId).collect(Collectors.toList());
+        nodeAccountIds = networkAddressBook.load().stream().map(NodeAddress::getId).collect(Collectors.toSet());
         Runtime.getRuntime().addShutdownHook(new Thread(signatureDownloadThreadPool::shutdown));
     }
 
@@ -92,6 +93,8 @@ public abstract class Downloader {
             var sigFilesMap = downloadSigFiles();
             // Verify signature files and download corresponding files of valid signature files
             verifySigsAndDownloadDataFiles(sigFilesMap);
+        } catch (SignatureVerificationException e) {
+            log.warn(e.getMessage());
         } catch (Exception e) {
             log.error("Error downloading files", e);
         }
@@ -104,16 +107,15 @@ public abstract class Downloader {
      *
      * @return key: sig file name value: a list of sig files with the same name and from different nodes folder;
      */
-    private Map<String, List<File>> downloadSigFiles() throws InterruptedException {
+    private Multimap<String, SignatureStream> downloadSigFiles() throws InterruptedException {
         String lastValidFileName = applicationStatusRepository.findByStatusCode(getLastValidDownloadedFileKey());
         // foo.rcd < foo.rcd_sig. If we read foo.rcd from application stats, we have to start listing from
         // next to 'foo.rcd_sig'.
         String lastValidSigFileName = lastValidFileName.isEmpty() ? "" : lastValidFileName + "_sig";
-
-        var sigFilesMap = new ConcurrentHashMap<String, List<File>>();
+        Multimap<String, SignatureStream> sigFilesMap = Multimaps.synchronizedSortedSetMultimap(TreeMultimap.create());
 
         // refresh node account ids
-        nodeAccountIds = networkAddressBook.load().stream().map(NodeAddress::getId).collect(Collectors.toList());
+        nodeAccountIds = networkAddressBook.load().stream().map(NodeAddress::getId).collect(Collectors.toSet());
         List<Callable<Object>> tasks = new ArrayList<>(nodeAccountIds.size());
         var totalDownloads = new AtomicInteger();
         /**
@@ -176,10 +178,10 @@ public abstract class Downloader {
                             if (pd.waitForCompletion()) {
                                 ref.count++;
                                 File sigFile = pd.getFile();
-                                String fileName = sigFile.getName();
-                                sigFilesMap.putIfAbsent(fileName, Collections.synchronizedList(new ArrayList<>()));
-                                List<File> files = sigFilesMap.get(fileName);
-                                files.add(sigFile);
+                                SignatureStream signatureStream = new SignatureStream();
+                                signatureStream.setFile(sigFile);
+                                signatureStream.setNode(Utility.getAccountIDStringFromFilePath(sigFile));
+                                sigFilesMap.put(sigFile.getName(), signatureStream);
                             }
                         } catch (InterruptedException ex) {
                             log.warn("Failed downloading {} in {}", pd.getS3key(), pd.getStopwatch(), ex);
@@ -268,44 +270,33 @@ public abstract class Downloader {
      *
      * @param sigFilesMap
      */
-    private void verifySigsAndDownloadDataFiles(Map<String, List<File>> sigFilesMap) {
+    private void verifySigsAndDownloadDataFiles(Multimap<String, SignatureStream> sigFilesMap) {
         // reload address book and keys in case it has been updated by RecordFileLogger
-        NodeSignatureVerifier verifier = new NodeSignatureVerifier(networkAddressBook);
+        NodeSignatureVerifier nodeSignatureVerifier = new NodeSignatureVerifier(networkAddressBook);
         Path validPath = downloaderProperties.getValidPath();
 
-        List<String> sigFileNames = new ArrayList<>(sigFilesMap.keySet());
-        // sort in increasing order of timestamp, so that we process files in the order they are written.
-        // It's very important for record and event files because they form immutable linked list by include one file's
-        // hash into next file.
-        Collections.sort(sigFileNames);
-
-        for (String sigFileName : sigFileNames) {
+        for (String sigFileName : sigFilesMap.keySet()) {
             if (ShutdownHelper.isStopping()) {
                 return;
             }
 
-            List<File> sigFiles = sigFilesMap.get(sigFileName);
+            Collection<SignatureStream> signatures = sigFilesMap.get(sigFileName);
+            nodeSignatureVerifier.verify(signatures);
             boolean valid = false;
 
-            // If the number of sigFiles is not greater than 2/3 of number of nodes, we don't need to verify them
-            if (sigFiles == null || !Utility.greaterThanSuperMajorityNum(sigFiles.size(), nodeAccountIds.size())) {
-                log.warn("Signature file count does not exceed 2/3 of nodes");
-                continue;
-            }
-
-            // validSigFiles are signed by node'key and contains the same Hash which has been agreed by more than 2/3
-            // nodes
-            Pair<byte[], List<File>> hashAndValidSigFiles = verifier.verifySignatureFiles(sigFiles);
-            byte[] validHash = hashAndValidSigFiles.getLeft();
-            for (File validSigFileName : hashAndValidSigFiles.getRight()) {
+            for (SignatureStream signature : signatures) {
                 if (ShutdownHelper.isStopping()) {
                     return;
                 }
-                log.debug("Verified signature file matches at least 2/3 of nodes: {}", sigFileName);
+
+                // One of the 1/3 that didn't validate, so skip
+                if (!signature.isValid()) {
+                    continue;
+                }
 
                 try {
-                    File signedDataFile = downloadSignedDataFile(validSigFileName);
-                    if (signedDataFile != null && Utility.hashMatch(validHash, signedDataFile)) {
+                    File signedDataFile = downloadSignedDataFile(signature.getFile());
+                    if (signedDataFile != null && Utility.hashMatch(signature.getHash(), signedDataFile)) {
                         log.debug("Downloaded data file {} corresponding to verified hash", signedDataFile.getName());
                         // Check that file is newer than last valid downloaded file.
                         // Additionally, if the file type uses prevFileHash based linking, verify that new file is
@@ -318,7 +309,7 @@ public abstract class Downloader {
                                 log.debug("Successfully moved file from {} to {}", signedDataFile, destination);
                                 if (getLastValidDownloadedFileHashKey() != null) {
                                     applicationStatusRepository.updateStatusValue(getLastValidDownloadedFileHashKey(),
-                                            Utility.bytesToHex(validHash));
+                                            signature.getHashAsHex());
                                 }
                                 applicationStatusRepository
                                         .updateStatusValue(getLastValidDownloadedFileKey(), destination.getName());
@@ -371,7 +362,7 @@ public abstract class Downloader {
         String fileName = sigFile.getName().replace("_sig", "");
         String s3Prefix = downloaderProperties.getPrefix();
 
-        String nodeAccountId = Utility.getAccountIDStringFromFilePath(sigFile.getPath());
+        String nodeAccountId = Utility.getAccountIDStringFromFilePath(sigFile);
         String s3ObjectKey = s3Prefix + nodeAccountId + "/" + fileName;
 
         Path localFile = downloaderProperties.getTempPath().resolve(fileName);

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/NodeSignatureVerifier.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/NodeSignatureVerifier.java
@@ -20,24 +20,23 @@ package com.hedera.mirror.importer.downloader;
  * ‍
  */
 
-import java.io.File;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
 import java.security.PublicKey;
 import java.security.Signature;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
-
 import lombok.extern.log4j.Log4j2;
-import org.apache.commons.codec.DecoderException;
-import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.lang3.tuple.Pair;
 
 import com.hedera.mirror.importer.addressbook.NetworkAddressBook;
 import com.hedera.mirror.importer.domain.NodeAddress;
+import com.hedera.mirror.importer.domain.SignatureStream;
+import com.hedera.mirror.importer.exception.SignatureVerificationException;
 import com.hedera.mirror.importer.util.Utility;
 
 @Log4j2
@@ -52,82 +51,88 @@ public class NodeSignatureVerifier {
                 .collect(Collectors.toMap(NodeAddress::getId, NodeAddress::getPublicKeyAsObject));
     }
 
+    private static boolean greaterThanSuperMajorityNum(long n, long N) {
+        return n > N * 2 / 3.0;
+    }
+
     /**
      * Verifies that the signature files are signed by corresponding node's PublicKey. For valid signature files, we
-     * compare their Hashes to see if more than 2/3 Hashes match. If more than 2/3 Hashes match, we return a List of
-     * Files which contains this Hash.
+     * compare their hashes to see if more than 2/3 Hashes match. If a signature is valid, we put the hash in its
+     * content and its File to the map, to see if more than 2/3 valid signatures have the same hash.
      *
-     * @param sigFiles a list of a sig files which have the same timestamp
-     * @return Pair of <hash of valid data file, list of valid sig files>. Valid means the signature is valid and the
-     * Hash is agreed by super-majority nodes. If validity of signatures can not be established, then returns <null,
-     * empty list>.
+     * @param signatures a list of a sig files which have the same timestamp
      */
-    public Pair<byte[], List<File>> verifySignatureFiles(List<File> sigFiles) {
-        // If a signature is valid, we put the Hash in its content and its File to the map, to see if more than 2/3
-        // valid signatures have the same Hash
-        Map<String, Set<File>> hashToSigFiles = new HashMap<>();
-        for (File sigFile : sigFiles) {
-            Pair<byte[], byte[]> hashAndSig = Utility.extractHashAndSigFromFile(sigFile);
+    public void verify(Collection<SignatureStream> signatures) {
+        Multimap<String, SignatureStream> signatureHashMap = HashMultimap.create();
+        String filename = signatures.stream().map(s -> s.getFile().getName()).findFirst().orElse("empty");
+
+        if (!greaterThanSuperMajorityNum(signatures.size(), nodeIDPubKeyMap.size())) {
+            Set<String> seenNodes = signatures.stream().map(SignatureStream::getNode).collect(Collectors.toSet());
+            Set<String> missingNodes = new TreeSet<>(Sets.difference(nodeIDPubKeyMap.keySet(), seenNodes));
+            String message = String.format("Signature verification failed for %s with %s of %s nodes missing: %s",
+                    filename, missingNodes.size(), nodeIDPubKeyMap.size(), missingNodes);
+            throw new SignatureVerificationException(message);
+        }
+
+        for (SignatureStream signatureStream : signatures) {
+            Pair<byte[], byte[]> hashAndSig = Utility.extractHashAndSigFromFile(signatureStream.getFile());
             if (hashAndSig == null) {
                 continue;
             }
-            String nodeAccountID = Utility.getAccountIDStringFromFilePath(sigFile.getPath());
-            if (verifySignature(hashAndSig.getLeft(), hashAndSig.getRight(), nodeAccountID, sigFile.getPath())) {
-                String hashString = Hex.encodeHexString(hashAndSig.getLeft());
-                hashToSigFiles
-                        .putIfAbsent(hashString, new HashSet<>());  // only one key present in common case, no
-                // efficiency issues.
-                hashToSigFiles.get(hashString).add(sigFile);
-            } else {
-                log.error("Invalid signature in file {}", sigFile.getPath());
+
+            signatureStream.setHash(hashAndSig.getLeft());
+            signatureStream.setSignature(hashAndSig.getRight());
+
+            if (verifySignature(signatureStream)) {
+                signatureHashMap.put(signatureStream.getHashAsHex(), signatureStream);
             }
         }
 
-        for (String key : hashToSigFiles.keySet()) {
-            if (Utility.greaterThanSuperMajorityNum(hashToSigFiles.get(key).size(),
-                    nodeIDPubKeyMap.size())) {
-                byte[] hash = null;
-                try {
-                    hash = Hex.decodeHex(key);
-                } catch (DecoderException e) {
-                    log.error("Error decoding hex string {}", key);
-                }
-                return Pair.of(hash, new ArrayList<>(hashToSigFiles.get(key)));
+        for (String key : signatureHashMap.keySet()) {
+            Collection<SignatureStream> validatedSignatures = signatureHashMap.get(key);
+            if (greaterThanSuperMajorityNum(validatedSignatures.size(), nodeIDPubKeyMap.size())) {
+                validatedSignatures.stream().forEach(s -> s.setValid(true));
+                log.debug("Verified signature file matches more than 2/3 of nodes: {}", filename);
+                return;
             }
         }
-        return Pair.of(null, new ArrayList<>());
+
+        Collection<String> invalidNodes = signatures.stream()
+                .filter(s -> !s.isValid())
+                .map(SignatureStream::getNode)
+                .sorted()
+                .collect(Collectors.toList());
+        String message = String.format("Signature verification failed for %s with %s of %s nodes not passing: %s",
+                filename, invalidNodes.size(), nodeIDPubKeyMap.size(), invalidNodes);
+        throw new SignatureVerificationException(message);
     }
 
     /**
      * check whether the given signature is valid
      *
-     * @param data          the data that was signed
-     * @param signature     the claimed signature of that data
-     * @param nodeAccountID the node's accountID string
+     * @param signatureStream the data that was signed
      * @return true if the signature is valid
      */
-    private boolean verifySignature(byte[] data, byte[] signature,
-                                    String nodeAccountID, String filePath) {
-        PublicKey publicKey = nodeIDPubKeyMap.get(nodeAccountID);
+    private boolean verifySignature(SignatureStream signatureStream) {
+        PublicKey publicKey = nodeIDPubKeyMap.get(signatureStream.getNode());
         if (publicKey == null) {
-            log.warn("Missing PublicKey for node {}", nodeAccountID);
+            log.warn("Missing PublicKey for node {}", signatureStream.getNode());
             return false;
         }
 
-        if (signature == null) {
-            log.error("Missing signature for file {}", filePath);
+        if (signatureStream.getSignature() == null) {
+            log.error("Missing signature data: {}", signatureStream);
             return false;
         }
 
         try {
-            log.trace("Verifying signature of file {} with public key of node {}", filePath, nodeAccountID);
+            log.trace("Verifying signature: {}", signatureStream);
             Signature sig = Signature.getInstance("SHA384withRSA", "SunRsaSign");
             sig.initVerify(publicKey);
-            sig.update(data);
-            return sig.verify(signature);
+            sig.update(signatureStream.getHash());
+            return sig.verify(signatureStream.getSignature());
         } catch (Exception e) {
-            log.error("Failed to verify Signature: {}, PublicKey: {}, NodeID: {}, File: {}", signature, publicKey,
-                    nodeAccountID, filePath, e);
+            log.error("Failed to verify signature with public key {}: {}", publicKey, signatureStream, e);
         }
         return false;
     }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/NodeSignatureVerifier.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/NodeSignatureVerifier.java
@@ -34,8 +34,9 @@ import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.tuple.Pair;
 
 import com.hedera.mirror.importer.addressbook.NetworkAddressBook;
+import com.hedera.mirror.importer.domain.FileStreamSignature;
+import com.hedera.mirror.importer.domain.FileStreamSignature.SignatureStatus;
 import com.hedera.mirror.importer.domain.NodeAddress;
-import com.hedera.mirror.importer.domain.SignatureStream;
 import com.hedera.mirror.importer.exception.SignatureVerificationException;
 import com.hedera.mirror.importer.util.Utility;
 
@@ -51,89 +52,100 @@ public class NodeSignatureVerifier {
                 .collect(Collectors.toMap(NodeAddress::getId, NodeAddress::getPublicKeyAsObject));
     }
 
-    private static boolean greaterThanSuperMajorityNum(long n, long N) {
+    private static boolean consensusReached(long n, long N) {
         return n > N * 2 / 3.0;
     }
 
     /**
      * Verifies that the signature files are signed by corresponding node's PublicKey. For valid signature files, we
      * compare their hashes to see if more than 2/3 Hashes match. If a signature is valid, we put the hash in its
-     * content and its File to the map, to see if more than 2/3 valid signatures have the same hash.
+     * content and its file to the map, to see if more than 2/3 valid signatures have the same hash.
      *
      * @param signatures a list of a sig files which have the same timestamp
+     * @throws SignatureVerificationException
      */
-    public void verify(Collection<SignatureStream> signatures) {
-        Multimap<String, SignatureStream> signatureHashMap = HashMultimap.create();
-        String filename = signatures.stream().map(s -> s.getFile().getName()).findFirst().orElse("empty");
+    public void verify(Collection<FileStreamSignature> signatures) throws SignatureVerificationException {
+        Multimap<String, FileStreamSignature> signatureHashMap = HashMultimap.create();
+        String filename = null;
+        int consensusCount = 0;
 
-        if (!greaterThanSuperMajorityNum(signatures.size(), nodeIDPubKeyMap.size())) {
-            Set<String> seenNodes = signatures.stream().map(SignatureStream::getNode).collect(Collectors.toSet());
-            Set<String> missingNodes = new TreeSet<>(Sets.difference(nodeIDPubKeyMap.keySet(), seenNodes));
-            String message = String.format("Signature verification failed for %s with %s of %s nodes missing: %s",
-                    filename, missingNodes.size(), nodeIDPubKeyMap.size(), missingNodes);
-            throw new SignatureVerificationException(message);
-        }
+        for (FileStreamSignature fileStreamSignature : signatures) {
+            if (filename == null) {
+                filename = fileStreamSignature.getFile().getName();
+            }
 
-        for (SignatureStream signatureStream : signatures) {
-            Pair<byte[], byte[]> hashAndSig = Utility.extractHashAndSigFromFile(signatureStream.getFile());
+            Pair<byte[], byte[]> hashAndSig = Utility.extractHashAndSigFromFile(fileStreamSignature.getFile());
             if (hashAndSig == null) {
                 continue;
             }
 
-            signatureStream.setHash(hashAndSig.getLeft());
-            signatureStream.setSignature(hashAndSig.getRight());
+            fileStreamSignature.setHash(hashAndSig.getLeft());
+            fileStreamSignature.setSignature(hashAndSig.getRight());
+            fileStreamSignature.setStatus(SignatureStatus.PARSED);
 
-            if (verifySignature(signatureStream)) {
-                signatureHashMap.put(signatureStream.getHashAsHex(), signatureStream);
+            if (verifySignature(fileStreamSignature)) {
+                fileStreamSignature.setStatus(SignatureStatus.VERIFIED);
+                signatureHashMap.put(fileStreamSignature.getHashAsHex(), fileStreamSignature);
             }
         }
 
         for (String key : signatureHashMap.keySet()) {
-            Collection<SignatureStream> validatedSignatures = signatureHashMap.get(key);
-            if (greaterThanSuperMajorityNum(validatedSignatures.size(), nodeIDPubKeyMap.size())) {
-                validatedSignatures.stream().forEach(s -> s.setValid(true));
-                log.debug("Verified signature file matches more than 2/3 of nodes: {}", filename);
-                return;
+            Collection<FileStreamSignature> validatedSignatures = signatureHashMap.get(key);
+
+            if (consensusReached(validatedSignatures.size(), nodeIDPubKeyMap.size())) {
+                consensusCount += validatedSignatures.size();
+                validatedSignatures.stream().forEach(s -> s.setStatus(SignatureStatus.CONSENSUS_REACHED));
             }
         }
 
-        Collection<String> invalidNodes = signatures.stream()
-                .filter(s -> !s.isValid())
-                .map(SignatureStream::getNode)
-                .sorted()
-                .collect(Collectors.toList());
-        String message = String.format("Signature verification failed for %s with %s of %s nodes not passing: %s",
-                filename, invalidNodes.size(), nodeIDPubKeyMap.size(), invalidNodes);
-        throw new SignatureVerificationException(message);
+        if (consensusCount == nodeIDPubKeyMap.size()) {
+            log.debug("Verified signature file {} reached consensus", filename);
+        } else if (consensusCount > 0) {
+            log.warn("Verified signature file {} reached consensus but with some errors: {}", filename,
+                    statusMap(signatures));
+        } else {
+            throw new SignatureVerificationException("Signature verification failed for " + filename + ": " + statusMap(signatures));
+        }
     }
 
     /**
      * check whether the given signature is valid
      *
-     * @param signatureStream the data that was signed
+     * @param fileStreamSignature the data that was signed
      * @return true if the signature is valid
      */
-    private boolean verifySignature(SignatureStream signatureStream) {
-        PublicKey publicKey = nodeIDPubKeyMap.get(signatureStream.getNode());
+    private boolean verifySignature(FileStreamSignature fileStreamSignature) {
+        PublicKey publicKey = nodeIDPubKeyMap.get(fileStreamSignature.getNode());
         if (publicKey == null) {
-            log.warn("Missing PublicKey for node {}", signatureStream.getNode());
+            log.warn("Missing PublicKey for node {}", fileStreamSignature.getNode());
             return false;
         }
 
-        if (signatureStream.getSignature() == null) {
-            log.error("Missing signature data: {}", signatureStream);
+        if (fileStreamSignature.getSignature() == null) {
+            log.error("Missing signature data: {}", fileStreamSignature);
             return false;
         }
 
         try {
-            log.trace("Verifying signature: {}", signatureStream);
+            log.trace("Verifying signature: {}", fileStreamSignature);
             Signature sig = Signature.getInstance("SHA384withRSA", "SunRsaSign");
             sig.initVerify(publicKey);
-            sig.update(signatureStream.getHash());
-            return sig.verify(signatureStream.getSignature());
+            sig.update(fileStreamSignature.getHash());
+            return sig.verify(fileStreamSignature.getSignature());
         } catch (Exception e) {
-            log.error("Failed to verify signature with public key {}: {}", publicKey, signatureStream, e);
+            log.error("Failed to verify signature with public key {}: {}", publicKey, fileStreamSignature, e);
         }
         return false;
+    }
+
+    private Map<String, Collection<String>> statusMap(Collection<FileStreamSignature> signatures) {
+        Map<String, Collection<String>> statusMap = signatures.stream()
+                .collect(Collectors.groupingBy(fss -> fss.getStatus().toString(),
+                        Collectors.mapping(FileStreamSignature::getNode, Collectors.toCollection(TreeSet::new))));
+        Set<String> seenNodes = signatures.stream().map(FileStreamSignature::getNode).collect(Collectors.toSet());
+        Set<String> missingNodes = new TreeSet<>(Sets.difference(nodeIDPubKeyMap.keySet(), seenNodes));
+        statusMap.put("MISSING", missingNodes);
+        statusMap.remove(SignatureStatus.CONSENSUS_REACHED.toString());
+        return statusMap;
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/exception/ImporterException.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/exception/ImporterException.java
@@ -20,22 +20,19 @@ package com.hedera.mirror.importer.exception;
  * ‍
  */
 
-/**
- * Invalid dataset such as an account balances dataset.
- */
-public class InvalidDatasetException extends ImporterException {
+public abstract class ImporterException extends RuntimeException {
 
-    private static final long serialVersionUID = 3679395824341309905L;
+    private static final long serialVersionUID = -4366690969696518274L;
 
-    public InvalidDatasetException(String message) {
+    public ImporterException(String message) {
         super(message);
     }
 
-    public InvalidDatasetException(Throwable throwable) {
+    public ImporterException(Throwable throwable) {
         super(throwable);
     }
 
-    public InvalidDatasetException(String message, Throwable throwable) {
+    public ImporterException(String message, Throwable throwable) {
         super(message, throwable);
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/exception/SignatureVerificationException.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/exception/SignatureVerificationException.java
@@ -20,22 +20,11 @@ package com.hedera.mirror.importer.exception;
  * ‍
  */
 
-/**
- * Invalid dataset such as an account balances dataset.
- */
-public class InvalidDatasetException extends ImporterException {
+public class SignatureVerificationException extends ImporterException {
 
-    private static final long serialVersionUID = 3679395824341309905L;
+    private static final long serialVersionUID = 4830495870121480440L;
 
-    public InvalidDatasetException(String message) {
+    public SignatureVerificationException(String message) {
         super(message);
-    }
-
-    public InvalidDatasetException(Throwable throwable) {
-        super(throwable);
-    }
-
-    public InvalidDatasetException(String message, Throwable throwable) {
-        super(message, throwable);
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/util/Utility.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/util/Utility.java
@@ -33,7 +33,6 @@ import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.Transaction;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionID;
-
 import java.io.DataInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -52,7 +51,6 @@ import java.util.Arrays;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
-
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.lang3.StringUtils;
@@ -514,8 +512,9 @@ public class Utility {
         }
     }
 
-    public static String getAccountIDStringFromFilePath(String path) {
+    public static String getAccountIDStringFromFilePath(File file) {
         String regex;
+        String path = file.getPath();
         if (isRecordFile(path) || isRecordSigFile(path)) {
             regex = "record([\\d]+[.][\\d]+[.][\\d]+)";
         } else if (isEventStreamFile(path) || isEventStreamSigFile(path)) {
@@ -583,10 +582,6 @@ public class Utility {
         }
     }
 
-    public static boolean greaterThanSuperMajorityNum(long n, long N) {
-        return n > N * 2 / 3.0;
-    }
-
     /**
      * Convert an Instant to a Long type timestampInNanos
      */
@@ -607,9 +602,9 @@ public class Utility {
     }
 
     /**
-     * Converts time in (second, nanos) to time in only nanos, with a fallback if overflow:
-     * If positive overflow, return the max time in the future (Long.MAX_VALUE).
-     * If negative overflow, return the max time in the past (Long.MIN_VALUE).
+     * Converts time in (second, nanos) to time in only nanos, with a fallback if overflow: If positive overflow, return
+     * the max time in the future (Long.MAX_VALUE). If negative overflow, return the max time in the past
+     * (Long.MIN_VALUE).
      */
     public static Long convertToNanosMax(long second, long nanos) {
         try {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/AbstractDownloaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/AbstractDownloaderTest.java
@@ -26,12 +26,10 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 
 import io.findify.s3mock.S3Mock;
-
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -217,7 +215,7 @@ public abstract class AbstractDownloaderTest {
 
     @Test
     @DisplayName("Invalid or incomplete file")
-    void invalidBalanceFile() throws Exception {
+    void invalidFile() throws Exception {
         fileCopier.copy();
         Files.walk(s3Path).filter(file -> !isSigFile(file)).forEach(AbstractDownloaderTest::corruptFile);
         downloader.download();

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/balance/AccountBalancesDownloaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/balance/AccountBalancesDownloaderTest.java
@@ -24,7 +24,6 @@ import static org.mockito.Mockito.verify;
 
 import java.nio.file.Path;
 import java.util.List;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -60,6 +59,18 @@ public class AccountBalancesDownloaderTest extends AbstractDownloaderTest {
     @DisplayName("Download and verify signatures")
     void downloadAndVerify() throws Exception {
         fileCopier.copy();
+        downloader.download();
+        verify(applicationStatusRepository).updateStatusValue(
+                ApplicationStatusCode.LAST_VALID_DOWNLOADED_BALANCE_FILE, "2019-08-30T18_30_00.010147001Z_Balances" +
+                        ".csv");
+        assertValidFiles(List
+                .of("2019-08-30T18_15_00.016002001Z_Balances.csv", "2019-08-30T18_30_00.010147001Z_Balances.csv"));
+    }
+
+    @Test
+    @DisplayName("More than 2/3 but less than 100% signatures")
+    void moreThanTwoThirdSignatures() throws Exception {
+        fileCopier.filterDirectories("*0.0.3").filterDirectories("*0.0.4").filterDirectories("*0.0.5").copy();
         downloader.download();
         verify(applicationStatusRepository).updateStatusValue(
                 ApplicationStatusCode.LAST_VALID_DOWNLOADED_BALANCE_FILE, "2019-08-30T18_30_00.010147001Z_Balances" +

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/record/RecordFileDownloaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/record/RecordFileDownloaderTest.java
@@ -29,7 +29,6 @@ import static org.mockito.Mockito.verify;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -89,6 +88,20 @@ public class RecordFileDownloaderTest extends AbstractDownloaderTest {
     @DisplayName("Download and verify V2 files")
     void downloadV2() throws Exception {
         fileCopier.copy();
+        downloader.download();
+        verify(applicationStatusRepository).updateStatusValue(
+                ApplicationStatusCode.LAST_VALID_DOWNLOADED_RECORD_FILE, "2019-08-30T18_10_00.419072Z.rcd");
+        verify(applicationStatusRepository).updateStatusValue(
+                ApplicationStatusCode.LAST_VALID_DOWNLOADED_RECORD_FILE, "2019-08-30T18_10_05.249678Z.rcd");
+        verify(applicationStatusRepository, times(2)).updateStatusValue(
+                eq(ApplicationStatusCode.LAST_VALID_DOWNLOADED_RECORD_FILE_HASH), any());
+        assertValidFiles(List.of("2019-08-30T18_10_05.249678Z.rcd", "2019-08-30T18_10_00.419072Z.rcd"));
+    }
+
+    @Test
+    @DisplayName("More than 2/3 but less than 100% signatures")
+    void moreThanTwoThirdSignatures() throws Exception {
+        fileCopier.filterDirectories("*0.0.3").filterDirectories("*0.0.4").filterDirectories("*0.0.5").copy();
         downloader.download();
         verify(applicationStatusRepository).updateStatusValue(
                 ApplicationStatusCode.LAST_VALID_DOWNLOADED_RECORD_FILE, "2019-08-30T18_10_00.419072Z.rcd");


### PR DESCRIPTION
**Detailed description**:
- Log nodes that don't pass signature verification
- Encapsulate the stream of signatures into a `FileStreamSignature` class that allows different methods to enrich it with data like hash, signature and validity
- Utilize Multimap to avoid NPE and avoid sorting unnecessarily
- Fix an issue with continuing to next file when signatures not verified (which would then download and fail hash chain)
- Update troubleshooting doc with logging changes

**Which issue(s) this PR fixes**:
Fixes #444

**Special notes for your reviewer**:
Example output:
```
 2019-12-19 12:56:22,082 INFO  [pool-5-thread-4] c.h.m.i.d.r.RecordFileDownloader Downloaded 2 signatures for node 0.0.3 in 656.2 ms
 2019-12-19 12:56:22,082 INFO  [pool-5-thread-2] c.h.m.i.d.r.RecordFileDownloader Downloaded 2 signatures for node 0.0.4 in 656.5 ms
 2019-12-19 12:56:22,082 INFO  [main ] c.h.m.i.d.r.RecordFileDownloader Downloaded 4 signatures in 658.6 ms (6/s)
 2019-12-19 12:56:22,104 WARN  [main ] c.h.m.i.d.r.RecordFileDownloader Signature verification failed for 2019-08-30T18_10_00.419072Z.rcd_sig: {MISSING=[0.0.5, 0.0.6], VERIFIED=[0.0.3, 0.0.4]}
```

```
 2019-12-19 12:56:22,379 INFO  [main ] c.h.m.i.d.r.RecordFileDownloader Downloaded 8 signatures in 98.44 ms (81/s)
 2019-12-19 12:56:22,380 ERROR [main ] c.h.m.i.u.Utility Unknown file delimiter 99 in signature file /var/folders/dy/3hk8nqg93nbctw8lchz_415r0000gn/T/junit17453419502341935375/recordstreams/record0.0.3/2019-08-30T18_10_00.419072Z.rcd_sig
 2019-12-19 12:56:22,380 ERROR [main ] c.h.m.i.u.Utility Unknown file delimiter 99 in signature file /var/folders/dy/3hk8nqg93nbctw8lchz_415r0000gn/T/junit17453419502341935375/recordstreams/record0.0.4/2019-08-30T18_10_00.419072Z.rcd_sig
 2019-12-19 12:56:22,381 ERROR [main ] c.h.m.i.u.Utility Unknown file delimiter 99 in signature file /var/folders/dy/3hk8nqg93nbctw8lchz_415r0000gn/T/junit17453419502341935375/recordstreams/record0.0.5/2019-08-30T18_10_00.419072Z.rcd_sig
 2019-12-19 12:56:22,381 ERROR [main ] c.h.m.i.u.Utility Unknown file delimiter 99 in signature file /var/folders/dy/3hk8nqg93nbctw8lchz_415r0000gn/T/junit17453419502341935375/recordstreams/record0.0.6/2019-08-30T18_10_00.419072Z.rcd_sig
 2019-12-19 12:56:22,381 WARN  [main ] c.h.m.i.d.r.RecordFileDownloader Signature verification failed for 2019-08-30T18_10_00.419072Z.rcd_sig: {DOWNLOADED=[0.0.3, 0.0.4, 0.0.5, 0.0.6], MISSING=[]}
```

```
 2019-12-19 12:56:23,066 INFO  [pool-34-thread-3] c.h.m.i.d.r.RecordFileDownloader Downloaded 2 signatures for node 0.0.5 in 29.32 ms
 2019-12-19 12:56:23,070 INFO  [pool-34-thread-2] c.h.m.i.d.r.RecordFileDownloader Downloaded 2 signatures for node 0.0.4 in 33.76 ms
 2019-12-19 12:56:23,072 INFO  [pool-34-thread-4] c.h.m.i.d.r.RecordFileDownloader Downloaded 2 signatures for node 0.0.3 in 35.78 ms
 2019-12-19 12:56:23,072 INFO  [main ] c.h.m.i.d.r.RecordFileDownloader Downloaded 6 signatures in 36.70 ms (163/s)
 2019-12-19 12:56:23,075 WARN  [main ] c.h.m.i.d.NodeSignatureVerifier Verified signature file 2019-08-30T18_10_00.419072Z.rcd_sig reached consensus but with some errors: {MISSING=[0.0.6], CONSENSUS_REACHED=[0.0.3, 0.0.4, 0.0.5]}
 2019-12-19 12:56:23,086 WARN  [main ] c.h.m.i.d.NodeSignatureVerifier Verified signature file 2019-08-30T18_10_05.249678Z.rcd_sig reached consensus but with some errors: {MISSING=[0.0.6], CONSENSUS_REACHED=[0.0.3, 0.0.4, 0.0.5]}
```
**Checklist**
- [x] Documentation added
- [x] Tests updated

