### PR TITLE
Push docker images on master and cleanup old images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,13 +53,11 @@ commands:
             OLD_IMAGES=$(gcloud container images list-tags ${IMAGE_PATH} \
               --limit=1000 \
               --sort-by=TIMESTAMP \
-              --filter="tags:image* AND timestamp.datetime < '${DELETE_BEFORE}'" \
-              --format="get(digest)")
+              --filter="tags:image* AND timestamp.datetime < '${DELETE_BEFORE}'")
             echo OLD_IMAGES: ${OLD_IMAGES}
             for digest in ${OLD_IMAGES[*]}; do
             (
-              echo Delete image: "${IMAGE_PATH}@${digest}"
-              echo Command: gcloud container images delete -q --force-delete-tags "${IMAGE_PATH}@${digest}"
+              echo image: "${digest}"
             )
             done
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,9 +44,9 @@ commands:
         default: "importer"
     steps:
       - run:
-          name: "Cleans up old master images"
+          name: "Clean up old master images"
           command: |
-            DELETE_BEFORE=$(date --utc -d "-4 hours" '+%FT%TZ')
+            DELETE_BEFORE=$(date --utc -d "-6 hours" '+%FT%TZ')
             echo DELETE_BEFORE: ${DELETE_BEFORE}
             IMAGE_PATH=gcr.io/mirrornode/hedera-mirror-<< parameters.imagepath >>
             echo IMAGE_PATH: ${IMAGE_PATH}
@@ -58,12 +58,11 @@ commands:
             OLD_IMAGES=$(gcloud container images list-tags ${IMAGE_PATH} \
               --limit=1000 \
               --sort-by=TIMESTAMP \
-              --filter="tags:image* AND timestamp.datetime < '${DELETE_BEFORE}'" \
-              --format="get(digest)")
+              --filter="tags:image* AND timestamp.datetime < '${DELETE_BEFORE}'")
+            echo OLD_IMAGES: ${OLD_IMAGES}
             for digest in ${OLD_IMAGES[*]}; do
             (
               echo Delete image: "${IMAGE_PATH}@${digest}"
-              echo Command: gcloud container images delete -q --force-delete-tags "${IMAGE_PATH}@${digest}"
             )
             done
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -266,10 +266,10 @@ jobs:
           command: |
             echo ${GCR_JSON_KEY_FILE} | gcloud auth activate-service-account --key-file=-
             gcloud --quiet config set project mirrornode
-            DELETE_BEFORE=$(date -d "-1 hours" '+%d-%m-%Y')
-            echo ${DELETE_BEFORE}
-            gcloud container images list-tags gcr.io/mirrornode/hedera-mirror-grpc --limit=1000 --sort-by=TIMESTAMP --filter="tags:image*  AND timestamp.datetime < '${DELETE_BEFORE}'" --format='get(digest)'
-            gcloud container images list-tags gcr.io/mirrornode/hedera-mirror-importer --limit=1000 --sort-by=TIMESTAMP --filter="tags:image*  AND timestamp.datetime < '${DELETE_BEFORE}'" --format='get(digest)'
-            gcloud container images list-tags gcr.io/mirrornode/hedera-mirror-rest --limit=1000 --sort-by=TIMESTAMP --filter="tags:image*  AND timestamp.datetime < '${DELETE_BEFORE}'" --format='get(digest)'
+            DELETE_BEFORE=$(date -d "-30 minutes" '+%d-%m-%Y')
+            echo DELETE_BEFORE: ${DELETE_BEFORE}
+            echo GRPC_IMAGES: ${gcloud container images list-tags gcr.io/mirrornode/hedera-mirror-grpc --limit=1000 --sort-by=TIMESTAMP --filter="tags:image*  AND timestamp.datetime < '${DELETE_BEFORE}'" --format='get(digest)'}
+            echo IMPORTER_IMAGES: ${gcloud container images list-tags gcr.io/mirrornode/hedera-mirror-importer --limit=1000 --sort-by=TIMESTAMP --filter="tags:image*  AND timestamp.datetime < '${DELETE_BEFORE}'" --format='get(digest)'}
+            echo REST_IMAGES: ${gcloud container images list-tags gcr.io/mirrornode/hedera-mirror-rest --limit=1000 --sort-by=TIMESTAMP --filter="tags:image*  AND timestamp.datetime < '${DELETE_BEFORE}'" --format='get(digest)'}
 #                        gcloud container images delete -q --force-delete-tags $(gcloud container images list-tags gcr.io/mirrornode/hedera-mirror-grpc --limit=1000 --sort-by=TIMESTAMP --filter="tags:image-deploy* AND timestamp.datetime < '${DELETE_BEFORE}'" --format='get(digest)')
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ commands:
             echo OLD_IMAGES: ${OLD_IMAGES}
             for image in ${OLD_IMAGES[*]}; do
             (
-              IFS=, read digest timestamp <<< ${image}
+              IFS=, read digest timestamp \<<< ${image}
               echo Delete image: "${IMAGE_PATH}@${digest} created on ${timestamp}"
               echo Command: gcloud container images delete -q --force-delete-tags "${IMAGE_PATH}@${digest}"
             )

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,8 +132,6 @@ workflows:
             branches:
               only:
                 - master
-            tags:
-              only: /^.*/
 
 jobs:
   build_maven:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -254,7 +254,7 @@ jobs:
             if [ "$CIRCLE_BRANCH" = "master" -o "$CIRCLE_BRANCH" = "image-deploy-cleanup" ]; then
                 DOCKERPUSHTAG=${CIRCLE_BRANCH}-${CIRCLE_SHA1}
             fi
-            echo ${DOCKERPUSHTAG}
+            echo DOCKERPUSHTAG: ${DOCKERPUSHTAG}
             ./mvnw ${MAVEN_CLI_OPTS} deploy -DskipTests -Dcircle.docker.tag=${DOCKERPUSHTAG}
       - *save_maven_cache
   cleanup_images:
@@ -268,6 +268,13 @@ jobs:
             gcloud --quiet config set project mirrornode
             DELETE_BEFORE=$(date -d "-30 minutes" '+%d-%m-%Y')
             echo DELETE_BEFORE: ${DELETE_BEFORE}
+            for digest in $(gcloud container images list-tags \
+              gcr.io/mirrornode/hedera-mirror-grpc --limit=1000 \
+              --sort-by=TIMESTAMP \
+              --filter="tags:image*  AND timestamp.datetime < '${DELETE_BEFORE}'" \
+              --format='get(digest)'; do
+                gcloud container images delete -q --force-delete-tags "gcr.io/mirrornode@${digest}"
+            done
             echo GRPC_IMAGES: ${gcloud container images list-tags gcr.io/mirrornode/hedera-mirror-grpc --limit=1000 --sort-by=TIMESTAMP --filter="tags:image*  AND timestamp.datetime < '${DELETE_BEFORE}'" --format='get(digest)'}
             echo IMPORTER_IMAGES: ${gcloud container images list-tags gcr.io/mirrornode/hedera-mirror-importer --limit=1000 --sort-by=TIMESTAMP --filter="tags:image*  AND timestamp.datetime < '${DELETE_BEFORE}'" --format='get(digest)'}
             echo REST_IMAGES: ${gcloud container images list-tags gcr.io/mirrornode/hedera-mirror-rest --limit=1000 --sort-by=TIMESTAMP --filter="tags:image*  AND timestamp.datetime < '${DELETE_BEFORE}'" --format='get(digest)'}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -299,8 +299,7 @@ jobs:
               --filter="tags:image*  AND timestamp.datetime < '${DELETE_BEFORE}'" \
               --format='get(digest)'); do \
               (
-                echo delete image: ${GRPC_IMAGE_PATH}@${digest} &&
-                gcloud container images delete -q --force-delete-tags "${GRPC_IMAGE_PATH}@${digest}"
+                echo delete image: ${GRPC_IMAGE_PATH}@${digest}
               )
             done
             IMPORTER_IMAGE_PATH=${IMAGE_PATH_BASE}importer
@@ -311,8 +310,7 @@ jobs:
               --filter="tags:image*  AND timestamp.datetime < '${DELETE_BEFORE}'" \
               --format='get(digest)'); do \
               (
-                echo delete image: ${IMPORTER_IMAGE_PATH}@${digest} &&
-                gcloud container images delete -q --force-delete-tags "${IMPORTER_IMAGE_PATH}@${digest}"
+                echo delete image: ${IMPORTER_IMAGE_PATH}@${digest}
               )
             done
             REST_IMAGE_PATH=${IMAGE_PATH_BASE}rest
@@ -323,8 +321,7 @@ jobs:
               --filter="tags:image* AND timestamp.datetime < '${DELETE_BEFORE}'" \
               --format='get(digest)'); do \
               (
-                echo delete image: ${REST_IMAGE_PATH}@${digest} &&
-                gcloud container images delete -q --force-delete-tags "${REST_IMAGE_PATH}@${digest}"
+                echo delete image: ${REST_IMAGE_PATH}@${digest}
               )
             done
       #            echo GRPC_IMAGES: ${gcloud container images list-tags gcr.io/mirrornode/hedera-mirror-grpc --limit=1000 --sort-by=TIMESTAMP --filter="tags:image*  AND timestamp.datetime < '${DELETE_BEFORE}'" --format='get(digest)'}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ commands:
               --filter="tags:image* AND timestamp.datetime < '${DELETE_BEFORE}'" \
               --format='get(digest)')
             echo OLD_IMAGES: ${OLD_IMAGES}
-            for digest in $(OLD_IMAGES); do  echo PathToDelete: "${IMAGE_PATH}@${digest}"; done
+            for digest in ${OLD_IMAGES}; do  echo PathToDelete: "${IMAGE_PATH}@${digest}"; done
 
 workflows:
   version: 2.1
@@ -310,7 +310,7 @@ jobs:
             echo GRPC_IMAGE_PATH: ${GRPC_IMAGE_PATH}
             GRPC_OLD_IMAGES=$(gcloud container images list-tags ${GRPC_IMAGE_PATH} --limit=1000 --sort-by=TIMESTAMP --filter="tags:image* AND timestamp.datetime < '${DELETE_BEFORE}'" --format='get(digest)')
             echo GRPC_OLD_IMAGES: ${GRPC_OLD_IMAGES}
-            for digest in $(GRPC_OLD_IMAGES); do  echo PathToDelete: "${GRPC_IMAGE_PATH}@${digest}"; done
+            for digest in ${GRPC_OLD_IMAGES}; do  echo PathToDelete: "${GRPC_IMAGE_PATH}@${digest}"; done
       #      - <<: *gcloud_image_clean
       #        imagepath: grpc
       #      - <<: *gcloud_image_clean

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,8 +79,8 @@ workflows:
             tags:
               only: /.*/
       - cleanup_images:
-          #          requires:
-          #            - publish_images
+          requires:
+            - publish_images
           filters:
             branches:
               only:
@@ -266,8 +266,10 @@ jobs:
           command: |
             echo ${GCR_JSON_KEY_FILE} | gcloud auth activate-service-account --key-file=-
             gcloud --quiet config set project mirrornode
-            DELETE_BEFORE=$(date '+%d-%m-%Y')
+            DELETE_BEFORE=$(date -d "-1 hours" '+%d-%m-%Y')
             echo ${DELETE_BEFORE}
-
-#            gcloud container images delete -q --force-delete-tags $(gcloud container images list-tags gcr.io/mirrornode/hedera-mirror-grpc --limit=1000 --sort-by=TIMESTAMP --filter="tags:master-* AND timestamp.datetime<=2018-01-15" --format='get(digest)')
+            gcloud container images list-tags gcr.io/mirrornode/hedera-mirror-grpc --limit=1000 --sort-by=TIMESTAMP --filter="tags:image*  AND timestamp.datetime < '${DELETE_BEFORE}'" --format='get(digest)'
+            gcloud container images list-tags gcr.io/mirrornode/hedera-mirror-importer --limit=1000 --sort-by=TIMESTAMP --filter="tags:image*  AND timestamp.datetime < '${DELETE_BEFORE}'" --format='get(digest)'
+            gcloud container images list-tags gcr.io/mirrornode/hedera-mirror-rest --limit=1000 --sort-by=TIMESTAMP --filter="tags:image*  AND timestamp.datetime < '${DELETE_BEFORE}'" --format='get(digest)'
+#                        gcloud container images delete -q --force-delete-tags $(gcloud container images list-tags gcr.io/mirrornode/hedera-mirror-grpc --limit=1000 --sort-by=TIMESTAMP --filter="tags:image-deploy* AND timestamp.datetime < '${DELETE_BEFORE}'" --format='get(digest)')
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,8 +95,6 @@ workflows:
             branches:
               only:
                 - master
-                # image-deploy-cleanup branch present for testing to be removed
-                - image-deploy-cleanup
             tags:
               only: /^.*/
       - perf_maven:
@@ -275,7 +273,7 @@ jobs:
       - run:
           name: Running maven deploy
           command: |
-            if [ "$CIRCLE_BRANCH" = "master" -o "$CIRCLE_BRANCH" = "image-deploy-cleanup" ]; then
+            if [ "$CIRCLE_BRANCH" = "master" ]; then
                 DOCKER_TAG_OVERRIDE="-Ddocker.tag.version=${CIRCLE_BRANCH}-${CIRCLE_SHA1} -Ddocker.tag.latest=master"
             fi
             echo DOCKER_TAG_OVERRIDE: ${DOCKER_TAG_OVERRIDE}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,9 +68,20 @@ commands:
             OLD_IMAGES=$(gcloud container images list-tags ${IMAGE_PATH} \
               --limit=1000 \
               --sort-by=TIMESTAMP \
+              --format='get(digest)')
+            echo OLD_IMAGES No Filter: ${OLD_IMAGES}
+            OLD_IMAGES=$(gcloud container images list-tags ${IMAGE_PATH} \
+              --limit=1000 \
+              --sort-by=TIMESTAMP \
+              --filter="tags:image*" \
+              --format='get(digest)')
+            echo OLD_IMAGES Branch Filter: ${OLD_IMAGES}
+            OLD_IMAGES=$(gcloud container images list-tags ${IMAGE_PATH} \
+              --limit=1000 \
+              --sort-by=TIMESTAMP \
               --filter="tags:image* AND timestamp.datetime < '${DELETE_BEFORE}'" \
               --format='get(digest)')
-            echo OLD_IMAGES: ${OLD_IMAGES}
+            echo OLD_IMAGES Branch and Tiem Filter: ${OLD_IMAGES}
             for digest in ${OLD_IMAGES}; do  echo PathToDelete: "${IMAGE_PATH}@${digest}"; done
 
 workflows:
@@ -304,12 +315,6 @@ jobs:
           command: |
             echo ${GCR_JSON_KEY_FILE} | gcloud auth activate-service-account --key-file=-
             gcloud --quiet config set project mirrornode
-            echo "Remove old untagged grpc master image"
-            gcloud container images delete -q --force-delete-tags "gcr.io/mirrornode/hedera-mirror-grpc@sha256:81dfd0bee03dd29f862dbf9cb825cf9af3fdc2d39408a7e7aeba348ad487c1f0"
-            echo "Remove old untagged importer master image"
-            gcloud container images delete -q --force-delete-tags "gcr.io/mirrornode/hedera-mirror-importer@sha256:8936be7ca988150625dcef3e9a8b094043f7059fa140cba8409c9ce0a31baa20"
-            echo "Remove old untagged rest master image"
-            gcloud container images delete -q --force-delete-tags "gcr.io/mirrornode/hedera-mirror-rest@sha256:3a5d7b9f414cabc10036430f6827e7b5264acec0ca06a6ff579e550e10448f40"
       - gcloud_image_clean:
           imagepath: "grpc"
       - gcloud_image_clean:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -297,10 +297,9 @@ jobs:
               ${GRPC_IMAGE_PATH} --limit=1000 \
               --sort-by=TIMESTAMP \
               --filter="tags:image*  AND timestamp.datetime < '${DELETE_BEFORE}'" \
-              --format='get(digest)'); do
+              --format='get(digest)'); do \
               (
-                set -x
-                echo delete image: ${GRPC_IMAGE_PATH}@${digest}
+                echo delete image: ${GRPC_IMAGE_PATH}@${digest} &&
                 gcloud container images delete -q --force-delete-tags "${GRPC_IMAGE_PATH}@${digest}"
               )
             done
@@ -310,10 +309,9 @@ jobs:
               ${IMPORTER_IMAGE_PATH} --limit=1000 \
               --sort-by=TIMESTAMP \
               --filter="tags:image*  AND timestamp.datetime < '${DELETE_BEFORE}'" \
-              --format='get(digest)'); do
+              --format='get(digest)'); do \
               (
-                set -x
-                echo delete image: ${IMPORTER_IMAGE_PATH}@${digest}
+                echo delete image: ${IMPORTER_IMAGE_PATH}@${digest} &&
                 gcloud container images delete -q --force-delete-tags "${IMPORTER_IMAGE_PATH}@${digest}"
               )
             done
@@ -323,10 +321,9 @@ jobs:
               ${REST_IMAGE_PATH} --limit=1000 \
               --sort-by=TIMESTAMP \
               --filter="tags:image* AND timestamp.datetime < '${DELETE_BEFORE}'" \
-              --format='get(digest)'); do
+              --format='get(digest)'); do \
               (
-                set -x
-                echo delete image: ${REST_IMAGE_PATH}@${digest}
+                echo delete image: ${REST_IMAGE_PATH}@${digest} &&
                 gcloud container images delete -q --force-delete-tags "${REST_IMAGE_PATH}@${digest}"
               )
             done

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,8 +61,7 @@ commands:
       - run:
           description: "Cleans up image under given path"
           command: |
-            echo $(gcloud config list)
-            DELETE_BEFORE=$(date -d "-14 hours" '+%d-%m-%Y')
+            DELETE_BEFORE=$(date -d "-14 hours" '+%d-%m-%Y %H:%M')
             echo DELETE_BEFORE: ${DELETE_BEFORE}
             IMAGE_PATH=gcr.io/mirrornode/hedera-mirror-<< parameters.imagepath >>
             echo IMAGE_PATH: ${IMAGE_PATH}
@@ -301,25 +300,14 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Delete old master images
+          name: Delete old untagged master images
           command: |
-            echo ${GCR_JSON_KEY_FILE} | gcloud auth activate-service-account --key-file=-
-            gcloud --quiet config set project mirrornode
-            echo $(gcloud config list)
-            DELETE_BEFORE=$(date -d "-4 hours" '+%d-%m-%Y %H:%M')
-            echo DELETE_BEFORE: ${DELETE_BEFORE}
-            IMAGE_PATH_BASE=gcr.io/mirrornode/hedera-mirror-
-            GRPC_IMAGE_PATH=${IMAGE_PATH_BASE}grpc
-            echo GRPC_IMAGE_PATH: ${GRPC_IMAGE_PATH}
-            GRPC_OLD_IMAGES=$(gcloud container images list-tags ${GRPC_IMAGE_PATH} --limit=1000 --sort-by=TIMESTAMP --filter="tags:image* AND timestamp.datetime < '${DELETE_BEFORE}'" --format='get(digest)')
-            echo GRPC_OLD_IMAGES: ${GRPC_OLD_IMAGES}
-            for digest in ${GRPC_OLD_IMAGES}; do  echo PathToDelete: "${GRPC_IMAGE_PATH}@${digest}"; done
-      #      - <<: *gcloud_image_clean
-      #        imagepath: grpc
-      #      - <<: *gcloud_image_clean
-      #        imagepath: importer
-      #      - <<: *gcloud_image_clean
-      #        imagepath: rest
+            echo "Remove old untagged grpc master image"
+            gcloud container images delete -q --force-delete-tags "gcr.io/mirrornode/hedera-mirror-grpc@sha256:81dfd0bee03dd29f862dbf9cb825cf9af3fdc2d39408a7e7aeba348ad487c1f0"
+            echo "Remove old untagged importer master image"
+            gcloud container images delete -q --force-delete-tags "gcr.io/mirrornode/hedera-mirror-importer@sha256:8936be7ca988150625dcef3e9a8b094043f7059fa140cba8409c9ce0a31baa20"
+            echo "Remove old untagged rest master image"
+            gcloud container images delete -q --force-delete-tags "gcr.io/mirrornode/hedera-mirror-rest@sha256:3a5d7b9f414cabc10036430f6827e7b5264acec0ca06a6ff579e550e10448f40"
       - gcloud_image_clean:
           imagepath: "grpc"
       - gcloud_image_clean:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2.1
+version: 2
 
 references:
   workspace_root: &workspace_root /tmp/workspace
@@ -34,29 +34,45 @@ references:
           POSTGRES_DB: mirror_node_test
           POSTGRES_PASSWORD: mirror_node_pass
           POSTGRES_USER: mirror_node
+#  gcloud_image_clean: &gcloud_image_clean
+#    - imagepath: importer
+#    - run:
+#        name: "Cleans up image under given path"
+#        command: |
+#          DELETE_BEFORE=$(date -d "-14 hours" '+%d-%m-%Y')
+#          IMAGE_PATH=gcr.io/mirrornode/hedera-mirror-<< imagepath >>
+#          echo IMAGE_PATH: ${IMAGE_PATH}
+#          OLD_IMAGES= gcloud container images list-tags ${IMAGE_PATH} \
+#            --limit=1000 \
+#            --sort-by=TIMESTAMP \
+#            --filter="tags:image* AND timestamp.datetime < '${DELETE_BEFORE}'" \
+#            --format='get(digest)'
+#          echo OLD_IMAGES: ${OLD_IMAGES}
+#          for digest in $(OLD_IMAGES); do  echo PathToDelete: "${IMAGE_PATH}@${digest}"; done
 
-commands:
-  gcloud_image_clean:
-    description: "Cleans up image under given path"
-    parameters:
-      imagepath:
-        type: string
-        default: "importer"
-    steps:
-      - run:
-          command: |
-            DELETE_BEFORE=$(date -d "-14 hours" '+%d-%m-%Y')
-            IMAGE_PATH=gcr.io/mirrornode/hedera-mirror-<< parameters.imagepath >>
-            echo IMAGE_PATH: ${IMAGE_PATH}
-            OLD_IMAGES= gcloud container images list-tags ${IMAGE_PATH} \
-              --limit=1000 \
-              --sort-by=TIMESTAMP \
-              --filter="tags:image* AND timestamp.datetime < '${DELETE_BEFORE}'" \
-              --format='get(digest)'
-            echo OLD_IMAGES: ${OLD_IMAGES}
-            for digest in $(OLD_IMAGES); do  echo PathToDelete: "${IMAGE_PATH}@${digest}"; done
+#commands:
+#  gcloud_image_clean:
+#    description: "Cleans up image under given path"
+#    parameters:
+#      imagepath:
+#        type: string
+#        default: "importer"
+#    steps:
+#      - run:
+#          command: |
+#            DELETE_BEFORE=$(date -d "-14 hours" '+%d-%m-%Y')
+#            IMAGE_PATH=gcr.io/mirrornode/hedera-mirror-<< parameters.imagepath >>
+#            echo IMAGE_PATH: ${IMAGE_PATH}
+#            OLD_IMAGES= gcloud container images list-tags ${IMAGE_PATH} \
+#              --limit=1000 \
+#              --sort-by=TIMESTAMP \
+#              --filter="tags:image* AND timestamp.datetime < '${DELETE_BEFORE}'" \
+#              --format='get(digest)'
+#            echo OLD_IMAGES: ${OLD_IMAGES}
+#            for digest in $(OLD_IMAGES); do  echo PathToDelete: "${IMAGE_PATH}@${digest}"; done
 
 workflows:
+  version: 2
   main:
     jobs:
       - build_maven:
@@ -188,7 +204,7 @@ jobs:
           POSTGRES_USER: mirror_node
           POSTGRES_PASSWORD: mirror_node_pass
     steps:
-      - checkout:
+      - checkout
       - restore_cache:
           keys:
             - npm-v1-{{ .Branch }}-{{ checksum "hedera-mirror-rest/package-lock.json" }}
@@ -291,16 +307,22 @@ jobs:
             IMAGE_PATH_BASE=gcr.io/mirrornode/hedera-mirror-
             GRPC_IMAGE_PATH=${IMAGE_PATH_BASE}grpc
             echo GRPC_IMAGE_PATH: ${GRPC_IMAGE_PATH}
-            for digest in $(gcloud container images list-tags ${GRPC_IMAGE_PATH} \
+            GRPC_OLD_IMAGES= gcloud container images list-tags ${GRPC_IMAGE_PATH} \
               --limit=1000 \
               --sort-by=TIMESTAMP \
               --filter="tags:image* AND timestamp.datetime < '${DELETE_BEFORE}'" \
-              --format='get(digest)'); do \
-              ( echo PathToDelete: "${GRPC_IMAGE_PATH}@${digest}" ); \
-            done
-      - gcloud_image_clean:
-          imagepath: "grpc"
-      - gcloud_image_clean:
-          imagepath: "importer"
-      - gcloud_image_clean:
-          imagepath: "rest"
+              --format='get(digest)'
+            echo GRPC_OLD_IMAGES: ${GRPC_OLD_IMAGES}
+            for digest in $(GRPC_OLD_IMAGES); do  echo PathToDelete: "${GRPC_IMAGE_PATH}@${digest}"; done
+#      - <<: *gcloud_image_clean
+#        imagepath: grpc
+#      - <<: *gcloud_image_clean
+#        imagepath: importer
+#      - <<: *gcloud_image_clean
+#        imagepath: rest
+#      - gcloud_image_clean:
+#          imagepath: "grpc"
+#      - gcloud_image_clean:
+#          imagepath: "importer"
+#      - gcloud_image_clean:
+#          imagepath: "rest"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,29 +59,23 @@ commands:
         default: "importer"
     steps:
       - run:
-          description: "Cleans up image under given path"
+          name: "Cleans up image under given path"
           command: |
-            DELETE_BEFORE=$(date -d "-14 hours" '+%d-%m-%Y %H:%M')
+            DELETE_BEFORE=$(date --utc -d "-14 hours" '+%FT%TZ')
             echo DELETE_BEFORE: ${DELETE_BEFORE}
             IMAGE_PATH=gcr.io/mirrornode/hedera-mirror-<< parameters.imagepath >>
             echo IMAGE_PATH: ${IMAGE_PATH}
             OLD_IMAGES=$(gcloud container images list-tags ${IMAGE_PATH} \
               --limit=1000 \
               --sort-by=TIMESTAMP \
-              --filter="tags:image*" \
-              --format='get(digest)')
-            echo OLD_IMAGES Branch Filter: ${OLD_IMAGES}
-            OLD_IMAGES=$(gcloud container images list-tags ${IMAGE_PATH} \
-              --limit=1000 \
-              --sort-by=TIMESTAMP \
-              --filter="tags:image* AND timestamp.datetime < '${DELETE_BEFORE}'" \
-              --format='get(digest)')
-            echo OLD_IMAGES Branch and Time Filter: ${OLD_IMAGES}
+              --filter="'tags:image* AND timestamp.datetime < ${DELETE_BEFORE}'" \
+              --format="'get(digest)'")
+            echo OLD_IMAGES: ${OLD_IMAGES}
             echo Command: gcloud container images list-tags ${IMAGE_PATH} \
               --limit=1000 \
               --sort-by=TIMESTAMP \
-              --filter="tags:image* AND timestamp.datetime < '${DELETE_BEFORE}'" \
-              --format='get(digest)'
+              --filter="'tags:image* AND timestamp.datetime < ${DELETE_BEFORE}'" \
+              --format="'get(digest)'"
             for digest in ${OLD_IMAGES}; do  echo PathToDelete: "${IMAGE_PATH}@${digest}"; done
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,19 @@ commands:
               --sort-by=TIMESTAMP \
               --filter="tags:image* AND timestamp.datetime < '${DELETE_BEFORE}'" \
               --format="csv[no-heading](digest,timestamp)")
-            echo OLD_IMAGES: ${OLD_IMAGES}
+            echo OLD_IMAGES 1: ${OLD_IMAGES}
+            OLD_IMAGES=$(gcloud container images list-tags ${IMAGE_PATH} \
+              --limit=1000 \
+              --sort-by=TIMESTAMP \
+              --filter="tags:image* AND timestamp < '${DELETE_BEFORE}'" \
+              --format="csv[no-heading](digest,timestamp)")
+            echo OLD_IMAGES 2: ${OLD_IMAGES}
+            OLD_IMAGES=$(gcloud container images list-tags ${IMAGE_PATH} \
+              --limit=1000 \
+              --sort-by=TIMESTAMP \
+              --filter="tags:image* AND timestamp < {DELETE_BEFORE}" \
+              --format="csv[no-heading](digest,timestamp)")
+            echo OLD_IMAGES 3: ${OLD_IMAGES}
             for image in ${OLD_IMAGES[*]}; do
             (
               IFS=, read digest timestamp \<<< ${image}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,34 +52,28 @@ references:
 
 commands:
   gcloud_image_clean:
-    description: "Cleans up image under given path"
+    description: "Cleans up old master images"
     parameters:
       imagepath:
         type: string
         default: "importer"
     steps:
       - run:
-          name: "Cleans up image under given path"
+          name: "Cleans up old master images"
           command: |
-            DELETE_BEFORE=$(date --utc -d "-14 hours" '+%FT%TZ')
+            DELETE_BEFORE=$(date --utc -d "-19 hours" '+%FT%TZ')
             echo DELETE_BEFORE: ${DELETE_BEFORE}
             IMAGE_PATH=gcr.io/mirrornode/hedera-mirror-<< parameters.imagepath >>
             echo IMAGE_PATH: ${IMAGE_PATH}
-            echo List tags command: gcloud container images list-tags ${IMAGE_PATH} \
-              --limit=1000 \
-              --sort-by=TIMESTAMP \
-              --filter="'tags:image* AND timestamp.datetime < ${DELETE_BEFORE}'" \
-              --format="'get(digest)'"
             OLD_IMAGES=$(gcloud container images list-tags ${IMAGE_PATH} \
               --limit=1000 \
               --sort-by=TIMESTAMP \
               --filter="tags:image* AND timestamp.datetime < ${DELETE_BEFORE}" \
               --format="get(digest)")
-            echo OLD_IMAGES: ${OLD_IMAGES}
             for digest in ${OLD_IMAGES}; do
             (
               echo Delete image: "${IMAGE_PATH}@${digest}"
-              echo Command: gcloud container images delete -q --force-delete-tags "${IMAGE_PATH}@${digest}"
+              gcloud container images delete -q --force-delete-tags "${IMAGE_PATH}@${digest}"
             )
             done
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,10 +77,9 @@ commands:
               --limit=1000 \
               --sort-by=TIMESTAMP \
               --filter="-tags:* AND timestamp.datetime < '${DELETE_BEFORE}'" \
-              --format="csv[no-heading](digest,timestamp)")
-            for image in ${OLD_IMAGES[*]}; do
+              --format="get(digest)")
+            for digest in ${OLD_IMAGES[*]}; do
             (
-              IFS=, read digest timestamp \<<< ${image}
               gcloud container images delete -q "${IMAGE_PATH}@${digest}"
             )
             done

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,21 +54,27 @@ commands:
             OLD_IMAGES=$(gcloud container images list-tags ${IMAGE_PATH} \
               --limit=1000 \
               --sort-by=TIMESTAMP \
-              --filter="tags:image* AND timestamp.datetime < '${DELETE_BEFORE}'" \
+              --filter="tags:image-* AND timestamp.datetime < '${DELETE_BEFORE}'" \
               --format="csv[no-heading](digest,timestamp)")
             echo OLD_IMAGES 1: ${OLD_IMAGES}
-            OLD_IMAGES=$(gcloud container images list-tags ${IMAGE_PATH} \
+            OLD_IMAGES_2=$(gcloud container images list-tags ${IMAGE_PATH} \
               --limit=1000 \
               --sort-by=TIMESTAMP \
-              --filter="tags:image* AND timestamp < '${DELETE_BEFORE}'" \
+              --filter="tags:image-* AND timestamp < '${DELETE_BEFORE}'" \
               --format="csv[no-heading](digest,timestamp)")
-            echo OLD_IMAGES 2: ${OLD_IMAGES}
-            OLD_IMAGES=$(gcloud container images list-tags ${IMAGE_PATH} \
+            echo OLD_IMAGES 2: ${OLD_IMAGES_2}
+            OLD_IMAGES_3=$(gcloud container images list-tags ${IMAGE_PATH} \
               --limit=1000 \
               --sort-by=TIMESTAMP \
-              --filter="tags:image* AND timestamp < {DELETE_BEFORE}" \
+              --filter="tags:image-* AND timestamp < {DELETE_BEFORE}" \
               --format="csv[no-heading](digest,timestamp)")
-            echo OLD_IMAGES 3: ${OLD_IMAGES}
+            echo OLD_IMAGES 3: ${OLD_IMAGES_3}
+            OLD_IMAGES_4=$(gcloud container images list-tags ${IMAGE_PATH} \
+              --limit=1000 \
+              --sort-by=TIMESTAMP \
+              --filter="tags:image-* AND timestamp < {DELETE_BEFORE}" \
+              --format="csv[no-heading](digest,timestamp.datetime)")
+            echo OLD_IMAGES 4: ${OLD_IMAGES_4}
             for image in ${OLD_IMAGES[*]}; do
             (
               IFS=, read digest timestamp \<<< ${image}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ commands:
           name: "Untags old master images"
           command: |
             set -x
-            UNTAG_BEFORE=$(date -d "-24 hours" '+%FT%T')
+            UNTAG_BEFORE=$(date -d "-3 hours" '+%FT%T')
             IMAGE_PATH=gcr.io/mirrornode/hedera-mirror-<< parameters.imagepath >>
             OLD_IMAGES=$(gcloud container images list-tags ${IMAGE_PATH} \
               --limit=1000 \
@@ -71,7 +71,7 @@ commands:
           name: "Deletes old untagged images"
           command: |
             set -x
-            DELETE_BEFORE=$(date -d "-24 hours" '+%FT%T')
+            DELETE_BEFORE=$(date -d "-3 hours" '+%FT%T')
             IMAGE_PATH=gcr.io/mirrornode/hedera-mirror-<< parameters.imagepath >>
             OLD_IMAGES=$(gcloud container images list-tags ${IMAGE_PATH} \
               --limit=1000 \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 
 references:
   workspace_root: &workspace_root /tmp/workspace
@@ -50,29 +50,29 @@ references:
 #          echo OLD_IMAGES: ${OLD_IMAGES}
 #          for digest in $(OLD_IMAGES); do  echo PathToDelete: "${IMAGE_PATH}@${digest}"; done
 
-#commands:
-#  gcloud_image_clean:
-#    description: "Cleans up image under given path"
-#    parameters:
-#      imagepath:
-#        type: string
-#        default: "importer"
-#    steps:
-#      - run:
-#          command: |
-#            DELETE_BEFORE=$(date -d "-14 hours" '+%d-%m-%Y')
-#            IMAGE_PATH=gcr.io/mirrornode/hedera-mirror-<< parameters.imagepath >>
-#            echo IMAGE_PATH: ${IMAGE_PATH}
-#            OLD_IMAGES= gcloud container images list-tags ${IMAGE_PATH} \
-#              --limit=1000 \
-#              --sort-by=TIMESTAMP \
-#              --filter="tags:image* AND timestamp.datetime < '${DELETE_BEFORE}'" \
-#              --format='get(digest)'
-#            echo OLD_IMAGES: ${OLD_IMAGES}
-#            for digest in $(OLD_IMAGES); do  echo PathToDelete: "${IMAGE_PATH}@${digest}"; done
+commands:
+  gcloud_image_clean:
+    description: "Cleans up image under given path"
+    parameters:
+      imagepath:
+        type: string
+        default: "importer"
+    steps:
+      - run:
+          command: |
+            DELETE_BEFORE=$(date -d "-14 hours" '+%d-%m-%Y')
+            IMAGE_PATH=gcr.io/mirrornode/hedera-mirror-<< parameters.imagepath >>
+            echo IMAGE_PATH: ${IMAGE_PATH}
+            OLD_IMAGES= gcloud container images list-tags ${IMAGE_PATH} \
+              --limit=1000 \
+              --sort-by=TIMESTAMP \
+              --filter="tags:image* AND timestamp.datetime < '${DELETE_BEFORE}'" \
+              --format='get(digest)'
+            echo OLD_IMAGES: ${OLD_IMAGES}
+            for digest in $(OLD_IMAGES); do  echo PathToDelete: "${IMAGE_PATH}@${digest}"; done
 
 workflows:
-  version: 2
+  version: 2.1
   main:
     jobs:
       - build_maven:
@@ -307,22 +307,18 @@ jobs:
             IMAGE_PATH_BASE=gcr.io/mirrornode/hedera-mirror-
             GRPC_IMAGE_PATH=${IMAGE_PATH_BASE}grpc
             echo GRPC_IMAGE_PATH: ${GRPC_IMAGE_PATH}
-            GRPC_OLD_IMAGES= gcloud container images list-tags ${GRPC_IMAGE_PATH} \
-              --limit=1000 \
-              --sort-by=TIMESTAMP \
-              --filter="tags:image* AND timestamp.datetime < '${DELETE_BEFORE}'" \
-              --format='get(digest)'
+            GRPC_OLD_IMAGES= gcloud container images list-tags ${GRPC_IMAGE_PATH} --limit=1000 --sort-by=TIMESTAMP --filter="tags:image* AND timestamp.datetime < '${DELETE_BEFORE}'" --format='get(digest)'
             echo GRPC_OLD_IMAGES: ${GRPC_OLD_IMAGES}
             for digest in $(GRPC_OLD_IMAGES); do  echo PathToDelete: "${GRPC_IMAGE_PATH}@${digest}"; done
-#      - <<: *gcloud_image_clean
-#        imagepath: grpc
-#      - <<: *gcloud_image_clean
-#        imagepath: importer
-#      - <<: *gcloud_image_clean
-#        imagepath: rest
-#      - gcloud_image_clean:
-#          imagepath: "grpc"
-#      - gcloud_image_clean:
-#          imagepath: "importer"
-#      - gcloud_image_clean:
-#          imagepath: "rest"
+      #      - <<: *gcloud_image_clean
+      #        imagepath: grpc
+      #      - <<: *gcloud_image_clean
+      #        imagepath: importer
+      #      - <<: *gcloud_image_clean
+      #        imagepath: rest
+      - gcloud_image_clean:
+          imagepath: "grpc"
+      - gcloud_image_clean:
+          imagepath: "importer"
+      - gcloud_image_clean:
+          imagepath: "rest"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ commands:
           name: "Untags old master images"
           command: |
             set -x
-            UNTAG_BEFORE=$(date -d "-7 days" '+%FT%T')
+            UNTAG_BEFORE=$(date -d "-24 hours" '+%FT%T')
             IMAGE_PATH=gcr.io/mirrornode/hedera-mirror-<< parameters.imagepath >>
             OLD_IMAGES=$(gcloud container images list-tags ${IMAGE_PATH} \
               --limit=1000 \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,7 @@ commands:
       - run:
           name: "Clean up old master images"
           command: |
+            echo $0
             DELETE_BEFORE=$(date -d "-14 hours" '+%FT%T')
             echo DELETE_BEFORE: ${DELETE_BEFORE}
             IMAGE_PATH=gcr.io/mirrornode/hedera-mirror-<< parameters.imagepath >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,15 +59,16 @@ commands:
         default: "importer"
     steps:
       - run:
+          description: "Cleans up image under given path"
           command: |
             DELETE_BEFORE=$(date -d "-14 hours" '+%d-%m-%Y')
             IMAGE_PATH=gcr.io/mirrornode/hedera-mirror-<< parameters.imagepath >>
             echo IMAGE_PATH: ${IMAGE_PATH}
-            OLD_IMAGES= gcloud container images list-tags ${IMAGE_PATH} \
+            OLD_IMAGES=$(gcloud container images list-tags ${IMAGE_PATH} \
               --limit=1000 \
               --sort-by=TIMESTAMP \
               --filter="tags:image* AND timestamp.datetime < '${DELETE_BEFORE}'" \
-              --format='get(digest)'
+              --format='get(digest)')
             echo OLD_IMAGES: ${OLD_IMAGES}
             for digest in $(OLD_IMAGES); do  echo PathToDelete: "${IMAGE_PATH}@${digest}"; done
 
@@ -75,48 +76,48 @@ workflows:
   version: 2.1
   main:
     jobs:
-      - build_maven:
-          filters: # required since `release_artifacts` has tag filters AND requires `this`
-            branches:
-              only: /.*/
-            tags:
-              only: /.*/
-      - build_rest:
-          filters: # required since `release_artifacts` has tag filters AND requires `this`
-            branches:
-              only: /.*/
-            tags:
-              only: /.*/
-      - release_artifacts:
-          requires:
-            - build_maven
-            - build_rest
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/
-      - publish_images:
-          requires:
-            - build_maven
-            - build_rest
-          filters:
-            branches:
-              only:
-                - master
-                # image-deploy-cleanup branch present for testing to be removed
-                - image-deploy-cleanup
-            tags:
-              only: /^.*/
-      - perf_maven:
-          filters:
-            branches:
-              only: /.*/
-            tags:
-              only: /.*/
+      #      - build_maven:
+      #          filters: # required since `release_artifacts` has tag filters AND requires `this`
+      #            branches:
+      #              only: /.*/
+      #            tags:
+      #              only: /.*/
+      #      - build_rest:
+      #          filters: # required since `release_artifacts` has tag filters AND requires `this`
+      #            branches:
+      #              only: /.*/
+      #            tags:
+      #              only: /.*/
+      #      - release_artifacts:
+      #          requires:
+      #            - build_maven
+      #            - build_rest
+      #          filters:
+      #            branches:
+      #              ignore: /.*/
+      #            tags:
+      #              only: /^v.*/
+      #      - publish_images:
+      #          requires:
+      #            - build_maven
+      #            - build_rest
+      #          filters:
+      #            branches:
+      #              only:
+      #                - master
+      #                # image-deploy-cleanup branch present for testing to be removed
+      #                - image-deploy-cleanup
+      #            tags:
+      #              only: /^.*/
+      #      - perf_maven:
+      #          filters:
+      #            branches:
+      #              only: /.*/
+      #            tags:
+      #              only: /.*/
       - cleanup_images:
-          requires:
-            - publish_images
+          #          requires:
+          #            - publish_images
           filters:
             branches:
               only:
@@ -307,7 +308,7 @@ jobs:
             IMAGE_PATH_BASE=gcr.io/mirrornode/hedera-mirror-
             GRPC_IMAGE_PATH=${IMAGE_PATH_BASE}grpc
             echo GRPC_IMAGE_PATH: ${GRPC_IMAGE_PATH}
-            GRPC_OLD_IMAGES= gcloud container images list-tags ${GRPC_IMAGE_PATH} --limit=1000 --sort-by=TIMESTAMP --filter="tags:image* AND timestamp.datetime < '${DELETE_BEFORE}'" --format='get(digest)'
+            GRPC_OLD_IMAGES=$(gcloud container images list-tags ${GRPC_IMAGE_PATH} --limit=1000 --sort-by=TIMESTAMP --filter="tags:image* AND timestamp.datetime < '${DELETE_BEFORE}'" --format='get(digest)')
             echo GRPC_OLD_IMAGES: ${GRPC_OLD_IMAGES}
             for digest in $(GRPC_OLD_IMAGES); do  echo PathToDelete: "${GRPC_IMAGE_PATH}@${digest}"; done
       #      - <<: *gcloud_image_clean

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -302,6 +302,8 @@ jobs:
       - run:
           name: Delete old untagged master images
           command: |
+            echo ${GCR_JSON_KEY_FILE} | gcloud auth activate-service-account --key-file=-
+            gcloud --quiet config set project mirrornode
             echo "Remove old untagged grpc master image"
             gcloud container images delete -q --force-delete-tags "gcr.io/mirrornode/hedera-mirror-grpc@sha256:81dfd0bee03dd29f862dbf9cb825cf9af3fdc2d39408a7e7aeba348ad487c1f0"
             echo "Remove old untagged importer master image"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,9 @@ commands:
       - run:
           description: "Cleans up image under given path"
           command: |
+            echo $(gcloud config list)
             DELETE_BEFORE=$(date -d "-14 hours" '+%d-%m-%Y')
+            echo DELETE_BEFORE: ${DELETE_BEFORE}
             IMAGE_PATH=gcr.io/mirrornode/hedera-mirror-<< parameters.imagepath >>
             echo IMAGE_PATH: ${IMAGE_PATH}
             OLD_IMAGES=$(gcloud container images list-tags ${IMAGE_PATH} \
@@ -303,6 +305,7 @@ jobs:
           command: |
             echo ${GCR_JSON_KEY_FILE} | gcloud auth activate-service-account --key-file=-
             gcloud --quiet config set project mirrornode
+            echo $(gcloud config list)
             DELETE_BEFORE=$(date -d "-4 hours" '+%d-%m-%Y %H:%M')
             echo DELETE_BEFORE: ${DELETE_BEFORE}
             IMAGE_PATH_BASE=gcr.io/mirrornode/hedera-mirror-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 
 references:
   workspace_root: &workspace_root /tmp/workspace
@@ -34,24 +34,29 @@ references:
           POSTGRES_DB: mirror_node_test
           POSTGRES_PASSWORD: mirror_node_pass
           POSTGRES_USER: mirror_node
-  gcloud_image_clean: &gcloud_image_clean
-    imagepath: importer
-    run:
-      name: "Cleans up image under given path"
-      command: |
-        DELETE_BEFORE=$(date -d "-14 hours" '+%d-%m-%Y')
-        IMAGE_PATH=gcr.io/mirrornode/hedera-mirror-<< imagepath >>
-        echo IMAGE_PATH: ${IMAGE_PATH}
-        OLD_IMAGES= gcloud container images list-tags ${IMAGE_PATH} \
-          --limit=1000 \
-          --sort-by=TIMESTAMP \
-          --filter="tags:image* AND timestamp.datetime < '${DELETE_BEFORE}'" \
-          --format='get(digest)'
-        echo OLD_IMAGES: ${OLD_IMAGES}
-        for digest in $(OLD_IMAGES); do  echo PathToDelete: "${IMAGE_PATH}@${digest}"; done
+
+commands:
+  gcloud_image_clean:
+    description: "Cleans up image under given path"
+    parameters:
+      imagepath:
+        type: string
+        default: "importer"
+    steps:
+      - run:
+          command: |
+            DELETE_BEFORE=$(date -d "-14 hours" '+%d-%m-%Y')
+            IMAGE_PATH=gcr.io/mirrornode/hedera-mirror-<< parameters.imagepath >>
+            echo IMAGE_PATH: ${IMAGE_PATH}
+            OLD_IMAGES= gcloud container images list-tags ${IMAGE_PATH} \
+              --limit=1000 \
+              --sort-by=TIMESTAMP \
+              --filter="tags:image* AND timestamp.datetime < '${DELETE_BEFORE}'" \
+              --format='get(digest)'
+            echo OLD_IMAGES: ${OLD_IMAGES}
+            for digest in $(OLD_IMAGES); do  echo PathToDelete: "${IMAGE_PATH}@${digest}"; done
 
 workflows:
-  version: 2
   main:
     jobs:
       - build_maven:
@@ -293,9 +298,9 @@ jobs:
               --format='get(digest)'); do \
               ( echo PathToDelete: "${GRPC_IMAGE_PATH}@${digest}" ); \
             done
-      - <<: *gcloud_image_clean
-          imagepath: grpc
-      - <<: *gcloud_image_clean
-          imagepath: importer
-      - <<: *gcloud_image_clean
-          imagepath: rest
+      - gcloud_image_clean:
+          imagepath: "grpc"
+      - gcloud_image_clean:
+          imagepath: "importer"
+      - gcloud_image_clean:
+          imagepath: "rest"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,8 +57,7 @@ commands:
             for image in ${OLD_IMAGES[*]}; do
             (
               IFS=, read digest tag timestamp \<<< ${image}
-              echo Untag image: "${IMAGE_PATH}:${tag} created on ${timestamp} with digest ${digest}"
-              echo Command: gcloud container images untag "${IMAGE_PATH}:${tag}"
+              gcloud container images untag "${IMAGE_PATH}:${tag}"
             )
             done
   gcloud_image_delete:
@@ -82,8 +81,7 @@ commands:
             for image in ${OLD_IMAGES[*]}; do
             (
               IFS=, read digest timestamp \<<< ${image}
-              echo Delete image: "${IMAGE_PATH}@${digest} created on ${timestamp}"
-              echo Command: gcloud container images delete -q "${IMAGE_PATH}@${digest}"
+              gcloud container images delete -q "${IMAGE_PATH}@${digest}"
             )
             done
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,239 +1,273 @@
 version: 2
 
 references:
-  workspace_root: &workspace_root /tmp/workspace
-  attach_workspace: &attach_workspace
-    attach_workspace:
-      at: *workspace_root
-  persist_artifacts: &persist_artifacts
-    persist_to_workspace:
-      root: *workspace_root
-      paths:
-        - artifacts
-  pom_checksum: &pom_checksum
-    run:
-      name: Calculate checksum of all pom.xml
-      command: find . -type f -name "pom.xml" | sort -u | xargs sha512sum > pom.xml.checksum
-  restore_maven_cache: &restore_maven_cache
-    restore_cache:
-      keys:
-        #  Perms on ~/.m2 differ by executor (docker/machine), so {{ arch }} is needed.
-        - maven-v2-{{ arch }}-{{ .Branch }}-{{ checksum "pom.xml.checksum" }}
-        - maven-v2-{{ arch }}-{{ .Branch }}
-        - maven-v2-{{ arch }}-
-  save_maven_cache: &save_maven_cache
-    save_cache:
-      key: maven-v2-{{ arch }}-{{ .Branch }}-{{ checksum "pom.xml.checksum" }}
-      paths:
-        - ~/.m2
-  db_docker: &db_docker
-    docker:
-      - image: adoptopenjdk:11-jdk-hotspot
-      - image: postgres:9.6-alpine
-        environment:
-          POSTGRES_DB: mirror_node_test
-          POSTGRES_PASSWORD: mirror_node_pass
-          POSTGRES_USER: mirror_node
+    workspace_root: &workspace_root /tmp/workspace
+    attach_workspace: &attach_workspace
+        attach_workspace:
+            at: *workspace_root
+    persist_artifacts: &persist_artifacts
+        persist_to_workspace:
+            root: *workspace_root
+            paths:
+                - artifacts
+    pom_checksum: &pom_checksum
+        run:
+            name: Calculate checksum of all pom.xml
+            command: find . -type f -name "pom.xml" | sort -u | xargs sha512sum > pom.xml.checksum
+    restore_maven_cache: &restore_maven_cache
+        restore_cache:
+            keys:
+                #  Perms on ~/.m2 differ by executor (docker/machine), so {{ arch }} is needed.
+                - maven-v2-{{ arch }}-{{ .Branch }}-{{ checksum "pom.xml.checksum" }}
+                - maven-v2-{{ arch }}-{{ .Branch }}
+                - maven-v2-{{ arch }}-
+    save_maven_cache: &save_maven_cache
+        save_cache:
+            key: maven-v2-{{ arch }}-{{ .Branch }}-{{ checksum "pom.xml.checksum" }}
+            paths:
+                - ~/.m2
+    db_docker: &db_docker
+        docker:
+            - image: adoptopenjdk:11-jdk-hotspot
+            - image: postgres:9.6-alpine
+              environment:
+                  POSTGRES_DB: mirror_node_test
+                  POSTGRES_PASSWORD: mirror_node_pass
+                  POSTGRES_USER: mirror_node
 
 workflows:
-  version: 2
-  main:
-    jobs:
-      - build_maven:
-          filters: # required since `release_artifacts` has tag filters AND requires `this`
-            branches:
-              only: /.*/
-            tags:
-              only: /.*/
-      - build_rest:
-          filters: # required since `release_artifacts` has tag filters AND requires `this`
-            branches:
-              only: /.*/
-            tags:
-              only: /.*/
-      - release_artifacts:
-          requires:
-            - build_maven
-            - build_rest
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/
-      - publish_images:
-          requires:
-            - build_maven
-            - build_rest
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^.*/
-      - perf_maven:
-          filters:
-            branches:
-              only: /.*/
-            tags:
-              only: /.*/
+    version: 2
+    main:
+        jobs:
+            - build_maven:
+                  filters: # required since `release_artifacts` has tag filters AND requires `this`
+                      branches:
+                          only: /.*/
+                      tags:
+                          only: /.*/
+            - build_rest:
+                  filters: # required since `release_artifacts` has tag filters AND requires `this`
+                      branches:
+                          only: /.*/
+                      tags:
+                          only: /.*/
+            - release_artifacts:
+                  requires:
+                      - build_maven
+                      - build_rest
+                  filters:
+                      branches:
+                          ignore: /.*/
+                      tags:
+                          only: /^v.*/
+            - publish_images:
+                  requires:
+                      - build_maven
+                      - build_rest
+                  filters:
+                      branches:
+                          only:
+                              - master
+                              # image-deploy-cleanup branch present for testing to be removed
+                              - image-deploy-cleanup
+                      tags:
+                          only: /^.*/
+            - perf_maven:
+                  filters:
+                      branches:
+                          only: /.*/
+                      tags:
+                          only: /.*/
+            - cleanup_images:
+                  requires:
+                      - publish_images
+                  filters:
+                      branches:
+                          only:
+                              - master
+                              # image-deploy-cleanup branch present for testing to be removed
+                              - image-deploy-cleanup
+                      tags:
+                          only: /^.*/
 
 jobs:
-  build_maven:
-    environment:
-      MAVEN_CLI_OPTS: --batch-mode --no-transfer-progress --show-version -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
-    <<: *db_docker
-    steps:
-      - checkout
-      - *pom_checksum
-      - *restore_maven_cache
-      - run:
-          name: Resolve dependencies
-          # See https://issues.apache.org/jira/browse/MDEP-516 for why we don't use maven-dependency-plugin
-          command: ./mvnw ${MAVEN_CLI_OPTS} de.qaware.maven:go-offline-maven-plugin:resolve-dependencies
-      - *save_maven_cache
-      - run:
-          name: Running maven (validate, compile, test, package)
-          command: ./mvnw ${MAVEN_CLI_OPTS} package
-      - store_artifacts:
-          path: hedera-mirror-importer/target/surefire-reports
-          destination: /importer-surefire
-      - store_artifacts:
-          path: hedera-mirror-grpc/target/surefire-reports
-          destination: /grpc-surefire
-      - store_test_results:
-          path: hedera-mirror-importer/target/surefire-reports
-      - run:
-          name: Upload Code Coverage
-          command: bash <(curl -s https://codecov.io/bash)
-      - run:
-          name: Collecting assets for hedera-mirror-grpc
-          command: |
-            set -ex
-            VERSION_TAG=${CIRCLE_TAG/*\//}
-            NAME=hedera-mirror-grpc-${VERSION_TAG:-b$CIRCLE_BUILD_NUM}
-            WORKSPACE=/tmp/workspace
-            mkdir -p ${WORKSPACE}/${NAME}
-            mv hedera-mirror-grpc/target/hedera-mirror-grpc-*-exec.jar ${WORKSPACE}/${NAME}/${NAME}.jar
-            mv hedera-mirror-grpc/scripts ${WORKSPACE}/${NAME}
-            mkdir -p ${WORKSPACE}/artifacts
-            tar -czf ${WORKSPACE}/artifacts/${NAME}.tgz -C ${WORKSPACE} ${NAME}
-      - run:
-          name: Collecting assets for hedera-mirror-importer
-          command: |
-            set -ex
-            VERSION_TAG=${CIRCLE_TAG/*\//}
-            NAME=hedera-mirror-importer-${VERSION_TAG:-b$CIRCLE_BUILD_NUM}
-            WORKSPACE=/tmp/workspace
-            mkdir -p ${WORKSPACE}/${NAME}
-            mv hedera-mirror-importer/target/hedera-mirror-importer-*-exec.jar ${WORKSPACE}/${NAME}/${NAME}.jar
-            mv hedera-mirror-importer/scripts ${WORKSPACE}/${NAME}
-            mkdir -p ${WORKSPACE}/artifacts
-            tar -czf ${WORKSPACE}/artifacts/${NAME}.tgz -C ${WORKSPACE} ${NAME}
-      - *persist_artifacts
-
-  perf_maven:
-    environment:
-      MAVEN_CLI_OPTS: --batch-mode --no-transfer-progress --show-version -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
-    <<: *db_docker
-    steps:
-      - checkout
-      - *pom_checksum
-      - *restore_maven_cache
-      - run:
-          name: Running maven (integration)
-          command: ./mvnw ${MAVEN_CLI_OPTS} integration-test --projects hedera-mirror-importer/ -P performance-test
-      - *save_maven_cache
-      - store_test_results:
-          path: hedera-mirror-importer/target/failsafe-reports
-
-  build_rest:
-    docker:
-      - image: node:12.10.0
-      - image: circleci/postgres:9.6.14
+    build_maven:
         environment:
-          POSTGRES_DB: mirror_node_integration
-          POSTGRES_USER: mirror_node
-          POSTGRES_PASSWORD: mirror_node_pass
-    steps:
-      - checkout:
-      - restore_cache:
-          keys:
-            - npm-v1-{{ .Branch }}-{{ checksum "hedera-mirror-rest/package-lock.json" }}
-            - npm-v1-{{ .Branch }}
-            - npm-v1-
-      - run:
-          working_directory: "hedera-mirror-rest"
-          name: Resolve dependencies
-          command: npm ci
-      - save_cache:
-          key: npm-v1-{{ .Branch }}-{{ checksum "hedera-mirror-rest/package-lock.json" }}
-          paths:
-            - node_modules
-            - .node-flywaydb
-            - ~/.npm
-      - run:
-          working_directory: "hedera-mirror-rest"
-          name: Run npm test
-          command: npm test
-          environment:
-            TEST_DB_HOST: "127.0.0.1"
-            TEST_DB_NAME: "mirror_node_integration"
-      - store_artifacts:
-          path: hedera-mirror-rest/target/jest-junit
-          destination: /rest-jest
-      - store_test_results:
-          path: hedera-mirror-rest/target/jest-junit
-      - run:
-          working_directory: "hedera-mirror-rest"
-          name: Upload Code Coverage
-          command: node_modules/codecov/bin/codecov
-      - run:
-          working_directory: "hedera-mirror-rest"
-          name: Collecting assets
-          command: |
-            set -ex
-            VERSION_TAG=${CIRCLE_TAG/*\//}
-            NAME=hedera-mirror-rest-${VERSION_TAG:-b$CIRCLE_BUILD_NUM}
-            npm pack
-            mkdir -p /tmp/workspace/artifacts
-            mv hedera-mirror-rest*.tgz /tmp/workspace/artifacts/${NAME}.tgz
-      - *persist_artifacts
+            MAVEN_CLI_OPTS: --batch-mode --no-transfer-progress --show-version -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+        <<: *db_docker
+        steps:
+            - checkout
+            - *pom_checksum
+            - *restore_maven_cache
+            - run:
+                  name: Resolve dependencies
+                  # See https://issues.apache.org/jira/browse/MDEP-516 for why we don't use maven-dependency-plugin
+                  command: ./mvnw ${MAVEN_CLI_OPTS} de.qaware.maven:go-offline-maven-plugin:resolve-dependencies
+            - *save_maven_cache
+            - run:
+                  name: Running maven (validate, compile, test, package)
+                  command: ./mvnw ${MAVEN_CLI_OPTS} package
+            - store_artifacts:
+                  path: hedera-mirror-importer/target/surefire-reports
+                  destination: /importer-surefire
+            - store_artifacts:
+                  path: hedera-mirror-grpc/target/surefire-reports
+                  destination: /grpc-surefire
+            - store_test_results:
+                  path: hedera-mirror-importer/target/surefire-reports
+            - run:
+                  name: Upload Code Coverage
+                  command: bash <(curl -s https://codecov.io/bash)
+            - run:
+                  name: Collecting assets for hedera-mirror-grpc
+                  command: |
+                      set -ex
+                      VERSION_TAG=${CIRCLE_TAG/*\//}
+                      NAME=hedera-mirror-grpc-${VERSION_TAG:-b$CIRCLE_BUILD_NUM}
+                      WORKSPACE=/tmp/workspace
+                      mkdir -p ${WORKSPACE}/${NAME}
+                      mv hedera-mirror-grpc/target/hedera-mirror-grpc-*-exec.jar ${WORKSPACE}/${NAME}/${NAME}.jar
+                      mv hedera-mirror-grpc/scripts ${WORKSPACE}/${NAME}
+                      mkdir -p ${WORKSPACE}/artifacts
+                      tar -czf ${WORKSPACE}/artifacts/${NAME}.tgz -C ${WORKSPACE} ${NAME}
+            - run:
+                  name: Collecting assets for hedera-mirror-importer
+                  command: |
+                      set -ex
+                      VERSION_TAG=${CIRCLE_TAG/*\//}
+                      NAME=hedera-mirror-importer-${VERSION_TAG:-b$CIRCLE_BUILD_NUM}
+                      WORKSPACE=/tmp/workspace
+                      mkdir -p ${WORKSPACE}/${NAME}
+                      mv hedera-mirror-importer/target/hedera-mirror-importer-*-exec.jar ${WORKSPACE}/${NAME}/${NAME}.jar
+                      mv hedera-mirror-importer/scripts ${WORKSPACE}/${NAME}
+                      mkdir -p ${WORKSPACE}/artifacts
+                      tar -czf ${WORKSPACE}/artifacts/${NAME}.tgz -C ${WORKSPACE} ${NAME}
+            - *persist_artifacts
 
-  release_artifacts:
-    docker:
-      - image: adoptopenjdk:11-jdk-hotspot
-    steps:
-      - *attach_workspace
-      - store_artifacts:
-          path: /tmp/workspace/artifacts
+    perf_maven:
+        environment:
+            MAVEN_CLI_OPTS: --batch-mode --no-transfer-progress --show-version -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+        <<: *db_docker
+        steps:
+            - checkout
+            - *pom_checksum
+            - *restore_maven_cache
+            - run:
+                  name: Running maven (integration)
+                  command: ./mvnw ${MAVEN_CLI_OPTS} integration-test --projects hedera-mirror-importer/ -P performance-test
+            - *save_maven_cache
+            - store_test_results:
+                  path: hedera-mirror-importer/target/failsafe-reports
 
-  publish_images:
-    machine:
-      image: ubuntu-1604:201903-01
-    environment:
-      MAVEN_CLI_OPTS: --batch-mode --no-transfer-progress --show-version -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
-      JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-      GOOGLE_APPLICATION_CREDENTIALS: json_key_file
-    steps:
-      - checkout
-      - run:
-          name: Install OpenJDK 11
-          command: |
-            sudo add-apt-repository ppa:openjdk-r/ppa \
-            && sudo apt-get update -q \
-            && sudo apt install -y openjdk-11-jdk
-      - run:
-          name: Setup docker-credential-gcr
-          command: |
-            VERSION=2.0.0
-            curl -fsSL "https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v${VERSION}/docker-credential-gcr_linux_amd64-${VERSION}.tar.gz" \
-              | tar xz > docker-credential-gcr
-            sudo mv docker-credential-gcr /usr/bin/docker-credential-gcr
-            chmod +x /usr/bin/docker-credential-gcr
-            echo ${GCR_JSON_KEY_FILE} > json_key_file
-            docker-credential-gcr configure-docker
-      - *pom_checksum
-      - *restore_maven_cache
-      - run:
-          name: Running maven deploy
-          command: ./mvnw ${MAVEN_CLI_OPTS} deploy -DskipTests
-      - *save_maven_cache
+    build_rest:
+        docker:
+            - image: node:12.10.0
+            - image: circleci/postgres:9.6.14
+              environment:
+                  POSTGRES_DB: mirror_node_integration
+                  POSTGRES_USER: mirror_node
+                  POSTGRES_PASSWORD: mirror_node_pass
+        steps:
+            - checkout:
+            - restore_cache:
+                  keys:
+                      - npm-v1-{{ .Branch }}-{{ checksum "hedera-mirror-rest/package-lock.json" }}
+                      - npm-v1-{{ .Branch }}
+                      - npm-v1-
+            - run:
+                  working_directory: "hedera-mirror-rest"
+                  name: Resolve dependencies
+                  command: npm ci
+            - save_cache:
+                  key: npm-v1-{{ .Branch }}-{{ checksum "hedera-mirror-rest/package-lock.json" }}
+                  paths:
+                      - node_modules
+                      - .node-flywaydb
+                      - ~/.npm
+            - run:
+                  working_directory: "hedera-mirror-rest"
+                  name: Run npm test
+                  command: npm test
+                  environment:
+                      TEST_DB_HOST: "127.0.0.1"
+                      TEST_DB_NAME: "mirror_node_integration"
+            - store_artifacts:
+                  path: hedera-mirror-rest/target/jest-junit
+                  destination: /rest-jest
+            - store_test_results:
+                  path: hedera-mirror-rest/target/jest-junit
+            - run:
+                  working_directory: "hedera-mirror-rest"
+                  name: Upload Code Coverage
+                  command: node_modules/codecov/bin/codecov
+            - run:
+                  working_directory: "hedera-mirror-rest"
+                  name: Collecting assets
+                  command: |
+                      set -ex
+                      VERSION_TAG=${CIRCLE_TAG/*\//}
+                      NAME=hedera-mirror-rest-${VERSION_TAG:-b$CIRCLE_BUILD_NUM}
+                      npm pack
+                      mkdir -p /tmp/workspace/artifacts
+                      mv hedera-mirror-rest*.tgz /tmp/workspace/artifacts/${NAME}.tgz
+            - *persist_artifacts
+
+    release_artifacts:
+        docker:
+            - image: adoptopenjdk:11-jdk-hotspot
+        steps:
+            - *attach_workspace
+            - store_artifacts:
+                  path: /tmp/workspace/artifacts
+
+    publish_images:
+        machine:
+            image: ubuntu-1604:201903-01
+        environment:
+            MAVEN_CLI_OPTS: --batch-mode --no-transfer-progress --show-version -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+            JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+            GOOGLE_APPLICATION_CREDENTIALS: json_key_file
+        steps:
+            - checkout
+            - run:
+                  name: Install OpenJDK 11
+                  command: |
+                      sudo add-apt-repository ppa:openjdk-r/ppa \
+                      && sudo apt-get update -q \
+                      && sudo apt install -y openjdk-11-jdk
+            - run:
+                  name: Setup docker-credential-gcr
+                  command: |
+                      VERSION=2.0.0
+                      curl -fsSL "https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v${VERSION}/docker-credential-gcr_linux_amd64-${VERSION}.tar.gz" \
+                        | tar xz > docker-credential-gcr
+                      sudo mv docker-credential-gcr /usr/bin/docker-credential-gcr
+                      chmod +x /usr/bin/docker-credential-gcr
+                      echo ${GCR_JSON_KEY_FILE} > json_key_file
+                      docker-credential-gcr configure-docker
+            - *pom_checksum
+            - *restore_maven_cache
+            - run:
+                  name: Running maven deploy
+                  command: |
+                      DOCKERPUSHTAG=
+                      if [ "$CIRCLE_BRANCH" = "master" -o "$CIRCLE_BRANCH" = "image-deploy-cleanup"]; then
+                          DOCKERPUSHTAG=${$CIRCLE_BRANCH-$CIRCLE_SHA1}
+                      fi
+                      echo ${DOCKERPUSHTAG}
+                      ./mvnw ${MAVEN_CLI_OPTS} deploy -DskipTests -Ddocker.push.tag=${DOCKERPUSHTAG}
+            - *save_maven_cache
+    cleanup_images:
+        machine: true
+        steps:
+            - checkout
+            - run:
+                  name: Delete old images
+                  command: |
+                      echo ${GCR_JSON_KEY_FILE} | gcloud auth activate-service-account --key-file=-
+                      gcloud --quiet config set project mirrornode
+                      DELETE_BEFORE=$(date '+%d-%m-%Y')
+                      echo ${DELETE_BEFORE}
+
+#            gcloud container images delete -q --force-delete-tags $(gcloud container images list-tags gcr.io/mirrornode/hedera-mirror-grpc --limit=1000 --sort-by=TIMESTAMP --filter="tags:master-* AND timestamp.datetime<=2018-01-15" --format='get(digest)')
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,25 +34,21 @@ references:
           POSTGRES_DB: mirror_node_test
           POSTGRES_PASSWORD: mirror_node_pass
           POSTGRES_USER: mirror_node
-  gcloud_image_clean:
-    description: "Cleans up image under given path"
-    parameters:
-      imagepath:
-        type: string
-        default: importer
-      steps:
-        - run:
-            command: |
-              DELETE_BEFORE=$(date -d "-1 hours" '+%d-%m-%Y')
-              IMAGE_PATH=gcr.io/mirrornode/hedera-mirror-<< parameters.imagepath >>
-              echo IMAGE_PATH: ${IMAGE_PATH}
-              for digest in $(gcloud container images list-tags ${IMAGE_PATH} \
-              --limit=1000 \
-              --sort-by=TIMESTAMP \
-              --filter="tags:image* AND timestamp.datetime < '${DELETE_BEFORE}'" \
-              --format='get(digest)'); do \
-              ( gcloud container images delete -q --force-delete-tags "${IMAGE_PATH}@${digest}" )
-              done
+  gcloud_image_clean: &gcloud_image_clean
+    imagepath: importer
+    run:
+      name: "Cleans up image under given path"
+      command: |
+        DELETE_BEFORE=$(date -d "-14 hours" '+%d-%m-%Y')
+        IMAGE_PATH=gcr.io/mirrornode/hedera-mirror-<< imagepath >>
+        echo IMAGE_PATH: ${IMAGE_PATH}
+        OLD_IMAGES= gcloud container images list-tags ${IMAGE_PATH} \
+          --limit=1000 \
+          --sort-by=TIMESTAMP \
+          --filter="tags:image* AND timestamp.datetime < '${DELETE_BEFORE}'" \
+          --format='get(digest)'
+        echo OLD_IMAGES: ${OLD_IMAGES}
+        for digest in $(OLD_IMAGES); do  echo PathToDelete: "${IMAGE_PATH}@${digest}"; done
 
 workflows:
   version: 2
@@ -295,5 +291,11 @@ jobs:
               --sort-by=TIMESTAMP \
               --filter="tags:image* AND timestamp.datetime < '${DELETE_BEFORE}'" \
               --format='get(digest)'); do \
-              ( gcloud container images delete -q --force-delete-tags "${GRPC_IMAGE_PATH}@${digest}" ); \
+              ( echo PathToDelete: "${GRPC_IMAGE_PATH}@${digest}" ); \
             done
+      - <<: *gcloud_image_clean
+          imagepath: grpc
+      - <<: *gcloud_image_clean
+          imagepath: importer
+      - <<: *gcloud_image_clean
+          imagepath: rest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,18 +44,15 @@ references:
         - run:
             command: |
               DELETE_BEFORE=$(date -d "-1 hours" '+%d-%m-%Y')
-              IMAGE_PATH_BASE=gcr.io/mirrornode/hedera-mirror-<< parameters.imagepath >>
-              echo IMAGE_PATH: ${REST_IMAGE_PATH}
-              echo DELETE_BEFORE: ${DELETE_BEFORE}
-              for digest in $(gcloud container images list-tags \
-                ${IMAGE_PATH} --limit=1000 \
-                --sort-by=TIMESTAMP \
-                --filter="tags:image*  AND timestamp.datetime < '${DELETE_BEFORE}'" \
-                --format='get(digest)'); do
-                (
-                  set -x
-                  gcloud container images delete -q --force-delete-tags "${IMAGE_PATH}@${digest}"
-                )
+              IMAGE_PATH=gcr.io/mirrornode/hedera-mirror-<< parameters.imagepath >>
+              echo IMAGE_PATH: ${IMAGE_PATH}
+              for digest in $(gcloud container images list-tags ${IMAGE_PATH} \
+              --limit=1000 \
+              --sort-by=TIMESTAMP \
+              --filter="tags:image* AND timestamp.datetime < '${DELETE_BEFORE}'" \
+              --format='get(digest)'); do \
+              ( gcloud container images delete -q --force-delete-tags "${IMAGE_PATH}@${digest}" )
+              done
 
 workflows:
   version: 2
@@ -293,38 +290,10 @@ jobs:
             IMAGE_PATH_BASE=gcr.io/mirrornode/hedera-mirror-
             GRPC_IMAGE_PATH=${IMAGE_PATH_BASE}grpc
             echo GRPC_IMAGE_PATH: ${GRPC_IMAGE_PATH}
-            for digest in $(gcloud container images list-tags \
-              ${GRPC_IMAGE_PATH} --limit=1000 \
-              --sort-by=TIMESTAMP \
-              --filter="tags:image*  AND timestamp.datetime < '${DELETE_BEFORE}'" \
-              --format='get(digest)'); do \
-              ( gcloud container images delete -q --force-delete-tags "${GRPC_IMAGE_PATH}@${digest}" )
-            done
-            IMPORTER_IMAGE_PATH=${IMAGE_PATH_BASE}importer
-            echo IMPORTER_IMAGE_PATH: ${IMPORTER_IMAGE_PATH}
-            for digest in $(gcloud container images list-tags \
-              ${IMPORTER_IMAGE_PATH} --limit=1000 \
-              --sort-by=TIMESTAMP \
-              --filter="tags:image*  AND timestamp.datetime < '${DELETE_BEFORE}'" \
-              --format='get(digest)'); do \
-              ( gcloud container images delete -q --force-delete-tags "${IMPORTER_IMAGE_PATH}@${digest}" )
-            done
-            REST_IMAGE_PATH=${IMAGE_PATH_BASE}rest
-            echo REST_IMAGE_PATH: ${REST_IMAGE_PATH}
-            for digest in $(gcloud container images list-tags \
-              ${REST_IMAGE_PATH} --limit=1000 \
+            for digest in $(gcloud container images list-tags ${GRPC_IMAGE_PATH} \
+              --limit=1000 \
               --sort-by=TIMESTAMP \
               --filter="tags:image* AND timestamp.datetime < '${DELETE_BEFORE}'" \
               --format='get(digest)'); do \
-              ( gcloud container images delete -q --force-delete-tags "${REST_IMAGE_PATH}@${digest}" )
+              ( gcloud container images delete -q --force-delete-tags "${GRPC_IMAGE_PATH}@${digest}" ); \
             done
-      #            echo GRPC_IMAGES: ${gcloud container images list-tags gcr.io/mirrornode/hedera-mirror-grpc --limit=1000 --sort-by=TIMESTAMP --filter="tags:image*  AND timestamp.datetime < '${DELETE_BEFORE}'" --format='get(digest)'}
-      #            echo IMPORTER_IMAGES: ${gcloud container images list-tags gcr.io/mirrornode/hedera-mirror-importer --limit=1000 --sort-by=TIMESTAMP --filter="tags:image*  AND timestamp.datetime < '${DELETE_BEFORE}'" --format='get(digest)'}
-      #            echo REST_IMAGES: ${gcloud container images list-tags gcr.io/mirrornode/hedera-mirror-rest --limit=1000 --sort-by=TIMESTAMP --filter="tags:image*  AND timestamp.datetime < '${DELETE_BEFORE}'" --format='get(digest)'}
-      #                        gcloud container images delete -q --force-delete-tags $(gcloud container images list-tags gcr.io/mirrornode/hedera-mirror-grpc --limit=1000 --sort-by=TIMESTAMP --filter="tags:image-deploy* AND timestamp.datetime < '${DELETE_BEFORE}'" --format='get(digest)')
-#      - gcloud_image_clean:
-#          imagepath: "grpc"
-#      - gcloud_image_clean:
-#          imagepath: "importer"
-#      - gcloud_image_clean:
-#          imagepath: "rest"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,273 +1,273 @@
 version: 2
 
 references:
-    workspace_root: &workspace_root /tmp/workspace
-    attach_workspace: &attach_workspace
-        attach_workspace:
-            at: *workspace_root
-    persist_artifacts: &persist_artifacts
-        persist_to_workspace:
-            root: *workspace_root
-            paths:
-                - artifacts
-    pom_checksum: &pom_checksum
-        run:
-            name: Calculate checksum of all pom.xml
-            command: find . -type f -name "pom.xml" | sort -u | xargs sha512sum > pom.xml.checksum
-    restore_maven_cache: &restore_maven_cache
-        restore_cache:
-            keys:
-                #  Perms on ~/.m2 differ by executor (docker/machine), so {{ arch }} is needed.
-                - maven-v2-{{ arch }}-{{ .Branch }}-{{ checksum "pom.xml.checksum" }}
-                - maven-v2-{{ arch }}-{{ .Branch }}
-                - maven-v2-{{ arch }}-
-    save_maven_cache: &save_maven_cache
-        save_cache:
-            key: maven-v2-{{ arch }}-{{ .Branch }}-{{ checksum "pom.xml.checksum" }}
-            paths:
-                - ~/.m2
-    db_docker: &db_docker
-        docker:
-            - image: adoptopenjdk:11-jdk-hotspot
-            - image: postgres:9.6-alpine
-              environment:
-                  POSTGRES_DB: mirror_node_test
-                  POSTGRES_PASSWORD: mirror_node_pass
-                  POSTGRES_USER: mirror_node
+  workspace_root: &workspace_root /tmp/workspace
+  attach_workspace: &attach_workspace
+    attach_workspace:
+      at: *workspace_root
+  persist_artifacts: &persist_artifacts
+    persist_to_workspace:
+      root: *workspace_root
+      paths:
+        - artifacts
+  pom_checksum: &pom_checksum
+    run:
+      name: Calculate checksum of all pom.xml
+      command: find . -type f -name "pom.xml" | sort -u | xargs sha512sum > pom.xml.checksum
+  restore_maven_cache: &restore_maven_cache
+    restore_cache:
+      keys:
+        #  Perms on ~/.m2 differ by executor (docker/machine), so {{ arch }} is needed.
+        - maven-v2-{{ arch }}-{{ .Branch }}-{{ checksum "pom.xml.checksum" }}
+        - maven-v2-{{ arch }}-{{ .Branch }}
+        - maven-v2-{{ arch }}-
+  save_maven_cache: &save_maven_cache
+    save_cache:
+      key: maven-v2-{{ arch }}-{{ .Branch }}-{{ checksum "pom.xml.checksum" }}
+      paths:
+        - ~/.m2
+  db_docker: &db_docker
+    docker:
+      - image: adoptopenjdk:11-jdk-hotspot
+      - image: postgres:9.6-alpine
+        environment:
+          POSTGRES_DB: mirror_node_test
+          POSTGRES_PASSWORD: mirror_node_pass
+          POSTGRES_USER: mirror_node
 
 workflows:
-    version: 2
-    main:
-        jobs:
-            - build_maven:
-                  filters: # required since `release_artifacts` has tag filters AND requires `this`
-                      branches:
-                          only: /.*/
-                      tags:
-                          only: /.*/
-            - build_rest:
-                  filters: # required since `release_artifacts` has tag filters AND requires `this`
-                      branches:
-                          only: /.*/
-                      tags:
-                          only: /.*/
-            - release_artifacts:
-                  requires:
-                      - build_maven
-                      - build_rest
-                  filters:
-                      branches:
-                          ignore: /.*/
-                      tags:
-                          only: /^v.*/
-            - publish_images:
-                  requires:
-                      - build_maven
-                      - build_rest
-                  filters:
-                      branches:
-                          only:
-                              - master
-                              # image-deploy-cleanup branch present for testing to be removed
-                              - image-deploy-cleanup
-                      tags:
-                          only: /^.*/
-            - perf_maven:
-                  filters:
-                      branches:
-                          only: /.*/
-                      tags:
-                          only: /.*/
-            - cleanup_images:
-                  requires:
-                      - publish_images
-                  filters:
-                      branches:
-                          only:
-                              - master
-                              # image-deploy-cleanup branch present for testing to be removed
-                              - image-deploy-cleanup
-                      tags:
-                          only: /^.*/
+  version: 2
+  main:
+    jobs:
+      - build_maven:
+          filters: # required since `release_artifacts` has tag filters AND requires `this`
+            branches:
+              only: /.*/
+            tags:
+              only: /.*/
+      - build_rest:
+          filters: # required since `release_artifacts` has tag filters AND requires `this`
+            branches:
+              only: /.*/
+            tags:
+              only: /.*/
+      - release_artifacts:
+          requires:
+            - build_maven
+            - build_rest
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
+      - publish_images:
+          requires:
+            - build_maven
+            - build_rest
+          filters:
+            branches:
+              only:
+                - master
+                # image-deploy-cleanup branch present for testing to be removed
+                - image-deploy-cleanup
+            tags:
+              only: /^.*/
+      - perf_maven:
+          filters:
+            branches:
+              only: /.*/
+            tags:
+              only: /.*/
+      - cleanup_images:
+          requires:
+            - publish_images
+          filters:
+            branches:
+              only:
+                - master
+                # image-deploy-cleanup branch present for testing to be removed
+                - image-deploy-cleanup
+            tags:
+              only: /^.*/
 
 jobs:
-    build_maven:
+  build_maven:
+    environment:
+      MAVEN_CLI_OPTS: --batch-mode --no-transfer-progress --show-version -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+    <<: *db_docker
+    steps:
+      - checkout
+      - *pom_checksum
+      - *restore_maven_cache
+      - run:
+          name: Resolve dependencies
+          # See https://issues.apache.org/jira/browse/MDEP-516 for why we don't use maven-dependency-plugin
+          command: ./mvnw ${MAVEN_CLI_OPTS} de.qaware.maven:go-offline-maven-plugin:resolve-dependencies
+      - *save_maven_cache
+      - run:
+          name: Running maven (validate, compile, test, package)
+          command: ./mvnw ${MAVEN_CLI_OPTS} package
+      - store_artifacts:
+          path: hedera-mirror-importer/target/surefire-reports
+          destination: /importer-surefire
+      - store_artifacts:
+          path: hedera-mirror-grpc/target/surefire-reports
+          destination: /grpc-surefire
+      - store_test_results:
+          path: hedera-mirror-importer/target/surefire-reports
+      - run:
+          name: Upload Code Coverage
+          command: bash <(curl -s https://codecov.io/bash)
+      - run:
+          name: Collecting assets for hedera-mirror-grpc
+          command: |
+            set -ex
+            VERSION_TAG=${CIRCLE_TAG/*\//}
+            NAME=hedera-mirror-grpc-${VERSION_TAG:-b$CIRCLE_BUILD_NUM}
+            WORKSPACE=/tmp/workspace
+            mkdir -p ${WORKSPACE}/${NAME}
+            mv hedera-mirror-grpc/target/hedera-mirror-grpc-*-exec.jar ${WORKSPACE}/${NAME}/${NAME}.jar
+            mv hedera-mirror-grpc/scripts ${WORKSPACE}/${NAME}
+            mkdir -p ${WORKSPACE}/artifacts
+            tar -czf ${WORKSPACE}/artifacts/${NAME}.tgz -C ${WORKSPACE} ${NAME}
+      - run:
+          name: Collecting assets for hedera-mirror-importer
+          command: |
+            set -ex
+            VERSION_TAG=${CIRCLE_TAG/*\//}
+            NAME=hedera-mirror-importer-${VERSION_TAG:-b$CIRCLE_BUILD_NUM}
+            WORKSPACE=/tmp/workspace
+            mkdir -p ${WORKSPACE}/${NAME}
+            mv hedera-mirror-importer/target/hedera-mirror-importer-*-exec.jar ${WORKSPACE}/${NAME}/${NAME}.jar
+            mv hedera-mirror-importer/scripts ${WORKSPACE}/${NAME}
+            mkdir -p ${WORKSPACE}/artifacts
+            tar -czf ${WORKSPACE}/artifacts/${NAME}.tgz -C ${WORKSPACE} ${NAME}
+      - *persist_artifacts
+
+  perf_maven:
+    environment:
+      MAVEN_CLI_OPTS: --batch-mode --no-transfer-progress --show-version -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+    <<: *db_docker
+    steps:
+      - checkout
+      - *pom_checksum
+      - *restore_maven_cache
+      - run:
+          name: Running maven (integration)
+          command: ./mvnw ${MAVEN_CLI_OPTS} integration-test --projects hedera-mirror-importer/ -P performance-test
+      - *save_maven_cache
+      - store_test_results:
+          path: hedera-mirror-importer/target/failsafe-reports
+
+  build_rest:
+    docker:
+      - image: node:12.10.0
+      - image: circleci/postgres:9.6.14
         environment:
-            MAVEN_CLI_OPTS: --batch-mode --no-transfer-progress --show-version -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
-        <<: *db_docker
-        steps:
-            - checkout
-            - *pom_checksum
-            - *restore_maven_cache
-            - run:
-                  name: Resolve dependencies
-                  # See https://issues.apache.org/jira/browse/MDEP-516 for why we don't use maven-dependency-plugin
-                  command: ./mvnw ${MAVEN_CLI_OPTS} de.qaware.maven:go-offline-maven-plugin:resolve-dependencies
-            - *save_maven_cache
-            - run:
-                  name: Running maven (validate, compile, test, package)
-                  command: ./mvnw ${MAVEN_CLI_OPTS} package
-            - store_artifacts:
-                  path: hedera-mirror-importer/target/surefire-reports
-                  destination: /importer-surefire
-            - store_artifacts:
-                  path: hedera-mirror-grpc/target/surefire-reports
-                  destination: /grpc-surefire
-            - store_test_results:
-                  path: hedera-mirror-importer/target/surefire-reports
-            - run:
-                  name: Upload Code Coverage
-                  command: bash <(curl -s https://codecov.io/bash)
-            - run:
-                  name: Collecting assets for hedera-mirror-grpc
-                  command: |
-                      set -ex
-                      VERSION_TAG=${CIRCLE_TAG/*\//}
-                      NAME=hedera-mirror-grpc-${VERSION_TAG:-b$CIRCLE_BUILD_NUM}
-                      WORKSPACE=/tmp/workspace
-                      mkdir -p ${WORKSPACE}/${NAME}
-                      mv hedera-mirror-grpc/target/hedera-mirror-grpc-*-exec.jar ${WORKSPACE}/${NAME}/${NAME}.jar
-                      mv hedera-mirror-grpc/scripts ${WORKSPACE}/${NAME}
-                      mkdir -p ${WORKSPACE}/artifacts
-                      tar -czf ${WORKSPACE}/artifacts/${NAME}.tgz -C ${WORKSPACE} ${NAME}
-            - run:
-                  name: Collecting assets for hedera-mirror-importer
-                  command: |
-                      set -ex
-                      VERSION_TAG=${CIRCLE_TAG/*\//}
-                      NAME=hedera-mirror-importer-${VERSION_TAG:-b$CIRCLE_BUILD_NUM}
-                      WORKSPACE=/tmp/workspace
-                      mkdir -p ${WORKSPACE}/${NAME}
-                      mv hedera-mirror-importer/target/hedera-mirror-importer-*-exec.jar ${WORKSPACE}/${NAME}/${NAME}.jar
-                      mv hedera-mirror-importer/scripts ${WORKSPACE}/${NAME}
-                      mkdir -p ${WORKSPACE}/artifacts
-                      tar -czf ${WORKSPACE}/artifacts/${NAME}.tgz -C ${WORKSPACE} ${NAME}
-            - *persist_artifacts
+          POSTGRES_DB: mirror_node_integration
+          POSTGRES_USER: mirror_node
+          POSTGRES_PASSWORD: mirror_node_pass
+    steps:
+      - checkout:
+      - restore_cache:
+          keys:
+            - npm-v1-{{ .Branch }}-{{ checksum "hedera-mirror-rest/package-lock.json" }}
+            - npm-v1-{{ .Branch }}
+            - npm-v1-
+      - run:
+          working_directory: "hedera-mirror-rest"
+          name: Resolve dependencies
+          command: npm ci
+      - save_cache:
+          key: npm-v1-{{ .Branch }}-{{ checksum "hedera-mirror-rest/package-lock.json" }}
+          paths:
+            - node_modules
+            - .node-flywaydb
+            - ~/.npm
+      - run:
+          working_directory: "hedera-mirror-rest"
+          name: Run npm test
+          command: npm test
+          environment:
+            TEST_DB_HOST: "127.0.0.1"
+            TEST_DB_NAME: "mirror_node_integration"
+      - store_artifacts:
+          path: hedera-mirror-rest/target/jest-junit
+          destination: /rest-jest
+      - store_test_results:
+          path: hedera-mirror-rest/target/jest-junit
+      - run:
+          working_directory: "hedera-mirror-rest"
+          name: Upload Code Coverage
+          command: node_modules/codecov/bin/codecov
+      - run:
+          working_directory: "hedera-mirror-rest"
+          name: Collecting assets
+          command: |
+            set -ex
+            VERSION_TAG=${CIRCLE_TAG/*\//}
+            NAME=hedera-mirror-rest-${VERSION_TAG:-b$CIRCLE_BUILD_NUM}
+            npm pack
+            mkdir -p /tmp/workspace/artifacts
+            mv hedera-mirror-rest*.tgz /tmp/workspace/artifacts/${NAME}.tgz
+      - *persist_artifacts
+            
+  release_artifacts:
+    docker:
+      - image: adoptopenjdk:11-jdk-hotspot
+    steps:
+      - *attach_workspace
+      - store_artifacts:
+          path: /tmp/workspace/artifacts
 
-    perf_maven:
-        environment:
-            MAVEN_CLI_OPTS: --batch-mode --no-transfer-progress --show-version -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
-        <<: *db_docker
-        steps:
-            - checkout
-            - *pom_checksum
-            - *restore_maven_cache
-            - run:
-                  name: Running maven (integration)
-                  command: ./mvnw ${MAVEN_CLI_OPTS} integration-test --projects hedera-mirror-importer/ -P performance-test
-            - *save_maven_cache
-            - store_test_results:
-                  path: hedera-mirror-importer/target/failsafe-reports
-
-    build_rest:
-        docker:
-            - image: node:12.10.0
-            - image: circleci/postgres:9.6.14
-              environment:
-                  POSTGRES_DB: mirror_node_integration
-                  POSTGRES_USER: mirror_node
-                  POSTGRES_PASSWORD: mirror_node_pass
-        steps:
-            - checkout:
-            - restore_cache:
-                  keys:
-                      - npm-v1-{{ .Branch }}-{{ checksum "hedera-mirror-rest/package-lock.json" }}
-                      - npm-v1-{{ .Branch }}
-                      - npm-v1-
-            - run:
-                  working_directory: "hedera-mirror-rest"
-                  name: Resolve dependencies
-                  command: npm ci
-            - save_cache:
-                  key: npm-v1-{{ .Branch }}-{{ checksum "hedera-mirror-rest/package-lock.json" }}
-                  paths:
-                      - node_modules
-                      - .node-flywaydb
-                      - ~/.npm
-            - run:
-                  working_directory: "hedera-mirror-rest"
-                  name: Run npm test
-                  command: npm test
-                  environment:
-                      TEST_DB_HOST: "127.0.0.1"
-                      TEST_DB_NAME: "mirror_node_integration"
-            - store_artifacts:
-                  path: hedera-mirror-rest/target/jest-junit
-                  destination: /rest-jest
-            - store_test_results:
-                  path: hedera-mirror-rest/target/jest-junit
-            - run:
-                  working_directory: "hedera-mirror-rest"
-                  name: Upload Code Coverage
-                  command: node_modules/codecov/bin/codecov
-            - run:
-                  working_directory: "hedera-mirror-rest"
-                  name: Collecting assets
-                  command: |
-                      set -ex
-                      VERSION_TAG=${CIRCLE_TAG/*\//}
-                      NAME=hedera-mirror-rest-${VERSION_TAG:-b$CIRCLE_BUILD_NUM}
-                      npm pack
-                      mkdir -p /tmp/workspace/artifacts
-                      mv hedera-mirror-rest*.tgz /tmp/workspace/artifacts/${NAME}.tgz
-            - *persist_artifacts
-
-    release_artifacts:
-        docker:
-            - image: adoptopenjdk:11-jdk-hotspot
-        steps:
-            - *attach_workspace
-            - store_artifacts:
-                  path: /tmp/workspace/artifacts
-
-    publish_images:
-        machine:
-            image: ubuntu-1604:201903-01
-        environment:
-            MAVEN_CLI_OPTS: --batch-mode --no-transfer-progress --show-version -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
-            JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-            GOOGLE_APPLICATION_CREDENTIALS: json_key_file
-        steps:
-            - checkout
-            - run:
-                  name: Install OpenJDK 11
-                  command: |
-                      sudo add-apt-repository ppa:openjdk-r/ppa \
-                      && sudo apt-get update -q \
-                      && sudo apt install -y openjdk-11-jdk
-            - run:
-                  name: Setup docker-credential-gcr
-                  command: |
-                      VERSION=2.0.0
-                      curl -fsSL "https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v${VERSION}/docker-credential-gcr_linux_amd64-${VERSION}.tar.gz" \
-                        | tar xz > docker-credential-gcr
-                      sudo mv docker-credential-gcr /usr/bin/docker-credential-gcr
-                      chmod +x /usr/bin/docker-credential-gcr
-                      echo ${GCR_JSON_KEY_FILE} > json_key_file
-                      docker-credential-gcr configure-docker
-            - *pom_checksum
-            - *restore_maven_cache
-            - run:
-                  name: Running maven deploy
-                  command: |
-                      DOCKERPUSHTAG=
-                      if [ "$CIRCLE_BRANCH" = "master" -o "$CIRCLE_BRANCH" = "image-deploy-cleanup"]; then
-                          DOCKERPUSHTAG=${$CIRCLE_BRANCH-$CIRCLE_SHA1}
-                      fi
-                      echo ${DOCKERPUSHTAG}
-                      ./mvnw ${MAVEN_CLI_OPTS} deploy -DskipTests -Dcircle.docker.tag=${DOCKERPUSHTAG}
-            - *save_maven_cache
-    cleanup_images:
-        machine: true
-        steps:
-            - checkout
-            - run:
-                  name: Delete old images
-                  command: |
-                      echo ${GCR_JSON_KEY_FILE} | gcloud auth activate-service-account --key-file=-
-                      gcloud --quiet config set project mirrornode
-                      DELETE_BEFORE=$(date '+%d-%m-%Y')
-                      echo ${DELETE_BEFORE}
+  publish_images:
+    machine:
+      image: ubuntu-1604:201903-01
+    environment:
+      MAVEN_CLI_OPTS: --batch-mode --no-transfer-progress --show-version -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+      JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+      GOOGLE_APPLICATION_CREDENTIALS: json_key_file
+    steps:
+      - checkout
+      - run:
+          name: Install OpenJDK 11
+          command: |
+            sudo add-apt-repository ppa:openjdk-r/ppa \
+            && sudo apt-get update -q \
+            && sudo apt install -y openjdk-11-jdk
+      - run:
+          name: Setup docker-credential-gcr
+          command: |
+            VERSION=2.0.0
+            curl -fsSL "https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v${VERSION}/docker-credential-gcr_linux_amd64-${VERSION}.tar.gz" \
+              | tar xz > docker-credential-gcr
+            sudo mv docker-credential-gcr /usr/bin/docker-credential-gcr
+            chmod +x /usr/bin/docker-credential-gcr
+            echo ${GCR_JSON_KEY_FILE} > json_key_file
+            docker-credential-gcr configure-docker
+      - *pom_checksum
+      - *restore_maven_cache
+      - run:
+          name: Running maven deploy
+          command: |
+            DOCKERPUSHTAG=
+            if [ "$CIRCLE_BRANCH" = "master" -o "$CIRCLE_BRANCH" = "image-deploy-cleanup" ]; then
+                DOCKERPUSHTAG=${$CIRCLE_BRANCH-$CIRCLE_SHA1}
+            fi
+            echo ${DOCKERPUSHTAG}
+            ./mvnw ${MAVEN_CLI_OPTS} deploy -DskipTests -Dcircle.docker.tag=${DOCKERPUSHTAG}
+      - *save_maven_cache
+  cleanup_images:
+    machine: true
+    steps:
+      - checkout
+      - run:
+          name: Delete old images
+          command: |
+            echo ${GCR_JSON_KEY_FILE} | gcloud auth activate-service-account --key-file=-
+            gcloud --quiet config set project mirrornode
+            DELETE_BEFORE=$(date '+%d-%m-%Y')
+            echo ${DELETE_BEFORE}
 
 #            gcloud container images delete -q --force-delete-tags $(gcloud container images list-tags gcr.io/mirrornode/hedera-mirror-grpc --limit=1000 --sort-by=TIMESTAMP --filter="tags:master-* AND timestamp.datetime<=2018-01-15" --format='get(digest)')
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,11 +53,13 @@ commands:
             OLD_IMAGES=$(gcloud container images list-tags ${IMAGE_PATH} \
               --limit=1000 \
               --sort-by=TIMESTAMP \
-              --filter="tags:image* AND timestamp.datetime < '${DELETE_BEFORE}'")
+              --filter="tags:image* AND timestamp.datetime < '${DELETE_BEFORE}'" \
+              --format="get(digest)")
             echo OLD_IMAGES: ${OLD_IMAGES}
             for digest in ${OLD_IMAGES[*]}; do
             (
-              echo image: "${digest}"
+              echo Delete image: "${IMAGE_PATH}@${digest}"
+              gcloud container images delete -q --force-delete-tags "${IMAGE_PATH}@${digest}"
             )
             done
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ commands:
           name: "Clean up old master images"
           command: |
             echo $0
-            DELETE_BEFORE=$(date -d "-14 hours" '+%FT%T')
+            DELETE_BEFORE=$(date -d "-7 days" '+%FT%T')
             echo DELETE_BEFORE: ${DELETE_BEFORE}
             IMAGE_PATH=gcr.io/mirrornode/hedera-mirror-<< parameters.imagepath >>
             echo IMAGE_PATH: ${IMAGE_PATH}
@@ -56,25 +56,7 @@ commands:
               --sort-by=TIMESTAMP \
               --filter="tags:image-* AND timestamp.datetime < '${DELETE_BEFORE}'" \
               --format="csv[no-heading](digest,timestamp)")
-            echo OLD_IMAGES 1: ${OLD_IMAGES}
-            OLD_IMAGES_2=$(gcloud container images list-tags ${IMAGE_PATH} \
-              --limit=1000 \
-              --sort-by=TIMESTAMP \
-              --filter="tags:image-* AND timestamp < '${DELETE_BEFORE}'" \
-              --format="csv[no-heading](digest,timestamp)")
-            echo OLD_IMAGES 2: ${OLD_IMAGES_2}
-            OLD_IMAGES_3=$(gcloud container images list-tags ${IMAGE_PATH} \
-              --limit=1000 \
-              --sort-by=TIMESTAMP \
-              --filter="tags:image-* AND timestamp < {DELETE_BEFORE}" \
-              --format="csv[no-heading](digest,timestamp)")
-            echo OLD_IMAGES 3: ${OLD_IMAGES_3}
-            OLD_IMAGES_4=$(gcloud container images list-tags ${IMAGE_PATH} \
-              --limit=1000 \
-              --sort-by=TIMESTAMP \
-              --filter="tags:image-* AND timestamp < {DELETE_BEFORE}" \
-              --format="csv[no-heading](digest,timestamp.datetime)")
-            echo OLD_IMAGES 4: ${OLD_IMAGES_4}
+            echo OLD_IMAGES: ${OLD_IMAGES}
             for image in ${OLD_IMAGES[*]}; do
             (
               IFS=, read digest timestamp \<<< ${image}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ commands:
           name: "Deletes old untagged images"
           command: |
             set -x
-            DELETE_BEFORE=$(date -d "-7 days" '+%FT%T')
+            DELETE_BEFORE=$(date -d "-24 hours" '+%FT%T')
             IMAGE_PATH=gcr.io/mirrornode/hedera-mirror-<< parameters.imagepath >>
             OLD_IMAGES=$(gcloud container images list-tags ${IMAGE_PATH} \
               --limit=1000 \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,14 +47,14 @@ commands:
           name: "Clean up old master images"
           command: |
             echo $0
-            DELETE_BEFORE=$(date -d "-2 days" '+%FT%T')
+            DELETE_BEFORE=$(date -d "-7 days" '+%FT%T')
             echo DELETE_BEFORE: ${DELETE_BEFORE}
             IMAGE_PATH=gcr.io/mirrornode/hedera-mirror-<< parameters.imagepath >>
             echo IMAGE_PATH: ${IMAGE_PATH}
             OLD_IMAGES=$(gcloud container images list-tags ${IMAGE_PATH} \
               --limit=1000 \
               --sort-by=TIMESTAMP \
-              --filter="tags:image-* AND timestamp.datetime < '${DELETE_BEFORE}'" \
+              --filter="tags:master-* AND timestamp.datetime < '${DELETE_BEFORE}'" \
               --format="csv[no-heading](digest,timestamp)")
             echo OLD_IMAGES: ${OLD_IMAGES}
             for image in ${OLD_IMAGES[*]}; do
@@ -98,8 +98,6 @@ workflows:
             branches:
               only:
                 - master
-                # image-deploy-cleanup branch present for testing to be removed
-                - image-deploy-cleanup
             tags:
               only: /^.*/
       - perf_maven:
@@ -115,8 +113,6 @@ workflows:
             branches:
               only:
                 - master
-                # image-deploy-cleanup branch present for testing to be removed
-                - image-deploy-cleanup
             tags:
               only: /^.*/
 
@@ -281,7 +277,7 @@ jobs:
           name: Running maven deploy
           command: |
             DOCKERPUSHTAG=
-            if [ "$CIRCLE_BRANCH" = "master" -o "$CIRCLE_BRANCH" = "image-deploy-cleanup" ]; then
+            if [ "$CIRCLE_BRANCH" = "master" ]; then
                 DOCKERPUSHTAG=${CIRCLE_BRANCH}-${CIRCLE_SHA1}
             fi
             echo DOCKERPUSHTAG: ${DOCKERPUSHTAG}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,11 @@ commands:
             echo DELETE_BEFORE: ${DELETE_BEFORE}
             IMAGE_PATH=gcr.io/mirrornode/hedera-mirror-<< parameters.imagepath >>
             echo IMAGE_PATH: ${IMAGE_PATH}
+            echo List tags command: gcloud container images list-tags ${IMAGE_PATH} \
+              --limit=1000 \
+              --sort-by=TIMESTAMP \
+              --filter="'tags:image* AND timestamp.datetime < ${DELETE_BEFORE}'" \
+              --format="'get(digest)'"
             OLD_IMAGES=$(gcloud container images list-tags ${IMAGE_PATH} \
               --limit=1000 \
               --sort-by=TIMESTAMP \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ commands:
             OLD_IMAGES=$(gcloud container images list-tags ${IMAGE_PATH} \
               --limit=1000 \
               --sort-by=TIMESTAMP \
-              --filter="tags:master-* AND timestamp.datetime < '${UNTAG_BEFORE}'" \
+              --filter="tags:image-* AND timestamp.datetime < '${UNTAG_BEFORE}'" \
               --format="csv[no-heading](digest,tags,timestamp)")
             for image in ${OLD_IMAGES[*]}; do
             (

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ commands:
       - run:
           name: "Clean up old master images"
           command: |
-            DELETE_BEFORE=$(date --utc -d "-14 hours" '+%FT%T')
+            DELETE_BEFORE=$(date -d "-14 hours" '+%FT%T')
             echo DELETE_BEFORE: ${DELETE_BEFORE}
             IMAGE_PATH=gcr.io/mirrornode/hedera-mirror-<< parameters.imagepath >>
             echo IMAGE_PATH: ${IMAGE_PATH}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ commands:
       - run:
           name: "Clean up old master images"
           command: |
-            DELETE_BEFORE=$(date --utc -d "-4 hours" '+%FT%TZ')
+            DELETE_BEFORE=$(date --utc -d "-14 hours" '+%FT%TZ')
             echo DELETE_BEFORE: ${DELETE_BEFORE}
             IMAGE_PATH=gcr.io/mirrornode/hedera-mirror-<< parameters.imagepath >>
             echo IMAGE_PATH: ${IMAGE_PATH}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ commands:
       - run:
           name: "Cleans up old master images"
           command: |
-            DELETE_BEFORE=$(date --utc -d "-2 hours" '+%FT%TZ')
+            DELETE_BEFORE=$(date --utc -d "-4 hours" '+%FT%TZ')
             echo DELETE_BEFORE: ${DELETE_BEFORE}
             IMAGE_PATH=gcr.io/mirrornode/hedera-mirror-<< parameters.imagepath >>
             echo IMAGE_PATH: ${IMAGE_PATH}
@@ -58,7 +58,7 @@ commands:
             OLD_IMAGES=$(gcloud container images list-tags ${IMAGE_PATH} \
               --limit=1000 \
               --sort-by=TIMESTAMP \
-              --filter="tags:image* AND timestamp.datetime < ${DELETE_BEFORE}" \
+              --filter="tags:image* AND timestamp.datetime < '${DELETE_BEFORE}'" \
               --format="get(digest)")
             for digest in ${OLD_IMAGES[*]}; do
             (

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,28 @@ references:
           POSTGRES_DB: mirror_node_test
           POSTGRES_PASSWORD: mirror_node_pass
           POSTGRES_USER: mirror_node
+  gcloud_image_clean:
+    description: "Cleans up image under given path"
+    parameters:
+      imagepath:
+        type: string
+        default: importer
+      steps:
+        - run:
+            command: |
+              DELETE_BEFORE=$(date -d "-1 hours" '+%d-%m-%Y')
+              IMAGE_PATH_BASE=gcr.io/mirrornode/hedera-mirror-<< parameters.imagepath >>
+              echo IMAGE_PATH: ${REST_IMAGE_PATH}
+              echo DELETE_BEFORE: ${DELETE_BEFORE}
+              for digest in $(gcloud container images list-tags \
+                ${IMAGE_PATH} --limit=1000 \
+                --sort-by=TIMESTAMP \
+                --filter="tags:image*  AND timestamp.datetime < '${DELETE_BEFORE}'" \
+                --format='get(digest)'); do
+                (
+                  set -x
+                  gcloud container images delete -q --force-delete-tags "${IMAGE_PATH}@${digest}"
+                )
 
 workflows:
   version: 2
@@ -262,21 +284,56 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Delete old images
+          name: Delete old master images
           command: |
             echo ${GCR_JSON_KEY_FILE} | gcloud auth activate-service-account --key-file=-
             gcloud --quiet config set project mirrornode
-            DELETE_BEFORE=$(date -d "-30 minutes" '+%d-%m-%Y')
+            DELETE_BEFORE=$(date -d "-2 hours" '+%d-%m-%Y')
             echo DELETE_BEFORE: ${DELETE_BEFORE}
+            IMAGE_PATH_BASE=gcr.io/mirrornode/hedera-mirror-
+            GRPC_IMAGE_PATH=${IMAGE_PATH_BASE}grpc
+            echo GRPC_IMAGE_PATH: ${GRPC_IMAGE_PATH}
             for digest in $(gcloud container images list-tags \
-              gcr.io/mirrornode/hedera-mirror-grpc --limit=1000 \
+              ${GRPC_IMAGE_PATH} --limit=1000 \
               --sort-by=TIMESTAMP \
               --filter="tags:image*  AND timestamp.datetime < '${DELETE_BEFORE}'" \
-              --format='get(digest)'; do
-                gcloud container images delete -q --force-delete-tags "gcr.io/mirrornode@${digest}"
+              --format='get(digest)'); do
+              (
+                set -x
+                gcloud container images delete -q --force-delete-tags "${GRPC_IMAGE_PATH}@${digest}"
+              )
             done
-            echo GRPC_IMAGES: ${gcloud container images list-tags gcr.io/mirrornode/hedera-mirror-grpc --limit=1000 --sort-by=TIMESTAMP --filter="tags:image*  AND timestamp.datetime < '${DELETE_BEFORE}'" --format='get(digest)'}
-            echo IMPORTER_IMAGES: ${gcloud container images list-tags gcr.io/mirrornode/hedera-mirror-importer --limit=1000 --sort-by=TIMESTAMP --filter="tags:image*  AND timestamp.datetime < '${DELETE_BEFORE}'" --format='get(digest)'}
-            echo REST_IMAGES: ${gcloud container images list-tags gcr.io/mirrornode/hedera-mirror-rest --limit=1000 --sort-by=TIMESTAMP --filter="tags:image*  AND timestamp.datetime < '${DELETE_BEFORE}'" --format='get(digest)'}
-#                        gcloud container images delete -q --force-delete-tags $(gcloud container images list-tags gcr.io/mirrornode/hedera-mirror-grpc --limit=1000 --sort-by=TIMESTAMP --filter="tags:image-deploy* AND timestamp.datetime < '${DELETE_BEFORE}'" --format='get(digest)')
-
+            IMPORTER_IMAGE_PATH=${IMAGE_PATH_BASE}importer
+            echo IMPORTER_IMAGE_PATH: ${IMPORTER_IMAGE_PATH}
+            for digest in $(gcloud container images list-tags \
+              ${IMPORTER_IMAGE_PATH} --limit=1000 \
+              --sort-by=TIMESTAMP \
+              --filter="tags:image*  AND timestamp.datetime < '${DELETE_BEFORE}'" \
+              --format='get(digest)'); do
+              (
+                set -x
+                gcloud container images delete -q --force-delete-tags "${IMPORTER_IMAGE_PATH}@${digest}"
+              )
+            done
+            REST_IMAGE_PATH=${IMAGE_PATH_BASE}rest
+            echo REST_IMAGE_PATH: ${REST_IMAGE_PATH}
+            for digest in $(gcloud container images list-tags \
+              ${REST_IMAGE_PATH} --limit=1000 \
+              --sort-by=TIMESTAMP \
+              --filter="tags:image*  AND timestamp.datetime < '${DELETE_BEFORE}'" \
+              --format='get(digest)'); do
+              (
+                set -x
+                gcloud container images delete -q --force-delete-tags "${REST_IMAGE_PATH}@${digest}"
+              )
+            done
+      #            echo GRPC_IMAGES: ${gcloud container images list-tags gcr.io/mirrornode/hedera-mirror-grpc --limit=1000 --sort-by=TIMESTAMP --filter="tags:image*  AND timestamp.datetime < '${DELETE_BEFORE}'" --format='get(digest)'}
+      #            echo IMPORTER_IMAGES: ${gcloud container images list-tags gcr.io/mirrornode/hedera-mirror-importer --limit=1000 --sort-by=TIMESTAMP --filter="tags:image*  AND timestamp.datetime < '${DELETE_BEFORE}'" --format='get(digest)'}
+      #            echo REST_IMAGES: ${gcloud container images list-tags gcr.io/mirrornode/hedera-mirror-rest --limit=1000 --sort-by=TIMESTAMP --filter="tags:image*  AND timestamp.datetime < '${DELETE_BEFORE}'" --format='get(digest)'}
+      #                        gcloud container images delete -q --force-delete-tags $(gcloud container images list-tags gcr.io/mirrornode/hedera-mirror-grpc --limit=1000 --sort-by=TIMESTAMP --filter="tags:image-deploy* AND timestamp.datetime < '${DELETE_BEFORE}'" --format='get(digest)')
+#      - gcloud_image_clean:
+#          imagepath: "grpc"
+#      - gcloud_image_clean:
+#          imagepath: "importer"
+#      - gcloud_image_clean:
+#          imagepath: "rest"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,8 +79,8 @@ workflows:
             tags:
               only: /.*/
       - cleanup_images:
-          requires:
-            - publish_images
+          #          requires:
+          #            - publish_images
           filters:
             branches:
               only:
@@ -211,7 +211,7 @@ jobs:
             mkdir -p /tmp/workspace/artifacts
             mv hedera-mirror-rest*.tgz /tmp/workspace/artifacts/${NAME}.tgz
       - *persist_artifacts
-            
+
   release_artifacts:
     docker:
       - image: adoptopenjdk:11-jdk-hotspot
@@ -252,7 +252,7 @@ jobs:
           command: |
             DOCKERPUSHTAG=
             if [ "$CIRCLE_BRANCH" = "master" -o "$CIRCLE_BRANCH" = "image-deploy-cleanup" ]; then
-                DOCKERPUSHTAG=${$CIRCLE_BRANCH-$CIRCLE_SHA1}
+                DOCKERPUSHTAG=${CIRCLE_BRANCH}-${CIRCLE_SHA1}
             fi
             echo ${DOCKERPUSHTAG}
             ./mvnw ${MAVEN_CLI_OPTS} deploy -DskipTests -Dcircle.docker.tag=${DOCKERPUSHTAG}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,12 +54,13 @@ commands:
               --limit=1000 \
               --sort-by=TIMESTAMP \
               --filter="tags:image* AND timestamp.datetime < '${DELETE_BEFORE}'" \
-              --format="get(digest)")
+              --format="[csv[no-heading](digest,timestamp)]")
             echo OLD_IMAGES: ${OLD_IMAGES}
-            for digest in ${OLD_IMAGES[*]}; do
+            for image in ${OLD_IMAGES[*]}; do
             (
-              echo Delete image: "${IMAGE_PATH}@${digest}"
-              gcloud container images delete -q --force-delete-tags "${IMAGE_PATH}@${digest}"
+              IFS=, read digest timestamp <<< ${image}
+              echo Delete image: "${IMAGE_PATH}@${digest} created on ${timestamp}"
+              echo Command: gcloud container images delete -q --force-delete-tags "${IMAGE_PATH}@${digest}"
             )
             done
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ commands:
       - run:
           name: "Cleans up old master images"
           command: |
-            DELETE_BEFORE=$(date --utc -d "-1 hours" '+%FT%TZ')
+            DELETE_BEFORE=$(date --utc -d "-2 hours" '+%FT%TZ')
             echo DELETE_BEFORE: ${DELETE_BEFORE}
             IMAGE_PATH=gcr.io/mirrornode/hedera-mirror-<< parameters.imagepath >>
             echo IMAGE_PATH: ${IMAGE_PATH}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ commands:
             for image in ${OLD_IMAGES[*]}; do
             (
               IFS=, read digest tag timestamp \<<< ${image}
-              gcloud container images untag "${IMAGE_PATH}:${tag}"
+              gcloud container images untag -q "${IMAGE_PATH}:${tag}"
             )
             done
   gcloud_image_delete:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,15 +36,40 @@ references:
           POSTGRES_USER: mirror_node
 
 commands:
-  gcloud_image_clean:
-    description: "Cleans up old master images"
+  gcloud_image_untag:
+    description: "Untags old master images"
     parameters:
       imagepath:
         type: string
         default: "importer"
     steps:
       - run:
-          name: "Clean up old master images"
+          name: "Untags old master images"
+          command: |
+            set -x
+            UNTAG_BEFORE=$(date -d "-7 days" '+%FT%T')
+            IMAGE_PATH=gcr.io/mirrornode/hedera-mirror-<< parameters.imagepath >>
+            OLD_IMAGES=$(gcloud container images list-tags ${IMAGE_PATH} \
+              --limit=1000 \
+              --sort-by=TIMESTAMP \
+              --filter="tags:master-* AND timestamp.datetime < '${UNTAG_BEFORE}'" \
+              --format="csv[no-heading](digest,tags,timestamp)")
+            for image in ${OLD_IMAGES[*]}; do
+            (
+              IFS=, read digest tag timestamp \<<< ${image}
+              echo Untag image: "${IMAGE_PATH}:${tag} created on ${timestamp} with digest ${digest}"
+              echo Command: gcloud container images untag "${IMAGE_PATH}:${tag}"
+            )
+            done
+  gcloud_image_delete:
+    description: "Deletes old untagged images"
+    parameters:
+      imagepath:
+        type: string
+        default: "importer"
+    steps:
+      - run:
+          name: "Deletes old untagged images"
           command: |
             set -x
             DELETE_BEFORE=$(date -d "-7 days" '+%FT%T')
@@ -52,13 +77,13 @@ commands:
             OLD_IMAGES=$(gcloud container images list-tags ${IMAGE_PATH} \
               --limit=1000 \
               --sort-by=TIMESTAMP \
-              --filter="tags:master-* AND timestamp.datetime < '${DELETE_BEFORE}'" \
+              --filter="-tags:* AND timestamp.datetime < '${DELETE_BEFORE}'" \
               --format="csv[no-heading](digest,timestamp)")
             for image in ${OLD_IMAGES[*]}; do
             (
               IFS=, read digest timestamp \<<< ${image}
               echo Delete image: "${IMAGE_PATH}@${digest} created on ${timestamp}"
-              echo Command: gcloud container images delete -q --force-delete-tags "${IMAGE_PATH}@${digest}"
+              echo Command: gcloud container images delete -q "${IMAGE_PATH}@${digest}"
             )
             done
 
@@ -95,6 +120,8 @@ workflows:
             branches:
               only:
                 - master
+                # image-deploy-cleanup branch present for testing to be removed
+                - image-deploy-cleanup
             tags:
               only: /^.*/
       - perf_maven:
@@ -110,6 +137,8 @@ workflows:
             branches:
               only:
                 - master
+                # image-deploy-cleanup branch present for testing to be removed
+                - image-deploy-cleanup
             tags:
               only: /^.*/
 
@@ -273,7 +302,7 @@ jobs:
       - run:
           name: Running maven deploy
           command: |
-            if [ "$CIRCLE_BRANCH" = "master" ]; then
+            if [ "$CIRCLE_BRANCH" = "master" -o "$CIRCLE_BRANCH" = "image-deploy-cleanup" ]; then
                 DOCKER_TAG_OVERRIDE="-Ddocker.tag.version=${CIRCLE_BRANCH}-${CIRCLE_SHA1} -Ddocker.tag.latest=master"
             fi
             echo DOCKER_TAG_OVERRIDE: ${DOCKER_TAG_OVERRIDE}
@@ -288,9 +317,15 @@ jobs:
           command: |
             echo ${GCR_JSON_KEY_FILE} | gcloud auth activate-service-account --key-file=-
             gcloud --quiet config set project mirrornode
-      - gcloud_image_clean:
+      - gcloud_image_untag:
           imagepath: "grpc"
-      - gcloud_image_clean:
+      - gcloud_image_untag:
           imagepath: "importer"
-      - gcloud_image_clean:
+      - gcloud_image_untag:
+          imagepath: "rest"
+      - gcloud_image_delete:
+          imagepath: "grpc"
+      - gcloud_image_delete:
+          imagepath: "importer"
+      - gcloud_image_delete:
           imagepath: "rest"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ commands:
               --limit=1000 \
               --sort-by=TIMESTAMP \
               --filter="tags:image* AND timestamp.datetime < '${DELETE_BEFORE}'" \
-              --format="[csv[no-heading](digest,timestamp)]")
+              --format="csv[no-heading](digest,timestamp)")
             echo OLD_IMAGES: ${OLD_IMAGES}
             for image in ${OLD_IMAGES[*]}; do
             (

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,23 +46,20 @@ commands:
       - run:
           name: "Clean up old master images"
           command: |
-            DELETE_BEFORE=$(date --utc -d "-6 hours" '+%FT%TZ')
+            DELETE_BEFORE=$(date --utc -d "-4 hours" '+%FT%TZ')
             echo DELETE_BEFORE: ${DELETE_BEFORE}
             IMAGE_PATH=gcr.io/mirrornode/hedera-mirror-<< parameters.imagepath >>
             echo IMAGE_PATH: ${IMAGE_PATH}
-            echo List tags command: gcloud container images list-tags ${IMAGE_PATH} \
-              --limit=1000 \
-              --sort-by=TIMESTAMP \
-              --filter="'tags:image* AND timestamp.datetime < ${DELETE_BEFORE}'" \
-              --format="'get(digest)'"
             OLD_IMAGES=$(gcloud container images list-tags ${IMAGE_PATH} \
               --limit=1000 \
               --sort-by=TIMESTAMP \
-              --filter="tags:image* AND timestamp.datetime < '${DELETE_BEFORE}'")
+              --filter="tags:image* AND timestamp.datetime < '${DELETE_BEFORE}'" \
+              --format="get(digest)")
             echo OLD_IMAGES: ${OLD_IMAGES}
             for digest in ${OLD_IMAGES[*]}; do
             (
               echo Delete image: "${IMAGE_PATH}@${digest}"
+              echo Command: gcloud container images delete -q --force-delete-tags "${IMAGE_PATH}@${digest}"
             )
             done
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ commands:
           name: "Clean up old master images"
           command: |
             echo $0
-            DELETE_BEFORE=$(date -d "-7 days" '+%FT%T')
+            DELETE_BEFORE=$(date -d "-2 days" '+%FT%T')
             echo DELETE_BEFORE: ${DELETE_BEFORE}
             IMAGE_PATH=gcr.io/mirrornode/hedera-mirror-<< parameters.imagepath >>
             echo IMAGE_PATH: ${IMAGE_PATH}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,17 +46,14 @@ commands:
       - run:
           name: "Clean up old master images"
           command: |
-            echo $0
+            set -x
             DELETE_BEFORE=$(date -d "-7 days" '+%FT%T')
-            echo DELETE_BEFORE: ${DELETE_BEFORE}
             IMAGE_PATH=gcr.io/mirrornode/hedera-mirror-<< parameters.imagepath >>
-            echo IMAGE_PATH: ${IMAGE_PATH}
             OLD_IMAGES=$(gcloud container images list-tags ${IMAGE_PATH} \
               --limit=1000 \
               --sort-by=TIMESTAMP \
               --filter="tags:master-* AND timestamp.datetime < '${DELETE_BEFORE}'" \
               --format="csv[no-heading](digest,timestamp)")
-            echo OLD_IMAGES: ${OLD_IMAGES}
             for image in ${OLD_IMAGES[*]}; do
             (
               IFS=, read digest timestamp \<<< ${image}
@@ -66,7 +63,7 @@ commands:
             done
 
 workflows:
-  version: 2.1
+  version: 2
   main:
     jobs:
       - build_maven:
@@ -98,6 +95,8 @@ workflows:
             branches:
               only:
                 - master
+                # image-deploy-cleanup branch present for testing to be removed
+                - image-deploy-cleanup
             tags:
               only: /^.*/
       - perf_maven:
@@ -276,12 +275,11 @@ jobs:
       - run:
           name: Running maven deploy
           command: |
-            DOCKERPUSHTAG=
-            if [ "$CIRCLE_BRANCH" = "master" ]; then
-                DOCKERPUSHTAG=${CIRCLE_BRANCH}-${CIRCLE_SHA1}
+            if [ "$CIRCLE_BRANCH" = "master" -o "$CIRCLE_BRANCH" = "image-deploy-cleanup" ]; then
+                DOCKER_TAG_OVERRIDE="-Ddocker.tag.version=${CIRCLE_BRANCH}-${CIRCLE_SHA1} -Ddocker.tag.latest=master"
             fi
-            echo DOCKERPUSHTAG: ${DOCKERPUSHTAG}
-            ./mvnw ${MAVEN_CLI_OPTS} deploy -DskipTests -Dcircle.docker.tag=${DOCKERPUSHTAG}
+            echo DOCKER_TAG_OVERRIDE: ${DOCKER_TAG_OVERRIDE}
+            ./mvnw ${MAVEN_CLI_OPTS} deploy -DskipTests ${DOCKER_TAG_OVERRIDE}
       - *save_maven_cache
   cleanup_images:
     machine: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,13 +46,13 @@ commands:
       - run:
           name: "Untags old master images"
           command: |
-            set -x
-            UNTAG_BEFORE=$(date -d "-3 hours" '+%FT%T')
+            set -ex
+            UNTAG_BEFORE=$(date -d "-7 days" '+%FT%T')
             IMAGE_PATH=gcr.io/mirrornode/hedera-mirror-<< parameters.imagepath >>
             OLD_IMAGES=$(gcloud container images list-tags ${IMAGE_PATH} \
               --limit=1000 \
               --sort-by=TIMESTAMP \
-              --filter="tags:image-* AND timestamp.datetime < '${UNTAG_BEFORE}'" \
+              --filter="tags:master-* AND timestamp.datetime < '${UNTAG_BEFORE}'" \
               --format="csv[no-heading](digest,tags,timestamp)")
             for image in ${OLD_IMAGES[*]}; do
             (
@@ -70,8 +70,8 @@ commands:
       - run:
           name: "Deletes old untagged images"
           command: |
-            set -x
-            DELETE_BEFORE=$(date -d "-3 hours" '+%FT%T')
+            set -ex
+            DELETE_BEFORE=$(date -d "-7 days" '+%FT%T')
             IMAGE_PATH=gcr.io/mirrornode/hedera-mirror-<< parameters.imagepath >>
             OLD_IMAGES=$(gcloud container images list-tags ${IMAGE_PATH} \
               --limit=1000 \
@@ -117,8 +117,6 @@ workflows:
             branches:
               only:
                 - master
-                # image-deploy-cleanup branch present for testing to be removed
-                - image-deploy-cleanup
             tags:
               only: /^.*/
       - perf_maven:
@@ -134,8 +132,6 @@ workflows:
             branches:
               only:
                 - master
-                # image-deploy-cleanup branch present for testing to be removed
-                - image-deploy-cleanup
             tags:
               only: /^.*/
 
@@ -299,7 +295,7 @@ jobs:
       - run:
           name: Running maven deploy
           command: |
-            if [ "$CIRCLE_BRANCH" = "master" -o "$CIRCLE_BRANCH" = "image-deploy-cleanup" ]; then
+            if [ "$CIRCLE_BRANCH" = "master" ]; then
                 DOCKER_TAG_OVERRIDE="-Ddocker.tag.version=${CIRCLE_BRANCH}-${CIRCLE_SHA1} -Ddocker.tag.latest=master"
             fi
             echo DOCKER_TAG_OVERRIDE: ${DOCKER_TAG_OVERRIDE}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,21 +34,6 @@ references:
           POSTGRES_DB: mirror_node_test
           POSTGRES_PASSWORD: mirror_node_pass
           POSTGRES_USER: mirror_node
-#  gcloud_image_clean: &gcloud_image_clean
-#    - imagepath: importer
-#    - run:
-#        name: "Cleans up image under given path"
-#        command: |
-#          DELETE_BEFORE=$(date -d "-14 hours" '+%d-%m-%Y')
-#          IMAGE_PATH=gcr.io/mirrornode/hedera-mirror-<< imagepath >>
-#          echo IMAGE_PATH: ${IMAGE_PATH}
-#          OLD_IMAGES= gcloud container images list-tags ${IMAGE_PATH} \
-#            --limit=1000 \
-#            --sort-by=TIMESTAMP \
-#            --filter="tags:image* AND timestamp.datetime < '${DELETE_BEFORE}'" \
-#            --format='get(digest)'
-#          echo OLD_IMAGES: ${OLD_IMAGES}
-#          for digest in $(OLD_IMAGES); do  echo PathToDelete: "${IMAGE_PATH}@${digest}"; done
 
 commands:
   gcloud_image_clean:
@@ -61,7 +46,7 @@ commands:
       - run:
           name: "Cleans up old master images"
           command: |
-            DELETE_BEFORE=$(date --utc -d "-19 hours" '+%FT%TZ')
+            DELETE_BEFORE=$(date --utc -d "-7 hours" '+%FT%TZ')
             echo DELETE_BEFORE: ${DELETE_BEFORE}
             IMAGE_PATH=gcr.io/mirrornode/hedera-mirror-<< parameters.imagepath >>
             echo IMAGE_PATH: ${IMAGE_PATH}
@@ -73,7 +58,7 @@ commands:
             for digest in ${OLD_IMAGES}; do
             (
               echo Delete image: "${IMAGE_PATH}@${digest}"
-              gcloud container images delete -q --force-delete-tags "${IMAGE_PATH}@${digest}"
+              echo Command: gcloud container images delete -q --force-delete-tags "${IMAGE_PATH}@${digest}"
             )
             done
 
@@ -81,48 +66,48 @@ workflows:
   version: 2.1
   main:
     jobs:
-      #      - build_maven:
-      #          filters: # required since `release_artifacts` has tag filters AND requires `this`
-      #            branches:
-      #              only: /.*/
-      #            tags:
-      #              only: /.*/
-      #      - build_rest:
-      #          filters: # required since `release_artifacts` has tag filters AND requires `this`
-      #            branches:
-      #              only: /.*/
-      #            tags:
-      #              only: /.*/
-      #      - release_artifacts:
-      #          requires:
-      #            - build_maven
-      #            - build_rest
-      #          filters:
-      #            branches:
-      #              ignore: /.*/
-      #            tags:
-      #              only: /^v.*/
-      #      - publish_images:
-      #          requires:
-      #            - build_maven
-      #            - build_rest
-      #          filters:
-      #            branches:
-      #              only:
-      #                - master
-      #                # image-deploy-cleanup branch present for testing to be removed
-      #                - image-deploy-cleanup
-      #            tags:
-      #              only: /^.*/
-      #      - perf_maven:
-      #          filters:
-      #            branches:
-      #              only: /.*/
-      #            tags:
-      #              only: /.*/
+      - build_maven:
+          filters: # required since `release_artifacts` has tag filters AND requires `this`
+            branches:
+              only: /.*/
+            tags:
+              only: /.*/
+      - build_rest:
+          filters: # required since `release_artifacts` has tag filters AND requires `this`
+            branches:
+              only: /.*/
+            tags:
+              only: /.*/
+      - release_artifacts:
+          requires:
+            - build_maven
+            - build_rest
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
+      - publish_images:
+          requires:
+            - build_maven
+            - build_rest
+          filters:
+            branches:
+              only:
+                - master
+                # image-deploy-cleanup branch present for testing to be removed
+                - image-deploy-cleanup
+            tags:
+              only: /^.*/
+      - perf_maven:
+          filters:
+            branches:
+              only: /.*/
+            tags:
+              only: /.*/
       - cleanup_images:
-          #          requires:
-          #            - publish_images
+          requires:
+            - publish_images
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,18 +65,23 @@ commands:
             echo DELETE_BEFORE: ${DELETE_BEFORE}
             IMAGE_PATH=gcr.io/mirrornode/hedera-mirror-<< parameters.imagepath >>
             echo IMAGE_PATH: ${IMAGE_PATH}
-            OLD_IMAGES=$(gcloud container images list-tags ${IMAGE_PATH} \
-              --limit=1000 \
-              --sort-by=TIMESTAMP \
-              --filter="'tags:image* AND timestamp.datetime < ${DELETE_BEFORE}'" \
-              --format="'get(digest)'")
-            echo OLD_IMAGES: ${OLD_IMAGES}
-            echo Command: gcloud container images list-tags ${IMAGE_PATH} \
+            echo List tags command: gcloud container images list-tags ${IMAGE_PATH} \
               --limit=1000 \
               --sort-by=TIMESTAMP \
               --filter="'tags:image* AND timestamp.datetime < ${DELETE_BEFORE}'" \
               --format="'get(digest)'"
-            for digest in ${OLD_IMAGES}; do  echo PathToDelete: "${IMAGE_PATH}@${digest}"; done
+            OLD_IMAGES=$(gcloud container images list-tags ${IMAGE_PATH} \
+              --limit=1000 \
+              --sort-by=TIMESTAMP \
+              --filter="tags:image* AND timestamp.datetime < ${DELETE_BEFORE}" \
+              --format="get(digest)")
+            echo OLD_IMAGES: ${OLD_IMAGES}
+            for digest in ${OLD_IMAGES}; do
+            (
+              echo Delete image: "${IMAGE_PATH}@${digest}"
+              echo Command: gcloud container images delete -q --force-delete-tags "${IMAGE_PATH}@${digest}"
+            )
+            done
 
 workflows:
   version: 2.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ commands:
       - run:
           name: "Cleans up old master images"
           command: |
-            DELETE_BEFORE=$(date --utc -d "-7 days" '+%FT%TZ')
+            DELETE_BEFORE=$(date --utc -d "-1 hours" '+%FT%TZ')
             echo DELETE_BEFORE: ${DELETE_BEFORE}
             IMAGE_PATH=gcr.io/mirrornode/hedera-mirror-<< parameters.imagepath >>
             echo IMAGE_PATH: ${IMAGE_PATH}
@@ -60,7 +60,7 @@ commands:
               --sort-by=TIMESTAMP \
               --filter="tags:image* AND timestamp.datetime < ${DELETE_BEFORE}" \
               --format="get(digest)")
-            for digest in ${OLD_IMAGES}; do
+            for digest in ${OLD_IMAGES[*]}; do
             (
               echo Delete image: "${IMAGE_PATH}@${digest}"
               echo Command: gcloud container images delete -q --force-delete-tags "${IMAGE_PATH}@${digest}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ commands:
       - run:
           name: "Cleans up old master images"
           command: |
-            DELETE_BEFORE=$(date --utc -d "-7 hours" '+%FT%TZ')
+            DELETE_BEFORE=$(date --utc -d "-7 days" '+%FT%TZ')
             echo DELETE_BEFORE: ${DELETE_BEFORE}
             IMAGE_PATH=gcr.io/mirrornode/hedera-mirror-<< parameters.imagepath >>
             echo IMAGE_PATH: ${IMAGE_PATH}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -288,7 +288,7 @@ jobs:
           command: |
             echo ${GCR_JSON_KEY_FILE} | gcloud auth activate-service-account --key-file=-
             gcloud --quiet config set project mirrornode
-            DELETE_BEFORE=$(date -d "-2 hours" '+%d-%m-%Y')
+            DELETE_BEFORE=$(date -d "-2 hours" '+%d-%m-%Y %H:%M')
             echo DELETE_BEFORE: ${DELETE_BEFORE}
             IMAGE_PATH_BASE=gcr.io/mirrornode/hedera-mirror-
             GRPC_IMAGE_PATH=${IMAGE_PATH_BASE}grpc
@@ -300,6 +300,7 @@ jobs:
               --format='get(digest)'); do
               (
                 set -x
+                echo delete image: ${GRPC_IMAGE_PATH}@${digest}
                 gcloud container images delete -q --force-delete-tags "${GRPC_IMAGE_PATH}@${digest}"
               )
             done
@@ -312,6 +313,7 @@ jobs:
               --format='get(digest)'); do
               (
                 set -x
+                echo delete image: ${IMPORTER_IMAGE_PATH}@${digest}
                 gcloud container images delete -q --force-delete-tags "${IMPORTER_IMAGE_PATH}@${digest}"
               )
             done
@@ -320,10 +322,11 @@ jobs:
             for digest in $(gcloud container images list-tags \
               ${REST_IMAGE_PATH} --limit=1000 \
               --sort-by=TIMESTAMP \
-              --filter="tags:image*  AND timestamp.datetime < '${DELETE_BEFORE}'" \
+              --filter="tags:image* AND timestamp.datetime < '${DELETE_BEFORE}'" \
               --format='get(digest)'); do
               (
                 set -x
+                echo delete image: ${REST_IMAGE_PATH}@${digest}
                 gcloud container images delete -q --force-delete-tags "${REST_IMAGE_PATH}@${digest}"
               )
             done

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -288,7 +288,7 @@ jobs:
           command: |
             echo ${GCR_JSON_KEY_FILE} | gcloud auth activate-service-account --key-file=-
             gcloud --quiet config set project mirrornode
-            DELETE_BEFORE=$(date -d "-2 hours" '+%d-%m-%Y %H:%M')
+            DELETE_BEFORE=$(date -d "-4 hours" '+%d-%m-%Y %H:%M')
             echo DELETE_BEFORE: ${DELETE_BEFORE}
             IMAGE_PATH_BASE=gcr.io/mirrornode/hedera-mirror-
             GRPC_IMAGE_PATH=${IMAGE_PATH_BASE}grpc
@@ -298,9 +298,7 @@ jobs:
               --sort-by=TIMESTAMP \
               --filter="tags:image*  AND timestamp.datetime < '${DELETE_BEFORE}'" \
               --format='get(digest)'); do \
-              (
-                echo delete image: ${GRPC_IMAGE_PATH}@${digest}
-              )
+              ( gcloud container images delete -q --force-delete-tags "${GRPC_IMAGE_PATH}@${digest}" )
             done
             IMPORTER_IMAGE_PATH=${IMAGE_PATH_BASE}importer
             echo IMPORTER_IMAGE_PATH: ${IMPORTER_IMAGE_PATH}
@@ -309,9 +307,7 @@ jobs:
               --sort-by=TIMESTAMP \
               --filter="tags:image*  AND timestamp.datetime < '${DELETE_BEFORE}'" \
               --format='get(digest)'); do \
-              (
-                echo delete image: ${IMPORTER_IMAGE_PATH}@${digest}
-              )
+              ( gcloud container images delete -q --force-delete-tags "${IMPORTER_IMAGE_PATH}@${digest}" )
             done
             REST_IMAGE_PATH=${IMAGE_PATH_BASE}rest
             echo REST_IMAGE_PATH: ${REST_IMAGE_PATH}
@@ -320,9 +316,7 @@ jobs:
               --sort-by=TIMESTAMP \
               --filter="tags:image* AND timestamp.datetime < '${DELETE_BEFORE}'" \
               --format='get(digest)'); do \
-              (
-                echo delete image: ${REST_IMAGE_PATH}@${digest}
-              )
+              ( gcloud container images delete -q --force-delete-tags "${REST_IMAGE_PATH}@${digest}" )
             done
       #            echo GRPC_IMAGES: ${gcloud container images list-tags gcr.io/mirrornode/hedera-mirror-grpc --limit=1000 --sort-by=TIMESTAMP --filter="tags:image*  AND timestamp.datetime < '${DELETE_BEFORE}'" --format='get(digest)'}
       #            echo IMPORTER_IMAGES: ${gcloud container images list-tags gcr.io/mirrornode/hedera-mirror-importer --limit=1000 --sort-by=TIMESTAMP --filter="tags:image*  AND timestamp.datetime < '${DELETE_BEFORE}'" --format='get(digest)'}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,11 +68,6 @@ commands:
             OLD_IMAGES=$(gcloud container images list-tags ${IMAGE_PATH} \
               --limit=1000 \
               --sort-by=TIMESTAMP \
-              --format='get(digest)')
-            echo OLD_IMAGES No Filter: ${OLD_IMAGES}
-            OLD_IMAGES=$(gcloud container images list-tags ${IMAGE_PATH} \
-              --limit=1000 \
-              --sort-by=TIMESTAMP \
               --filter="tags:image*" \
               --format='get(digest)')
             echo OLD_IMAGES Branch Filter: ${OLD_IMAGES}
@@ -81,7 +76,12 @@ commands:
               --sort-by=TIMESTAMP \
               --filter="tags:image* AND timestamp.datetime < '${DELETE_BEFORE}'" \
               --format='get(digest)')
-            echo OLD_IMAGES Branch and Tiem Filter: ${OLD_IMAGES}
+            echo OLD_IMAGES Branch and Time Filter: ${OLD_IMAGES}
+            echo Command: gcloud container images list-tags ${IMAGE_PATH} \
+              --limit=1000 \
+              --sort-by=TIMESTAMP \
+              --filter="tags:image* AND timestamp.datetime < '${DELETE_BEFORE}'" \
+              --format='get(digest)'
             for digest in ${OLD_IMAGES}; do  echo PathToDelete: "${IMAGE_PATH}@${digest}"; done
 
 workflows:
@@ -311,7 +311,7 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Delete old untagged master images
+          name: GCloud Setup
           command: |
             echo ${GCR_JSON_KEY_FILE} | gcloud auth activate-service-account --key-file=-
             gcloud --quiet config set project mirrornode

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -255,7 +255,7 @@ jobs:
                           DOCKERPUSHTAG=${$CIRCLE_BRANCH-$CIRCLE_SHA1}
                       fi
                       echo ${DOCKERPUSHTAG}
-                      ./mvnw ${MAVEN_CLI_OPTS} deploy -DskipTests -Ddocker.push.tag=${DOCKERPUSHTAG}
+                      ./mvnw ${MAVEN_CLI_OPTS} deploy -DskipTests -Dcircle.docker.tag=${DOCKERPUSHTAG}
             - *save_maven_cache
     cleanup_images:
         machine: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ commands:
       - run:
           name: "Clean up old master images"
           command: |
-            DELETE_BEFORE=$(date --utc -d "-14 hours" '+%FT%TZ')
+            DELETE_BEFORE=$(date --utc -d "-14 hours" '+%FT%T')
             echo DELETE_BEFORE: ${DELETE_BEFORE}
             IMAGE_PATH=gcr.io/mirrornode/hedera-mirror-<< parameters.imagepath >>
             echo IMAGE_PATH: ${IMAGE_PATH}

--- a/hedera-mirror-rest/.prettierignore
+++ b/hedera-mirror-rest/.prettierignore
@@ -3,4 +3,5 @@ charts/**
 hedera-mirror-importer/**
 hedera-mirror-grpc/**
 hedera-mirror-datagenerator/**
+*.yml
 

--- a/hedera-mirror-rest/.prettierignore
+++ b/hedera-mirror-rest/.prettierignore
@@ -4,4 +4,5 @@ hedera-mirror-importer/**
 hedera-mirror-grpc/**
 hedera-mirror-datagenerator/**
 *.yml
+*.yaml
 

--- a/hedera-mirror-rest/pom.xml
+++ b/hedera-mirror-rest/pom.xml
@@ -41,7 +41,7 @@
                                 <contextDir>${project.basedir}</contextDir>
                                 <tags>
                                     <tag>latest</tag>
-                                    <tag>${project.version}</tag>
+                                    <tag>${docker.push.tag}</tag>
                                 </tags>
                             </build>
                             <name>${docker.push.repository}/${project.artifactId}</name>

--- a/hedera-mirror-rest/pom.xml
+++ b/hedera-mirror-rest/pom.xml
@@ -40,8 +40,8 @@
                             <build>
                                 <contextDir>${project.basedir}</contextDir>
                                 <tags>
-                                    <tag>latest</tag>
-                                    <tag>${docker.push.tag}</tag>
+                                    <tag>${docker.push.latest.tag}</tag>
+                                    <tag>${docker.push.version.tag}</tag>
                                 </tags>
                             </build>
                             <name>${docker.push.repository}/${project.artifactId}</name>

--- a/hedera-mirror-rest/pom.xml
+++ b/hedera-mirror-rest/pom.xml
@@ -40,8 +40,8 @@
                             <build>
                                 <contextDir>${project.basedir}</contextDir>
                                 <tags>
-                                    <tag>${docker.push.latest.tag}</tag>
-                                    <tag>${docker.push.version.tag}</tag>
+                                    <tag>${docker.tag.latest}</tag>
+                                    <tag>${docker.tag.version}</tag>
                                 </tags>
                             </build>
                             <name>${docker.push.repository}/${project.artifactId}</name>

--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
                             </tags>
                         </to>
                         <container>
-                            <useCurrentTimestamp>true</useCurrentTimestamp>
+                            <creationTime>USE_CURRENT_TIMESTAMP</creationTime>
                         </container>
                     </configuration>
                     <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -55,8 +55,8 @@
     <properties>
         <disruptor.version>3.4.2</disruptor.version> <!-- Used for asynchronous logging -->
         <docker.push.repository>gcr.io/mirrornode</docker.push.repository>
-        <docker.push.version.tag>${project.version}</docker.push.version.tag>
-        <docker.push.latest.tag>latest</docker.push.latest.tag>
+        <docker.tag.version>${project.version}</docker.tag.version>
+        <docker.tag.latest>latest</docker.tag.latest>
         <grpc.version>1.25.0</grpc.version>
         <guava.version>28.2-jre</guava.version>
         <hedera-protobuf.version>0.4.0</hedera-protobuf.version>
@@ -85,21 +85,6 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-
-    <profiles>
-        <profile>
-            <id>master-image-deploy</id>
-            <activation>
-                <property>
-                    <name>circle.docker.tag</name>
-                </property>
-            </activation>
-            <properties>
-                <docker.push.version.tag>${circle.docker.tag}</docker.push.version.tag>
-                <docker.push.latest.tag>master</docker.push.latest.tag>
-            </properties>
-        </profile>
-    </profiles>
 
     <build>
         <pluginManagement>
@@ -142,8 +127,8 @@
                         <to>
                             <image>${docker.push.repository}/${project.artifactId}</image>
                             <tags>
-                                <tag>${docker.push.latest.tag}</tag>
-                                <tag>${docker.push.version.tag}</tag>
+                                <tag>${docker.tag.latest}</tag>
+                                <tag>${docker.tag.version}</tag>
                             </tags>
                         </to>
                         <container>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,8 @@
     <properties>
         <disruptor.version>3.4.2</disruptor.version> <!-- Used for asynchronous logging -->
         <docker.push.repository>gcr.io/mirrornode</docker.push.repository>
-        <docker.push.tag>${project.version}</docker.push.tag>
+        <docker.push.version.tag>${project.version}</docker.push.version.tag>
+        <docker.push.latest.tag>latest</docker.push.latest.tag>
         <grpc.version>1.25.0</grpc.version>
         <guava.version>28.2-jre</guava.version>
         <hedera-protobuf.version>0.4.0</hedera-protobuf.version>
@@ -94,7 +95,8 @@
                 </property>
             </activation>
             <properties>
-                <docker.push.tag>${circle.docker.tag}</docker.push.tag>
+                <docker.push.version.tag>${circle.docker.tag}</docker.push.version.tag>
+                <docker.push.latest.tag>master</docker.push.latest.tag>
             </properties>
         </profile>
     </profiles>
@@ -140,8 +142,8 @@
                         <to>
                             <image>${docker.push.repository}/${project.artifactId}</image>
                             <tags>
-                                <tag>latest</tag>
-                                <tag>${docker.push.tag}</tag>
+                                <tag>${docker.push.latest.tag}</tag>
+                                <tag>${docker.push.version.tag}</tag>
                             </tags>
                         </to>
                         <container>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
     <properties>
         <disruptor.version>3.4.2</disruptor.version> <!-- Used for asynchronous logging -->
         <docker.push.repository>gcr.io/mirrornode</docker.push.repository>
+        <docker.push.tag>${project.version}</docker.push.tag>
         <grpc.version>1.25.0</grpc.version>
         <guava.version>28.2-jre</guava.version>
         <hedera-protobuf.version>0.4.0</hedera-protobuf.version>
@@ -83,6 +84,20 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <profiles>
+        <profile>
+            <id>master-image-deploy</id>
+            <activation>
+                <property>
+                    <name>circle.docker.tag</name>
+                </property>
+            </activation>
+            <properties>
+                <docker.push.tag>${circle.docker.tag}</docker.push.tag>
+            </properties>
+        </profile>
+    </profiles>
 
     <build>
         <pluginManagement>
@@ -126,9 +141,12 @@
                             <image>${docker.push.repository}/${project.artifactId}</image>
                             <tags>
                                 <tag>latest</tag>
-                                <tag>${project.version}</tag>
+                                <tag>${docker.push.tag}</tag>
                             </tags>
                         </to>
+                        <container>
+                            <useCurrentTimestamp>true</useCurrentTimestamp>
+                        </container>
                     </configuration>
                     <executions>
                         <execution>


### PR DESCRIPTION
**Detailed description**:
To support continuous deployment of docker images for helm chart it's necessary to push docker images on master builds.

To facilitate that this change
- Updates circle CI to push docker image on master branches. 
- Updated circle ci with cleanup_images job that would loop through tags and delete tags after certain threshold e.g. older than 7 days
- Updates pom files to default use project version and latest as docker tag.
- Updates circle ci config to set docker tag of master-SHA if in master branch
- Updates poms to check if circle.docker.tag is set. If so use this instead of project version tag

**Which issue(s) this PR fixes**:
Partially addresses #625

**Special notes for your reviewer**:
Still testing out filtering in grc. Seeing minor inconsistencies between what service account sees and what my tests in gcloud console see.
In some tests when filtering on images older than a few hours ago the console would return an expected subset, upon running the delete all images with that tag were removed.
Seems to not occur when accuracy of timing is in days and not hours.
Leaving actual delete as echo and we can observe till we have more than 7 days worth of image tags
Delete resolve will be handled by #689

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

