### PR TITLE
Add getEntityId() to Transaction Handler

### DIFF
--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/domain/writer/PostgresCSVDomainWriter.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/domain/writer/PostgresCSVDomainWriter.java
@@ -8,9 +8,9 @@ package com.hedera.datagenerator.domain.writer;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -187,7 +187,7 @@ public class PostgresCSVDomainWriter implements DomainWriter {
                     entity.getEntityTypeId(), entity.getAutoRenewPeriod(), toHex(entity.getKey()), entity
                             .getProxyAccountId(), entity.isDeleted(), entity.getExpiryTimeNs(), entity
                             .getEd25519PublicKeyHex(), toHex(entity.getSubmitKey()), entity.getMemo(),
-                            entity.getAutoRenewAccount() != null ? entity.getAutoRenewAccount().getId() : null);
+                            entity.getAutoRenewAccountId());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/Entities.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/Entities.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.importer.domain;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,6 +20,7 @@ package com.hedera.mirror.importer.domain;
  * ‍
  */
 
+import com.hederahashgraph.api.proto.java.AccountID;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -88,5 +89,9 @@ public class Entities {
 
     public String getDisplayId() {
         return String.format("%d.%d.%d", entityShard, entityRealm, entityNum);
+    }
+
+    public EntityId toEntityId() {
+        return new EntityId(id, entityShard, entityRealm, entityNum, entityTypeId);
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/Entities.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/Entities.java
@@ -20,13 +20,11 @@ package com.hedera.mirror.importer.domain;
  * ‍
  */
 
-import com.hederahashgraph.api.proto.java.AccountID;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import lombok.Data;
 import lombok.ToString;
@@ -54,8 +52,7 @@ public class Entities {
     @Column(name = "fk_entity_type_id")
     private Integer entityTypeId;
 
-    @ManyToOne
-    private Entities autoRenewAccount;
+    private Long autoRenewAccountId;
 
     private Long autoRenewPeriod;
 
@@ -85,10 +82,6 @@ public class Entities {
                     "will be nulled", entityShard, entityRealm, entityNum, e);
             ed25519PublicKeyHex = null;
         }
-    }
-
-    public String getDisplayId() {
-        return String.format("%d.%d.%d", entityShard, entityRealm, entityNum);
     }
 
     public EntityId toEntityId() {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/EntityId.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/EntityId.java
@@ -51,6 +51,10 @@ public class EntityId {
         return entity;
     }
 
+    public String getDisplayId() {
+        return String.format("%d.%d.%d", entityShard, entityRealm, entityNum);
+    }
+
     public static EntityId of(AccountID accountID) {
         return of(accountID.getShardNum(), accountID.getRealmNum(), accountID.getAccountNum(), EntityTypeEnum.ACCOUNT);
     }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/EntityId.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/EntityId.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.importer.domain;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,8 +20,19 @@ package com.hedera.mirror.importer.domain;
  * ‍
  */
 
+import com.hederahashgraph.api.proto.java.AccountID;
+import com.hederahashgraph.api.proto.java.ContractID;
+import com.hederahashgraph.api.proto.java.FileID;
+import com.hederahashgraph.api.proto.java.TopicID;
 import lombok.Value;
 
+/**
+ * Common encapsulation for accountID, fileID, contractID, and topicID.
+ *
+ * There is no valid entity in Hedera network with an id '0.0.0'. When AccountID/FileID/ContractID/TopicID are not set,
+ * their values default to '0.0.0'. If such an unset (default) instance is used to create EntityId using one of the
+ * of(..) functions, null is returned.
+ */
 @Value
 public class EntityId {
     private Long id;
@@ -29,4 +40,38 @@ public class EntityId {
     private Long entityRealm;
     private Long entityNum;
     private Integer entityTypeId;
+
+    public Entities toEntity() {
+        Entities entity = new Entities();
+        entity.setId(id);
+        entity.setEntityShard(entityShard);
+        entity.setEntityRealm(entityRealm);
+        entity.setEntityNum(entityNum);
+        entity.setEntityTypeId(entityTypeId);
+        return entity;
+    }
+
+    public static EntityId of(AccountID accountID) {
+        return of(accountID.getShardNum(), accountID.getRealmNum(), accountID.getAccountNum(), EntityTypeEnum.ACCOUNT);
+    }
+
+    public static EntityId of(ContractID contractID) {
+        return of(contractID.getShardNum(), contractID.getRealmNum(), contractID.getContractNum(),
+                EntityTypeEnum.CONTRACT);
+    }
+
+    public static EntityId of(FileID fileID) {
+        return of(fileID.getShardNum(), fileID.getRealmNum(), fileID.getFileNum(), EntityTypeEnum.FILE);
+    }
+
+    public static EntityId of(TopicID topicID) {
+        return of(topicID.getShardNum(), topicID.getRealmNum(), topicID.getTopicNum(), EntityTypeEnum.TOPIC);
+    }
+
+    private static EntityId of(long entityShard, long entityRealm, long entityNum, EntityTypeEnum type) {
+        if (entityNum == 0 && entityRealm == 0 && entityShard == 0) {
+            return null;
+        }
+        return new EntityId(null, entityShard, entityRealm, entityNum, type.ordinal());
+    }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/EntityId.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/EntityId.java
@@ -28,7 +28,7 @@ import lombok.Value;
 
 /**
  * Common encapsulation for accountID, fileID, contractID, and topicID.
- *
+ * <p>
  * There is no valid entity in Hedera network with an id '0.0.0'. When AccountID/FileID/ContractID/TopicID are not set,
  * their values default to '0.0.0'. If such an unset (default) instance is used to create EntityId using one of the
  * of(..) functions, null is returned.
@@ -72,6 +72,6 @@ public class EntityId {
         if (entityNum == 0 && entityRealm == 0 && entityShard == 0) {
             return null;
         }
-        return new EntityId(null, entityShard, entityRealm, entityNum, type.ordinal());
+        return new EntityId(null, entityShard, entityRealm, entityNum, type.getId());
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/Transaction.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/Transaction.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.importer.domain;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -77,10 +77,6 @@ public class Transaction implements Persistable<Long> {
     // Helper to avoid having to update a 100 places in tests
     public Long getEntityId() {
         return entity != null ? entity.getId() : null;
-    }
-
-    public TransactionTypeEnum getTypeEnum() {
-        return TransactionTypeEnum.of(type);
     }
 
     @Override

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/TransactionFilterFields.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/TransactionFilterFields.java
@@ -1,4 +1,4 @@
-package com.hedera.mirror.importer.parser.record.transactionhandler;
+package com.hedera.mirror.importer.domain;
 
 /*-
  * ‌
@@ -20,23 +20,16 @@ package com.hedera.mirror.importer.parser.record.transactionhandler;
  * ‍
  */
 
-import javax.inject.Named;
-import lombok.AllArgsConstructor;
+import lombok.Value;
 
-import com.hedera.mirror.importer.domain.EntityId;
-import com.hedera.mirror.importer.parser.domain.RecordItem;
-
-@Named
-@AllArgsConstructor
-public class ContractCreateTransactionHandler implements TransactionHandler {
-
-    @Override
-    public EntityId getEntityId(RecordItem recordItem) {
-        return EntityId.of(recordItem.getRecord().getReceipt().getContractID());
-    }
-
-    @Override
-    public boolean updatesEntity() {
-        return true;
-    }
+/**
+ * Collection of fields that can be used by Transaction Filter to filter on.
+ */
+@Value
+public class TransactionFilterFields {
+    /**
+     * Main entity associated with the transaction
+     */
+    EntityId entity;
+    TransactionTypeEnum transactionType;
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/CommonParserProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/CommonParserProperties.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.importer.parser;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,12 +26,15 @@ import java.util.LinkedHashSet;
 import java.util.function.Predicate;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
+
+import com.hedera.mirror.importer.domain.EntityId;
+import com.hedera.mirror.importer.domain.TransactionFilterFields;
+
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
 import com.hedera.mirror.importer.domain.Entities;
-import com.hedera.mirror.importer.domain.Transaction;
 import com.hedera.mirror.importer.domain.TransactionTypeEnum;
 
 @Data
@@ -48,11 +51,11 @@ public class CommonParserProperties {
     @NotNull
     private Collection<TransactionFilter> include = new ArrayList<>();
 
-    public Predicate<Transaction> getFilter() {
+    public Predicate<TransactionFilterFields> getFilter() {
         return includeFilter().and(excludeFilter());
     }
 
-    private Predicate<Transaction> excludeFilter() {
+    private Predicate<TransactionFilterFields> excludeFilter() {
         if (exclude.isEmpty()) {
             return t -> true;
         }
@@ -61,7 +64,7 @@ public class CommonParserProperties {
                 .reduce(a -> true, Predicate::and);
     }
 
-    private Predicate<Transaction> includeFilter() {
+    private Predicate<TransactionFilterFields> includeFilter() {
         if (include.isEmpty()) {
             return t -> true;
         }
@@ -78,21 +81,21 @@ public class CommonParserProperties {
         private Collection<String> entity = new LinkedHashSet<>();
 
         @NotNull
-        private Collection<TransactionTypeEnum> transaction = new LinkedHashSet<>();
+        private Collection<TransactionTypeEnum> transactionType = new LinkedHashSet<>();
 
-        public Predicate<Transaction> getFilter() {
+        public Predicate<TransactionFilterFields> getFilter() {
             return t -> (matches(t) && matches(t.getEntity()));
         }
 
-        private boolean matches(Transaction t) {
-            if (transaction.isEmpty()) {
+        private boolean matches(TransactionFilterFields t) {
+            if (transactionType.isEmpty()) {
                 return true;
             }
 
-            return transaction.contains(t.getTypeEnum());
+            return transactionType.contains(t.getTransactionType());
         }
 
-        private boolean matches(Entities e) {
+        private boolean matches(EntityId e) {
             if (entity.isEmpty()) {
                 return true;
             }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/CommonParserProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/CommonParserProperties.java
@@ -34,7 +34,6 @@ import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
-import com.hedera.mirror.importer.domain.Entities;
 import com.hedera.mirror.importer.domain.TransactionTypeEnum;
 
 @Data
@@ -81,18 +80,18 @@ public class CommonParserProperties {
         private Collection<String> entity = new LinkedHashSet<>();
 
         @NotNull
-        private Collection<TransactionTypeEnum> transactionType = new LinkedHashSet<>();
+        private Collection<TransactionTypeEnum> transaction = new LinkedHashSet<>();
 
         public Predicate<TransactionFilterFields> getFilter() {
             return t -> (matches(t) && matches(t.getEntity()));
         }
 
         private boolean matches(TransactionFilterFields t) {
-            if (transactionType.isEmpty()) {
+            if (transaction.isEmpty()) {
                 return true;
             }
 
-            return transactionType.contains(t.getTransactionType());
+            return transaction.contains(t.getTransactionType());
         }
 
         private boolean matches(EntityId e) {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordItemParser.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordItemParser.java
@@ -675,7 +675,7 @@ public class RecordItemParser implements RecordItemListener {
      */
     public long lookupOrCreateId(EntityId entityId) {
         log.debug("lookupOrCreateId for {}", entityId);
-        if (entityId.getId() != 0) {
+        if (entityId.getId() != null && entityId.getId() != 0) {
             return entityId.getId();
         }
         return entityRepository.findEntityIdByNativeIds(

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordItemParser.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordItemParser.java
@@ -130,12 +130,14 @@ public class RecordItemParser implements RecordItemListener {
         log.trace("Storing transaction body: {}", () -> Utility.printProtoMessage(body));
 
         int transactionType = getTransactionType(body);
+        long consensusNs = Utility.timeStampInNanos(txRecord.getConsensusTimestamp());
         EntityId entityId = transactionHandler.getEntityId(recordItem);
 
         TransactionFilterFields transactionFilterFields =
                 new TransactionFilterFields(entityId, TransactionTypeEnum.of(transactionType));
         if (!transactionFilter.test(transactionFilterFields)) {
-            log.debug("Ignoring recordItem {}", txRecord);
+            log.debug("Ignoring transaction. consensusTimestamp={}, transactionType={}, entityId={}",
+                    consensusNs, TransactionTypeEnum.of(transactionType), entityId);
             return;
         }
 
@@ -295,7 +297,6 @@ public class RecordItemParser implements RecordItemListener {
         long validDurationSeconds = body.hasTransactionValidDuration() ? body.getTransactionValidDuration()
                 .getSeconds() : null;
         long validStartNs = Utility.timeStampInNanos(transactionID.getTransactionValidStart());
-        long consensusNs = Utility.timeStampInNanos(txRecord.getConsensusTimestamp());
         AccountID payerAccountId = transactionID.getAccountID();
 
         com.hedera.mirror.importer.domain.Transaction tx = new com.hedera.mirror.importer.domain.Transaction();
@@ -645,8 +646,8 @@ public class RecordItemParser implements RecordItemListener {
     }
 
     /**
-     * @return entity looked up (using shard/realm/num of given entityId) from the repo. If no entity is found,
-     *         then a new entity is returned without being persisted to the repo.
+     * @return entity looked up (using shard/realm/num of given entityId) from the repo. If no entity is found, then a
+     * new entity is returned without being persisted to the repo.
      */
     private Entities getEntity(EntityId entityId) {
         if (entityId == null) {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ConsensusCreateTopicTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ConsensusCreateTopicTransactionHandler.java
@@ -23,7 +23,20 @@ package com.hedera.mirror.importer.parser.record.transactionhandler;
 import javax.inject.Named;
 import lombok.AllArgsConstructor;
 
+import com.hedera.mirror.importer.domain.EntityId;
+import com.hedera.mirror.importer.parser.domain.RecordItem;
+
 @Named
 @AllArgsConstructor
 public class ConsensusCreateTopicTransactionHandler implements TransactionHandler {
+
+    @Override
+    public EntityId getEntityId(RecordItem recordItem) {
+        return EntityId.of(recordItem.getRecord().getReceipt().getTopicID());
+    }
+
+    @Override
+    public boolean updatesEntity() {
+        return true;
+    }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ConsensusDeleteTopicTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ConsensusDeleteTopicTransactionHandler.java
@@ -23,7 +23,20 @@ package com.hedera.mirror.importer.parser.record.transactionhandler;
 import javax.inject.Named;
 import lombok.AllArgsConstructor;
 
+import com.hedera.mirror.importer.domain.EntityId;
+import com.hedera.mirror.importer.parser.domain.RecordItem;
+
 @Named
 @AllArgsConstructor
 public class ConsensusDeleteTopicTransactionHandler implements TransactionHandler {
+
+    @Override
+    public EntityId getEntityId(RecordItem recordItem) {
+        return EntityId.of(recordItem.getTransactionBody().getConsensusDeleteTopic().getTopicID());
+    }
+
+    @Override
+    public boolean updatesEntity() {
+        return true;
+    }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ConsensusSubmitMessageTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ConsensusSubmitMessageTransactionHandler.java
@@ -23,7 +23,15 @@ package com.hedera.mirror.importer.parser.record.transactionhandler;
 import javax.inject.Named;
 import lombok.AllArgsConstructor;
 
+import com.hedera.mirror.importer.domain.EntityId;
+import com.hedera.mirror.importer.parser.domain.RecordItem;
+
 @Named
 @AllArgsConstructor
 public class ConsensusSubmitMessageTransactionHandler implements TransactionHandler {
+
+    @Override
+    public EntityId getEntityId(RecordItem recordItem) {
+        return EntityId.of(recordItem.getTransactionBody().getConsensusSubmitMessage().getTopicID());
+    }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ConsensusUpdateTopicTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ConsensusUpdateTopicTransactionHandler.java
@@ -23,7 +23,20 @@ package com.hedera.mirror.importer.parser.record.transactionhandler;
 import javax.inject.Named;
 import lombok.AllArgsConstructor;
 
+import com.hedera.mirror.importer.domain.EntityId;
+import com.hedera.mirror.importer.parser.domain.RecordItem;
+
 @Named
 @AllArgsConstructor
 public class ConsensusUpdateTopicTransactionHandler implements TransactionHandler {
+
+    @Override
+    public EntityId getEntityId(RecordItem recordItem) {
+        return EntityId.of(recordItem.getTransactionBody().getConsensusUpdateTopic().getTopicID());
+    }
+
+    @Override
+    public boolean updatesEntity() {
+        return true;
+    }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractCallTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractCallTransactionHandler.java
@@ -23,7 +23,15 @@ package com.hedera.mirror.importer.parser.record.transactionhandler;
 import javax.inject.Named;
 import lombok.AllArgsConstructor;
 
+import com.hedera.mirror.importer.domain.EntityId;
+import com.hedera.mirror.importer.parser.domain.RecordItem;
+
 @Named
 @AllArgsConstructor
 public class ContractCallTransactionHandler implements TransactionHandler {
+
+    @Override
+    public EntityId getEntityId(RecordItem recordItem) {
+        return EntityId.of(recordItem.getTransactionBody().getContractCall().getContractID());
+    }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractCreateTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractCreateTransactionHandler.java
@@ -23,7 +23,25 @@ package com.hedera.mirror.importer.parser.record.transactionhandler;
 import javax.inject.Named;
 import lombok.AllArgsConstructor;
 
+import com.hedera.mirror.importer.domain.EntityId;
+import com.hedera.mirror.importer.parser.domain.RecordItem;
+
 @Named
 @AllArgsConstructor
 public class ContractCreateTransactionHandler implements TransactionHandler {
+
+    @Override
+    public EntityId getEntityId(RecordItem recordItem) {
+        return EntityId.of(recordItem.getRecord().getReceipt().getContractID());
+    }
+
+    @Override
+    public EntityId getProxyAccountId(RecordItem recordItem) {
+        return EntityId.of(recordItem.getTransactionBody().getContractCreateInstance().getProxyAccountID());
+    }
+
+    @Override
+    public boolean updatesEntity() {
+        return true;
+    }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractDeleteTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractDeleteTransactionHandler.java
@@ -23,7 +23,20 @@ package com.hedera.mirror.importer.parser.record.transactionhandler;
 import javax.inject.Named;
 import lombok.AllArgsConstructor;
 
+import com.hedera.mirror.importer.domain.EntityId;
+import com.hedera.mirror.importer.parser.domain.RecordItem;
+
 @Named
 @AllArgsConstructor
 public class ContractDeleteTransactionHandler implements TransactionHandler {
+
+    @Override
+    public EntityId getEntityId(RecordItem recordItem) {
+        return EntityId.of(recordItem.getTransactionBody().getContractDeleteInstance().getContractID());
+    }
+
+    @Override
+    public boolean updatesEntity() {
+        return true;
+    }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractUpdateTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractUpdateTransactionHandler.java
@@ -23,7 +23,25 @@ package com.hedera.mirror.importer.parser.record.transactionhandler;
 import javax.inject.Named;
 import lombok.AllArgsConstructor;
 
+import com.hedera.mirror.importer.domain.EntityId;
+import com.hedera.mirror.importer.parser.domain.RecordItem;
+
 @Named
 @AllArgsConstructor
 public class ContractUpdateTransactionHandler implements TransactionHandler {
+
+    @Override
+    public EntityId getEntityId(RecordItem recordItem) {
+        return EntityId.of(recordItem.getTransactionBody().getContractUpdateInstance().getContractID());
+    }
+
+    @Override
+    public EntityId getProxyAccountId(RecordItem recordItem) {
+        return EntityId.of(recordItem.getTransactionBody().getContractUpdateInstance().getProxyAccountID());
+    }
+
+    @Override
+    public boolean updatesEntity() {
+        return true;
+    }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractUpdateTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractUpdateTransactionHandler.java
@@ -36,11 +36,6 @@ public class ContractUpdateTransactionHandler implements TransactionHandler {
     }
 
     @Override
-    public EntityId getProxyAccountId(RecordItem recordItem) {
-        return EntityId.of(recordItem.getTransactionBody().getContractUpdateInstance().getProxyAccountID());
-    }
-
-    @Override
     public boolean updatesEntity() {
         return true;
     }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoAddClaimTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoAddClaimTransactionHandler.java
@@ -23,7 +23,15 @@ package com.hedera.mirror.importer.parser.record.transactionhandler;
 import javax.inject.Named;
 import lombok.AllArgsConstructor;
 
+import com.hedera.mirror.importer.domain.EntityId;
+import com.hedera.mirror.importer.parser.domain.RecordItem;
+
 @Named
 @AllArgsConstructor
 public class CryptoAddClaimTransactionHandler implements TransactionHandler {
+
+    @Override
+    public EntityId getEntityId(RecordItem recordItem) {
+        return EntityId.of(recordItem.getTransactionBody().getCryptoAddClaim().getClaim().getAccountID());
+    }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoCreateTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoCreateTransactionHandler.java
@@ -23,7 +23,25 @@ package com.hedera.mirror.importer.parser.record.transactionhandler;
 import javax.inject.Named;
 import lombok.AllArgsConstructor;
 
+import com.hedera.mirror.importer.domain.EntityId;
+import com.hedera.mirror.importer.parser.domain.RecordItem;
+
 @Named
 @AllArgsConstructor
 public class CryptoCreateTransactionHandler implements TransactionHandler {
+
+    @Override
+    public EntityId getEntityId(RecordItem recordItem) {
+        return EntityId.of(recordItem.getRecord().getReceipt().getAccountID());
+    }
+
+    @Override
+    public EntityId getProxyAccountId(RecordItem recordItem) {
+        return EntityId.of(recordItem.getTransactionBody().getCryptoCreateAccount().getProxyAccountID());
+    }
+
+    @Override
+    public boolean updatesEntity() {
+        return true;
+    }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoCreateTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoCreateTransactionHandler.java
@@ -36,11 +36,6 @@ public class CryptoCreateTransactionHandler implements TransactionHandler {
     }
 
     @Override
-    public EntityId getProxyAccountId(RecordItem recordItem) {
-        return EntityId.of(recordItem.getTransactionBody().getCryptoCreateAccount().getProxyAccountID());
-    }
-
-    @Override
     public boolean updatesEntity() {
         return true;
     }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoDeleteClaimTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoDeleteClaimTransactionHandler.java
@@ -23,7 +23,15 @@ package com.hedera.mirror.importer.parser.record.transactionhandler;
 import javax.inject.Named;
 import lombok.AllArgsConstructor;
 
+import com.hedera.mirror.importer.domain.EntityId;
+import com.hedera.mirror.importer.parser.domain.RecordItem;
+
 @Named
 @AllArgsConstructor
 public class CryptoDeleteClaimTransactionHandler implements TransactionHandler {
+
+    @Override
+    public EntityId getEntityId(RecordItem recordItem) {
+        return EntityId.of(recordItem.getTransactionBody().getCryptoDeleteClaim().getAccountIDToDeleteFrom());
+    }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoDeleteTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoDeleteTransactionHandler.java
@@ -23,7 +23,20 @@ package com.hedera.mirror.importer.parser.record.transactionhandler;
 import javax.inject.Named;
 import lombok.AllArgsConstructor;
 
+import com.hedera.mirror.importer.domain.EntityId;
+import com.hedera.mirror.importer.parser.domain.RecordItem;
+
 @Named
 @AllArgsConstructor
 public class CryptoDeleteTransactionHandler implements TransactionHandler {
+
+    @Override
+    public EntityId getEntityId(RecordItem recordItem) {
+        return EntityId.of(recordItem.getTransactionBody().getCryptoDelete().getDeleteAccountID());
+    }
+
+    @Override
+    public boolean updatesEntity() {
+        return true;
+    }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoTransferTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoTransferTransactionHandler.java
@@ -20,10 +20,18 @@ package com.hedera.mirror.importer.parser.record.transactionhandler;
  * ‍
  */
 
-import lombok.AllArgsConstructor;
 import javax.inject.Named;
+import lombok.AllArgsConstructor;
+
+import com.hedera.mirror.importer.domain.EntityId;
+import com.hedera.mirror.importer.parser.domain.RecordItem;
 
 @Named
 @AllArgsConstructor
 public class CryptoTransferTransactionHandler implements TransactionHandler {
+
+    @Override
+    public EntityId getEntityId(RecordItem recordItem) {
+        return null;
+    }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoUpdateTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoUpdateTransactionHandler.java
@@ -36,11 +36,6 @@ public class CryptoUpdateTransactionHandler implements TransactionHandler {
     }
 
     @Override
-    public EntityId getProxyAccountId(RecordItem recordItem) {
-        return EntityId.of(recordItem.getTransactionBody().getCryptoUpdateAccount().getProxyAccountID());
-    }
-
-    @Override
     public boolean updatesEntity() {
         return true;
     }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoUpdateTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoUpdateTransactionHandler.java
@@ -23,7 +23,25 @@ package com.hedera.mirror.importer.parser.record.transactionhandler;
 import javax.inject.Named;
 import lombok.AllArgsConstructor;
 
+import com.hedera.mirror.importer.domain.EntityId;
+import com.hedera.mirror.importer.parser.domain.RecordItem;
+
 @Named
 @AllArgsConstructor
 public class CryptoUpdateTransactionHandler implements TransactionHandler {
+
+    @Override
+    public EntityId getEntityId(RecordItem recordItem) {
+        return EntityId.of(recordItem.getTransactionBody().getCryptoUpdateAccount().getAccountIDToUpdate());
+    }
+
+    @Override
+    public EntityId getProxyAccountId(RecordItem recordItem) {
+        return EntityId.of(recordItem.getTransactionBody().getCryptoUpdateAccount().getProxyAccountID());
+    }
+
+    @Override
+    public boolean updatesEntity() {
+        return true;
+    }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/FileAppendTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/FileAppendTransactionHandler.java
@@ -23,7 +23,15 @@ package com.hedera.mirror.importer.parser.record.transactionhandler;
 import javax.inject.Named;
 import lombok.AllArgsConstructor;
 
+import com.hedera.mirror.importer.domain.EntityId;
+import com.hedera.mirror.importer.parser.domain.RecordItem;
+
 @Named
 @AllArgsConstructor
 public class FileAppendTransactionHandler implements TransactionHandler {
+
+    @Override
+    public EntityId getEntityId(RecordItem recordItem) {
+        return EntityId.of(recordItem.getTransactionBody().getFileAppend().getFileID());
+    }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/FileCreateTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/FileCreateTransactionHandler.java
@@ -23,7 +23,20 @@ package com.hedera.mirror.importer.parser.record.transactionhandler;
 import javax.inject.Named;
 import lombok.AllArgsConstructor;
 
+import com.hedera.mirror.importer.domain.EntityId;
+import com.hedera.mirror.importer.parser.domain.RecordItem;
+
 @Named
 @AllArgsConstructor
 public class FileCreateTransactionHandler implements TransactionHandler {
+
+    @Override
+    public EntityId getEntityId(RecordItem recordItem) {
+        return EntityId.of(recordItem.getRecord().getReceipt().getFileID());
+    }
+
+    @Override
+    public boolean updatesEntity() {
+        return true;
+    }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/FileDeleteTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/FileDeleteTransactionHandler.java
@@ -23,7 +23,20 @@ package com.hedera.mirror.importer.parser.record.transactionhandler;
 import javax.inject.Named;
 import lombok.AllArgsConstructor;
 
+import com.hedera.mirror.importer.domain.EntityId;
+import com.hedera.mirror.importer.parser.domain.RecordItem;
+
 @Named
 @AllArgsConstructor
 public class FileDeleteTransactionHandler implements TransactionHandler {
+
+    @Override
+    public EntityId getEntityId(RecordItem recordItem) {
+        return EntityId.of(recordItem.getTransactionBody().getFileDelete().getFileID());
+    }
+
+    @Override
+    public boolean updatesEntity() {
+        return true;
+    }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/FileUpdateTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/FileUpdateTransactionHandler.java
@@ -23,7 +23,20 @@ package com.hedera.mirror.importer.parser.record.transactionhandler;
 import javax.inject.Named;
 import lombok.AllArgsConstructor;
 
+import com.hedera.mirror.importer.domain.EntityId;
+import com.hedera.mirror.importer.parser.domain.RecordItem;
+
 @Named
 @AllArgsConstructor
 public class FileUpdateTransactionHandler implements TransactionHandler {
+
+    @Override
+    public EntityId getEntityId(RecordItem recordItem) {
+        return EntityId.of(recordItem.getTransactionBody().getFileUpdate().getFileID());
+    }
+
+    @Override
+    public boolean updatesEntity() {
+        return true;
+    }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/SystemDeleteTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/SystemDeleteTransactionHandler.java
@@ -20,10 +20,30 @@ package com.hedera.mirror.importer.parser.record.transactionhandler;
  * ‍
  */
 
+import com.hederahashgraph.api.proto.java.SystemDeleteTransactionBody;
 import javax.inject.Named;
 import lombok.AllArgsConstructor;
+
+import com.hedera.mirror.importer.domain.EntityId;
+import com.hedera.mirror.importer.parser.domain.RecordItem;
 
 @Named
 @AllArgsConstructor
 public class SystemDeleteTransactionHandler implements TransactionHandler {
+
+    @Override
+    public EntityId getEntityId(RecordItem recordItem) {
+        SystemDeleteTransactionBody systemDelete = recordItem.getTransactionBody().getSystemDelete();
+        if (systemDelete.hasContractID()) {
+            return EntityId.of(systemDelete.getContractID());
+        } else if (systemDelete.hasFileID()) {
+            return EntityId.of(systemDelete.getFileID());
+        }
+        return null;
+    }
+
+    @Override
+    public boolean updatesEntity() {
+        return true;
+    }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/SystemUndeleteTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/SystemUndeleteTransactionHandler.java
@@ -20,10 +20,30 @@ package com.hedera.mirror.importer.parser.record.transactionhandler;
  * ‍
  */
 
+import com.hederahashgraph.api.proto.java.SystemUndeleteTransactionBody;
 import javax.inject.Named;
 import lombok.AllArgsConstructor;
+
+import com.hedera.mirror.importer.domain.EntityId;
+import com.hedera.mirror.importer.parser.domain.RecordItem;
 
 @Named
 @AllArgsConstructor
 public class SystemUndeleteTransactionHandler implements TransactionHandler {
+
+    @Override
+    public EntityId getEntityId(RecordItem recordItem) {
+        SystemUndeleteTransactionBody systemUndelete = recordItem.getTransactionBody().getSystemUndelete();
+        if (systemUndelete.hasContractID()) {
+            return EntityId.of(systemUndelete.getContractID());
+        } else if (systemUndelete.hasFileID()) {
+            return EntityId.of(systemUndelete.getFileID());
+        }
+        return null;
+    }
+
+    @Override
+    public boolean updatesEntity() {
+        return true;
+    }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TransactionHandler.java
@@ -37,15 +37,6 @@ public interface TransactionHandler {
     EntityId getEntityId(RecordItem recordItem);
 
     /**
-     * Override this function if a transaction needs to update proxyAccountId in {@link
-     * com.hedera.mirror.importer.domain.Entities}. If value returned is null, or if {@link EntityId#getEntityNum()} is
-     * 0 for the returned value, then proxyAccountId is not updated.
-     */
-    default EntityId getProxyAccountId(RecordItem recordItem) {
-        return null;
-    }
-
-    /**
      * Override to return true if an implementation wants to be able to update the entity returned by
      * {@link #getEntityId(RecordItem)}.
      */

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TransactionHandler.java
@@ -20,5 +20,36 @@ package com.hedera.mirror.importer.parser.record.transactionhandler;
  * ‍
  */
 
+import com.hedera.mirror.importer.domain.EntityId;
+import com.hedera.mirror.importer.parser.domain.RecordItem;
+
+/**
+ * TransactionHandler interface abstracts the logic for processing different kinds for transactions. For each
+ * transaction type, there exists an unique implementation of TransactionHandler which encapsulates all logic specific
+ * to processing of that transaction type. A single {@link com.hederahashgraph.api.proto.java.Transaction} and its
+ * associated info (TransactionRecord, deserialized TransactionBody, etc) are all encapsulated together in a single
+ * {@link RecordItem}. Hence, most functions of this interface require RecordItem as a parameter.
+ */
 public interface TransactionHandler {
+    /**
+     * @return main entity associated with this transaction
+     */
+    EntityId getEntityId(RecordItem recordItem);
+
+    /**
+     * Override this function if a transaction needs to update proxyAccountId in {@link
+     * com.hedera.mirror.importer.domain.Entities}. If value returned is null, or if {@link EntityId#getEntityNum()} is
+     * 0 for the returned value, then proxyAccountId is not updated.
+     */
+    default EntityId getProxyAccountId(RecordItem recordItem) {
+        return null;
+    }
+
+    /**
+     * Override to return true if an implementation wants to be able to update the entity returned by
+     * {@link #getEntityId(RecordItem)}.
+     */
+    default boolean updatesEntity() {
+        return false;
+    }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/UnknownDataTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/UnknownDataTransactionHandler.java
@@ -23,7 +23,15 @@ package com.hedera.mirror.importer.parser.record.transactionhandler;
 import javax.inject.Named;
 import lombok.AllArgsConstructor;
 
+import com.hedera.mirror.importer.domain.EntityId;
+import com.hedera.mirror.importer.parser.domain.RecordItem;
+
 @Named
 @AllArgsConstructor
 public class UnknownDataTransactionHandler implements TransactionHandler {
+
+    @Override
+    public EntityId getEntityId(RecordItem recordItem) {
+        return null;
+    }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/EntityRepositoryCustomImpl.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/EntityRepositoryCustomImpl.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.importer.repository;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -51,8 +51,6 @@ public class EntityRepositoryCustomImpl implements EntityRepositoryCustom {
 
     public <S extends Entities> EntityId saveAndCacheEntityId(S entity) {
         var saved = entityRepository.save(entity);
-        return entityRepository.cache(
-                    new EntityId(saved.getId(), saved.getEntityShard(), saved.getEntityRealm(), saved.getEntityNum(),
-                            saved.getEntityTypeId()));
+        return entityRepository.cache(saved.toEntityId());
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/domain/RecordItemTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/domain/RecordItemTest.java
@@ -33,9 +33,8 @@ import com.hederahashgraph.api.proto.java.TransactionRecord;
 import org.junit.jupiter.api.Test;
 
 import com.hedera.mirror.importer.exception.ParserException;
-import com.hedera.mirror.importer.parser.record.transactionhandler.AbstractTransactionHandlerTest;
 
-class RecordItemTest extends AbstractTransactionHandlerTest {
+class RecordItemTest {
 
     private static final Transaction DEFAULT_TRANSACTION = Transaction.newBuilder()
             .setBodyBytes(TransactionBody.getDefaultInstance().toByteString())

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/domain/RecordItemTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/domain/RecordItemTest.java
@@ -20,11 +20,10 @@ package com.hedera.mirror.importer.parser.domain;
  * ‍
  */
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import com.google.protobuf.ByteString;
-
-import com.hedera.mirror.importer.exception.ParserException;
-import com.hedera.mirror.importer.parser.record.transactionhandler.AbstractTransactionHandlerTest;
-
 import com.hederahashgraph.api.proto.java.SignatureMap;
 import com.hederahashgraph.api.proto.java.SignaturePair;
 import com.hederahashgraph.api.proto.java.Transaction;
@@ -33,7 +32,8 @@ import com.hederahashgraph.api.proto.java.TransactionReceipt;
 import com.hederahashgraph.api.proto.java.TransactionRecord;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import com.hedera.mirror.importer.exception.ParserException;
+import com.hedera.mirror.importer.parser.record.transactionhandler.AbstractTransactionHandlerTest;
 
 class RecordItemTest extends AbstractTransactionHandlerTest {
 
@@ -95,17 +95,16 @@ class RecordItemTest extends AbstractTransactionHandlerTest {
     }
 
     private void testException(byte[] transactionBytes, byte[] recordBytes, String expectedMessage) {
-        Exception exception = assertThrows(ParserException.class, () -> {
-            new RecordItem(transactionBytes, recordBytes);
-        });
-        assertEquals(expectedMessage, exception.getMessage());
+        assertThatThrownBy(() -> new RecordItem(transactionBytes, recordBytes))
+                .isInstanceOf(ParserException.class)
+                .hasMessage(expectedMessage);
     }
 
     private void assertRecordItem(Transaction transaction, RecordItem recordItem) {
-        assertEquals(transaction, recordItem.getTransaction());
-        assertEquals(TRANSACTION_RECORD, recordItem.getRecord());
-        assertEquals(TRANSACTION_BODY, recordItem.getTransactionBody());
-        assertArrayEquals(transaction.toByteArray(), recordItem.getTransactionBytes());
-        assertArrayEquals(TRANSACTION_RECORD.toByteArray(), recordItem.getRecordBytes());
+        assertThat(recordItem.getTransaction()).isEqualTo(transaction);
+        assertThat(recordItem.getRecord()).isEqualTo(TRANSACTION_RECORD);
+        assertThat(recordItem.getTransactionBody()).isEqualTo(TRANSACTION_BODY);
+        assertThat(recordItem.getTransactionBytes()).isEqualTo(transaction.toByteArray());
+        assertThat(recordItem.getRecordBytes()).isEqualTo(TRANSACTION_RECORD.toByteArray());
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/AbstractRecordItemParserTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/AbstractRecordItemParserTest.java
@@ -24,6 +24,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.google.protobuf.ByteString;
+
+import com.hedera.mirror.importer.domain.EntityId;
+import com.hedera.mirror.importer.domain.EntityTypeEnum;
+
 import com.hederahashgraph.api.proto.java.AccountAmount;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ContractID;
@@ -36,6 +40,7 @@ import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionBody.Builder;
 import com.hederahashgraph.api.proto.java.TransactionRecord;
 import com.hederahashgraph.api.proto.java.TransferList;
+import java.util.Optional;
 import java.util.UUID;
 import javax.annotation.Resource;
 import org.junit.jupiter.api.BeforeEach;
@@ -215,7 +220,7 @@ public class AbstractRecordItemParserTest extends IntegrationTest {
         );
     }
 
-    protected final Builder defaultTransactionBodyBuilder(String memo) {
+    protected static Builder defaultTransactionBodyBuilder(String memo) {
 
         long validDuration = 120;
         AccountID payerAccountId = AccountID.newBuilder().setShardNum(0).setRealmNum(0).setAccountNum(2).build();
@@ -229,5 +234,22 @@ public class AbstractRecordItemParserTest extends IntegrationTest {
         body.setTransactionID(Utility.getTransactionId(payerAccountId));
         body.setTransactionValidDuration(Duration.newBuilder().setSeconds(validDuration).build());
         return body;
+    }
+
+    public Long assertEntityExistsAndLookupId(Long entityNum) {
+        if (entityNum == null) { // ignore when entity is not set in test case
+            return null;
+        }
+        Optional<Entities> entity = entityRepository.findByPrimaryKey(0L, 0L, entityNum);
+        assertThat(entity).isPresent();
+        return entity.get().getId();
+    }
+
+    public Long createIdForAccountNum(Long accountNum) {
+        if (accountNum == null) { // ignore when entity is not set in test case
+            return null;
+        }
+        EntityId entityId = new EntityId(null, 0L, 0L, accountNum, EntityTypeEnum.ACCOUNT.getId());
+        return entityRepository.saveAndCacheEntityId(entityId.toEntity()).getId();
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/AbstractRecordItemParserTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/AbstractRecordItemParserTest.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.importer.parser.record;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,12 +22,8 @@ package com.hedera.mirror.importer.parser.record;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.mock;
 
 import com.google.protobuf.ByteString;
-
-import com.hedera.mirror.importer.parser.RecordStreamFileListener;
-
 import com.hederahashgraph.api.proto.java.AccountAmount;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ContractID;
@@ -42,12 +38,15 @@ import com.hederahashgraph.api.proto.java.TransactionRecord;
 import com.hederahashgraph.api.proto.java.TransferList;
 import java.util.UUID;
 import javax.annotation.Resource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
 import org.springframework.test.context.jdbc.Sql;
 
 import com.hedera.mirror.importer.IntegrationTest;
 import com.hedera.mirror.importer.domain.Entities;
 import com.hedera.mirror.importer.domain.RecordFile;
 import com.hedera.mirror.importer.domain.Transaction;
+import com.hedera.mirror.importer.parser.RecordStreamFileListener;
 import com.hedera.mirror.importer.parser.domain.RecordItem;
 import com.hedera.mirror.importer.parser.domain.StreamFileData;
 import com.hedera.mirror.importer.repository.ContractResultRepository;
@@ -114,6 +113,11 @@ public class AbstractRecordItemParserTest extends IntegrationTest {
         sigMap.addSigPair(sigPair);
 
         return sigMap.build();
+    }
+
+    @BeforeEach
+    void beforeEach(TestInfo testInfo) {
+        System.out.println("Before test: " + testInfo.getTestMethod().get().getName());
     }
 
     protected static Key keyFromString(String key) {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/CommonParserPropertiesTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/CommonParserPropertiesTest.java
@@ -8,9 +8,9 @@ package com.hedera.mirror.importer.parser.record;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,6 +25,10 @@ import com.google.common.base.Splitter;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import com.hedera.mirror.importer.domain.EntityId;
+import com.hedera.mirror.importer.domain.TransactionFilterFields;
+
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -47,10 +51,8 @@ public class CommonParserPropertiesTest {
     @DisplayName("Filter empty")
     @Test
     void filterEmpty() {
-        Transaction transaction = new Transaction();
-        transaction.setEntity(entity("0.0.1"));
-        transaction.setType(TransactionTypeEnum.CONSENSUSSUBMITMESSAGE.getProtoId());
-        assertTrue(commonParserProperties.getFilter().test(transaction));
+        assertTrue(commonParserProperties.getFilter().test(
+                new TransactionFilterFields(entity("0.0.1"), TransactionTypeEnum.CONSENSUSSUBMITMESSAGE)));
     }
 
     @DisplayName("Filter using include")
@@ -68,16 +70,13 @@ public class CommonParserPropertiesTest {
             ", UNKNOWN, false"
     })
     void filterInclude(String entityId, TransactionTypeEnum type, boolean result) {
-        Transaction transaction = new Transaction();
-        transaction.setEntity(entity(entityId));
-        transaction.setType(type.getProtoId());
-
         commonParserProperties.getInclude().add(filter("0.0.1", TransactionTypeEnum.CONSENSUSSUBMITMESSAGE));
         commonParserProperties.getInclude().add(filter("0.0.2", TransactionTypeEnum.CRYPTOCREATEACCOUNT));
         commonParserProperties.getInclude().add(filter("0.0.3", null));
         commonParserProperties.getInclude().add(filter(null, TransactionTypeEnum.FILECREATE));
 
-        assertEquals(result, commonParserProperties.getFilter().test(transaction));
+        assertEquals(result, commonParserProperties.getFilter().test(
+                new TransactionFilterFields(entity(entityId), type)));
     }
 
     @DisplayName("Filter using exclude")
@@ -95,16 +94,13 @@ public class CommonParserPropertiesTest {
             ", UNKNOWN, true"
     })
     void filterExclude(String entityId, TransactionTypeEnum type, boolean result) {
-        Transaction transaction = new Transaction();
-        transaction.setEntity(entity(entityId));
-        transaction.setType(type.getProtoId());
-
         commonParserProperties.getExclude().add(filter("0.0.1", TransactionTypeEnum.CONSENSUSSUBMITMESSAGE));
         commonParserProperties.getExclude().add(filter("0.0.2", TransactionTypeEnum.CRYPTOCREATEACCOUNT));
         commonParserProperties.getExclude().add(filter("0.0.3", null));
         commonParserProperties.getExclude().add(filter(null, TransactionTypeEnum.FILECREATE));
 
-        assertEquals(result, commonParserProperties.getFilter().test(transaction));
+        assertEquals(result, commonParserProperties.getFilter().test(
+                new TransactionFilterFields(entity(entityId), type)));
     }
 
     @DisplayName("Filter using include and exclude")
@@ -120,10 +116,6 @@ public class CommonParserPropertiesTest {
             "0.0.5, CONSENSUSSUBMITMESSAGE, false",
     })
     void filterBoth(String entityId, TransactionTypeEnum type, boolean result) {
-        Transaction transaction = new Transaction();
-        transaction.setEntity(entity(entityId));
-        transaction.setType(type.getProtoId());
-
         commonParserProperties.getInclude().add(filter("0.0.1", TransactionTypeEnum.CONSENSUSSUBMITMESSAGE));
         commonParserProperties.getInclude().add(filter("0.0.2", TransactionTypeEnum.CRYPTOCREATEACCOUNT));
         commonParserProperties.getInclude().add(filter("0.0.3", TransactionTypeEnum.FREEZE));
@@ -135,10 +127,11 @@ public class CommonParserPropertiesTest {
         commonParserProperties.getExclude().add(filter(null, TransactionTypeEnum.FILECREATE));
         commonParserProperties.getExclude().add(filter("0.0.5", TransactionTypeEnum.CONSENSUSCREATETOPIC));
 
-        assertEquals(result, commonParserProperties.getFilter().test(transaction));
+        assertEquals(result, commonParserProperties.getFilter().test(
+                new TransactionFilterFields(entity(entityId), type)));
     }
 
-    private Entities entity(String entityId) {
+    private EntityId entity(String entityId) {
         if (StringUtils.isBlank(entityId)) {
             return null;
         }
@@ -148,12 +141,7 @@ public class CommonParserPropertiesTest {
                 .stream()
                 .map(Long::valueOf)
                 .collect(Collectors.toList());
-
-        Entities entities = new Entities();
-        entities.setEntityShard(parts.get(0));
-        entities.setEntityRealm(parts.get(1));
-        entities.setEntityNum(parts.get(2));
-        return entities;
+        return new EntityId(null, parts.get(0), parts.get(1), parts.get(2), 1 /* account */);
     }
 
     private TransactionFilter filter(String entity, TransactionTypeEnum type) {
@@ -164,7 +152,7 @@ public class CommonParserPropertiesTest {
         }
 
         if (type != null) {
-            transactionFilter.setTransaction(Arrays.asList(type));
+            transactionFilter.setTransactionType(Arrays.asList(type));
         }
 
         return transactionFilter;

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/CommonParserPropertiesTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/CommonParserPropertiesTest.java
@@ -25,10 +25,6 @@ import com.google.common.base.Splitter;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
-
-import com.hedera.mirror.importer.domain.EntityId;
-import com.hedera.mirror.importer.domain.TransactionFilterFields;
-
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -37,8 +33,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.hedera.mirror.importer.domain.Entities;
-import com.hedera.mirror.importer.domain.Transaction;
+import com.hedera.mirror.importer.domain.EntityId;
+import com.hedera.mirror.importer.domain.TransactionFilterFields;
 import com.hedera.mirror.importer.domain.TransactionTypeEnum;
 import com.hedera.mirror.importer.parser.CommonParserProperties;
 import com.hedera.mirror.importer.parser.CommonParserProperties.TransactionFilter;
@@ -152,7 +148,7 @@ public class CommonParserPropertiesTest {
         }
 
         if (type != null) {
-            transactionFilter.setTransactionType(Arrays.asList(type));
+            transactionFilter.setTransaction(Arrays.asList(type));
         }
 
         return transactionFilter;

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordItemParserCryptoTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordItemParserCryptoTest.java
@@ -1028,7 +1028,7 @@ public class RecordItemParserCryptoTest extends AbstractRecordItemParserTest {
         return transaction.build();
     }
 
-    private Transaction cryptoUpdateTransaction() {
+    private static Transaction cryptoUpdateTransaction() {
 
         Transaction.Builder transaction = Transaction.newBuilder();
         CryptoUpdateTransactionBody.Builder cryptoUpdate = CryptoUpdateTransactionBody.newBuilder();

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordItemParserTopicTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordItemParserTopicTest.java
@@ -74,20 +74,17 @@ public class RecordItemParserTopicTest extends AbstractRecordItemParserTest {
         var transaction = createCreateTopicTransaction(adminKey, submitKey, memo, autoRenewAccount, autoRenewPeriod);
         var transactionRecord = createTransactionRecord(topicId, null, null, consensusTimestamp,
                 responseCode);
-        var expectedEntity = createTopicEntity(topicId, null, null, adminKey, submitKey, memo, autoRenewAccount,
-                autoRenewPeriod);
 
         parseRecordItemAndCommit(new RecordItem(transaction, transactionRecord));
 
         long entityCount = autoRenewAccount != null ? 4 : 3; // Node, payer, topic & optionally autorenew
-        var entity = entityRepository
-                .findByPrimaryKey(topicId.getShardNum(), topicId.getRealmNum(), topicId.getTopicNum()).get();
+        var entity = entityRepository.findByPrimaryKey(
+                topicId.getShardNum(), topicId.getRealmNum(), topicId.getTopicNum()).get();
         assertTransactionInRepository(responseCode, consensusTimestamp, entity.getId());
         assertEquals(entityCount, entityRepository.count());
-        assertThat(entity).isEqualToIgnoringGivenFields(expectedEntity, "id", "autoRenewAccount");
-        if (autoRenewAccount != null) {
-            assertThat(entity.getAutoRenewAccount()).isEqualToIgnoringGivenFields(entity.getAutoRenewAccount(), "id");
-        }
+        var expectedEntity = createTopicEntity(topicId, null, null, adminKey, submitKey, memo,
+                assertEntityExistsAndLookupId(autoRenewAccount), autoRenewPeriod);
+        assertThat(entity).isEqualToIgnoringGivenFields(expectedEntity, "id");
     }
 
     @Test
@@ -115,11 +112,12 @@ public class RecordItemParserTopicTest extends AbstractRecordItemParserTest {
     // https://github.com/hashgraph/hedera-mirror-node/issues/501
     @Test
     void createTopicTestExistingAutoRenewAccount() throws Exception {
-        Entities autoRenewAccount = createEntity(100L, EntityTypeEnum.ACCOUNT);
+        Long autoRenewAccount = 100L;
+        Long autoRenewAccountId = createIdForAccountNum(autoRenewAccount);
         var topicId = 200L;
         var consensusTimestamp = 2_000_000L;
         var responseCode = ResponseCodeEnum.SUCCESS;
-        var transaction = createCreateTopicTransaction(null, null, null, autoRenewAccount.getEntityNum(), null);
+        var transaction = createCreateTopicTransaction(null, null, null, autoRenewAccount, null);
         var transactionRecord = createTransactionRecord(TopicID.newBuilder().setTopicNum(topicId)
                 .build(), null, null, consensusTimestamp, responseCode);
 
@@ -134,7 +132,7 @@ public class RecordItemParserTopicTest extends AbstractRecordItemParserTest {
                 .returns("", from(Entities::getMemo))
                 .returns(false, from(Entities::isDeleted))
                 .returns(EntityTypeEnum.TOPIC.getId(), from(Entities::getEntityTypeId))
-                .returns(autoRenewAccount, from(Entities::getAutoRenewAccount));
+                .returns(autoRenewAccountId, from(Entities::getAutoRenewAccountId));
     }
 
     @Test
@@ -180,11 +178,9 @@ public class RecordItemParserTopicTest extends AbstractRecordItemParserTest {
                          @ConvertWith(KeyConverter.class) Key updatedSubmitKey,
                          String updatedMemo, long consensusTimestamp, Long autoRenewAccount, Long autoRenewPeriod) throws Exception {
         // Store topic to be updated.
+        Long autoRenewAccountEntityId = createIdForAccountNum(autoRenewAccount);
         var topic = createTopicEntity(topicId, expirationTimeSeconds, expirationTimeNanos, adminKey, submitKey, memo,
-                autoRenewAccount, autoRenewPeriod);
-        if (topic.getAutoRenewAccount() != null) {
-            topic.setAutoRenewAccount(entityRepository.save(topic.getAutoRenewAccount()));
-        }
+                autoRenewAccountEntityId, autoRenewPeriod);
         entityRepository.save(topic);
 
         var responseCode = ResponseCodeEnum.SUCCESS;
@@ -194,7 +190,7 @@ public class RecordItemParserTopicTest extends AbstractRecordItemParserTest {
         var transactionRecord = createTransactionRecord(topicId, null, null, consensusTimestamp,
                 responseCode);
         var expectedEntity = createTopicEntity(topicId, updatedExpirationTimeSeconds, updatedExpirationTimeNanos,
-                updatedAdminKey, updatedSubmitKey, updatedMemo, autoRenewAccount, autoRenewPeriod);
+                updatedAdminKey, updatedSubmitKey, updatedMemo, autoRenewAccountEntityId, autoRenewPeriod);
 
         parseRecordItemAndCommit(new RecordItem(transaction, transactionRecord));
 
@@ -203,10 +199,7 @@ public class RecordItemParserTopicTest extends AbstractRecordItemParserTest {
                 .findByPrimaryKey(topicId.getShardNum(), topicId.getRealmNum(), topicId.getTopicNum()).get();
         assertTransactionInRepository(responseCode, consensusTimestamp, entity.getId());
         assertEquals(entityCount, entityRepository.count());
-        assertThat(entity).isEqualToIgnoringGivenFields(expectedEntity, "id", "autoRenewAccount");
-        if (autoRenewAccount != null) {
-            assertThat(entity.getAutoRenewAccount()).isEqualToIgnoringGivenFields(entity.getAutoRenewAccount(), "id");
-        }
+        assertThat(entity).isEqualToIgnoringGivenFields(expectedEntity, "id");
     }
 
     @Test
@@ -245,25 +238,24 @@ public class RecordItemParserTopicTest extends AbstractRecordItemParserTest {
         var submitKey = (Key) new KeyConverter().convert("updated-submit-key", null);
         var consensusTimestamp = 6_000_000L;
         var responseCode = ResponseCodeEnum.SUCCESS;
-
-        var topic = createTopicEntity(topicId, 11L, 0, adminKey, submitKey, "updated-memo", 1L, 30L);
+        var memo = "updated-memo";
+        Long autoRenewAccount = 1L;
         // Topic does not get stored in the repository beforehand.
 
-        var transaction = createUpdateTopicTransaction(topicId, 11L, 0, adminKey, submitKey, topic
-                .getMemo(), 1L, 30L);
-        var transactionRecord = createTransactionRecord(topicId, null, null, consensusTimestamp,
-                responseCode);
+        var transaction = createUpdateTopicTransaction(topicId, 11L, 0, adminKey, submitKey, memo, autoRenewAccount,
+                30L);
+        var transactionRecord = createTransactionRecord(topicId, null, null, consensusTimestamp, responseCode);
 
         parseRecordItemAndCommit(new RecordItem(transaction, transactionRecord));
 
-        var entity = entityRepository
-                .findByPrimaryKey(topicId.getShardNum(), topicId.getRealmNum(), topicId.getTopicNum()).get();
+        var entity = entityRepository.findByPrimaryKey(
+                topicId.getShardNum(), topicId.getRealmNum(), topicId.getTopicNum()).get();
         assertTransactionInRepository(responseCode, consensusTimestamp, entity.getId());
         assertEquals(4L, entityRepository.count()); // Node, payer, topic, autorenew
-        assertThat(entity)
-                .isEqualToIgnoringGivenFields(topic, "id", "autoRenewAccount")
-                .extracting(Entities::getAutoRenewAccount)
-                .isEqualToIgnoringGivenFields(entity.getAutoRenewAccount(), "id");
+
+        var expectedTopic = createTopicEntity(topicId, 11L, 0, adminKey, submitKey, memo,
+                assertEntityExistsAndLookupId(autoRenewAccount), 30L);
+        assertThat(entity).isEqualToIgnoringGivenFields(expectedTopic, "id");
     }
 
     @ParameterizedTest
@@ -285,22 +277,11 @@ public class RecordItemParserTopicTest extends AbstractRecordItemParserTest {
                                        Long autoRenewAccount, Long autoRenewPeriod, Long updatedAutoRenewAccount,
                                        Long updatedAutoRenewPeriod) throws Exception {
         // Store topic to be updated.
+        Long autoRenewAccountEntityId = createIdForAccountNum(autoRenewAccount);
         var topic = createTopicEntity(topicId, expirationTimeSeconds, expirationTimeNanos, adminKey, submitKey, memo,
-                autoRenewAccount, autoRenewPeriod);
-        if (topic.getAutoRenewAccount() != null) {
-            topic.setAutoRenewAccount(entityRepository.save(topic.getAutoRenewAccount()));
-        }
+                autoRenewAccountEntityId, autoRenewPeriod);
         entityRepository.save(topic);
 
-        // Setup the expected entity.
-        if (updatedAutoRenewAccount != null) {
-            var autoRenewEntity = new Entities();
-            autoRenewEntity.setEntityShard(topic.getEntityShard());
-            autoRenewEntity.setEntityRealm(topic.getEntityRealm());
-            autoRenewEntity.setEntityNum(updatedAutoRenewAccount);
-            autoRenewEntity.setEntityTypeId(1);
-            topic.setAutoRenewAccount(autoRenewEntity);
-        }
         if (updatedAutoRenewPeriod != null) {
             topic.setAutoRenewPeriod(updatedAutoRenewPeriod);
         }
@@ -332,15 +313,13 @@ public class RecordItemParserTopicTest extends AbstractRecordItemParserTest {
         }
         if (updatedAutoRenewAccount != null) {
             ++entityCount;
+            topic.setAutoRenewAccountId(assertEntityExistsAndLookupId(updatedAutoRenewAccount));
         }
         var entity = entityRepository
                 .findByPrimaryKey(topicId.getShardNum(), topicId.getRealmNum(), topicId.getTopicNum()).get();
         assertTransactionInRepository(responseCode, consensusTimestamp, entity.getId());
         assertEquals(entityCount, entityRepository.count());
-        assertThat(entity).isEqualToIgnoringGivenFields(topic, "id", "autoRenewAccount");
-        if (autoRenewAccount != null) {
-            assertThat(entity.getAutoRenewAccount()).isEqualToIgnoringGivenFields(entity.getAutoRenewAccount(), "id");
-        }
+        assertThat(entity).isEqualToIgnoringGivenFields(topic, "id");
     }
 
     @Test
@@ -591,19 +570,14 @@ public class RecordItemParserTopicTest extends AbstractRecordItemParserTest {
     }
 
     private Entities createTopicEntity(TopicID topicId, Long expirationTimeSeconds, Integer expirationTimeNanos,
-                                       Key adminKey, Key submitKey, String memo, Long autoRenewAccount,
+                                       Key adminKey, Key submitKey, String memo, Long autoRenewAccountEntityId,
                                        Long autoRenewPeriod) {
         var topic = new Entities();
         topic.setEntityShard(topicId.getShardNum());
         topic.setEntityRealm(topicId.getRealmNum());
         topic.setEntityNum(topicId.getTopicNum());
-        if (autoRenewAccount != null) {
-            var autoRenewEntity = new Entities();
-            autoRenewEntity.setEntityShard(topic.getEntityShard());
-            autoRenewEntity.setEntityRealm(topic.getEntityRealm());
-            autoRenewEntity.setEntityNum(autoRenewAccount);
-            autoRenewEntity.setEntityTypeId(EntityTypeEnum.ACCOUNT.getId());
-            topic.setAutoRenewAccount(autoRenewEntity);
+        if (autoRenewAccountEntityId != null) {
+            topic.setAutoRenewAccountId(autoRenewAccountEntityId);
         }
         if (autoRenewPeriod != null) {
             topic.setAutoRenewPeriod(autoRenewPeriod);

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordItemParserTopicTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordItemParserTopicTest.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.importer.parser.record;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -482,21 +482,24 @@ public class RecordItemParserTopicTest extends AbstractRecordItemParserTest {
 
     @Test
     void submitMessageTestFiltered() throws Exception {
+        // given
         var responseCode = ResponseCodeEnum.SUCCESS;
-        var topicId = (TopicID) new TopicIdConverter().convert("0.0.999", null);
+        var topicId = (TopicID) new TopicIdConverter().convert("0.0.999", null); // excluded in application-default.yml
         var consensusTimestamp = 10_000_000L;
         var message = "message";
         var sequenceNumber = 10_000L;
         var runningHash = "running-hash";
 
-        var topic = createTopicEntity(topicId, null, null, null, null, null, null, null);
         var transaction = createSubmitMessageTransaction(topicId, message);
         var transactionRecord = createTransactionRecord(topicId, sequenceNumber, runningHash
                 .getBytes(), consensusTimestamp, responseCode);
 
+        // when
         parseRecordItemAndCommit(new RecordItem(transaction, transactionRecord));
 
-        assertEquals(1L, entityRepository.count());
+        // then
+        // if the transaction is filtered out, nothing in it should affect the state
+        assertEquals(0L, entityRepository.count());
         assertEquals(0L, topicMessageRepository.count());
     }
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/EntityRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/EntityRepositoryTest.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.importer.repository;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,8 +21,7 @@ package com.hedera.mirror.importer.repository;
  */
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
 
@@ -50,7 +49,7 @@ public class EntityRepositoryTest extends AbstractRepositoryTest {
 
         Entities entity = new Entities();
         entity.setAutoRenewPeriod(100L);
-        entity.setAutoRenewAccount(autoRenewAccount);
+        entity.setAutoRenewAccountId(autoRenewAccount.getId());
         entity.setDeleted(true);
         entity.setEd25519PublicKeyHex("0123456789abcdef");
         entity.setEntityNum(5L);
@@ -86,15 +85,15 @@ public class EntityRepositoryTest extends AbstractRepositoryTest {
         entity.setEntityShard(1L);
         entity.setEntityRealm(2L);
         entity.setEntityNum(3L);
-        final var expected = entityRepository.save(entity);
+        var expected = entityRepository.save(entity);
 
         var entityId = entityRepository.findEntityIdByNativeIds(entity.getEntityShard(), entity.getEntityRealm(),
                 entity.getEntityNum()).get();
 
         assertAll(() -> assertEquals(expected.getId(), entityId.getId())
-                ,() -> assertEquals(expected.getEntityShard(), entityId.getEntityShard())
-                ,() -> assertEquals(expected.getEntityRealm(), entityId.getEntityRealm())
-                ,() -> assertEquals(expected.getEntityNum(), entityId.getEntityNum())
+                , () -> assertEquals(expected.getEntityShard(), entityId.getEntityShard())
+                , () -> assertEquals(expected.getEntityRealm(), entityId.getEntityRealm())
+                , () -> assertEquals(expected.getEntityNum(), entityId.getEntityNum())
         );
     }
 }


### PR DESCRIPTION
**Detailed description**:

- Address followups from #638 and #639
- Moved transaction filtering to starting of RecordItemParser.onItem().
      Makes it easier to enforce the invariant - "No state changes (db writes) if transaction is ignored"
  - getEntityId() was violating it by writing entities before filtering. Corrected it.
- entity.proxyAccountId: If present, id is looked up using big cache.
- entity.autoRenewAccount: Changed to Long to follow same pattern
  as proxyAccountId i.e. look up id in big cache or create new one.
  - Updated affected tests in RecordItemParserTopicTest
- Adapt logic updating entities for easy cut-paste into TransacionHandlers in followup PRs
- Added code comments to explain lot of non-obvious existing logic which was easy to
  trip on and took decent amount of time to decipher
- Replaced 'createEntity(geEntity(xyz))' => 'lookupOrCreateId(EntityId.of(xyz))'.
  Latter has same caching advantage as above.

Signed-off-by: Apekshit Sharma <apekshit.sharma@hedera.com>

**Which issue(s) this PR fixes**:
Part of #571 . Needed to do #560 in right way, hence P1.

**Special notes for your reviewer**:
Tests for Transaction Handlers will be in PR right after this.
After that, there will be followup PRs for moving entity update logic to TransactionHandlers.

**Checklist**
- [ ] Documentation added
- [x] Tests updated

