### PR TITLE
Postgres Writer #3 : Move transaction and batching

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/Transaction.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/Transaction.java
@@ -27,12 +27,16 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.springframework.data.domain.Persistable;
 
 @Data
 @Entity
+@NoArgsConstructor
+@AllArgsConstructor
 @Table(name = "t_transactions")
 @ToString(exclude = {"memo", "transactionHash", "transactionBytes"})
 public class Transaction implements Persistable<Long> {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/PostgresWriterProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/PostgresWriterProperties.java
@@ -1,0 +1,13 @@
+package com.hedera.mirror.importer.parser.record;
+
+import lombok.Data;
+import javax.inject.Named;
+
+@Data
+@Named
+public class PostgresWriterProperties {
+    /**
+     * PreparedStatement.executeBatch() is called after every batchSize number of transactions from record stream file.
+     */
+    private int batchSize = 100;
+}

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordParserProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordParserProperties.java
@@ -60,6 +60,8 @@ public class RecordParserProperties implements ParserProperties {
     // bytes on the t_transaction table
     private boolean persistTransactionBytes = false;
 
+    private final PostgresWriterProperties postgresWriter;
+
     @Override
     public Path getStreamPath() {
         return mirrorProperties.getDataPath().resolve(getStreamType().getPath());

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/AbstractRecordFileLoggerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/AbstractRecordFileLoggerTest.java
@@ -88,6 +88,8 @@ public class AbstractRecordFileLoggerTest extends IntegrationTest {
     protected TopicMessageRepository topicMessageRepository;
     @Resource
     protected NonFeeTransferRepository nonFeeTransferRepository;
+    @Resource
+    protected PostgresWriterProperties postgresWriterProperties;
 
     @Resource
     protected RecordParserProperties parserProperties;

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/AbstractRecordFileLoggerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/AbstractRecordFileLoggerTest.java
@@ -24,9 +24,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.google.protobuf.ByteString;
-
-import com.hedera.mirror.importer.parser.domain.RecordItem;
-
 import com.hederahashgraph.api.proto.java.AccountAmount;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ContractID;
@@ -48,6 +45,7 @@ import org.springframework.test.context.jdbc.Sql;
 import com.hedera.mirror.importer.IntegrationTest;
 import com.hedera.mirror.importer.domain.Entities;
 import com.hedera.mirror.importer.domain.Transaction;
+import com.hedera.mirror.importer.parser.domain.RecordItem;
 import com.hedera.mirror.importer.repository.ContractResultRepository;
 import com.hedera.mirror.importer.repository.CryptoTransferRepository;
 import com.hedera.mirror.importer.repository.EntityRepository;
@@ -88,8 +86,6 @@ public class AbstractRecordFileLoggerTest extends IntegrationTest {
     protected TopicMessageRepository topicMessageRepository;
     @Resource
     protected NonFeeTransferRepository nonFeeTransferRepository;
-    @Resource
-    protected PostgresWriterProperties postgresWriterProperties;
 
     @Resource
     protected RecordParserProperties parserProperties;

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/PostgresWritingRecordParserItemHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/PostgresWritingRecordParserItemHandlerTest.java
@@ -97,8 +97,9 @@ public class PostgresWritingRecordParserItemHandlerTest extends IntegrationTest 
     }
 
     @AfterEach
-    final void afterEach() {
+    final void afterEach() throws Exception {
         postgresWriter.finish();
+        connection.close();
     }
 
     void completeFileAndCommit() throws Exception {
@@ -221,9 +222,9 @@ public class PostgresWritingRecordParserItemHandlerTest extends IntegrationTest 
         // setup
         int batchSize = 10;
         postgresWriterProperties.setBatchSize(batchSize);
-        Connection connection = Mockito.mock(Connection.class);
+        Connection connection2 = Mockito.mock(Connection.class);
         List<PreparedStatement> preparedStatements = new ArrayList<>(); // tracks all PreparedStatements
-        when(connection.prepareStatement(any())).then(ignored -> {
+        when(connection2.prepareStatement(any())).then(ignored -> {
             PreparedStatement preparedStatement = Mockito.mock(PreparedStatement.class);
             when(preparedStatement.executeBatch()).thenReturn(new int[] {});
             preparedStatements.add(preparedStatement);
@@ -231,7 +232,7 @@ public class PostgresWritingRecordParserItemHandlerTest extends IntegrationTest 
         });
         PostgresWritingRecordParsedItemHandler postgresWriter2 =
                 new PostgresWritingRecordParsedItemHandler(postgresWriterProperties);
-        postgresWriter2.initSqlStatements(connection);
+        postgresWriter2.initSqlStatements(connection2);
 
         // when
         for (int i = 0; i < batchSize; i++) {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileLoggerCryptoTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileLoggerCryptoTest.java
@@ -139,9 +139,8 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
 
     @Test
     void cryptoCreateBatch() throws Exception {
-
-        long testBatchSize = 10;
-        RecordFileLogger.setBatchSize(testBatchSize);
+        int testBatchSize = 10;
+        postgresWriterProperties.setBatchSize(testBatchSize);
 
         for (int i = 0; i < testBatchSize + 1; i++) {
             Transaction transaction = cryptoCreateTransaction();

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileLoggerCryptoTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileLoggerCryptoTest.java
@@ -138,28 +138,6 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
     }
 
     @Test
-    void cryptoCreateBatch() throws Exception {
-        int testBatchSize = 10;
-        postgresWriterProperties.setBatchSize(testBatchSize);
-
-        for (int i = 0; i < testBatchSize + 1; i++) {
-            Transaction transaction = cryptoCreateTransaction();
-            TransactionBody transactionBody = TransactionBody.parseFrom(transaction.getBodyBytes());
-            TransactionRecord record = transactionRecordSuccess(transactionBody);
-
-            RecordFileLogger.storeRecord(transaction, record);
-        }
-        RecordFileLogger.completeFile("", "");
-
-        long txCount = transactionRepository.count();
-
-        assertAll(
-                // row counts
-                () -> assertEquals(testBatchSize + 1, txCount)
-        );
-    }
-
-    @Test
     void cryptoCreateTransactionWithBody() throws Exception {
 
         Transaction transaction = createTransactionWithBody();


### PR DESCRIPTION
**Detailed description**:
Move transaction and batching to `PostgresWritingRecordParserItemHandlerTest`.

Followups from previous reviews:
- Add NotImplementedException to methods missing logic
- share code between two insertFile*() functions

Signed-off-by: Apekshit Sharma <apekshit.sharma@hedera.com>


**Which issue(s) this PR fixes**:
Partially fixes #566 

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated

