### PR TITLE
Clear topic notifications on error

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityBatchCleanupEvent.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityBatchCleanupEvent.java
@@ -1,0 +1,38 @@
+package com.hedera.mirror.importer.parser.record.entity;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import org.springframework.context.ApplicationEvent;
+
+public class EntityBatchCleanupEvent extends ApplicationEvent {
+
+    private static final long serialVersionUID = -1720341150125359382L;
+
+    /**
+     * Create a new {@code ApplicationEvent}.
+     *
+     * @param source the object on which the event initially occurred or with which the event is associated (never
+     *               {@code null})
+     */
+    public EntityBatchCleanupEvent(Object source) {
+        super(source);
+    }
+}

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityBatchSaveEvent.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityBatchSaveEvent.java
@@ -22,7 +22,7 @@ package com.hedera.mirror.importer.parser.record.entity;
 
 import org.springframework.context.ApplicationEvent;
 
-public class EntityBatchEvent extends ApplicationEvent {
+public class EntityBatchSaveEvent extends ApplicationEvent {
     private static final long serialVersionUID = -5121039174183266247L;
 
     /**
@@ -31,7 +31,7 @@ public class EntityBatchEvent extends ApplicationEvent {
      * @param source the object on which the event initially occurred or with which the event is associated (never
      *               {@code null})
      */
-    public EntityBatchEvent(Object source) {
+    public EntityBatchSaveEvent(Object source) {
         super(source);
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListener.java
@@ -52,7 +52,8 @@ import com.hedera.mirror.importer.exception.ParserException;
 import com.hedera.mirror.importer.parser.domain.StreamFileData;
 import com.hedera.mirror.importer.parser.record.RecordStreamFileListener;
 import com.hedera.mirror.importer.parser.record.entity.ConditionOnEntityRecordParser;
-import com.hedera.mirror.importer.parser.record.entity.EntityBatchEvent;
+import com.hedera.mirror.importer.parser.record.entity.EntityBatchCleanupEvent;
+import com.hedera.mirror.importer.parser.record.entity.EntityBatchSaveEvent;
 import com.hedera.mirror.importer.parser.record.entity.EntityListener;
 import com.hedera.mirror.importer.repository.ApplicationStatusRepository;
 import com.hedera.mirror.importer.repository.EntityRepository;
@@ -155,6 +156,7 @@ public class SqlEntityListener implements EntityListener, RecordStreamFileListen
         nonFeeTransfers.clear();
         topicMessages.clear();
         transactions.clear();
+        eventPublisher.publishEvent(new EntityBatchCleanupEvent(this));
     }
 
     private void executeBatches() {
@@ -172,7 +174,7 @@ public class SqlEntityListener implements EntityListener, RecordStreamFileListen
             topicMessagePgCopy.copy(topicMessages, connection);
             persistEntities();
             log.info("Completed batch inserts in {}", stopwatch);
-            eventPublisher.publishEvent(new EntityBatchEvent(this));
+            eventPublisher.publishEvent(new EntityBatchSaveEvent(this));
         } catch (ParserException e) {
             throw e;
         } catch (Exception e) {


### PR DESCRIPTION
**Detailed description**:
- Add `hedera.mirror.importer.publish.duration` metric to track pg notifications
- Fix `NotifyingEntityListener` not being notified of rollbacks and cleaning up its list of topic messages
- Fix `NotifyingEntityListener.onSave(..)` still attempting to notify when disabled

**Which issue(s) this PR fixes**:
Fixes #1028

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

