### PR TITLE
Fix address book updates that span transactions

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/Downloader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/Downloader.java
@@ -81,7 +81,7 @@ public abstract class Downloader {
         this.networkAddressBook = networkAddressBook;
         this.downloaderProperties = downloaderProperties;
         signatureDownloadThreadPool = Executors.newFixedThreadPool(downloaderProperties.getThreads());
-        nodeAccountIds = networkAddressBook.load().stream().map(NodeAddress::getId).collect(Collectors.toSet());
+        nodeAccountIds = networkAddressBook.getAddresses().stream().map(NodeAddress::getId).collect(Collectors.toSet());
         Runtime.getRuntime().addShutdownHook(new Thread(signatureDownloadThreadPool::shutdown));
     }
 
@@ -119,7 +119,7 @@ public abstract class Downloader {
                 .synchronizedSortedSetMultimap(TreeMultimap.create());
 
         // refresh node account ids
-        nodeAccountIds = networkAddressBook.load().stream().map(NodeAddress::getId).collect(Collectors.toSet());
+        nodeAccountIds = networkAddressBook.getAddresses().stream().map(NodeAddress::getId).collect(Collectors.toSet());
         List<Callable<Object>> tasks = new ArrayList<>(nodeAccountIds.size());
         var totalDownloads = new AtomicInteger();
         /**

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/NodeSignatureVerifier.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/NodeSignatureVerifier.java
@@ -47,7 +47,7 @@ public class NodeSignatureVerifier {
 
     public NodeSignatureVerifier(NetworkAddressBook networkAddressBook) {
         nodeIDPubKeyMap = networkAddressBook
-                .load()
+                .getAddresses()
                 .stream()
                 .collect(Collectors.toMap(NodeAddress::getId, NodeAddress::getPublicKeyAsObject));
     }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/addressbook/NetworkAddressBookTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/addressbook/NetworkAddressBookTest.java
@@ -69,19 +69,6 @@ public class NetworkAddressBookTest {
     }
 
     @Test
-    void startupWithUnreadable() throws Exception {
-        assertThat(addressBookPath.toFile().setReadable(false)).isTrue();
-        NetworkAddressBook networkAddressBook = new NetworkAddressBook(mirrorProperties);
-
-        assertThat(networkAddressBook.getAddresses())
-                .describedAs("Loads default address book from classpath")
-                .hasSize(4);
-        assertThat(addressBookPath.resolveSibling(addressBookPath + ".unreadable")).exists();
-        assertThat(addressBookPath).exists();
-        assertThat(tempPath).doesNotExist();
-    }
-
-    @Test
     void startupWithExisting() throws Exception {
         mirrorProperties.setNetwork(HederaNetwork.MAINNET);
         NetworkAddressBook networkAddressBook = new NetworkAddressBook(mirrorProperties);

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/addressbook/NetworkAddressBookTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/addressbook/NetworkAddressBookTest.java
@@ -1,0 +1,162 @@
+package com.hedera.mirror.importer.addressbook;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.hederahashgraph.api.proto.java.NodeAddress;
+import com.hederahashgraph.api.proto.java.NodeAddressBook;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.hedera.mirror.importer.MirrorProperties;
+import com.hedera.mirror.importer.domain.HederaNetwork;
+
+public class NetworkAddressBookTest {
+
+    private static final NodeAddressBook INITIAL = addressBook(5);
+    private static final NodeAddressBook UPDATED = addressBook(10);
+
+    @TempDir
+    Path dataPath;
+
+    private MirrorProperties mirrorProperties;
+    private Path addressBookPath;
+    private Path tempPath;
+
+    @BeforeEach
+    void setup() throws Exception {
+        mirrorProperties = new MirrorProperties();
+        mirrorProperties.setDataPath(dataPath);
+        addressBookPath = mirrorProperties.getAddressBookPath();
+        tempPath = addressBookPath.resolveSibling(addressBookPath + ".tmp");
+        Files.write(addressBookPath, INITIAL.toByteArray());
+    }
+
+    @Test
+    void startupWithoutExisting() throws Exception {
+        Files.deleteIfExists(addressBookPath);
+        NetworkAddressBook networkAddressBook = new NetworkAddressBook(mirrorProperties);
+
+        assertThat(networkAddressBook.getAddresses())
+                .describedAs("Loads default address book from classpath")
+                .hasSize(4);
+        assertThat(addressBookPath).exists();
+        assertThat(tempPath).doesNotExist();
+    }
+
+    @Test
+    void startupWithUnreadable() throws Exception {
+        assertThat(addressBookPath.toFile().setReadable(false)).isTrue();
+        NetworkAddressBook networkAddressBook = new NetworkAddressBook(mirrorProperties);
+
+        assertThat(networkAddressBook.getAddresses())
+                .describedAs("Loads default address book from classpath")
+                .hasSize(4);
+        assertThat(addressBookPath.resolveSibling(addressBookPath + ".unreadable")).exists();
+        assertThat(addressBookPath).exists();
+        assertThat(tempPath).doesNotExist();
+    }
+
+    @Test
+    void startupWithExisting() throws Exception {
+        mirrorProperties.setNetwork(HederaNetwork.MAINNET);
+        NetworkAddressBook networkAddressBook = new NetworkAddressBook(mirrorProperties);
+
+        assertThat(networkAddressBook.getAddresses())
+                .describedAs("Continue using previous address book")
+                .hasSize(INITIAL.getNodeAddressCount());
+        assertThat(addressBookPath).exists().hasBinaryContent(INITIAL.toByteArray());
+        assertThat(tempPath).doesNotExist();
+    }
+
+    @Test
+    void startupWithInvalid() throws Exception {
+        Files.write(addressBookPath, new byte[] {'a', 'b', 'c'});
+        assertThatThrownBy(() -> new NetworkAddressBook(mirrorProperties))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void updateCompleteFile() throws Exception {
+        byte[] addressBookBytes = UPDATED.toByteArray();
+        NetworkAddressBook networkAddressBook = new NetworkAddressBook(mirrorProperties);
+        networkAddressBook.update(addressBookBytes);
+
+        assertThat(networkAddressBook.getAddresses()).hasSize(UPDATED.getNodeAddressCount());
+        assertThat(tempPath).doesNotExist();
+        assertThat(addressBookPath).exists().hasBinaryContent(addressBookBytes);
+    }
+
+    @Test
+    void updatePartialFile() throws Exception {
+        byte[] addressBookBytes = UPDATED.toByteArray();
+        int index = addressBookBytes.length / 2;
+        byte[] addressBookPartial = Arrays.copyOfRange(addressBookBytes, 0, index);
+
+        NetworkAddressBook networkAddressBook = new NetworkAddressBook(mirrorProperties);
+        networkAddressBook.update(addressBookPartial);
+
+        assertThat(networkAddressBook.getAddresses()).hasSize(INITIAL.getNodeAddressCount());
+        assertThat(addressBookPath).exists().hasBinaryContent(INITIAL.toByteArray());
+        assertThat(tempPath).exists().hasBinaryContent(addressBookPartial);
+    }
+
+    @Test
+    void appendPartialFile() throws Exception {
+        byte[] addressBookBytes = UPDATED.toByteArray();
+        int index = addressBookBytes.length / 2;
+        byte[] addressBookBytes1 = Arrays.copyOfRange(addressBookBytes, 0, index);
+        byte[] addressBookBytes2 = Arrays.copyOfRange(addressBookBytes, index, addressBookBytes.length);
+
+        NetworkAddressBook networkAddressBook = new NetworkAddressBook(mirrorProperties);
+        networkAddressBook.update(addressBookBytes1);
+        networkAddressBook.append(addressBookBytes2);
+
+        assertThat(networkAddressBook.getAddresses()).hasSize(UPDATED.getNodeAddressCount());
+        assertThat(addressBookPath).exists().hasBinaryContent(UPDATED.toByteArray());
+        assertThat(tempPath).doesNotExist();
+    }
+
+    @Test
+    void ignoreEmptyByteArray() throws Exception {
+        NetworkAddressBook networkAddressBook = new NetworkAddressBook(mirrorProperties);
+        networkAddressBook.update(null);
+        networkAddressBook.append(new byte[] {});
+
+        assertThat(networkAddressBook.getAddresses()).hasSize(INITIAL.getNodeAddressCount());
+        assertThat(addressBookPath).exists().hasBinaryContent(INITIAL.toByteArray());
+        assertThat(tempPath).doesNotExist();
+    }
+
+    private static NodeAddressBook addressBook(int size) {
+        NodeAddressBook.Builder builder = NodeAddressBook.newBuilder();
+        for (int i = 0; i < size; ++i) {
+            builder.addNodeAddress(NodeAddress.newBuilder().setPortno(i).build());
+        }
+        return builder.build();
+    }
+}

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/AbstractDownloaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/AbstractDownloaderTest.java
@@ -165,15 +165,6 @@ public abstract class AbstractDownloaderTest {
         assertValidFiles(List.of(fileName1, fileName2));
     }
 
-    @Test
-    @DisplayName("Missing address book")
-    void testMissingAddressBook() throws Exception {
-        Files.delete(mirrorProperties.getAddressBookPath());
-        fileCopier.copy();
-        downloader.download();
-        assertNoFilesinValidPath();
-    }
-
     protected void testMaxDownloadItemsReached(String filename) throws Exception {
         fileCopier.copy();
         downloader.download();

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/balance/AccountBalancesDownloaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/balance/AccountBalancesDownloaderTest.java
@@ -89,7 +89,7 @@ public class AccountBalancesDownloaderTest extends AbstractDownloaderTest {
         byte[] addressBook = Files.readAllBytes(mirrorProperties.getAddressBookPath());
         int index = Bytes.lastIndexOf(addressBook, (byte) '\n');
         addressBook = Arrays.copyOfRange(addressBook, 0, index);
-        Files.write(mirrorProperties.getAddressBookPath(), addressBook);
+        networkAddressBook.update(addressBook);
 
         fileCopier.filterDirectories("*0.0.3").copy();
         downloader.download();

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/record/RecordFileDownloaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/record/RecordFileDownloaderTest.java
@@ -70,7 +70,7 @@ public class RecordFileDownloaderTest extends AbstractDownloaderTest {
     @DisplayName("Download and verify V1 files")
     void downloadV1() throws Exception {
         Path addressBook = ResourceUtils.getFile("classpath:addressbook/test-v1").toPath();
-        mirrorProperties.setAddressBookPath(addressBook);
+        networkAddressBook.update(Files.readAllBytes(addressBook));
         fileCopier = FileCopier.create(Utility.getResource("data").toPath(), s3Path)
                 .from(downloaderProperties.getStreamType().getPath(), "v1")
                 .to(commonDownloaderProperties.getBucketName(), downloaderProperties.getStreamType().getPath());
@@ -122,7 +122,7 @@ public class RecordFileDownloaderTest extends AbstractDownloaderTest {
         byte[] addressBook = Files.readAllBytes(mirrorProperties.getAddressBookPath());
         int index = Bytes.lastIndexOf(addressBook, (byte) '\n');
         addressBook = Arrays.copyOfRange(addressBook, 0, index);
-        Files.write(mirrorProperties.getAddressBookPath(), addressBook);
+        networkAddressBook.update(addressBook);
 
         fileCopier.filterDirectories("*0.0.3").copy();
         downloader.download();


### PR DESCRIPTION
**Detailed description**:
- Fix losing partial updates during restart due to storing temporary state in memory
- Fix incomplete address books from being used for signature validation by using an `addressbook.bin.tmp` to store address books that don't fit in a single file update or don't parse
- Fix unreadable address book not correcting itself
- Fix not failing on startup if no valid address book could be found
- Fix null or empty byte array throwing NPE or being persisted
- Enhance reads to return cached immutable object instead of hitting disk
- Rename `NetworkAddressBook.load()` to `NetworkAddressBook.getAddresses()` since it no longer loads from disk
- Add unit test coverage

**Which issue(s) this PR fixes**:
Fixes #58
Fixes #353
Fixes #695

**Special notes for your reviewer**:
- Unable to test unreadable address book due to CircleCI limitation

**Checklist**
- [ ] Documentation added
- [x] Tests updated

