### PR TITLE
Add download latency metrics

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,7 +62,7 @@ value, it is recommended to only populate overridden properties in the custom `a
 | `hedera.mirror.importer.parser.include.entity`                       | []                      | A list of entity IDs to store in shard.realm.num (e.g. 0.0.3) format                           |
 | `hedera.mirror.importer.parser.include.transaction`                  | []                      | A list of transaction types to store. See `TransactionTypeEnum.java` for possible values       |
 | `hedera.mirror.importer.parser.record.enabled`                       | true                    | Whether to enable record file parsing                                                          |
-| `hedera.mirror.importer.parser.record.frequency`                     | 500ms                   | The fixed period between invocations. Can accept duration units like `10s`, `2m` etc.          |
+| `hedera.mirror.importer.parser.record.frequency`                     | 100ms                   | The fixed period between invocations. Can accept duration units like `10s`, `2m` etc.          |
 | `hedera.mirror.importer.parser.record.keepFiles`                     | false                   | Whether to keep parsed files after successful parsing. If false, files are deleted.            |
 | `hedera.mirror.importer.parser.record.entity.persist.claims`                | false                   | Persist claim data to the database                                                             |
 | `hedera.mirror.importer.parser.record.entity.persist.contracts`             | true                    | Persist contract data to the database                                                          |

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/record/RecordFileDownloader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/record/RecordFileDownloader.java
@@ -22,6 +22,8 @@ package com.hedera.mirror.importer.downloader.record;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import java.io.File;
+import java.time.Duration;
+import java.time.Instant;
 import javax.inject.Named;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.codec.binary.Hex;
@@ -78,6 +80,9 @@ public class RecordFileDownloader extends Downloader {
             if (!recordFile.getFileHash().contentEquals(Hex.encodeHexString(verifiedHash))) {
                 return false;
             }
+
+            Instant consensusEnd = Instant.ofEpochSecond(0, recordFile.getConsensusEnd());
+            downloadLatencyMetric.record(Duration.between(consensusEnd, Instant.now()));
         } catch (HashMismatchException e) {
             log.error(e);
             return false;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordParserProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordParserProperties.java
@@ -41,7 +41,7 @@ public class RecordParserProperties implements ParserProperties {
     private boolean enabled = true;
 
     @NotNull
-    private Duration frequency = Duration.ofMillis(500L);
+    private Duration frequency = Duration.ofMillis(100L);
 
     private boolean keepFiles = false;
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/util/FileDelimiter.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/util/FileDelimiter.java
@@ -23,12 +23,10 @@ package com.hedera.mirror.importer.util;
 public class FileDelimiter {
     public static final String HASH_ALGORITHM = "SHA-384";
 
-    public static final byte RECORD_TYPE_PREV_HASH = 1;       // next 48 bytes are hash384 or previous files
+    public static final byte RECORD_TYPE_PREV_HASH = 1; // next 48 bytes are hash384 or previous files
     public static final int RECORD_FORMAT_VERSION = 2;
-    public static final byte RECORD_TYPE_RECORD = 2;          // next data type is transaction and its record
-    public static final byte RECORD_TYPE_SIGNATURE = 3;       // the file content signature, should not be hashed
+    public static final byte RECORD_TYPE_RECORD = 2; // next data type is transaction and its record
 
-    public static final byte SIGNATURE_TYPE_SIGNATURE = 3;       // the file content signature, should not be hashed
-    public static final byte SIGNATURE_TYPE_FILE_HASH = 4;       // next 48 bytes are hash384 of content of
-    // corresponding RecordFile
+    public static final byte SIGNATURE_TYPE_SIGNATURE = 3; // the file content signature, should not be hashed
+    public static final byte SIGNATURE_TYPE_FILE_HASH = 4; // next 48 bytes are SHA-384 of content of record file
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileParserPerformanceTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileParserPerformanceTest.java
@@ -69,7 +69,7 @@ public class RecordFileParserPerformanceTest extends IntegrationTest {
         parserProperties.init();
     }
 
-    @Timeout(20)
+    @Timeout(10)
     @Test
     void parseAndIngestMultipleFiles60000Transactions() throws Exception {
         parse("*.rcd");


### PR DESCRIPTION
**Detailed description**:
- Add `hedera.mirror.download.latency` metric to track consensus to download/verification latency
- Add `hedera.mirror.stream.close.latency` metric to track time to close record file
- Change frequency of polling the filesystem for record files from 500ms to 100ms to reduce overall latency
- Change `hedera.mirror.topicmessage.latency` to `hedera.mirror.publish.latency` with a tag to indicate type of entity being published. This 
- Change `hedera.mirror.signature.verification` to `hedera.mirror.download.signature.verification`
- Change `hedera.mirror.stream.verification` to `hedera.mirror.download.stream.verification`
- Remove dead code parsing a signature from the record file after confirming signatures are not present in that file

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

