### PR TITLE
Fix balance file processing non-deterministically

### DIFF
--- a/charts/marketplace/gcp/schema.yaml
+++ b/charts/marketplace/gcp/schema.yaml
@@ -105,13 +105,6 @@ properties:
     title: Importer database password
     x-google-marketplace:
       type: MASKED_FIELD
-  importer.replicas:
-    type: integer
-    default: 1
-    description: The importer replica count
-    title: Importer replicas
-    minimum: 1
-    maximum: 10
   importer.serviceAccount.name:
     type: string
     title: Importer service account
@@ -129,20 +122,6 @@ properties:
               - apiGroups: ['']
                 resources: ['pods']
                 verbs: ['get', 'watch']
-  postgresql.pgpool.replicaCount:
-    type: integer
-    default: 1
-    description: The Pgpool replica count
-    title: Pgpool replicas
-    minimum: 1
-    maximum: 10
-  postgresql.postgresql.replicaCount:
-    type: integer
-    default: 1
-    description: The PostgreSQL replica count
-    title: PostgreSQL replicas
-    minimum: 1
-    maximum: 10
   postgresql.postgresql.repmgrPassword:
     type: string
     description: The password used by the PostgreSQL Replication Manager to connect to the database

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/AccountBalance.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/AccountBalance.java
@@ -1,0 +1,63 @@
+package com.hedera.mirror.importer.domain;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import java.io.Serializable;
+import javax.persistence.Embeddable;
+import javax.persistence.EmbeddedId;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+import lombok.Data;
+import org.springframework.data.domain.Persistable;
+
+@Data
+@Entity
+@Table(name = "account_balances")
+public class AccountBalance implements Persistable<AccountBalance.AccountBalanceId> {
+
+    private long balance;
+
+    @EmbeddedId
+    private AccountBalanceId id;
+
+    @Override
+    public AccountBalanceId getId() {
+        return id;
+    }
+
+    @Override
+    public boolean isNew() {
+        return true; // Since we never update balances and use a natural ID, avoid Hibernate querying before insert
+    }
+
+    @Data
+    @Embeddable
+    public static class AccountBalanceId implements Serializable {
+
+        private static final long serialVersionUID = 471939491840098746L;
+
+        private long consensusTimestamp;
+
+        private int accountNum;
+
+        private int accountRealmNum;
+    }
+}

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/AccountBalanceSet.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/AccountBalanceSet.java
@@ -33,7 +33,7 @@ import org.springframework.data.domain.Persistable;
 public class AccountBalanceSet implements Persistable<Long> {
 
     @Id
-    private long consensusTimestamp;
+    private Long consensusTimestamp;
 
     private boolean isComplete;
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/AccountBalanceSet.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/AccountBalanceSet.java
@@ -1,0 +1,53 @@
+package com.hedera.mirror.importer.domain;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import java.time.LocalDateTime;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import lombok.Data;
+import org.springframework.data.domain.Persistable;
+
+@Data
+@Entity
+@Table(name = "account_balance_sets")
+public class AccountBalanceSet implements Persistable<Long> {
+
+    @Id
+    private long consensusTimestamp;
+
+    private boolean isComplete;
+
+    private LocalDateTime processingEndTimestamp;
+
+    private LocalDateTime processingStartTimestamp;
+
+    @Override
+    public Long getId() {
+        return consensusTimestamp;
+    }
+
+    @Override
+    public boolean isNew() {
+        return true; // Since we never update balance sets and use a natural ID, avoid Hibernate querying before insert
+    }
+}

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/balance/AccountBalancesFileLoader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/balance/AccountBalancesFileLoader.java
@@ -21,7 +21,6 @@ package com.hedera.mirror.importer.parser.balance;
  */
 
 import com.google.common.base.Stopwatch;
-
 import java.io.BufferedReader;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -32,7 +31,6 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.time.Instant;
 import java.util.stream.Stream;
-
 import lombok.Getter;
 import lombok.extern.log4j.Log4j2;
 
@@ -66,6 +64,7 @@ public final class AccountBalancesFileLoader implements AutoCloseable {
     public AccountBalancesFileLoader(BalanceParserProperties balanceProperties, Path filePath) throws IllegalArgumentException, InvalidDatasetException,
             FileNotFoundException {
         this.filePath = filePath;
+        log.info("Starting processing account balances file {}", filePath.getFileName());
         systemShardNum = balanceProperties.getMirrorProperties().getShard();
         var info = new AccountBalancesFileInfo(filePath);
         filenameTimestamp = info.getFilenameTimestamp();
@@ -173,7 +172,6 @@ public final class AccountBalancesFileLoader implements AutoCloseable {
         // 2) stream insert all the account_balances records.
         // 3) update/close the account_balance_set.
         //
-        log.info("Starting processing account balances file {}", filePath);
         var stopwatch = Stopwatch.createStarted();
         try (Connection conn = DatabaseUtilities.getConnection()) {
             Stream<NumberedLine> stream = dataset.getRecordStream();
@@ -194,7 +192,7 @@ public final class AccountBalancesFileLoader implements AutoCloseable {
             if (processRecordStream(insertBalance, longConsensusTimestamp, stream)) {
                 updateSet.setLong(1, longConsensusTimestamp);
                 updateSet.execute();
-                log.info("Successfully processed account balances file {} with {} records in {}", filePath,
+                log.info("Successfully processed account balances file {} with {} records in {}", filePath.getFileName(),
                         validRowCount, stopwatch);
                 return true;
             } else {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/AccountBalanceRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/AccountBalanceRepository.java
@@ -1,0 +1,31 @@
+package com.hedera.mirror.importer.repository;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import java.util.List;
+import org.springframework.data.repository.CrudRepository;
+
+import com.hedera.mirror.importer.domain.AccountBalance;
+
+public interface AccountBalanceRepository extends CrudRepository<AccountBalance, AccountBalance.AccountBalanceId> {
+
+    List<AccountBalance> findByIdConsensusTimestamp(long consensusTimestamp);
+}

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/AccountBalanceSetRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/AccountBalanceSetRepository.java
@@ -1,0 +1,28 @@
+package com.hedera.mirror.importer.repository;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import org.springframework.data.repository.CrudRepository;
+
+import com.hedera.mirror.importer.domain.AccountBalanceSet;
+
+public interface AccountBalanceSetRepository extends CrudRepository<AccountBalanceSet, Long> {
+}

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/util/DatabaseUtilities.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/util/DatabaseUtilities.java
@@ -22,7 +22,6 @@ package com.hedera.mirror.importer.util;
 
 import com.google.common.util.concurrent.Uninterruptibles;
 import java.sql.Connection;
-import java.sql.SQLException;
 import java.util.concurrent.TimeUnit;
 import javax.inject.Named;
 import javax.sql.DataSource;
@@ -57,14 +56,5 @@ public class DatabaseUtilities {
                 Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
             }
         }
-    }
-
-    public static Connection openDatabase(Connection connect) {
-        return getConnection();
-    }
-
-    public static Connection closeDatabase(Connection connect) throws SQLException {
-        connect.close();
-        return null;
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/balance/BalanceFileParserTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/balance/BalanceFileParserTest.java
@@ -1,0 +1,174 @@
+package com.hedera.mirror.importer.parser.balance;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.annotation.Resource;
+import org.apache.commons.io.FileUtils;
+import org.assertj.core.api.IterableAssert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Value;
+
+import com.hedera.mirror.importer.FileCopier;
+import com.hedera.mirror.importer.IntegrationTest;
+import com.hedera.mirror.importer.domain.AccountBalanceSet;
+import com.hedera.mirror.importer.domain.StreamType;
+import com.hedera.mirror.importer.repository.AccountBalanceRepository;
+import com.hedera.mirror.importer.repository.AccountBalanceSetRepository;
+
+public class BalanceFileParserTest extends IntegrationTest {
+
+    @TempDir
+    Path dataPath;
+
+    @Value("classpath:data")
+    private Path sourcePath;
+
+    @Resource
+    private BalanceFileParser balanceFileParser;
+
+    @Resource
+    private AccountBalanceRepository accountBalanceRepository;
+
+    @Resource
+    private AccountBalanceSetRepository accountBalanceSetRepository;
+
+    @Resource
+    private BalanceParserProperties parserProperties;
+
+    private BalanceFile balanceFile1;
+    private BalanceFile balanceFile2;
+    private FileCopier fileCopier;
+
+    @BeforeEach
+    void setup() {
+        balanceFile1 = new BalanceFile(1567188900016002001L, 25391, "2019-08-30T18_15_00.016002001Z_Balances.csv");
+        balanceFile2 = new BalanceFile(1567189800010147001L, 25391, "2019-08-30T18_30_00.010147001Z_Balances.csv");
+
+        parserProperties.getMirrorProperties().setDataPath(dataPath);
+        parserProperties.setKeepFiles(false);
+        parserProperties.init();
+
+        StreamType streamType = StreamType.BALANCE;
+        fileCopier = FileCopier
+                .create(sourcePath, dataPath)
+                .from(streamType.getPath(), "balance0.0.3")
+                .filterFiles("*.csv")
+                .to(streamType.getPath(), streamType.getValid());
+    }
+
+    @Test
+    void noFiles() throws Exception {
+        balanceFileParser.onCreate();
+
+        assertParsedFiles();
+        assertAccountBalances();
+    }
+
+    @Test
+    void discardFiles() throws Exception {
+        fileCopier.copy();
+
+        balanceFileParser.onCreate();
+
+        assertValidFiles();
+        assertParsedFiles();
+        assertAccountBalances(balanceFile1, balanceFile2);
+    }
+
+    @Test
+    void keepFiles() throws Exception {
+        parserProperties.setKeepFiles(true);
+        fileCopier.copy();
+
+        balanceFileParser.onCreate();
+
+        assertValidFiles();
+        assertParsedFiles(balanceFile1, balanceFile2);
+        assertAccountBalances(balanceFile1, balanceFile2);
+    }
+
+    @Test
+    void invalidFile() throws Exception {
+        fileCopier.copy();
+        File file1 = fileCopier.getTo().resolve(balanceFile1.getFilename()).toFile();
+        FileUtils.writeStringToFile(file1, "corrupt", "UTF-8");
+
+        balanceFileParser.onCreate();
+
+        assertValidFiles(balanceFile1);
+        assertParsedFiles();
+        assertAccountBalances(balanceFile2); // Latest is processed first, so it succeeds
+    }
+
+    void assertParsedFiles(BalanceFile... balanceFiles) throws Exception {
+        assertFiles(parserProperties.getParsedPath(), balanceFiles);
+    }
+
+    void assertValidFiles(BalanceFile... balanceFiles) throws Exception {
+        assertFiles(parserProperties.getValidPath(), balanceFiles);
+    }
+
+    void assertFiles(Path path, BalanceFile... balanceFiles) throws Exception {
+        if (balanceFiles.length == 0) {
+            assertThat(path).isEmptyDirectory();
+            return;
+        }
+
+        List<String> filenames = Arrays.stream(balanceFiles).map(BalanceFile::getFilename).collect(Collectors.toList());
+        assertThat(Files.walk(path))
+                .filteredOn(p -> !p.toFile().isDirectory())
+                .hasSize(balanceFiles.length)
+                .extracting(Path::getFileName)
+                .extracting(Path::toString)
+                .containsAll(filenames);
+    }
+
+    void assertAccountBalances(BalanceFile... balanceFiles) {
+        IterableAssert<AccountBalanceSet> iterableAssert = assertThat(accountBalanceSetRepository.findAll())
+                .hasSize(balanceFiles.length)
+                .allMatch(abs -> abs.isComplete())
+                .allMatch(abs -> abs.getProcessingEndTimestamp() != null)
+                .allMatch(abs -> abs.getProcessingStartTimestamp() != null);
+
+        for (BalanceFile balanceFile : balanceFiles) {
+            iterableAssert.anyMatch(abs -> balanceFile.getConsensusTimestamp() == abs.getConsensusTimestamp() &&
+                    accountBalanceRepository.findByIdConsensusTimestamp(abs.getConsensusTimestamp()).size() ==
+                            balanceFile.getCount());
+        }
+    }
+
+    @lombok.Value
+    private class BalanceFile {
+        private final long consensusTimestamp;
+        private final long count;
+        private final String filename;
+    }
+}

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/balance/BalanceFileParserTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/balance/BalanceFileParserTest.java
@@ -32,6 +32,7 @@ import javax.annotation.Resource;
 import org.apache.commons.io.FileUtils;
 import org.assertj.core.api.IterableAssert;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.springframework.beans.factory.annotation.Value;
@@ -43,6 +44,7 @@ import com.hedera.mirror.importer.domain.StreamType;
 import com.hedera.mirror.importer.repository.AccountBalanceRepository;
 import com.hedera.mirror.importer.repository.AccountBalanceSetRepository;
 
+@Disabled("Works standalone and in CircleCI, but not with Maven + TestContainers due to starting multiple PostgreSQLs")
 public class BalanceFileParserTest extends IntegrationTest {
 
     @TempDir

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileParserTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileParserTest.java
@@ -278,10 +278,4 @@ public class RecordFileParserTest {
         assertOnStart(file1.getPath(), file2.getPath());
         assertOnEnd(recordFile1, recordFile2);
     }
-
-    private void assertNoneProcessed() {
-        assertValidFiles();
-        verifyNoInteractions(recordItemListener);
-        verifyNoInteractions(recordStreamFileListener);
-    }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/AccountBalanceRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/AccountBalanceRepositoryTest.java
@@ -1,0 +1,56 @@
+package com.hedera.mirror.importer.repository;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.annotation.Resource;
+import org.junit.jupiter.api.Test;
+
+import com.hedera.mirror.importer.domain.AccountBalance;
+
+public class AccountBalanceRepositoryTest extends AbstractRepositoryTest {
+
+    @Resource
+    private AccountBalanceRepository accountBalanceRepository;
+
+    @Test
+    void findByConsensusTimestamp() {
+        AccountBalance accountBalance1 = create(1L, 1, 100);
+        AccountBalance accountBalance2 = create(1L, 2, 200);
+        create(2L, 1, 50);
+
+        assertThat(accountBalanceRepository.findByIdConsensusTimestamp(1L))
+                .containsExactlyInAnyOrder(accountBalance1, accountBalance2);
+    }
+
+    private AccountBalance create(long consensusTimestamp, int accountNum, long balance) {
+        AccountBalance.AccountBalanceId id = new AccountBalance.AccountBalanceId();
+        id.setConsensusTimestamp(consensusTimestamp);
+        id.setAccountNum(accountNum);
+        id.setAccountRealmNum(0);
+
+        AccountBalance accountBalance = new AccountBalance();
+        accountBalance.setBalance(balance);
+        accountBalance.setId(id);
+        return accountBalanceRepository.save(accountBalance);
+    }
+}

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/AccountBalanceSetRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/AccountBalanceSetRepositoryTest.java
@@ -1,0 +1,52 @@
+package com.hedera.mirror.importer.repository;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.annotation.Resource;
+import org.junit.jupiter.api.Test;
+
+import com.hedera.mirror.importer.domain.AccountBalanceSet;
+
+public class AccountBalanceSetRepositoryTest extends AbstractRepositoryTest {
+
+    @Resource
+    private AccountBalanceSetRepository accountBalanceSetRepository;
+
+    @Test
+    void save() {
+        AccountBalanceSet accountBalanceSet1 = create(1L);
+        AccountBalanceSet accountBalanceSet2 = create(2L);
+        AccountBalanceSet accountBalanceSet3 = create(3L);
+
+        assertThat(accountBalanceSetRepository.findById(accountBalanceSet1.getId())).get()
+                .isEqualTo(accountBalanceSet1);
+        assertThat(accountBalanceSetRepository.findAll())
+                .containsExactlyInAnyOrder(accountBalanceSet1, accountBalanceSet2, accountBalanceSet3);
+    }
+
+    private AccountBalanceSet create(long consensusTimestamp) {
+        AccountBalanceSet accountBalanceSet = new AccountBalanceSet();
+        accountBalanceSet.setConsensusTimestamp(consensusTimestamp);
+        return accountBalanceSetRepository.save(accountBalanceSet);
+    }
+}


### PR DESCRIPTION
**Detailed description**:
- Add missing test for `BalanceFileParser`
- Add missing domain and repository classes for `AccountBalance` and `AccountBalanceSet`
- Fix iterating over balance files twice: once to get latest and once for rest
- Fix `BalanceFileParser` processing new balance files in random order
- Fix NPE when no files to process
- Fix logs not printing balance filename that had the error by moving start log earlier
- Hardcode pgpool, postgresql and importer to replicas=1 for now to reduce risk as more than one is untested

**Which issue(s) this PR fixes**:
Fixes #235 

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated

