### PR TITLE
Utilize plural rest api endpoints without breaking support

### DIFF
--- a/hedera-mirror-rest/__tests__/specs/topicmessage-01-timestamp-valid.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/topicmessage-01-timestamp-valid.spec.json
@@ -23,7 +23,7 @@
       }
     ]
   },
-  "url": "/api/v1/topic/message/1234567890.000000002",
+  "url": "/api/v1/topics/messages/1234567890.000000002",
   "responseStatus": 200,
   "responseJson": {
     "consensus_timestamp": "1234567890.000000002",

--- a/hedera-mirror-rest/__tests__/specs/topicmessage-02-timestamp-invalid.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/topicmessage-02-timestamp-invalid.spec.json
@@ -1,21 +1,21 @@
 {
-    "description": "Invalid consensus timestamp",
-    "setup": {
-        "accounts": [],
-        "balances": [],
-        "transactions": [],
-        "cryptotransfers": [],
-        "topicmessages": []
-    },
-    "url": "/api/v1/topic/message/123abc",
-    "responseStatus": 400,
-    "responseJson": {
-        "_status": {
-            "messages": [
-                {
-                    "message": "Invalid parameter: consensus_timestamp"
-                }
-            ]
+  "description": "Invalid consensus timestamp",
+  "setup": {
+    "accounts": [],
+    "balances": [],
+    "transactions": [],
+    "cryptotransfers": [],
+    "topicmessages": []
+  },
+  "url": "/api/v1/topics/messages/123abc",
+  "responseStatus": 400,
+  "responseJson": {
+    "_status": {
+      "messages": [
+        {
+          "message": "Invalid parameter: consensus_timestamp"
         }
+      ]
     }
+  }
 }

--- a/hedera-mirror-rest/__tests__/specs/topicmessage-03-timestamp-not-found.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/topicmessage-03-timestamp-not-found.spec.json
@@ -7,7 +7,7 @@
     "cryptotransfers": [],
     "topicmessages": []
   },
-  "url": "/api/v1/topic/message/123.123456789",
+  "url": "/api/v1/topics/messages/123.123456789",
   "responseStatus": 404,
   "responseJson": {
     "_status": {

--- a/hedera-mirror-rest/__tests__/specs/topicmessage-04-idseq-valid.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/topicmessage-04-idseq-valid.spec.json
@@ -30,7 +30,7 @@
       }
     ]
   },
-  "url": "/api/v1/topic/7/message/3",
+  "url": "/api/v1/topics/7/messages/3",
   "responseStatus": 200,
   "responseJson": {
     "consensus_timestamp": "1234567890.000000003",

--- a/hedera-mirror-rest/__tests__/specs/topicmessage-05-idseq-valid-full-id.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/topicmessage-05-idseq-valid-full-id.spec.json
@@ -34,7 +34,7 @@
       }
     ]
   },
-  "url": "/api/v1/topic/0.2.3/message/2",
+  "url": "/api/v1/topics/0.2.3/messages/2",
   "responseStatus": 200,
   "responseJson": {
     "consensus_timestamp": "1234567890.000000002",

--- a/hedera-mirror-rest/__tests__/specs/topicmessage-06-idseq-invalid-path.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/topicmessage-06-idseq-invalid-path.spec.json
@@ -7,7 +7,7 @@
     "cryptotransfers": [],
     "topicmessages": []
   },
-  "url": "/api/v1/topic/0.0.-3/message/a",
+  "url": "/api/v1/topics/0.0.-3/messages/a",
   "responseStatus": 400,
   "responseJson": {
     "_status": {

--- a/hedera-mirror-rest/__tests__/specs/topicmessage-07-idseq-not-found.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/topicmessage-07-idseq-not-found.spec.json
@@ -18,7 +18,7 @@
       }
     ]
   },
-  "url": "/api/v1/topic/7/message/2",
+  "url": "/api/v1/topics/7/messages/2",
   "responseStatus": 404,
   "responseJson": {
     "_status": {

--- a/hedera-mirror-rest/__tests__/specs/topicmessages-01-no-args.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/topicmessages-01-no-args.spec.json
@@ -23,7 +23,7 @@
       }
     ]
   },
-  "url": "/api/v1/topic/7/messages",
+  "url": "/api/v1/topics/7/messages",
   "responseStatus": 200,
   "responseJson": {
     "messages": [

--- a/hedera-mirror-rest/__tests__/specs/topicmessages-02-specific-sequence.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/topicmessages-02-specific-sequence.spec.json
@@ -23,7 +23,7 @@
       }
     ]
   },
-  "url": "/api/v1/topic/7/messages?sequencenumber=2",
+  "url": "/api/v1/topics/7/messages?sequencenumber=2",
   "responseStatus": 200,
   "responseJson": {
     "messages": [

--- a/hedera-mirror-rest/__tests__/specs/topicmessages-03-none.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/topicmessages-03-none.spec.json
@@ -23,7 +23,7 @@
       }
     ]
   },
-  "url": "/api/v1/topic/7/messages?sequencenumber=2&sequencenumber=gte:3&timestamp=lt:1234567890.000000004",
+  "url": "/api/v1/topics/7/messages?sequencenumber=2&sequencenumber=gte:3&timestamp=lt:1234567890.000000004",
   "responseStatus": 200,
   "responseJson": {
     "messages": [],

--- a/hedera-mirror-rest/__tests__/specs/topicmessages-04-timestamp.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/topicmessages-04-timestamp.spec.json
@@ -23,7 +23,7 @@
       }
     ]
   },
-  "url": "/api/v1/topic/7/messages?timestamp=1234567890.000000003",
+  "url": "/api/v1/topics/7/messages?timestamp=1234567890.000000003",
   "responseStatus": 200,
   "responseJson": {
     "messages": [

--- a/hedera-mirror-rest/__tests__/specs/topicmessages-05-all-params.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/topicmessages-05-all-params.spec.json
@@ -38,7 +38,7 @@
       }
     ]
   },
-  "url": "/api/v1/topic/7/messages?sequencenumber=gt:3&timestamp=lte:1234567890.000000005",
+  "url": "/api/v1/topics/7/messages?sequencenumber=gt:3&timestamp=lte:1234567890.000000005",
   "responseStatus": 200,
   "responseJson": {
     "messages": [

--- a/hedera-mirror-rest/__tests__/specs/topicmessages-06-invalid-topid-id.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/topicmessages-06-invalid-topid-id.spec.json
@@ -23,7 +23,7 @@
       }
     ]
   },
-  "url": "/api/v1/topic/-1/messages",
+  "url": "/api/v1/topics/-1/messages",
   "responseStatus": 400,
   "responseJson": {
     "_status": {

--- a/hedera-mirror-rest/__tests__/specs/topicmessages-07-invalid-param-values.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/topicmessages-07-invalid-param-values.spec.json
@@ -23,7 +23,7 @@
       }
     ]
   },
-  "url": "/api/v1/topic/7/messages?sequencenumber=2_2&timestamp=18:34&limit=12345",
+  "url": "/api/v1/topics/7/messages?sequencenumber=2_2&timestamp=18:34&limit=12345",
   "responseStatus": 400,
   "responseJson": {
     "_status": {

--- a/hedera-mirror-rest/__tests__/specs/topicmessages-08-repeated-valid-params.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/topicmessages-08-repeated-valid-params.spec.json
@@ -23,7 +23,7 @@
       }
     ]
   },
-  "url": "/api/v1/topic/7/messages?sequencenumber=lt:4&sequencenumber=gte:1&timestamp=lte:1234567890.000000004&timestamp=gt:1234567890.000000001&timestamp=1234567890.000000002&sequencenumber=2",
+  "url": "/api/v1/topics/7/messages?sequencenumber=lt:4&sequencenumber=gte:1&timestamp=lte:1234567890.000000004&timestamp=gt:1234567890.000000001&timestamp=1234567890.000000002&sequencenumber=2",
   "responseStatus": 200,
   "responseJson": {
     "messages": [

--- a/hedera-mirror-rest/__tests__/specs/topicmessages-09-limit.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/topicmessages-09-limit.spec.json
@@ -38,7 +38,7 @@
       }
     ]
   },
-  "url": "/api/v1/topic/7/messages?sequencenumber=gt:2&timestamp=lte:1234567890.000000006&limit=2",
+  "url": "/api/v1/topics/7/messages?sequencenumber=gt:2&timestamp=lte:1234567890.000000006&limit=2",
   "responseStatus": 200,
   "responseJson": {
     "messages": [
@@ -58,7 +58,7 @@
       }
     ],
     "links": {
-      "next": "/api/v1/topic/7/messages?sequencenumber=gt:2&timestamp=lte:1234567890.000000006&timestamp=gt:1234567890.000000004&limit=2"
+      "next": "/api/v1/topics/7/messages?sequencenumber=gt:2&timestamp=lte:1234567890.000000006&timestamp=gt:1234567890.000000004&limit=2"
     }
   }
 }

--- a/hedera-mirror-rest/__tests__/specs/topicmessages-10-order.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/topicmessages-10-order.spec.json
@@ -38,7 +38,7 @@
       }
     ]
   },
-  "url": "/api/v1/topic/7/messages?sequencenumber=gt:2&timestamp=lte:1234567890.000000006&limit=3&order=desc",
+  "url": "/api/v1/topics/7/messages?sequencenumber=gt:2&timestamp=lte:1234567890.000000006&limit=3&order=desc",
   "responseStatus": 200,
   "responseJson": {
     "messages": [
@@ -65,7 +65,7 @@
       }
     ],
     "links": {
-      "next": "/api/v1/topic/7/messages?sequencenumber=gt:2&limit=3&order=desc&timestamp=lt:1234567890.000000004"
+      "next": "/api/v1/topics/7/messages?sequencenumber=gt:2&limit=3&order=desc&timestamp=lt:1234567890.000000004"
     }
   }
 }

--- a/hedera-mirror-rest/server.js
+++ b/hedera-mirror-rest/server.js
@@ -101,20 +101,21 @@ if (config.api.metrics.enabled) {
 
 let apiPrefix = '/api/v1';
 
-// routes
-app.getAsync(apiPrefix + '/transactions', transactions.getTransactions);
-app.getAsync(apiPrefix + '/transactions/:id', transactions.getOneTransaction);
-app.getAsync(apiPrefix + '/balances', balances.getBalances);
+// accounts routes
 app.getAsync(apiPrefix + '/accounts', accounts.getAccounts);
 app.getAsync(apiPrefix + '/accounts/:id', accounts.getOneAccount);
-app.getAsync(apiPrefix + '/topic/message/:consensusTimestamp', topicmessage.getMessageByConsensusTimestamp);
 
-// support singular and plural resource naming for single topic message via id and sequence
-app.getAsync(apiPrefix + '/topic/:id/message/:sequencenumber', topicmessage.getMessageByTopicAndSequenceRequest);
-app.getAsync(apiPrefix + '/topics/:id/messages/:sequencenumber', topicmessage.getMessageByTopicAndSequenceRequest);
+// balances routes
+app.getAsync(apiPrefix + '/balances', balances.getBalances);
 
-app.getAsync(apiPrefix + '/topics/:id/messages', topicmessage.getTopicMessages);
-app.getAsync(apiPrefix + '/topic/:id/messages', topicmessage.getTopicMessages);
+// transactions routes
+app.getAsync(apiPrefix + '/transactions', transactions.getTransactions);
+app.getAsync(apiPrefix + '/transactions/:id', transactions.getOneTransaction);
+
+// topics routes
+app.getAsync(apiPrefix + '/topics/:id/messages?', topicmessage.getTopicMessages);
+app.getAsync(apiPrefix + '/topics?/:id/messages?/:sequencenumber', topicmessage.getMessageByTopicAndSequenceRequest);
+app.getAsync(apiPrefix + '/topics?/messages?/:consensusTimestamp', topicmessage.getMessageByConsensusTimestamp);
 
 // response data handling middleware
 app.use(responseHandler);

--- a/hedera-mirror-rest/server.js
+++ b/hedera-mirror-rest/server.js
@@ -113,8 +113,8 @@ app.getAsync(apiPrefix + '/transactions', transactions.getTransactions);
 app.getAsync(apiPrefix + '/transactions/:id', transactions.getOneTransaction);
 
 // topics routes
-app.getAsync(apiPrefix + '/topics/:id/messages?', topicmessage.getTopicMessages);
-app.getAsync(apiPrefix + '/topics?/:id/messages?/:sequencenumber', topicmessage.getMessageByTopicAndSequenceRequest);
+app.getAsync(apiPrefix + '/topics/:id/messages', topicmessage.getTopicMessages);
+app.getAsync(apiPrefix + '/topics/:id/messages/:sequencenumber', topicmessage.getMessageByTopicAndSequenceRequest);
 app.getAsync(apiPrefix + '/topics?/messages?/:consensusTimestamp', topicmessage.getMessageByConsensusTimestamp);
 
 // response data handling middleware

--- a/hedera-mirror-rest/topicmessage.js
+++ b/hedera-mirror-rest/topicmessage.js
@@ -258,7 +258,7 @@ const getMessages = async (pgSqlQuery, pgSqlParams) => {
 };
 
 /**
- * Handler function for /message/:consensusTimestamp API.
+ * Handler function for /messages/:consensusTimestamp API.
  * @param {Request} req HTTP request object
  * @return {Promise} Promise for PostgreSQL query
  */
@@ -269,7 +269,7 @@ const getMessageByConsensusTimestamp = async (req, res) => {
 };
 
 /**
- * Handler function for /:id/message/:sequencenumber API.
+ * Handler function for /:id/messages/:sequencenumber API.
  * @param {Request} req HTTP request object
  * @return {Promise} Promise for PostgreSQL query
  */


### PR DESCRIPTION
**Detailed description**:
The /api/v1/topic(s) endpoint introduced inconsistencies in resource path names.
This change subscribes to consistently use plural resource names as they refer to collections unless an exception resource or path arises.

- Update servers.js topic routes to use plural. 
- Utilize regex ? to still match old non plurals to not break any customers.
- Updates singular references in tests and comments 

**Which issue(s) this PR fixes**:
Fixes #700 

**Special notes for your reviewer**:
This is a non breaking change and utilizes expresses support of regex match.
Going forward we should conform to the plural

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

