### PR TITLE
Add consensusTimestamp attribute to PubSub messages

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/pubsub/PubSubRecordItemListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/pubsub/PubSubRecordItemListener.java
@@ -63,7 +63,10 @@ public class PubSubRecordItemListener implements RecordItemListener {
         EntityId entity = transactionHandler.getEntityId(recordItem);
         PubSubMessage pubSubMessage = buildPubSubMessage(consensusTimestamp, entity, recordItem);
         try {
-            pubsubOutputChannel.send(MessageBuilder.withPayload(pubSubMessage).build());
+            pubsubOutputChannel.send(MessageBuilder
+                    .withPayload(pubSubMessage)
+                    .setHeader("consensusTimestamp", consensusTimestamp)
+                    .build());
         } catch (Exception e) {
             // This will make RecordFileParser to retry whole file, thus sending duplicates of previous transactions
             // in this file. In needed in future, this can be optimized to resend only the txns with consensusTimestamp

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/PubSubIntegrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/PubSubIntegrationTest.java
@@ -21,6 +21,7 @@ package com.hedera.mirror.importer;
  */
 
 import com.google.api.gax.rpc.NotFoundException;
+import com.google.pubsub.v1.PubsubMessage;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.annotation.Resource;
@@ -59,12 +60,12 @@ public class PubSubIntegrationTest extends IntegrationTest {
     }
 
     // Synchronously waits for numMessages from the subscription. Acks them and extracts payloads from them.
-    public List<String> getAllMessages(int numMessages) {
+    public List<PubsubMessage> getAllMessages(int numMessages) {
         return pubSubTemplate.pull(SUBSCRIPTION, numMessages, false)
                 .stream()
                 .map(m -> {
                     m.ack();
-                    return m.getPubsubMessage().getData().toStringUtf8();
+                    return m.getPubsubMessage();
                 })
                 .collect(Collectors.toList());
     }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/pubsub/PubSubRecordItemListenerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/pubsub/PubSubRecordItemListenerTest.java
@@ -55,7 +55,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
-import org.springframework.messaging.MessageHeaders;
 
 import com.hedera.mirror.importer.addressbook.NetworkAddressBook;
 import com.hedera.mirror.importer.domain.EntityId;
@@ -214,9 +213,9 @@ class PubSubRecordItemListenerTest {
         } else {
             assertThat(actual.getNonFeeTransfers()).isEqualTo(expectedNonFeeTransfers);
         }
-        MessageHeaders headers = argument.getValue().getHeaders();
-        assertThat(headers.size()).isEqualTo(3); // +2 are default attributes 'id' and 'timestamp' (publish)
-        assertThat(headers.get("consensusTimestamp")).isEqualTo(CONSENSUS_TIMESTAMP);
+        assertThat(argument.getValue().getHeaders()).describedAs("Headers contain consensus timestamp")
+                .hasSize(3) // +2 are default attributes 'id' and 'timestamp' (publish)
+                .containsEntry("consensusTimestamp", CONSENSUS_TIMESTAMP);
     }
 
     private static AccountAmount buildAccountAmount(long accountNum, long amount) {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/pubsub/PubSubRecordItemListenerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/pubsub/PubSubRecordItemListenerTest.java
@@ -55,6 +55,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageHeaders;
 
 import com.hedera.mirror.importer.addressbook.NetworkAddressBook;
 import com.hedera.mirror.importer.domain.EntityId;
@@ -213,6 +214,9 @@ class PubSubRecordItemListenerTest {
         } else {
             assertThat(actual.getNonFeeTransfers()).isEqualTo(expectedNonFeeTransfers);
         }
+        MessageHeaders headers = argument.getValue().getHeaders();
+        assertThat(headers.size()).isEqualTo(3); // +2 are default attributes 'id' and 'timestamp' (publish)
+        assertThat(headers.get("consensusTimestamp")).isEqualTo(CONSENSUS_TIMESTAMP);
     }
 
     private static AccountAmount buildAccountAmount(long accountNum, long amount) {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/pubsub/PubSubRecordParserTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/pubsub/PubSubRecordParserTest.java
@@ -22,14 +22,19 @@ package com.hedera.mirror.importer.parser.record.pubsub;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.google.protobuf.ByteString;
+import com.google.pubsub.v1.PubsubMessage;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import javax.annotation.Resource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.springframework.beans.factory.annotation.Value;
+import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.hedera.mirror.importer.FileCopier;
 import com.hedera.mirror.importer.PubSubIntegrationTest;
@@ -73,6 +78,26 @@ public class PubSubRecordParserTest extends PubSubIntegrationTest {
         // then
         List<String> expectedMessages =
                 Files.readAllLines(testResourcesPath.resolve("pubsub-messages.txt"));
-        assertThat(getAllMessages(NUM_TXNS)).isEqualTo(expectedMessages);
+        List<PubsubMessage> pubsubMessages = getAllMessages(NUM_TXNS);
+        List<String> messages = pubsubMessages.stream()
+                .map(PubsubMessage::getData)
+                .map(ByteString::toStringUtf8)
+                .collect(Collectors.toList());
+        assertThat(messages).isEqualTo(expectedMessages);
+
+        List<String> actualConsensusTimestampAttributeValues = pubsubMessages.stream()
+                .map(m -> m.getAttributesMap().get("consensusTimestamp"))
+                .collect(Collectors.toList());
+        ObjectMapper objectMapper = new ObjectMapper();
+        List<String> expectedConsensusTimestampAttributeValues = expectedMessages.stream()
+                .map(m -> {
+                    try {
+                      return objectMapper.readValue(m, Map.class).get("consensusTimestamp").toString();
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                })
+                .collect(Collectors.toList());
+        assertThat(actualConsensusTimestampAttributeValues).isEqualTo(expectedConsensusTimestampAttributeValues);
     }
 }


### PR DESCRIPTION
**Detailed description**:
The attribute is used by Dataflow pipeline to dedupe messages internally

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated

