### PR TITLE
Optimize parser performance

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/converter/EntityIdConverter.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/converter/EntityIdConverter.java
@@ -22,14 +22,17 @@ package com.hedera.mirror.importer.converter;
 
 import javax.inject.Named;
 import javax.persistence.AttributeConverter;
-import javax.persistence.Converter;
+import org.springframework.boot.context.properties.ConfigurationPropertiesBinding;
+import org.springframework.core.convert.converter.Converter;
 
 import com.hedera.mirror.importer.domain.EntityId;
+import com.hedera.mirror.importer.domain.EntityTypeEnum;
 import com.hedera.mirror.importer.util.EntityIdEndec;
 
 @Named
-@Converter
-public class EntityIdConverter implements AttributeConverter<EntityId, Long> {
+@javax.persistence.Converter
+@ConfigurationPropertiesBinding
+public class EntityIdConverter implements AttributeConverter<EntityId, Long>, Converter<String, EntityId> {
     @Override
     public Long convertToDatabaseColumn(EntityId entityId) {
         if (entityId == null) {
@@ -44,5 +47,10 @@ public class EntityIdConverter implements AttributeConverter<EntityId, Long> {
             return null;
         }
         return EntityIdEndec.decode(encodedId);
+    }
+
+    @Override
+    public EntityId convert(String source) {
+        return EntityId.of(source, EntityTypeEnum.ACCOUNT); // We just use for config properties and don't need type
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/EntityId.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/EntityId.java
@@ -47,6 +47,7 @@ import com.hedera.mirror.importer.util.EntityIdEndec;
 public class EntityId implements Serializable {
 
     private static final Splitter SPLITTER = Splitter.on('.').omitEmptyStrings().trimResults();
+    private static final long serialVersionUID = 1427649605832330197L;
 
     // Ignored so not included in json serialization of PubSubMessage
     @JsonIgnore
@@ -58,26 +59,11 @@ public class EntityId implements Serializable {
     private Integer type;
 
     public EntityId(Long shardNum, Long realmNum, Long entityNum, Integer type) {
-        this.id = EntityIdEndec.encode(shardNum, realmNum, entityNum);
+        id = EntityIdEndec.encode(shardNum, realmNum, entityNum);
         this.shardNum = shardNum;
         this.realmNum = realmNum;
         this.entityNum = entityNum;
         this.type = type;
-    }
-
-    public Entities toEntity() {
-        Entities entity = new Entities();
-        entity.setId(id);
-        entity.setEntityShard(shardNum);
-        entity.setEntityRealm(realmNum);
-        entity.setEntityNum(entityNum);
-        entity.setEntityTypeId(type);
-        return entity;
-    }
-
-    @JsonIgnore
-    public String getDisplayId() {
-        return String.format("%d.%d.%d", shardNum, realmNum, entityNum);
     }
 
     public static EntityId of(AccountID accountID) {
@@ -115,5 +101,15 @@ public class EntityId implements Serializable {
             return null;
         }
         return new EntityId(entityShard, entityRealm, entityNum, type.getId());
+    }
+
+    public Entities toEntity() {
+        Entities entity = new Entities();
+        entity.setId(id);
+        entity.setEntityShard(shardNum);
+        entity.setEntityRealm(realmNum);
+        entity.setEntityNum(entityNum);
+        entity.setEntityTypeId(type);
+        return entity;
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/CommonParserProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/CommonParserProperties.java
@@ -71,7 +71,7 @@ public class CommonParserProperties {
     public static class TransactionFilter {
 
         @NotNull
-        private Collection<String> entity = new LinkedHashSet<>();
+        private Collection<EntityId> entity = new LinkedHashSet<>();
 
         @NotNull
         private Collection<TransactionTypeEnum> transaction = new LinkedHashSet<>();
@@ -93,7 +93,7 @@ public class CommonParserProperties {
                 return true;
             }
 
-            return e != null && entity.contains(e.getDisplayId());
+            return e != null && entity.contains(e);
         }
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityProperties.java
@@ -1,10 +1,5 @@
 package com.hedera.mirror.importer.parser.record.entity;
 
-import javax.validation.constraints.NotNull;
-import lombok.Data;
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.validation.annotation.Validated;
-
 /*-
  * ‌
  * Hedera Mirror Node
@@ -24,8 +19,12 @@ import org.springframework.validation.annotation.Validated;
  * limitations under the License.
  * ‍
  */
+
+import javax.validation.constraints.NotNull;
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
 @Data
-@Validated
 @ConditionOnEntityRecordParser
 @ConfigurationProperties("hedera.mirror.importer.parser.record.entity")
 public class EntityProperties {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListener.java
@@ -177,7 +177,7 @@ public class EntityRecordItemListener implements RecordItemListener {
         TransactionRecord txRecord = recordItem.getRecord();
         tx.setChargedTxFee(txRecord.getTransactionFee());
         tx.setConsensusNs(consensusTimestamp);
-        tx.setMemo(body.getMemo().getBytes());
+        tx.setMemo(body.getMemoBytes().toByteArray());
         tx.setMaxFee(body.getTransactionFee());
         tx.setResult(txRecord.getReceipt().getStatusValue());
         tx.setType(recordItem.getTransactionType());

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlProperties.java
@@ -23,10 +23,8 @@ package com.hedera.mirror.importer.parser.record.entity.sql;
 import javax.validation.constraints.Min;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.validation.annotation.Validated;
 
 @Data
-@Validated
 @ConfigurationProperties("hedera.mirror.importer.parser.record.entity.sql")
 public class SqlProperties {
     /**

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/CommonParserPropertiesTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/CommonParserPropertiesTest.java
@@ -21,10 +21,7 @@ package com.hedera.mirror.importer.parser.record;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.google.common.base.Splitter;
 import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -133,19 +130,14 @@ public class CommonParserPropertiesTest {
             return null;
         }
 
-        List<Long> parts = Splitter.on('.')
-                .splitToList(entityId)
-                .stream()
-                .map(Long::valueOf)
-                .collect(Collectors.toList());
-        return EntityId.of(parts.get(0), parts.get(1), parts.get(2), EntityTypeEnum.ACCOUNT);
+        return EntityId.of(entityId, EntityTypeEnum.ACCOUNT);
     }
 
     private TransactionFilter filter(String entity, TransactionTypeEnum type) {
         TransactionFilter transactionFilter = new TransactionFilter();
 
         if (StringUtils.isNotBlank(entity)) {
-            transactionFilter.setEntity(Arrays.asList(entity));
+            transactionFilter.setEntity(Arrays.asList(EntityId.of(entity, EntityTypeEnum.ACCOUNT)));
         }
 
         if (type != null) {

--- a/hedera-mirror-importer/src/test/resources/scripts/restore-client/Dockerfile
+++ b/hedera-mirror-importer/src/test/resources/scripts/restore-client/Dockerfile
@@ -1,18 +1,15 @@
 # Creates image to be used as an executable container that performs a pg_restore against an already existing database
-# docker build -f hedera-mirror-importer/src/test/resources/scripts/restore-client/Dockerfile \
-#   ./hedera-mirror-importer/src/test/resources/scripts/  \
-#   --build-arg dumpfile=<pgdump.gz>  --build-arg jsonkeyfile=bucket-download-key.json
-#   -t gcr.io/mirrornode/hedera-mirror-node/postgres-restore-client:latest
+# docker build -f hedera-mirror-importer/src/test/resources/scripts/restore-client/Dockerfile ./hedera-mirror-importer/src/test/resources/scripts/ --build-arg dumpfile=testnet_100k_pgdump.gz --build-arg jsonkeyfile=bucket-download-key.json -t gcr.io/mirrornode/hedera-mirror-node/postgres-restore-client:latest
 FROM alpine:latest AS build
-
-ARG dumpfile
-ARG jsonkeyfile
 
 # install gcloud tools
 RUN apk --update add curl python3
 RUN curl https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz > /tmp/google-cloud-sdk.tar.gz
 RUN tar -C /usr/local/ -xvf /tmp/google-cloud-sdk.tar.gz
 RUN /usr/local/google-cloud-sdk/install.sh
+
+ARG dumpfile
+ARG jsonkeyfile
 
 # pull in key file and set up account
 COPY ./$jsonkeyfile /tmp/config.json


### PR DESCRIPTION
**Detailed description**:
- Fix slow string creation and comparison in transaction filter by using EntityId
- Fix slow metric recording by pre-creating metrics objects in constructor
- Fix slow configuration properties getters due to reflection by removing `@Validated`
- Fix saving record file before all batches complete (recordfile save is in separate transaction)
- Fix NullPointerException if exception during `StreamFileListener.onStart()`
- Fix slow file reading due to unbuffered input stream
- Fix unnecessary ByteBuffer allocation by using library to convert int to bytes
- Fix unnecessary String creation for transaction memo

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

These statistics from running the importer locally on my Macbook. As such, only the relative performance gain from before and after can be considered.

**RecordFileParserPerformanceTest**:
  Before: ~6s
  After: ~3s

**Perf test bucket with test run of 3500TPS at 256B topic messages closing every 5s**:
  Database state: 20M transactions, 20M topic messages and 61M cryptotransfers
  Before: ~4.05s per record file
  After: ~1.827s perf record file

**Perf test bucket with test run of 3500TPS at 256B topic messages closing every 1s**:
  Database state: 16M transactions, 16M topic messages and 48M cryptotransfers in DB
  Before: ~1.2975s per record file
  After: ~.396s avg per record file

So anywhere from a 2x to a 3x improvement

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

