### PR TITLE
Enable reWriteBatchedInserts in driver

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,7 +71,7 @@ value, it is recommended to only populate overridden properties in the custom `a
 | `hedera.mirror.importer.parser.record.entity.persist.nonFeeTransfers`       | false                   | Persist non-fee transfers for transactions that explicitly request hbar transfers              |
 | `hedera.mirror.importer.parser.record.entity.persist.systemFiles`           | true                    | Persist only system files (number lower than `1000`) to the database                           |
 | `hedera.mirror.importer.parser.record.entity.persist.transactionBytes`      | false                   | Persist raw transaction bytes to the database                                                  |
-| `hedera.mirror.importer.parser.record.entity.sql.batchSize`                 | 100                     | When inserting transactions into db, executeBatches() is called every these many transactions  |
+| `hedera.mirror.importer.parser.record.entity.sql.batchSize`                 | 2000                    | When inserting transactions into db, executeBatches() is called every these many transactions  |
 | `hedera.mirror.importer.parser.record.pubsub.topicName`                     |                         | Pubsub topic to publish transactions to                                                        |
 | `hedera.mirror.importer.topicRunningHashV2AddedTimestamp`            | Network-based  | Unix timestamp (in nanos) of first topic message with v2 as running hash version. Use this config to override the default network based value |
 | `hedera.mirror.importer.shard`                                       | 0                       | The default shard number that the component participates in                                    |

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlProperties.java
@@ -33,5 +33,5 @@ public class SqlProperties {
      * PreparedStatement.executeBatch() is called after every batchSize number of transactions from record stream file.
      */
     @Min(1)
-    private int batchSize = 100;
+    private int batchSize = 2000;
 }

--- a/hedera-mirror-importer/src/main/resources/application.yml
+++ b/hedera-mirror-importer/src/main/resources/application.yml
@@ -54,6 +54,9 @@ spring:
     password: ${hedera.mirror.importer.db.password}
     url: jdbc:postgresql://${hedera.mirror.importer.db.host}:${hedera.mirror.importer.db.port}/${hedera.mirror.importer.db.name}
     username: ${hedera.mirror.importer.db.username}
+    hikari:
+      data-source-properties:
+        reWriteBatchedInserts: true
   flyway:
     connectRetries: 20
     baselineOnMigrate: true

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileParserPerformanceTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileParserPerformanceTest.java
@@ -1,4 +1,4 @@
-package com.hedera.mirror.importer.benchmark;
+package com.hedera.mirror.importer.parser.record;
 
 /*-
  * ‌
@@ -35,13 +35,11 @@ import org.springframework.beans.factory.annotation.Value;
 import com.hedera.mirror.importer.FileCopier;
 import com.hedera.mirror.importer.IntegrationTest;
 import com.hedera.mirror.importer.domain.StreamType;
-import com.hedera.mirror.importer.parser.record.RecordFileParser;
-import com.hedera.mirror.importer.parser.record.RecordParserProperties;
 
 @Log4j2
 @Tag("performance")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class ParserRecordIngestionTest extends IntegrationTest {
+public class RecordFileParserPerformanceTest extends IntegrationTest {
 
     @TempDir
     static Path dataPath;
@@ -71,7 +69,7 @@ public class ParserRecordIngestionTest extends IntegrationTest {
         parserProperties.init();
     }
 
-    @Timeout(400)
+    @Timeout(15)
     @Test
     void parseAndIngestMultipleFiles60000Transactions() throws Exception {
         parse("*.rcd");


### PR DESCRIPTION
**Detailed description**:
- Enable reWriteBatchedInserts in PostgreSQL driver
- Increase transaction batch size to 2000
- Improved performance of `RecordFileParserPerformanceTest` from ~30s to ~10s
- Improved TPS from 3400 to 5600 in performance test environment

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Checklist**
- [x] Documentation added
- [ ] Tests updated

