### PR TITLE
Add a NotifyingTopicListener

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -109,9 +109,9 @@ value, it is recommended to only populate overridden properties in the custom `a
 | `hedera.mirror.grpc.endTimeInterval`                        | 30s              | How often we should check if a subscription has gone past the end time                         |
 | `hedera.mirror.grpc.entityCacheSize`                        | 50000            | The maximum size of the cache to store entities used for existence check                       |
 | `hedera.mirror.grpc.listener.enabled`                       | true             | Whether to listen for incoming massages or not                                                 |
-| `hedera.mirror.grpc.listener.maxPageSize`                   | 10000            | The maximum number of messages the listener can return in a single call to the database        |
-| `hedera.mirror.grpc.listener.pollingFrequency`              | 1s               | How often to polling for new topic messages. Can accept duration units like `50ms`, `10s` etc. |
-| `hedera.mirror.grpc.listener.type`                          | SHARED_POLL      | The type of listener to use for incoming messages. Accepts either POLL or SHARED_POLL          |
+| `hedera.mirror.grpc.listener.maxPageSize`                   | 5000             | The maximum number of messages the listener can return in a single call to the database        |
+| `hedera.mirror.grpc.listener.frequency`                     | 500ms            | How often to poll or retry errors (varies by type). Can accept duration units like `50ms`, `10s`, etc. |
+| `hedera.mirror.grpc.listener.type`                          | NOTIFY           | The type of listener to use for incoming messages. Accepts either NOTIFY, POLL or SHARED_POLL  |
 | `hedera.mirror.grpc.netty.executorCoreThreadCount`          | 10               | The number of core threads                                                                     |
 | `hedera.mirror.grpc.netty.executorMaxThreadCount`           | 1000             | The maximum allowed number of threads                                                          |
 | `hedera.mirror.grpc.netty.flowControlWindow`                | 64 \* 1024       | The HTTP/2 flow control window                                                                 |

--- a/hedera-mirror-grpc/pom.xml
+++ b/hedera-mirror-grpc/pom.xml
@@ -16,6 +16,7 @@
 
     <properties>
         <grpc-spring-boot.version>2.7.0.RELEASE</grpc-spring-boot.version>
+        <vertx.version>3.9.1</vertx.version>
     </properties>
 
     <dependencies>
@@ -57,6 +58,11 @@
         <dependency>
             <groupId>io.projectreactor.addons</groupId>
             <artifactId>reactor-extra</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-pg-client</artifactId>
+            <version>${vertx.version}</version>
         </dependency>
         <dependency>
             <groupId>javax.inject</groupId>

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/DbProperties.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/DbProperties.java
@@ -1,4 +1,4 @@
-package com.hedera.mirror.grpc.listener;
+package com.hedera.mirror.grpc;
 
 /*-
  * ‌
@@ -20,32 +20,28 @@ package com.hedera.mirror.grpc.listener;
  * ‍
  */
 
-import java.time.Duration;
 import javax.validation.constraints.Min;
-import javax.validation.constraints.NotNull;
+import javax.validation.constraints.NotBlank;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
 @Data
 @Validated
-@ConfigurationProperties("hedera.mirror.grpc.listener")
-public class ListenerProperties {
+@ConfigurationProperties("hedera.mirror.grpc.db")
+public class DbProperties {
+    @NotBlank
+    private String host = "";
 
-    private boolean enabled = true;
+    @NotBlank
+    private String name = "";
 
-    @Min(32)
-    private int maxPageSize = 5000;
+    @NotBlank
+    private String password = "";
 
-    @NotNull
-    private Duration frequency = Duration.ofMillis(500L);
+    @Min(0)
+    private int port = 5432;
 
-    @NotNull
-    private ListenerType type = ListenerType.NOTIFY;
-
-    public enum ListenerType {
-        NOTIFY,
-        POLL,
-        SHARED_POLL
-    }
+    @NotBlank
+    private String username = "";
 }

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/CompositeTopicListener.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/CompositeTopicListener.java
@@ -41,6 +41,7 @@ import com.hedera.mirror.grpc.listener.ListenerProperties.ListenerType;
 public class CompositeTopicListener implements TopicListener {
 
     private final ListenerProperties listenerProperties;
+    private final NotifyingTopicListener notifyingTopicListener;
     private final PollingTopicListener pollingTopicListener;
     private final SharedPollingTopicListener sharedPollingTopicListener;
     private final MeterRegistry meterRegistry;
@@ -69,6 +70,8 @@ public class CompositeTopicListener implements TopicListener {
         ListenerType type = listenerProperties.getType();
 
         switch (type) {
+            case NOTIFY:
+                return notifyingTopicListener;
             case POLL:
                 return pollingTopicListener;
             case SHARED_POLL:

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/NotifyingTopicListener.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/NotifyingTopicListener.java
@@ -1,0 +1,118 @@
+package com.hedera.mirror.grpc.listener;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import io.vertx.core.Vertx;
+import io.vertx.pgclient.PgConnectOptions;
+import io.vertx.pgclient.pubsub.PgChannel;
+import io.vertx.pgclient.pubsub.PgSubscriber;
+import java.time.Duration;
+import javax.inject.Named;
+import lombok.extern.log4j.Log4j2;
+import reactor.core.publisher.EmitterProcessor;
+import reactor.core.publisher.Flux;
+import reactor.core.scheduler.Schedulers;
+import reactor.util.retry.Retry;
+
+import com.hedera.mirror.grpc.DbProperties;
+import com.hedera.mirror.grpc.domain.TopicMessage;
+import com.hedera.mirror.grpc.domain.TopicMessageFilter;
+
+@Named
+@Log4j2
+public class NotifyingTopicListener implements TopicListener {
+
+    private final ObjectMapper objectMapper;
+    private final Flux<TopicMessage> topicMessages;
+    private final PgChannel channel;
+
+    public NotifyingTopicListener(DbProperties dbProperties, ListenerProperties listenerProperties) {
+        this.objectMapper = new ObjectMapper().setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
+        PgConnectOptions connectOptions = new PgConnectOptions()
+                .setDatabase(dbProperties.getName())
+                .setHost(dbProperties.getHost())
+                .setPassword(dbProperties.getPassword())
+                .setPort(dbProperties.getPort())
+                .setUser(dbProperties.getUsername());
+
+        Duration frequency = listenerProperties.getFrequency();
+        Vertx vertx = Vertx.vertx();
+        PgSubscriber subscriber = PgSubscriber.subscriber(vertx, connectOptions)
+                .reconnectPolicy(retries -> {
+                    log.warn("Attempting reconnect");
+                    return frequency.toMillis();
+                });
+
+        // Connect asynchronously to avoid crashing the application on startup if the database is down
+        vertx.setTimer(100L, v -> subscriber.connect(connectResult -> {
+            if (connectResult.failed()) {
+                throw new RuntimeException(connectResult.cause());
+            }
+            log.info("Connected to database");
+        }));
+
+        channel = subscriber.channel("topic_message");
+
+        topicMessages = Flux.defer(() -> listen())
+                .publishOn(Schedulers.boundedElastic())
+                .map(this::toTopicMessage)
+                .name("notify")
+                .metrics()
+                .doFinally(s -> unlisten())
+                .doOnError(t -> log.error("Error listening for messages", t))
+                .retryWhen(Retry.backoff(Long.MAX_VALUE, frequency).maxBackoff(frequency.multipliedBy(4L)))
+                .share();
+    }
+
+    @Override
+    public Flux<TopicMessage> listen(TopicMessageFilter filter) {
+        return topicMessages.filter(t -> filterMessage(t, filter))
+                .doOnSubscribe(s -> log.info("Subscribing: {}", filter));
+    }
+
+    private boolean filterMessage(TopicMessage message, TopicMessageFilter filter) {
+        return message.getRealmNum() == filter.getRealmNum() &&
+                message.getTopicNum() == filter.getTopicNum() &&
+                message.getConsensusTimestamp() >= filter.getStartTimeLong();
+    }
+
+    private Flux<String> listen() {
+        EmitterProcessor<String> emitterProcessor = EmitterProcessor.create();
+        channel.handler(json -> emitterProcessor.onNext(json));
+        log.info("Listening for messages");
+        return emitterProcessor;
+    }
+
+    private void unlisten() {
+        channel.handler(null);
+        log.info("Stopped listening for messages");
+    }
+
+    private TopicMessage toTopicMessage(String payload) {
+        try {
+            return objectMapper.readValue(payload, TopicMessage.class);
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+}

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/PollingTopicListener.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/PollingTopicListener.java
@@ -50,7 +50,7 @@ public class PollingTopicListener implements TopicListener {
     @Override
     public Flux<TopicMessage> listen(TopicMessageFilter filter) {
         PollingContext context = new PollingContext(filter);
-        Duration frequency = listenerProperties.getPollingFrequency();
+        Duration frequency = listenerProperties.getFrequency();
 
         return Flux.defer(() -> poll(context))
                 .delaySubscription(frequency, scheduler)

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/SharedPollingTopicListener.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/SharedPollingTopicListener.java
@@ -59,7 +59,7 @@ public class SharedPollingTopicListener implements TopicListener {
         this.instantToLongConverter = instantToLongConverter;
 
         Scheduler scheduler = Schedulers.newSingle("shared-poll", true);
-        Duration frequency = listenerProperties.getPollingFrequency();
+        Duration frequency = listenerProperties.getFrequency();
         PollingContext context = new PollingContext();
 
         poller = Flux.defer(() -> poll(context)
@@ -131,7 +131,7 @@ public class SharedPollingTopicListener implements TopicListener {
 
         void onStart(Subscription subscription) {
             lastConsensusTimestamp = instantToLongConverter.convert(Instant.now());
-            log.info("Starting to poll every {}ms", listenerProperties.getPollingFrequency().toMillis());
+            log.info("Starting to poll every {}ms", listenerProperties.getFrequency().toMillis());
         }
     }
 }

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/listener/AbstractTopicListenerTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/listener/AbstractTopicListenerTest.java
@@ -68,9 +68,9 @@ public abstract class AbstractTopicListenerTest extends GrpcIntegrationTest {
         getTopicListener().listen(filter)
                 .map(TopicMessage::getSequenceNumber)
                 .as(StepVerifier::create)
-                .expectNextCount(0L)
-                .thenCancel()
-                .verify(Duration.ofMillis(500));
+                .expectSubscription()
+                .expectTimeout(Duration.ofMillis(500L))
+                .verify();
     }
 
     @Test

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/listener/NotifyingTopicListenerTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/listener/NotifyingTopicListenerTest.java
@@ -1,0 +1,58 @@
+package com.hedera.mirror.grpc.listener;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import java.time.Duration;
+import java.time.Instant;
+import javax.annotation.Resource;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import reactor.test.StepVerifier;
+
+import com.hedera.mirror.grpc.domain.TopicMessageFilter;
+
+public class NotifyingTopicListenerTest extends AbstractTopicListenerTest {
+
+    @Resource
+    private NotifyingTopicListener topicListener;
+
+    @Resource
+    private JdbcTemplate jdbcTemplate;
+
+    @Override
+    protected TopicListener getTopicListener() {
+        return topicListener;
+    }
+
+    @Test
+    void jsonError() {
+        TopicMessageFilter filter = TopicMessageFilter.builder()
+                .startTime(Instant.EPOCH)
+                .build();
+
+        // Parsing errors will be logged and ignored and the message will be lost
+        topicListener.listen(filter)
+                .as(StepVerifier::create)
+                .thenAwait(Duration.ofMillis(50))
+                .then(() -> jdbcTemplate.execute("NOTIFY topic_message, 'invalid'"))
+                .expectNoEvent(Duration.ofMillis(500L));
+    }
+}

--- a/hedera-mirror-grpc/src/test/resources/config/application.yml
+++ b/hedera-mirror-grpc/src/test/resources/config/application.yml
@@ -19,7 +19,7 @@ hedera:
       endTimeInterval: 100ms
       listener:
         enabled: false # Disabled except in tests that use it since it polls in background repeatedly every 50ms
-        pollingFrequency: 50ms
+        frequency: 50ms
       retriever:
         pollingFrequency: 50ms
 spring:

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/converter/EntityIdSerializer.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/converter/EntityIdSerializer.java
@@ -1,0 +1,24 @@
+package com.hedera.mirror.importer.converter;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import java.io.IOException;
+
+import com.hedera.mirror.importer.domain.EntityId;
+
+public class EntityIdSerializer extends StdSerializer<EntityId> {
+
+    private static final long serialVersionUID = 5158286630945397464L;
+
+    public EntityIdSerializer() {
+        super(EntityId.class);
+    }
+
+    @Override
+    public void serialize(EntityId value, JsonGenerator jsonGenerator, SerializerProvider provider) throws IOException {
+        if (value != null) {
+            jsonGenerator.writeNumber(value.getId());
+        }
+    }
+}

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/TopicMessage.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/TopicMessage.java
@@ -20,42 +20,41 @@ package com.hedera.mirror.importer.domain;
  * ‍
  */
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import javax.persistence.Convert;
 import javax.persistence.Entity;
 import javax.persistence.Id;
-import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 
 import com.hedera.mirror.importer.converter.EntityIdConverter;
+import com.hedera.mirror.importer.converter.EntityIdSerializer;
 
 @Data
 @Entity
-@NoArgsConstructor
-@AllArgsConstructor
 public class TopicMessage {
+
+    private Integer chunkNum;
+
+    private Integer chunkTotal;
 
     @Id
     private long consensusTimestamp;
 
     private byte[] message;
 
+    @Convert(converter = EntityIdConverter.class)
+    @JsonSerialize(using = EntityIdSerializer.class)
+    private EntityId payerAccountId;
+
     private int realmNum;
 
     private byte[] runningHash;
 
+    private int runningHashVersion;
+
     private long sequenceNumber;
 
     private int topicNum;
-
-    private int runningHashVersion;
-
-    private Integer chunkNum;
-
-    private Integer chunkTotal;
-
-    @Convert(converter = EntityIdConverter.class)
-    private EntityId payerAccountId;
 
     private Long validStartTimestamp;
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListener.java
@@ -225,30 +225,28 @@ public class EntityRecordItemListener implements RecordItemListener {
         var topicId = transactionBody.getTopicID();
         int runningHashVersion = receipt.getTopicRunningHashVersion() == 0 ? 1 : (int) receipt
                 .getTopicRunningHashVersion();
+        TopicMessage topicMessage = new TopicMessage();
 
-        EntityId payerAccountId = null;
-        Long validStartNs = null;
-        Integer chunkTotal = null;
-        Integer chunkNum = null;
-
-        // handle fragmented topic message
+        // Handle optional fragmented topic message
         if (transactionBody.hasChunkInfo()) {
             ConsensusMessageChunkInfo chunkInfo = transactionBody.getChunkInfo();
-            chunkNum = chunkInfo.getNumber();
-            chunkTotal = chunkInfo.getTotal();
+            topicMessage.setChunkNum(chunkInfo.getNumber());
+            topicMessage.setChunkTotal(chunkInfo.getTotal());
 
             if (chunkInfo.hasInitialTransactionID()) {
                 TransactionID transactionID = chunkInfo.getInitialTransactionID();
-                payerAccountId = EntityId.of(transactionID.getAccountID());
-                validStartNs = Utility.timeStampInNanos(transactionID.getTransactionValidStart());
+                topicMessage.setPayerAccountId(EntityId.of(transactionID.getAccountID()));
+                topicMessage.setValidStartTimestamp(Utility.timeStampInNanos(transactionID.getTransactionValidStart()));
             }
         }
 
-        TopicMessage topicMessage = new TopicMessage(
-                Utility.timeStampInNanos(transactionRecord.getConsensusTimestamp()),
-                transactionBody.getMessage().toByteArray(), (int) topicId.getRealmNum(),
-                receipt.getTopicRunningHash().toByteArray(), receipt.getTopicSequenceNumber(),
-                (int) topicId.getTopicNum(), runningHashVersion, chunkNum, chunkTotal, payerAccountId, validStartNs);
+        topicMessage.setConsensusTimestamp(Utility.timeStampInNanos(transactionRecord.getConsensusTimestamp()));
+        topicMessage.setMessage(transactionBody.getMessage().toByteArray());
+        topicMessage.setRealmNum((int) topicId.getRealmNum());
+        topicMessage.setRunningHash(receipt.getTopicRunningHash().toByteArray());
+        topicMessage.setRunningHashVersion(runningHashVersion);
+        topicMessage.setSequenceNumber(receipt.getTopicSequenceNumber());
+        topicMessage.setTopicNum((int) topicId.getTopicNum());
         entityListener.onTopicMessage(topicMessage);
     }
 

--- a/hedera-mirror-importer/src/main/resources/db/migration/V1.26.1__pg_notify.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/V1.26.1__pg_notify.sql
@@ -8,18 +8,22 @@ declare
     topicmessage text := TG_ARGV[0];
 begin
     perform (
-        with payload(consensus_timestamp, message, realm_num, running_hash, running_hash_version, sequence_number, topic_num) as
-                 (
-                     select NEW.consensus_timestamp,
-                            encode(NEW.message, 'base64'),
-                            NEW.realm_num,
-                            encode(NEW.running_hash, 'base64'),
-                            NEW.running_hash_version,
-                            NEW.sequence_number,
-                            NEW.topic_num
-                 )
-        select pg_notify(topicmessage, row_to_json(payload)::text)
-        from payload
+        with payload(chunk_num, chunk_total, consensus_timestamp, message, payer_account_id, realm_num, running_hash,
+                     running_hash_version, sequence_number, topic_num, valid_start_timestamp) as
+             (
+                 select NEW.chunk_num,
+                        NEW.chunk_total,
+                        NEW.consensus_timestamp,
+                        encode(NEW.message, 'base64'),
+                        NEW.payer_account_id,
+                        NEW.realm_num,
+                        encode(NEW.running_hash, 'base64'),
+                        NEW.running_hash_version,
+                        NEW.sequence_number,
+                        NEW.topic_num,
+                        NEW.valid_start_timestamp
+             )
+        select pg_notify(topicmessage, row_to_json(payload)::text) from payload
     );
     return null;
 end;

--- a/hedera-mirror-importer/src/main/resources/db/migration/V1.26.1__pg_notify.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/V1.26.1__pg_notify.sql
@@ -1,0 +1,34 @@
+-- Define trigger function. Base64 encoding is required since JSON doesn't support binary
+create or replace function topic_message_notifier()
+    returns trigger
+    language plpgsql
+as
+$$
+declare
+    topicmessage text := TG_ARGV[0];
+begin
+    perform (
+        with payload(consensus_timestamp, message, realm_num, running_hash, running_hash_version, sequence_number, topic_num) as
+                 (
+                     select NEW.consensus_timestamp,
+                            encode(NEW.message, 'base64'),
+                            NEW.realm_num,
+                            encode(NEW.running_hash, 'base64'),
+                            NEW.running_hash_version,
+                            NEW.sequence_number,
+                            NEW.topic_num
+                 )
+        select pg_notify(topicmessage, row_to_json(payload)::text)
+        from payload
+    );
+    return null;
+end;
+$$;
+
+-- Setup trigger
+create trigger topic_message_trigger
+    after insert
+    on topic_message
+    for each row
+execute procedure topic_message_notifier('topic_message');
+commit;

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/TopicMessageTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/TopicMessageTest.java
@@ -1,0 +1,62 @@
+package com.hedera.mirror.importer.domain;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import org.junit.jupiter.api.Test;
+
+public class TopicMessageTest {
+
+    // Test serialization to JSON to verify contract with PostgreSQL listen/notify
+    @Test
+    void toJson() throws Exception {
+        TopicMessage topicMessage = new TopicMessage();
+        topicMessage.setChunkNum(1);
+        topicMessage.setChunkTotal(2);
+        topicMessage.setConsensusTimestamp(1594401417000000000L);
+        topicMessage.setMessage(new byte[] {1, 2, 3});
+        topicMessage.setPayerAccountId(EntityId.of("0.1.1000", EntityTypeEnum.ACCOUNT));
+        topicMessage.setRealmNum(0);
+        topicMessage.setRunningHash(new byte[] {4, 5, 6});
+        topicMessage.setRunningHashVersion(2);
+        topicMessage.setSequenceNumber(1L);
+        topicMessage.setTopicNum(1001);
+        topicMessage.setValidStartTimestamp(1594401416000000000L);
+
+        ObjectMapper objectMapper = new ObjectMapper().setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
+        String json = objectMapper.writeValueAsString(topicMessage);
+        assertThat(json).isEqualTo("{" +
+                "\"chunk_num\":1," +
+                "\"chunk_total\":2," +
+                "\"consensus_timestamp\":1594401417000000000," +
+                "\"message\":\"AQID\"," +
+                "\"payer_account_id\":4294968296," +
+                "\"realm_num\":0," +
+                "\"running_hash\":\"BAUG\"," +
+                "\"running_hash_version\":2," +
+                "\"sequence_number\":1," +
+                "\"topic_num\":1001," +
+                "\"valid_start_timestamp\":1594401416000000000}");
+    }
+}

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListenerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListenerTest.java
@@ -44,6 +44,7 @@ import com.hedera.mirror.importer.IntegrationTest;
 import com.hedera.mirror.importer.domain.ContractResult;
 import com.hedera.mirror.importer.domain.CryptoTransfer;
 import com.hedera.mirror.importer.domain.EntityId;
+import com.hedera.mirror.importer.domain.EntityTypeEnum;
 import com.hedera.mirror.importer.domain.FileData;
 import com.hedera.mirror.importer.domain.LiveHash;
 import com.hedera.mirror.importer.domain.NonFeeTransfer;
@@ -147,18 +148,26 @@ public class SqlEntityListenerTest extends IntegrationTest {
     @Test
     void onTopicMessage() throws Exception {
         // given
-        byte[] message = Strings.toByteArray("test message");
-        byte[] runningHash = Strings.toByteArray("running hash");
-        TopicMessage expectedTopicMessage = new TopicMessage(1L, message, 0, runningHash,
-                10L, 1001, 1, 2, 3, EntityId.of(0L, 0L, 3L, ACCOUNT), 4L);
+        TopicMessage topicMessage = new TopicMessage();
+        topicMessage.setChunkNum(1);
+        topicMessage.setChunkTotal(2);
+        topicMessage.setConsensusTimestamp(1L);
+        topicMessage.setMessage(Strings.toByteArray("test message"));
+        topicMessage.setPayerAccountId(EntityId.of("0.1.1000", EntityTypeEnum.ACCOUNT));
+        topicMessage.setRealmNum(0);
+        topicMessage.setRunningHash(Strings.toByteArray("running hash"));
+        topicMessage.setRunningHashVersion(2);
+        topicMessage.setSequenceNumber(1L);
+        topicMessage.setTopicNum(1001);
+        topicMessage.setValidStartTimestamp(4L);
 
         // when
-        sqlEntityListener.onTopicMessage(expectedTopicMessage);
+        sqlEntityListener.onTopicMessage(topicMessage);
         completeFileAndCommit();
 
         // then
         assertEquals(1, topicMessageRepository.count());
-        assertExistsAndEquals(topicMessageRepository, expectedTopicMessage, 1L);
+        assertExistsAndEquals(topicMessageRepository, topicMessage, 1L);
     }
 
     @Test


### PR DESCRIPTION
**Detailed description**:
- Add a `NotifyingTopicListener` that uses PostgreSQL listen/notify and set as default
- Change `hedera.mirror.grpc.listener.pollingFrequency` to `hedera.mirror.grpc.listener.frequency` so it can be used by all listener types
- Change `hedera.mirror.grpc.listener.frequency` to 500ms for notify error retry
- Change `hedera.mirror.grpc.listener.maxPageSize` to 5000 to improve latency with polling types

**Which issue(s) this PR fixes**:
Fixes #859 

**Special notes for your reviewer**:

**Checklist**
- [x] Documentation added
- [x] Tests updated
