### PR TITLE
Fix Monitor Error Handling for long running tests

### DIFF
--- a/hedera-mirror-rest/monitoring/monitor_apis/account_tests.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/account_tests.js
@@ -31,14 +31,14 @@ const maxLimit = config.api.maxLimit;
  * @param {String} pathandquery
  * @return {Object} Accounts object from response
  */
-const getAccounts = pathandquery => {
+const getAccounts = (pathandquery, currentTestResult) => {
   return acctestutils
     .getAPIResponse(pathandquery)
     .then(json => {
       return json.accounts;
     })
     .catch(error => {
-      testResult.failureMessages.push(error);
+      currentTestResult.failureMessages.push(error);
     });
 };
 

--- a/hedera-mirror-rest/monitoring/monitor_apis/balance_tests.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/balance_tests.js
@@ -205,7 +205,7 @@ const getSingleBalanceById = async (server, classResults) => {
   currentTestResult.url = url;
   let singleBalance = await getBalances(url, currentTestResult);
 
-  if (undefined === singleBalance) {
+  if (undefined === singleBalance || undefined === singleBalance[0]) {
     var message = `singleBalance is undefined`;
     currentTestResult.failureMessages.push(message);
     acctestutils.addTestResult(classResults, currentTestResult, false);

--- a/hedera-mirror-rest/monitoring/monitor_apis/balance_tests.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/balance_tests.js
@@ -32,14 +32,14 @@ const balanceFileUpdateRefreshTime = 900;
  * @param {String} pathandquery
  * @return {Object} Transactions object from response
  */
-const getBalances = pathandquery => {
+const getBalances = (pathandquery, currentTestResult) => {
   return acctestutils
     .getAPIResponse(pathandquery)
     .then(json => {
       return json.balances;
     })
     .catch(error => {
-      testResult.failureMessages.push(error);
+      currentTestResult.failureMessages.push(error);
     });
 };
 

--- a/hedera-mirror-rest/monitoring/monitor_apis/common.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/common.js
@@ -147,9 +147,14 @@ const getProcess = server => {
  * @param {Object} server the server for which the pid needs to be stored
  * @return {} None
  */
-const saveProcess = (server, pid) => {
+const saveProcess = (server, count) => {
   const key = `${server.ip}_${server.port}`;
-  pids[key] = pid;
+  const processObject = {
+    id: server.name,
+    encountered: count
+  };
+
+  pids[key] = processObject;
 };
 
 /**

--- a/hedera-mirror-rest/monitoring/monitor_apis/monitor.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/monitor.js
@@ -48,7 +48,9 @@ const runEverything = async servers => {
           if (outJson.hasOwnProperty('testResults')) {
             results = outJson;
             console.log(
-              `Completed tests run for ${server.name} at: ${new Date()} with ${results.testResults.length} tests run`
+              `Completed tests run for ${server.name} at: ${new Date()} with ${results.numPassedTests}/${
+                results.testResults.length
+              } tests passed`
             );
           } else {
             results = monitorTestutils.createFailedResultJson(

--- a/hedera-mirror-rest/monitoring/monitor_apis/monitor.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/monitor.js
@@ -22,6 +22,8 @@
 
 const common = require('./common.js');
 const monitorTests = require('./monitor_tests.js');
+const monitorTestutils = require('./monitortest_utils.js');
+const retryCountMax = 3; // # of times a single process can retry
 
 /**
  * Main function to run the tests and save results
@@ -37,7 +39,9 @@ const runEverything = async servers => {
     }
 
     for (const server of restservers) {
-      if (common.getProcess(server) == undefined) {
+      let processObj = common.getProcess(server);
+
+      if (processObj == undefined) {
         // execute test and store name
         monitorTests.runTests(`http://${server.ip}:${server.port}`).then(outJson => {
           let results = {};
@@ -47,7 +51,7 @@ const runEverything = async servers => {
               `Completed tests run for ${server.name} at: ${new Date()} with ${results.testResults.length} tests run`
             );
           } else {
-            results = createFailedResultJson(
+            results = monitorTestutils.createFailedResultJson(
               `Test result unavailable`,
               `Test results not available for: ${server.name}`
             );
@@ -58,12 +62,26 @@ const runEverything = async servers => {
           common.saveResults(server, results);
         });
 
-        common.saveProcess(server, server.name);
+        common.saveProcess(server, 1);
       } else {
-        const results = createFailedResultJson(
+        const results = monitorTestutils.createFailedResultJson(
           `Test result unavailable`,
           `Previous tests are still running for: ${server.name}`
         );
+
+        // escape race condition, kill stored process and allow next process to attempt test
+        if (processObj.encountered >= retryCountMax) {
+          console.warn(
+            `Previous tests for ${server.name} persisted for ${processObj.encountered} rounds. Clearing saved process.`
+          );
+          common.deleteProcess(server);
+        } else {
+          console.log(
+            `Previous tests for ${server.name} still running after ${processObj.encountered} rounds. Incrementing count.`
+          );
+          common.saveProcess(server, processObj.encountered + 1);
+        }
+
         common.saveResults(server, results);
         console.log(`Incomplete tests for ${server.name} at: ${new Date()}`);
       }
@@ -73,39 +91,6 @@ const runEverything = async servers => {
     console.log(err.stack);
     console.trace();
   }
-};
-
-/**
- * Helper function to create a json object for failed test results
- * @param {String} title Title in the jest output
- * @param {String} msg Message in the jest output
- * @return {Object} Constructed failed result object
- */
-const createFailedResultJson = (title, msg) => {
-  const fail = {
-    numPassedTests: 0,
-    numFailedTests: 1,
-    success: false,
-    message: 'Prerequisite tests failed',
-    testResults: [
-      {
-        at: (new Date().getTime() / 1000).toFixed(3),
-        message: `${title}: ${msg}`,
-        result: 'failed',
-        assertionResults: [
-          {
-            ancestorTitles: title,
-            failureMessages: [],
-            fullName: `${title}: ${msg}`,
-            location: null,
-            status: 'failed',
-            title: msg
-          }
-        ]
-      }
-    ]
-  };
-  return fail;
 };
 
 module.exports = {

--- a/hedera-mirror-rest/monitoring/monitor_apis/monitortest_utils.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/monitortest_utils.js
@@ -20,6 +20,7 @@
 const math = require('mathjs');
 const config = require('../../config.js');
 const fetch = require('node-fetch');
+const AbortController = require('abort-controller');
 
 const apiPrefix = '/api/v1';
 
@@ -102,7 +103,15 @@ const getAPIResponse = url => {
     url = getUrl(url);
   }
 
-  return fetch(url)
+  const controller = new AbortController();
+  const timeout = setTimeout(
+    () => {
+      controller.abort();
+    },
+    60 * 1000 // in ms
+  );
+
+  return fetch(url, {signal: controller.signal})
     .then(response => {
       if (!response.ok) {
         console.log(`Non success response for call to '${url}'`);
@@ -115,6 +124,9 @@ const getAPIResponse = url => {
       var message = `Fetch error, url : ${url}, error : ${error}`;
       console.log(message);
       throw message;
+    })
+    .finally(() => {
+      clearTimeout(timeout);
     });
 };
 

--- a/hedera-mirror-rest/monitoring/monitor_apis/monitortest_utils.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/monitortest_utils.js
@@ -30,8 +30,8 @@ const classResults = {
   numFailedTests: 0,
   success: true,
   message: '',
-  startTime: '',
-  endTime: ''
+  startTime: 0,
+  endTime: 0
 };
 
 // monitoring single test result template

--- a/hedera-mirror-rest/monitoring/monitor_apis/monitortest_utils.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/monitortest_utils.js
@@ -153,6 +153,38 @@ const addTestResult = (clssRes, res, passed) => {
   }
 };
 
+/**
+ * Helper function to create a json object for failed test results
+ * @param {String} title Title in the jest output
+ * @param {String} msg Message in the jest output
+ * @return {Object} Constructed failed result object
+ */
+const createFailedResultJson = (title, msg) => {
+  const failedResultJson = getMonitorClassResult();
+  failedResultJson.numFailedTests = 1;
+  failedResultJson.success = false;
+  failedResultJson.message = 'Prerequisite tests failed';
+  failedResultJson.testResults = [
+    {
+      at: (new Date().getTime() / 1000).toFixed(3),
+      message: `${title}: ${msg}`,
+      result: 'failed',
+      assertionResults: [
+        {
+          ancestorTitles: title,
+          failureMessages: [],
+          fullName: `${title}: ${msg}`,
+          location: null,
+          status: 'failed',
+          title: msg
+        }
+      ]
+    }
+  ];
+
+  return failedResultJson;
+};
+
 module.exports = {
   toAccNum: toAccNum,
   fromAccNum: fromAccNum,
@@ -162,5 +194,6 @@ module.exports = {
   getAPIResponse: getAPIResponse,
   getMonitorClassResult: getMonitorClassResult,
   getMonitorTestResult: getMonitorTestResult,
-  addTestResult: addTestResult
+  addTestResult: addTestResult,
+  createFailedResultJson: createFailedResultJson
 };

--- a/hedera-mirror-rest/monitoring/monitor_apis/package-lock.json
+++ b/hedera-mirror-rest/monitoring/monitor_apis/package-lock.json
@@ -483,6 +483,14 @@
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
+    },
     "accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -1634,6 +1642,11 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+    },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
     },
     "exec-sh": {
       "version": "0.3.2",

--- a/hedera-mirror-rest/monitoring/monitor_apis/package.json
+++ b/hedera-mirror-rest/monitoring/monitor_apis/package.json
@@ -10,6 +10,7 @@
   "author": "Atul Mahamuni",
   "license": "Apache-2.0",
   "dependencies": {
+    "abort-controller": "^3.0.0",
     "body-parser": "^1.19.0",
     "compression": "^1.7.4",
     "cors": "^2.8.5",

--- a/hedera-mirror-rest/monitoring/monitor_apis/transaction_tests.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/transaction_tests.js
@@ -32,14 +32,14 @@ const recordsFileUpdateRefreshTime = 5;
  * @param {String} pathandquery
  * @return {Object} Transactions object from response
  */
-const getTransactions = pathandquery => {
+const getTransactions = (pathandquery, currentTestResult) => {
   return acctestutils
     .getAPIResponse(pathandquery)
     .then(json => {
       return json.transactions;
     })
     .catch(error => {
-      testResult.failureMessages.push(error);
+      currentTestResult.failureMessages.push(error);
     });
 };
 

--- a/hedera-mirror-rest/monitoring/monitor_apis/transaction_tests.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/transaction_tests.js
@@ -129,6 +129,13 @@ const getTransactionsWithAccountCheck = async (server, classResults) => {
   currentTestResult.url = url;
 
   let accTransactions = await getTransactions(url, currentTestResult);
+  if (undefined === accTransactions) {
+    var message = `transactions is undefined`;
+    currentTestResult.failureMessages.push(message);
+    acctestutils.addTestResult(classResults, currentTestResult, false);
+    return;
+  }
+
   if (accTransactions.length !== 1) {
     var message = `accTransactions.length of ${transactions.length} is not 1`;
     currentTestResult.failureMessages.push(message);

--- a/hedera-mirror-rest/monitoring/monitor_dashboard/js/main.js
+++ b/hedera-mirror-rest/monitoring/monitor_dashboard/js/main.js
@@ -51,6 +51,10 @@ const init = () => {
  * @return {HTML} HTML for the table
  */
 const makeTable = (data, server) => {
+  if (data.results.testResults === undefined) {
+    return 'No result yet to display';
+  }
+
   let h = '';
   h += `
         <table border="1px">

--- a/hedera-mirror-rest/monitoring/monitor_dashboard/js/main.js
+++ b/hedera-mirror-rest/monitoring/monitor_dashboard/js/main.js
@@ -65,7 +65,7 @@ const makeTable = (data, server) => {
       return;
     }
     const failureMsg =
-      result.failureMessages == undefined ? '' : result.failureMessages.join('<br>').replace('\n', '<br>');
+      result.failureMessages == undefined ? '' : result.failureMessages.join('<br>,').replace('\n', '<br>');
 
     h +=
       '<tr>' +
@@ -105,15 +105,17 @@ const makeCard = (data, server) => {
 
   const cntTotal = data.results.numPassedTests + data.results.numFailedTests;
   const dotcolor = data.results.success ? 'green' : 'red';
+  const startTime = data.results.startTime ? data.results.startTime : 0;
+  const endTime = data.results.endTime ? data.results.endTime : 0;
 
   let h = '';
   // Create a summary card
   h += `
         <div class="card my-card">
           <div class="card-body" data-toggle="modal" data-target="#modal-${server}">
-            <div class="card-title">Network: ${server}, ${new Date(
-    Number(data.results.startTime)
-  ).toISOString()} - ${new Date(Number(data.results.endTime)).toISOString()}
+            <div class="card-title">Network: ${server}, ${new Date(Number(startTime)).toISOString()} - ${new Date(
+    Number(endTime)
+  ).toISOString()}
             </div>
             <div class="ip-addr"> (${data.ip}:${data.port})</div>
             <div class="card-text">


### PR DESCRIPTION
**Detailed description**:
Should a test encounter a legitimate http error such as a gateway timeout the tests currently hold onto the result and have no logic to clear the process store.
The result is a perpetual failure status for a given server.

This fix
- Adds logic to allow a process to take 3 rounds to finish and populate results. After this the process is cleared and a new flow is allowed to try
- Adds logic to handle results display in initial few seconds when results have not returned
- Add logic to ensure request errors are correctly surfaced

**Which issue(s) this PR fixes**:
Fixes #461

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

