### PR TITLE
Fix database table metrics

### DIFF
--- a/hedera-mirror-grpc/src/main/resources/application.yml
+++ b/hedera-mirror-grpc/src/main/resources/application.yml
@@ -23,6 +23,8 @@ management:
         enabled: false
         index: mirror
         step: 30s
+    tags:
+      app: ${spring.application.name}
 server:
   port: 8081
 spring:

--- a/hedera-mirror-importer/src/main/resources/application.yml
+++ b/hedera-mirror-importer/src/main/resources/application.yml
@@ -22,6 +22,8 @@ management:
         enabled: false
         index: mirror
         step: 30s
+    tags:
+      app: ${spring.application.name}
 spring:
   application:
     name: hedera-mirror-importer

--- a/pom.xml
+++ b/pom.xml
@@ -56,13 +56,13 @@
         <disruptor.version>3.4.2</disruptor.version> <!-- Used for asynchronous logging -->
         <docker.push.repository>gcr.io/mirrornode</docker.push.repository>
         <grpc.version>1.25.0</grpc.version>
-        <guava.version>28.1-jre</guava.version>
+        <guava.version>28.2-jre</guava.version>
         <hedera-protobuf.version>0.4.0</hedera-protobuf.version>
         <jacoco.version>0.8.5</jacoco.version>
         <java.version>11</java.version>
         <javax.version>1</javax.version>
-        <jib.version>1.8.0</jib.version>
-        <testcontainers.version>1.12.1</testcontainers.version>
+        <jib.version>2.0.0</jib.version>
+        <testcontainers.version>1.12.5</testcontainers.version>
     </properties>
 
     <scm>


### PR DESCRIPTION
**Detailed description**:
- Fixes database table metrics taking forever due to `select count(1) from topic_message` being so slow
- This slowdown would cause the metrics thread to not shutdown promptly on SIGTERM, causing the application to hang for minutes
- Instead we use a PostgreSQL statistics table to estimate the current count, which is accurate enough for our needs
- Add an option to disable table metrics in case of any future problems
- Set metric tag to application name so we can differentiate metrics from different components

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
