### PR TITLE
Update SqlProperties bufferSize to handle large topic messages effectively

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -76,7 +76,7 @@ value, it is recommended to only populate overridden properties in the custom `a
 | `hedera.mirror.importer.parser.record.entity.persist.systemFiles`           | true                    | Persist only system files (number lower than `1000`) to the database                           |
 | `hedera.mirror.importer.parser.record.entity.persist.transactionBytes`      | false                   | Persist raw transaction bytes to the database                                                  |
 | `hedera.mirror.importer.parser.record.entity.sql.batchSize`                 | 20_000                  | When inserting transactions into db, executeBatches() is called every these many transactions  |
-| `hedera.mirror.importer.parser.record.entity.sql.bufferSize`                | 65536                   | The size of the byte buffer to allocate for each batch                                         |
+| `hedera.mirror.importer.parser.record.entity.sql.bufferSize`                | 11441                   | The size of the byte buffer to allocate for each batch                                         |
 | `hedera.mirror.importer.parser.record.entity.sql.maxJsonPayloadSize`        | 8000                    | Max number of bytes for json payload used in pg_notify of db inserts                           |
 | `hedera.mirror.importer.parser.record.pubsub.topicName`                     |                         | Pubsub topic to publish transactions to                                                        |
 | `hedera.mirror.importer.parser.record.pubsub.maxSendAttempts`               | 5                       | Number of attempts when sending messages to PubSub (only for retryable errors)                 |

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/PgCopy.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/PgCopy.java
@@ -96,7 +96,7 @@ public class PgCopy<T> {
             insertDurationMetric.record(stopwatch.elapsed());
             log.info("Copied {} rows to {} table in {}", rowsCount, tableName, stopwatch);
         } catch (Exception e) {
-            throw new ParserException(e);
+            throw new ParserException(String.format("Error copying %d items to table %s", items.size(), tableName), e);
         }
     }
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlProperties.java
@@ -35,7 +35,7 @@ public class SqlProperties {
     private int batchSize = 20_000;
 
     @Min(1)
-    private int bufferSize = 65536;
+    private int bufferSize = 11441; // tested max byte size of buffer used by postgres CopyManger.copyIn()
 
     private int maxJsonPayloadSize = 8000;
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListenerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListenerTest.java
@@ -226,6 +226,8 @@ public class SqlEntityListenerTest extends IntegrationTest {
         TopicMessage topicMessage = getTopicMessage();
 
         TopicMessage topicMessage2 = getTopicMessage();
+        topicMessage2.setConsensusTimestamp(2L);
+        topicMessage2.setSequenceNumber(2L);
         topicMessage2.setMessage(RandomUtils.nextBytes(10000)); // Just exceeds 8000B
 
         CryptoTransfer cryptoTransfer1 = new CryptoTransfer(1L, 1L, EntityId.of(0L, 0L, 1L, ACCOUNT));


### PR DESCRIPTION
**Detailed description**:
In dev environment we noticed the parser got blocked with the following error when trying to insert topic_messages
`PSQLException: Database connection failed when canceling copy operation`

```
Caused by: java.net.SocketException: Connection or outbound has closed
at sun.security.ssl.SSLSocketImpl$AppOutputStream.write(SSLSocketImpl.java:976) ~[?:?]
at java.io.BufferedOutputStream.flushBuffer(BufferedOutputStream.java:81) ~[?:?]
at java.io.BufferedOutputStream.flush(BufferedOutputStream.java:142) ~[?:?]
at org.postgresql.core.PGStream.flush(PGStream.java:592) ~[postgresql-42.2.12.jar!/:42.2.12]
at org.postgresql.core.v3.QueryExecutorImpl.cancelCopy(QueryExecutorImpl.java:937) ~[postgresql-42.2.12.jar!/:42.2.12]
at org.postgresql.core.v3.CopyOperationImpl.cancelCopy(CopyOperationImpl.java:28) ~[postgresql-42.2.12.jar!/:42.2.12]
at org.postgresql.copy.CopyManager.copyIn(CopyManager.java:188) ~[postgresql-42.2.12.jar!/:42.2.12]
at com.hedera.mirror.importer.parser.record.entity.sql.PgCopy.copy(PgCopy.java:95) ~[classes!/:0.16.0-rc1]
```

```
Caused by: java.net.SocketException: Connection or outbound has closed
at sun.security.ssl.SSLSocketImpl$AppOutputStream.write(SSLSocketImpl.java:976) ~[?:?]
at java.io.BufferedOutputStream.flushBuffer(BufferedOutputStream.java:81) ~[?:?]
at java.io.BufferedOutputStream.flush(BufferedOutputStream.java:142) ~[?:?]
at org.postgresql.core.PGStream.flush(PGStream.java:592) ~[postgresql-42.2.12.jar!/:42.2.12]
at org.postgresql.core.v3.QueryExecutorImpl.sendSync(QueryExecutorImpl.java:1459) ~[postgresql-42.2.12.jar!/:42.2.12]
at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:311) ~[postgresql-42.2.12.jar!/:42.2.12]
```

Turns out to be related to the bufferSize used in breaking up large csv contents when sending to the db server for copy.
This change 

- Sets the bufferSize to a value tested to effectively manage large topic messages
- Updates PgCopy throw exception with a bit more detail on table in question
- Updates SqlEntityListenerTest overflow test to be more precise in logic
- Adds PgCopy Test to copy topic messages with 6KiB max message size

**Which issue(s) this PR fixes**:
Fixes #932 

**Special notes for your reviewer**:
It's till unclear the combination of environment configs that causes the issue when the bufferSize is set above 11441 B.
I'm unable to repro locally but tested in dev and was unable to block and effectively catch up with set values.

Using the reduced bufferSize on a 6K rcd file the record parsing time is at worse ~80 ms longer.
In some cases it's 10s ms improved, so bufferSize change seems marginal

**Checklist**
- [x] Documentation added
- [x] Tests updated

