### PR TITLE
fix the issue importer gets stuck when >=2 groups of signature files in same bucket

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,7 +29,6 @@ value, it is recommended to only populate overridden properties in the custom `a
 | `hedera.mirror.importer.db.username`                                 | mirror_node             | The username the processor uses to connect to the database                                     |
 | `hedera.mirror.importer.downloader.accessKey`                        | ""                      | The cloud storage access key                                                                   |
 | `hedera.mirror.importer.downloader.balance.batchSize`                | 15                      | The number of signature files to download per node before downloading the signed files         |
-| `hedera.mirror.importer.downloader.balance.closeInterval`            | 15m                     | The expected interval between balance files                                                    |
 | `hedera.mirror.importer.downloader.balance.enabled`                  | true                    | Whether to enable balance file downloads                                                       |
 | `hedera.mirror.importer.downloader.balance.frequency`                | 30s                     | The fixed period between invocations. Can accept duration units like `10s`, `2m` etc.          |
 | `hedera.mirror.importer.downloader.balance.keepSignatures`           | false                   | Whether to keep balance signature files after successful verification. If false, files are deleted. |
@@ -39,7 +38,6 @@ value, it is recommended to only populate overridden properties in the custom `a
 | `hedera.mirror.importer.downloader.cloudProvider`                    | S3                      | The cloud provider to download files from. Either `S3` or `GCP`                                |
 | `hedera.mirror.importer.downloader.endpointOverride`                 |                         | Can be specified to download streams from a source other than S3 and GCP. Should be S3 compatible |
 | `hedera.mirror.importer.downloader.event.batchSize`                  | 100                     | The number of signature files to download per node before downloading the signed files         |
-| `hedera.mirror.importer.downloader.event.closeInterval`              | 5s                      | The expected interval between event files                                                      |
 | `hedera.mirror.importer.downloader.event.enabled`                    | false                   | Whether to enable event file downloads                                                         |
 | `hedera.mirror.importer.downloader.event.frequency`                  | 5s                      | The fixed period between invocations. Can accept duration units like `10s`, `2m` etc.          |
 | `hedera.mirror.importer.downloader.event.keepSignatures`             | false                   | Whether to keep event signature files after successful verification. If false, files are deleted. |
@@ -48,7 +46,6 @@ value, it is recommended to only populate overridden properties in the custom `a
 | `hedera.mirror.importer.downloader.gcpProjectId`                     |                         | GCP project id to bill for requests to GCS bucket which has Requester Pays enabled.            |
 | `hedera.mirror.importer.downloader.maxConcurrency`                   | 1000                    | The maximum number of allowed open HTTP connections. Used by AWS SDK directly.                 |
 | `hedera.mirror.importer.downloader.record.batchSize`                 | 40                      | The number of signature files to download per node before downloading the signed files         |
-| `hedera.mirror.importer.downloader.record.closeInterval`             | 2s                      | The expected interval between record files                                                     |
 | `hedera.mirror.importer.downloader.record.enabled`                   | true                    | Whether to enable record file downloads                                                        |
 | `hedera.mirror.importer.downloader.record.frequency`                 | 500ms                   | The fixed period between invocations. Can accept duration units like `10s`, `2m` etc.          |
 | `hedera.mirror.importer.downloader.record.keepSignatures`            | false                   | Whether to keep record signature files after successful verification. If false, files are deleted. |

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/DownloaderProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/DownloaderProperties.java
@@ -32,10 +32,6 @@ public interface DownloaderProperties {
 
     int getBatchSize();
 
-    Duration getCloseInterval();
-
-    void setCloseInterval(Duration closeInterval);
-
     CommonDownloaderProperties getCommon();
 
     MirrorProperties getMirrorProperties();

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/NodeSignatureVerifier.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/NodeSignatureVerifier.java
@@ -52,7 +52,7 @@ public class NodeSignatureVerifier {
                 .collect(Collectors.toMap(NodeAddress::getId, NodeAddress::getPublicKeyAsObject));
     }
 
-    private static boolean consensusReached(long actualNodes, long expectedNodes) {
+    private static boolean canReachConsensus(long actualNodes, long expectedNodes) {
         return actualNodes >= Math.ceil(expectedNodes / 3.0);
     }
 
@@ -72,7 +72,7 @@ public class NodeSignatureVerifier {
 
         final long sigFileCount = signatures.size();
         final long nodeCount = nodeIDPubKeyMap.size();
-        if (!consensusReached(sigFileCount, nodeCount)) {
+        if (!canReachConsensus(sigFileCount, nodeCount)) {
             throw new SignatureVerificationException("Require at least 1/3 signature files to reach consensus, got " +
                     sigFileCount + " out of " + nodeCount + " for file " + filename + ": " + statusMap(signatures));
         }
@@ -96,7 +96,7 @@ public class NodeSignatureVerifier {
         for (String key : signatureHashMap.keySet()) {
             Collection<FileStreamSignature> validatedSignatures = signatureHashMap.get(key);
 
-            if (consensusReached(validatedSignatures.size(), nodeIDPubKeyMap.size())) {
+            if (canReachConsensus(validatedSignatures.size(), nodeIDPubKeyMap.size())) {
                 consensusCount += validatedSignatures.size();
                 validatedSignatures.forEach(s -> s.setStatus(SignatureStatus.CONSENSUS_REACHED));
             }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/balance/BalanceDownloaderProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/balance/BalanceDownloaderProperties.java
@@ -46,9 +46,6 @@ public class BalanceDownloaderProperties implements DownloaderProperties {
     @Min(1)
     private int batchSize = 15;
 
-    @NotNull
-    private Duration closeInterval = Duration.ofMinutes(15L);
-
     private boolean enabled = true;
 
     @NotNull

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/event/EventDownloaderProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/event/EventDownloaderProperties.java
@@ -46,9 +46,6 @@ public class EventDownloaderProperties implements DownloaderProperties {
     @Min(1)
     private int batchSize = 100;
 
-    @NotNull
-    private Duration closeInterval = Duration.ofSeconds(5L);
-
     private boolean enabled = false;
 
     @NotNull

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/record/RecordDownloaderProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/record/RecordDownloaderProperties.java
@@ -46,9 +46,6 @@ public class RecordDownloaderProperties implements DownloaderProperties {
     @Min(1)
     private int batchSize = 40;
 
-    @NotNull
-    private Duration closeInterval = Duration.ofSeconds(2L);
-
     private boolean enabled = true;
 
     @NotNull

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/balance/AccountBalancesDownloaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/balance/AccountBalancesDownloaderTest.java
@@ -21,6 +21,7 @@ package com.hedera.mirror.importer.downloader.balance;
  */
 
 import java.nio.file.Path;
+import java.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -48,6 +49,11 @@ public class AccountBalancesDownloaderTest extends AbstractDownloaderTest {
     @Override
     protected Path getTestDataDir() {
         return Path.of("accountBalances");
+    }
+
+    @Override
+    protected Duration getCloseInterval() {
+        return Duration.ofMinutes(15L);
     }
 
     @BeforeEach

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/event/EventFileDownloaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/event/EventFileDownloaderTest.java
@@ -22,6 +22,7 @@ package com.hedera.mirror.importer.downloader.event;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -52,6 +53,11 @@ public class EventFileDownloaderTest extends AbstractLinkedStreamDownloaderTest 
     @Override
     protected Path getTestDataDir() {
         return Paths.get("eventsStreams", "v3");
+    }
+
+    @Override
+    protected Duration getCloseInterval() {
+        return Duration.ofSeconds(5L);
     }
 
     @Test

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/record/RecordFileDownloaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/record/RecordFileDownloaderTest.java
@@ -63,11 +63,15 @@ public class RecordFileDownloaderTest extends AbstractLinkedStreamDownloaderTest
         return Paths.get("recordstreams", "v2");
     }
 
+    @Override
+    protected Duration getCloseInterval() {
+        return Duration.ofSeconds(5L);
+    }
+
     @BeforeEach
     void beforeEach() {
         file1 = "2019-08-30T18_10_00.419072Z.rcd";
         file2 = "2019-08-30T18_10_05.249678Z.rcd";
-        downloaderProperties.setCloseInterval(Duration.ofSeconds(5)); // Test rcd files use older 5s interval
     }
 
     @Test


### PR DESCRIPTION

Signed-off-by: Xin Li <xin.li@swirlds.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
-->

**Detailed description**:

There are a couple of occurrences in the DEMO bucket that adjacent groups of record signature files' timestamp difference 
< 2s, and all these signature files are **VALID**.

The fix to address the balance files timestamp issue assumed that when >= 2 groups of signature files fall into the same bucket (based on predefined close interval), only one is valid and all but the verified group will be dropped. In addition, the dropped groups will be again dropped on next try since its timestamp falls into the bucket of **last** processed signature files.

So the importer will get stuck and could not continue processing the record files in the DEMO bucket.

To fix it, most part of the previous fix is reverted and a loose restriction is adopted:

1. signatures files are grouped by its timestamp as before
2. when a group of signature files fail to verify and its not the last in the batch, we will skip it and try to process the next group of signature files

This can address the balance file issue, since the single balance file will fail the signature verification:

* if it's not the last in the batch, the next group of balance signature files will pass verification so the single file will be skipped forever
* if it's the last in the batch, it'll be downloaded again in the next batch and become the first, then it'll be skipped and the next group of signature files in the new batch will pass verification so the single file will be skipped forever

**Which issue(s) this PR fixes**:
Fixes #914 

**Special notes for your reviewer**:

**Checklist**
- [x] Documentation added
- [x] Tests updated

