### PR TITLE
Final protobuf & bump to v0.5.1-rc1

### DIFF
--- a/docs/design/hcs.md
+++ b/docs/design/hcs.md
@@ -64,7 +64,7 @@ message ConsensusTopicQuery {
 
 message ConsensusTopicResponse {
     .proto.Timestamp consensusTimestamp = 1; // The time at which the transaction reached consensus
-    bytes message = 2; // The message body originally in the ConsensusSubmitMessageTransactionBody. Message size will be less than 4K.
+    bytes message = 2; // The message body originally in the ConsensusSubmitMessageTransactionBody. Message size will be less than 6KiB.
     bytes runningHash = 3; // The running hash (SHA384) of every message.
     uint64 sequenceNumber = 4; // Starts at 1 for first submitted message. Incremented on each submitted message.
 }
@@ -207,7 +207,6 @@ public class TransactionEvent {
     -   `INVALID_TOPIC_MESSAGE = 158`
     -   `INVALID_AUTORENEW_ACCOUNT = 159`
     -   `AUTORENEW_ACCOUNT_NOT_ALLOWED = 160`
-    -   `AUTORENEW_ACCOUNT_SIGNATURE_MISSING = 161`
     -   `TOPIC_EXPIRED = 162`
 -   Add new table `topic_message`:
 

--- a/hedera-mirror-coverage/pom.xml
+++ b/hedera-mirror-coverage/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.5.0</version>
+        <version>0.5.1-rc1</version>
     </parent>
 
     <dependencies>

--- a/hedera-mirror-datagenerator/pom.xml
+++ b/hedera-mirror-datagenerator/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.5.0</version>
+        <version>0.5.1-rc1</version>
     </parent>
 
     <dependencies>

--- a/hedera-mirror-grpc/pom.xml
+++ b/hedera-mirror-grpc/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.5.0</version>
+        <version>0.5.1-rc1</version>
     </parent>
 
     <dependencies>

--- a/hedera-mirror-grpc/src/main/resources/application.yml
+++ b/hedera-mirror-grpc/src/main/resources/application.yml
@@ -28,3 +28,5 @@ spring:
     password: ${hedera.mirror.grpc.db.password}
     url: r2dbc:postgresql://${hedera.mirror.grpc.db.host}:${hedera.mirror.grpc.db.port}/${hedera.mirror.grpc.db.name}?useJDBCCompliantTimezoneShift=true&useLegacyDatetimeCode=false&serverTimezone=UTC
     username: ${hedera.mirror.grpc.db.username}
+    pool:
+      max-size: 25

--- a/hedera-mirror-importer/pom.xml
+++ b/hedera-mirror-importer/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.5.0</version>
+        <version>0.5.1-rc1</version>
     </parent>
 
     <properties>
@@ -27,8 +27,8 @@
             <artifactId>caffeine</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.hashgraph</groupId>
-            <artifactId>hedera-protobuf</artifactId>
+            <groupId>com.hedera.hashgraph</groupId>
+            <artifactId>hedera-protobuf-java-api</artifactId>
             <version>${hedera-protobuf.version}</version>
             <exclusions>
                 <exclusion>

--- a/hedera-mirror-importer/src/main/resources/db/migration/V1.17.4__hcs_proto_changes.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/V1.17.4__hcs_proto_changes.sql
@@ -13,5 +13,4 @@ insert into t_transaction_results (proto_id, result) values (157, 'UNAUTHORIZED'
 insert into t_transaction_results (proto_id, result) values (158, 'INVALID_TOPIC_MESSAGE');
 insert into t_transaction_results (proto_id, result) values (159, 'INVALID_AUTORENEW_ACCOUNT');
 insert into t_transaction_results (proto_id, result) values (160, 'AUTORENEW_ACCOUNT_NOT_ALLOWED');
-insert into t_transaction_results (proto_id, result) values (161, 'AUTORENEW_ACCOUNT_SIGNATURE_MISSING');
 insert into t_transaction_results (proto_id, result) values (162, 'TOPIC_EXPIRED');

--- a/hedera-mirror-protobuf/pom.xml
+++ b/hedera-mirror-protobuf/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.5.0</version>
+        <version>0.5.1-rc1</version>
     </parent>
 
     <properties>
@@ -32,8 +32,8 @@
             <version>${grpc.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.github.hashgraph</groupId>
-            <artifactId>hedera-protobuf</artifactId>
+            <groupId>com.hedera.hashgraph</groupId>
+            <artifactId>hedera-protobuf-java-api</artifactId>
             <version>${hedera-protobuf.version}</version>
             <exclusions>
                 <exclusion>

--- a/hedera-mirror-protobuf/src/main/proto/com/hedera/mirror/api/proto/ConsensusService.proto
+++ b/hedera-mirror-protobuf/src/main/proto/com/hedera/mirror/api/proto/ConsensusService.proto
@@ -45,7 +45,7 @@ message ConsensusTopicQuery {
 message ConsensusTopicResponse {
     .proto.Timestamp consensusTimestamp = 1; // The time at which the transaction reached consensus
 
-    // The message body originally in the ConsensusSubmitMessageTransactionBody. Message size will be less than 4K.
+    // The message body originally in the ConsensusSubmitMessageTransactionBody. Message size will be less than 6KiB.
     bytes message = 2;
 
     bytes runningHash = 3; // The running hash (SHA384) of every message.

--- a/hedera-mirror-rest/package-lock.json
+++ b/hedera-mirror-rest/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-mirror-rest",
-  "version": "0.5.0",
+  "version": "0.5.1-rc1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hedera-mirror-rest/package.json
+++ b/hedera-mirror-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-mirror-rest",
-  "version": "0.5.0",
+  "version": "0.5.1-rc1",
   "description": "Hedera Mirror Node REST API",
   "main": "server.js",
   "scripts": {

--- a/hedera-mirror-rest/pom.xml
+++ b/hedera-mirror-rest/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.5.0</version>
+        <version>0.5.1-rc1</version>
     </parent>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.hedera</groupId>
     <artifactId>hedera-mirror-node</artifactId>
-    <version>0.5.0</version>
+    <version>0.5.1-rc1</version>
     <description>Hedera Mirror Node mirrors data from Hedera nodes and serves it via an API</description>
     <inceptionYear>2019</inceptionYear>
     <modelVersion>4.0.0</modelVersion>
@@ -56,7 +56,7 @@
         <docker.repository>docker.pkg.github.com/hashgraph/hedera-mirror-node</docker.repository>
         <grpc.version>1.25.0</grpc.version>
         <guava.version>28.1-jre</guava.version>
-        <hedera-protobuf.version>hcs-4e1dd97dc6-1</hedera-protobuf.version>
+        <hedera-protobuf.version>0.4.0</hedera-protobuf.version>
         <jacoco.version>0.8.5</jacoco.version>
         <java.version>11</java.version>
         <javax.version>1</javax.version>
@@ -154,10 +154,4 @@
             </plugins>
         </pluginManagement>
     </build>
-    <repositories>
-        <repository>
-            <id>jitpack.io</id> <!-- Used for the com.github.hashgraph:hedera-protobuf HCS snapshots -->
-            <url>https://jitpack.io</url>
-        </repository>
-    </repositories>
 </project>


### PR DESCRIPTION
**Detailed description**:
- Replaces temporary hedera-protobuf with Maven Central official release 0.4.0
- Removes deprecated response code
- Bumps version to v0.5.1-rc1
- Increases r2dbc connection pool max size to 25 based upon testing
- Clarifies comments about max proto size being 6KiB not 4KiB

**Which issue(s) this PR fixes**:
Fixes #490

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

