### PR TITLE
Add a drop.sql script for OPS usage when resetting the mirror node to…

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -186,8 +186,11 @@ sudo mv accountBalances eventsStreams recordstreams backup20191114/
 ```console
 scp hedera-mirror-importer/src/main/resources/db/scripts/cleanup.sql user@server:~
 ssh user@server
-psql -h dbhost -d mirror_node -U mirror_node -f cleanup.sql
+psql -h dbhost -d mirror_node -U mirror_node -f drop.sql
 ```
+> **_NOTE:_** The `cleanup.sql` script was previously used to wipe the database as it truncates the tables and resets identities.
+> However, it was not designed to account for bootstrap data such as address books which are persisted during flyway migrations.
+> Hence, `drop.sql` is favored over `cleanup.sql` as it clears the schema and allows migrations to be re-run accordingly.
 
 5 ) Start Mirror Node Importer
 

--- a/hedera-mirror-importer/src/main/resources/db/scripts/drop.sql
+++ b/hedera-mirror-importer/src/main/resources/db/scripts/drop.sql
@@ -6,12 +6,11 @@ drop schema if exists public cascade;
 
 -- recreate schema used by init.sql
 create schema public;
+grant usage on schema public to public;
 
 -- drop api user created in v1 flyway migration
 drop user if exists mirror_api;
 
--- grant grpc stream user permissions
-grant usage on schema public to public;
--- grant usage on schema public to mirror_grpc;
+-- re-grant grpc stream user access
 alter default privileges in schema public grant select on tables to mirror_grpc;
 grant select on all tables in schema public to mirror_grpc;

--- a/hedera-mirror-importer/src/main/resources/db/scripts/drop.sql
+++ b/hedera-mirror-importer/src/main/resources/db/scripts/drop.sql
@@ -1,0 +1,17 @@
+-- drop db items allowing for restart of mirror node parsing operations against a new network
+-- Change the values below appropriately if not using defaults
+
+-- drop tables, views, indexes, data types, functions, stored procedures and operators associated with db
+drop schema if exists public cascade;
+
+-- recreate schema used by init.sql
+create schema public;
+
+-- drop api user created in v1 flyway migration
+drop user if exists mirror_api;
+
+-- grant grpc stream user permissions
+grant usage on schema public to public;
+-- grant usage on schema public to mirror_grpc;
+alter default privileges in schema public grant select on tables to mirror_grpc;
+grant select on all tables in schema public to mirror_grpc;


### PR DESCRIPTION
**Detailed description**:

During network resets the mirror node database is reset with cleanup.sql.
The flywaydb migrations populate the db with the needed address books for parsing, as such the importer can't process streams due to the missing addressbook.
`2020-08-12 18:26:15,382 ERROR [scheduling-1] c.h.m.i.d.r.RecordFileDownloader Error downloading files
java.lang.IllegalStateException: No valid address book found in DB
    at com.hedera.mirror.importer.addressbook.AddressBookServiceImpl.lambda$getCurrent$0(AddressBookServiceImpl.java:92) ~[classes/:?]
    at java.util.Optional.orElseThrow(…`


This fix
- Adds a drop.sql script that can be used when resetting the mirror node. Clears schema and manages roles.
- Updated troubleshooting documentation 

**Which issue(s) this PR fixes**:
Fixes #951

**Special notes for your reviewer**:
Verified correct functionality locally and the script commands in integration.
Full script run has also been verified in integration

**Checklist**
- [x] Documentation added
- [ ] Tests updated

