### PR TITLE
Fix the issue gRPC notify thread blocked

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -115,6 +115,7 @@ value, it is recommended to only populate overridden properties in the custom `a
 | `hedera.mirror.grpc.endTimeInterval`                        | 30s              | How often we should check if a subscription has gone past the end time                         |
 | `hedera.mirror.grpc.entityCacheSize`                        | 50000            | The maximum size of the cache to store entities used for existence check                       |
 | `hedera.mirror.grpc.listener.enabled`                       | true             | Whether to listen for incoming massages or not                                                 |
+| `hedera.mirror.grpc.listener.maxBufferSize`                 | 32               | The maximum number of messages the notifying listener buffers before sending an error to a client |
 | `hedera.mirror.grpc.listener.maxPageSize`                   | 5000             | The maximum number of messages the listener can return in a single call to the database        |
 | `hedera.mirror.grpc.listener.frequency`                     | 500ms            | How often to poll or retry errors (varies by type). Can accept duration units like `50ms`, `10s`, etc. |
 | `hedera.mirror.grpc.listener.type`                          | NOTIFY           | The type of listener to use for incoming messages. Accepts either NOTIFY, POLL or SHARED_POLL  |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -115,7 +115,7 @@ value, it is recommended to only populate overridden properties in the custom `a
 | `hedera.mirror.grpc.endTimeInterval`                        | 30s              | How often we should check if a subscription has gone past the end time                         |
 | `hedera.mirror.grpc.entityCacheSize`                        | 50000            | The maximum size of the cache to store entities used for existence check                       |
 | `hedera.mirror.grpc.listener.enabled`                       | true             | Whether to listen for incoming massages or not                                                 |
-| `hedera.mirror.grpc.listener.maxBufferSize`                 | 32               | The maximum number of messages the notifying listener buffers before sending an error to a client |
+| `hedera.mirror.grpc.listener.maxBufferSize`                 | 2048             | The maximum number of messages the notifying listener or the shared polling listener buffers before sending an error to a client |
 | `hedera.mirror.grpc.listener.maxPageSize`                   | 5000             | The maximum number of messages the listener can return in a single call to the database        |
 | `hedera.mirror.grpc.listener.frequency`                     | 500ms            | How often to poll or retry errors (varies by type). Can accept duration units like `50ms`, `10s`, etc. |
 | `hedera.mirror.grpc.listener.type`                          | NOTIFY           | The type of listener to use for incoming messages. Accepts either NOTIFY, POLL or SHARED_POLL  |

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/controller/ConsensusController.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/controller/ConsensusController.java
@@ -31,6 +31,7 @@ import lombok.extern.log4j.Log4j2;
 import net.devh.boot.grpc.server.service.GrpcService;
 import org.springframework.dao.NonTransientDataAccessResourceException;
 import org.springframework.dao.TransientDataAccessException;
+import reactor.core.Exceptions;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -56,6 +57,7 @@ import com.hedera.mirror.grpc.util.ProtoUtil;
 public class ConsensusController extends ReactorConsensusServiceGrpc.ConsensusServiceImplBase {
 
     private static final String DB_ERROR = "Unable to connect to database. Please retry later";
+    private static final String OVERFLOW_ERROR = "Client lags too much behind. Please retry later";
 
     private final TopicMessageService topicMessageService;
 
@@ -70,6 +72,7 @@ public class ConsensusController extends ReactorConsensusServiceGrpc.ConsensusSe
                 .onErrorMap(TimeoutException.class, e -> error(e, Status.RESOURCE_EXHAUSTED))
                 .onErrorMap(TopicNotFoundException.class, e -> error(e, Status.NOT_FOUND))
                 .onErrorMap(TransientDataAccessException.class, e -> error(e, Status.RESOURCE_EXHAUSTED))
+                .onErrorMap(Exceptions::isOverflow, e -> error(e, Status.RESOURCE_EXHAUSTED, OVERFLOW_ERROR))
                 .onErrorMap(t -> unknownError(t));
     }
 

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/controller/ConsensusController.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/controller/ConsensusController.java
@@ -72,7 +72,7 @@ public class ConsensusController extends ReactorConsensusServiceGrpc.ConsensusSe
                 .onErrorMap(TimeoutException.class, e -> error(e, Status.RESOURCE_EXHAUSTED))
                 .onErrorMap(TopicNotFoundException.class, e -> error(e, Status.NOT_FOUND))
                 .onErrorMap(TransientDataAccessException.class, e -> error(e, Status.RESOURCE_EXHAUSTED))
-                .onErrorMap(Exceptions::isOverflow, e -> error(e, Status.RESOURCE_EXHAUSTED, OVERFLOW_ERROR))
+                .onErrorMap(Exceptions::isOverflow, e -> error(e, Status.DEADLINE_EXCEEDED, OVERFLOW_ERROR))
                 .onErrorMap(t -> unknownError(t));
     }
 

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/ListenerProperties.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/ListenerProperties.java
@@ -21,6 +21,7 @@ package com.hedera.mirror.grpc.listener;
  */
 
 import java.time.Duration;
+import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import lombok.Data;
@@ -36,6 +37,10 @@ public class ListenerProperties {
 
     @Min(32)
     private int maxPageSize = 5000;
+
+    @Min(32)
+    @Max(256)
+    private int maxBufferSize = 32;
 
     @NotNull
     private Duration frequency = Duration.ofMillis(500L);

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/ListenerProperties.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/ListenerProperties.java
@@ -38,9 +38,9 @@ public class ListenerProperties {
     @Min(32)
     private int maxPageSize = 5000;
 
-    @Min(32)
-    @Max(256)
-    private int maxBufferSize = 32;
+    @Min(1024)
+    @Max(8192)
+    private int maxBufferSize = 2048;
 
     @NotNull
     private Duration frequency = Duration.ofMillis(500L);

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/NotifyingTopicListener.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/NotifyingTopicListener.java
@@ -47,7 +47,7 @@ public class NotifyingTopicListener implements TopicListener {
     private final ObjectMapper objectMapper;
     private final Flux<TopicMessage> topicMessages;
     private final PgChannel channel;
-    private final int maxBufferSize;
+    private final ListenerProperties listenerProperties;
 
     public NotifyingTopicListener(DbProperties dbProperties, ListenerProperties listenerProperties) {
         this.objectMapper = new ObjectMapper().setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
@@ -58,6 +58,7 @@ public class NotifyingTopicListener implements TopicListener {
                 .setPort(dbProperties.getPort())
                 .setUser(dbProperties.getUsername());
 
+        this.listenerProperties = listenerProperties;
         Duration frequency = listenerProperties.getFrequency();
         Vertx vertx = Vertx.vertx();
         PgSubscriber subscriber = PgSubscriber.subscriber(vertx, connectOptions)
@@ -77,6 +78,7 @@ public class NotifyingTopicListener implements TopicListener {
         channel = subscriber.channel("topic_message");
 
         topicMessages = Flux.defer(() -> listen())
+                .publishOn(Schedulers.boundedElastic())
                 .map(this::toTopicMessage)
                 .filter(Objects::nonNull)
                 .name("notify")
@@ -84,15 +86,13 @@ public class NotifyingTopicListener implements TopicListener {
                 .doOnError(t -> log.error("Error listening for messages", t))
                 .retryWhen(Retry.backoff(Long.MAX_VALUE, frequency).maxBackoff(frequency.multipliedBy(4L)))
                 .share();
-        maxBufferSize = listenerProperties.getMaxBufferSize();
     }
 
     @Override
     public Flux<TopicMessage> listen(TopicMessageFilter filter) {
         return topicMessages.filter(t -> filterMessage(t, filter))
                 .doOnSubscribe(s -> log.info("Subscribing: {}", filter))
-                .onBackpressureBuffer(maxBufferSize)
-                .publishOn(Schedulers.boundedElastic());
+                .onBackpressureBuffer(listenerProperties.getMaxBufferSize());
     }
 
     private boolean filterMessage(TopicMessage message, TopicMessageFilter filter) {

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/SharedPollingTopicListener.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/SharedPollingTopicListener.java
@@ -81,7 +81,8 @@ public class SharedPollingTopicListener implements TopicListener {
     @Override
     public Flux<TopicMessage> listen(TopicMessageFilter filter) {
         return poller.filter(t -> filterMessage(t, filter))
-                .doOnSubscribe(s -> log.info("Subscribing: {}", filter));
+                .doOnSubscribe(s -> log.info("Subscribing: {}", filter))
+                .onBackpressureBuffer(listenerProperties.getMaxBufferSize());
     }
 
     private Flux<TopicMessage> poll(PollingContext context) {

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/controller/ConsensusControllerTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/controller/ConsensusControllerTest.java
@@ -33,7 +33,6 @@ import lombok.extern.log4j.Log4j2;
 import net.devh.boot.grpc.client.inject.GrpcClient;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/listener/AbstractSharedTopicListenerTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/listener/AbstractSharedTopicListenerTest.java
@@ -21,7 +21,7 @@ public abstract class AbstractSharedTopicListenerTest extends AbstractTopicListe
     @DisplayName("slow subscriber receives overflow exception and normal subscriber is not affected")
     void slowSubscriberOverflowException() {
         int maxBufferSize = 16;
-        listenerProperties.setMaxBufferSize(16);
+        listenerProperties.setMaxBufferSize(maxBufferSize);
 
         TopicMessageFilter filter = TopicMessageFilter.builder()
                 .startTime(Instant.EPOCH)

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/listener/AbstractSharedTopicListenerTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/listener/AbstractSharedTopicListenerTest.java
@@ -1,0 +1,38 @@
+package com.hedera.mirror.grpc.listener;
+
+import java.time.Duration;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+import reactor.core.Exceptions;
+import reactor.test.StepVerifier;
+
+import com.hedera.mirror.grpc.domain.TopicMessage;
+import com.hedera.mirror.grpc.domain.TopicMessageFilter;
+
+public abstract class AbstractSharedTopicListenerTest extends AbstractTopicListenerTest {
+
+    @Test
+    void slowSubscriberOverflowException() {
+        int maxBufferSize = 16;
+        listenerProperties.setMaxBufferSize(16);
+        TopicMessageFilter filter = TopicMessageFilter.builder()
+                .startTime(Instant.EPOCH)
+                .build();
+        getTopicListener().listen(filter)
+                .map(TopicMessage::getSequenceNumber)
+                .as(p -> StepVerifier.create(p, 1)) // initial request amount - 1
+                .thenRequest(1) // trigger subscription
+                .thenAwait(Duration.ofMillis(10L))
+                .then(() -> {
+                    // upon subscription, step verifier will request 2, so we need 2 + maxBufferSize + 1 to trigger
+                    // overflow error
+                    domainBuilder.topicMessages(maxBufferSize + 3, future).blockLast();
+                })
+                .expectNext(1L, 2L)
+                .thenAwait(Duration.ofMillis(500L))
+                .thenRequest(Long.MAX_VALUE)
+                .expectNextCount(maxBufferSize)
+                .expectErrorMatches(Exceptions::isOverflow)
+                .verify(Duration.ofMillis(600L));
+    }
+}

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/listener/AbstractTopicListenerTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/listener/AbstractTopicListenerTest.java
@@ -39,7 +39,7 @@ import com.hedera.mirror.grpc.domain.TopicMessageFilter;
 
 public abstract class AbstractTopicListenerTest extends GrpcIntegrationTest {
 
-    protected final Instant future = Instant.now().plusSeconds(10L);
+    protected final Instant future = Instant.now().plusSeconds(30L);
 
     @Resource
     protected DomainBuilder domainBuilder;

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/listener/NotifyingTopicListenerTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/listener/NotifyingTopicListenerTest.java
@@ -74,7 +74,7 @@ public class NotifyingTopicListenerTest extends AbstractSharedTopicListenerTest 
                 "\"running_hash\":\"BAUG\"," +
                 "\"running_hash_version\":2," +
                 "\"sequence_number\":1," +
-                "\"topic_num\":0," +
+                "\"topic_num\":1001," +
                 "\"valid_start_timestamp\":1594401416000000000" +
                 "}";
 
@@ -87,11 +87,12 @@ public class NotifyingTopicListenerTest extends AbstractSharedTopicListenerTest 
                 .runningHash(new byte[] {4, 5, 6})
                 .runningHashVersion(2)
                 .sequenceNumber(1L)
-                .topicNum(0)
+                .topicNum(1001)
                 .validStartTimestamp(Instant.ofEpochSecond(1594401416)).build();
 
         TopicMessageFilter filter = TopicMessageFilter.builder()
                 .startTime(Instant.EPOCH)
+                .topicNum(1001)
                 .build();
 
         topicListener.listen(filter)

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/listener/NotifyingTopicListenerTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/listener/NotifyingTopicListenerTest.java
@@ -27,34 +27,12 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.jdbc.core.JdbcTemplate;
-import reactor.core.Exceptions;
 import reactor.test.StepVerifier;
 
 import com.hedera.mirror.grpc.domain.TopicMessage;
 import com.hedera.mirror.grpc.domain.TopicMessageFilter;
 
-public class NotifyingTopicListenerTest extends AbstractTopicListenerTest {
-
-    private static final int topicNum = 1001;
-
-    private static final String jsonTemplate = "{" +
-            "\"chunk_num\":1," +
-            "\"chunk_total\":2," +
-            "\"consensus_timestamp\":1594401417000000000," +
-            "\"message\":\"AQID\"," +
-            "\"payer_account_id\":4294968296," +
-            "\"realm_num\":0," +
-            "\"running_hash\":\"BAUG\"," +
-            "\"running_hash_version\":2," +
-            "\"sequence_number\":%d," +
-            "\"topic_num\":" + topicNum + "," +
-            "\"valid_start_timestamp\":1594401416000000000" +
-            "}";
-
-    private static final TopicMessageFilter filter = TopicMessageFilter.builder()
-            .startTime(Instant.EPOCH)
-            .topicNum(topicNum)
-            .build();
+public class NotifyingTopicListenerTest extends AbstractSharedTopicListenerTest {
 
     @Resource
     private NotifyingTopicListener topicListener;
@@ -86,53 +64,21 @@ public class NotifyingTopicListenerTest extends AbstractTopicListenerTest {
     // Test deserialization from JSON to verify contract with PostgreSQL listen/notify
     @Test
     void json() {
-        final String jsonMessage = String.format(jsonTemplate, 1);
-        topicListener.listen(filter)
-                .as(StepVerifier::create)
-                .thenAwait(Duration.ofMillis(50))
-                .then(() -> jdbcTemplate.execute("NOTIFY topic_message, '" + jsonMessage + "'"))
-                .expectNext(makeExpectedTopicMessage(1))
-                .thenCancel()
-                .verify(Duration.ofMillis(500L));
-    }
+        String json = "{" +
+                "\"chunk_num\":1," +
+                "\"chunk_total\":2," +
+                "\"consensus_timestamp\":1594401417000000000," +
+                "\"message\":\"AQID\"," +
+                "\"payer_account_id\":4294968296," +
+                "\"realm_num\":0," +
+                "\"running_hash\":\"BAUG\"," +
+                "\"running_hash_version\":2," +
+                "\"sequence_number\":1," +
+                "\"topic_num\":0," +
+                "\"valid_start_timestamp\":1594401416000000000" +
+                "}";
 
-    @Test
-    void jsonError() {
-        // Parsing errors will be logged and ignored and the message will be lost
-        topicListener.listen(filter)
-                .as(StepVerifier::create)
-                .thenAwait(Duration.ofMillis(50))
-                .then(() -> jdbcTemplate.execute("NOTIFY topic_message, 'invalid'"))
-                .expectNoEvent(Duration.ofMillis(500L))
-                .thenCancel()
-                .verify(Duration.ofMillis(500L));
-    }
-
-    @Test
-    void slowSubscriberOverflowException() {
-        final int maxBufferSize = listenerProperties.getMaxBufferSize();
-        topicListener.listen(filter)
-                .as(p -> StepVerifier.create(p, 1)) // initial request amount - 1
-                .thenRequest(1) // trigger subscription
-                .thenAwait(Duration.ofMillis(10L))
-                .then(() -> {
-                    // upon subscription, step verifier will request 2, so we need 2 + maxBufferSize + 1 to trigger
-                    // overflow error
-                    for (int i = 0; i < maxBufferSize + 3; i++) {
-                        final String jsonMessage = String.format(jsonTemplate, i + 1);
-                        jdbcTemplate.execute("NOTIFY topic_message, '" + jsonMessage + "'");
-                    }
-                })
-                .expectNext(makeExpectedTopicMessage(1), makeExpectedTopicMessage(2))
-                .thenAwait(Duration.ofMillis(500L))
-                .thenRequest(Long.MAX_VALUE)
-                .expectNextCount(maxBufferSize)
-                .expectErrorMatches(Exceptions::isOverflow)
-                .verify(Duration.ofMillis(600L));
-    }
-
-    private TopicMessage makeExpectedTopicMessage(long sequenceNumber) {
-        return TopicMessage.builder().chunkNum(1)
+        TopicMessage topicMessage = TopicMessage.builder().chunkNum(1)
                 .chunkTotal(2)
                 .consensusTimestamp(Instant.ofEpochSecond(1594401417))
                 .message(new byte[] {1, 2, 3})
@@ -140,8 +86,36 @@ public class NotifyingTopicListenerTest extends AbstractTopicListenerTest {
                 .realmNum(0)
                 .runningHash(new byte[] {4, 5, 6})
                 .runningHashVersion(2)
-                .sequenceNumber(sequenceNumber)
-                .topicNum(topicNum)
+                .sequenceNumber(1L)
+                .topicNum(0)
                 .validStartTimestamp(Instant.ofEpochSecond(1594401416)).build();
+
+        TopicMessageFilter filter = TopicMessageFilter.builder()
+                .startTime(Instant.EPOCH)
+                .build();
+
+        topicListener.listen(filter)
+                .as(StepVerifier::create)
+                .thenAwait(Duration.ofMillis(50))
+                .then(() -> jdbcTemplate.execute("NOTIFY topic_message, '" + json + "'"))
+                .expectNext(topicMessage)
+                .thenCancel()
+                .verify(Duration.ofMillis(500L));
+    }
+
+    @Test
+    void jsonError() {
+        TopicMessageFilter filter = TopicMessageFilter.builder()
+                .startTime(Instant.EPOCH)
+                .build();
+
+        // Parsing errors will be logged and ignored and the message will be lost
+        topicListener.listen(filter)
+                .as(StepVerifier::create)
+                .thenAwait(Duration.ofMillis(50))
+                .then(() -> jdbcTemplate.execute("NOTIFY topic_message, 'invalid'"))
+                .expectNoEvent(Duration.ofMillis(500L))
+                .thenCancel()
+                .verify(Duration.ofMillis(600L));
     }
 }

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/listener/SharedPollingTopicListenerTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/listener/SharedPollingTopicListenerTest.java
@@ -22,7 +22,7 @@ package com.hedera.mirror.grpc.listener;
 
 import javax.annotation.Resource;
 
-public class SharedPollingTopicListenerTest extends AbstractTopicListenerTest {
+public class SharedPollingTopicListenerTest extends AbstractSharedTopicListenerTest {
 
     @Resource
     private SharedPollingTopicListener topicListener;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
-->

**Detailed description**:

Add backpressure buffer with ERROR strategy to notifying and shared polling topic listeners. When overflow happens, the controller will send a gRPC error after all buffered messages and disconnect the client.

**Which issue(s) this PR fixes**:
Fixes #945 

**Special notes for your reviewer**:

**Checklist**
- [x] Documentation added
- [x] Tests updated

