### PR TITLE
Cherry pick pgcopy buffer

### DIFF
--- a/charts/hedera-mirror-common/Chart.yaml
+++ b/charts/hedera-mirror-common/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.16.0-rc1
+appVersion: 0.16.0-rc2
 description: Hedera Mirror Node common components installed globally for use across namespaces
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067

--- a/charts/hedera-mirror-grpc/Chart.yaml
+++ b/charts/hedera-mirror-grpc/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.16.0-rc1
+appVersion: 0.16.0-rc2
 description: GRPC API for the Hedera Mirror Node
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067

--- a/charts/hedera-mirror-importer/Chart.yaml
+++ b/charts/hedera-mirror-importer/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.16.0-rc1
+appVersion: 0.16.0-rc2
 description: Hedera Mirror Importer downloads and validates file streams from the cloud and imports them into the database
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067

--- a/charts/hedera-mirror-rest/Chart.yaml
+++ b/charts/hedera-mirror-rest/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.16.0-rc1
+appVersion: 0.16.0-rc2
 description: REST API for the Hedera Mirror Node
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067

--- a/charts/hedera-mirror/Chart.yaml
+++ b/charts/hedera-mirror/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.16.0-rc1
+appVersion: 0.16.0-rc2
 description: Hedera Mirror Node mirrors data from Hedera nodes and serves it via an API
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - 5432:5432
 
   grpc:
-    image: gcr.io/mirrornode/hedera-mirror-grpc:0.16.0-rc1
+    image: gcr.io/mirrornode/hedera-mirror-grpc:0.16.0-rc2
     restart: unless-stopped
     environment:
       HEDERA_MIRROR_GRPC_DB_HOST: db
@@ -28,7 +28,7 @@ services:
       - 5600:5600
 
   importer:
-    image: gcr.io/mirrornode/hedera-mirror-importer:0.16.0-rc1
+    image: gcr.io/mirrornode/hedera-mirror-importer:0.16.0-rc2
     restart: unless-stopped
     environment:
       HEDERA_MIRROR_IMPORTER_DATAPATH: /var/lib/hedera-mirror-importer
@@ -39,7 +39,7 @@ services:
       - ./application.yml:/usr/etc/hedera-mirror-importer/application.yml
 
   rest:
-    image: gcr.io/mirrornode/hedera-mirror-rest:0.16.0-rc1
+    image: gcr.io/mirrornode/hedera-mirror-rest:0.16.0-rc2
     environment:
       HEDERA_MIRROR_REST_DB_HOST: db
     restart: unless-stopped

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -76,7 +76,7 @@ value, it is recommended to only populate overridden properties in the custom `a
 | `hedera.mirror.importer.parser.record.entity.persist.systemFiles`           | true                    | Persist only system files (number lower than `1000`) to the database                           |
 | `hedera.mirror.importer.parser.record.entity.persist.transactionBytes`      | false                   | Persist raw transaction bytes to the database                                                  |
 | `hedera.mirror.importer.parser.record.entity.sql.batchSize`                 | 20_000                  | When inserting transactions into db, executeBatches() is called every these many transactions  |
-| `hedera.mirror.importer.parser.record.entity.sql.bufferSize`                | 65536                   | The size of the byte buffer to allocate for each batch                                         |
+| `hedera.mirror.importer.parser.record.entity.sql.bufferSize`                | 11441                   | The size of the byte buffer to allocate for each batch                                         |
 | `hedera.mirror.importer.parser.record.entity.sql.maxJsonPayloadSize`        | 8000                    | Max number of bytes for json payload used in pg_notify of db inserts                           |
 | `hedera.mirror.importer.parser.record.pubsub.topicName`                     |                         | Pubsub topic to publish transactions to                                                        |
 | `hedera.mirror.importer.parser.record.pubsub.maxSendAttempts`               | 5                       | Number of attempts when sending messages to PubSub (only for retryable errors)                 |

--- a/hedera-mirror-coverage/pom.xml
+++ b/hedera-mirror-coverage/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.16.0-rc1</version>
+        <version>0.16.0-rc2</version>
     </parent>
 
     <dependencies>

--- a/hedera-mirror-datagenerator/pom.xml
+++ b/hedera-mirror-datagenerator/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.16.0-rc1</version>
+        <version>0.16.0-rc2</version>
     </parent>
 
     <properties>

--- a/hedera-mirror-grpc/pom.xml
+++ b/hedera-mirror-grpc/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.16.0-rc1</version>
+        <version>0.16.0-rc2</version>
     </parent>
 
     <properties>

--- a/hedera-mirror-importer/pom.xml
+++ b/hedera-mirror-importer/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.16.0-rc1</version>
+        <version>0.16.0-rc2</version>
     </parent>
 
     <properties>

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/PgCopy.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/PgCopy.java
@@ -96,7 +96,7 @@ public class PgCopy<T> {
             insertDurationMetric.record(stopwatch.elapsed());
             log.info("Copied {} rows to {} table in {}", rowsCount, tableName, stopwatch);
         } catch (Exception e) {
-            throw new ParserException(e);
+            throw new ParserException(String.format("Error copying %d items to table %s", items.size(), tableName), e);
         }
     }
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlProperties.java
@@ -35,7 +35,7 @@ public class SqlProperties {
     private int batchSize = 20_000;
 
     @Min(1)
-    private int bufferSize = 65536;
+    private int bufferSize = 11441; // tested max byte size of buffer used by postgres CopyManger.copyIn()
 
     private int maxJsonPayloadSize = 8000;
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListenerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListenerTest.java
@@ -225,6 +225,8 @@ public class SqlEntityListenerTest extends IntegrationTest {
         TopicMessage topicMessage = getTopicMessage();
 
         TopicMessage topicMessage2 = getTopicMessage();
+        topicMessage2.setConsensusTimestamp(2L);
+        topicMessage2.setSequenceNumber(2L);
         topicMessage2.setMessage(RandomUtils.nextBytes(10000)); // Just exceeds 8000B
 
         CryptoTransfer cryptoTransfer1 = new CryptoTransfer(1L, 1L, EntityId.of(0L, 0L, 1L, ACCOUNT));

--- a/hedera-mirror-protobuf/pom.xml
+++ b/hedera-mirror-protobuf/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.16.0-rc1</version>
+        <version>0.16.0-rc2</version>
     </parent>
 
     <properties>

--- a/hedera-mirror-rest/monitoring/monitor_apis/package-lock.json
+++ b/hedera-mirror-rest/monitoring/monitor_apis/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-mirror-monitor",
-  "version": "0.16.0-rc1",
+  "version": "0.16.0-rc2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hedera-mirror-rest/monitoring/monitor_apis/package.json
+++ b/hedera-mirror-rest/monitoring/monitor_apis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-mirror-monitor",
-  "version": "0.16.0-rc1",
+  "version": "0.16.0-rc2",
   "description": "Hedera Mirror Node Monitor",
   "main": "server.js",
   "private": true,

--- a/hedera-mirror-rest/package-lock.json
+++ b/hedera-mirror-rest/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-mirror-rest",
-  "version": "0.16.0-rc1",
+  "version": "0.16.0-rc2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hedera-mirror-rest/package.json
+++ b/hedera-mirror-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-mirror-rest",
-  "version": "0.16.0-rc1",
+  "version": "0.16.0-rc2",
   "description": "Hedera Mirror Node REST API",
   "main": "server.js",
   "private": true,

--- a/hedera-mirror-rest/pom.xml
+++ b/hedera-mirror-rest/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.16.0-rc1</version>
+        <version>0.16.0-rc2</version>
     </parent>
 
     <build>

--- a/hedera-mirror-test/pom.xml
+++ b/hedera-mirror-test/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.16.0-rc1</version>
+        <version>0.16.0-rc2</version>
     </parent>
 
     <properties>

--- a/hedera-mirror-test/src/test/resources/k8s/hcs-perf-message-submit.yml
+++ b/hedera-mirror-test/src/test/resources/k8s/hcs-perf-message-submit.yml
@@ -41,7 +41,7 @@ spec:
                     app.kubernetes.io/name: test
       restartPolicy: Never
       containers:
-        - image: gcr.io/mirrornode/hedera-mirror-test:0.16.0-rc1
+        - image: gcr.io/mirrornode/hedera-mirror-test:0.16.0-rc2
           name: test
           env:
             - name: testProfile

--- a/hedera-mirror-test/src/test/resources/k8s/hcs-perf-publish-test.yml
+++ b/hedera-mirror-test/src/test/resources/k8s/hcs-perf-publish-test.yml
@@ -43,7 +43,7 @@ spec:
                     app.kubernetes.io/name: test
       restartPolicy: Never
       containers:
-        - image: gcr.io/mirrornode/hedera-mirror-test:0.16.0-rc1
+        - image: gcr.io/mirrornode/hedera-mirror-test:0.16.0-rc2
           name: test
           env:
             - name: testProfile

--- a/hedera-mirror-test/src/test/resources/k8s/hcs-perf-subscribe-test.yml
+++ b/hedera-mirror-test/src/test/resources/k8s/hcs-perf-subscribe-test.yml
@@ -46,7 +46,7 @@ spec:
                     app.kubernetes.io/name: test
       restartPolicy: Never
       containers:
-        - image: gcr.io/mirrornode/hedera-mirror-test:0.16.0-rc1
+        - image: gcr.io/mirrornode/hedera-mirror-test:0.16.0-rc2
           name: test
           env:
             - name: testProfile

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.hedera</groupId>
     <artifactId>hedera-mirror-node</artifactId>
-    <version>0.16.0-rc1</version>
+    <version>0.16.0-rc2</version>
     <description>Hedera Mirror Node mirrors data from Hedera nodes and serves it via an API</description>
     <inceptionYear>2019</inceptionYear>
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
**Detailed description**:
Cherry picks #935 to unblock importer pgcopy db connection issue #932 and bumps version to 0.16.0-rc2 


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:
It's unclear the combination of environment configs that causes the issue when the bufferSize is set above 11441 B.
Changes tested in dev and were able to unblock  #932 and effectively catch up.

Using the reduced bufferSize on a 6K rcd file the record parsing time is at worse ~80 ms longer.
In some cases it's 10s ms improved, so bufferSize change seems marginal

**Checklist**
- [x] Documentation added
- [x] Tests updated

