### PR TITLE
Use RecordItem in tests

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/domain/RecordItem.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/domain/RecordItem.java
@@ -22,10 +22,16 @@ package com.hedera.mirror.importer.parser.domain;
 
 import com.hederahashgraph.api.proto.java.Transaction;
 import com.hederahashgraph.api.proto.java.TransactionRecord;
+import lombok.AllArgsConstructor;
 import lombok.Value;
 
 @Value
+@AllArgsConstructor
 public class RecordItem implements StreamItem {
+    public RecordItem(Transaction transaction, TransactionRecord record) {
+        this(transaction, record, null, null);
+    }
+
     private final Transaction transaction;
     private final TransactionRecord record;
     private final byte[] transactionBytes;

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileLoggerContractTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileLoggerContractTest.java
@@ -51,6 +51,7 @@ import org.junit.jupiter.api.Test;
 
 import com.hedera.mirror.importer.domain.ContractResult;
 import com.hedera.mirror.importer.domain.Entities;
+import com.hedera.mirror.importer.parser.domain.RecordItem;
 import com.hedera.mirror.importer.util.Utility;
 
 public class RecordFileLoggerContractTest extends AbstractRecordFileLoggerTest {
@@ -78,8 +79,7 @@ public class RecordFileLoggerContractTest extends AbstractRecordFileLoggerTest {
         ContractCreateTransactionBody contractCreateTransactionBody = transactionBody.getContractCreateInstance();
         TransactionRecord record = createOrUpdateRecord(transactionBody);
 
-        RecordFileLogger.storeRecord(transaction, record);
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -104,16 +104,13 @@ public class RecordFileLoggerContractTest extends AbstractRecordFileLoggerTest {
                 , () -> assertTransaction(transactionBody, dbTransaction)
 
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
+                , () -> assertRecord(record)
                 , () -> assertArrayEquals(record.getContractCreateResult().toByteArray(), dbContractResults
                         .getCallResult())
                 , () -> assertEquals(record.getContractCreateResult().getGasUsed(), dbContractResults.getGasUsed())
 
                 // receipt
                 , () -> assertContract(record.getReceipt().getContractID(), dbContractEntity)
-
-                // record transfer list
-                , () -> assertRecordTransfers(record)
 
                 // transaction body inputs
                 , () -> assertEquals(contractCreateTransactionBody.getAutoRenewPeriod().getSeconds(), dbContractEntity
@@ -142,8 +139,7 @@ public class RecordFileLoggerContractTest extends AbstractRecordFileLoggerTest {
         TransactionRecord record = createOrUpdateRecord(transactionBody,
                 ResponseCodeEnum.INSUFFICIENT_ACCOUNT_BALANCE);
 
-        RecordFileLogger.storeRecord(transaction, record);
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -166,13 +162,10 @@ public class RecordFileLoggerContractTest extends AbstractRecordFileLoggerTest {
                 , () -> assertTransaction(transactionBody, dbTransaction)
 
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
+                , () -> assertRecord(record)
 
                 // receipt
                 , () -> assertContract(record.getReceipt().getContractID(), dbContractEntity)
-
-                // record transfer list
-                , () -> assertRecordTransfers(record)
 
                 // transaction body inputs
                 , () -> assertEquals(contractCreateTransactionBody.getAutoRenewPeriod().getSeconds(), dbContractEntity
@@ -199,8 +192,7 @@ public class RecordFileLoggerContractTest extends AbstractRecordFileLoggerTest {
         ContractCreateTransactionBody contractCreateTransactionBody = transactionBody.getContractCreateInstance();
         TransactionRecord record = createOrUpdateRecord(transactionBody);
 
-        RecordFileLogger.storeRecord(transaction, record);
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -227,13 +219,10 @@ public class RecordFileLoggerContractTest extends AbstractRecordFileLoggerTest {
                 , () -> assertTransaction(transactionBody, dbTransaction)
 
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
+                , () -> assertRecord(record)
 
                 // receipt
                 , () -> assertContract(record.getReceipt().getContractID(), dbContractEntity)
-
-                // record transfer list
-                , () -> assertRecordTransfers(record)
 
                 // transaction body inputs
                 , () -> assertEquals(contractCreateTransactionBody.getAutoRenewPeriod().getSeconds(), dbContractEntity
@@ -266,9 +255,7 @@ public class RecordFileLoggerContractTest extends AbstractRecordFileLoggerTest {
         TransactionRecord record = createOrUpdateRecord(transactionBody);
         ContractUpdateTransactionBody contractUpdateTransactionBody = transactionBody.getContractUpdateInstance();
 
-        RecordFileLogger.storeRecord(transaction, record);
-
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -291,13 +278,10 @@ public class RecordFileLoggerContractTest extends AbstractRecordFileLoggerTest {
                 , () -> assertTransaction(transactionBody, dbTransaction)
 
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
+                , () -> assertRecord(record)
 
                 // receipt
                 , () -> assertContract(record.getReceipt().getContractID(), dbContractEntity)
-
-                // record transfer list
-                , () -> assertRecordTransfers(record)
 
                 // transaction body inputs
                 , () -> assertEquals(contractUpdateTransactionBody.getAutoRenewPeriod().getSeconds(), dbContractEntity
@@ -324,9 +308,7 @@ public class RecordFileLoggerContractTest extends AbstractRecordFileLoggerTest {
         TransactionRecord record = createOrUpdateRecord(transactionBody);
         ContractUpdateTransactionBody contractUpdateTransactionBody = transactionBody.getContractUpdateInstance();
 
-        RecordFileLogger.storeRecord(transaction, record);
-
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -349,13 +331,10 @@ public class RecordFileLoggerContractTest extends AbstractRecordFileLoggerTest {
                 , () -> assertTransaction(transactionBody, dbTransaction)
 
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
+                , () -> assertRecord(record)
 
                 // receipt
                 , () -> assertContract(record.getReceipt().getContractID(), dbContractEntity)
-
-                // record transfer list
-                , () -> assertRecordTransfers(record)
 
                 // transaction body inputs
                 , () -> assertEquals(contractUpdateTransactionBody.getAutoRenewPeriod().getSeconds(), dbContractEntity
@@ -391,9 +370,7 @@ public class RecordFileLoggerContractTest extends AbstractRecordFileLoggerTest {
         TransactionRecord record = createOrUpdateRecord(transactionBody,
                 ResponseCodeEnum.INSUFFICIENT_ACCOUNT_BALANCE);
 
-        RecordFileLogger.storeRecord(transaction, record);
-
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -416,13 +393,10 @@ public class RecordFileLoggerContractTest extends AbstractRecordFileLoggerTest {
                 , () -> assertTransaction(transactionBody, dbTransaction)
 
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
+                , () -> assertRecord(record)
 
                 // receipt
                 , () -> assertContract(record.getReceipt().getContractID(), dbContractEntity)
-
-                // record transfer list
-                , () -> assertRecordTransfers(record)
 
                 // transaction body inputs
                 , () -> assertEquals(contractCreateTransactionBody.getAutoRenewPeriod().getSeconds(), dbContractEntity
@@ -453,9 +427,7 @@ public class RecordFileLoggerContractTest extends AbstractRecordFileLoggerTest {
         TransactionBody transactionBody = TransactionBody.parseFrom(transaction.getBodyBytes());
         TransactionRecord record = createOrUpdateRecord(transactionBody);
 
-        RecordFileLogger.storeRecord(transaction, record);
-
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -476,13 +448,10 @@ public class RecordFileLoggerContractTest extends AbstractRecordFileLoggerTest {
                 , () -> assertTransaction(transactionBody, dbTransaction)
 
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
+                , () -> assertRecord(record)
 
                 // receipt
                 , () -> assertContract(record.getReceipt().getContractID(), dbContractEntity)
-
-                // record transfer list
-                , () -> assertRecordTransfers(record)
 
                 // transaction body inputs
                 , () -> assertTrue(dbContractEntity.isDeleted())
@@ -503,9 +472,7 @@ public class RecordFileLoggerContractTest extends AbstractRecordFileLoggerTest {
         TransactionBody transactionBody = TransactionBody.parseFrom(transaction.getBodyBytes());
         TransactionRecord record = createOrUpdateRecord(transactionBody);
 
-        RecordFileLogger.storeRecord(transaction, record);
-
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -526,13 +493,10 @@ public class RecordFileLoggerContractTest extends AbstractRecordFileLoggerTest {
                 , () -> assertTransaction(transactionBody, dbTransaction)
 
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
+                , () -> assertRecord(record)
 
                 // receipt
                 , () -> assertContract(record.getReceipt().getContractID(), dbContractEntity)
-
-                // record transfer list
-                , () -> assertRecordTransfers(record)
 
                 // transaction body inputs
                 , () -> assertTrue(dbContractEntity.isDeleted())
@@ -554,9 +518,7 @@ public class RecordFileLoggerContractTest extends AbstractRecordFileLoggerTest {
         TransactionRecord record = createOrUpdateRecord(transactionBody,
                 ResponseCodeEnum.INSUFFICIENT_ACCOUNT_BALANCE);
 
-        RecordFileLogger.storeRecord(transaction, record);
-
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -577,13 +539,10 @@ public class RecordFileLoggerContractTest extends AbstractRecordFileLoggerTest {
                 , () -> assertTransaction(transactionBody, dbTransaction)
 
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
+                , () -> assertRecord(record)
 
                 // receipt
                 , () -> assertContract(record.getReceipt().getContractID(), dbContractEntity)
-
-                // record transfer list
-                , () -> assertRecordTransfers(record)
 
                 // transaction body inputs
                 , () -> assertFalse(dbContractEntity.isDeleted())
@@ -613,9 +572,7 @@ public class RecordFileLoggerContractTest extends AbstractRecordFileLoggerTest {
         TransactionRecord record = callRecord(transactionBody);
         ContractCallTransactionBody contractCallTransactionBody = transactionBody.getContractCall();
 
-        RecordFileLogger.storeRecord(transaction, record);
-
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -638,16 +595,13 @@ public class RecordFileLoggerContractTest extends AbstractRecordFileLoggerTest {
                 , () -> assertTransaction(transactionBody, dbTransaction)
 
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
+                , () -> assertRecord(record)
                 , () -> assertArrayEquals(record.getContractCallResult().toByteArray(), dbContractResults
                         .getCallResult())
                 , () -> assertEquals(record.getContractCallResult().getGasUsed(), dbContractResults.getGasUsed())
 
                 // receipt
                 , () -> assertContract(record.getReceipt().getContractID(), dbContractEntity)
-
-                // record transfer list
-                , () -> assertRecordTransfers(record)
 
                 // transaction body inputs
                 , () -> assertArrayEquals(contractCallTransactionBody.getFunctionParameters()
@@ -668,9 +622,7 @@ public class RecordFileLoggerContractTest extends AbstractRecordFileLoggerTest {
         TransactionRecord record = callRecord(transactionBody);
         ContractCallTransactionBody contractCallTransactionBody = transactionBody.getContractCall();
 
-        RecordFileLogger.storeRecord(transaction, record);
-
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -693,16 +645,13 @@ public class RecordFileLoggerContractTest extends AbstractRecordFileLoggerTest {
                 , () -> assertTransaction(transactionBody, dbTransaction)
 
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
+                , () -> assertRecord(record)
                 , () -> assertArrayEquals(record.getContractCallResult().toByteArray(), dbContractResults
                         .getCallResult())
                 , () -> assertEquals(record.getContractCallResult().getGasUsed(), dbContractResults.getGasUsed())
 
                 // receipt
                 , () -> assertContract(record.getReceipt().getContractID(), dbContractEntity)
-
-                // record transfer list
-                , () -> assertRecordTransfers(record)
 
                 // transaction body inputs
                 , () -> assertArrayEquals(contractCallTransactionBody.getFunctionParameters()
@@ -722,9 +671,7 @@ public class RecordFileLoggerContractTest extends AbstractRecordFileLoggerTest {
         TransactionBody transactionBody = TransactionBody.parseFrom(transaction.getBodyBytes());
         TransactionRecord record = callRecord(transactionBody, ResponseCodeEnum.INSUFFICIENT_ACCOUNT_BALANCE);
 
-        RecordFileLogger.storeRecord(transaction, record);
-
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -745,13 +692,10 @@ public class RecordFileLoggerContractTest extends AbstractRecordFileLoggerTest {
                 , () -> assertTransaction(transactionBody, dbTransaction)
 
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
+                , () -> assertRecord(record)
 
                 // receipt
                 , () -> assertContract(record.getReceipt().getContractID(), dbContractEntity)
-
-                // record transfer list
-                , () -> assertRecordTransfers(record)
 
                 // Additional entity checks
                 , () -> assertFalse(dbContractEntity.isDeleted())
@@ -769,9 +713,7 @@ public class RecordFileLoggerContractTest extends AbstractRecordFileLoggerTest {
         TransactionBody transactionBody = TransactionBody.parseFrom(transaction.getBodyBytes());
         TransactionRecord record = callRecord(transactionBody);
 
-        RecordFileLogger.storeRecord(transaction, record);
-
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -791,13 +733,10 @@ public class RecordFileLoggerContractTest extends AbstractRecordFileLoggerTest {
                 , () -> assertTransaction(transactionBody, dbTransaction)
 
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
+                , () -> assertRecord(record)
 
                 // receipt
                 , () -> assertContract(record.getReceipt().getContractID(), dbContractEntity)
-
-                // record transfer list
-                , () -> assertRecordTransfers(record)
 
                 // Additional entity checks
                 , () -> assertFalse(dbContractEntity.isDeleted())

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileLoggerCryptoTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileLoggerCryptoTest.java
@@ -54,6 +54,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 import com.hedera.mirror.importer.domain.CryptoTransfer;
 import com.hedera.mirror.importer.domain.Entities;
 import com.hedera.mirror.importer.domain.LiveHash;
+import com.hedera.mirror.importer.parser.domain.RecordItem;
 import com.hedera.mirror.importer.util.Utility;
 
 public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
@@ -91,8 +92,7 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
         CryptoCreateTransactionBody cryptoCreateTransactionBody = transactionBody.getCryptoCreateAccount();
         TransactionRecord record = transactionRecordSuccess(transactionBody);
 
-        RecordFileLogger.storeRecord(transaction, record);
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -114,12 +114,9 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
                 // transaction
                 , () -> assertTransaction(transactionBody, dbTransaction)
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
+                , () -> assertRecord(record)
                 // receipt
                 , () -> assertAccount(record.getReceipt().getAccountID(), dbNewAccountEntity)
-
-                // record transfer list
-                , () -> assertRecordTransfers(record)
 
                 // transaction body inputs
                 , () -> assertEquals(cryptoCreateTransactionBody.getAutoRenewPeriod().getSeconds(), dbNewAccountEntity
@@ -171,8 +168,7 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
         CryptoCreateTransactionBody cryptoCreateTransactionBody = transactionBody.getCryptoCreateAccount();
         TransactionRecord record = transactionRecordSuccess(transactionBody);
 
-        RecordFileLogger.storeRecord(transaction, record);
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -199,12 +195,9 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
                 // transaction
                 , () -> assertTransaction(transactionBody, dbTransaction)
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
+                , () -> assertRecord(record)
                 // receipt
                 , () -> assertAccount(record.getReceipt().getAccountID(), dbNewAccountEntity)
-
-                // record transfer list
-                , () -> assertRecordTransfers(record)
 
                 // transaction body inputs
                 , () -> assertEquals(cryptoCreateTransactionBody.getAutoRenewPeriod().getSeconds(), dbNewAccountEntity
@@ -240,8 +233,7 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
         TransactionRecord record = transactionRecord(transactionBody,
                 ResponseCodeEnum.INSUFFICIENT_PAYER_BALANCE);
 
-        RecordFileLogger.storeRecord(transaction, record);
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -263,12 +255,9 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
                 // transaction
                 , () -> assertTransaction(transactionBody, dbTransaction)
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
+                , () -> assertRecord(record)
                 // receipt
                 , () -> assertAccount(record.getReceipt().getAccountID(), dbNewAccountEntity)
-
-                // record transfer list
-                , () -> assertRecordTransfers(record)
 
                 // transaction body inputs
                 , () -> assertEquals(cryptoCreateTransactionBody.getAutoRenewPeriod().getSeconds(), dbNewAccountEntity
@@ -307,8 +296,7 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
                 .setAmount(-initialBalance));
         TransactionRecord record = tempRecord.toBuilder().setTransferList(transferList).build();
 
-        RecordFileLogger.storeRecord(transaction, record);
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -330,12 +318,9 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
                 // transaction
                 , () -> assertTransaction(transactionBody, dbTransaction)
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
+                , () -> assertRecord(record)
                 // receipt
                 , () -> assertAccount(record.getReceipt().getAccountID(), dbNewAccountEntity)
-
-                // record transfer list
-                , () -> assertRecordTransfers(record)
 
                 // transaction body inputs
                 , () -> assertEquals(cryptoCreateTransactionBody.getAutoRenewPeriod().getSeconds(), dbNewAccountEntity
@@ -370,8 +355,7 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
         CryptoCreateTransactionBody cryptoCreateTransactionBody = transactionBody.getCryptoCreateAccount();
         TransactionRecord record = transactionRecordSuccess(transactionBody);
 
-        RecordFileLogger.storeRecord(transaction, record);
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -393,12 +377,9 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
                 // transaction
                 , () -> assertTransaction(transactionBody, dbTransaction)
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
+                , () -> assertRecord(record)
                 // receipt
                 , () -> assertAccount(record.getReceipt().getAccountID(), dbNewAccountEntity)
-
-                // record transfer list
-                , () -> assertRecordTransfers(record)
 
                 // transaction body inputs
                 , () -> assertEquals(cryptoCreateTransactionBody.getAutoRenewPeriod().getSeconds(), dbNewAccountEntity
@@ -435,8 +416,7 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
         CryptoUpdateTransactionBody cryptoUpdateTransactionBody = transactionBody.getCryptoUpdateAccount();
         TransactionRecord record = transactionRecordSuccess(transactionBody);
 
-        RecordFileLogger.storeRecord(transaction, record);
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -458,12 +438,9 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
                 // transaction
                 , () -> assertTransaction(transactionBody, dbTransaction)
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
+                , () -> assertRecord(record)
                 // receipt
                 , () -> assertAccount(record.getReceipt().getAccountID(), dbAccountEntity)
-
-                // record transfer list
-                , () -> assertRecordTransfers(record)
 
                 // transaction body inputs
                 , () -> assertEquals(cryptoUpdateTransactionBody.getAutoRenewPeriod().getSeconds(), dbAccountEntity
@@ -499,8 +476,7 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
         CryptoUpdateTransactionBody cryptoUpdateTransactionBody = transactionBody.getCryptoUpdateAccount();
         TransactionRecord record = transactionRecordSuccess(transactionBody);
 
-        RecordFileLogger.storeRecord(transaction, record);
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
     }
 
     @DisplayName("update account such that expiration timestamp overflows nanos_timestamp")
@@ -565,8 +541,7 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
         TransactionRecord record = transactionRecord(transactionBody,
                 ResponseCodeEnum.INSUFFICIENT_ACCOUNT_BALANCE);
 
-        RecordFileLogger.storeRecord(transaction, record);
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbCreateTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(createRecord.getConsensusTimestamp())).get();
@@ -591,11 +566,9 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
                 // transaction
                 , () -> assertTransaction(transactionBody, dbTransaction)
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
+                , () -> assertRecord(record)
                 // receipt
                 , () -> assertAccount(record.getReceipt().getAccountID(), dbAccountEntity)
-                // record transfer list
-                , () -> assertRecordTransfers(record)
                 // no changes to entity
                 , () -> assertEquals(dbAccountEntityBefore, dbAccountEntity)
         );
@@ -619,8 +592,7 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
         TransactionBody transactionBody = TransactionBody.parseFrom(transaction.getBodyBytes());
         TransactionRecord record = transactionRecordSuccess(transactionBody);
 
-        RecordFileLogger.storeRecord(transaction, record);
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -642,12 +614,9 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
                 // transaction
                 , () -> assertTransaction(transactionBody, dbTransaction)
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
+                , () -> assertRecord(record)
                 // receipt
                 , () -> assertAccount(record.getReceipt().getAccountID(), dbAccountEntity)
-
-                // record transfer list
-                , () -> assertRecordTransfers(record)
 
                 // transaction body inputs
                 , () -> assertTrue(dbAccountEntity.isDeleted())
@@ -680,8 +649,7 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
         TransactionRecord record = transactionRecord(transactionBody,
                 ResponseCodeEnum.INSUFFICIENT_ACCOUNT_BALANCE);
 
-        RecordFileLogger.storeRecord(transaction, record);
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -703,12 +671,9 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
                 // transaction
                 , () -> assertTransaction(transactionBody, dbTransaction)
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
+                , () -> assertRecord(record)
                 // receipt
                 , () -> assertAccount(record.getReceipt().getAccountID(), dbAccountEntity)
-
-                // record transfer list
-                , () -> assertRecordTransfers(record)
 
                 // transaction body inputs
                 , () -> assertFalse(dbAccountEntity.isDeleted())
@@ -741,8 +706,7 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
         CryptoAddClaimTransactionBody cryptoAddClaimTransactionBody = transactionBody.getCryptoAddClaim();
         TransactionRecord record = transactionRecordSuccess(transactionBody);
 
-        RecordFileLogger.storeRecord(transaction, record);
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -763,12 +727,9 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
                 // transaction
                 , () -> assertTransaction(transactionBody, dbTransaction)
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
+                , () -> assertRecord(record)
                 // receipt
                 , () -> assertAccount(record.getReceipt().getAccountID(), dbAccountEntity)
-
-                // record transfer list
-                , () -> assertRecordTransfers(record)
 
                 // transaction body inputs
                 , () -> assertAccount(cryptoAddClaimTransactionBody.getClaim().getAccountID(), dbAccountEntity)
@@ -797,8 +758,7 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
         CryptoAddClaimTransactionBody cryptoAddClaimTransactionBody = transactionBody.getCryptoAddClaim();
         TransactionRecord record = transactionRecordSuccess(transactionBody);
 
-        RecordFileLogger.storeRecord(transaction, record);
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -818,12 +778,9 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
                 // transaction
                 , () -> assertTransaction(transactionBody, dbTransaction)
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
+                , () -> assertRecord(record)
                 // receipt
                 , () -> assertAccount(record.getReceipt().getAccountID(), dbAccountEntity)
-
-                // record transfer list
-                , () -> assertRecordTransfers(record)
 
                 // transaction body inputs
                 , () -> assertAccount(cryptoAddClaimTransactionBody.getClaim().getAccountID(), dbAccountEntity)
@@ -856,8 +813,7 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
         CryptoDeleteClaimTransactionBody deleteClaimTransactionBody = transactionBody.getCryptoDeleteClaim();
         TransactionRecord record = transactionRecordSuccess(transactionBody);
 
-        RecordFileLogger.storeRecord(transaction, record);
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -876,12 +832,9 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
                 // transaction
                 , () -> assertTransaction(transactionBody, dbTransaction)
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
+                , () -> assertRecord(record)
                 // receipt
                 , () -> assertAccount(record.getReceipt().getAccountID(), dbAccountEntity)
-
-                // record transfer list
-                , () -> assertRecordTransfers(record)
 
                 // transaction body inputs
                 , () -> assertAccount(deleteClaimTransactionBody.getAccountIDToDeleteFrom(), dbAccountEntity)
@@ -900,9 +853,7 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
         TransactionBody transactionBody = TransactionBody.parseFrom(transaction.getBodyBytes());
         TransactionRecord record = transactionRecordSuccess(transactionBody);
 
-        RecordFileLogger.storeRecord(transaction, record);
-
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -920,10 +871,7 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
                 // transaction
                 , () -> assertTransaction(transactionBody, dbTransaction)
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
-
-                // record transfer list
-                , () -> assertRecordTransfers(record)
+                , () -> assertRecord(record)
         );
 
         // Crypto transfer list
@@ -938,9 +886,7 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
         TransactionBody transactionBody = TransactionBody.parseFrom(transaction.getBodyBytes());
         TransactionRecord record = transactionRecordSuccess(transactionBody);
 
-        RecordFileLogger.storeRecord(transaction, record);
-
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -958,7 +904,7 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
                 // transaction
                 , () -> assertTransaction(transactionBody, dbTransaction)
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
+                , () -> assertRecord(record)
         );
 
         // Crypto transfer list
@@ -984,8 +930,7 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
         CryptoCreateTransactionBody cryptoCreateTransactionBody = transactionBody.getCryptoCreateAccount();
         TransactionRecord record = transactionRecord(transactionBody, unknownResult);
 
-        RecordFileLogger.storeRecord(transaction, record);
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
 
         org.assertj.core.api.Assertions.assertThat(transactionRepository.findAll())
                 .hasSize(1)
@@ -1013,8 +958,7 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
 
         TransactionRecord record = transactionRecordSuccess(transactionBody);
 
-        RecordFileLogger.storeRecord(transaction, record);
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
 
         org.assertj.core.api.Assertions.assertThat(transactionRepository.findAll())
                 .hasSize(1)

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileLoggerFileTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileLoggerFileTest.java
@@ -58,6 +58,7 @@ import com.hedera.mirror.importer.MirrorProperties;
 import com.hedera.mirror.importer.addressbook.NetworkAddressBook;
 import com.hedera.mirror.importer.domain.Entities;
 import com.hedera.mirror.importer.domain.FileData;
+import com.hedera.mirror.importer.parser.domain.RecordItem;
 import com.hedera.mirror.importer.util.Utility;
 
 public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
@@ -100,8 +101,7 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
         FileCreateTransactionBody fileCreateTransactionBody = transactionBody.getFileCreate();
         TransactionRecord record = transactionRecord(transactionBody);
 
-        RecordFileLogger.storeRecord(transaction, record);
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -123,13 +123,10 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
                 , () -> assertTransaction(transactionBody, dbTransaction)
 
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
+                , () -> assertRecord(record)
 
                 // receipt
                 , () -> assertFile(record.getReceipt().getFileID(), dbFileEntity)
-
-                // record transfer list
-                , () -> assertRecordTransfers(record)
 
                 // transaction body inputs
                 , () -> assertEquals(Utility
@@ -156,8 +153,7 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
         TransactionBody transactionBody = TransactionBody.parseFrom(transaction.getBodyBytes());
         TransactionRecord record = transactionRecord(transactionBody);
 
-        RecordFileLogger.storeRecord(transaction, record);
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -178,13 +174,10 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
                 , () -> assertTransaction(transactionBody, dbTransaction)
 
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
+                , () -> assertRecord(record)
 
                 // receipt
                 , () -> assertFile(record.getReceipt().getFileID(), dbFileEntity)
-
-                // record transfer list
-                , () -> assertRecordTransfers(record)
         );
     }
 
@@ -197,8 +190,7 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
         TransactionRecord record = transactionRecord(transactionBody, FileID.newBuilder().setShardNum(0)
                 .setRealmNum(0).setFileNum(10).build());
 
-        RecordFileLogger.storeRecord(transaction, record);
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -220,13 +212,10 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
                 , () -> assertTransaction(transactionBody, dbTransaction)
 
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
+                , () -> assertRecord(record)
 
                 // receipt
                 , () -> assertFile(record.getReceipt().getFileID(), dbFileEntity)
-
-                // record transfer list
-                , () -> assertRecordTransfers(record)
 
                 // transaction body inputs
                 , () -> assertEquals(Utility
@@ -254,8 +243,7 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
         TransactionRecord record = transactionRecord(transactionBody, FileID.newBuilder().setShardNum(0)
                 .setRealmNum(0).setFileNum(2000).build());
 
-        RecordFileLogger.storeRecord(transaction, record);
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -276,13 +264,10 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
                 , () -> assertTransaction(transactionBody, dbTransaction)
 
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
+                , () -> assertRecord(record)
 
                 // receipt
                 , () -> assertFile(record.getReceipt().getFileID(), dbFileEntity)
-
-                // record transfer list
-                , () -> assertRecordTransfers(record)
 
                 // transaction body inputs
                 , () -> assertEquals(Utility
@@ -309,8 +294,7 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
         TransactionBody transactionBody = TransactionBody.parseFrom(transaction.getBodyBytes());
         TransactionRecord record = transactionRecord(transactionBody);
 
-        RecordFileLogger.storeRecord(transaction, record);
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
 
         var dbTransaction = transactionRepository.findById(Utility.timeStampInNanos(record.getConsensusTimestamp()))
                 .get();
@@ -334,9 +318,7 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
         FileAppendTransactionBody fileAppendTransactionBody = transactionBody.getFileAppend();
         TransactionRecord record = transactionRecord(transactionBody);
 
-        RecordFileLogger.storeRecord(transaction, record);
-
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -358,13 +340,10 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
                 , () -> assertTransaction(transactionBody, dbTransaction)
 
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
+                , () -> assertRecord(record)
 
                 // receipt
                 , () -> assertFile(record.getReceipt().getFileID(), dbFileEntity)
-
-                // record transfer list
-                , () -> assertRecordTransfers(record)
 
                 // file data
                 , () -> assertArrayEquals(fileAppendTransactionBody.getContents().toByteArray(), dbfileData
@@ -386,9 +365,7 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
         FileAppendTransactionBody fileAppendTransactionBody = transactionBody.getFileAppend();
         TransactionRecord record = transactionRecord(transactionBody);
 
-        RecordFileLogger.storeRecord(transaction, record);
-
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -410,13 +387,10 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
                 , () -> assertTransaction(transactionBody, dbTransaction)
 
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
+                , () -> assertRecord(record)
 
                 // receipt
                 , () -> assertFile(record.getReceipt().getFileID(), dbFileEntity)
-
-                // record transfer list
-                , () -> assertRecordTransfers(record)
 
                 // file data
                 , () -> assertArrayEquals(fileAppendTransactionBody.getContents().toByteArray(), dbfileData
@@ -443,9 +417,7 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
         parserProperties.setPersistFiles(true);
         parserProperties.setPersistSystemFiles(true);
 
-        RecordFileLogger.storeRecord(transaction, record);
-
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -467,13 +439,10 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
                 , () -> assertTransaction(transactionBody, dbTransaction)
 
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
+                , () -> assertRecord(record)
 
                 // receipt
                 , () -> assertFile(record.getReceipt().getFileID(), dbFileEntity)
-
-                // record transfer list
-                , () -> assertRecordTransfers(record)
 
                 // file data
                 , () -> assertArrayEquals(fileAppendTransactionBody.getContents().toByteArray(), dbfileData
@@ -503,9 +472,7 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
         TransactionRecord record = transactionRecord(transactionBody);
         FileUpdateTransactionBody fileUpdateTransactionBody = transactionBody.getFileUpdate();
 
-        RecordFileLogger.storeRecord(transaction, record);
-
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -527,13 +494,10 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
                 , () -> assertTransaction(transactionBody, dbTransaction)
 
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
+                , () -> assertRecord(record)
 
                 // receipt
                 , () -> assertFile(record.getReceipt().getFileID(), dbFileEntity)
-
-                // record transfer list
-                , () -> assertRecordTransfers(record)
 
                 // transaction body inputs
                 , () -> assertEquals(Utility
@@ -569,9 +533,7 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
         TransactionRecord record = transactionRecord(transactionBody,
                 ResponseCodeEnum.INSUFFICIENT_PAYER_BALANCE);
 
-        RecordFileLogger.storeRecord(transaction, record);
-
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -592,13 +554,10 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
                 , () -> assertTransaction(transactionBody, dbTransaction)
 
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
+                , () -> assertRecord(record)
 
                 // receipt
                 , () -> assertFile(record.getReceipt().getFileID(), dbFileEntity)
-
-                // record transfer list
-                , () -> assertRecordTransfers(record)
 
                 // transaction body inputs
                 , () -> assertEquals(Utility
@@ -628,9 +587,7 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
         TransactionRecord record = transactionRecord(transactionBody, FileID.newBuilder().setShardNum(0)
                 .setRealmNum(0).setFileNum(102).build());
 
-        RecordFileLogger.storeRecord(transaction, record);
-
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -652,13 +609,10 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
                 , () -> assertTransaction(transactionBody, dbTransaction)
 
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
+                , () -> assertRecord(record)
 
                 // receipt
                 , () -> assertFile(record.getReceipt().getFileID(), dbFileEntity)
-
-                // record transfer list
-                , () -> assertRecordTransfers(record)
 
                 // file data
                 , () -> assertArrayEquals(fileAppendTransactionBody.getContents().toByteArray(), dbfileData
@@ -684,9 +638,7 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
         FileUpdateTransactionBody fileUpdateTransactionBody = transactionBody.getFileUpdate();
         TransactionRecord record = transactionRecord(transactionBody);
 
-        RecordFileLogger.storeRecord(transaction, record);
-
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -708,13 +660,10 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
                 , () -> assertTransaction(transactionBody, dbTransaction)
 
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
+                , () -> assertRecord(record)
 
                 // receipt
                 , () -> assertFile(record.getReceipt().getFileID(), dbFileEntity)
-
-                // record transfer list
-                , () -> assertRecordTransfers(record)
 
                 // transaction body inputs
                 , () -> assertEquals(Utility
@@ -749,9 +698,7 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
         TransactionRecord record = transactionRecord(transactionBody);
         FileUpdateTransactionBody fileUpdateTransactionBody = transactionBody.getFileUpdate();
 
-        RecordFileLogger.storeRecord(transaction, record);
-
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -773,13 +720,10 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
                 , () -> assertTransaction(transactionBody, dbTransaction)
 
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
+                , () -> assertRecord(record)
 
                 // receipt
                 , () -> assertFile(record.getReceipt().getFileID(), dbFileEntity)
-
-                // record transfer list
-                , () -> assertRecordTransfers(record)
 
                 // transaction body inputs
                 , () -> assertNotNull(dbFileEntity.getExpiryTimeNs())
@@ -804,9 +748,7 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
         FileUpdateTransactionBody fileUpdateTransactionBody = transactionBody.getFileUpdate();
         TransactionRecord record = transactionRecord(transactionBody);
 
-        RecordFileLogger.storeRecord(transaction, record);
-
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -828,16 +770,10 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
                 , () -> assertTransaction(transactionBody, dbTransaction)
 
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
+                , () -> assertRecord(record)
 
                 // receipt
                 , () -> assertFile(record.getReceipt().getFileID(), dbFileEntity)
-
-                // record transfer list
-                , () -> assertRecordTransfers(record)
-
-                // transaction body inputs
-                , () -> assertNull(dbFileEntity.getExpiryTimeNs())
                 , () -> assertNull(dbFileEntity.getKey())
 
                 // file data
@@ -867,9 +803,7 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
         TransactionRecord record = transactionRecord(transactionBody);
         FileUpdateTransactionBody fileUpdateTransactionBody = transactionBody.getFileUpdate();
 
-        RecordFileLogger.storeRecord(transaction, record);
-
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -891,13 +825,10 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
                 , () -> assertTransaction(transactionBody, dbTransaction)
 
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
+                , () -> assertRecord(record)
 
                 // receipt
                 , () -> assertFile(record.getReceipt().getFileID(), dbFileEntity)
-
-                // record transfer list
-                , () -> assertRecordTransfers(record)
 
                 // transaction body inputs
                 , () -> assertEquals(Utility
@@ -920,9 +851,7 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
         FileUpdateTransactionBody fileUpdateTransactionBody = transactionBody.getFileUpdate();
         TransactionRecord record = transactionRecord(transactionBody);
 
-        RecordFileLogger.storeRecord(transaction, record);
-
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -944,13 +873,10 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
                 , () -> assertTransaction(transactionBody, dbTransaction)
 
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
+                , () -> assertRecord(record)
 
                 // receipt
                 , () -> assertFile(record.getReceipt().getFileID(), dbFileEntity)
-
-                // record transfer list
-                , () -> assertRecordTransfers(record)
 
                 // transaction body inputs
                 , () -> assertEquals(Utility
@@ -981,9 +907,7 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
         TransactionRecord record = transactionRecord(transactionBody);
         FileUpdateTransactionBody fileUpdateTransactionBody = transactionBody.getFileUpdate();
 
-        RecordFileLogger.storeRecord(transaction, record);
-
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -1005,13 +929,10 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
                 , () -> assertTransaction(transactionBody, dbTransaction)
 
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
+                , () -> assertRecord(record)
 
                 // receipt
                 , () -> assertFile(record.getReceipt().getFileID(), dbFileEntity)
-
-                // record transfer list
-                , () -> assertRecordTransfers(record)
 
                 // transaction body inputs
                 , () -> assertNotNull(dbFileEntity.getExpiryTimeNs())
@@ -1032,9 +953,7 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
         FileUpdateTransactionBody fileUpdateTransactionBody = transactionBody.getFileUpdate();
         TransactionRecord record = transactionRecord(transactionBody);
 
-        RecordFileLogger.storeRecord(transaction, record);
-
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -1056,13 +975,10 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
                 , () -> assertTransaction(transactionBody, dbTransaction)
 
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
+                , () -> assertRecord(record)
 
                 // receipt
                 , () -> assertFile(record.getReceipt().getFileID(), dbFileEntity)
-
-                // record transfer list
-                , () -> assertRecordTransfers(record)
 
                 // transaction body inputs
                 , () -> assertNull(dbFileEntity.getExpiryTimeNs())
@@ -1088,9 +1004,7 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
         parserProperties.setPersistFiles(true);
         parserProperties.setPersistSystemFiles(true);
 
-        RecordFileLogger.storeRecord(transaction, record);
-
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -1112,13 +1026,10 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
                 , () -> assertTransaction(transactionBody, dbTransaction)
 
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
+                , () -> assertRecord(record)
 
                 // receipt
                 , () -> assertFile(record.getReceipt().getFileID(), dbFileEntity)
-
-                // record transfer list
-                , () -> assertRecordTransfers(record)
 
                 // transaction body inputs
                 , () -> assertEquals(Utility
@@ -1150,9 +1061,7 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
         parserProperties.setPersistFiles(true);
         parserProperties.setPersistSystemFiles(true);
 
-        RecordFileLogger.storeRecord(transaction, record);
-
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -1174,13 +1083,10 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
                 , () -> assertTransaction(transactionBody, dbTransaction)
 
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
+                , () -> assertRecord(record)
 
                 // receipt
                 , () -> assertFile(record.getReceipt().getFileID(), dbFileEntity)
-
-                // record transfer list
-                , () -> assertRecordTransfers(record)
 
                 // transaction body inputs
                 , () -> assertEquals(Utility
@@ -1218,9 +1124,7 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
         TransactionBody transactionBody = TransactionBody.parseFrom(transaction.getBodyBytes());
         TransactionRecord record = transactionRecord(transactionBody);
 
-        RecordFileLogger.storeRecord(transaction, record);
-
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -1241,13 +1145,10 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
                 , () -> assertTransaction(transactionBody, dbTransaction)
 
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
+                , () -> assertRecord(record)
 
                 // receipt
                 , () -> assertFile(record.getReceipt().getFileID(), dbFileEntity)
-
-                // record transfer list
-                , () -> assertRecordTransfers(record)
 
                 // transaction body inputs
                 , () -> assertTrue(dbFileEntity.isDeleted())
@@ -1290,13 +1191,10 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
                 , () -> assertTransaction(transactionBody, dbTransaction)
 
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
+                , () -> assertRecord(record)
 
                 // receipt
                 , () -> assertFile(record.getReceipt().getFileID(), dbFileEntity)
-
-                // record transfer list
-                , () -> assertRecordTransfers(record)
 
                 // transaction body inputs
                 , () -> assertTrue(dbFileEntity.isDeleted())
@@ -1340,13 +1238,10 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
                 , () -> assertTransaction(transactionBody, dbTransaction)
 
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
+                , () -> assertRecord(record)
 
                 // receipt
                 , () -> assertFile(record.getReceipt().getFileID(), dbFileEntity)
-
-                // record transfer list
-                , () -> assertRecordTransfers(record)
 
                 // transaction body inputs
                 , () -> assertFalse(dbFileEntity.isDeleted())
@@ -1389,13 +1284,10 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
                 , () -> assertTransaction(transactionBody, dbTransaction)
 
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
+                , () -> assertRecord(record)
 
                 // receipt
                 , () -> assertFile(record.getReceipt().getFileID(), dbFileEntity)
-
-                // record transfer list
-                , () -> assertRecordTransfers(record)
 
                 // transaction body inputs
                 , () -> assertTrue(dbFileEntity.isDeleted())
@@ -1437,13 +1329,10 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
                 , () -> assertTransaction(transactionBody, dbTransaction)
 
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
+                , () -> assertRecord(record)
 
                 // receipt
                 , () -> assertFile(record.getReceipt().getFileID(), dbFileEntity)
-
-                // record transfer list
-                , () -> assertRecordTransfers(record)
 
                 // transaction body inputs
                 , () -> assertFalse(dbFileEntity.isDeleted())
@@ -1485,10 +1374,7 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
                 , () -> assertTransaction(transactionBody, dbTransaction)
 
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
-
-                // record transfer list
-                , () -> assertRecordTransfers(record)
+                , () -> assertRecord(record)
         );
     }
 
@@ -1521,10 +1407,7 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
                 , () -> assertTransaction(transactionBody, dbTransaction)
 
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
-
-                // record transfer list
-                , () -> assertRecordTransfers(record)
+                , () -> assertRecord(record)
         );
     }
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileLoggerFreezeTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileLoggerFreezeTest.java
@@ -37,6 +37,7 @@ import java.time.Instant;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import com.hedera.mirror.importer.parser.domain.RecordItem;
 import com.hedera.mirror.importer.util.Utility;
 
 public class RecordFileLoggerFreezeTest extends AbstractRecordFileLoggerTest {
@@ -56,8 +57,7 @@ public class RecordFileLoggerFreezeTest extends AbstractRecordFileLoggerTest {
         TransactionBody transactionBody = TransactionBody.parseFrom(transaction.getBodyBytes());
         TransactionRecord record = transactionRecord(transactionBody);
 
-        RecordFileLogger.storeRecord(transaction, record);
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -76,10 +76,7 @@ public class RecordFileLoggerFreezeTest extends AbstractRecordFileLoggerTest {
                 , () -> assertTransaction(transactionBody, dbTransaction)
 
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
-
-                // record transfer list
-                , () -> assertRecordTransfers(record)
+                , () -> assertRecord(record)
         );
     }
 
@@ -90,8 +87,7 @@ public class RecordFileLoggerFreezeTest extends AbstractRecordFileLoggerTest {
         TransactionRecord record = transactionRecord(transactionBody,
                 ResponseCodeEnum.INSUFFICIENT_ACCOUNT_BALANCE);
 
-        RecordFileLogger.storeRecord(transaction, record);
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -110,10 +106,7 @@ public class RecordFileLoggerFreezeTest extends AbstractRecordFileLoggerTest {
                 , () -> assertTransaction(transactionBody, dbTransaction)
 
                 // record inputs
-                , () -> assertRecord(record, dbTransaction)
-
-                // record transfer list
-                , () -> assertRecordTransfers(record)
+                , () -> assertRecord(record)
         );
     }
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileLoggerNFTTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileLoggerNFTTest.java
@@ -24,6 +24,8 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.google.protobuf.ByteString;
 
+import com.hedera.mirror.importer.parser.domain.RecordItem;
+
 import com.hederahashgraph.api.proto.java.AccountAmount;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ContractCallTransactionBody;
@@ -111,7 +113,6 @@ public class RecordFileLoggerNFTTest extends AbstractRecordFileLoggerTest {
     @Test
     void contractCallItemizedTransfers() throws Exception {
         givenSuccessfulContractCallTransaction();
-        processRecords();
         assertEverything();
     }
 
@@ -119,14 +120,12 @@ public class RecordFileLoggerNFTTest extends AbstractRecordFileLoggerTest {
     void contractCallAggregatedTransfers() throws Exception {
         parserProperties.setPersistNonFeeTransfers(true);
         givenSuccessfulContractCallTransactionAggregatedTransfers();
-        processRecords();
         assertEverything();
     }
 
     @Test
     void contractCreateItemizedTransfers() throws Exception {
         givenSuccessfulContractCreateTransaction();
-        processRecords();
         assertEverything();
     }
 
@@ -134,14 +133,12 @@ public class RecordFileLoggerNFTTest extends AbstractRecordFileLoggerTest {
     void contractCreateAggregatedTransfers() throws Exception {
         parserProperties.setPersistNonFeeTransfers(true);
         givenSuccessfulContractCreateTransactionAggregatedTransfers();
-        processRecords();
         assertEverything();
     }
 
     @Test
     void cryptoCreateItemizedTransfers() throws Exception {
         givenSuccessfulCryptoCreateTransaction();
-        processRecords();
         assertEverything();
     }
 
@@ -149,7 +146,6 @@ public class RecordFileLoggerNFTTest extends AbstractRecordFileLoggerTest {
     void cryptoCreateItemizedTransfersStoreNonFeeTransfers() throws Exception {
         parserProperties.setPersistNonFeeTransfers(true);
         givenSuccessfulCryptoCreateTransaction();
-        processRecords();
         assertEverything();
     }
 
@@ -157,14 +153,12 @@ public class RecordFileLoggerNFTTest extends AbstractRecordFileLoggerTest {
     void cryptoCreateAggregatedTransfers() throws Exception {
         parserProperties.setPersistNonFeeTransfers(true);
         givenSuccessfulCryptoCreateTransactionAggregatedTransfers();
-        processRecords();
         assertEverything();
     }
 
     @Test
     void cryptoTransferItemizedTransfers() throws Exception {
         givenSuccessfulCryptoTransferTransaction();
-        processRecords();
         assertEverything();
     }
 
@@ -172,21 +166,18 @@ public class RecordFileLoggerNFTTest extends AbstractRecordFileLoggerTest {
     void cryptoTransferAggregatedTransfers() throws Exception {
         parserProperties.setPersistNonFeeTransfers(true);
         givenSuccessfulCryptoTransferTransactionAggregatedTransfers();
-        processRecords();
         assertEverything();
     }
 
     @Test
     void cryptoTransferFailedItemizedTransfers() throws Exception {
         givenFailedCryptoTransferTransaction();
-        processRecords();
         assertEverything();
     }
 
     @Test
     void cryptoTransferFailedAggregatedTransfers() throws Exception {
         givenFailedCryptoTransferTransactionAggregatedTransfers();
-        processRecords();
         assertEverything();
     }
 
@@ -194,7 +185,6 @@ public class RecordFileLoggerNFTTest extends AbstractRecordFileLoggerTest {
     void cryptoTransferFailedItemizedTransfersConfigAlways() throws Exception {
         parserProperties.setPersistNonFeeTransfers(true);
         givenFailedCryptoTransferTransaction();
-        processRecords();
         assertEverything();
     }
 
@@ -262,7 +252,7 @@ public class RecordFileLoggerNFTTest extends AbstractRecordFileLoggerTest {
         var record = transactionRecordSuccess(transactionBody, transferList).build();
 
         expectedTransactions.add(new TransactionContext(transaction, record));
-        RecordFileLogger.storeRecord(transaction, record);
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
     }
 
     private Transaction contractCreate() {
@@ -281,7 +271,7 @@ public class RecordFileLoggerNFTTest extends AbstractRecordFileLoggerTest {
         var record = transactionRecordSuccess(transactionBody, transferList).build();
 
         expectedTransactions.add(new TransactionContext(transaction, record));
-        RecordFileLogger.storeRecord(transaction, record);
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
     }
 
     private Transaction cryptoCreate() {
@@ -303,7 +293,7 @@ public class RecordFileLoggerNFTTest extends AbstractRecordFileLoggerTest {
         var record = transactionRecordSuccess(transactionBody, transferList).build();
 
         expectedTransactions.add(new TransactionContext(transaction, record));
-        RecordFileLogger.storeRecord(transaction, record);
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
     }
 
     private Transaction cryptoTransfer() {
@@ -325,7 +315,7 @@ public class RecordFileLoggerNFTTest extends AbstractRecordFileLoggerTest {
         var record = transactionRecord(transactionBody, rc, transferList).build();
 
         expectedTransactions.add(new TransactionContext(transaction, record));
-        RecordFileLogger.storeRecord(transaction, record);
+        parseRecordItemAndCommit(new RecordItem(transaction, record));
     }
 
     private void cryptoTransferWithTransferList(TransferList.Builder transferList) throws Exception {
@@ -412,10 +402,6 @@ public class RecordFileLoggerNFTTest extends AbstractRecordFileLoggerTest {
         if (parserProperties.isPersistNonFeeTransfers()) {
             expectedNonFeeTransfersCount += 2;
         }
-    }
-
-    private void processRecords() throws SQLException {
-        RecordFileLogger.completeFile("", "");
     }
 
     private TransactionBody.Builder transactionBody() {


### PR DESCRIPTION
RecordFileLogger tests are written in a very non-modular way.
Changing storeRecord(..) fans out to changes in 50+ places in tests.
This PR is not changing any prod code (to make review easier), it is
refactoring part of these tests so that the PR changing prod-code looks sane.

Bonus: Since Transfer list is part of TransactionRecord proto, updated
assertRecord() to directly call assertRecordTransfer().

Signed-off-by: Apekshit Sharma <apekshit.sharma@hedera.com>


**Detailed description**:

**Which issue(s) this PR fixes**:
Partially fixes #566 

**Special notes for your reviewer**:
This PR is independent of other PRs and can be merged in directly anytime.

**Checklist**
- [ ] Documentation added
- [x] Tests updated

