### PR TITLE
Improve handling of HCS missing messages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,8 @@ workflows:
 
 jobs:
   build_maven:
+    environment:
+      MAVEN_CLI_OPTS: --batch-mode --no-transfer-progress --show-version -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
     docker:
       - image: adoptopenjdk:11-jdk-hotspot
       - image: postgres:9.6-alpine
@@ -54,14 +56,14 @@ jobs:
       - run:
           name: Resolve dependencies
           # See https://issues.apache.org/jira/browse/MDEP-516 for why we don't use maven-dependency-plugin
-          command: ./mvnw de.qaware.maven:go-offline-maven-plugin:resolve-dependencies
+          command: ./mvnw ${MAVEN_CLI_OPTS} de.qaware.maven:go-offline-maven-plugin:resolve-dependencies
       - save_cache:
           key: maven-v2-{{ .Branch }}-{{ checksum "pom.xml.checksum" }}
           paths:
             - ~/.m2
       - run:
           name: Running maven (validate, compile, test, package)
-          command: ./mvnw package
+          command: ./mvnw ${MAVEN_CLI_OPTS} package
       - store_test_results:
           path: hedera-mirror-importer/target/surefire-reports
       - run:

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.1/apache-maven-3.6.1-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.5/maven-wrapper-0.5.5.jar
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar


### PR DESCRIPTION
**Detailed description**:
- Change missing message logic from `flatMapSequential()` to `concatMap()` since former would run inner flux concurrently then order at the end, causing race conditions with state of `TopicContext`
- Moved missing messages to top level so it could take advantage of the filtering for duplicates. This helped in dev when sequence numbers and timestamps didn't match or were duplicated
- Re-wrote the missing message test to be more accurate using mocks
- Change CircleCI Maven logging to not show download transfer progress
- Bump version of Maven and Maven Wrapper

**Which issue(s) this PR fixes**:
Fixes #505

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated

