### PR TITLE
Fixed up large db perf test flow

### DIFF
--- a/hedera-mirror-importer/pom.xml
+++ b/hedera-mirror-importer/pom.xml
@@ -238,8 +238,7 @@
                             <execution>
                                 <id>default-test</id>
                                 <configuration>
-                                    <excludedGroups>performance</excludedGroups>
-                                    <excludedGroups>largedbperf</excludedGroups>
+                                    <excludedGroups>performance, largedbperf</excludedGroups>
                                 </configuration>
                             </execution>
                         </executions>

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/db/DBProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/db/DBProperties.java
@@ -46,8 +46,10 @@ public class DBProperties {
     @Min(0)
     private int port = 5432;
 
+    @NotBlank
     private String restPassword = "";
 
+    @NotBlank
     private String restUsername = "";
 
     @NotBlank

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/performance/PerformanceIntegrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/performance/PerformanceIntegrationTest.java
@@ -78,6 +78,9 @@ public abstract class PerformanceIntegrationTest {
     Connection connection;
 
     @Resource
+    private DBProperties dbProperties;
+
+    @Resource
     private ApplicationStatusRepository applicationStatusRepository;
 
     @Resource
@@ -95,12 +98,13 @@ public abstract class PerformanceIntegrationTest {
     private static final String restoreClientImagePrefix = "gcr.io/mirrornode/hedera-mirror-node/postgres-restore" +
             "-client:";
 
-    public static GenericContainer createRestoreContainer(String dockerImageTag, DBProperties db) {
+    protected GenericContainer createRestoreContainer(String dockerImageTag) {
+        log.debug("Creating restore container to connect to {}", dbProperties);
         return new GenericContainer(restoreClientImagePrefix + dockerImageTag)
-                .withEnv("DB_NAME", db.getName())
-                .withEnv("DB_USER", db.getUsername())
-                .withEnv("DB_PASS", db.getPassword())
-                .withEnv("DB_PORT", Integer.toString(db.getPort()))
+                .withEnv("DB_NAME", dbProperties.getName())
+                .withEnv("DB_USER", dbProperties.getUsername())
+                .withEnv("DB_PASS", dbProperties.getPassword())
+                .withEnv("DB_PORT", Integer.toString(dbProperties.getPort()))
                 .withNetworkMode("host")
                 .withStartupCheckStrategy(
                         new IndefiniteWaitOneShotStartupCheckStrategy()

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/performance/RestoreClientIntegrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/performance/RestoreClientIntegrationTest.java
@@ -21,7 +21,6 @@ package com.hedera.mirror.importer.parser.performance;
  */
 
 import java.sql.SQLException;
-import javax.annotation.Resource;
 import lombok.extern.log4j.Log4j2;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -32,27 +31,21 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-import com.hedera.mirror.importer.db.DBProperties;
-
 @Log4j2
 @Tag("largedbperf")
 @Testcontainers
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class RestoreClientIntegrationTest extends PerformanceIntegrationTest {
-    @Resource
-    private DBProperties dbProperties;
 
     @Container
     GenericContainer customContainer;
 
     @BeforeAll
     void warmUp() throws SQLException {
-        customContainer = createRestoreContainer("100k",
-                dbProperties);
+        customContainer = createRestoreContainer("100k");
 
         log.info("Start container {}", customContainer);
         customContainer.start();
-        log.info("Database restore complete to {}", dbProperties);
 
         connection = dataSource.getConnection();
         checkSeededTablesArePresent();


### PR DESCRIPTION
**Detailed description**:
The recent largest PR had one issue and some remaining touch up items that are addressed here

- Corrected excludedgroupds syntax. This was causing the RecordFileParserPerformanceTest to be run as part of maven build
- Made rest credentials mandatory in DBProperties
- Updated container create logic in PerformanceIntegrationTest.createRestoreContainer()

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

