### PR TITLE
Continuously deploy to development

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -352,7 +352,7 @@ jobs:
       - restore_maven_cache
       - run:
           name: Running maven deploy
-          command: ./mvnw ${MAVEN_CLI_OPTS} deploy -DskipTest
+          command: ./mvnw ${MAVEN_CLI_OPTS} deploy -DskipTests
 
   cleanup_images:
     <<: *machine_ubuntu

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,17 +179,10 @@ workflows:
               only: /.*/
             tags:
               only: /.*/
-      - helm:
-          filters: # required since `release_artifacts` has tag filters AND requires `this`
-            branches:
-              only: /.*/
-            tags:
-              only: /.*/
       - release_artifacts:
           requires:
             - build_maven
             - build_rest
-            - helm
           filters:
             branches:
               ignore: /.*/
@@ -199,11 +192,9 @@ workflows:
           requires:
             - build_maven
             - build_rest
-            - helm
           filters:
             branches:
-              only:
-                - master
+              ignore: /.*/
             tags:
               only: /^.*/
       - perf_maven:
@@ -213,12 +204,11 @@ workflows:
             tags:
               only: /.*/
       - cleanup_images:
-          requires:
-            - publish_images
           filters:
             branches:
-              only:
-                - master
+              ignore: /.*/
+            tags:
+              only: /^.*/
 
 jobs:
   build_maven:
@@ -331,33 +321,6 @@ jobs:
             mv hedera-mirror-rest*.tgz ${WORKSPACE}/artifacts/${NAME}.tgz
       - persist_artifacts_to_workspace
 
-  helm:
-    docker:
-      - image: alpine/helm:3.2.0
-    steps:
-      - checkout
-      - run:
-          name: build dependencies
-          command: |
-            helm dependency update charts/hedera-mirror
-            helm dependency update charts/hedera-mirror-common
-      - run:
-          name: lint
-          command: |
-            helm lint charts/hedera-mirror
-            helm lint charts/hedera-mirror-common
-            helm lint charts/hedera-mirror-grpc
-            helm lint charts/hedera-mirror-importer
-            helm lint charts/hedera-mirror-rest
-      - run:
-          name: template
-          command: |
-            helm template charts/hedera-mirror
-            helm template charts/hedera-mirror-common
-            helm template charts/hedera-mirror-grpc
-            helm template charts/hedera-mirror-importer
-            helm template charts/hedera-mirror-rest
-
   release_artifacts:
     docker:
       - *docker_jdk11
@@ -389,19 +352,7 @@ jobs:
       - restore_maven_cache
       - run:
           name: Running maven deploy
-          command: |
-            set -ex
-            if [ "$CIRCLE_BRANCH" = "master" ]; then
-                DOCKER_TAG_OVERRIDE="-Ddocker.tag.version=${CIRCLE_BRANCH}-${CIRCLE_SHA1} -Ddocker.tags.0=master -Djib.to.tags=master"
-            fi
-            if [ -n "$CIRCLE_TAG" ]; then
-                IFS=. read major minor build \<<< ${CIRCLE_TAG}
-                if [[ $major == v* ]]; then
-                  major=${major:1}
-                fi
-                DOCKER_TAG_OVERRIDE="-Ddocker.tags.0=${major}.${minor} -Djib.to.tags=${major}.${minor}"
-            fi
-            ./mvnw ${MAVEN_CLI_OPTS} deploy -DskipTests ${DOCKER_TAG_OVERRIDE}
+          command: ./mvnw ${MAVEN_CLI_OPTS} deploy -DskipTests ${DOCKER_TAG_OVERRIDE}
 
   cleanup_images:
     <<: *machine_ubuntu

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -352,7 +352,7 @@ jobs:
       - restore_maven_cache
       - run:
           name: Running maven deploy
-          command: ./mvnw ${MAVEN_CLI_OPTS} deploy -DskipTests ${DOCKER_TAG_OVERRIDE}
+          command: ./mvnw ${MAVEN_CLI_OPTS} deploy -DskipTest
 
   cleanup_images:
     <<: *machine_ubuntu

--- a/.github/ct-install.yaml
+++ b/.github/ct-install.yaml
@@ -1,0 +1,9 @@
+chart-repos:
+  - stable=https://kubernetes-charts.storage.googleapis.com
+  - bitnami=https://charts.bitnami.com/bitnami
+  - fluxcd=https://charts.fluxcd.io
+  - loki=https://grafana.github.io/loki/charts
+  - traefik=https://containous.github.io/traefik-helm-chart
+check-version-increment: false
+charts:
+  - charts/hedera-mirror

--- a/.github/ct-lint.yaml
+++ b/.github/ct-lint.yaml
@@ -1,0 +1,7 @@
+chart-repos:
+  - stable=https://kubernetes-charts.storage.googleapis.com
+  - bitnami=https://charts.bitnami.com/bitnami
+  - fluxcd=https://charts.fluxcd.io
+  - loki=https://grafana.github.io/loki/charts
+  - traefik=https://containous.github.io/traefik-helm-chart
+check-version-increment: false

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -27,8 +27,10 @@ jobs:
       with:
         project_id: ${{ secrets.GCP_PROJECT_ID }}
         service_account_key: ${{ secrets.GCR_KEY }}
-    - run: gcloud auth configure-docker gcr.io,marketplace.gcr.io
-    - run: ./mvnw ${MAVEN_CLI_OPTS} deploy -Ddocker.tag.version=cd-${GITHUB_SHA} -Djib.to.tags=cd-${GITHUB_SHA}
+    - name: Configure Docker
+      run: gcloud auth configure-docker gcr.io,marketplace.gcr.io
+    - name: Build and push images
+      run: ./mvnw ${MAVEN_CLI_OPTS} deploy -Ddocker.tag.version=master-${GITHUB_SHA} -Djib.to.tags=master-${GITHUB_SHA}
   deploy:
     needs: images
     runs-on: ubuntu-latest
@@ -39,7 +41,7 @@ jobs:
     - name: Update dev tag
       run: |-
         sed -i "s/ref: .*/ref: ${GITHUB_SHA}/" ./dev/helmrelease.yaml
-        sed -i "s/tag: .*/tag: cd-${GITHUB_SHA}/" ./dev/helmrelease.yaml
+        sed -i "s/tag: .*/tag: master-${GITHUB_SHA}/" ./dev/helmrelease.yaml
       shell: bash
     - uses: stefanzweifel/git-auto-commit-action@v4.4.0
       with:

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -1,0 +1,47 @@
+name: Deploy Development
+
+on:
+  push:
+    branches:
+    - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      MAVEN_CLI_OPTS: --batch-mode --no-transfer-progress --show-version -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    - name: Cache Maven packages
+      uses: actions/cache@v1
+      with:
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        path: ~/.m2
+        restore-keys: ${{ runner.os }}-m2
+    - name: Login to Google Container Registry
+      uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+      with:
+        project_id: ${{ secrets.GCP_PROJECT_ID }}
+        service_account_key: ${{ secrets.GCR_KEY }}
+    - run: gcloud auth configure-docker gcr.io,marketplace.gcr.io
+    - run: ./mvnw ${MAVEN_CLI_OPTS} deploy -Ddocker.tag.version=cd-${GITHUB_SHA} -Djib.to.tags=cd-${GITHUB_SHA}
+  deploy:
+    needs: images
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: deploy
+    - name: Update dev tag
+      run: |-
+        sed -i "s/ref: .*/ref: ${GITHUB_SHA}/" ./dev/helmrelease.yaml
+        sed -i "s/tag: .*/tag: cd-${GITHUB_SHA}/" ./dev/helmrelease.yaml
+      shell: bash
+    - uses: stefanzweifel/git-auto-commit-action@v4.4.0
+      with:
+        commit_message: Update dev HelmRelease to master
+

--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -1,0 +1,36 @@
+name: Helm tests
+
+on: 
+  - pull_request
+
+jobs:
+  helm-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Fetch history
+        run: git fetch --prune --unshallow
+
+      - name: Helm lint
+        id: lint
+        uses: helm/chart-testing-action@v1.0.0
+        with:
+          command: lint
+          config: .github/ct-lint.yaml
+
+      - name: Create Kubernetes cluster
+        id: k8s
+        uses: debianmaster/actions-k3s@master
+        if: steps.lint.outputs.changed == 'true' # Only create cluster if there are chart changes
+        with:
+          version: v1.16.9-k3s1
+
+      - name: Helm install
+        uses: helm/chart-testing-action@v1.0.0
+        if: steps.lint.outputs.changed == 'true'
+        with:
+          command: install
+          config: .github/ct-install.yaml
+          kubeconfig: ${{ steps.k8s.outputs.kubeconfig }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Publish helm chart
-        uses: steven-sheehy/helm-gh-pages@target-dir
+        uses: stefanprodan/helm-gh-pages@master
         with:
           target_dir: charts
           token: ${{ secrets.REPO_RW_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,20 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  helm-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Publish helm chart
+        uses: steven-sheehy/helm-gh-pages@target-dir
+        with:
+          target_dir: charts
+          token: ${{ secrets.REPO_RW_TOKEN }}
+

--- a/charts/README.md
+++ b/charts/README.md
@@ -20,14 +20,8 @@ export RELEASE="mirror1"
 To install the wrapper chart:
 
 ```shell script
-$ helm upgrade --install "${RELEASE}" charts/hedera-mirror
-```
-
-Note that dependent charts are already downloaded and checked in, allowing for a quicker and repeatable installation without
-any external dependencies. If you make changes to a sub chart or want to update other dependent charts, please run:
-
-```shell script
-$ helm dependency update charts/hedera-mirror
+$ helm repo add hedera https://hashgraph.github.io/hedera-mirror-node/charts
+$ helm upgrade --install "${RELEASE}" hedera/hedera-mirror
 ```
 
 ## Testing

--- a/charts/hedera-mirror-importer/templates/statefulset.yaml
+++ b/charts/hedera-mirror-importer/templates/statefulset.yaml
@@ -83,5 +83,7 @@ spec:
         resources:
           requests:
             storage: "{{ .Values.persistence.size }}"
+        {{- if .Values.persistence.storageClass }}
         storageClassName: "{{ .Values.persistence.storageClass }}"
+        {{- end }}
 {{- end }}

--- a/charts/hedera-mirror-importer/values.yaml
+++ b/charts/hedera-mirror-importer/values.yaml
@@ -52,7 +52,7 @@ persistence:
   annotations: {}
   enabled: true
   size: 10Gi
-  storageClass: standard
+  storageClass: ""
 
 podDisruptionBudget:
   enabled: false

--- a/charts/marketplace/gcp/README.md
+++ b/charts/marketplace/gcp/README.md
@@ -147,6 +147,12 @@ You can use [Google Cloud Shell](https://cloud.google.com/shell/) or a local wor
 
 ### Configure
 
+Add the Hedera Mirror Node Helm chart repository:
+
+```shell
+helm repo add hedera https://hashgraph.github.io/hedera-mirror-node/charts
+```
+
 Optional: Use a function to generate the password for the components:
 
 ```shell
@@ -201,7 +207,7 @@ for additional configuration options. You can pass any application configuration
 Use `helm upgrade` to install and upgrade the application:
 
 ```shell
-helm upgrade "${APP_NAME}" charts/hedera-mirror \
+helm upgrade "${APP_NAME}" hedera/hedera-mirror \
   --namespace "${NAMESPACE}" \
   --install \
   -f charts/marketplace/gcp/values.yaml \

--- a/hedera-mirror-rest/Dockerfile
+++ b/hedera-mirror-rest/Dockerfile
@@ -1,11 +1,16 @@
-FROM node:13.12.0-alpine3.11 as build
-WORKDIR /usr/src/app
-COPY package*.json ./
-RUN npm install --no-package-lock
+FROM node:14.7.0-alpine3.12
+LABEL maintainer="mirrornode@hedera.com"
 
-FROM node:13.12.0-alpine3.11
-WORKDIR /usr/src/app
-COPY --from=build /usr/src/app .
-COPY . ./
+# Setup
+WORKDIR /home/node/app/
+RUN chown -R node:node .
+COPY --chown=node:node . ./
 USER node
-CMD npm start --no-update-notifier
+
+# Build
+ENV NODE_ENV production
+RUN npm ci --only=production && npm cache clean --force --loglevel=error
+
+# Run
+EXPOSE 5551
+CMD ["node", "server.js"]


### PR DESCRIPTION
**Detailed description**:
- Add GitHub Action to build and push Docker images on every push to master and update `deploy` branch
- Add GitHub Action to publish Helm charts to a GitHub Pages-based chart [repository](https://hashgraph.github.io/hedera-mirror-node/charts) on every tag
- Add GitHub Action to start a Kubernetes cluster on every PR, install Helm chart and run tests
- Fix hardcoded `StorageClass` not allowing install in some Kubernetes clusters like k3s
- Fix REST Dockerfile to not write files as root, remove pointless multi-stage and don't use `npm install` as it doesn't use package-lock.json

**Which issue(s) this PR fixes**:
Fixes #652 

**Special notes for your reviewer**:
- Docker build for tags is still handled by CircleCI for now.
- GitHub Actions can run TestContainers directly. No need for external containers like CircleCI.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

