### PR TITLE
Fix NPE parsing chunk payer account

### DIFF
--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/domain/TopicMessage.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/domain/TopicMessage.java
@@ -116,22 +116,25 @@ public class TopicMessage implements Comparable<TopicMessage>, Persistable<Long>
                     .setSequenceNumber(sequenceNumber);
 
             if (getChunkNum() != null) {
-                consensusTopicResponseBuilder
-                        .setChunkInfo(ConsensusMessageChunkInfo.newBuilder()
-                                .setInitialTransactionID(TransactionID.newBuilder()
-                                        .setAccountID(AccountID.newBuilder()
-                                                .setShardNum(getPayerAccountEntity().getEntityShard())
-                                                .setRealmNum(getPayerAccountEntity().getEntityRealm())
-                                                .setAccountNum(getPayerAccountEntity().getEntityNum())
-                                                .build())
-                                        .setTransactionValidStart(Timestamp.newBuilder()
-                                                .setSeconds(getValidStartInstant().getEpochSecond())
-                                                .setNanos(getValidStartInstant().getNano())
-                                                .build())
-                                        .build())
-                                .setNumber(getChunkNum())
-                                .setTotal(getChunkTotal())
-                                .build());
+                ConsensusMessageChunkInfo.Builder chunkBuilder = ConsensusMessageChunkInfo.newBuilder()
+                        .setNumber(getChunkNum())
+                        .setTotal(getChunkTotal());
+
+                if (getPayerAccountEntity() != null && getValidStartTimestamp() != null) {
+                    chunkBuilder.setInitialTransactionID(TransactionID.newBuilder()
+                            .setAccountID(AccountID.newBuilder()
+                                    .setShardNum(getPayerAccountEntity().getEntityShard())
+                                    .setRealmNum(getPayerAccountEntity().getEntityRealm())
+                                    .setAccountNum(getPayerAccountEntity().getEntityNum())
+                                    .build())
+                            .setTransactionValidStart(Timestamp.newBuilder()
+                                    .setSeconds(getValidStartInstant().getEpochSecond())
+                                    .setNanos(getValidStartInstant().getNano())
+                                    .build())
+                            .build());
+                }
+
+                consensusTopicResponseBuilder.setChunkInfo(chunkBuilder.build());
             }
 
             response.set(consensusTopicResponseBuilder.build());

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListener.java
@@ -307,15 +307,18 @@ public class SqlEntityListener implements EntityListener, RecordStreamFileListen
             if (topicMessage.getChunkNum() != null) {
                 sqlInsertTopicMessage.setInt(F_TOPICMESSAGE.CHUNK_NUM.ordinal(), topicMessage.getChunkNum());
                 sqlInsertTopicMessage.setInt(F_TOPICMESSAGE.CHUNK_TOTAL.ordinal(), topicMessage.getChunkTotal());
-                sqlInsertTopicMessage
-                        .setLong(F_TOPICMESSAGE.PAYER_ACCOUNT_ID.ordinal(), topicMessage.getPayerAccountId().getId());
+                if (topicMessage.getPayerAccountId() != null) {
+                    sqlInsertTopicMessage.setLong(F_TOPICMESSAGE.PAYER_ACCOUNT_ID.ordinal(),
+                            topicMessage.getPayerAccountId().getId());
+                } else {
+                    sqlInsertTopicMessage.setObject(F_TOPICMESSAGE.PAYER_ACCOUNT_ID.ordinal(), null);
+                }
                 sqlInsertTopicMessage
                         .setLong(F_TOPICMESSAGE.VALID_START_TIMESTAMP.ordinal(), topicMessage.getValidStartTimestamp());
             } else {
                 sqlInsertTopicMessage.setNull(F_TOPICMESSAGE.CHUNK_NUM.ordinal(), Types.SMALLINT);
                 sqlInsertTopicMessage.setNull(F_TOPICMESSAGE.CHUNK_TOTAL.ordinal(), Types.SMALLINT);
-                sqlInsertTopicMessage
-                        .setObject(F_TOPICMESSAGE.PAYER_ACCOUNT_ID.ordinal(), null);
+                sqlInsertTopicMessage.setObject(F_TOPICMESSAGE.PAYER_ACCOUNT_ID.ordinal(), null);
                 sqlInsertTopicMessage.setNull(F_TOPICMESSAGE.VALID_START_TIMESTAMP.ordinal(), Types.BIGINT);
             }
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/TestUtils.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/TestUtils.java
@@ -20,13 +20,13 @@ package com.hedera.mirror.importer;
  * ‍
  */
 
-import com.hedera.mirror.importer.util.Utility;
-
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TransactionID;
 import java.time.Instant;
+
+import com.hedera.mirror.importer.util.Utility;
 
 public final class TestUtils {
     public static AccountID toAccountId(String accountId) {
@@ -41,7 +41,10 @@ public final class TestUtils {
                 .setTransactionValidStart(toTimestamp(Long.valueOf(parts[1]))).build();
     }
 
-    public static Timestamp toTimestamp(long nanosecondsSinceEpoch) {
+    public static Timestamp toTimestamp(Long nanosecondsSinceEpoch) {
+        if (nanosecondsSinceEpoch == null) {
+            return null;
+        }
         return Utility.instantToTimestamp(Instant.ofEpochSecond(0, nanosecondsSinceEpoch));
     }
 


### PR DESCRIPTION
**Detailed description**:
Fixes NPE parsing chunk payer account:
```
Jul 16 04:19:33 mirrornode-dev-1 java[23423]: 2020-07-16 04:19:33,901 ERROR [scheduling-2] c.h.m.i.p.r.RecordFileParser Error parsing file /var/lib/hedera-mirror-importer/recordstreams/valid/2020-07-16T03_14_15.175281Z.rcd
Jul 16 04:19:33 mirrornode-dev-1 java[23423]: java.lang.IllegalArgumentException: Error parsing bad record file 2020-07-16T03_14_15.175281Z.rcd
Jul 16 04:19:33 mirrornode-dev-1 java[23423]:         at com.hedera.mirror.importer.util.Utility.parseRecordFile(Utility.java:220) ~[classes!/:0.15.1]
Jul 16 04:19:33 mirrornode-dev-1 java[23423]:         at com.hedera.mirror.importer.parser.record.RecordFileParser.loadRecordFile(RecordFileParser.java:150) ~[classes!/:0.15.1]
Jul 16 04:19:33 mirrornode-dev-1 java[23423]:         at com.hedera.mirror.importer.parser.record.RecordFileParser.loadRecordFiles(RecordFileParser.java:206) ~[classes!/:0.15.1]
Jul 16 04:19:33 mirrornode-dev-1 java[23423]:         at com.hedera.mirror.importer.parser.record.RecordFileParser.parse(RecordFileParser.java:261) ~[classes!/:0.15.1]
Jul 16 04:19:33 mirrornode-dev-1 java[23423]:         at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
Jul 16 04:19:33 mirrornode-dev-1 java[23423]:         at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:?]
Jul 16 04:19:33 mirrornode-dev-1 java[23423]:         at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
Jul 16 04:19:33 mirrornode-dev-1 java[23423]:         at java.lang.reflect.Method.invoke(Method.java:566) ~[?:?]
Jul 16 04:19:33 mirrornode-dev-1 java[23423]:         at org.springframework.scheduling.support.ScheduledMethodRunnable.run(ScheduledMethodRunnable.java:84) ~[spring-context-5.2.6.RELEASE.jar!/:5.2.6.RELEASE]
Jul 16 04:19:33 mirrornode-dev-1 java[23423]:         at org.springframework.scheduling.support.DelegatingErrorHandlingRunnable.run(DelegatingErrorHandlingRunnable.java:54) ~[spring-context-5.2.6.RELEASE.jar!/:5.2.6.RELEASE]
Jul 16 04:19:33 mirrornode-dev-1 java[23423]:         at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) ~[?:?]
Jul 16 04:19:33 mirrornode-dev-1 java[23423]:         at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305) ~[?:?]
Jul 16 04:19:33 mirrornode-dev-1 java[23423]:         at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305) ~[?:?]
Jul 16 04:19:33 mirrornode-dev-1 java[23423]:         at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?]
Jul 16 04:19:33 mirrornode-dev-1 java[23423]:         at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[?:?]
Jul 16 04:19:33 mirrornode-dev-1 java[23423]:         at java.lang.Thread.run(Thread.java:834) [?:?]
Jul 16 04:19:33 mirrornode-dev-1 java[23423]: Caused by: java.lang.NullPointerException
Jul 16 04:19:33 mirrornode-dev-1 java[23423]:         at com.hedera.mirror.importer.parser.record.entity.sql.SqlEntityListener.onTopicMessage(SqlEntityListener.java:311) ~[classes!/:0.15.1]
Jul 16 04:19:33 mirrornode-dev-1 java[23423]:         at com.hedera.mirror.importer.parser.record.entity.EntityRecordItemListener.insertConsensusTopicMessage(EntityRecordItemListener.java:251) ~[classes!/:0.15.1]
Jul 16 04:19:33 mirrornode-dev-1 java[23423]:         at com.hedera.mirror.importer.parser.record.entity.EntityRecordItemListener.onItem(EntityRecordItemListener.java:155) ~[classes!/:0.15.1]
Jul 16 04:19:33 mirrornode-dev-1 java[23423]:         at com.hedera.mirror.importer.parser.record.entity.EntityRecordItemListener.onItem(EntityRecordItemListener.java:63) ~[classes!/:0.15.1]
Jul 16 04:19:33 mirrornode-dev-1 java[23423]:         at com.hedera.mirror.importer.parser.record.RecordFileParser.processRecordItem(RecordFileParser.java:181) ~[classes!/:0.15.1]
Jul 16 04:19:33 mirrornode-dev-1 java[23423]:         at com.hedera.mirror.importer.parser.record.RecordFileParser.lambda$loadRecordFile$0(RecordFileParser.java:155) ~[classes!/:0.15.1]
Jul 16 04:19:33 mirrornode-dev-1 java[23423]:         at com.hedera.mirror.importer.util.Utility.parseRecordFile(Utility.java:193) ~[classes!/:0.15.1]
Jul 16 04:19:33 mirrornode-dev-1 java[23423]:         ... 15 more
```

- Adds a test to validate fix for both null account and out of range valid start timestamp

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated

