### PR TITLE
Improve Record Parser tests

### DIFF
--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/AbstractEntityRecordItemListenerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/AbstractEntityRecordItemListenerTest.java
@@ -30,6 +30,7 @@ import com.hederahashgraph.api.proto.java.ContractID;
 import com.hederahashgraph.api.proto.java.Duration;
 import com.hederahashgraph.api.proto.java.FileID;
 import com.hederahashgraph.api.proto.java.Key;
+import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.SignatureMap;
 import com.hederahashgraph.api.proto.java.SignaturePair;
 import com.hederahashgraph.api.proto.java.Timestamp;
@@ -267,7 +268,12 @@ public class AbstractEntityRecordItemListenerTest extends IntegrationTest {
             accountAmount.setAmount(transferAmounts[i]);
             transferList.addAccountAmounts(accountAmount);
         }
-    customBuilder.accept(recordBuilder);
+        if (transactionBody.hasCryptoTransfer() && status == ResponseCodeEnum.SUCCESS.getNumber()) {
+            for (var aa : transactionBody.getCryptoTransfer().getTransfers().getAccountAmountsList()) {
+                transferList.addAccountAmounts(aa);
+            }
+        }
+        customBuilder.accept(recordBuilder);
         return recordBuilder.build();
     }
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerCryptoTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerCryptoTest.java
@@ -518,8 +518,8 @@ public class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItem
 
         assertAll(
                 () -> assertEquals(1, transactionRepository.count())
-                , () -> assertEquals(3, entityRepository.count())
-                , () -> assertEquals(3, cryptoTransferRepository.count())
+                , () -> assertEquals(5, entityRepository.count())
+                , () -> assertEquals(6, cryptoTransferRepository.count())
                 , () -> assertEquals(0, contractResultRepository.count())
                 , () -> assertEquals(0, liveHashRepository.count())
                 , () -> assertEquals(0, fileDataRepository.count())

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerCryptoTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerCryptoTest.java
@@ -28,8 +28,6 @@ import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.CryptoAddLiveHashTransactionBody;
 import com.hederahashgraph.api.proto.java.CryptoCreateTransactionBody;
 import com.hederahashgraph.api.proto.java.CryptoDeleteLiveHashTransactionBody;
-import com.hederahashgraph.api.proto.java.CryptoDeleteTransactionBody;
-import com.hederahashgraph.api.proto.java.CryptoTransferTransactionBody;
 import com.hederahashgraph.api.proto.java.CryptoUpdateTransactionBody;
 import com.hederahashgraph.api.proto.java.Duration;
 import com.hederahashgraph.api.proto.java.KeyList;
@@ -39,7 +37,6 @@ import com.hederahashgraph.api.proto.java.ShardID;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.Transaction;
 import com.hederahashgraph.api.proto.java.TransactionBody;
-import com.hederahashgraph.api.proto.java.TransactionReceipt;
 import com.hederahashgraph.api.proto.java.TransactionRecord;
 import com.hederahashgraph.api.proto.java.TransferList;
 import java.time.Instant;
@@ -56,25 +53,10 @@ import com.hedera.mirror.importer.parser.domain.RecordItem;
 import com.hedera.mirror.importer.util.Utility;
 
 public class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItemListenerTest {
-
-    //TODO: These transaction data items are not saved to the database
-    //  cryptoCreateTransactionBody.getReceiveRecordThreshold()
-    //  cryptoCreateTransactionBody.getShardID()
-    //  cryptoCreateTransactionBody.getRealmID()
-    //  cryptoCreateTransactionBody.getNewRealmAdminKey()
-    //  cryptoCreateTransactionBody.getReceiverSigRequired()
-    //  cryptoCreateTransactionBody.getSendRecordThreshold()
-    //  cryptoCreateTransactionBody.getReceiveRecordThreshold()
-    //  transactionBody.getTransactionFee()
-    //  transactionBody.getTransactionValidDuration()
-    //  transaction.getSigMap()
-    //  record.getTransactionHash();
-
     private static final AccountID accountId = AccountID.newBuilder().setShardNum(0).setRealmNum(0).setAccountNum(1001)
             .build();
-    private static final String memo = "Crypto test memo";
-    private static final long[] transferAccounts = {98, 2002, 3};
-    private static final long[] transferAmounts = {1000, -2000, 20};
+    private static final long[] additionalTransfers = {5000, 6000, PAYER.getAccountNum()};
+    private static final long[] additionalTransferAmounts = {1000, 1000, -2000};
 
     @BeforeEach
     void before() {
@@ -84,7 +66,6 @@ public class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItem
 
     @Test
     void cryptoCreate() throws Exception {
-
         Transaction transaction = cryptoCreateTransaction();
         TransactionBody transactionBody = TransactionBody.parseFrom(transaction.getBodyBytes());
         CryptoCreateTransactionBody cryptoCreateTransactionBody = transactionBody.getCryptoCreateAccount();
@@ -92,114 +73,60 @@ public class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItem
 
         parseRecordItemAndCommit(new RecordItem(transaction, record));
 
-        com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
-                .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
-        com.hedera.mirror.importer.domain.Entities dbNewAccountEntity = entityRepository
-                .findById(dbTransaction.getEntityId()).get();
-        com.hedera.mirror.importer.domain.Entities dbProxyAccountId = entityRepository
-                .findById(dbNewAccountEntity.getProxyAccountId()).get();
+        var dbTransaction = getDbTransaction(record.getConsensusTimestamp());
 
         assertAll(
-                // row counts
                 () -> assertEquals(1, transactionRepository.count())
-                , () -> assertEquals(6, entityRepository.count())
+                , () -> assertEquals(5, entityRepository.count()) // accounts: node, treasury, payer, new crypto, proxy
                 , () -> assertEquals(5, cryptoTransferRepository.count())
                 , () -> assertEquals(0, contractResultRepository.count())
                 , () -> assertEquals(0, liveHashRepository.count())
                 , () -> assertEquals(0, fileDataRepository.count())
-
-                // transaction
-                , () -> assertTransaction(transactionBody, dbTransaction)
-                // record inputs
-                , () -> assertRecord(record)
-                // receipt
-                , () -> assertAccount(record.getReceipt().getAccountID(), dbNewAccountEntity)
-
-                // transaction body inputs
-                , () -> assertEquals(cryptoCreateTransactionBody.getAutoRenewPeriod().getSeconds(), dbNewAccountEntity
-                        .getAutoRenewPeriod())
+                , () -> assertCryptoTransaction(transactionBody, record, false)
+                , () -> assertCryptoEntity(cryptoCreateTransactionBody, record.getConsensusTimestamp())
                 , () -> assertEquals(cryptoCreateTransactionBody.getInitialBalance(), dbTransaction.getInitialBalance())
-                , () -> assertEquals(Utility.protobufKeyToHexIfEd25519OrNull(cryptoCreateTransactionBody.getKey()
-                        .toByteArray()), dbNewAccountEntity.getEd25519PublicKeyHex())
-                , () -> assertAccount(cryptoCreateTransactionBody.getProxyAccountID(), dbProxyAccountId)
-                , () -> assertArrayEquals(cryptoCreateTransactionBody.getKey().toByteArray(), dbNewAccountEntity
-                        .getKey())
-
-                // Additional entity checks
-                , () -> assertFalse(dbNewAccountEntity.isDeleted())
-                , () -> assertNull(dbNewAccountEntity.getExpiryTimeNs())
         );
-
-        // Crypto transfer list
-        verifyRepoCryptoTransferList(record);
     }
 
     @Test
     void cryptoCreateTransactionWithBody() throws Exception {
-
         Transaction transaction = createTransactionWithBody();
-        TransactionBody transactionBody = transaction.getBody();
+        TransactionBody transactionBody = TransactionBody.parseFrom(transaction.getBodyBytes());
         CryptoCreateTransactionBody cryptoCreateTransactionBody = transactionBody.getCryptoCreateAccount();
         TransactionRecord record = transactionRecordSuccess(transactionBody);
 
         parseRecordItemAndCommit(new RecordItem(transaction, record));
 
-        com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
-                .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
-        com.hedera.mirror.importer.domain.Entities dbNewAccountEntity = entityRepository
-                .findById(dbTransaction.getEntityId()).get();
-        com.hedera.mirror.importer.domain.Entities dbProxyAccountId = entityRepository
-                .findById(dbNewAccountEntity.getProxyAccountId()).get();
-        CryptoTransfer dbCryptoTransfer = cryptoTransferRepository
-                .findByConsensusTimestampAndEntityNum(
-                        Utility.timeStampInNanos(record.getConsensusTimestamp()),
-                        dbNewAccountEntity.getEntityNum()).get();
+        var dbTransaction = getDbTransaction(record.getConsensusTimestamp());
+        Entities dbNewAccountEntity = getEntity(dbTransaction.getEntityId());
+        CryptoTransfer dbCryptoTransfer = cryptoTransferRepository.findByConsensusTimestampAndEntityNum(
+                Utility.timeStampInNanos(record.getConsensusTimestamp()),
+                dbNewAccountEntity.getEntityNum()).get();
         AccountID recordReceiptAccountId = record.getReceipt().getAccountID();
 
         assertAll(
-                // row counts
                 () -> assertEquals(1, transactionRepository.count())
-                , () -> assertEquals(6, entityRepository.count())
+                , () -> assertEquals(5, entityRepository.count())
                 , () -> assertEquals(5, cryptoTransferRepository.count())
                 , () -> assertEquals(0, contractResultRepository.count())
                 , () -> assertEquals(0, liveHashRepository.count())
                 , () -> assertEquals(0, fileDataRepository.count())
-
-                // transaction
-                , () -> assertTransaction(transactionBody, dbTransaction)
-                // record inputs
-                , () -> assertRecord(record)
-                // receipt
-                , () -> assertAccount(record.getReceipt().getAccountID(), dbNewAccountEntity)
+                , () -> assertCryptoTransaction(transactionBody, record, false)
+                , () -> assertCryptoEntity(cryptoCreateTransactionBody, record.getConsensusTimestamp())
 
                 // transaction body inputs
-                , () -> assertEquals(cryptoCreateTransactionBody.getAutoRenewPeriod().getSeconds(), dbNewAccountEntity
-                        .getAutoRenewPeriod())
                 , () -> assertEquals(cryptoCreateTransactionBody.getInitialBalance(), dbTransaction.getInitialBalance())
-                , () -> assertEquals(Utility.protobufKeyToHexIfEd25519OrNull(cryptoCreateTransactionBody.getKey()
-                        .toByteArray()), dbNewAccountEntity.getEd25519PublicKeyHex())
-                , () -> assertAccount(cryptoCreateTransactionBody.getProxyAccountID(), dbProxyAccountId)
-                , () -> assertArrayEquals(cryptoCreateTransactionBody.getKey().toByteArray(), dbNewAccountEntity
-                        .getKey())
-
-                // Additional entity checks
-                , () -> assertFalse(dbNewAccountEntity.isDeleted())
-                , () -> assertNull(dbNewAccountEntity.getExpiryTimeNs())
 
                 // Crypto transfer list
-                , () -> assertEquals(Utility.timeStampInNanos(record.getConsensusTimestamp()), dbCryptoTransfer
-                        .getConsensusTimestamp())
+                , () -> assertEquals(Utility.timeStampInNanos(record.getConsensusTimestamp()),
+                        dbCryptoTransfer.getConsensusTimestamp())
                 , () -> assertEquals(recordReceiptAccountId.getRealmNum(), dbCryptoTransfer.getRealmNum())
                 , () -> assertEquals(recordReceiptAccountId.getAccountNum(), dbCryptoTransfer.getEntityNum())
         );
-
-        // Crypto transfer list
-        verifyRepoCryptoTransferList(record);
     }
 
     @Test
     void cryptoCreateFailedTransaction() throws Exception {
-
         Transaction transaction = cryptoCreateTransaction();
         TransactionBody transactionBody = TransactionBody.parseFrom(transaction.getBodyBytes());
         CryptoCreateTransactionBody cryptoCreateTransactionBody = transactionBody.getCryptoCreateAccount();
@@ -211,35 +138,23 @@ public class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItem
 
         parseRecordItemAndCommit(new RecordItem(transaction, record));
 
-        com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository.findById(
-                Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
+        var dbTransaction = getDbTransaction(record.getConsensusTimestamp());
 
         assertAll(
-                // row counts
                 () -> assertEquals(1, transactionRepository.count())
                 , () -> assertEquals(3, entityRepository.count())
-                , () -> assertEquals(2, cryptoTransferRepository.count())
+                , () -> assertEquals(3, cryptoTransferRepository.count())
                 , () -> assertEquals(0, contractResultRepository.count())
                 , () -> assertEquals(0, liveHashRepository.count())
                 , () -> assertEquals(0, fileDataRepository.count())
-
-                // transaction
-                , () -> assertTransaction(transactionBody, dbTransaction)
+                , () -> assertTransactionAndRecord(transactionBody, record)
                 , () -> assertNull(dbTransaction.getEntityId())
-                // record inputs
-                , () -> assertRecord(record)
-
-                // transaction body inputs
                 , () -> assertEquals(cryptoCreateTransactionBody.getInitialBalance(), dbTransaction.getInitialBalance())
         );
-
-        // Crypto transfer list
-        verifyRepoCryptoTransferList(record);
     }
 
     @Test
     void cryptoCreateInitialBalanceInTransferList() throws Exception {
-
         Transaction transaction = cryptoCreateTransaction();
         TransactionBody transactionBody = TransactionBody.parseFrom(transaction.getBodyBytes());
         CryptoCreateTransactionBody cryptoCreateTransactionBody = transactionBody.getCryptoCreateAccount();
@@ -250,58 +165,28 @@ public class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItem
 
         TransferList.Builder transferList = tempRecord.getTransferList().toBuilder();
         transferList.addAccountAmounts(AccountAmount.newBuilder().setAccountID(accountId).setAmount(initialBalance));
-        transferList.addAccountAmounts(AccountAmount.newBuilder()
-                .setAccountID(AccountID.newBuilder().setShardNum(0).setRealmNum(0).setAccountNum(202))
-                .setAmount(-initialBalance));
+        transferList.addAccountAmounts(AccountAmount.newBuilder().setAccountID(PAYER).setAmount(-initialBalance));
         TransactionRecord record = tempRecord.toBuilder().setTransferList(transferList).build();
 
         parseRecordItemAndCommit(new RecordItem(transaction, record));
 
-        com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
-                .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
-        com.hedera.mirror.importer.domain.Entities dbNewAccountEntity = entityRepository
-                .findById(dbTransaction.getEntityId()).get();
-        com.hedera.mirror.importer.domain.Entities dbProxyAccountId = entityRepository
-                .findById(dbNewAccountEntity.getProxyAccountId()).get();
+        var dbTransaction = getDbTransaction(record.getConsensusTimestamp());
 
         assertAll(
-                // row counts
                 () -> assertEquals(1, transactionRepository.count())
-                , () -> assertEquals(7, entityRepository.count())
+                , () -> assertEquals(5, entityRepository.count())
                 , () -> assertEquals(5, cryptoTransferRepository.count())
                 , () -> assertEquals(0, contractResultRepository.count())
                 , () -> assertEquals(0, liveHashRepository.count())
                 , () -> assertEquals(0, fileDataRepository.count())
-
-                // transaction
-                , () -> assertTransaction(transactionBody, dbTransaction)
-                // record inputs
-                , () -> assertRecord(record)
-                // receipt
-                , () -> assertAccount(record.getReceipt().getAccountID(), dbNewAccountEntity)
-
-                // transaction body inputs
-                , () -> assertEquals(cryptoCreateTransactionBody.getAutoRenewPeriod().getSeconds(), dbNewAccountEntity
-                        .getAutoRenewPeriod())
+                , () -> assertCryptoTransaction(transactionBody, record, false)
+                , () -> assertCryptoEntity(cryptoCreateTransactionBody, record.getConsensusTimestamp())
                 , () -> assertEquals(cryptoCreateTransactionBody.getInitialBalance(), dbTransaction.getInitialBalance())
-                , () -> assertEquals(Utility.protobufKeyToHexIfEd25519OrNull(cryptoCreateTransactionBody.getKey()
-                        .toByteArray()), dbNewAccountEntity.getEd25519PublicKeyHex())
-                , () -> assertAccount(cryptoCreateTransactionBody.getProxyAccountID(), dbProxyAccountId)
-                , () -> assertArrayEquals(cryptoCreateTransactionBody.getKey().toByteArray(), dbNewAccountEntity
-                        .getKey())
-
-                // Additional entity checks
-                , () -> assertFalse(dbNewAccountEntity.isDeleted())
-                , () -> assertNull(dbNewAccountEntity.getExpiryTimeNs())
         );
-
-        // Crypto transfer list
-        verifyRepoCryptoTransferList(record);
     }
 
     @Test
     void cryptoCreateTwice() throws Exception {
-
         Transaction firstTransaction = cryptoCreateTransaction();
         TransactionBody firstTransactionBody = TransactionBody.parseFrom(firstTransaction.getBodyBytes());
         TransactionRecord firstRecord = transactionRecordSuccess(firstTransactionBody);
@@ -315,57 +200,21 @@ public class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItem
 
         parseRecordItemAndCommit(new RecordItem(transaction, record));
 
-        com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
-                .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
-        com.hedera.mirror.importer.domain.Entities dbNewAccountEntity = entityRepository
-                .findById(dbTransaction.getEntityId()).get();
-        com.hedera.mirror.importer.domain.Entities dbProxyAccountId = entityRepository
-                .findById(dbNewAccountEntity.getProxyAccountId()).get();
-
         assertAll(
-                // row counts
                 () -> assertEquals(2, transactionRepository.count())
-                , () -> assertEquals(6, entityRepository.count())
+                , () -> assertEquals(5, entityRepository.count())
                 , () -> assertEquals(10, cryptoTransferRepository.count())
                 , () -> assertEquals(0, contractResultRepository.count())
                 , () -> assertEquals(0, liveHashRepository.count())
                 , () -> assertEquals(0, fileDataRepository.count())
-
-                // transaction
-                , () -> assertTransaction(transactionBody, dbTransaction)
-                // record inputs
-                , () -> assertRecord(record)
-                // receipt
-                , () -> assertAccount(record.getReceipt().getAccountID(), dbNewAccountEntity)
-
-                // transaction body inputs
-                , () -> assertEquals(cryptoCreateTransactionBody.getAutoRenewPeriod().getSeconds(), dbNewAccountEntity
-                        .getAutoRenewPeriod())
-                , () -> assertEquals(cryptoCreateTransactionBody.getInitialBalance(), dbTransaction.getInitialBalance())
-                , () -> assertEquals(Utility.protobufKeyToHexIfEd25519OrNull(cryptoCreateTransactionBody.getKey()
-                        .toByteArray()), dbNewAccountEntity.getEd25519PublicKeyHex())
-                , () -> assertAccount(cryptoCreateTransactionBody.getProxyAccountID(), dbProxyAccountId)
-                , () -> assertArrayEquals(cryptoCreateTransactionBody.getKey().toByteArray(), dbNewAccountEntity
-                        .getKey())
-
-                // Additional entity checks
-                , () -> assertFalse(dbNewAccountEntity.isDeleted())
-                , () -> assertNull(dbNewAccountEntity.getExpiryTimeNs())
+                , () -> assertCryptoTransaction(transactionBody, record, false)
+                , () -> assertCryptoEntity(cryptoCreateTransactionBody, record.getConsensusTimestamp())
         );
-
-        // Crypto transfer list
-        verifyRepoCryptoTransferList(record);
     }
 
     @Test
     void cryptoUpdateSuccessfulTransaction() throws Exception {
-
-        // first create the account
-        Transaction createTransaction = cryptoCreateTransaction();
-        TransactionBody createTransactionBody = TransactionBody.parseFrom(createTransaction.getBodyBytes());
-        TransactionRecord createRecord = transactionRecordSuccess(createTransactionBody);
-
-        parseRecordItemAndCommit(new RecordItem(createTransaction, createRecord));
+        createAccount();
 
         // now update
         Transaction transaction = cryptoUpdateTransaction();
@@ -375,46 +224,28 @@ public class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItem
 
         parseRecordItemAndCommit(new RecordItem(transaction, record));
 
-        com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
-                .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
-        com.hedera.mirror.importer.domain.Entities dbAccountEntity = entityRepository
-                .findById(dbTransaction.getEntityId()).get();
-        com.hedera.mirror.importer.domain.Entities dbProxyAccountId = entityRepository
-                .findById(dbAccountEntity.getProxyAccountId()).get();
+        Entities dbAccountEntity = getTransactionEntity(record.getConsensusTimestamp());
+        Entities dbProxyAccountId = getEntity(dbAccountEntity.getProxyAccountId());
 
         assertAll(
-                // row counts
                 () -> assertEquals(2, transactionRepository.count())
-                , () -> assertEquals(7, entityRepository.count())
+                , () -> assertEquals(6, entityRepository.count())
                 , () -> assertEquals(8, cryptoTransferRepository.count())
                 , () -> assertEquals(0, contractResultRepository.count())
                 , () -> assertEquals(0, liveHashRepository.count())
                 , () -> assertEquals(0, fileDataRepository.count())
-
-                // transaction
-                , () -> assertTransaction(transactionBody, dbTransaction)
-                // record inputs
-                , () -> assertRecord(record)
-                // receipt
-                , () -> assertAccount(record.getReceipt().getAccountID(), dbAccountEntity)
+                , () -> assertCryptoTransaction(transactionBody, record, false)
 
                 // transaction body inputs
-                , () -> assertEquals(cryptoUpdateTransactionBody.getAutoRenewPeriod().getSeconds(), dbAccountEntity
-                        .getAutoRenewPeriod())
-                , () -> assertEquals(Utility.protobufKeyToHexIfEd25519OrNull(cryptoUpdateTransactionBody.getKey()
-                        .toByteArray()), dbAccountEntity.getEd25519PublicKeyHex())
+                , () -> assertEquals(cryptoUpdateTransactionBody.getAutoRenewPeriod().getSeconds(),
+                        dbAccountEntity.getAutoRenewPeriod())
+                , () -> assertEquals(Utility.protobufKeyToHexIfEd25519OrNull(
+                        cryptoUpdateTransactionBody.getKey().toByteArray()), dbAccountEntity.getEd25519PublicKeyHex())
                 , () -> assertAccount(cryptoUpdateTransactionBody.getProxyAccountID(), dbProxyAccountId)
                 , () -> assertArrayEquals(cryptoUpdateTransactionBody.getKey().toByteArray(), dbAccountEntity.getKey())
-                , () -> assertEquals(Utility
-                        .timeStampInNanos(cryptoUpdateTransactionBody.getExpirationTime()), dbAccountEntity
-                        .getExpiryTimeNs())
-
-                // Additional entity checks
-                , () -> assertFalse(dbAccountEntity.isDeleted())
+                , () -> assertEquals(Utility.timeStampInNanos(cryptoUpdateTransactionBody.getExpirationTime()),
+                        dbAccountEntity.getExpiryTimeNs())
         );
-
-        // Crypto transfer list
-        verifyRepoCryptoTransferList(record);
     }
 
     /**
@@ -429,7 +260,6 @@ public class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItem
                 .setTransactionID(Utility.getTransactionId(accountId))
                 .build();
         transaction = Transaction.newBuilder().setBodyBytes(transactionBody.toByteString()).build();
-        CryptoUpdateTransactionBody cryptoUpdateTransactionBody = transactionBody.getCryptoUpdateAccount();
         TransactionRecord record = transactionRecordSuccess(transactionBody);
 
         parseRecordItemAndCommit(new RecordItem(transaction, record));
@@ -461,34 +291,22 @@ public class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItem
             "-1000000000000000000, -9223372036854775808"
     })
     void cryptoUpdateExpirationOverflow(long seconds, long expectedNanosTimestamp) throws Exception {
-
-        // first create the account
-        var createTransaction = cryptoCreateTransaction();
-        var createTransactionBody = TransactionBody.parseFrom(createTransaction.getBodyBytes());
-        var createRecord = transactionRecordSuccess(createTransactionBody);
-
-        parseRecordItemAndCommit(new RecordItem(createTransaction, createRecord));
+        createAccount();
 
         // now update
-        var updateTransaction = Transaction.newBuilder();
-        var updateTransactionBody = CryptoUpdateTransactionBody.newBuilder();
-        updateTransactionBody.setAccountIDToUpdate(accountId);
+        var updateTransaction = buildTransaction(builder -> {
+            builder.getCryptoUpdateAccountBuilder()
+                    .setAccountIDToUpdate(accountId)
+                    // *** THIS IS THE OVERFLOW WE WANT TO TEST ***
+                    // This should result in the entity having a Long.MAX_VALUE or Long.MIN_VALUE expirations
+                    // (the results of overflows).
+                    .setExpirationTime(Timestamp.newBuilder().setSeconds(seconds));
+        });
+        var record = transactionRecordSuccess(TransactionBody.parseFrom(updateTransaction.getBodyBytes()));
 
-        // *** THIS IS THE OVERFLOW WE WANT TO TEST ***
-        // This should result in the entity having a Long.MAX_VALUE or Long.MIN_VALUE expirations (the results of
-        // overflows).
-        updateTransactionBody.setExpirationTime(Timestamp.newBuilder().setSeconds(seconds));
+        parseRecordItemAndCommit(new RecordItem(updateTransaction, record));
 
-        var transactionBody = defaultTransactionBodyBuilder(memo);
-        transactionBody.setCryptoUpdateAccount(updateTransactionBody.build());
-        updateTransaction.setBodyBytes(transactionBody.build().toByteString());
-        var rec = transactionRecordSuccess(transactionBody.build());
-
-        parseRecordItemAndCommit(new RecordItem(updateTransaction.build(), rec));
-
-        var dbTransaction = transactionRepository
-                .findById(Utility.timeStampInNanos(rec.getConsensusTimestamp())).get();
-        var dbAccountEntity = entityRepository.findById(dbTransaction.getEntityId()).get();
+        var dbAccountEntity = getTransactionEntity(record.getConsensusTimestamp());
 
         assertAll(
                 () -> assertEquals(2, transactionRepository.count()),
@@ -498,64 +316,40 @@ public class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItem
 
     @Test
     void cryptoUpdateFailedTransaction() throws Exception {
-
-        // first create the account
         Transaction createTransaction = cryptoCreateTransaction();
-        TransactionBody createTransactionBody = TransactionBody.parseFrom(createTransaction.getBodyBytes());
-        TransactionRecord createRecord = transactionRecordSuccess(createTransactionBody);
-
+        TransactionRecord createRecord = transactionRecordSuccess(
+                TransactionBody.parseFrom(createTransaction.getBodyBytes()));
         parseRecordItemAndCommit(new RecordItem(createTransaction, createRecord));
 
         // now update
         Transaction transaction = cryptoUpdateTransaction();
         TransactionBody transactionBody = TransactionBody.parseFrom(transaction.getBodyBytes());
-        TransactionRecord record = transactionRecord(transactionBody,
-                ResponseCodeEnum.INSUFFICIENT_ACCOUNT_BALANCE);
+        TransactionRecord record = transactionRecord(transactionBody, ResponseCodeEnum.INSUFFICIENT_ACCOUNT_BALANCE);
 
         parseRecordItemAndCommit(new RecordItem(transaction, record));
 
-        com.hedera.mirror.importer.domain.Transaction dbCreateTransaction = transactionRepository
-                .findById(Utility.timeStampInNanos(createRecord.getConsensusTimestamp())).get();
-        com.hedera.mirror.importer.domain.Entities dbAccountEntityBefore = entityRepository
-                .findById(dbCreateTransaction.getEntityId()).get();
-
-        com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
-                .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
-        com.hedera.mirror.importer.domain.Entities dbAccountEntity = entityRepository
-                .findById(dbTransaction.getEntityId()).get();
+        Entities dbAccountEntityBefore = getTransactionEntity(createRecord.getConsensusTimestamp());
+        Entities dbAccountEntity = getTransactionEntity(record.getConsensusTimestamp());
 
         assertAll(
-                // row counts
                 () -> assertEquals(2, transactionRepository.count())
-                , () -> assertEquals(6, entityRepository.count())
-                , () -> assertEquals(7, cryptoTransferRepository.count())
+                , () -> assertEquals(5, entityRepository.count())
+                , () -> assertEquals(8, cryptoTransferRepository.count()) // 3 + 3 fee transfers + 2 for initial balance
                 , () -> assertEquals(0, contractResultRepository.count())
                 , () -> assertEquals(0, liveHashRepository.count())
                 , () -> assertEquals(0, fileDataRepository.count())
-
-                // transaction
-                , () -> assertTransaction(transactionBody, dbTransaction)
-                // record inputs
-                , () -> assertRecord(record)
+                , () -> assertTransactionAndRecord(transactionBody, record)
                 // receipt
                 , () -> assertAccount(record.getReceipt().getAccountID(), dbAccountEntity)
                 // no changes to entity
                 , () -> assertEquals(dbAccountEntityBefore, dbAccountEntity)
         );
-
-        // Crypto transfer list
-        verifyRepoCryptoTransferList(record);
     }
 
     @Test
     void cryptoDeleteSuccessfulTransaction() throws Exception {
-
         // first create the account
-        Transaction createTransaction = cryptoCreateTransaction();
-        TransactionBody createTransactionBody = TransactionBody.parseFrom(createTransaction.getBodyBytes());
-        TransactionRecord createRecord = transactionRecordSuccess(createTransactionBody);
-
-        parseRecordItemAndCommit(new RecordItem(createTransaction, createRecord));
+        createAccount();
 
         // now delete
         Transaction transaction = cryptoDeleteTransaction();
@@ -564,31 +358,17 @@ public class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItem
 
         parseRecordItemAndCommit(new RecordItem(transaction, record));
 
-        com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
-                .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
-        com.hedera.mirror.importer.domain.Entities dbAccountEntity = entityRepository
-                .findById(dbTransaction.getEntityId()).get();
-        com.hedera.mirror.importer.domain.Entities dbProxyAccountId = entityRepository
-                .findById(dbAccountEntity.getProxyAccountId()).get();
+        Entities dbAccountEntity = getTransactionEntity(record.getConsensusTimestamp());
+        Entities dbProxyAccountId = getEntity(dbAccountEntity.getProxyAccountId());
 
         assertAll(
-                // row counts
                 () -> assertEquals(2, transactionRepository.count())
-                , () -> assertEquals(6, entityRepository.count())
-                , () -> assertEquals(8, cryptoTransferRepository.count())
+                , () -> assertEquals(5, entityRepository.count())
+                , () -> assertEquals(8, cryptoTransferRepository.count()) // 3 + 3 fee transfers + 2 for initial balance
                 , () -> assertEquals(0, contractResultRepository.count())
                 , () -> assertEquals(0, liveHashRepository.count())
                 , () -> assertEquals(0, fileDataRepository.count())
-
-                // transaction
-                , () -> assertTransaction(transactionBody, dbTransaction)
-                // record inputs
-                , () -> assertRecord(record)
-                // receipt
-                , () -> assertAccount(record.getReceipt().getAccountID(), dbAccountEntity)
-
-                // transaction body inputs
-                , () -> assertTrue(dbAccountEntity.isDeleted())
+                , () -> assertCryptoTransaction(transactionBody, record, true)
 
                 // Additional entity checks
                 , () -> assertNotNull(dbAccountEntity.getEd25519PublicKeyHex())
@@ -597,20 +377,11 @@ public class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItem
                 , () -> assertNotNull(dbProxyAccountId)
                 , () -> assertNull(dbAccountEntity.getExpiryTimeNs())
         );
-
-        // Crypto transfer list
-        verifyRepoCryptoTransferList(record);
     }
 
     @Test
     void cryptoDeleteFailedTransaction() throws Exception {
-
-        // first create the account
-        Transaction createTransaction = cryptoCreateTransaction();
-        TransactionBody createTransactionBody = TransactionBody.parseFrom(createTransaction.getBodyBytes());
-        TransactionRecord createRecord = transactionRecordSuccess(createTransactionBody);
-
-        parseRecordItemAndCommit(new RecordItem(createTransaction, createRecord));
+        createAccount();
 
         // now delete
         Transaction transaction = cryptoDeleteTransaction();
@@ -620,31 +391,17 @@ public class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItem
 
         parseRecordItemAndCommit(new RecordItem(transaction, record));
 
-        com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
-                .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
-        com.hedera.mirror.importer.domain.Entities dbAccountEntity = entityRepository
-                .findById(dbTransaction.getEntityId()).get();
-        com.hedera.mirror.importer.domain.Entities dbProxyAccountId = entityRepository
-                .findById(dbAccountEntity.getProxyAccountId()).get();
+        Entities dbAccountEntity = getTransactionEntity(record.getConsensusTimestamp());
+        Entities dbProxyAccountId = getEntity(dbAccountEntity.getProxyAccountId());
 
         assertAll(
-                // row counts
                 () -> assertEquals(2, transactionRepository.count())
-                , () -> assertEquals(6, entityRepository.count())
-                , () -> assertEquals(7, cryptoTransferRepository.count())
+                , () -> assertEquals(5, entityRepository.count())
+                , () -> assertEquals(8, cryptoTransferRepository.count()) // 3 + 3 fee transfers + 2 for initial balance
                 , () -> assertEquals(0, contractResultRepository.count())
                 , () -> assertEquals(0, liveHashRepository.count())
                 , () -> assertEquals(0, fileDataRepository.count())
-
-                // transaction
-                , () -> assertTransaction(transactionBody, dbTransaction)
-                // record inputs
-                , () -> assertRecord(record)
-                // receipt
-                , () -> assertAccount(record.getReceipt().getAccountID(), dbAccountEntity)
-
-                // transaction body inputs
-                , () -> assertFalse(dbAccountEntity.isDeleted())
+                , () -> assertCryptoTransaction(transactionBody, record, false)
 
                 // Additional entity checks
                 , () -> assertNotNull(dbAccountEntity.getEd25519PublicKeyHex())
@@ -653,22 +410,12 @@ public class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItem
                 , () -> assertNotNull(dbProxyAccountId)
                 , () -> assertNull(dbAccountEntity.getExpiryTimeNs())
         );
-
-        // Crypto transfer list
-        verifyRepoCryptoTransferList(record);
     }
 
     @Test
     void cryptoAddLiveHashPersist() throws Exception {
-
-        // first create the account
-        Transaction createTransaction = cryptoCreateTransaction();
-        TransactionBody createTransactionBody = TransactionBody.parseFrom(createTransaction.getBodyBytes());
-        TransactionRecord createRecord = transactionRecordSuccess(createTransactionBody);
-
-        parseRecordItemAndCommit(new RecordItem(createTransaction, createRecord));
-
-        // now add live hash
+        // create the account and add live hash
+        createAccount();
         Transaction transaction = cryptoAddLiveHashTransaction();
         TransactionBody transactionBody = TransactionBody.parseFrom(transaction.getBodyBytes());
         CryptoAddLiveHashTransactionBody cryptoAddLiveHashTransactionBody = transactionBody.getCryptoAddLiveHash();
@@ -676,27 +423,18 @@ public class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItem
 
         parseRecordItemAndCommit(new RecordItem(transaction, record));
 
-        com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
-                .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
-        com.hedera.mirror.importer.domain.Entities dbAccountEntity = entityRepository
-                .findById(dbTransaction.getEntityId()).get();
+        var dbTransaction = getDbTransaction(record.getConsensusTimestamp());
+        Entities dbAccountEntity = getEntity(dbTransaction.getEntityId());
         LiveHash dbLiveHash = liveHashRepository.findById(dbTransaction.getConsensusNs()).get();
 
         assertAll(
-                // row counts
                 () -> assertEquals(2, transactionRepository.count())
-                , () -> assertEquals(6, entityRepository.count())
-                , () -> assertEquals(8, cryptoTransferRepository.count())
+                , () -> assertEquals(5, entityRepository.count())
+                , () -> assertEquals(8, cryptoTransferRepository.count()) // 3 + 3 fee transfers + 2 for initial balance
                 , () -> assertEquals(0, contractResultRepository.count())
                 , () -> assertEquals(1, liveHashRepository.count())
                 , () -> assertEquals(0, fileDataRepository.count())
-
-                // transaction
-                , () -> assertTransaction(transactionBody, dbTransaction)
-                // record inputs
-                , () -> assertRecord(record)
-                // receipt
-                , () -> assertAccount(record.getReceipt().getAccountID(), dbAccountEntity)
+                , () -> assertCryptoTransaction(transactionBody, record, false)
 
                 // transaction body inputs
                 , () -> assertAccount(cryptoAddLiveHashTransactionBody.getLiveHash().getAccountId(), dbAccountEntity)
@@ -705,22 +443,13 @@ public class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItem
                         .toByteArray(), dbLiveHash
                         .getLivehash())
         );
-
-        // Crypto transfer list
-        verifyRepoCryptoTransferList(record);
     }
 
     @Test
     void cryptoAddLiveHashDoNotPersist() throws Exception {
         entityProperties.getPersist().setClaims(false);
-        // first create the account
-        Transaction createTransaction = cryptoCreateTransaction();
-        TransactionBody createTransactionBody = TransactionBody.parseFrom(createTransaction.getBodyBytes());
-        TransactionRecord createRecord = transactionRecordSuccess(createTransactionBody);
-
-        parseRecordItemAndCommit(new RecordItem(createTransaction, createRecord));
-
-        // now add live hash
+        // create the account and add live hash
+        createAccount();
         Transaction transaction = cryptoAddLiveHashTransaction();
         TransactionBody transactionBody = TransactionBody.parseFrom(transaction.getBodyBytes());
         CryptoAddLiveHashTransactionBody cryptoAddLiveHashTransactionBody = transactionBody.getCryptoAddLiveHash();
@@ -728,51 +457,29 @@ public class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItem
 
         parseRecordItemAndCommit(new RecordItem(transaction, record));
 
-        com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
-                .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
-        com.hedera.mirror.importer.domain.Entities dbAccountEntity = entityRepository
-                .findById(dbTransaction.getEntityId()).get();
+        Entities dbAccountEntity = getTransactionEntity(record.getConsensusTimestamp());
 
         assertAll(
-                // row counts
                 () -> assertEquals(2, transactionRepository.count())
-                , () -> assertEquals(6, entityRepository.count())
-                , () -> assertEquals(8, cryptoTransferRepository.count())
+                , () -> assertEquals(5, entityRepository.count())
+                , () -> assertEquals(8, cryptoTransferRepository.count()) // 3 + 3 fee transfers + 2 for initial balance
                 , () -> assertEquals(0, contractResultRepository.count())
                 , () -> assertEquals(0, liveHashRepository.count())
                 , () -> assertEquals(0, fileDataRepository.count())
-
-                // transaction
-                , () -> assertTransaction(transactionBody, dbTransaction)
-                // record inputs
-                , () -> assertRecord(record)
-                // receipt
-                , () -> assertAccount(record.getReceipt().getAccountID(), dbAccountEntity)
+                , () -> assertCryptoTransaction(transactionBody, record, false)
 
                 // transaction body inputs
                 , () -> assertAccount(cryptoAddLiveHashTransactionBody.getLiveHash().getAccountId(), dbAccountEntity)
         );
-
-        // Crypto transfer list
-        verifyRepoCryptoTransferList(record);
     }
 
     @Test
     void cryptoDeleteLiveHash() throws Exception {
-
-        // first create the account
-        Transaction createTransaction = cryptoCreateTransaction();
-        TransactionBody createTransactionBody = TransactionBody.parseFrom(createTransaction.getBodyBytes());
-        TransactionRecord createRecord = transactionRecordSuccess(createTransactionBody);
-
-        parseRecordItemAndCommit(new RecordItem(createTransaction, createRecord));
-
-        // add a live hash
+        // create the account and add live hash
+        createAccount();
         Transaction transactionAddLiveHash = cryptoAddLiveHashTransaction();
-        TransactionBody transactionBodyAddLiveHash = TransactionBody.parseFrom(transactionAddLiveHash.getBodyBytes());
-        TransactionRecord recordAddLiveHash = transactionRecordSuccess(transactionBodyAddLiveHash);
-
-        parseRecordItemAndCommit(new RecordItem(transactionAddLiveHash, recordAddLiveHash));
+        parseRecordItemAndCommit(new RecordItem(transactionAddLiveHash,
+                transactionRecordSuccess(TransactionBody.parseFrom(transactionAddLiveHash.getBodyBytes()))));
 
         // now delete the live hash
         Transaction transaction = cryptoDeleteLiveHashTransaction();
@@ -782,33 +489,21 @@ public class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItem
 
         parseRecordItemAndCommit(new RecordItem(transaction, record));
 
-        com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
-                .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
-        Entities dbAccountEntity = entityRepository.findById(dbTransaction.getEntityId()).get();
+        Entities dbAccountEntity = getTransactionEntity(record.getConsensusTimestamp());
 
         assertAll(
-                // row counts
                 () -> assertEquals(3, transactionRepository.count())
-                , () -> assertEquals(6, entityRepository.count())
+                , () -> assertEquals(5, entityRepository.count())
                 , () -> assertEquals(11, cryptoTransferRepository.count())
                 , () -> assertEquals(0, contractResultRepository.count())
                 , () -> assertEquals(1, liveHashRepository.count())
                 , () -> assertEquals(0, fileDataRepository.count())
-
-                // transaction
-                , () -> assertTransaction(transactionBody, dbTransaction)
-                // record inputs
-                , () -> assertRecord(record)
-                // receipt
-                , () -> assertAccount(record.getReceipt().getAccountID(), dbAccountEntity)
+                , () -> assertCryptoTransaction(transactionBody, record, false)
 
                 // transaction body inputs
                 , () -> assertAccount(deleteLiveHashTransactionBody.getAccountOfLiveHash(), dbAccountEntity)
                 // TODO (issue #303) check deleted
         );
-
-        // Crypto transfer list
-        verifyRepoCryptoTransferList(record);
     }
 
     @Test
@@ -821,26 +516,15 @@ public class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItem
 
         parseRecordItemAndCommit(new RecordItem(transaction, record));
 
-        com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
-                .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
-
         assertAll(
-                // row counts
                 () -> assertEquals(1, transactionRepository.count())
-                , () -> assertEquals(4, entityRepository.count())
+                , () -> assertEquals(3, entityRepository.count())
                 , () -> assertEquals(3, cryptoTransferRepository.count())
                 , () -> assertEquals(0, contractResultRepository.count())
                 , () -> assertEquals(0, liveHashRepository.count())
                 , () -> assertEquals(0, fileDataRepository.count())
-
-                // transaction
-                , () -> assertTransaction(transactionBody, dbTransaction)
-                // record inputs
-                , () -> assertRecord(record)
+                , () -> assertTransactionAndRecord(transactionBody, record)
         );
-
-        // Crypto transfer list
-        verifyRepoCryptoTransferList(record);
     }
 
     @Test
@@ -853,26 +537,17 @@ public class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItem
 
         parseRecordItemAndCommit(new RecordItem(transaction, record));
 
-        com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
-                .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
-
         assertAll(
-                // row counts
                 () -> assertEquals(1, transactionRepository.count())
                 , () -> assertEquals(2, entityRepository.count())
                 , () -> assertEquals(0, cryptoTransferRepository.count())
                 , () -> assertEquals(0, contractResultRepository.count())
                 , () -> assertEquals(0, liveHashRepository.count())
                 , () -> assertEquals(0, fileDataRepository.count())
-
-                // transaction
-                , () -> assertTransaction(transactionBody, dbTransaction)
-                // record inputs
-                , () -> assertRecord(record)
+                , () -> assertTransactionAndRecord(transactionBody, record)
         );
 
         // Crypto transfer list
-        CryptoTransfer tempDbCryptoTransfer;
         TransferList transferList = record.getTransferList();
         for (int i = 0; i < transferList.getAccountAmountsCount(); ++i) {
             var aa = transferList.getAccountAmounts(i);
@@ -896,20 +571,15 @@ public class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItem
 
         parseRecordItemAndCommit(new RecordItem(transaction, record));
 
-        com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
-                .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
-
         assertAll(
                 () -> assertEquals(1, transactionRepository.count()),
                 () -> assertEquals(3, entityRepository.count(), "Payer, node and treasury"),
-                () -> assertEquals(2, cryptoTransferRepository.count(), "Node and network fee"),
+                () -> assertEquals(3, cryptoTransferRepository.count(), "Node and network fee"),
                 () -> assertEquals(0, nonFeeTransferRepository.count()),
                 () -> assertEquals(0, contractResultRepository.count()),
                 () -> assertEquals(0, liveHashRepository.count()),
                 () -> assertEquals(0, fileDataRepository.count()),
-                () -> assertTransaction(transactionBody, dbTransaction),
-                () -> assertRecord(record),
-                () -> verifyRepoCryptoTransferList(record)
+                () -> assertTransactionAndRecord(transactionBody, record)
         );
     }
 
@@ -918,7 +588,6 @@ public class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItem
         int unknownResult = -1000;
         Transaction transaction = cryptoCreateTransaction();
         TransactionBody transactionBody = TransactionBody.parseFrom(transaction.getBodyBytes());
-        CryptoCreateTransactionBody cryptoCreateTransactionBody = transactionBody.getCryptoCreateAccount();
         TransactionRecord record = transactionRecord(transactionBody, unknownResult);
 
         parseRecordItemAndCommit(new RecordItem(transaction, record));
@@ -929,6 +598,35 @@ public class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItem
                 .containsOnly(unknownResult);
     }
 
+    private void createAccount() throws Exception {
+        Transaction createTransaction = cryptoCreateTransaction();
+        TransactionBody createTransactionBody = TransactionBody.parseFrom(createTransaction.getBodyBytes());
+        TransactionRecord createRecord = transactionRecordSuccess(createTransactionBody);
+        parseRecordItemAndCommit(new RecordItem(createTransaction, createRecord));
+    }
+
+    private void assertCryptoTransaction(TransactionBody transactionBody, TransactionRecord record, boolean deleted) {
+        Entities actualAccount = getTransactionEntity(record.getConsensusTimestamp());
+        assertAll(
+                () -> assertTransactionAndRecord(transactionBody, record),
+                () -> assertAccount(record.getReceipt().getAccountID(), actualAccount),
+                () -> assertEquals(deleted, actualAccount.isDeleted()));
+    }
+
+    private void assertCryptoEntity(CryptoCreateTransactionBody expected, Timestamp consensusTimestamp) {
+        Entities actualAccount = getTransactionEntity(consensusTimestamp);
+        Entities actualProxyAccountId = getEntity(actualAccount.getProxyAccountId());
+        assertAll(
+                () -> assertEquals(expected.getAutoRenewPeriod().getSeconds(), actualAccount.getAutoRenewPeriod()),
+                () -> assertEquals(Utility.protobufKeyToHexIfEd25519OrNull(expected.getKey().toByteArray()),
+                        actualAccount.getEd25519PublicKeyHex()),
+                () -> assertArrayEquals(expected.getKey().toByteArray(), actualAccount.getKey()),
+                () -> assertNull(actualAccount.getExpiryTimeNs()),
+                () -> assertAccount(expected.getProxyAccountID(), actualProxyAccountId),
+                () -> assertNull(actualAccount.getExpiryTimeNs())
+        );
+    }
+
     private TransactionRecord transactionRecordSuccess(TransactionBody transactionBody) {
         return transactionRecord(transactionBody, ResponseCodeEnum.SUCCESS);
     }
@@ -937,248 +635,78 @@ public class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItem
         return transactionRecord(transactionBody, responseCode.getNumber());
     }
 
-    private TransactionRecord transactionRecord(TransactionBody transactionBody, int responseCode) {
-        TransactionRecord.Builder record = TransactionRecord.newBuilder();
-
-        // record
-        Timestamp consensusTimeStamp = Utility.instantToTimestamp(Instant.now());
-        TransactionReceipt.Builder receipt = TransactionReceipt.newBuilder();
-
-        // Build the record
-        record.setConsensusTimestamp(consensusTimeStamp);
-        record.setMemoBytes(ByteString.copyFromUtf8(transactionBody.getMemo()));
-        receipt.setAccountID(accountId);
-        receipt.setStatusValue(responseCode);
-
-        record.setReceipt(receipt.build());
-        record.setTransactionFee(transactionBody.getTransactionFee());
-        record.setTransactionHash(ByteString.copyFromUtf8("TransactionHash"));
-        record.setTransactionID(transactionBody.getTransactionID());
-
-        TransferList.Builder transferList = TransferList.newBuilder();
-
-        for (int i = 0; i < transferAccounts.length; i++) {
-            // Unsuccessful transactions will only include node and network fees to system accounts
-            if (responseCode == ResponseCodeEnum.SUCCESS_VALUE || transferAccounts[i] < 1000) {
-                AccountAmount.Builder accountAmount = AccountAmount.newBuilder();
-                accountAmount.setAccountID(AccountID.newBuilder().setShardNum(0).setRealmNum(0)
-                        .setAccountNum(transferAccounts[i]));
-                accountAmount.setAmount(transferAmounts[i]);
-                transferList.addAccountAmounts(accountAmount);
-            }
-        }
-
-        record.setTransferList(transferList);
-
-        return record.build();
+    private TransactionRecord transactionRecord(TransactionBody transactionBody, int status) {
+        return buildTransactionRecord(recordBuilder -> recordBuilder.getReceiptBuilder().setAccountID(accountId),
+                transactionBody, status);
     }
 
     private Transaction cryptoCreateTransaction() {
-
-        Transaction.Builder transaction = Transaction.newBuilder();
-        CryptoCreateTransactionBody.Builder cryptoCreate = CryptoCreateTransactionBody.newBuilder();
-
-        // Build a transaction
-        cryptoCreate.setAutoRenewPeriod(Duration.newBuilder().setSeconds(1500L));
-        cryptoCreate.setInitialBalance(1000L);
-        cryptoCreate.setKey(keyFromString("0a2212200aa8e21064c61eab86e2a9c164565b4e7a9a4146106e0a6cd03a8c395a110e92"));
-        cryptoCreate
-                .setNewRealmAdminKey(keyFromString(
-                        "0a3312200aa8e21064c61eab86e2a9c164565b4e7a9a4146106e0a6cd03a8c395a110e92"));
-        cryptoCreate.setProxyAccountID(AccountID.newBuilder().setShardNum(1).setRealmNum(2).setAccountNum(3));
-        cryptoCreate.setRealmID(RealmID.newBuilder().setShardNum(0).setRealmNum(0).build());
-        cryptoCreate.setShardID(ShardID.newBuilder().setShardNum(0));
-        cryptoCreate.setReceiveRecordThreshold(2000L);
-        cryptoCreate.setReceiverSigRequired(true);
-        cryptoCreate.setSendRecordThreshold(3000L);
-
-        // Transaction body
-        TransactionBody.Builder body = defaultTransactionBodyBuilder(memo);
-
-        // body transaction
-        body.setCryptoCreateAccount(cryptoCreate.build());
-        transaction.setBodyBytes(body.build().toByteString());
-        transaction.setSigMap(getSigMap());
-
-        return transaction.build();
+        return buildTransaction(builder -> builder.getCryptoCreateAccountBuilder()
+                .setAutoRenewPeriod(Duration.newBuilder().setSeconds(1500L))
+                .setInitialBalance(1000L)
+                .setKey(keyFromString("0a2212200aa8e21064c61eab86e2a9c164565b4e7a9a4146106e0a6cd03a8c395a110e92"))
+                .setNewRealmAdminKey(keyFromString("0a3312200aa8e21064c61eab86e2a9c164565b4e7a9a4146106e0a6cd03a8c395a110e92"))
+                .setProxyAccountID(AccountID.newBuilder().setShardNum(1).setRealmNum(2).setAccountNum(3))
+                .setRealmID(RealmID.newBuilder().setShardNum(0).setRealmNum(0).build())
+                .setShardID(ShardID.newBuilder().setShardNum(0))
+                .setReceiveRecordThreshold(2000L)
+                .setReceiverSigRequired(true)
+                .setSendRecordThreshold(3000L));
     }
 
     private Transaction createTransactionWithBody() {
-
-        Transaction.Builder transaction = Transaction.newBuilder();
-        CryptoCreateTransactionBody.Builder cryptoCreate = CryptoCreateTransactionBody.newBuilder();
-
-        // Build a transaction
-        cryptoCreate.setAutoRenewPeriod(Duration.newBuilder().setSeconds(1500L));
-        cryptoCreate.setInitialBalance(1000L);
-        cryptoCreate.setKey(keyFromString("0a2212200aa8e21064c61eab86e2a9c164565b4e7a9a4146106e0a6cd03a8c395a110e92"));
-        cryptoCreate
-                .setNewRealmAdminKey(keyFromString(
-                        "0a3312200aa8e21064c61eab86e2a9c164565b4e7a9a4146106e0a6cd03a8c395a110e92"));
-        cryptoCreate.setProxyAccountID(AccountID.newBuilder().setShardNum(1).setRealmNum(2).setAccountNum(3));
-        cryptoCreate.setRealmID(RealmID.newBuilder().setShardNum(0).setRealmNum(0).build());
-        cryptoCreate.setShardID(ShardID.newBuilder().setShardNum(0));
-        cryptoCreate.setReceiveRecordThreshold(2000L);
-        cryptoCreate.setReceiverSigRequired(true);
-        cryptoCreate.setSendRecordThreshold(3000L);
-
-        // Transaction body
-        TransactionBody.Builder body = defaultTransactionBodyBuilder(memo);
-
-        // body transaction
-        body.setCryptoCreateAccount(cryptoCreate.build());
-        transaction.setBody(body.build());
-        transaction.setSigMap(getSigMap());
-
-        return transaction.build();
+        return buildTransaction(builder -> builder.getCryptoCreateAccountBuilder()
+                .setAutoRenewPeriod(Duration.newBuilder().setSeconds(1500L))
+                .setInitialBalance(1000L)
+                .setKey(keyFromString(KEY))
+                .setNewRealmAdminKey(keyFromString(KEY2))
+                .setProxyAccountID(AccountID.newBuilder().setShardNum(1).setRealmNum(2).setAccountNum(3))
+                .setRealmID(RealmID.newBuilder().setShardNum(0).setRealmNum(0).build())
+                .setShardID(ShardID.newBuilder().setShardNum(0))
+                .setReceiveRecordThreshold(2000L)
+                .setReceiverSigRequired(true)
+                .setSendRecordThreshold(3000L));
     }
 
     private Transaction cryptoUpdateTransaction() {
-
-        Transaction.Builder transaction = Transaction.newBuilder();
-        CryptoUpdateTransactionBody.Builder cryptoUpdate = CryptoUpdateTransactionBody.newBuilder();
-        String key = "0a2312200aa8e21064c61eab86e2a9c164565b4e7a9a4146106e0a6cd03a8c395a110aaa";
-
-        // Build a transaction
-        cryptoUpdate.setAccountIDToUpdate(accountId);
-        cryptoUpdate.setAutoRenewPeriod(Duration.newBuilder().setSeconds(5001L));
-        cryptoUpdate.setExpirationTime(Utility.instantToTimestamp(Instant.now()));
-        cryptoUpdate.setKey(keyFromString(key));
-        cryptoUpdate.setProxyAccountID(AccountID.newBuilder().setShardNum(5).setRealmNum(6).setAccountNum(8));
-        cryptoUpdate.setReceiveRecordThreshold(5001L);
-        cryptoUpdate.setReceiverSigRequired(false);
-        cryptoUpdate.setSendRecordThreshold(6001L);
-
-        // Transaction body
-        TransactionBody.Builder body = defaultTransactionBodyBuilder(memo);
-        // body transaction
-        body.setCryptoUpdateAccount(cryptoUpdate.build());
-
-        transaction.setBodyBytes(body.build().toByteString());
-        transaction.setSigMap(getSigMap());
-
-        return transaction.build();
+        return buildTransaction(builder -> builder.getCryptoUpdateAccountBuilder()
+                .setAccountIDToUpdate(accountId)
+                .setAutoRenewPeriod(Duration.newBuilder().setSeconds(5001L))
+                .setExpirationTime(Utility.instantToTimestamp(Instant.now()))
+                .setKey(keyFromString(KEY))
+                .setProxyAccountID(AccountID.newBuilder().setShardNum(5).setRealmNum(6).setAccountNum(8))
+                .setReceiveRecordThreshold(5001L)
+                .setReceiverSigRequired(false)
+                .setSendRecordThreshold(6001L));
     }
 
     private Transaction cryptoDeleteTransaction() {
-
-        // transaction id
-        Transaction.Builder transaction = Transaction.newBuilder();
-        CryptoDeleteTransactionBody.Builder cryptoDelete = CryptoDeleteTransactionBody.newBuilder();
-
-        // Build a transaction
-        cryptoDelete.setDeleteAccountID(accountId);
-
-        // Transaction body
-        TransactionBody.Builder body = defaultTransactionBodyBuilder(memo);
-        // body transaction
-        body.setCryptoDelete(cryptoDelete.build());
-
-        transaction.setBodyBytes(body.build().toByteString());
-        transaction.setSigMap(getSigMap());
-
-        return transaction.build();
+        return buildTransaction(builder -> builder.getCryptoDeleteBuilder()
+                .setDeleteAccountID(accountId));
     }
 
     private Transaction cryptoAddLiveHashTransaction() {
-
-        // transaction id
-        Transaction.Builder transaction = Transaction.newBuilder();
-        CryptoAddLiveHashTransactionBody.Builder cryptoLiveHash = CryptoAddLiveHashTransactionBody.newBuilder();
-
-        // Build a live hash
-        com.hederahashgraph.api.proto.java.LiveHash.Builder liveHash = com.hederahashgraph.api.proto.java.LiveHash
-                .newBuilder();
-        liveHash.setAccountId(accountId);
-        liveHash.setDuration(Duration.newBuilder().setSeconds(10000L));
-        liveHash.setHash(ByteString.copyFromUtf8("live hash"));
-        KeyList.Builder keyList = KeyList.newBuilder();
-        keyList.addKeys(keyFromString("0a2312200aa8e21064c61eab86e2a9c164565b4e7a9a4146106e0a6cd03a8c395a110aaa"));
-        liveHash.setKeys(keyList);
-
-        // Build a transaction
-        cryptoLiveHash.setLiveHash(liveHash);
-
-        // Transaction body
-        TransactionBody.Builder body = defaultTransactionBodyBuilder(memo);
-        // body transaction
-        body.setCryptoAddLiveHash(cryptoLiveHash);
-
-        transaction.setBodyBytes(body.build().toByteString());
-        transaction.setSigMap(getSigMap());
-
-        return transaction.build();
+        return buildTransaction(builder -> builder.getCryptoAddLiveHashBuilder()
+                .getLiveHashBuilder()
+                .setAccountId(accountId)
+                .setDuration(Duration.newBuilder().setSeconds(10000L))
+                .setHash(ByteString.copyFromUtf8("live hash"))
+                .setKeys(KeyList.newBuilder().addKeys(keyFromString(KEY))));
     }
 
     private Transaction cryptoDeleteLiveHashTransaction() {
-
-        // transaction id
-        Transaction.Builder transaction = Transaction.newBuilder();
-        CryptoDeleteLiveHashTransactionBody.Builder cryptoDeleteLiveHash = CryptoDeleteLiveHashTransactionBody
-                .newBuilder();
-
-        // Build a transaction
-        cryptoDeleteLiveHash.setAccountOfLiveHash(accountId);
-        cryptoDeleteLiveHash.setLiveHashToDelete(ByteString.copyFromUtf8("live hash"));
-
-        // Transaction body
-        TransactionBody.Builder body = defaultTransactionBodyBuilder(memo);
-        // body transaction
-        body.setCryptoDeleteLiveHash(cryptoDeleteLiveHash);
-
-        transaction.setBodyBytes(body.build().toByteString());
-        transaction.setSigMap(getSigMap());
-
-        return transaction.build();
+        return buildTransaction(builder -> builder.getCryptoDeleteLiveHashBuilder()
+                .setAccountOfLiveHash(accountId)
+                .setLiveHashToDelete(ByteString.copyFromUtf8("live hash")));
     }
 
     private Transaction cryptoTransferTransaction() {
-
-        // transaction id
-        Transaction.Builder transaction = Transaction.newBuilder();
-        CryptoTransferTransactionBody.Builder cryptoTransferBody = CryptoTransferTransactionBody.newBuilder();
-
-        // Build a transaction
-        TransferList.Builder transferList = TransferList.newBuilder();
-
-        for (int i = 0; i < transferAccounts.length; i++) {
-            AccountAmount.Builder accountAmount = AccountAmount.newBuilder();
-            accountAmount.setAccountID(AccountID.newBuilder().setShardNum(0).setRealmNum(0)
-                    .setAccountNum(transferAccounts[i]));
-            accountAmount.setAmount(transferAmounts[i]);
-            transferList.addAccountAmounts(accountAmount);
-        }
-
-        cryptoTransferBody.setTransfers(transferList);
-
-        // Transaction body
-        TransactionBody.Builder body = defaultTransactionBodyBuilder(memo);
-        // body transaction
-        body.setCryptoTransfer(cryptoTransferBody);
-
-        transaction.setBodyBytes(body.build().toByteString());
-        transaction.setSigMap(getSigMap());
-
-        return transaction.build();
-    }
-
-    private void verifyRepoCryptoTransferList(TransactionRecord record) {
-        CryptoTransfer tempDbCryptoTransfer;
-        TransferList transferList = record.getTransferList();
-        for (int i = 0; i < transferList.getAccountAmountsCount(); ++i) {
-            var aa = transferList.getAccountAmounts(i);
-            var accountId = aa.getAccountID();
-
-            tempDbCryptoTransfer = cryptoTransferRepository.findByConsensusTimestampAndEntityNum(
-                    Utility.timeStampInNanos(record.getConsensusTimestamp()),
-                    accountId.getAccountNum()).get();
-
-            assertEquals(Utility.timeStampInNanos(record.getConsensusTimestamp()), tempDbCryptoTransfer
-                    .getConsensusTimestamp());
-            assertEquals(aa.getAmount(), tempDbCryptoTransfer.getAmount());
-            assertEquals(accountId.getRealmNum(), tempDbCryptoTransfer.getRealmNum());
-            assertEquals(accountId.getAccountNum(), tempDbCryptoTransfer.getEntityNum());
-        }
+        return buildTransaction(builder -> {
+            for (int i = 0; i < additionalTransfers.length; i++) {
+                builder.getCryptoTransferBuilder().getTransfersBuilder()
+                        .addAccountAmounts(accountAmount(additionalTransfers[i],additionalTransferAmounts[i]));
+            }
+        });
     }
 
     @Test
@@ -1213,8 +741,7 @@ public class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItem
         parseRecordItemAndCommit(new RecordItem(transaction.toByteArray(), record.toByteArray()));
 
         // then
-        com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
-                .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
+        var dbTransaction = getDbTransaction(record.getConsensusTimestamp());
         assertArrayEquals(expectedBytes, dbTransaction.getTransactionBytes());
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerFreezeTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerFreezeTest.java
@@ -22,28 +22,17 @@ package com.hedera.mirror.importer.parser.record.entity;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.google.protobuf.ByteString;
-import com.hederahashgraph.api.proto.java.AccountAmount;
-import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.FileID;
-import com.hederahashgraph.api.proto.java.FreezeTransactionBody;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
-import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.Transaction;
 import com.hederahashgraph.api.proto.java.TransactionBody;
-import com.hederahashgraph.api.proto.java.TransactionReceipt;
 import com.hederahashgraph.api.proto.java.TransactionRecord;
-import com.hederahashgraph.api.proto.java.TransferList;
-import java.time.Instant;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.hedera.mirror.importer.parser.domain.RecordItem;
-import com.hedera.mirror.importer.util.Utility;
 
 public class EntityRecordItemListenerFreezeTest extends AbstractEntityRecordItemListenerTest {
-
-    private static final String memo = "File test memo";
 
     @BeforeEach
     void before() {
@@ -60,23 +49,9 @@ public class EntityRecordItemListenerFreezeTest extends AbstractEntityRecordItem
 
         parseRecordItemAndCommit(new RecordItem(transaction, record));
 
-        com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
-                .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
-
         assertAll(
-                // row counts
-                () -> assertEquals(1, transactionRepository.count())
-                , () -> assertEquals(4, entityRepository.count())
-                , () -> assertEquals(0, contractResultRepository.count())
-                , () -> assertEquals(3, cryptoTransferRepository.count())
-                , () -> assertEquals(0, liveHashRepository.count())
-                , () -> assertEquals(0, fileDataRepository.count())
-
-                // transaction
-                , () -> assertTransaction(transactionBody, dbTransaction)
-
-                // record inputs
-                , () -> assertRecord(record)
+                () -> assertRowCount(),
+                () -> assertTransactionAndRecord(transactionBody, record)
         );
     }
 
@@ -84,28 +59,24 @@ public class EntityRecordItemListenerFreezeTest extends AbstractEntityRecordItem
     void freezeInvalidTransaction() throws Exception {
         Transaction transaction = freezeTransaction();
         TransactionBody transactionBody = TransactionBody.parseFrom(transaction.getBodyBytes());
-        TransactionRecord record = transactionRecord(transactionBody,
-                ResponseCodeEnum.INSUFFICIENT_ACCOUNT_BALANCE);
+        TransactionRecord record = transactionRecord(transactionBody, ResponseCodeEnum.INSUFFICIENT_ACCOUNT_BALANCE);
 
         parseRecordItemAndCommit(new RecordItem(transaction, record));
 
-        com.hedera.mirror.importer.domain.Transaction dbTransaction = transactionRepository
-                .findById(Utility.timeStampInNanos(record.getConsensusTimestamp())).get();
-
         assertAll(
-                // row counts
-                () -> assertEquals(1, transactionRepository.count())
-                , () -> assertEquals(4, entityRepository.count())
-                , () -> assertEquals(0, contractResultRepository.count())
-                , () -> assertEquals(3, cryptoTransferRepository.count())
-                , () -> assertEquals(0, liveHashRepository.count())
-                , () -> assertEquals(0, fileDataRepository.count())
+                () -> assertRowCount(),
+                () -> assertTransactionAndRecord(transactionBody, record)
+        );
+    }
 
-                // transaction
-                , () -> assertTransaction(transactionBody, dbTransaction)
-
-                // record inputs
-                , () -> assertRecord(record)
+    private void assertRowCount() {
+        assertAll(
+                () -> assertEquals(1, transactionRepository.count()),
+                () -> assertEquals(3, entityRepository.count()),
+                () -> assertEquals(0, contractResultRepository.count()),
+                () -> assertEquals(3, cryptoTransferRepository.count()),
+                () -> assertEquals(0, liveHashRepository.count()),
+                () -> assertEquals(0, fileDataRepository.count())
         );
     }
 
@@ -114,59 +85,15 @@ public class EntityRecordItemListenerFreezeTest extends AbstractEntityRecordItem
     }
 
     private TransactionRecord transactionRecord(TransactionBody transactionBody, ResponseCodeEnum result) {
-        TransactionRecord.Builder record = TransactionRecord.newBuilder();
-
-        // record
-        Timestamp consensusTimeStamp = Utility.instantToTimestamp(Instant.now());
-        long[] transferAccounts = {98, 2002, 3};
-        long[] transferAmounts = {1000, -2000, 20};
-        ResponseCodeEnum responseCode = result;
-        TransactionReceipt.Builder receipt = TransactionReceipt.newBuilder();
-
-        // Build the record
-        record.setConsensusTimestamp(consensusTimeStamp);
-        record.setMemoBytes(ByteString.copyFromUtf8(transactionBody.getMemo()));
-        receipt.setStatus(responseCode);
-
-        record.setReceipt(receipt.build());
-        record.setTransactionFee(transactionBody.getTransactionFee());
-        record.setTransactionHash(ByteString.copyFromUtf8("TransactionHash"));
-        record.setTransactionID(transactionBody.getTransactionID());
-
-        TransferList.Builder transferList = TransferList.newBuilder();
-
-        for (int i = 0; i < transferAccounts.length; i++) {
-            AccountAmount.Builder accountAmount = AccountAmount.newBuilder();
-            accountAmount.setAccountID(AccountID.newBuilder().setShardNum(0).setRealmNum(0)
-                    .setAccountNum(transferAccounts[i]));
-            accountAmount.setAmount(transferAmounts[i]);
-            transferList.addAccountAmounts(accountAmount);
-        }
-
-        record.setTransferList(transferList);
-
-        return record.build();
+        return buildTransactionRecord(recordBuilder -> {}, transactionBody, result.getNumber());
     }
 
     private Transaction freezeTransaction() {
-        Transaction.Builder transaction = Transaction.newBuilder();
-        FreezeTransactionBody.Builder freezeTransactionBody = FreezeTransactionBody.newBuilder();
-
-        // Build a transaction
-        freezeTransactionBody.setEndHour(1);
-        freezeTransactionBody.setEndMin(2);
-        freezeTransactionBody.setStartHour(3);
-        freezeTransactionBody.setStartMin(4);
-        freezeTransactionBody.setUpdateFile(FileID.newBuilder().setFileNum(5).build());
-
-        // Transaction body
-        TransactionBody.Builder body = defaultTransactionBodyBuilder(memo);
-
-        // body transaction
-        body.setFreeze(freezeTransactionBody.build());
-        transaction.setBodyBytes(body.build().toByteString());
-        transaction.setSigMap(getSigMap());
-
-        return transaction.build();
+        return buildTransaction(builder -> builder.getFreezeBuilder()
+            .setEndHour(1)
+            .setEndMin(2)
+            .setStartHour(3)
+            .setStartMin(4)
+            .setUpdateFile(FileID.newBuilder().setFileNum(5).build()));
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerNFTTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerNFTTest.java
@@ -23,7 +23,6 @@ package com.hedera.mirror.importer.parser.record.entity;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.google.protobuf.ByteString;
-import com.hederahashgraph.api.proto.java.AccountAmount;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ContractCallTransactionBody;
 import com.hederahashgraph.api.proto.java.ContractCreateTransactionBody;
@@ -182,11 +181,6 @@ public class EntityRecordItemListenerNFTTest extends AbstractEntityRecordItemLis
         entityProperties.getPersist().setNonFeeTransfers(true);
         givenFailedCryptoTransferTransaction();
         assertEverything();
-    }
-
-    private AccountAmount.Builder accountAmount(long accountNum, long amount) {
-        return AccountAmount.newBuilder().setAccountID(AccountID.newBuilder().setAccountNum(accountNum))
-                .setAmount(amount);
     }
 
     private void assertEntities() {


### PR DESCRIPTION
**Detailed description**:
These tests have been really painful to modify in the past and continue to be hinderance in major record parser changes. If we had time to refactor them before, that would have also made previous refactors easier. Latest, they were causing pain when I was trying out 1 column vs 2 columns approaches for entities. Took some extra time out on the weekend to fix these.

- Change touches only test files
- 99% code is just refactoring.
- 1% non-refactor: For sharing `TransactionRecord` builder code in `AbstractEntityRecordItemListenerTest`, I had to fix the logic around transfer list.
  - Clearly defined PAYER account. Shared code adds only the fee transfers.
  - Change in expected entity count in many places is due to this fix.
- Removed `EntityRecordItemListenerCryptoTest#verifyRepoCryptoTransferList()` since it was duplicating the check already done by `assertRecord()`. `assertRecord()` already verifies that all transfers in `TransactionRecord` are present in the table. In fact, `verifyRepoCryptoTransferList()` works incorrect for the case when transfer list contains two transfers for same entity.
- Enabled the 2 disabled tests. I couldn't understand why they were failing, let's reenable and see.
- Removed unnecessary variable assignments (there were too many in crypto tests)

Couldn't get to everything, there are just so many. Will need another iteration in future.

Signed-off-by: Apekshit Sharma <apekshit.sharma@hedera.com>

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated

