### PR TITLE
Add a shared poller

### DIFF
--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/CompositeTopicListener.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/CompositeTopicListener.java
@@ -39,6 +39,7 @@ public class CompositeTopicListener implements TopicListener {
     private final ListenerProperties listenerProperties;
     private final NotifyingTopicListener notifyingTopicListener;
     private final PollingTopicListener pollingTopicListener;
+    private final SharedPollingTopicListener sharedPollingTopicListener;
 
     @Override
     public Flux<TopicMessage> listen(TopicMessageFilter filter) {
@@ -53,6 +54,8 @@ public class CompositeTopicListener implements TopicListener {
                 return notifyingTopicListener;
             case POLL:
                 return pollingTopicListener;
+            case SHARED_POLL:
+                return sharedPollingTopicListener;
             default:
                 throw new UnsupportedOperationException("Unknown listener type: " + type);
         }

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/ListenerProperties.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/ListenerProperties.java
@@ -39,6 +39,7 @@ public class ListenerProperties {
 
     public enum ListenerType {
         NOTIFY,
-        POLL
+        POLL,
+        SHARED_POLL
     }
 }

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/PollingTopicListener.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/PollingTopicListener.java
@@ -73,6 +73,7 @@ public class PollingTopicListener implements TopicListener {
         log.debug("Polling for messages: {}", newFilter);
         return topicMessageRepository.findByFilter(newFilter)
                 .doOnSubscribe(s -> context.setRunning(true))
+                .doOnCancel(() -> context.setRunning(false))
                 .doOnComplete(() -> context.setRunning(false));
     }
 

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/SharedPollingTopicListener.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/SharedPollingTopicListener.java
@@ -58,8 +58,8 @@ public class SharedPollingTopicListener implements TopicListener {
                 .metrics()
                 .doOnNext(context::onNext)
                 .doOnSubscribe(s -> log.info("Starting to poll every {}ms", frequency.toMillis()))
-                .doOnComplete(() -> log.info("Stopped polling"))
-                .doOnCancel(() -> log.info("Stopped polling"))
+                .doOnComplete(() -> log.info("Completed polling"))
+                .doOnCancel(() -> log.info("Cancelled polling"))
                 .share();
     }
 

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/SharedPollingTopicListener.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/SharedPollingTopicListener.java
@@ -1,0 +1,100 @@
+package com.hedera.mirror.grpc.listener;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import java.time.Duration;
+import java.time.Instant;
+import javax.inject.Named;
+import lombok.Data;
+import lombok.extern.log4j.Log4j2;
+import reactor.core.publisher.Flux;
+
+import com.hedera.mirror.grpc.converter.InstantToLongConverter;
+import com.hedera.mirror.grpc.domain.TopicMessage;
+import com.hedera.mirror.grpc.domain.TopicMessageFilter;
+import com.hedera.mirror.grpc.repository.TopicMessageRepository;
+
+@Named
+@Log4j2
+public class SharedPollingTopicListener implements TopicListener {
+
+    private final ListenerProperties listenerProperties;
+    private final TopicMessageRepository topicMessageRepository;
+    private final InstantToLongConverter instantToLongConverter;
+    private final Flux<TopicMessage> poller;
+
+    public SharedPollingTopicListener(ListenerProperties listenerProperties,
+                                      TopicMessageRepository topicMessageRepository,
+                                      InstantToLongConverter instantToLongConverter) {
+        this.listenerProperties = listenerProperties;
+        this.topicMessageRepository = topicMessageRepository;
+        this.instantToLongConverter = instantToLongConverter;
+
+        Duration frequency = listenerProperties.getPollingFrequency();
+        PollingContext context = new PollingContext();
+
+        poller = Flux.interval(frequency)
+                .filter(i -> !context.isRunning()) // Discard polling requests while querying
+                .concatMap(i -> poll(context))
+                .name("shared-poll")
+                .metrics()
+                .doOnNext(context::onNext)
+                .doOnSubscribe(s -> log.info("Starting to poll every {}ms", frequency.toMillis()))
+                .doOnComplete(() -> log.info("Stopped polling"))
+                .doOnCancel(() -> log.info("Stopped polling"))
+                .share();
+    }
+
+    @Override
+    public Flux<TopicMessage> listen(TopicMessageFilter filter) {
+        return poller.filter(t -> filterMessage(t, filter))
+                .doOnSubscribe(s -> log.info("Listening for messages: {}", filter));
+    }
+
+    private Flux<TopicMessage> poll(PollingContext context) {
+        Instant instant = context.getLastConsensusTimestamp();
+        Long consensusTimestamp = instantToLongConverter.convert(instant);
+        log.debug("Querying for messages after: {}", instant);
+
+        return topicMessageRepository.findByConsensusTimestampGreaterThan(consensusTimestamp)
+                .doOnSubscribe(s -> context.setRunning(true))
+                .doOnCancel(() -> context.setRunning(false))
+                .doOnComplete(() -> context.setRunning(false));
+    }
+
+    private boolean filterMessage(TopicMessage message, TopicMessageFilter filter) {
+        return filter.getRealmNum() == message.getRealmNum() &&
+                filter.getTopicNum() == message.getTopicNum() &&
+                !filter.getStartTime().isAfter(message.getConsensusTimestamp());
+    }
+
+    @Data
+    private class PollingContext {
+
+        private volatile Instant lastConsensusTimestamp = Instant.now();
+        private volatile boolean running = false;
+
+        void onNext(TopicMessage topicMessage) {
+            lastConsensusTimestamp = topicMessage.getConsensusTimestamp();
+            log.trace("Next message: {}", topicMessage);
+        }
+    }
+}

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/repository/TopicMessageRepository.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/repository/TopicMessageRepository.java
@@ -21,10 +21,15 @@ package com.hedera.mirror.grpc.repository;
  */
 
 import java.time.Instant;
+import org.springframework.data.r2dbc.repository.Query;
 import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Flux;
 
 import com.hedera.mirror.grpc.domain.TopicMessage;
 
 public interface TopicMessageRepository extends ReactiveCrudRepository<TopicMessage, Instant>,
         TopicMessageRepositoryCustom {
+
+    @Query("select * from topic_message where consensus_timestamp > :? order by consensus_timestamp asc")
+    Flux<TopicMessage> findByConsensusTimestampGreaterThan(long consensusTimestamp);
 }

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/listener/SharedPollingTopicListenerTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/listener/SharedPollingTopicListenerTest.java
@@ -1,0 +1,95 @@
+package com.hedera.mirror.grpc.listener;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.google.common.util.concurrent.Uninterruptibles;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Resource;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+import com.hedera.mirror.grpc.domain.TopicMessage;
+import com.hedera.mirror.grpc.domain.TopicMessageFilter;
+
+public class SharedPollingTopicListenerTest extends AbstractTopicListenerTest {
+
+    @Resource
+    private SharedPollingTopicListener topicListener;
+
+    @Override
+    protected TopicListener getTopicListener() {
+        return topicListener;
+    }
+
+    @Test
+    void multipleSubscribers() {
+        Flux<TopicMessage> generator = Flux.concat(
+                domainBuilder.topicMessage(t -> t.topicNum(1).sequenceNumber(1)),
+                domainBuilder.topicMessage(t -> t.topicNum(1).sequenceNumber(2)),
+                domainBuilder.topicMessage(t -> t.topicNum(2).sequenceNumber(7)),
+                domainBuilder.topicMessage(t -> t.topicNum(2).sequenceNumber(8)),
+                domainBuilder.topicMessage(t -> t.topicNum(1).sequenceNumber(3))
+        );
+
+        TopicMessageFilter filter1 = TopicMessageFilter.builder()
+                .startTime(Instant.EPOCH)
+                .topicNum(1)
+                .build();
+        TopicMessageFilter filter2 = TopicMessageFilter.builder()
+                .startTime(Instant.EPOCH)
+                .topicNum(2)
+                .build();
+
+        StepVerifier stepVerifier1 = getTopicListener()
+                .listen(filter1)
+                .map(TopicMessage::getSequenceNumber)
+                .as(StepVerifier::create)
+                .expectNext(1L, 2L, 3L)
+                .thenCancel()
+                .verifyLater();
+
+        StepVerifier stepVerifier2 = getTopicListener()
+                .listen(filter2)
+                .map(TopicMessage::getSequenceNumber)
+                .as(StepVerifier::create)
+                .expectNext(7L, 8L)
+                .thenCancel()
+                .verifyLater();
+
+        Uninterruptibles.sleepUninterruptibly(50, TimeUnit.MILLISECONDS);
+        generator.blockLast();
+
+        stepVerifier1.verify(Duration.ofMillis(500));
+        stepVerifier2.verify(Duration.ofMillis(500));
+
+        getTopicListener()
+                .listen(filter1)
+                .map(TopicMessage::getSequenceNumber)
+                .as(StepVerifier::create)
+                .as("Verify can still re-subscribe after shared poller cancelled when no subscriptions")
+                .expectNextCount(0)
+                .thenCancel()
+                .verify(Duration.ofMillis(100));
+    }
+}

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/repository/TopicMessageRepositoryTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/repository/TopicMessageRepositoryTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import reactor.test.StepVerifier;
 
 import com.hedera.mirror.grpc.GrpcIntegrationTest;
+import com.hedera.mirror.grpc.converter.InstantToLongConverter;
 import com.hedera.mirror.grpc.domain.DomainBuilder;
 import com.hedera.mirror.grpc.domain.TopicMessage;
 import com.hedera.mirror.grpc.domain.TopicMessageFilter;
@@ -37,6 +38,9 @@ public class TopicMessageRepositoryTest extends GrpcIntegrationTest {
 
     @Resource
     private DomainBuilder domainBuilder;
+
+    @Resource
+    private InstantToLongConverter instantToLongConverter;
 
     @Test
     void findByFilterEmpty() {
@@ -149,6 +153,19 @@ public class TopicMessageRepositoryTest extends GrpcIntegrationTest {
         topicMessageRepository.findByFilter(filter)
                 .as(StepVerifier::create)
                 .expectNext(topicMessage1)
+                .verifyComplete();
+    }
+
+    @Test
+    void findByConsensusTimestampGreaterThan() {
+        TopicMessage topicMessage1 = domainBuilder.topicMessage().block();
+        TopicMessage topicMessage2 = domainBuilder.topicMessage().block();
+        TopicMessage topicMessage3 = domainBuilder.topicMessage().block();
+        long consensusTimestamp = instantToLongConverter.convert(topicMessage1.getConsensusTimestamp());
+
+        topicMessageRepository.findByConsensusTimestampGreaterThan(consensusTimestamp)
+                .as(StepVerifier::create)
+                .expectNext(topicMessage2, topicMessage3)
                 .verifyComplete();
     }
 }


### PR DESCRIPTION
**Detailed description**:
- Adds a shared polling topic listener
- Default stays as previous non-shared poller and we can enable in production based upon demand later

**Which issue(s) this PR fixes**:
Fixes #496 

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated

