### PR TITLE
Update Spring Boot to 2.2.7 to fix NPE in GRPC

### DIFF
--- a/charts/hedera-mirror/templates/application.yaml
+++ b/charts/hedera-mirror/templates/application.yaml
@@ -47,6 +47,7 @@ spec:
     keywords:
       - blockchain
       - dtl
+      - hedera
       - hashgraph
       - mirror
     links:

--- a/hedera-mirror-datagenerator/pom.xml
+++ b/hedera-mirror-datagenerator/pom.xml
@@ -14,6 +14,10 @@
         <version>0.11.0-rc1</version>
     </parent>
 
+    <properties>
+        <commons-csv.version>1.8</commons-csv.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.hedera</groupId>
@@ -28,7 +32,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-csv</artifactId>
-            <version>1.7</version>
+            <version>${commons-csv.version}</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/hedera-mirror-grpc/pom.xml
+++ b/hedera-mirror-grpc/pom.xml
@@ -14,6 +14,11 @@
         <version>0.11.0-rc1</version>
     </parent>
 
+    <properties>
+        <grpc-spring-boot.version>2.7.0.RELEASE</grpc-spring-boot.version>
+        <jmeter.version>5.2.1</jmeter.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -62,7 +67,7 @@
         <dependency>
             <groupId>net.devh</groupId>
             <artifactId>grpc-spring-boot-starter</artifactId>
-            <version>2.6.2.RELEASE</version>
+            <version>${grpc-spring-boot.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.springframework.boot</groupId>
@@ -157,6 +162,16 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-logging</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.junit.vintage</groupId>
+                    <artifactId>junit-vintage-engine</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.playtika.testcontainers</groupId>
@@ -167,19 +182,19 @@
         <dependency>
             <groupId>org.apache.jmeter</groupId>
             <artifactId>ApacheJMeter_core</artifactId>
-            <version>5.1.1</version>
+            <version>${jmeter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.jmeter</groupId>
             <artifactId>ApacheJMeter_java</artifactId>
-            <version>5.1.1</version>
+            <version>${jmeter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.hedera.hashgraph</groupId>
             <artifactId>sdk</artifactId>
-            <version>1.1.0</version>
+            <version>${hedera-sdk.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -213,10 +228,6 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>pl.project13.maven</groupId>
-                <artifactId>git-commit-id-plugin</artifactId>
             </plugin>
             <!-- Create test case jar to allow jmeter to utilize samplers -->
             <plugin>

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/service/TopicMessageServiceTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/service/TopicMessageServiceTest.java
@@ -308,7 +308,7 @@ public class TopicMessageServiceTest extends GrpcIntegrationTest {
     void historicalMessagesWithLimit() {
         TopicMessage topicMessage1 = domainBuilder.topicMessage().block();
         TopicMessage topicMessage2 = domainBuilder.topicMessage().block();
-        TopicMessage topicMessage3 = domainBuilder.topicMessage().block();
+        domainBuilder.topicMessage().block();
 
         TopicMessageFilter filter = TopicMessageFilter.builder()
                 .limit(2)
@@ -373,7 +373,7 @@ public class TopicMessageServiceTest extends GrpcIntegrationTest {
                 .map(TopicMessage::getSequenceNumber)
                 .as(StepVerifier::create)
                 .thenAwait(Duration.ofMillis(50))
-                .then(() -> generator.blockLast())
+                .then(generator::blockLast)
                 .expectNext(1L, 2L)
                 .expectComplete()
                 .verify(Duration.ofMillis(1000));
@@ -397,7 +397,7 @@ public class TopicMessageServiceTest extends GrpcIntegrationTest {
                 .map(TopicMessage::getSequenceNumber)
                 .as(StepVerifier::create)
                 .thenAwait(Duration.ofMillis(100))
-                .then(() -> generator.blockLast())
+                .then(generator::blockLast)
                 .expectNext(1L, 2L)
                 .expectComplete()
                 .verify(Duration.ofMillis(500));
@@ -405,9 +405,9 @@ public class TopicMessageServiceTest extends GrpcIntegrationTest {
 
     @Test
     void bothMessages() {
-        TopicMessage topicMessage1 = domainBuilder.topicMessage().block();
-        TopicMessage topicMessage2 = domainBuilder.topicMessage().block();
-        TopicMessage topicMessage3 = domainBuilder.topicMessage().block();
+        domainBuilder.topicMessage().block();
+        domainBuilder.topicMessage().block();
+        domainBuilder.topicMessage().block();
 
         TopicMessageFilter filter = TopicMessageFilter.builder()
                 .limit(5)
@@ -446,7 +446,7 @@ public class TopicMessageServiceTest extends GrpcIntegrationTest {
                 .map(TopicMessage::getSequenceNumber)
                 .as(StepVerifier::create)
                 .thenAwait(Duration.ofMillis(100))
-                .then(() -> generator.blockLast())
+                .then(generator::blockLast)
                 .expectNext(1L, 2L)
                 .thenCancel()
                 .verify(Duration.ofMillis(500));
@@ -474,7 +474,7 @@ public class TopicMessageServiceTest extends GrpcIntegrationTest {
                 .map(TopicMessage::getSequenceNumber)
                 .as(StepVerifier::create)
                 .thenAwait(Duration.ofMillis(100))
-                .then(() -> generator.blockLast())
+                .then(generator::blockLast)
                 .expectNext(1L, 2L)
                 .thenCancel()
                 .verify(Duration.ofMillis(500));
@@ -496,7 +496,7 @@ public class TopicMessageServiceTest extends GrpcIntegrationTest {
                 .findByCompositeKey(0, retrieverFilter.getRealmNum(), retrieverFilter.getTopicNum()))
                 .thenReturn(Optional
                         .of(Entity.builder().entityTypeId(EntityType.TOPIC).build()));
-        
+
         Mockito.when(topicMessageRetriever.retrieve(ArgumentMatchers
                 .any()))
                 .thenReturn(Flux
@@ -636,13 +636,14 @@ public class TopicMessageServiceTest extends GrpcIntegrationTest {
                 .thenReturn(Flux.just(beforeMissing1, beforeMissing2, afterMissing1, afterMissing2, afterMissing3));
 
         Mockito.when(topicMessageRetriever.retrieve(ArgumentMatchers
-                .any()))
-                .thenReturn(Flux.just(retrieved1),
-                        Flux.just(retrieved2), // missing historic
-                        Flux.just(
-                                topicMessage(5), // missing incoming
-                                topicMessage(6),
-                                topicMessage(7)));
+                .isA(TopicMessageFilter.class)))
+                .thenReturn(Flux.just(
+                        retrieved1,
+                        retrieved2, // missing historic
+                        topicMessage(5), // missing incoming
+                        topicMessage(6),
+                        topicMessage(7)
+                ));
 
         topicMessageService.subscribeTopic(retrieverFilter)
                 .map(TopicMessage::getSequenceNumber)

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/service/TopicMessageServiceTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/service/TopicMessageServiceTest.java
@@ -601,6 +601,7 @@ public class TopicMessageServiceTest extends GrpcIntegrationTest {
                 .verify(Duration.ofMillis(700));
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     void missingMessagesFromRetrieverAndListener() {
         TopicListener topicListener = Mockito.mock(TopicListener.class);
@@ -635,15 +636,15 @@ public class TopicMessageServiceTest extends GrpcIntegrationTest {
                 .listen(ArgumentMatchers.argThat(l -> l.getStartTime().equals(listenerFilter.getStartTime()))))
                 .thenReturn(Flux.just(beforeMissing1, beforeMissing2, afterMissing1, afterMissing2, afterMissing3));
 
-        Mockito.when(topicMessageRetriever.retrieve(ArgumentMatchers
-                .isA(TopicMessageFilter.class)))
-                .thenReturn(Flux.just(
-                        retrieved1,
-                        retrieved2, // missing historic
-                        topicMessage(5), // missing incoming
-                        topicMessage(6),
-                        topicMessage(7)
-                ));
+        Mockito.when(topicMessageRetriever.retrieve(ArgumentMatchers.isA(TopicMessageFilter.class)))
+                .thenReturn(
+                        Flux.just(retrieved1),
+                        Flux.just(retrieved2), // missing historic
+                        Flux.just(
+                                topicMessage(5), // missing incoming
+                                topicMessage(6),
+                                topicMessage(7)
+                        ));
 
         topicMessageService.subscribeTopic(retrieverFilter)
                 .map(TopicMessage::getSequenceNumber)

--- a/hedera-mirror-importer/pom.xml
+++ b/hedera-mirror-importer/pom.xml
@@ -18,8 +18,20 @@
 
     <properties>
         <commons-io.version>2.6</commons-io.version>
-        <hedera-sdk.version>0.6.1</hedera-sdk.version>
+        <s3mock.version>0.2.5</s3mock.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>bom</artifactId>
+                <version>2.13.11</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -45,7 +57,7 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>3.10.0</version>
+            <version>${protobuf.version}</version>
         </dependency>
         <dependency>
             <groupId>com.lmax</groupId>
@@ -171,13 +183,23 @@
         <dependency>
             <groupId>io.findify</groupId>
             <artifactId>s3mock_2.12</artifactId>
-            <version>0.2.5</version>
+            <version>${s3mock.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-logging</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.junit.vintage</groupId>
+                    <artifactId>junit-vintage-engine</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.playtika.testcontainers</groupId>
@@ -192,18 +214,6 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>software.amazon.awssdk</groupId>
-                <artifactId>bom</artifactId>
-                <version>2.10.54</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <profiles>
         <profile>
@@ -278,10 +288,6 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>pl.project13.maven</groupId>
-                <artifactId>git-commit-id-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/hedera-mirror-importer/pom.xml
+++ b/hedera-mirror-importer/pom.xml
@@ -18,6 +18,7 @@
 
     <properties>
         <commons-io.version>2.6</commons-io.version>
+        <guava.version>29.0-jre</guava.version>
         <s3mock.version>0.2.5</s3mock.version>
     </properties>
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordFileParser.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordFileParser.java
@@ -175,7 +175,7 @@ public class RecordFileParser implements FileParser {
                                     .compareTo(Utility.getFileName(fileName)) < 0) {
                                 // last file for which mismatch is allowed is in the past
                                 throw new ParserException(String.format(
-                                        "Hash mismatch for file %s. Actual = %s, Expected = %s",
+                                        "Hash mismatch for file %s. Expected = %s, Actual = %s",
                                         fileName, expectedPrevFileHash, actualPrevFileHash));
                             }
                         }

--- a/hedera-mirror-protobuf/pom.xml
+++ b/hedera-mirror-protobuf/pom.xml
@@ -16,7 +16,6 @@
 
     <properties>
         <protobuf.plugin.version>0.6.1</protobuf.plugin.version>
-        <protoc.version>3.11.1</protoc.version>
         <reactor-grpc.version>1.0.0</reactor-grpc.version>
     </properties>
 
@@ -55,9 +54,8 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
+                    <source>1.8</source> <!-- Target older Java version to be compatible with more clients -->
                     <target>1.8</target>
                 </configuration>
             </plugin>
@@ -72,7 +70,7 @@
                 <version>${protobuf.plugin.version}</version>
                 <configuration>
                     <protocArtifact>
-                        com.google.protobuf:protoc:${protoc.version}:exe:${os.detected.classifier}
+                        com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}
                     </protocArtifact>
                     <pluginId>grpc-java</pluginId>
                     <pluginArtifact>

--- a/hedera-mirror-rest/pom.xml
+++ b/hedera-mirror-rest/pom.xml
@@ -19,7 +19,7 @@
             <plugin>
                 <groupId>io.fabric8</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
-                <version>0.31.0</version>
+                <version>${docker-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>dockerBuild</id>

--- a/hedera-mirror-test/pom.xml
+++ b/hedera-mirror-test/pom.xml
@@ -82,6 +82,7 @@
                     <artifactId>spring-boot-starter-logging</artifactId>
                 </exclusion>
                 <exclusion>
+                    <!-- Caused compilation errors when included -->
                     <groupId>org.junit.vintage</groupId>
                     <artifactId>junit-vintage-engine</artifactId>
                 </exclusion>

--- a/hedera-mirror-test/pom.xml
+++ b/hedera-mirror-test/pom.xml
@@ -18,7 +18,8 @@
     <properties>
         <jmeter.test>E2E_Subscribe_Only.jmx</jmeter.test>
         <jmeter.subscribeThreadCount></jmeter.subscribeThreadCount>
-        <cucumber.version>5.6.0</cucumber.version>
+        <cucumber.version>5.7.0</cucumber.version>
+        <cucumber-reporting.version>4.0.48</cucumber-reporting.version>
         <skipTests>true</skipTests>
     </properties>
 
@@ -26,7 +27,7 @@
         <dependency>
             <groupId>com.hedera.hashgraph</groupId>
             <artifactId>sdk</artifactId>
-            <version>1.1.4</version>
+            <version>${hedera-sdk.version}</version>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
@@ -80,12 +81,16 @@
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-starter-logging</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.junit.vintage</groupId>
+                    <artifactId>junit-vintage-engine</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
             <groupId>de.monochromata.cucumber</groupId>
             <artifactId>reporting-plugin</artifactId>
-            <version>4.0.15</version>
+            <version>${cucumber-reporting.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,6 @@
         <docker.tag.version>${project.version}</docker.tag.version>
         <docker.tag.latest>latest</docker.tag.latest>
         <grpc.version>1.29.0</grpc.version>
-        <guava.version>29.0-jre</guava.version>
         <hedera-protobuf.version>0.4.2</hedera-protobuf.version>
         <hedera-sdk.version>1.1.5</hedera-sdk.version>
         <jacoco.version>0.8.5</jacoco.version>

--- a/pom.xml
+++ b/pom.xml
@@ -48,26 +48,29 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.2.4.RELEASE</version>
+        <version>2.2.7.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
     <properties>
         <disruptor.version>3.4.2</disruptor.version> <!-- Used for asynchronous logging -->
+        <docker-maven-plugin.version>0.33.0</docker-maven-plugin.version>
         <docker.push.repository>gcr.io/mirrornode</docker.push.repository>
         <docker.tag.version>${project.version}</docker.tag.version>
         <docker.tag.latest>latest</docker.tag.latest>
-        <grpc.version>1.25.0</grpc.version>
-        <guava.version>28.2-jre</guava.version>
+        <grpc.version>1.29.0</grpc.version>
+        <guava.version>29.0-jre</guava.version>
         <hedera-protobuf.version>0.4.2</hedera-protobuf.version>
+        <hedera-sdk.version>1.1.5</hedera-sdk.version>
         <jacoco.version>0.8.5</jacoco.version>
         <java.version>11</java.version>
         <javax.version>1</javax.version>
-        <jib.version>2.1.0</jib.version>
+        <jib.version>2.2.0</jib.version>
         <micrometer-jvm-extras.version>0.2.0</micrometer-jvm-extras.version>
+        <protobuf.version>3.11.1</protobuf.version>
         <release.version>${project.version}</release.version> <!-- Used to replace release versions in all files -->
         <release.chartVersion>0.1.0</release.chartVersion>
-        <testcontainers.version>1.54</testcontainers.version>
+        <testcontainers.version>1.62</testcontainers.version>
     </properties>
 
     <scm>
@@ -81,7 +84,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-dependencies</artifactId>
-                <version>Hoxton.SR3</version>
+                <version>Hoxton.SR4</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -170,7 +173,7 @@
                     </configuration>
                 </plugin>
                 <plugin>
-                    <!-- To download licenses: ./mvnw license:download-licenses -N -->
+                    <!-- To download licenses: ./mvnw license:download-licenses -->
                     <!-- To generate license report: ./mvnw license:aggregate-third-party-report -->
                     <!-- To update license headers: ./mvnw license:update-file-header -N -->
                     <groupId>org.codehaus.mojo</groupId>
@@ -220,6 +223,18 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>pl.project13.maven</groupId>
+                <artifactId>git-commit-id-plugin</artifactId>
+                <configuration>
+                    <failOnNoGitDirectory>false</failOnNoGitDirectory>
+                    <injectAllReactorProjects>true</injectAllReactorProjects>
+                    <runOnlyOnce>true</runOnlyOnce>
+                    <skipPoms>false</skipPoms>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
 
     <profiles>


### PR DESCRIPTION
**Detailed description**:
- Fix NullPointerException in GRPC module by upgrading Spring Boot to 2.2.7
- Fix compilation warning `TopicMessageServiceTest.java uses unchecked or unsafe operations.`
- Fix git-commit-id-plugin running multiple times and generating a lot of output
- Fix incorrect log statement in RecordFileParser
- Move dependency versions to properties section
- Move some version properties to parent pom to reduce duplication

**Which issue(s) this PR fixes**:
Fixes #739 

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated

