### PR TITLE
Monitor script/service to bounce hedera-mirror-grpc when it gets stuck.

### DIFF
--- a/hedera-mirror-grpc/scripts/deploy.sh
+++ b/hedera-mirror-grpc/scripts/deploy.sh
@@ -5,8 +5,11 @@ cd "$(dirname $0)/.."
 
 # name of the service and directories
 name=hedera-mirror-grpc
+monitor_name=hedera-mirror-grpc-monitor
 usretc="/usr/etc/${name}"
 usrlib="/usr/lib/${name}"
+monitor_usretc="/usr/etc/${monitor_name}"
+monitor_usrlib="/usr/lib/${monitor_name}"
 jarname="$(ls -1 ${name}-*.jar)"
 
 if [[ ! -f "${jarname}" ]]; then
@@ -15,7 +18,9 @@ if [[ ! -f "${jarname}" ]]; then
 fi
 
 mkdir -p "${usretc}" "${usrlib}"
+mkdir -p "${monitor_usretc}" "${monitor_usrlib}"
 systemctl stop "${name}.service" || true
+systemctl stop "${monitor_name}.service" || true
 
 if [[ ! -f "${usretc}/application.yml" ]]; then
     echo "Fresh install of ${version}"
@@ -31,17 +36,38 @@ hedera:
 EOF
 fi
 
+if [[ ! -f "${monitor_usretc}/config" ]]; then
+    echo "Fresh install of monitor ${version}"
+    if [ -z "${dbHost}" ]; then
+        read -p "Database hostname: " dbHost
+    fi
+    if [ -z "${dbPassword}" ]; then
+        read -p "Database password: " dbPassword
+    fi
+    cat > "${monitor_usretc}/config" <<EOF
+PGPASSWORD=${dbPassword}
+DBHOST=${dbHost}
+EOF
+fi
+
 echo "Copying new binary"
 rm -f "${usrlib}/${name}.jar"
 cp "${jarname}" "${usrlib}"
 ln -s "${usrlib}/${jarname}" "${usrlib}/${name}.jar"
 
+echo "Copying new monitor script"
+cp -f "scripts/monitor.sh" "${monitor_usrlib}"
+
 echo "Setting up ${name} systemd service"
 cp "scripts/${name}.service" /etc/systemd/system
+cp "scripts/${monitor_name}.service" /etc/systemd/system
 systemctl daemon-reload
 systemctl enable "${name}.service"
+systemctl enable "${monitor_name}.service"
 
 echo "Starting ${name} service"
 systemctl start "${name}.service"
+echo "Starting ${monitor_name} service"
+systemctl start "${monitor_name}.service"
 
 echo "Installation completed successfully"

--- a/hedera-mirror-grpc/scripts/hedera-mirror-grpc-monitor.service
+++ b/hedera-mirror-grpc/scripts/hedera-mirror-grpc-monitor.service
@@ -1,0 +1,14 @@
+[Unit]
+After=syslog.target
+Description=Hedera Mirror Node GRPC Monitor
+
+[Service]
+ExecStart=/bin/bash -c /usr/lib/hedera-mirror-grpc-monitor/monitor.sh
+EnvironmentFile=/usr/etc/hedera-mirror-grpc-monitor/config
+Restart=on-failure
+RestartSec=1
+Type=simple
+WorkingDirectory=/usr/lib/hedera-mirror-grpc-monitor
+
+[Install]
+WantedBy=multi-user.target

--- a/hedera-mirror-grpc/scripts/monitor.sh
+++ b/hedera-mirror-grpc/scripts/monitor.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+PERIOD_SECONDS=${PERIOD_SECONDS:-5}
+MAX_QUERY_AGE_SECONDS=${MAX_AGE_SECONDS:-15}
+echo "INFO Started. polling period ${PERIOD_SECONDS}s. queries locking topic_message older than ${MAX_QUERY_AGE_SECONDS}s will be killed."
+
+while true
+do
+  bounce_service=false
+  for pid in `psql -h "${DBHOST:-dbhost}" -d "${DBNAME:-mirror_node}" -U "${DBUSER:-mirror_grpc}" -tc "select pl.pid from pg_locks pl join pg_stat_activity pa on pa.pid = pl.pid join pg_class pc on pl.relation = pc.OID where pa.query like 'SELECT%' and pc.relname = 'topic_message' and now() - query_start > '${MAX_QUERY_AGE_SECONDS} seconds';"`
+  do
+    case $pid in
+      ''|*[!0-9]*) echo "ERROR SQL query results did not appear to return PIDs." ;;
+      *) res=$(psql -h "${DBHOST:-dbhost}" -d "${DBNAME:-mirror_node}" -U "${DBUSER:-mirror_grpc}" -tc "select pg_terminate_backend($pid);" | head -1)
+        rc=$?
+        if [ $rc -ne 0 ] || [ "$res" != " t" ] ; then
+          echo "ERROR SQL query failed attempting to kill pid $pid."
+        else
+          echo "INFO Terminated postgres pid $pid."
+        fi
+        bounce_service=true
+        ;;
+    esac
+  done
+  if [ "${bounce_service}" == "true" ] ; then
+    echo "INFO Restarting hedera-mirror-grpc."
+    systemctl restart hedera-mirror-grpc
+  fi
+  sleep ${PERIOD_SECONDS}
+done


### PR DESCRIPTION
- Adds `hedera-mirror-grpc-monitor` systemd service installed via same deploy.sh script as hedera-mirror-grpc.
- Service periodically (5 secs) polls DB for "stuck" or long running (default 15 seconds) selects locking the topic_message table, and pg_terminate_backends them as well as restarting the hedera-mirror-grpc systemd service when these possibly-stuck queries are detected.
- New service is configured via environment variables set in `/usr/etc/hedera-mirror-grpc-monitor/config`
  - PGPASSWORD=_mirror_grpc-users-password_
  - DBHOST=_dbhost_
  - PERIOD_SECONDS=_5_ polling inverval in seconds for querying DB for stuck select queries
  - MAX_QUERY_AGE_SECONDS=_15_ when querying for stuck queries, kill select statements that have the topic_message table locked and have been running longer than 15 seconds