### PR TITLE
Updated performance tests to use DbClient 

### DIFF
--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/jmeter/ConnectionHandler.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/jmeter/ConnectionHandler.java
@@ -22,12 +22,10 @@ package com.hedera.mirror.grpc.jmeter;
 
 import io.r2dbc.postgresql.PostgresqlConnectionConfiguration;
 import io.r2dbc.postgresql.PostgresqlConnectionFactory;
-import io.r2dbc.postgresql.api.PostgresqlConnection;
-import io.r2dbc.postgresql.api.PostgresqlStatement;
-import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import lombok.extern.log4j.Log4j2;
+import org.springframework.data.r2dbc.core.DatabaseClient;
 
 import com.hedera.mirror.grpc.converter.InstantToLongConverter;
 
@@ -35,7 +33,7 @@ import com.hedera.mirror.grpc.converter.InstantToLongConverter;
 public class ConnectionHandler {
 
     private final InstantToLongConverter converter = new InstantToLongConverter();
-    private final PostgresqlConnection connection;
+    private final DatabaseClient client;
     private final String host;
     private final int port;
     private final String dbName;
@@ -49,7 +47,7 @@ public class ConnectionHandler {
         this.dbUser = dbUser;
         this.dbPassword = dbPassword;
 
-        connection = getConnection();
+        client = getClient();
     }
 
     private PostgresqlConnectionFactory getConnectionFactory() {
@@ -66,15 +64,66 @@ public class ConnectionHandler {
         return connectionFactory;
     }
 
-    private PostgresqlConnection getConnection() {
-        log.debug("Obtain PostgresqlConnection");
-        return getConnectionFactory().create().block(Duration.ofMillis(500));
+    private DatabaseClient getClient() {
+        return DatabaseClient.create(getConnectionFactory());
+    }
+
+    public long createTopic() {
+        long topicNum = getNextAvailableTopicID();
+
+        String entityInsertSql = "insert into t_entities"
+                + " (id, entity_num, entity_realm, entity_shard, fk_entity_type_id, key, ed25519_public_key_hex)"
+                + " values ($1, $2, $3, $4, $5, $6, $7)";
+        client.execute(entityInsertSql)
+                .bind("$1", topicNum)
+                .bind("$2", topicNum)
+                .bind("$3", 0)
+                .bind("$4", 0)
+                .bind("$5", 4)
+                .bind("$6", new byte[] {55, 66, 77})
+                .bind("$7", "4a5ad514f0957fa170a676210c9bdbddf3bc9519702cf915fa6767a40463b96f")
+                .then().block();
+
+        log.trace("Created new Topic {}", topicNum);
+        return topicNum;
+    }
+
+    public boolean topicExists(long topicId) {
+        boolean topicExists = false;
+
+        String topicSelectSql = "select id from t_entities where entity_shard = $1 and entity_realm = $2 and " +
+                "entity_num = $3";
+
+        topicExists = client.execute(topicSelectSql)
+                .bind("$1", 0)
+                .bind("$2", 0)
+                .bind("$3", topicId)
+                .map((row, metadata) -> {
+                    Long topicNum = row.get(0, Long.class);
+
+                    if (topicNum == null) {
+                        return false;
+                    }
+
+                    return true;
+                })
+                .first()
+                .defaultIfEmpty(false)
+                .block();
+
+        return topicExists;
     }
 
     public void insertTopicMessage(int newTopicsMessageCount, long topicNum, Instant startTime, long seqStart) {
         if (newTopicsMessageCount == 0) {
             // no messages to create, abort and db logic
             return;
+        }
+
+        if (!topicExists(topicNum)) {
+            topicNum = createTopic();
+        } else {
+            log.info("Topic {} does exist, no need to create to it", topicNum);
         }
 
         long nextSequenceNum = seqStart == -1 ? getNextAvailableSequenceNumber(topicNum) : seqStart;
@@ -90,14 +139,14 @@ public class ConnectionHandler {
                     + " (consensus_timestamp, realm_num, topic_num, message, running_hash, sequence_number)"
                     + " values ($1, $2, $3, $4, $5, $6)";
 
-            PostgresqlStatement statement = connection.createStatement(topicMessageInsertSql)
+            client.execute(topicMessageInsertSql)
                     .bind("$1", consensusTimestamp)
                     .bind("$2", 0)
                     .bind("$3", topicNum)
                     .bind("$4", new byte[] {22, 33, 44})
                     .bind("$5", new byte[] {55, 66, 77})
-                    .bind("$6", sequenceNum);
-            statement.execute().blockLast();
+                    .bind("$6", sequenceNum)
+                    .then().block();
 
             log.trace("Stored TopicMessage {}, Time: {}, count: {}, seq : {}", topicNum, consensusTimestamp, i,
                     sequenceNum);
@@ -107,44 +156,41 @@ public class ConnectionHandler {
     }
 
     public long getNextAvailableTopicID() {
-        String nextTopicIdSql = "SELECT MAX(topic_num) FROM topic_message";
-        PostgresqlStatement statement = connection.createStatement(nextTopicIdSql);
+        String nextTopicIdSql = "SELECT MAX(entity_num) FROM t_entities";
 
-        long nextTopicId = 1 + statement.execute()
-                .flatMap(result ->
-                        result.map((row, metadata) -> {
-                            Long topicNum = row.get(0, Long.class);
+        long nextTopicId = 1 + client.execute(nextTopicIdSql)
+                .map((row, metadata) -> {
+                    Long topicNum = row.get(0, Long.class);
 
-                            if (topicNum == null) {
-                                throw new IllegalStateException("Topic num query failed");
-                            }
+                    if (topicNum == null) {
+                        throw new IllegalStateException("Topic num query failed");
+                    }
 
-                            return topicNum;
-                        })).blockFirst();
+                    return topicNum;
+                }).first().block();
 
-        log.trace("Next available topic ID number is {}", nextTopicId);
+        log.debug("Next available topic ID number is {}", nextTopicId);
         return nextTopicId;
     }
 
     public long getNextAvailableSequenceNumber(long topicId) {
         String nextSeqSql = "SELECT MAX(sequence_number) FROM topic_message WHERE topic_num = $1";
-        PostgresqlStatement statement = connection.createStatement(nextSeqSql).bind("$1", topicId);
 
-        long nextSeqNum = 1 + statement.execute()
-                .flatMap(result ->
-                        result.map((row, metadata) -> {
-                            Long max = row.get(0, Long.class);
+        long nextSeqNum = 1 + client.execute(nextSeqSql)
+                .bind("$1", topicId)
+                .map((row, metadata) -> {
+                    Long max = row.get(0, Long.class);
 
-                            if (max == null) {
-                                max = -1L;
-                                log.trace("Max sequence num query failed, setting max to -1 as likely not messages " +
-                                        "for this topic exist");
-                            }
+                    if (max == null) {
+                        max = -1L;
+                        log.trace("Max sequence num query failed, setting max to -1 as likely no messages " +
+                                "for this topic exist");
+                    }
 
-                            return max;
-                        })).blockFirst();
+                    return max;
+                }).first().block();
 
-        log.trace("Next available topic ID sequence number is {}", nextSeqNum);
+        log.info("Next available topic ID sequence number is {}", nextSeqNum);
         return nextSeqNum;
     }
 
@@ -156,16 +202,12 @@ public class ConnectionHandler {
         }
 
         String delTopicMsgsSql = "delete from topic_message where topic_num = $1 and sequence_number >= $2";
-        PostgresqlStatement statement = connection.createStatement(delTopicMsgsSql)
+
+        client.execute(delTopicMsgsSql)
                 .bind("$1", topicId)
-                .bind("$2", seqNumFrom);
+                .bind("$2", seqNumFrom)
+                .then().block();
 
-        statement.execute().blockLast();
         log.info("Cleared topic messages for topic ID {} after sequence {}", topicId, seqNumFrom);
-    }
-
-    public void close() {
-        log.debug("Closing connection");
-        connection.close().block(Duration.ofMillis(500));
     }
 }

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/jmeter/ConnectionHandler.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/jmeter/ConnectionHandler.java
@@ -122,8 +122,6 @@ public class ConnectionHandler {
 
         if (!topicExists(topicNum)) {
             topicNum = createTopic();
-        } else {
-            log.info("Topic {} does exist, no need to create to it", topicNum);
         }
 
         long nextSequenceNum = seqStart == -1 ? getNextAvailableSequenceNumber(topicNum) : seqStart;
@@ -169,7 +167,7 @@ public class ConnectionHandler {
                     return topicNum;
                 }).first().block();
 
-        log.debug("Next available topic ID number is {}", nextTopicId);
+        log.trace("Next available topic ID number is {}", nextTopicId);
         return nextTopicId;
     }
 
@@ -190,7 +188,7 @@ public class ConnectionHandler {
                     return max;
                 }).first().block();
 
-        log.info("Next available topic ID sequence number is {}", nextSeqNum);
+        log.trace("Next available topic ID sequence number is {}", nextSeqNum);
         return nextSeqNum;
     }
 

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/jmeter/client/TopicMessageGeneratorClient.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/jmeter/client/TopicMessageGeneratorClient.java
@@ -121,17 +121,4 @@ public class TopicMessageGeneratorClient extends AbstractJavaSamplerClient {
 
         return result;
     }
-
-    @Override
-    public void teardownTest(JavaSamplerContext context) {
-        try {
-            if (connectionHandler != null) {
-                connectionHandler.close();
-            }
-        } catch (Exception ex) {
-            log.error("Unable to close connection", ex);
-        }
-
-        super.teardownTest(context);
-    }
 }

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/jmeter/sampler/HCSTopicSampler.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/jmeter/sampler/HCSTopicSampler.java
@@ -120,7 +120,7 @@ public class HCSTopicSampler {
                 result.success = false;
             }
 
-            log.info("{} Historic messages obtained in {} ({}/s)", result.getTotalMessageCount(), result
+            log.info("{} Historic messages obtained in {} ({}/s)", result.getHistoricalMessageCount(), result
                     .getStopwatch(), result.getMessageRate());
 
             if (historicMessagesLatch.getCount() == 0 && !incomingMessagesLatch

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/jmeter/sampler/TopicMessageGeneratorSampler.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/jmeter/sampler/TopicMessageGeneratorSampler.java
@@ -34,7 +34,7 @@ import com.hedera.mirror.grpc.jmeter.props.MessageGenerator;
 @RequiredArgsConstructor
 public class TopicMessageGeneratorSampler {
 
-    public static final Instant INCOMING_START = Instant.now();
+    public static Instant INCOMING_START;
     private final ConnectionHandler connectionHandler;
 
     /**
@@ -63,8 +63,11 @@ public class TopicMessageGeneratorSampler {
         if (messageGenerator.getHistoricMessagesCount() > 0) {
             Instant pastInstant = Instant.EPOCH.plus(7, ChronoUnit.DAYS);
             connectionHandler.insertTopicMessage(messageGenerator.getHistoricMessagesCount(), messageGenerator
-                    .getTopicNum(), pastInstant, -1);
+                    .getTopicNum(), Instant.now(), -1);
         }
+
+        // all messages from this point will be considered future
+        INCOMING_START = Instant.now();
     }
 
     private void generateIncomingMessages(MessageGenerator messageGenerator) {
@@ -74,11 +77,11 @@ public class TopicMessageGeneratorSampler {
 
             if (messageGenerator.getNewTopicsMessageDelay() <= 0) {
                 connectionHandler.insertTopicMessage(messageGenerator.getFutureMessagesCount(), messageGenerator
-                        .getTopicNum(), INCOMING_START, -1);
+                        .getTopicNum(), Instant.now(), -1);
             } else {
                 while (cycleCount < messageGenerator.getTopicMessageEmitCycles()) {
                     connectionHandler.insertTopicMessage(messageGenerator.getFutureMessagesCount(), messageGenerator
-                            .getTopicNum(), INCOMING_START, -1);
+                            .getTopicNum(), Instant.now(), -1);
                     ++cycleCount;
                     Uninterruptibles
                             .sleepUninterruptibly(messageGenerator.getNewTopicsMessageDelay(), TimeUnit.MILLISECONDS);

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/jmeter/sampler/TopicMessageGeneratorSampler.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/jmeter/sampler/TopicMessageGeneratorSampler.java
@@ -54,8 +54,6 @@ public class TopicMessageGeneratorSampler {
 
         populateHistoricalMessages(messageGen);
         generateIncomingMessages(messageGen);
-
-        connectionHandler.close();
         log.debug("Successfully populated topic messages");
     }
 

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TopicFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TopicFeature.java
@@ -200,7 +200,7 @@ public class TopicFeature {
         messageSubscribeCount = numGroups * messageCount;
     }
 
-    @When("I publish and verify {int} messages")
+    @When("I publish and verify {int} messages sent")
     public void publishAndVerifyTopicMessages(int messageCount) throws InterruptedException, HederaStatusException {
         messageSubscribeCount = messageCount;
         publishedTransactionReceipts = topicClient

--- a/hedera-mirror-test/src/test/resources/features/hcs/hcs.feature
+++ b/hedera-mirror-test/src/test/resources/features/hcs/hcs.feature
@@ -4,7 +4,7 @@ Feature: HCS Base Coverage Feature
     @Sanity @BasicSubscribe @Acceptance
     Scenario Outline: Validate Topic message submission
         Given I successfully create a new topic id
-        And I publish and verify <numMessages> messages
+        And I publish and verify <numMessages> messages sent
         When I provide a number of messages <numMessages> I want to receive
         And I subscribe with a filter to retrieve messages
         Then the network should successfully observe these messages
@@ -15,7 +15,7 @@ Feature: HCS Base Coverage Feature
     @OpenSubscribe @Acceptance
     Scenario Outline: Validate Topic message submission to an open submit topic
         Given I successfully create a new open topic
-        And I publish and verify <numMessages> messages
+        And I publish and verify <numMessages> messages sent
         When I provide a number of messages <numMessages> I want to receive
         And I subscribe with a filter to retrieve messages
         Then the network should successfully observe these messages
@@ -30,8 +30,8 @@ Feature: HCS Base Coverage Feature
         And I subscribe with a filter to retrieve messages
         Then the network should successfully observe these messages
         Examples:
-            | topicId  | numMessages |
-            | "169223" | 680         |
+            | topicId     | numMessages |
+            | "200002151" | 5           |
 
     @PublishOnly
     Scenario Outline: Validate topic message subscription
@@ -46,7 +46,7 @@ Feature: HCS Base Coverage Feature
     @PublishAndVerify
     Scenario Outline: Validate topic message subscription
         Given I provide a topic id <topicId>
-        And I publish and verify <numMessages> messages
+        And I publish and verify <numMessages> messages sent
         And I subscribe with a filter to retrieve these published messages
         Then the network should successfully observe these messages
         Examples:
@@ -66,7 +66,7 @@ Feature: HCS Base Coverage Feature
     @Acceptance
     Scenario Outline: Validate Topic message listener latency
         Given I successfully create a new topic id
-        And I publish and verify <numMessages> messages
+        And I publish and verify <numMessages> messages sent
         When I provide a number of messages <numMessages> I want to receive within <latency> seconds
         And I subscribe with a filter to retrieve messages
         Then the network should successfully observe these messages

--- a/hedera-mirror-test/src/test/resources/features/topicfilter/hcstopicfilter.feature
+++ b/hedera-mirror-test/src/test/resources/features/topicfilter/hcstopicfilter.feature
@@ -4,7 +4,7 @@ Feature: HCS Message Filter Coverage Feature
     @Sanity @Acceptance
     Scenario Outline: Validate topic filtering with past date and get X previous
         Given I successfully create a new topic id
-        And I publish and verify <numMessages> messages
+        And I publish and verify <numMessages> messages sent
         When I provide a startDate <startDate> and a number of messages <numMessages> I want to receive
         And I subscribe with a filter to retrieve messages
         Then the network should successfully observe these messages
@@ -15,7 +15,7 @@ Feature: HCS Message Filter Coverage Feature
 
     Scenario Outline: Validate resubscribe topic filtering
         Given I successfully create a new topic id
-        And I publish and verify <numMessages> messages
+        And I publish and verify <numMessages> messages sent
         When I provide a startDate <startDate> and a number of messages <numMessages> I want to receive
         And I subscribe with a filter to retrieve messages
         And I unsubscribe from a topic
@@ -29,7 +29,7 @@ Feature: HCS Message Filter Coverage Feature
     @Edge
     Scenario Outline: Validate topic filtering with start and end time in between min and max messages (e.g. if 100 messages get 25-30)
         Given I successfully create a new topic id
-        And I publish and verify <publishCount> messages
+        And I publish and verify <publishCount> messages sent
         When I provide a startSequence <startSequence> and endSequence <endSequence> and a number of messages <numMessages> I want to receive
         And I subscribe with a filter to retrieve messages
         Then the network should successfully observe <numMessages> messages
@@ -40,7 +40,7 @@ Feature: HCS Message Filter Coverage Feature
     @Acceptance
     Scenario Outline: Validate topic filtering with past date and a specified limit
         Given I successfully create a new topic id
-        And I publish and verify <numMessages> messages
+        And I publish and verify <numMessages> messages sent
         When I provide a startDate <startDate> and endDate <endDate> and a limit of <limit> messages I want to receive
         And I subscribe with a filter to retrieve messages
         Then the network should successfully observe these messages


### PR DESCRIPTION
**Detailed description**:
Recently I realized the performance tests weren't working because the db inserts and deletes weren't working.
It seems with our r2dbc update the enforcement for transactional statements was enforced.

As such I took the opportunity to 
- update the ConnectionHandler to use DatabaseClient.
- Added the logic to ensure a topic entity exists before adding to it. This is since the gRPC layer added a check for it
- Applied PR feedback to update the acceptance test hcs feature scenarios

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated

