### PR TITLE
allow individual maxLimit config in rest service monitor

### DIFF
--- a/hedera-mirror-rest/check-state-proof/README.md
+++ b/hedera-mirror-rest/check-state-proof/README.md
@@ -42,7 +42,7 @@ If you would like to configure your mirror node to support State Proof Alpha you
 ### Install CLI
 The node based CLI tool `check-state-proof` can be installed as follows
 1. Ensure you've installed [NodeJS](https://nodejs.org/en/about/)
-2. Navigate to the `hedera-mirror-rest/state-proof-demo` directory
+2. Navigate to the `hedera-mirror-rest/check-state-proof` directory
 3. Npm install the tool -  `npm install -g .`
 
 To verify correct installation simply run `check-state-proof --help` or `npm start -- --help` to show usage instructions.

--- a/hedera-mirror-rest/monitoring/README.md
+++ b/hedera-mirror-rest/monitoring/README.md
@@ -39,22 +39,6 @@ git clone git@github.com:hashgraph/hedera-mirror-node.git
 cd hedera-mirror-node/hedera-mirror-rest/monitoring
 ```
 
-To configure a smaller `maxLimit` threshold for individual resources (`account`, `balance`, or `transaction`), for example,
-for environments with lower traffic volume, add the following section to `application.yml`:
-
-```yaml
-hedera:
-  mirror:
-    rest:
-      monitor:
-        account:
-                maxLimit: 100
-        balance:
-                maxLimit: 200
-        transaction:
-                maxLimit: 500
-```
-
 To run the monitor_apis backend:
 
 ```
@@ -63,6 +47,21 @@ cp config/sample.serverlist.json config/serverlist.json // Start with the sample
 nano config/serverlist.json // Insert the mirror node deployments you want to monitor
 npm install
 PORT=3000 pm2 start server.js
+```
+
+To configure a smaller `limit` threshold for individual resources (`account`, `balance`, or `transaction`), for example,
+for environments with lower traffic volume, adjust the values of the following section in `config/serverlist.json`:
+
+```json
+"account": {
+"limit": 1000
+},
+"balance": {
+"limit": 1000
+},
+"transaction": {
+"limit": 1000
+}
 ```
 
 The server will start polling Hedera mirror nodes specified in the config/serverlist.json file.

--- a/hedera-mirror-rest/monitoring/README.md
+++ b/hedera-mirror-rest/monitoring/README.md
@@ -39,6 +39,22 @@ git clone git@github.com:hashgraph/hedera-mirror-node.git
 cd hedera-mirror-node/hedera-mirror-rest/monitoring
 ```
 
