### PR TITLE
Set additional netty properties and memory limits 

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -83,6 +83,10 @@ value, it is recommended to only populate overridden properties in the custom `a
 | `hedera.mirror.grpc.db.username`                           | mirror_grpc             | The username the GRPC API uses to connect to the database                                      |
 | `hedera.mirror.grpc.listener.pollingFrequency`             | 2s                      | How often to polling for new topic messages. Can accept duration units like `50ms`, `10s` etc. |
 | `hedera.mirror.grpc.listener.type`                         | POLL                    | The type of listener to use for incoming messages. Accepts either NOTIFY or POLL               |
+| `hedera.mirror.grpc.netty.flowControlWindow`               | 64 \* 1024              | The HTTP/2 flow control window                                                                 |
+| `hedera.mirror.grpc.netty.maxConcurrentCallsPerConnection` | 5                       | The maximum number of concurrent calls permitted for each incoming connection                  |
+| `hedera.mirror.grpc.netty.maxMessageSize`                  | 6 \* 1024               | The maximum message size allowed to be received on the server                                  |
+| `hedera.mirror.grpc.netty.maxMetadataSize`                 | 1024                    | The maximum size of metadata allowed to be received                                            |
 | `hedera.mirror.grpc.port`                                  | 5600                    | The GRPC API port                                                                              |
 | `hedera.mirror.importer.parser.exclude`                    | []                      | A list of filters that determine which transactions are ignored. Takes precedence over include |
 | `hedera.mirror.importer.parser.exclude.entity`             | []                      | A list of entity IDs to ignore in shard.realm.num (e.g. 0.0.3) format                          |

--- a/hedera-mirror-grpc/scripts/hedera-mirror-grpc.service
+++ b/hedera-mirror-grpc/scripts/hedera-mirror-grpc.service
@@ -3,7 +3,7 @@ After=syslog.target
 Description=Hedera Mirror Node GRPC API
 
 [Service]
-ExecStart=/usr/bin/java -jar hedera-mirror-grpc.jar --spring.config.additional-location=file:/usr/etc/hedera-mirror-grpc/ -DLog4jContextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector
+ExecStart=/usr/bin/java -jar hedera-mirror-grpc.jar --spring.config.additional-location=file:/usr/etc/hedera-mirror-grpc/ -DLog4jContextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector -Xms512m -Xmx12g -XX:MinHeapFreeRatio=25 -XX:MaxHeapFreeRatio=75
 Restart=on-failure
 RestartSec=1
 Type=simple

--- a/hedera-mirror-grpc/scripts/hedera-mirror-grpc.service
+++ b/hedera-mirror-grpc/scripts/hedera-mirror-grpc.service
@@ -3,7 +3,7 @@ After=syslog.target
 Description=Hedera Mirror Node GRPC API
 
 [Service]
-ExecStart=/usr/bin/java -jar hedera-mirror-grpc.jar --spring.config.additional-location=file:/usr/etc/hedera-mirror-grpc/ -DLog4jContextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector -Xmx12g
+ExecStart=/usr/bin/java -jar hedera-mirror-grpc.jar --spring.config.additional-location=file:/usr/etc/hedera-mirror-grpc/ -DLog4jContextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector -Xmx10g
 Restart=on-failure
 RestartSec=1
 Type=simple

--- a/hedera-mirror-grpc/scripts/hedera-mirror-grpc.service
+++ b/hedera-mirror-grpc/scripts/hedera-mirror-grpc.service
@@ -3,7 +3,7 @@ After=syslog.target
 Description=Hedera Mirror Node GRPC API
 
 [Service]
-ExecStart=/usr/bin/java -jar hedera-mirror-grpc.jar --spring.config.additional-location=file:/usr/etc/hedera-mirror-grpc/ -DLog4jContextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector -Xms512m -Xmx12g -XX:MinHeapFreeRatio=25 -XX:MaxHeapFreeRatio=75
+ExecStart=/usr/bin/java -jar hedera-mirror-grpc.jar --spring.config.additional-location=file:/usr/etc/hedera-mirror-grpc/ -DLog4jContextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector -Xmx12g
 Restart=on-failure
 RestartSec=1
 Type=simple

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/config/GrpcConfiguration.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/config/GrpcConfiguration.java
@@ -24,6 +24,7 @@ import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder;
 import io.grpc.services.HealthStatusManager;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import net.devh.boot.grpc.server.serverfactory.GrpcServerConfigurer;
 import net.devh.boot.grpc.server.service.GrpcServiceDefinition;
 import net.devh.boot.grpc.server.service.GrpcServiceDiscoverer;
@@ -53,7 +54,14 @@ public class GrpcConfiguration {
 
     @Bean
     public GrpcServerConfigurer grpcServerConfigurer(GrpcProperties grpcProperties) {
+        NettyProperties nettyProperties = grpcProperties.getNetty();
         return serverBuilder -> ((NettyServerBuilder) serverBuilder)
-                .maxConcurrentCallsPerConnection(grpcProperties.getNetty().getMaxConcurrentCallsPerConnection());
+                .flowControlWindow(nettyProperties.getFlowControlWindow())
+                .keepAliveTime(nettyProperties.getKeepAlive(), TimeUnit.SECONDS)
+                .keepAliveTimeout(nettyProperties.getKeepAliveTimeout(), TimeUnit.SECONDS)
+                .maxConcurrentCallsPerConnection(nettyProperties.getMaxConcurrentCallsPerConnection())
+                .maxInboundMessageSize(nettyProperties.getMaxMessageSize())
+                .maxInboundMetadataSize(nettyProperties.getMaxMetadataSize())
+                .permitKeepAliveWithoutCalls(true);
     }
 }

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/config/GrpcConfiguration.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/config/GrpcConfiguration.java
@@ -24,7 +24,6 @@ import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder;
 import io.grpc.services.HealthStatusManager;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import net.devh.boot.grpc.server.serverfactory.GrpcServerConfigurer;
 import net.devh.boot.grpc.server.service.GrpcServiceDefinition;
 import net.devh.boot.grpc.server.service.GrpcServiceDiscoverer;
@@ -57,11 +56,8 @@ public class GrpcConfiguration {
         NettyProperties nettyProperties = grpcProperties.getNetty();
         return serverBuilder -> ((NettyServerBuilder) serverBuilder)
                 .flowControlWindow(nettyProperties.getFlowControlWindow())
-                .keepAliveTime(nettyProperties.getKeepAlive(), TimeUnit.SECONDS)
-                .keepAliveTimeout(nettyProperties.getKeepAliveTimeout(), TimeUnit.SECONDS)
                 .maxConcurrentCallsPerConnection(nettyProperties.getMaxConcurrentCallsPerConnection())
                 .maxInboundMessageSize(nettyProperties.getMaxMessageSize())
-                .maxInboundMetadataSize(nettyProperties.getMaxMetadataSize())
-                .permitKeepAliveWithoutCalls(true);
+                .maxInboundMetadataSize(nettyProperties.getMaxMetadataSize());
     }
 }

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/config/NettyProperties.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/config/NettyProperties.java
@@ -27,17 +27,11 @@ import org.springframework.validation.annotation.Validated;
 @Data
 @Validated
 public class NettyProperties {
-    @Min(1)
-    private int maxConcurrentCallsPerConnection = 5;
-
     @Min(1024) // 64 kb
     private int flowControlWindow = 64 * 1024;
 
     @Min(1)
-    private int keepAlive = 30;
-
-    @Min(1)
-    private int keepAliveTimeout = 5;
+    private int maxConcurrentCallsPerConnection = 5;
 
     @Min(8) // 6 kb
     private int maxMessageSize = 6 * 1024;

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/config/NettyProperties.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/config/NettyProperties.java
@@ -29,4 +29,19 @@ import org.springframework.validation.annotation.Validated;
 public class NettyProperties {
     @Min(1)
     private int maxConcurrentCallsPerConnection = 5;
+
+    @Min(1024) // 64 kb
+    private int flowControlWindow = 64 * 1024;
+
+    @Min(1)
+    private int keepAlive = 30;
+
+    @Min(1)
+    private int keepAliveTimeout = 5;
+
+    @Min(8) // 6 kb
+    private int maxMessageSize = 6 * 1024;
+
+    @Min(8) // 1 kb
+    private int maxMetadataSize = 1024;
 }

--- a/hedera-mirror-grpc/src/main/resources/application.yml
+++ b/hedera-mirror-grpc/src/main/resources/application.yml
@@ -15,7 +15,6 @@ hedera:
       port: 5600
 grpc:
   server:
-    max-inbound-message-size: 6144
     port: ${hedera.mirror.grpc.port}
 logging:
   level:


### PR DESCRIPTION
**Detailed description**:
We recently experienced undesirable effects of traffic in testnet which prompted us to visit our grips service configurations around security and performance.
This change sets further Netty properties to aid security and performance as well as sets the Jim memory thresholds for the service at deployment

- Set flowControlWindow, maxMessageSize and maxMetadataSize Netty properties
- Set max heap

**Which issue(s) this PR fixes**:
Partially addresses #536 

**Special notes for your reviewer**:

**Checklist**
- [x] Documentation added
- [ ] Tests updated

