### PR TITLE
Fix parsing ConsensusCreateTopic with existing autorenew account

### DIFF
--- a/hedera-mirror-coverage/pom.xml
+++ b/hedera-mirror-coverage/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.5.1</version>
+        <version>0.5.2</version>
     </parent>
 
     <dependencies>

--- a/hedera-mirror-datagenerator/pom.xml
+++ b/hedera-mirror-datagenerator/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.5.1</version>
+        <version>0.5.2</version>
     </parent>
 
     <dependencies>

--- a/hedera-mirror-grpc/pom.xml
+++ b/hedera-mirror-grpc/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.5.1</version>
+        <version>0.5.2</version>
     </parent>
 
     <dependencies>

--- a/hedera-mirror-importer/pom.xml
+++ b/hedera-mirror-importer/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.5.1</version>
+        <version>0.5.2</version>
     </parent>
 
     <properties>

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/Entities.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/Entities.java
@@ -20,7 +20,6 @@ package com.hedera.mirror.importer.domain;
  * ‍
  */
 
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -54,7 +53,7 @@ public class Entities {
     @Column(name = "fk_entity_type_id")
     private Integer entityTypeId;
 
-    @ManyToOne(cascade = CascadeType.ALL)
+    @ManyToOne
     private Entities autoRenewAccount;
 
     private Long autoRenewPeriod;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/EntityTypeEnum.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/EntityTypeEnum.java
@@ -1,0 +1,36 @@
+package com.hedera.mirror.importer.domain;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum EntityTypeEnum {
+
+    ACCOUNT(1),
+    CONTRACT(2),
+    FILE(3),
+    TOPIC(4);
+
+    private final int id;
+}

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordFileLogger.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordFileLogger.java
@@ -245,6 +245,7 @@ public class RecordFileLogger {
             body = TransactionBody.parseFrom(transaction.getBodyBytes());
         }
 
+        log.trace("Storing transaction body: {}", () -> Utility.printProtoMessage(body));
         long initialBalance = 0;
         Entities entity = null;
         Entities proxyEntity = null;
@@ -469,6 +470,7 @@ public class RecordFileLogger {
             if (proxyEntity != null) {
                 entity.setProxyAccountId(proxyEntity.getId());
             }
+            entity.setAutoRenewAccount(createEntity(entity.getAutoRenewAccount()));
             entity = entityRepository.save(entity);
             sqlInsertTransaction.setLong(F_TRANSACTION.CUD_ENTITY_ID.ordinal(), entity.getId());
         } else {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordFileParser.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordFileParser.java
@@ -197,15 +197,15 @@ public class RecordFileParser implements FileParser {
                                 TransactionRecord txRecord = TransactionRecord.parseFrom(rawBytes);
 
                                 try {
-                                    RecordFileLogger.storeRecord(transaction, txRecord, rawBytes);
-
                                     if (log.isTraceEnabled()) {
                                         log.trace("Transaction = {}, Record = {}", Utility
                                                 .printProtoMessage(transaction), Utility.printProtoMessage(txRecord));
                                     } else {
-                                        log.debug("Stored transaction with consensus timestamp {}", () -> Utility
+                                        log.debug("Storing transaction with consensus timestamp {}", () -> Utility
                                                 .printProtoMessage(txRecord.getConsensusTimestamp()));
                                     }
+
+                                    RecordFileLogger.storeRecord(transaction, txRecord, rawBytes);
                                 } finally {
                                     // TODO: Refactor to not parse TransactionBody twice
                                     DataCase dc = Utility.getTransactionBody(transaction).getDataCase();

--- a/hedera-mirror-importer/src/main/resources/db/migration/V1.17.5__fix_mirror_api_permissions.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/V1.17.5__fix_mirror_api_permissions.sql
@@ -1,0 +1,3 @@
+alter default privileges in schema public grant select on tables to ${api-user};
+
+grant select on all tables in schema public to ${api-user};

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/EntityRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/EntityRepositoryTest.java
@@ -37,6 +37,7 @@ public class EntityRepositoryTest extends AbstractRepositoryTest {
         autoRenewAccount.setEntityShard(0L);
         autoRenewAccount.setEntityRealm(0L);
         autoRenewAccount.setEntityNum(101L);
+        autoRenewAccount = entityRepository.save(autoRenewAccount);
 
         Entities proxyEntity = new Entities();
         proxyEntity.setEntityTypeId(entityTypeId);
@@ -59,11 +60,6 @@ public class EntityRepositoryTest extends AbstractRepositoryTest {
         entity.setProxyAccountId(proxyEntity.getId());
         entity.setSubmitKey("SubmitKey".getBytes());
         entity = entityRepository.save(entity);
-
-        assertThat(entityRepository.findByPrimaryKey(autoRenewAccount.getEntityShard(),
-                autoRenewAccount.getEntityRealm(), autoRenewAccount.getEntityNum()))
-                .get()
-                .isEqualToIgnoringGivenFields(autoRenewAccount, "id");
 
         assertThat(entityRepository
                 .findByPrimaryKey(entity.getEntityShard(), entity.getEntityRealm(), entity.getEntityNum()))

--- a/hedera-mirror-protobuf/pom.xml
+++ b/hedera-mirror-protobuf/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.5.1</version>
+        <version>0.5.2</version>
     </parent>
 
     <properties>

--- a/hedera-mirror-rest/package-lock.json
+++ b/hedera-mirror-rest/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-mirror-rest",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hedera-mirror-rest/package.json
+++ b/hedera-mirror-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-mirror-rest",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Hedera Mirror Node REST API",
   "main": "server.js",
   "scripts": {

--- a/hedera-mirror-rest/pom.xml
+++ b/hedera-mirror-rest/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.5.1</version>
+        <version>0.5.2</version>
     </parent>
 
     <build>

--- a/hedera-mirror-test/pom.xml
+++ b/hedera-mirror-test/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <artifactId>hedera-mirror-node</artifactId>
         <groupId>com.hedera</groupId>
-        <version>0.5.1</version>
+        <version>0.5.2</version>
     </parent>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.hedera</groupId>
     <artifactId>hedera-mirror-node</artifactId>
-    <version>0.5.1</version>
+    <version>0.5.2</version>
     <description>Hedera Mirror Node mirrors data from Hedera nodes and serves it via an API</description>
     <inceptionYear>2019</inceptionYear>
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
**Detailed description**:
Issue occurred when trying to save a topic entity that contained an autorenew account that already existed. The autorenew account was properly retrieved from the DB, but because the topic entity is an insert it couldn't handle updating the parent autorenew entity.  Instead we remove cascading save from entities.autoRenewAccount and manually insert autorenew account if it doesn't exist.

Fixed mirror_api db user not having permission to select t_cryptotransferlists after previous patch that recreated it

Also move/add some logging of the transaction details before `storeRecord()` so we can figure out which transaction is causing the parse issue in the future.

Bump version to v0.5.2

**Which issue(s) this PR fixes**:
Fixes #501

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated

