### PR TITLE
Make RecordFileLogger implementation of RecordItemListener

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/exception/ParserException.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/exception/ParserException.java
@@ -1,0 +1,18 @@
+package com.hedera.mirror.importer.exception;
+
+public class ParserException extends ImporterException {
+
+    private static final long serialVersionUID = 5216154273755649844L;
+
+    public ParserException(String message) {
+        super(message);
+    }
+
+    public ParserException(Throwable throwable) {
+        super(throwable);
+    }
+
+    public ParserException(String message, Throwable throwable) {
+        super(message, throwable);
+    }
+}

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/exception/ParserSQLException.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/exception/ParserSQLException.java
@@ -20,7 +20,7 @@ package com.hedera.mirror.importer.exception;
  * ‍
  */
 
-public class ParserSQLException extends ImporterException {
+public class ParserSQLException extends ParserException {
 
     private static final long serialVersionUID = 5216154273755649844L;
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/AbstractRecordFileLoggerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/AbstractRecordFileLoggerTest.java
@@ -88,17 +88,20 @@ public class AbstractRecordFileLoggerTest extends IntegrationTest {
     protected NonFeeTransferRepository nonFeeTransferRepository;
 
     @Resource
+    protected RecordFileLogger recordFileLogger;
+
+    @Resource
     protected RecordParserProperties parserProperties;
 
     @BeforeEach
     final void beforeCommon() throws Exception {
-        assertTrue(RecordFileLogger.start());
-        assertEquals(RecordFileLogger.INIT_RESULT.OK, RecordFileLogger.initFile(UUID.randomUUID().toString()));
+        assertTrue(recordFileLogger.start());
+        assertEquals(RecordFileLogger.INIT_RESULT.OK, recordFileLogger.initFile(UUID.randomUUID().toString()));
     }
 
     @AfterEach
     final void afterCommon() {
-        RecordFileLogger.finish();
+        recordFileLogger.finish();
     }
 
     protected final void assertAccount(AccountID accountId, com.hedera.mirror.importer.domain.Entities dbEntity) {
@@ -129,8 +132,8 @@ public class AbstractRecordFileLoggerTest extends IntegrationTest {
     }
 
     protected void parseRecordItemAndCommit(RecordItem recordItem) throws Exception {
-        RecordFileLogger.storeRecord(recordItem.getTransaction(), recordItem.getRecord());
-        RecordFileLogger.completeFile("", "");
+        recordFileLogger.onItem(recordItem);
+        recordFileLogger.completeFile("", "");
     }
 
     protected void assertRecordTransfers(TransactionRecord record) {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileLoggerContractTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileLoggerContractTest.java
@@ -247,7 +247,7 @@ public class RecordFileLoggerContractTest extends AbstractRecordFileLoggerTest {
                 .parseFrom(contractCreateTransaction.getBodyBytes());
         TransactionRecord recordCreate = createOrUpdateRecord(createTransactionBody);
 
-        RecordFileLogger.storeRecord(contractCreateTransaction, recordCreate);
+        parseRecordItemAndCommit(new RecordItem(contractCreateTransaction, recordCreate));
 
         // now update
         Transaction transaction = contractUpdateAllTransaction();
@@ -362,7 +362,7 @@ public class RecordFileLoggerContractTest extends AbstractRecordFileLoggerTest {
         ContractCreateTransactionBody contractCreateTransactionBody = createTransactionBody
                 .getContractCreateInstance();
 
-        RecordFileLogger.storeRecord(contractCreateTransaction, recordCreate);
+        parseRecordItemAndCommit(new RecordItem(contractCreateTransaction, recordCreate));
 
         // now update
         Transaction transaction = contractUpdateAllTransaction();
@@ -420,7 +420,7 @@ public class RecordFileLoggerContractTest extends AbstractRecordFileLoggerTest {
                 .parseFrom(contractCreateTransaction.getBodyBytes());
         TransactionRecord recordCreate = createOrUpdateRecord(createTransactionBody);
 
-        RecordFileLogger.storeRecord(contractCreateTransaction, recordCreate);
+        parseRecordItemAndCommit(new RecordItem(contractCreateTransaction, recordCreate));
 
         // now update
         Transaction transaction = contractDeleteTransaction();
@@ -564,7 +564,7 @@ public class RecordFileLoggerContractTest extends AbstractRecordFileLoggerTest {
                 .parseFrom(contractCreateTransaction.getBodyBytes());
         TransactionRecord recordCreate = createOrUpdateRecord(createTransactionBody);
 
-        RecordFileLogger.storeRecord(contractCreateTransaction, recordCreate);
+        parseRecordItemAndCommit(new RecordItem(contractCreateTransaction, recordCreate));
 
         // now call
         Transaction transaction = contractCallTransaction();

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileLoggerCryptoTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileLoggerCryptoTest.java
@@ -325,7 +325,7 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
         TransactionBody firstTransactionBody = TransactionBody.parseFrom(firstTransaction.getBodyBytes());
         TransactionRecord firstRecord = transactionRecordSuccess(firstTransactionBody);
 
-        RecordFileLogger.storeRecord(firstTransaction, firstRecord);
+        parseRecordItemAndCommit(new RecordItem(firstTransaction, firstRecord));
 
         Transaction transaction = cryptoCreateTransaction();
         TransactionBody transactionBody = TransactionBody.parseFrom(transaction.getBodyBytes());
@@ -385,7 +385,7 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
         TransactionBody createTransactionBody = TransactionBody.parseFrom(createTransaction.getBodyBytes());
         TransactionRecord createRecord = transactionRecordSuccess(createTransactionBody);
 
-        RecordFileLogger.storeRecord(createTransaction, createRecord);
+        parseRecordItemAndCommit(new RecordItem(createTransaction, createRecord));
 
         // now update
         Transaction transaction = cryptoUpdateTransaction();
@@ -471,7 +471,7 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
         var createTransactionBody = TransactionBody.parseFrom(createTransaction.getBodyBytes());
         var createRecord = transactionRecordSuccess(createTransactionBody);
 
-        RecordFileLogger.storeRecord(createTransaction, createRecord);
+        parseRecordItemAndCommit(new RecordItem(createTransaction, createRecord));
 
         // now update
         var updateTransaction = Transaction.newBuilder();
@@ -488,8 +488,7 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
         updateTransaction.setBodyBytes(transactionBody.build().toByteString());
         var rec = transactionRecordSuccess(transactionBody.build());
 
-        RecordFileLogger.storeRecord(updateTransaction.build(), rec);
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(updateTransaction.build(), rec));
 
         var dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(rec.getConsensusTimestamp())).get();
@@ -510,7 +509,7 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
         TransactionBody createTransactionBody = TransactionBody.parseFrom(createTransaction.getBodyBytes());
         TransactionRecord createRecord = transactionRecordSuccess(createTransactionBody);
 
-        RecordFileLogger.storeRecord(createTransaction, createRecord);
+        parseRecordItemAndCommit(new RecordItem(createTransaction, createRecord));
 
         // now update
         Transaction transaction = cryptoUpdateTransaction();
@@ -562,7 +561,7 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
         TransactionBody createTransactionBody = TransactionBody.parseFrom(createTransaction.getBodyBytes());
         TransactionRecord createRecord = transactionRecordSuccess(createTransactionBody);
 
-        RecordFileLogger.storeRecord(createTransaction, createRecord);
+        parseRecordItemAndCommit(new RecordItem(createTransaction, createRecord));
 
         // now delete
         Transaction transaction = cryptoDeleteTransaction();
@@ -618,7 +617,7 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
         TransactionBody createTransactionBody = TransactionBody.parseFrom(createTransaction.getBodyBytes());
         TransactionRecord createRecord = transactionRecordSuccess(createTransactionBody);
 
-        RecordFileLogger.storeRecord(createTransaction, createRecord);
+        parseRecordItemAndCommit(new RecordItem(createTransaction, createRecord));
 
         // now delete
         Transaction transaction = cryptoDeleteTransaction();
@@ -675,7 +674,7 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
         TransactionBody createTransactionBody = TransactionBody.parseFrom(createTransaction.getBodyBytes());
         TransactionRecord createRecord = transactionRecordSuccess(createTransactionBody);
 
-        RecordFileLogger.storeRecord(createTransaction, createRecord);
+        parseRecordItemAndCommit(new RecordItem(createTransaction, createRecord));
 
         // now add claim
         Transaction transaction = cryptoAddClaimTransaction();
@@ -727,7 +726,7 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
         TransactionBody createTransactionBody = TransactionBody.parseFrom(createTransaction.getBodyBytes());
         TransactionRecord createRecord = transactionRecordSuccess(createTransactionBody);
 
-        RecordFileLogger.storeRecord(createTransaction, createRecord);
+        parseRecordItemAndCommit(new RecordItem(createTransaction, createRecord));
 
         // now add claim
         Transaction transaction = cryptoAddClaimTransaction();
@@ -775,14 +774,14 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
         TransactionBody createTransactionBody = TransactionBody.parseFrom(createTransaction.getBodyBytes());
         TransactionRecord createRecord = transactionRecordSuccess(createTransactionBody);
 
-        RecordFileLogger.storeRecord(createTransaction, createRecord);
+        parseRecordItemAndCommit(new RecordItem(createTransaction, createRecord));
 
         // add a claim
         Transaction transactionAddClaim = cryptoAddClaimTransaction();
         TransactionBody transactionBodyAddClaim = TransactionBody.parseFrom(transactionAddClaim.getBodyBytes());
         TransactionRecord recordAddClaim = transactionRecordSuccess(transactionBodyAddClaim);
 
-        RecordFileLogger.storeRecord(transactionAddClaim, recordAddClaim);
+        parseRecordItemAndCommit(new RecordItem(transactionAddClaim, recordAddClaim));
 
         // now delete the claim
         Transaction transaction = cryptoDeleteClaimTransaction();
@@ -1200,9 +1199,7 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
         TransactionRecord record = transactionRecordSuccess(transactionBody);
         byte[] rawBytes = transaction.getBodyBytes().toByteArray();
 
-        RecordFileLogger.storeRecord(transaction, record, rawBytes);
-
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record, rawBytes, null));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -1219,9 +1216,7 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
         TransactionRecord record = transactionRecordSuccess(transactionBody);
         byte[] rawBytes = transaction.getBodyBytes().toByteArray();
 
-        RecordFileLogger.storeRecord(transaction, record, rawBytes);
-
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record, rawBytes, null));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -1238,9 +1233,7 @@ public class RecordFileLoggerCryptoTest extends AbstractRecordFileLoggerTest {
         TransactionRecord record = transactionRecordSuccess(transactionBody);
         byte[] rawBytes = transaction.getBodyBytes().toByteArray();
 
-        RecordFileLogger.storeRecord(transaction, record, rawBytes);
-
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, record, rawBytes, null));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileLoggerFileTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileLoggerFileTest.java
@@ -310,7 +310,7 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
         TransactionBody createTransactionBody = TransactionBody.parseFrom(fileCreateTransaction.getBodyBytes());
         TransactionRecord recordCreate = transactionRecord(createTransactionBody);
 
-        RecordFileLogger.storeRecord(fileCreateTransaction, recordCreate);
+        parseRecordItemAndCommit(new RecordItem(fileCreateTransaction, recordCreate));
 
         // now append
         Transaction transaction = fileAppendTransaction();
@@ -464,7 +464,7 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
         TransactionBody createTransactionBody = TransactionBody.parseFrom(fileCreateTransaction.getBodyBytes());
         TransactionRecord recordCreate = transactionRecord(createTransactionBody);
 
-        RecordFileLogger.storeRecord(fileCreateTransaction, recordCreate);
+        parseRecordItemAndCommit(new RecordItem(fileCreateTransaction, recordCreate));
 
         // now update
         Transaction transaction = fileUpdateAllTransaction();
@@ -525,7 +525,7 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
         TransactionRecord recordCreate = transactionRecord(createTransactionBody);
         FileCreateTransactionBody fileCreateTransactionBody = createTransactionBody.getFileCreate();
 
-        RecordFileLogger.storeRecord(fileCreateTransaction, recordCreate);
+        parseRecordItemAndCommit(new RecordItem(fileCreateTransaction, recordCreate));
 
         // now update
         Transaction transaction = fileUpdateAllTransaction();
@@ -690,7 +690,7 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
         TransactionBody createTransactionBody = TransactionBody.parseFrom(fileCreateTransaction.getBodyBytes());
         TransactionRecord recordCreate = transactionRecord(createTransactionBody);
 
-        RecordFileLogger.storeRecord(fileCreateTransaction, recordCreate);
+        parseRecordItemAndCommit(new RecordItem(fileCreateTransaction, recordCreate));
 
         // now update
         Transaction transaction = fileUpdateContentsTransaction();
@@ -795,7 +795,7 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
         TransactionBody createTransactionBody = TransactionBody.parseFrom(fileCreateTransaction.getBodyBytes());
         TransactionRecord recordCreate = transactionRecord(createTransactionBody);
 
-        RecordFileLogger.storeRecord(fileCreateTransaction, recordCreate);
+        parseRecordItemAndCommit(new RecordItem(fileCreateTransaction, recordCreate));
 
         // now update
         Transaction transaction = fileUpdateExpiryTransaction();
@@ -899,7 +899,7 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
         TransactionBody createTransactionBody = TransactionBody.parseFrom(fileCreateTransaction.getBodyBytes());
         TransactionRecord recordCreate = transactionRecord(createTransactionBody);
 
-        RecordFileLogger.storeRecord(fileCreateTransaction, recordCreate);
+        parseRecordItemAndCommit(new RecordItem(fileCreateTransaction, recordCreate));
 
         // now update
         Transaction transaction = fileUpdateKeysTransaction();
@@ -1117,7 +1117,7 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
         TransactionBody createTransactionBody = TransactionBody.parseFrom(fileCreateTransaction.getBodyBytes());
         TransactionRecord recordCreate = transactionRecord(createTransactionBody);
 
-        RecordFileLogger.storeRecord(fileCreateTransaction, recordCreate);
+        parseRecordItemAndCommit(new RecordItem(fileCreateTransaction, recordCreate));
 
         // now update
         Transaction transaction = fileDeleteTransaction();
@@ -1168,9 +1168,7 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
         TransactionBody transactionBody = TransactionBody.parseFrom(fileDeleteTransaction.getBodyBytes());
         TransactionRecord record = transactionRecord(transactionBody);
 
-        RecordFileLogger.storeRecord(fileDeleteTransaction, record);
-
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(fileDeleteTransaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -1215,9 +1213,7 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
         TransactionRecord record = transactionRecord(transactionBody,
                 ResponseCodeEnum.INSUFFICIENT_PAYER_BALANCE);
 
-        RecordFileLogger.storeRecord(fileDeleteTransaction, record);
-
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(fileDeleteTransaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -1261,9 +1257,7 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
         TransactionBody transactionBody = TransactionBody.parseFrom(systemDeleteTransaction.getBodyBytes());
         TransactionRecord record = transactionRecord(transactionBody);
 
-        RecordFileLogger.storeRecord(systemDeleteTransaction, record);
-
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(systemDeleteTransaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -1307,9 +1301,7 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
         TransactionBody transactionBody = TransactionBody.parseFrom(systemUndeleteTransaction.getBodyBytes());
         TransactionRecord record = transactionRecord(transactionBody);
 
-        RecordFileLogger.storeRecord(systemUndeleteTransaction, record);
-
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(systemUndeleteTransaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -1353,9 +1345,7 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
         TransactionRecord record = transactionRecord(transactionBody,
                 ResponseCodeEnum.INSUFFICIENT_ACCOUNT_BALANCE);
 
-        RecordFileLogger.storeRecord(systemDeleteTransaction, record);
-
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(systemDeleteTransaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
@@ -1386,9 +1376,7 @@ public class RecordFileLoggerFileTest extends AbstractRecordFileLoggerTest {
         TransactionRecord record = transactionRecord(transactionBody,
                 ResponseCodeEnum.INSUFFICIENT_ACCOUNT_BALANCE);
 
-        RecordFileLogger.storeRecord(systemUndeleteTransaction, record);
-
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(systemUndeleteTransaction, record));
 
         com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
                 .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileLoggerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileLoggerTest.java
@@ -31,38 +31,38 @@ public class RecordFileLoggerTest extends AbstractRecordFileLoggerTest {
 
     @Test
     void initFile() throws Exception {
-        assertEquals(RecordFileLogger.INIT_RESULT.OK, RecordFileLogger.initFile("TestFile"));
-        RecordFileLogger.completeFile("", "");
-        RecordFile recordFile = recordFileRepository.findById(RecordFileLogger.getFileId()).get();
+        assertEquals(RecordFileLogger.INIT_RESULT.OK, recordFileLogger.initFile("TestFile"));
+        recordFileLogger.completeFile("", "");
+        RecordFile recordFile = recordFileRepository.findById(recordFileLogger.getFileId()).get();
         assertEquals("TestFile", recordFile.getName());
     }
 
     @Test
     void initFileDuplicate() throws Exception {
-        assertEquals(RecordFileLogger.INIT_RESULT.OK, RecordFileLogger.initFile("TestFile"));
-        assertEquals(RecordFileLogger.INIT_RESULT.SKIP, RecordFileLogger.initFile("TestFile"));
+        assertEquals(RecordFileLogger.INIT_RESULT.OK, recordFileLogger.initFile("TestFile"));
+        assertEquals(RecordFileLogger.INIT_RESULT.SKIP, recordFileLogger.initFile("TestFile"));
     }
 
     @Test
     void completeFileNoHashes() throws Exception {
-        RecordFileLogger.completeFile("", "");
-        RecordFile recordFile = recordFileRepository.findById(RecordFileLogger.getFileId()).get();
+        recordFileLogger.completeFile("", "");
+        RecordFile recordFile = recordFileRepository.findById(recordFileLogger.getFileId()).get();
         assertNull(recordFile.getFileHash());
         assertNull(recordFile.getPreviousHash());
     }
 
     @Test
     void completeFileWithHashes() throws Exception {
-        RecordFileLogger.completeFile("123", "456");
-        RecordFile recordFile = recordFileRepository.findById(RecordFileLogger.getFileId()).get();
+        recordFileLogger.completeFile("123", "456");
+        RecordFile recordFile = recordFileRepository.findById(recordFileLogger.getFileId()).get();
         assertEquals("123", recordFile.getFileHash());
         assertEquals("456", recordFile.getPreviousHash());
     }
 
     @Test
     void rollback() throws Exception {
-        RecordFileLogger.rollback();
-        Optional<RecordFile> recordFile = recordFileRepository.findById(RecordFileLogger.getFileId());
+        recordFileLogger.rollback();
+        Optional<RecordFile> recordFile = recordFileRepository.findById(recordFileLogger.getFileId());
         assertFalse(recordFile.isPresent());
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileLoggerTopicTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileLoggerTopicTest.java
@@ -26,6 +26,9 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.google.protobuf.ByteString;
 import com.google.protobuf.StringValue;
+
+import com.hedera.mirror.importer.parser.domain.RecordItem;
+
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ConsensusCreateTopicTransactionBody;
 import com.hederahashgraph.api.proto.java.ConsensusDeleteTopicTransactionBody;
@@ -76,8 +79,7 @@ public class RecordFileLoggerTopicTest extends AbstractRecordFileLoggerTest {
         var expectedEntity = createTopicEntity(topicId, null, null, adminKey, submitKey, memo, autoRenewAccount,
                 autoRenewPeriod);
 
-        RecordFileLogger.storeRecord(transaction, transactionRecord);
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, transactionRecord));
 
         long entityCount = autoRenewAccount != null ? 4 : 3; // Node, payer, topic & optionally autorenew
         var entity = entityRepository
@@ -99,8 +101,7 @@ public class RecordFileLoggerTopicTest extends AbstractRecordFileLoggerTest {
         var transactionRecord = createTransactionRecord(TopicID.newBuilder().setTopicNum(topicId)
                 .build(), null, null, consensusTimestamp, responseCode);
 
-        RecordFileLogger.storeRecord(transaction, transactionRecord);
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, transactionRecord));
 
         var entity = entityRepository.findByPrimaryKey(0L, 0L, topicId).get();
         assertTransactionInRepository(responseCode, consensusTimestamp, entity.getId());
@@ -124,8 +125,7 @@ public class RecordFileLoggerTopicTest extends AbstractRecordFileLoggerTest {
         var transactionRecord = createTransactionRecord(TopicID.newBuilder().setTopicNum(topicId)
                 .build(), null, null, consensusTimestamp, responseCode);
 
-        RecordFileLogger.storeRecord(transaction, transactionRecord);
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, transactionRecord));
 
         var entity = entityRepository.findByPrimaryKey(0L, 0L, topicId).get();
         assertTransactionInRepository(responseCode, consensusTimestamp, entity.getId());
@@ -148,8 +148,7 @@ public class RecordFileLoggerTopicTest extends AbstractRecordFileLoggerTest {
         var transactionRecord = createTransactionRecord(TopicID.newBuilder().setTopicNum(topicId)
                 .build(), null, null, consensusTimestamp, responseCode);
 
-        RecordFileLogger.storeRecord(transaction, transactionRecord);
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, transactionRecord));
 
         assertEquals(0L, entityRepository.count());
         assertEquals(0L, transactionRepository.count());
@@ -162,8 +161,7 @@ public class RecordFileLoggerTopicTest extends AbstractRecordFileLoggerTest {
         var transaction = createCreateTopicTransaction(null, null, "memo", null, null);
         var transactionRecord = createTransactionRecord(null, null, null, consensusTimestamp, responseCode);
 
-        RecordFileLogger.storeRecord(transaction, transactionRecord);
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, transactionRecord));
 
         assertTransactionInRepository(responseCode, consensusTimestamp, null);
         assertEquals(2L, entityRepository.count()); // Node, payer, no topic
@@ -200,8 +198,7 @@ public class RecordFileLoggerTopicTest extends AbstractRecordFileLoggerTest {
         var expectedEntity = createTopicEntity(topicId, updatedExpirationTimeSeconds, updatedExpirationTimeNanos,
                 updatedAdminKey, updatedSubmitKey, updatedMemo, autoRenewAccount, autoRenewPeriod);
 
-        RecordFileLogger.storeRecord(transaction, transactionRecord);
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, transactionRecord));
 
         long entityCount = autoRenewAccount != null ? 4 : 3; // Node, payer, topic & optionally autorenew
         var entity = entityRepository
@@ -233,8 +230,7 @@ public class RecordFileLoggerTopicTest extends AbstractRecordFileLoggerTest {
         var transactionRecord = createTransactionRecord(topicId, null, null, consensusTimestamp,
                 responseCode);
 
-        RecordFileLogger.storeRecord(transaction, transactionRecord);
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, transactionRecord));
 
         var entity = entityRepository
                 .findByPrimaryKey(topicId.getShardNum(), topicId.getRealmNum(), topicId.getTopicNum()).get();
@@ -260,8 +256,7 @@ public class RecordFileLoggerTopicTest extends AbstractRecordFileLoggerTest {
         var transactionRecord = createTransactionRecord(topicId, null, null, consensusTimestamp,
                 responseCode);
 
-        RecordFileLogger.storeRecord(transaction, transactionRecord);
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, transactionRecord));
 
         var entity = entityRepository
                 .findByPrimaryKey(topicId.getShardNum(), topicId.getRealmNum(), topicId.getTopicNum()).get();
@@ -331,8 +326,7 @@ public class RecordFileLoggerTopicTest extends AbstractRecordFileLoggerTest {
         var transactionRecord = createTransactionRecord(topicId, null, null, consensusTimestamp,
                 responseCode);
 
-        RecordFileLogger.storeRecord(transaction, transactionRecord);
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, transactionRecord));
 
         long entityCount = 3;
         if (autoRenewAccount != null) {
@@ -368,8 +362,7 @@ public class RecordFileLoggerTopicTest extends AbstractRecordFileLoggerTest {
         var transactionRecord = createTransactionRecord(topicId, null, null, consensusTimestamp,
                 responseCode);
 
-        RecordFileLogger.storeRecord(transaction, transactionRecord);
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, transactionRecord));
 
         var entity = entityRepository
                 .findByPrimaryKey(topicId.getShardNum(), topicId.getRealmNum(), topicId.getTopicNum()).get();
@@ -394,8 +387,7 @@ public class RecordFileLoggerTopicTest extends AbstractRecordFileLoggerTest {
         var transactionRecord = createTransactionRecord(topicId, null, null, consensusTimestamp,
                 responseCode);
 
-        RecordFileLogger.storeRecord(transaction, transactionRecord);
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, transactionRecord));
 
         var entity = entityRepository
                 .findByPrimaryKey(topicId.getShardNum(), topicId.getRealmNum(), topicId.getTopicNum()).get();
@@ -419,8 +411,7 @@ public class RecordFileLoggerTopicTest extends AbstractRecordFileLoggerTest {
         var transactionRecord = createTransactionRecord(topicId, null, null, consensusTimestamp,
                 responseCode);
 
-        RecordFileLogger.storeRecord(transaction, transactionRecord);
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, transactionRecord));
 
         var entity = entityRepository
                 .findByPrimaryKey(topicId.getShardNum(), topicId.getRealmNum(), topicId.getTopicNum()).get();
@@ -449,8 +440,7 @@ public class RecordFileLoggerTopicTest extends AbstractRecordFileLoggerTest {
         var transactionRecord = createTransactionRecord(topicId, sequenceNumber, runningHash
                 .getBytes(), consensusTimestamp, responseCode);
 
-        RecordFileLogger.storeRecord(transaction, transactionRecord);
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, transactionRecord));
 
         var entity = entityRepository
                 .findByPrimaryKey(topicId.getShardNum(), topicId.getRealmNum(), topicId.getTopicNum()).get();
@@ -479,8 +469,7 @@ public class RecordFileLoggerTopicTest extends AbstractRecordFileLoggerTest {
         var transactionRecord = createTransactionRecord(topicId, sequenceNumber, runningHash
                 .getBytes(), consensusTimestamp, responseCode);
 
-        RecordFileLogger.storeRecord(transaction, transactionRecord);
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, transactionRecord));
 
         var entity = entityRepository
                 .findByPrimaryKey(topicId.getShardNum(), topicId.getRealmNum(), topicId.getTopicNum()).get();
@@ -507,8 +496,7 @@ public class RecordFileLoggerTopicTest extends AbstractRecordFileLoggerTest {
         var transactionRecord = createTransactionRecord(topicId, sequenceNumber, runningHash
                 .getBytes(), consensusTimestamp, responseCode);
 
-        RecordFileLogger.storeRecord(transaction, transactionRecord);
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, transactionRecord));
 
         assertEquals(1L, entityRepository.count());
         assertEquals(0L, topicMessageRepository.count());
@@ -530,8 +518,7 @@ public class RecordFileLoggerTopicTest extends AbstractRecordFileLoggerTest {
         var transactionRecord = createTransactionRecord(topicId, sequenceNumber, runningHash
                 .getBytes(), consensusTimestamp, responseCode);
 
-        RecordFileLogger.storeRecord(transaction, transactionRecord);
-        RecordFileLogger.completeFile("", "");
+        parseRecordItemAndCommit(new RecordItem(transaction, transactionRecord));
 
         var entity = entityRepository
                 .findByPrimaryKey(topicId.getShardNum(), topicId.getRealmNum(), topicId.getTopicNum()).get();


### PR DESCRIPTION
**Detailed description**:
- RecordFileLogger.storeRecord() is now onItem() and takes
  in RecordItem
- Rename to RecordItemParser would be done in followup
- Make RecordFileLogger proper class rather than global
  utility of static functions
- Changing static storeRecord() and fields to non-static
  means many other functions need to be non-static too
- Changed missed tests to use helper method

Signed-off-by: Apekshit Sharma <apekshit.sharma@hedera.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
-->



**Which issue(s) this PR fixes**:
Partially fixes #566 

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

