### PR TITLE
Change 'left outer join' to 'join' with t_cryptotransferlists

### DIFF
--- a/hedera-mirror-rest/__tests__/transactionsTest.test.js
+++ b/hedera-mirror-rest/__tests__/transactionsTest.test.js
@@ -39,7 +39,7 @@ const boilerplateSufffix = ` join t_transactions t on tlist.consensus_timestamp 
     join t_entities enode on enode.id = t.fk_node_acc_id
     join t_entities etrans on etrans.id = t.fk_payer_acc_id
     left outer join t_transaction_types ttt on ttt.proto_id = t.type
-    left outer join t_cryptotransferlists ctl on tlist.consensus_timestamp = ctl.consensus_timestamp
+    join t_cryptotransferlists ctl on tlist.consensus_timestamp = ctl.consensus_timestamp
     order by t.consensus_ns desc,account_num asc,amount asc`;
 
 test('transactions by timestamp gte', () => {

--- a/hedera-mirror-rest/transactions.js
+++ b/hedera-mirror-rest/transactions.js
@@ -117,7 +117,7 @@ const getTransactionsOuterQuery = function (innerQuery, order) {
     '   join t_entities enode on enode.id = t.fk_node_acc_id\n' +
     '   join t_entities etrans on etrans.id = t.fk_payer_acc_id\n' +
     '   left outer join t_transaction_types ttt on ttt.proto_id = t.type\n' +
-    '   left outer join t_cryptotransferlists ctl on  tlist.consensus_timestamp = ctl.consensus_timestamp\n' +
+    '   join t_cryptotransferlists ctl on  tlist.consensus_timestamp = ctl.consensus_timestamp\n' +
     '   order by t.consensus_ns ' +
     order +
     ', account_num asc, amount asc ' +


### PR DESCRIPTION
**Detailed description**:
Removing left outer join doesn't cause any tests to fail, so i guess whatever was blocking it is no more after many recent rest api test cleanups.

**Which issue(s) this PR fixes**:
Fixes #136 

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated