### PR TITLE
Fixing REST spec tests causing bigint overflow

### DIFF
--- a/hedera-mirror-rest/__tests__/specs/transactions-11-not-found.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-11-not-found.spec.json
@@ -28,7 +28,7 @@
       }
     ]
   },
-  "url": "/api/v1/transactions/0.1.10-9999999999-000000000",
+  "url": "/api/v1/transactions/0.1.10-1234567891-000000000",
   "responseStatus": 404,
   "responseJson": {
     "_status": {

--- a/hedera-mirror-rest/__tests__/specs/transactions-12-invalid-transaction-id.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-12-invalid-transaction-id.spec.json
@@ -28,7 +28,7 @@
       }
     ]
   },
-  "url": "/api/v1/transactions/0.1.10-9999999999.000000000",
+  "url": "/api/v1/transactions/0.1.10-1234567891.000000000",
   "responseStatus": 400,
   "responseJson": {
     "_status": {


### PR DESCRIPTION
**Detailed description**:
2 of the REST spec files are causing bigint overflow errors.
This changes those 2 tests to use appropriate parameters

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated

