### PR TITLE
Elasticsearch Metrics

### DIFF
--- a/hedera-mirror-grpc/pom.xml
+++ b/hedera-mirror-grpc/pom.xml
@@ -34,6 +34,10 @@
             <version>${disruptor.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-elastic</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.r2dbc</groupId>
             <artifactId>r2dbc-postgresql</artifactId>
         </dependency>
@@ -61,6 +65,16 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot.experimental</groupId>
+            <artifactId>spring-boot-actuator-autoconfigure-r2dbc</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/MirrorGrpcApplication.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/MirrorGrpcApplication.java
@@ -23,12 +23,14 @@ package com.hedera.mirror.grpc;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import reactor.core.scheduler.Schedulers;
 
 @ConfigurationPropertiesScan
 @SpringBootApplication
 public class MirrorGrpcApplication {
 
     public static void main(String[] args) {
+        Schedulers.enableMetrics();
         SpringApplication.run(MirrorGrpcApplication.class, args);
     }
 }

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/NotifyingTopicListener.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/NotifyingTopicListener.java
@@ -44,15 +44,18 @@ public class NotifyingTopicListener implements TopicListener {
 
     public NotifyingTopicListener(ConnectionFactory connectionFactory) {
         ConnectionPool connectionPool = (ConnectionPool) connectionFactory;
-        PostgresqlConnectionFactory postgressqlConnectionFactory = (PostgresqlConnectionFactory) connectionPool
+        PostgresqlConnectionFactory postgresqlConnectionFactory = (PostgresqlConnectionFactory) connectionPool
                 .unwrap();
 
-        topicMessages = postgressqlConnectionFactory.create().flatMapMany(it -> {
+        topicMessages = postgresqlConnectionFactory.create().flatMapMany(it -> {
             return it.createStatement("LISTEN topic_message")
                     .execute()
                     .thenMany(it.getNotifications())
                     .map(this::toTopicMessage);
-        }).share();
+        })
+                .share()
+                .name("notify")
+                .metrics();
     }
 
     @Override

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/PollingTopicListener.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/PollingTopicListener.java
@@ -49,6 +49,8 @@ public class PollingTopicListener implements TopicListener {
         return Flux.interval(frequency)
                 .filter(i -> !context.isRunning()) // Discard polling requests while querying
                 .concatMap(i -> poll(context))
+                .name("poll")
+                .metrics()
                 .doOnNext(context::onNext)
                 .doOnSubscribe(s -> log.info("Starting to poll every {}ms: {}", frequency.toMillis(), filter));
     }

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/repository/TopicMessageRepositoryCustomImpl.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/repository/TopicMessageRepositoryCustomImpl.java
@@ -58,6 +58,8 @@ public class TopicMessageRepositoryCustomImpl implements TopicMessageRepositoryC
                 .orderBy(Sort.by("consensus_timestamp"))
                 .fetch()
                 .all()
-                .as(t -> filter.hasLimit() ? t.limitRequest(filter.getLimit()) : t);
+                .as(t -> filter.hasLimit() ? t.limitRequest(filter.getLimit()) : t)
+                .name("findByFilter")
+                .metrics();
     }
 }

--- a/hedera-mirror-grpc/src/main/resources/application.yml
+++ b/hedera-mirror-grpc/src/main/resources/application.yml
@@ -15,6 +15,11 @@ logging:
   level:
     root: warn
     com.hedera.mirror.grpc: info
+management:
+  metrics:
+    export:
+      elastic:
+        enabled: false
 spring:
   application:
     name: hedera-mirror-grpc

--- a/hedera-mirror-importer/pom.xml
+++ b/hedera-mirror-importer/pom.xml
@@ -62,6 +62,10 @@
             <version>${commons-io.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-elastic</artifactId>
+        </dependency>
+        <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
             <version>${javax.version}</version>
@@ -91,6 +95,16 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/MirrorImporterApplication.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/MirrorImporterApplication.java
@@ -26,9 +26,9 @@ import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @ConfigurationPropertiesScan
 @SpringBootApplication
-public class MirrorNodeApplication {
+public class MirrorImporterApplication {
 
     public static void main(String[] args) {
-        SpringApplication.run(MirrorNodeApplication.class, args);
+        SpringApplication.run(MirrorImporterApplication.class, args);
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/MetricsConfiguration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/MetricsConfiguration.java
@@ -1,0 +1,73 @@
+package com.hedera.mirror.importer.config;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import io.micrometer.core.instrument.binder.MeterBinder;
+import io.micrometer.core.instrument.binder.db.DatabaseTableMetrics;
+import io.micrometer.core.instrument.binder.db.PostgreSQLDatabaseMetrics;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import javax.sql.DataSource;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Log4j2
+@Configuration
+@RequiredArgsConstructor
+public class MetricsConfiguration {
+
+    private final DataSource dataSource;
+    private final DataSourceProperties dataSourceProperties;
+
+    @Bean
+    MeterBinder postgreSQLDatabaseMetrics() {
+        return new PostgreSQLDatabaseMetrics(dataSource, dataSourceProperties.getName());
+    }
+
+    @Bean
+    MeterBinder tableMetrics() {
+        return registry -> getTablesNames().stream()
+                .map(table -> new DatabaseTableMetrics(dataSource, dataSourceProperties.getName(), table, null))
+                .forEach(mb -> mb.bindTo(registry));
+    }
+
+    private Collection<String> getTablesNames() {
+        Collection<String> tableNames = new LinkedHashSet<>();
+
+        try (Connection connection = dataSource.getConnection();
+             ResultSet rs = connection.getMetaData().getTables(null, null, null, new String[] {"TABLE"})) {
+
+            while (rs.next()) {
+                tableNames.add(rs.getString("TABLE_NAME"));
+            }
+        } catch (Exception e) {
+            log.warn("Unable to list table names. No table metrics will be available", e);
+        }
+
+        log.info("Collecting table metrics: {}", tableNames);
+        return tableNames;
+    }
+}

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/TransactionTypeEnum.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/TransactionTypeEnum.java
@@ -31,6 +31,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum TransactionTypeEnum {
 
+    UNKNOWN(-1),
     CONTRACTCALL(7),
     CONTRACTCREATEINSTANCE(8),
     CONTRACTUPDATEINSTANCE(9),
@@ -59,6 +60,6 @@ public enum TransactionTypeEnum {
     private final int protoId;
 
     public static TransactionTypeEnum of(int protoId) {
-        return idMap.get(protoId);
+        return idMap.getOrDefault(protoId, UNKNOWN);
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/CommonParserProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/CommonParserProperties.java
@@ -85,8 +85,7 @@ public class CommonParserProperties {
                 return true;
             }
 
-            TransactionTypeEnum transactionType = t.getTypeEnum();
-            return transactionType != null && transaction.contains(transactionType);
+            return transaction.contains(t.getTypeEnum());
         }
 
         private boolean matches(Entities e) {
@@ -94,8 +93,7 @@ public class CommonParserProperties {
                 return true;
             }
 
-            String entityId = e != null ? e.getDisplayId() : null;
-            return entityId != null && entity.contains(entityId);
+            return e != null && entity.contains(e.getDisplayId());
         }
     }
 }

--- a/hedera-mirror-importer/src/main/resources/application.yml
+++ b/hedera-mirror-importer/src/main/resources/application.yml
@@ -15,6 +15,11 @@ logging:
     org.flywaydb.core.internal.command.DbMigrate: info
     #org.hibernate.SQL: debug
     #org.hibernate.type.descriptor.sql.BasicBinder: trace
+management:
+  metrics:
+    export:
+      elastic:
+        enabled: false
 spring:
   application:
     name: hedera-mirror-importer
@@ -33,6 +38,10 @@ spring:
       api-user: ${hedera.mirror.db.api-username}
       db-name: ${hedera.mirror.db.name}
       db-user: ${hedera.mirror.db.username}
+  jpa:
+    properties:
+      hibernate:
+        generate_statistics: true
   task:
     scheduling:
       pool:

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/AbstractDownloaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/AbstractDownloaderTest.java
@@ -44,7 +44,7 @@ import software.amazon.awssdk.services.s3.S3AsyncClient;
 import com.hedera.mirror.importer.FileCopier;
 import com.hedera.mirror.importer.MirrorProperties;
 import com.hedera.mirror.importer.addressbook.NetworkAddressBook;
-import com.hedera.mirror.importer.config.MirrorNodeConfiguration;
+import com.hedera.mirror.importer.config.MirrorImporterConfiguration;
 import com.hedera.mirror.importer.domain.ApplicationStatusCode;
 import com.hedera.mirror.importer.domain.HederaNetwork;
 import com.hedera.mirror.importer.repository.ApplicationStatusRepository;
@@ -96,7 +96,7 @@ public abstract class AbstractDownloaderTest {
         System.out.println("Before test: " + testInfo.getTestMethod().get().getName());
 
         initProperties();
-        s3AsyncClient = (new MirrorNodeConfiguration()).s3AsyncClient(commonDownloaderProperties);
+        s3AsyncClient = (new MirrorImporterConfiguration()).s3AsyncClient(commonDownloaderProperties);
         networkAddressBook = new NetworkAddressBook(mirrorProperties);
         downloader = getDownloader();
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/CommonParserPropertiesTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/CommonParserPropertiesTest.java
@@ -64,13 +64,13 @@ public class CommonParserPropertiesTest {
             "0.0.2, CONSENSUSSUBMITMESSAGE, false",
             "0.0.4, FREEZE, false",
             ", CONSENSUSSUBMITMESSAGE, false",
-            "0.0.1, , false",
-            ", , false"
+            "0.0.1, UNKNOWN, false",
+            ", UNKNOWN, false"
     })
     void filterInclude(String entityId, TransactionTypeEnum type, boolean result) {
         Transaction transaction = new Transaction();
         transaction.setEntity(entity(entityId));
-        transaction.setType(type != null ? type.getProtoId() : -1); // null simulates unknown transaction type
+        transaction.setType(type.getProtoId());
 
         commonParserProperties.getInclude().add(filter("0.0.1", TransactionTypeEnum.CONSENSUSSUBMITMESSAGE));
         commonParserProperties.getInclude().add(filter("0.0.2", TransactionTypeEnum.CRYPTOCREATEACCOUNT));
@@ -91,13 +91,13 @@ public class CommonParserPropertiesTest {
             "0.0.2, CONSENSUSSUBMITMESSAGE, true",
             "0.0.4, FREEZE, true",
             ", CONSENSUSSUBMITMESSAGE, true",
-            "0.0.1, , true",
-            ", , true"
+            "0.0.1, UNKNOWN, true",
+            ", UNKNOWN, true"
     })
     void filterExclude(String entityId, TransactionTypeEnum type, boolean result) {
         Transaction transaction = new Transaction();
         transaction.setEntity(entity(entityId));
-        transaction.setType(type != null ? type.getProtoId() : -1);
+        transaction.setType(type.getProtoId());
 
         commonParserProperties.getExclude().add(filter("0.0.1", TransactionTypeEnum.CONSENSUSSUBMITMESSAGE));
         commonParserProperties.getExclude().add(filter("0.0.2", TransactionTypeEnum.CRYPTOCREATEACCOUNT));
@@ -122,7 +122,7 @@ public class CommonParserPropertiesTest {
     void filterBoth(String entityId, TransactionTypeEnum type, boolean result) {
         Transaction transaction = new Transaction();
         transaction.setEntity(entity(entityId));
-        transaction.setType(type != null ? type.getProtoId() : -1);
+        transaction.setType(type.getProtoId());
 
         commonParserProperties.getInclude().add(filter("0.0.1", TransactionTypeEnum.CONSENSUSSUBMITMESSAGE));
         commonParserProperties.getInclude().add(filter("0.0.2", TransactionTypeEnum.CRYPTOCREATEACCOUNT));

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/TransactionTypeRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/TransactionTypeRepositoryTest.java
@@ -43,9 +43,11 @@ public class TransactionTypeRepositoryTest extends AbstractRepositoryTest {
         Iterable<TransactionType> transactionTypes = transactionTypeRepository.findAll();
 
         for (TransactionTypeEnum transactionTypeEnum : TransactionTypeEnum.values()) {
-            assertThat(transactionTypes)
-                    .extracting(TransactionType::getName)
-                    .contains(transactionTypeEnum.name());
+            if (transactionTypeEnum != TransactionTypeEnum.UNKNOWN) {
+                assertThat(transactionTypes)
+                        .extracting(TransactionType::getName)
+                        .contains(transactionTypeEnum.name());
+            }
         }
 
         for (TransactionType transactionType : transactionTypes) {


### PR DESCRIPTION
**Detailed description**:
- Adds Micrometer to provide out of the box metrics for most cross cutting concerns:
  - Project reactor
  - Hibernate/JPA
  - Hikari connection pool
  - GRPC requests
  - R2DBC connection pool
  - CPU usage
  - File descriptors
  - JVM (memory)
  - Log4j2
  - Postgres server
- Add table count metrics
- Adds custom metrics `hedera.mirror.transaction.size`, `hedera.mirror.transaction.latency` and `hedera.mirror.parse.duration`

**Which issue(s) this PR fixes**:
Partially addresses #81

**Special notes for your reviewer**:
Still need to implement more metrics to close out the ticket, but this is a good first pass for this release.

**Checklist**
- [ ] Documentation added
- [x] Tests updated

