### PR TITLE
Fix GRPC user permissions and deploy script

### DIFF
--- a/hedera-mirror-coverage/pom.xml
+++ b/hedera-mirror-coverage/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.5.0-beta3</version>
+        <version>0.5.0-rc1</version>
     </parent>
 
     <dependencies>

--- a/hedera-mirror-datagenerator/pom.xml
+++ b/hedera-mirror-datagenerator/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.5.0-beta3</version>
+        <version>0.5.0-rc1</version>
     </parent>
 
     <dependencies>

--- a/hedera-mirror-grpc/pom.xml
+++ b/hedera-mirror-grpc/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.5.0-beta3</version>
+        <version>0.5.0-rc1</version>
     </parent>
 
     <dependencies>

--- a/hedera-mirror-grpc/scripts/db/init.sh
+++ b/hedera-mirror-grpc/scripts/db/init.sh
@@ -7,7 +7,8 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-E
 
     grant connect on database "$POSTGRES_DB" to mirror_grpc;
 
-    alter default privileges in schema public
-        grant select on tables to mirror_grpc;
+    alter default privileges in schema public grant select on tables to mirror_grpc;
+
+    grant select on all tables in schema public to mirror_grpc;
 
 EOSQL

--- a/hedera-mirror-grpc/scripts/deploy.sh
+++ b/hedera-mirror-grpc/scripts/deploy.sh
@@ -1,21 +1,15 @@
 #!/usr/bin/env bash
 set -ex
 
+cd "$(dirname $0)/.."
+
 # name of the service and directories
 name=hedera-mirror-grpc
 usretc="/usr/etc/${name}"
 usrlib="/usr/lib/${name}"
+jarname="$(ls -1 ${name}-*.jar)"
 
-# CD to parent directory
-cd "$(dirname $0)/.."
-version=$(ls -1 -d "../"${name}-[vb]* | tr '\n' '\0' | xargs -0 -n 1 basename | tail -1 | sed -e "s/${name}-//")
-if [ -z "${version}" ]; then
-    echo "Can't find ${name}-[vb]* versioned parent directory. Unrecognized layout. Aborting"
-    exit 1
-fi
-
-jarname="${name}-${version:1}.jar"
-if [ ! -f "${jarname}" ]; then
+if [[ ! -f "${jarname}" ]]; then
     echo "Can't find ${jarname}. Aborting"
     exit 1
 fi
@@ -23,7 +17,7 @@ fi
 mkdir -p "${usretc}" "${usrlib}"
 systemctl stop "${name}.service" || true
 
-if [ ! -f "${usretc}/application.yml" ]; then
+if [[ ! -f "${usretc}/application.yml" ]]; then
     echo "Fresh install of ${version}"
     read -p "Database hostname: " dbHost
     read -p "Database password: " dbPassword

--- a/hedera-mirror-importer/pom.xml
+++ b/hedera-mirror-importer/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.5.0-beta3</version>
+        <version>0.5.0-rc1</version>
     </parent>
 
     <properties>

--- a/hedera-mirror-importer/scripts/deploy.sh
+++ b/hedera-mirror-importer/scripts/deploy.sh
@@ -1,22 +1,16 @@
 #!/usr/bin/env bash
 set -ex
 
+cd "$(dirname $0)/.."
+
 # name of the service and directories
 name=hedera-mirror-importer
 usretc="/usr/etc/${name}"
 usrlib="/usr/lib/${name}"
 varlib="/var/lib/${name}"
+jarname="$(ls -1 ${name}-*.jar)"
 
-# CD to parent directory
-cd "$(dirname $0)/.."
-version=$(ls -1 -d "../"${name}-[vb]* | tr '\n' '\0' | xargs -0 -n 1 basename | tail -1 | sed -e "s/${name}-//")
-if [ -z "${version}" ]; then
-    echo "Can't find ${name}-[vb]* versioned parent directory. Unrecognized layout. Aborting"
-    exit 1
-fi
-
-jarname="${name}-${version:1}.jar"
-if [ ! -f "${jarname}" ]; then
+if [[ ! -f "${jarname}" ]]; then
     echo "Can't find ${jarname}. Aborting"
     exit 1
 fi
@@ -24,11 +18,11 @@ fi
 mkdir -p "${usretc}" "${usrlib}" "${varlib}"
 systemctl stop "${name}.service" || true
 
