### PR TITLE
Fix importer jar name in release artifact

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,26 +70,24 @@ jobs:
       - run:
           name: Collecting assets for hedera-mirror-grpc
           command: |
-            set -x
+            set -ex
             VERSION_TAG=${CIRCLE_TAG/*\//}
             NAME=hedera-mirror-grpc-${VERSION_TAG:-b$CIRCLE_BUILD_NUM}
             WORKSPACE=/tmp/workspace
             mkdir -p ${WORKSPACE}/${NAME}
-            mv hedera-mirror-grpc/target/hedera-mirror-grpc-*.jar ${WORKSPACE}/${NAME}
+            mv hedera-mirror-grpc/target/hedera-mirror-grpc-*.jar ${WORKSPACE}/${NAME}/${NAME}.jar
             mv hedera-mirror-grpc/scripts ${WORKSPACE}/${NAME}
             mkdir -p ${WORKSPACE}/artifacts
             tar -czf ${WORKSPACE}/artifacts/${NAME}.tgz -C ${WORKSPACE} ${NAME}
       - run:
           name: Collecting assets for hedera-mirror-importer
           command: |
-            set -x
+            set -ex
             VERSION_TAG=${CIRCLE_TAG/*\//}
             NAME=hedera-mirror-importer-${VERSION_TAG:-b$CIRCLE_BUILD_NUM}
             WORKSPACE=/tmp/workspace
             mkdir -p ${WORKSPACE}/${NAME}
-            # Truncate '-exec' from jar name
-            jarname=jarname=$(ls hedera-mirror-importer/target/hedera-mirror-importer-*-exec.jar | sed -E "s:.*target/(.*)-exec.jar:\1:")
-            mv hedera-mirror-importer/target/hedera-mirror-importer-*-exec.jar ${WORKSPACE}/${NAME}/${jarname}.jar
+            mv hedera-mirror-importer/target/hedera-mirror-importer-*-exec.jar ${WORKSPACE}/${NAME}/${NAME}.jar
             mv hedera-mirror-importer/scripts ${WORKSPACE}/${NAME}
             mkdir -p ${WORKSPACE}/artifacts
             tar -czf ${WORKSPACE}/artifacts/${NAME}.tgz -C ${WORKSPACE} ${NAME}
@@ -136,7 +134,7 @@ jobs:
           working_directory: "hedera-mirror-rest"
           name: Collecting assets
           command: |
-            set -x
+            set -ex
             VERSION_TAG=${CIRCLE_TAG/*\//}
             NAME=hedera-mirror-rest-${VERSION_TAG:-b$CIRCLE_BUILD_NUM}
             npm pack

--- a/hedera-mirror-coverage/pom.xml
+++ b/hedera-mirror-coverage/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.5.0-beta2</version>
+        <version>0.5.0-beta3</version>
     </parent>
 
     <dependencies>

--- a/hedera-mirror-datagenerator/pom.xml
+++ b/hedera-mirror-datagenerator/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.5.0-beta2</version>
+        <version>0.5.0-beta3</version>
     </parent>
 
     <dependencies>

--- a/hedera-mirror-grpc/pom.xml
+++ b/hedera-mirror-grpc/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.5.0-beta2</version>
+        <version>0.5.0-beta3</version>
     </parent>
 
     <dependencies>

--- a/hedera-mirror-importer/pom.xml
+++ b/hedera-mirror-importer/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.5.0-beta2</version>
+        <version>0.5.0-beta3</version>
     </parent>
 
     <properties>

--- a/hedera-mirror-protobuf/pom.xml
+++ b/hedera-mirror-protobuf/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.5.0-beta2</version>
+        <version>0.5.0-beta3</version>
     </parent>
 
     <properties>

--- a/hedera-mirror-rest/package-lock.json
+++ b/hedera-mirror-rest/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-mirror-rest",
-  "version": "0.5.0-beta2",
+  "version": "0.5.0-beta3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hedera-mirror-rest/package.json
+++ b/hedera-mirror-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-mirror-rest",
-  "version": "0.5.0-beta2",
+  "version": "0.5.0-beta3",
   "description": "Hedera Mirror Node REST API",
   "main": "server.js",
   "scripts": {

--- a/hedera-mirror-rest/pom.xml
+++ b/hedera-mirror-rest/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.5.0-beta2</version>
+        <version>0.5.0-beta3</version>
     </parent>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.hedera</groupId>
     <artifactId>hedera-mirror-node</artifactId>
-    <version>0.5.0-beta2</version>
+    <version>0.5.0-beta3</version>
     <description>Hedera Mirror Node mirrors data from Hedera nodes and serves it via an API</description>
     <inceptionYear>2019</inceptionYear>
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
**Detailed description**:
- Fix jar named as `jarname=hedera-mirror-importer-0.5.0-beta2.jar` inside tgz
- Simplify script to just use `$NAME` (having a version with or without v doesn't matter to `deploy.sh`)
- Add `set -e` to fail fast when any commands returns non-zero
- Bump version to 0.5.0-beta3

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

