### PR TITLE
Added logic to fail if all missing messages were not retrieved during a subscription

### DIFF
--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/controller/ConsensusControllerTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/controller/ConsensusControllerTest.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.grpc.controller;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -194,6 +194,33 @@ public class ConsensusControllerTest extends GrpcIntegrationTest {
                 .thenAwait(Duration.ofMillis(50))
                 .then(() -> generator.blockLast())
                 .expectNextCount(2)
+                .expectComplete()
+                .verify(Duration.ofMillis(500));
+    }
+
+    @Test
+    void subscribeVerifySequence() throws Exception {
+        domainBuilder.topicMessage().block();
+        domainBuilder.topicMessage().block();
+        domainBuilder.topicMessage().block();
+
+        ConsensusTopicQuery query = ConsensusTopicQuery.newBuilder()
+                .setLimit(7L)
+                .setConsensusStartTime(Timestamp.newBuilder().setSeconds(0).build())
+                .setTopicID(TopicID.newBuilder().setRealmNum(0).setTopicNum(0).build())
+                .build();
+
+        Flux<TopicMessage> generator = Flux
+                .concat(domainBuilder.topicMessage(), domainBuilder.topicMessage(), domainBuilder
+                        .topicMessage(), domainBuilder.topicMessage());
+
+        grpcConsensusService.subscribeTopic(Mono.just(query))
+                .map(ConsensusTopicResponse::getSequenceNumber)
+                .as(StepVerifier::create)
+                .expectNext(1L, 2L, 3L)
+                .thenAwait(Duration.ofMillis(50))
+                .then(() -> generator.blockLast())
+                .expectNext(4L, 5L, 6L, 7L)
                 .expectComplete()
                 .verify(Duration.ofMillis(500));
     }

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/service/TopicMessageServiceTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/service/TopicMessageServiceTest.java
@@ -570,7 +570,7 @@ public class TopicMessageServiceTest extends GrpcIntegrationTest {
         topicMessageService.subscribeTopic(filter)
                 .map(TopicMessage::getSequenceNumber)
                 .as(StepVerifier::create)
-                .expectNext(1L, 2L, 3L, 4L, 5L, 6L, 8L)
+                .expectNext(1L, 2L, 3L, 4L, 5L, 6L)
                 .expectError(IllegalStateException.class)
                 .verify(Duration.ofMillis(700));
     }
@@ -586,13 +586,13 @@ public class TopicMessageServiceTest extends GrpcIntegrationTest {
         topicMessageService.subscribeTopic(filter)
                 .map(TopicMessage::getSequenceNumber)
                 .as(StepVerifier::create)
-                .expectNext(1L, 2L, 3L, 4L, 8L)
+                .expectNext(1L, 2L, 3L, 4L)
                 .expectError(IllegalStateException.class)
                 .verify(Duration.ofMillis(700));
     }
 
     @Test
-    void missingMessagesFromRetriever() {
+    void missingMessagesFromRetrieverAndListener() {
         TopicListener topicListener = Mockito.mock(TopicListener.class);
         EntityRepository entityRepository = Mockito.mock(EntityRepository.class);
         TopicMessageRetriever topicMessageRetriever = Mockito.mock(TopicMessageRetriever.class);
@@ -628,7 +628,7 @@ public class TopicMessageServiceTest extends GrpcIntegrationTest {
         Mockito.when(topicMessageRetriever.retrieve(ArgumentMatchers
                 .any()))
                 .thenReturn(Flux.just(retrieved1),
-                        Flux.empty(), // missing historic
+                        Flux.just(retrieved2), // missing historic
                         Flux.just(
                                 topicMessage(5), // missing incoming
                                 topicMessage(6),
@@ -637,8 +637,8 @@ public class TopicMessageServiceTest extends GrpcIntegrationTest {
         topicMessageService.subscribeTopic(retrieverFilter)
                 .map(TopicMessage::getSequenceNumber)
                 .as(StepVerifier::create)
-                .expectNext(1L, 3L)
-                .expectError(IllegalStateException.class)
+                .expectNext(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L)
+                .expectComplete()
                 .verify(Duration.ofMillis(700));
     }
 


### PR DESCRIPTION
**Detailed description**:
As noted in #589 Currently if subscribe topic detects a gap in sequence number (say if importer is down), it will fill in the missing messages. If this missing message query can't find the missing messages it currently proceeds instead of halting with an error.

This change adds logic to error out should final messages be out of order  for any reason
- Moved missingMessages() from outer flow into incoming messages flow. This avoids the race condition and out of order messages. 
- Added a fail fast check for out of order messages in out onNext
- Added logic in missingMessages to ignore duplicate messages. 
- Added test case to ensure ordering and  appropriate tests to verify missing messages from the listener.

**Which issue(s) this PR fixes**:
Fixes #589 

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated

