### PR TITLE
Add a Redis HCS topic listener

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,9 +120,10 @@ commands:
                   \<<: *db
                 grpc:
                   \<<: *db
-
+            spring:
+              redis:
+                url: redis://127.0.0.1:6379
             ---
-
             spring:
               profiles: pubsub
               cloud:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,9 @@ references:
     image: google/cloud-sdk:290.0.1
     command: [ "/bin/sh", "-c", "gcloud beta emulators pubsub start" ]
 
+  docker_redis: &docker_redis
+    image: redis:6.0.8-alpine
+
   machine_ubuntu: &machine_ubuntu
     machine:
       image: ubuntu-1604:201903-01
@@ -219,6 +222,7 @@ jobs:
       - *docker_jdk11
       - *docker_db
       - *docker_pubsub
+      - *docker_redis
     steps:
       - checkout
       - restore_maven_cache
@@ -255,6 +259,7 @@ jobs:
     docker:
       - *docker_jdk11
       - *docker_db
+      - *docker_redis
     steps:
       - checkout
       - restore_maven_cache

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -72,7 +72,7 @@ value, it is recommended to only populate overridden properties in the custom `a
 | `hedera.mirror.importer.parser.record.enabled`                       | true                    | Whether to enable record file parsing                                                          |
 | `hedera.mirror.importer.parser.record.frequency`                     | 100ms                   | The fixed period between invocations. Can accept duration units like `10s`, `2m` etc.          |
 | `hedera.mirror.importer.parser.record.keepFiles`                     | false                   | Whether to keep parsed files after successful parsing. If false, files are deleted.            |
-| `hedera.mirror.importer.parser.record.entity.notify.enabled`                | false                    | Whether to use PostgreSQL Notify to send topic messages to the gRPC process                    |
+| `hedera.mirror.importer.parser.record.entity.notify.enabled`                | true                    | Whether to use PostgreSQL Notify to send topic messages to the gRPC process                    |
 | `hedera.mirror.importer.parser.record.entity.notify.maxJsonPayloadSize`     | 8000                    | Max number of bytes for json payload used in pg_notify of db inserts                           |
 | `hedera.mirror.importer.parser.record.entity.persist.claims`                | false                   | Persist claim data to the database                                                             |
 | `hedera.mirror.importer.parser.record.entity.persist.contracts`             | true                    | Persist contract data to the database                                                          |
@@ -81,7 +81,7 @@ value, it is recommended to only populate overridden properties in the custom `a
 | `hedera.mirror.importer.parser.record.entity.persist.nonFeeTransfers`       | false                   | Persist non-fee transfers for transactions that explicitly request hbar transfers              |
 | `hedera.mirror.importer.parser.record.entity.persist.systemFiles`           | true                    | Persist only system files (number lower than `1000`) to the database                           |
 | `hedera.mirror.importer.parser.record.entity.persist.transactionBytes`      | false                   | Persist raw transaction bytes to the database                                                  |
-| `hedera.mirror.importer.parser.record.entity.redis.enabled`                 | true                    | Whether to use Redis to send messages to the gRPC process                                      |
+| `hedera.mirror.importer.parser.record.entity.redis.enabled`                 | false                   | Whether to use Redis to send messages to the gRPC process                                      |
 | `hedera.mirror.importer.parser.record.entity.repository.enabled`            | false                   | Whether to use Spring Data JPA repositories to insert into the database (experimental)         |
 | `hedera.mirror.importer.parser.record.entity.sql.batchSize`                 | 20_000                  | When inserting transactions into db, executeBatches() is called every these many transactions  |
 | `hedera.mirror.importer.parser.record.entity.sql.bufferSize`                | 11441                   | The size of the byte buffer to allocate for each batch                                         |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -72,7 +72,7 @@ value, it is recommended to only populate overridden properties in the custom `a
 | `hedera.mirror.importer.parser.record.enabled`                       | true                    | Whether to enable record file parsing                                                          |
 | `hedera.mirror.importer.parser.record.frequency`                     | 100ms                   | The fixed period between invocations. Can accept duration units like `10s`, `2m` etc.          |
 | `hedera.mirror.importer.parser.record.keepFiles`                     | false                   | Whether to keep parsed files after successful parsing. If false, files are deleted.            |
-| `hedera.mirror.importer.parser.record.entity.notify.enabled`                | true                    | Whether to use PostgreSQL Notify to send topic messages to the gRPC process                    |
+| `hedera.mirror.importer.parser.record.entity.notify.enabled`                | false                    | Whether to use PostgreSQL Notify to send topic messages to the gRPC process                    |
 | `hedera.mirror.importer.parser.record.entity.notify.maxJsonPayloadSize`     | 8000                    | Max number of bytes for json payload used in pg_notify of db inserts                           |
 | `hedera.mirror.importer.parser.record.entity.persist.claims`                | false                   | Persist claim data to the database                                                             |
 | `hedera.mirror.importer.parser.record.entity.persist.contracts`             | true                    | Persist contract data to the database                                                          |
@@ -81,6 +81,7 @@ value, it is recommended to only populate overridden properties in the custom `a
 | `hedera.mirror.importer.parser.record.entity.persist.nonFeeTransfers`       | false                   | Persist non-fee transfers for transactions that explicitly request hbar transfers              |
 | `hedera.mirror.importer.parser.record.entity.persist.systemFiles`           | true                    | Persist only system files (number lower than `1000`) to the database                           |
 | `hedera.mirror.importer.parser.record.entity.persist.transactionBytes`      | false                   | Persist raw transaction bytes to the database                                                  |
+| `hedera.mirror.importer.parser.record.entity.redis.enabled`                 | true                    | Whether to use PostgreSQL Notify to send topic messages to the gRPC process                    |
 | `hedera.mirror.importer.parser.record.entity.repository.enabled`            | false                   | Whether to use Spring Data JPA repositories to insert into the database (experimental)         |
 | `hedera.mirror.importer.parser.record.entity.sql.batchSize`                 | 20_000                  | When inserting transactions into db, executeBatches() is called every these many transactions  |
 | `hedera.mirror.importer.parser.record.entity.sql.bufferSize`                | 11441                   | The size of the byte buffer to allocate for each batch                                         |
@@ -155,12 +156,12 @@ value, it is recommended to only populate overridden properties in the custom `a
 | `hedera.mirror.grpc.db.username`                            | mirror_grpc      | The username the GRPC API uses to connect to the database                                      |
 | `hedera.mirror.grpc.endTimeInterval`                        | 30s              | How often we should check if a subscription has gone past the end time                         |
 | `hedera.mirror.grpc.entityCacheSize`                        | 50000            | The maximum size of the cache to store entities used for existence check                       |
-| `hedera.mirror.grpc.listener.bufferTimeout`                 | 4000             | The time in milliseconds to wait for a client to receive all buffered messages after buffer overflow. On timeout, server will send an error |
+| `hedera.mirror.grpc.listener.bufferTimeout`                 | 4s               | The time to wait for a client to receive all buffered messages after buffer overflow. On timeout, server will send an error. Can accept duration units like `50ms`, `10s`, etc. |
 | `hedera.mirror.grpc.listener.enabled`                       | true             | Whether to listen for incoming massages or not                                                 |
 | `hedera.mirror.grpc.listener.frequency`                     | 500ms            | How often to poll or retry errors (varies by type). Can accept duration units like `50ms`, `10s`, etc. |
 | `hedera.mirror.grpc.listener.maxBufferSize`                 | 16384            | The maximum number of messages the notifying listener or the shared polling listener buffers before sending an error to a client |
 | `hedera.mirror.grpc.listener.maxPageSize`                   | 5000             | The maximum number of messages the listener can return in a single call to the database        |
-| `hedera.mirror.grpc.listener.type`                          | NOTIFY           | The type of listener to use for incoming messages. Accepts either NOTIFY, POLL or SHARED_POLL  |
+| `hedera.mirror.grpc.listener.type`                          | REDIS            | The type of listener to use for incoming messages. Accepts either NOTIFY, POLL, REDIS or SHARED_POLL |
 | `hedera.mirror.grpc.netty.executorCoreThreadCount`          | 10               | The number of core threads                                                                     |
 | `hedera.mirror.grpc.netty.executorMaxThreadCount`           | 1000             | The maximum allowed number of threads                                                          |
 | `hedera.mirror.grpc.netty.keepAliveTime`                    | 60               | The seconds limit for which threads may remain idle before being terminated                    |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -81,7 +81,7 @@ value, it is recommended to only populate overridden properties in the custom `a
 | `hedera.mirror.importer.parser.record.entity.persist.nonFeeTransfers`       | false                   | Persist non-fee transfers for transactions that explicitly request hbar transfers              |
 | `hedera.mirror.importer.parser.record.entity.persist.systemFiles`           | true                    | Persist only system files (number lower than `1000`) to the database                           |
 | `hedera.mirror.importer.parser.record.entity.persist.transactionBytes`      | false                   | Persist raw transaction bytes to the database                                                  |
-| `hedera.mirror.importer.parser.record.entity.redis.enabled`                 | true                    | Whether to use PostgreSQL Notify to send topic messages to the gRPC process                    |
+| `hedera.mirror.importer.parser.record.entity.redis.enabled`                 | true                    | Whether to use Redis to send messages to the gRPC process                                      |
 | `hedera.mirror.importer.parser.record.entity.repository.enabled`            | false                   | Whether to use Spring Data JPA repositories to insert into the database (experimental)         |
 | `hedera.mirror.importer.parser.record.entity.sql.batchSize`                 | 20_000                  | When inserting transactions into db, executeBatches() is called every these many transactions  |
 | `hedera.mirror.importer.parser.record.entity.sql.bufferSize`                | 11441                   | The size of the byte buffer to allocate for each batch                                         |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -161,7 +161,7 @@ value, it is recommended to only populate overridden properties in the custom `a
 | `hedera.mirror.grpc.listener.frequency`                     | 500ms            | How often to poll or retry errors (varies by type). Can accept duration units like `50ms`, `10s`, etc. |
 | `hedera.mirror.grpc.listener.maxBufferSize`                 | 16384            | The maximum number of messages the notifying listener or the shared polling listener buffers before sending an error to a client |
 | `hedera.mirror.grpc.listener.maxPageSize`                   | 5000             | The maximum number of messages the listener can return in a single call to the database        |
-| `hedera.mirror.grpc.listener.type`                          | REDIS            | The type of listener to use for incoming messages. Accepts either NOTIFY, POLL, REDIS or SHARED_POLL |
+| `hedera.mirror.grpc.listener.type`                          | NOTIFY           | The type of listener to use for incoming messages. Accepts either NOTIFY, POLL, REDIS or SHARED_POLL |
 | `hedera.mirror.grpc.netty.executorCoreThreadCount`          | 10               | The number of core threads                                                                     |
 | `hedera.mirror.grpc.netty.executorMaxThreadCount`           | 1000             | The maximum allowed number of threads                                                          |
 | `hedera.mirror.grpc.netty.keepAliveTime`                    | 60               | The seconds limit for which threads may remain idle before being terminated                    |

--- a/hedera-mirror-grpc/pom.xml
+++ b/hedera-mirror-grpc/pom.xml
@@ -89,6 +89,11 @@
             <artifactId>hibernate-validator</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.msgpack</groupId>
+            <artifactId>jackson-dataformat-msgpack</artifactId>
+            <version>${msgpack.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <scope>runtime</scope>
@@ -131,6 +136,10 @@
                     <artifactId>spring-boot-starter-logging</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-redis</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -181,6 +190,12 @@
         <dependency>
             <groupId>com.playtika.testcontainers</groupId>
             <artifactId>embedded-postgresql</artifactId>
+            <version>${embedded.testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.playtika.testcontainers</groupId>
+            <artifactId>embedded-redis</artifactId>
             <version>${embedded.testcontainers.version}</version>
             <scope>test</scope>
         </dependency>

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/config/RedisConfiguration.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/config/RedisConfiguration.java
@@ -33,7 +33,7 @@ import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.RedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
-import com.hedera.mirror.grpc.domain.TopicMessage;
+import com.hedera.mirror.grpc.domain.StreamMessage;
 
 @Configuration
 @RequiredArgsConstructor
@@ -42,16 +42,16 @@ public class RedisConfiguration {
     private final ReactiveRedisConnectionFactory reactiveRedisConnectionFactory;
 
     @Bean
-    RedisSerializer<TopicMessage> redisSerializer() {
+    RedisSerializer<?> redisSerializer() {
         ObjectMapper objectMapper = new ObjectMapper(new MessagePackFactory());
-        Jackson2JsonRedisSerializer jackson2JsonRedisSerializer = new Jackson2JsonRedisSerializer(TopicMessage.class);
+        Jackson2JsonRedisSerializer jackson2JsonRedisSerializer = new Jackson2JsonRedisSerializer(StreamMessage.class);
         jackson2JsonRedisSerializer.setObjectMapper(objectMapper);
         return jackson2JsonRedisSerializer;
     }
 
     @Bean
-    ReactiveRedisOperations<String, TopicMessage> reactiveRedisOperations() {
-        RedisSerializationContext<String, TopicMessage> serializationContext = RedisSerializationContext
+    ReactiveRedisOperations<String, StreamMessage> reactiveRedisOperations() {
+        RedisSerializationContext<String, StreamMessage> serializationContext = RedisSerializationContext
                 .newSerializationContext()
                 .key((RedisSerializer) StringRedisSerializer.UTF_8)
                 .value(redisSerializer())

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/config/RedisConfiguration.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/config/RedisConfiguration.java
@@ -28,7 +28,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
 import org.springframework.data.redis.core.ReactiveRedisOperations;
 import org.springframework.data.redis.core.ReactiveRedisTemplate;
-import org.springframework.data.redis.listener.ReactiveRedisMessageListenerContainer;
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.RedisSerializer;
@@ -60,10 +59,5 @@ public class RedisConfiguration {
                 .hashValue(redisSerializer())
                 .build();
         return new ReactiveRedisTemplate<>(reactiveRedisConnectionFactory, serializationContext);
-    }
-
-    @Bean
-    ReactiveRedisMessageListenerContainer reactiveRedisMessageListenerContainer() {
-        return new ReactiveRedisMessageListenerContainer(reactiveRedisConnectionFactory);
     }
 }

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/config/RedisConfiguration.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/config/RedisConfiguration.java
@@ -1,0 +1,69 @@
+package com.hedera.mirror.grpc.config;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.msgpack.jackson.dataformat.MessagePackFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
+import org.springframework.data.redis.core.ReactiveRedisOperations;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.data.redis.listener.ReactiveRedisMessageListenerContainer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import com.hedera.mirror.grpc.domain.TopicMessage;
+
+@Configuration
+@RequiredArgsConstructor
+public class RedisConfiguration {
+
+    private final ReactiveRedisConnectionFactory reactiveRedisConnectionFactory;
+
+    @Bean
+    RedisSerializer<TopicMessage> redisSerializer() {
+        ObjectMapper objectMapper = new ObjectMapper(new MessagePackFactory());
+        Jackson2JsonRedisSerializer jackson2JsonRedisSerializer = new Jackson2JsonRedisSerializer(TopicMessage.class);
+        jackson2JsonRedisSerializer.setObjectMapper(objectMapper);
+        return jackson2JsonRedisSerializer;
+    }
+
+    @Bean
+    ReactiveRedisOperations<String, TopicMessage> reactiveRedisOperations() {
+        RedisSerializationContext<String, TopicMessage> serializationContext = RedisSerializationContext
+                .newSerializationContext()
+                .key((RedisSerializer) StringRedisSerializer.UTF_8)
+                .value(redisSerializer())
+                .hashKey(StringRedisSerializer.UTF_8)
+                .hashValue(redisSerializer())
+                .build();
+        return new ReactiveRedisTemplate<>(reactiveRedisConnectionFactory, serializationContext);
+    }
+
+    @Bean
+    ReactiveRedisMessageListenerContainer reactiveRedisMessageListenerContainer() {
+        return new ReactiveRedisMessageListenerContainer(reactiveRedisConnectionFactory);
+    }
+}

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/controller/ConsensusController.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/controller/ConsensusController.java
@@ -59,7 +59,6 @@ public class ConsensusController extends ReactorConsensusServiceGrpc.ConsensusSe
 
     private static final String DB_ERROR = "Unable to connect to database. Please retry later";
     private static final String OVERFLOW_ERROR = "Client lags too much behind. Please retry later";
-    private static final String TIMEOUT_ERROR = "Client times out after buffer overflow. Please retry later";
 
     private final TopicMessageService topicMessageService;
 
@@ -75,7 +74,7 @@ public class ConsensusController extends ReactorConsensusServiceGrpc.ConsensusSe
                 .onErrorMap(TopicNotFoundException.class, e -> error(e, Status.NOT_FOUND))
                 .onErrorMap(TransientDataAccessException.class, e -> error(e, Status.RESOURCE_EXHAUSTED))
                 .onErrorMap(Exceptions::isOverflow, e -> error(e, Status.DEADLINE_EXCEEDED, OVERFLOW_ERROR))
-                .onErrorMap(ClientTimeoutException.class, e -> error(e, Status.DEADLINE_EXCEEDED, TIMEOUT_ERROR))
+                .onErrorMap(ClientTimeoutException.class, e -> error(e, Status.DEADLINE_EXCEEDED, OVERFLOW_ERROR))
                 .onErrorMap(t -> unknownError(t));
     }
 

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/domain/StreamMessage.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/domain/StreamMessage.java
@@ -1,0 +1,31 @@
+package com.hedera.mirror.grpc.domain;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME)
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = TopicMessage.class, name = "TopicMessage")
+})
+public interface StreamMessage {
+}

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/domain/TopicMessage.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/domain/TopicMessage.java
@@ -20,7 +20,10 @@ package com.hedera.mirror.grpc.domain;
  * ‍
  */
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.protobuf.UnsafeByteOperations;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ConsensusMessageChunkInfo;
@@ -50,9 +53,11 @@ import com.hedera.mirror.grpc.converter.LongToInstantConverter;
 @Builder
 @Entity
 @JsonIgnoreProperties(ignoreUnknown = true, value = {"consensusTimestampInstant", "response"})
+@JsonTypeInfo(use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME)
+@JsonTypeName("TopicMessage")
 @NoArgsConstructor(force = true)
 @Value
-public class TopicMessage implements Comparable<TopicMessage>, Persistable<Long> {
+public class TopicMessage implements Comparable<TopicMessage>, Persistable<Long>, StreamMessage {
 
     private static final Comparator<TopicMessage> COMPARATOR = Comparator
             .nullsFirst(Comparator.comparingLong(TopicMessage::getSequenceNumber));
@@ -61,6 +66,7 @@ public class TopicMessage implements Comparable<TopicMessage>, Persistable<Long>
     @ToString.Exclude
     private Long consensusTimestamp;
 
+    @JsonIgnore
     @Getter(lazy = true)
     @Transient
     private Instant consensusTimestampInstant = LongToInstantConverter.INSTANCE.convert(consensusTimestamp);

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/ListenerProperties.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/ListenerProperties.java
@@ -25,6 +25,8 @@ import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import lombok.Data;
+import org.hibernate.validator.constraints.time.DurationMax;
+import org.hibernate.validator.constraints.time.DurationMin;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
@@ -42,19 +44,22 @@ public class ListenerProperties {
     @Max(65536)
     private int maxBufferSize = 16384;
 
-    @Min(2000)
-    @Max(10000)
-    private long bufferTimeout = 4000;
+    @DurationMin(seconds = 2)
+    @DurationMax(seconds = 10)
+    @NotNull
+    private Duration bufferTimeout = Duration.ofSeconds(4);
 
+    @DurationMin(millis = 50)
     @NotNull
     private Duration frequency = Duration.ofMillis(500L);
 
     @NotNull
-    private ListenerType type = ListenerType.NOTIFY;
+    private ListenerType type = ListenerType.REDIS;
 
     public enum ListenerType {
         NOTIFY,
         POLL,
+        REDIS,
         SHARED_POLL
     }
 }

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/ListenerProperties.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/ListenerProperties.java
@@ -54,7 +54,7 @@ public class ListenerProperties {
     private Duration frequency = Duration.ofMillis(500L);
 
     @NotNull
-    private ListenerType type = ListenerType.REDIS;
+    private ListenerType type = ListenerType.NOTIFY;
 
     public enum ListenerType {
         NOTIFY,

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/NotifyingTopicListener.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/NotifyingTopicListener.java
@@ -37,12 +37,14 @@ import reactor.util.retry.Retry;
 
 import com.hedera.mirror.grpc.DbProperties;
 import com.hedera.mirror.grpc.domain.TopicMessage;
+import com.hedera.mirror.grpc.domain.TopicMessageFilter;
 
 @Named
 public class NotifyingTopicListener extends SharedTopicListener {
 
     private final ObjectMapper objectMapper;
     private final PgChannel channel;
+    private final Flux<TopicMessage> topicMessages;
 
     public NotifyingTopicListener(DbProperties dbProperties, ListenerProperties listenerProperties) {
         super(listenerProperties);
@@ -73,7 +75,7 @@ public class NotifyingTopicListener extends SharedTopicListener {
 
         channel = subscriber.channel("topic_message");
 
-        sharedTopicMessages = Flux.defer(() -> listen())
+        topicMessages = Flux.defer(() -> listen())
                 .publishOn(Schedulers.boundedElastic())
                 .map(this::toTopicMessage)
                 .filter(Objects::nonNull)
@@ -82,6 +84,11 @@ public class NotifyingTopicListener extends SharedTopicListener {
                 .doOnError(t -> log.error("Error listening for messages", t))
                 .retryWhen(Retry.backoff(Long.MAX_VALUE, frequency).maxBackoff(frequency.multipliedBy(4L)))
                 .share();
+    }
+
+    @Override
+    protected Flux<TopicMessage> getSharedListener(TopicMessageFilter filter) {
+        return topicMessages;
     }
 
     private Flux<String> listen() {

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/NotifyingTopicListener.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/NotifyingTopicListener.java
@@ -42,7 +42,7 @@ import com.hedera.mirror.grpc.domain.TopicMessageFilter;
 @Named
 public class NotifyingTopicListener extends SharedTopicListener {
 
-    private final ObjectMapper objectMapper;
+    final ObjectMapper objectMapper;
     private final PgChannel channel;
     private final Flux<TopicMessage> topicMessages;
 

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/RedisTopicListener.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/RedisTopicListener.java
@@ -57,11 +57,11 @@ public class RedisTopicListener extends SharedTopicListener {
     public RedisTopicListener(GrpcProperties grpcProperties,
                               ListenerProperties listenerProperties,
                               ReactiveRedisConnectionFactory connectionFactory,
-                              RedisSerializer<TopicMessage> redisSerializer) {
+                              RedisSerializer<?> redisSerializer) {
         super(listenerProperties);
         this.grpcProperties = grpcProperties;
         this.channelSerializer = SerializationPair.fromSerializer(RedisSerializer.string());
-        this.messageSerializer = SerializationPair.fromSerializer(redisSerializer);
+        this.messageSerializer = (SerializationPair<TopicMessage>) SerializationPair.fromSerializer(redisSerializer);
         this.topicMessages = new ConcurrentHashMap<>();
 
         // Workaround Spring DATAREDIS-1208 by lazily starting connection once with retry

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/RedisTopicListener.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/RedisTopicListener.java
@@ -1,0 +1,97 @@
+package com.hedera.mirror.grpc.listener;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.inject.Named;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.data.redis.connection.ReactiveSubscription.Message;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.ReactiveRedisMessageListenerContainer;
+import org.springframework.data.redis.listener.Topic;
+import org.springframework.data.redis.serializer.RedisSerializationContext.SerializationPair;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import reactor.core.publisher.Flux;
+import reactor.core.scheduler.Schedulers;
+import reactor.util.retry.Retry;
+
+import com.hedera.mirror.grpc.GrpcProperties;
+import com.hedera.mirror.grpc.domain.TopicMessage;
+import com.hedera.mirror.grpc.domain.TopicMessageFilter;
+
+@Log4j2
+@Named
+public class RedisTopicListener extends SharedTopicListener {
+
+    private final GrpcProperties grpcProperties;
+    private final ReactiveRedisMessageListenerContainer container;
+    private final SerializationPair<String> channelSerializer;
+    private final SerializationPair<TopicMessage> messageSerializer;
+    private final Map<String, Flux<TopicMessage>> topicMessages; // Topic name to active subscription
+
+    public RedisTopicListener(GrpcProperties grpcProperties,
+                              ListenerProperties listenerProperties,
+                              ReactiveRedisMessageListenerContainer container,
+                              RedisSerializer<TopicMessage> redisSerializer) {
+        super(listenerProperties);
+        this.grpcProperties = grpcProperties;
+        this.container = container;
+        this.channelSerializer = SerializationPair.fromSerializer(RedisSerializer.string());
+        this.messageSerializer = SerializationPair.fromSerializer(redisSerializer);
+        this.topicMessages = new ConcurrentHashMap<>();
+    }
+
+    @Override
+    protected Flux<TopicMessage> getSharedListener(TopicMessageFilter filter) {
+        Topic topic = getTopic(filter);
+        return topicMessages.computeIfAbsent(topic.getTopic(), key -> subscribe(topic))
+                .doOnSubscribe(s -> log.info("Subscribing: {}", filter));
+    }
+
+    private Topic getTopic(TopicMessageFilter filter) {
+        return ChannelTopic.of(String.format("topic.%d.%d.%d",
+                grpcProperties.getShard(), filter.getRealmNum(), filter.getTopicNum()));
+    }
+
+    private Flux<TopicMessage> subscribe(Topic topic) {
+        Duration frequency = listenerProperties.getFrequency();
+
+        return container.receive(Arrays.asList(topic), channelSerializer, messageSerializer)
+                .map(Message::getMessage)
+                .name("redis")
+                .metrics()
+                .publishOn(Schedulers.boundedElastic())
+                .doOnCancel(() -> unsubscribe(topic))
+                .doOnComplete(() -> unsubscribe(topic))
+                .doOnError(t -> log.error("Error listening for messages", t))
+                .doOnSubscribe(s -> log.info("Creating shared subscription to {}", topic))
+                .retryWhen(Retry.backoff(Long.MAX_VALUE, frequency).maxBackoff(frequency.multipliedBy(4L)))
+                .share();
+    }
+
+    private void unsubscribe(Topic topic) {
+        topicMessages.remove(topic.getTopic());
+        log.info("Cancelled shared subscription to {}", topic);
+    }
+}

--- a/hedera-mirror-grpc/src/main/resources/application.yml
+++ b/hedera-mirror-grpc/src/main/resources/application.yml
@@ -39,7 +39,7 @@ management:
         liveness:
           include: ping
         readiness:
-          include: db, grpcServices, grpcChannel, ping
+          include: db, grpcServices, grpcChannel, ping, redis
 server:
   shutdown: graceful
   port: 8081
@@ -77,3 +77,9 @@ spring:
   test:
     database:
       replace: NONE
+  redis:
+    lettuce:
+      cluster:
+        refresh:
+          period: 60s
+    timeout: 5s

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/listener/AbstractSharedTopicListenerTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/listener/AbstractSharedTopicListenerTest.java
@@ -24,26 +24,30 @@ public abstract class AbstractSharedTopicListenerTest extends AbstractTopicListe
         int maxBufferSize = 16;
         listenerProperties.setMaxBufferSize(maxBufferSize);
 
-        TopicMessageFilter filter = TopicMessageFilter.builder()
+        TopicMessageFilter filterFast = TopicMessageFilter.builder()
                 .startTime(Instant.EPOCH)
                 .build();
 
         // create a normal subscriber to keep the shared flux open
         Vector<Long> sequenceNumbers = new Vector<>();
-        var subscription = getTopicListener().listen(filter)
+        var subscription = topicListener.listen(filterFast)
                 .map(TopicMessage::getSequenceNumber)
                 .subscribe(sequenceNumbers::add);
 
+        TopicMessageFilter filterSlow = TopicMessageFilter.builder()
+                .startTime(Instant.EPOCH)
+                .build();
+
         // the slow subscriber
-        getTopicListener().listen(filter)
+        topicListener.listen(filterSlow)
                 .map(TopicMessage::getSequenceNumber)
-                .as(p -> StepVerifier.create(p, 1)) // initial request amount - 1
+                .as(p -> StepVerifier.create(p, 1)) // initial request amount of 1
                 .thenRequest(1) // trigger subscription
                 .thenAwait(Duration.ofMillis(10L))
                 .then(() -> {
                     // upon subscription, step verifier will request 2, so we need 2 + maxBufferSize + 1 to trigger
                     // overflow error
-                    domainBuilder.topicMessages(maxBufferSize + 3, future).blockLast();
+                    publish(domainBuilder.topicMessages(maxBufferSize + 3, future));
                 })
                 .expectNext(1L, 2L)
                 .thenAwait(Duration.ofMillis(500L)) // stall to overrun backpressure buffer
@@ -54,7 +58,8 @@ public abstract class AbstractSharedTopicListenerTest extends AbstractTopicListe
 
         assertThat(subscription.isDisposed()).isFalse();
         subscription.dispose();
-        assertThat(sequenceNumbers).isEqualTo(LongStream.range(1, maxBufferSize + 4).boxed().collect(Collectors.toList()));
+        assertThat(sequenceNumbers)
+                .isEqualTo(LongStream.range(1, maxBufferSize + 4).boxed().collect(Collectors.toList()));
     }
 
     @Test
@@ -62,14 +67,14 @@ public abstract class AbstractSharedTopicListenerTest extends AbstractTopicListe
     void slowSubscribeOverflowThenTimeout() {
         int maxBufferSize = 16;
         listenerProperties.setMaxBufferSize(maxBufferSize);
-        listenerProperties.setBufferTimeout(550L);
+        listenerProperties.setBufferTimeout(Duration.ofMillis(550L));
 
         TopicMessageFilter filter = TopicMessageFilter.builder()
                 .startTime(Instant.EPOCH)
                 .build();
 
         // the slow subscriber
-        getTopicListener().listen(filter)
+        topicListener.listen(filter)
                 .map(TopicMessage::getSequenceNumber)
                 .as(p -> StepVerifier.create(p, 1)) // initial request amount - 1
                 .thenRequest(1) // trigger subscription
@@ -77,7 +82,7 @@ public abstract class AbstractSharedTopicListenerTest extends AbstractTopicListe
                 .then(() -> {
                     // upon subscription, step verifier will request 2, so we need 2 + maxBufferSize + 1 to trigger
                     // overflow error
-                    domainBuilder.topicMessages(maxBufferSize + 3, future).blockLast();
+                    publish(domainBuilder.topicMessages(maxBufferSize + 3, future));
                 })
                 .expectNext(1L, 2L)
                 .thenAwait(Duration.ofMillis(500L)) // stall to overrun backpressure buffer

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/listener/NotifyingTopicListenerTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/listener/NotifyingTopicListenerTest.java
@@ -23,10 +23,10 @@ package com.hedera.mirror.grpc.listener;
 import java.time.Duration;
 import java.time.Instant;
 import javax.annotation.Resource;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.jdbc.core.JdbcTemplate;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import com.hedera.mirror.grpc.domain.TopicMessage;
@@ -45,26 +45,11 @@ public class NotifyingTopicListenerTest extends AbstractSharedTopicListenerTest 
         return ListenerProperties.ListenerType.NOTIFY;
     }
 
-    // Since importer manually calls pg_notify, we simulate that here with a rule that invokes pg_notify on insert
-    @BeforeEach
-    void createRule() {
-        jdbcTemplate.execute("create rule topic_message_rule " +
-                "as on insert to topic_message do also " +
-                "select pg_notify('topic_message', (select row_to_json(payload)::text from (select NEW.chunk_num,NEW" +
-                ".chunk_total,NEW.consensus_timestamp,encode(NEW.message, 'base64') as message,NEW.payer_account_id," +
-                "NEW.realm_num,encode(NEW.running_hash, 'base64') as running_hash,NEW.running_hash_version,NEW" +
-                ".sequence_number,NEW.topic_num,NEW.valid_start_timestamp) payload)) payload2");
-    }
-
-    @AfterEach
-    void dropRule() {
-        jdbcTemplate.execute("drop rule if exists topic_message_rule on topic_message");
-    }
-
     // Test deserialization from JSON to verify contract with PostgreSQL listen/notify
     @Test
     void json() {
         String json = "{" +
+                "\"@type\":\"TopicMessage\"," +
                 "\"chunk_num\":1," +
                 "\"chunk_total\":2," +
                 "\"consensus_timestamp\":1594401417000000000," +
@@ -118,5 +103,21 @@ public class NotifyingTopicListenerTest extends AbstractSharedTopicListenerTest 
                 .expectNoEvent(Duration.ofMillis(500L))
                 .thenCancel()
                 .verify(Duration.ofMillis(600L));
+    }
+
+    @Override
+    protected void publish(Flux<TopicMessage> publisher) {
+        publisher.concatMap(t -> {
+            jdbcTemplate.execute("NOTIFY topic_message, '" + toJson(t) + "'");
+            return Mono.just(t);
+        }).blockLast();
+    }
+
+    private String toJson(TopicMessage topicMessage) {
+        try {
+            return topicListener.objectMapper.writeValueAsString(topicMessage);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/listener/NotifyingTopicListenerTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/listener/NotifyingTopicListenerTest.java
@@ -41,8 +41,8 @@ public class NotifyingTopicListenerTest extends AbstractSharedTopicListenerTest 
     private JdbcTemplate jdbcTemplate;
 
     @Override
-    protected TopicListener getTopicListener() {
-        return topicListener;
+    protected ListenerProperties.ListenerType getType() {
+        return ListenerProperties.ListenerType.NOTIFY;
     }
 
     // Since importer manually calls pg_notify, we simulate that here with a rule that invokes pg_notify on insert

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/listener/RedisTopicListenerTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/listener/RedisTopicListenerTest.java
@@ -25,13 +25,14 @@ import lombok.extern.log4j.Log4j2;
 import org.springframework.data.redis.core.ReactiveRedisOperations;
 import reactor.core.publisher.Flux;
 
+import com.hedera.mirror.grpc.domain.StreamMessage;
 import com.hedera.mirror.grpc.domain.TopicMessage;
 
 @Log4j2
 public class RedisTopicListenerTest extends AbstractSharedTopicListenerTest {
 
     @Resource
-    private ReactiveRedisOperations<String, TopicMessage> redisOperations;
+    private ReactiveRedisOperations<String, StreamMessage> redisOperations;
 
     @Override
     protected ListenerProperties.ListenerType getType() {

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/listener/RedisTopicListenerTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/listener/RedisTopicListenerTest.java
@@ -20,10 +20,30 @@ package com.hedera.mirror.grpc.listener;
  * ‍
  */
 
-public class PollingTopicListenerTest extends AbstractTopicListenerTest {
+import javax.annotation.Resource;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.data.redis.core.ReactiveRedisOperations;
+import reactor.core.publisher.Flux;
+
+import com.hedera.mirror.grpc.domain.TopicMessage;
+
+@Log4j2
+public class RedisTopicListenerTest extends AbstractSharedTopicListenerTest {
+
+    @Resource
+    private ReactiveRedisOperations<String, TopicMessage> redisOperations;
 
     @Override
     protected ListenerProperties.ListenerType getType() {
-        return ListenerProperties.ListenerType.POLL;
+        return ListenerProperties.ListenerType.REDIS;
+    }
+
+    @Override
+    protected void publish(Flux<TopicMessage> publisher) {
+        publisher.concatMap(t -> redisOperations.convertAndSend(getTopic(t), t)).blockLast();
+    }
+
+    private String getTopic(TopicMessage topicMessage) {
+        return "topic.0." + topicMessage.getRealmNum() + "." + topicMessage.getTopicNum();
     }
 }

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/listener/SharedPollingTopicListenerTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/listener/SharedPollingTopicListenerTest.java
@@ -20,15 +20,10 @@ package com.hedera.mirror.grpc.listener;
  * ‍
  */
 
-import javax.annotation.Resource;
-
 public class SharedPollingTopicListenerTest extends AbstractSharedTopicListenerTest {
 
-    @Resource
-    private SharedPollingTopicListener topicListener;
-
     @Override
-    protected TopicListener getTopicListener() {
-        return topicListener;
+    protected ListenerProperties.ListenerType getType() {
+        return ListenerProperties.ListenerType.SHARED_POLL;
     }
 }

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/service/TopicMessageServiceTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/service/TopicMessageServiceTest.java
@@ -22,6 +22,7 @@ package com.hedera.mirror.grpc.service;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -476,7 +477,7 @@ public class TopicMessageServiceTest extends GrpcIntegrationTest {
         EntityRepository entityRepository = Mockito.mock(EntityRepository.class);
         TopicMessageRetriever topicMessageRetriever = Mockito.mock(TopicMessageRetriever.class);
         topicMessageService = new TopicMessageServiceImpl(new GrpcProperties(), topicListener, entityRepository,
-                topicMessageRetriever);
+                topicMessageRetriever, new SimpleMeterRegistry());
 
         TopicMessageFilter retrieverFilter = TopicMessageFilter.builder()
                 .startTime(Instant.EPOCH)
@@ -512,7 +513,7 @@ public class TopicMessageServiceTest extends GrpcIntegrationTest {
         EntityRepository entityRepository = Mockito.mock(EntityRepository.class);
         TopicMessageRetriever topicMessageRetriever = Mockito.mock(TopicMessageRetriever.class);
         topicMessageService = new TopicMessageServiceImpl(new GrpcProperties(), topicListener, entityRepository,
-                topicMessageRetriever);
+                topicMessageRetriever, new SimpleMeterRegistry());
 
         TopicMessageFilter filter = TopicMessageFilter.builder()
                 .startTime(Instant.EPOCH)
@@ -597,7 +598,7 @@ public class TopicMessageServiceTest extends GrpcIntegrationTest {
         EntityRepository entityRepository = Mockito.mock(EntityRepository.class);
         TopicMessageRetriever topicMessageRetriever = Mockito.mock(TopicMessageRetriever.class);
         topicMessageService = new TopicMessageServiceImpl(new GrpcProperties(), topicListener, entityRepository,
-                topicMessageRetriever);
+                topicMessageRetriever, new SimpleMeterRegistry());
 
         TopicMessageFilter retrieverFilter = TopicMessageFilter.builder()
                 .startTime(Instant.EPOCH)
@@ -648,7 +649,7 @@ public class TopicMessageServiceTest extends GrpcIntegrationTest {
         EntityRepository entityRepository = Mockito.mock(EntityRepository.class);
         TopicMessageRetriever topicMessageRetriever = Mockito.mock(TopicMessageRetriever.class);
         topicMessageService = new TopicMessageServiceImpl(new GrpcProperties(), topicListener, entityRepository,
-                topicMessageRetriever);
+                topicMessageRetriever, new SimpleMeterRegistry());
 
         // historic messages
         TopicMessage retrieved1 = topicMessage(1);

--- a/hedera-mirror-grpc/src/test/resources/config/application.yml
+++ b/hedera-mirror-grpc/src/test/resources/config/application.yml
@@ -41,3 +41,5 @@ spring:
       db-name: ${hedera.mirror.grpc.db.name}
       db-user: ${hedera.mirror.grpc.db.username}
       topicRunningHashV2AddedTimestamp: 0
+  redis:
+    url: redis://${embedded.redis.user}:${embedded.redis.password}@${embedded.redis.host}:${embedded.redis.port}

--- a/hedera-mirror-importer/pom.xml
+++ b/hedera-mirror-importer/pom.xml
@@ -114,6 +114,11 @@
             <artifactId>hibernate-validator-annotation-processor</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.msgpack</groupId>
+            <artifactId>jackson-dataformat-msgpack</artifactId>
+            <version>${msgpack.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
         </dependency>
@@ -155,6 +160,10 @@
                     <artifactId>spring-boot-starter-logging</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-redis</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -226,6 +235,17 @@
             <groupId>com.playtika.testcontainers</groupId>
             <artifactId>embedded-postgresql</artifactId>
             <version>${embedded.testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.playtika.testcontainers</groupId>
+            <artifactId>embedded-redis</artifactId>
+            <version>${embedded.testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/RedisConfiguration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/RedisConfiguration.java
@@ -1,0 +1,52 @@
+package com.hedera.mirror.importer.config;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.msgpack.jackson.dataformat.MessagePackFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializer;
+
+import com.hedera.mirror.importer.domain.TopicMessage;
+
+@Configuration
+public class RedisConfiguration {
+
+    @Bean
+    RedisSerializer<TopicMessage> redisSerializer() {
+        Jackson2JsonRedisSerializer jackson2JsonRedisSerializer = new Jackson2JsonRedisSerializer(TopicMessage.class);
+        jackson2JsonRedisSerializer.setObjectMapper(new ObjectMapper(new MessagePackFactory()));
+        return jackson2JsonRedisSerializer;
+    }
+
+    @Bean
+    RedisOperations<String, TopicMessage> redisOperations(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, TopicMessage> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+        redisTemplate.setValueSerializer(redisSerializer());
+        return redisTemplate;
+    }
+}

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/RedisConfiguration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/RedisConfiguration.java
@@ -30,21 +30,21 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializer;
 
-import com.hedera.mirror.importer.domain.TopicMessage;
+import com.hedera.mirror.importer.domain.StreamMessage;
 
 @Configuration
 public class RedisConfiguration {
 
     @Bean
-    RedisSerializer<TopicMessage> redisSerializer() {
-        Jackson2JsonRedisSerializer jackson2JsonRedisSerializer = new Jackson2JsonRedisSerializer(TopicMessage.class);
+    RedisSerializer<StreamMessage> redisSerializer() {
+        Jackson2JsonRedisSerializer jackson2JsonRedisSerializer = new Jackson2JsonRedisSerializer(StreamMessage.class);
         jackson2JsonRedisSerializer.setObjectMapper(new ObjectMapper(new MessagePackFactory()));
         return jackson2JsonRedisSerializer;
     }
 
     @Bean
-    RedisOperations<String, TopicMessage> redisOperations(RedisConnectionFactory redisConnectionFactory) {
-        RedisTemplate<String, TopicMessage> redisTemplate = new RedisTemplate<>();
+    RedisOperations<String, StreamMessage> redisOperations(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, StreamMessage> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory);
         redisTemplate.setValueSerializer(redisSerializer());
         return redisTemplate;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/converter/AccountIdDeserializer.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/converter/AccountIdDeserializer.java
@@ -30,7 +30,7 @@ import com.hedera.mirror.importer.domain.EntityId;
 import com.hedera.mirror.importer.domain.EntityTypeEnum;
 import com.hedera.mirror.importer.util.EntityIdEndec;
 
-public class EntityIdDeserializer extends JsonDeserializer<EntityId> {
+public class AccountIdDeserializer extends JsonDeserializer<EntityId> {
     @Override
     public EntityId deserialize(JsonParser jsonParser, DeserializationContext context) throws IOException,
             JsonProcessingException {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/converter/EntityIdDeserializer.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/converter/EntityIdDeserializer.java
@@ -1,0 +1,40 @@
+package com.hedera.mirror.importer.converter;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import java.io.IOException;
+
+import com.hedera.mirror.importer.domain.EntityId;
+import com.hedera.mirror.importer.domain.EntityTypeEnum;
+import com.hedera.mirror.importer.util.EntityIdEndec;
+
+public class EntityIdDeserializer extends JsonDeserializer<EntityId> {
+    @Override
+    public EntityId deserialize(JsonParser jsonParser, DeserializationContext context) throws IOException,
+            JsonProcessingException {
+        Long value = jsonParser.readValueAs(Long.class);
+        return value != null ? EntityIdEndec.decode(value, EntityTypeEnum.ACCOUNT) : null;
+    }
+}

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamMessage.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamMessage.java
@@ -1,0 +1,31 @@
+package com.hedera.mirror.importer.domain;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME)
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = TopicMessage.class, name = "TopicMessage")
+})
+public interface StreamMessage {
+}

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/TopicMessage.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/TopicMessage.java
@@ -21,6 +21,8 @@ package com.hedera.mirror.importer.domain;
  */
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import javax.persistence.Convert;
@@ -31,13 +33,15 @@ import lombok.ToString;
 import org.springframework.data.domain.Persistable;
 
 import com.hedera.mirror.importer.converter.AccountIdConverter;
-import com.hedera.mirror.importer.converter.EntityIdDeserializer;
+import com.hedera.mirror.importer.converter.AccountIdDeserializer;
 import com.hedera.mirror.importer.converter.EntityIdSerializer;
 
 @Data
 @Entity
+@JsonTypeInfo(use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME)
+@JsonTypeName("TopicMessage")
 @ToString(exclude = {"message", "runningHash"})
-public class TopicMessage implements Persistable<Long> {
+public class TopicMessage implements Persistable<Long>, StreamMessage {
 
     private Integer chunkNum;
 
@@ -50,7 +54,7 @@ public class TopicMessage implements Persistable<Long> {
 
     @Convert(converter = AccountIdConverter.class)
     @JsonSerialize(using = EntityIdSerializer.class)
-    @JsonDeserialize(using = EntityIdDeserializer.class)
+    @JsonDeserialize(using = AccountIdDeserializer.class)
     private EntityId payerAccountId;
 
     private int realmNum;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/TopicMessage.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/TopicMessage.java
@@ -21,6 +21,7 @@ package com.hedera.mirror.importer.domain;
  */
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import javax.persistence.Convert;
 import javax.persistence.Entity;
@@ -30,6 +31,7 @@ import lombok.ToString;
 import org.springframework.data.domain.Persistable;
 
 import com.hedera.mirror.importer.converter.AccountIdConverter;
+import com.hedera.mirror.importer.converter.EntityIdDeserializer;
 import com.hedera.mirror.importer.converter.EntityIdSerializer;
 
 @Data
@@ -48,6 +50,7 @@ public class TopicMessage implements Persistable<Long> {
 
     @Convert(converter = AccountIdConverter.class)
     @JsonSerialize(using = EntityIdSerializer.class)
+    @JsonDeserialize(using = EntityIdDeserializer.class)
     private EntityId payerAccountId;
 
     private int realmNum;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/BatchEntityListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/BatchEntityListener.java
@@ -1,4 +1,4 @@
-package com.hedera.mirror.grpc.listener;
+package com.hedera.mirror.importer.parser.record.entity;
 
 /*-
  * ‌
@@ -20,10 +20,9 @@ package com.hedera.mirror.grpc.listener;
  * ‍
  */
 
-public class PollingTopicListenerTest extends AbstractTopicListenerTest {
+public interface BatchEntityListener extends EntityListener {
 
-    @Override
-    protected ListenerProperties.ListenerType getType() {
-        return ListenerProperties.ListenerType.POLL;
-    }
+    void onSave(EntityBatchSaveEvent event);
+
+    void onCleanup(EntityBatchCleanupEvent event);
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityListenerProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityListenerProperties.java
@@ -1,4 +1,4 @@
-package com.hedera.mirror.grpc.listener;
+package com.hedera.mirror.importer.parser.record.entity;
 
 /*-
  * ‌
@@ -20,10 +20,9 @@ package com.hedera.mirror.grpc.listener;
  * ‍
  */
 
-public class PollingTopicListenerTest extends AbstractTopicListenerTest {
+public interface EntityListenerProperties {
 
-    @Override
-    protected ListenerProperties.ListenerType getType() {
-        return ListenerProperties.ListenerType.POLL;
-    }
+    boolean isEnabled();
+
+    void setEnabled(boolean enabled);
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/notify/NotifyProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/notify/NotifyProperties.java
@@ -24,13 +24,14 @@ import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import com.hedera.mirror.importer.parser.record.entity.ConditionOnEntityRecordParser;
+import com.hedera.mirror.importer.parser.record.entity.EntityListenerProperties;
 
 @Data
 @ConditionOnEntityRecordParser
 @ConfigurationProperties("hedera.mirror.importer.parser.record.entity.notify")
-public class NotifyProperties {
+public class NotifyProperties implements EntityListenerProperties {
 
-    private boolean enabled = true;
+    private boolean enabled = false;
 
     private int maxJsonPayloadSize = 8000;
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/notify/NotifyProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/notify/NotifyProperties.java
@@ -31,7 +31,7 @@ import com.hedera.mirror.importer.parser.record.entity.EntityListenerProperties;
 @ConfigurationProperties("hedera.mirror.importer.parser.record.entity.notify")
 public class NotifyProperties implements EntityListenerProperties {
 
-    private boolean enabled = false;
+    private boolean enabled = true;
 
     private int maxJsonPayloadSize = 8000;
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/redis/RedisEntityListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/redis/RedisEntityListener.java
@@ -36,6 +36,7 @@ import org.springframework.data.redis.core.RedisOperations;
 import org.springframework.data.redis.core.SessionCallback;
 
 import com.hedera.mirror.importer.MirrorProperties;
+import com.hedera.mirror.importer.domain.StreamMessage;
 import com.hedera.mirror.importer.domain.TopicMessage;
 import com.hedera.mirror.importer.exception.ImporterException;
 import com.hedera.mirror.importer.parser.record.entity.BatchEntityListener;
@@ -52,7 +53,7 @@ public class RedisEntityListener implements BatchEntityListener {
 
     private final MirrorProperties mirrorProperties;
     private final RedisProperties redisProperties;
-    private final RedisOperations<String, TopicMessage> redisOperations;
+    private final RedisOperations<String, StreamMessage> redisOperations;
     private final List<TopicMessage> topicMessages = new ArrayList<>();
     private final MeterRegistry meterRegistry;
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/redis/RedisProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/redis/RedisProperties.java
@@ -31,5 +31,5 @@ import com.hedera.mirror.importer.parser.record.entity.EntityListenerProperties;
 @ConfigurationProperties("hedera.mirror.importer.parser.record.entity.redis")
 public class RedisProperties implements EntityListenerProperties {
 
-    private boolean enabled = true;
+    private boolean enabled = false;
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/redis/RedisProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/redis/RedisProperties.java
@@ -1,4 +1,4 @@
-package com.hedera.mirror.grpc.listener;
+package com.hedera.mirror.importer.parser.record.entity.redis;
 
 /*-
  * ‌
@@ -20,10 +20,16 @@ package com.hedera.mirror.grpc.listener;
  * ‍
  */
 
-public class PollingTopicListenerTest extends AbstractTopicListenerTest {
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 
-    @Override
-    protected ListenerProperties.ListenerType getType() {
-        return ListenerProperties.ListenerType.POLL;
-    }
+import com.hedera.mirror.importer.parser.record.entity.ConditionOnEntityRecordParser;
+import com.hedera.mirror.importer.parser.record.entity.EntityListenerProperties;
+
+@Data
+@ConditionOnEntityRecordParser
+@ConfigurationProperties("hedera.mirror.importer.parser.record.entity.redis")
+public class RedisProperties implements EntityListenerProperties {
+
+    private boolean enabled = true;
 }

--- a/hedera-mirror-importer/src/main/resources/application.yml
+++ b/hedera-mirror-importer/src/main/resources/application.yml
@@ -42,7 +42,7 @@ management:
         liveness:
           include: ping
         readiness:
-          include: db,diskSpace,ping
+          include: db, diskSpace, ping, redis
 server:
   shutdown: graceful
 spring:

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/TopicMessageTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/TopicMessageTest.java
@@ -47,6 +47,7 @@ public class TopicMessageTest {
         ObjectMapper objectMapper = new ObjectMapper().setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
         String json = objectMapper.writeValueAsString(topicMessage);
         assertThat(json).isEqualTo("{" +
+                "\"@type\":\"TopicMessage\"," +
                 "\"chunk_num\":1," +
                 "\"chunk_total\":2," +
                 "\"consensus_timestamp\":1594401417000000000," +

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/BatchEntityListenerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/BatchEntityListenerTest.java
@@ -73,7 +73,7 @@ public abstract class BatchEntityListenerTest extends IntegrationTest {
         topicMessages.as(StepVerifier::create)
                 .expectNext(topicMessage1, topicMessage2)
                 .thenCancel()
-                .verify(Duration.ofMillis(500));
+                .verify(Duration.ofMillis(1000));
     }
 
     @Test

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/BatchEntityListenerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/BatchEntityListenerTest.java
@@ -1,0 +1,149 @@
+package com.hedera.mirror.importer.parser.record.entity;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+import com.hedera.mirror.importer.IntegrationTest;
+import com.hedera.mirror.importer.domain.EntityId;
+import com.hedera.mirror.importer.domain.EntityTypeEnum;
+import com.hedera.mirror.importer.domain.TopicMessage;
+
+@RequiredArgsConstructor
+public abstract class BatchEntityListenerTest extends IntegrationTest {
+
+    protected final BatchEntityListener entityListener;
+    protected final EntityListenerProperties properties;
+
+    private long sequenceNumber = 1;
+
+    @BeforeEach
+    void setup() {
+        properties.setEnabled(true);
+    }
+
+    @Test
+    void isEnabled() {
+        properties.setEnabled(false);
+        assertThat(entityListener.isEnabled()).isFalse();
+
+        properties.setEnabled(true);
+        assertThat(entityListener.isEnabled()).isTrue();
+    }
+
+    @Test
+    void onTopicMessage() {
+        // given
+        TopicMessage topicMessage1 = topicMessage();
+        TopicMessage topicMessage2 = topicMessage();
+        Flux<TopicMessage> topicMessages = subscribe(topicMessage1.getTopicNum());
+
+        // when
+        entityListener.onTopicMessage(topicMessage1);
+        entityListener.onTopicMessage(topicMessage2);
+        entityListener.onSave(new EntityBatchSaveEvent(this));
+        entityListener.onCleanup(new EntityBatchCleanupEvent(this));
+
+        // then
+        topicMessages.as(StepVerifier::create)
+                .expectNext(topicMessage1, topicMessage2)
+                .thenCancel()
+                .verify(Duration.ofMillis(500));
+    }
+
+    @Test
+    void onTopicMessageEmpty() {
+        // given
+        Flux<TopicMessage> topicMessages = subscribe(1);
+
+        // when
+        entityListener.onSave(new EntityBatchSaveEvent(this));
+        entityListener.onCleanup(new EntityBatchCleanupEvent(this));
+
+        // then
+        topicMessages.as(StepVerifier::create)
+                .expectNextCount(0L)
+                .thenCancel()
+                .verify(Duration.ofMillis(500));
+    }
+
+    @Test
+    void onTopicMessageDisabled() {
+        // given
+        properties.setEnabled(false);
+        TopicMessage topicMessage = topicMessage();
+        Flux<TopicMessage> topicMessages = subscribe(topicMessage.getTopicNum());
+
+        // when
+        entityListener.onTopicMessage(topicMessage);
+        entityListener.onSave(new EntityBatchSaveEvent(this));
+        entityListener.onCleanup(new EntityBatchCleanupEvent(this));
+
+        // then
+        topicMessages.as(StepVerifier::create)
+                .expectNextCount(0L)
+                .thenCancel()
+                .verify(Duration.ofMillis(500));
+    }
+
+    @Test
+    void onCleanup() {
+        // given
+        TopicMessage topicMessage = topicMessage();
+        Flux<TopicMessage> topicMessages = subscribe(topicMessage.getTopicNum());
+
+        // when
+        entityListener.onTopicMessage(topicMessage);
+        entityListener.onCleanup(new EntityBatchCleanupEvent(this));
+        entityListener.onSave(new EntityBatchSaveEvent(this));
+
+        // then
+        topicMessages.as(StepVerifier::create)
+                .expectNextCount(0L)
+                .thenCancel()
+                .verify(Duration.ofMillis(500));
+    }
+
+    protected abstract Flux<TopicMessage> subscribe(long topicNum);
+
+    protected TopicMessage topicMessage() {
+        TopicMessage topicMessage = new TopicMessage();
+        topicMessage.setChunkNum(1);
+        topicMessage.setChunkTotal(2);
+        topicMessage.setConsensusTimestamp(1L);
+        topicMessage.setMessage("test message".getBytes());
+        topicMessage.setPayerAccountId(EntityId.of("0.1.1000", EntityTypeEnum.ACCOUNT));
+        topicMessage.setRealmNum(0);
+        topicMessage.setRunningHash("running hash".getBytes());
+        topicMessage.setRunningHashVersion(2);
+        topicMessage.setSequenceNumber(sequenceNumber++);
+        topicMessage.setTopicNum(1001);
+        topicMessage.setValidStartTimestamp(4L);
+        return topicMessage;
+    }
+}

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/redis/RedisEntityListenerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/redis/RedisEntityListenerTest.java
@@ -28,16 +28,17 @@ import org.springframework.data.redis.serializer.RedisSerializer;
 import reactor.core.publisher.DirectProcessor;
 import reactor.core.publisher.Flux;
 
+import com.hedera.mirror.importer.domain.StreamMessage;
 import com.hedera.mirror.importer.domain.TopicMessage;
 import com.hedera.mirror.importer.parser.record.entity.BatchEntityListenerTest;
 
 public class RedisEntityListenerTest extends BatchEntityListenerTest {
 
-    private final RedisOperations<String, TopicMessage> redisOperations;
+    private final RedisOperations<String, StreamMessage> redisOperations;
 
     @Autowired
     public RedisEntityListenerTest(RedisEntityListener entityListener, RedisProperties properties,
-                                   RedisOperations<String, TopicMessage> redisOperations) {
+                                   RedisOperations<String, StreamMessage> redisOperations) {
         super(entityListener, properties);
         this.redisOperations = redisOperations;
     }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/redis/RedisEntityListenerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/redis/RedisEntityListenerTest.java
@@ -1,0 +1,61 @@
+package com.hedera.mirror.importer.parser.record.entity.redis;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.RedisOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import reactor.core.publisher.DirectProcessor;
+import reactor.core.publisher.Flux;
+
+import com.hedera.mirror.importer.domain.TopicMessage;
+import com.hedera.mirror.importer.parser.record.entity.BatchEntityListenerTest;
+
+public class RedisEntityListenerTest extends BatchEntityListenerTest {
+
+    private final RedisOperations<String, TopicMessage> redisOperations;
+
+    @Autowired
+    public RedisEntityListenerTest(RedisEntityListener entityListener, RedisProperties properties,
+                                   RedisOperations<String, TopicMessage> redisOperations) {
+        super(entityListener, properties);
+        this.redisOperations = redisOperations;
+    }
+
+    @Override
+    protected Flux<TopicMessage> subscribe(long topicNum) {
+        DirectProcessor<TopicMessage> directProcessor = DirectProcessor.create();
+        RedisSerializer stringSerializer = ((RedisTemplate<String, ?>) redisOperations).getStringSerializer();
+        RedisSerializer<TopicMessage> serializer = (RedisSerializer<TopicMessage>) redisOperations.getValueSerializer();
+
+        RedisCallback<TopicMessage> redisCallback = connection -> {
+            byte[] channel = stringSerializer.serialize("topic.0.0." + topicNum);
+            connection.subscribe((message, pattern) -> directProcessor
+                    .onNext(serializer.deserialize(message.getBody())), channel);
+            return null;
+        };
+
+        redisOperations.execute(redisCallback);
+        return directProcessor;
+    }
+}

--- a/hedera-mirror-importer/src/test/resources/config/application.yml
+++ b/hedera-mirror-importer/src/test/resources/config/application.yml
@@ -22,6 +22,8 @@ hedera:
       startDate: 1970-01-01T00:00:00Z
 
 spring:
+  redis:
+    url: redis://${embedded.redis.user}:${embedded.redis.password}@${embedded.redis.host}:${embedded.redis.port}
   task:
     scheduling:
       enabled: false

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
         <jib.version>2.5.2</jib.version>
         <jmeter.version>5.3</jmeter.version>
         <micrometer-jvm-extras.version>0.2.0</micrometer-jvm-extras.version>
+        <msgpack.version>0.8.20</msgpack.version>
         <protobuf.version>3.11.1</protobuf.version>
         <release.version>${project.version}</release.version> <!-- Used to replace release versions in all files -->
         <release.chartVersion>0.6.0-rc1</release.chartVersion>


### PR DESCRIPTION
**Detailed description**:
- Add a `RedisEntityListener` that uses [Redis Pub/Sub](https://redis.io/topics/pubsub) to notify the gRPC component of new topic messages
- Add a `RedisTopicListener` that consumes topic message notifications from Redis Pub/Sub
- Add a `hedera.mirror.subscribers` gauge metric that tracks the current number of active subscribers
- Change `bufferTimeout` from a number to `Duration`

**Which issue(s) this PR fixes**:
Fixes #893 

**Special notes for your reviewer**:
Helm chart updates will be done in a follow-up

**Checklist**
- [x] Documentation added
- [x] Tests updated

