### PR TITLE
Followup of #817

### DIFF
--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/common/TransactionGenerator.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/common/TransactionGenerator.java
@@ -46,7 +46,7 @@ public abstract class TransactionGenerator {
         Transaction transaction = new Transaction();
         // Set default value for fields
         transaction.setConsensusNs(consensusTimestampNs);
-        transaction.setNodeAccount(entityManager.getNodeAccount());
+        transaction.setNodeAccountId(entityManager.getNodeAccount());
         transaction.setResult(RESULT_SUCCESS);
         transaction.setChargedTxFee(100_000L); // Note: place holder value only. Doesn't affect balances.
         // set to fixed 10 sec before consensus time
@@ -54,7 +54,7 @@ public abstract class TransactionGenerator {
         transaction.setValidDurationSeconds(120L);
         transaction.setMaxFee(1_000_000L);
         transaction.setInitialBalance(0L);
-        transaction.setPayerAccount(entityManager.getAccounts().getRandomEntity());
+        transaction.setPayerAccountId(entityManager.getAccounts().getRandomEntity());
         transaction.setMemo(MEMO);
 
         if (numTransactionsGenerated < numSeedEntities) {

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/domain/generators/transaction/CryptoTransactionGenerator.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/domain/generators/transaction/CryptoTransactionGenerator.java
@@ -69,8 +69,8 @@ public class CryptoTransactionGenerator extends TransactionGenerator {
         transaction.setInitialBalance(value);
         transaction.setType(11);  // 11 = CRYPTOCREATEACCOUNT
         EntityId newAccount = entityManager.getAccounts().newEntity();
-        transaction.setEntity(newAccount);
-        transaction.setPayerAccount(entityManager.getPortalEntity());
+        transaction.setEntityId(newAccount);
+        transaction.setPayerAccountId(entityManager.getPortalEntity());
         domainWriter.addCryptoTransfer(createCryptoTransfer(
                 transaction.getConsensusNs(), entityManager.getPortalEntity(), -value));
         domainWriter.addCryptoTransfer(createCryptoTransfer(
@@ -82,8 +82,8 @@ public class CryptoTransactionGenerator extends TransactionGenerator {
         transaction.setInitialBalance(0L);
         transaction.setType(15);  // 15 = CRYPTOUPDATEACCOUNT
         EntityId account = entityManager.getAccounts().getRandomEntity();
-        transaction.setEntity(account);
-        transaction.setPayerAccount(account);
+        transaction.setEntityId(account);
+        transaction.setPayerAccountId(account);
         log.trace("CRYPTOUPDATEACCOUNT transaction: entity {}", account);
     }
 
@@ -101,7 +101,7 @@ public class CryptoTransactionGenerator extends TransactionGenerator {
         }
         domainWriter.addCryptoTransfer(createCryptoTransfer(
                 transaction.getConsensusNs(), accountIds.get(0), -1 * singleTransferAmount * numTransferLists));
-        transaction.setPayerAccount(accountIds.get(0));
+        transaction.setPayerAccountId(accountIds.get(0));
         log.trace("CRYPTOTRANSFER transaction: num transfer lists {}", numTransferLists);
     }
 
@@ -110,8 +110,8 @@ public class CryptoTransactionGenerator extends TransactionGenerator {
         transaction.setType(12);  // 12 = CRYPTODELETE
         EntityId account = entityManager.getAccounts().getRandomEntity();
         entityManager.getAccounts().delete(account);
-        transaction.setEntity(account);
-        transaction.setPayerAccount(account);
+        transaction.setEntityId(account);
+        transaction.setPayerAccountId(account);
         log.trace("CRYPTODELETE transaction: entity {}", account);
     }
 

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/domain/generators/transaction/FileTransactionGenerator.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/domain/generators/transaction/FileTransactionGenerator.java
@@ -67,7 +67,7 @@ public class FileTransactionGenerator extends TransactionGenerator {
     private void createFile(Transaction transaction) {
         transaction.setType(17);  // 17 = FILECREATE
         EntityId newFileNum = entityManager.getFiles().newEntity();
-        transaction.setEntity(newFileNum);
+        transaction.setEntityId(newFileNum);
         createFileData(transaction.getConsensusNs());
         log.trace("FILECREATE transaction: fileId {}", newFileNum);
     }
@@ -75,7 +75,7 @@ public class FileTransactionGenerator extends TransactionGenerator {
     private void appendFile(Transaction transaction) {
         transaction.setType(16);  // 16 = FILEAPPEND
         EntityId file = entityManager.getFiles().getRandomEntity();
-        transaction.setEntity(file);
+        transaction.setEntityId(file);
         createFileData(transaction.getConsensusNs());
         log.trace("FILEAPPEND transaction: fileId {}", file);
     }
@@ -83,7 +83,7 @@ public class FileTransactionGenerator extends TransactionGenerator {
     private void updateFile(Transaction transaction) {
         transaction.setType(19);  // 19 = FILEUPDATE
         EntityId fileNum = entityManager.getFiles().getRandomEntity();
-        transaction.setEntity(fileNum);
+        transaction.setEntityId(fileNum);
         createFileData(transaction.getConsensusNs());
         log.trace("FILEUPDATE transaction: fileId {}", fileNum);
     }
@@ -92,7 +92,7 @@ public class FileTransactionGenerator extends TransactionGenerator {
         transaction.setType(18);  // 18 = FILEDELETE
         EntityId fileNum = entityManager.getFiles().getRandomEntity();
         entityManager.getFiles().delete(fileNum);
-        transaction.setEntity(fileNum);
+        transaction.setEntityId(fileNum);
         log.trace("FILEDELETE transaction: fileId {}", fileNum);
     }
 

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/domain/generators/transaction/TopicTransactionGenerator.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/domain/generators/transaction/TopicTransactionGenerator.java
@@ -75,7 +75,7 @@ public class TopicTransactionGenerator extends TransactionGenerator {
     private void createTopic(Transaction transaction) {
         transaction.setType(24);  // 24 = CONSENSUSCREATETOPIC
         EntityId newTopicNum = entityManager.getTopics().newEntity();
-        transaction.setEntity(newTopicNum);
+        transaction.setEntityId(newTopicNum);
         topicToNextSequenceNumber.put(newTopicNum, 0);
         createTopicMessage(transaction.getConsensusNs(), newTopicNum);
         log.trace("CONSENSUSCREATETOPIC transaction: topicId {}", newTopicNum);
@@ -85,14 +85,14 @@ public class TopicTransactionGenerator extends TransactionGenerator {
         transaction.setType(26);  // 26 = CONSENSUSDELETETOPIC
         EntityId topicNum = entityManager.getTopics().getRandomEntity();
         entityManager.getTopics().delete(topicNum);
-        transaction.setEntity(topicNum);
+        transaction.setEntityId(topicNum);
         log.trace("CONSENSUSDELETETOPIC transaction: topicId {}", topicNum);
     }
 
     private void updateTopic(Transaction transaction) {
         transaction.setType(25);  // 25 = CONSENSUSUPDATETOPIC
         EntityId topicNum = entityManager.getTopics().getRandomEntity();
-        transaction.setEntity(topicNum);
+        transaction.setEntityId(topicNum);
         createTopicMessage(transaction.getConsensusNs(), topicNum);
         log.trace("CONSENSUSUPDATETOPIC transaction: topicId {}", topicNum);
     }
@@ -100,7 +100,7 @@ public class TopicTransactionGenerator extends TransactionGenerator {
     private void submitMessage(Transaction transaction) {
         transaction.setType(27);  // 27 = CONSENSUSSUBMITMESSAGE
         EntityId topicNum = entityManager.getTopics().getRandomEntity();
-        transaction.setEntity(topicNum);
+        transaction.setEntityId(topicNum);
         createTopicMessage(transaction.getConsensusNs(), topicNum);
         log.trace("CONSENSUSSUBMITMESSAGE transaction: topicId {}", topicNum);
     }

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/domain/writer/PostgresCSVDomainWriter.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/domain/writer/PostgresCSVDomainWriter.java
@@ -167,7 +167,7 @@ public class PostgresCSVDomainWriter implements DomainWriter {
     public void addTransaction(Transaction transaction) {
         try {
             transactionsWriter.printRecord(
-                    transaction.getNodeAccountId(), toHex(transaction.getMemo()), transaction.getPayerAccountId(),
+                    transaction.getNodeAccountId(), toHex(transaction.getMemo()), transaction.getPayerAccountId().getId(),
                     transaction.getChargedTxFee(), transaction.getInitialBalance(), transaction.getEntityId(),
                     transaction.getValidStartNs(), transaction.getConsensusNs(), transaction.getValidDurationSeconds(),
                     transaction.getMaxFee(), toHex(transaction.getTransactionHash()), transaction.getResult(),

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/converter/EntityIdConverter.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/converter/EntityIdConverter.java
@@ -1,0 +1,48 @@
+package com.hedera.mirror.importer.converter;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import javax.inject.Named;
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+
+import com.hedera.mirror.importer.domain.EntityId;
+import com.hedera.mirror.importer.util.EntityIdEndec;
+
+@Named
+@Converter
+public class EntityIdConverter implements AttributeConverter<EntityId, Long> {
+    @Override
+    public Long convertToDatabaseColumn(EntityId entityId) {
+        if (entityId == null) {
+            return null;
+        }
+        return entityId.getId();
+    }
+
+    @Override
+    public EntityId convertToEntityAttribute(Long encodedId) {
+        if (encodedId == null) {
+            return null;
+        }
+        return EntityIdEndec.decode(encodedId);
+    }
+}

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/Entities.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/Entities.java
@@ -21,6 +21,7 @@ package com.hedera.mirror.importer.domain;
  */
 
 import javax.persistence.Column;
+import javax.persistence.Convert;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Table;
@@ -28,6 +29,7 @@ import lombok.Data;
 import lombok.ToString;
 import lombok.extern.log4j.Log4j2;
 
+import com.hedera.mirror.importer.converter.EntityIdConverter;
 import com.hedera.mirror.importer.util.Utility;
 
 @Data
@@ -48,13 +50,15 @@ public class Entities {
     @Column(name = "fk_entity_type_id")
     private Integer entityTypeId;
 
-    private Long autoRenewAccountId;
+    @Convert(converter = EntityIdConverter.class)
+    private EntityId autoRenewAccountId;
 
     private Long autoRenewPeriod;
 
     private byte[] key;
 
-    private Long proxyAccountId;
+    @Convert(converter = EntityIdConverter.class)
+    private EntityId proxyAccountId;
 
     private boolean deleted;
 
@@ -81,13 +85,5 @@ public class Entities {
 
     public EntityId toEntityId() {
         return new EntityId(entityShard, entityRealm, entityNum, entityTypeId);
-    }
-
-    public void setAutoRenewAccount(EntityId autoRenewAccount) {
-        autoRenewAccountId = autoRenewAccount.getId();
-    }
-
-    public void setProxyAccount(EntityId proxyAccount) {
-        proxyAccountId = proxyAccount.getId();
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/EntityId.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/EntityId.java
@@ -26,9 +26,11 @@ import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ContractID;
 import com.hederahashgraph.api.proto.java.FileID;
 import com.hederahashgraph.api.proto.java.TopicID;
+import java.io.Serializable;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import lombok.EqualsAndHashCode;
 import lombok.Value;
 
 import com.hedera.mirror.importer.util.EntityIdEndec;
@@ -41,12 +43,14 @@ import com.hedera.mirror.importer.util.EntityIdEndec;
  * of(..) functions, null is returned.
  */
 @Value
-public class EntityId {
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+public class EntityId implements Serializable {
 
     private static final Splitter SPLITTER = Splitter.on('.').omitEmptyStrings().trimResults();
 
     // Ignored so not included in json serialization of PubSubMessage
     @JsonIgnore
+    @EqualsAndHashCode.Include
     private Long id;
     private Long shardNum;
     private Long realmNum;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/Transaction.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/Transaction.java
@@ -20,6 +20,7 @@ package com.hedera.mirror.importer.domain;
  * ‍
  */
 
+import javax.persistence.Convert;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Table;
@@ -28,6 +29,8 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.springframework.data.domain.Persistable;
+
+import com.hedera.mirror.importer.converter.EntityIdConverter;
 
 @Data
 @Entity
@@ -40,7 +43,8 @@ public class Transaction implements Persistable<Long> {
     @Id
     private Long consensusNs;
 
-    private Long nodeAccountId;
+    @Convert(converter = EntityIdConverter.class)
+    private EntityId nodeAccountId;
 
     private byte[] memo;
 
@@ -48,13 +52,15 @@ public class Transaction implements Persistable<Long> {
 
     private Integer result;
 
-    private Long payerAccountId;
+    @Convert(converter = EntityIdConverter.class)
+    private EntityId payerAccountId;
 
     private Long chargedTxFee;
 
     private Long initialBalance;
 
-    private Long entityId;
+    @Convert(converter = EntityIdConverter.class)
+    private EntityId entityId;
 
     private Long validStartNs;
 
@@ -65,18 +71,6 @@ public class Transaction implements Persistable<Long> {
     private byte[] transactionHash;
 
     private byte[] transactionBytes;
-
-    public void setEntity(EntityId entity) {
-        entityId = entity.getId();
-    }
-
-    public void setNodeAccount(EntityId nodeAccount) {
-        nodeAccountId = nodeAccount.getId();
-    }
-
-    public void setPayerAccount(EntityId payerAccount) {
-        payerAccountId = payerAccount.getId();
-    }
 
     @Override
     public Long getId() {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/exception/InvalidEntityException.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/exception/InvalidEntityException.java
@@ -1,0 +1,30 @@
+package com.hedera.mirror.importer.exception;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+public class InvalidEntityException extends RuntimeException {
+
+    private static final long serialVersionUID = 1988238764876411857L;
+
+    public InvalidEntityException(String message) {
+        super(message);
+    }
+}

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/exception/InvalidEntityException.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/exception/InvalidEntityException.java
@@ -20,7 +20,7 @@ package com.hedera.mirror.importer.exception;
  * ‍
  */
 
-public class InvalidEntityException extends RuntimeException {
+public class InvalidEntityException extends ImporterException {
 
     private static final long serialVersionUID = 1988238764876411857L;
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/V1_11_6__Missing_Entities.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/V1_11_6__Missing_Entities.java
@@ -129,7 +129,7 @@ public class V1_11_6__Missing_Entities extends BaseJavaMigration {
             // Persist if doesn't exist
             entityRepository.findById(proxyAccountEntityId.getId())
                     .orElseGet(() -> entityRepository.save(proxyAccountEntityId.toEntity()));
-            entity.setProxyAccountId(proxyAccountEntityId.getId());
+            entity.setProxyAccountId(proxyAccountEntityId);
         }
 
         if (accountInfo.getDeleted()) {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListener.java
@@ -100,7 +100,7 @@ public class EntityRecordItemListener implements RecordItemListener {
         try {
             entityId = transactionHandler.getEntity(recordItem);
         } catch (InvalidEntityException e) { // transaction can have invalid topic/contract/file id
-            log.error(e);
+            log.warn("Invalid entity encountered for consensusTimestamp {} : {}", consensusNs, e.getMessage());
             entityId = null;
         }
         TransactionTypeEnum transactionTypeEnum = TransactionTypeEnum.of(recordItem.getTransactionType());

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListener.java
@@ -23,6 +23,7 @@ package com.hedera.mirror.importer.parser.record.entity.sql;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.util.Collection;
 import java.util.HashSet;
 import javax.inject.Named;
 import javax.sql.DataSource;
@@ -59,7 +60,7 @@ public class SqlEntityListener implements EntityListener, RecordStreamFileListen
     private long batch_count = 0;
     // Keeps track of entityIds seen in the current file being processed. This is for optimizing inserts into
     // t_entities table so that insertion of node and treasury ids are not tried for every transaction.
-    private HashSet<EntityId> entityIds;
+    private Collection<EntityId> entityIds;
     private PreparedStatement sqlInsertTransaction;
     private PreparedStatement sqlInsertEntityId;
     private PreparedStatement sqlInsertTransferList;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListener.java
@@ -23,6 +23,7 @@ package com.hedera.mirror.importer.parser.record.entity.sql;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.util.HashSet;
 import javax.inject.Named;
 import javax.sql.DataSource;
 import lombok.RequiredArgsConstructor;
@@ -56,6 +57,9 @@ public class SqlEntityListener implements EntityListener, RecordStreamFileListen
     private final DataSource dataSource;
     private final RecordFileRepository recordFileRepository;
     private long batch_count = 0;
+    // Keeps track of entityIds seen in the current file being processed. This is for optimizing inserts into
+    // t_entities table so that insertion of node and treasury ids are not tried for every transaction.
+    private HashSet<EntityId> entityIds;
     private PreparedStatement sqlInsertTransaction;
     private PreparedStatement sqlInsertEntityId;
     private PreparedStatement sqlInsertTransferList;
@@ -69,6 +73,7 @@ public class SqlEntityListener implements EntityListener, RecordStreamFileListen
     @Override
     public void onStart(StreamFileData streamFileData) {
         String fileName = streamFileData.getFilename();
+        entityIds = new HashSet<>();
         if (recordFileRepository.findByName(fileName).size() > 0) {
             throw new DuplicateFileException("File already exists in the database: " + fileName);
         }
@@ -194,17 +199,19 @@ public class SqlEntityListener implements EntityListener, RecordStreamFileListen
         try {
             // Temporary until we convert SQL statements to repository invocations
             if (transaction.getEntityId() != null) {
-                sqlInsertTransaction.setLong(F_TRANSACTION.ENTITY_ID.ordinal(), transaction.getEntityId());
+                sqlInsertTransaction.setLong(F_TRANSACTION.ENTITY_ID.ordinal(), transaction.getEntityId().getId());
             } else {
                 sqlInsertTransaction.setObject(F_TRANSACTION.ENTITY_ID.ordinal(), null);
             }
-            sqlInsertTransaction.setLong(F_TRANSACTION.NODE_ACCOUNT_ID.ordinal(), transaction.getNodeAccountId());
+            sqlInsertTransaction.setLong(F_TRANSACTION.NODE_ACCOUNT_ID.ordinal(),
+                    transaction.getNodeAccountId().getId());
             sqlInsertTransaction.setBytes(F_TRANSACTION.MEMO.ordinal(), transaction.getMemo());
             sqlInsertTransaction.setLong(F_TRANSACTION.VALID_START_NS.ordinal(), transaction.getValidStartNs());
             sqlInsertTransaction.setInt(F_TRANSACTION.TYPE.ordinal(), transaction.getType());
             sqlInsertTransaction.setLong(F_TRANSACTION.VALID_DURATION_SECONDS.ordinal(),
                     transaction.getValidDurationSeconds());
-            sqlInsertTransaction.setLong(F_TRANSACTION.PAYER_ACCOUNT_ID.ordinal(), transaction.getPayerAccountId());
+            sqlInsertTransaction.setLong(F_TRANSACTION.PAYER_ACCOUNT_ID.ordinal(),
+                    transaction.getPayerAccountId().getId());
             sqlInsertTransaction.setLong(F_TRANSACTION.RESULT.ordinal(), transaction.getResult());
             sqlInsertTransaction.setLong(F_TRANSACTION.CONSENSUS_NS.ordinal(), transaction.getConsensusNs());
             sqlInsertTransaction.setLong(F_TRANSACTION.CHARGED_TX_FEE.ordinal(), transaction.getChargedTxFee());
@@ -227,6 +234,9 @@ public class SqlEntityListener implements EntityListener, RecordStreamFileListen
 
     @Override
     public void onEntityId(EntityId entityId) throws ImporterException {
+        if (entityIds.contains(entityId)) {
+            return;
+        }
         try {
             sqlInsertEntityId.setLong(F_ENTITY_ID.ID.ordinal(), entityId.getId());
             sqlInsertEntityId.setLong(F_ENTITY_ID.ENTITY_SHARD.ordinal(), entityId.getShardNum());
@@ -237,6 +247,7 @@ public class SqlEntityListener implements EntityListener, RecordStreamFileListen
         } catch (SQLException e) {
             throw new ParserSQLException(e);
         }
+        entityIds.add(entityId);
     }
 
     @Override

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/converter/EntityIdConverterTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/converter/EntityIdConverterTest.java
@@ -1,0 +1,49 @@
+package com.hedera.mirror.importer.converter;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import static com.hedera.mirror.importer.domain.EntityTypeEnum.ACCOUNT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.hedera.mirror.importer.domain.EntityId;
+
+class EntityIdConverterTest {
+    EntityIdConverter converter = new EntityIdConverter();
+
+    @Test
+    void testForNulls() {
+        assertThat(converter.convertToDatabaseColumn(null)).isNull();
+        assertThat(converter.convertToEntityAttribute(null)).isNull();
+    }
+
+    @Test
+    void testToDatabaseColumn() {
+        assertThat(converter.convertToDatabaseColumn(EntityId.of(10L, 10L, 10L, ACCOUNT))).isEqualTo(2814792716779530L);
+    }
+
+    @Test
+    void testToEntityAttribute() {
+        assertThat(converter.convertToEntityAttribute(9223372036854775807L))
+                .isEqualTo(EntityId.of(32767L, 65535L, 4294967295L, ACCOUNT));
+    }
+}

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/AbstractEntityRecordItemListenerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/AbstractEntityRecordItemListenerTest.java
@@ -39,7 +39,6 @@ import com.hederahashgraph.api.proto.java.TransactionBody.Builder;
 import com.hederahashgraph.api.proto.java.TransactionRecord;
 import com.hederahashgraph.api.proto.java.TransferList;
 import java.time.Instant;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Consumer;
 import javax.annotation.Resource;
@@ -48,6 +47,8 @@ import org.junit.jupiter.api.TestInfo;
 
 import com.hedera.mirror.importer.IntegrationTest;
 import com.hedera.mirror.importer.domain.Entities;
+import com.hedera.mirror.importer.domain.EntityId;
+import com.hedera.mirror.importer.domain.EntityTypeEnum;
 import com.hedera.mirror.importer.domain.RecordFile;
 import com.hedera.mirror.importer.domain.Transaction;
 import com.hedera.mirror.importer.parser.domain.RecordItem;
@@ -57,7 +58,6 @@ import com.hedera.mirror.importer.parser.record.RecordStreamFileListener;
 import com.hedera.mirror.importer.repository.ContractResultRepository;
 import com.hedera.mirror.importer.repository.CryptoTransferRepository;
 import com.hedera.mirror.importer.repository.EntityRepository;
-import com.hedera.mirror.importer.repository.EntityTypeRepository;
 import com.hedera.mirror.importer.repository.FileDataRepository;
 import com.hedera.mirror.importer.repository.LiveHashRepository;
 import com.hedera.mirror.importer.repository.NonFeeTransferRepository;
@@ -84,8 +84,6 @@ public class AbstractEntityRecordItemListenerTest extends IntegrationTest {
     protected LiveHashRepository liveHashRepository;
     @Resource
     protected FileDataRepository fileDataRepository;
-    @Resource
-    protected EntityTypeRepository entityTypeRepository;
     @Resource
     protected TopicMessageRepository topicMessageRepository;
     @Resource
@@ -140,7 +138,7 @@ public class AbstractEntityRecordItemListenerTest extends IntegrationTest {
                 .extracting(AccountID::getShardNum, AccountID::getRealmNum, AccountID::getAccountNum)
                 .containsExactly(dbEntity.getEntityShard(), dbEntity.getEntityRealm(), dbEntity.getEntityNum());
         assertThat(dbEntity.getEntityTypeId())
-                .isEqualTo(entityTypeRepository.findByName("account").get().getId());
+                .isEqualTo(EntityTypeEnum.ACCOUNT.getId());
     }
 
     protected final void assertFile(FileID fileId, Entities dbEntity) {
@@ -149,7 +147,7 @@ public class AbstractEntityRecordItemListenerTest extends IntegrationTest {
                 .extracting(FileID::getShardNum, FileID::getRealmNum, FileID::getFileNum)
                 .containsExactly(dbEntity.getEntityShard(), dbEntity.getEntityRealm(), dbEntity.getEntityNum());
         assertThat(dbEntity.getEntityTypeId())
-                .isEqualTo(entityTypeRepository.findByName("file").get().getId());
+                .isEqualTo(EntityTypeEnum.FILE.getId());
     }
 
     protected final void assertContract(ContractID contractId, Entities dbEntity) {
@@ -158,7 +156,7 @@ public class AbstractEntityRecordItemListenerTest extends IntegrationTest {
                 .extracting(ContractID::getShardNum, ContractID::getRealmNum, ContractID::getContractNum)
                 .containsExactly(dbEntity.getEntityShard(), dbEntity.getEntityRealm(), dbEntity.getEntityNum());
         assertThat(dbEntity.getEntityTypeId())
-                .isEqualTo(entityTypeRepository.findByName("contract").get().getId());
+                .isEqualTo(EntityTypeEnum.CONTRACT.getId());
     }
 
     protected void parseRecordItemAndCommit(RecordItem recordItem) {
@@ -193,8 +191,6 @@ public class AbstractEntityRecordItemListenerTest extends IntegrationTest {
     private void assertRecord(TransactionRecord record, Transaction dbTransaction) {
         // record inputs
         assertEquals(record.getTransactionFee(), dbTransaction.getChargedTxFee());
-        // payer
-        Entities dbPayerEntity = entityRepository.findById(dbTransaction.getPayerAccountId()).get();
         // transaction id
         assertEquals(Utility.timeStampInNanos(record.getTransactionID().getTransactionValidStart()),
                 dbTransaction.getValidStartNs());
@@ -284,8 +280,12 @@ public class AbstractEntityRecordItemListenerTest extends IntegrationTest {
         return entityRepository.findById(entityId).get();
     }
 
-    protected Optional<Entities> getEntity(long shard, long realm, long num) {
-        return entityRepository.findById(EntityIdEndec.encode(shard, realm, num));
+    protected Entities getEntity(EntityId entityId) {
+        return getEntity(entityId.getId());
+    }
+
+    protected Entities getEntity(long shard, long realm, long num) {
+        return getEntity(EntityIdEndec.encode(shard, realm, num));
     }
 
     protected AccountAmount.Builder accountAmount(long accountNum, long amount) {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerNFTTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerNFTTest.java
@@ -216,12 +216,12 @@ public class EntityRecordItemListenerNFTTest extends AbstractEntityRecordItemLis
     private void assertTransactions() {
         expectedTransactions.forEach(t -> {
             var dbTransaction = getDbTransaction(t.record.getConsensusTimestamp());
-            var dbNode = getEntity(0, 0, NODE_ACCOUNT_NUM).get();
-            var dbPayer = getEntity(0, 0, PAYER_ACCOUNT_NUM).get();
+            var dbNodeEntity = getEntity(0, 0, NODE_ACCOUNT_NUM);
+            var dbPayerEntity = getEntity(0, 0, PAYER_ACCOUNT_NUM);
 
             assertAll(
-                    () -> assertEquals(dbNode.getId(), dbTransaction.getNodeAccountId()),
-                    () -> assertEquals(dbPayer.getId(), dbTransaction.getPayerAccountId())
+                    () -> assertEquals(dbNodeEntity.getId(), dbTransaction.getNodeAccountId().getId()),
+                    () -> assertEquals(dbPayerEntity.getId(), dbTransaction.getPayerAccountId().getId())
             );
         });
     }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListenerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListenerTest.java
@@ -206,8 +206,7 @@ public class SqlEntityListenerTest extends IntegrationTest {
     @Test
     void onTransaction() throws Exception {
         // given
-        Transaction expectedTransaction = new Transaction(101L, 0L, Strings.toByteArray("memo"), 0, 0, 1L,
-                1L, 1L, null, 1L, 1L, 1L, Strings.toByteArray("transactionHash"), null);
+        var expectedTransaction = makeTransaction();
 
         // when
         sqlEntityListener.onTransaction(expectedTransaction);
@@ -257,7 +256,7 @@ public class SqlEntityListenerTest extends IntegrationTest {
 
         // when
         for (int i = 0; i < batchSize; i++) {
-            sqlEntityListener2.onTransaction(mock(Transaction.class));
+            sqlEntityListener2.onTransaction(makeTransaction());
         }
 
         // then
@@ -299,5 +298,24 @@ public class SqlEntityListenerTest extends IntegrationTest {
         Optional<T> actual = repository.findById(id);
         assertTrue(actual.isPresent());
         assertEquals(expected, actual.get());
+    }
+
+    private Transaction makeTransaction() {
+        EntityId entityId = EntityId.of(10, 10, 10, EntityTypeEnum.ACCOUNT);
+        Transaction transaction = new Transaction();
+        transaction.setConsensusNs(101L);
+        transaction.setEntityId(entityId);
+        transaction.setNodeAccountId(entityId);
+        transaction.setMemo(Strings.toByteArray("memo"));
+        transaction.setType(14);
+        transaction.setResult(22);
+        transaction.setTransactionHash(Strings.toByteArray("transactionHash"));
+        transaction.setPayerAccountId(entityId);
+        transaction.setValidStartNs(1L);
+        transaction.setValidDurationSeconds(1L);
+        transaction.setMaxFee(1L);
+        transaction.setChargedTxFee(1L);
+        transaction.setInitialBalance(0L);
+        return transaction;
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/AbstractRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/AbstractRepositoryTest.java
@@ -74,9 +74,9 @@ public abstract class AbstractRepositoryTest extends IntegrationTest {
         Transaction transaction = new Transaction();
         transaction.setChargedTxFee(chargedTxFee);
         transaction.setConsensusNs(consensusNs);
-        transaction.setEntity(entity);
-        transaction.setNodeAccount(entity);
-        transaction.setPayerAccount(entity);
+        transaction.setEntityId(entity);
+        transaction.setNodeAccountId(entity);
+        transaction.setPayerAccountId(entity);
         transaction.setResult(ResponseCodeEnum.SUCCESS.getNumber());
         transaction.setType(TransactionBody.DataCase.valueOf(type).getNumber());
         transaction.setValidStartNs(validStartNs);

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/TransactionRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/TransactionRepositoryTest.java
@@ -42,11 +42,11 @@ public class TransactionRepositoryTest extends AbstractRepositoryTest {
         Transaction transaction = new Transaction();
         transaction.setChargedTxFee(100L);
         transaction.setConsensusNs(10L);
-        transaction.setEntity(insertAccountEntity());
+        transaction.setEntityId(insertAccountEntity());
         transaction.setInitialBalance(1000L);
         transaction.setMemo("transaction memo".getBytes());
-        transaction.setNodeAccount(insertAccountEntity());
-        transaction.setPayerAccount(insertAccountEntity());
+        transaction.setNodeAccountId(insertAccountEntity());
+        transaction.setPayerAccountId(insertAccountEntity());
         transaction.setResult(ResponseCodeEnum.SUCCESS.getNumber());
         transaction.setType(TransactionBody.DataCase.CRYPTOCREATEACCOUNT.getNumber());
         transaction.setValidStartNs(20L);

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/util/EntityIdEndecTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/util/EntityIdEndecTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 import com.hedera.mirror.importer.domain.EntityId;
+import com.hedera.mirror.importer.exception.InvalidEntityException;
 
 class EntityIdEndecTest {
 
@@ -30,16 +31,28 @@ class EntityIdEndecTest {
 
     @Test
     void throwsExceptionEncoding() {
-        assertThrows(IllegalArgumentException.class, () -> {
+        assertThrows(InvalidEntityException.class, () -> {
             EntityIdEndec.encode(1L << SHARD_BITS, 0, 0);
         });
 
-        assertThrows(IllegalArgumentException.class, () -> {
+        assertThrows(InvalidEntityException.class, () -> {
             EntityIdEndec.encode(0, 1L << REALM_BITS, 0);
         });
 
-        assertThrows(IllegalArgumentException.class, () -> {
+        assertThrows(InvalidEntityException.class, () -> {
             EntityIdEndec.encode(0, 0, 1L << NUM_BITS);
+        });
+
+        assertThrows(InvalidEntityException.class, () -> {
+            EntityIdEndec.encode(-1, 0, 0);
+        });
+
+        assertThrows(InvalidEntityException.class, () -> {
+            EntityIdEndec.encode(0, -1, 0);
+        });
+
+        assertThrows(InvalidEntityException.class, () -> {
+            EntityIdEndec.encode(0, 0, -1);
         });
     }
 
@@ -58,7 +71,7 @@ class EntityIdEndecTest {
 
     @Test
     void throwsExceptionDecoding() {
-        assertThrows(IllegalArgumentException.class, () -> {
+        assertThrows(InvalidEntityException.class, () -> {
             EntityIdEndec.decode(-1);
         });
     }


### PR DESCRIPTION
**Detailed description**:
- Change `Long` to `EntityId` in `Transaction` and `Entities`. Added `EntityIdConverter` for the same.
- Use only `id` field in EntityId for `EqualsAndHashCode` since that is sufficient
- Add InvalidEntityException. Thrown for invalid entities when encoding/decoding
- Handle the case for invalid entityId (contract/topic/file id) in a failed transaction. Added test.

Signed-off-by: Apekshit Sharma <apekshit.sharma@hedera.com>

**Which issue(s) this PR fixes**:
Fixes #570 
Part of #820 

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated

