### PR TITLE
Publish official Docker images to GCR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /^v.\d*.\d*.\d*/ # Do not push docker images to registry for rc, alpha, beta, etc.
+              only: /^v.*/
 
 jobs:
   build_maven:
@@ -193,6 +193,7 @@ jobs:
             chmod +x /usr/bin/docker-credential-gcr
             echo ${GCR_JSON_KEY_FILE} > json_key_file
             export GOOGLE_APPLICATION_CREDENTIALS=`pwd`/json_key_file
+            docker-credential-gcr configure-docker
       - *pom_checksum
       - *restore_maven_cache
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,7 +188,7 @@ jobs:
           command: |
             VERSION=2.0.0
             curl -fsSL "https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v${VERSION}/docker-credential-gcr_linux_amd64-${VERSION}.tar.gz" \
-              | tar xz > docker-credential-gcr \
+              | tar xz > docker-credential-gcr
             sudo mv docker-credential-gcr /usr/bin/docker-credential-gcr
             chmod +x /usr/bin/docker-credential-gcr
             echo ${GCR_JSON_KEY_FILE} > json_key_file

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,26 @@ references:
   attach_workspace: &attach_workspace
     attach_workspace:
       at: *workspace_root
+  persist_artifacts: &persist_artifacts
+    persist_to_workspace:
+      root: *workspace_root
+      paths:
+        - artifacts
+  pom_checksum: &pom_checksum
+    run:
+      name: Calculate checksum of all pom.xml
+      command: find . -type f -name "pom.xml" | sort -u | xargs sha512sum > pom.xml.checksum
+  restore_maven_cache: &restore_maven_cache
+    restore_cache:
+      keys:
+        - maven-v2-{{ arch }}-{{ .Branch }}-{{ checksum "pom.xml.checksum" }}
+        - maven-v2-{{ arch }}-{{ .Branch }}
+        - maven-v2-{{ arch }}-
+  save_maven_cache: &save_maven_cache
+    save_cache:
+      key: maven-v2-{{ arch }}-{{ .Branch }}-{{ checksum "pom.xml.checksum" }}
+      paths:
+        - ~/.m2
 
 workflows:
   version: 2
@@ -31,6 +51,15 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v.*/
+      - release_docker_images:
+          requires:
+            - build_maven
+            - build_rest
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.\d*.\d*.\d*/ # Do not push docker images to registry for rc, alpha, beta, etc.
 
 jobs:
   build_maven:
@@ -45,22 +74,13 @@ jobs:
           POSTGRES_USER: mirror_node
     steps:
       - checkout
-      - run:
-          name: Calculate checksum of all pom.xml
-          command: find . -type f -name "pom.xml" | sort -u | xargs sha512sum > pom.xml.checksum
-      - restore_cache:
-          keys:
-            - maven-v2-{{ .Branch }}-{{ checksum "pom.xml.checksum" }}
-            - maven-v2-{{ .Branch }}
-            - maven-v2-
+      - *pom_checksum
+      - *restore_maven_cache
       - run:
           name: Resolve dependencies
           # See https://issues.apache.org/jira/browse/MDEP-516 for why we don't use maven-dependency-plugin
           command: ./mvnw ${MAVEN_CLI_OPTS} de.qaware.maven:go-offline-maven-plugin:resolve-dependencies
-      - save_cache:
-          key: maven-v2-{{ .Branch }}-{{ checksum "pom.xml.checksum" }}
-          paths:
-            - ~/.m2
+      - *save_maven_cache
       - run:
           name: Running maven (validate, compile, test, package)
           command: ./mvnw ${MAVEN_CLI_OPTS} package
@@ -93,10 +113,7 @@ jobs:
             mv hedera-mirror-importer/scripts ${WORKSPACE}/${NAME}
             mkdir -p ${WORKSPACE}/artifacts
             tar -czf ${WORKSPACE}/artifacts/${NAME}.tgz -C ${WORKSPACE} ${NAME}
-      - persist_to_workspace:
-          root: *workspace_root
-          paths:
-            - artifacts
+      - *persist_artifacts
 
   build_rest:
     docker:
@@ -142,10 +159,7 @@ jobs:
             npm pack
             mkdir -p /tmp/workspace/artifacts
             mv hedera-mirror-rest*.tgz /tmp/workspace/artifacts/${NAME}.tgz
-      - persist_to_workspace:
-          root: *workspace_root
-          paths:
-            - artifacts
+      - *persist_artifacts
 
   release_artifacts:
     docker:
@@ -154,3 +168,24 @@ jobs:
       - *attach_workspace
       - store_artifacts:
           path: /tmp/workspace/artifacts
+
+  release_docker_images:
+    machine:
+      image: ubuntu-1604:201903-01
+    environment:
+      MAVEN_CLI_OPTS: --batch-mode --no-transfer-progress --show-version -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+      JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+    steps:
+      - checkout
+      - run:
+          name: Install OpenJDK 11
+          command: |
+            sudo add-apt-repository ppa:openjdk-r/ppa \
+            && sudo apt-get update -q \
+            && sudo apt install -y openjdk-11-jdk
+      - *pom_checksum
+      - *restore_maven_cache
+      - run:
+          name: Running maven deploy
+          command: ./mvnw ${MAVEN_CLI_OPTS} deploy -Ddocker.push.username={TODO} -Ddocker.push.password=${TODO} -DskipTests
+      - *save_maven_cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,5 +187,5 @@ jobs:
       - *restore_maven_cache
       - run:
           name: Running maven deploy
-          command: ./mvnw ${MAVEN_CLI_OPTS} deploy -Ddocker.push.username={TODO} -Ddocker.push.password=${TODO} -DskipTests
+          command: ./mvnw ${MAVEN_CLI_OPTS} deploy -Ddocker.push.username=_json_key -Ddocker.push.password=${GCR_JSON_KEY_FILE} -DskipTests
       - *save_maven_cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,9 +183,19 @@ jobs:
             sudo add-apt-repository ppa:openjdk-r/ppa \
             && sudo apt-get update -q \
             && sudo apt install -y openjdk-11-jdk
+      - run:
+          name: Setup docker-credential-gcr
+          command: |
+            VERSION=2.0.0
+            curl -fsSL "https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v${VERSION}/docker-credential-gcr_linux_amd64-${VERSION}.tar.gz" \
+              | tar xz > docker-credential-gcr \
+            sudo mv docker-credential-gcr /usr/bin/docker-credential-gcr
+            chmod +x /usr/bin/docker-credential-gcr
+            echo ${GCR_JSON_KEY_FILE} > json_key_file
+            export GOOGLE_APPLICATION_CREDENTIALS=`pwd`/json_key_file
       - *pom_checksum
       - *restore_maven_cache
       - run:
           name: Running maven deploy
-          command: ./mvnw ${MAVEN_CLI_OPTS} deploy -Ddocker.push.username=_json_key -Ddocker.push.password="${GCR_JSON_KEY_FILE}" -DskipTests
+          command: ./mvnw ${MAVEN_CLI_OPTS} deploy -DskipTests
       - *save_maven_cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,6 +175,7 @@ jobs:
     environment:
       MAVEN_CLI_OPTS: --batch-mode --no-transfer-progress --show-version -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
       JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+      GOOGLE_APPLICATION_CREDENTIALS: json_key_file
     steps:
       - checkout
       - run:
@@ -192,7 +193,6 @@ jobs:
             sudo mv docker-credential-gcr /usr/bin/docker-credential-gcr
             chmod +x /usr/bin/docker-credential-gcr
             echo ${GCR_JSON_KEY_FILE} > json_key_file
-            export GOOGLE_APPLICATION_CREDENTIALS=`pwd`/json_key_file
             docker-credential-gcr configure-docker
       - *pom_checksum
       - *restore_maven_cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ references:
   restore_maven_cache: &restore_maven_cache
     restore_cache:
       keys:
+        #  Perms on ~/.m2 differ by executor (docker/machine), so {{ arch }} is needed.
         - maven-v2-{{ arch }}-{{ .Branch }}-{{ checksum "pom.xml.checksum" }}
         - maven-v2-{{ arch }}-{{ .Branch }}
         - maven-v2-{{ arch }}-
@@ -51,7 +52,7 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v.*/
-      - release_docker_images:
+      - publish_images:
           requires:
             - build_maven
             - build_rest
@@ -59,7 +60,7 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /^v.*/
+              only: /^.*/
 
 jobs:
   build_maven:
@@ -169,7 +170,7 @@ jobs:
       - store_artifacts:
           path: /tmp/workspace/artifacts
 
-  release_docker_images:
+  publish_images:
     machine:
       image: ubuntu-1604:201903-01
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,5 +187,5 @@ jobs:
       - *restore_maven_cache
       - run:
           name: Running maven deploy
-          command: ./mvnw ${MAVEN_CLI_OPTS} deploy -Ddocker.push.username=_json_key -Ddocker.push.password=${GCR_JSON_KEY_FILE} -DskipTests
+          command: ./mvnw ${MAVEN_CLI_OPTS} deploy -Ddocker.push.username=_json_key -Ddocker.push.password="${GCR_JSON_KEY_FILE}" -DskipTests
       - *save_maven_cache

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - 5432:5432
 
   grpc:
-    image: docker.pkg.github.com/hashgraph/hedera-mirror-node/hedera-mirror-grpc
+    image: gcr.io/mirrornode/hedera-mirror-grpc
     restart: unless-stopped
     environment:
       HEDERA_MIRROR_GRPC_DB_HOST: db
@@ -28,7 +28,7 @@ services:
       - 5600:5600
 
   importer:
-    image: docker.pkg.github.com/hashgraph/hedera-mirror-node/hedera-mirror-importer
+    image: gcr.io/mirrornode/hedera-mirror-importer
     restart: unless-stopped
     environment:
       HEDERA_MIRROR_DATAPATH: /var/lib/hedera-mirror-importer
@@ -39,7 +39,7 @@ services:
       #- ./application.yml:/usr/etc/hedera-mirror-importer/application.yml
 
   rest:
