### PR TITLE
HCS proto changes

### DIFF
--- a/docs/design/hcs.md
+++ b/docs/design/hcs.md
@@ -191,9 +191,8 @@ public class TransactionEvent {
 ## Database
 
 -   Add new `t_entity_types` row with name `topic`
--   Add new columns to `t_entities`:
+-   Add new column to `t_entities`:
     -   `submit_key bytea`
-    -   `topic_valid_start_time nanos_timestamp`
 -   Add new `t_transaction_types`:
     -   `CONSENSUSCREATETOPIC=24`
     -   `CONSENSUSUPDATETOPIC=25`
@@ -236,6 +235,5 @@ See GitHub issue [374](https://github.com/hashgraph/hedera-mirror-node/issues/37
 
 ## Open Questions
 
-1. Should filter properties not apply to some tables or apply to all tables?
-2. Will `pg_notify` be able to handle the scale of data and clients required? See [Alternatives](#alternatives) section
-3. How will we optimize for multiple clients requesting the same topic ID?
+1. Will `pg_notify` be able to handle the scale of data and clients required? See [Alternatives](#alternatives) section
+2. How will we optimize for multiple clients requesting the same topic ID?

--- a/docs/design/hcs.md
+++ b/docs/design/hcs.md
@@ -200,15 +200,15 @@ public class TransactionEvent {
     -   `CONSENSUSDELETETOPIC=26`
     -   `CONSENSUSSUBMITMESSAGE=27`
 -   Add new `t_transaction_result`:
-    -   INVALID_TOPIC_ID = 150`
-    -   INVALID_ADMIN_KEY = 155`
-    -   INVALID_SUBMIT_KEY = 156`
-    -   UNAUTHORIZED = 157`
-    -   INVALID_TOPIC_MESSAGE = 158`
-    -   INVALID_AUTORENEW_ACCOUNT = 159`
-    -   AUTORENEW_ACCOUNT_NOT_ALLOWED = 160`
-    -   AUTORENEW_ACCOUNT_SIGNATURE_MISSING = 161`
-    -   TOPIC_EXPIRED = 162`
+    -   `INVALID_TOPIC_ID = 150`
+    -   `INVALID_ADMIN_KEY = 155`
+    -   `INVALID_SUBMIT_KEY = 156`
+    -   `UNAUTHORIZED = 157`
+    -   `INVALID_TOPIC_MESSAGE = 158`
+    -   `INVALID_AUTORENEW_ACCOUNT = 159`
+    -   `AUTORENEW_ACCOUNT_NOT_ALLOWED = 160`
+    -   `AUTORENEW_ACCOUNT_SIGNATURE_MISSING = 161`
+    -   `TOPIC_EXPIRED = 162`
 -   Add new table `topic_message`:
 
 ```postgres-sql

--- a/docs/design/hcs.md
+++ b/docs/design/hcs.md
@@ -200,16 +200,15 @@ public class TransactionEvent {
     -   `CONSENSUSDELETETOPIC=26`
     -   `CONSENSUSSUBMITMESSAGE=27`
 -   Add new `t_transaction_result`:
-    -   `INVALID_TOPIC_ID = 150`
-    -   `TOPIC_DELETED = 151`
-    -   `MESSAGE_TOO_LONG = 152`
-    -   `TOPIC_NOT_ENABLED = 153`
-    -   `INVALID_TOPIC_VALID_START_TIME = 154`
-    -   `INVALID_TOPIC_EXPIRATION_TIME = 155`
-    -   `INVALID_TOPIC_ADMIN_KEY = 156`
-    -   `INVALID_TOPIC_SUBMIT_KEY = 157`
-    -   `UNAUTHORIZED = 158`
-    -   `INVALID_TOPIC_MESSAGE = 159`
+    -   INVALID_TOPIC_ID = 150`
+    -   INVALID_ADMIN_KEY = 155`
+    -   INVALID_SUBMIT_KEY = 156`
+    -   UNAUTHORIZED = 157`
+    -   INVALID_TOPIC_MESSAGE = 158`
+    -   INVALID_AUTORENEW_ACCOUNT = 159`
+    -   AUTORENEW_ACCOUNT_NOT_ALLOWED = 160`
+    -   AUTORENEW_ACCOUNT_SIGNATURE_MISSING = 161`
+    -   TOPIC_EXPIRED = 162`
 -   Add new table `topic_message`:
 
 ```postgres-sql

--- a/docs/design/hcs.md
+++ b/docs/design/hcs.md
@@ -191,8 +191,9 @@ public class TransactionEvent {
 ## Database
 
 -   Add new `t_entity_types` row with name `topic`
--   Add new column to `t_entities`:
+-   Add new columns to `t_entities`:
     -   `submit_key bytea`
+    -   `auto_renew_account_id bigint`
 -   Add new `t_transaction_types`:
     -   `CONSENSUSCREATETOPIC=24`
     -   `CONSENSUSUPDATETOPIC=25`

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/domain/generators/entity/EntityGenerator.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/domain/generators/entity/EntityGenerator.java
@@ -20,10 +20,10 @@ package com.hedera.datagenerator.domain.generators.entity;
  */
 
 import com.google.common.base.Stopwatch;
-import java.util.function.Function;
-import javax.inject.Named;
 import com.google.protobuf.ByteString;
 import com.hederahashgraph.api.proto.java.Key;
+import java.util.function.Function;
+import javax.inject.Named;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.codec.binary.Hex;
 
@@ -51,17 +51,6 @@ public class EntityGenerator {
         }
     }
 
-    /**
-     * Generate entities and write them out to the DomainWriter.
-     */
-    public void generateAndWriteEntities(EntityManager entityManager, DomainWriter domainWriter) {
-        Stopwatch stopwatch = Stopwatch.createStarted();
-        generateAndWriteEntityType(entityManager.getAccounts(), domainWriter, this::generateAccountEntity, "account");
-        generateAndWriteEntityType(entityManager.getFiles(), domainWriter, this::generateFileEntity, "file");
-        generateAndWriteEntityType(entityManager.getTopics(), domainWriter, this::generateTopicEntity, "topic");
-        log.info("Generated all entities in {}", stopwatch);
-    }
-
     private static void generateAndWriteEntityType(EntityManager.EntitySet entitySet, DomainWriter domainWriter,
                                                    Function<Long, Entities> generateFn, String type) {
         int count = 0;
@@ -78,6 +67,17 @@ public class EntityGenerator {
         log.info("Wrote {} entities, containing {} marked deleted", count, deleted);
     }
 
+    /**
+     * Generate entities and write them out to the DomainWriter.
+     */
+    public void generateAndWriteEntities(EntityManager entityManager, DomainWriter domainWriter) {
+        Stopwatch stopwatch = Stopwatch.createStarted();
+        generateAndWriteEntityType(entityManager.getAccounts(), domainWriter, this::generateAccountEntity, "account");
+        generateAndWriteEntityType(entityManager.getFiles(), domainWriter, this::generateFileEntity, "file");
+        generateAndWriteEntityType(entityManager.getTopics(), domainWriter, this::generateTopicEntity, "topic");
+        log.info("Generated all entities in {}", stopwatch);
+    }
+
     private Entities createBaseEntity(Long id) {
         Entities entity = new Entities();
         entity.setId(id);
@@ -85,9 +85,6 @@ public class EntityGenerator {
         entity.setEntityRealm(0L);
         entity.setEntityNum(id);
         entity.setKey(fixedKey);
-        // Following fields are left null: exp_time_seconds, exp_time_nanos, exp_time_ns
-        entity.setAutoRenewPeriod(null);
-        entity.setProxyAccountId(null);
         return entity;
     }
 

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/controller/ConsensusController.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/controller/ConsensusController.java
@@ -1,4 +1,4 @@
-package com.hedera.mirror.grpc.service;
+package com.hedera.mirror.grpc.controller;
 
 /*-
  * ‌
@@ -35,12 +35,19 @@ import com.hedera.mirror.api.proto.ConsensusTopicResponse;
 import com.hedera.mirror.api.proto.ReactorConsensusServiceGrpc;
 import com.hedera.mirror.grpc.domain.TopicMessage;
 import com.hedera.mirror.grpc.domain.TopicMessageFilter;
+import com.hedera.mirror.grpc.service.TopicMessageService;
 import com.hedera.mirror.grpc.util.ProtoUtil;
 
+/**
+ * GRPC calls their protocol adapter layer a service, but most of the industry calls this layer the controller layer.
+ * See the Front Controller pattern or Model-View-Controller (MVC) pattern. The service layer is generally reserved for
+ * non-protocol specific business logic so to avoid confusion with our TopicMessageService we'll name this GRPC layer as
+ * controller.
+ */
 @GrpcService
 @Log4j2
 @RequiredArgsConstructor
-public class ConsensusService extends ReactorConsensusServiceGrpc.ConsensusServiceImplBase {
+public class ConsensusController extends ReactorConsensusServiceGrpc.ConsensusServiceImplBase {
 
     private final TopicMessageService topicMessageService;
 
@@ -94,7 +101,7 @@ public class ConsensusService extends ReactorConsensusServiceGrpc.ConsensusServi
             return t;
         }
 
-        log.error("Error", t);
+        log.error("Unknown error subscribing to topic", t);
         return Status.INTERNAL.augmentDescription(t.getMessage()).asRuntimeException();
     }
 }

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/controller/ConsensusControllerTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/controller/ConsensusControllerTest.java
@@ -1,4 +1,4 @@
-package com.hedera.mirror.grpc.service;
+package com.hedera.mirror.grpc.controller;
 
 /*-
  * ‌
@@ -44,7 +44,7 @@ import com.hedera.mirror.grpc.domain.DomainBuilder;
 import com.hedera.mirror.grpc.domain.TopicMessage;
 import com.hedera.mirror.grpc.util.ProtoUtil;
 
-public class ConsensusServiceTest extends GrpcIntegrationTest {
+public class ConsensusControllerTest extends GrpcIntegrationTest {
 
     @GrpcClient("local")
     private ReactorConsensusServiceGrpc.ReactorConsensusServiceStub grpcConsensusService;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/Entities.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/Entities.java
@@ -21,11 +21,13 @@ package com.hedera.mirror.importer.domain;
  */
 
 import java.time.Instant;
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import lombok.Data;
 import lombok.ToString;
@@ -58,6 +60,9 @@ public class Entities {
 
     @Column(name = "exp_time_nanos")
     private Long expiryTimeNanos;
+
+    @ManyToOne(cascade = CascadeType.ALL)
+    private Entities autoRenewAccount;
 
     private Long autoRenewPeriod;
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/Entities.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/Entities.java
@@ -76,8 +76,6 @@ public class Entities {
 
     private byte[] submitKey;
 
-    private Long topicValidStartTime;
-
     private String memo;
 
     public void setKey(byte[] key) {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/Entities.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/Entities.java
@@ -20,7 +20,6 @@ package com.hedera.mirror.importer.domain;
  * ‍
  */
 
-import java.time.Instant;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -55,12 +54,6 @@ public class Entities {
     @Column(name = "fk_entity_type_id")
     private Integer entityTypeId;
 
-    @Column(name = "exp_time_seconds")
-    private Long expiryTimeSeconds;
-
-    @Column(name = "exp_time_nanos")
-    private Long expiryTimeNanos;
-
     @ManyToOne(cascade = CascadeType.ALL)
     private Entities autoRenewAccount;
 
@@ -92,13 +85,6 @@ public class Entities {
                     "will be nulled", entityShard, entityRealm, entityNum, e);
             ed25519PublicKeyHex = null;
         }
-    }
-
-    public void setExpiryTimeNs(Long expiryTimeNs) {
-        this.expiryTimeNs = expiryTimeNs;
-        Instant instant = Instant.ofEpochSecond(0, expiryTimeNs);
-        setExpiryTimeSeconds(instant.getEpochSecond());
-        setExpiryTimeNanos((long) instant.getNano());
     }
 
     public String getDisplayId() {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordFileLogger.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordFileLogger.java
@@ -558,19 +558,19 @@ public class RecordFileLogger {
         Entities entity = getEntity(transactionRecord.getReceipt().getTopicID());
         var transactionBody = body.getConsensusCreateTopic();
 
-        if (transactionBody.hasExpirationTime()) {
-            Timestamp expirationTime = transactionBody.getExpirationTime();
-            entity.setExpiryTimeNs(Utility.timestampInNanosMax(expirationTime));
-            entity.setExpiryTimeSeconds(expirationTime.getSeconds());
-            entity.setExpiryTimeNanos((long) expirationTime.getNanos());
+        if (transactionBody.hasAutoRenewAccount()) {
+            Entities autoRenewAccount = getEntity(transactionBody.getAutoRenewAccount());
+            entity.setAutoRenewAccount(autoRenewAccount);
+        }
+
+        if (transactionBody.hasAutoRenewPeriod()) {
+            entity.setAutoRenewPeriod(transactionBody.getAutoRenewPeriod().getSeconds());
         }
 
         // If either key is empty, they should end up as empty bytea in the DB to indicate that there is
         // explicitly no value, as opposed to null which has been used to indicate the value is unknown.
-        var adminKey = transactionBody.hasAdminKey() ? transactionBody.getAdminKey()
-                .toByteArray() : new byte[0];
-        var submitKey = transactionBody.hasSubmitKey() ? transactionBody.getSubmitKey()
-                .toByteArray() : new byte[0];
+        var adminKey = transactionBody.hasAdminKey() ? transactionBody.getAdminKey().toByteArray() : new byte[0];
+        var submitKey = transactionBody.hasSubmitKey() ? transactionBody.getSubmitKey().toByteArray() : new byte[0];
 
         entity.setMemo(transactionBody.getMemo());
         entity.setKey(adminKey);
@@ -607,6 +607,15 @@ public class RecordFileLogger {
                 entity.setExpiryTimeNs(Utility.timestampInNanosMax(expirationTime));
                 entity.setExpiryTimeSeconds(expirationTime.getSeconds());
                 entity.setExpiryTimeNanos((long) expirationTime.getNanos());
+            }
+
+            if (transactionBody.hasAutoRenewAccount()) {
+                Entities autoRenewAccount = getEntity(transactionBody.getAutoRenewAccount());
+                entity.setAutoRenewAccount(autoRenewAccount);
+            }
+
+            if (transactionBody.hasAutoRenewPeriod()) {
+                entity.setAutoRenewPeriod(transactionBody.getAutoRenewPeriod().getSeconds());
             }
 
             if (transactionBody.hasAdminKey()) {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordFileLogger.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordFileLogger.java
@@ -605,8 +605,6 @@ public class RecordFileLogger {
             if (transactionBody.hasExpirationTime()) {
                 Timestamp expirationTime = transactionBody.getExpirationTime();
                 entity.setExpiryTimeNs(Utility.timestampInNanosMax(expirationTime));
-                entity.setExpiryTimeSeconds(expirationTime.getSeconds());
-                entity.setExpiryTimeNanos((long) expirationTime.getNanos());
             }
 
             if (transactionBody.hasAutoRenewAccount()) {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordFileLogger.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordFileLogger.java
@@ -572,10 +572,6 @@ public class RecordFileLogger {
         var submitKey = transactionBody.hasSubmitKey() ? transactionBody.getSubmitKey()
                 .toByteArray() : new byte[0];
 
-        if (transactionBody.hasValidStartTime()) {
-            entity.setTopicValidStartTime(Utility.timestampInNanosMax(transactionBody.getValidStartTime()));
-        }
-
         entity.setMemo(transactionBody.getMemo());
         entity.setKey(adminKey);
         entity.setSubmitKey(submitKey);
@@ -619,10 +615,6 @@ public class RecordFileLogger {
 
             if (transactionBody.hasSubmitKey()) {
                 entity.setSubmitKey(transactionBody.getSubmitKey().toByteArray());
-            }
-
-            if (transactionBody.hasValidStartTime()) {
-                entity.setTopicValidStartTime(Utility.timestampInNanosMax(transactionBody.getValidStartTime()));
             }
 
             if (transactionBody.hasMemo()) {

--- a/hedera-mirror-importer/src/main/resources/db/migration/V1.17.4__hcs_proto_changes.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/V1.17.4__hcs_proto_changes.sql
@@ -1,0 +1,1 @@
+alter table t_entities drop column topic_valid_start_time;

--- a/hedera-mirror-importer/src/main/resources/db/migration/V1.17.4__hcs_proto_changes.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/V1.17.4__hcs_proto_changes.sql
@@ -1,3 +1,14 @@
 alter table t_entities drop column topic_valid_start_time;
 alter table t_entities add column auto_renew_account_id bigint null;
 alter table t_entities add constraint autorenew_account foreign key (auto_renew_account_id) references t_entities(id);
+
+delete from t_transaction_results where proto_id >= 150;
+insert into t_transaction_results (proto_id, result) values (150, 'INVALID_TOPIC_ID');
+insert into t_transaction_results (proto_id, result) values (155, 'INVALID_ADMIN_KEY'); -- 151-154 were deleted in proto
+insert into t_transaction_results (proto_id, result) values (156, 'INVALID_SUBMIT_KEY');
+insert into t_transaction_results (proto_id, result) values (157, 'UNAUTHORIZED');
+insert into t_transaction_results (proto_id, result) values (158, 'INVALID_TOPIC_MESSAGE');
+insert into t_transaction_results (proto_id, result) values (159, 'INVALID_AUTORENEW_ACCOUNT');
+insert into t_transaction_results (proto_id, result) values (160, 'AUTORENEW_ACCOUNT_NOT_ALLOWED');
+insert into t_transaction_results (proto_id, result) values (161, 'AUTORENEW_ACCOUNT_SIGNATURE_MISSING');
+insert into t_transaction_results (proto_id, result) values (162, 'TOPIC_EXPIRED');

--- a/hedera-mirror-importer/src/main/resources/db/migration/V1.17.4__hcs_proto_changes.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/V1.17.4__hcs_proto_changes.sql
@@ -1,1 +1,3 @@
 alter table t_entities drop column topic_valid_start_time;
+alter table t_entities add column auto_renew_account_id bigint null;
+alter table t_entities add constraint autorenew_account foreign key (auto_renew_account_id) references t_entities(id);

--- a/hedera-mirror-importer/src/main/resources/db/migration/V1.17.4__hcs_proto_changes.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/V1.17.4__hcs_proto_changes.sql
@@ -1,4 +1,7 @@
 alter table t_entities drop column topic_valid_start_time;
+alter table t_entities drop column admin_key__deprecated;
+alter table t_entities drop column exp_time_seconds;
+alter table t_entities drop column exp_time_nanos;
 alter table t_entities add column auto_renew_account_id bigint null;
 alter table t_entities add constraint autorenew_account foreign key (auto_renew_account_id) references t_entities(id);
 

--- a/hedera-mirror-importer/src/main/resources/db/migration/V1.17.4__hcs_proto_changes.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/V1.17.4__hcs_proto_changes.sql
@@ -5,7 +5,7 @@ alter table t_entities drop column exp_time_nanos;
 alter table t_entities add column auto_renew_account_id bigint null;
 alter table t_entities add constraint autorenew_account foreign key (auto_renew_account_id) references t_entities(id);
 
-delete from t_transaction_results where proto_id >= 150;
+delete from t_transaction_results where proto_id >= 150 and proto_id <= 159;
 insert into t_transaction_results (proto_id, result) values (150, 'INVALID_TOPIC_ID');
 insert into t_transaction_results (proto_id, result) values (155, 'INVALID_ADMIN_KEY'); -- 151-154 were deleted in proto
 insert into t_transaction_results (proto_id, result) values (156, 'INVALID_SUBMIT_KEY');

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/V1_11_6__Missing_EntitiesTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/V1_11_6__Missing_EntitiesTest.java
@@ -29,14 +29,12 @@ import com.hederahashgraph.api.proto.java.CryptoGetInfoResponse.AccountInfo;
 import com.hederahashgraph.api.proto.java.Duration;
 import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.Timestamp;
-
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.Connection;
 import java.time.Instant;
 import javax.annotation.Resource;
 import javax.sql.DataSource;
-
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.binary.Hex;
 import org.assertj.core.api.Assertions;
@@ -68,7 +66,7 @@ public class V1_11_6__Missing_EntitiesTest extends IntegrationTest {
 
     @TempDir
     Path tempDir;
-    private AccountID accountId = AccountID.newBuilder().setShardNum(0).setRealmNum(0).setAccountNum(1).build();
+    private final AccountID accountId = AccountID.newBuilder().setShardNum(0).setRealmNum(0).setAccountNum(1).build();
     @Resource
     private V1_11_6__Missing_Entities migration;
     @Resource
@@ -100,8 +98,6 @@ public class V1_11_6__Missing_EntitiesTest extends IntegrationTest {
                 .returns(accountInfo.getAutoRenewPeriod().getSeconds(), from(Entities::getAutoRenewPeriod))
                 .returns(Utility.protobufKeyToHexIfEd25519OrNull(accountInfo.getKey()
                         .toByteArray()), from(Entities::getEd25519PublicKeyHex))
-                .returns(accountInfo.getExpirationTime().getSeconds(), from(Entities::getExpiryTimeSeconds))
-                .returns(Long.valueOf(accountInfo.getExpirationTime().getNanos()), from(Entities::getExpiryTimeNanos))
                 .returns(Utility.timeStampInNanos(accountInfo.getExpirationTime()), from(Entities::getExpiryTimeNs))
                 .returns(accountInfo.getKey().toByteArray(), from(Entities::getKey));
     }
@@ -115,8 +111,6 @@ public class V1_11_6__Missing_EntitiesTest extends IntegrationTest {
                 .get()
                 .returns(null, from(Entities::getAutoRenewPeriod))
                 .returns(null, from(Entities::getEd25519PublicKeyHex))
-                .returns(null, from(Entities::getExpiryTimeSeconds))
-                .returns(null, from(Entities::getExpiryTimeNanos))
                 .returns(null, from(Entities::getExpiryTimeNs))
                 .returns(null, from(Entities::getKey));
     }
@@ -167,8 +161,6 @@ public class V1_11_6__Missing_EntitiesTest extends IntegrationTest {
                 .returns(accountInfo.getAutoRenewPeriod().getSeconds(), from(Entities::getAutoRenewPeriod))
                 .returns(Utility.protobufKeyToHexIfEd25519OrNull(accountInfo.getKey()
                         .toByteArray()), from(Entities::getEd25519PublicKeyHex))
-                .returns(accountInfo.getExpirationTime().getSeconds(), from(Entities::getExpiryTimeSeconds))
-                .returns(Long.valueOf(accountInfo.getExpirationTime().getNanos()), from(Entities::getExpiryTimeNanos))
                 .returns(Utility.timeStampInNanos(accountInfo.getExpirationTime()), from(Entities::getExpiryTimeNs))
                 .returns(accountInfo.getKey().toByteArray(), from(Entities::getKey));
     }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileLoggerContractTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileLoggerContractTest.java
@@ -306,10 +306,6 @@ public class RecordFileLoggerContractTest extends AbstractRecordFileLoggerTest {
                         .getKey())
                 , () -> assertEquals(contractUpdateTransactionBody.getMemo(), dbContractEntity.getMemo())
                 , () -> assertAccount(contractUpdateTransactionBody.getProxyAccountID(), dbProxyAccountId)
-                , () -> assertEquals(contractUpdateTransactionBody.getExpirationTime().getSeconds(), dbContractEntity
-                        .getExpiryTimeSeconds())
-                , () -> assertEquals(contractUpdateTransactionBody.getExpirationTime().getNanos(), dbContractEntity
-                        .getExpiryTimeNanos())
                 , () -> assertEquals(Utility
                         .timeStampInNanos(contractUpdateTransactionBody.getExpirationTime()), dbContractEntity
                         .getExpiryTimeNs())
@@ -367,10 +363,6 @@ public class RecordFileLoggerContractTest extends AbstractRecordFileLoggerTest {
                 , () -> assertArrayEquals(contractUpdateTransactionBody.getAdminKey().toByteArray(), dbContractEntity
                         .getKey())
                 , () -> assertAccount(contractUpdateTransactionBody.getProxyAccountID(), dbProxyAccountId)
-                , () -> assertEquals(contractUpdateTransactionBody.getExpirationTime().getSeconds(), dbContractEntity
-                        .getExpiryTimeSeconds())
-                , () -> assertEquals(contractUpdateTransactionBody.getExpirationTime().getNanos(), dbContractEntity
-                        .getExpiryTimeNanos())
                 , () -> assertEquals(Utility
                         .timeStampInNanos(contractUpdateTransactionBody.getExpirationTime()), dbContractEntity
                         .getExpiryTimeNs())
@@ -441,8 +433,6 @@ public class RecordFileLoggerContractTest extends AbstractRecordFileLoggerTest {
 
                 // Additional entity checks
                 , () -> assertFalse(dbContractEntity.isDeleted())
-                , () -> assertNull(dbContractEntity.getExpiryTimeSeconds())
-                , () -> assertNull(dbContractEntity.getExpiryTimeNanos())
                 , () -> assertNull(dbContractEntity.getExpiryTimeNs())
         );
     }
@@ -499,8 +489,6 @@ public class RecordFileLoggerContractTest extends AbstractRecordFileLoggerTest {
 
                 // Additional entity checks
                 , () -> assertNotNull(dbContractEntity.getKey())
-                , () -> assertNull(dbContractEntity.getExpiryTimeSeconds())
-                , () -> assertNull(dbContractEntity.getExpiryTimeNanos())
                 , () -> assertNull(dbContractEntity.getExpiryTimeNs())
                 , () -> assertNotNull(dbContractEntity.getAutoRenewPeriod())
                 , () -> assertNotNull(dbContractEntity.getProxyAccountId())
@@ -551,8 +539,6 @@ public class RecordFileLoggerContractTest extends AbstractRecordFileLoggerTest {
 
                 // Additional entity checks
                 , () -> assertNull(dbContractEntity.getKey())
-                , () -> assertNull(dbContractEntity.getExpiryTimeSeconds())
-                , () -> assertNull(dbContractEntity.getExpiryTimeNanos())
                 , () -> assertNull(dbContractEntity.getExpiryTimeNs())
                 , () -> assertNull(dbContractEntity.getAutoRenewPeriod())
                 , () -> assertNull(dbContractEntity.getProxyAccountId())
@@ -604,8 +590,6 @@ public class RecordFileLoggerContractTest extends AbstractRecordFileLoggerTest {
 
                 // Additional entity checks
                 , () -> assertNull(dbContractEntity.getKey())
-                , () -> assertNull(dbContractEntity.getExpiryTimeSeconds())
-                , () -> assertNull(dbContractEntity.getExpiryTimeNanos())
                 , () -> assertNull(dbContractEntity.getExpiryTimeNs())
                 , () -> assertNull(dbContractEntity.getAutoRenewPeriod())
                 , () -> assertNull(dbContractEntity.getProxyAccountId())

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileLoggerCryptoTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileLoggerCryptoTest.java
@@ -55,7 +55,6 @@ import com.hedera.mirror.importer.domain.CryptoTransfer;
 import com.hedera.mirror.importer.domain.Entities;
 import com.hedera.mirror.importer.domain.LiveHash;
 import com.hedera.mirror.importer.util.Utility;
-import java.util.Arrays;
 
 public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
 
@@ -134,8 +133,6 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
 
                 // Additional entity checks
                 , () -> assertFalse(dbNewAccountEntity.isDeleted())
-                , () -> assertNull(dbNewAccountEntity.getExpiryTimeNanos())
-                , () -> assertNull(dbNewAccountEntity.getExpiryTimeSeconds())
                 , () -> assertNull(dbNewAccountEntity.getExpiryTimeNs())
         );
 
@@ -221,8 +218,6 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
 
                 // Additional entity checks
                 , () -> assertFalse(dbNewAccountEntity.isDeleted())
-                , () -> assertNull(dbNewAccountEntity.getExpiryTimeNanos())
-                , () -> assertNull(dbNewAccountEntity.getExpiryTimeSeconds())
                 , () -> assertNull(dbNewAccountEntity.getExpiryTimeNs())
 
                 // Crypto transfer list
@@ -287,8 +282,6 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
 
                 // Additional entity checks
                 , () -> assertFalse(dbNewAccountEntity.isDeleted())
-                , () -> assertNull(dbNewAccountEntity.getExpiryTimeNanos())
-                , () -> assertNull(dbNewAccountEntity.getExpiryTimeSeconds())
                 , () -> assertNull(dbNewAccountEntity.getExpiryTimeNs())
         );
 
@@ -356,8 +349,6 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
 
                 // Additional entity checks
                 , () -> assertFalse(dbNewAccountEntity.isDeleted())
-                , () -> assertNull(dbNewAccountEntity.getExpiryTimeNanos())
-                , () -> assertNull(dbNewAccountEntity.getExpiryTimeSeconds())
                 , () -> assertNull(dbNewAccountEntity.getExpiryTimeNs())
         );
 
@@ -421,8 +412,6 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
 
                 // Additional entity checks
                 , () -> assertFalse(dbNewAccountEntity.isDeleted())
-                , () -> assertNull(dbNewAccountEntity.getExpiryTimeNanos())
-                , () -> assertNull(dbNewAccountEntity.getExpiryTimeSeconds())
                 , () -> assertNull(dbNewAccountEntity.getExpiryTimeNs())
         );
 
@@ -486,10 +475,6 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
                 , () -> assertEquals(Utility
                         .timeStampInNanos(cryptoUpdateTransactionBody.getExpirationTime()), dbAccountEntity
                         .getExpiryTimeNs())
-                , () -> assertEquals(cryptoUpdateTransactionBody.getExpirationTime().getSeconds(), dbAccountEntity
-                        .getExpiryTimeSeconds())
-                , () -> assertEquals(cryptoUpdateTransactionBody.getExpirationTime().getNanos(), dbAccountEntity
-                        .getExpiryTimeNanos())
 
                 // Additional entity checks
                 , () -> assertFalse(dbAccountEntity.isDeleted())
@@ -654,8 +639,6 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
                 , () -> assertNotNull(dbAccountEntity.getAutoRenewPeriod())
                 , () -> assertNotNull(dbProxyAccountId)
                 , () -> assertNull(dbAccountEntity.getExpiryTimeNs())
-                , () -> assertNull(dbAccountEntity.getExpiryTimeSeconds())
-                , () -> assertNull(dbAccountEntity.getExpiryTimeNanos())
         );
 
         // Crypto transfer list
@@ -717,8 +700,6 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
                 , () -> assertNotNull(dbAccountEntity.getAutoRenewPeriod())
                 , () -> assertNotNull(dbProxyAccountId)
                 , () -> assertNull(dbAccountEntity.getExpiryTimeNs())
-                , () -> assertNull(dbAccountEntity.getExpiryTimeSeconds())
-                , () -> assertNull(dbAccountEntity.getExpiryTimeNanos())
         );
 
         // Crypto transfer list

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileLoggerFileTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileLoggerFileTest.java
@@ -132,10 +132,6 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
                 , () -> assertRecordTransfers(record)
 
                 // transaction body inputs
-                , () -> assertEquals(fileCreateTransactionBody.getExpirationTime().getSeconds(), dbFileEntity
-                        .getExpiryTimeSeconds())
-                , () -> assertEquals(fileCreateTransactionBody.getExpirationTime().getNanos(), dbFileEntity
-                        .getExpiryTimeNanos())
                 , () -> assertEquals(Utility
                         .timeStampInNanos(fileCreateTransactionBody.getExpirationTime()), dbFileEntity
                         .getExpiryTimeNs())
@@ -233,10 +229,6 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
                 , () -> assertRecordTransfers(record)
 
                 // transaction body inputs
-                , () -> assertEquals(fileCreateTransactionBody.getExpirationTime().getSeconds(), dbFileEntity
-                        .getExpiryTimeSeconds())
-                , () -> assertEquals(fileCreateTransactionBody.getExpirationTime().getNanos(), dbFileEntity
-                        .getExpiryTimeNanos())
                 , () -> assertEquals(Utility
                         .timeStampInNanos(fileCreateTransactionBody.getExpirationTime()), dbFileEntity
                         .getExpiryTimeNs())
@@ -293,10 +285,6 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
                 , () -> assertRecordTransfers(record)
 
                 // transaction body inputs
-                , () -> assertEquals(fileCreateTransactionBody.getExpirationTime().getSeconds(), dbFileEntity
-                        .getExpiryTimeSeconds())
-                , () -> assertEquals(fileCreateTransactionBody.getExpirationTime().getNanos(), dbFileEntity
-                        .getExpiryTimeNanos())
                 , () -> assertEquals(Utility
                         .timeStampInNanos(fileCreateTransactionBody.getExpirationTime()), dbFileEntity
                         .getExpiryTimeNs())
@@ -383,8 +371,6 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
                         .getFileData())
 
                 // Additional entity checks
-                , () -> assertNotNull(dbFileEntity.getExpiryTimeSeconds())
-                , () -> assertNotNull(dbFileEntity.getExpiryTimeNanos())
                 , () -> assertNotNull(dbFileEntity.getExpiryTimeNs())
                 , () -> assertNull(dbFileEntity.getAutoRenewPeriod())
                 , () -> assertNull(dbFileEntity.getProxyAccountId())
@@ -437,8 +423,6 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
                         .getFileData())
 
                 // Additional entity checks
-                , () -> assertNull(dbFileEntity.getExpiryTimeSeconds())
-                , () -> assertNull(dbFileEntity.getExpiryTimeNanos())
                 , () -> assertNull(dbFileEntity.getExpiryTimeNs())
                 , () -> assertNull(dbFileEntity.getAutoRenewPeriod())
                 , () -> assertNull(dbFileEntity.getProxyAccountId())
@@ -496,8 +480,6 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
                         .getFileData())
 
                 // Additional entity checks
-                , () -> assertNull(dbFileEntity.getExpiryTimeSeconds())
-                , () -> assertNull(dbFileEntity.getExpiryTimeNanos())
                 , () -> assertNull(dbFileEntity.getExpiryTimeNs())
                 , () -> assertNull(dbFileEntity.getAutoRenewPeriod())
                 , () -> assertNull(dbFileEntity.getProxyAccountId())
@@ -554,10 +536,6 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
                 , () -> assertRecordTransfers(record)
 
                 // transaction body inputs
-                , () -> assertEquals(fileUpdateTransactionBody.getExpirationTime().getSeconds(), dbFileEntity
-                        .getExpiryTimeSeconds())
-                , () -> assertEquals(fileUpdateTransactionBody.getExpirationTime().getNanos(), dbFileEntity
-                        .getExpiryTimeNanos())
                 , () -> assertEquals(Utility
                         .timeStampInNanos(fileUpdateTransactionBody.getExpirationTime()), dbFileEntity
                         .getExpiryTimeNs())
@@ -623,10 +601,6 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
                 , () -> assertRecordTransfers(record)
 
                 // transaction body inputs
-                , () -> assertEquals(fileCreateTransactionBody.getExpirationTime().getSeconds(), dbFileEntity
-                        .getExpiryTimeSeconds())
-                , () -> assertEquals(fileCreateTransactionBody.getExpirationTime().getNanos(), dbFileEntity
-                        .getExpiryTimeNanos())
                 , () -> assertEquals(Utility
                         .timeStampInNanos(fileCreateTransactionBody.getExpirationTime()), dbFileEntity
                         .getExpiryTimeNs())
@@ -695,8 +669,6 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
                 )
 
                 // Additional entity checks
-                , () -> assertNull(dbFileEntity.getExpiryTimeSeconds())
-                , () -> assertNull(dbFileEntity.getExpiryTimeNanos())
                 , () -> assertNull(dbFileEntity.getExpiryTimeNs())
                 , () -> assertNull(dbFileEntity.getAutoRenewPeriod())
                 , () -> assertNull(dbFileEntity.getProxyAccountId())
@@ -745,10 +717,6 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
                 , () -> assertRecordTransfers(record)
 
                 // transaction body inputs
-                , () -> assertEquals(fileUpdateTransactionBody.getExpirationTime().getSeconds(), dbFileEntity
-                        .getExpiryTimeSeconds())
-                , () -> assertEquals(fileUpdateTransactionBody.getExpirationTime().getNanos(), dbFileEntity
-                        .getExpiryTimeNanos())
                 , () -> assertEquals(Utility
                         .timeStampInNanos(fileUpdateTransactionBody.getExpirationTime()), dbFileEntity
                         .getExpiryTimeNs())
@@ -814,8 +782,6 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
                 , () -> assertRecordTransfers(record)
 
                 // transaction body inputs
-                , () -> assertNotNull(dbFileEntity.getExpiryTimeSeconds())
-                , () -> assertNotNull(dbFileEntity.getExpiryTimeNanos())
                 , () -> assertNotNull(dbFileEntity.getExpiryTimeNs())
                 , () -> assertNotNull(dbFileEntity.getKey())
 
@@ -871,8 +837,6 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
                 , () -> assertRecordTransfers(record)
 
                 // transaction body inputs
-                , () -> assertNull(dbFileEntity.getExpiryTimeSeconds())
-                , () -> assertNull(dbFileEntity.getExpiryTimeNanos())
                 , () -> assertNull(dbFileEntity.getExpiryTimeNs())
                 , () -> assertNull(dbFileEntity.getKey())
 
@@ -936,10 +900,6 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
                 , () -> assertRecordTransfers(record)
 
                 // transaction body inputs
-                , () -> assertEquals(fileUpdateTransactionBody.getExpirationTime().getSeconds(), dbFileEntity
-                        .getExpiryTimeSeconds())
-                , () -> assertEquals(fileUpdateTransactionBody.getExpirationTime().getNanos(), dbFileEntity
-                        .getExpiryTimeNanos())
                 , () -> assertEquals(Utility
                         .timeStampInNanos(fileUpdateTransactionBody.getExpirationTime()), dbFileEntity
                         .getExpiryTimeNs())
@@ -993,10 +953,6 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
                 , () -> assertRecordTransfers(record)
 
                 // transaction body inputs
-                , () -> assertEquals(fileUpdateTransactionBody.getExpirationTime().getSeconds(), dbFileEntity
-                        .getExpiryTimeSeconds())
-                , () -> assertEquals(fileUpdateTransactionBody.getExpirationTime().getNanos(), dbFileEntity
-                        .getExpiryTimeNanos())
                 , () -> assertEquals(Utility
                         .timeStampInNanos(fileUpdateTransactionBody.getExpirationTime()), dbFileEntity
                         .getExpiryTimeNs())
@@ -1058,8 +1014,6 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
                 , () -> assertRecordTransfers(record)
 
                 // transaction body inputs
-                , () -> assertNotNull(dbFileEntity.getExpiryTimeSeconds())
-                , () -> assertNotNull(dbFileEntity.getExpiryTimeNanos())
                 , () -> assertNotNull(dbFileEntity.getExpiryTimeNs())
                 , () -> assertArrayEquals(fileUpdateTransactionBody.getKeys().toByteArray(), dbFileEntity.getKey())
 
@@ -1111,8 +1065,6 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
                 , () -> assertRecordTransfers(record)
 
                 // transaction body inputs
-                , () -> assertNull(dbFileEntity.getExpiryTimeSeconds())
-                , () -> assertNull(dbFileEntity.getExpiryTimeNanos())
                 , () -> assertNull(dbFileEntity.getExpiryTimeNs())
                 , () -> assertArrayEquals(fileUpdateTransactionBody.getKeys().toByteArray(), dbFileEntity.getKey())
 
@@ -1169,10 +1121,6 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
                 , () -> assertRecordTransfers(record)
 
                 // transaction body inputs
-                , () -> assertEquals(fileUpdateTransactionBody.getExpirationTime().getSeconds(), dbFileEntity
-                        .getExpiryTimeSeconds())
-                , () -> assertEquals(fileUpdateTransactionBody.getExpirationTime().getNanos(), dbFileEntity
-                        .getExpiryTimeNanos())
                 , () -> assertEquals(Utility
                         .timeStampInNanos(fileUpdateTransactionBody.getExpirationTime()), dbFileEntity
                         .getExpiryTimeNs())
@@ -1235,10 +1183,6 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
                 , () -> assertRecordTransfers(record)
 
                 // transaction body inputs
-                , () -> assertEquals(fileUpdateTransactionBody.getExpirationTime().getSeconds(), dbFileEntity
-                        .getExpiryTimeSeconds())
-                , () -> assertEquals(fileUpdateTransactionBody.getExpirationTime().getNanos(), dbFileEntity
-                        .getExpiryTimeNanos())
                 , () -> assertEquals(Utility
                         .timeStampInNanos(fileUpdateTransactionBody.getExpirationTime()), dbFileEntity
                         .getExpiryTimeNs())
@@ -1310,8 +1254,6 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
 
                 // Additional entity checks
                 , () -> assertNotNull(dbFileEntity.getKey())
-                , () -> assertNotNull(dbFileEntity.getExpiryTimeSeconds())
-                , () -> assertNotNull(dbFileEntity.getExpiryTimeNanos())
                 , () -> assertNotNull(dbFileEntity.getExpiryTimeNs())
                 , () -> assertNull(dbFileEntity.getAutoRenewPeriod())
                 , () -> assertNull(dbFileEntity.getProxyAccountId())
@@ -1361,8 +1303,6 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
 
                 // Additional entity checks
                 , () -> assertNull(dbFileEntity.getKey())
-                , () -> assertNull(dbFileEntity.getExpiryTimeSeconds())
-                , () -> assertNull(dbFileEntity.getExpiryTimeNanos())
                 , () -> assertNull(dbFileEntity.getExpiryTimeNs())
                 , () -> assertNull(dbFileEntity.getAutoRenewPeriod())
                 , () -> assertNull(dbFileEntity.getProxyAccountId())
@@ -1413,8 +1353,6 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
 
                 // Additional entity checks
                 , () -> assertNull(dbFileEntity.getKey())
-                , () -> assertNull(dbFileEntity.getExpiryTimeSeconds())
-                , () -> assertNull(dbFileEntity.getExpiryTimeNanos())
                 , () -> assertNull(dbFileEntity.getExpiryTimeNs())
                 , () -> assertNull(dbFileEntity.getAutoRenewPeriod())
                 , () -> assertNull(dbFileEntity.getProxyAccountId())
@@ -1464,8 +1402,6 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
 
                 // Additional entity checks
                 , () -> assertNull(dbFileEntity.getKey())
-                , () -> assertNull(dbFileEntity.getExpiryTimeSeconds())
-                , () -> assertNull(dbFileEntity.getExpiryTimeNanos())
                 , () -> assertNull(dbFileEntity.getExpiryTimeNs())
                 , () -> assertNull(dbFileEntity.getAutoRenewPeriod())
                 , () -> assertNull(dbFileEntity.getProxyAccountId())
@@ -1514,8 +1450,6 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
 
                 // Additional entity checks
                 , () -> assertNull(dbFileEntity.getKey())
-                , () -> assertNull(dbFileEntity.getExpiryTimeSeconds())
-                , () -> assertNull(dbFileEntity.getExpiryTimeNanos())
                 , () -> assertNull(dbFileEntity.getExpiryTimeNs())
                 , () -> assertNull(dbFileEntity.getAutoRenewPeriod())
                 , () -> assertNull(dbFileEntity.getProxyAccountId())

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileLoggerTopicTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileLoggerTopicTest.java
@@ -223,11 +223,11 @@ public class RecordFileLoggerTopicTest extends AbstractRecordFileLoggerTest {
         var consensusTimestamp = 6_000_000L;
         var responseCode = ResponseCodeEnum.SUCCESS;
 
-        var topic = createTopicEntity(topicId, 11L, 21, adminKey, submitKey, "updated-memo", 1L, 30L);
+        var topic = createTopicEntity(topicId, 11L, 0, adminKey, submitKey, "updated-memo", 1L, 30L);
         // Topic does not get stored in the repository beforehand.
 
-        var transaction = createUpdateTopicTransaction(topicId, topic.getExpiryTimeSeconds(), topic.getExpiryTimeNanos()
-                .intValue(), adminKey, submitKey, topic.getMemo(), 1L, 30L);
+        var transaction = createUpdateTopicTransaction(topicId, 11L, 0, adminKey, submitKey, topic
+                .getMemo(), 1L, 30L);
         var transactionRecord = createTransactionRecord(topicId, null, null, consensusTimestamp,
                 responseCode);
 
@@ -281,8 +281,6 @@ public class RecordFileLoggerTopicTest extends AbstractRecordFileLoggerTest {
         }
         if (updatedExpirationTimeSeconds != null && updatedExpirationTimeNanos != null) {
             topic.setExpiryTimeNs(Utility.convertToNanosMax(updatedExpirationTimeSeconds, updatedExpirationTimeNanos));
-            topic.setExpiryTimeSeconds(updatedExpirationTimeSeconds);
-            topic.setExpiryTimeNanos((long) updatedExpirationTimeNanos);
         }
         if (updatedAdminKey != null) {
             topic.setKey(updatedAdminKey.toByteArray());
@@ -582,10 +580,7 @@ public class RecordFileLoggerTopicTest extends AbstractRecordFileLoggerTest {
             topic.setAutoRenewPeriod(autoRenewPeriod);
         }
         if (expirationTimeSeconds != null && expirationTimeNanos != null) {
-            topic.setExpiryTimeNs(Utility
-                    .convertToNanosMax(expirationTimeSeconds, expirationTimeNanos));
-            topic.setExpiryTimeSeconds(expirationTimeSeconds);
-            topic.setExpiryTimeNanos(expirationTimeNanos.longValue());
+            topic.setExpiryTimeNs(Utility.convertToNanosMax(expirationTimeSeconds, expirationTimeNanos));
         }
         if (null != adminKey) {
             topic.setKey(adminKey.toByteArray());

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileLoggerTopicTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileLoggerTopicTest.java
@@ -59,22 +59,21 @@ public class RecordFileLoggerTopicTest extends AbstractRecordFileLoggerTest {
 
     @ParameterizedTest
     @CsvSource({
-            "0.0.65537, 10, 20, admin-key, submit-key, 30, '', 1000000",
-            "0.0.2147483647, 9223372036854775807, 2147483647, admin-key, '', 9223372036854775807, memo, 1000001",
-            "0.0.1, -9223372036854775808, -2147483648, '', '', -9223372036854775808, memo, 1000002",
-            "0.0.55, 10, 20, admin-key, submit-key, 30, memo, 1000003"
+            "0.0.65537, 10, 20, admin-key, submit-key, '', 1000000",
+            "0.0.2147483647, 9223372036854775807, 2147483647, admin-key, '', memo, 1000001",
+            "0.0.1, -9223372036854775808, -2147483648, '', '', memo, 1000002",
+            "0.0.55, 10, 20, admin-key, submit-key, memo, 1000003"
     })
     void createTopicTest(@ConvertWith(TopicIdConverter.class) TopicID topicId, long expirationTimeSeconds,
                          int expirationTimeNanos, @ConvertWith(KeyConverter.class) Key adminKey,
-                         @ConvertWith(KeyConverter.class) Key submitKey, long validStartTime, String memo,
-                         long consensusTimestamp) throws Exception {
+                         @ConvertWith(KeyConverter.class) Key submitKey, String memo, long consensusTimestamp) throws Exception {
         var responseCode = ResponseCodeEnum.SUCCESS;
         var transaction = createCreateTopicTransaction(expirationTimeSeconds, expirationTimeNanos, adminKey,
-                submitKey, validStartTime, memo);
+                submitKey, memo);
         var transactionRecord = createTransactionRecord(topicId, null, null, consensusTimestamp,
                 responseCode);
         var expectedEntity = createTopicEntity(topicId, expirationTimeSeconds, expirationTimeNanos, adminKey, submitKey,
-                validStartTime, memo);
+                memo);
 
         RecordFileLogger.storeRecord(transaction, transactionRecord);
         RecordFileLogger.completeFile("", "");
@@ -93,7 +92,7 @@ public class RecordFileLoggerTopicTest extends AbstractRecordFileLoggerTest {
         var consensusTimestamp = 2_000_000L;
         var responseCode = ResponseCodeEnum.SUCCESS;
         var transaction = createCreateTopicTransaction(10, 20, null, null,
-                30, null);
+                null);
         var transactionRecord = createTransactionRecord(TopicID.newBuilder().setTopicNum(topicId)
                 .build(), null, null, consensusTimestamp, responseCode);
 
@@ -117,7 +116,7 @@ public class RecordFileLoggerTopicTest extends AbstractRecordFileLoggerTest {
         var consensusTimestamp = 2_000_000L;
         var responseCode = ResponseCodeEnum.SUCCESS;
         var transaction = createCreateTopicTransaction(10, 20, null, null,
-                30, null);
+                null);
         var transactionRecord = createTransactionRecord(TopicID.newBuilder().setTopicNum(topicId)
                 .build(), null, null, consensusTimestamp, responseCode);
 
@@ -133,7 +132,7 @@ public class RecordFileLoggerTopicTest extends AbstractRecordFileLoggerTest {
         var consensusTimestamp = 3_000_000L;
         var responseCode = ResponseCodeEnum.INSUFFICIENT_ACCOUNT_BALANCE;
         var transaction = createCreateTopicTransaction(10, 20, null, null,
-                30, "memo");
+                "memo");
         var transactionRecord = createTransactionRecord(null, null, null, consensusTimestamp, responseCode);
 
         RecordFileLogger.storeRecord(transaction, transactionRecord);
@@ -145,31 +144,29 @@ public class RecordFileLoggerTopicTest extends AbstractRecordFileLoggerTest {
 
     @ParameterizedTest
     @CsvSource({
-            "0.0.1300, 10, 20, admin-key, submit-key, 30, memo,   11, 21, updated-admin-key, updated-submit-key, 31, " +
+            "0.0.1300, 10, 20, admin-key, submit-key, 30, memo,   11, 21, updated-admin-key, updated-submit-key, " +
                     "updated-memo, 4000000",
-            "0.0.1301, 10, 20, admin-key, submit-key, 30, memo,   11, 21, '', '', 31, '', 4000001",
-            "0.0.1302, 0, 0, '', '', 0, '',   11, 21, updated-admin-key, updated-submit-key, 31, updated-memo, 4000002"
+            "0.0.1301, 10, 20, admin-key, submit-key, 30, memo,   11, 21, '', '', '', 4000001",
+            "0.0.1302, 0, 0, '', '', 0, '',   11, 21, updated-admin-key, updated-submit-key, updated-memo, 4000002"
     })
     void updateTopicTest(@ConvertWith(TopicIdConverter.class) TopicID topicId, long expirationTimeSeconds,
                          int expirationTimeNanos, @ConvertWith(KeyConverter.class) Key adminKey,
                          @ConvertWith(KeyConverter.class) Key submitKey, long validStartTime, String memo,
                          long updatedExpirationTimeSeconds, int updatedExpirationTimeNanos,
                          @ConvertWith(KeyConverter.class) Key updatedAdminKey,
-                         @ConvertWith(KeyConverter.class) Key updatedSubmitKey, long updatedValidStartTime,
+                         @ConvertWith(KeyConverter.class) Key updatedSubmitKey,
                          String updatedMemo, long consensusTimestamp) throws Exception {
         // Store topic to be updated.
-        var topic = createTopicEntity(topicId, expirationTimeSeconds, expirationTimeNanos, adminKey, submitKey,
-                validStartTime, memo);
+        var topic = createTopicEntity(topicId, expirationTimeSeconds, expirationTimeNanos, adminKey, submitKey, memo);
         entityRepository.save(topic);
 
         var responseCode = ResponseCodeEnum.SUCCESS;
         var transaction = createUpdateTopicTransaction(topicId, updatedExpirationTimeSeconds,
-                updatedExpirationTimeNanos, updatedAdminKey, updatedSubmitKey, updatedValidStartTime, updatedMemo);
+                updatedExpirationTimeNanos, updatedAdminKey, updatedSubmitKey, updatedMemo);
         var transactionRecord = createTransactionRecord(topicId, null, null, consensusTimestamp,
                 responseCode);
         var expectedEntity = createTopicEntity(topicId, updatedExpirationTimeSeconds, updatedExpirationTimeNanos,
-                updatedAdminKey, updatedSubmitKey,
-                updatedValidStartTime, updatedMemo);
+                updatedAdminKey, updatedSubmitKey, updatedMemo);
 
         RecordFileLogger.storeRecord(transaction, transactionRecord);
         RecordFileLogger.completeFile("", "");
@@ -193,10 +190,10 @@ public class RecordFileLoggerTopicTest extends AbstractRecordFileLoggerTest {
         var responseCode = ResponseCodeEnum.INVALID_TOPIC_ID;
 
         // Store topic to be updated.
-        var topic = createTopicEntity(topicId, 10L, 20, adminKey, submitKey, 30L, "memo");
+        var topic = createTopicEntity(topicId, 10L, 20, adminKey, submitKey, "memo");
         entityRepository.save(topic);
 
-        var transaction = createUpdateTopicTransaction(topicId, 11L, 21, updatedAdminKey, updatedSubmitKey, 31L,
+        var transaction = createUpdateTopicTransaction(topicId, 11L, 21, updatedAdminKey, updatedSubmitKey,
                 "updated-memo");
         var transactionRecord = createTransactionRecord(topicId, null, null, consensusTimestamp,
                 responseCode);
@@ -220,11 +217,11 @@ public class RecordFileLoggerTopicTest extends AbstractRecordFileLoggerTest {
         var consensusTimestamp = 6_000_000L;
         var responseCode = ResponseCodeEnum.SUCCESS;
 
-        var topic = createTopicEntity(topicId, 11L, 21, adminKey, submitKey, 31L, "updated-memo");
+        var topic = createTopicEntity(topicId, 11L, 21, adminKey, submitKey, "updated-memo");
         // Topic does not get stored in the repository beforehand.
 
         var transaction = createUpdateTopicTransaction(topicId, topic.getExpiryTimeSeconds(), topic.getExpiryTimeNanos()
-                .intValue(), adminKey, submitKey, topic.getTopicValidStartTime(), topic.getMemo());
+                .intValue(), adminKey, submitKey, topic.getMemo());
         var transactionRecord = createTransactionRecord(topicId, null, null, consensusTimestamp,
                 responseCode);
 
@@ -241,24 +238,21 @@ public class RecordFileLoggerTopicTest extends AbstractRecordFileLoggerTest {
 
     @ParameterizedTest
     @CsvSource({
-            "0.0.1500, 10, 20, admin-key, submit-key, 30, memo, 5000000,   0, 0, , , 0,",
-            "0.0.1500, 10, 20, admin-key, submit-key, 30, memo, 5000000,   , , , , ,",
-            "0.0.1501, 0, 0, '', '', 0, '', 5000001,   0, 0, , , 0,",
-            "0.0.1502, , , admin-key, submit-key, 30, memo, 5000002,   10, 20, updated-admin-key, " +
-                    "updated-submit-key, 0, updated-memo",
-            "0.0.1503, 10, 20, admin-key, submit-key, 30, memo, 5000003,   11, 21, , , 31,"
+            "0.0.1500, 10, 20, admin-key, submit-key, memo, 5000000,   0, 0, , ,",
+            "0.0.1500, 10, 20, admin-key, submit-key, memo, 5000000,   , , , ,",
+            "0.0.1501, 0, 0, '', '', '', 5000001,   0, 0, , ,",
+            "0.0.1502,,,admin-key, submit-key, memo, 5000002,10,20,updated-admin-key, updated-submit-key, updated-memo",
+            "0.0.1503, 10, 20, admin-key, submit-key, memo, 5000003,   11, 21, , 31,"
     })
     void updateTopicTestPartialUpdates(@ConvertWith(TopicIdConverter.class) TopicID topicId, Long expirationTimeSeconds,
                                        Integer expirationTimeNanos, @ConvertWith(KeyConverter.class) Key adminKey,
-                                       @ConvertWith(KeyConverter.class) Key submitKey, Long validStartTime, String memo,
+                                       @ConvertWith(KeyConverter.class) Key submitKey, String memo,
                                        long consensusTimestamp, Long updatedExpirationTimeSeconds,
                                        Integer updatedExpirationTimeNanos,
                                        @ConvertWith(KeyConverter.class) Key updatedAdminKey,
-                                       @ConvertWith(KeyConverter.class) Key updatedSubmitKey,
-                                       Long updatedValidStartTime, String updatedMemo) throws Exception {
+                                       @ConvertWith(KeyConverter.class) Key updatedSubmitKey, String updatedMemo) throws Exception {
         // Store topic to be updated.
-        var topic = createTopicEntity(topicId, expirationTimeSeconds, expirationTimeNanos, adminKey, submitKey,
-                validStartTime, memo);
+        var topic = createTopicEntity(topicId, expirationTimeSeconds, expirationTimeNanos, adminKey, submitKey, memo);
         entityRepository.save(topic);
 
         // Setup the expected entity.
@@ -266,9 +260,6 @@ public class RecordFileLoggerTopicTest extends AbstractRecordFileLoggerTest {
             topic.setExpiryTimeNs(Utility.convertToNanosMax(updatedExpirationTimeSeconds, updatedExpirationTimeNanos));
             topic.setExpiryTimeSeconds(updatedExpirationTimeSeconds);
             topic.setExpiryTimeNanos((long) updatedExpirationTimeNanos);
-        }
-        if (updatedValidStartTime != null) {
-            topic.setTopicValidStartTime(updatedValidStartTime);
         }
         if (updatedAdminKey != null) {
             topic.setKey(updatedAdminKey.toByteArray());
@@ -282,7 +273,7 @@ public class RecordFileLoggerTopicTest extends AbstractRecordFileLoggerTest {
 
         var responseCode = ResponseCodeEnum.SUCCESS;
         var transaction = createUpdateTopicTransaction(topicId, updatedExpirationTimeSeconds,
-                updatedExpirationTimeNanos, updatedAdminKey, updatedSubmitKey, updatedValidStartTime, updatedMemo);
+                updatedExpirationTimeNanos, updatedAdminKey, updatedSubmitKey, updatedMemo);
         var transactionRecord = createTransactionRecord(topicId, null, null, consensusTimestamp,
                 responseCode);
 
@@ -304,7 +295,7 @@ public class RecordFileLoggerTopicTest extends AbstractRecordFileLoggerTest {
         var responseCode = ResponseCodeEnum.SUCCESS;
 
         // Store topic to be deleted.
-        var topic = createTopicEntity(topicId, null, null, null, null, null, null);
+        var topic = createTopicEntity(topicId, null, null, null, null, null);
         entityRepository.save(topic);
 
         // Setup expected data
@@ -332,7 +323,7 @@ public class RecordFileLoggerTopicTest extends AbstractRecordFileLoggerTest {
         var responseCode = ResponseCodeEnum.SUCCESS;
 
         // Setup expected data
-        var topic = createTopicEntity(topicId, null, null, null, null, null, null);
+        var topic = createTopicEntity(topicId, null, null, null, null, null);
         topic.setDeleted(true);
         // Topic not saved to the repository.
 
@@ -358,7 +349,7 @@ public class RecordFileLoggerTopicTest extends AbstractRecordFileLoggerTest {
         var responseCode = ResponseCodeEnum.INSUFFICIENT_ACCOUNT_BALANCE;
 
         // Store topic to be deleted.
-        var topic = createTopicEntity(topicId, 10L, 20, null, null, 30L, null);
+        var topic = createTopicEntity(topicId, 10L, 20, null, null, null);
         entityRepository.save(topic);
 
         var transaction = createDeleteTopicTransaction(topicId);
@@ -387,7 +378,7 @@ public class RecordFileLoggerTopicTest extends AbstractRecordFileLoggerTest {
                            long sequenceNumber) throws Exception {
         var responseCode = ResponseCodeEnum.SUCCESS;
 
-        var topic = createTopicEntity(topicId, 10L, 20, null, null, 30L, null);
+        var topic = createTopicEntity(topicId, 10L, 20, null, null, null);
         entityRepository.save(topic);
 
         var topicMessage = createTopicMessage(topicId, message, sequenceNumber, runningHash, consensusTimestamp);
@@ -417,7 +408,7 @@ public class RecordFileLoggerTopicTest extends AbstractRecordFileLoggerTest {
         var sequenceNumber = 10_000L;
         var runningHash = "running-hash";
 
-        var topic = createTopicEntity(topicId, null, null, null, null, null, null);
+        var topic = createTopicEntity(topicId, null, null, null, null, null);
         // Topic NOT saved in the repository.
 
         var topicMessage = createTopicMessage(topicId, message, sequenceNumber, runningHash, consensusTimestamp);
@@ -448,7 +439,7 @@ public class RecordFileLoggerTopicTest extends AbstractRecordFileLoggerTest {
         var sequenceNumber = 10_000L;
         var runningHash = "running-hash";
 
-        var topic = createTopicEntity(topicId, null, null, null, null, null, null);
+        var topic = createTopicEntity(topicId, null, null, null, null, null);
         var transaction = createSubmitMessageTransaction(topicId, message);
         var transactionRecord = createTransactionRecord(topicId, sequenceNumber, runningHash
                 .getBytes(), consensusTimestamp, responseCode);
@@ -469,7 +460,7 @@ public class RecordFileLoggerTopicTest extends AbstractRecordFileLoggerTest {
         var sequenceNumber = 11_000L;
         var runningHash = "running-hash";
 
-        var topic = createTopicEntity(topicId, 10L, 20, null, null, 30L, null);
+        var topic = createTopicEntity(topicId, 10L, 20, null, null, null);
         entityRepository.save(topic);
 
         var transaction = createSubmitMessageTransaction(topicId, message);
@@ -491,11 +482,9 @@ public class RecordFileLoggerTopicTest extends AbstractRecordFileLoggerTest {
     private com.hederahashgraph.api.proto.java.Transaction createCreateTopicTransaction(long expirationTimeSeconds,
                                                                                         int expirationTimeNanos,
                                                                                         Key adminKey, Key submitKey,
-                                                                                        long validStartTime,
                                                                                         String memo) {
         var innerBody = ConsensusCreateTopicTransactionBody.newBuilder()
-                .setExpirationTime(TestUtils.toTimestamp(expirationTimeSeconds, expirationTimeNanos))
-                .setValidStartTime(TestUtils.toTimestamp(validStartTime));
+                .setExpirationTime(TestUtils.toTimestamp(expirationTimeSeconds, expirationTimeNanos));
         if (adminKey != null) {
             innerBody.setAdminKey(adminKey);
         }
@@ -537,7 +526,7 @@ public class RecordFileLoggerTopicTest extends AbstractRecordFileLoggerTest {
     }
 
     private Entities createTopicEntity(TopicID topicId, Long expirationTimeSeconds, Integer expirationTimeNanos,
-                                       Key adminKey, Key submitKey, Long validStartTime, String memo) {
+                                       Key adminKey, Key submitKey, String memo) {
         var topic = new Entities();
         topic.setEntityShard(topicId.getShardNum());
         topic.setEntityRealm(topicId.getRealmNum());
@@ -554,7 +543,6 @@ public class RecordFileLoggerTopicTest extends AbstractRecordFileLoggerTest {
         if (null != submitKey) {
             topic.setSubmitKey(submitKey.toByteArray());
         }
-        topic.setTopicValidStartTime(validStartTime);
         topic.setMemo(memo);
         topic.setEntityTypeId(TOPIC_ENTITY_TYPE_ID);
         return topic;
@@ -576,15 +564,11 @@ public class RecordFileLoggerTopicTest extends AbstractRecordFileLoggerTest {
                                                                                         Long expirationTimeSeconds,
                                                                                         Integer expirationTimeNanos,
                                                                                         Key adminKey, Key submitKey,
-                                                                                        Long validStartTime,
                                                                                         String memo) {
         var innerBody = ConsensusUpdateTopicTransactionBody.newBuilder().setTopicID(topicId);
 
         if (expirationTimeSeconds != null && expirationTimeNanos != null) {
             innerBody.setExpirationTime(TestUtils.toTimestamp(expirationTimeSeconds, expirationTimeNanos));
-        }
-        if (validStartTime != null) {
-            innerBody.setValidStartTime(TestUtils.toTimestamp(validStartTime));
         }
         if (adminKey != null) {
             innerBody.setAdminKey(adminKey);

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/EntityRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/EntityRepositoryTest.java
@@ -32,6 +32,12 @@ public class EntityRepositoryTest extends AbstractRepositoryTest {
     void findByPrimaryKey() {
         int entityTypeId = entityTypeRepository.findByName("account").get().getId();
 
+        Entities autoRenewAccount = new Entities();
+        autoRenewAccount.setEntityTypeId(entityTypeId);
+        autoRenewAccount.setEntityShard(0L);
+        autoRenewAccount.setEntityRealm(0L);
+        autoRenewAccount.setEntityNum(101L);
+
         Entities proxyEntity = new Entities();
         proxyEntity.setEntityTypeId(entityTypeId);
         proxyEntity.setEntityShard(0L);
@@ -41,6 +47,7 @@ public class EntityRepositoryTest extends AbstractRepositoryTest {
 
         Entities entity = new Entities();
         entity.setAutoRenewPeriod(100L);
+        entity.setAutoRenewAccount(autoRenewAccount);
         entity.setDeleted(true);
         entity.setEd25519PublicKeyHex("0123456789abcdef");
         entity.setEntityNum(5L);
@@ -54,6 +61,11 @@ public class EntityRepositoryTest extends AbstractRepositoryTest {
         entity.setProxyAccountId(proxyEntity.getId());
         entity.setSubmitKey("SubmitKey".getBytes());
         entity = entityRepository.save(entity);
+
+        assertThat(entityRepository.findByPrimaryKey(autoRenewAccount.getEntityShard(),
+                autoRenewAccount.getEntityRealm(), autoRenewAccount.getEntityNum()))
+                .get()
+                .isEqualToIgnoringGivenFields(autoRenewAccount, "id");
 
         assertThat(entityRepository
                 .findByPrimaryKey(entity.getEntityShard(), entity.getEntityRealm(), entity.getEntityNum()))

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/EntityRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/EntityRepositoryTest.java
@@ -54,9 +54,7 @@ public class EntityRepositoryTest extends AbstractRepositoryTest {
         entity.setEntityRealm(4L);
         entity.setEntityShard(3L);
         entity.setEntityTypeId(entityTypeId);
-        entity.setExpiryTimeNanos(200L);
         entity.setExpiryTimeNs(300L);
-        entity.setExpiryTimeSeconds(400L);
         entity.setKey("key".getBytes());
         entity.setProxyAccountId(proxyEntity.getId());
         entity.setSubmitKey("SubmitKey".getBytes());

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/EntityRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/EntityRepositoryTest.java
@@ -53,7 +53,6 @@ public class EntityRepositoryTest extends AbstractRepositoryTest {
         entity.setKey("key".getBytes());
         entity.setProxyAccountId(proxyEntity.getId());
         entity.setSubmitKey("SubmitKey".getBytes());
-        entity.setTopicValidStartTime(700L);
         entity = entityRepository.save(entity);
 
         assertThat(entityRepository
@@ -61,7 +60,7 @@ public class EntityRepositoryTest extends AbstractRepositoryTest {
                 .get()
                 .isEqualTo(entity);
 
-        entity.setTopicValidStartTime(600L);
+        entity.setExpiryTimeNs(600L);
         entity = entityRepository.save(entity);
 
         assertThat(entityRepository

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <docker.repository>docker.pkg.github.com/hashgraph/hedera-mirror-node</docker.repository>
         <grpc.version>1.25.0</grpc.version>
         <guava.version>28.1-jre</guava.version>
-        <hedera-protobuf.version>hcs-11c0d9176b-1</hedera-protobuf.version>
+        <hedera-protobuf.version>hcs-4e1dd97dc6-1</hedera-protobuf.version>
         <jacoco.version>0.8.5</jacoco.version>
         <java.version>11</java.version>
         <javax.version>1</javax.version>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.2.1.RELEASE</version>
+        <version>2.2.2.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 


### PR DESCRIPTION
**Detailed description**:
- Removes `t_entities.admin_key__deprecated`
- Removes `t_entities.exp_time_seconds`
- Removes `t_entities.exp_time_nanos`
- Removes `t_entities.topic_valid_start_time`
- Adds `t_entities.auto_renew_account_id`
- Adds new HCS protobuf response codes
- Fixes previous HCS protobuf response codes that had changed from Mike's branch
- Renames `ConsensusService` to `ConsensusController` to avoid confusion with business logic service layer (see code comment)
- Bumps Spring Boot bugfix version
- Pull in latest HCS services protobuf with above changes

**Which issue(s) this PR fixes**:
Fixes #440
Fixes #325

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated

