### PR TITLE
Update home README w knowledge areas and tools

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - 5432:5432
 
   grpc:
-    image: gcr.io/mirrornode/hedera-mirror-grpc
+    image: gcr.io/mirrornode/hedera-mirror-grpc:0.12.0-beta2
     restart: unless-stopped
     environment:
       HEDERA_MIRROR_GRPC_DB_HOST: db
@@ -28,7 +28,7 @@ services:
       - 5600:5600
 
   importer:
-    image: gcr.io/mirrornode/hedera-mirror-importer
+    image: gcr.io/mirrornode/hedera-mirror-importer:0.12.0-beta2
     restart: unless-stopped
     environment:
       HEDERA_MIRROR_IMPORTER_DATAPATH: /var/lib/hedera-mirror-importer
@@ -39,7 +39,7 @@ services:
       #- ./application.yml:/usr/etc/hedera-mirror-importer/application.yml
 
   rest:
-    image: gcr.io/mirrornode/hedera-mirror-rest
+    image: gcr.io/mirrornode/hedera-mirror-rest:0.12.0-beta2
     environment:
       HEDERA_MIRROR_REST_DB_HOST: db
     restart: unless-stopped

--- a/pom.xml
+++ b/pom.xml
@@ -365,6 +365,7 @@
                             <basedir>${project.basedir}</basedir>
                             <includes>
                                 <include>charts/**/Chart.yaml</include>
+                                <include>docker-compose.yml</include>
                                 <include>hedera-mirror-rest/package*.json</include>
                                 <include>hedera-mirror-rest/monitoring/monitor_apis/package*.json</include>
                                 <include>*/pom.xml</include>
@@ -388,6 +389,10 @@
                                 <replacement>
                                     <token><![CDATA[(?<=version: )[0-9a-z.-]+]]></token>
                                     <value>${release.chartVersion}</value>
+                                </replacement>
+                                <replacement>
+                                    <token><![CDATA[(?<=gcr.io/mirrornode/hedera-mirror-(grpc|importer|rest):)[0-9a-z.-]+]]></token>
+                                    <value>${release.version}</value>
                                 </replacement>
                             </replacements>
                         </configuration>


### PR DESCRIPTION
**Detailed description**:
Current repo documentation assumes users have knowledge of things like postgres, docker and also have docker and other tools installed.
We don't call these out explicitly and should as users of varying technical abilities will need to ramp up and get going on mirror node.

This change update README.md with

- Knowledge area - PostgresSql, docker commands, java spring configurations etc
- Prerequisite tools e.g. docker, open jdk, nodejs etc
- Adds note for if not using the demo-bucket please create an application.yaml file in desired sub project to customize run


Additionally it
- Updates Dockerfile w version tag
- Updates version plugin to keep it updated. 

**Which issue(s) this PR fixes**:
Fixes #790

**Special notes for your reviewer**:

**Checklist**
- [x] Documentation added
- [ ] Tests updated

