### PR TITLE
Add missing transactionType to PubSubMessge

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/addressbook/NetworkAddressBook.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/addressbook/NetworkAddressBook.java
@@ -60,8 +60,8 @@ public class NetworkAddressBook {
     }
 
     public static boolean isAddressBook(EntityId entityId) {
-        return entityId != null && entityId.getEntityTypeId() == EntityTypeEnum.FILE.getId()
-                && entityId.getEntityNum() == 102 && entityId.getEntityShard() == 0 && entityId.getEntityRealm() == 0;
+        return entityId != null && entityId.getType() == EntityTypeEnum.FILE.getId()
+                && entityId.getEntityNum() == 102 && entityId.getShardNum() == 0 && entityId.getRealmNum() == 0;
     }
 
     public void updateFrom(TransactionBody transactionBody) {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/EntityId.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/EntityId.java
@@ -39,24 +39,24 @@ public class EntityId {
     // Ignored so not included in json serialization of PubSubMessage
     @JsonIgnore
     private Long id;
-    private Long entityShard;
-    private Long entityRealm;
+    private Long shardNum;
+    private Long realmNum;
     private Long entityNum;
-    private Integer entityTypeId;
+    private Integer type;
 
     public Entities toEntity() {
         Entities entity = new Entities();
         entity.setId(id);
-        entity.setEntityShard(entityShard);
-        entity.setEntityRealm(entityRealm);
+        entity.setEntityShard(shardNum);
+        entity.setEntityRealm(realmNum);
         entity.setEntityNum(entityNum);
-        entity.setEntityTypeId(entityTypeId);
+        entity.setEntityTypeId(type);
         return entity;
     }
 
     @JsonIgnore
     public String getDisplayId() {
-        return String.format("%d.%d.%d", entityShard, entityRealm, entityNum);
+        return String.format("%d.%d.%d", shardNum, realmNum, entityNum);
     }
 
     public static EntityId of(AccountID accountID) {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/domain/PubSubMessage.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/domain/PubSubMessage.java
@@ -37,6 +37,8 @@ public class PubSubMessage {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private final EntityId entity;
 
+    private final int transactionType;
+
     @JsonSerialize(using = ProtoJsonSerializer.class)
     private final Transaction transaction;
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordItemParser.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordItemParser.java
@@ -339,7 +339,7 @@ public class RecordItemParser implements RecordItemListener {
         //   immediately in TransactionHandler.updateEntity(..).
         if (transactionHandler.updatesEntity() && isSuccessful && entityId != null) {
             Entities entity = entityRepository.findByPrimaryKey(
-                    entityId.getEntityShard(), entityId.getEntityRealm(), entityId.getEntityNum())
+                    entityId.getShardNum(), entityId.getRealmNum(), entityId.getEntityNum())
                     .orElseGet(entityId::toEntity);
             transactionHandler.updateEntity(entity, recordItem);
             return entityRepository.save(entity);

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/pubsub/PubSubRecordItemListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/pubsub/PubSubRecordItemListener.java
@@ -83,7 +83,8 @@ public class PubSubRecordItemListener implements RecordItemListener {
                 .setBody(recordItem.getTransactionBody()) // setting deprecated field makes json conversion easier
                 .build();
         var nonFeeTransfers = addNonFeeTransfers(recordItem.getTransactionBody(), recordItem.getRecord());
-        return new PubSubMessage(consensusTimestamp, entity, transaction, recordItem.getRecord(), nonFeeTransfers);
+        return new PubSubMessage(consensusTimestamp, entity, recordItem.getTransactionType(), transaction,
+                recordItem.getRecord(), nonFeeTransfers);
     }
 
     /**

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/EntityRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/EntityRepository.java
@@ -47,7 +47,7 @@ public interface EntityRepository extends PagingAndSortingRepository<Entities, L
     @Query("select id from Entities where entityShard = ?1 and entityRealm = ?2 and entityNum = ?3")
     Optional<Long> findEntityIdByNativeIds(long entityShard, long entityRealm, long entityNum);
 
-    @CachePut(key = "{#p0.entityShard, #p0.entityRealm, #p0.entityNum}", cacheNames = "entity_ids",
+    @CachePut(key = "{#p0.shardNum, #p0.realmNum, #p0.entityNum}", cacheNames = "entity_ids",
             cacheManager = CacheConfiguration.BIG_LRU_CACHE)
     default <S extends EntityId> Long cache(S entity) {
         return entity.getId();

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/EntityRepositoryCustomImpl.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/EntityRepositoryCustomImpl.java
@@ -22,8 +22,6 @@ package com.hedera.mirror.importer.repository;
 
 import java.util.Collection;
 
-import com.hedera.mirror.importer.domain.Entities;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 
@@ -63,7 +61,7 @@ public class EntityRepositoryCustomImpl implements EntityRepositoryCustom {
             return id;
         }
         return entityRepository.findEntityIdByNativeIds(
-                entityId.getEntityShard(), entityId.getEntityRealm(), entityId.getEntityNum())
+                entityId.getShardNum(), entityId.getRealmNum(), entityId.getEntityNum())
                 .orElseGet(() -> {
                     var entity = entityRepository.save(entityId.toEntity());
                     entityRepository.cache(entity.toEntityId()); // save to big cache

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/domain/PubSubMessageTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/domain/PubSubMessageTest.java
@@ -64,6 +64,7 @@ class PubSubMessageTest {
         PubSubMessage pubSubMessage = new PubSubMessage(
                 DEFAULT_TIMESTAMP_LONG,
                 EntityId.of(TOPIC_ID),
+                10,
                 getTransaction(),
                 getTransactionRecord(),
                 nonFeeTransfers);
@@ -72,11 +73,12 @@ class PubSubMessageTest {
         JsonNode expected = objectMapper.readTree("{" +
                 "  \"consensusTimestamp\" : 123456789," +
                 "  \"entity\" : {" +
-                "    \"entityShard\" : 0," +
-                "    \"entityRealm\" : 0," +
+                "    \"shardNum\" : 0," +
+                "    \"realmNum\" : 0," +
                 "    \"entityNum\" : 20," +
-                "    \"entityTypeId\" : 4" +
+                "    \"type\" : 4" +
                 "  }," +
+                "  \"transactionType\" : 10," +
                 getExpectedTransactionJson() + "," +
                 getExpectedTransactionRecord() + "," +
                 "  \"nonFeeTransfers\" : [ {" +
@@ -100,12 +102,13 @@ class PubSubMessageTest {
 
     @Test
     void testSerializationWithNullFields() throws Exception {
-        PubSubMessage pubSubMessage = new PubSubMessage(DEFAULT_TIMESTAMP_LONG, null, getTransaction(),
+        PubSubMessage pubSubMessage = new PubSubMessage(DEFAULT_TIMESTAMP_LONG, null, 10, getTransaction(),
                 getTransactionRecord(), null);
         ObjectMapper objectMapper = new ObjectMapper();
         JsonNode actual = objectMapper.readTree(objectMapper.writeValueAsString(pubSubMessage));
         JsonNode expected = objectMapper.readTree("{" +
                 "  \"consensusTimestamp\" : 123456789," +
+                "  \"transactionType\" : 10," +
                 getExpectedTransactionJson() + "," +
                 getExpectedTransactionRecord() +
                 "}");


### PR DESCRIPTION
**Detailed description**:
Rename EntityId fields to be consistent with naming
in AccountID/FileID/ContractID/TopicID.

Signed-off-by: Apekshit Sharma <apekshit.sharma@hedera.com>

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
Alternative to EntityId fields renaming, we can add `@JsonProperty`

**Checklist**
- [ ] Documentation added
- [x] Tests updated

