### PR TITLE
Recover from account balance files with different timestamps

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-The three components of the Hedera Mirror Node, Importer, REST API and GRPC API, all support loading configuration
+The three components of the Hedera Mirror Node, Importer, REST API and gRPC API, all support loading configuration
 from an `application.yml` file or via the environment.
 
 Most configuration settings have appropriate defaults and can be left unchanged. One of the important settings that
@@ -10,7 +10,7 @@ Additionally, the password properties have a default, but it is recommended they
 ## Importer
 
 The Importer component uses [Spring Boot](https://spring.io/projects/spring-boot) properties to configure the application.
-As as a result, propertiy files, YAML files, environment variables and command-line arguments can all be use to configure
+As a result, property files, YAML files, environment variables and command-line arguments can all be used to configure
 the application. See the Spring Boot [documentation](https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config)
 for the location and order it loads configuration.
 
@@ -29,23 +29,26 @@ value, it is recommended to only populate overridden properties in the custom `a
 | `hedera.mirror.importer.db.username`                                 | mirror_node             | The username the processor uses to connect to the database                                     |
 | `hedera.mirror.importer.downloader.accessKey`                        | ""                      | The cloud storage access key                                                                   |
 | `hedera.mirror.importer.downloader.balance.batchSize`                | 15                      | The number of signature files to download per node before downloading the signed files         |
+| `hedera.mirror.importer.downloader.balance.closeInterval`            | 15m                     | The expected interval between balance files                                                    |
 | `hedera.mirror.importer.downloader.balance.enabled`                  | true                    | Whether to enable balance file downloads                                                       |
 | `hedera.mirror.importer.downloader.balance.frequency`                | 30s                     | The fixed period between invocations. Can accept duration units like `10s`, `2m` etc.          |
 | `hedera.mirror.importer.downloader.balance.keepSignatures`           | false                   | Whether to keep balance signature files after successful verification. If false, files are deleted. |
 | `hedera.mirror.importer.downloader.balance.prefix`                   | accountBalances/balance | The prefix to search cloud storage for balance files                                           |
 | `hedera.mirror.importer.downloader.balance.threads`                  | 13                      | The number of threads to search for new files to download                                      |
 | `hedera.mirror.importer.downloader.bucketName`                       |                         | The cloud storage bucket name to download streamed files. This value takes priority over network hardcoded bucket names regardless of `hedera.mirror.importer.network` value.|
-| `hedera.mirror.importer.downloader.cloudProvider`                    | S3                      | The cloud provider to download files from. Either `S3` or `GCP`                       |
+| `hedera.mirror.importer.downloader.cloudProvider`                    | S3                      | The cloud provider to download files from. Either `S3` or `GCP`                                |
 | `hedera.mirror.importer.downloader.endpointOverride`                 |                         | Can be specified to download streams from a source other than S3 and GCP. Should be S3 compatible |
 | `hedera.mirror.importer.downloader.event.batchSize`                  | 100                     | The number of signature files to download per node before downloading the signed files         |
+| `hedera.mirror.importer.downloader.event.closeInterval`              | 5s                      | The expected interval between event files                                                      |
 | `hedera.mirror.importer.downloader.event.enabled`                    | false                   | Whether to enable event file downloads                                                         |
-| `hedera.mirror.importer.downloader.event.frequency`                  | 5s                      | The fixed period between invocations. Can accept duration units like `10s`, `2m` etc.        |
+| `hedera.mirror.importer.downloader.event.frequency`                  | 5s                      | The fixed period between invocations. Can accept duration units like `10s`, `2m` etc.          |
 | `hedera.mirror.importer.downloader.event.keepSignatures`             | false                   | Whether to keep event signature files after successful verification. If false, files are deleted. |
 | `hedera.mirror.importer.downloader.event.prefix`                     | eventsStreams/events\_  | The prefix to search cloud storage for event files                                             |
-| `hedera.mirror.importer.downloader.event.threads`                    | 13                      | The number of threads to search for new files to download
+| `hedera.mirror.importer.downloader.event.threads`                    | 13                      | The number of threads to search for new files to download                                      |
 | `hedera.mirror.importer.downloader.gcpProjectId`                     |                         | GCP project id to bill for requests to GCS bucket which has Requester Pays enabled.            |
 | `hedera.mirror.importer.downloader.maxConcurrency`                   | 1000                    | The maximum number of allowed open HTTP connections. Used by AWS SDK directly.                 |
 | `hedera.mirror.importer.downloader.record.batchSize`                 | 40                      | The number of signature files to download per node before downloading the signed files         |
+| `hedera.mirror.importer.downloader.record.closeInterval`             | 2s                      | The expected interval between record files                                                     |
 | `hedera.mirror.importer.downloader.record.enabled`                   | true                    | Whether to enable record file downloads                                                        |
 | `hedera.mirror.importer.downloader.record.frequency`                 | 500ms                   | The fixed period between invocations. Can accept duration units like `10s`, `2m` etc.          |
 | `hedera.mirror.importer.downloader.record.keepSignatures`            | false                   | Whether to keep record signature files after successful verification. If false, files are deleted. |
@@ -97,7 +100,7 @@ for more info about `spring.cloud.gcp.*` properties.
 
 ## GRPC API
 
-Similar to the [Importer](#importer), the GRPC API uses [Spring Boot](https://spring.io/projects/spring-boot) properties to configure the application.
+Similar to the [Importer](#importer), the gRPC API uses [Spring Boot](https://spring.io/projects/spring-boot) properties to configure the application.
 
 The following table lists the available properties along with their default values. Unless you need to set a non-default
 value, it is recommended to only populate overridden properties in the custom `application.yml`.
@@ -133,7 +136,7 @@ value, it is recommended to only populate overridden properties in the custom `a
 
 ## REST API
 
-The REST API supports loading configuration from YAML or environment variables. By default it loads a file named
+The REST API supports loading configuration from YAML or environment variables. By default, it loads a file named
 `application.yml` or `application.yaml` in each of the search paths (see below). The file name can be changed by setting
 the `CONFIG_NAME` environment variable. A custom location can be loaded by setting the `CONFIG_PATH` environment variable.
 The configuration is loaded in the following order with the latter configuration overwriting (technically recursively

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/FileStreamSignature.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/FileStreamSignature.java
@@ -22,10 +22,12 @@ package com.hedera.mirror.importer.domain;
 
 import java.io.File;
 import lombok.Data;
+import lombok.ToString;
 
 import com.hedera.mirror.importer.util.Utility;
 
 @Data
+@ToString(exclude = {"hash", "signature"})
 public class FileStreamSignature implements Comparable<FileStreamSignature> {
 
     private File file;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamType.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamType.java
@@ -27,16 +27,24 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum StreamType {
 
-    BALANCE("accountBalances"),
-    RECORD("recordstreams"),
-    EVENT("eventsStreams");
+    BALANCE("accountBalances", "balance", "_Balances", ".csv"),
+    EVENT("eventsStreams", "events_", "", ".evts"),
+    RECORD("recordstreams", "record", "", ".rcd");
 
     private static final String PARSED = "parsed";
     private static final String SIGNATURES = "signatures";
     private static final String TEMP = "tmp";
     private static final String VALID = "valid";
+    private static final String SIGNATURE_EXTENSION = "_sig";
 
     private final String path;
+    private final String nodePrefix;
+    private final String suffix;
+    private final String extension;
+
+    public String getSignatureExtension() {
+        return extension + SIGNATURE_EXTENSION;
+    }
 
     public String getParsed() {
         return PARSED;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamType.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamType.java
@@ -22,14 +22,15 @@ package com.hedera.mirror.importer.domain;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.io.FilenameUtils;
 
 @Getter
 @RequiredArgsConstructor
 public enum StreamType {
 
-    BALANCE("accountBalances", "balance", "_Balances", ".csv"),
-    EVENT("eventsStreams", "events_", "", ".evts"),
-    RECORD("recordstreams", "record", "", ".rcd");
+    BALANCE("accountBalances", "balance", "_Balances", "csv"),
+    EVENT("eventsStreams", "events_", "", "evts"),
+    RECORD("recordstreams", "record", "", "rcd");
 
     private static final String PARSED = "parsed";
     private static final String SIGNATURES = "signatures";
@@ -60,5 +61,17 @@ public enum StreamType {
 
     public String getValid() {
         return VALID;
+    }
+
+    public static StreamType fromFilename(String filename) {
+        String extension = FilenameUtils.getExtension(filename);
+
+        for (StreamType streamType : values()) {
+            if (streamType.getExtension().equals(extension) || streamType.getSignatureExtension().equals(extension)) {
+                return streamType;
+            }
+        }
+
+        return null;
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/Downloader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/Downloader.java
@@ -86,6 +86,7 @@ public abstract class Downloader {
     private final Counter.Builder signatureVerificationMetric;
     private final Timer.Builder streamVerificationMetric;
     protected final Timer downloadLatencyMetric;
+    protected final Timer streamCloseMetric;
 
     public Downloader(S3AsyncClient s3Client, ApplicationStatusRepository applicationStatusRepository,
                       NetworkAddressBook networkAddressBook, DownloaderProperties downloaderProperties,
@@ -97,7 +98,10 @@ public abstract class Downloader {
         this.meterRegistry = meterRegistry;
         signatureDownloadThreadPool = Executors.newFixedThreadPool(downloaderProperties.getThreads());
         Runtime.getRuntime().addShutdownHook(new Thread(signatureDownloadThreadPool::shutdown));
+        commonDownloaderProperties = downloaderProperties.getCommon();
+        mirrorProperties = downloaderProperties.getMirrorProperties();
 
+        // Metrics
         signatureVerificationMetric = Counter.builder("hedera.mirror.download.signature.verification")
                 .description("The number of signatures verified from a particular node")
                 .tag("type", downloaderProperties.getStreamType().toString());
@@ -112,8 +116,11 @@ public abstract class Downloader {
                 .tag("type", downloaderProperties.getStreamType().toString())
                 .register(meterRegistry);
 
-        commonDownloaderProperties = downloaderProperties.getCommon();
-        mirrorProperties = downloaderProperties.getMirrorProperties();
+        streamCloseMetric = Timer.builder("hedera.mirror.stream.close.latency")
+                .description("The difference between the consensus time of the last and first transaction in the " +
+                        "stream file")
+                .tag("type", downloaderProperties.getStreamType().toString())
+                .register(meterRegistry);
     }
 
     protected void downloadNextBatch() {
@@ -143,26 +150,27 @@ public abstract class Downloader {
     }
 
     /**
-     * Download all sig files (*.rcd_sig for records, *_Balances.csv_sig for balances) with timestamp later than
-     * lastValid<Type>FileName Validate each file with corresponding node's PubKey. Put valid files into HashMap<String,
-     * List<File>>
+     * Download all signature files with a timestamp later than the last valid file. Put signature files into a
+     * multi-map sorted and grouped by the expected closing interval.
      *
-     * @return key: sig file name value: a list of sig files with the same name and from different nodes folder;
+     * @return a multi-map of expected close interval to signature file objects from different nodes
      */
-    private Multimap<String, FileStreamSignature> downloadSigFiles() throws InterruptedException {
+    private Multimap<Long, FileStreamSignature> downloadSigFiles() throws InterruptedException {
         String lastValidFileName = applicationStatusRepository.findByStatusCode(getLastValidDownloadedFileKey());
         // foo.rcd < foo.rcd_sig. If we read foo.rcd from application stats, we have to start listing from
         // next to 'foo.rcd_sig'.
         String lastValidSigFileName = lastValidFileName.isEmpty() ? "" : lastValidFileName + "_sig";
-        Multimap<String, FileStreamSignature> sigFilesMap = Multimaps
+        Multimap<Long, FileStreamSignature> sigFilesMap = Multimaps
                 .synchronizedSortedSetMultimap(TreeMultimap.create());
-
         Set<String> nodeAccountIds = networkAddressBook.getAddresses()
                 .stream()
                 .map(NodeAddress::getId)
                 .collect(Collectors.toSet());
         List<Callable<Object>> tasks = new ArrayList<>(nodeAccountIds.size());
         var totalDownloads = new AtomicInteger();
+        long closeInterval = downloaderProperties.getCloseInterval().toNanos();
+        long lastValidTimestamp = Utility.getTimestampFromFilename(lastValidFileName);
+        log.info("Downloading signature files created after file: {}", lastValidSigFileName);
 
         /**
          * For each node, create a thread that will make S3 ListObject requests as many times as necessary to
@@ -170,8 +178,6 @@ public abstract class Downloader {
          */
         for (String nodeAccountId : nodeAccountIds) {
             tasks.add(Executors.callable(() -> {
-                log.debug("Downloading signature files for node {} created after file {}", nodeAccountId,
-                        lastValidSigFileName);
                 Stopwatch stopwatch = Stopwatch.createStarted();
                 // Get a list of objects in the bucket, 100 at a time
                 String s3Prefix = downloaderProperties.getPrefix() + nodeAccountId + "/";
@@ -192,10 +198,8 @@ public abstract class Downloader {
                             .build();
                     CompletableFuture<ListObjectsResponse> response = s3Client.listObjects(listRequest);
                     Collection<PendingDownload> pendingDownloads = new ArrayList<>(downloaderProperties.getBatchSize());
+
                     // Loop through the list of remote files beginning a download for each relevant sig file
-                    // Note:
-                    // lastValidSigFileName specified as marker above is not returned in these results by AWS S3.
-                    // However, it is returned by mockS3 implementation we use in our tests.
                     for (S3Object content : response.get().contents()) {
                         String s3ObjectKey = content.key();
                         if (s3ObjectKey.endsWith("_sig")) {
@@ -211,18 +215,36 @@ public abstract class Downloader {
                      * of downloaded signature files.
                      */
                     AtomicLong count = new AtomicLong();
-                    pendingDownloads.forEach((pd) -> {
+                    pendingDownloads.forEach(pendingDownload -> {
                         try {
-                            if (pd.waitForCompletion()) {
+                            if (pendingDownload.waitForCompletion()) {
                                 count.incrementAndGet();
-                                File sigFile = pd.getFile();
+                                File sigFile = pendingDownload.getFile();
                                 FileStreamSignature fileStreamSignature = new FileStreamSignature();
                                 fileStreamSignature.setFile(sigFile);
                                 fileStreamSignature.setNode(nodeAccountId);
-                                sigFilesMap.put(sigFile.getName(), fileStreamSignature);
+                                long currentTimestamp = Utility.getTimestampFromFilename(sigFile.getName());
+
+                                // Initial file has no previous so we can't calculate offset from that
+                                if (lastValidTimestamp <= 0) {
+                                    sigFilesMap.put(currentTimestamp, fileStreamSignature);
+                                } else {
+                                    double interval = (double) (currentTimestamp - lastValidTimestamp);
+                                    long bucket = Math.round(interval / closeInterval);
+                                    long groupTimestamp = lastValidTimestamp + bucket * closeInterval +
+                                            closeInterval / 2;
+
+                                    if (bucket > 0) {
+                                        sigFilesMap.put(groupTimestamp, fileStreamSignature);
+                                    } else {
+                                        log.warn("Ignoring signature file {} from node {} associated with the " +
+                                                "previous close interval", sigFile.getName(), nodeAccountId);
+                                    }
+                                }
                             }
                         } catch (InterruptedException ex) {
-                            log.warn("Failed downloading {} in {}", pd.getS3key(), pd.getStopwatch(), ex);
+                            log.warn("Failed downloading {} in {}", pendingDownload.getS3key(),
+                                    pendingDownload.getStopwatch(), ex);
                         }
                     });
                     if (count.get() > 0) {
@@ -269,11 +291,13 @@ public abstract class Downloader {
                         file);
             }
         }
-        var future = s3Client.getObject(
-                GetObjectRequest.builder().bucket(commonDownloaderProperties.getBucketName()).key(s3ObjectKey)
-                        .requestPayer(RequestPayer.REQUESTER)
-                        .build(),
-                AsyncResponseTransformer.toFile(file));
+
+        var request = GetObjectRequest.builder()
+                .bucket(commonDownloaderProperties.getBucketName())
+                .key(s3ObjectKey)
+                .requestPayer(RequestPayer.REQUESTER)
+                .build();
+        var future = s3Client.getObject(request, AsyncResponseTransformer.toFile(localFile));
         return new PendingDownload(future, file, s3ObjectKey);
     }
 
@@ -314,18 +338,17 @@ public abstract class Downloader {
      * the data file into `valid` directory; else download the data file from other valid node folder and compare the
      * hash until we find a match.
      */
-    private void verifySigsAndDownloadDataFiles(Multimap<String, FileStreamSignature> sigFilesMap) {
-        // reload address book and keys in case it has been updated by RecordItemParser
+    private void verifySigsAndDownloadDataFiles(Multimap<Long, FileStreamSignature> sigFilesMap) {
         NodeSignatureVerifier nodeSignatureVerifier = new NodeSignatureVerifier(networkAddressBook);
         Path validPath = downloaderProperties.getValidPath();
 
-        for (String sigFileName : sigFilesMap.keySet()) {
+        for (Long groupId : sigFilesMap.keySet()) {
             if (ShutdownHelper.isStopping()) {
                 return;
             }
 
             Instant startTime = Instant.now();
-            Collection<FileStreamSignature> signatures = sigFilesMap.get(sigFileName);
+            Collection<FileStreamSignature> signatures = sigFilesMap.get(groupId);
             boolean valid = false;
 
             try {
@@ -377,12 +400,12 @@ public abstract class Downloader {
                     }
                 } catch (Exception e) {
                     log.error("Error downloading data file from node {} corresponding to {}. Will retry another node",
-                            signature.getNode(), sigFileName, e);
+                            signature.getNode(), signature.getFile().getName(), e);
                 }
             }
 
             if (!valid) {
-                log.error("File could not be verified by at least 1/3 of nodes: {}", sigFileName);
+                log.error("File could not be verified by at least 1/3 of nodes: {}", signatures);
             }
 
             streamVerificationMetric.tag("success", String.valueOf(valid))

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/DownloaderProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/DownloaderProperties.java
@@ -21,6 +21,7 @@ package com.hedera.mirror.importer.downloader;
  */
 
 import java.nio.file.Path;
+import java.time.Duration;
 import javax.annotation.PostConstruct;
 
 import com.hedera.mirror.importer.MirrorProperties;
@@ -30,6 +31,10 @@ import com.hedera.mirror.importer.util.Utility;
 public interface DownloaderProperties {
 
     int getBatchSize();
+
+    Duration getCloseInterval();
+
+    void setCloseInterval(Duration closeInterval);
 
     CommonDownloaderProperties getCommon();
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/NodeSignatureVerifier.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/NodeSignatureVerifier.java
@@ -23,6 +23,7 @@ package com.hedera.mirror.importer.downloader;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
+import com.google.common.collect.TreeMultimap;
 import java.security.PublicKey;
 import java.security.Signature;
 import java.util.Collection;
@@ -58,16 +59,45 @@ public class NodeSignatureVerifier {
 
     /**
      * Verifies that the signature files are signed by corresponding node's PublicKey. For valid signature files, we
-     * compare their hashes to see if at least 1/3 hashes match. If a signature is valid, we put the hash in its content
-     * and its file to the map, to see if at least 1/3 valid signatures have the same hash.
+     * compare their hashes to see if at least 1/3 with the same filename have hashes that match. If a signature is
+     * valid, we put the hash in its content and its file to the map, to see if at least 1/3 valid signatures have the
+     * same hash.
      *
      * @param signatures a list of a sig files which have the same timestamp
      * @throws SignatureVerificationException
      */
     public void verify(Collection<FileStreamSignature> signatures) throws SignatureVerificationException {
+        Multimap<String, FileStreamSignature> signaturesByName = TreeMultimap.create();
+        signatures.forEach(s -> signaturesByName.put(s.getFile().getName(), s));
+        Collection<String> filenames = signaturesByName.keySet();
+
+        if (filenames.size() > 1) {
+            log.warn("Found {} unique filenames for stream interval: {}", filenames.size(), signatures);
+        }
+
+        for (String filename : filenames) {
+            if (verifyFileGroup(signaturesByName.get(filename))) {
+                return;
+            }
+        }
+
+        throw new SignatureVerificationException("Signature verification failed for files " + filenames + ": " + statusMap(signatures));
+    }
+
+    /**
+     * Since balance files can occasionally generate a file with a different timestamp from different nodes or a rogue
+     * node can send a bad filename, we group files into time buckets then within that bucket check if a particular
+     * filename reaches consensus.
+     *
+     * @param signatures grouped by filename
+     * @return whether this file was verified
+     * @throws SignatureVerificationException
+     */
+    private boolean verifyFileGroup(Collection<FileStreamSignature> signatures) {
         Multimap<String, FileStreamSignature> signatureHashMap = HashMultimap.create();
         String filename = null;
         int consensusCount = 0;
+        boolean verified = false;
 
         for (FileStreamSignature fileStreamSignature : signatures) {
             if (filename == null) {
@@ -100,12 +130,14 @@ public class NodeSignatureVerifier {
 
         if (consensusCount == nodeIDPubKeyMap.size()) {
             log.debug("Verified signature file {} reached consensus", filename);
+            verified = true;
         } else if (consensusCount > 0) {
             log.warn("Verified signature file {} reached consensus but with some errors: {}", filename,
                     statusMap(signatures));
-        } else {
-            throw new SignatureVerificationException("Signature verification failed for " + filename + ": " + statusMap(signatures));
+            verified = true;
         }
+
+        return verified;
     }
 
     /**

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/balance/BalanceDownloaderProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/balance/BalanceDownloaderProperties.java
@@ -46,6 +46,9 @@ public class BalanceDownloaderProperties implements DownloaderProperties {
     @Min(1)
     private int batchSize = 15;
 
+    @NotNull
+    private Duration closeInterval = Duration.ofMinutes(15L);
+
     private boolean enabled = true;
 
     @NotNull

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/event/EventDownloaderProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/event/EventDownloaderProperties.java
@@ -46,6 +46,9 @@ public class EventDownloaderProperties implements DownloaderProperties {
     @Min(1)
     private int batchSize = 100;
 
+    @NotNull
+    private Duration closeInterval = Duration.ofSeconds(5L);
+
     private boolean enabled = false;
 
     @NotNull

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/record/RecordDownloaderProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/record/RecordDownloaderProperties.java
@@ -46,6 +46,9 @@ public class RecordDownloaderProperties implements DownloaderProperties {
     @Min(1)
     private int batchSize = 40;
 
+    @NotNull
+    private Duration closeInterval = Duration.ofSeconds(2L);
+
     private boolean enabled = true;
 
     @NotNull

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/record/RecordFileDownloader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/record/RecordFileDownloader.java
@@ -21,7 +21,6 @@ package com.hedera.mirror.importer.downloader.record;
  */
 
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Timer;
 import java.io.File;
 import java.time.Duration;
 import java.time.Instant;
@@ -45,19 +44,11 @@ import com.hedera.mirror.importer.util.Utility;
 @Named
 public class RecordFileDownloader extends Downloader {
 
-    private final Timer streamCloseMetric;
-
     public RecordFileDownloader(
             S3AsyncClient s3Client, ApplicationStatusRepository applicationStatusRepository,
             NetworkAddressBook networkAddressBook, RecordDownloaderProperties downloaderProperties,
             MeterRegistry meterRegistry) {
         super(s3Client, applicationStatusRepository, networkAddressBook, downloaderProperties, meterRegistry);
-
-        streamCloseMetric = Timer.builder("hedera.mirror.stream.close.latency")
-                .description("The difference between the consensus time of the last and first transaction in the " +
-                        "record file")
-                .tag("type", downloaderProperties.getStreamType().toString())
-                .register(meterRegistry);
     }
 
     @Leader

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/util/Utility.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/util/Utility.java
@@ -45,18 +45,20 @@ import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
+import lombok.experimental.UtilityClass;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.codec.binary.Hex;
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
 import com.hedera.mirror.importer.domain.RecordFile;
+import com.hedera.mirror.importer.domain.StreamType;
 import com.hedera.mirror.importer.exception.HashMismatchException;
 import com.hedera.mirror.importer.parser.domain.RecordItem;
 
 @Log4j2
+@UtilityClass
 public class Utility {
 
     private static final Long SCALAR = 1_000_000_000L;
@@ -127,12 +129,12 @@ public class Utility {
 
     /**
      * Parses record stream file.
-
-     * @param filePath path to record file
+     *
+     * @param filePath             path to record file
      * @param expectedPrevFileHash expected previous file's hash in current file. Throws {@link HashMismatchException}
      *                             on mismatch
-     * @param verifyHashAfter previous file's hash mismatch is ignored if file is from before this time
-     * @param recordItemConsumer if not null, consumer is invoked for each transaction in the record file
+     * @param verifyHashAfter      previous file's hash mismatch is ignored if file is from before this time
+     * @param recordItemConsumer   if not null, consumer is invoked for each transaction in the record file
      * @return parsed record file
      */
     public static RecordFile parseRecordFile(String filePath, String expectedPrevFileHash, Instant verifyHashAfter,
@@ -399,6 +401,17 @@ public class Utility {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public static final long getTimestampFromFilename(String filename) {
+        if (StringUtils.isBlank(filename)) {
+            return 0L;
+        }
+
+        String nameWithoutExtension = FilenameUtils.removeExtension(filename);
+        String date = StringUtils.removeEnd(nameWithoutExtension, StreamType.BALANCE.getSuffix()).replace('_', ':');
+        Instant instant = Instant.parse(date);
+        return Utility.convertToNanosMax(instant.getEpochSecond(), instant.getNano());
     }
 
     /**

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/util/Utility.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/util/Utility.java
@@ -408,8 +408,14 @@ public class Utility {
             return 0L;
         }
 
-        String nameWithoutExtension = FilenameUtils.removeExtension(filename);
-        String date = StringUtils.removeEnd(nameWithoutExtension, StreamType.BALANCE.getSuffix()).replace('_', ':');
+        StreamType streamType = StreamType.fromFilename(filename);
+        String date = FilenameUtils.removeExtension(filename);
+
+        if (streamType != null) {
+            date = StringUtils.removeEnd(date, streamType.getSuffix());
+        }
+
+        date = date.replace('_', ':');
         Instant instant = Instant.parse(date);
         return Utility.convertToNanosMax(instant.getEpochSecond(), instant.getNano());
     }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/AbstractLinkedStreamDownloaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/AbstractLinkedStreamDownloaderTest.java
@@ -36,7 +36,7 @@ public abstract class AbstractLinkedStreamDownloaderTest extends AbstractDownloa
     @Test
     @DisplayName("Doesn't match last valid hash")
     void hashMismatchWithPrevious() throws Exception {
-        doReturn("2019-01-01T01_00_00.000000Z" + downloaderProperties.getStreamType().getExtension())
+        doReturn("2019-01-01T01_00_00.000000Z." + downloaderProperties.getStreamType().getExtension())
                 .when(applicationStatusRepository)
                 .findByStatusCode(downloader.getLastValidDownloadedFileKey());
         doReturn("123").when(applicationStatusRepository)
@@ -49,7 +49,7 @@ public abstract class AbstractLinkedStreamDownloaderTest extends AbstractDownloa
     @Test
     @DisplayName("Bypass previous hash mismatch")
     void hashMismatchWithBypass() throws Exception {
-        doReturn("2019-01-01T14_12_00.000000Z" + downloaderProperties.getStreamType().getExtension())
+        doReturn("2019-01-01T14_12_00.000000Z." + downloaderProperties.getStreamType().getExtension())
                 .when(applicationStatusRepository)
                 .findByStatusCode(downloader.getLastValidDownloadedFileKey());
         doReturn("123").when(applicationStatusRepository)

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/AbstractLinkedStreamDownloaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/AbstractLinkedStreamDownloaderTest.java
@@ -33,12 +33,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 public abstract class AbstractLinkedStreamDownloaderTest extends AbstractDownloaderTest {
 
-    protected String fileExtension;
-
     @Test
     @DisplayName("Doesn't match last valid hash")
     void hashMismatchWithPrevious() throws Exception {
-        doReturn("2019-01-01T01:00:00.000000Z" + fileExtension).when(applicationStatusRepository)
+        doReturn("2019-01-01T01_00_00.000000Z" + downloaderProperties.getStreamType().getExtension())
+                .when(applicationStatusRepository)
                 .findByStatusCode(downloader.getLastValidDownloadedFileKey());
         doReturn("123").when(applicationStatusRepository)
                 .findByStatusCode(downloader.getLastValidDownloadedFileHashKey());
@@ -50,7 +49,8 @@ public abstract class AbstractLinkedStreamDownloaderTest extends AbstractDownloa
     @Test
     @DisplayName("Bypass previous hash mismatch")
     void hashMismatchWithBypass() throws Exception {
-        doReturn("2019-01-01T14:12:00.000000Z" + fileExtension).when(applicationStatusRepository)
+        doReturn("2019-01-01T14_12_00.000000Z" + downloaderProperties.getStreamType().getExtension())
+                .when(applicationStatusRepository)
                 .findByStatusCode(downloader.getLastValidDownloadedFileKey());
         doReturn("123").when(applicationStatusRepository)
                 .findByStatusCode(downloader.getLastValidDownloadedFileHashKey());

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/event/EventFileDownloaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/event/EventFileDownloaderTest.java
@@ -27,18 +27,18 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
-import com.hedera.mirror.importer.reader.event.EventFileReaderImpl;
 
 import com.hedera.mirror.importer.downloader.AbstractLinkedStreamDownloaderTest;
 import com.hedera.mirror.importer.downloader.Downloader;
 import com.hedera.mirror.importer.downloader.DownloaderProperties;
+import com.hedera.mirror.importer.reader.event.EventFileReaderImpl;
 
 @ExtendWith(MockitoExtension.class)
 public class EventFileDownloaderTest extends AbstractLinkedStreamDownloaderTest {
 
     @Override
     protected DownloaderProperties getDownloaderProperties() {
-        var eventDownloaderProperties =  new EventDownloaderProperties(mirrorProperties, commonDownloaderProperties);
+        var eventDownloaderProperties = new EventDownloaderProperties(mirrorProperties, commonDownloaderProperties);
         eventDownloaderProperties.setEnabled(true);
         return eventDownloaderProperties;
     }
@@ -65,6 +65,5 @@ public class EventFileDownloaderTest extends AbstractLinkedStreamDownloaderTest 
     void beforeEach() {
         file1 = "2020-04-11T00_12_00.025035Z.evts";
         file2 = "2020-04-11T00_12_05.059945Z.evts";
-        fileExtension = ".evts";
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/record/RecordFileDownloaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/record/RecordFileDownloaderTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.verify;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -66,7 +67,7 @@ public class RecordFileDownloaderTest extends AbstractLinkedStreamDownloaderTest
     void beforeEach() {
         file1 = "2019-08-30T18_10_00.419072Z.rcd";
         file2 = "2019-08-30T18_10_05.249678Z.rcd";
-        fileExtension = ".rcd";
+        downloaderProperties.setCloseInterval(Duration.ofSeconds(5)); // Test rcd files use older 5s interval
     }
 
     @Test

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/util/UtilityTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/util/UtilityTest.java
@@ -70,6 +70,20 @@ public class UtilityTest {
         assertThatThrownBy(() -> Utility.ensureDirectory(null)).isInstanceOf(IllegalArgumentException.class);
     }
 
+    @DisplayName("Get timestamp from filename")
+    @ParameterizedTest(name = "{0}")
+    @CsvSource({
+            ", 0",
+            "1970-01-01T00_00_00.0Z.rcd, 0",
+            "2020-06-03T16_45_00.000000001Z_Balances.csv_sig, 1591202700000000001",
+            "2020-06-03T16_45_00.1Z_Balances.csv, 1591202700100000000",
+            "2020-06-03T16:45:00.000000003Z_Balances.csv, 1591202700000000003",
+            "2262-04-11T23:47:16.854775808Z.evts_sig, 9223372036854775807",
+    })
+    void getTimestampFromFilename(String filename, long timestamp) {
+        assertThat(Utility.getTimestampFromFilename(filename)).isEqualTo(timestamp);
+    }
+
     @Test
     @DisplayName("Loads resource from classpath")
     void getResource() {
@@ -77,14 +91,10 @@ public class UtilityTest {
         assertThat(Utility.getResource("log4j2-test.xml")).exists().canRead();
     }
 
-    private Utility getCut() throws SQLException {
-        return new Utility();
-    }
-
     @Test
     @DisplayName("protobufKeyToHexIfEd25519OrNull null key")
     public void protobufKeyToHexIfEd25519OrNull_Null() throws InvalidProtocolBufferException, SQLException {
-        var result = getCut().protobufKeyToHexIfEd25519OrNull(null);
+        var result = Utility.protobufKeyToHexIfEd25519OrNull(null);
 
         assertThat(result).isNull();
     }
@@ -94,7 +104,7 @@ public class UtilityTest {
     public void protobufKeyToHexIfEd25519OrNull_Valid() throws Exception {
         var instr = "0011223344556677889900aabbccddeeff0011223344556677889900aabbccddeeff";
         var input = Key.newBuilder().setEd25519(ByteString.copyFrom(Hex.decodeHex(instr))).build();
-        var result = getCut().protobufKeyToHexIfEd25519OrNull(input.toByteArray());
+        var result = Utility.protobufKeyToHexIfEd25519OrNull(input.toByteArray());
 
         assertThat(result).isEqualTo(instr);
     }
@@ -108,7 +118,7 @@ public class UtilityTest {
         var tk = ThresholdKey.newBuilder().setThreshold(1).setKeys(keyList).build();
         var input = Key.newBuilder().setThresholdKey(tk).build();
 
-        var result = getCut().protobufKeyToHexIfEd25519OrNull(input.toByteArray());
+        var result = Utility.protobufKeyToHexIfEd25519OrNull(input.toByteArray());
 
         assertThat(result).isNull();
     }


### PR DESCRIPTION
**Detailed description**:
- Add `hedera.mirror.importer.downloader.(balance|event|record).closeInterval` for use in calculating expected buckets
- Move stream close metric to parent so it can be used later with events
- Change signature verification to group files into time buckets then group by filename within that bucket and ensure at least one file in bucket reaches 1/3 consensus

**Which issue(s) this PR fixes**:
Fixes #804 

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated

