### PR TITLE
Fix topic messages REST route

### DIFF
--- a/hedera-mirror-rest/__tests__/specs/topicmessages-01-no-args.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/topicmessages-01-no-args.spec.json
@@ -23,7 +23,7 @@
       }
     ]
   },
-  "url": "/api/v1/topic/7",
+  "url": "/api/v1/topic/7/messages",
   "responseStatus": 200,
   "responseJson": {
     "messages": [

--- a/hedera-mirror-rest/__tests__/specs/topicmessages-02-specific-sequence.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/topicmessages-02-specific-sequence.spec.json
@@ -23,7 +23,7 @@
       }
     ]
   },
-  "url": "/api/v1/topic/7?sequencenumber=2",
+  "url": "/api/v1/topic/7/messages?sequencenumber=2",
   "responseStatus": 200,
   "responseJson": {
     "messages": [

--- a/hedera-mirror-rest/__tests__/specs/topicmessages-03-none.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/topicmessages-03-none.spec.json
@@ -23,7 +23,7 @@
       }
     ]
   },
-  "url": "/api/v1/topic/7?sequencenumber=2&sequencenumber=gte:3&timestamp=lt:1234567890.000000004",
+  "url": "/api/v1/topic/7/messages?sequencenumber=2&sequencenumber=gte:3&timestamp=lt:1234567890.000000004",
   "responseStatus": 200,
   "responseJson": {
     "messages": [],

--- a/hedera-mirror-rest/__tests__/specs/topicmessages-04-timestamp.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/topicmessages-04-timestamp.spec.json
@@ -23,7 +23,7 @@
       }
     ]
   },
-  "url": "/api/v1/topic/7?timestamp=1234567890.000000003",
+  "url": "/api/v1/topic/7/messages?timestamp=1234567890.000000003",
   "responseStatus": 200,
   "responseJson": {
     "messages": [

--- a/hedera-mirror-rest/__tests__/specs/topicmessages-05-all-params.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/topicmessages-05-all-params.spec.json
@@ -38,7 +38,7 @@
       }
     ]
   },
-  "url": "/api/v1/topic/7?sequencenumber=gt:3&timestamp=lte:1234567890.000000005",
+  "url": "/api/v1/topic/7/messages?sequencenumber=gt:3&timestamp=lte:1234567890.000000005",
   "responseStatus": 200,
   "responseJson": {
     "messages": [

--- a/hedera-mirror-rest/__tests__/specs/topicmessages-06-invalid-topid-id.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/topicmessages-06-invalid-topid-id.spec.json
@@ -23,7 +23,7 @@
       }
     ]
   },
-  "url": "/api/v1/topic/-1",
+  "url": "/api/v1/topic/-1/messages",
   "responseStatus": 400,
   "responseJson": {
     "_status": {

--- a/hedera-mirror-rest/__tests__/specs/topicmessages-07-invalid-param-values.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/topicmessages-07-invalid-param-values.spec.json
@@ -23,7 +23,7 @@
       }
     ]
   },
-  "url": "/api/v1/topic/7?sequencenumber=2_2&timestamp=18:34&limit=12345",
+  "url": "/api/v1/topic/7/messages?sequencenumber=2_2&timestamp=18:34&limit=12345",
   "responseStatus": 400,
   "responseJson": {
     "_status": {

--- a/hedera-mirror-rest/__tests__/specs/topicmessages-08-repeated-valid-params.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/topicmessages-08-repeated-valid-params.spec.json
@@ -23,7 +23,7 @@
       }
     ]
   },
-  "url": "/api/v1/topic/7?sequencenumber=lt:4&sequencenumber=gte:1&timestamp=lte:1234567890.000000004&timestamp=gt:1234567890.000000001&timestamp=1234567890.000000002&sequencenumber=2",
+  "url": "/api/v1/topic/7/messages?sequencenumber=lt:4&sequencenumber=gte:1&timestamp=lte:1234567890.000000004&timestamp=gt:1234567890.000000001&timestamp=1234567890.000000002&sequencenumber=2",
   "responseStatus": 200,
   "responseJson": {
     "messages": [

--- a/hedera-mirror-rest/__tests__/specs/topicmessages-09-limit.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/topicmessages-09-limit.spec.json
@@ -38,7 +38,7 @@
       }
     ]
   },
-  "url": "/api/v1/topic/7?sequencenumber=gt:2&timestamp=lte:1234567890.000000006&limit=2",
+  "url": "/api/v1/topic/7/messages?sequencenumber=gt:2&timestamp=lte:1234567890.000000006&limit=2",
   "responseStatus": 200,
   "responseJson": {
     "messages": [
@@ -58,7 +58,7 @@
       }
     ],
     "links": {
-      "next": "/api/v1/topic/7?sequencenumber=gt:2&timestamp=lte:1234567890.000000006&timestamp=gt:1234567890.000000004&limit=2"
+      "next": "/api/v1/topic/7/messages?sequencenumber=gt:2&timestamp=lte:1234567890.000000006&timestamp=gt:1234567890.000000004&limit=2"
     }
   }
 }

--- a/hedera-mirror-rest/__tests__/specs/topicmessages-10-order.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/topicmessages-10-order.spec.json
@@ -38,7 +38,7 @@
       }
     ]
   },
-  "url": "/api/v1/topic/7?sequencenumber=gt:2&timestamp=lte:1234567890.000000006&limit=3&order=desc",
+  "url": "/api/v1/topic/7/messages?sequencenumber=gt:2&timestamp=lte:1234567890.000000006&limit=3&order=desc",
   "responseStatus": 200,
   "responseJson": {
     "messages": [
@@ -65,7 +65,7 @@
       }
     ],
     "links": {
-      "next": "/api/v1/topic/7?sequencenumber=gt:2&limit=3&order=desc&timestamp=lt:1234567890.000000004"
+      "next": "/api/v1/topic/7/messages?sequencenumber=gt:2&limit=3&order=desc&timestamp=lt:1234567890.000000004"
     }
   }
 }

--- a/hedera-mirror-rest/__tests__/utilsFilters.test.js
+++ b/hedera-mirror-rest/__tests__/utilsFilters.test.js
@@ -77,7 +77,7 @@ const verifyFilter = (filter, key, op, val) => {
 };
 
 describe('utils buildFilterObject tests', () => {
-  test('Verify buildComparatorFilter for /api/v1/topic/7?sequencenumber=2', () => {
+  test('Verify buildComparatorFilter for /api/v1/topic/7/messages?sequencenumber=2', () => {
     const filters = {
       sequencenumber: '2',
     };
@@ -88,7 +88,7 @@ describe('utils buildFilterObject tests', () => {
     verifyFilter(formattedFilters[0], constants.filterKeys.SEQUENCE_NUMBER, 'eq', '2');
   });
 
-  test('Verify buildComparatorFilter for /api/v1/topic/7?timestamp=1234567890.000000004', () => {
+  test('Verify buildComparatorFilter for /api/v1/topic/7/messages?timestamp=1234567890.000000004', () => {
     const filters = {
       timestamp: '1234567890.000000004',
     };
@@ -99,7 +99,7 @@ describe('utils buildFilterObject tests', () => {
     verifyFilter(formattedFilters[0], constants.filterKeys.TIMESTAMP, 'eq', '1234567890.000000004');
   });
 
-  test('Verify buildComparatorFilter for /api/v1/topic/7?sequencenumber=lt:2&sequencenumber=gte:3&timestamp=1234567890.000000004&order=desc&limit=5', () => {
+  test('Verify buildComparatorFilter for /api/v1/topic/7/messages?sequencenumber=lt:2&sequencenumber=gte:3&timestamp=1234567890.000000004&order=desc&limit=5', () => {
     const filters = {
       sequencenumber: ['lt:2', 'gte:3'],
       timestamp: '1234567890.000000004',

--- a/hedera-mirror-rest/constants.js
+++ b/hedera-mirror-rest/constants.js
@@ -45,27 +45,21 @@ const orderFilterValues = {
   DESC: 'desc',
 };
 
-// topic messages filter options
-const topicMessagesFormatFilterValues = {
-  BINARY: 'binary',
-  TEXT: 'text',
-};
-
-const transactionsResultFilterValues = {
+const transactionResultFilter = {
   SUCCESS: 'success',
   FAIL: 'fail',
 };
 
-const transactionsTypeFilterValues = {
+const cryptoTransferType = {
   CREDIT: 'credit',
   DEBIT: 'debit',
 };
 
 module.exports = {
-  entityColumns: entityColumns,
-  filterKeys: filterKeys,
+  entityColumns,
+  filterKeys,
   orderFilterValues,
   responseDataLabel,
-  transactionsResultFilterValues,
-  transactionsTypeFilterValues,
+  transactionResultFilter,
+  cryptoTransferType,
 };

--- a/hedera-mirror-rest/constants.js
+++ b/hedera-mirror-rest/constants.js
@@ -40,8 +40,32 @@ const entityColumns = {
 
 const responseDataLabel = 'mirrorRestData';
 
+const orderFilterValues = {
+  ASC: 'asc',
+  DESC: 'desc',
+};
+
+// topic messages filter options
+const topicMessagesFormatFilterValues = {
+  BINARY: 'binary',
+  TEXT: 'text',
+};
+
+const transactionsResultFilterValues = {
+  SUCCESS: 'success',
+  FAIL: 'fail',
+};
+
+const transactionsTypeFilterValues = {
+  CREDIT: 'credit',
+  DEBIT: 'debit',
+};
+
 module.exports = {
   entityColumns: entityColumns,
   filterKeys: filterKeys,
+  orderFilterValues,
   responseDataLabel,
+  transactionsResultFilterValues,
+  transactionsTypeFilterValues,
 };

--- a/hedera-mirror-rest/middleware/httpErrorHandler.js
+++ b/hedera-mirror-rest/middleware/httpErrorHandler.js
@@ -31,6 +31,10 @@ const httpStatusCodes = {
   SERVICE_UNAVAILABLE: 503,
 };
 
+const httpErrorMessages = {
+  INTERNAL_ERROR: 'Internal error',
+};
+
 // Error middleware which formats thrown errors and maps them to appropriate http status codes
 // next param is required to ensure express maps to this middleware and can also be used to pass onto future middleware
 const handleError = (err, req, res, next) => {
@@ -55,8 +59,8 @@ const handleError = (err, req, res, next) => {
       res.status(httpStatusCodes.NOT_FOUND).json(errorMessage);
       return;
     default:
-      logger.trace(`Unhandled error encountered`);
-      res.status(httpStatusCodes.INTERNAL_ERROR).json(errorMessage);
+      logger.trace(`Unhandled error encountered: ${err.message}`);
+      res.status(httpStatusCodes.INTERNAL_ERROR).json(errorMessageFormat(httpErrorMessages.INTERNAL_ERROR));
   }
 };
 

--- a/hedera-mirror-rest/server.js
+++ b/hedera-mirror-rest/server.js
@@ -25,7 +25,7 @@ const {addAsync} = require('@awaitjs/express');
 const bodyParser = require('body-parser');
 const cors = require('cors');
 const log4js = require('log4js');
-var compression = require('compression');
+const compression = require('compression');
 
 // local files
 const config = require('./config.js');

--- a/hedera-mirror-rest/server.js
+++ b/hedera-mirror-rest/server.js
@@ -19,20 +19,15 @@
  */
 'uses strict';
 
+// external libraries
 const express = require('express');
 const {addAsync} = require('@awaitjs/express');
 const bodyParser = require('body-parser');
-let Pool;
-if (process.env.NODE_ENV !== 'test') {
-  Pool = require('pg').Pool;
-} else {
-  Pool = require('./__tests__/mockpool.js'); // Use a mocked up DB for jest unit tests
-}
-const app = addAsync(express());
 const cors = require('cors');
 const log4js = require('log4js');
-const logger = log4js.getLogger();
+var compression = require('compression');
 
+// local files
 const config = require('./config.js');
 const transactions = require('./transactions.js');
 const balances = require('./balances.js');
@@ -42,19 +37,8 @@ const {handleError} = require('./middleware/httpErrorHandler');
 const {responseHandler} = require('./middleware/responseHandler');
 const {metricsHandler} = require('./middleware/metricsHandler');
 
-var compression = require('compression');
-
-let port = config.api.port;
-if (process.env.NODE_ENV == 'test') {
-  port = 3000; // Use a dummy port for jest unit tests
-}
-if (port === undefined || isNaN(Number(port))) {
-  logger.error('Server started with unknown port');
-  console.log('Please specify the port');
-  process.exit(1);
-}
-
 // Logger
+const logger = log4js.getLogger();
 log4js.configure({
   appenders: {
     everything: {
@@ -70,7 +54,24 @@ log4js.configure({
 });
 global.logger = log4js.getLogger();
 
+let port = config.api.port;
+if (process.env.NODE_ENV == 'test') {
+  port = 3000; // Use a dummy port for jest unit tests
+}
+if (port === undefined || isNaN(Number(port))) {
+  logger.error('Server started with unknown port');
+  console.log('Please specify the port');
+  process.exit(1);
+}
+
 // Postgres pool
+let Pool;
+if (process.env.NODE_ENV !== 'test') {
+  Pool = require('pg').Pool;
+} else {
+  Pool = require('./__tests__/mockpool.js'); // Use a mocked up DB for jest unit tests
+}
+
 const pool = new Pool({
   user: config.db.apiUsername,
   host: config.db.host,
@@ -80,6 +81,8 @@ const pool = new Pool({
 });
 global.pool = pool;
 
+// Express configuration
+const app = addAsync(express());
 app.set('trust proxy', true);
 app.set('port', port);
 app.use(
@@ -110,8 +113,8 @@ app.getAsync(apiPrefix + '/topic/message/:consensusTimestamp', topicmessage.getM
 app.getAsync(apiPrefix + '/topic/:id/message/:sequencenumber', topicmessage.getMessageByTopicAndSequenceRequest);
 app.getAsync(apiPrefix + '/topics/:id/messages/:sequencenumber', topicmessage.getMessageByTopicAndSequenceRequest);
 
-app.getAsync(apiPrefix + '/topics/:id', topicmessage.getTopicMessages);
-app.getAsync(apiPrefix + '/topic/:id', topicmessage.getTopicMessages);
+app.getAsync(apiPrefix + '/topics/:id/messages', topicmessage.getTopicMessages);
+app.getAsync(apiPrefix + '/topic/:id/messages', topicmessage.getTopicMessages);
 
 // response data handling middleware
 app.use(responseHandler);


### PR DESCRIPTION
**Detailed description**:
In v0.9 we released the /topics/:id endpoint which returned a collection of topic messages under a topic.
This route was incorrect and should have been /topics/:id/messages as it refers to the messages entity and not the topic entity.

This changes 
- Updates server.js with the correct api path
- Re organizes server.js to make it easier to follow
- Updates spec topic messages tests
- Encapsulates some regex logic into methods.
- Moves some text to the constants.js file 
- Ensure a standard message is shown for unhandled messages and internal code is not exposed in error message

**Which issue(s) this PR fixes**:
Fixes #699 

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated

