### PR TITLE
Monitor REST endpoint test scripts

### DIFF
--- a/hedera-mirror-rest/monitoring/monitor_apis/endpointTester.sh
+++ b/hedera-mirror-rest/monitoring/monitor_apis/endpointTester.sh
@@ -1,0 +1,80 @@
+#! /usr/bin/env bash
+# Script to allow OPS to be able to hit monitor api endpoint continuously in between intervals
+# The /status endpoint is hit with headers returned showing status
+# /status endpoint gets results for all servers available
+host=
+looptimes=1
+sleepseconds=5
+individual=false
+
+while getopts “h:l:s:i” OPTION; do
+    case $OPTION in
+    h)
+        host=$OPTARG
+        ;;
+    l)
+        looptimes=$OPTARG
+        ;;
+    s)
+        sleepseconds=$OPTARG
+        ;;
+    i)
+        individual=$OPTARG
+        ;;
+    ?)
+        echo "Please call script as follows './endpointTester.sh -h <host> -l <looptimes> -s <sleepseconds>' -h is the only mandatory param"
+        exit
+        ;;
+    esac
+done
+
+if [ "$#" -lt 1 ] || [[ -z $host ]]; then
+    echo "Endpoint host parameter is missing. Please call script as follows './endpointTester.sh -h <host>'"
+    exit 1
+fi
+
+url=http://$host/api/v1/status
+
+function hit_status() {
+    echo "Call ${url} for status"
+    result=$(curl --silent -I ${url} --stderr - | grep HTTP)
+    if [[ $result == *"200"* ]]; then
+        echo "Success : 200 returned"
+    else
+        echo "Failure: Non 200 returned"
+    fi
+}
+
+function hit_status_id() {
+    # read servers from list
+    servers=($(cat ./config/serverlist.json | jq --raw-output '.servers[] .name'))
+
+    for s in "${servers[@]}"; do
+        # form single server url
+        indvurl="$url/$s"
+        echo "Call ${indvurl} for status"
+
+        result=$(curl --silent ${indvurl} --stderr - | jq '.httpCode')
+
+        if [[ $result == "200" ]]; then
+            echo "Success : ${result} returned"
+        else
+            echo "Failure: ${result} returned"
+        fi
+    done
+}
+
+for ((i = 1; i <= looptimes; ++i)); do
+
+    if $individual; then
+        echo "Multi endpoint scenario chosen"
+        hit_status_id
+    else
+        echo "Single endpoint scenario chosen"
+        hit_status
+    fi
+
+    echo "Run ${i}, wait ${sleepseconds} seconds before next run"
+    sleep ${sleepseconds}
+
+done

--- a/hedera-mirror-rest/monitoring/monitor_apis/endpointTester.sh
+++ b/hedera-mirror-rest/monitoring/monitor_apis/endpointTester.sh
@@ -1,13 +1,20 @@
 #! /usr/bin/env bash
 # Script to allow OPS to be able to hit monitor api endpoint continuously in between intervals
-# The /status endpoint is hit with headers returned showing status
-# /status endpoint gets results for all servers available
+# Usage is as follows
+# Multi endpoint check $ ./endpointTester.sh -h 34.66.207.234:5552 -l 1 -s 2
+# Single endpoint check $ ./endpointTester.sh -h 34.66.207.234:5552 -n mainnet-6551 -l 1 -s 2
+# Set servername using -n option to monitor a single desired server.
+# Else each of the available servers in serverlist.json will be checked
+# The /status/id endpoint is hit for each call and the http code response aswell as test success count is printed
+# Reponses will be in the form "Success : 200 returned, 13 / 13 Passed" or "Failure : 409 returned, 0 / 1 Passed"
+
 host=
 looptimes=1
 sleepseconds=5
-individual=false
+multiendpoint=false
+servername=
 
-while getopts “h:l:s:i” OPTION; do
+while getopts “h:l:s:m:n:” OPTION; do
     case $OPTION in
     h)
         host=$OPTARG
@@ -18,11 +25,11 @@ while getopts “h:l:s:i” OPTION; do
     s)
         sleepseconds=$OPTARG
         ;;
-    i)
-        individual=$OPTARG
+    n)
+        servername=$OPTARG
         ;;
     ?)
-        echo "Please call script as follows './endpointTester.sh -h <host> -l <looptimes> -s <sleepseconds>' -h is the only mandatory param"
+        echo "Please call script as follows './endpointTester.sh -h <host:port> -n <servername> -l <looptimes> -s <sleepseconds>' -h is the only mandatory param"
         exit
         ;;
     esac
@@ -33,45 +40,62 @@ if [ "$#" -lt 1 ] || [[ -z $host ]]; then
     exit 1
 fi
 
+#set url
 url=http://$host/api/v1/status
 
-function hit_status() {
-    echo "Call ${url} for status"
-    result=$(curl --silent -I ${url} --stderr - | grep HTTP)
-    if [[ $result == *"200"* ]]; then
-        echo "Success : 200 returned"
+function hit_single_status_id() {
+    indvurl=$1
+    echo "Call ${indvurl} for status"
+
+    response=$(curl --silent ${indvurl} --stderr -)
+    #        echo "${response}"
+    httpStatus=$(echo "${response}" | jq '.httpCode')
+    numPassed=$(echo "${response}" | jq '.results.numPassedTests')
+    numFailed=$(echo "${response}" | jq '.results.numFailedTests')
+    nomTotal=$((numPassed + numFailed))
+    report="${httpStatus} returned, ${numPassed} / ${nomTotal} Passed"
+
+    if [[ $httpStatus == "200" ]]; then
+        echo "Success : ${report}"
     else
-        echo "Failure: Non 200 returned"
+        echo "Failure: ${report}"
     fi
 }
 
-function hit_status_id() {
+function hit_multi_status_id() {
     # read servers from list
     servers=($(cat ./config/serverlist.json | jq --raw-output '.servers[] .name'))
 
     for s in "${servers[@]}"; do
         # form single server url
-        indvurl="$url/$s"
-        echo "Call ${indvurl} for status"
-
-        result=$(curl --silent ${indvurl} --stderr - | jq '.httpCode')
-
-        if [[ $result == "200" ]]; then
-            echo "Success : ${result} returned"
-        else
-            echo "Failure: ${result} returned"
-        fi
+        hit_single_status_id "$url/$s"
+        #        indvurl="$url/$s"
+        #        echo "Call ${indvurl} for status"
+        #
+        #        response=$(curl --silent ${indvurl} --stderr -)
+        #        #        echo "${response}"
+        #        httpStatus=$(echo "${response}" | jq '.httpCode')
+        #        numPassed=$(echo "${response}" | jq '.results.numPassedTests')
+        #        numFailed=$(echo "${response}" | jq '.results.numFailedTests')
+        #        nomTotal=$((numPassed + numFailed))
+        #        report="${httpStatus} returned, ${numPassed} / ${nomTotal} Passed"
+        #
+        #        if [[ $httpStatus == "200" ]]; then
+        #            echo "Success : ${report}"
+        #        else
+        #            echo "Failure: ${report}"
+        #        fi
     done
 }
 
 for ((i = 1; i <= looptimes; ++i)); do
 
-    if $individual; then
+    if [[ -z $servername ]]; then
         echo "Multi endpoint scenario chosen"
-        hit_status_id
+        hit_multi_status_id
     else
         echo "Single endpoint scenario chosen"
-        hit_status
+        hit_single_status_id "$url/$servername"
     fi
 
     echo "Run ${i}, wait ${sleepseconds} seconds before next run"


### PR DESCRIPTION
**Detailed description**:
Currently we have a monitor api that checks the REST api endpoints and highlights their status.
During deployment this ends up being a manual process of refreshing the browsers to see if results have changed.

This is a script that lets you hit the monitor api endpoints for a single server or all servers in a deployment over a given period of time to view it's status.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:
I'm open to suggestions on missing features or improved usage

Usage looks like the following
./endpointTester.sh -h <host:port> -n <servername> -l <looptimes> -s <sleepseconds>

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

