### PR TITLE
Removed subscribe flag as acceptance test and updated cucumber version

### DIFF
--- a/hedera-mirror-test/pom.xml
+++ b/hedera-mirror-test/pom.xml
@@ -19,7 +19,7 @@
         <jmeter.test>E2E_Subscribe_Only.jmx</jmeter.test>
         <jmeter.subscribeThreadCount></jmeter.subscribeThreadCount>
         <cucumber.version>5.7.0</cucumber.version>
-        <cucumber-reporting.version>4.0.48</cucumber-reporting.version>
+        <cucumber-reporting.version>4.0.52</cucumber-reporting.version>
         <skipTests>true</skipTests>
     </properties>
 
@@ -80,11 +80,6 @@
                 <exclusion>
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-starter-logging</artifactId>
-                </exclusion>
-                <exclusion>
-                    <!-- Caused compilation errors when included -->
-                    <groupId>org.junit.vintage</groupId>
-                    <artifactId>junit-vintage-engine</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/hedera-mirror-test/src/test/resources/features/hcs/hcs.feature
+++ b/hedera-mirror-test/src/test/resources/features/hcs/hcs.feature
@@ -23,7 +23,7 @@ Feature: HCS Base Coverage Feature
             | numMessages |
             | 2           |
 
-    @SubscribeOnly @Acceptance
+    @SubscribeOnly
     Scenario Outline: Validate topic message subscription only
         Given I provide a topic id <topicId>
         And I provide a starting timestamp <startTimestamp> and a number of messages <numMessages> I want to receive


### PR DESCRIPTION
**Detailed description**:
Removed subscribe flag as acceptance test and updated cucumber version

**Which issue(s) this PR fixes**:
Fixes #752 

**Special notes for your reviewer**:
Had to remove exclusion of junit-vintage-engine as these are needed by cucumber to run acceptance tests.
Apparently there were compilation errors but I didn't witness them on build

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

