### PR TITLE
Acceptance test improvements to support subscribe and publish only scenarios

### DIFF
--- a/hedera-mirror-test/README.md
+++ b/hedera-mirror-test/README.md
@@ -19,7 +19,7 @@ Further details may be explored at https://cucumber.io/. Additionally, cucumbers
 
 Tests can be compiled and run by running the following command from the root folder
 
-    `./mvnw clean integration-test --projects hedera-mirror-test/`
+    `./mvnw clean integration-test --projects hedera-mirror-test/ -P=acceptance-tests`
 
 ### Test Configuration
 
@@ -32,14 +32,20 @@ Tests can be compiled and run by running the following command from the root fol
     -   operatorId - account id on network 'x.y.z' format
     -   operatorKey - account private key, to be used for signing transaction and client identification #Be careful with showing this, do not check this value in.
 
+Options can be set through the command line as follows
+
+    `./mvnw integration-test --projects hedera-mirror-test/ -P=acceptance-tests -Dhedera.mirror.test.acceptance.nodeId=0.0.4 -Dhedera.mirror.test.acceptance.nodeAddress=1.testnet.hedera.com:50211`
+
 -   Tags : Tags allow you to filter which cucumber scenarios and files are run. By default tests marked with the @Sanity tag are run. To run a different set of files different tags can be specified
     -   All test cases
 
-*               `./mvnw clean integration-test --projects hedera-mirror-test/ -P=acceptance-tests -Dcucumber.filter.tags="@FullSuite"`
+*                 `./mvnw clean integration-test --projects hedera-mirror-test/ -P=acceptance-tests -Dcucumber.filter.tags="@AcceptanceSuite"`
     -   Negative cases
-*               `./mvnw clean integration-test --projects hedera-mirror-test/ -P=acceptance-tests -Dcucumber.filter.tags="@Negative"`
+*                 `./mvnw clean integration-test --projects hedera-mirror-test/ -P=acceptance-tests -Dcucumber.filter.tags="@FullSuite"`
+    -   Negative cases
+*                 `./mvnw clean integration-test --projects hedera-mirror-test/ -P=acceptance-tests -Dcucumber.filter.tags="@Negative"`
     -   Edge cases
-*               `./mvnw clean integration-test --projects hedera-mirror-test/ -P=acceptance-tests -Dcucumber.filter.tags="@Edge"`
+*                 `./mvnw clean integration-test --projects hedera-mirror-test/ -P=acceptance-tests -Dcucumber.filter.tags="@Edge"`
     -   ... (search for @? tags within the .feature files for further tags)
 
 ### Test Layout

--- a/hedera-mirror-test/pom.xml
+++ b/hedera-mirror-test/pom.xml
@@ -57,12 +57,6 @@
             <version>${cucumber.version}</version>
             <scope>test</scope>
         </dependency>
-<!--        <dependency>-->
-<!--            <groupId>io.cucumber</groupId>-->
-<!--            <artifactId>cucumber-jvm</artifactId>-->
-<!--            <version>${cucumber.version}</version>-->
-<!--            <scope>test</scope>-->
-<!--        </dependency>-->
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>

--- a/hedera-mirror-test/pom.xml
+++ b/hedera-mirror-test/pom.xml
@@ -18,7 +18,7 @@
     <properties>
         <jmeter.test>E2E_Subscribe_Only.jmx</jmeter.test>
         <jmeter.subscribeThreadCount></jmeter.subscribeThreadCount>
-        <cucumber.version>5.0.0</cucumber.version>
+        <cucumber.version>5.2.0</cucumber.version>
         <skipTests>true</skipTests>
     </properties>
 
@@ -57,6 +57,12 @@
             <version>${cucumber.version}</version>
             <scope>test</scope>
         </dependency>
