### PR TITLE
Fix shared poller's buffer

### DIFF
--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/SharedPollingTopicListener.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/SharedPollingTopicListener.java
@@ -84,8 +84,9 @@ public class SharedPollingTopicListener implements TopicListener {
                 .doOnComplete(() -> log.info("Completed polling"))
                 .doOnNext(context::onNext)
                 .doOnSubscribe(context::onStart)
-                .replay(listenerProperties.getBufferSize())
-                .autoConnect(0, disposable -> pollerDisposable = disposable);
+                .cache(listenerProperties.getBufferSize());
+
+        pollerDisposable = poller.subscribe();
     }
 
     @Override

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/retriever/PollingTopicMessageRetrieverTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/retriever/PollingTopicMessageRetrieverTest.java
@@ -22,7 +22,6 @@ package com.hedera.mirror.grpc.retriever;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.concurrent.TimeoutException;
 import javax.annotation.Resource;
 import org.junit.jupiter.api.Test;
 import reactor.test.StepVerifier;
@@ -232,9 +231,9 @@ public class PollingTopicMessageRetrieverTest extends GrpcIntegrationTest {
         pollingTopicMessageRetriever.retrieve(filter)
                 .map(TopicMessage::getSequenceNumber)
                 .as(StepVerifier::create)
-                .expectNext(1L)
-                .expectError(TimeoutException.class)
-                .verify(Duration.ofMillis(500));
+                .thenConsumeWhile(i -> true)
+                .expectTimeout(Duration.ofMillis(500))
+                .verify();
 
         retrieverProperties.setMaxPageSize(maxPageSize);
         retrieverProperties.setTimeout(timeout);


### PR DESCRIPTION
**Detailed description**:
- Fix shared poller not polling once buffer fills up
- Fix a flaky test in `PollingTopicMessageRetrieverTest`

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated

