### PR TITLE
Release v0.5.1

### DIFF
--- a/hedera-mirror-coverage/pom.xml
+++ b/hedera-mirror-coverage/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.5.1-rc1</version>
+        <version>0.5.1</version>
     </parent>
 
     <dependencies>

--- a/hedera-mirror-datagenerator/pom.xml
+++ b/hedera-mirror-datagenerator/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.5.1-rc1</version>
+        <version>0.5.1</version>
     </parent>
 
     <dependencies>

--- a/hedera-mirror-grpc/pom.xml
+++ b/hedera-mirror-grpc/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.5.1-rc1</version>
+        <version>0.5.1</version>
     </parent>
 
     <dependencies>

--- a/hedera-mirror-grpc/src/main/resources/application.yml
+++ b/hedera-mirror-grpc/src/main/resources/application.yml
@@ -10,6 +10,7 @@ hedera:
       port: 5600
 grpc:
   server:
+    max-inbound-message-size: 6144
     port: ${hedera.mirror.grpc.port}
 logging:
   level:
@@ -29,4 +30,4 @@ spring:
     url: r2dbc:postgresql://${hedera.mirror.grpc.db.host}:${hedera.mirror.grpc.db.port}/${hedera.mirror.grpc.db.name}?useJDBCCompliantTimezoneShift=true&useLegacyDatetimeCode=false&serverTimezone=UTC
     username: ${hedera.mirror.grpc.db.username}
     pool:
-      max-size: 25
+      max-size: 100

--- a/hedera-mirror-importer/pom.xml
+++ b/hedera-mirror-importer/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.5.1-rc1</version>
+        <version>0.5.1</version>
     </parent>
 
     <properties>

--- a/hedera-mirror-protobuf/pom.xml
+++ b/hedera-mirror-protobuf/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.5.1-rc1</version>
+        <version>0.5.1</version>
     </parent>
 
     <properties>

--- a/hedera-mirror-rest/package-lock.json
+++ b/hedera-mirror-rest/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-mirror-rest",
-  "version": "0.5.1-rc1",
+  "version": "0.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hedera-mirror-rest/package.json
+++ b/hedera-mirror-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-mirror-rest",
-  "version": "0.5.1-rc1",
+  "version": "0.5.1",
   "description": "Hedera Mirror Node REST API",
   "main": "server.js",
   "scripts": {

--- a/hedera-mirror-rest/pom.xml
+++ b/hedera-mirror-rest/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.5.1-rc1</version>
+        <version>0.5.1</version>
     </parent>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.hedera</groupId>
     <artifactId>hedera-mirror-node</artifactId>
-    <version>0.5.1-rc1</version>
+    <version>0.5.1</version>
     <description>Hedera Mirror Node mirrors data from Hedera nodes and serves it via an API</description>
     <inceptionYear>2019</inceptionYear>
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
**Detailed description**:
- Bump versions to v0.5.1 for imminent release
- Limit GRPC inbound message size to 6KiB
- Increase database connection pool to 100 max

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

