### PR TITLE
Fix REST bundled dependencies

### DIFF
--- a/hedera-mirror-coverage/pom.xml
+++ b/hedera-mirror-coverage/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.8.0</version>
+        <version>0.8.1</version>
     </parent>
 
     <dependencies>

--- a/hedera-mirror-datagenerator/pom.xml
+++ b/hedera-mirror-datagenerator/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.8.0</version>
+        <version>0.8.1</version>
     </parent>
 
     <dependencies>

--- a/hedera-mirror-grpc/pom.xml
+++ b/hedera-mirror-grpc/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.8.0</version>
+        <version>0.8.1</version>
     </parent>
 
     <dependencies>

--- a/hedera-mirror-importer/pom.xml
+++ b/hedera-mirror-importer/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.8.0</version>
+        <version>0.8.1</version>
     </parent>
 
     <properties>

--- a/hedera-mirror-protobuf/pom.xml
+++ b/hedera-mirror-protobuf/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.8.0</version>
+        <version>0.8.1</version>
     </parent>
 
     <properties>

--- a/hedera-mirror-rest/package-lock.json
+++ b/hedera-mirror-rest/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-mirror-rest",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hedera-mirror-rest/package.json
+++ b/hedera-mirror-rest/package.json
@@ -1,8 +1,9 @@
 {
   "name": "hedera-mirror-rest",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Hedera Mirror Node REST API",
   "main": "server.js",
+  "private": true,
   "scripts": {
     "test": "jest --testPathPattern='__tests__/*'",
     "acceptancetest": "__acceptancetests__/acceptancetests",
@@ -31,6 +32,7 @@
     "compression",
     "cors",
     "express",
+    "extend",
     "log4js",
     "mathjs",
     "node-cache",

--- a/hedera-mirror-rest/pom.xml
+++ b/hedera-mirror-rest/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.8.0</version>
+        <version>0.8.1</version>
     </parent>
 
     <build>

--- a/hedera-mirror-test/pom.xml
+++ b/hedera-mirror-test/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <artifactId>hedera-mirror-node</artifactId>
         <groupId>com.hedera</groupId>
-        <version>0.8.0</version>
+        <version>0.8.1</version>
     </parent>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.hedera</groupId>
     <artifactId>hedera-mirror-node</artifactId>
-    <version>0.8.0</version>
+    <version>0.8.1</version>
     <description>Hedera Mirror Node mirrors data from Hedera nodes and serves it via an API</description>
     <inceptionYear>2019</inceptionYear>
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
**Detailed description**:
- Fixes an issue with REST tgz artifact not include required "extend" module that was encountered during deployment to pre-production environments
- Sets private to true to avoid accidentally publishing package to npm
- Bumps version to 0.8.1

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
```
0|6551  | Error: Cannot find module 'extend'
0|6551  | Require stack:
0|6551  | - /opt/restapi/config.js
0|6551  | - /opt/restapi/server.js
0|6551  |     at Function.Module._resolveFilename (internal/modules/cjs/loader.js:772:15)
0|6551  |     at Module.Hook._require.Module.require (/home/restapi/.nvm/versions/node/v12.10.0/lib/node_modules/pm2/node_modules/require-in-the-middle/index.js:61:29)
0|6551  |     at require (internal/modules/cjs/helpers.js:68:18)
0|6551  |     at Object.<anonymous> (/opt/restapi/config.js:21:16)
0|6551  |     at Module._compile (internal/modules/cjs/loader.js:936:30)
0|6551  |     at Object.Module._extensions..js (internal/modules/cjs/loader.js:947:10)
0|6551  |     at Module.load (internal/modules/cjs/loader.js:790:32)
0|6551  |     at Function.Module._load (internal/modules/cjs/loader.js:703:12)
0|6551  |     at Module.require (internal/modules/cjs/loader.js:830:19)
0|6551  |     at Module.Hook._require.Module.require (/home/restapi/.nvm/versions/node/v12.10.0/lib/node_modules/pm2/node_modules/require-in-the-middle/index.js:80:39) {
0|6551  |   code: 'MODULE_NOT_FOUND',
0|6551  |   requireStack: [ '/opt/restapi/config.js', '/opt/restapi/server.js' ]
0|6551  | }
```
**Checklist**
- [ ] Documentation added
- [ ] Tests updated

