### PR TITLE
Slight performance and acceptance test improvements and corrections

### DIFF
--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/jmeter/client/MultiTopicHCSClient.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/jmeter/client/MultiTopicHCSClient.java
@@ -55,8 +55,8 @@ public class MultiTopicHCSClient extends AbstractJavaSamplerClient {
         propHandler = new PropertiesHandler(javaSamplerContext);
 
         host = propHandler.getTestParam("host", "localhost");
-        port = propHandler.getIntTestParam("port", "5600");
-        clientCount = propHandler.getIntTestParam("clientCount", "0");
+        port = propHandler.getIntTestParam("port", 5600);
+        clientCount = propHandler.getIntTestParam("clientCount", 0);
 
         for (int i = 0; i < clientCount; i++) {
             TopicSubscription topicSubscription = TopicSubscription.builder()

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/jmeter/client/SingleTopicHCSClient.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/jmeter/client/SingleTopicHCSClient.java
@@ -28,7 +28,6 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.time.Instant;
 import lombok.extern.log4j.Log4j2;
-import org.apache.jmeter.config.Arguments;
 import org.apache.jmeter.protocol.java.sampler.AbstractJavaSamplerClient;
 import org.apache.jmeter.protocol.java.sampler.JavaSamplerContext;
 import org.apache.jmeter.samplers.SampleResult;
@@ -61,27 +60,27 @@ public class SingleTopicHCSClient extends AbstractJavaSamplerClient {
     public void setupTest(JavaSamplerContext context) {
         propHandler = new PropertiesHandler(context);
         String host = propHandler.getTestParam("host", "localhost");
-        int port = propHandler.getIntTestParam("port", "5600");
+        int port = propHandler.getIntTestParam("port", 5600);
         boolean sharedChannel = Boolean.valueOf(propHandler.getTestParam("sharedChannel", "false"));
-        long startTime = propHandler.getLongClientTestParam("StartTime", 0, "0");
+        Long startTime = propHandler.getLongClientTestParam("StartTime", 0, null);
         int nanoStartTime = 0;
 
         // allow for subscribe from now
-        if (startTime < 0) {
+        if (startTime == null) {
             Instant now = Instant.now();
             startTime = now.getEpochSecond();
             nanoStartTime = now.getNano();
         }
 
-        long endTimeSecs = propHandler.getLongClientTestParam("EndTime", 0, "0");
-        long limit = propHandler.getLongClientTestParam("Limit", 0, "100");
+        long endTimeSecs = propHandler.getLongClientTestParam("EndTime", 0, 0L);
+        long limit = propHandler.getLongClientTestParam("Limit", 0, 100L);
 
         ConsensusTopicQuery.Builder builder = ConsensusTopicQuery.newBuilder()
                 .setConsensusStartTime(Timestamp.newBuilder().setSeconds(startTime).setNanos(nanoStartTime).build())
                 .setTopicID(
                         TopicID.newBuilder()
-                                .setRealmNum(propHandler.getLongClientTestParam("RealmNum", 0, "0"))
-                                .setTopicNum(propHandler.getLongClientTestParam("TopicId", 0, "0"))
+                                .setRealmNum(propHandler.getLongClientTestParam("RealmNum", 0, 0L))
+                                .setTopicNum(propHandler.getLongClientTestParam("TopicId", 0, 0L))
                                 .build());
 
         if (endTimeSecs != 0) {
@@ -117,29 +116,6 @@ public class SingleTopicHCSClient extends AbstractJavaSamplerClient {
         } else {
             hcsTopicSampler = new HCSDirectStubTopicSampler(host, port, consensusTopicQuery);
         }
-    }
-
-    /**
-     * Specifies and makes available parameters and their defaults to the jMeter GUI when editing Test Plans
-     *
-     * @return Sampler arguments
-     */
-    @Override
-    public Arguments getDefaultParameters() {
-        Arguments defaultParameters = new Arguments();
-        defaultParameters.addArgument("host", "localhost");
-        defaultParameters.addArgument("port", "5600");
-        defaultParameters.addArgument("limit", "100");
-        defaultParameters.addArgument("consensusStartTimeSeconds", "0");
-        defaultParameters.addArgument("consensusEndTimeSeconds", "0");
-        defaultParameters.addArgument("topicID", "0");
-        defaultParameters.addArgument("realmNum", "0");
-        defaultParameters.addArgument("historicMessagesCount", "0");
-        defaultParameters.addArgument("newTopicsMessageCount", "0");
-        defaultParameters.addArgument("messagesLatchWaitSeconds", "60");
-        defaultParameters.addArgument("sharedChannel", "false");
-        defaultParameters.addArgument("useMAPI", "false");
-        return defaultParameters;
     }
 
     /**

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/jmeter/handler/PropertiesHandler.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/jmeter/handler/PropertiesHandler.java
@@ -22,6 +22,7 @@ package com.hedera.mirror.grpc.jmeter.handler;
 
 import lombok.extern.log4j.Log4j2;
 import org.apache.jmeter.protocol.java.sampler.JavaSamplerContext;
+import org.assertj.core.util.Strings;
 
 /**
  * A utility class for easily retrieving jmeter user properties from a properties file Offers numerous method overloads
@@ -48,13 +49,23 @@ public class PropertiesHandler {
         return retrievedValue;
     }
 
-    public long getLongTestParam(String property, String defaultVal) {
-        String value = getTestParam(property, defaultVal);
+    public Long getLongTestParam(String property, Long defaultVal) {
+        String value = getTestParam(property);
+
+        if (Strings.isNullOrEmpty(value)) {
+            return defaultVal;
+        }
+
         return Long.parseLong(value);
     }
 
-    public int getIntTestParam(String property, String defaultVal) {
-        String value = getTestParam(property, defaultVal);
+    public int getIntTestParam(String property, int defaultVal) {
+        String value = getTestParam(property);
+
+        if (Strings.isNullOrEmpty(value)) {
+            return defaultVal;
+        }
+
         return Integer.parseInt(value);
     }
 
@@ -65,7 +76,7 @@ public class PropertiesHandler {
     public String getClientTestParam(String property, int num, String defaultVal) {
         String retrievedValue = getTestParam(String.format(clientPattern, property, num));
 
-        if (retrievedValue == null || retrievedValue.isEmpty()) {
+        if (Strings.isNullOrEmpty(retrievedValue)) {
             return defaultVal;
         }
 
@@ -77,9 +88,8 @@ public class PropertiesHandler {
         return Long.parseLong(value);
     }
 
-    public long getLongClientTestParam(String property, int num, String defaultVal) {
-        String value = getTestParam(String.format(clientPattern, property, num), defaultVal);
-        return Long.parseLong(value);
+    public Long getLongClientTestParam(String property, int num, Long defaultVal) {
+        return getLongTestParam(String.format(clientPattern, property, num), defaultVal);
     }
 
     public int getIntClientTestParam(String property, int num) {

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/jmeter/sampler/HCSDirectStubTopicSampler.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/jmeter/sampler/HCSDirectStubTopicSampler.java
@@ -101,7 +101,7 @@ public class HCSDirectStubTopicSampler implements HCSTopicSampler {
             @SneakyThrows
             @Override
             public void onError(Throwable t) {
-                log.error("Error in ConsensusTopicResponse StreamObserver", t);
+                log.error("Error in ConsensusTopicResponse StreamObserver : {}", t.getMessage());
                 throw t;
             }
 

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/jmeter/sampler/HCSDirectStubTopicSampler.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/jmeter/sampler/HCSDirectStubTopicSampler.java
@@ -101,7 +101,6 @@ public class HCSDirectStubTopicSampler implements HCSTopicSampler {
             @SneakyThrows
             @Override
             public void onError(Throwable t) {
-                log.error("Error in ConsensusTopicResponse StreamObserver : {}", t.getMessage());
                 throw t;
             }
 

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/jmeter/sampler/result/HCSSamplerResult.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/jmeter/sampler/result/HCSSamplerResult.java
@@ -73,11 +73,11 @@ public abstract class HCSSamplerResult<T> {
     }
 
     public void onComplete() {
-        String errorMessage = subscribeError == null ? "" : " : with " + subscribeError.getMessage();
-        log.info("Observed {} historic and {} incoming messages in {} ({}/s): {}. Last message received {} ago",
+        String errorMessage = subscribeError == null ? "" : subscribeError.getMessage();
+        log.info("Observed {} historic and {} incoming messages in {} ({}/s). Last message received {} ago. {}",
                 historicalMessageCount,
-                incomingMessageCount, stopwatch, getMessageRate(), success ? "success" :
-                        "failed" + errorMessage, lastMessage);
+                incomingMessageCount, stopwatch, getMessageRate(), lastMessage, success ? "Success" :
+                        "Failed : " + errorMessage);
     }
 
     public void onError(Throwable err) {

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/jmeter/sampler/result/HCSSamplerResult.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/jmeter/sampler/result/HCSSamplerResult.java
@@ -35,6 +35,7 @@ public abstract class HCSSamplerResult<T> {
     private final long topicNum;
     private final Stopwatch stopwatch = Stopwatch.createStarted();
     private final Instant subscribeStart = Instant.now();
+    private Stopwatch lastMessage = Stopwatch.createStarted();
     private long historicalMessageCount = 0L;
     private long incomingMessageCount = 0L;
     private T last;
@@ -57,7 +58,7 @@ public abstract class HCSSamplerResult<T> {
     }
 
     public void onNext(T result) {
-
+        lastMessage = Stopwatch.createStarted();
         historical = getConsensusInstant(result).isBefore(subscribeStart);
         if (historical) {
             ++historicalMessageCount;
@@ -71,12 +72,18 @@ public abstract class HCSSamplerResult<T> {
     }
 
     public void onComplete() {
-        log.info("Observed {} historic and {} incoming messages in {} ({}/s): {}", historicalMessageCount,
-                incomingMessageCount, stopwatch, getMessageRate(), success ? "success" : "failed");
+        log.info("Observed {} historic and {} incoming messages in {} ({}/s): {}. Last message received {} ago",
+                historicalMessageCount,
+                incomingMessageCount, stopwatch, getMessageRate(), success ? "success" : "failed", lastMessage);
     }
 
     public void onError(Throwable err) {
         log.error("GRPC error on subscription : {}", err.getMessage());
+        if (err.getMessage().contains("CANCELLED: unsubscribed")) {
+            // ignore error message on cancel
+            return;
+        }
+
         throw new IllegalArgumentException("Error on subscription");
     }
 
@@ -92,12 +99,12 @@ public abstract class HCSSamplerResult<T> {
                     getMessage(currentResponse), currentConsensusInstant, currentSequenceNumber);
 
             if (currentSequenceNumber != lastSequenceNumber + 1) {
-                log.error("Out of order messgae sequence. Last : {}, current : {}", last, currentResponse);
+                log.error("Out of order message sequence. Last : {}, current : {}", last, currentResponse);
                 throw new IllegalArgumentException("Out of order message sequence. Expected " + (lastSequenceNumber + 1) + " got " + currentSequenceNumber);
             }
 
             if (!currentConsensusInstant.isAfter(lastConsensusInstant)) {
-                log.error("Out of order messgae sequence. Last : {}, current : {}", last, currentResponse);
+                log.error("Out of order message sequence. Last : {}, current : {}", last, currentResponse);
                 throw new IllegalArgumentException("Out of order message timestamp. Expected " + currentConsensusInstant +
                         " to be after " + lastConsensusInstant);
             }

--- a/hedera-mirror-test/README.md
+++ b/hedera-mirror-test/README.md
@@ -39,13 +39,13 @@ Options can be set through the command line as follows
 -   Tags : Tags allow you to filter which cucumber scenarios and files are run. By default tests marked with the @Sanity tag are run. To run a different set of files different tags can be specified
     -   All test cases
 
-*                   `./mvnw clean integration-test --projects hedera-mirror-test/ -P=acceptance-tests -Dcucumber.filter.tags="@AcceptanceSuite"`
+*                     `./mvnw clean integration-test --projects hedera-mirror-test/ -P=acceptance-tests -Dcucumber.filter.tags="@Acceptance"`
     -   Negative cases
-*                   `./mvnw clean integration-test --projects hedera-mirror-test/ -P=acceptance-tests -Dcucumber.filter.tags="@FullSuite"`
+*                     `./mvnw clean integration-test --projects hedera-mirror-test/ -P=acceptance-tests -Dcucumber.filter.tags="@FullSuite"`
     -   Negative cases
-*                   `./mvnw clean integration-test --projects hedera-mirror-test/ -P=acceptance-tests -Dcucumber.filter.tags="@Negative"`
+*                     `./mvnw clean integration-test --projects hedera-mirror-test/ -P=acceptance-tests -Dcucumber.filter.tags="@Negative"`
     -   Edge cases
-*                   `./mvnw clean integration-test --projects hedera-mirror-test/ -P=acceptance-tests -Dcucumber.filter.tags="@Edge"`
+*                     `./mvnw clean integration-test --projects hedera-mirror-test/ -P=acceptance-tests -Dcucumber.filter.tags="@Edge"`
     -   ... (search for @? tags within the .feature files for further tags)
 
 ### Test Layout

--- a/hedera-mirror-test/README.md
+++ b/hedera-mirror-test/README.md
@@ -39,13 +39,13 @@ Options can be set through the command line as follows
 -   Tags : Tags allow you to filter which cucumber scenarios and files are run. By default tests marked with the @Sanity tag are run. To run a different set of files different tags can be specified
     -   All test cases
 
-*                 `./mvnw clean integration-test --projects hedera-mirror-test/ -P=acceptance-tests -Dcucumber.filter.tags="@AcceptanceSuite"`
+*                   `./mvnw clean integration-test --projects hedera-mirror-test/ -P=acceptance-tests -Dcucumber.filter.tags="@AcceptanceSuite"`
     -   Negative cases
-*                 `./mvnw clean integration-test --projects hedera-mirror-test/ -P=acceptance-tests -Dcucumber.filter.tags="@FullSuite"`
+*                   `./mvnw clean integration-test --projects hedera-mirror-test/ -P=acceptance-tests -Dcucumber.filter.tags="@FullSuite"`
     -   Negative cases
-*                 `./mvnw clean integration-test --projects hedera-mirror-test/ -P=acceptance-tests -Dcucumber.filter.tags="@Negative"`
+*                   `./mvnw clean integration-test --projects hedera-mirror-test/ -P=acceptance-tests -Dcucumber.filter.tags="@Negative"`
     -   Edge cases
-*                 `./mvnw clean integration-test --projects hedera-mirror-test/ -P=acceptance-tests -Dcucumber.filter.tags="@Edge"`
+*                   `./mvnw clean integration-test --projects hedera-mirror-test/ -P=acceptance-tests -Dcucumber.filter.tags="@Edge"`
     -   ... (search for @? tags within the .feature files for further tags)
 
 ### Test Layout
@@ -122,7 +122,7 @@ Then using the [JMeter Maven Plugin](https://github.com/jmeter-maven-plugin/jmet
 
 -   Start the tests:
 
-    `./mvnw clean verify -P=performance-tests --projects hedera-mirror-test`
+    `./mvnw clean integration-test -P=performance-tests --projects hedera-mirror-test`
 
     Optional properties follow the 'Modifying Properties' logic (https://github.com/jmeter-maven-plugin/jmeter-maven-plugin/wiki/Modifying-Properties) and include the following
 
@@ -152,7 +152,7 @@ The initial jmx test plan files under `hedera-mirror-test/src/test/jmeter/` foll
     -   delSeqFrom (sequence number to delete messages in a topic from)
 2.  DB_Future_Sampler - Simulates incoming messages
     -   (See DB_Setup_Sampler options)
-3.  Subcribe_Sampler - Subscribes and listens for messages
+3.  Subscribe_Sampler - Subscribes and listens for messages
     -   host
     -   port
     -   limit

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TopicFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TopicFeature.java
@@ -113,6 +113,7 @@ public class TopicFeature {
 
     @Given("I provide a topic id {string}")
     public void setTopicIdParam(String topicId) {
+        testInstantReference = Instant.now();
         mirrorConsensusTopicQuery = new MirrorConsensusTopicQuery();
         if (!topicId.isEmpty()) {
             consensusTopicId = new ConsensusTopicId(0, 0, Long.parseLong(topicId));
@@ -133,6 +134,11 @@ public class TopicFeature {
     @Given("I provide a number of messages {int} I want to receive within {int} seconds")
     public void setTopicListenParams(int numMessages, int latency) {
         messageSubscribeCount = numMessages;
+        this.latency = latency;
+    }
+
+    @Given("I provide a {int} in seconds of which I want to receive messages within")
+    public void setSubscribeParams(int latency) {
         this.latency = latency;
     }
 

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TopicFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TopicFeature.java
@@ -142,23 +142,24 @@ public class TopicFeature {
         this.latency = latency;
     }
 
-    @Given("I provide a startDate {string} and a number of messages {int} I want to receive")
-    public void setTopicListenParams(String startDate, int numMessages) {
+    @Given("I provide a starting timestamp {string} and a number of messages {int} I want to receive")
+    public void setTopicListenParams(String startTimestamp, int numMessages) {
         messageSubscribeCount = numMessages;
 
-        Instant startTime = FeatureInputHandler.messageQueryDateStringToInstant(startDate, testInstantReference);
+        Instant startTime = FeatureInputHandler.messageQueryDateStringToInstant(startTimestamp, testInstantReference);
         log.trace("Subscribe mirrorConsensusTopicQuery : StartTime : {}", startTime);
 
         mirrorConsensusTopicQuery
                 .setStartTime(startTime);
     }
 
-    @Given("I provide a startDate {string} and endDate {string} and a number of messages {int} I want to receive")
-    public void setTopicListenParams(String startDate, String endDate, int numMessages) {
+    @Given("I provide a starting timestamp {string} and ending timestamp {string} and a number of messages {int} I " +
+            "want to receive")
+    public void setTopicListenParams(String startTimestamp, String endTimestamp, int numMessages) {
         messageSubscribeCount = numMessages;
 
-        Instant startTime = FeatureInputHandler.messageQueryDateStringToInstant(startDate, testInstantReference);
-        Instant endTime = FeatureInputHandler.messageQueryDateStringToInstant(endDate, Instant.now());
+        Instant startTime = FeatureInputHandler.messageQueryDateStringToInstant(startTimestamp, testInstantReference);
+        Instant endTime = FeatureInputHandler.messageQueryDateStringToInstant(endTimestamp, Instant.now());
         log.trace("Subscribe mirrorConsensusTopicQuery : StartTime : {}. EndTime : {}", startTime, endTime);
 
         mirrorConsensusTopicQuery
@@ -179,13 +180,14 @@ public class TopicFeature {
                 .setEndTime(endTime);
     }
 
-    @Given("I provide a startDate {string} and endDate {string} and a limit of {int} messages I want to receive")
-    public void setTopicListenParamswLimit(String startDate, String endDate, int limit) {
+    @Given("I provide a starting timestamp {string} and ending timestamp {string} and a limit of {int} messages I " +
+            "want to receive")
+    public void setTopicListenParamswLimit(String startTimestamp, String endTimestamp, int limit) {
         messageSubscribeCount = limit;
 
         mirrorConsensusTopicQuery
-                .setStartTime(FeatureInputHandler.messageQueryDateStringToInstant(startDate))
-                .setEndTime(FeatureInputHandler.messageQueryDateStringToInstant(endDate))
+                .setStartTime(FeatureInputHandler.messageQueryDateStringToInstant(startTimestamp))
+                .setEndTime(FeatureInputHandler.messageQueryDateStringToInstant(endTimestamp))
                 .setLimit(limit);
     }
 

--- a/hedera-mirror-test/src/test/jmeter/E2E_200_TPS_All_Messages.jmx
+++ b/hedera-mirror-test/src/test/jmeter/E2E_200_TPS_All_Messages.jmx
@@ -192,61 +192,7 @@
         <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
       </ThreadGroup>
       <hashTree>
-        <JavaSampler guiclass="JavaTestSamplerGui" testclass="JavaSampler" testname="Subcribe_Sampler" enabled="true">
-          <elementProp name="arguments" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" enabled="true">
-            <collectionProp name="Arguments.arguments">
-              <elementProp name="host" elementType="Argument">
-                <stringProp name="Argument.name">host</stringProp>
-                <stringProp name="Argument.value">localhost</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="port" elementType="Argument">
-                <stringProp name="Argument.name">port</stringProp>
-                <stringProp name="Argument.value">5600</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="limit" elementType="Argument">
-                <stringProp name="Argument.name">limit</stringProp>
-                <stringProp name="Argument.value">3000</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="consensusStartTimeSeconds" elementType="Argument">
-                <stringProp name="Argument.name">consensusStartTimeSeconds</stringProp>
-                <stringProp name="Argument.value">0</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="consensusEndTimeSeconds" elementType="Argument">
-                <stringProp name="Argument.name">consensusEndTimeSeconds</stringProp>
-                <stringProp name="Argument.value">0</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="topicID" elementType="Argument">
-                <stringProp name="Argument.name">topicID</stringProp>
-                <stringProp name="Argument.value">5</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="realmNum" elementType="Argument">
-                <stringProp name="Argument.name">realmNum</stringProp>
-                <stringProp name="Argument.value">0</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="historicMessagesCount" elementType="Argument">
-                <stringProp name="Argument.name">historicMessagesCount</stringProp>
-                <stringProp name="Argument.value">2500</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="newTopicsMessageCount" elementType="Argument">
-                <stringProp name="Argument.name">newTopicsMessageCount</stringProp>
-                <stringProp name="Argument.value">70</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="messagesLatchWaitSeconds" elementType="Argument">
-                <stringProp name="Argument.name">messagesLatchWaitSeconds</stringProp>
-                <stringProp name="Argument.value">60</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-            </collectionProp>
-          </elementProp>
+        <JavaSampler guiclass="JavaTestSamplerGui" testclass="JavaSampler" testname="Subscribe_Sampler" enabled="true">
           <stringProp name="classname">com.hedera.mirror.grpc.jmeter.client.SingleTopicHCSClient</stringProp>
         </JavaSampler>
         <hashTree>

--- a/hedera-mirror-test/src/test/jmeter/E2E_Multi_Client_Subscribe_Only.jmx
+++ b/hedera-mirror-test/src/test/jmeter/E2E_Multi_Client_Subscribe_Only.jmx
@@ -18,7 +18,7 @@
           <boolProp name="LoopController.continue_forever">false</boolProp>
           <stringProp name="LoopController.loops">1</stringProp>
         </elementProp>
-        <stringProp name="ThreadGroup.num_threads">${__P(subcribeThreadCount,1)}</stringProp>
+        <stringProp name="ThreadGroup.num_threads">${__P(subscribeThreadCount,1)}</stringProp>
         <stringProp name="ThreadGroup.ramp_time">1</stringProp>
         <boolProp name="ThreadGroup.scheduler">false</boolProp>
         <stringProp name="ThreadGroup.duration"></stringProp>
@@ -26,7 +26,7 @@
         <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
       </ThreadGroup>
       <hashTree>
-        <JavaSampler guiclass="JavaTestSamplerGui" testclass="JavaSampler" testname="Subcribe_Sampler" enabled="true">
+        <JavaSampler guiclass="JavaTestSamplerGui" testclass="JavaSampler" testname="Subscribe_Sampler" enabled="true">
           <elementProp name="arguments" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" enabled="true">
             <collectionProp name="Arguments.arguments">
               <elementProp name="propertiesBase" elementType="Argument">

--- a/hedera-mirror-test/src/test/jmeter/E2E_Multi_User_All_Messages.jmx
+++ b/hedera-mirror-test/src/test/jmeter/E2E_Multi_User_All_Messages.jmx
@@ -184,7 +184,7 @@
           <boolProp name="LoopController.continue_forever">false</boolProp>
           <stringProp name="LoopController.loops">1</stringProp>
         </elementProp>
-        <stringProp name="ThreadGroup.num_threads">${__P(subcribeThreadCount,5)}</stringProp>
+        <stringProp name="ThreadGroup.num_threads">${__P(subscribeThreadCount,5)}</stringProp>
         <stringProp name="ThreadGroup.ramp_time">1</stringProp>
         <boolProp name="ThreadGroup.scheduler">false</boolProp>
         <stringProp name="ThreadGroup.duration"></stringProp>
@@ -192,61 +192,7 @@
         <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
       </ThreadGroup>
       <hashTree>
-        <JavaSampler guiclass="JavaTestSamplerGui" testclass="JavaSampler" testname="Subcribe_Sampler" enabled="true">
-          <elementProp name="arguments" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" enabled="true">
-            <collectionProp name="Arguments.arguments">
-              <elementProp name="host" elementType="Argument">
-                <stringProp name="Argument.name">host</stringProp>
-                <stringProp name="Argument.value">localhost</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="port" elementType="Argument">
-                <stringProp name="Argument.name">port</stringProp>
-                <stringProp name="Argument.value">5600</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="limit" elementType="Argument">
-                <stringProp name="Argument.name">limit</stringProp>
-                <stringProp name="Argument.value">100</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="consensusStartTimeSeconds" elementType="Argument">
-                <stringProp name="Argument.name">consensusStartTimeSeconds</stringProp>
-                <stringProp name="Argument.value">0</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="consensusEndTimeSeconds" elementType="Argument">
-                <stringProp name="Argument.name">consensusEndTimeSeconds</stringProp>
-                <stringProp name="Argument.value">0</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="topicID" elementType="Argument">
-                <stringProp name="Argument.name">topicID</stringProp>
-                <stringProp name="Argument.value">0</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="realmNum" elementType="Argument">
-                <stringProp name="Argument.name">realmNum</stringProp>
-                <stringProp name="Argument.value">0</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="historicMessagesCount" elementType="Argument">
-                <stringProp name="Argument.name">historicMessagesCount</stringProp>
-                <stringProp name="Argument.value">3</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="newTopicsMessageCount" elementType="Argument">
-                <stringProp name="Argument.name">newTopicsMessageCount</stringProp>
-                <stringProp name="Argument.value">2</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="messagesLatchWaitSeconds" elementType="Argument">
-                <stringProp name="Argument.name">messagesLatchWaitSeconds</stringProp>
-                <stringProp name="Argument.value">60</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-            </collectionProp>
-          </elementProp>
+        <JavaSampler guiclass="JavaTestSamplerGui" testclass="JavaSampler" testname="Subscribe_Sampler" enabled="true">
           <stringProp name="classname">com.hedera.mirror.grpc.jmeter.client.SingleTopicHCSClient</stringProp>
         </JavaSampler>
         <hashTree>

--- a/hedera-mirror-test/src/test/jmeter/E2E_Multi_User_Heavy_Load_All_Messages.jmx
+++ b/hedera-mirror-test/src/test/jmeter/E2E_Multi_User_Heavy_Load_All_Messages.jmx
@@ -184,7 +184,7 @@
           <boolProp name="LoopController.continue_forever">false</boolProp>
           <stringProp name="LoopController.loops">1</stringProp>
         </elementProp>
-        <stringProp name="ThreadGroup.num_threads">${__P(subcribeThreadCount,5)}</stringProp>
+        <stringProp name="ThreadGroup.num_threads">${__P(subscribeThreadCount,5)}</stringProp>
         <stringProp name="ThreadGroup.ramp_time">1</stringProp>
         <boolProp name="ThreadGroup.scheduler">false</boolProp>
         <stringProp name="ThreadGroup.duration"></stringProp>
@@ -192,61 +192,7 @@
         <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
       </ThreadGroup>
       <hashTree>
-        <JavaSampler guiclass="JavaTestSamplerGui" testclass="JavaSampler" testname="Subcribe_Sampler" enabled="true">
-          <elementProp name="arguments" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" enabled="true">
-            <collectionProp name="Arguments.arguments">
-              <elementProp name="host" elementType="Argument">
-                <stringProp name="Argument.name">host</stringProp>
-                <stringProp name="Argument.value">localhost</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="port" elementType="Argument">
-                <stringProp name="Argument.name">port</stringProp>
-                <stringProp name="Argument.value">5600</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="limit" elementType="Argument">
-                <stringProp name="Argument.name">limit</stringProp>
-                <stringProp name="Argument.value">2500</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="consensusStartTimeSeconds" elementType="Argument">
-                <stringProp name="Argument.name">consensusStartTimeSeconds</stringProp>
-                <stringProp name="Argument.value">0</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="consensusEndTimeSeconds" elementType="Argument">
-                <stringProp name="Argument.name">consensusEndTimeSeconds</stringProp>
-                <stringProp name="Argument.value">0</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="topicID" elementType="Argument">
-                <stringProp name="Argument.name">topicID</stringProp>
-                <stringProp name="Argument.value">5</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="realmNum" elementType="Argument">
-                <stringProp name="Argument.name">realmNum</stringProp>
-                <stringProp name="Argument.value">0</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="historicMessagesCount" elementType="Argument">
-                <stringProp name="Argument.name">historicMessagesCount</stringProp>
-                <stringProp name="Argument.value">2000</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="newTopicsMessageCount" elementType="Argument">
-                <stringProp name="Argument.name">newTopicsMessageCount</stringProp>
-                <stringProp name="Argument.value">50</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="messagesLatchWaitSeconds" elementType="Argument">
-                <stringProp name="Argument.name">messagesLatchWaitSeconds</stringProp>
-                <stringProp name="Argument.value">60</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-            </collectionProp>
-          </elementProp>
+        <JavaSampler guiclass="JavaTestSamplerGui" testclass="JavaSampler" testname="Subscribe_Sampler" enabled="true">
           <stringProp name="classname">com.hedera.mirror.grpc.jmeter.client.SingleTopicHCSClient</stringProp>
         </JavaSampler>
         <hashTree>

--- a/hedera-mirror-test/src/test/jmeter/E2E_Single_User_All_Messages.jmx
+++ b/hedera-mirror-test/src/test/jmeter/E2E_Single_User_All_Messages.jmx
@@ -184,7 +184,7 @@
           <boolProp name="LoopController.continue_forever">false</boolProp>
           <stringProp name="LoopController.loops">1</stringProp>
         </elementProp>
-        <stringProp name="ThreadGroup.num_threads">${__P(subcribeThreadCount,1)}</stringProp>
+        <stringProp name="ThreadGroup.num_threads">${__P(subscribeThreadCount,1)}</stringProp>
         <stringProp name="ThreadGroup.ramp_time">1</stringProp>
         <boolProp name="ThreadGroup.scheduler">false</boolProp>
         <stringProp name="ThreadGroup.duration"></stringProp>
@@ -192,61 +192,7 @@
         <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
       </ThreadGroup>
       <hashTree>
-        <JavaSampler guiclass="JavaTestSamplerGui" testclass="JavaSampler" testname="Subcribe_Sampler" enabled="true">
-          <elementProp name="arguments" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" enabled="true">
-            <collectionProp name="Arguments.arguments">
-              <elementProp name="host" elementType="Argument">
-                <stringProp name="Argument.name">host</stringProp>
-                <stringProp name="Argument.value">localhost</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="port" elementType="Argument">
-                <stringProp name="Argument.name">port</stringProp>
-                <stringProp name="Argument.value">5600</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="limit" elementType="Argument">
-                <stringProp name="Argument.name">limit</stringProp>
-                <stringProp name="Argument.value">100</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="consensusStartTimeSeconds" elementType="Argument">
-                <stringProp name="Argument.name">consensusStartTimeSeconds</stringProp>
-                <stringProp name="Argument.value">0</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="consensusEndTimeSeconds" elementType="Argument">
-                <stringProp name="Argument.name">consensusEndTimeSeconds</stringProp>
-                <stringProp name="Argument.value">0</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="topicID" elementType="Argument">
-                <stringProp name="Argument.name">topicID</stringProp>
-                <stringProp name="Argument.value">0</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="realmNum" elementType="Argument">
-                <stringProp name="Argument.name">realmNum</stringProp>
-                <stringProp name="Argument.value">0</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="historicMessagesCount" elementType="Argument">
-                <stringProp name="Argument.name">historicMessagesCount</stringProp>
-                <stringProp name="Argument.value">3</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="newTopicsMessageCount" elementType="Argument">
-                <stringProp name="Argument.name">newTopicsMessageCount</stringProp>
-                <stringProp name="Argument.value">2</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="messagesLatchWaitSeconds" elementType="Argument">
-                <stringProp name="Argument.name">messagesLatchWaitSeconds</stringProp>
-                <stringProp name="Argument.value">60</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-            </collectionProp>
-          </elementProp>
+        <JavaSampler guiclass="JavaTestSamplerGui" testclass="JavaSampler" testname="Subscribe_Sampler" enabled="true">
           <stringProp name="classname">com.hedera.mirror.grpc.jmeter.client.SingleTopicHCSClient</stringProp>
         </JavaSampler>
         <hashTree>

--- a/hedera-mirror-test/src/test/jmeter/E2E_Subscribe_Only.jmx
+++ b/hedera-mirror-test/src/test/jmeter/E2E_Subscribe_Only.jmx
@@ -18,7 +18,7 @@
           <boolProp name="LoopController.continue_forever">false</boolProp>
           <stringProp name="LoopController.loops">1</stringProp>
         </elementProp>
-        <stringProp name="ThreadGroup.num_threads">${__P(subcribeThreadCount,1)}</stringProp>
+        <stringProp name="ThreadGroup.num_threads">${__P(subscribeThreadCount,20)}</stringProp>
         <stringProp name="ThreadGroup.ramp_time">1</stringProp>
         <boolProp name="ThreadGroup.scheduler">false</boolProp>
         <stringProp name="ThreadGroup.duration"></stringProp>
@@ -26,76 +26,12 @@
         <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
       </ThreadGroup>
       <hashTree>
-        <JavaSampler guiclass="JavaTestSamplerGui" testclass="JavaSampler" testname="Subcribe_Sampler" enabled="true">
-          <elementProp name="arguments" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" enabled="true">
-            <collectionProp name="Arguments.arguments">
-              <elementProp name="host" elementType="Argument">
-                <stringProp name="Argument.name">host</stringProp>
-                <stringProp name="Argument.value">localhost</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="port" elementType="Argument">
-                <stringProp name="Argument.name">port</stringProp>
-                <stringProp name="Argument.value">5600</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="limit" elementType="Argument">
-                <stringProp name="Argument.name">limit</stringProp>
-                <stringProp name="Argument.value">0</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="consensusStartTimeSeconds" elementType="Argument">
-                <stringProp name="Argument.name">consensusStartTimeSeconds</stringProp>
-                <stringProp name="Argument.value">0</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="consensusEndTimeSeconds" elementType="Argument">
-                <stringProp name="Argument.name">consensusEndTimeSeconds</stringProp>
-                <stringProp name="Argument.value">0</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="topicID" elementType="Argument">
-                <stringProp name="Argument.name">topicID</stringProp>
-                <stringProp name="Argument.value">0</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="realmNum" elementType="Argument">
-                <stringProp name="Argument.name">realmNum</stringProp>
-                <stringProp name="Argument.value">0</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="historicMessagesCount" elementType="Argument">
-                <stringProp name="Argument.name">historicMessagesCount</stringProp>
-                <stringProp name="Argument.value">5</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="newTopicsMessageCount" elementType="Argument">
-                <stringProp name="Argument.name">newTopicsMessageCount</stringProp>
-                <stringProp name="Argument.value">0</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="messagesLatchWaitSeconds" elementType="Argument">
-                <stringProp name="Argument.name">messagesLatchWaitSeconds</stringProp>
-                <stringProp name="Argument.value">60</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="sharedChannel" elementType="Argument">
-                <stringProp name="Argument.name">sharedChannel</stringProp>
-                <stringProp name="Argument.value">false</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="useMAPI" elementType="Argument">
-                <stringProp name="Argument.name">useMAPI</stringProp>
-                <stringProp name="Argument.value">false</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-            </collectionProp>
-          </elementProp>
+        <JavaSampler guiclass="JavaTestSamplerGui" testclass="JavaSampler" testname="Subscribe_Sampler" enabled="true">
           <stringProp name="classname">com.hedera.mirror.grpc.jmeter.client.SingleTopicHCSClient</stringProp>
         </JavaSampler>
         <hashTree>
           <DurationAssertion guiclass="DurationAssertionGui" testclass="DurationAssertion" testname="SubscribeAssert" enabled="true">
-            <stringProp name="DurationAssertion.duration">20000</stringProp>
+            <stringProp name="DurationAssertion.duration">500000</stringProp>
           </DurationAssertion>
           <hashTree/>
         </hashTree>

--- a/hedera-mirror-test/src/test/jmeter/E2E_Subscribe_Only.jmx
+++ b/hedera-mirror-test/src/test/jmeter/E2E_Subscribe_Only.jmx
@@ -31,7 +31,7 @@
         </JavaSampler>
         <hashTree>
           <DurationAssertion guiclass="DurationAssertionGui" testclass="DurationAssertion" testname="SubscribeAssert" enabled="true">
-            <stringProp name="DurationAssertion.duration">500000</stringProp>
+            <stringProp name="DurationAssertion.duration">20000</stringProp>
           </DurationAssertion>
           <hashTree/>
         </hashTree>

--- a/hedera-mirror-test/src/test/jmeter/Netty_MaxConcurrentCallsPerConnection.jmx
+++ b/hedera-mirror-test/src/test/jmeter/Netty_MaxConcurrentCallsPerConnection.jmx
@@ -18,7 +18,7 @@
           <boolProp name="LoopController.continue_forever">false</boolProp>
           <stringProp name="LoopController.loops">1</stringProp>
         </elementProp>
-        <stringProp name="ThreadGroup.num_threads">${__P(subcribeThreadCount,100)}</stringProp>
+        <stringProp name="ThreadGroup.num_threads">${__P(subscribeThreadCount,100)}</stringProp>
         <stringProp name="ThreadGroup.ramp_time">1</stringProp>
         <boolProp name="ThreadGroup.scheduler">false</boolProp>
         <stringProp name="ThreadGroup.duration"></stringProp>
@@ -26,66 +26,7 @@
         <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
       </ThreadGroup>
       <hashTree>
-        <JavaSampler guiclass="JavaTestSamplerGui" testclass="JavaSampler" testname="Subcribe_Sampler" enabled="true">
-          <elementProp name="arguments" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" enabled="true">
-            <collectionProp name="Arguments.arguments">
-              <elementProp name="host" elementType="Argument">
-                <stringProp name="Argument.name">host</stringProp>
-                <stringProp name="Argument.value">localhost</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="port" elementType="Argument">
-                <stringProp name="Argument.name">port</stringProp>
-                <stringProp name="Argument.value">5600</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="limit" elementType="Argument">
-                <stringProp name="Argument.name">limit</stringProp>
-                <stringProp name="Argument.value">0</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="consensusStartTimeSeconds" elementType="Argument">
-                <stringProp name="Argument.name">consensusStartTimeSeconds</stringProp>
-                <stringProp name="Argument.value">0</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="consensusEndTimeSeconds" elementType="Argument">
-                <stringProp name="Argument.name">consensusEndTimeSeconds</stringProp>
-                <stringProp name="Argument.value">0</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="topicID" elementType="Argument">
-                <stringProp name="Argument.name">topicID</stringProp>
-                <stringProp name="Argument.value">0</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="realmNum" elementType="Argument">
-                <stringProp name="Argument.name">realmNum</stringProp>
-                <stringProp name="Argument.value">0</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="historicMessagesCount" elementType="Argument">
-                <stringProp name="Argument.name">historicMessagesCount</stringProp>
-                <stringProp name="Argument.value">1000</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="newTopicsMessageCount" elementType="Argument">
-                <stringProp name="Argument.name">newTopicsMessageCount</stringProp>
-                <stringProp name="Argument.value">0</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="messagesLatchWaitSeconds" elementType="Argument">
-                <stringProp name="Argument.name">messagesLatchWaitSeconds</stringProp>
-                <stringProp name="Argument.value">60</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="sharedChannel" elementType="Argument">
-                <stringProp name="Argument.name">sharedChannel</stringProp>
-                <stringProp name="Argument.value">true</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-            </collectionProp>
-          </elementProp>
+        <JavaSampler guiclass="JavaTestSamplerGui" testclass="JavaSampler" testname="Subscribe_Sampler" enabled="true">
           <stringProp name="classname">com.hedera.mirror.grpc.jmeter.client.SingleTopicHCSClient</stringProp>
         </JavaSampler>
         <hashTree>

--- a/hedera-mirror-test/src/test/resources/features/hcs/hcs.feature
+++ b/hedera-mirror-test/src/test/resources/features/hcs/hcs.feature
@@ -26,12 +26,12 @@ Feature: HCS Base Coverage Feature
     @SubscribeOnly @Acceptance
     Scenario Outline: Validate topic message subscription only
         Given I provide a topic id <topicId>
-        And I provide a startDate <startDate> and a number of messages <numMessages> I want to receive
+        And I provide a starting timestamp <startTimestamp> and a number of messages <numMessages> I want to receive
         When I subscribe with a filter to retrieve messages
         Then the network should successfully observe these messages
         Examples:
-            | topicId     | startDate | numMessages |
-            | "200002151" | "0"       | 5           |
+            | topicId     | startTimestamp | numMessages |
+            | "200002151" | "0"            | 5           |
 
     @PublishOnly
     Scenario Outline: Validate topic message subscription

--- a/hedera-mirror-test/src/test/resources/features/hcs/hcs.feature
+++ b/hedera-mirror-test/src/test/resources/features/hcs/hcs.feature
@@ -26,12 +26,12 @@ Feature: HCS Base Coverage Feature
     @SubscribeOnly @Acceptance
     Scenario Outline: Validate topic message subscription only
         Given I provide a topic id <topicId>
-        When I provide a number of messages <numMessages> I want to receive
-        And I subscribe with a filter to retrieve messages
+        And I provide a startDate <startDate> and a number of messages <numMessages> I want to receive
+        When I subscribe with a filter to retrieve messages
         Then the network should successfully observe these messages
         Examples:
-            | topicId     | numMessages |
-            | "200002151" | 5           |
+            | topicId     | startDate | numMessages |
+            | "200002151" | "0"       | 5           |
 
     @PublishOnly
     Scenario Outline: Validate topic message subscription

--- a/hedera-mirror-test/src/test/resources/features/topicfilter/hcstopicfilter.feature
+++ b/hedera-mirror-test/src/test/resources/features/topicfilter/hcstopicfilter.feature
@@ -5,24 +5,24 @@ Feature: HCS Message Filter Coverage Feature
     Scenario Outline: Validate topic filtering with past date and get X previous
         Given I successfully create a new topic id
         And I publish and verify <numMessages> messages sent
-        When I provide a startDate <startDate> and a number of messages <numMessages> I want to receive
+        When I provide a starting timestamp <startTimestamp> and a number of messages <numMessages> I want to receive
         And I subscribe with a filter to retrieve messages
         Then the network should successfully observe these messages
         Examples:
-            | startDate                 | numMessages |
+            | startTimestamp            | numMessages |
             | "1970-01-01T00:00:00.00Z" | 2           |
             | "-60"                     | 5           |
 
     Scenario Outline: Validate resubscribe topic filtering
         Given I successfully create a new topic id
         And I publish and verify <numMessages> messages sent
-        When I provide a startDate <startDate> and a number of messages <numMessages> I want to receive
+        When I provide a starting timestamp <startTimestamp> and a number of messages <numMessages> I want to receive
         And I subscribe with a filter to retrieve messages
         And I unsubscribe from a topic
         And I subscribe with a filter to retrieve messages
         Then the network should successfully observe these messages
         Examples:
-            | startDate                 | numMessages |
+            | startTimestamp            | numMessages |
             | "1970-01-01T00:00:00.00Z" | 2           |
             | "2000-01-01T00:00:00.00Z" | 5           |
 
@@ -41,9 +41,9 @@ Feature: HCS Message Filter Coverage Feature
     Scenario Outline: Validate topic filtering with past date and a specified limit
         Given I successfully create a new topic id
         And I publish and verify <numMessages> messages sent
-        When I provide a startDate <startDate> and endDate <endDate> and a limit of <limit> messages I want to receive
+        When I provide a starting timestamp <startTimestamp> and ending timestamp <endTimestamp> and a limit of <limit> messages I want to receive
         And I subscribe with a filter to retrieve messages
         Then the network should successfully observe these messages
         Examples:
-            | numMessages | startDate                 | endDate | limit |
-            | 10          | "2020-01-01T00:00:00.00Z" | "180"   | 5     |
+            | numMessages | startTimestamp            | endTimestamp | limit |
+            | 10          | "2020-01-01T00:00:00.00Z" | "180"        | 5     |


### PR DESCRIPTION
**Detailed description**:
Minor improvements in a few files and some spelling corrections.

- Updated SingleTopicHCClient to support now() subscribe time for incoming messages scenario. 
- Updated HCSSamplerResult to note when last message was received and log this on success/failure. This helps when a stalled client is encountered
- Spelling corrections in README and jmx files
- Removed subscribe test parameters from jmx files as these were moved to user.properties
- Updated hcs.feature @SubscribeOnly scenario to support specifying start time

**Special notes for your reviewer**:
The JMeter layout is still in transition. For subscribe scenarios the test properties are in user.properties. For db related properties that populate or cleanup these are still in imx files.
Also number of threads specification is still done in imx files.

In a future ticket we'd want to explore using a yaml file instead to capture everything.
There's also some room to see if a non-jmeter option exists for performance that will allow for use within the modules and not force coupling. 

**Checklist**
- [x] Documentation added
- [x] Tests updated

