### PR TITLE
Fix memory leak and deadlock in record parser

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -78,9 +78,9 @@ value, it is recommended to only populate overridden properties in the custom `a
 | `hedera.mirror.importer.parser.record.entity.persist.nonFeeTransfers`       | false                   | Persist non-fee transfers for transactions that explicitly request hbar transfers              |
 | `hedera.mirror.importer.parser.record.entity.persist.systemFiles`           | true                    | Persist only system files (number lower than `1000`) to the database                           |
 | `hedera.mirror.importer.parser.record.entity.persist.transactionBytes`      | false                   | Persist raw transaction bytes to the database                                                  |
-| `hedera.mirror.importer.parser.record.entity.sql.batchSize`                 | 100_000_000             | When inserting transactions into db, executeBatches() is called every these many transactions  |
+| `hedera.mirror.importer.parser.record.entity.sql.batchSize`                 | 20_000                  | When inserting transactions into db, executeBatches() is called every these many transactions  |
+| `hedera.mirror.importer.parser.record.entity.sql.bufferSize`                | 65536                   | The size of the byte buffer to allocate for each batch                                         |
 | `hedera.mirror.importer.parser.record.entity.sql.maxJsonPayloadSize`        | 8000                    | Max number of bytes for json payload used in pg_notify of db inserts                           |
-| `hedera.mirror.importer.parser.record.entity.sql.threads`                   | 10                      | Number of executor threads used by sql entity listener                                         |
 | `hedera.mirror.importer.parser.record.pubsub.topicName`                     |                         | Pubsub topic to publish transactions to                                                        |
 | `hedera.mirror.importer.parser.record.pubsub.maxSendAttempts`               | 5                       | Number of attempts when sending messages to PubSub (only for retryable errors)                 |
 | `hedera.mirror.importer.topicRunningHashV2AddedTimestamp`            | Network-based  | Unix timestamp (in nanos) of first topic message with v2 as running hash version. Use this config to override the default network based value |

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/domain/DomainDriver.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/domain/DomainDriver.java
@@ -76,7 +76,8 @@ public class DomainDriver implements ApplicationRunner {
         long currentSimulationTime = properties.getStartTimeSec();
         long totalDurationSec = properties.getTotalDuration().toSeconds();
         long endTime = currentSimulationTime + totalDurationSec;
-        log.info("Simulation time from {} to {} (time period: {}sec)", currentSimulationTime, endTime, totalDurationSec);
+        log.info("Simulation time from {} to {} (time period: {}sec)", currentSimulationTime, endTime,
+                totalDurationSec);
         int numTransactionsGenerated = 0;
         Stopwatch stopwatch = Stopwatch.createStarted();
         // Iterate from start time to end time.
@@ -104,7 +105,6 @@ public class DomainDriver implements ApplicationRunner {
         new EntityGenerator().generateAndWriteEntities(entityManager, domainWriter);
         log.info("Writing data to db");
         sqlEntityListener.onEnd(new RecordFile(0L, 1L, 1L, "", 0L, 1L, "", "", 0)); // writes data to db
-        sqlEntityListener.close();
         domainWriter.flush(); // writes data to db
         log.info("Total time taken: {}", stopwatch);
     }

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/domain/writer/DomainWriterImpl.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/domain/writer/DomainWriterImpl.java
@@ -52,8 +52,7 @@ public class DomainWriterImpl implements DomainWriter {
     public DomainWriterImpl(DataSource dataSource, EntityRepository entityRepository, SqlProperties sqlProperties) throws SQLException {
         this.dataSource = dataSource;
         this.entityRepository = entityRepository;
-        accountBalancePgCopy = new PgCopy<>(dataSource, AccountBalance.class, new SimpleMeterRegistry(), sqlProperties
-                .getBatchSize());
+        accountBalancePgCopy = new PgCopy<>(AccountBalance.class, new SimpleMeterRegistry(), sqlProperties);
         accountBalances = new HashSet<>();
         entities = new HashSet<>();
         this.sqlProperties = sqlProperties;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlProperties.java
@@ -20,7 +20,6 @@ package com.hedera.mirror.importer.parser.record.entity.sql;
  * ‍
  */
 
-import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -31,15 +30,15 @@ import com.hedera.mirror.importer.parser.record.entity.ConditionOnEntityRecordPa
 @ConditionOnEntityRecordParser
 @ConfigurationProperties("hedera.mirror.importer.parser.record.entity.sql")
 public class SqlProperties {
-    @Min(1)
-    private int threads = 10;
 
     @Min(1)
-    @Max(100000000)
-    private int batchSize = 100_000_000;
+    private int batchSize = 20_000;
+
+    @Min(1)
+    private int bufferSize = 65536;
+
+    private int maxJsonPayloadSize = 8000;
 
     // Not documenting this for now since it may be temporary pending further refactorings
     private boolean notifyTopicMessage = true;
-
-    private int maxJsonPayloadSize = 8000;
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/sql/PgCopyTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/sql/PgCopyTest.java
@@ -71,10 +71,8 @@ class PgCopyTest extends IntegrationTest {
 
     @BeforeEach
     void beforeEach() throws Exception {
-        cryptoTransferPgCopy = new PgCopy<>(dataSource, CryptoTransfer.class, meterRegistry, sqlProperties
-                .getBatchSize());
-        transactionPgCopy = new PgCopy<>(dataSource, Transaction.class, meterRegistry, sqlProperties
-                .getBatchSize());
+        cryptoTransferPgCopy = new PgCopy<>(CryptoTransfer.class, meterRegistry, sqlProperties);
+        transactionPgCopy = new PgCopy<>(Transaction.class, meterRegistry, sqlProperties);
     }
 
     @Test
@@ -113,10 +111,10 @@ class PgCopyTest extends IntegrationTest {
         Connection conn = mock(Connection.class);
         doReturn(conn).when(dataSource).getConnection();
         doReturn(pgConnection).when(conn).unwrap(any());
-        var cryptoTransferPgCopy2 = new PgCopy<>(dataSource, CryptoTransfer.class, meterRegistry, sqlProperties
-                .getBatchSize());
+        var cryptoTransferPgCopy2 = new PgCopy<>(CryptoTransfer.class, meterRegistry, sqlProperties);
         var cryptoTransfers = new HashSet<CryptoTransfer>();
         cryptoTransfers.add(cryptoTransfer(1));
+
         // when
         assertThatThrownBy(() -> cryptoTransferPgCopy2.copy(cryptoTransfers, dataSource.getConnection()))
                 .isInstanceOf(ParserException.class);

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListenerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListenerTest.java
@@ -24,31 +24,18 @@ import static com.hedera.mirror.importer.domain.EntityTypeEnum.ACCOUNT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
 
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import java.io.Reader;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.ExecutionException;
 import javax.annotation.Resource;
 import javax.sql.DataSource;
 import org.apache.commons.lang3.RandomUtils;
 import org.bouncycastle.util.Strings;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.postgresql.PGConnection;
 import org.postgresql.PGNotification;
-import org.postgresql.copy.CopyManager;
 import org.postgresql.jdbc.PgConnection;
-import org.springframework.cache.CacheManager;
 import org.springframework.data.repository.CrudRepository;
 
 import com.hedera.mirror.importer.IntegrationTest;
@@ -250,15 +237,12 @@ public class SqlEntityListenerTest extends IntegrationTest {
         sqlEntityListener.onCryptoTransfer(cryptoTransfer1);
         sqlEntityListener.onEntityId(entityId);
 
-        boolean rollback = false;
-        try {
-            completeFileAndCommit();
-        } catch (Exception ex) {
-            sqlEntityListener.onError();
-            rollback = true;
-        }
+        assertThatThrownBy(() -> completeFileAndCommit())
+                .isInstanceOf(ParserException.class)
+                .extracting(Throwable::getCause)
+                .isInstanceOf(SQLException.class);
+        sqlEntityListener.onError();
 
-        assertThat(rollback).isTrue();
         assertEquals(0, topicMessageRepository.count());
         assertEquals(0, cryptoTransferRepository.count());
         assertEquals(0, entityRepository.count());
@@ -373,39 +357,6 @@ public class SqlEntityListenerTest extends IntegrationTest {
         // then
         assertThat(recordFileRepository.count()).isEqualTo(1);
         assertThat(recordFileRepository.findByName(fileName)).hasSize(1);
-    }
-
-    @Test
-    void testExceptionInCopyPropagatesUp() throws Exception {
-        // given
-        SQLException exception = new SQLException("test exception");
-        CopyManager copyManager = mock(CopyManager.class);
-        doThrow(exception).when(copyManager).copyIn(any(), (Reader) any(), anyInt());
-        PGConnection pgConnection = mock(PGConnection.class);
-        doReturn(copyManager).when(pgConnection).getCopyAPI();
-        Connection conn = mock(Connection.class);
-        PreparedStatement statement = mock(PreparedStatement.class);
-        doReturn(pgConnection).when(conn).unwrap(any());
-        doReturn(statement).when(conn).prepareStatement(any());
-        DataSource dataSource = mock(DataSource.class);
-        doReturn(conn).when(dataSource).getConnection();
-        CacheManager cacheManager = mock(CacheManager.class);
-        var sqlEntityListener2 = new SqlEntityListener(
-                sqlProperties, dataSource, recordFileRepository, entityRepository, new SimpleMeterRegistry(),
-                cacheManager);
-        sqlEntityListener2.onStart(new StreamFileData(fileName, null));
-        sqlEntityListener2.onTransaction(makeTransaction());
-
-        // when, then
-        assertThatThrownBy(() -> sqlEntityListener2.onEnd(
-                new RecordFile(0L, 0L, null, fileName, 0L, 0L, UUID.randomUUID().toString(), "", 0)))
-                .isInstanceOf(ParserException.class)
-                .extracting(Throwable::getCause)
-                .isInstanceOf(ExecutionException.class)
-                .extracting(Throwable::getCause)
-                .isInstanceOf(ParserException.class)
-                .extracting(Throwable::getCause)
-                .isSameAs(exception);
     }
 
     static <T, ID> void assertExistsAndEquals(CrudRepository<T, ID> repository, T expected, ID id) throws Exception {


### PR DESCRIPTION
**Detailed description**:
- Add missing bufferSize property
- Change batchSize to a more reasonable 20K (e.g. 10K TPS at 2s close interval)
- Fix deadlock by reverting to non-concurrent insert
- Fix large buffer allocation inside CopyManager due to passing batchSize=100M instead of bufferSize=65356
- Fix not resetting batchCount and clearing domain object lists when inserting batch

**Which issue(s) this PR fixes**:
Fixes #910

**Special notes for your reviewer**:
Concurrent inserts with the same connection caused resource contention over the connection lock, eventually causing a deadlock. We can move to use separate connections for each insert, but if any one fails it would not roll back the others since JDBC/Hibernate/Spring doesn't support transactions that span connections. Implementing a manual rollback on the client side via delete queries would be brittle and error prone.

**Checklist**
- [x] Documentation added
- [x] Tests updated

