### PR TITLE
Utilize https protocol instead of git for easy repo cloning

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Ensure these tools are installed prior to running the mirror node
 
 To run the mirror node, execute these 3 commands in your terminal.
 ```bash
-git clone git@github.com:hashgraph/hedera-mirror-node.git
+git clone https://github.com/hashgraph/hedera-mirror-node.git
 cd hedera-mirror-node
 docker-compose up
 ```


### PR DESCRIPTION
**Detailed description**:
Performing a git clone using the git protocol makes a challenge for permissions
We want the 3rd party ramp up steps to be easy and so we should use the easier and more used https flow

Switched `git clone git@github.com:hashgraph/hedera-mirror-node.git` to `git clone https://github.com/hashgraph/hedera-mirror-node.git`

See [Git-on-the-Server-The-Protocols](https://git-scm.com/book/en/v2/Git-on-the-Server-The-Protocols) for more details 

**Which issue(s) this PR fixes**:
Fixes #805  

**Special notes for your reviewer**:

**Checklist**
- [x] Documentation added
- [ ] Tests updated

