### PR TITLE
Include 3rd party licenses and source in container images

### DIFF
--- a/hedera-mirror-grpc/pom.xml
+++ b/hedera-mirror-grpc/pom.xml
@@ -202,6 +202,14 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
             </plugin>

--- a/hedera-mirror-grpc/pom.xml
+++ b/hedera-mirror-grpc/pom.xml
@@ -202,6 +202,10 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>com.googlecode.maven-download-plugin</groupId>
+                <artifactId>download-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
             </plugin>

--- a/hedera-mirror-importer/pom.xml
+++ b/hedera-mirror-importer/pom.xml
@@ -263,6 +263,10 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>com.googlecode.maven-download-plugin</groupId>
+                <artifactId>download-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
             </plugin>

--- a/hedera-mirror-importer/pom.xml
+++ b/hedera-mirror-importer/pom.xml
@@ -263,6 +263,14 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
         <disruptor.version>3.4.2</disruptor.version> <!-- Used for asynchronous logging -->
         <docker-maven-plugin.version>0.33.0</docker-maven-plugin.version>
         <docker.push.repository>gcr.io/mirrornode</docker.push.repository>
+        <docker.resources>${project.build.directory}/container</docker.resources>
         <docker.tag.version>${project.version}</docker.tag.version>
         <docker.tag.latest>latest</docker.tag.latest>
         <grpc.version>1.29.0</grpc.version>
@@ -101,6 +102,25 @@
     <build>
         <pluginManagement>
             <plugins>
+                <!-- Download library source jars and package in container image for GCP Marketplace compliance -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <executions>
+                        <execution>
+                            <phase>verify</phase>
+                            <goals>
+                                <goal>copy-dependencies</goal>
+                            </goals>
+                            <configuration>
+                                <classifier>sources</classifier>
+                                <includeScope>runtime</includeScope>
+                                <outputDirectory>${docker.resources}/third_party/sources</outputDirectory>
+                                <prependGroupId>true</prependGroupId>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
@@ -136,6 +156,11 @@
                     <artifactId>jib-maven-plugin</artifactId>
                     <version>${jib.version}</version>
                     <configuration>
+                        <extraDirectories>
+                            <paths>
+                                <path>${docker.resources}</path>
+                            </paths>
+                        </extraDirectories>
                         <to>
                             <image>${docker.push.repository}/${project.artifactId}</image>
                             <tags>
@@ -172,13 +197,11 @@
                     </configuration>
                 </plugin>
                 <plugin>
-                    <!-- To download licenses: ./mvnw license:download-licenses -->
                     <!-- To generate license report: ./mvnw license:aggregate-third-party-report -->
                     <!-- To update license headers: ./mvnw license:update-file-header -N -->
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>license-maven-plugin</artifactId>
                     <version>2.0.0</version>
-                    <inherited>false</inherited>
                     <configuration>
                         <canUpdateCopyright>true</canUpdateCopyright>
                         <excludes>
@@ -186,7 +209,6 @@
                             <exclude>**/target/**/*</exclude>
                             <exclude>.mvn/**/*</exclude>
                         </excludes>
-                        <excludedScopes>test</excludedScopes>
                         <includes>
                             <include>**/*.js</include>
                             <include>**/*.java</include>
@@ -219,6 +241,27 @@
                         </roots>
                         <sectionDelimiter>​</sectionDelimiter>
                     </configuration>
+                    <executions>
+                        <execution>
+                            <id>download-licenses-for-container</id>
+                            <phase>verify</phase>
+                            <goals>
+                                <goal>download-licenses</goal>
+                            </goals>
+                            <configuration>
+                                <excludedScopes>test</excludedScopes>
+                                <licensesOutputDirectory>${docker.resources}/third_party/licenses
+                                </licensesOutputDirectory>
+                                <licenseUrlReplacements>
+                                    <licenseUrlReplacement>
+                                        <regexp>\Qhttps://glassfish.dev.java.net/nonav/public/CDDL+GPL.html\E</regexp>
+                                        <replacement>https://oss.oracle.com/licenses/CDDL+GPL-1.1</replacement>
+                                    </licenseUrlReplacement>
+                                </licenseUrlReplacements>
+                                <organizeLicensesByDependencies>true</organizeLicensesByDependencies>
+                            </configuration>
+                        </execution>
+                    </executions>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -226,6 +269,7 @@
             <plugin>
                 <groupId>pl.project13.maven</groupId>
                 <artifactId>git-commit-id-plugin</artifactId>
+                <inherited>false</inherited>
                 <configuration>
                     <failOnNoGitDirectory>false</failOnNoGitDirectory>
                     <injectAllReactorProjects>true</injectAllReactorProjects>

--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,25 @@
                         </execution>
                     </executions>
                 </plugin>
+                <!-- antlr 2.x (Hibernate dependency) is so old it doesn't have sources in Maven Central -->
+                <plugin>
+                    <groupId>com.googlecode.maven-download-plugin</groupId>
+                    <artifactId>download-maven-plugin</artifactId>
+                    <version>1.6.0</version>
+                    <executions>
+                        <execution>
+                            <id>download-antlr-source</id>
+                            <phase>verify</phase>
+                            <goals>
+                                <goal>wget</goal>
+                            </goals>
+                            <configuration>
+                                <outputDirectory>${docker.resources}/third_party/sources</outputDirectory>
+                                <url>https://www.antlr2.org/download/antlr-2.7.7.tar.gz</url>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>


### PR DESCRIPTION
**Detailed description**:
- Uses `dependency:copy-dependencies` plugin to download source jars to `target/container/third_party/sources`
- Uses `download:wget` plugin to manually download antlr 2.x source since it's so old it's not in Maven Central
- Uses `license:download-licenses` plugin to download licenses to `target/container/third_party/licenses`
- Uses jib plugin to copy all files in `target/container` to GPRC and Importer images

**Which issue(s) this PR fixes**:
Fixes #746

**Special notes for your reviewer**:
Directory structure in container:
```
$ docker export 3abdb1e3a663cac3981bcead1f6f53d373f83e72688e2c3ae59520f8cf3435f1 | tar t | grep -F "third_party" | sort
third_party/
third_party/licenses/
third_party/licenses/antlr.antlr_bsd_license.html
third_party/licenses/com.fasterxml.classmate_apache_license,_version_2.0.txt
third_party/licenses/com.fasterxml.jackson.core.jackson-annotations_the_apache_software_license,_version_2.0.txt
third_party/licenses/com.fasterxml.jackson.core.jackson-core_the_apache_software_license,_version_2.0
third_party/licenses/com.fasterxml.jackson.core.jackson-databind_the_apache_software_license,_version_2.0
third_party/licenses/com.fasterxml.jackson.dataformat.jackson-dataformat-yaml_the_apache_software_license,_version_2.0
third_party/licenses/com.fasterxml.jackson.datatype.jackson-datatype-jdk8_the_apache_software_license,_version_2.0
third_party/licenses/com.fasterxml.jackson.datatype.jackson-datatype-jsr310_the_apache_software_license,_version_2.0
third_party/licenses/com.fasterxml.jackson.module.jackson-module-jaxb-annotations_the_apache_software_license,_version_2.0
third_party/licenses/com.fasterxml.jackson.module.jackson-module-parameter-names_the_apache_software_license,_version_2.0
third_party/licenses/com.github.ben-manes.caffeine.caffeine_apache_license,_version_2.0
third_party/licenses/com.github.mifmif.generex_the_apache_software_license,_version_2.0
third_party/licenses/com.google.android.annotations_apache_2.0.txt
third_party/licenses/com.google.api.api-common_bsd.html
third_party/licenses/com.google.api.gax-grpc_bsd.html
third_party/licenses/com.google.api.gax_bsd
third_party/licenses/com.google.api.grpc.proto-google-cloud-pubsub-v1_apache-2.0
third_party/licenses/com.google.api.grpc.proto-google-common-protos_apache-2.0
third_party/licenses/com.google.api.grpc.proto-google-iam-v1_apache-2.0
third_party/licenses/com.google.auth.google-auth-library-credentials_bsd_new_license.html
third_party/licenses/com.google.auth.google-auth-library-oauth2-http_bsd_new_license
third_party/licenses/com.google.auto.value.auto-value-annotations_apache_2.0
third_party/licenses/com.google.cloud.google-cloud-core_apache-2.0
third_party/licenses/com.google.cloud.google-cloud-pubsub_apache-2.0
third_party/licenses/com.google.code.findbugs.jsr305_the_apache_software_license,_version_2.0
third_party/licenses/com.google.code.gson.gson_apache_2.0
third_party/licenses/com.google.errorprone.error_prone_annotations_apache_2.0
third_party/licenses/com.google.guava.failureaccess_the_apache_software_license,_version_2.0
third_party/licenses/com.google.guava.guava_apache_license,_version_2.0
third_party/licenses/com.google.guava.listenablefuture_the_apache_software_license,_version_2.0
third_party/licenses/com.google.http-client.google-http-client-jackson2_the_apache_software_license,_version_2.0
third_party/licenses/com.google.http-client.google-http-client_the_apache_software_license,_version_2.0
third_party/licenses/com.google.j2objc.j2objc-annotations_the_apache_software_license,_version_2.0
third_party/licenses/com.google.protobuf.protobuf-java-util_3-clause_bsd_license.html
third_party/licenses/com.google.protobuf.protobuf-java_3-clause_bsd_license
third_party/licenses/com.hedera.hashgraph.hedera-protobuf-java-api_apache_license,_version_2.0
third_party/licenses/com.lmax.disruptor_the_apache_software_license,_version_2.0
third_party/licenses/com.squareup.okhttp3.logging-interceptor_apache_2.0
third_party/licenses/com.squareup.okhttp3.okhttp_apache_2.0
third_party/licenses/com.squareup.okio.okio_apache_2.0
third_party/licenses/com.sun.activation.jakarta.activation_edl_1.0.html
third_party/licenses/com.sun.istack.istack-commons-runtime_eclipse_distribution_license_-_v_1.0
third_party/licenses/com.typesafe.netty.netty-reactive-streams-http_apache_license,_version_2.0
third_party/licenses/com.typesafe.netty.netty-reactive-streams_apache_license,_version_2.0
third_party/licenses/com.zaxxer.hikaricp_the_apache_software_license,_version_2.0
third_party/licenses/commons-codec.commons-codec_apache_license,_version_2.0
third_party/licenses/commons-io.commons-io_apache_license,_version_2.0
third_party/licenses/dk.brics.automaton.automaton_bsd.html
third_party/licenses/io.fabric8.kubernetes-client_apache_license,_version_2.0
third_party/licenses/io.fabric8.kubernetes-model-common_apache_license,_version_2.0
third_party/licenses/io.fabric8.kubernetes-model_apache_license,_version_2.0
third_party/licenses/io.fabric8.zjsonpatch_the_apache_software_license,_version_2.0
third_party/licenses/io.github.mweirauch.micrometer-jvm-extras_the_apache_license,_version_2.0
third_party/licenses/io.grpc.grpc-alts_apache_2.0.html
third_party/licenses/io.grpc.grpc-api_apache_2.0
third_party/licenses/io.grpc.grpc-auth_apache_2.0
third_party/licenses/io.grpc.grpc-context_apache_2.0
third_party/licenses/io.grpc.grpc-core_apache_2.0
third_party/licenses/io.grpc.grpc-grpclb_apache_2.0
third_party/licenses/io.grpc.grpc-netty-shaded_apache_2.0
third_party/licenses/io.grpc.grpc-protobuf-lite_apache_2.0
third_party/licenses/io.grpc.grpc-protobuf_apache_2.0
third_party/licenses/io.grpc.grpc-stub_apache_2.0
third_party/licenses/io.micrometer.micrometer-core_the_apache_software_license,_version_2.0
third_party/licenses/io.micrometer.micrometer-registry-elastic_the_apache_software_license,_version_2.0
third_party/licenses/io.micrometer.micrometer-registry-prometheus_the_apache_software_license,_version_2.0
third_party/licenses/io.netty.netty-buffer_apache_license,_version_2.0
third_party/licenses/io.netty.netty-codec-http2_apache_license,_version_2.0
third_party/licenses/io.netty.netty-codec-http_apache_license,_version_2.0
third_party/licenses/io.netty.netty-codec-socks_apache_license,_version_2.0
third_party/licenses/io.netty.netty-codec_apache_license,_version_2.0
third_party/licenses/io.netty.netty-common_apache_license,_version_2.0
third_party/licenses/io.netty.netty-handler-proxy_apache_license,_version_2.0
third_party/licenses/io.netty.netty-handler_apache_license,_version_2.0
third_party/licenses/io.netty.netty-resolver_apache_license,_version_2.0
third_party/licenses/io.netty.netty-transport-native-epoll_apache_license,_version_2.0
third_party/licenses/io.netty.netty-transport-native-unix-common_apache_license,_version_2.0
third_party/licenses/io.netty.netty-transport_apache_license,_version_2.0
third_party/licenses/io.opencensus.opencensus-api_the_apache_license,_version_2.0
third_party/licenses/io.opencensus.opencensus-contrib-http-util_the_apache_license,_version_2.0
third_party/licenses/io.perfmark.perfmark-api_apache_2.0
third_party/licenses/io.projectreactor.netty.reactor-netty_the_apache_software_license,_version_2.0
third_party/licenses/io.projectreactor.reactor-core_apache_license,_version_2.0
third_party/licenses/io.prometheus.simpleclient_common_the_apache_software_license,_version_2.0
third_party/licenses/io.prometheus.simpleclient_the_apache_software_license,_version_2.0
third_party/licenses/jakarta.activation.jakarta.activation-api_edl_1.0
third_party/licenses/jakarta.annotation.jakarta.annotation-api_epl_2.0.html
third_party/licenses/jakarta.annotation.jakarta.annotation-api_gpl2_w__cpe.html
third_party/licenses/jakarta.persistence.jakarta.persistence-api_eclipse_distribution_license_v._1.0
third_party/licenses/jakarta.persistence.jakarta.persistence-api_eclipse_public_license_v._2.0
third_party/licenses/jakarta.transaction.jakarta.transaction-api_epl_2.0
third_party/licenses/jakarta.transaction.jakarta.transaction-api_gpl2_w__cpe
third_party/licenses/jakarta.validation.jakarta.validation-api_apache_license_2.0
third_party/licenses/jakarta.xml.bind.jakarta.xml.bind-api_eclipse_distribution_license_-_v_1.0
third_party/licenses/javax.activation.javax.activation-api_cddl_gplv2+ce.html
third_party/licenses/javax.annotation.javax.annotation-api_cddl_+_gplv2_with_classpath_exception.html
third_party/licenses/javax.inject.javax.inject_the_apache_software_license,_version_2.0
third_party/licenses/javax.validation.validation-api_apache_license_2.0
third_party/licenses/javax.xml.bind.jaxb-api_cddl_1.1.txt
third_party/licenses/javax.xml.bind.jaxb-api_gpl2_w__cpe
third_party/licenses/net.bytebuddy.byte-buddy_apache_license,_version_2.0
third_party/licenses/org.apache.commons.commons-lang3_apache_license,_version_2.0
third_party/licenses/org.apache.httpcomponents.httpclient_apache_license,_version_2.0
third_party/licenses/org.apache.httpcomponents.httpcore_apache_license,_version_2.0
third_party/licenses/org.apache.logging.log4j.log4j-api_apache_license,_version_2.0
third_party/licenses/org.apache.logging.log4j.log4j-core_apache_license,_version_2.0
third_party/licenses/org.apache.logging.log4j.log4j-jul_apache_license,_version_2.0
third_party/licenses/org.apache.logging.log4j.log4j-slf4j-impl_apache_license,_version_2.0
third_party/licenses/org.aspectj.aspectjweaver_eclipse_public_license_-_v_1.0.html
third_party/licenses/org.bouncycastle.bcpkix-jdk15on_bouncy_castle_licence.html
third_party/licenses/org.bouncycastle.bcprov-jdk15on_bouncy_castle_licence
third_party/licenses/org.checkerframework.checker-qual_the_mit_license.html
third_party/licenses/org.codehaus.mojo.animal-sniffer-annotations_mit_license.html
third_party/licenses/org.conscrypt.conscrypt-openjdk-uber_apache_2.txt
third_party/licenses/org.dom4j.dom4j_bsd_3-clause_new_license.html
third_party/licenses/org.flywaydb.flyway-core_apache_license,_version_2.0.html
third_party/licenses/org.glassfish.jakarta.el_epl_2.0
third_party/licenses/org.glassfish.jakarta.el_gpl2_w__cpe
third_party/licenses/org.glassfish.javax.el_cddl_+_gplv2_with_classpath_exception
third_party/licenses/org.glassfish.jaxb.jaxb-runtime_eclipse_distribution_license_-_v_1.0
third_party/licenses/org.glassfish.jaxb.txw2_eclipse_distribution_license_-_v_1.0
third_party/licenses/org.hdrhistogram.hdrhistogram_bsd-2-clause.html
third_party/licenses/org.hdrhistogram.hdrhistogram_public_domain,_per_creative_commons_cc0.html
third_party/licenses/org.hibernate.common.hibernate-commons-annotations_gnu_library_general_public_license_v2.1_or_later.html
third_party/licenses/org.hibernate.hibernate-core_gnu_library_general_public_license_v2.1_or_later
third_party/licenses/org.hibernate.validator.hibernate-validator-annotation-processor_apache_license_2.0
third_party/licenses/org.hibernate.validator.hibernate-validator_apache_license_2.0
third_party/licenses/org.javassist.javassist_apache_license_2.0.html
third_party/licenses/org.javassist.javassist_lgpl_2.1.html
third_party/licenses/org.javassist.javassist_mpl_1.1.html
third_party/licenses/org.jboss.jandex_apache_license,_version_2.0
third_party/licenses/org.jboss.logging.jboss-logging_apache_license,_version_2.0
third_party/licenses/org.latencyutils.latencyutils_public_domain,_per_creative_commons_cc0
third_party/licenses/org.postgresql.postgresql_bsd-2-clause.html
third_party/licenses/org.projectlombok.lombok_the_mit_license.txt
third_party/licenses/org.reactivestreams.reactive-streams_cc0
third_party/licenses/org.slf4j.jul-to-slf4j_mit_license
third_party/licenses/org.slf4j.slf4j-api_mit_license
third_party/licenses/org.springframework.boot.spring-boot-actuator-autoconfigure_apache_license,_version_2.0
third_party/licenses/org.springframework.boot.spring-boot-actuator_apache_license,_version_2.0
third_party/licenses/org.springframework.boot.spring-boot-autoconfigure_apache_license,_version_2.0
third_party/licenses/org.springframework.boot.spring-boot-starter-actuator_apache_license,_version_2.0
third_party/licenses/org.springframework.boot.spring-boot-starter-aop_apache_license,_version_2.0
third_party/licenses/org.springframework.boot.spring-boot-starter-cache_apache_license,_version_2.0
third_party/licenses/org.springframework.boot.spring-boot-starter-data-jpa_apache_license,_version_2.0
third_party/licenses/org.springframework.boot.spring-boot-starter-jdbc_apache_license,_version_2.0
third_party/licenses/org.springframework.boot.spring-boot-starter-json_apache_license,_version_2.0
third_party/licenses/org.springframework.boot.spring-boot-starter-log4j2_apache_license,_version_2.0
third_party/licenses/org.springframework.boot.spring-boot-starter-reactor-netty_apache_license,_version_2.0
third_party/licenses/org.springframework.boot.spring-boot-starter-validation_apache_license,_version_2.0
third_party/licenses/org.springframework.boot.spring-boot-starter-webflux_apache_license,_version_2.0
third_party/licenses/org.springframework.boot.spring-boot-starter_apache_license,_version_2.0
third_party/licenses/org.springframework.boot.spring-boot_apache_license,_version_2.0
third_party/licenses/org.springframework.cloud.spring-cloud-context_apache_license,_version_2.0
third_party/licenses/org.springframework.cloud.spring-cloud-gcp-autoconfigure_apache_license,_version_2.0
third_party/licenses/org.springframework.cloud.spring-cloud-gcp-core_apache_license,_version_2.0
third_party/licenses/org.springframework.cloud.spring-cloud-gcp-pubsub_apache_license,_version_2.0
third_party/licenses/org.springframework.cloud.spring-cloud-gcp-starter-pubsub_apache_license,_version_2.0
third_party/licenses/org.springframework.cloud.spring-cloud-gcp-starter_apache_license,_version_2.0
third_party/licenses/org.springframework.cloud.spring-cloud-kubernetes-config_apache_license,_version_2.0
third_party/licenses/org.springframework.cloud.spring-cloud-kubernetes-core_apache_license,_version_2.0
third_party/licenses/org.springframework.cloud.spring-cloud-kubernetes-leader_apache_license,_version_2.0
third_party/licenses/org.springframework.cloud.spring-cloud-starter-kubernetes-config_apache_license,_version_2.0
third_party/licenses/org.springframework.data.spring-data-commons_apache_license,_version_2.0
third_party/licenses/org.springframework.data.spring-data-jpa_apache_license,_version_2.0
third_party/licenses/org.springframework.integration.spring-integration-core_the_apache_software_license,_version_2.0
third_party/licenses/org.springframework.retry.spring-retry_apache_2.0
third_party/licenses/org.springframework.security.spring-security-crypto_the_apache_software_license,_version_2.0
third_party/licenses/org.springframework.security.spring-security-rsa_apache_2.0
third_party/licenses/org.springframework.spring-aop_apache_license,_version_2.0
third_party/licenses/org.springframework.spring-aspects_apache_license,_version_2.0
third_party/licenses/org.springframework.spring-beans_apache_license,_version_2.0
third_party/licenses/org.springframework.spring-context-support_apache_license,_version_2.0
third_party/licenses/org.springframework.spring-context_apache_license,_version_2.0
third_party/licenses/org.springframework.spring-core_apache_license,_version_2.0
third_party/licenses/org.springframework.spring-expression_apache_license,_version_2.0
third_party/licenses/org.springframework.spring-jcl_apache_license,_version_2.0
third_party/licenses/org.springframework.spring-jdbc_apache_license,_version_2.0
third_party/licenses/org.springframework.spring-messaging_apache_license,_version_2.0
third_party/licenses/org.springframework.spring-orm_apache_license,_version_2.0
third_party/licenses/org.springframework.spring-tx_apache_license,_version_2.0
third_party/licenses/org.springframework.spring-web_apache_license,_version_2.0
third_party/licenses/org.springframework.spring-webflux_apache_license,_version_2.0
third_party/licenses/org.synchronoss.cloud.nio-multipart-parser_the_apache_software_license,_version_2.0
third_party/licenses/org.synchronoss.cloud.nio-stream-storage_the_apache_software_license,_version_2.0
third_party/licenses/org.threeten.threetenbp_bsd_3-clause.txt
third_party/licenses/org.yaml.snakeyaml_apache_license,_version_2.0
third_party/licenses/software.amazon.awssdk.annotations_apache_license,_version_2.0.html
third_party/licenses/software.amazon.awssdk.apache-client_apache_license,_version_2.0
third_party/licenses/software.amazon.awssdk.arns_apache_license,_version_2.0
third_party/licenses/software.amazon.awssdk.auth_apache_license,_version_2.0
third_party/licenses/software.amazon.awssdk.aws-core_apache_license,_version_2.0
third_party/licenses/software.amazon.awssdk.aws-query-protocol_apache_license,_version_2.0
third_party/licenses/software.amazon.awssdk.aws-xml-protocol_apache_license,_version_2.0
third_party/licenses/software.amazon.awssdk.http-client-spi_apache_license,_version_2.0
third_party/licenses/software.amazon.awssdk.netty-nio-client_apache_license,_version_2.0
third_party/licenses/software.amazon.awssdk.profiles_apache_license,_version_2.0
third_party/licenses/software.amazon.awssdk.protocol-core_apache_license,_version_2.0
third_party/licenses/software.amazon.awssdk.regions_apache_license,_version_2.0
third_party/licenses/software.amazon.awssdk.s3_apache_license,_version_2.0
third_party/licenses/software.amazon.awssdk.sdk-core_apache_license,_version_2.0
third_party/licenses/software.amazon.awssdk.utils_apache_license,_version_2.0
third_party/licenses/software.amazon.eventstream.eventstream_apache_license,_version_2.0
third_party/sources/
third_party/sources/antlr-2.7.7.tar.gz
third_party/sources/com.fasterxml.classmate-1.5.1-sources.jar
third_party/sources/com.fasterxml.jackson.core.jackson-annotations-2.10.4-sources.jar
third_party/sources/com.fasterxml.jackson.core.jackson-core-2.10.4-sources.jar
third_party/sources/com.fasterxml.jackson.core.jackson-databind-2.10.4-sources.jar
third_party/sources/com.fasterxml.jackson.dataformat.jackson-dataformat-yaml-2.10.4-sources.jar
third_party/sources/com.fasterxml.jackson.datatype.jackson-datatype-jdk8-2.10.4-sources.jar
third_party/sources/com.fasterxml.jackson.datatype.jackson-datatype-jsr310-2.10.4-sources.jar
third_party/sources/com.fasterxml.jackson.module.jackson-module-jaxb-annotations-2.10.4-sources.jar
third_party/sources/com.fasterxml.jackson.module.jackson-module-parameter-names-2.10.4-sources.jar
third_party/sources/com.github.ben-manes.caffeine.caffeine-2.8.2-sources.jar
third_party/sources/com.github.mifmif.generex-1.0.2-sources.jar
third_party/sources/com.google.android.annotations-4.1.1.4-sources.jar
third_party/sources/com.google.api.api-common-1.8.1-sources.jar
third_party/sources/com.google.api.gax-1.54.0-sources.jar
third_party/sources/com.google.api.gax-grpc-1.54.0-sources.jar
third_party/sources/com.google.api.grpc.proto-google-cloud-pubsub-v1-1.85.0-sources.jar
third_party/sources/com.google.api.grpc.proto-google-common-protos-1.17.0-sources.jar
third_party/sources/com.google.api.grpc.proto-google-iam-v1-0.13.0-sources.jar
third_party/sources/com.google.auth.google-auth-library-credentials-0.20.0-sources.jar
third_party/sources/com.google.auth.google-auth-library-oauth2-http-0.20.0-sources.jar
third_party/sources/com.google.auto.value.auto-value-annotations-1.7-sources.jar
third_party/sources/com.google.cloud.google-cloud-core-1.93.0-sources.jar
third_party/sources/com.google.cloud.google-cloud-pubsub-1.103.0-sources.jar
third_party/sources/com.google.code.findbugs.jsr305-3.0.2-sources.jar
third_party/sources/com.google.code.gson.gson-2.8.6-sources.jar
third_party/sources/com.google.errorprone.error_prone_annotations-2.3.4-sources.jar
third_party/sources/com.google.guava.failureaccess-1.0.1-sources.jar
third_party/sources/com.google.guava.guava-29.0-jre-sources.jar
third_party/sources/com.google.http-client.google-http-client-1.34.2-sources.jar
third_party/sources/com.google.http-client.google-http-client-jackson2-1.34.2-sources.jar
third_party/sources/com.google.j2objc.j2objc-annotations-1.3-sources.jar
third_party/sources/com.google.protobuf.protobuf-java-3.11.1-sources.jar
third_party/sources/com.google.protobuf.protobuf-java-util-3.11.4-sources.jar
third_party/sources/com.hedera.hashgraph.hedera-protobuf-java-api-0.4.2-sources.jar
third_party/sources/com.lmax.disruptor-3.4.2-sources.jar
third_party/sources/com.squareup.okhttp3.logging-interceptor-3.14.8-sources.jar
third_party/sources/com.squareup.okhttp3.okhttp-3.14.8-sources.jar
third_party/sources/com.squareup.okio.okio-1.17.2-sources.jar
third_party/sources/com.sun.activation.jakarta.activation-1.2.2-sources.jar
third_party/sources/com.sun.istack.istack-commons-runtime-3.0.11-sources.jar
third_party/sources/com.typesafe.netty.netty-reactive-streams-2.0.4-sources.jar
third_party/sources/com.typesafe.netty.netty-reactive-streams-http-2.0.4-sources.jar
third_party/sources/com.zaxxer.HikariCP-3.4.3-sources.jar
third_party/sources/commons-codec.commons-codec-1.13-sources.jar
third_party/sources/commons-io.commons-io-2.6-sources.jar
third_party/sources/dk.brics.automaton.automaton-1.11-8-sources.jar
third_party/sources/io.fabric8.kubernetes-client-4.4.1-sources.jar
third_party/sources/io.fabric8.kubernetes-model-4.4.1-sources.jar
third_party/sources/io.fabric8.kubernetes-model-common-4.4.1-sources.jar
third_party/sources/io.fabric8.zjsonpatch-0.3.0-sources.jar
third_party/sources/io.github.mweirauch.micrometer-jvm-extras-0.2.0-sources.jar
third_party/sources/io.grpc.grpc-alts-1.27.2-sources.jar
third_party/sources/io.grpc.grpc-api-1.27.2-sources.jar
third_party/sources/io.grpc.grpc-auth-1.27.2-sources.jar
third_party/sources/io.grpc.grpc-context-1.27.2-sources.jar
third_party/sources/io.grpc.grpc-core-1.27.2-sources.jar
third_party/sources/io.grpc.grpc-grpclb-1.27.2-sources.jar
third_party/sources/io.grpc.grpc-netty-shaded-1.27.2-sources.jar
third_party/sources/io.grpc.grpc-protobuf-1.27.2-sources.jar
third_party/sources/io.grpc.grpc-protobuf-lite-1.27.2-sources.jar
third_party/sources/io.grpc.grpc-stub-1.27.2-sources.jar
third_party/sources/io.micrometer.micrometer-core-1.3.8-sources.jar
third_party/sources/io.micrometer.micrometer-registry-elastic-1.3.8-sources.jar
third_party/sources/io.micrometer.micrometer-registry-prometheus-1.3.8-sources.jar
third_party/sources/io.netty.netty-buffer-4.1.49.Final-sources.jar
third_party/sources/io.netty.netty-codec-4.1.49.Final-sources.jar
third_party/sources/io.netty.netty-codec-http-4.1.49.Final-sources.jar
third_party/sources/io.netty.netty-codec-http2-4.1.49.Final-sources.jar
third_party/sources/io.netty.netty-codec-socks-4.1.49.Final-sources.jar
third_party/sources/io.netty.netty-common-4.1.49.Final-sources.jar
third_party/sources/io.netty.netty-handler-4.1.49.Final-sources.jar
third_party/sources/io.netty.netty-handler-proxy-4.1.49.Final-sources.jar
third_party/sources/io.netty.netty-resolver-4.1.49.Final-sources.jar
third_party/sources/io.netty.netty-transport-4.1.49.Final-sources.jar
third_party/sources/io.netty.netty-transport-native-epoll-4.1.49.Final-sources.jar
third_party/sources/io.netty.netty-transport-native-unix-common-4.1.49.Final-sources.jar
third_party/sources/io.opencensus.opencensus-api-0.24.0-sources.jar
third_party/sources/io.opencensus.opencensus-contrib-http-util-0.24.0-sources.jar
third_party/sources/io.perfmark.perfmark-api-0.19.0-sources.jar
third_party/sources/io.projectreactor.netty.reactor-netty-0.9.7.RELEASE-sources.jar
third_party/sources/io.projectreactor.reactor-core-3.3.5.RELEASE-sources.jar
third_party/sources/io.prometheus.simpleclient-0.7.0-sources.jar
third_party/sources/io.prometheus.simpleclient_common-0.7.0-sources.jar
third_party/sources/jakarta.activation.jakarta.activation-api-1.2.2-sources.jar
third_party/sources/jakarta.annotation.jakarta.annotation-api-1.3.5-sources.jar
third_party/sources/jakarta.persistence.jakarta.persistence-api-2.2.3-sources.jar
third_party/sources/jakarta.transaction.jakarta.transaction-api-1.3.3-sources.jar
third_party/sources/jakarta.validation.jakarta.validation-api-2.0.2-sources.jar
third_party/sources/jakarta.xml.bind.jakarta.xml.bind-api-2.3.3-sources.jar
third_party/sources/javax.activation.javax.activation-api-1.2.0-sources.jar
third_party/sources/javax.annotation.javax.annotation-api-1.3.2-sources.jar
third_party/sources/javax.inject.javax.inject-1-sources.jar
third_party/sources/javax.validation.validation-api-2.0.1.Final-sources.jar
third_party/sources/javax.xml.bind.jaxb-api-2.3.1-sources.jar
third_party/sources/net.bytebuddy.byte-buddy-1.10.10-sources.jar
third_party/sources/org.apache.commons.commons-lang3-3.9-sources.jar
third_party/sources/org.apache.httpcomponents.httpclient-4.5.12-sources.jar
third_party/sources/org.apache.httpcomponents.httpcore-4.4.13-sources.jar
third_party/sources/org.apache.logging.log4j.log4j-api-2.12.1-sources.jar
third_party/sources/org.apache.logging.log4j.log4j-core-2.12.1-sources.jar
third_party/sources/org.apache.logging.log4j.log4j-jul-2.12.1-sources.jar
third_party/sources/org.apache.logging.log4j.log4j-slf4j-impl-2.12.1-sources.jar
third_party/sources/org.aspectj.aspectjweaver-1.9.5-sources.jar
third_party/sources/org.bouncycastle.bcpkix-jdk15on-1.64-sources.jar
third_party/sources/org.bouncycastle.bcprov-jdk15on-1.64-sources.jar
third_party/sources/org.checkerframework.checker-qual-3.3.0-sources.jar
third_party/sources/org.codehaus.mojo.animal-sniffer-annotations-1.18-sources.jar
third_party/sources/org.conscrypt.conscrypt-openjdk-uber-2.2.1-sources.jar
third_party/sources/org.dom4j.dom4j-2.1.3-sources.jar
third_party/sources/org.flywaydb.flyway-core-6.0.8-sources.jar
third_party/sources/org.glassfish.jakarta.el-3.0.3-sources.jar
third_party/sources/org.glassfish.javax.el-3.0.1-b11-sources.jar
third_party/sources/org.glassfish.jaxb.jaxb-runtime-2.3.3-sources.jar
third_party/sources/org.glassfish.jaxb.txw2-2.3.3-sources.jar
third_party/sources/org.hdrhistogram.HdrHistogram-2.1.11-sources.jar
third_party/sources/org.hibernate.common.hibernate-commons-annotations-5.1.0.Final-sources.jar
third_party/sources/org.hibernate.hibernate-core-5.4.15.Final-sources.jar
third_party/sources/org.hibernate.validator.hibernate-validator-6.0.19.Final-sources.jar
third_party/sources/org.hibernate.validator.hibernate-validator-annotation-processor-6.0.19.Final-sources.jar
third_party/sources/org.javassist.javassist-3.24.0-GA-sources.jar
third_party/sources/org.jboss.jandex-2.1.3.Final-sources.jar
third_party/sources/org.jboss.logging.jboss-logging-3.4.1.Final-sources.jar
third_party/sources/org.latencyutils.LatencyUtils-2.0.3-sources.jar
third_party/sources/org.postgresql.postgresql-42.2.12-sources.jar
third_party/sources/org.projectlombok.lombok-1.18.12-sources.jar
third_party/sources/org.reactivestreams.reactive-streams-1.0.3-sources.jar
third_party/sources/org.slf4j.jul-to-slf4j-1.7.30-sources.jar
third_party/sources/org.slf4j.slf4j-api-1.7.30-sources.jar
third_party/sources/org.springframework.boot.spring-boot-2.2.7.RELEASE-sources.jar
third_party/sources/org.springframework.boot.spring-boot-actuator-2.2.7.RELEASE-sources.jar
third_party/sources/org.springframework.boot.spring-boot-actuator-autoconfigure-2.2.7.RELEASE-sources.jar
third_party/sources/org.springframework.boot.spring-boot-autoconfigure-2.2.7.RELEASE-sources.jar
third_party/sources/org.springframework.boot.spring-boot-starter-2.2.7.RELEASE-sources.jar
third_party/sources/org.springframework.boot.spring-boot-starter-actuator-2.2.7.RELEASE-sources.jar
third_party/sources/org.springframework.boot.spring-boot-starter-aop-2.2.7.RELEASE-sources.jar
third_party/sources/org.springframework.boot.spring-boot-starter-cache-2.2.7.RELEASE-sources.jar
third_party/sources/org.springframework.boot.spring-boot-starter-data-jpa-2.2.7.RELEASE-sources.jar
third_party/sources/org.springframework.boot.spring-boot-starter-jdbc-2.2.7.RELEASE-sources.jar
third_party/sources/org.springframework.boot.spring-boot-starter-json-2.2.7.RELEASE-sources.jar
third_party/sources/org.springframework.boot.spring-boot-starter-log4j2-2.2.7.RELEASE-sources.jar
third_party/sources/org.springframework.boot.spring-boot-starter-reactor-netty-2.2.7.RELEASE-sources.jar
third_party/sources/org.springframework.boot.spring-boot-starter-validation-2.2.7.RELEASE-sources.jar
third_party/sources/org.springframework.boot.spring-boot-starter-webflux-2.2.7.RELEASE-sources.jar
third_party/sources/org.springframework.cloud.spring-cloud-context-2.2.2.RELEASE-sources.jar
third_party/sources/org.springframework.cloud.spring-cloud-gcp-autoconfigure-1.2.2.RELEASE-sources.jar
third_party/sources/org.springframework.cloud.spring-cloud-gcp-core-1.2.2.RELEASE-sources.jar
third_party/sources/org.springframework.cloud.spring-cloud-gcp-pubsub-1.2.2.RELEASE-sources.jar
third_party/sources/org.springframework.cloud.spring-cloud-kubernetes-config-1.1.2.RELEASE-sources.jar
third_party/sources/org.springframework.cloud.spring-cloud-kubernetes-core-1.1.2.RELEASE-sources.jar
third_party/sources/org.springframework.cloud.spring-cloud-kubernetes-leader-1.1.2.RELEASE-sources.jar
third_party/sources/org.springframework.data.spring-data-commons-2.2.7.RELEASE-sources.jar
third_party/sources/org.springframework.data.spring-data-jpa-2.2.7.RELEASE-sources.jar
third_party/sources/org.springframework.integration.spring-integration-core-5.2.6.RELEASE-sources.jar
third_party/sources/org.springframework.retry.spring-retry-1.2.5.RELEASE-sources.jar
third_party/sources/org.springframework.security.spring-security-crypto-5.2.4.RELEASE-sources.jar
third_party/sources/org.springframework.security.spring-security-rsa-1.0.9.RELEASE-sources.jar
third_party/sources/org.springframework.spring-aop-5.2.6.RELEASE-sources.jar
third_party/sources/org.springframework.spring-aspects-5.2.6.RELEASE-sources.jar
third_party/sources/org.springframework.spring-beans-5.2.6.RELEASE-sources.jar
third_party/sources/org.springframework.spring-context-5.2.6.RELEASE-sources.jar
third_party/sources/org.springframework.spring-context-support-5.2.6.RELEASE-sources.jar
third_party/sources/org.springframework.spring-core-5.2.6.RELEASE-sources.jar
third_party/sources/org.springframework.spring-expression-5.2.6.RELEASE-sources.jar
third_party/sources/org.springframework.spring-jcl-5.2.6.RELEASE-sources.jar
third_party/sources/org.springframework.spring-jdbc-5.2.6.RELEASE-sources.jar
third_party/sources/org.springframework.spring-messaging-5.2.6.RELEASE-sources.jar
third_party/sources/org.springframework.spring-orm-5.2.6.RELEASE-sources.jar
third_party/sources/org.springframework.spring-tx-5.2.6.RELEASE-sources.jar
third_party/sources/org.springframework.spring-web-5.2.6.RELEASE-sources.jar
third_party/sources/org.springframework.spring-webflux-5.2.6.RELEASE-sources.jar
third_party/sources/org.synchronoss.cloud.nio-multipart-parser-1.1.0-sources.jar
third_party/sources/org.synchronoss.cloud.nio-stream-storage-1.1.3-sources.jar
third_party/sources/org.threeten.threetenbp-1.4.1-sources.jar
third_party/sources/org.yaml.snakeyaml-1.25-sources.jar
third_party/sources/software.amazon.awssdk.annotations-2.13.11-sources.jar
third_party/sources/software.amazon.awssdk.apache-client-2.13.11-sources.jar
third_party/sources/software.amazon.awssdk.arns-2.13.11-sources.jar
third_party/sources/software.amazon.awssdk.auth-2.13.11-sources.jar
third_party/sources/software.amazon.awssdk.aws-core-2.13.11-sources.jar
third_party/sources/software.amazon.awssdk.aws-query-protocol-2.13.11-sources.jar
third_party/sources/software.amazon.awssdk.aws-xml-protocol-2.13.11-sources.jar
third_party/sources/software.amazon.awssdk.http-client-spi-2.13.11-sources.jar
third_party/sources/software.amazon.awssdk.netty-nio-client-2.13.11-sources.jar
third_party/sources/software.amazon.awssdk.profiles-2.13.11-sources.jar
third_party/sources/software.amazon.awssdk.protocol-core-2.13.11-sources.jar
third_party/sources/software.amazon.awssdk.regions-2.13.11-sources.jar
third_party/sources/software.amazon.awssdk.s3-2.13.11-sources.jar
third_party/sources/software.amazon.awssdk.sdk-core-2.13.11-sources.jar
third_party/sources/software.amazon.awssdk.utils-2.13.11-sources.jar
third_party/sources/software.amazon.eventstream.eventstream-1.0.1-sources.jar
```

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

