### PR TITLE
Increase rest api integration coverage to match api offerings

### DIFF
--- a/hedera-mirror-rest/__tests__/specs/accounts-02-specific-id.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/accounts-02-specific-id.spec.json
@@ -1,0 +1,55 @@
+{
+  "description": "Account api calls for specific account",
+  "setup": {
+    "accounts": [
+      {
+        "entity_num": 7
+      },
+      {
+        "entity_num": 8
+      },
+      {
+        "entity_num": 9
+      }
+    ],
+    "balances": [
+      {
+        "timestamp": 2345,
+        "id": 7,
+        "balance": 70
+      },
+      {
+        "timestamp": 2345,
+        "id": 8,
+        "balance": 80
+      },
+      {
+        "timestamp": 2345,
+        "id": 9,
+        "balance": 90
+      }
+    ],
+    "transactions": [],
+    "cryptotransfers": []
+  },
+  "url": "/api/v1/accounts?account.id=0.0.8",
+  "responseStatus": 200,
+  "responseJson": {
+    "accounts": [
+      {
+        "balance": {
+          "timestamp": "0.000002345",
+          "balance": 80
+        },
+        "account": "0.0.8",
+        "expiry_timestamp": null,
+        "auto_renew_period": null,
+        "key": null,
+        "deleted": false
+      }
+    ],
+    "links": {
+      "next": null
+    }
+  }
+}

--- a/hedera-mirror-rest/__tests__/specs/accounts-03-accounts-range.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/accounts-03-accounts-range.spec.json
@@ -1,0 +1,82 @@
+{
+  "description": "Account api call for specific a range of account",
+  "setup": {
+    "accounts": [
+      {
+        "entity_num": 17
+      },
+      {
+        "entity_num": 18
+      },
+      {
+        "entity_num": 19
+      },
+      {
+        "entity_num": 20
+      },
+      {
+        "entity_num": 21
+      }
+    ],
+    "balances": [
+      {
+        "timestamp": 2345,
+        "id": 17,
+        "balance": 70
+      },
+      {
+        "timestamp": 2345,
+        "id": 18,
+        "balance": 80
+      },
+      {
+        "timestamp": 2345,
+        "id": 19,
+        "balance": 90
+      },
+      {
+        "timestamp": 2345,
+        "id": 20,
+        "balance": 100
+      },
+      {
+        "timestamp": 2345,
+        "id": 21,
+        "balance": 110
+      }
+    ],
+    "transactions": [],
+    "cryptotransfers": []
+  },
+  "url": "/api/v1/accounts?account.id=gte:0.0.18&account.id=lt:0.0.20",
+  "responseStatus": 200,
+  "responseJson": {
+    "accounts": [
+      {
+        "balance": {
+          "timestamp": "0.000002345",
+          "balance": 80
+        },
+        "account": "0.0.18",
+        "expiry_timestamp": null,
+        "auto_renew_period": null,
+        "key": null,
+        "deleted": false
+      },
+      {
+        "balance": {
+          "timestamp": "0.000002345",
+          "balance": 90
+        },
+        "account": "0.0.19",
+        "expiry_timestamp": null,
+        "auto_renew_period": null,
+        "key": null,
+        "deleted": false
+      }
+    ],
+    "links": {
+      "next": null
+    }
+  }
+}

--- a/hedera-mirror-rest/__tests__/specs/accounts-04-balance-range.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/accounts-04-balance-range.spec.json
@@ -1,0 +1,82 @@
+{
+  "description": "Account api call for all accounts with a balance that matches the range",
+  "setup": {
+    "accounts": [
+      {
+        "entity_num": 17
+      },
+      {
+        "entity_num": 18
+      },
+      {
+        "entity_num": 19
+      },
+      {
+        "entity_num": 20
+      },
+      {
+        "entity_num": 21
+      }
+    ],
+    "balances": [
+      {
+        "timestamp": 2345,
+        "id": 17,
+        "balance": 70
+      },
+      {
+        "timestamp": 2345,
+        "id": 18,
+        "balance": 20
+      },
+      {
+        "timestamp": 2345,
+        "id": 19,
+        "balance": 90
+      },
+      {
+        "timestamp": 2345,
+        "id": 20,
+        "balance": 45
+      },
+      {
+        "timestamp": 2345,
+        "id": 21,
+        "balance": 30
+      }
+    ],
+    "transactions": [],
+    "cryptotransfers": []
+  },
+  "url": "/api/v1/accounts?account.balance=gt:45&order=desc",
+  "responseStatus": 200,
+  "responseJson": {
+    "accounts": [
+      {
+        "balance": {
+          "timestamp": "0.000002345",
+          "balance": 90
+        },
+        "account": "0.0.19",
+        "expiry_timestamp": null,
+        "auto_renew_period": null,
+        "key": null,
+        "deleted": false
+      },
+      {
+        "balance": {
+          "timestamp": "0.000002345",
+          "balance": 70
+        },
+        "account": "0.0.17",
+        "expiry_timestamp": null,
+        "auto_renew_period": null,
+        "key": null,
+        "deleted": false
+      }
+    ],
+    "links": {
+      "next": null
+    }
+  }
+}

--- a/hedera-mirror-rest/__tests__/specs/accounts-05-publickey.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/accounts-05-publickey.spec.json
@@ -1,0 +1,58 @@
+{
+  "description": "Account api call for specific id with a matching public key",
+  "setup": {
+    "accounts": [
+      {
+        "entity_num": 7,
+        "public_key": "6ceecd8bb224da4914d53f292e5624f6f4cf8c134c920e1cac8d06f879df5819"
+      },
+      {
+        "entity_num": 8,
+        "public_key": "519a008fabde4d28d68293c71fcdcdcca38d8fae6102a832b31e802f257fd1d9"
+      },
+      {
+        "entity_num": 9,
+        "public_key": "3c3d546321ff6f63d701d2ec5c277095874e19f4a235bee1e6bb19258bf362be"
+      }
+    ],
+    "balances": [
+      {
+        "timestamp": 2345,
+        "id": 7,
+        "balance": 70
+      },
+      {
+        "timestamp": 2345,
+        "id": 8,
+        "balance": 80
+      },
+      {
+        "timestamp": 2345,
+        "id": 9,
+        "balance": 90
+      }
+    ],
+    "transactions": [],
+    "cryptotransfers": []
+  },
+  "url": "/api/v1/accounts?account.publickey=3c3d546321ff6f63d701d2ec5c277095874e19f4a235bee1e6bb19258bf362be",
+  "responseStatus": 200,
+  "responseJson": {
+    "accounts": [
+      {
+        "balance": {
+          "timestamp": "0.000002345",
+          "balance": 90
+        },
+        "account": "0.0.9",
+        "expiry_timestamp": null,
+        "auto_renew_period": null,
+        "key": null,
+        "deleted": false
+      }
+    ],
+    "links": {
+      "next": null
+    }
+  }
+}

--- a/hedera-mirror-rest/__tests__/specs/balances-02-specific-id.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/balances-02-specific-id.spec.json
@@ -1,0 +1,49 @@
+{
+  "description": "Balance api calls for a specific account",
+  "setup": {
+    "accounts": [
+      {
+        "entity_num": 7
+      },
+      {
+        "entity_num": 8
+      },
+      {
+        "entity_num": 9
+      }
+    ],
+    "balances": [
+      {
+        "timestamp": 2345,
+        "id": 7,
+        "balance": 70
+      },
+      {
+        "timestamp": 2345,
+        "id": 8,
+        "balance": 80
+      },
+      {
+        "timestamp": 2345,
+        "id": 9,
+        "balance": 90
+      }
+    ],
+    "transactions": [],
+    "cryptotransfers": []
+  },
+  "url": "/api/v1/balances?account.id=0.0.8",
+  "responseStatus": 200,
+  "responseJson": {
+    "timestamp": "0.000002345",
+    "balances": [
+      {
+        "account": "0.0.8",
+        "balance": 80
+      }
+    ],
+    "links": {
+      "next": null
+    }
+  }
+}

--- a/hedera-mirror-rest/__tests__/specs/balances-03-balance-range.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/balances-03-balance-range.spec.json
@@ -1,0 +1,69 @@
+{
+  "description": "Balance api calls for a range of balances",
+  "setup": {
+    "accounts": [
+      {
+        "entity_num": 17
+      },
+      {
+        "entity_num": 18
+      },
+      {
+        "entity_num": 19
+      },
+      {
+        "entity_num": 20
+      },
+      {
+        "entity_num": 21
+      }
+    ],
+    "balances": [
+      {
+        "timestamp": 2345,
+        "id": 17,
+        "balance": 700
+      },
+      {
+        "timestamp": 2345,
+        "id": 18,
+        "balance": 200
+      },
+      {
+        "timestamp": 2345,
+        "id": 19,
+        "balance": 900
+      },
+      {
+        "timestamp": 2345,
+        "id": 20,
+        "balance": 450
+      },
+      {
+        "timestamp": 2345,
+        "id": 21,
+        "balance": 300
+      }
+    ],
+    "transactions": [],
+    "cryptotransfers": []
+  },
+  "url": "/api/v1/balances?account.balance=gt:300&account.balance=lte:700&&order=asc",
+  "responseStatus": 200,
+  "responseJson": {
+    "timestamp": "0.000002345",
+    "balances": [
+      {
+        "account": "0.0.17",
+        "balance": 700
+      },
+      {
+        "account": "0.0.20",
+        "balance": 450
+      }
+    ],
+    "links": {
+      "next": null
+    }
+  }
+}

--- a/hedera-mirror-rest/__tests__/specs/balances-04-publickey.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/balances-04-publickey.spec.json
@@ -1,0 +1,52 @@
+{
+  "description": "Balance api calls for specific account with a matching public key",
+  "setup": {
+    "accounts": [
+      {
+        "entity_num": 7,
+        "public_key": "6ceecd8bb224da4914d53f292e5624f6f4cf8c134c920e1cac8d06f879df5819"
+      },
+      {
+        "entity_num": 8,
+        "public_key": "519a008fabde4d28d68293c71fcdcdcca38d8fae6102a832b31e802f257fd1d9"
+      },
+      {
+        "entity_num": 9,
+        "public_key": "3c3d546321ff6f63d701d2ec5c277095874e19f4a235bee1e6bb19258bf362be"
+      }
+    ],
+    "balances": [
+      {
+        "timestamp": 2345,
+        "id": 7,
+        "balance": 70
+      },
+      {
+        "timestamp": 2345,
+        "id": 8,
+        "balance": 80
+      },
+      {
+        "timestamp": 2345,
+        "id": 9,
+        "balance": 90
+      }
+    ],
+    "transactions": [],
+    "cryptotransfers": []
+  },
+  "url": "/api/v1/balances?account.publickey=519a008fabde4d28d68293c71fcdcdcca38d8fae6102a832b31e802f257fd1d9",
+  "responseStatus": 200,
+  "responseJson": {
+    "timestamp": "0.000002345",
+    "balances": [
+      {
+        "account": "0.0.8",
+        "balance": 80
+      }
+    ],
+    "links": {
+      "next": null
+    }
+  }
+}

--- a/hedera-mirror-rest/__tests__/specs/balances-05-timestamp.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/balances-05-timestamp.spec.json
@@ -1,0 +1,94 @@
+{
+  "description": "Balance api calls for all account balances referencing the latest snapshot that occurred prior to timestamp",
+  "setup": {
+    "accounts": [
+      {
+        "entity_num": 4
+      },
+      {
+        "entity_num": 5
+      },
+      {
+        "entity_num": 6
+      },
+      {
+        "entity_num": 7
+      }
+    ],
+    "balances": [
+      {
+        "timestamp": 1566560001000000000,
+        "id": 4,
+        "balance": 40
+      },
+      {
+        "timestamp": 1566560001000000000,
+        "id": 5,
+        "balance": 50
+      },
+      {
+        "timestamp": 1566560001000000000,
+        "id": 6,
+        "balance": 60
+      },
+      {
+        "timestamp": 1566560003000000000,
+        "id": 4,
+        "balance": 444
+      },
+      {
+        "timestamp": 1566560003000000000,
+        "id": 5,
+        "balance": 555
+      },
+      {
+        "timestamp": 1566560003000000000,
+        "id": 6,
+        "balance": 666
+      },
+      {
+        "timestamp": 1566560003000000000,
+        "id": 7,
+        "balance": 777
+      },
+      {
+        "timestamp": 1566560007000000000,
+        "id": 5,
+        "balance": 5
+      },
+      {
+        "timestamp": 1566560007000000000,
+        "id": 6,
+        "balance": 6
+      }
+    ],
+    "transactions": [],
+    "cryptotransfers": []
+  },
+  "url": "/api/v1/balances?timestamp=1566560004.000000000",
+  "responseStatus": 200,
+  "responseJson": {
+    "timestamp": "1566560003.000000000",
+    "balances": [
+      {
+        "account": "0.0.7",
+        "balance": 777
+      },
+      {
+        "account": "0.0.6",
+        "balance": 666
+      },
+      {
+        "account": "0.0.5",
+        "balance": 555
+      },
+      {
+        "account": "0.0.4",
+        "balance": 444
+      }
+    ],
+    "links": {
+      "next": null
+    }
+  }
+}

--- a/hedera-mirror-rest/__tests__/specs/transactions-04-timestamp.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-04-timestamp.spec.json
@@ -1,0 +1,85 @@
+{
+  "description": "Transaction api calls for transactions at timestamp",
+  "setup": {
+    "accounts": [
+      {
+        "entity_num": 3
+      },
+      {
+        "entity_num": 8
+      },
+      {
+        "entity_num": 9
+      },
+      {
+        "entity_num": 10
+      },
+      {
+        "entity_num": 98
+      }
+    ],
+    "balances": [],
+    "transactions": [],
+    "cryptotransfers": [
+      {
+        "consensus_timestamp": "1565779111711927001",
+        "payerAccountId": "0.0.10",
+        "recipientAccountId": "0.0.9",
+        "amount": 10,
+        "nodeAccountId": "0.0.3",
+        "treasuryAccountId": "0.0.98"
+      },
+      {
+        "consensus_timestamp": "1565779209711927001",
+        "payerAccountId": "0.0.10",
+        "recipientAccountId": "0.0.9",
+        "amount": 20,
+        "nodeAccountId": "0.0.3",
+        "treasuryAccountId": "0.0.98"
+      },
+      {
+        "consensus_timestamp": "1565779333711927001",
+        "payerAccountId": "0.0.8",
+        "recipientAccountId": "0.0.9",
+        "amount": 30,
+        "nodeAccountId": "0.0.3",
+        "treasuryAccountId": "0.0.98"
+      }
+    ]
+  },
+  "url": "/api/v1/transactions?timestamp=1565779209.711927001",
+  "responseStatus": 200,
+  "responseJson": {
+    "transactions": [
+      {
+        "consensus_timestamp": "1565779209.711927001",
+        "valid_start_timestamp": "1565779209.711927000",
+        "charged_tx_fee": 7,
+        "memo_base64": null,
+        "result": "SUCCESS",
+        "name": "CRYPTOTRANSFER",
+        "node": "0.0.3",
+        "transaction_id": "0.0.10-1565779209-711927000",
+        "valid_duration_seconds": "11",
+        "max_fee": "33",
+        "transfers": [
+          {
+            "account": "0.0.9",
+            "amount": 20
+          },
+          {
+            "account": "0.0.10",
+            "amount": -21
+          },
+          {
+            "account": "0.0.98",
+            "amount": 1
+          }
+        ]
+      }
+    ],
+    "links": {
+      "next": null
+    }
+  }
+}

--- a/hedera-mirror-rest/__tests__/specs/transactions-05-success-result.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-05-success-result.spec.json
@@ -1,5 +1,5 @@
 {
-  "description": "Transaction api calls with no arguments",
+  "description": "Transaction api calls for transactions with success result type",
   "setup": {
     "accounts": [
       {
@@ -22,15 +22,16 @@
     "transactions": [],
     "cryptotransfers": [
       {
-        "consensus_timestamp": "1234567890000000001",
+        "consensus_timestamp": "1565779111711927001",
         "payerAccountId": "0.0.10",
         "recipientAccountId": "0.0.9",
         "amount": 10,
         "nodeAccountId": "0.0.3",
-        "treasuryAccountId": "0.0.98"
+        "treasuryAccountId": "0.0.98",
+        "result": 24
       },
       {
-        "consensus_timestamp": "1234567890000000002",
+        "consensus_timestamp": "1565779209711927001",
         "payerAccountId": "0.0.10",
         "recipientAccountId": "0.0.9",
         "amount": 20,
@@ -38,38 +39,47 @@
         "treasuryAccountId": "0.0.98"
       },
       {
-        "consensus_timestamp": "1234567890000000003",
+        "consensus_timestamp": "1565779333711927001",
         "payerAccountId": "0.0.8",
         "recipientAccountId": "0.0.9",
         "amount": 30,
+        "nodeAccountId": "0.0.3",
+        "treasuryAccountId": "0.0.98",
+        "result": 25
+      },
+      {
+        "consensus_timestamp": "1565779666711927001",
+        "payerAccountId": "0.0.8",
+        "recipientAccountId": "0.0.9",
+        "amount": 40,
         "nodeAccountId": "0.0.3",
         "treasuryAccountId": "0.0.98"
       }
     ]
   },
-  "url": "/api/v1/transactions",
+  "url": "/api/v1/transactions?result=success",
   "responseStatus": 200,
   "responseJson": {
     "transactions": [
       {
-        "consensus_timestamp": "1234567890.000000003",
-        "valid_start_timestamp": "1234567890.000000002",
+        "consensus_timestamp": "1565779666.711927001",
+        "valid_start_timestamp": "1565779666.711927000",
         "charged_tx_fee": 7,
         "memo_base64": null,
         "result": "SUCCESS",
         "name": "CRYPTOTRANSFER",
         "node": "0.0.3",
-        "transaction_id": "0.0.8-1234567890-000000002",
+        "transaction_id": "0.0.8-1565779666-711927000",
         "valid_duration_seconds": "11",
         "max_fee": "33",
         "transfers": [
           {
             "account": "0.0.8",
-            "amount": -31
+            "amount": -41
           },
           {
             "account": "0.0.9",
-            "amount": 30
+            "amount": 40
           },
           {
             "account": "0.0.98",
@@ -78,14 +88,14 @@
         ]
       },
       {
-        "consensus_timestamp": "1234567890.000000002",
-        "valid_start_timestamp": "1234567890.000000001",
+        "consensus_timestamp": "1565779209.711927001",
+        "valid_start_timestamp": "1565779209.711927000",
         "charged_tx_fee": 7,
         "memo_base64": null,
         "result": "SUCCESS",
         "name": "CRYPTOTRANSFER",
         "node": "0.0.3",
-        "transaction_id": "0.0.10-1234567890-000000001",
+        "transaction_id": "0.0.10-1565779209-711927000",
         "valid_duration_seconds": "11",
         "max_fee": "33",
         "transfers": [
@@ -96,32 +106,6 @@
           {
             "account": "0.0.10",
             "amount": -21
-          },
-          {
-            "account": "0.0.98",
-            "amount": 1
-          }
-        ]
-      },
-      {
-        "consensus_timestamp": "1234567890.000000001",
-        "valid_start_timestamp": "1234567890.000000000",
-        "charged_tx_fee": 7,
-        "memo_base64": null,
-        "result": "SUCCESS",
-        "name": "CRYPTOTRANSFER",
-        "node": "0.0.3",
-        "transaction_id": "0.0.10-1234567890-000000000",
-        "valid_duration_seconds": "11",
-        "max_fee": "33",
-        "transfers": [
-          {
-            "account": "0.0.9",
-            "amount": 10
-          },
-          {
-            "account": "0.0.10",
-            "amount": -11
           },
           {
             "account": "0.0.98",

--- a/hedera-mirror-rest/__tests__/specs/transactions-06-fail-result.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-06-fail-result.spec.json
@@ -1,5 +1,5 @@
 {
-  "description": "Transaction api calls with no arguments",
+  "description": "Transaction api calls for transactions with fail result type",
   "setup": {
     "accounts": [
       {
@@ -22,15 +22,16 @@
     "transactions": [],
     "cryptotransfers": [
       {
-        "consensus_timestamp": "1234567890000000001",
+        "consensus_timestamp": "1565779111711927001",
         "payerAccountId": "0.0.10",
         "recipientAccountId": "0.0.9",
         "amount": 10,
         "nodeAccountId": "0.0.3",
-        "treasuryAccountId": "0.0.98"
+        "treasuryAccountId": "0.0.98",
+        "result": 24
       },
       {
-        "consensus_timestamp": "1234567890000000002",
+        "consensus_timestamp": "1565779209711927001",
         "payerAccountId": "0.0.10",
         "recipientAccountId": "0.0.9",
         "amount": 20,
@@ -38,28 +39,37 @@
         "treasuryAccountId": "0.0.98"
       },
       {
-        "consensus_timestamp": "1234567890000000003",
+        "consensus_timestamp": "1565779333711927001",
         "payerAccountId": "0.0.8",
         "recipientAccountId": "0.0.9",
         "amount": 30,
+        "nodeAccountId": "0.0.3",
+        "treasuryAccountId": "0.0.98",
+        "result": 25
+      },
+      {
+        "consensus_timestamp": "1565779666711927001",
+        "payerAccountId": "0.0.8",
+        "recipientAccountId": "0.0.9",
+        "amount": 40,
         "nodeAccountId": "0.0.3",
         "treasuryAccountId": "0.0.98"
       }
     ]
   },
-  "url": "/api/v1/transactions",
+  "url": "/api/v1/transactions?result=fail",
   "responseStatus": 200,
   "responseJson": {
     "transactions": [
       {
-        "consensus_timestamp": "1234567890.000000003",
-        "valid_start_timestamp": "1234567890.000000002",
+        "consensus_timestamp": "1565779333.711927001",
+        "valid_start_timestamp": "1565779333.711927000",
         "charged_tx_fee": 7,
         "memo_base64": null,
-        "result": "SUCCESS",
+        "result": "FAIL_BALANCE",
         "name": "CRYPTOTRANSFER",
         "node": "0.0.3",
-        "transaction_id": "0.0.8-1234567890-000000002",
+        "transaction_id": "0.0.8-1565779333-711927000",
         "valid_duration_seconds": "11",
         "max_fee": "33",
         "transfers": [
@@ -78,40 +88,14 @@
         ]
       },
       {
-        "consensus_timestamp": "1234567890.000000002",
-        "valid_start_timestamp": "1234567890.000000001",
+        "consensus_timestamp": "1565779111.711927001",
+        "valid_start_timestamp": "1565779111.711927000",
         "charged_tx_fee": 7,
         "memo_base64": null,
-        "result": "SUCCESS",
+        "result": "FAIL_FEE",
         "name": "CRYPTOTRANSFER",
         "node": "0.0.3",
-        "transaction_id": "0.0.10-1234567890-000000001",
-        "valid_duration_seconds": "11",
-        "max_fee": "33",
-        "transfers": [
-          {
-            "account": "0.0.9",
-            "amount": 20
-          },
-          {
-            "account": "0.0.10",
-            "amount": -21
-          },
-          {
-            "account": "0.0.98",
-            "amount": 1
-          }
-        ]
-      },
-      {
-        "consensus_timestamp": "1234567890.000000001",
-        "valid_start_timestamp": "1234567890.000000000",
-        "charged_tx_fee": 7,
-        "memo_base64": null,
-        "result": "SUCCESS",
-        "name": "CRYPTOTRANSFER",
-        "node": "0.0.3",
-        "transaction_id": "0.0.10-1234567890-000000000",
+        "transaction_id": "0.0.10-1565779111-711927000",
         "valid_duration_seconds": "11",
         "max_fee": "33",
         "transfers": [

--- a/hedera-mirror-rest/__tests__/specs/transactions-07-credit-type.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-07-credit-type.spec.json
@@ -1,5 +1,5 @@
 {
-  "description": "Transaction api calls with no arguments",
+  "description": "Transaction api calls for transactions with the credit result type",
   "setup": {
     "accounts": [
       {
@@ -22,15 +22,16 @@
     "transactions": [],
     "cryptotransfers": [
       {
-        "consensus_timestamp": "1234567890000000001",
+        "consensus_timestamp": "1565779111711927001",
         "payerAccountId": "0.0.10",
         "recipientAccountId": "0.0.9",
         "amount": 10,
         "nodeAccountId": "0.0.3",
-        "treasuryAccountId": "0.0.98"
+        "treasuryAccountId": "0.0.98",
+        "result": 24
       },
       {
-        "consensus_timestamp": "1234567890000000002",
+        "consensus_timestamp": "1565779209711927001",
         "payerAccountId": "0.0.10",
         "recipientAccountId": "0.0.9",
         "amount": 20,
@@ -38,28 +39,37 @@
         "treasuryAccountId": "0.0.98"
       },
       {
-        "consensus_timestamp": "1234567890000000003",
+        "consensus_timestamp": "1565779333711927001",
         "payerAccountId": "0.0.8",
         "recipientAccountId": "0.0.9",
         "amount": 30,
+        "nodeAccountId": "0.0.3",
+        "treasuryAccountId": "0.0.98",
+        "result": 25
+      },
+      {
+        "consensus_timestamp": "1565779666711927001",
+        "payerAccountId": "0.0.8",
+        "recipientAccountId": "0.0.10",
+        "amount": 40,
         "nodeAccountId": "0.0.3",
         "treasuryAccountId": "0.0.98"
       }
     ]
   },
-  "url": "/api/v1/transactions",
+  "url": "/api/v1/transactions?account.id=0.0.9&type=credit",
   "responseStatus": 200,
   "responseJson": {
     "transactions": [
       {
-        "consensus_timestamp": "1234567890.000000003",
-        "valid_start_timestamp": "1234567890.000000002",
+        "consensus_timestamp": "1565779333.711927001",
+        "valid_start_timestamp": "1565779333.711927000",
         "charged_tx_fee": 7,
         "memo_base64": null,
-        "result": "SUCCESS",
+        "result": "FAIL_BALANCE",
         "name": "CRYPTOTRANSFER",
         "node": "0.0.3",
-        "transaction_id": "0.0.8-1234567890-000000002",
+        "transaction_id": "0.0.8-1565779333-711927000",
         "valid_duration_seconds": "11",
         "max_fee": "33",
         "transfers": [
@@ -78,14 +88,14 @@
         ]
       },
       {
-        "consensus_timestamp": "1234567890.000000002",
-        "valid_start_timestamp": "1234567890.000000001",
+        "consensus_timestamp": "1565779209.711927001",
+        "valid_start_timestamp": "1565779209.711927000",
         "charged_tx_fee": 7,
         "memo_base64": null,
         "result": "SUCCESS",
         "name": "CRYPTOTRANSFER",
         "node": "0.0.3",
-        "transaction_id": "0.0.10-1234567890-000000001",
+        "transaction_id": "0.0.10-1565779209-711927000",
         "valid_duration_seconds": "11",
         "max_fee": "33",
         "transfers": [
@@ -104,14 +114,14 @@
         ]
       },
       {
-        "consensus_timestamp": "1234567890.000000001",
-        "valid_start_timestamp": "1234567890.000000000",
+        "consensus_timestamp": "1565779111.711927001",
+        "valid_start_timestamp": "1565779111.711927000",
         "charged_tx_fee": 7,
         "memo_base64": null,
-        "result": "SUCCESS",
+        "result": "FAIL_FEE",
         "name": "CRYPTOTRANSFER",
         "node": "0.0.3",
-        "transaction_id": "0.0.10-1234567890-000000000",
+        "transaction_id": "0.0.10-1565779111-711927000",
         "valid_duration_seconds": "11",
         "max_fee": "33",
         "transfers": [

--- a/hedera-mirror-rest/__tests__/specs/transactions-08-debit-type.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-08-debit-type.spec.json
@@ -1,5 +1,5 @@
 {
-  "description": "Transaction api calls with no arguments",
+  "description": "Transaction api calls for transactions with the debit result type",
   "setup": {
     "accounts": [
       {
@@ -22,15 +22,16 @@
     "transactions": [],
     "cryptotransfers": [
       {
-        "consensus_timestamp": "1234567890000000001",
+        "consensus_timestamp": "1565779111711927001",
         "payerAccountId": "0.0.10",
         "recipientAccountId": "0.0.9",
         "amount": 10,
         "nodeAccountId": "0.0.3",
-        "treasuryAccountId": "0.0.98"
+        "treasuryAccountId": "0.0.98",
+        "result": 24
       },
       {
-        "consensus_timestamp": "1234567890000000002",
+        "consensus_timestamp": "1565779209711927001",
         "payerAccountId": "0.0.10",
         "recipientAccountId": "0.0.9",
         "amount": 20,
@@ -38,56 +39,37 @@
         "treasuryAccountId": "0.0.98"
       },
       {
-        "consensus_timestamp": "1234567890000000003",
+        "consensus_timestamp": "1565779333711927001",
         "payerAccountId": "0.0.8",
         "recipientAccountId": "0.0.9",
         "amount": 30,
+        "nodeAccountId": "0.0.3",
+        "treasuryAccountId": "0.0.98",
+        "result": 25
+      },
+      {
+        "consensus_timestamp": "1565779666711927001",
+        "payerAccountId": "0.0.8",
+        "recipientAccountId": "0.0.10",
+        "amount": 40,
         "nodeAccountId": "0.0.3",
         "treasuryAccountId": "0.0.98"
       }
     ]
   },
-  "url": "/api/v1/transactions",
+  "url": "/api/v1/transactions?account.id=0.0.10&type=debit",
   "responseStatus": 200,
   "responseJson": {
     "transactions": [
       {
-        "consensus_timestamp": "1234567890.000000003",
-        "valid_start_timestamp": "1234567890.000000002",
         "charged_tx_fee": 7,
+        "consensus_timestamp": "1565779209.711927001",
+        "max_fee": "33",
         "memo_base64": null,
-        "result": "SUCCESS",
         "name": "CRYPTOTRANSFER",
         "node": "0.0.3",
-        "transaction_id": "0.0.8-1234567890-000000002",
-        "valid_duration_seconds": "11",
-        "max_fee": "33",
-        "transfers": [
-          {
-            "account": "0.0.8",
-            "amount": -31
-          },
-          {
-            "account": "0.0.9",
-            "amount": 30
-          },
-          {
-            "account": "0.0.98",
-            "amount": 1
-          }
-        ]
-      },
-      {
-        "consensus_timestamp": "1234567890.000000002",
-        "valid_start_timestamp": "1234567890.000000001",
-        "charged_tx_fee": 7,
-        "memo_base64": null,
         "result": "SUCCESS",
-        "name": "CRYPTOTRANSFER",
-        "node": "0.0.3",
-        "transaction_id": "0.0.10-1234567890-000000001",
-        "valid_duration_seconds": "11",
-        "max_fee": "33",
+        "transaction_id": "0.0.10-1565779209-711927000",
         "transfers": [
           {
             "account": "0.0.9",
@@ -101,19 +83,19 @@
             "account": "0.0.98",
             "amount": 1
           }
-        ]
+        ],
+        "valid_duration_seconds": "11",
+        "valid_start_timestamp": "1565779209.711927000"
       },
       {
-        "consensus_timestamp": "1234567890.000000001",
-        "valid_start_timestamp": "1234567890.000000000",
         "charged_tx_fee": 7,
+        "consensus_timestamp": "1565779111.711927001",
+        "max_fee": "33",
         "memo_base64": null,
-        "result": "SUCCESS",
         "name": "CRYPTOTRANSFER",
         "node": "0.0.3",
-        "transaction_id": "0.0.10-1234567890-000000000",
-        "valid_duration_seconds": "11",
-        "max_fee": "33",
+        "result": "FAIL_FEE",
+        "transaction_id": "0.0.10-1565779111-711927000",
         "transfers": [
           {
             "account": "0.0.9",
@@ -127,7 +109,9 @@
             "account": "0.0.98",
             "amount": 1
           }
-        ]
+        ],
+        "valid_duration_seconds": "11",
+        "valid_start_timestamp": "1565779111.711927000"
       }
     ],
     "links": {


### PR DESCRIPTION
**Detailed description**:
As noted in #412 "We keep having regressions in the REST API because we don't have good test coverage. We have an integration test framework but it is not filled out with specs for all URLs and combinations of parameters."

This PR increases the integration test coverage by providing parity coverage with The REST API endpoints and parameter options

- Updated integrationDomainOps.js to insert value for public key
- Added accounts-02-specific-id.spec.json to verify api/v1/accounts?account.id=x.y.z
- Added accounts-03-accounts-range.spec.json to verify account rage /api/v1/accounts?account.id=gte:x1.y1.y1&account.id=lt:x2.y2.z2
- Added accounts-04-balance-range.spec.json to verify /api/v1/accounts?account.balance=gt:x  and desc order param
- Added accounts-05-publickey.spec.json to verify /api/v1/accounts?account.publickey=x
- Added balances-02-specific-id.spec.json to verify /api/v1/balances?account.id=x.y.z
- Added balances-03-balance-range.spec.json to verify /api/v1/balances?account.balance=gt:x&account.balance=lte:y and ascending order param
- Added balances-04-publickey.spec.json to verify /api/v1/balances?account.publickey=x
- Added balances-05-timestamp.spec.json to verify /api/v1/balances?timestamp=<seconds>.<nanos>
- Removed duplicate valid_duration_seconds and valid_start_timestamp from transactions-01-no-args.spec.json
- Added transactions-04-timestamp.spec.json to verify /api/v1/transactions?timestamp=<seconds>.<nanos>
- Added transactions-05-success-result.spec.json to verify /api/v1/transactions?result=success
- Added transactions-06-fail-result.spec.json to verify /api/v1/transactions?result=fail
- Added transactions-07-credit-type.spec.json to verify /api/v1/transactions?account.id=x.y.z&type=credit
- Added transactions-08-debit-type.spec.json to verify /api/v1/transactions?account.id=x.y.z&type=debit

**Which issue(s) this PR fixes**:
Partially addresses #412

**Special notes for your reviewer**:
Will add negative and empty response cases in a new PR

**Checklist**
- [ ] Documentation added
- [x] Tests updated

