### PR TITLE
GCP Requester Pays - add project id config

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,6 +39,8 @@ value, it is recommended to only populate overridden properties in the custom `a
 | `hedera.mirror.importer.downloader.balance.threads`                  | 13                      | The number of threads to search for new files to download                                      |
 | `hedera.mirror.importer.downloader.bucketName`                       | "hedera-demo-streams"   | The cloud storage bucket name to download streamed files                                       |
 | `hedera.mirror.importer.downloader.cloudProvider`                    | S3                      | The cloud provider to download files from. Either `S3`, `GCP` or `LOCAL`                       |
+| `hedera.mirror.importer.downloader.endpointOverride`                 |                         | Can be specified to download streams from a source other than S3 and GCP. Should be S3 compatible |
+| `hedera.mirror.importer.downloader.gcpProjectId`                     |                         | GCP project id to bill for requests to GCS bucket which has Requester Pays enabled.            |
 | `hedera.mirror.importer.downloader.maxConcurrency`                   | 1000                    | The maximum number of allowed open HTTP connections. Used by AWS SDK directly.                 |
 | `hedera.mirror.importer.downloader.record.batchSize`                 | 40                      | The number of signature files to download per node before downloading the signed files         |
 | `hedera.mirror.importer.downloader.record.enabled`                   | true                    | Whether to enable record file downloads                                                        |

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/CommonDownloaderProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/CommonDownloaderProperties.java
@@ -42,6 +42,8 @@ public class CommonDownloaderProperties {
     @NotNull
     private CloudProvider cloudProvider = CloudProvider.S3;
 
+    private String endpointOverride;
+
     @Min(0)
     private int maxConcurrency = 1000; // aws sdk default = 50
 
@@ -49,12 +51,13 @@ public class CommonDownloaderProperties {
 
     private String secretKey;
 
+    private String gcpProjectId;
+
     @Getter
     @RequiredArgsConstructor
     public enum CloudProvider {
         S3("https://s3.amazonaws.com"),
-        GCP("https://storage.googleapis.com"),
-        LOCAL("http://127.0.0.1:8001"); // Testing
+        GCP("https://storage.googleapis.com");
 
         private final String endpoint;
     }

--- a/hedera-mirror-importer/src/test/resources/config/application.yml
+++ b/hedera-mirror-importer/src/test/resources/config/application.yml
@@ -10,7 +10,6 @@ hedera:
         password: ${embedded.postgresql.password}
       downloader:
         bucketName: test
-        cloudProvider: LOCAL
       parser:
         balance:
           enabled: false


### PR DESCRIPTION
**Detailed description**:

- Remove test specific configuration in CommonDownloaderProperties
- Remove hard-coded testing value in prod code. Was used for local testing with mock S3.
- Additionally, `endpointOverride` config makes it possible to run mirrornode with any S3
  compatible cloud storage system, not just S3 and GCS. It can be azure, wasabi, etc
- Tested with mainnet bucket and my personal GCP account's keys.

Signed-off-by: Apekshit Sharma <apekshit.sharma@hedera.com>

**Which issue(s) this PR fixes**:
Fixes #792 

**Special notes for your reviewer**:

**Checklist**
- [x] Documentation added
- [x] Tests updated

