### PR TITLE
Set default topicRunningHashV2AddedTimestamp based on network

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,7 +71,7 @@ value, it is recommended to only populate overridden properties in the custom `a
 | `hedera.mirror.importer.parser.record.entity.persist.transactionBytes`      | false                   | Persist raw transaction bytes to the database                                                  |
 | `hedera.mirror.importer.parser.record.entity.sql.batchSize`                 | 100                     | When inserting transactions into db, executeBatches() is called every these many transactions  |
 | `hedera.mirror.importer.parser.record.pubsub.topicName`                     |                         | Pubsub topic to publish transactions to                                                        |
-| `hedera.mirror.importer.topicRunningHashV2AddedTimestamp`            | If network is `MAINNET`, then null, otherwise 1588706343553042000  | Used for setting running hash version of topic messages when migrating from v1 to v2. Messages with consensusTimestamp >= this value will be marked version 2, and those less will be marked version 1 |
+| `hedera.mirror.importer.topicRunningHashV2AddedTimestamp`            | Network-based  | Unix timestamp (in nanos) of first topic message with v2 as running hash version. Use this config to override the default network based value |
 | `hedera.mirror.importer.shard`                                       | 0                       | The default shard number that the component participates in                                    |
 
 #### Export transactions to PubSub

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,7 +71,7 @@ value, it is recommended to only populate overridden properties in the custom `a
 | `hedera.mirror.importer.parser.record.entity.persist.transactionBytes`      | false                   | Persist raw transaction bytes to the database                                                  |
 | `hedera.mirror.importer.parser.record.entity.sql.batchSize`                 | 100                     | When inserting transactions into db, executeBatches() is called every these many transactions  |
 | `hedera.mirror.importer.parser.record.pubsub.topicName`                     |                         | Pubsub topic to publish transactions to                                                        |
-| `hedera.mirror.importer.topicRunningHashV2AddedTimestamp`            |                         | The Unix timestamp when topic message running hash v2 was introduced                           |
+| `hedera.mirror.importer.topicRunningHashV2AddedTimestamp`            | If network is `MAINNET`, then null, otherwise 1588706343553042000  | Used for setting running hash version of topic messages when migrating from v1 to v2. Messages with consensusTimestamp >= this value will be marked version 2, and those less will be marked version 1 |
 | `hedera.mirror.importer.shard`                                       | 0                       | The default shard number that the component participates in                                    |
 
 #### Export transactions to PubSub

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/MirrorProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/MirrorProperties.java
@@ -52,6 +52,8 @@ public class MirrorProperties {
     @Min(0)
     private long shard = 0L;
 
+    private Long topicRunningHashV2AddedTimestamp;
+
     public Path getAddressBookPath() {
         return dataPath.resolve(ADDRESS_BOOK_FILE);
     }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/MirrorImporterConfiguration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/MirrorImporterConfiguration.java
@@ -116,11 +116,7 @@ public class MirrorImporterConfiguration {
             Long timestamp = mirrorProperties.getTopicRunningHashV2AddedTimestamp();
             if (timestamp == null) {
                 if (mirrorProperties.getNetwork() == HederaNetwork.MAINNET) {
-                    throw new IllegalArgumentException("topicRunningHashV2AddedTimestamp is unknown for MAINNET. To " +
-                            "circumvent this error in local/test setup, override " +
-                            "hedera.mirror.importer.topicRunningHashV2AddedTimestamp to 0 in your config. NOTE: " +
-                            "highly discouraged for production setup unless you know what you are doing.");
-                    // TODO: after R5 mainnet release, set correct value here.
+                    timestamp = 1590080400000000000L;
                 } else {
                     timestamp = 1588706343553042000L;
                 }

--- a/hedera-mirror-importer/src/main/resources/application.yml
+++ b/hedera-mirror-importer/src/main/resources/application.yml
@@ -9,10 +9,6 @@ hedera:
         restPassword: mirror_api_pass
         restUsername: mirror_api
         username: mirror_node
-      # Used for setting running hash version of topic messages when migrating from v1 to v2.
-      # All messages with consensusTimestamp >= this value will be marked version 2, and those less will be marked
-      # version 1.
-      topicRunningHashV2AddedTimestamp:
 logging:
   level:
     root: warn
@@ -68,7 +64,6 @@ spring:
       api-user: ${hedera.mirror.importer.db.restUsername}
       db-name: ${hedera.mirror.importer.db.name}
       db-user: ${hedera.mirror.importer.db.username}
-      topicRunningHashV2AddedTimestamp: ${hedera.mirror.importer.topicRunningHashV2AddedTimestamp}
   jpa:
     properties:
       hibernate:

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/AbstractDownloaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/AbstractDownloaderTest.java
@@ -102,7 +102,7 @@ public abstract class AbstractDownloaderTest {
         System.out.println("Before test: " + testInfo.getTestMethod().get().getName());
 
         initProperties();
-        s3AsyncClient = new MirrorImporterConfiguration(commonDownloaderProperties)
+        s3AsyncClient = new MirrorImporterConfiguration(null, commonDownloaderProperties)
                 .s3AsyncClient(new ExecutionInterceptor() {
                 });
         networkAddressBook = new NetworkAddressBook(mirrorProperties);

--- a/hedera-mirror-importer/src/test/resources/config/application.yml
+++ b/hedera-mirror-importer/src/test/resources/config/application.yml
@@ -20,7 +20,6 @@ hedera:
           pubsub:
             topicName: testTopic
       network: TESTNET
-      topicRunningHashV2AddedTimestamp: 0 # Zero since tests use clean db with no data.
 
 spring:
   task:


### PR DESCRIPTION
**Detailed description**:
Signed-off-by: Apekshit Sharma <apekshit.sharma@hedera.com>


**Which issue(s) this PR fixes**:
Part of #745

**Special notes for your reviewer**:
Didn't add estimated time for mainnet since it could be very risky for partners.
Next release (after 0.12.0 around 20th) would be 2 weeks later.  After the release goes out and mainnet is updated, we don't know who may update to 0.12.0 in next 2 weeks. In so, they'd end up with corrupt data in db and know way to know about it.

**Checklist**
- [x] Documentation added
- [ ] Tests updated

