### PR TITLE
Fix Marketplace deployer image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -399,7 +399,7 @@ jobs:
                 if [[ $major == v* ]]; then
                   major=${major:1}
                 fi
-                DOCKER_TAG_OVERRIDE="-Ddocker.tags.0=${major}.${minor} -Djib.to.tags=${major}.${minor} -Ddocker.skip.deployer=false"
+                DOCKER_TAG_OVERRIDE="-Ddocker.tags.0=${major}.${minor} -Djib.to.tags=${major}.${minor}"
             fi
             ./mvnw ${MAVEN_CLI_OPTS} deploy -DskipTests ${DOCKER_TAG_OVERRIDE}
 

--- a/charts/marketplace/gcp/Dockerfile
+++ b/charts/marketplace/gcp/Dockerfile
@@ -6,12 +6,12 @@ RUN wget https://github.com/mikefarah/yq/releases/download/2.4.0/yq_linux_amd64 
     && mv yq_linux_amd64 /usr/local/bin/yq \
     && chmod +x /usr/local/bin/yq
 
-# Pull in chart
-COPY hedera-mirror /tmp/chart
+# Pull in charts
+COPY . /tmp/charts
 COPY marketplace/gcp/values.yaml /tmp/values-marketplace.yaml
 
 # Merge values files
-RUN yq m -i --overwrite /tmp/chart/values.yaml /tmp/values-marketplace.yaml
+RUN yq m -i --overwrite /tmp/charts/hedera-mirror/values.yaml /tmp/values-marketplace.yaml
 
 # Pull in and update schema for marketplace deployer
 COPY marketplace/gcp/schema.yaml /tmp/schema.yaml
@@ -25,11 +25,12 @@ RUN cat /tmp/schema.yaml \
     && mv /tmp/schema.yaml.new /tmp/schema.yaml
 
 # Run helm template to render and verify templates
-RUN helm template /tmp/chart -f /tmp/chart/values.yaml
-RUN cd /tmp && tar -czvf hedera-mirror-node.tar.gz chart
+RUN helm dependency update /tmp/charts/hedera-mirror
+RUN helm template /tmp/charts/hedera-mirror -f /tmp/charts/hedera-mirror/values.yaml
+RUN cd /tmp/charts && tar -czvf hedera-mirror-node.tar.gz hedera-mirror
 
 # Setup marketplace structure on helm deployer image base
 FROM gcr.io/cloud-marketplace-tools/k8s/deployer_helm
-COPY --from=build /tmp/hedera-mirror-node.tar.gz /data/chart
+COPY --from=build /tmp/charts/hedera-mirror-node.tar.gz /data/chart
 COPY --from=build /tmp/schema-test.yaml /data-test/schema.yaml
 COPY --from=build /tmp/schema.yaml /data

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,6 @@
         <docker-maven-plugin.version>0.33.0</docker-maven-plugin.version>
         <docker.push.repository>gcr.io/mirrornode</docker.push.repository>
         <docker.resources>${project.build.directory}/container</docker.resources>
-        <docker.skip.deployer>true</docker.skip.deployer>
         <docker.tag.version>${project.version}</docker.tag.version>
         <grpc.version>1.29.0</grpc.version>
         <hedera-protobuf.version>0.6.0-alpha1</hedera-protobuf.version>
@@ -327,26 +326,6 @@
                     <injectAllReactorProjects>true</injectAllReactorProjects>
                     <runOnlyOnce>true</runOnlyOnce>
                     <skipPoms>false</skipPoms>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>io.fabric8</groupId>
-                <artifactId>docker-maven-plugin</artifactId>
-                <inherited>false</inherited>
-                <configuration>
-                    <images>
-                        <image>
-                            <build>
-                                <contextDir>${project.basedir}/charts</contextDir>
-                                <dockerFile>${project.basedir}/charts/marketplace/gcp/Dockerfile</dockerFile>
-                                <args>
-                                    <tag>${docker.tag.version}</tag>
-                                </args>
-                            </build>
-                            <name>${docker.push.repository}/hedera-mirror-node/deployer:${docker.tag.version}</name>
-                        </image>
-                    </images>
-                    <skip>${docker.skip.deployer}</skip>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
**Detailed description**:
- Fix Marketplace deployer image regression due to no longer storing dependent charts in git
- Remove Marketplace deployer image from CircleCI image building

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:
Marketplace deployment is a manual, ad-hoc process and doesn't need to be pushed to gcr.io/mirrornode as those images are never used.

Will retag v0.16.0-rc1

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

