### PR TITLE
Extend timeout in subscribeverifysequence to retrieve messages

### DIFF
--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/controller/ConsensusControllerTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/controller/ConsensusControllerTest.java
@@ -222,7 +222,7 @@ public class ConsensusControllerTest extends GrpcIntegrationTest {
                 .then(() -> generator.blockLast())
                 .expectNext(4L, 5L, 6L, 7L)
                 .expectComplete()
-                .verify(Duration.ofMillis(500));
+                .verify(Duration.ofMillis(1000));
     }
 
     void assertException(Throwable t, Status.Code status, String message) {


### PR DESCRIPTION
**Detailed description**:
subscribeverifysequence fails intermittently in Circle CI builds. Upon investigation it's caused by a timeout which is reproducible locally when the timeout is made small.

This fix increases the timeout from 500ms to 1000ms

**Which issue(s) this PR fixes**:
Fixes #640 

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

