### PR TITLE
Postgres Writer #1 : move ctl and non-fee transfers

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/CryptoTransfer.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/CryptoTransfer.java
@@ -24,10 +24,14 @@ import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Table;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @Entity
+@NoArgsConstructor
+@AllArgsConstructor
 @Table(name = "t_cryptotransferlists")
 public class CryptoTransfer {
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/NonFeeTransfer.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/NonFeeTransfer.java
@@ -20,13 +20,17 @@ package com.hedera.mirror.importer.domain;
  * ‍
  */
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Table;
 
 @Data
 @Entity
+@NoArgsConstructor
+@AllArgsConstructor
 @Table(name = "non_fee_transfers")
 public class NonFeeTransfer {
     // There is not actually a pk on non_fee_transfers.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/exception/ParserSQLException.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/exception/ParserSQLException.java
@@ -1,5 +1,24 @@
 package com.hedera.mirror.importer.exception;
 
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
 
 public class ParserSQLException extends ImporterException {
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/exception/ParserSQLException.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/exception/ParserSQLException.java
@@ -1,0 +1,19 @@
+package com.hedera.mirror.importer.exception;
+
+
+public class ParserSQLException extends ImporterException {
+
+    private static final long serialVersionUID = 5216154273755649844L;
+
+    public ParserSQLException(String message) {
+        super(message);
+    }
+
+    public ParserSQLException(Throwable throwable) {
+        super(throwable);
+    }
+
+    public ParserSQLException(String message, Throwable throwable) {
+        super(message, throwable);
+    }
+}

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/PostgresWritingRecordParsedItemHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/PostgresWritingRecordParsedItemHandler.java
@@ -1,0 +1,136 @@
+package com.hedera.mirror.importer.parser.record;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import javax.inject.Named;
+
+import com.hedera.mirror.importer.domain.ContractResult;
+import com.hedera.mirror.importer.domain.CryptoTransfer;
+import com.hedera.mirror.importer.domain.FileData;
+import com.hedera.mirror.importer.domain.LiveHash;
+import com.hedera.mirror.importer.domain.NonFeeTransfer;
+import com.hedera.mirror.importer.domain.TopicMessage;
+import com.hedera.mirror.importer.domain.Transaction;
+import com.hedera.mirror.importer.exception.ImporterException;
+import com.hedera.mirror.importer.exception.ParserSQLException;
+
+import lombok.extern.log4j.Log4j2;
+
+@Log4j2
+@Named
+public class PostgresWritingRecordParsedItemHandler implements RecordParsedItemHandler {
+    private PreparedStatement sqlInsertTransferList;
+    private PreparedStatement sqlInsertNonFeeTransfers;
+
+    void initSqlStatements(Connection connection) throws ParserSQLException {
+        try {
+            sqlInsertTransferList = connection.prepareStatement("INSERT INTO t_cryptotransferlists"
+                    + " (consensus_timestamp, amount, realm_num, entity_num)"
+                    + " VALUES (?, ?, ?, ?)");
+
+            sqlInsertNonFeeTransfers = connection.prepareStatement("insert into non_fee_transfers"
+                    + " (consensus_timestamp, amount, realm_num, entity_num)"
+                    + " values (?, ?, ?, ?)");
+        } catch (SQLException e) {
+            throw new ParserSQLException("Unable to prepare SQL statements", e);
+        }
+    }
+
+    public void finish() {
+        closeStatements();
+    }
+
+    @Override
+    public void onFileComplete() {
+        executeBatches();
+    }
+
+    private void closeStatements() {
+        try {
+            sqlInsertTransferList.close();
+            sqlInsertNonFeeTransfers.close();
+        } catch (SQLException e) {
+            throw new ParserSQLException("Error closing connection", e);
+        }
+    }
+
+    void executeBatches() {
+        try {
+            int[] transferLists = sqlInsertTransferList.executeBatch();
+            int[] nonFeeTransfers = sqlInsertNonFeeTransfers.executeBatch();
+            log.info("Inserted {} transfer lists, {} non-fee transfers", transferLists.length, nonFeeTransfers.length);
+        } catch (SQLException e) {
+            log.error("Error committing sql insert batch ", e);
+            throw new ParserSQLException(e);
+        }
+    }
+
+    @Override
+    public void onTransaction(Transaction transaction) throws ImporterException {
+        // to be implemented in followup change
+    }
+
+    @Override
+    public void onCryptoTransferList(CryptoTransfer cryptoTransfer) throws ImporterException {
+        try {
+            sqlInsertTransferList.setLong(F_TRANSFERLIST.CONSENSUS_TIMESTAMP.ordinal(),
+                    cryptoTransfer.getConsensusTimestamp());
+            sqlInsertTransferList.setLong(F_TRANSFERLIST.REALM_NUM.ordinal(), cryptoTransfer.getRealmNum());
+            sqlInsertTransferList.setLong(F_TRANSFERLIST.ENTITY_NUM.ordinal(), cryptoTransfer.getEntityNum());
+            sqlInsertTransferList.setLong(F_TRANSFERLIST.AMOUNT.ordinal(), cryptoTransfer.getAmount());
+            sqlInsertTransferList.addBatch();
+        } catch (SQLException e) {
+            throw new ParserSQLException(e);
+        }
+    }
+
+    @Override
+    public void onNonFeeTransfer(NonFeeTransfer nonFeeTransfer) throws ImporterException {
+        try {
+            sqlInsertNonFeeTransfers.setLong(F_NONFEETRANSFER.CONSENSUS_TIMESTAMP.ordinal(),
+                    nonFeeTransfer.getConsensusTimestamp());
+            sqlInsertNonFeeTransfers.setLong(F_NONFEETRANSFER.AMOUNT.ordinal(), nonFeeTransfer.getAmount());
+            sqlInsertNonFeeTransfers.setLong(F_NONFEETRANSFER.REALM_NUM.ordinal(), nonFeeTransfer.getRealmNum());
+            sqlInsertNonFeeTransfers.setLong(F_NONFEETRANSFER.ENTITY_NUM.ordinal(), nonFeeTransfer.getEntityNum());
+            sqlInsertNonFeeTransfers.addBatch();
+        } catch (SQLException e) {
+            throw new ParserSQLException(e);
+        }
+    }
+
+    @Override
+    public void onTopicMessage(TopicMessage topicMessage) throws ImporterException {
+        // to be implemented in followup change
+    }
+
+    @Override
+    public void onContractResult(ContractResult contractResult) throws ImporterException {
+        // to be implemented in followup change
+    }
+
+    @Override
+    public void onFileData(FileData fileData) throws ImporterException {
+        // to be implemented in followup change
+    }
+
+    @Override
+    public void onLiveHash(LiveHash liveHash) throws ImporterException {
+        // to be implemented in followup change
+    }
+
+    @Override
+    public void onError(Throwable e) {
+        // to be implemented in followup change
+    }
+
+    enum F_TRANSFERLIST {
+        ZERO // column indices start at 1, this creates the necessary offset
+        , CONSENSUS_TIMESTAMP, AMOUNT, REALM_NUM, ENTITY_NUM
+    }
+
+    enum F_NONFEETRANSFER {
+        ZERO // column indices start at 1, this creates the necessary offset
+        , CONSENSUS_TIMESTAMP, AMOUNT, REALM_NUM, ENTITY_NUM
+    }
+}

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/PostgresWritingRecordParsedItemHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/PostgresWritingRecordParsedItemHandler.java
@@ -1,9 +1,30 @@
 package com.hedera.mirror.importer.parser.record;
 
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import javax.inject.Named;
+import lombok.extern.log4j.Log4j2;
 
 import com.hedera.mirror.importer.domain.ContractResult;
 import com.hedera.mirror.importer.domain.CryptoTransfer;
@@ -14,8 +35,6 @@ import com.hedera.mirror.importer.domain.TopicMessage;
 import com.hedera.mirror.importer.domain.Transaction;
 import com.hedera.mirror.importer.exception.ImporterException;
 import com.hedera.mirror.importer.exception.ParserSQLException;
-
-import lombok.extern.log4j.Log4j2;
 
 @Log4j2
 @Named

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/PostgresWritingRecordParserItemHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/PostgresWritingRecordParserItemHandlerTest.java
@@ -1,5 +1,25 @@
 package com.hedera.mirror.importer.parser.record;
 
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.sql.Connection;

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/PostgresWritingRecordParserItemHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/PostgresWritingRecordParserItemHandlerTest.java
@@ -1,0 +1,88 @@
+package com.hedera.mirror.importer.parser.record;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.sql.Connection;
+import javax.annotation.Resource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.jdbc.Sql;
+
+import com.hedera.mirror.importer.IntegrationTest;
+import com.hedera.mirror.importer.domain.CryptoTransfer;
+import com.hedera.mirror.importer.domain.NonFeeTransfer;
+import com.hedera.mirror.importer.repository.CryptoTransferRepository;
+import com.hedera.mirror.importer.repository.NonFeeTransferRepository;
+import com.hedera.mirror.importer.util.DatabaseUtilities;
+
+@Sql(executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD, scripts = "classpath:db/scripts/cleanup.sql")
+@Sql(executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD, scripts = "classpath:db/scripts/cleanup.sql")
+public class PostgresWritingRecordParserItemHandlerTest extends IntegrationTest {
+
+    @Resource
+    protected CryptoTransferRepository cryptoTransferRepository;
+
+    @Resource
+    protected NonFeeTransferRepository nonFeeTransferRepository;
+
+    @Resource
+    protected PostgresWritingRecordParsedItemHandler postgresWriter;
+
+    protected Connection connection;
+
+    @BeforeEach
+    final void beforeEach() throws Exception {
+        connection = DatabaseUtilities.getConnection();
+        connection.setAutoCommit(false);
+        postgresWriter.initSqlStatements(connection);
+    }
+
+    @AfterEach
+    final void afterEach() {
+        postgresWriter.finish();
+    }
+
+    void completeFileAndCommit() throws Exception {
+        postgresWriter.onFileComplete();
+        connection.commit();
+    }
+
+    @Test
+    void onCryptoTransferList() throws Exception {
+        // when
+        postgresWriter.onCryptoTransferList(new CryptoTransfer(1L, 1L, 0L, 1L));
+        postgresWriter.onCryptoTransferList(new CryptoTransfer(2L, -2L, 0L, 2L));
+        completeFileAndCommit();
+
+        // expect
+        assertEquals(2, cryptoTransferRepository.count());
+        assertTrue(cryptoTransferRepository.findByConsensusTimestampAndEntityNumAndAmount(1L, 1L, 1L).isPresent());
+        assertTrue(cryptoTransferRepository.findByConsensusTimestampAndEntityNumAndAmount(2L, 2L, -2L).isPresent());
+    }
+
+    @Test
+    void onNonFeeTransfer() throws Exception {
+        // when
+        postgresWriter.onNonFeeTransfer(new NonFeeTransfer(1L, 1L, 0L, 1L));
+        postgresWriter.onNonFeeTransfer(new NonFeeTransfer(2L, -2L, 0L, 2L));
+        completeFileAndCommit();
+
+        // expect
+        assertEquals(2, nonFeeTransferRepository.count());
+        assertTrue(nonFeeTransferRepository.findById(1L).isPresent());
+        assertTrue(nonFeeTransferRepository.findById(2L).isPresent());
+    }
+
+    @Test
+    void rollback() throws Exception {
+        // when
+        postgresWriter.onNonFeeTransfer(new NonFeeTransfer(1L, 1L, 0L, 1L));
+        postgresWriter.onCryptoTransferList(new CryptoTransfer(2L, -2L, 0L, 2L));
+        connection.rollback();
+
+        // expect
+        assertEquals(0, nonFeeTransferRepository.count());
+        assertEquals(0, cryptoTransferRepository.count());
+    }
+}


### PR DESCRIPTION
**Detailed description**:
- Add `PostgresWritingRecordParsedItemHandler`
- Move CTL and non-fee transfers to `PostgresWritingRecordParsedItemHandler`

**Which issue(s) this PR fixes**:
Partially fixes #566 

**Special notes for your reviewer**:
Locally, i had complete refactor of 566, but it was big change. Chunking it up into small PRs as requested during design review. Additionally, would like to propose following for swift progress:
- if reviewer feels that there are no critical/blocking comments, please also approve the PR. I'll address everything in the next batch of changes. That'll save precious iterations. :) Thanks.

**Checklist**
- [ ] Documentation added
- [x] Tests updated

