### PR TITLE
Fix monitor API returning invalid JSON when REST API down

### DIFF
--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/domain/TopicMessage.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/domain/TopicMessage.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.time.Instant;
 import java.util.Comparator;
 import lombok.Builder;
+import lombok.ToString;
 import lombok.Value;
 import org.springframework.data.annotation.Id;
 
@@ -37,10 +38,12 @@ public class TopicMessage implements Comparable<TopicMessage> {
     @JsonDeserialize(using = LongToInstantDeserializer.class)
     private Instant consensusTimestamp;
 
+    @ToString.Exclude
     private byte[] message;
 
     private int realmNum;
 
+    @ToString.Exclude
     private byte[] runningHash;
 
     private long sequenceNumber;

--- a/hedera-mirror-rest/monitoring/monitor_apis/balance_tests.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/balance_tests.js
@@ -71,7 +71,7 @@ const getBalancesCheck = async (server, classResults) => {
   if (undefined === balances) {
     var message = `balances is undefined`;
     currentTestResult.failureMessages.push(message);
-    acctestutils.addTestResult(classResults, classResults, currentTestResult, false);
+    acctestutils.addTestResult(classResults, currentTestResult, false);
     return;
   }
 

--- a/hedera-mirror-rest/monitoring/monitor_apis/common.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/common.js
@@ -35,6 +35,7 @@ const initResults = () => {
   for (const server of restservers) {
     currentResults[server.name] = {
       ip: server.ip,
+      name: server.name,
       port: server.port,
       results: []
     };
@@ -51,6 +52,7 @@ const saveResults = (server, results) => {
   if (server.name != undefined && server.name != null) {
     currentResults[server.name] = {
       ip: server.ip,
+      name: server.name,
       port: server.port,
       results: results
     };
@@ -64,8 +66,6 @@ const saveResults = (server, results) => {
  */
 const getStatus = () => {
   let results = Object.keys(currentResults).map(net => {
-    currentResults[net].name = net;
-
     return currentResults[net];
   });
   return {

--- a/hedera-mirror-rest/monitoring/monitor_apis/server.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/server.js
@@ -53,6 +53,8 @@ app.use(cors());
 
 let apiPrefix = '/api/v1';
 
+common.initResults();
+
 // routes
 app.get(apiPrefix + '/status', (req, res) => {
   let status = common.getStatus();
@@ -76,20 +78,15 @@ if (!(serverlist.hasOwnProperty('interval') && serverlist.hasOwnProperty('server
   process.exit(1);
 }
 
-let interval = serverlist.interval;
-common.initResults();
-
-let servers = serverlist.servers;
-
 const runMonitorTests = () => {
   console.log('Running the tests at: ' + new Date());
-  monitor.runEverything(servers);
+  monitor.runEverything(serverlist.servers);
 };
 
 runMonitorTests();
 setInterval(() => {
   // Run all the tests periodically
   runMonitorTests();
-}, interval * 1000);
+}, serverlist.interval * 1000);
 
 module.exports = app;


### PR DESCRIPTION
**Detailed description**:
- Fix circular reference in result structure as a result of extra parameter to `acctestutils.addTestResult()`
- Set results.name during init and save instead of on every invocation
- Move `common.initResults()` before listening for API calls
- Fix `TopicMessage` logs printing large byte arrays of message and running hash when at trace level

**Which issue(s) this PR fixes**:
Fixes #499

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

