### PR TITLE
ignore NodeAddress fields not set in protobuf

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/addressbook/AddressBookServiceImpl.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/addressbook/AddressBookServiceImpl.java
@@ -225,10 +225,6 @@ public class AddressBookServiceImpl implements AddressBookService {
      */
     private Collection<AddressBookEntry> retrieveNodeAddressesFromAddressBook(NodeAddressBook nodeAddressBook,
                                                                               long consensusTimestamp) {
-        if (nodeAddressBook == null) {
-            return Collections.emptyList();
-        }
-
         ImmutableList.Builder<AddressBookEntry> listBuilder = ImmutableList.builder();
 
         for (NodeAddress nodeAddressProto : nodeAddressBook.getNodeAddressList()) {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/addressbook/AddressBookServiceImpl.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/addressbook/AddressBookServiceImpl.java
@@ -21,14 +21,11 @@ package com.hedera.mirror.importer.addressbook;
  */
 
 import com.google.common.collect.ImmutableList;
-import com.google.protobuf.Descriptors.FieldDescriptor;
-import com.hederahashgraph.api.proto.java.NodeAddress;
 import com.hederahashgraph.api.proto.java.NodeAddressBook;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import javax.inject.Named;
@@ -53,8 +50,6 @@ public class AddressBookServiceImpl implements AddressBookService {
 
     public static final EntityId ADDRESS_BOOK_101_ENTITY_ID = EntityId.of(0, 0, 101, EntityTypeEnum.FILE);
     public static final EntityId ADDRESS_BOOK_102_ENTITY_ID = EntityId.of(0, 0, 102, EntityTypeEnum.FILE);
-
-    private static final List<FieldDescriptor> nodeAddressFieldDescriptors = NodeAddress.getDescriptor().getFields();
 
     private final AddressBookRepository addressBookRepository;
     private final FileDataRepository fileDataRepository;
@@ -225,48 +220,26 @@ public class AddressBookServiceImpl implements AddressBookService {
      */
     private Collection<AddressBookEntry> retrieveNodeAddressesFromAddressBook(NodeAddressBook nodeAddressBook,
                                                                               long consensusTimestamp) {
-        ImmutableList.Builder<AddressBookEntry> listBuilder = ImmutableList.builder();
+        ImmutableList.Builder<AddressBookEntry> builder = ImmutableList.builder();
 
-        for (NodeAddress nodeAddressProto : nodeAddressBook.getNodeAddressList()) {
-            AddressBookEntry.AddressBookEntryBuilder builder = AddressBookEntry.builder()
-                    .consensusTimestamp(consensusTimestamp);
-
-            nodeAddressFieldDescriptors.stream()
-                    .filter(nodeAddressProto::hasField)
-                    .map(FieldDescriptor::getNumber)
-                    .forEach(fieldNumber -> {
-                        switch (fieldNumber) {
-                            case NodeAddress.IPADDRESS_FIELD_NUMBER:
-                                builder.ip(nodeAddressProto.getIpAddress().toStringUtf8());
-                                break;
-                            case NodeAddress.PORTNO_FIELD_NUMBER:
-                                builder.port(nodeAddressProto.getPortno());
-                                break;
-                            case NodeAddress.MEMO_FIELD_NUMBER:
-                                builder.memo(nodeAddressProto.getMemo().toStringUtf8());
-                                break;
-                            case NodeAddress.RSA_PUBKEY_FIELD_NUMBER:
-                                builder.publicKey(nodeAddressProto.getRSAPubKey());
-                                break;
-                            case NodeAddress.NODEID_FIELD_NUMBER:
-                                builder.nodeId(nodeAddressProto.getNodeId());
-                                break;
-                            case NodeAddress.NODEACCOUNTID_FIELD_NUMBER:
-                                builder.nodeAccountId(EntityId.of(nodeAddressProto.getNodeAccountId()));
-                                break;
-                            case NodeAddress.NODECERTHASH_FIELD_NUMBER:
-                                builder.nodeCertHash(nodeAddressProto.getNodeCertHash().toByteArray());
-                                break;
-                            default:
-                                log.warn("Unhandled field of NodeAddress protobuf - {}", fieldNumber);
-                                break;
-                        }
-                    });
-
-            listBuilder.add(builder.build());
+        if (nodeAddressBook != null) {
+            for (com.hederahashgraph.api.proto.java.NodeAddress nodeAddressProto : nodeAddressBook
+                    .getNodeAddressList()) {
+                AddressBookEntry addressBookEntry = AddressBookEntry.builder()
+                        .consensusTimestamp(consensusTimestamp)
+                        .memo(nodeAddressProto.getMemo().toStringUtf8())
+                        .ip(nodeAddressProto.getIpAddress().toStringUtf8())
+                        .port(nodeAddressProto.getPortno())
+                        .publicKey(nodeAddressProto.getRSAPubKey())
+                        .nodeCertHash(nodeAddressProto.getNodeCertHash().toByteArray())
+                        .nodeId(nodeAddressProto.getNodeId())
+                        .nodeAccountId(EntityId.of(nodeAddressProto.getNodeAccountId()))
+                        .build();
+                builder.add(addressBookEntry);
+            }
         }
 
-        return listBuilder.build();
+        return builder.build();
     }
 
     /**

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/AddressBookEntry.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/AddressBookEntry.java
@@ -56,11 +56,12 @@ public class AddressBookEntry {
 
     private String ip;
 
-    private Integer port;
+    @Builder.Default
+    private int port = 50211;
 
     private String publicKey;
 
-    private Long nodeId;
+    private long nodeId;
 
     @Convert(converter = AccountIdConverter.class)
     private EntityId nodeAccountId;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/AddressBookEntry.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/AddressBookEntry.java
@@ -56,12 +56,11 @@ public class AddressBookEntry {
 
     private String ip;
 
-    @Builder.Default
-    private int port = 50211;
+    private Integer port;
 
     private String publicKey;
 
-    private long nodeId;
+    private Long nodeId;
 
     @Convert(converter = AccountIdConverter.class)
     private EntityId nodeAccountId;

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/addressbook/AddressBookServiceImplTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/addressbook/AddressBookServiceImplTest.java
@@ -407,8 +407,8 @@ class AddressBookServiceImplTest {
                     .setNodeId(nodeId)
                     .setMemo(ByteString.copyFromUtf8("0.0." + nodeId))
                     .setNodeAccountId(AccountID.newBuilder().setAccountNum(nodeId).build())
-                    .setNodeCertHash(ByteString.copyFromUtf8("nodeCertHash"))
-                    .setRSAPubKey("rsa+public/key");
+                    .setNodeCertHash(ByteString.copyFromUtf8("nodeCertHash" + nodeId))
+                    .setRSAPubKey("rsa+public/key" + nodeId);
             nodeId++;
 
             switch (fieldNumber) {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/addressbook/AddressBookServiceImplTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/addressbook/AddressBookServiceImplTest.java
@@ -24,12 +24,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.google.protobuf.ByteString;
+import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.NodeAddress;
 import com.hederahashgraph.api.proto.java.NodeAddressBook;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import javax.annotation.Resource;
+import lombok.extern.log4j.Log4j2;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -40,6 +46,7 @@ import org.springframework.test.context.jdbc.Sql;
 import com.hedera.mirror.importer.MirrorProperties;
 import com.hedera.mirror.importer.ResetCacheTestExecutionListener;
 import com.hedera.mirror.importer.domain.AddressBook;
+import com.hedera.mirror.importer.domain.AddressBookEntry;
 import com.hedera.mirror.importer.domain.EntityId;
 import com.hedera.mirror.importer.domain.EntityTypeEnum;
 import com.hedera.mirror.importer.domain.FileData;
@@ -48,6 +55,7 @@ import com.hedera.mirror.importer.repository.AddressBookEntryRepository;
 import com.hedera.mirror.importer.repository.AddressBookRepository;
 import com.hedera.mirror.importer.repository.FileDataRepository;
 
+@Log4j2
 @SpringBootTest
 @Sql(executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD, scripts = "classpath:db/scripts/cleanup.sql")
 @TestExecutionListeners(value = {ResetCacheTestExecutionListener.class},
@@ -56,6 +64,7 @@ class AddressBookServiceImplTest {
 
     private static final NodeAddressBook UPDATED = addressBook(10);
     private static final NodeAddressBook FINAL = addressBook(15);
+    private static final List<FieldDescriptor> allNodeAddressFieldDescriptors = NodeAddress.getDescriptor().getFields();
 
     @TempDir
     Path dataPath;
@@ -335,9 +344,103 @@ class AddressBookServiceImplTest {
         assertThat(prevAddressBook.getEndConsensusTimestamp()).isNotNull();
     }
 
+    @Test
+    void verifyAddressBookWithEmptyAddressBookEntryFields() {
+        NodeAddressBook nodeAddressBook = addressBookWithEmptyAddressBookEntryFields();
+        byte[] nodeAddressBookBytes = nodeAddressBook.toByteArray();
+        update(nodeAddressBookBytes, 1L, true);
+
+        AddressBook current = addressBookService.getCurrent();
+
+        assertThat(current.getEntries()).hasSize(nodeAddressBook.getNodeAddressCount());
+        assertAddressBookData(nodeAddressBookBytes, 1L);
+
+        Map<Long, NodeAddress> nodeAddressMap = nodeAddressBook.getNodeAddressList()
+                .stream()
+                .collect(Collectors.toMap(n -> {
+                    if (n.getNodeId() != 0) {
+                        return n.getNodeId();
+                    } else {
+                        return n.getNodeAccountId().getAccountNum();
+                    }
+                }, n -> n));
+        for (AddressBookEntry actual : current.getEntries()) {
+            NodeAddress expected = nodeAddressMap.get(actual.getNodeAccountId().getEntityNum());
+            Set<Integer> setFieldNumbers = allNodeAddressFieldDescriptors.stream()
+                    .filter(expected::hasField)
+                    .map(FieldDescriptor::getNumber)
+                    .collect(Collectors.toSet());
+            // can't check nodeAccountId since AddressBookEntry tries to get nodeAccountId from both memo and
+            // nodeAccountId fields
+            String ip = setFieldNumbers.contains(NodeAddress.IPADDRESS_FIELD_NUMBER) ? expected.getIpAddress().toStringUtf8() : null;
+            Integer portNo = setFieldNumbers.contains(NodeAddress.PORTNO_FIELD_NUMBER) ? expected.getPortno() : null;
+            String memo = setFieldNumbers.contains(NodeAddress.MEMO_FIELD_NUMBER) ? expected.getMemo().toStringUtf8() : null;
+            String pubKey = setFieldNumbers.contains(NodeAddress.RSA_PUBKEY_FIELD_NUMBER) ? expected.getRSAPubKey() : null;
+            Long nodeId = setFieldNumbers.contains(NodeAddress.NODEID_FIELD_NUMBER) ? expected.getNodeId() : null;
+            byte[] nodeCertHash = setFieldNumbers.contains(NodeAddress.NODECERTHASH_FIELD_NUMBER) ? expected.getNodeCertHash().toByteArray() : null;
+
+            assertAll(() -> assertThat(actual.getIp()).isEqualTo(ip),
+                    () -> assertThat(actual.getPort()).isEqualTo(portNo),
+                    () -> assertThat(actual.getMemo()).isEqualTo(memo),
+                    () -> assertThat(actual.getPublicKey()).isEqualTo(pubKey),
+                    () -> assertThat(actual.getNodeId()).isEqualTo(nodeId),
+                    () -> assertThat(actual.getNodeCertHash()).isEqualTo(nodeCertHash));
+        }
+    }
+
     private void assertAddressBookData(byte[] expected, long consensusTimestamp) {
-        // addressBook.startConsensusTimestamp = consensusTimestamp + 1
         AddressBook actualAddressBook = addressBookRepository.findById(consensusTimestamp + 1).get();
         assertArrayEquals(expected, actualAddressBook.getFileData());
+    }
+
+    private NodeAddressBook addressBookWithEmptyAddressBookEntryFields() {
+        NodeAddressBook.Builder addressBookBuilder = NodeAddressBook.newBuilder();
+        List<Integer> allFieldNumbers = allNodeAddressFieldDescriptors.stream()
+                .map(FieldDescriptor::getNumber)
+                .collect(Collectors.toList());
+
+        int nodeId = 3;
+        for (int fieldNumber : allFieldNumbers) {
+            NodeAddress.Builder builder = NodeAddress.newBuilder()
+                    .setIpAddress(ByteString.copyFromUtf8("127.0.0." + nodeId))
+                    .setPortno(1000 + nodeId)
+                    .setNodeId(nodeId)
+                    .setMemo(ByteString.copyFromUtf8("0.0." + nodeId))
+                    .setNodeAccountId(AccountID.newBuilder().setAccountNum(nodeId).build())
+                    .setNodeCertHash(ByteString.copyFromUtf8("nodeCertHash"))
+                    .setRSAPubKey("rsa+public/key");
+            nodeId++;
+
+            switch (fieldNumber) {
+                case NodeAddress.IPADDRESS_FIELD_NUMBER:
+                    builder.clearIpAddress();
+                    break;
+                case NodeAddress.PORTNO_FIELD_NUMBER:
+                    builder.clearPortno();
+                    break;
+                case NodeAddress.MEMO_FIELD_NUMBER:
+                    builder.clearMemo();
+                    break;
+                case NodeAddress.RSA_PUBKEY_FIELD_NUMBER:
+                    builder.clearRSAPubKey();
+                    break;
+                case NodeAddress.NODEID_FIELD_NUMBER:
+                    builder.clearNodeId();
+                    break;
+                case NodeAddress.NODEACCOUNTID_FIELD_NUMBER:
+                    builder.clearNodeAccountId();
+                    break;
+                case NodeAddress.NODECERTHASH_FIELD_NUMBER:
+                    builder.clearNodeCertHash();
+                    break;
+                default:
+                    log.warn("Unhandled field of NodeAddress protobuf - {}", fieldNumber);
+                    break;
+            }
+
+            addressBookBuilder.addNodeAddress(builder);
+        }
+
+        return addressBookBuilder.build();
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/AddressBookEntryRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/AddressBookEntryRepositoryTest.java
@@ -49,7 +49,7 @@ public class AddressBookEntryRepositoryTest extends AbstractRepositoryTest {
                 .publicKey("rsa+public/key")
                 .memo("0.0.3")
                 .nodeAccountId(EntityId.of("0.0.5", EntityTypeEnum.ACCOUNT))
-                .nodeId(5L)
+                .nodeId(5)
                 .nodeCertHash("nodeCertHash".getBytes());
 
         if (nodeAddressCustomizer != null) {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/AddressBookEntryRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/AddressBookEntryRepositoryTest.java
@@ -49,7 +49,7 @@ public class AddressBookEntryRepositoryTest extends AbstractRepositoryTest {
                 .publicKey("rsa+public/key")
                 .memo("0.0.3")
                 .nodeAccountId(EntityId.of("0.0.5", EntityTypeEnum.ACCOUNT))
-                .nodeId(5)
+                .nodeId(5L)
                 .nodeCertHash("nodeCertHash".getBytes());
 
         if (nodeAddressCustomizer != null) {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/AddressBookRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/AddressBookRepositoryTest.java
@@ -77,7 +77,7 @@ public class AddressBookRepositoryTest extends AbstractRepositoryTest {
                 .publicKey("rsa+public/key")
                 .memo("0.0.3")
                 .nodeAccountId(EntityId.of("0.0.5", EntityTypeEnum.ACCOUNT))
-                .nodeId(5)
+                .nodeId(5L)
                 .nodeCertHash("nodeCertHash".getBytes());
 
         if (nodeAddressCustomizer != null) {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/AddressBookRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/AddressBookRepositoryTest.java
@@ -77,7 +77,7 @@ public class AddressBookRepositoryTest extends AbstractRepositoryTest {
                 .publicKey("rsa+public/key")
                 .memo("0.0.3")
                 .nodeAccountId(EntityId.of("0.0.5", EntityTypeEnum.ACCOUNT))
-                .nodeId(5L)
+                .nodeId(5)
                 .nodeCertHash("nodeCertHash".getBytes());
 
         if (nodeAddressCustomizer != null) {


### PR DESCRIPTION
Signed-off-by: Xin Li <xin.li@swirlds.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
-->

**Detailed description**:

- Change `port` and `nodeId` in `AddressBookEntry` to boxed types to allow `null` values
- Remove default value of `port`
- Set `port` to `null` in `AddressBookEntry` if in protobuf it's 0
- Set `nodeId` to `null` in `AddressBookEntry` if in protobuf all nodes have the same `nodeId`

**Which issue(s) this PR fixes**:
Fixes #968 

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated

