### PR TITLE
Fix memory leak in performance tests

### DIFF
--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/jmeter/handler/SDKClientHandler.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/jmeter/handler/SDKClientHandler.java
@@ -35,7 +35,6 @@ import com.hedera.hashgraph.sdk.Client;
 import com.hedera.hashgraph.sdk.HederaStatusException;
 import com.hedera.hashgraph.sdk.Status;
 import com.hedera.hashgraph.sdk.TransactionId;
-import com.hedera.hashgraph.sdk.TransactionList;
 import com.hedera.hashgraph.sdk.TransactionReceipt;
 import com.hedera.hashgraph.sdk.account.AccountId;
 import com.hedera.hashgraph.sdk.account.CryptoTransferTransaction;
@@ -108,9 +107,7 @@ public class SDKClientHandler {
     }
 
     public List<TransactionId> submitTopicMessage(ConsensusMessageSubmitTransaction consensusMessageSubmitTransaction) throws HederaStatusException {
-        TransactionList transactionList = consensusMessageSubmitTransaction.build(client);
-
-        return transactionList.execute(client);
+        return consensusMessageSubmitTransaction.execute(client);
     }
 
     public TransactionId submitCryptoTransfer(AccountId operatorId, AccountId recipientId, int amount) throws HederaStatusException {

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/jmeter/handler/SDKClientHandler.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/jmeter/handler/SDKClientHandler.java
@@ -107,7 +107,7 @@ public class SDKClientHandler {
     }
 
     public List<TransactionId> submitTopicMessage(ConsensusMessageSubmitTransaction consensusMessageSubmitTransaction) throws HederaStatusException {
-        return consensusMessageSubmitTransaction.execute(client);
+        return consensusMessageSubmitTransaction.executeAll(client);
     }
 
     public TransactionId submitCryptoTransfer(AccountId operatorId, AccountId recipientId, int amount) throws HederaStatusException {

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/jmeter/props/TopicMessagePublishRequest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/jmeter/props/TopicMessagePublishRequest.java
@@ -27,7 +27,7 @@ import lombok.Data;
 import lombok.ToString;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.codec.binary.Base64;
-import org.testcontainers.shaded.org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 
 import com.hedera.hashgraph.sdk.account.AccountId;
 import com.hedera.hashgraph.sdk.consensus.ConsensusTopicId;

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/jmeter/sampler/result/HCSDirectStubSamplerResult.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/jmeter/sampler/result/HCSDirectStubSamplerResult.java
@@ -56,6 +56,6 @@ public class HCSDirectStubSamplerResult extends HCSSamplerResult<ConsensusTopicR
 
     @Override
     byte[] getMessageByteArray(ConsensusTopicResponse response) {
-        return response.toByteArray();
+        return response.getMessage().toByteArray();
     }
 }

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/jmeter/sampler/result/HCSSamplerResult.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/jmeter/sampler/result/HCSSamplerResult.java
@@ -29,7 +29,7 @@ import lombok.Data;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
+import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
 
 @SuperBuilder
 @Data
@@ -51,12 +51,12 @@ public abstract class HCSSamplerResult<T> {
     private boolean success = true;
     private boolean historical = true;
     private boolean calculateLatencies = true;
-    private DescriptiveStatistics e2eLatencyStats = new DescriptiveStatistics();
-    private DescriptiveStatistics publishToConsensusLatencyStats = new DescriptiveStatistics();
-    private DescriptiveStatistics consensusToDeliveryLatencyStats = new DescriptiveStatistics();
-    private final DescriptiveStatistics e2eLatencyTotalStats = new DescriptiveStatistics();
-    private final DescriptiveStatistics publishToConsensusLatencyTotalStats = new DescriptiveStatistics();
-    private final DescriptiveStatistics consensusToDeliveryLatencyTotalStats = new DescriptiveStatistics();
+    private SummaryStatistics e2eLatencyStats = new SummaryStatistics();
+    private SummaryStatistics publishToConsensusLatencyStats = new SummaryStatistics();
+    private SummaryStatistics consensusToDeliveryLatencyStats = new SummaryStatistics();
+    private final SummaryStatistics e2eLatencyTotalStats = new SummaryStatistics();
+    private final SummaryStatistics publishToConsensusLatencyTotalStats = new SummaryStatistics();
+    private final SummaryStatistics consensusToDeliveryLatencyTotalStats = new SummaryStatistics();
 
     abstract Instant getConsensusInstant(T t);
 
@@ -213,7 +213,7 @@ public abstract class HCSSamplerResult<T> {
                 consensusToDelivery);
     }
 
-    private void updateE2ELatencyStats(DescriptiveStatistics interval, DescriptiveStatistics total, double latency) {
+    private void updateE2ELatencyStats(SummaryStatistics interval, SummaryStatistics total, double latency) {
         if (latency > 0) {
             // update interval stats
             interval.addValue(latency);
@@ -234,9 +234,9 @@ public abstract class HCSSamplerResult<T> {
         printIndividualStat(consensusToDeliveryLatencyStats, "Interval ConsensusToDelivery Latency");
 
         // clear interval stat buckets
-        e2eLatencyStats = new DescriptiveStatistics();
-        publishToConsensusLatencyStats = new DescriptiveStatistics();
-        consensusToDeliveryLatencyStats = new DescriptiveStatistics();
+        e2eLatencyStats = new SummaryStatistics();
+        publishToConsensusLatencyStats = new SummaryStatistics();
+        consensusToDeliveryLatencyStats = new SummaryStatistics();
     }
 
     private void printTotalStats() {
@@ -251,20 +251,15 @@ public abstract class HCSSamplerResult<T> {
         printIndividualStat(consensusToDeliveryLatencyTotalStats, "Total ConsensusToDelivery Latency");
     }
 
-    private void printIndividualStat(DescriptiveStatistics stats, String name) {
+    private void printIndividualStat(SummaryStatistics stats, String name) {
         if (stats != null) {
             // Compute some statistics
             double min = stats.getMin();
             double max = stats.getMax();
             double mean = stats.getMean();
-            double median = stats.getPercentile(50);
-            double seventyFifthPercentile = stats.getPercentile(75);
-            double ninetyFifthPercentile = stats.getPercentile(95);
 
-            log.info("{} stats, min: {}s, max: {}s, avg: {}s, median: {}s, 75th percentile: {}s, " +
-                            "95th percentile: {}s", name, String.format("%.03f", min), String.format("%.03f", max),
-                    String.format("%.03f", mean), String.format("%.03f", median),
-                    String.format("%.03f", seventyFifthPercentile), String.format("%.03f", ninetyFifthPercentile));
+            log.info("{} stats, min: {}s, max: {}s, avg: {}s",
+                    name, String.format("%.03f", min), String.format("%.03f", max), String.format("%.03f", mean));
         }
     }
 }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TopicClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TopicClient.java
@@ -150,7 +150,7 @@ public class TopicClient {
             transactionList.sign(submitKey);
         }
 
-        List<TransactionId> transactionIdList = transactionList.execute(client);
+        List<TransactionId> transactionIdList = transactionList.executeAll(client);
 
         TransactionRecord transactionRecord = transactionIdList.get(0).getRecord(client);
         // get only the 1st sequence number

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <docker.tag.version>${project.version}</docker.tag.version>
         <grpc.version>1.31.1</grpc.version>
         <hedera-protobuf.version>0.6.0-alpha1</hedera-protobuf.version>
-        <hedera-sdk.version>1.2.0</hedera-sdk.version>
+        <hedera-sdk.version>1.2.2</hedera-sdk.version>
         <jacoco.version>0.8.5</jacoco.version>
         <java.version>11</java.version>
         <javax.version>1</javax.version>


### PR DESCRIPTION
**Detailed description**:
- Fix memory leak in SDK by bumping version to 1.2.2
- Fix memory leak in subscriber by switching from `DescriptiveStatistics` to `SummaryStatistics` which doesn't store every time value. Unfortunately we lose percentiles/median as a result.
- Fix non-SDK code (e.g. `clientUseMAPI=false`) not working for subscriptions

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated

