### PR TITLE
Added running_hash_version column and logic to migrate

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -68,6 +68,8 @@ value, it is recommended to only populate overridden properties in the custom `a
 | `hedera.mirror.importer.parser.record.persist.nonFeeTransfers`       | false                   | Persist non-fee transfers for transactions that explicitly request hbar transfers              |
 | `hedera.mirror.importer.parser.record.persist.systemFiles`           | true                    | Persist only system files (number lower than `1000`) to the database                           |
 | `hedera.mirror.importer.parser.record.persist.transactionBytes`      | false                   | Persist raw transaction bytes to the database                                                  |
+| `hedera.mirror.importer.r5-rc4-deployDate`                           | 1588636800000000001     | The deployment date of the r5-rc4 version which introduced the running hash version            |
+| `hedera.mirror.importer.runningHashDefaultVersion`                   | 2                       | The default running hash version used by service. Is 2 as of r5-rc4                            |
 | `hedera.mirror.grpc.shard`                                           | 0                       | The default shard number that the component participates in                                    |
 
 ## GRPC API

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/TopicMessage.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/TopicMessage.java
@@ -44,4 +44,6 @@ public class TopicMessage {
     private long sequenceNumber;
 
     private int topicNum;
+
+    private long runningHashVersion;
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/PostgresWritingRecordParsedItemHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/PostgresWritingRecordParsedItemHandler.java
@@ -136,8 +136,9 @@ public class PostgresWritingRecordParsedItemHandler implements RecordParsedItemH
                     + " VALUES (?, ?)");
 
             sqlInsertTopicMessage = connection.prepareStatement("insert into topic_message"
-                    + " (consensus_timestamp, realm_num, topic_num, message, running_hash, sequence_number)"
-                    + " values (?, ?, ?, ?, ?, ?)");
+                    + " (consensus_timestamp, realm_num, topic_num, message, running_hash, sequence_number, " +
+                    "runningHashVersion)"
+                    + " values (?, ?, ?, ?, ?, ?, ?)");
         } catch (SQLException e) {
             throw new ParserSQLException("Unable to prepare SQL statements", e);
         }
@@ -253,6 +254,8 @@ public class PostgresWritingRecordParsedItemHandler implements RecordParsedItemH
             sqlInsertTopicMessage.setBytes(F_TOPICMESSAGE.MESSAGE.ordinal(), topicMessage.getMessage());
             sqlInsertTopicMessage.setBytes(F_TOPICMESSAGE.RUNNING_HASH.ordinal(), topicMessage.getRunningHash());
             sqlInsertTopicMessage.setLong(F_TOPICMESSAGE.SEQUENCE_NUMBER.ordinal(), topicMessage.getSequenceNumber());
+            sqlInsertTopicMessage
+                    .setInt(F_TOPICMESSAGE.RUNNING_HASH_VERSION.ordinal(), (int) topicMessage.getRunningHashVersion());
             sqlInsertTopicMessage.addBatch();
         } catch (SQLException e) {
             throw new ParserSQLException(e);
@@ -317,7 +320,7 @@ public class PostgresWritingRecordParsedItemHandler implements RecordParsedItemH
 
     enum F_TOPICMESSAGE {
         ZERO // column indices start at 1, this creates the necessary offset
-        , CONSENSUS_TIMESTAMP, REALM_NUM, TOPIC_NUM, MESSAGE, RUNNING_HASH, SEQUENCE_NUMBER
+        , CONSENSUS_TIMESTAMP, REALM_NUM, TOPIC_NUM, MESSAGE, RUNNING_HASH, SEQUENCE_NUMBER, RUNNING_HASH_VERSION
     }
 
     enum F_FILE_DATA {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordItemParser.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordItemParser.java
@@ -202,7 +202,7 @@ public class RecordItemParser implements RecordItemListener {
                 Utility.timeStampInNanos(transactionRecord.getConsensusTimestamp()),
                 transactionBody.getMessage().toByteArray(), (int) topicId.getRealmNum(),
                 receipt.getTopicRunningHash().toByteArray(), receipt.getTopicSequenceNumber(),
-                (int) topicId.getTopicNum());
+                (int) topicId.getTopicNum(), receipt.getTopicRunningHashVersion());
         recordParsedItemHandler.onTopicMessage(topicMessage);
     }
 

--- a/hedera-mirror-importer/src/main/resources/application.yml
+++ b/hedera-mirror-importer/src/main/resources/application.yml
@@ -64,6 +64,8 @@ spring:
       api-user: ${hedera.mirror.importer.db.restUsername}
       db-name: ${hedera.mirror.importer.db.name}
       db-user: ${hedera.mirror.importer.db.username}
+      # service r5-rc4 deployDate in consensus_timestamp format e.g. 1587068400721029030, must be set for v1.23.1 migration
+      r5-rc4-deployDate:
   jpa:
     properties:
       hibernate:

--- a/hedera-mirror-importer/src/main/resources/application.yml
+++ b/hedera-mirror-importer/src/main/resources/application.yml
@@ -9,6 +9,9 @@ hedera:
         restPassword: mirror_api_pass
         restUsername: mirror_api
         username: mirror_node
+      # service r5-rc4 deployDate in consensus_timestamp format e.g. 1588636800000000001, must be set for v1.23.1 migration
+      r5-rc4-deployDate: 1588636800000000001
+      runningHashDefaultVersion: 2
 logging:
   level:
     root: warn
@@ -64,8 +67,8 @@ spring:
       api-user: ${hedera.mirror.importer.db.restUsername}
       db-name: ${hedera.mirror.importer.db.name}
       db-user: ${hedera.mirror.importer.db.username}
-      # service r5-rc4 deployDate in consensus_timestamp format e.g. 1587068400721029030, must be set for v1.23.1 migration
-      r5-rc4-deployDate:
+      r5-rc4-deployDate: ${hedera.mirror.importer.r5-rc4-deployDate}
+      runningHashDefaultVersion: ${hedera.mirror.importer.runningHashDefaultVersion}
   jpa:
     properties:
       hibernate:

--- a/hedera-mirror-importer/src/main/resources/db/migration/V1.23.1__add_topicmessage_runninghashversion.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/V1.23.1__add_topicmessage_runninghashversion.sql
@@ -1,4 +1,4 @@
 -- add the column conditionally
 alter table topic_message add column if not exists running_hash_version smallint null;
 
-UPDATE topic_message SET running_hash_version = CASE WHEN consensus_timestamp < ${r5-rc4-deployDate} THEN 1 ELSE 2 END WHERE running_hash_version IS NULL;
+UPDATE topic_message SET running_hash_version = CASE WHEN consensus_timestamp < ${r5-rc4-deployDate} THEN 1 ELSE ${runningHashDefaultVersion} END WHERE running_hash_version IS NULL;

--- a/hedera-mirror-importer/src/main/resources/db/migration/V1.23.1__add_topicmessage_runninghashversion.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/V1.23.1__add_topicmessage_runninghashversion.sql
@@ -1,0 +1,4 @@
+-- add the column conditionally
+alter table topic_message add column if not exists running_hash_version smallint null;
+
+UPDATE topic_message SET running_hash_version = CASE WHEN consensus_timestamp < ${r5-rc4-deployDate} THEN 1 ELSE 2 END WHERE running_hash_version IS NULL;

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/PostgresWritingRecordParserItemHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/PostgresWritingRecordParserItemHandlerTest.java
@@ -20,29 +20,45 @@ package com.hedera.mirror.importer.parser.record;
  * ‍
  */
 
-import com.hedera.mirror.importer.IntegrationTest;
-import com.hedera.mirror.importer.domain.*;
-import com.hedera.mirror.importer.exception.DuplicateFileException;
-import com.hedera.mirror.importer.parser.domain.StreamFileData;
-import com.hedera.mirror.importer.repository.*;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.springframework.data.repository.CrudRepository;
-import org.springframework.test.context.jdbc.Sql;
-import org.testcontainers.shaded.org.bouncycastle.util.Strings;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-import javax.annotation.Resource;
-import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import javax.annotation.Resource;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.test.context.jdbc.Sql;
+import org.testcontainers.shaded.org.bouncycastle.util.Strings;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import com.hedera.mirror.importer.IntegrationTest;
+import com.hedera.mirror.importer.domain.ContractResult;
+import com.hedera.mirror.importer.domain.CryptoTransfer;
+import com.hedera.mirror.importer.domain.FileData;
+import com.hedera.mirror.importer.domain.LiveHash;
+import com.hedera.mirror.importer.domain.NonFeeTransfer;
+import com.hedera.mirror.importer.domain.RecordFile;
+import com.hedera.mirror.importer.domain.TopicMessage;
+import com.hedera.mirror.importer.domain.Transaction;
+import com.hedera.mirror.importer.exception.DuplicateFileException;
+import com.hedera.mirror.importer.parser.domain.StreamFileData;
+import com.hedera.mirror.importer.repository.ContractResultRepository;
+import com.hedera.mirror.importer.repository.CryptoTransferRepository;
+import com.hedera.mirror.importer.repository.FileDataRepository;
+import com.hedera.mirror.importer.repository.LiveHashRepository;
+import com.hedera.mirror.importer.repository.NonFeeTransferRepository;
+import com.hedera.mirror.importer.repository.RecordFileRepository;
+import com.hedera.mirror.importer.repository.TopicMessageRepository;
+import com.hedera.mirror.importer.repository.TransactionRepository;
 
 @Sql(executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD, scripts = "classpath:db/scripts/cleanup.sql")
 @Sql(executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD, scripts = "classpath:db/scripts/cleanup.sql")
@@ -79,6 +95,12 @@ public class PostgresWritingRecordParserItemHandlerTest extends IntegrationTest 
     protected PostgresWriterProperties postgresWriterProperties;
 
     private String fileName;
+
+    static <T, ID> void assertExistsAndEquals(CrudRepository<T, ID> repository, T expected, ID id) throws Exception {
+        Optional<T> actual = repository.findById(id);
+        assertTrue(actual.isPresent());
+        assertEquals(expected, actual.get());
+    }
 
     @BeforeEach
     final void beforeEach() {
@@ -129,7 +151,7 @@ public class PostgresWritingRecordParserItemHandlerTest extends IntegrationTest 
         // given
         byte[] message = Strings.toByteArray("test message");
         byte[] runningHash = Strings.toByteArray("running hash");
-        TopicMessage expectedTopicMessage = new TopicMessage(1L, message, 0, runningHash, 10L, 1001);
+        TopicMessage expectedTopicMessage = new TopicMessage(1L, message, 0, runningHash, 10L, 1001, 2);
 
         // when
         postgresWriter.onTopicMessage(expectedTopicMessage);
@@ -210,7 +232,7 @@ public class PostgresWritingRecordParserItemHandlerTest extends IntegrationTest 
         List<PreparedStatement> insertStatements = new ArrayList<>(); // tracks all PreparedStatements
         when(connection.prepareStatement(any())).then(ignored -> {
             PreparedStatement preparedStatement = mock(PreparedStatement.class);
-            when(preparedStatement.executeBatch()).thenReturn(new int[]{});
+            when(preparedStatement.executeBatch()).thenReturn(new int[] {});
             insertStatements.add(preparedStatement);
             return preparedStatement;
         });
@@ -246,6 +268,8 @@ public class PostgresWritingRecordParserItemHandlerTest extends IntegrationTest 
         assertEquals(0, cryptoTransferRepository.count());
     }
 
+    // TODO: add test to check contents of recordFileRepo
+
     @Test
     void onDuplicateFileReturnEmpty() {
         // given: file processed once
@@ -253,17 +277,9 @@ public class PostgresWritingRecordParserItemHandlerTest extends IntegrationTest 
 
         // when, then
         assertThrows(DuplicateFileException.class, () -> {
-                    postgresWriter.onStart(new StreamFileData(fileName, null));
-                });
+            postgresWriter.onStart(new StreamFileData(fileName, null));
+        });
 
         postgresWriter.onError();  // close connection
-    }
-
-    // TODO: add test to check contents of recordFileRepo
-
-    static <T, ID> void assertExistsAndEquals(CrudRepository<T, ID> repository, T expected, ID id) throws Exception {
-        Optional<T> actual = repository.findById(id);
-        assertTrue(actual.isPresent());
-        assertEquals(expected, actual.get());
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordItemParserTopicTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordItemParserTopicTest.java
@@ -401,18 +401,19 @@ public class RecordItemParserTopicTest extends AbstractRecordItemParserTest {
 
     @ParameterizedTest
     @CsvSource({
-            "0.0.9000, test-message0, 9000000, runninghash, 1",
-            "0.0.9001, '', 9000001, '', 9223372036854775807"
+            "0.0.9000, test-message0, 9000000, runninghash, 1, 1",
+            "0.0.9001, '', 9000001, '', 9223372036854775807, 2"
     })
     void submitMessageTest(@ConvertWith(TopicIdConverter.class) TopicID topicId, String message,
                            long consensusTimestamp, String runningHash,
-                           long sequenceNumber) throws Exception {
+                           long sequenceNumber, long runningHashVersion) throws Exception {
         var responseCode = ResponseCodeEnum.SUCCESS;
 
         var topic = createTopicEntity(topicId, 10L, 20, null, null, null, null, null);
         entityRepository.save(topic);
 
-        var topicMessage = createTopicMessage(topicId, message, sequenceNumber, runningHash, consensusTimestamp);
+        var topicMessage = createTopicMessage(topicId, message, sequenceNumber, runningHash, consensusTimestamp,
+                runningHashVersion);
         var transaction = createSubmitMessageTransaction(topicId, message);
         var transactionRecord = createTransactionRecord(topicId, sequenceNumber, runningHash
                 .getBytes(), consensusTimestamp, responseCode);
@@ -437,11 +438,13 @@ public class RecordItemParserTopicTest extends AbstractRecordItemParserTest {
         var message = "message";
         var sequenceNumber = 10_000L;
         var runningHash = "running-hash";
+        var runningHashVersion = 2;
 
         var topic = createTopicEntity(topicId, null, null, null, null, null, null, null);
         // Topic NOT saved in the repository.
 
-        var topicMessage = createTopicMessage(topicId, message, sequenceNumber, runningHash, consensusTimestamp);
+        var topicMessage = createTopicMessage(topicId, message, sequenceNumber, runningHash, consensusTimestamp,
+                runningHashVersion);
         var transaction = createSubmitMessageTransaction(topicId, message);
         var transactionRecord = createTransactionRecord(topicId, sequenceNumber, runningHash
                 .getBytes(), consensusTimestamp, responseCode);
@@ -597,7 +600,7 @@ public class RecordItemParserTopicTest extends AbstractRecordItemParserTest {
     }
 
     private TopicMessage createTopicMessage(TopicID topicId, String message, long sequenceNumber, String runningHash,
-                                            long consensusTimestamp) {
+                                            long consensusTimestamp, long runningHashVersion) {
         var topicMessage = new TopicMessage();
         topicMessage.setConsensusTimestamp(consensusTimestamp);
         topicMessage.setRealmNum((int) topicId.getRealmNum());
@@ -605,6 +608,7 @@ public class RecordItemParserTopicTest extends AbstractRecordItemParserTest {
         topicMessage.setMessage(message.getBytes());
         topicMessage.setSequenceNumber(sequenceNumber);
         topicMessage.setRunningHash(runningHash.getBytes());
+        topicMessage.setRunningHashVersion(runningHashVersion);
         return topicMessage;
     }
 


### PR DESCRIPTION
**Detailed description**:
The r5-rc4 update contained a few changes and additions.
This change

- Adds the running_hash_version column to the topic_message table 
- Sets running_hash_version of topic_message table if null. Based on comparison of consensus_timestamp with r5-rc4 deployDate it will be set to default 

**Which issue(s) this PR fixes**:
Fixes #688 

**Special notes for your reviewer**:
Ran migration locally to verify cases of
- No running_hash_version with messages pre and post deploy date
- running_hash_version column present with empty values
- running_hash_version column present and set

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

