### PR TITLE
Add TransactionBody to RecordItem

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/domain/RecordItem.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/domain/RecordItem.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.importer.parser.domain;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,20 +20,80 @@ package com.hedera.mirror.importer.parser.domain;
  * ‍
  */
 
+import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.hederahashgraph.api.proto.java.Transaction;
+import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionRecord;
 import lombok.AllArgsConstructor;
 import lombok.Value;
 
+import com.hedera.mirror.importer.exception.ParserException;
+
 @Value
 @AllArgsConstructor
 public class RecordItem implements StreamItem {
-    public RecordItem(Transaction transaction, TransactionRecord record) {
-        this(transaction, record, null, null);
-    }
+    static final String BAD_TRANSACTION_BYTES_MESSAGE = "Failed to parse transaction bytes";
+    static final String BAD_RECORD_BYTES_MESSAGE = "Failed to parse record bytes";
+    static final String BAD_TRANSACTION_BODY_BYTES_MESSAGE = "Error parsing transactionBody from bodyBytes";
 
     private final Transaction transaction;
+    private final TransactionBody transactionBody;
     private final TransactionRecord record;
     private final byte[] transactionBytes;
     private final byte[] recordBytes;
+
+    /**
+     * Constructs RecordItem from serialized transactionBytes and recordBytes.
+     *
+     * @throws ParserException if
+     *                         <ul>
+     *                          <li>transactionBytes or recordBytes fail to parse</li>
+     *                          <li>parsed Transaction does not have valid TransactionBody i.e. 'body' is not set
+     *                          and 'bodyBytes' is empty</li>
+     *                          <li>parsed Transaction has non-empty 'bodyBytes' and it fails to parse</li>
+     *                         </ul>
+     */
+    public RecordItem(byte[] transactionBytes, byte[] recordBytes) {
+        try {
+            transaction = Transaction.parseFrom(transactionBytes);
+        } catch (InvalidProtocolBufferException e) {
+            throw new ParserException(BAD_TRANSACTION_BYTES_MESSAGE, e);
+        }
+        try {
+            record = TransactionRecord.parseFrom(recordBytes);
+        } catch (InvalidProtocolBufferException e) {
+            throw new ParserException(BAD_RECORD_BYTES_MESSAGE, e);
+        }
+        transactionBody = parseTransactionBody(transaction);
+        this.transactionBytes = transactionBytes;
+        this.recordBytes = recordBytes;
+    }
+
+    // Used only in tests
+    public RecordItem(Transaction transaction, TransactionRecord record) {
+        this.transaction = transaction;
+        transactionBody = parseTransactionBody(transaction);
+        this.record = record;
+        transactionBytes = null;
+        recordBytes = null;
+    }
+
+    private static TransactionBody parseTransactionBody(Transaction transaction) {
+        if (transaction.hasBody()) {
+            return transaction.getBody();
+        } else {
+            // Not possible to check existence of bodyBytes field since there is no 'hasBodyBytes()'.
+            // If unset, getBodyBytes() returns empty ByteString which always parses successfully to "empty"
+            //TransactionBody. However, every transaction should have a valid (non "empty") TransactionBody.
+            if (transaction.getBodyBytes() == ByteString.EMPTY) {
+                throw new ParserException(BAD_TRANSACTION_BODY_BYTES_MESSAGE);
+            }
+            try {
+                return TransactionBody.parseFrom(transaction.getBodyBytes());
+            } catch (InvalidProtocolBufferException e) {
+                throw new ParserException(BAD_TRANSACTION_BODY_BYTES_MESSAGE, e);
+            }
+        }
+    }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordItemParser.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordItemParser.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.importer.parser.record;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -127,19 +127,8 @@ public class RecordItemParser implements RecordItemListener {
 
     @Override
     public void onItem(RecordItem recordItem) throws ImporterException {
-        Transaction transaction = recordItem.getTransaction();
         TransactionRecord txRecord = recordItem.getRecord();
-
-        TransactionBody body;
-        if (transaction.hasBody()) {
-            body = transaction.getBody();
-        } else {
-            try {
-                body = TransactionBody.parseFrom(transaction.getBodyBytes());
-            } catch (InvalidProtocolBufferException e) {
-                throw new ParserException("Error parsing transaction from body bytes", e);
-            }
-        }
+        TransactionBody body = recordItem.getTransactionBody();
 
         log.trace("Storing transaction body: {}", () -> Utility.printProtoMessage(body));
         long initialBalance = 0;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/util/Utility.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/util/Utility.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.importer.util;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,11 +25,10 @@ import static com.hederahashgraph.api.proto.java.Key.KeyCase.ED25519;
 import com.google.protobuf.GeneratedMessageV3;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.TextFormat;
+
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.Timestamp;
-import com.hederahashgraph.api.proto.java.Transaction;
-import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionID;
 import java.io.DataInputStream;
 import java.io.File;
@@ -382,14 +381,6 @@ public class Utility {
      */
     public static String printProtoMessage(GeneratedMessageV3 message) {
         return TextFormat.shortDebugString(message);
-    }
-
-    public static TransactionBody getTransactionBody(Transaction transaction) throws InvalidProtocolBufferException {
-        if (transaction.hasBody()) {
-            return transaction.getBody();
-        } else {
-            return TransactionBody.parseFrom(transaction.getBodyBytes());
-        }
     }
 
     /**

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/domain/RecordItemTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/domain/RecordItemTest.java
@@ -1,0 +1,111 @@
+package com.hedera.mirror.importer.parser.domain;
+
+/*
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.google.protobuf.ByteString;
+
+import com.hedera.mirror.importer.exception.ParserException;
+import com.hedera.mirror.importer.parser.record.transactionhandler.AbstractTransactionHandlerTest;
+
+import com.hederahashgraph.api.proto.java.SignatureMap;
+import com.hederahashgraph.api.proto.java.SignaturePair;
+import com.hederahashgraph.api.proto.java.Transaction;
+import com.hederahashgraph.api.proto.java.TransactionBody;
+import com.hederahashgraph.api.proto.java.TransactionReceipt;
+import com.hederahashgraph.api.proto.java.TransactionRecord;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RecordItemTest extends AbstractTransactionHandlerTest {
+
+    private static final Transaction DEFAULT_TRANSACTION = Transaction.newBuilder()
+            .setBodyBytes(TransactionBody.getDefaultInstance().toByteString())
+            .build();
+    private static final byte[] DEFAULT_TRANSACTION_BYTES = DEFAULT_TRANSACTION.toByteArray();
+    private static final TransactionRecord DEFAULT_RECORD = TransactionRecord.getDefaultInstance();
+    private static final byte[] DEFAULT_RECORD_BYTES = DEFAULT_RECORD.toByteArray();
+
+    // 'body' and 'bodyBytes' feilds left empty
+    private static final Transaction TRANSACTION = Transaction.newBuilder()
+            .setSigMap(SignatureMap.newBuilder()
+                    .addSigPair(SignaturePair.newBuilder()
+                            .setEd25519(ByteString.copyFromUtf8("ed25519"))
+                            .setPubKeyPrefix(ByteString.copyFromUtf8("pubKeyPrefix"))
+                            .build())
+                    .build())
+            .build();
+
+    private static final TransactionBody TRANSACTION_BODY = TransactionBody.newBuilder()
+            .setTransactionFee(10L)
+            .setMemo("memo")
+            .build();
+
+    private static final TransactionRecord TRANSACTION_RECORD = TransactionRecord.newBuilder()
+            .setReceipt(TransactionReceipt.newBuilder().setStatusValue(22).build())
+            .setMemo("memo")
+            .build();
+
+    @Test
+    public void testBadTransactionBytesThrowException() {
+        testException(new byte[] {0x0, 0x1}, DEFAULT_RECORD_BYTES, RecordItem.BAD_TRANSACTION_BYTES_MESSAGE);
+    }
+
+    @Test
+    public void testBadRecordBytesThrowException() {
+        testException(DEFAULT_TRANSACTION_BYTES, new byte[] {0x0, 0x1}, RecordItem.BAD_RECORD_BYTES_MESSAGE);
+    }
+
+    @Test
+    public void testTransactionBytesWithoutTransactionBodyThrowException() {
+        testException(Transaction.newBuilder().build().toByteArray(),
+                DEFAULT_RECORD_BYTES, RecordItem.BAD_TRANSACTION_BODY_BYTES_MESSAGE);
+    }
+
+    @Test
+    public void testWithBody() {
+        Transaction transaction = TRANSACTION.toBuilder().setBody(TRANSACTION_BODY).build();
+        RecordItem recordItem = new RecordItem(transaction.toByteArray(), TRANSACTION_RECORD.toByteArray());
+        assertRecordItem(transaction, recordItem);
+    }
+
+    @Test
+    public void testWithBodyBytes() {
+        Transaction transaction = TRANSACTION.toBuilder().setBodyBytes(TRANSACTION_BODY.toByteString()).build();
+        RecordItem recordItem = new RecordItem(transaction.toByteArray(), TRANSACTION_RECORD.toByteArray());
+        assertRecordItem(transaction, recordItem);
+    }
+
+    private void testException(byte[] transactionBytes, byte[] recordBytes, String expectedMessage) {
+        Exception exception = assertThrows(ParserException.class, () -> {
+            new RecordItem(transactionBytes, recordBytes);
+        });
+        assertEquals(expectedMessage, exception.getMessage());
+    }
+
+    private void assertRecordItem(Transaction transaction, RecordItem recordItem) {
+        assertEquals(transaction, recordItem.getTransaction());
+        assertEquals(TRANSACTION_RECORD, recordItem.getRecord());
+        assertEquals(TRANSACTION_BODY, recordItem.getTransactionBody());
+        assertArrayEquals(transaction.toByteArray(), recordItem.getTransactionBytes());
+        assertArrayEquals(TRANSACTION_RECORD.toByteArray(), recordItem.getRecordBytes());
+    }
+}


### PR DESCRIPTION
**Detailed description**:
- Functionality in all TransactionHandlers (to be added in followups) require TransactionBody.
  Transaction.bodyBytes needs to be deserialized only once and stored somewhere accessible to TransactionHandlers. Transaction.body field is not good candidate since it is deprecated. RecordItem is the best place to keep it.
- RecordItem has uniform ctor pattern now. Can be constructed from either:
  - transaction & record proto instances
  - transaction & record bytes
- Deserialization is done in RecordItem constructor because:
  - Passing both Transaction (which has body) and TransactionBody to ctor (two sources of truth) would be bad
  - Don't have to change 50+ places in tests
- Side benefit: Removed duplicate deserialization that was happening in RecordFileParser.

Signed-off-by: Apekshit Sharma <apekshit.sharma@hedera.com>

**Which issue(s) this PR fixes**:
Part of #571 . Needed to do #560 in right way, hence P1.

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated

