### PR TITLE
Add support for Requester Pays S3 buckets

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/Downloader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/Downloader.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.importer.downloader;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -50,6 +50,7 @@ import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.ListObjectsRequest;
 import software.amazon.awssdk.services.s3.model.ListObjectsResponse;
+import software.amazon.awssdk.services.s3.model.RequestPayer;
 import software.amazon.awssdk.services.s3.model.S3Object;
 
 import com.hedera.mirror.importer.addressbook.NetworkAddressBook;
@@ -151,6 +152,7 @@ public abstract class Downloader {
                             .delimiter("/")
                             .marker(s3Prefix + lastValidSigFileName)
                             .maxKeys(listSize)
+                            .requestPayer(RequestPayer.REQUESTER)
                             .build();
                     CompletableFuture<ListObjectsResponse> response = s3Client.listObjects(listRequest);
                     Collection<PendingDownload> pendingDownloads = new ArrayList<>(downloaderProperties.getBatchSize());
@@ -233,6 +235,7 @@ public abstract class Downloader {
         }
         var future = s3Client.getObject(
                 GetObjectRequest.builder().bucket(downloaderProperties.getCommon().getBucketName()).key(s3ObjectKey)
+                        .requestPayer(RequestPayer.REQUESTER)
                         .build(),
                 AsyncResponseTransformer.toFile(file));
         return new PendingDownload(future, file, s3ObjectKey);


### PR DESCRIPTION
Testing:
We currently use S3Mock for testing Downloader, but it doesn't support
authentication (which means it won't have support to test RP buckets).

Signed-off-by: Apekshit Sharma <apekshit.sharma@hedera.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
-->

**Detailed description**:

**Which issue(s) this PR fixes**:
Partially addresses #357

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

