### PR TITLE
Remove hcs from artifacts and bump to 0.5.0-beta1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
           command: |
             set -x
             VERSION_TAG=${CIRCLE_TAG/*\//}
-            NAME=hedera-mirror-grpc-hcs-${VERSION_TAG:-b$CIRCLE_BUILD_NUM}
+            NAME=hedera-mirror-grpc-${VERSION_TAG:-b$CIRCLE_BUILD_NUM}
             WORKSPACE=/tmp/workspace
             mkdir -p ${WORKSPACE}/${NAME}
             mv hedera-mirror-grpc/target/hedera-mirror-grpc-*.jar ${WORKSPACE}/${NAME}
@@ -84,7 +84,7 @@ jobs:
           command: |
             set -x
             VERSION_TAG=${CIRCLE_TAG/*\//}
-            NAME=hedera-mirror-importer-hcs-${VERSION_TAG:-b$CIRCLE_BUILD_NUM}
+            NAME=hedera-mirror-importer-${VERSION_TAG:-b$CIRCLE_BUILD_NUM}
             WORKSPACE=/tmp/workspace
             mkdir -p ${WORKSPACE}/${NAME}
             # Truncate '-exec' from jar name
@@ -138,7 +138,7 @@ jobs:
           command: |
             set -x
             VERSION_TAG=${CIRCLE_TAG/*\//}
-            NAME=hedera-mirror-rest-hcs-${VERSION_TAG:-b$CIRCLE_BUILD_NUM}
+            NAME=hedera-mirror-rest-${VERSION_TAG:-b$CIRCLE_BUILD_NUM}
             npm pack
             mkdir -p /tmp/workspace/artifacts
             mv hedera-mirror-rest*.tgz /tmp/workspace/artifacts/${NAME}.tgz

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - 5432:5432
 
   grpc:
-    image: docker.pkg.github.com/hashgraph/hedera-mirror-node/hedera-mirror-grpc-hcs
+    image: docker.pkg.github.com/hashgraph/hedera-mirror-node/hedera-mirror-grpc
     restart: unless-stopped
     environment:
       HEDERA_MIRROR_GRPC_DB_HOST: db
@@ -28,7 +28,7 @@ services:
       - 5600:5600
 
   importer:
-    image: docker.pkg.github.com/hashgraph/hedera-mirror-node/hedera-mirror-importer-hcs
+    image: docker.pkg.github.com/hashgraph/hedera-mirror-node/hedera-mirror-importer
     restart: unless-stopped
     environment:
       HEDERA_MIRROR_DATAPATH: /var/lib/hedera-mirror-importer
@@ -39,7 +39,7 @@ services:
       #- ./application.yml:/usr/etc/hedera-mirror-importer/application.yml
 
   rest:
-    image: docker.pkg.github.com/hashgraph/hedera-mirror-node/hedera-mirror-rest-hcs
+    image: docker.pkg.github.com/hashgraph/hedera-mirror-node/hedera-mirror-rest
     environment:
       HEDERA_MIRROR_DB_HOST: db
     restart: unless-stopped

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,19 +1,64 @@
 # Operations
 
-## Importer
+-   [GRPC API](#grpc-api)
+-   [Importer](#importer)
+-   [REST API](#rest-api)
 
-The record stream should be downloaded every 5-10 seconds, account balances approximately every 15 minutes.
+## GRPC API
+
+The GRPC process is a Java-based application and should be able to run on any platform that Java supports. That said,
+we recommend Ubuntu 18.04 be used as the base operating system as that is the only OS we've tested against.
 
 ### File Layout
 
+-   `/etc/systemd/system/hedera-mirror-grpc.service` - systemd service definitions
+-   `/usr/etc/hedera-mirror-grpc/application.yml` - Configuration file
+-   `/usr/lib/hedera-mirror-grpc` - Binaries
+
+### Starting
+
+```
+sudo systemctl start hedera-mirror-grpc.service
+```
+
+### Stopping
+
+```
+sudo systemctl stop hedera-mirror-grpc.service
+```
+
+### Upgrading
+
+Download release artifact from the [releases](https://github.com/hashgraph/hedera-mirror-node/releases) page and scp it
+to the target server. Then execute:
+
+```shell script
+tar -xvf ./hedera-mirror-grpc-*.tgz
+cd hedera-mirror-grpc-*/scripts
+sudo ./deploy.sh
+```
+
+### Monitoring
+
+```
+systemctl status hedera-mirror-grpc.service
+sudo journalctl -fu hedera-mirror-grpc.service
+```
+
+## Importer
+
+The Importer process is a Java-based application and should be able to run on any platform that Java supports. That
+said, we recommend Ubuntu 18.04 be used as the base operating system as that is the only OS we've tested against.
+
+### File Layout
+
+-   `/etc/systemd/system/hedera-mirror-importer.service` - systemd service definitions
+-   `/usr/etc/hedera-mirror-importer/application.yml` - Configuration file
 -   `/usr/lib/hedera-mirror-importer` - Binaries
--   `/usr/etc/hedera-mirror-importer` - Configuration files
-    -   `application.yml`
 -   `/var/lib/hedera-mirror-importer` - Data
     -   `addressbook.bin` - The current address book in use
     -   `accountBalances` - The downloaded balance and signature files
     -   `recordstreams` - The downloaded record and signature files
--   `/etc/systemd/system/hedera-mirror-importer.service` - systemd service definitions
 
 ### Starting
 
@@ -27,31 +72,116 @@ sudo systemctl start hedera-mirror-importer.service
 sudo systemctl stop hedera-mirror-importer.service
 ```
 
-### Monitoring logs (tailing)
+If shutdown cleanly the service will log a `Shutting down.....` message
+
+### Upgrading
+
+Download release artifact from the [releases](https://github.com/hashgraph/hedera-mirror-node/releases) page and scp it
+to the target server. Then execute:
+
+```shell script
+tar -xvf ./hedera-mirror-importer-*.tgz
+cd hedera-mirror-importer-*/scripts
+sudo ./deploy.sh
+```
+
+### Monitoring
 
 ```
+systemctl status hedera-mirror-importer.service
 sudo journalctl -fu hedera-mirror-importer.service
 ```
 
-### Normal system logs
+## REST API
 
-Normal output should include several frequent INFO level messages such as:
+### Initial Installation
 
--   `RecordFileDownloader Downloaded .* RCD signatures for node .*`
--   `RecordFileParser Loading version .* record file: .*`
--   `AccountBalancesDownloader Downloaded .* BALANCE signatures for node .*`
--   `AccountBalancesFileLoader Starting processing account balances file`
--   `AccountBalancesFileLoader Starting processing account balances file`
--   `BalanceFileParser Completed processing .* balance files`
+The REST API runs on [Node.js](https://nodejs.org) and should be able to run on any platform that Node.js supports. That
+said, we recommend Ubuntu 18.04 be used as the base operating system as that is the only OS we've tested against. It is
+also recommended to create a `restapi` user and execute all commands as that user.
 
-### Parsed files
+```shell script
+sudo apt-get install build-essential libssl-dev git postgresql-client
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | bash
+bash # reload shell
+nvm install stable #pin the current versions node: v12.10.0, npm: 6.10.3
+npm install -g pm2
+sudo mkdir -p /opt/restapi
+cd /opt/restapi
+git clone https://github.com/hashgraph/hedera-mirror-node.git
+cd hedera-mirror-node/hedera-mirror-rest
+cat > application.yml <<EOF
+hedera:
+  mirror:
+    db:
+      apiPassword: mirror_api_pass
+      host: dbhost
+EOF
+```
 
-Record stream files that have successfully been downloaded and parsed will be moved to
-`${hedera.mirror.dataPath}/recordstreams/parsedRecordFiles`.
+### File Layout
 
-Account balances stream files that have successfully been downloaded and parsed will be moved to
-`${hedera.mirror.dataPath}/accountBalances/parsedBalanceFiles`.
+-   `/opt/restapi/logs` - Logs
+-   `/opt/restapi/hedera-mirror-rest` - Binaries
+-   `/opt/restapi/hedera-mirror-rest/application.yml` - Configuration
 
-### State changes
+### Upgrading
 
-The mirror importer service, if shutdown cleanly will log `Shutting down.....` message
+```shell script
+sudo su - restapi
+cd /opt/restapi/hedera-mirror-rest
+pm2 stop all
+git fetch --all --tags --prune
+git checkout tags/${version}
+npm install
+pm2 start pm2.json
+```
+
+### Starting
+
+To start all 10 ports (6551-6560):
+
+```shell script
+pm2 start /opt/restapi/hedera-mirror-rest/pm2.json
+```
+
+To manually start on a specific port:
+
+```shell script
+HEDERA_MIRROR_API_PORT=8080 pm2 start server.js
+```
+
+### Stopping
+
+```shell script
+pm2 stop all
+```
+
+### Monitoring
+
+```shell script
+pm2 monit
+pm2 status
+tail -f /opt/restapi/logs/hedera_mirrornode_api_6551.log
+```
+
+Verify individual APIs manually:
+
+```shell script
+curl http://127.0.0.1:6551/api/v1/accounts
+curl http://127.0.0.1:6551/api/v1/balances
+curl http://127.0.0.1:6551/api/v1/transactions
+```
+
+Verify all ports:
+
+```shell script
+for port in {6551..6560}; do curl -s "http://127.0.0.1:${port}/api/v1/transactions?limit=1" && echo; done
+```
+
+Acceptance tests:
+
+```shell script
+cd /opt/restapi/hedera-mirror-rest
+for port in {6551..6560}; do TARGET=127.0.0.1:${port} npm run acceptancetest; done
+```

--- a/hedera-mirror-coverage/pom.xml
+++ b/hedera-mirror-coverage/pom.xml
@@ -2,22 +2,22 @@
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-    <artifactId>hedera-mirror-coverage-hcs</artifactId>
+    <artifactId>hedera-mirror-coverage</artifactId>
     <modelVersion>4.0.0</modelVersion>
-    <name>Hedera Mirror Node Coverage (HCS)</name>
+    <name>Hedera Mirror Node Coverage</name>
     <description>Aggregates module-specific code coverage reports</description>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>com.hedera</groupId>
-        <artifactId>hedera-mirror-node-hcs</artifactId>
-        <version>0.1.0-rc1</version>
+        <artifactId>hedera-mirror-node</artifactId>
+        <version>0.5.0-beta1</version>
     </parent>
 
     <dependencies>
         <dependency>
             <groupId>com.hedera</groupId>
-            <artifactId>hedera-mirror-importer-hcs</artifactId>
+            <artifactId>hedera-mirror-importer</artifactId>
             <version>${project.version}</version>
         </dependency>
     </dependencies>

--- a/hedera-mirror-datagenerator/pom.xml
+++ b/hedera-mirror-datagenerator/pom.xml
@@ -2,22 +2,22 @@
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-    <artifactId>hedera-mirror-datagenerator-hcs</artifactId>
+    <artifactId>hedera-mirror-datagenerator</artifactId>
     <description>Generates data for testing</description>
     <modelVersion>4.0.0</modelVersion>
-    <name>Hedera Mirror Data Generator (HCS)</name>
+    <name>Hedera Mirror Data Generator</name>
     <packaging>jar</packaging>
 
     <parent>
         <groupId>com.hedera</groupId>
-        <artifactId>hedera-mirror-node-hcs</artifactId>
-        <version>0.1.0-rc1</version>
+        <artifactId>hedera-mirror-node</artifactId>
+        <version>0.5.0-beta1</version>
     </parent>
 
     <dependencies>
         <dependency>
             <groupId>com.hedera</groupId>
-            <artifactId>hedera-mirror-importer-hcs</artifactId>
+            <artifactId>hedera-mirror-importer</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/hedera-mirror-grpc/pom.xml
+++ b/hedera-mirror-grpc/pom.xml
@@ -2,16 +2,16 @@
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-    <artifactId>hedera-mirror-grpc-hcs</artifactId>
+    <artifactId>hedera-mirror-grpc</artifactId>
     <description>GRPC API for Hedera Hashgraph Mirror Nodes</description>
     <modelVersion>4.0.0</modelVersion>
-    <name>Hedera Mirror Node GRPC API (HCS)</name>
+    <name>Hedera Mirror Node GRPC API</name>
     <packaging>jar</packaging>
 
     <parent>
         <groupId>com.hedera</groupId>
-        <artifactId>hedera-mirror-node-hcs</artifactId>
-        <version>0.1.0-rc1</version>
+        <artifactId>hedera-mirror-node</artifactId>
+        <version>0.5.0-beta1</version>
     </parent>
 
     <dependencies>
@@ -25,7 +25,7 @@
         </dependency>
         <dependency>
             <groupId>com.hedera</groupId>
-            <artifactId>hedera-mirror-protobuf-hcs</artifactId>
+            <artifactId>hedera-mirror-protobuf</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/hedera-mirror-grpc/scripts/deploy.sh
+++ b/hedera-mirror-grpc/scripts/deploy.sh
@@ -1,6 +1,5 @@
-#!/bin/sh -ex
-
-artifactname=hedera-mirror-grpc-hcs
+#!/usr/bin/env bash
+set -ex
 
 # name of the service and directories
 name=hedera-mirror-grpc
@@ -9,12 +8,13 @@ usrlib="/usr/lib/${name}"
 
 # CD to parent directory
 cd "$(dirname $0)/.."
-version=$(ls -1 -d "../"${artifactname}-[vb]* | tr '\n' '\0' | xargs -0 -n 1 basename | tail -1 | sed -e "s/${artifactname}-//")
+version=$(ls -1 -d "../"${name}-[vb]* | tr '\n' '\0' | xargs -0 -n 1 basename | tail -1 | sed -e "s/${name}-//")
 if [ -z "${version}" ]; then
-    echo "Can't find ${artifactname}-[vb]* versioned parent directory. Unrecognized layout. Aborting"
+    echo "Can't find ${name}-[vb]* versioned parent directory. Unrecognized layout. Aborting"
     exit 1
 fi
-jarname="${artifactname}-${version:1}.jar"
+
+jarname="${name}-${version:1}.jar"
 if [ ! -f "${jarname}" ]; then
     echo "Can't find ${jarname}. Aborting"
     exit 1

--- a/hedera-mirror-importer/pom.xml
+++ b/hedera-mirror-importer/pom.xml
@@ -2,18 +2,18 @@
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-    <artifactId>hedera-mirror-importer-hcs</artifactId>
+    <artifactId>hedera-mirror-importer</artifactId>
     <description>
         Hedera Mirror Importer downloads and validates file streams from the cloud and imports them into the database
     </description>
     <modelVersion>4.0.0</modelVersion>
-    <name>Hedera Mirror Node Importer (HCS)</name>
+    <name>Hedera Mirror Node Importer</name>
     <packaging>jar</packaging>
 
     <parent>
         <groupId>com.hedera</groupId>
-        <artifactId>hedera-mirror-node-hcs</artifactId>
-        <version>0.1.0-rc1</version>
+        <artifactId>hedera-mirror-node</artifactId>
+        <version>0.5.0-beta1</version>
     </parent>
 
     <properties>

--- a/hedera-mirror-protobuf/pom.xml
+++ b/hedera-mirror-protobuf/pom.xml
@@ -2,16 +2,16 @@
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-    <artifactId>hedera-mirror-protobuf-hcs</artifactId>
+    <artifactId>hedera-mirror-protobuf</artifactId>
     <description>Protobuf definitions for the Hedera Hashgraph Mirror Node API (MAPI)</description>
     <modelVersion>4.0.0</modelVersion>
-    <name>Hedera Mirror Node Protobuf (HCS)</name>
+    <name>Hedera Mirror Node Protobuf</name>
     <packaging>jar</packaging>
 
     <parent>
         <groupId>com.hedera</groupId>
-        <artifactId>hedera-mirror-node-hcs</artifactId>
-        <version>0.1.0-rc1</version>
+        <artifactId>hedera-mirror-node</artifactId>
+        <version>0.5.0-beta1</version>
     </parent>
 
     <properties>

--- a/hedera-mirror-rest/__acceptancetests__/acceptancetests
+++ b/hedera-mirror-rest/__acceptancetests__/acceptancetests
@@ -9,9 +9,9 @@
 #  * Licensed under the Apache License, Version 2.0 (the "License");
 #  * you may not use this file except in compliance with the License.
 #  * You may obtain a copy of the License at
-#  * 
+#  *
 #  *      http://www.apache.org/licenses/LICENSE-2.0
-#  * 
+#  *
 #  * Unless required by applicable law or agreed to in writing, software
 #  * distributed under the License is distributed on an "AS IS" BASIS,
 #  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,15 +25,16 @@ set +x
 # Jest executable location
 jestExecutable='./node_modules/.bin/jest'
 
-if [ "$TARGET" == "" ]; then 
+if [ "$TARGET" == "" ]; then
     echo -e "\n\n"
     echo -e "-----------------------------------------------------------------------------\n"
     echo -e "Error: You need to specify the target API server to run acceptance tests against.\n"
-    echo -e "Please set TARGET variable to server:port\n"; 
-    echo -e "Example: TARGET=11.22.33.44:5551 npm run acceptancetest\n\n"; 
+    echo -e "Please set TARGET variable to server:port\n";
+    echo -e "Example: TARGET=11.22.33.44:5551 npm run acceptancetest\n\n";
     echo -e "-----------------------------------------------------------------------------\n\n"
-else 
-    $jestExecutable --testPathPattern='__acceptancetests__/' $*; 
+else
+    echo "Running acceptance tests against ${TARGET}"
+    $jestExecutable --testPathPattern='__acceptancetests__/' $*;
 fi
 
 set -x

--- a/hedera-mirror-rest/package-lock.json
+++ b/hedera-mirror-rest/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "hedera-mirror-rest-hcs",
-  "version": "0.1.0-rc1",
+  "name": "hedera-mirror-rest",
+  "version": "0.5.0-beta1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hedera-mirror-rest/package.json
+++ b/hedera-mirror-rest/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "hedera-mirror-rest-hcs",
-  "version": "0.1.0-rc1",
-  "description": "Hedera Mirror Node REST API (HCS)",
+  "name": "hedera-mirror-rest",
+  "version": "0.5.0-beta1",
+  "description": "Hedera Mirror Node REST API",
   "main": "server.js",
   "scripts": {
     "test": "jest --testPathPattern='__tests__/*'",

--- a/hedera-mirror-rest/pom.xml
+++ b/hedera-mirror-rest/pom.xml
@@ -2,16 +2,16 @@
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-    <artifactId>hedera-mirror-rest-hcs</artifactId>
+    <artifactId>hedera-mirror-rest</artifactId>
     <description>REST API for Hedera Hashgraph Mirror Nodes</description>
     <modelVersion>4.0.0</modelVersion>
-    <name>Hedera Mirror Node REST API (HCS)</name>
+    <name>Hedera Mirror Node REST API</name>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>com.hedera</groupId>
-        <artifactId>hedera-mirror-node-hcs</artifactId>
-        <version>0.1.0-rc1</version>
+        <artifactId>hedera-mirror-node</artifactId>
+        <version>0.5.0-beta1</version>
     </parent>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -3,12 +3,12 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <groupId>com.hedera</groupId>
-    <artifactId>hedera-mirror-node-hcs</artifactId>
-    <version>0.1.0-rc1</version>
+    <artifactId>hedera-mirror-node</artifactId>
+    <version>0.5.0-beta1</version>
     <description>Hedera Mirror Node mirrors data from Hedera nodes and serves it via an API</description>
     <inceptionYear>2019</inceptionYear>
     <modelVersion>4.0.0</modelVersion>
-    <name>Hedera Mirror Node (HCS)</name>
+    <name>Hedera Mirror Node</name>
     <packaging>pom</packaging>
     <url>https://github.com/hashgraph/hedera-mirror-node</url>
 


### PR DESCRIPTION
**Detailed description**:
- Remove `-hcs` suffix from all artifacts
- Bump version to 0.5.0-beta1 in preparation for first HCS release
- Add GRPC and REST API to operations document
- Remove migrations from importer shell script that have already been executed in prod
- Add prompt for configuration input on initial install of importer
- Print target when running acceptance tests (helps when looping)

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [x] Documentation added
- [ ] Tests updated