-    image: docker.pkg.github.com/hashgraph/hedera-mirror-node/hedera-mirror-rest
+    image: gcr.io/mirrornode/hedera-mirror-rest
     environment:
       HEDERA_MIRROR_DB_HOST: db
     restart: unless-stopped

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,7 +1,14 @@
 # Installation
 
 The Mirror Node can be ran [locally](#running-locally) or via [Docker](#running-via-docker-compose).
-Either way, it will first need to be built using Java locally.
+To run locally, it'll first need to be built using Java. To run via Docker, either build locally, or pull latest images
+from GCR.
+
+```console
+docker pull gcr.io/mirrornode/hedera-mirror-importer:latest
+docker pull gcr.io/mirrornode/hedera-mirror-rest:latest
+docker pull gcr.io/mirrornode/hedera-mirror-grpc:latest
+```
 
 ## Building
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -5,9 +5,7 @@ To run locally, it'll first need to be built using Java. To run via Docker, eith
 from GCR.
 
 ```console
-docker pull gcr.io/mirrornode/hedera-mirror-importer:latest
-docker pull gcr.io/mirrornode/hedera-mirror-rest:latest
-docker pull gcr.io/mirrornode/hedera-mirror-grpc:latest
+docker-compose pull
 ```
 
 ## Building

--- a/hedera-mirror-rest/pom.xml
+++ b/hedera-mirror-rest/pom.xml
@@ -32,12 +32,6 @@
                         <goals>
                             <goal>push</goal>
                         </goals>
-                        <configuration>
-                            <authConfig>
-                                <username>${docker.push.username}</username>
-                                <password>${docker.push.password}</password>
-                            </authConfig>
-                        </configuration>
                     </execution>
                 </executions>
                 <configuration>

--- a/hedera-mirror-rest/pom.xml
+++ b/hedera-mirror-rest/pom.xml
@@ -22,9 +22,22 @@
                 <version>0.31.0</version>
                 <executions>
                     <execution>
+                        <id>dockerBuild</id>
                         <goals>
                             <goal>build</goal>
                         </goals>
+                    </execution>
+                    <execution>
+                        <id>dockerPush</id>
+                        <goals>
+                            <goal>push</goal>
+                        </goals>
+                        <configuration>
+                            <authConfig>
+                                <username>${docker.push.username}</username>
+                                <password>${docker.push.password}</password>
+                            </authConfig>
+                        </configuration>
                     </execution>
                 </executions>
                 <configuration>
@@ -37,7 +50,7 @@
                                     <tag>${project.version}</tag>
                                 </tags>
                             </build>
-                            <name>${docker.repository}/${project.artifactId}</name>
+                            <name>${docker.push.repository}/${project.artifactId}</name>
                         </image>
                     </images>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -114,10 +114,6 @@
                                 <tag>latest</tag>
                                 <tag>${project.version}</tag>
                             </tags>
-                            <auth>
-                                <username>${docker.push.username}</username>
-                                <password>${docker.push.password}</password>
-                            </auth>
                         </to>
                     </configuration>
                     <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
 
     <properties>
         <disruptor.version>3.4.2</disruptor.version> <!-- Used for asynchronous logging -->
-        <docker.repository>docker.pkg.github.com/hashgraph/hedera-mirror-node</docker.repository>
+        <docker.push.repository>gcr.io/mirrornode</docker.push.repository>
         <grpc.version>1.25.0</grpc.version>
         <guava.version>28.1-jre</guava.version>
         <hedera-protobuf.version>0.4.0</hedera-protobuf.version>
@@ -109,20 +109,40 @@
                     <version>${jib.version}</version>
                     <configuration>
                         <to>
-                            <image>${docker.repository}/${project.artifactId}</image>
+                            <image>${docker.push.repository}/${project.artifactId}</image>
                             <tags>
+                                <tag>latest</tag>
                                 <tag>${project.version}</tag>
                             </tags>
+                            <auth>
+                                <username>${docker.push.username}</username>
+                                <password>${docker.push.password}</password>
+                            </auth>
                         </to>
                     </configuration>
                     <executions>
                         <execution>
+                            <id>dockerBuild</id>
                             <phase>install</phase>
                             <goals>
                                 <goal>dockerBuild</goal>
                             </goals>
                         </execution>
+                        <execution>
+                            <id>dockerPush</id>
+                            <phase>deploy</phase>
+                            <goals>
+                                <goal>build</goal>
+                            </goals>
+                        </execution>
                     </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <configuration>
+                        <skip>true</skip>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <!-- To update license headers: ./mvnw license:update-file-header -N -->


### PR DESCRIPTION
**Detailed description**:
Automatically push mirrornode images (importer, grpc, rest) to grc.io when a release is finalized and tagged with vX.Y.Z.

**Which issue(s) this PR fixes**:
Fixes #335 

**Special notes for your reviewer**:
Due to https://github.com/fabric8io/docker-maven-plugin/issues/1033, maven-docker-plugin doesn't work with `-u _json_key` (https://cloud.google.com/container-registry/docs/advanced-authentication?hl=en_US#json-key).

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

