### PR TITLE
Add option to archive verified signature files

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -34,7 +34,7 @@ value, it is recommended to only populate overridden properties in the custom `a
 | `hedera.mirror.importer.downloader.balance.batchSize`                | 15                      | The number of signature files to download per node before downloading the signed files         |
 | `hedera.mirror.importer.downloader.balance.enabled`                  | true                    | Whether to enable balance file downloads                                                       |
 | `hedera.mirror.importer.downloader.balance.frequency`                | 30s                     | The fixed period between invocations. Can accept duration units like `10s`, `2m` etc.          |
-| `hedera.mirror.importer.downloader.balance.keepSignatures`           | false                   | Whether to keep signature files after successful verification. If false, files are deleted.    |
+| `hedera.mirror.importer.downloader.balance.keepSignatures`           | false                   | Whether to keep balance signature files after successful verification. If false, files are deleted. |
 | `hedera.mirror.importer.downloader.balance.prefix`                   | accountBalances/balance | The prefix to search cloud storage for balance files                                           |
 | `hedera.mirror.importer.downloader.balance.threads`                  | 13                      | The number of threads to search for new files to download                                      |
 | `hedera.mirror.importer.downloader.bucketName`                       | "hedera-demo-streams"   | The cloud storage bucket name to download streamed files                                       |
@@ -43,7 +43,7 @@ value, it is recommended to only populate overridden properties in the custom `a
 | `hedera.mirror.importer.downloader.record.batchSize`                 | 40                      | The number of signature files to download per node before downloading the signed files         |
 | `hedera.mirror.importer.downloader.record.enabled`                   | true                    | Whether to enable record file downloads                                                        |
 | `hedera.mirror.importer.downloader.record.frequency`                 | 500ms                   | The fixed period between invocations. Can accept duration units like `10s`, `2m` etc.          |
-| `hedera.mirror.importer.downloader.record.keepSignatures`            | false                   | Whether to keep signature files after successful verification. If false, files are deleted.    |
+| `hedera.mirror.importer.downloader.record.keepSignatures`            | false                   | Whether to keep record signature files after successful verification. If false, files are deleted. |
 | `hedera.mirror.importer.downloader.record.prefix`                    | recordstreams/record    | The prefix to search cloud storage for record files                                            |
 | `hedera.mirror.importer.downloader.record.threads`                   | 13                      | The number of threads to search for new files to download                                      |
 | `hedera.mirror.importer.downloader.region`                           | us-east-1               | The region associated with the bucket                                                          |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -34,6 +34,7 @@ value, it is recommended to only populate overridden properties in the custom `a
 | `hedera.mirror.importer.downloader.balance.batchSize`                | 15                      | The number of signature files to download per node before downloading the signed files         |
 | `hedera.mirror.importer.downloader.balance.enabled`                  | true                    | Whether to enable balance file downloads                                                       |
 | `hedera.mirror.importer.downloader.balance.frequency`                | 30s                     | The fixed period between invocations. Can accept duration units like `10s`, `2m` etc.          |
+| `hedera.mirror.importer.downloader.balance.keepSignatures`           | false                   | Whether to keep signature files after successful verification. If false, files are deleted.    |
 | `hedera.mirror.importer.downloader.balance.prefix`                   | accountBalances/balance | The prefix to search cloud storage for balance files                                           |
 | `hedera.mirror.importer.downloader.balance.threads`                  | 13                      | The number of threads to search for new files to download                                      |
 | `hedera.mirror.importer.downloader.bucketName`                       | "hedera-demo-streams"   | The cloud storage bucket name to download streamed files                                       |
@@ -42,6 +43,7 @@ value, it is recommended to only populate overridden properties in the custom `a
 | `hedera.mirror.importer.downloader.record.batchSize`                 | 40                      | The number of signature files to download per node before downloading the signed files         |
 | `hedera.mirror.importer.downloader.record.enabled`                   | true                    | Whether to enable record file downloads                                                        |
 | `hedera.mirror.importer.downloader.record.frequency`                 | 500ms                   | The fixed period between invocations. Can accept duration units like `10s`, `2m` etc.          |
+| `hedera.mirror.importer.downloader.record.keepSignatures`            | false                   | Whether to keep signature files after successful verification. If false, files are deleted.    |
 | `hedera.mirror.importer.downloader.record.prefix`                    | recordstreams/record    | The prefix to search cloud storage for record files                                            |
 | `hedera.mirror.importer.downloader.record.threads`                   | 13                      | The number of threads to search for new files to download                                      |
 | `hedera.mirror.importer.downloader.region`                           | us-east-1               | The region associated with the bucket                                                          |

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamType.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamType.java
@@ -31,6 +31,7 @@ public enum StreamType {
     RECORD("recordstreams");
 
     private static final String PARSED = "parsed";
+    private static final String SIGNATURES = "signatures";
     private static final String TEMP = "tmp";
     private static final String VALID = "valid";
 
@@ -38,6 +39,10 @@ public enum StreamType {
 
     public String getParsed() {
         return PARSED;
+    }
+
+    public String getSignatures() {
+        return SIGNATURES;
     }
 
     public String getTemp() {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/DownloaderProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/DownloaderProperties.java
@@ -47,6 +47,10 @@ public interface DownloaderProperties {
 
     StreamType getStreamType();
 
+    default Path getSignaturesPath() {
+        return getStreamPath().resolve(getStreamType().getSignatures());
+    }
+
     default Path getTempPath() {
         return getStreamPath().resolve(getStreamType().getTemp());
     }
@@ -58,6 +62,10 @@ public interface DownloaderProperties {
     boolean isEnabled();
 
     void setEnabled(boolean enabled);
+
+    boolean isKeepSignatures();
+
+    void setKeepSignatures(boolean keepSignatures);
 
     @PostConstruct
     default void init() {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/balance/BalanceDownloaderProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/balance/BalanceDownloaderProperties.java
@@ -51,6 +51,8 @@ public class BalanceDownloaderProperties implements DownloaderProperties {
     @NotNull
     private Duration frequency = Duration.ofSeconds(30);
 
+    private boolean keepSignatures = false;
+
     @NotBlank
     private String prefix = "accountBalances/balance";
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/record/RecordDownloaderProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/record/RecordDownloaderProperties.java
@@ -51,6 +51,8 @@ public class RecordDownloaderProperties implements DownloaderProperties {
     @NotNull
     private Duration frequency = Duration.ofMillis(500L);
 
+    private boolean keepSignatures = false;
+
     @NotBlank
     private String prefix = "recordstreams/record";
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/balance/BalanceFileParser.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/balance/BalanceFileParser.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import javax.inject.Named;
+import org.apache.commons.io.FileUtils;
 
 import com.hedera.mirror.importer.parser.FileWatcher;
 import com.hedera.mirror.importer.util.ShutdownHelper;
@@ -103,9 +104,15 @@ public class BalanceFileParser extends FileWatcher {
     }
 
     private void processBalanceFile(File balanceFile) throws Exception {
-        if (new AccountBalancesFileLoader((BalanceParserProperties) parserProperties, balanceFile.toPath())
-                .loadAccountBalances()) {
-            Utility.moveOrDeleteParsedFile(balanceFile.getCanonicalPath(), parserProperties);
+        BalanceParserProperties balanceParserProperties = (BalanceParserProperties) parserProperties;
+        AccountBalancesFileLoader loader = new AccountBalancesFileLoader(balanceParserProperties, balanceFile.toPath());
+
+        if (loader.loadAccountBalances()) {
+            if (parserProperties.isKeepFiles()) {
+                Utility.archiveFile(balanceFile, parserProperties.getParsedPath());
+            } else {
+                FileUtils.deleteQuietly(balanceFile);
+            }
         }
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordFileParser.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordFileParser.java
@@ -37,6 +37,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import javax.inject.Named;
 import lombok.extern.log4j.Log4j2;
+import org.apache.commons.io.FileUtils;
 import org.springframework.scheduling.annotation.Scheduled;
 
 import com.hedera.mirror.importer.domain.ApplicationStatusCode;
@@ -172,9 +173,16 @@ public class RecordFileParser implements FileParser {
                 return;
             }
 
-            try (InputStream fileInputStream = new FileInputStream(new File(name))) {
+            File file = new File(name);
+
+            try (InputStream fileInputStream = new FileInputStream(file)) {
                 loadRecordFile(new StreamFileData(name, fileInputStream));
-                Utility.moveOrDeleteParsedFile(name, parserProperties);
+
+                if (parserProperties.isKeepFiles()) {
+                    Utility.archiveFile(file, parserProperties.getParsedPath());
+                } else {
+                    FileUtils.deleteQuietly(file);
+                }
             } catch (FileNotFoundException e) {
                 log.warn("File does not exist {}", name);
                 return;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/util/Utility.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/util/Utility.java
@@ -49,7 +49,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
 import com.hedera.mirror.importer.domain.RecordFile;
-import com.hedera.mirror.importer.parser.ParserProperties;
 import com.hedera.mirror.importer.parser.domain.RecordItem;
 
 @Log4j2
@@ -311,35 +310,18 @@ public class Utility {
         return StringUtils.isBlank(hash) || hash.equals(EMPTY_HASH);
     }
 
-    public static void moveFileToParsedDir(String filePath, ParserProperties parserProperties) {
-        Path source = Path.of(filePath);
-        String fileName = source.getFileName().toString();
-        String dateSubDir = fileName.substring(0, 10).replace("-", File.separator);
-        Path destination = parserProperties.getParsedPath().resolve(dateSubDir).resolve(fileName);
-        destination.getParent().toFile().mkdirs();
+    // Moves a file in the form 2019-08-30T18_10_00.419072Z.rcd to destinationRoot/2019/08/30
+    public static void archiveFile(File source, Path destinationRoot) {
+        String filename = source.getName();
+        String date = filename.substring(0, 10).replace("-", File.separator);
+        Path destination = destinationRoot.resolve(date);
 
         try {
-            Files.move(source, destination, StandardCopyOption.REPLACE_EXISTING);
+            destination.toFile().mkdirs();
+            Files.move(source.toPath(), destination.resolve(filename), StandardCopyOption.REPLACE_EXISTING);
             log.trace("Moved {} to {}", source, destination);
         } catch (Exception e) {
             log.error("Error moving file {} to {}", source, destination, e);
-        }
-    }
-
-    public static void deleteFile(String fileName) {
-        try {
-            Files.delete(new File(fileName).toPath());
-            log.trace("Deleted file {}", fileName);
-        } catch (Exception e) {
-            log.error("Error deleting file {}", fileName);
-        }
-    }
-
-    public static void moveOrDeleteParsedFile(String fileName, ParserProperties parserProperties) {
-        if (parserProperties.isKeepFiles()) {
-            Utility.moveFileToParsedDir(fileName, parserProperties);
-        } else {
-            Utility.deleteFile(fileName);
         }
     }
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/balance/AccountBalancesDownloaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/balance/AccountBalancesDownloaderTest.java
@@ -20,6 +20,7 @@ package com.hedera.mirror.importer.downloader.balance;
  * ‍
  */
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 
 import com.google.common.primitives.Bytes;
@@ -68,6 +69,7 @@ public class AccountBalancesDownloaderTest extends AbstractDownloaderTest {
                         ".csv");
         assertValidFiles(List
                 .of("2019-08-30T18_15_00.016002001Z_Balances.csv", "2019-08-30T18_30_00.010147001Z_Balances.csv"));
+        assertThat(downloaderProperties.getSignaturesPath()).doesNotExist();
     }
 
     @Test
@@ -110,6 +112,7 @@ public class AccountBalancesDownloaderTest extends AbstractDownloaderTest {
     @Test
     @DisplayName("overwrite on download")
     void overwriteOnDownload() throws Exception {
+        downloaderProperties.setKeepSignatures(true);
         overwriteOnDownloadHelper(
                 "2019-08-30T18_15_00.016002001Z_Balances.csv", "2019-08-30T18_30_00.010147001Z_Balances.csv",
                 ApplicationStatusCode.LAST_VALID_DOWNLOADED_BALANCE_FILE);

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/record/RecordFileDownloaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/record/RecordFileDownloaderTest.java
@@ -20,6 +20,7 @@ package com.hedera.mirror.importer.downloader.record;
  * ‍
  */
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
@@ -47,8 +48,6 @@ import com.hedera.mirror.importer.util.Utility;
 
 @ExtendWith(MockitoExtension.class)
 public class RecordFileDownloaderTest extends AbstractDownloaderTest {
-    private static final String FILE1_HASH =
-            "591558e059bd1629ee386c4e35a6875b4c67a096718f5d225772a651042715189414df7db5588495efb2a85dc4a0ffda";
 
     @Override
     protected DownloaderProperties getDownloaderProperties() {
@@ -101,6 +100,7 @@ public class RecordFileDownloaderTest extends AbstractDownloaderTest {
         verify(applicationStatusRepository, times(2)).updateStatusValue(
                 eq(ApplicationStatusCode.LAST_VALID_DOWNLOADED_RECORD_FILE_HASH), any());
         assertValidFiles(List.of("2019-08-30T18_10_05.249678Z.rcd", "2019-08-30T18_10_00.419072Z.rcd"));
+        assertThat(downloaderProperties.getSignaturesPath()).doesNotExist();
     }
 
     @Test
@@ -148,6 +148,7 @@ public class RecordFileDownloaderTest extends AbstractDownloaderTest {
     @Test
     @DisplayName("overwrite on download")
     void overwriteOnDownload() throws Exception {
+        downloaderProperties.setKeepSignatures(true);
         overwriteOnDownloadHelper("2019-08-30T18_10_00.419072Z.rcd", "2019-08-30T18_10_05.249678Z.rcd",
                 ApplicationStatusCode.LAST_VALID_DOWNLOADED_RECORD_FILE);
     }


### PR DESCRIPTION
**Detailed description**:
- Add property `hedera.mirror.importer.downloader.balance.keepSignatures=false`
- Add property `hedera.mirror.importer.downloader.record.keepSignatures=false`
- Download signatures to `tmp/0.0.X`
- Move verified signatures to `signatures/0.0.X/YYYY/MM/DD` if keepSignatures is true
- Delete verified signatures if keepSignatures is false

**Which issue(s) this PR fixes**:
Fixes #510 

**Special notes for your reviewer**:

**Checklist**
- [x] Documentation added
- [x] Tests updated

