### PR TITLE
Replace account_realm_num and account_num with  account_id in account_balance table

### DIFF
--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/domain/AccountBalance.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/domain/AccountBalance.java
@@ -23,14 +23,14 @@ package com.hedera.datagenerator.domain;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 
+import com.hedera.mirror.importer.domain.EntityId;
+
 @Data
 @RequiredArgsConstructor
 public class AccountBalance {
     private final long consensusTimestamp;
 
-    private final int accountRealmNum;
-
-    private final int accountNum;
+    private final EntityId accountId;
 
     private final long balance;
 }

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/domain/DomainDriver.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/domain/DomainDriver.java
@@ -106,7 +106,8 @@ public class DomainDriver implements ApplicationRunner {
         log.info("Generated {} transactions in {}", numTransactionsGenerated, stopwatch);
         new EntityGenerator().generateAndWriteEntities(entityManager, domainWriter);
         log.info("Writing data to db");
-        sqlEntityListener.onEnd(new RecordFile(0L, 1L, 1L, "", 0L, 1L, "", "", nodeAccountId, 0L, 0)); // writes data to db
+        sqlEntityListener
+                .onEnd(new RecordFile(0L, 1L, 1L, "", 0L, 1L, "", "", nodeAccountId, 0L, 0)); // writes data to db
         domainWriter.flush(); // writes data to db
         log.info("Total time taken: {}", stopwatch);
     }
@@ -115,8 +116,7 @@ public class DomainDriver implements ApplicationRunner {
     private void writeBalances(long consensusNs) {
         for (Map.Entry<EntityId, Long> entry : entityManager.getBalances().entrySet()) {
             var entity = entry.getKey();
-            domainWriter.onAccountBalance(new AccountBalance(consensusNs, entity.getRealmNum().intValue(),
-                    entity.getEntityNum().intValue(), entry.getValue()));
+            domainWriter.onAccountBalance(new AccountBalance(consensusNs, entity, entry.getValue()));
         }
         log.debug("Wrote balances data at {}", consensusNs);
     }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/AccountBalance.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/AccountBalance.java
@@ -21,7 +21,9 @@ package com.hedera.mirror.importer.domain;
  */
 
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.io.Serializable;
+import javax.persistence.Convert;
 import javax.persistence.Embeddable;
 import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;
@@ -29,6 +31,9 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.springframework.data.domain.Persistable;
+
+import com.hedera.mirror.importer.converter.AccountIdConverter;
+import com.hedera.mirror.importer.converter.EntityIdSerializer;
 
 @Data
 @AllArgsConstructor
@@ -57,8 +62,8 @@ public class AccountBalance implements Persistable<AccountBalance.Id> {
 
         private long consensusTimestamp;
 
-        private int accountNum;
-
-        private int accountRealmNum;
+        @Convert(converter = AccountIdConverter.class)
+        @JsonSerialize(using = EntityIdSerializer.class)
+        private EntityId accountId;
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/AccountBalance.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/AccountBalance.java
@@ -58,7 +58,7 @@ public class AccountBalance implements Persistable<AccountBalance.Id> {
     @Embeddable
     public static class Id implements Serializable {
 
-        private static final long serialVersionUID = -2399552489266593375L;
+        private static final long serialVersionUID = 1345295043157256768L;
 
         private long consensusTimestamp;
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/balance/AccountBalanceLineParser.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/balance/AccountBalanceLineParser.java
@@ -3,6 +3,8 @@ package com.hedera.mirror.importer.parser.balance;
 import javax.inject.Named;
 
 import com.hedera.mirror.importer.domain.AccountBalance;
+import com.hedera.mirror.importer.domain.EntityId;
+import com.hedera.mirror.importer.domain.EntityTypeEnum;
 import com.hedera.mirror.importer.exception.InvalidDatasetException;
 
 @Named
@@ -39,7 +41,8 @@ public class AccountBalanceLineParser {
                         "shard (%d), got shard (%d)", line, systemShardNum, shardNum));
             }
 
-            return new AccountBalance(balance, new AccountBalance.Id(consensusTimestamp, accountNum, realmNum));
+            return new AccountBalance(balance, new AccountBalance.Id(consensusTimestamp, EntityId
+                    .of(shardNum, realmNum, accountNum, EntityTypeEnum.ACCOUNT)));
         } catch (NullPointerException | NumberFormatException ex) {
             throw new InvalidDatasetException("Invalid account balance line: " + line, ex);
         }

--- a/hedera-mirror-importer/src/main/resources/db/migration/V1.30.0__balance_entity_id.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/V1.30.0__balance_entity_id.sql
@@ -1,0 +1,29 @@
+-------------------
+-- Update account_balance to use single entity_id column instead of account_realm_num and account_num
+-------------------
+
+-- Drop pk and index that used account_realm_num and account_num. Drop first to make migration quicker
+alter table account_balance drop constraint pk__account_balances;
+drop index if exists idx__account_balances__account_then_timestamp;
+
+--  Add account_id entity_id column and set based on existing account_realm_num and account_num
+alter table if exists account_balance
+    add column account_id entity_id null;
+
+update account_balance
+    set account_id = encodeEntityId(0, account_realm_num, account_num);
+
+alter table if exists account_balance
+    alter column account_id set not null;
+
+-- Drop account_realm_num and account_num
+alter table if exists account_balance
+    drop column if exists account_realm_num,
+    drop column if exists account_num;
+
+-- Add new pk and index using account_id
+alter table account_balance
+    add constraint pk__account_balance primary key (consensus_timestamp, account_id);
+
+create index if not exists account_balance__account_timestamp
+    on account_balance (account_id desc, consensus_timestamp desc);

--- a/hedera-mirror-importer/src/main/resources/db/migration/V1.30.0__balance_entity_id.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/V1.30.0__balance_entity_id.sql
@@ -23,7 +23,7 @@ alter table if exists account_balance
 
 -- Add new pk and index using account_id
 alter table account_balance
-    add constraint pk__account_balance primary key (consensus_timestamp, account_id);
+    add constraint account_balance__pk primary key (consensus_timestamp, account_id);
 
 create index if not exists account_balance__account_timestamp
     on account_balance (account_id desc, consensus_timestamp desc);

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/balance/AccountBalanceLineParserTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/balance/AccountBalanceLineParserTest.java
@@ -40,15 +40,15 @@ class AccountBalanceLineParserTest {
             "'';true;;;",
             ";true;;;"
     }, delimiter = ';')
-    void parse(String line, boolean expectThrow, Integer expectedRealm, Integer expectedAccount, Long expectedBalance) {
+    void parse(String line, boolean expectThrow, Long expectedRealm, Long expectedAccount, Long expectedBalance) {
         AccountBalanceLineParser parser = new AccountBalanceLineParser();
         if (!expectThrow) {
             AccountBalance accountBalance = parser.parse(line, timestamp, systemShardNum);
             var id = accountBalance.getId();
 
             assertThat(accountBalance.getBalance()).isEqualTo(expectedBalance);
-            assertThat(id.getAccountRealmNum()).isEqualTo(expectedRealm);
-            assertThat(id.getAccountNum()).isEqualTo(expectedAccount);
+            assertThat(id.getAccountId().getRealmNum()).isEqualTo(expectedRealm);
+            assertThat(id.getAccountId().getEntityNum()).isEqualTo(expectedAccount);
             assertThat(id.getConsensusTimestamp()).isEqualTo(timestamp);
         } else {
             assertThrows(InvalidDatasetException.class, () -> {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/AccountBalanceRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/AccountBalanceRepositoryTest.java
@@ -26,6 +26,8 @@ import javax.annotation.Resource;
 import org.junit.jupiter.api.Test;
 
 import com.hedera.mirror.importer.domain.AccountBalance;
+import com.hedera.mirror.importer.domain.EntityId;
+import com.hedera.mirror.importer.domain.EntityTypeEnum;
 
 public class AccountBalanceRepositoryTest extends AbstractRepositoryTest {
 
@@ -45,8 +47,7 @@ public class AccountBalanceRepositoryTest extends AbstractRepositoryTest {
     private AccountBalance create(long consensusTimestamp, int accountNum, long balance) {
         AccountBalance.Id id = new AccountBalance.Id();
         id.setConsensusTimestamp(consensusTimestamp);
-        id.setAccountNum(accountNum);
-        id.setAccountRealmNum(0);
+        id.setAccountId(EntityId.of(0, 0, accountNum, EntityTypeEnum.ACCOUNT));
 
         AccountBalance accountBalance = new AccountBalance();
         accountBalance.setBalance(balance);

--- a/hedera-mirror-rest/__tests__/accounts.test.js
+++ b/hedera-mirror-rest/__tests__/accounts.test.js
@@ -51,8 +51,9 @@ const validateAccNumRange = function (accounts, low, high) {
   let ret = true;
   let offender = null;
   for (const acc of accounts.accounts) {
-    if (acc.id < low || acc.id > high) {
-      offender = acc.id;
+    const accNum = acc.account.split('.')[2];
+    if (accNum < low || accNum > high) {
+      offender = accNum;
       ret = false;
     }
   }

--- a/hedera-mirror-rest/__tests__/accounts.test.js
+++ b/hedera-mirror-rest/__tests__/accounts.test.js
@@ -51,9 +51,8 @@ const validateAccNumRange = function (accounts, low, high) {
   let ret = true;
   let offender = null;
   for (const acc of accounts.accounts) {
-    const accNum = acc.account.split('.')[2];
-    if (accNum < low || accNum > high) {
-      offender = accNum;
+    if (acc.id < low || acc.id > high) {
+      offender = acc.id;
       ret = false;
     }
   }
@@ -154,7 +153,7 @@ const validateOrder = function (accounts, order) {
 const singletests = {
   accountid_lowerlimit: {
     urlparam: 'account.id=gte:0.0.1111',
-    checks: [{field: 'account_num', operator: '>=', value: 1111}],
+    checks: [{field: 'account_id', operator: '>=', value: 1111}],
     checkFunctions: [
       {func: validateAccNumRange, args: [1111, Number.MAX_SAFE_INTEGER]},
       {func: validateFields, args: []},
@@ -162,7 +161,7 @@ const singletests = {
   },
   accountid_higherlimit: {
     urlparam: 'account.id=lt:0.0.2222',
-    checks: [{field: 'account_num', operator: '<', value: 2222}],
+    checks: [{field: 'account_id', operator: '<', value: 2222}],
     checkFunctions: [
       {func: validateAccNumRange, args: [0, 2222]},
       {func: validateFields, args: []},
@@ -170,7 +169,7 @@ const singletests = {
   },
   accountid_equal: {
     urlparam: 'account.id=0.0.3333',
-    checks: [{field: 'account_num', operator: '=', value: 3333}],
+    checks: [{field: 'account_id', operator: '=', value: 3333}],
     checkFunctions: [
       {func: validateAccNumRange, args: [3333, 3333]},
       {func: validateFields, args: []},

--- a/hedera-mirror-rest/__tests__/balances.test.js
+++ b/hedera-mirror-rest/__tests__/balances.test.js
@@ -198,7 +198,7 @@ const singletests = {
   },
   accountid_lowerlimit: {
     urlparam: 'account.id=gte:0.0.1111',
-    checks: [{field: 'account_num', operator: '>=', value: 1111}],
+    checks: [{field: 'account_id', operator: '>=', value: 1111}],
     checkFunctions: [
       {func: validateAccNumRange, args: [1111, Number.MAX_SAFE_INTEGER]},
       {func: validateFields, args: []},
@@ -206,7 +206,7 @@ const singletests = {
   },
   accountid_higherlimit: {
     urlparam: 'account.id=lt:0.0.2222',
-    checks: [{field: 'account_num', operator: '<', value: 2222}],
+    checks: [{field: 'account_id', operator: '<', value: 2222}],
     checkFunctions: [
       {func: validateAccNumRange, args: [0, 2222]},
       {func: validateFields, args: []},
@@ -214,7 +214,7 @@ const singletests = {
   },
   accountid_equal: {
     urlparam: 'account.id=0.0.3333',
-    checks: [{field: 'account_num', operator: '=', value: 3333}],
+    checks: [{field: 'account_id', operator: '=', value: 3333}],
     checkFunctions: [
       {func: validateAccNumRange, args: [3333, 3333]},
       {func: validateFields, args: []},

--- a/hedera-mirror-rest/__tests__/integrationDomainOps.js
+++ b/hedera-mirror-rest/__tests__/integrationDomainOps.js
@@ -124,11 +124,15 @@ const addAccount = async function (account) {
 };
 
 const setAccountBalance = async function (account) {
-  account = Object.assign({timestamp: 0, realm_num: 0, id: null, balance: 0}, account);
+  account = Object.assign({timestamp: 0, id: null, balance: 0, entity_shard: 0, realm_num: 0}, account);
   await sqlConnection.query(
-    `INSERT INTO account_balance (consensus_timestamp, account_realm_num, account_num, balance)
-    VALUES (\$1, \$2, \$3, \$4);`,
-    [account.timestamp, account.realm_num, account.id, account.balance]
+    `INSERT INTO account_balance (consensus_timestamp, account_id, balance)
+    VALUES (\$1, \$2, \$3);`,
+    [
+      account.timestamp,
+      EntityId.of(account.entity_shard, account.realm_num, account.id).getEncodedId(),
+      account.balance,
+    ]
   );
 };
 

--- a/hedera-mirror-rest/__tests__/mockpool.js
+++ b/hedera-mirror-rest/__tests__/mockpool.js
@@ -84,10 +84,10 @@ class Pool {
         orderprefix = 'consensus_ns';
         break;
       case 'balances':
-        orderprefix = 'account_num';
+        orderprefix = 'account_id';
         break;
       case 'accounts':
-        orderprefix = 'coalesce\\(ab.account_num, e.entity_num\\)';
+        orderprefix = 'coalesce\\(ab.account_id, e.id\\)';
         break;
       default:
         break;
@@ -229,7 +229,7 @@ class Pool {
     // Adjust the low/high values based on the SQL query parameters
     for (const param of parsedparams) {
       switch (param.field) {
-        case 'account_num':
+        case 'account_id':
           accountNum = this.adjustRangeBasedOnConstraints(param, accountNum);
           break;
         case 'consensus_timestamp':
@@ -261,8 +261,7 @@ class Pool {
     for (let i = 0; i < limit.high; i++) {
       let row = {};
       row.consensus_timestamp = this.toNs(Math.floor((timestamp.low + timestamp.high) / 2));
-      row.realm_num = 0;
-      row.entity_num =
+      row.account_id =
         Number(accountNum.high) - (accountNum.high == accountNum.low ? 0 : i % (accountNum.high - accountNum.low));
       row.balance = balance.low + Math.floor((balance.high - balance.low) / limit.high);
 
@@ -299,7 +298,7 @@ class Pool {
     // Adjust the low/high values based on the SQL query parameters
     for (const param of parsedparams) {
       switch (param.field) {
-        case 'account_num':
+        case 'account_id':
           accountNum = this.adjustRangeBasedOnConstraints(param, accountNum);
           break;
         case 'balance':
@@ -326,9 +325,7 @@ class Pool {
 
       row.account_balance = balance.low + Math.floor((balance.high - balance.low) / limit.high);
       row.consensus_timestamp = this.toNs(this.timeNow);
-      row.entity_shard = 0;
-      row.entity_realm = 0;
-      row.entity_num =
+      row.entity_id =
         Number(accountNum.high) - (accountNum.high == accountNum.low ? 0 : i % (accountNum.high - accountNum.low));
       row.exp_time_ns = this.toNs(this.timeNow + 1000);
       row.auto_renew_period = i * 1000;

--- a/hedera-mirror-rest/__tests__/testutils.js
+++ b/hedera-mirror-rest/__tests__/testutils.js
@@ -26,7 +26,9 @@ const checkSql = function (parsedparams, condition) {
     }
   }
   console.log(
-    `ERROR: Condition: ${condition.field} ${condition.operator} ${condition.value} not present in the generated SQL`
+    `ERROR: Condition: ${condition.field} ${condition.operator} ${
+      condition.value
+    } not present in the generated SQL: ${JSON.stringify(parsedparams)}`
   );
   return false;
 };

--- a/hedera-mirror-rest/accounts.js
+++ b/hedera-mirror-rest/accounts.js
@@ -56,7 +56,7 @@ const getAccountQueryPrefix = function () {
        e.deleted
     from account_balance ab
     full outer join t_entities e on (
-        ab.account_id =  e.id
+        ab.account_id = e.id
         and e.fk_entity_type_id < ${utils.ENTITY_TYPE_FILE}
     )
     where ab.consensus_timestamp = (select max(consensus_timestamp) from account_balance)`;

--- a/hedera-mirror-rest/accounts.js
+++ b/hedera-mirror-rest/accounts.js
@@ -35,7 +35,7 @@ const {DbError} = require('./errors/dbError');
 const processRow = function (row) {
   let accRecord = {};
   accRecord.balance = {};
-  accRecord.account = row.entity_shard + '.' + row.entity_realm + '.' + row.entity_num;
+  accRecord.account = EntityId.fromEncodedId(row['entity_id']).toString();
   accRecord.balance.timestamp = row.consensus_timestamp === null ? null : utils.nsToSecNs(row.consensus_timestamp);
   accRecord.balance.balance = row.account_balance === null ? null : Number(row.account_balance);
   accRecord.expiry_timestamp = row.exp_time_ns === null ? null : utils.nsToSecNs(row.exp_time_ns);
@@ -49,18 +49,14 @@ const processRow = function (row) {
 const getAccountQueryPrefix = function () {
   return `select ab.balance as account_balance,
        ab.consensus_timestamp as consensus_timestamp,
-       ${config.shard} as entity_shard,
-       coalesce(ab.account_realm_num, e.entity_realm) as entity_realm,
-       coalesce(ab.account_num, e.entity_num) as entity_num,
+       coalesce(ab.account_id, e.id) as entity_id,
        e.exp_time_ns,
        e.auto_renew_period,
        e.key,
        e.deleted
     from account_balance ab
     full outer join t_entities e on (
-        ${config.shard} = e.entity_shard
-        and ab.account_realm_num = e.entity_realm
-        and ab.account_num =  e.entity_num
+        ab.account_id =  e.id
         and e.fk_entity_type_id < ${utils.ENTITY_TYPE_FILE}
     )
     where ab.consensus_timestamp = (select max(consensus_timestamp) from account_balance)`;
@@ -79,16 +75,8 @@ const getAccounts = async (req, res) => {
 
   // Because of the outer join on the 'account_balance ab' and 't_entities e' below, we
   // need to look  for the given account.id in both account_balance and t_entities table and combine with an 'or'
-  const [balancesAccountQuery, balancesAccountParams] = utils.parseAccountIdQueryParam(
-    req.query,
-    'ab.account_realm_num',
-    'ab.account_num'
-  );
-  const [entityAccountQuery, entityAccountParams] = utils.parseAccountIdQueryParam(
-    req.query,
-    'e.entity_realm',
-    ' e.entity_num'
-  );
+  const [balancesAccountQuery, balancesAccountParams] = utils.parseAccountIdQueryParam(req.query, 'ab.account_id');
+  const [entityAccountQuery, entityAccountParams] = utils.parseAccountIdQueryParam(req.query, 'e.id');
   const accountQuery =
     balancesAccountQuery === ''
       ? ''
@@ -101,7 +89,7 @@ const getAccounts = async (req, res) => {
     getAccountQueryPrefix() +
     '    and \n' +
     [accountQuery, balanceQuery, pubKeyQuery].map((q) => (q === '' ? '1=1' : q)).join(' and ') +
-    ' order by coalesce(ab.account_num, e.entity_num) ' +
+    ' order by coalesce(ab.account_id, e.id) ' +
     order +
     '\n' +
     query;
@@ -179,14 +167,15 @@ const getOneAccount = async (req, res) => {
   const entitySql =
     getAccountQueryPrefix() +
     'and (\n' +
-    '    (ab.account_realm_num  =  ? and ab.account_num  =  ?)\n' +
-    '    or (e.entity_shard = ? and e.entity_realm = ? and e.entity_num = ?\n' +
+    '    (ab.account_id  =  ?)\n' +
+    '    or (e.id = ?\n' +
     '        and e.fk_entity_type_id < ' +
     utils.ENTITY_TYPE_FILE +
     ')\n' +
     ')\n';
 
-  const entityParams = [acc.realm, acc.num, config.shard, acc.realm, acc.num];
+  const accountId = EntityId.of(acc.shard, acc.realm, acc.num).getEncodedId();
+  const entityParams = [accountId, accountId];
   const pgEntityQuery = utils.convertMySqlStyleQueryToPostgres(entitySql, entityParams);
 
   if (logger.isTraceEnabled()) {

--- a/hedera-mirror-rest/transactions.js
+++ b/hedera-mirror-rest/transactions.js
@@ -150,7 +150,7 @@ const getTransactionsInnerQuery = function (
 const reqToSql = function (req) {
   // Parse the filter parameters for credit/debit, account-numbers, timestamp, and pagination (limit)
   const [creditDebitQuery] = utils.parseCreditDebitParams(req.query, 'ctl.amount');
-  let [accountQuery, accountParams] = utils.parseAccountIdQueryParamAsEncoded(req.query, 'ctl.entity_id');
+  let [accountQuery, accountParams] = utils.parseAccountIdQueryParam(req.query, 'ctl.entity_id');
   const [tsQuery, tsParams] = utils.parseTimestampQueryParam(req.query, 't.consensus_ns');
   const resultTypeQuery = utils.parseResultParams(req);
   const {query, params, order, limit} = utils.parseLimitAndOrderParams(req);

--- a/hedera-mirror-rest/utils.js
+++ b/hedera-mirror-rest/utils.js
@@ -322,21 +322,10 @@ const parseParams = function (paramValues, processOpAndValue) {
   return [partialQueries.join(' and '), values];
 };
 
-const parseAccountIdQueryParamAsEncoded = function (parsedQueryParams, columnName) {
-  return parseAccountIdQueryParamCommon(parsedQueryParams, '', columnName, true);
-};
-
-const parseAccountIdQueryParam = function (parsedQueryParams, realmColumnName, numColumnName) {
-  return parseAccountIdQueryParamCommon(parsedQueryParams, realmColumnName, numColumnName, false);
-};
-
-const parseAccountIdQueryParamCommon = function (parsedQueryParams, realmColumnName, numColumnName, isEncoded) {
+const parseAccountIdQueryParam = function (parsedQueryParams, columnName) {
   return parseParams(parsedQueryParams[constants.filterKeys.ACCOUNT_ID], (op, value) => {
-    let entity = parseEntityId(value);
-    if (isEncoded) {
-      return [`${numColumnName} ${op} ?`, [EntityId.of(config.shard, entity.realm, entity.num).getEncodedId()]];
-    }
-    return [`${realmColumnName} ${opsMap['eq']} ? and ${numColumnName} ${op} ?`, [entity.realm, entity.num]];
+    const entity = parseEntityId(value);
+    return [`${columnName} ${op} ?`, [EntityId.of(entity.shard, entity.realm, entity.num).getEncodedId()]];
   });
 };
 
@@ -746,7 +735,6 @@ module.exports = {
   parseBalanceQueryParam: parseBalanceQueryParam,
   parsePublicKeyQueryParam: parsePublicKeyQueryParam,
   parseAccountIdQueryParam: parseAccountIdQueryParam,
-  parseAccountIdQueryParamAsEncoded: parseAccountIdQueryParamAsEncoded,
   parseTimestampQueryParam: parseTimestampQueryParam,
   parseResultParams: parseResultParams,
   parseTimestampParam: parseTimestampParam,


### PR DESCRIPTION
**Detailed description**:
`account_balance` table was one of the few tables that still used separate realm and num columns instead of the aggregated entity_id table.

The change
- Replaces account_realm_num and account_num with  account_id in account_balance table
- Updates `AccountBalance` domain replacing `accoutnRealmNum` and `accountNum` with new `accountId` 
- Updates `account.js` and balances.js` REST API queries with updated columns
- Updates `AccountBalanceLineParser` to use new column on inserts
- Updates affected tests


**Which issue(s) this PR fixes**:
Fixes #1070 

**Special notes for your reviewer**:
Migration tested on dev
`account_balance` 1814 MB, 36555409 rows
`Sep 21 23:38:58 mirrornode-dev-1 java[1410]: 2020-09-21 23:38:58,597 INFO  [main ] o.f.c.i.c.DbMigrate Migrating schema "public" to version 1.30.0 - balance entity id
Sep 21 23:44:22 mirrornode-dev-1 java[1410]: 2020-09-21 23:44:22,718 INFO  [main ] o.f.c.i.c.DbMigrate Successfully applied 1 migrations to schema "public" (execution time 05:24.159s)`


**Checklist**
- [ ] Documentation added
- [x] Tests updated

