### PR TITLE
Add updateEntity() and updateTransaction() to TransactionHandler

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordItemParser.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordItemParser.java
@@ -24,18 +24,12 @@ import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ConsensusSubmitMessageTransactionBody;
 import com.hederahashgraph.api.proto.java.ContractCallTransactionBody;
 import com.hederahashgraph.api.proto.java.ContractCreateTransactionBody;
-import com.hederahashgraph.api.proto.java.ContractUpdateTransactionBody;
 import com.hederahashgraph.api.proto.java.CryptoAddClaimTransactionBody;
-import com.hederahashgraph.api.proto.java.CryptoCreateTransactionBody;
-import com.hederahashgraph.api.proto.java.CryptoUpdateTransactionBody;
 import com.hederahashgraph.api.proto.java.FileAppendTransactionBody;
-import com.hederahashgraph.api.proto.java.FileCreateTransactionBody;
 import com.hederahashgraph.api.proto.java.FileID;
 import com.hederahashgraph.api.proto.java.FileUpdateTransactionBody;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
-import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TransactionBody;
-import com.hederahashgraph.api.proto.java.TransactionID;
 import com.hederahashgraph.api.proto.java.TransactionRecord;
 import com.hederahashgraph.api.proto.java.TransferList;
 import java.io.IOException;
@@ -52,6 +46,7 @@ import com.hedera.mirror.importer.domain.FileData;
 import com.hedera.mirror.importer.domain.LiveHash;
 import com.hedera.mirror.importer.domain.NonFeeTransfer;
 import com.hedera.mirror.importer.domain.TopicMessage;
+import com.hedera.mirror.importer.domain.Transaction;
 import com.hedera.mirror.importer.domain.TransactionFilterFields;
 import com.hedera.mirror.importer.domain.TransactionTypeEnum;
 import com.hedera.mirror.importer.exception.ImporterException;
@@ -115,185 +110,33 @@ public class RecordItemParser implements RecordItemListener {
             return;
         }
 
-        // TODO: updatesEntity() is true for all and only the transaction types which are in body.has*() if-else
-        //   conditions below. This is temporary to keep scope of changes in single PR limited and will be fixed in
-        //   followup PR quickly. All if-else conditions will be replaced by:
-        //     transactionHandler.updateEntity(entity, recordItem).
-        Entities entity = null; // Entity used when t_entities row must be updated.
-        if (transactionHandler.updatesEntity()) {
-            entity = getEntity(entityId);
-        }
+        boolean isSuccessful = isSuccessful(txRecord);
+        Transaction tx = buildTransaction(consensusNs, recordItem);
+        transactionHandler.updateTransaction(tx, recordItem);
 
-        // Only when transaction is successful:
-        // - Fields of 'entity' will be updated. Fields are not updated for failed transactions since 'entity' may be an
-        //   instance from cache and reused in future.
-        // - proxyAccountId/autoRenewAccountId: If present, the account's id will be looked up (from big cache)
-        //   or created immediately.
-
-        // For all transactions:
-        // - 'entity' (may have been updated or not) is always inserted into repo since
+        // Irrespective of transaction failure/success, if entityId is not null, it will be inserted into repo since:
         //   (1) it is guaranteed to be valid entity on network (validated to exist in pre-consensus checks)
         //   (2) fk_cud_entity_id is foreign key in t_transactions
-        boolean doUpdateEntity = isSuccessful(txRecord);
-        long initialBalance = 0;
-
-        if (entity == null) {
-            // Do nothing. This can be true if transaction is of type that doesn't update the entity. Or, if the
-            // transaction doesn't contain non-zero entity id (i.e. with entityNum != 0).
-        } else if (body.hasContractCreateInstance()) {
-            if (txRecord.getReceipt().hasContractID()) { // implies SUCCESS
-                ContractCreateTransactionBody txMessage = body.getContractCreateInstance();
-                setProxyAccountID(txMessage.getProxyAccountID(), entity);
-                if (txMessage.hasAutoRenewPeriod()) {
-                    entity.setAutoRenewPeriod(txMessage.getAutoRenewPeriod().getSeconds());
-                }
-                // Can't clear memo on contracts. 0 length indicates no change
-                if (txMessage.getMemo() != null && txMessage.getMemo().length() > 0) {
-                    entity.setMemo(txMessage.getMemo());
-                }
-
-                if (txMessage.hasAdminKey()) {
-                    entity.setKey(txMessage.getAdminKey().toByteArray());
-                }
-            }
-
-            initialBalance = body.getContractCreateInstance().getInitialBalance();
-        } else if (body.hasContractDeleteInstance()) {
-            if (body.getContractDeleteInstance().hasContractID()) {
-                if (doUpdateEntity) {
-                    entity.setDeleted(true);
-                }
-            }
-        } else if (body.hasContractUpdateInstance()) {
-            ContractUpdateTransactionBody txMessage = body.getContractUpdateInstance();
-            if (doUpdateEntity) {
-                setProxyAccountID(txMessage.getProxyAccountID(), entity);
-                if (txMessage.hasExpirationTime()) {
-                    entity.setExpiryTimeNs(Utility.timestampInNanosMax(txMessage.getExpirationTime()));
-                }
-                if (txMessage.hasAutoRenewPeriod()) {
-                    entity.setAutoRenewPeriod(txMessage.getAutoRenewPeriod().getSeconds());
-                }
-                if (txMessage.hasAdminKey()) {
-                    entity.setKey(txMessage.getAdminKey().toByteArray());
-                }
-                // Can't clear memo on contracts. 0 length indicates no change
-                if (txMessage.getMemo() != null && txMessage.getMemo().length() > 0) {
-                    entity.setMemo(txMessage.getMemo());
-                }
-            }
-        } else if (body.hasCryptoCreateAccount()) {
-            if (txRecord.getReceipt().hasAccountID()) { // Implies SUCCESS
-                CryptoCreateTransactionBody txMessage = body.getCryptoCreateAccount();
-                setProxyAccountID(txMessage.getProxyAccountID(), entity);
-                if (txMessage.hasAutoRenewPeriod()) {
-                    entity.setAutoRenewPeriod(txMessage.getAutoRenewPeriod().getSeconds());
-                }
-                if (txMessage.hasKey()) {
-                    entity.setKey(txMessage.getKey().toByteArray());
-                }
-            }
-
-            initialBalance = body.getCryptoCreateAccount().getInitialBalance();
-        } else if (body.hasCryptoDelete()) {
-            if (body.getCryptoDelete().hasDeleteAccountID()) {
-                if (doUpdateEntity) {
-                    entity.setDeleted(true);
-                }
-            }
-        } else if (body.hasCryptoUpdateAccount()) {
-            CryptoUpdateTransactionBody txMessage = body.getCryptoUpdateAccount();
-            if (doUpdateEntity) {
-                setProxyAccountID(txMessage.getProxyAccountID(), entity);
-                if (txMessage.hasExpirationTime()) {
-                    entity.setExpiryTimeNs(Utility.timestampInNanosMax(txMessage.getExpirationTime()));
-                }
-                if (txMessage.hasAutoRenewPeriod()) {
-                    entity.setAutoRenewPeriod(txMessage.getAutoRenewPeriod().getSeconds());
-                }
-                if (txMessage.hasKey()) {
-                    entity.setKey(txMessage.getKey().toByteArray());
-                }
-            }
-        } else if (body.hasFileCreate()) {
-            if (txRecord.getReceipt().hasFileID()) { // Implies SUCCESS
-                FileCreateTransactionBody txMessage = body.getFileCreate();
-                if (txMessage.hasExpirationTime()) {
-                    entity.setExpiryTimeNs(Utility.timestampInNanosMax(txMessage.getExpirationTime()));
-                }
-
-                if (txMessage.hasKeys()) {
-                    entity.setKey(txMessage.getKeys().toByteArray());
-                }
-            }
-        } else if (body.hasFileDelete()) {
-            if (body.getFileDelete().hasFileID()) {
-                if (doUpdateEntity) {
-                    entity.setDeleted(true);
-                }
-            }
-        } else if (body.hasFileUpdate()) {
-            FileUpdateTransactionBody txMessage = body.getFileUpdate();
-            if (doUpdateEntity) {
-                if (txMessage.hasExpirationTime()) {
-                    entity.setExpiryTimeNs(Utility.timestampInNanosMax(txMessage.getExpirationTime()));
-                }
-
-                if (txMessage.hasKeys()) {
-                    entity.setKey(txMessage.getKeys().toByteArray());
-                }
-            }
-        } else if (body.hasSystemDelete()) {
-            if (doUpdateEntity) {
-                entity.setDeleted(true);
-            }
-        } else if (body.hasSystemUndelete()) {
-            if (doUpdateEntity) {
-                entity.setDeleted(false);
-            }
-        } else if (body.hasConsensusCreateTopic()) {
-            consensusCreateTopicUpdateEntity(entity, body, txRecord);
-        } else if (body.hasConsensusUpdateTopic()) {
-            consensusUpdateTopicUpdateEntity(entity, body, txRecord);
-        } else if (body.hasConsensusDeleteTopic()) {
-            consensusDeleteTopicUpdateEntity(entity, body, txRecord);
-        }
-
-        TransactionID transactionID = body.getTransactionID();
-        long validDurationSeconds = body.hasTransactionValidDuration() ? body.getTransactionValidDuration()
-                .getSeconds() : null;
-        long validStartNs = Utility.timeStampInNanos(transactionID.getTransactionValidStart());
-        AccountID payerAccountId = transactionID.getAccountID();
-
-        com.hedera.mirror.importer.domain.Transaction tx = new com.hedera.mirror.importer.domain.Transaction();
-        tx.setChargedTxFee(txRecord.getTransactionFee());
-        tx.setConsensusNs(consensusNs);
-        tx.setInitialBalance(initialBalance);
-        tx.setMemo(body.getMemo().getBytes());
-        tx.setMaxFee(body.getTransactionFee());
-        tx.setResult(txRecord.getReceipt().getStatusValue());
-        tx.setType(transactionType);
-        tx.setTransactionBytes(parserProperties.getPersist().isTransactionBytes() ?
-                recordItem.getTransactionBytes() : null);
-        tx.setTransactionHash(txRecord.getTransactionHash().toByteArray());
-        tx.setValidDurationSeconds(validDurationSeconds);
-        tx.setValidStartNs(validStartNs);
-        if (entity != null) {
+        //
+        // Additionally, if transaction is successful:
+        // - Fields of 'entity' will be updated.
+        // - proxyAccountId/autoRenewAccountId: If present, the account's id are looked up (from big cache) or created
+        //   immediately in TransactionHandler.updateEntity(..).
+        if (transactionHandler.updatesEntity() && isSuccessful && entityId != null) {
+            Entities entity = getEntity(entityId);
+            transactionHandler.updateEntity(entity, recordItem);
             tx.setEntity(entity);
             entityRepository.save(entity);
         } else if (entityId != null) {
-            Entities tempEntity = entityId.toEntity();
-            tempEntity.setId(lookupOrCreateId(entityId)); // look up in big cache
-            tx.setEntity(tempEntity);
-        }  // else leave tx.entity null
-        tx.setNodeAccountId(lookupOrCreateId(EntityId.of(body.getNodeAccountID())));
-        tx.setPayerAccountId(lookupOrCreateId(EntityId.of(payerAccountId)));
+            Entities entity = entityId.toEntity();
+            entity.setId(entityRepository.lookupOrCreateId(entityId)); // look up in big cache
+            tx.setEntity(entity);
+        } // else leave tx.entity null
 
         if ((txRecord.hasTransferList()) && parserProperties.getPersist().isCryptoTransferAmounts()) {
-            processNonFeeTransfers(consensusNs, payerAccountId, body, txRecord);
+            processNonFeeTransfers(consensusNs, body, txRecord);
             if (body.hasCryptoCreateAccount() && isSuccessful(txRecord)) {
-                insertCryptoCreateTransferList(consensusNs, txRecord, body, txRecord.getReceipt()
-                        .getAccountID(), payerAccountId);
+                insertCryptoCreateTransferList(consensusNs, txRecord, body);
             } else {
                 insertTransferList(consensusNs, txRecord.getTransferList());
             }
@@ -305,7 +148,7 @@ public class RecordItemParser implements RecordItemListener {
         } else if (body.hasContractCreateInstance()) {
             insertContractCreateInstance(consensusNs, body.getContractCreateInstance(), txRecord);
         }
-        if (doUpdateEntity) {
+        if (isSuccessful) {
             if (body.hasConsensusSubmitMessage()) {
                 insertConsensusTopicMessage(body.getConsensusSubmitMessage(), txRecord);
             } else if (body.hasCryptoAddClaim()) {
@@ -324,14 +167,27 @@ public class RecordItemParser implements RecordItemListener {
         log.debug("Storing transaction: {}", tx);
     }
 
-    private void setProxyAccountID(AccountID proxyAccountID, Entities entity) {
-        // Stream contains transactions with proxyAccountID explicitly set to '0.0.0' i.e. hasProxyAccountID returns
-        // true. 0.0.0 is not a valid entity and maybe consensus nodes just ignore that value. Either ways, no need to
-        // persist 0.0.0 in database on mirror node side.
-        EntityId proxyAccountEntityId = EntityId.of(proxyAccountID);
-        if (proxyAccountEntityId != null) {
-            entity.setProxyAccountId(lookupOrCreateId(proxyAccountEntityId));
-        }
+    private Transaction buildTransaction(long consensusTimestamp, RecordItem recordItem) {
+        Transaction tx = new Transaction();
+        TransactionBody body = recordItem.getTransactionBody();
+        TransactionRecord txRecord = recordItem.getRecord();
+        tx.setChargedTxFee(txRecord.getTransactionFee());
+        tx.setConsensusNs(consensusTimestamp);
+        tx.setMemo(body.getMemo().getBytes());
+        tx.setMaxFee(body.getTransactionFee());
+        tx.setResult(txRecord.getReceipt().getStatusValue());
+        tx.setType(recordItem.getTransactionType());
+        tx.setTransactionBytes(parserProperties.getPersist().isTransactionBytes() ?
+                recordItem.getTransactionBytes() : null);
+        tx.setTransactionHash(txRecord.getTransactionHash().toByteArray());
+        Long validDurationSeconds = body.hasTransactionValidDuration() ?
+                body.getTransactionValidDuration().getSeconds() : null;
+        tx.setValidDurationSeconds(validDurationSeconds);
+        tx.setValidStartNs(Utility.timeStampInNanos(body.getTransactionID().getTransactionValidStart()));
+        tx.setNodeAccountId(entityRepository.lookupOrCreateId(EntityId.of(body.getNodeAccountID())));
+        tx.setPayerAccountId(entityRepository.lookupOrCreateId(EntityId.of(body.getTransactionID().getAccountID())));
+        tx.setInitialBalance(0L);
+        return tx;
     }
 
     /**
@@ -351,126 +207,19 @@ public class RecordItemParser implements RecordItemListener {
      * an itemized set of transfers that reflects non-fees (explicit transfers), threshold records, node fee, and
      * network+service fee (paid to treasury).
      */
-    private void processNonFeeTransfers(long consensusTimestamp, AccountID payerAccountId,
-                                        TransactionBody body, TransactionRecord transactionRecord) {
+    private void processNonFeeTransfers(
+            long consensusTimestamp, TransactionBody body, TransactionRecord transactionRecord) {
         if (!shouldStoreNonFeeTransfers(body)) {
             return;
         }
 
+        AccountID payerAccountId = body.getTransactionID().getAccountID();
         for (var aa : nonFeeTransfersExtractor.extractNonFeeTransfers(payerAccountId, body, transactionRecord)) {
-            addNonFeeTransferInserts(consensusTimestamp, aa.getAccountID().getRealmNum(),
-                    aa.getAccountID().getAccountNum(), aa.getAmount());
-        }
-    }
-
-    private void addNonFeeTransferInserts(long consensusTimestamp, long realm, long accountNum, long amount) {
-        if (0 != amount) {
-            recordParsedItemHandler.onNonFeeTransfer(
-                    new NonFeeTransfer(consensusTimestamp, realm, accountNum, amount));
-        }
-    }
-
-    /**
-     * Store ConsensusCreateTopic transaction in the database.
-     *
-     * @throws IllegalArgumentException
-     */
-    private void consensusCreateTopicUpdateEntity(
-            Entities entity, TransactionBody body, TransactionRecord transactionRecord) {
-        if (!body.hasConsensusCreateTopic()) {
-            throw new IllegalArgumentException("transaction is not a ConsensusCreateTopic");
-        }
-
-        if (!transactionRecord.getReceipt().hasTopicID()) { // tx not successful. Equivalent to doUpdateEntity check.
-            return;
-        }
-
-        var transactionBody = body.getConsensusCreateTopic();
-
-        if (transactionBody.hasAutoRenewAccount()) {
-            // Looks up (in the big cache) or creates new id.
-            entity.setAutoRenewAccountId(lookupOrCreateId(EntityId.of(transactionBody.getAutoRenewAccount())));
-        }
-
-        if (transactionBody.hasAutoRenewPeriod()) {
-            entity.setAutoRenewPeriod(transactionBody.getAutoRenewPeriod().getSeconds());
-        }
-
-        // If either key is empty, they should end up as empty bytea in the DB to indicate that there is
-        // explicitly no value, as opposed to null which has been used to indicate the value is unknown.
-        var adminKey = transactionBody.hasAdminKey() ? transactionBody.getAdminKey().toByteArray() : new byte[0];
-        var submitKey = transactionBody.hasSubmitKey() ? transactionBody.getSubmitKey().toByteArray() : new byte[0];
-
-        entity.setMemo(transactionBody.getMemo());
-        entity.setKey(adminKey);
-        entity.setSubmitKey(submitKey);
-    }
-
-    /**
-     * Store ConsensusUpdateTopic transaction in the database.
-     *
-     * @throws IllegalArgumentException
-     */
-    private void consensusUpdateTopicUpdateEntity(
-            Entities entity, TransactionBody body, TransactionRecord transactionRecord) {
-        if (!body.hasConsensusUpdateTopic()) {
-            throw new IllegalArgumentException("transaction is not a ConsensusUpdateTopic");
-        }
-
-        var transactionBody = body.getConsensusUpdateTopic();
-        if (!transactionBody.hasTopicID()) {
-            log.warn("Encountered a ConsensusUpdateTopic transaction without topic ID: {}", body);
-            return;
-        }
-
-        if (isSuccessful(transactionRecord)) {
-            if (transactionBody.hasExpirationTime()) {
-                Timestamp expirationTime = transactionBody.getExpirationTime();
-                entity.setExpiryTimeNs(Utility.timestampInNanosMax(expirationTime));
+            if (aa.getAmount() != 0) {
+                recordParsedItemHandler.onNonFeeTransfer(
+                        new NonFeeTransfer(consensusTimestamp, aa.getAccountID().getRealmNum(),
+                                aa.getAccountID().getAccountNum(), aa.getAmount()));
             }
-
-            if (transactionBody.hasAutoRenewAccount()) {
-                // Looks up (in the big cache) or creates new id.
-                entity.setAutoRenewAccountId(lookupOrCreateId(EntityId.of(transactionBody.getAutoRenewAccount())));
-            }
-
-            if (transactionBody.hasAutoRenewPeriod()) {
-                entity.setAutoRenewPeriod(transactionBody.getAutoRenewPeriod().getSeconds());
-            }
-
-            if (transactionBody.hasAdminKey()) {
-                entity.setKey(transactionBody.getAdminKey().toByteArray());
-            }
-
-            if (transactionBody.hasSubmitKey()) {
-                entity.setSubmitKey(transactionBody.getSubmitKey().toByteArray());
-            }
-
-            if (transactionBody.hasMemo()) {
-                entity.setMemo(transactionBody.getMemo().getValue());
-            }
-        }
-    }
-
-    /**
-     * Store ConsensusDeleteTopic transaction in the database.
-     *
-     * @throws IllegalArgumentException
-     */
-    private void consensusDeleteTopicUpdateEntity(
-            Entities entity, TransactionBody body, TransactionRecord transactionRecord) {
-        if (!body.hasConsensusDeleteTopic()) {
-            throw new IllegalArgumentException("transaction is not a ConsensusDeleteTopic");
-        }
-
-        var transactionBody = body.getConsensusDeleteTopic();
-        if (!transactionBody.hasTopicID()) {
-            log.warn("Encountered a ConsensusDeleteTopic transaction without topic ID: {}", body);
-            return;
-        }
-
-        if (isSuccessful(transactionRecord)) {
-            entity.setDeleted(true);
         }
     }
 
@@ -550,17 +299,14 @@ public class RecordItemParser implements RecordItemListener {
         for (int i = 0; i < transferList.getAccountAmountsCount(); ++i) {
             var aa = transferList.getAccountAmounts(i);
             var accountId = aa.getAccountID();
-            lookupOrCreateId(EntityId.of(aa.getAccountID())); // ensures existence of entity in db
+            entityRepository.lookupOrCreateId(EntityId.of(aa.getAccountID())); // ensures existence of entity in db
             addCryptoTransferList(consensusTimestamp, accountId.getRealmNum(), accountId.getAccountNum(), aa
                     .getAmount());
         }
     }
 
-    private void insertCryptoCreateTransferList(long consensusTimestamp,
-                                                TransactionRecord txRecord,
-                                                TransactionBody body,
-                                                AccountID createdAccountId,
-                                                AccountID payerAccountId) {
+    private void insertCryptoCreateTransferList(
+            long consensusTimestamp, TransactionRecord txRecord, TransactionBody body) {
 
         long initialBalance = 0;
         long createdAccountNum = 0;
@@ -578,7 +324,7 @@ public class RecordItemParser implements RecordItemListener {
             var aa = transferList.getAccountAmounts(i);
             var accountId = aa.getAccountID();
             long accountNum = accountId.getAccountNum();
-            lookupOrCreateId(EntityId.of(accountId)); // ensures existence of entity in db
+            entityRepository.lookupOrCreateId(EntityId.of(accountId)); // ensures existence of entity in db
             addCryptoTransferList(consensusTimestamp, accountId.getRealmNum(), accountNum, aa.getAmount());
 
             if (addInitialBalance && (initialBalance == aa.getAmount()) && (accountNum == createdAccountNum)) {
@@ -587,10 +333,12 @@ public class RecordItemParser implements RecordItemListener {
         }
 
         if (addInitialBalance) {
-            lookupOrCreateId(EntityId.of(payerAccountId)); // ensures existence of entity in db
+            AccountID payerAccountId = body.getTransactionID().getAccountID();
+            AccountID createdAccountId = txRecord.getReceipt().getAccountID();
+            entityRepository.lookupOrCreateId(EntityId.of(payerAccountId)); // ensures existence of entity in db
             addCryptoTransferList(consensusTimestamp, payerAccountId.getRealmNum(), payerAccountId
                     .getAccountNum(), -initialBalance);
-            lookupOrCreateId(EntityId.of(createdAccountId)); // ensures existence of entity in db
+            entityRepository.lookupOrCreateId(EntityId.of(createdAccountId)); // ensures existence of entity in db
             addCryptoTransferList(consensusTimestamp, createdAccountId
                     .getRealmNum(), createdAccountNum, initialBalance);
         }
@@ -626,27 +374,8 @@ public class RecordItemParser implements RecordItemListener {
      * new entity is returned without being persisted to the repo.
      */
     private Entities getEntity(EntityId entityId) {
-        if (entityId == null) {
-            return null;
-        }
         return entityRepository.findByPrimaryKey(
                 entityId.getEntityShard(), entityId.getEntityRealm(), entityId.getEntityNum())
                 .orElseGet(entityId::toEntity);
-    }
-
-    /**
-     * @param entityId for which the id needs to be looked up (from cache/repo). If no id is found, the the entity is
-     *                 inserted into the repo and the newly minted id is returned.
-     * @return looked up/newly minted id of the given entityId.
-     */
-    public long lookupOrCreateId(EntityId entityId) {
-        log.debug("lookupOrCreateId for {}", entityId);
-        if (entityId.getId() != null && entityId.getId() != 0) {
-            return entityId.getId();
-        }
-        return entityRepository.findEntityIdByNativeIds(
-                entityId.getEntityShard(), entityId.getEntityRealm(), entityId.getEntityNum())
-                .orElseGet(() -> entityRepository.saveAndCacheEntityId(entityId.toEntity()))
-                .getId();
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ConsensusCreateTopicTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ConsensusCreateTopicTransactionHandler.java
@@ -23,12 +23,15 @@ package com.hedera.mirror.importer.parser.record.transactionhandler;
 import javax.inject.Named;
 import lombok.AllArgsConstructor;
 
+import com.hedera.mirror.importer.domain.Entities;
 import com.hedera.mirror.importer.domain.EntityId;
 import com.hedera.mirror.importer.parser.domain.RecordItem;
+import com.hedera.mirror.importer.repository.EntityRepository;
 
 @Named
 @AllArgsConstructor
 public class ConsensusCreateTopicTransactionHandler implements TransactionHandler {
+    private final EntityRepository entityRepository;
 
     @Override
     public EntityId getEntityId(RecordItem recordItem) {
@@ -38,5 +41,25 @@ public class ConsensusCreateTopicTransactionHandler implements TransactionHandle
     @Override
     public boolean updatesEntity() {
         return true;
+    }
+
+    @Override
+    public void updateEntity(Entities entity, RecordItem recordItem) {
+        var createTopic = recordItem.getTransactionBody().getConsensusCreateTopic();
+        if (createTopic.hasAutoRenewAccount()) {
+            // Looks up (in the big cache) or creates new id.
+            entity.setAutoRenewAccountId(
+                    entityRepository.lookupOrCreateId(EntityId.of(createTopic.getAutoRenewAccount())));
+        }
+        if (createTopic.hasAutoRenewPeriod()) {
+            entity.setAutoRenewPeriod(createTopic.getAutoRenewPeriod().getSeconds());
+        }
+        // If either key is empty, they should end up as empty bytea in the DB to indicate that there is
+        // explicitly no value, as opposed to null which has been used to indicate the value is unknown.
+        var adminKey = createTopic.hasAdminKey() ? createTopic.getAdminKey().toByteArray() : new byte[0];
+        var submitKey = createTopic.hasSubmitKey() ? createTopic.getSubmitKey().toByteArray() : new byte[0];
+        entity.setMemo(createTopic.getMemo());
+        entity.setKey(adminKey);
+        entity.setSubmitKey(submitKey);
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ConsensusCreateTopicTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ConsensusCreateTopicTransactionHandler.java
@@ -46,10 +46,10 @@ public class ConsensusCreateTopicTransactionHandler implements TransactionHandle
     @Override
     public void updateEntity(Entities entity, RecordItem recordItem) {
         var createTopic = recordItem.getTransactionBody().getConsensusCreateTopic();
-        if (createTopic.hasAutoRenewAccount()) {
-            // Looks up (in the big cache) or creates new id.
-            entity.setAutoRenewAccountId(
-                    entityRepository.lookupOrCreateId(EntityId.of(createTopic.getAutoRenewAccount())));
+        // Looks up (in the big cache) or creates new id.
+        Long autoRenewAccountId = entityRepository.lookupOrCreateId(EntityId.of(createTopic.getAutoRenewAccount()));
+        if (autoRenewAccountId != null) {
+            entity.setAutoRenewAccountId(autoRenewAccountId);
         }
         if (createTopic.hasAutoRenewPeriod()) {
             entity.setAutoRenewPeriod(createTopic.getAutoRenewPeriod().getSeconds());

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ConsensusDeleteTopicTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ConsensusDeleteTopicTransactionHandler.java
@@ -23,6 +23,7 @@ package com.hedera.mirror.importer.parser.record.transactionhandler;
 import javax.inject.Named;
 import lombok.AllArgsConstructor;
 
+import com.hedera.mirror.importer.domain.Entities;
 import com.hedera.mirror.importer.domain.EntityId;
 import com.hedera.mirror.importer.parser.domain.RecordItem;
 
@@ -38,5 +39,10 @@ public class ConsensusDeleteTopicTransactionHandler implements TransactionHandle
     @Override
     public boolean updatesEntity() {
         return true;
+    }
+
+    @Override
+    public void updateEntity(Entities entity, RecordItem recordItem) {
+        entity.setDeleted(true);
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ConsensusUpdateTopicTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ConsensusUpdateTopicTransactionHandler.java
@@ -20,15 +20,20 @@ package com.hedera.mirror.importer.parser.record.transactionhandler;
  * ‍
  */
 
+import com.hederahashgraph.api.proto.java.Timestamp;
 import javax.inject.Named;
 import lombok.AllArgsConstructor;
 
+import com.hedera.mirror.importer.domain.Entities;
 import com.hedera.mirror.importer.domain.EntityId;
 import com.hedera.mirror.importer.parser.domain.RecordItem;
+import com.hedera.mirror.importer.repository.EntityRepository;
+import com.hedera.mirror.importer.util.Utility;
 
 @Named
 @AllArgsConstructor
 public class ConsensusUpdateTopicTransactionHandler implements TransactionHandler {
+    private final EntityRepository entityRepository;
 
     @Override
     public EntityId getEntityId(RecordItem recordItem) {
@@ -38,5 +43,31 @@ public class ConsensusUpdateTopicTransactionHandler implements TransactionHandle
     @Override
     public boolean updatesEntity() {
         return true;
+    }
+
+    @Override
+    public void updateEntity(Entities entity, RecordItem recordItem) {
+        var updateTopic = recordItem.getTransactionBody().getConsensusUpdateTopic();
+        if (updateTopic.hasExpirationTime()) {
+            Timestamp expirationTime = updateTopic.getExpirationTime();
+            entity.setExpiryTimeNs(Utility.timestampInNanosMax(expirationTime));
+        }
+        if (updateTopic.hasAutoRenewAccount()) {
+            // Looks up (in the big cache) or creates new id.
+            entity.setAutoRenewAccountId(
+                    entityRepository.lookupOrCreateId(EntityId.of(updateTopic.getAutoRenewAccount())));
+        }
+        if (updateTopic.hasAutoRenewPeriod()) {
+            entity.setAutoRenewPeriod(updateTopic.getAutoRenewPeriod().getSeconds());
+        }
+        if (updateTopic.hasAdminKey()) {
+            entity.setKey(updateTopic.getAdminKey().toByteArray());
+        }
+        if (updateTopic.hasSubmitKey()) {
+            entity.setSubmitKey(updateTopic.getSubmitKey().toByteArray());
+        }
+        if (updateTopic.hasMemo()) {
+            entity.setMemo(updateTopic.getMemo().getValue());
+        }
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ConsensusUpdateTopicTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ConsensusUpdateTopicTransactionHandler.java
@@ -52,10 +52,10 @@ public class ConsensusUpdateTopicTransactionHandler implements TransactionHandle
             Timestamp expirationTime = updateTopic.getExpirationTime();
             entity.setExpiryTimeNs(Utility.timestampInNanosMax(expirationTime));
         }
-        if (updateTopic.hasAutoRenewAccount()) {
-            // Looks up (in the big cache) or creates new id.
-            entity.setAutoRenewAccountId(
-                    entityRepository.lookupOrCreateId(EntityId.of(updateTopic.getAutoRenewAccount())));
+        // Looks up (in the big cache) or creates new id.
+        Long autoRenewAccountId = entityRepository.lookupOrCreateId(EntityId.of(updateTopic.getAutoRenewAccount()));
+        if (autoRenewAccountId != null) {
+            entity.setAutoRenewAccountId(autoRenewAccountId);
         }
         if (updateTopic.hasAutoRenewPeriod()) {
             entity.setAutoRenewPeriod(updateTopic.getAutoRenewPeriod().getSeconds());

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractCreateTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractCreateTransactionHandler.java
@@ -20,15 +20,20 @@ package com.hedera.mirror.importer.parser.record.transactionhandler;
  * ‍
  */
 
+import com.hederahashgraph.api.proto.java.ContractCreateTransactionBody;
 import javax.inject.Named;
 import lombok.AllArgsConstructor;
 
+import com.hedera.mirror.importer.domain.Entities;
 import com.hedera.mirror.importer.domain.EntityId;
+import com.hedera.mirror.importer.domain.Transaction;
 import com.hedera.mirror.importer.parser.domain.RecordItem;
+import com.hedera.mirror.importer.repository.EntityRepository;
 
 @Named
 @AllArgsConstructor
 public class ContractCreateTransactionHandler implements TransactionHandler {
+    private final EntityRepository entityRepository;
 
     @Override
     public EntityId getEntityId(RecordItem recordItem) {
@@ -38,5 +43,31 @@ public class ContractCreateTransactionHandler implements TransactionHandler {
     @Override
     public boolean updatesEntity() {
         return true;
+    }
+
+    @Override
+    public void updateTransaction(Transaction transaction, RecordItem recordItem) {
+        transaction.setInitialBalance(recordItem.getTransactionBody().getContractCreateInstance().getInitialBalance());
+    }
+
+    @Override
+    public void updateEntity(Entities entity, RecordItem recordItem) {
+        ContractCreateTransactionBody txMessage = recordItem.getTransactionBody().getContractCreateInstance();
+        if (txMessage.hasAutoRenewPeriod()) {
+            entity.setAutoRenewPeriod(txMessage.getAutoRenewPeriod().getSeconds());
+        }
+        // Can't clear memo on contracts. 0 length indicates no change
+        if (txMessage.getMemo() != null && txMessage.getMemo().length() > 0) {
+            entity.setMemo(txMessage.getMemo());
+        }
+        if (txMessage.hasAdminKey()) {
+            entity.setKey(txMessage.getAdminKey().toByteArray());
+        }
+        // Stream contains transactions with proxyAccountID explicitly set to '0.0.0'. However it's not a valid entity,
+        // so no need to persist it to repo.
+        EntityId proxyAccountEntityId = EntityId.of(txMessage.getProxyAccountID());
+        if (proxyAccountEntityId != null) {
+            entity.setProxyAccountId(entityRepository.lookupOrCreateId(proxyAccountEntityId));
+        }
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractCreateTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractCreateTransactionHandler.java
@@ -65,9 +65,9 @@ public class ContractCreateTransactionHandler implements TransactionHandler {
         }
         // Stream contains transactions with proxyAccountID explicitly set to '0.0.0'. However it's not a valid entity,
         // so no need to persist it to repo.
-        EntityId proxyAccountEntityId = EntityId.of(txMessage.getProxyAccountID());
-        if (proxyAccountEntityId != null) {
-            entity.setProxyAccountId(entityRepository.lookupOrCreateId(proxyAccountEntityId));
+        Long proxyAccountId = entityRepository.lookupOrCreateId(EntityId.of(txMessage.getProxyAccountID()));
+        if (proxyAccountId != null) {
+            entity.setProxyAccountId(proxyAccountId);
         }
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractDeleteTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractDeleteTransactionHandler.java
@@ -23,6 +23,7 @@ package com.hedera.mirror.importer.parser.record.transactionhandler;
 import javax.inject.Named;
 import lombok.AllArgsConstructor;
 
+import com.hedera.mirror.importer.domain.Entities;
 import com.hedera.mirror.importer.domain.EntityId;
 import com.hedera.mirror.importer.parser.domain.RecordItem;
 
@@ -38,5 +39,10 @@ public class ContractDeleteTransactionHandler implements TransactionHandler {
     @Override
     public boolean updatesEntity() {
         return true;
+    }
+
+    @Override
+    public void updateEntity(Entities entity, RecordItem recordItem) {
+        entity.setDeleted(true);
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractUpdateTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractUpdateTransactionHandler.java
@@ -61,11 +61,9 @@ public class ContractUpdateTransactionHandler implements TransactionHandler {
         if (txMessage.getMemo() != null && txMessage.getMemo().length() > 0) {
             entity.setMemo(txMessage.getMemo());
         }
-        // Stream contains transactions with proxyAccountID explicitly set to '0.0.0'. However it's not a valid entity,
-        // so no need to persist it to repo.
-        EntityId proxyAccountEntityId = EntityId.of(txMessage.getProxyAccountID());
-        if (proxyAccountEntityId != null) {
-            entity.setProxyAccountId(entityRepository.lookupOrCreateId(proxyAccountEntityId));
+        Long proxyAccountId = entityRepository.lookupOrCreateId(EntityId.of(txMessage.getProxyAccountID()));
+        if (proxyAccountId != null) {
+            entity.setProxyAccountId(proxyAccountId);
         }
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoCreateTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoCreateTransactionHandler.java
@@ -59,11 +59,9 @@ public class CryptoCreateTransactionHandler implements TransactionHandler {
         if (txMessage.hasKey()) {
             entity.setKey(txMessage.getKey().toByteArray());
         }
-        // Stream contains transactions with proxyAccountID explicitly set to '0.0.0'. However it's not a valid entity,
-        // so no need to persist it to repo.
-        EntityId proxyAccountEntityId = EntityId.of(txMessage.getProxyAccountID());
-        if (proxyAccountEntityId != null) {
-            entity.setProxyAccountId(entityRepository.lookupOrCreateId(proxyAccountEntityId));
+        Long proxyAccountId = entityRepository.lookupOrCreateId(EntityId.of(txMessage.getProxyAccountID()));
+        if (proxyAccountId != null) {
+            entity.setProxyAccountId(proxyAccountId);
         }
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoDeleteTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoDeleteTransactionHandler.java
@@ -23,6 +23,7 @@ package com.hedera.mirror.importer.parser.record.transactionhandler;
 import javax.inject.Named;
 import lombok.AllArgsConstructor;
 
+import com.hedera.mirror.importer.domain.Entities;
 import com.hedera.mirror.importer.domain.EntityId;
 import com.hedera.mirror.importer.parser.domain.RecordItem;
 
@@ -38,5 +39,10 @@ public class CryptoDeleteTransactionHandler implements TransactionHandler {
     @Override
     public boolean updatesEntity() {
         return true;
+    }
+
+    @Override
+    public void updateEntity(Entities entity, RecordItem recordItem) {
+        entity.setDeleted(true);
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoUpdateTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoUpdateTransactionHandler.java
@@ -57,11 +57,9 @@ public class CryptoUpdateTransactionHandler implements TransactionHandler {
         if (txMessage.hasKey()) {
             entity.setKey(txMessage.getKey().toByteArray());
         }
-        // Stream contains transactions with proxyAccountID explicitly set to '0.0.0'. However it's not a valid entity,
-        // so no need to persist it to repo.
-        EntityId proxyAccountEntityId = EntityId.of(txMessage.getProxyAccountID());
-        if (proxyAccountEntityId != null) {
-            entity.setProxyAccountId(entityRepository.lookupOrCreateId(proxyAccountEntityId));
+        Long proxyAccountId = entityRepository.lookupOrCreateId(EntityId.of(txMessage.getProxyAccountID()));
+        if (proxyAccountId != null) {
+            entity.setProxyAccountId(proxyAccountId);
         }
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/FileCreateTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/FileCreateTransactionHandler.java
@@ -20,11 +20,14 @@ package com.hedera.mirror.importer.parser.record.transactionhandler;
  * ‍
  */
 
+import com.hederahashgraph.api.proto.java.FileCreateTransactionBody;
 import javax.inject.Named;
 import lombok.AllArgsConstructor;
 
+import com.hedera.mirror.importer.domain.Entities;
 import com.hedera.mirror.importer.domain.EntityId;
 import com.hedera.mirror.importer.parser.domain.RecordItem;
+import com.hedera.mirror.importer.util.Utility;
 
 @Named
 @AllArgsConstructor
@@ -38,5 +41,16 @@ public class FileCreateTransactionHandler implements TransactionHandler {
     @Override
     public boolean updatesEntity() {
         return true;
+    }
+
+    @Override
+    public void updateEntity(Entities entity, RecordItem recordItem) {
+        FileCreateTransactionBody txMessage = recordItem.getTransactionBody().getFileCreate();
+        if (txMessage.hasExpirationTime()) {
+            entity.setExpiryTimeNs(Utility.timestampInNanosMax(txMessage.getExpirationTime()));
+        }
+        if (txMessage.hasKeys()) {
+            entity.setKey(txMessage.getKeys().toByteArray());
+        }
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/FileDeleteTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/FileDeleteTransactionHandler.java
@@ -23,6 +23,7 @@ package com.hedera.mirror.importer.parser.record.transactionhandler;
 import javax.inject.Named;
 import lombok.AllArgsConstructor;
 
+import com.hedera.mirror.importer.domain.Entities;
 import com.hedera.mirror.importer.domain.EntityId;
 import com.hedera.mirror.importer.parser.domain.RecordItem;
 
@@ -38,5 +39,10 @@ public class FileDeleteTransactionHandler implements TransactionHandler {
     @Override
     public boolean updatesEntity() {
         return true;
+    }
+
+    @Override
+    public void updateEntity(Entities entity, RecordItem recordItem) {
+        entity.setDeleted(true);
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/FileUpdateTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/FileUpdateTransactionHandler.java
@@ -20,11 +20,14 @@ package com.hedera.mirror.importer.parser.record.transactionhandler;
  * ‍
  */
 
+import com.hederahashgraph.api.proto.java.FileUpdateTransactionBody;
 import javax.inject.Named;
 import lombok.AllArgsConstructor;
 
+import com.hedera.mirror.importer.domain.Entities;
 import com.hedera.mirror.importer.domain.EntityId;
 import com.hedera.mirror.importer.parser.domain.RecordItem;
+import com.hedera.mirror.importer.util.Utility;
 
 @Named
 @AllArgsConstructor
@@ -38,5 +41,16 @@ public class FileUpdateTransactionHandler implements TransactionHandler {
     @Override
     public boolean updatesEntity() {
         return true;
+    }
+
+    @Override
+    public void updateEntity(Entities entity, RecordItem recordItem) {
+        FileUpdateTransactionBody txMessage = recordItem.getTransactionBody().getFileUpdate();
+        if (txMessage.hasExpirationTime()) {
+            entity.setExpiryTimeNs(Utility.timestampInNanosMax(txMessage.getExpirationTime()));
+        }
+        if (txMessage.hasKeys()) {
+            entity.setKey(txMessage.getKeys().toByteArray());
+        }
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/SystemDeleteTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/SystemDeleteTransactionHandler.java
@@ -24,6 +24,7 @@ import com.hederahashgraph.api.proto.java.SystemDeleteTransactionBody;
 import javax.inject.Named;
 import lombok.AllArgsConstructor;
 
+import com.hedera.mirror.importer.domain.Entities;
 import com.hedera.mirror.importer.domain.EntityId;
 import com.hedera.mirror.importer.parser.domain.RecordItem;
 
@@ -45,5 +46,10 @@ public class SystemDeleteTransactionHandler implements TransactionHandler {
     @Override
     public boolean updatesEntity() {
         return true;
+    }
+
+    @Override
+    public void updateEntity(Entities entity, RecordItem recordItem) {
+        entity.setDeleted(true);
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/SystemUndeleteTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/SystemUndeleteTransactionHandler.java
@@ -24,6 +24,7 @@ import com.hederahashgraph.api.proto.java.SystemUndeleteTransactionBody;
 import javax.inject.Named;
 import lombok.AllArgsConstructor;
 
+import com.hedera.mirror.importer.domain.Entities;
 import com.hedera.mirror.importer.domain.EntityId;
 import com.hedera.mirror.importer.parser.domain.RecordItem;
 
@@ -45,5 +46,10 @@ public class SystemUndeleteTransactionHandler implements TransactionHandler {
     @Override
     public boolean updatesEntity() {
         return true;
+    }
+
+    @Override
+    public void updateEntity(Entities entity, RecordItem recordItem) {
+        entity.setDeleted(false);
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TransactionHandler.java
@@ -20,7 +20,9 @@ package com.hedera.mirror.importer.parser.record.transactionhandler;
  * ‍
  */
 
+import com.hedera.mirror.importer.domain.Entities;
 import com.hedera.mirror.importer.domain.EntityId;
+import com.hedera.mirror.importer.domain.Transaction;
 import com.hedera.mirror.importer.parser.domain.RecordItem;
 
 /**
@@ -37,10 +39,25 @@ public interface TransactionHandler {
     EntityId getEntityId(RecordItem recordItem);
 
     /**
-     * Override to return true if an implementation wants to be able to update the entity returned by
+     * Override to return true if an implementation wants to update the entity returned by
      * {@link #getEntityId(RecordItem)}.
      */
     default boolean updatesEntity() {
         return false;
+    }
+
+    /**
+     * Override to update fields of the entity.
+     * If {@link #updatesEntity()} returns true, and {@link #getEntityId(RecordItem)} returns a non-null id, and the
+     * transaction is successful, then this function will be called.
+     * @param entity latest state of entity (fetched from the repo)
+     */
+    default void updateEntity(Entities entity, RecordItem recordItem) {
+    }
+
+    /**
+     * Override to update fields of the Transaction's (domain) fields.
+     */
+    default void updateTransaction(Transaction transaction, RecordItem recordItem) {
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/EntityRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/EntityRepository.java
@@ -21,18 +21,15 @@ package com.hedera.mirror.importer.repository;
  */
 
 import java.util.Optional;
-
-import com.hedera.mirror.importer.domain.EntityId;
-
 import org.springframework.cache.annotation.CacheConfig;
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.PagingAndSortingRepository;
 
 import com.hedera.mirror.importer.config.CacheConfiguration;
 import com.hedera.mirror.importer.domain.Entities;
-
-import org.springframework.data.repository.PagingAndSortingRepository;
+import com.hedera.mirror.importer.domain.EntityId;
 
 @CacheConfig(cacheNames = "entities", cacheManager = CacheConfiguration.EXPIRE_AFTER_30M)
 public interface EntityRepository extends PagingAndSortingRepository<Entities, Long>, EntityRepositoryCustom {
@@ -47,12 +44,12 @@ public interface EntityRepository extends PagingAndSortingRepository<Entities, L
 
     @Cacheable(key = "{#p0, #p1, #p2}", sync = true, cacheNames = "entity_ids",
             cacheManager = CacheConfiguration.BIG_LRU_CACHE)
-    @Query("select new com.hedera.mirror.importer.domain.EntityId(id, entityShard, entityRealm, entityNum, entityTypeId) from Entities where entityShard = ?1 and entityRealm = ?2 and entityNum = ?3")
-    Optional<EntityId> findEntityIdByNativeIds(long entityShard, long entityRealm, long entityNum);
+    @Query("select id from Entities where entityShard = ?1 and entityRealm = ?2 and entityNum = ?3")
+    Optional<Long> findEntityIdByNativeIds(long entityShard, long entityRealm, long entityNum);
 
     @CachePut(key = "{#p0.entityShard, #p0.entityRealm, #p0.entityNum}", cacheNames = "entity_ids",
             cacheManager = CacheConfiguration.BIG_LRU_CACHE)
-    default <S extends EntityId> S cache(S entity) {
-        return entity;
+    default <S extends EntityId> Long cache(S entity) {
+        return entity.getId();
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/EntityRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/EntityRepository.java
@@ -48,7 +48,7 @@ public interface EntityRepository extends PagingAndSortingRepository<Entities, L
     Optional<Long> findEntityIdByNativeIds(long entityShard, long entityRealm, long entityNum);
 
     @CachePut(key = "{#p0.entityShard, #p0.entityRealm, #p0.entityNum}", cacheNames = "entity_ids",
-            cacheManager = CacheConfiguration.BIG_LRU_CACHE, unless = "#result == null")
+            cacheManager = CacheConfiguration.BIG_LRU_CACHE)
     default <S extends EntityId> Long cache(S entity) {
         return entity.getId();
     }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/EntityRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/EntityRepository.java
@@ -42,7 +42,7 @@ public interface EntityRepository extends PagingAndSortingRepository<Entities, L
     @Override
     <S extends Entities> S save(S entity);
 
-    @Cacheable(key = "{#p0, #p1, #p2}", sync = true, cacheNames = "entity_ids",
+    @Cacheable(key = "{#p0, #p1, #p2}", cacheNames = "entity_ids",
             cacheManager = CacheConfiguration.BIG_LRU_CACHE, unless = "#result == null")
     @Query("select id from Entities where entityShard = ?1 and entityRealm = ?2 and entityNum = ?3")
     Optional<Long> findEntityIdByNativeIds(long entityShard, long entityRealm, long entityNum);

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/EntityRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/EntityRepository.java
@@ -43,12 +43,12 @@ public interface EntityRepository extends PagingAndSortingRepository<Entities, L
     <S extends Entities> S save(S entity);
 
     @Cacheable(key = "{#p0, #p1, #p2}", sync = true, cacheNames = "entity_ids",
-            cacheManager = CacheConfiguration.BIG_LRU_CACHE)
+            cacheManager = CacheConfiguration.BIG_LRU_CACHE, unless = "#result == null")
     @Query("select id from Entities where entityShard = ?1 and entityRealm = ?2 and entityNum = ?3")
     Optional<Long> findEntityIdByNativeIds(long entityShard, long entityRealm, long entityNum);
 
     @CachePut(key = "{#p0.entityShard, #p0.entityRealm, #p0.entityNum}", cacheNames = "entity_ids",
-            cacheManager = CacheConfiguration.BIG_LRU_CACHE)
+            cacheManager = CacheConfiguration.BIG_LRU_CACHE, unless = "#result == null")
     default <S extends EntityId> Long cache(S entity) {
         return entity.getId();
     }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/EntityRepositoryCustom.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/EntityRepositoryCustom.java
@@ -20,12 +20,12 @@ package com.hedera.mirror.importer.repository;
  * ‍
  */
 
-import com.hedera.mirror.importer.domain.Entities;
-import com.hedera.mirror.importer.domain.EntityId;
-
 import java.util.Collection;
+
+import com.hedera.mirror.importer.domain.EntityId;
 
 public interface EntityRepositoryCustom {
     Collection<EntityId> findAllEntityIds(int limit);
-    <S extends Entities> EntityId saveAndCacheEntityId(S entity);
+
+    long lookupOrCreateId(EntityId entityId);
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/EntityRepositoryCustom.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/EntityRepositoryCustom.java
@@ -27,5 +27,5 @@ import com.hedera.mirror.importer.domain.EntityId;
 public interface EntityRepositoryCustom {
     Collection<EntityId> findAllEntityIds(int limit);
 
-    long lookupOrCreateId(EntityId entityId);
+    Long lookupOrCreateId(EntityId entityId);
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/EntityRepositoryCustomImpl.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/EntityRepositoryCustomImpl.java
@@ -54,9 +54,13 @@ public class EntityRepositoryCustomImpl implements EntityRepositoryCustom {
      *                 inserted into the repo and the newly minted id is returned.
      * @return looked up/newly minted id of the given entityId.
      */
-    public long lookupOrCreateId(EntityId entityId) {
-        if (entityId.getId() != null && entityId.getId() != 0) {
-            return entityId.getId();
+    public Long lookupOrCreateId(EntityId entityId) {
+        if (entityId == null) {
+            return null;
+        }
+        Long id = entityId.getId();
+        if (id != null && id != 0) {
+            return id;
         }
         return entityRepository.findEntityIdByNativeIds(
                 entityId.getEntityShard(), entityId.getEntityRealm(), entityId.getEntityNum())

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/AbstractRecordItemParserTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/AbstractRecordItemParserTest.java
@@ -247,6 +247,6 @@ public class AbstractRecordItemParserTest extends IntegrationTest {
             return null;
         }
         EntityId entityId = new EntityId(null, 0L, 0L, accountNum, EntityTypeEnum.ACCOUNT.getId());
-        return entityRepository.saveAndCacheEntityId(entityId.toEntity()).getId();
+        return entityRepository.save(entityId.toEntity()).getId();
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/AbstractTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/AbstractTransactionHandlerTest.java
@@ -39,8 +39,6 @@ public abstract class AbstractTransactionHandlerTest {
     protected static final Long DEFAULT_ENTITY_NUM = 100L;
     @Mock
     protected EntityRepository entityRepository;
-    protected TransactionBody transactionBody;
-    protected TransactionRecord transactionRecord;
     private TransactionHandler transactionHandler;
 
     protected abstract TransactionHandler getTransactionHandler();
@@ -59,9 +57,6 @@ public abstract class AbstractTransactionHandlerTest {
     void beforeEach(TestInfo testInfo) {
         System.out.println("Before test: " + testInfo.getTestMethod().get().getName());
         transactionHandler = getTransactionHandler();
-
-        transactionBody = getDefaultTransactionBody().build();
-        transactionRecord = getDefaultTransactionRecord().build();
     }
 
     @Test
@@ -71,7 +66,8 @@ public abstract class AbstractTransactionHandlerTest {
         if (entityType != null) {
             expectedEntityId = new EntityId(null, 0L, 0L, DEFAULT_ENTITY_NUM, entityType.getId());
         }
-        testGetEntityIdHelper(transactionBody, transactionRecord, expectedEntityId);
+        testGetEntityIdHelper(getDefaultTransactionBody().build(), getDefaultTransactionRecord().build(),
+                expectedEntityId);
     }
 
     protected void testGetEntityIdHelper(

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/AbstractTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/AbstractTransactionHandlerTest.java
@@ -28,14 +28,19 @@ import com.hederahashgraph.api.proto.java.TransactionRecord;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+import org.mockito.Mock;
 
 import com.hedera.mirror.importer.domain.EntityId;
 import com.hedera.mirror.importer.domain.EntityTypeEnum;
 import com.hedera.mirror.importer.parser.domain.RecordItem;
+import com.hedera.mirror.importer.repository.EntityRepository;
 
 public abstract class AbstractTransactionHandlerTest {
     protected static final Long DEFAULT_ENTITY_NUM = 100L;
-
+    @Mock
+    protected EntityRepository entityRepository;
+    protected TransactionBody transactionBody;
+    protected TransactionRecord transactionRecord;
     private TransactionHandler transactionHandler;
 
     protected abstract TransactionHandler getTransactionHandler();
@@ -49,9 +54,6 @@ public abstract class AbstractTransactionHandlerTest {
 
     // For testGetEntityId
     protected abstract EntityTypeEnum getExpectedEntityIdType();
-
-    protected TransactionBody transactionBody;
-    protected TransactionRecord transactionRecord;
 
     @BeforeEach
     void beforeEach(TestInfo testInfo) {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/ConsensusCreateTopicTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/ConsensusCreateTopicTransactionHandlerTest.java
@@ -31,7 +31,7 @@ import com.hedera.mirror.importer.domain.EntityTypeEnum;
 class ConsensusCreateTopicTransactionHandlerTest extends AbstractTransactionHandlerTest {
     @Override
     protected TransactionHandler getTransactionHandler() {
-        return new ConsensusCreateTopicTransactionHandler();
+        return new ConsensusCreateTopicTransactionHandler(entityRepository);
     }
 
     @Override

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/ConsensusUpdateTopicTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/ConsensusUpdateTopicTransactionHandlerTest.java
@@ -29,7 +29,7 @@ import com.hedera.mirror.importer.domain.EntityTypeEnum;
 class ConsensusUpdateTopicTransactionHandlerTest extends AbstractTransactionHandlerTest {
     @Override
     protected TransactionHandler getTransactionHandler() {
-        return new ConsensusUpdateTopicTransactionHandler();
+        return new ConsensusUpdateTopicTransactionHandler(entityRepository);
     }
 
     @Override

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractCreateTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractCreateTransactionHandlerTest.java
@@ -31,7 +31,7 @@ import com.hedera.mirror.importer.domain.EntityTypeEnum;
 class ContractCreateTransactionHandlerTest extends AbstractTransactionHandlerTest {
     @Override
     protected TransactionHandler getTransactionHandler() {
-        return new ContractCreateTransactionHandler();
+        return new ContractCreateTransactionHandler(entityRepository);
     }
 
     @Override

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractUpdateTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractUpdateTransactionHandlerTest.java
@@ -29,7 +29,7 @@ import com.hedera.mirror.importer.domain.EntityTypeEnum;
 class ContractUpdateTransactionHandlerTest extends AbstractTransactionHandlerTest {
     @Override
     protected TransactionHandler getTransactionHandler() {
-        return new ContractUpdateTransactionHandler();
+        return new ContractUpdateTransactionHandler(entityRepository);
     }
 
     @Override

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoCreateTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoCreateTransactionHandlerTest.java
@@ -31,7 +31,7 @@ import com.hedera.mirror.importer.domain.EntityTypeEnum;
 class CryptoCreateTransactionHandlerTest extends AbstractTransactionHandlerTest {
     @Override
     protected TransactionHandler getTransactionHandler() {
-        return new CryptoCreateTransactionHandler();
+        return new CryptoCreateTransactionHandler(entityRepository);
     }
 
     @Override

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoUpdateTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoUpdateTransactionHandlerTest.java
@@ -29,7 +29,7 @@ import com.hedera.mirror.importer.domain.EntityTypeEnum;
 class CryptoUpdateTransactionHandlerTest extends AbstractTransactionHandlerTest {
     @Override
     protected TransactionHandler getTransactionHandler() {
-        return new CryptoUpdateTransactionHandler();
+        return new CryptoUpdateTransactionHandler(entityRepository);
     }
 
     @Override

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/SystemDeleteTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/SystemDeleteTransactionHandlerTest.java
@@ -56,7 +56,7 @@ class SystemDeleteTransactionHandlerTest extends AbstractTransactionHandlerTest 
                         .setContractID(ContractID.newBuilder().setContractNum(DEFAULT_ENTITY_NUM).build()))
                 .build();
 
-        testGetEntityIdHelper(transactionBody, transactionRecord,
+        testGetEntityIdHelper(transactionBody, getDefaultTransactionRecord().build(),
                 new EntityId(null, 0L, 0L, DEFAULT_ENTITY_NUM, EntityTypeEnum.CONTRACT.getId()));
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/SystemUndeleteTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/SystemUndeleteTransactionHandlerTest.java
@@ -56,7 +56,7 @@ class SystemUndeleteTransactionHandlerTest extends AbstractTransactionHandlerTes
                         .setContractID(ContractID.newBuilder().setContractNum(DEFAULT_ENTITY_NUM).build()))
                 .build();
 
-        testGetEntityIdHelper(transactionBody, transactionRecord,
+        testGetEntityIdHelper(transactionBody, getDefaultTransactionRecord().build(),
                 new EntityId(null, 0L, 0L, DEFAULT_ENTITY_NUM, EntityTypeEnum.CONTRACT.getId()));
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/EntityRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/EntityRepositoryTest.java
@@ -29,9 +29,6 @@ import com.hedera.mirror.importer.domain.EntityId;
 import com.hedera.mirror.importer.domain.EntityTypeEnum;
 
 public class EntityRepositoryTest extends AbstractRepositoryTest {
-    private static final EntityId ENTITY_ID = new EntityId(null, 1L, 2L, 3L, EntityTypeEnum.ACCOUNT.getId());
-    private static final Entities ENTITY = ENTITY_ID.toEntity();
-
     @Test
     void findByPrimaryKey() {
         int entityTypeId = entityTypeRepository.findByName("account").get().getId();
@@ -81,26 +78,34 @@ public class EntityRepositoryTest extends AbstractRepositoryTest {
 
     @Test
     void findEntityIdByNativeIds() {
-        var expected = entityRepository.save(ENTITY);
+        EntityId entityId = getDefaultEntityId();
+        Entities entity = entityId.toEntity();
+        var expected = entityRepository.save(entity);
 
-        var dbId = entityRepository.findEntityIdByNativeIds(ENTITY.getEntityShard(), ENTITY.getEntityRealm(),
-                ENTITY.getEntityNum()).get();
+        var dbId = entityRepository.findEntityIdByNativeIds(entity.getEntityShard(), entity.getEntityRealm(),
+                entity.getEntityNum()).get();
 
         assertThat(dbId).isEqualTo(expected.getId());
     }
 
     @Test
     void lookupExistingId() {
-        var expected = entityRepository.save(ENTITY);
+        EntityId entityId = getDefaultEntityId();
+        var expected = entityRepository.save(entityId.toEntity());
 
-        assertThat(entityRepository.lookupOrCreateId(ENTITY_ID)).isEqualTo(expected.getId());
+        assertThat(entityRepository.lookupOrCreateId(entityId)).isEqualTo(expected.getId());
     }
 
     @Test
     void lookupOrCreateIdIsIdempotent() {
-        var createdId = entityRepository.lookupOrCreateId(ENTITY_ID);
-        var lookupId = entityRepository.lookupOrCreateId(ENTITY_ID);
+        EntityId entityId = getDefaultEntityId();
+        var createdId = entityRepository.lookupOrCreateId(entityId);
+        var lookupId = entityRepository.lookupOrCreateId(entityId);
 
         assertThat(lookupId).isEqualTo(createdId);
+    }
+
+    private EntityId getDefaultEntityId() {
+        return new EntityId(null, 1L, 2L, 3L, EntityTypeEnum.ACCOUNT.getId());
     }
 }


### PR DESCRIPTION
**Detailed description**:
- Moved functionality from RecordItemParser to respective implementations of
  TransactionHandler.updateEntity() and updateTransaction()
- Before recent cleanups, RIP.onItem() used to be 300+ lines. Now it's ~75.
- EntityRepository:
  - Moved lookupOrCreateId(EntityId) to EntityRepository
  - Removed saveAndCacheEntityId(), not needed anymore after recent cleanups
  - Big cache is needed only to lookup db id for an entity because of FKs.
    No need of entity type in cache. Going forward, we want to removing FKs, and hence the cache.
    So changed findEntityIdByNativeIds() to return just Long. Simplifies the query too.
- Fix bad tests in RecordItemParserContractTest and RecordItemParserCryptoTest

Signed-off-by: Apekshit Sharma <apekshit.sharma@hedera.com>

**Which issue(s) this PR fixes**:
Part of #571 

**Special notes for your reviewer**:
90% of the code was in an old branch from last sprint. This was after we discussed the design in one of the stand-ups. I think better to get it in than stale out.
Extensive RecordItemParser integration tests ensure no regression.
Later, the followups would be:
- Add TransactionHandler unit tests.
- move RIP.insert*() fns to TransactionHandler

**Checklist**
- [ ] Documentation added
- [x] Tests updated

