### PR TITLE
Store surefire logs in artifacts for debugging of failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,12 @@ jobs:
       - run:
           name: Running maven (validate, compile, test, package)
           command: ./mvnw ${MAVEN_CLI_OPTS} package
+      - store_artifacts:
+          path: hedera-mirror-importer/target/surefire-reports
+          destination: /importer-surefire
+      - store_artifacts:
+          path: hedera-mirror-grpc/target/surefire-reports
+          destination: /grpc-surefire
       - store_test_results:
           path: hedera-mirror-importer/target/surefire-reports
       - run:
@@ -123,12 +129,6 @@ jobs:
             mkdir -p ${WORKSPACE}/artifacts
             tar -czf ${WORKSPACE}/artifacts/${NAME}.tgz -C ${WORKSPACE} ${NAME}
       - *persist_artifacts
-      - run:
-          name: Storing surefire logs for debugging
-          command: |
-            mv hedera-mirror-importer/target/surefire-reports ${WORKSPACE}/importer-surefire
-      - store_artifacts:
-          path: ${WORKSPACE}/importer-surefire
 
   perf_maven:
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,9 +124,9 @@ jobs:
             tar -czf ${WORKSPACE}/artifacts/${NAME}.tgz -C ${WORKSPACE} ${NAME}
       - *persist_artifacts
       - run:
-          - Storing surefire logs for debugging
-          - command: |
-              mv hedera-mirror-importer/target/surefire-reports ${WORKSPACE}/importer-surefire
+          name: Storing surefire logs for debugging
+          command: |
+            mv hedera-mirror-importer/target/surefire-reports ${WORKSPACE}/importer-surefire
       - store_artifacts:
           path: ${WORKSPACE}/importer-surefire
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ jobs:
       - *save_maven_cache
       - run:
           name: Running maven (validate, compile, test, package)
-          command: ./mvnw ${MAVEN_CLI_OPTS} package -Xmx1024m
+          command: ./mvnw ${MAVEN_CLI_OPTS} package
       - store_artifacts:
           path: hedera-mirror-importer/target/surefire-reports
           destination: /importer-surefire

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,6 +123,12 @@ jobs:
             mkdir -p ${WORKSPACE}/artifacts
             tar -czf ${WORKSPACE}/artifacts/${NAME}.tgz -C ${WORKSPACE} ${NAME}
       - *persist_artifacts
+      - run:
+          - Storing surefire logs for debugging
+          - command: |
+              mv hedera-mirror-importer/target/surefire-reports ${WORKSPACE}/importer-surefire
+      - store_artifacts:
+          path: ${WORKSPACE}/importer-surefire
 
   perf_maven:
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ jobs:
       - *save_maven_cache
       - run:
           name: Running maven (validate, compile, test, package)
-          command: ./mvnw ${MAVEN_CLI_OPTS} package
+          command: ./mvnw ${MAVEN_CLI_OPTS} package -Xmx1024m
       - store_artifacts:
           path: hedera-mirror-importer/target/surefire-reports
           destination: /importer-surefire
@@ -177,6 +177,9 @@ jobs:
           environment:
             TEST_DB_HOST: "127.0.0.1"
             TEST_DB_NAME: "mirror_node_integration"
+      - store_artifacts:
+          path: hedera-mirror-rest/target/jest-junit
+          destination: /rest-jest
       - store_test_results:
           path: hedera-mirror-rest/target/jest-junit
       - run:

--- a/pom.xml
+++ b/pom.xml
@@ -77,11 +77,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
+                    <version>3.0.0-M4</version>
                     <configuration>
                         <!-- Jacoco prepare-agent builds some command-line params without -->
                         <!-- which jacoco will not instrument. Hence it is important to add -->
                         <!-- those command-line params here (${argLine} holds those params) -->
-                        <argLine>${argLine} -Xms512m</argLine>
+                        <argLine>${argLine} -Xms512m -Xmx1024m</argLine>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
**Detailed description**:
We experience intermittent build failures in circle ci 

> SurefireBooterForkException: The forked VM terminated without properly saying goodbye. VM crash or System.exit called?

To help troubleshoot we are uploading test artifacts

- Add store_artifacts for importer, grpc and rest build runs 
- Sets surefire -Xmx to 1024m to avoid out of memory issue
- Updated surefire version to 3.0.0.M4

**Which issue(s) this PR fixes**:
Fixes #621 

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