-if [ -f "/usr/lib/mirror-node/mirror-node.jar" ] || [ -f "${usrlib}/${name}.jar" ]; then
-    echo "Upgrading to ${version}"
+if [[ -f "/usr/lib/mirror-node/mirror-node.jar" || -f "${usrlib}/${name}.jar" ]]; then
+    echo "Upgrading to ${jarname}"
 
     # Migrate from mirror-node directory structure
-    if [ -f "/usr/lib/mirror-node/mirror-node.jar" ]; then
+    if [[ -f "/usr/lib/mirror-node/mirror-node.jar" ]]; then
         echo "Migrating from 'mirror-node' to '${name}'"
         systemctl stop mirror-node.service || true
         systemctl disable mirror-node.service || true
@@ -41,8 +35,8 @@ if [ -f "/usr/lib/mirror-node/mirror-node.jar" ] || [ -f "${usrlib}/${name}.jar"
     fi
 fi
 
-if [ ! -f "${usretc}/application.yml" ]; then
-    echo "Fresh install of ${version}"
+if [[ ! -f "${usretc}/application.yml" ]]; then
+    echo "Fresh install of ${jarname}"
     read -p "Bucket name: " bucketName
     read -p "Hedera network: " network
     read -p "Database hostname: " dbHost

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/MirrorProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/MirrorProperties.java
@@ -49,10 +49,6 @@ public class MirrorProperties {
     @Min(0)
     private long shard = 0L;
 
-    public MirrorProperties() {
-        Utility.ensureDirectory(dataPath);
-    }
-
     public Path getAddressBookPath() {
         return addressBookPath != null ? addressBookPath : dataPath.resolve(ADDRESS_BOOK_FILE);
     }

--- a/hedera-mirror-importer/src/main/resources/db/scripts/init.sql
+++ b/hedera-mirror-importer/src/main/resources/db/scripts/init.sql
@@ -1,13 +1,9 @@
--- Change the values below if you are not installing via Docker (environment variable values come from .env file)
+-- Change the values below if you are not installing via Docker
 
--- name of the database
 \set db_name 'mirror_node'
---username
 \set db_user 'mirror_node'
---user password
 \set db_password 'mirror_node_pass'
 \set db_owner 'mirror_node'
-
 \set grpc_user 'mirror_grpc'
 \set grpc_password 'mirror_grpc_pass'
 
@@ -15,11 +11,12 @@ create user :db_user with login createrole password :'db_password';
 
 create database :db_name with owner :db_owner;
 
-create user :grpc_user with login createrole password :'grpc_password';
+create user :grpc_user with login password :'grpc_password';
 
 grant connect on database :db_name to :grpc_user;
 
 \c :db_name
 
-alter default privileges in schema public
-    grant select on tables to :grpc_user;
+alter default privileges in schema public grant select on tables to :grpc_user;
+
+grant select on all tables in schema public to :grpc_user;

--- a/hedera-mirror-protobuf/pom.xml
+++ b/hedera-mirror-protobuf/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.5.0-beta3</version>
+        <version>0.5.0-rc1</version>
     </parent>
 
     <properties>

--- a/hedera-mirror-rest/package-lock.json
+++ b/hedera-mirror-rest/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-mirror-rest",
-  "version": "0.5.0-beta3",
+  "version": "0.5.0-rc1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hedera-mirror-rest/package.json
+++ b/hedera-mirror-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-mirror-rest",
-  "version": "0.5.0-beta3",
+  "version": "0.5.0-rc1",
   "description": "Hedera Mirror Node REST API",
   "main": "server.js",
   "scripts": {

--- a/hedera-mirror-rest/pom.xml
+++ b/hedera-mirror-rest/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.5.0-beta3</version>
+        <version>0.5.0-rc1</version>
     </parent>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.hedera</groupId>
     <artifactId>hedera-mirror-node</artifactId>
-    <version>0.5.0-beta3</version>
+    <version>0.5.0-rc1</version>
     <description>Hedera Mirror Node mirrors data from Hedera nodes and serves it via an API</description>
     <inceptionYear>2019</inceptionYear>
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
**Detailed description**:
- Fix deploy script not finding jar
- Simplify deploy script to not parse version and just use entire jar name instead
- Bump version to v0.5.0-rc1
- Fix `init.sql` and `init.sh` not granting permissions to GRPC user for existing tables
- Fix `init.sql` accidentally granting createrole permission to GRPC user
- Fix `MirrorProperties` creating an unused directory in default path of `/usr/lib/hedera-mirror-importer/data` before the setter is called with the correct path

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