+To configure a smaller `maxLimit` threshold for individual resources (`account`, `balance`, or `transaction`), for example,
+for environments with lower traffic volume, add the following section to `application.yml`:
+
+```yaml
+hedera:
+  mirror:
+    rest:
+      monitor:
+        account:
+                maxLimit: 100
+        balance:
+                maxLimit: 200
+        transaction:
+                maxLimit: 500
+```
+
 To run the monitor_apis backend:
 
 ```

--- a/hedera-mirror-rest/monitoring/monitor_apis/account_tests.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/account_tests.js
@@ -103,9 +103,9 @@ const getAccountsWithAccountCheck = async (server, classResults) => {
   const highestAcc = _.max(_.map(accounts, (acct) => acctestutils.toAccNum(acct.account)));
 
   url = acctestutils.getUrl(server, accountsPath, {
-    "account.id": highestAcc,
+    'account.id': highestAcc,
     type: 'credit',
-    limit: 1
+    limit: 1,
   });
   currentTestResult.url = url;
 
@@ -168,11 +168,8 @@ const getAccountsWithTimeAndLimitParams = async (server, classResults) => {
   const minusOne = math.subtract(math.bignumber(accounts[0].balance.timestamp), math.bignumber(1));
 
   url = acctestutils.getUrl(server, accountsPath, {
-    timestamp: [
-      `gt:${minusOne.toString()}`,
-      `lt:${plusOne.toString()}`
-      ],
-    limit: 1
+    timestamp: [`gt:${minusOne.toString()}`, `lt:${plusOne.toString()}`],
+    limit: 1,
   });
   currentTestResult.url = url;
   accounts = await getAccounts(url, currentTestResult);

--- a/hedera-mirror-rest/monitoring/monitor_apis/account_tests.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/account_tests.js
@@ -22,6 +22,7 @@
 
 const _ = require('lodash');
 const math = require('mathjs');
+const config = require('./config');
 const {
   checkAPIResponseError,
   checkRespObjDefined,
@@ -29,16 +30,16 @@ const {
   checkAccountNumber,
   checkMandatoryParams,
   getAPIResponse,
-  getMaxLimit,
   getUrl,
   fromAccNum,
   testRunner,
   toAccNum,
   CheckRunner,
-} = require('./monitortest_utils');
+} = require('./utils');
 
 const accountsPath = '/accounts';
 const resource = 'account';
+const resourceLimit = config[resource].limit;
 const jsonRespKey = 'accounts';
 const mandatoryParams = [
   'balance',
@@ -58,15 +59,14 @@ const mandatoryParams = [
  * @returns {{url: string, passed: boolean, message: string}}
  */
 const getAccountsWithAccountCheck = async (server) => {
-  const {maxLimit, isGlobal} = getMaxLimit(resource);
-  let url = getUrl(server, accountsPath, !isGlobal ? {limit: maxLimit} : undefined);
+  let url = getUrl(server, accountsPath, {limit: resourceLimit});
   const accounts = await getAPIResponse(url, jsonRespKey);
 
   let result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
     .withCheckSpec(checkRespObjDefined, {message: 'account is undefined'})
     .withCheckSpec(checkRespArrayLength, {
-      limit: maxLimit,
+      limit: resourceLimit,
       message: (accts, limit) => `accounts.length of ${accts.length}  is less than limit ${limit}`,
     })
     .withCheckSpec(checkMandatoryParams, {
@@ -147,15 +147,14 @@ const getAccountsWithTimeAndLimitParams = async (server) => {
  * @param {Object} server API host endpoint
  */
 const getSingleAccount = async (server) => {
-  const {maxLimit, isGlobal} = getMaxLimit(resource);
-  let url = getUrl(server, accountsPath, !isGlobal ? {limit: maxLimit} : undefined);
+  let url = getUrl(server, accountsPath, {limit: resourceLimit});
   const accounts = await getAPIResponse(url, jsonRespKey);
 
   let result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
     .withCheckSpec(checkRespObjDefined, {message: 'accounts is undefined'})
     .withCheckSpec(checkRespArrayLength, {
-      limit: maxLimit,
+      limit: resourceLimit,
       message: (accts, limit) => `accounts.length of ${accts.length} was expected to be ${limit}`,
     })
     .withCheckSpec(checkMandatoryParams, {

--- a/hedera-mirror-rest/monitoring/monitor_apis/balance_tests.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/balance_tests.js
@@ -22,6 +22,7 @@
 
 const _ = require('lodash');
 const math = require('mathjs');
+const config = require('./config');
 const {
   checkAPIResponseError,
   checkRespObjDefined,
@@ -30,17 +31,17 @@ const {
   checkMandatoryParams,
   checkRespDataFreshness,
   getAPIResponse,
-  getMaxLimit,
   getUrl,
   fromAccNum,
   testRunner,
   toAccNum,
   CheckRunner,
-} = require('./monitortest_utils');
+} = require('./utils');
 
 const balancesPath = '/balances';
 const balanceFileUpdateRefreshTime = 900;
 const resource = 'balance';
+const resourceLimit = config[resource].limit;
 const jsonRespKey = 'balances';
 const mandatoryParams = ['account', 'balance'];
 
@@ -49,15 +50,14 @@ const mandatoryParams = ['account', 'balance'];
  * @param {String} server API host endpoint
  */
 const getBalancesCheck = async (server) => {
-  const {maxLimit, isGlobal} = getMaxLimit(resource);
-  const url = getUrl(server, balancesPath, !isGlobal ? {limit: maxLimit} : undefined);
+  const url = getUrl(server, balancesPath, {limit: resourceLimit});
   const balances = await getAPIResponse(url, jsonRespKey);
 
   const result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
     .withCheckSpec(checkRespObjDefined, {message: 'balances is undefined'})
     .withCheckSpec(checkRespArrayLength, {
-      limit: maxLimit,
+      limit: resourceLimit,
       message: (elements, limit) => `balances.length of ${elements.length} is less than limit ${limit}`,
     })
     .withCheckSpec(checkMandatoryParams, {

--- a/hedera-mirror-rest/monitoring/monitor_apis/balance_tests.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/balance_tests.js
@@ -67,12 +67,12 @@ const getBalancesCheck = async (server, classResults) => {
   const currentTestResult = acctestutils.getMonitorTestResult();
 
   const query = {};
-  const {maxLimit, isGlobal} =  acctestutils.getMaxLimit(resource);
+  const {maxLimit, isGlobal} = acctestutils.getMaxLimit(resource);
   if (!isGlobal) {
     query.limit = maxLimit;
   }
 
-  let url = acctestutils.getUrl(server, balancesPath, query);
+  const url = acctestutils.getUrl(server, balancesPath, query);
   currentTestResult.url = url;
   const balances = await getBalances(url, currentTestResult);
 
@@ -141,11 +141,8 @@ const getBalancesWithTimeAndLimitParams = async (server, classResults) => {
   const plusOne = math.add(math.bignumber(balancesResponse.timestamp), math.bignumber(1));
   const minusOne = math.subtract(math.bignumber(balancesResponse.timestamp), math.bignumber(1));
   url = acctestutils.getUrl(server, balancesPath, {
-    timestamp: [
-      `gt:${minusOne.toString()}`,
-      `lt:${plusOne.toString()}`
-    ],
-    limit: 1
+    timestamp: [`gt:${minusOne.toString()}`, `lt:${plusOne.toString()}`],
+    limit: 1,
   });
   currentTestResult.url = url;
   balances = await getBalances(url, currentTestResult);

--- a/hedera-mirror-rest/monitoring/monitor_apis/common.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/common.js
@@ -65,7 +65,7 @@ const getStatus = () => {
   const httpErrorCodes = results
     .map((result) => result.httpCode)
     .filter((httpCode) => httpCode < 200 || httpCode > 299);
-  const httpCode = httpErrorCodes.length === 0 ? 200 : httpErrorCodes[0];
+  const httpCode = httpErrorCodes.length === 0 ? 200 : 409;
   return {
     results,
     httpCode,

--- a/hedera-mirror-rest/monitoring/monitor_apis/config.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/config.js
@@ -1,0 +1,47 @@
+/*-
+ * ‌
+ * Hedera Mirror Node
+ *
+ * Copyright (C) 2019 - 2020 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+'use strict';
+
+const fs = require('fs');
+const _ = require('lodash');
+const path = require('path');
+
+const REQUIRED_FIELDS = ['servers', 'interval', 'shard', 'account.limit', 'balance.limit', 'transaction.limit'];
+const SERVERLIST_FILE = path.join(__dirname, 'config', 'serverlist.json');
+let config = {};
+let loaded = false;
+
+if (!loaded) {
+  config = JSON.parse(fs.readFileSync(SERVERLIST_FILE).toString('utf-8'));
+  for (const field of REQUIRED_FIELDS) {
+    if (!_.has(config, field)) {
+      throw new Error(`required field "${field}" not found in configuration file ${SERVERLIST_FILE}`);
+    }
+  }
+
+  if (!Array.isArray(config.servers) || config.servers.length === 0) {
+    throw new Error(`invalid servers "${JSON.stringify(config.servers)}" in configuration file ${SERVERLIST_FILE}`);
+  }
+
+  loaded = true;
+}
+
+module.exports = config;

--- a/hedera-mirror-rest/monitoring/monitor_apis/config/sample.serverlist.json
+++ b/hedera-mirror-rest/monitoring/monitor_apis/config/sample.serverlist.json
@@ -6,5 +6,15 @@
       "name": "MyLocalMirrorNode"
     }
   ],
-  "interval": 60
+  "interval": 60,
+  "shard": 0,
+  "account": {
+    "limit": 1000
+  },
+  "balance": {
+    "limit": 1000
+  },
+  "transaction": {
+    "limit": 1000
+  }
 }

--- a/hedera-mirror-rest/monitoring/monitor_apis/monitor.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/monitor.js
@@ -22,7 +22,7 @@
 
 const common = require('./common.js');
 const monitorTests = require('./monitor_tests.js');
-const monitorTestutils = require('./monitortest_utils.js');
+const monitorTestutils = require('./utils.js');
 const retryCountMax = 3; // # of times a single process can retry
 
 /**

--- a/hedera-mirror-rest/monitoring/monitor_apis/monitor_tests.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/monitor_tests.js
@@ -20,7 +20,7 @@
 
 'use strict';
 
-const acctestutils = require('./monitortest_utils.js');
+const acctestutils = require('./utils.js');
 const transactionTests = require('./transaction_tests');
 const accountTests = require('./account_tests');
 const balanceTests = require('./balance_tests');

--- a/hedera-mirror-rest/monitoring/monitor_apis/monitortest_utils.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/monitortest_utils.js
@@ -112,11 +112,6 @@ const getUrl = (server, path, query = undefined) => {
  * @return {Object} JSON object representing api response
  */
 const getAPIResponse = (url) => {
-  if (url.indexOf('/') === 0) {
-    // if url is path get full url including host
-    url = getUrl(url);
-  }
-
   const controller = new AbortController();
   const timeout = setTimeout(
     () => {
@@ -214,13 +209,14 @@ const createFailedResultJson = (title, msg) => {
 /**
  * Helper function to get max limit for a resource. Returns the lesser of the resource specific maxLimit if exists and
  * the global maxLimit, otherwise the global maxLimit.
- * @param resource {String} Name of the resource
+ * @param {String} resource name of the resource
+ * @returns {{maxLimit: number, isGlobal: boolean}}
  */
 const getMaxLimit = (resource) => {
   const result = {
     maxLimit: config.maxLimit,
-    isGlobal: true
-  }
+    isGlobal: true,
+  };
 
   const {monitor} = config;
   if (!monitor) {

--- a/hedera-mirror-rest/monitoring/monitor_apis/monitortest_utils.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/monitortest_utils.js
@@ -20,7 +20,6 @@
 
 const AbortController = require('abort-controller');
 const config = require('../../config');
-const long = require('long');
 const fetch = require('node-fetch');
 const querystring = require('querystring');
 
@@ -44,18 +43,6 @@ const testResult = {
   url: '', // last rest-api endpoint call made in test
   message: '', // test message
   failureMessages: [], // failure messages
-};
-
-/**
- * Converts consensus timestamp seconds.nanoseconds to nanoseconds
- * @param {String} consensusTimestamp consensus timestamp
- * @return {Long} timestamp in nanoseconds
- */
-const consensusTimestampToNanos = (consensusTimestamp) => {
-  const parts = consensusTimestamp.split('.');
-  const seconds = long.fromString(parts[0]);
-  const nanos = parseInt(parts[1], 10);
-  return seconds.mul(1000000000).add(nanos);
 };
 
 /**
@@ -237,7 +224,6 @@ const getMaxLimit = (resource) => {
 module.exports = {
   toAccNum,
   fromAccNum,
-  consensusTimestampToNanos,
   getUrl,
   cloneObject,
   getAPIResponse,

--- a/hedera-mirror-rest/monitoring/monitor_apis/package-lock.json
+++ b/hedera-mirror-rest/monitoring/monitor_apis/package-lock.json
@@ -3768,8 +3768,7 @@
     "lodash": {
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-      "dev": true
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -3803,6 +3802,11 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
+    },
+    "long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
     "lowercase-keys": {
       "version": "1.0.1",
@@ -4495,6 +4499,11 @@
       "version": "6.7.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
       "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "range-parser": {
       "version": "1.2.1",

--- a/hedera-mirror-rest/monitoring/monitor_apis/package-lock.json
+++ b/hedera-mirror-rest/monitoring/monitor_apis/package-lock.json
@@ -3803,11 +3803,6 @@
         }
       }
     },
-    "long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
-    },
     "lowercase-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",

--- a/hedera-mirror-rest/monitoring/monitor_apis/package.json
+++ b/hedera-mirror-rest/monitoring/monitor_apis/package.json
@@ -17,8 +17,11 @@
     "cors": "^2.8.5",
     "dotenv": "^8.0.0",
     "express": "^4.17.1",
+    "lodash": "^4.17.20",
     "log4js": "^6.3.0",
+    "long": "^4.0.0",
     "mathjs": "^7.2.0",
+    "querystring": "^0.2.0",
     "shelljs": "^0.8.4"
   },
   "devDependencies": {

--- a/hedera-mirror-rest/monitoring/monitor_apis/package.json
+++ b/hedera-mirror-rest/monitoring/monitor_apis/package.json
@@ -19,7 +19,6 @@
     "express": "^4.17.1",
     "lodash": "^4.17.20",
     "log4js": "^6.3.0",
-    "long": "^4.0.0",
     "mathjs": "^7.2.0",
     "querystring": "^0.2.0",
     "shelljs": "^0.8.4"

--- a/hedera-mirror-rest/monitoring/monitor_apis/transaction_tests.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/transaction_tests.js
@@ -79,7 +79,7 @@ const getTransactionsWithAccountCheck = async (server, classResults) => {
 
   const query = {};
   const {maxLimit, isGlobal} = acctestutils.getMaxLimit(resource);
-  if (!isGlobal)  {
+  if (!isGlobal) {
     query.limit = maxLimit;
   }
 
@@ -132,7 +132,7 @@ const getTransactionsWithAccountCheck = async (server, classResults) => {
   url = acctestutils.getUrl(server, transactionsPath, {
     'account.id': highestAcc,
     type: 'credit',
-    limit: 1
+    limit: 1,
   });
   currentTestResult.url = url;
 
@@ -174,12 +174,12 @@ const getTransactionsWithOrderParam = async (server, classResults) => {
   const currentTestResult = acctestutils.getMonitorTestResult();
 
   const query = {order: 'asc'};
-  const {maxLimit, isGlobal} =  acctestutils.getMaxLimit(resource);
+  const {maxLimit, isGlobal} = acctestutils.getMaxLimit(resource);
   if (!isGlobal) {
     query.limit = maxLimit;
   }
 
-  let url = acctestutils.getUrl(server, transactionsPath, query);
+  const url = acctestutils.getUrl(server, transactionsPath, query);
   currentTestResult.url = url;
   const transactions = await getTransactions(url, currentTestResult);
 
@@ -198,7 +198,7 @@ const getTransactionsWithOrderParam = async (server, classResults) => {
   }
 
   let previousNanos = long.ZERO;
-  for (let txn of transactions) {
+  for (const txn of transactions) {
     const nanos = acctestutils.consensusTimestampToNanos(txn.consensus_timestamp);
     if (nanos.lessThan(previousNanos)) {
       currentTestResult.failureMessages.push('consensus timestamps are not in ascending order');
@@ -225,7 +225,7 @@ const getTransactionsWithLimitParams = async (server, classResults) => {
 
   const url = acctestutils.getUrl(server, transactionsPath, {limit: 10});
   currentTestResult.url = url;
-  let transactions = await getTransactions(url, currentTestResult);
+  const transactions = await getTransactions(url, currentTestResult);
 
   if (undefined === transactions) {
     const message = `transactions is undefined`;
@@ -276,11 +276,8 @@ const getTransactionsWithTimeAndLimitParams = async (server, classResults) => {
   const plusOne = math.add(math.bignumber(transactions[0].consensus_timestamp), math.bignumber(1));
   const minusOne = math.subtract(math.bignumber(transactions[0].consensus_timestamp), math.bignumber(1));
   url = acctestutils.getUrl(server, transactionsPath, {
-    timestamp: [
-      `gt:${minusOne.toString()}`,
-      `lt:${plusOne.toString()}`
-    ],
-    limit: 1
+    timestamp: [`gt:${minusOne.toString()}`, `lt:${plusOne.toString()}`],
+    limit: 1,
   });
   currentTestResult.url = url;
   transactions = await getTransactions(url, currentTestResult);

--- a/hedera-mirror-rest/monitoring/monitor_apis/transaction_tests.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/transaction_tests.js
@@ -21,7 +21,6 @@
 'use strict';
 
 const _ = require('lodash');
-const long = require('long');
 const math = require('mathjs');
 const acctestutils = require('./monitortest_utils');
 
@@ -197,16 +196,14 @@ const getTransactionsWithOrderParam = async (server, classResults) => {
     return;
   }
 
-  let previousNanos = long.ZERO;
+  let previousConsensusTimestamp = '0';
   for (const txn of transactions) {
-    const nanos = acctestutils.consensusTimestampToNanos(txn.consensus_timestamp);
-    if (nanos.lessThan(previousNanos)) {
+    if (txn.consensus_timestamp <= previousConsensusTimestamp) {
       currentTestResult.failureMessages.push('consensus timestamps are not in ascending order');
       acctestutils.addTestResult(classResults, currentTestResult, false);
       return;
     }
-
-    previousNanos = nanos;
+    previousConsensusTimestamp = txn.consensus_timestamp;
   }
 
   currentTestResult.result = 'passed';

--- a/hedera-mirror-rest/monitoring/monitor_apis/utils.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/utils.js
@@ -18,11 +18,13 @@
  * ‍
  */
 
+'use strict';
+
 const AbortController = require('abort-controller');
-const config = require('../../config');
 const _ = require('lodash');
 const fetch = require('node-fetch');
 const querystring = require('querystring');
+const config = require('./config');
 
 const apiPrefix = '/api/v1';
 
@@ -169,34 +171,6 @@ const createFailedResultJson = (title, msg) => {
   return failedResultJson;
 };
 
-/**
- * Helper function to get max limit for a resource. Returns the lesser of the resource specific maxLimit if exists and
- * the global maxLimit, otherwise the global maxLimit.
- * @param {String} resource name of the resource
- * @returns {{maxLimit: number, isGlobal: boolean}}
- */
-const getMaxLimit = (resource) => {
-  const result = {
-    maxLimit: config.maxLimit,
-    isGlobal: true,
-  };
-
-  const {monitor} = config;
-  if (!monitor) {
-    return result;
-  }
-
-  if (monitor[resource] && monitor[resource].maxLimit) {
-    const {maxLimit: resourceMaxLimit} = monitor[resource];
-    if (resourceMaxLimit < result.maxLimit) {
-      result.maxLimit = resourceMaxLimit;
-      result.isGlobal = false;
-    }
-  }
-
-  return result;
-};
-
 const checkAPIResponseError = (resp) => {
   if (resp instanceof Error) {
     return {
@@ -302,7 +276,6 @@ module.exports = {
   getAPIResponse,
   getMonitorClassResult,
   createFailedResultJson,
-  getMaxLimit,
   testRunner,
   checkAPIResponseError,
   checkRespObjDefined,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
-->

**Detailed description**:

Supports per-resource `maxLimit` config in rest service monitor, so ops can configure a smaller threshold for low traffic environments.

- Adds separate configuration option `maxLimit` for `account`, `balance`, and `transaction`. The value will overrides the global `maxLimit` if it's smaller
- Adds missing consensus timestamp ascending order check for transactions query
- Removes dependency on hedera-mirror-rest/config and moves all configuration to `serverlist.json`
- Aggregates http response code from all servers, returns 409 if there is at least one failed test 

**Which issue(s) this PR fixes**:
Fixes #1033  #462 

**Special notes for your reviewer**:

Tested in perfnet.

```shell
$ curl http://localhost:9001/api/v1/status/performance-6557 | jq .
```

```json
{
  "ip": "127.0.0.1",
  "name": "performance-6557",
  "port": "6557",
  "results": {
    "testResults": [
      {
        "at": 1600439717484,
        "result": "passed",
        "url": "http://127.0.0.1:6557/api/v1/balances?limit=100",
        "message": "Successfully called balances and performed account check",
        "failureMessages": []
      },
      {
        "at": 1600439717484,
        "result": "passed",
        "url": "http://127.0.0.1:6557/api/v1/balances?limit=1",
        "message": "Successfully retrieved balance from with 1800 seconds ago",
        "failureMessages": []
      },
      {
        "at": 1600439717484,
        "result": "passed",
        "url": "http://127.0.0.1:6557/api/v1/accounts?timestamp=gt%3A1600439399.310535&timestamp=lt%3A1600439401.310535&limit=1",
        "message": "Successfully called accounts with time and limit params",
        "failureMessages": []
      },
      {
        "at": 1600439717484,
        "result": "passed",
        "url": "http://127.0.0.1:6557/api/v1/balances?timestamp=gt%3A1600439399.310535&timestamp=lt%3A1600439401.310535&limit=1",
        "message": "Successfully called balances with time and limit params",
        "failureMessages": []
      },
      {
        "at": 1600439717484,
        "result": "passed",
        "url": "http://127.0.0.1:6557/api/v1/transactions?limit=1",
        "message": "Successfully retrieved transactions from with 50 seconds ago",
        "failureMessages": []
      },
      {
        "at": 1600439717484,
        "result": "passed",
        "url": "http://127.0.0.1:6557/api/v1/balances?account.id=0.0.1009",
        "message": "Successfully called balances and performed account check",
        "failureMessages": []
      },
      {
        "at": 1600439717483,
        "result": "passed",
        "url": "http://127.0.0.1:6557/api/v1/transactions?timestamp=gt%3A1600439702.316232&timestamp=lt%3A1600439704.316232&limit=1",
        "message": "Successfully called transactions with time and limit params",
        "failureMessages": []
      },
      {
        "at": 1600439717483,
        "result": "passed",
        "url": "http://127.0.0.1:6557/api/v1/transactions/0.0.2-1600439692-302595000",
        "message": "Successfully retrieved single transactions by id",
        "failureMessages": []
      },
      {
        "at": 1600439717483,
        "result": "passed",
        "url": "http://127.0.0.1:6557/api/v1/transactions?limit=10",
        "message": "Successfully called transactions with limit params only",
        "failureMessages": []
      },
      {
        "at": 1600439717484,
        "result": "passed",
        "url": "http://127.0.0.1:6557/api/v1/accounts?account.id=1001&type=credit&limit=1",
        "message": "Successfully called accounts and performed account check",
        "failureMessages": []
      },
      {
        "at": 1600439717483,
        "result": "passed",
        "url": "http://127.0.0.1:6557/api/v1/transactions?order=asc&limit=102",
        "message": "Successfully called transactions with order params only",
        "failureMessages": []
      },
      {
        "at": 1600439717483,
        "result": "passed",
        "url": "http://127.0.0.1:6557/api/v1/transactions?account.id=3&type=credit&limit=1",
        "message": "Successfully called transactions and performed account check",
        "failureMessages": []
      },
      {
        "at": 1600439717484,
        "result": "passed",
        "url": "http://127.0.0.1:6557/api/v1/accounts/0.0.1001",
        "message": "Successfully called accounts for single account",
        "failureMessages": []
      }
    ],
    "numPassedTests": 13,
    "numFailedTests": 0,
    "success": true,
    "message": "",
    "startTime": 1600439717483,
    "endTime": 1600439717888
  },
  "httpCode": 200
}
```
**Checklist**
- [x] Documentation added
- [ ] Tests updated

