### PR TITLE
Importer will use default credentials provider for S3 buckets by default

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/condition/AwsDefaultCredentialsCondition.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/condition/AwsDefaultCredentialsCondition.java
@@ -1,0 +1,41 @@
+package com.hedera.mirror.importer.config.condition;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+import com.hedera.mirror.importer.downloader.CommonDownloaderProperties;
+
+public class AwsDefaultCredentialsCondition implements Condition {
+
+    // We can only use the AWS default credentials chain for S3 buckets
+    @Override
+    public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+        String cloudProvider = context.getEnvironment().getProperty("hedera.mirror.importer.downloader.cloudProvider");
+        if (cloudProvider == null) {
+            cloudProvider = CommonDownloaderProperties.CloudProvider.S3.name();
+        }
+        return StringUtils.equals(CommonDownloaderProperties.CloudProvider.S3.name(), cloudProvider);
+    }
+}

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/CommonDownloaderProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/CommonDownloaderProperties.java
@@ -22,12 +22,10 @@ package com.hedera.mirror.importer.downloader;
 
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
-
 import lombok.Data;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
@@ -56,7 +54,7 @@ public class CommonDownloaderProperties {
     @Min(0)
     private int maxConcurrency = 1000; // aws sdk default = 50
 
-    private String region = "us-east-1";
+    private String region;
 
     private String secretKey;
 
@@ -82,6 +80,5 @@ public class CommonDownloaderProperties {
         private String roleArn;
 
         private String roleSessionName = "hedera-mirror-node";
-
     }
 }


### PR DESCRIPTION
Signed-off-by: Ian Jungmann <ian.jungmann@hedera.com>

**Detailed description**:
This will allow the Importer to use the AWS default credentials chain when connecting to S3 buckets, unless specifically overridden by provided config values.  This will allow users to authenticate in whichever manner they choose (static credentials, assume roles, etc), and will no longer require them to add credentials to the yaml.

**Which issue(s) this PR fixes**:
Fixes #900 

**Special notes for your reviewer**:
This has been tested running with config set using the aws cli to confirm that it still connects, however it has not been tested with the web identity token file

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