+<!--        <dependency>-->
+<!--            <groupId>io.cucumber</groupId>-->
+<!--            <artifactId>cucumber-jvm</artifactId>-->
+<!--            <version>${cucumber.version}</version>-->
+<!--            <scope>test</scope>-->
+<!--        </dependency>-->
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/SubscriptionResponse.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/SubscriptionResponse.java
@@ -58,7 +58,7 @@ public class SubscriptionResponse {
         MirrorConsensusTopicResponse lastMirrorConsensusTopicResponse = null;
         for (MirrorConsensusTopicResponse mirrorConsensusTopicResponse : messages) {
             String messageAsString = new String(mirrorConsensusTopicResponse.message, StandardCharsets.UTF_8);
-            log.info("Observed message: {}, consensus timestamp: {}, topic sequence number: {}",
+            log.trace("Observed message: {}, consensus timestamp: {}, topic sequence number: {}",
                     messageAsString, mirrorConsensusTopicResponse.consensusTimestamp,
                     mirrorConsensusTopicResponse.sequenceNumber);
 

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TopicClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TopicClient.java
@@ -24,12 +24,15 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import lombok.Value;
 import lombok.extern.log4j.Log4j2;
 
 import com.hedera.hashgraph.sdk.Client;
 import com.hedera.hashgraph.sdk.HederaStatusException;
+import com.hedera.hashgraph.sdk.Transaction;
 import com.hedera.hashgraph.sdk.TransactionId;
 import com.hedera.hashgraph.sdk.TransactionReceipt;
 import com.hedera.hashgraph.sdk.consensus.ConsensusMessageSubmitTransaction;
@@ -46,26 +49,31 @@ public class TopicClient {
 
     private final SDKClient sdkClient;
     private final Client client;
-    private final List<Instant> recordPublishInstants;
+    private final Map<Long, Instant> recordPublishInstants;
 
     public TopicClient(SDKClient sdkClient) {
         this.sdkClient = sdkClient;
         client = sdkClient.getClient();
-        recordPublishInstants = new ArrayList<>();
+        recordPublishInstants = new HashMap<>();
         log.debug("Creating Topic Client");
     }
 
     public TransactionReceipt createTopic(Ed25519PublicKey adminKey, Ed25519PublicKey submitKey) throws HederaStatusException {
 
         Instant refInstant = Instant.now();
-        TransactionReceipt transactionReceipt = new ConsensusTopicCreateTransaction()
+        ConsensusTopicCreateTransaction consensusTopicCreateTransaction = new ConsensusTopicCreateTransaction()
                 .setAdminKey(adminKey)
-                .setSubmitKey(submitKey)
                 .setAutoRenewAccountId(sdkClient.getOperatorId())
                 .setMaxTransactionFee(1_000_000_000)
-                .setTopicMemo("HCS Topic_" + refInstant)
+                .setTopicMemo("HCS Topic_" + refInstant);
 //                .setAutoRenewPeriod(Duration.ofDays(7000000)) // INSUFFICIENT_TX_FEE, also unsupported
 //                .setAutoRenewAccountId()
+
+        if (submitKey != null) {
+            consensusTopicCreateTransaction.setSubmitKey(submitKey);
+        }
+
+        TransactionReceipt transactionReceipt = consensusTopicCreateTransaction
                 .execute(client)
                 .getReceipt(client);
 
@@ -123,27 +131,33 @@ public class TopicClient {
 
     public TransactionReceipt publishMessageToTopic(ConsensusTopicId topicId, String message,
                                                     Ed25519PrivateKey submitKey) throws HederaStatusException {
-        TransactionId transactionId = new ConsensusMessageSubmitTransaction()
+        Transaction transaction = new ConsensusMessageSubmitTransaction()
                 .setTopicId(topicId)
                 .setMessage(message)
-                .build(client)
-                // The transaction is automatically signed by the payer.
-                // Due to the topic having a submitKey requirement, additionally sign the transaction with that key.
-                .sign(submitKey)
-                .execute(client);
+                .build(client);
 
-        // note time stamp
-        recordPublishInstants.add(transactionId.getRecord(client).consensusTimestamp);
+        if (submitKey != null) {
+            // The transaction is automatically signed by the payer.
+            // Due to the topic having a submitKey requirement, additionally sign the transaction with that key.
+            transaction.sign(submitKey);
+        }
 
-        TransactionReceipt transactionReceipt = transactionId.getReceipt(client);
+        TransactionId transactionId = transaction.execute(client);
 
-        log.trace("Published message : '{}' to topicId : {} with sequence number : {}", message, topicId,
-                transactionReceipt.getConsensusTopicSequenceNumber());
+        TransactionReceipt transactionReceipt = null;
+//        transactionReceipt = transactionId.getReceipt(client);
 
+//        log.trace("Published message : '{}' to topicId : {} with sequence number : {}", message, topicId,
+//                transactionReceipt.getConsensusTopicSequenceNumber());
+//
+//        // note time stamp
+//        recordPublishInstants.put(transactionReceipt.getConsensusTopicSequenceNumber(), transactionId
+//                .getRecord(client).consensusTimestamp);
+//
         return transactionReceipt;
     }
 
-    public Instant getInstantOfPublishedMessage(int sequenceNumber) {
+    public Instant getInstantOfPublishedMessage(long sequenceNumber) {
         return recordPublishInstants.get(sequenceNumber);
     }
 }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TopicFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TopicFeature.java
@@ -46,7 +46,7 @@ import com.hedera.mirror.test.e2e.acceptance.util.FeatureInputHandler;
 @Log4j2
 @Cucumber
 public class TopicFeature {
-    private int numMessages;
+    private int messageSubscribeCount;
     private int latency;
     private MirrorConsensusTopicQuery mirrorConsensusTopicQuery;
     private ConsensusTopicId consensusTopicId;
@@ -122,23 +122,23 @@ public class TopicFeature {
             log.debug("Set mirrorConsensusTopicQuery with topic {}, {}", topicId, mirrorConsensusTopicQuery);
         }
 
-        numMessages = 0;
+        messageSubscribeCount = 0;
     }
 
     @Given("I provide a number of messages {int} I want to receive")
     public void setTopicListenParams(int numMessages) {
-        this.numMessages = numMessages;
+        messageSubscribeCount = numMessages;
     }
 
     @Given("I provide a number of messages {int} I want to receive within {int} seconds")
     public void setTopicListenParams(int numMessages, int latency) {
-        this.numMessages = numMessages;
+        messageSubscribeCount = numMessages;
         this.latency = latency;
     }
 
     @Given("I provide a startDate {string} and a number of messages {int} I want to receive")
     public void setTopicListenParams(String startDate, int numMessages) {
-        this.numMessages = numMessages;
+        messageSubscribeCount = numMessages;
 
         Instant startTime = FeatureInputHandler.messageQueryDateStringToInstant(startDate, testInstantReference);
         log.trace("Subscribe mirrorConsensusTopicQuery : StartTime : {}", startTime);
@@ -149,7 +149,7 @@ public class TopicFeature {
 
     @Given("I provide a startDate {string} and endDate {string} and a number of messages {int} I want to receive")
     public void setTopicListenParams(String startDate, String endDate, int numMessages) {
-        this.numMessages = numMessages;
+        messageSubscribeCount = numMessages;
 
         Instant startTime = FeatureInputHandler.messageQueryDateStringToInstant(startDate, testInstantReference);
         Instant endTime = FeatureInputHandler.messageQueryDateStringToInstant(endDate, Instant.now());
@@ -162,7 +162,7 @@ public class TopicFeature {
 
     @Given("I provide a startSequence {int} and endSequence {int} and a number of messages {int} I want to receive")
     public void setTopicListenParams(int startSequence, int endSequence, int numMessages) {
-        this.numMessages = numMessages;
+        messageSubscribeCount = numMessages;
 
         Instant startTime = topicClient.getInstantOfPublishedMessage(startSequence - 1).minusMillis(10);
         Instant endTime = topicClient.getInstantOfPublishedMessage(endSequence - 1).plusMillis(10);
@@ -175,7 +175,7 @@ public class TopicFeature {
 
     @Given("I provide a startDate {string} and endDate {string} and a limit of {int} messages I want to receive")
     public void setTopicListenParamswLimit(String startDate, String endDate, int limit) {
-        numMessages = limit;
+        messageSubscribeCount = limit;
 
         mirrorConsensusTopicQuery
                 .setStartTime(FeatureInputHandler.messageQueryDateStringToInstant(startDate))
@@ -192,17 +192,18 @@ public class TopicFeature {
     @When("I publish {int} batches of {int} messages every {long} milliseconds")
     public void publishTopicMessages(int numGroups, int messageCount, long milliSleep) throws InterruptedException,
             HederaStatusException {
-        numMessages = messageCount;
-
         for (int i = 0; i < numGroups; i++) {
             publishedTransactionReceipts = topicClient
                     .publishMessagesToTopic(consensusTopicId, "New message", submitKey, messageCount);
             Thread.sleep(milliSleep, 0);
         }
+
+        messageSubscribeCount = numGroups * messageCount;
     }
 
     @When("I publish and verify {int} messages")
     public void publishAndVerifyTopicMessages(int messageCount) throws InterruptedException, HederaStatusException {
+        messageSubscribeCount = messageCount;
         publishTopicMessages(1, messageCount, 0);
         assertEquals(messageCount, publishedTransactionReceipts.size());
     }
@@ -239,7 +240,7 @@ public class TopicFeature {
         assertNotNull(mirrorConsensusTopicQuery, "mirrorConsensusTopicQuery null");
 
         subscriptionResponse = mirrorClient
-                .subscribeToTopicAndRetrieveMessages(mirrorConsensusTopicQuery, numMessages, latency);
+                .subscribeToTopicAndRetrieveMessages(mirrorConsensusTopicQuery, messageSubscribeCount, latency);
     }
 
     @Then("I subscribe with a filter to retrieve these published messages")
@@ -254,7 +255,7 @@ public class TopicFeature {
         mirrorConsensusTopicQuery.setStartTime(startTime);
 
         subscriptionResponse = mirrorClient
-                .subscribeToTopicAndRetrieveMessages(mirrorConsensusTopicQuery, numMessages, latency);
+                .subscribeToTopicAndRetrieveMessages(mirrorConsensusTopicQuery, messageSubscribeCount, latency);
     }
 
     @Then("the network should successfully observe these messages")
@@ -262,7 +263,7 @@ public class TopicFeature {
         assertNotNull(subscriptionResponse, "subscriptionResponse is null");
         assertFalse(subscriptionResponse.errorEncountered(), "Error encountered");
 
-        assertEquals(numMessages, subscriptionResponse.getMessages().size());
+        assertEquals(messageSubscribeCount, subscriptionResponse.getMessages().size());
         subscriptionResponse.validateReceivedMessages();
         mirrorClient.unSubscribeFromTopic(subscriptionResponse.getSubscription());
     }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TopicFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TopicFeature.java
@@ -250,7 +250,7 @@ public class TopicFeature {
 
         // get start time from first published messages
         Instant startTime;
-        if (publishedTransactionReceipts.size() == 0) {
+        if (publishedTransactionReceipts == null) {
             startTime = topicClient.getInstantOfFirstPublishedMessage();
         } else {
             long firstMessageSeqNum = publishedTransactionReceipts.get(0).getConsensusTopicSequenceNumber();

--- a/hedera-mirror-test/src/test/resources/features/account/account.feature
+++ b/hedera-mirror-test/src/test/resources/features/account/account.feature
@@ -1,7 +1,7 @@
 @Accounts @FullSuite
 Feature: Account Coverage Feature
 
-    @BalanceCheck @Sanity
+    @BalanceCheck @Sanity @SubscribeOnly
     Scenario Outline: Validate account balance check scenario
         When I request balance info for this account
         Then the result should be greater than or equal to <threshold>

--- a/hedera-mirror-test/src/test/resources/features/account/account.feature
+++ b/hedera-mirror-test/src/test/resources/features/account/account.feature
@@ -1,7 +1,7 @@
 @Accounts @FullSuite
 Feature: Account Coverage Feature
 
-    @BalanceCheck @Sanity @SubscribeOnly
+    @BalanceCheck @Sanity @Acceptance
     Scenario Outline: Validate account balance check scenario
         When I request balance info for this account
         Then the result should be greater than or equal to <threshold>

--- a/hedera-mirror-test/src/test/resources/features/hcs/hcs.feature
+++ b/hedera-mirror-test/src/test/resources/features/hcs/hcs.feature
@@ -1,7 +1,7 @@
 @TopicMessagesBase @FullSuite
 Feature: HCS Base Coverage Feature
 
-    @Sanity @BasicSubscribe
+    @Sanity @BasicSubscribe @Acceptance
     Scenario Outline: Validate Topic message submission
         Given I successfully create a new topic id
         And I publish <numMessages> messages
@@ -11,10 +11,9 @@ Feature: HCS Base Coverage Feature
         Examples:
             | numMessages |
             | 100         |
-#            | 7           |
 
-    @Sanity @OpenSubscribe
-    Scenario Outline: Validate Topic message submission
+    @OpenSubscribe @Acceptance
+    Scenario Outline: Validate Topic message submission to an open submit topic
         Given I successfully create a new open topic
         And I publish and verify <numMessages> messages
         When I provide a number of messages <numMessages> I want to receive
@@ -24,8 +23,8 @@ Feature: HCS Base Coverage Feature
             | numMessages |
             | 1           |
 
-    @SubscribeOnly
-    Scenario Outline: Validate topic message subscription
+    @SubscribeOnly @Acceptance
+    Scenario Outline: Validate topic message subscription only
         Given I provide a topic id <topicId>
         When I provide a number of messages <numMessages> I want to receive
         And I subscribe with a filter to retrieve messages
@@ -38,7 +37,7 @@ Feature: HCS Base Coverage Feature
     Scenario Outline: Validate topic message subscription
         Given I provide a topic id <topicId>
         And I publish <numBatches> batches of <numMessages> messages every <milliSleep> milliseconds
-        And I subscribe with a filter to retrieve messages
+        And I subscribe with a filter to retrieve these published messages
         Then the network should successfully observe these messages
         Examples:
             | topicId | numBatches | numMessages | milliSleep |
@@ -54,17 +53,18 @@ Feature: HCS Base Coverage Feature
             | topicId  | numMessages |
             | "171231" | 340         |
 
-    @UpdateTopic
+    @UpdateTopic @Acceptance
     Scenario: Validate Topic Updates
         Given I successfully create a new topic id
         Then I successfully update an existing topic
 
-    @DeleteTopic
+    @DeleteTopic @Acceptance
     Scenario: Validate topic deletion
         Given I successfully create a new topic id
         Then I successfully delete the topic
 
-    Scenario Outline: Validate Topic message listener
+    @Acceptance
+    Scenario Outline: Validate Topic message listener latency
         Given I successfully create a new topic id
         And I publish and verify <numMessages> messages
         When I provide a number of messages <numMessages> I want to receive within <latency> seconds
@@ -75,7 +75,7 @@ Feature: HCS Base Coverage Feature
             | 2           | 30      |
             | 5           | 30      |
 
-    @Negative
+    @Negative @Acceptance
     Scenario Outline: Validate topic subscription with missing topic id
         Given I provide a topic id <topicId>
         Then the network should observe an error <errorCode>

--- a/hedera-mirror-test/src/test/resources/features/hcs/hcs.feature
+++ b/hedera-mirror-test/src/test/resources/features/hcs/hcs.feature
@@ -41,7 +41,7 @@ Feature: HCS Base Coverage Feature
         Then the network should successfully observe these messages
         Examples:
             | topicId  | numBatches | numMessages | milliSleep |
-            | "171231" | 10         | 1000        | 2000       |
+            | "171231" | 2          | 3           | 2000       |
 
     @PublishAndVerify
     Scenario Outline: Validate topic message subscription

--- a/hedera-mirror-test/src/test/resources/features/hcs/hcs.feature
+++ b/hedera-mirror-test/src/test/resources/features/hcs/hcs.feature
@@ -1,7 +1,7 @@
 @TopicMessagesBase @FullSuite
 Feature: HCS Base Coverage Feature
 
-    @Sanity
+    @Sanity @BasicSubscribe
     Scenario Outline: Validate Topic message submission
         Given I successfully create a new topic id
         And I publish <numMessages> messages
@@ -10,8 +10,49 @@ Feature: HCS Base Coverage Feature
         Then the network should successfully observe these messages
         Examples:
             | numMessages |
+            | 100         |
+#            | 7           |
+
+    @Sanity @OpenSubscribe
+    Scenario Outline: Validate Topic message submission
+        Given I successfully create a new open topic
+        And I publish and verify <numMessages> messages
+        When I provide a number of messages <numMessages> I want to receive
+        And I subscribe with a filter to retrieve messages
+        Then the network should successfully observe these messages
+        Examples:
+            | numMessages |
             | 1           |
-            | 7           |
+
+    @SubscribeOnly
+    Scenario Outline: Validate topic message subscription
+        Given I provide a topic id <topicId>
+        When I provide a number of messages <numMessages> I want to receive
+        And I subscribe with a filter to retrieve messages
+        Then the network should successfully observe these messages
+        Examples:
+            | topicId  | numMessages |
+            | "169223" | 680         |
+
+    @PublishOnly
+    Scenario Outline: Validate topic message subscription
+        Given I provide a topic id <topicId>
+        And I publish <numBatches> batches of <numMessages> messages every <milliSleep> milliseconds
+        And I subscribe with a filter to retrieve messages
+        Then the network should successfully observe these messages
+        Examples:
+            | topicId | numBatches | numMessages | milliSleep |
+            | "30950" | 10         | 1000        | 2000       |
+
+    @PublishAndVerify
+    Scenario Outline: Validate topic message subscription
+        Given I provide a topic id <topicId>
+        And I publish and verify <numMessages> messages
+        And I subscribe with a filter to retrieve these published messages
+        Then the network should successfully observe these messages
+        Examples:
+            | topicId  | numMessages |
+            | "171231" | 340         |
 
     @UpdateTopic
     Scenario: Validate Topic Updates
@@ -25,7 +66,7 @@ Feature: HCS Base Coverage Feature
 
     Scenario Outline: Validate Topic message listener
         Given I successfully create a new topic id
-        And I publish <numMessages> messages
+        And I publish and verify <numMessages> messages
         When I provide a number of messages <numMessages> I want to receive within <latency> seconds
         And I subscribe with a filter to retrieve messages
         Then the network should successfully observe these messages

--- a/hedera-mirror-test/src/test/resources/features/hcs/hcs.feature
+++ b/hedera-mirror-test/src/test/resources/features/hcs/hcs.feature
@@ -4,7 +4,7 @@ Feature: HCS Base Coverage Feature
     @Sanity @BasicSubscribe @Acceptance
     Scenario Outline: Validate Topic message submission
         Given I successfully create a new topic id
-        And I publish <numMessages> messages
+        And I publish and verify <numMessages> messages
         When I provide a number of messages <numMessages> I want to receive
         And I subscribe with a filter to retrieve messages
         Then the network should successfully observe these messages
@@ -40,8 +40,8 @@ Feature: HCS Base Coverage Feature
         And I subscribe with a filter to retrieve these published messages
         Then the network should successfully observe these messages
         Examples:
-            | topicId | numBatches | numMessages | milliSleep |
-            | "30950" | 10         | 1000        | 2000       |
+            | topicId  | numBatches | numMessages | milliSleep |
+            | "171231" | 10         | 1000        | 2000       |
 
     @PublishAndVerify
     Scenario Outline: Validate topic message subscription

--- a/hedera-mirror-test/src/test/resources/features/topicfilter/hcstopicfilter.feature
+++ b/hedera-mirror-test/src/test/resources/features/topicfilter/hcstopicfilter.feature
@@ -1,7 +1,7 @@
 @TopicMessagesFilter @FullSuite
 Feature: HCS Message Filter Coverage Feature
 
-    @Sanity
+    @Sanity @Acceptance
     Scenario Outline: Validate topic filtering with past date and get X previous
         Given I successfully create a new topic id
         And I publish and verify <numMessages> messages
@@ -37,6 +37,7 @@ Feature: HCS Message Filter Coverage Feature
             | publishCount | startSequence | endSequence | numMessages |
             | 50           | 25            | 30          | 5           |
 
+    @Acceptance
     Scenario Outline: Validate topic filtering with past date and a specified limit
         Given I successfully create a new topic id
         And I publish and verify <numMessages> messages

--- a/hedera-mirror-test/src/test/resources/features/topicfilter/hsctopicfilter.feature
+++ b/hedera-mirror-test/src/test/resources/features/topicfilter/hsctopicfilter.feature
@@ -4,7 +4,7 @@ Feature: HCS Message Filter Coverage Feature
     @Sanity
     Scenario Outline: Validate topic filtering with past date and get X previous
         Given I successfully create a new topic id
-        And I publish <numMessages> messages
+        And I publish and verify <numMessages> messages
         When I provide a startDate <startDate> and a number of messages <numMessages> I want to receive
         And I subscribe with a filter to retrieve messages
         Then the network should successfully observe these messages
@@ -15,7 +15,7 @@ Feature: HCS Message Filter Coverage Feature
 
     Scenario Outline: Validate resubscribe topic filtering
         Given I successfully create a new topic id
-        And I publish <numMessages> messages
+        And I publish and verify <numMessages> messages
         When I provide a startDate <startDate> and a number of messages <numMessages> I want to receive
         And I subscribe with a filter to retrieve messages
         And I unsubscribe from a topic
@@ -29,7 +29,7 @@ Feature: HCS Message Filter Coverage Feature
     @Edge
     Scenario Outline: Validate topic filtering with start and end time in between min and max messages (e.g. if 100 messages get 25-30)
         Given I successfully create a new topic id
-        And I publish <publishCount> messages
+        And I publish and verify <publishCount> messages
         When I provide a startSequence <startSequence> and endSequence <endSequence> and a number of messages <numMessages> I want to receive
         And I subscribe with a filter to retrieve messages
         Then the network should successfully observe <numMessages> messages
@@ -39,7 +39,7 @@ Feature: HCS Message Filter Coverage Feature
 
     Scenario Outline: Validate topic filtering with past date and a specified limit
         Given I successfully create a new topic id
-        And I publish <numMessages> messages
+        And I publish and verify <numMessages> messages
         When I provide a startDate <startDate> and endDate <endDate> and a limit of <limit> messages I want to receive
         And I subscribe with a filter to retrieve messages
         Then the network should successfully observe these messages


### PR DESCRIPTION
**Detailed description**:
The acceptance tests currently all create a new topic with a submit signature and publish to this topic. The result is quick tests to publish to an existing topic or just subscribe require modifications.

This change adds a few scenarios to 
- create open topics (i.e. allow anyone to submit)
- publish only scenarios to an existing topic
- Not wait for a receipt when publishing 
- Publish multiple messages in batches over time
- readme update of above

**Special notes for your reviewer**:
I used these changes to test against Mainnet with multiple instances of each client.

**Checklist**
- [x] Documentation added
- [ ] Tests updated

