### PR TITLE
Set maxConcurrentCallsPerConnection to prevent excessive calls 

### DIFF
--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/GrpcProperties.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/GrpcProperties.java
@@ -41,5 +41,5 @@ public class GrpcProperties {
     private Map<String, String> connectionOptions = new HashMap<>();
 
     @NotNull
-    private NettyProperties netty;
+    private NettyProperties netty = new NettyProperties();
 }

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/GrpcProperties.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/GrpcProperties.java
@@ -28,6 +28,8 @@ import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
+import com.hedera.mirror.grpc.config.NettyProperties;
+
 @Data
 @Validated
 @ConfigurationProperties("hedera.mirror.grpc")
@@ -37,4 +39,7 @@ public class GrpcProperties {
 
     @NotNull
     private Map<String, String> connectionOptions = new HashMap<>();
+
+    @NotNull
+    private NettyProperties netty;
 }

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/config/GrpcConfiguration.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/config/GrpcConfiguration.java
@@ -20,9 +20,12 @@ package com.hedera.mirror.grpc.config;
  * ‍
  */
 
+import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder;
 import io.grpc.services.HealthStatusManager;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import lombok.extern.log4j.Log4j2;
+import net.devh.boot.grpc.server.serverfactory.GrpcServerConfigurer;
 import net.devh.boot.grpc.server.service.GrpcServiceDefinition;
 import net.devh.boot.grpc.server.service.GrpcServiceDiscoverer;
 import org.springframework.boot.actuate.health.CompositeHealthContributor;
@@ -30,6 +33,7 @@ import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+@Log4j2
 @Configuration
 public class GrpcConfiguration {
 
@@ -45,5 +49,11 @@ public class GrpcConfiguration {
         }
 
         return CompositeHealthContributor.fromMap(healthIndicators);
+    }
+
+    @Bean
+    public GrpcServerConfigurer grpcServerConfigurer(NettyProperties nettyProperties) {
+        return serverBuilder -> ((NettyServerBuilder) serverBuilder)
+                .maxConcurrentCallsPerConnection(nettyProperties.getMaxConcurrentCallsPerConnection());
     }
 }

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/config/GrpcConfiguration.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/config/GrpcConfiguration.java
@@ -24,7 +24,6 @@ import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder;
 import io.grpc.services.HealthStatusManager;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import lombok.extern.log4j.Log4j2;
 import net.devh.boot.grpc.server.serverfactory.GrpcServerConfigurer;
 import net.devh.boot.grpc.server.service.GrpcServiceDefinition;
 import net.devh.boot.grpc.server.service.GrpcServiceDiscoverer;
@@ -33,7 +32,8 @@ import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-@Log4j2
+import com.hedera.mirror.grpc.GrpcProperties;
+
 @Configuration
 public class GrpcConfiguration {
 
@@ -52,8 +52,8 @@ public class GrpcConfiguration {
     }
 
     @Bean
-    public GrpcServerConfigurer grpcServerConfigurer(NettyProperties nettyProperties) {
+    public GrpcServerConfigurer grpcServerConfigurer(GrpcProperties grpcProperties) {
         return serverBuilder -> ((NettyServerBuilder) serverBuilder)
-                .maxConcurrentCallsPerConnection(nettyProperties.getMaxConcurrentCallsPerConnection());
+                .maxConcurrentCallsPerConnection(grpcProperties.getNetty().getMaxConcurrentCallsPerConnection());
     }
 }

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/config/NettyProperties.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/config/NettyProperties.java
@@ -22,13 +22,11 @@ package com.hedera.mirror.grpc.config;
 
 import javax.validation.constraints.Min;
 import lombok.Data;
-import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
 @Data
 @Validated
-@ConfigurationProperties("hedera.mirror.grpc.netty")
 public class NettyProperties {
-    @Min(5)
-    private int maxConcurrentCallsPerConnection = 10;
+    @Min(1)
+    private int maxConcurrentCallsPerConnection = 5;
 }

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/config/NettyProperties.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/config/NettyProperties.java
@@ -1,0 +1,34 @@
+package com.hedera.mirror.grpc.config;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import javax.validation.constraints.Min;
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@Data
+@Validated
+@ConfigurationProperties("hedera.mirror.grpc.netty")
+public class NettyProperties {
+    @Min(5)
+    private int maxConcurrentCallsPerConnection = 10;
+}

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/jmeter/client/SingleTopicHCSClient.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/jmeter/client/SingleTopicHCSClient.java
@@ -42,6 +42,12 @@ public class SingleTopicHCSClient extends AbstractJavaSamplerClient {
     private static ManagedChannel channel;
     private HCSTopicSampler hcsTopicSampler;
 
+    private static synchronized void setChannel(String host, int port) {
+        if (channel == null) {
+            channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+        }
+    }
+
     /**
      * Setup test by instantiating client using user defined test properties
      */
@@ -77,11 +83,7 @@ public class SingleTopicHCSClient extends AbstractJavaSamplerClient {
 
     private void setSampler(boolean sharedChannel, String host, int port, ConsensusTopicQuery consensusTopicQuery) {
         if (sharedChannel) {
-            if (channel == null) {
-                synchronized (this) {
-                    channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
-                }
-            }
+            setChannel(host, port);
 
             hcsTopicSampler = new HCSTopicSampler(channel, consensusTopicQuery);
         } else {

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/jmeter/client/SingleTopicHCSClient.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/jmeter/client/SingleTopicHCSClient.java
@@ -78,7 +78,9 @@ public class SingleTopicHCSClient extends AbstractJavaSamplerClient {
     private void setSampler(boolean sharedChannel, String host, int port, ConsensusTopicQuery consensusTopicQuery) {
         if (sharedChannel) {
             if (channel == null) {
-                channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+                synchronized (this) {
+                    channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build();
+                }
             }
 
             hcsTopicSampler = new HCSTopicSampler(channel, consensusTopicQuery);

--- a/hedera-mirror-test/src/test/jmeter/E2E_Subscribe_Only.jmx
+++ b/hedera-mirror-test/src/test/jmeter/E2E_Subscribe_Only.jmx
@@ -79,6 +79,11 @@
                 <stringProp name="Argument.value">60</stringProp>
                 <stringProp name="Argument.metadata">=</stringProp>
               </elementProp>
+              <elementProp name="sharedChannel" elementType="Argument">
+                <stringProp name="Argument.name">sharedChannel</stringProp>
+                <stringProp name="Argument.value">true</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
             </collectionProp>
           </elementProp>
           <stringProp name="classname">com.hedera.mirror.grpc.jmeter.client.SingleTopicHCSClient</stringProp>

--- a/hedera-mirror-test/src/test/jmeter/E2E_Subscribe_Only.jmx
+++ b/hedera-mirror-test/src/test/jmeter/E2E_Subscribe_Only.jmx
@@ -81,7 +81,7 @@
               </elementProp>
               <elementProp name="sharedChannel" elementType="Argument">
                 <stringProp name="Argument.name">sharedChannel</stringProp>
-                <stringProp name="Argument.value">true</stringProp>
+                <stringProp name="Argument.value">false</stringProp>
                 <stringProp name="Argument.metadata">=</stringProp>
               </elementProp>
             </collectionProp>

--- a/hedera-mirror-test/src/test/jmeter/Netty_MaxConcurrentCallsPerConnection.jmx
+++ b/hedera-mirror-test/src/test/jmeter/Netty_MaxConcurrentCallsPerConnection.jmx
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.2.1">
+  <hashTree>
+    <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="Netty MaxConcurrentCallsPerConnection Test Plan" enabled="true">
+      <stringProp name="TestPlan.comments"></stringProp>
+      <boolProp name="TestPlan.functional_mode">false</boolProp>
+      <boolProp name="TestPlan.tearDown_on_shutdown">true</boolProp>
+      <boolProp name="TestPlan.serialize_threadgroups">false</boolProp>
+      <elementProp name="TestPlan.user_defined_variables" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+        <collectionProp name="Arguments.arguments"/>
+      </elementProp>
+      <stringProp name="TestPlan.user_define_classpath"></stringProp>
+    </TestPlan>
+    <hashTree>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Subscribe_TG" enabled="true">
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+          <stringProp name="LoopController.loops">1</stringProp>
+        </elementProp>
+        <stringProp name="ThreadGroup.num_threads">${__P(subcribeThreadCount,100)}</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">1</stringProp>
+        <boolProp name="ThreadGroup.scheduler">false</boolProp>
+        <stringProp name="ThreadGroup.duration"></stringProp>
+        <stringProp name="ThreadGroup.delay"></stringProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
+      </ThreadGroup>
+      <hashTree>
+        <JavaSampler guiclass="JavaTestSamplerGui" testclass="JavaSampler" testname="Subcribe_Sampler" enabled="true">
+          <elementProp name="arguments" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" enabled="true">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="host" elementType="Argument">
+                <stringProp name="Argument.name">host</stringProp>
+                <stringProp name="Argument.value">localhost</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+              <elementProp name="port" elementType="Argument">
+                <stringProp name="Argument.name">port</stringProp>
+                <stringProp name="Argument.value">5600</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+              <elementProp name="limit" elementType="Argument">
+                <stringProp name="Argument.name">limit</stringProp>
+                <stringProp name="Argument.value">0</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+              <elementProp name="consensusStartTimeSeconds" elementType="Argument">
+                <stringProp name="Argument.name">consensusStartTimeSeconds</stringProp>
+                <stringProp name="Argument.value">0</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+              <elementProp name="consensusEndTimeSeconds" elementType="Argument">
+                <stringProp name="Argument.name">consensusEndTimeSeconds</stringProp>
+                <stringProp name="Argument.value">0</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+              <elementProp name="topicID" elementType="Argument">
+                <stringProp name="Argument.name">topicID</stringProp>
+                <stringProp name="Argument.value">0</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+              <elementProp name="realmNum" elementType="Argument">
+                <stringProp name="Argument.name">realmNum</stringProp>
+                <stringProp name="Argument.value">0</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+              <elementProp name="historicMessagesCount" elementType="Argument">
+                <stringProp name="Argument.name">historicMessagesCount</stringProp>
+                <stringProp name="Argument.value">1000</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+              <elementProp name="newTopicsMessageCount" elementType="Argument">
+                <stringProp name="Argument.name">newTopicsMessageCount</stringProp>
+                <stringProp name="Argument.value">0</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+              <elementProp name="messagesLatchWaitSeconds" elementType="Argument">
+                <stringProp name="Argument.name">messagesLatchWaitSeconds</stringProp>
+                <stringProp name="Argument.value">60</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+              <elementProp name="sharedChannel" elementType="Argument">
+                <stringProp name="Argument.name">sharedChannel</stringProp>
+                <stringProp name="Argument.value">true</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="classname">com.hedera.mirror.grpc.jmeter.client.SingleTopicHCSClient</stringProp>
+        </JavaSampler>
+        <hashTree>
+          <DurationAssertion guiclass="DurationAssertionGui" testclass="DurationAssertion" testname="SubscribeAssert" enabled="true">
+            <stringProp name="DurationAssertion.duration">20000</stringProp>
+          </DurationAssertion>
+          <hashTree/>
+        </hashTree>
+      </hashTree>
+    </hashTree>
+  </hashTree>
+</jmeterTestPlan>


### PR DESCRIPTION
**Detailed description**:
Recently in testnet we observed a single IP client with multiple subscriptions to from a single connection. This resulted in a high CPU usage as Netty scaled to support all the calls to HCS topics.

This fix puts a cap on the number of allowed calls by setting the NettyServerBuilder.maxConcurrentCallsPerConnection property. In this case calls above this number will be rejected. 

**Which issue(s) this PR fixes**:
Partially addresses #536 

**Special notes for your reviewer**:
Verified using jmeter performance tests and observing gRPC process CPU usage.
In the unbounded case CPU usage could go as high as 851% and hold for over a minute.
In the bounded case CPU usage was seen to go as high as 430% but only for 1-3 seconds before averaging at around 70% for the length of the subscription where messages were being delivered.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

