### PR TITLE
Rosetta: Cache operation types & statuses

### DIFF
--- a/hedera-mirror-rosetta/app/domain/repositories/transaction.go
+++ b/hedera-mirror-rosetta/app/domain/repositories/transaction.go
@@ -23,13 +23,14 @@ package repositories
 import (
 	rTypes "github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/app/domain/types"
+	"sync"
 )
 
 // TransactionRepository Interface that all TransactionRepository structs must implement
 type TransactionRepository interface {
 	FindByHashInBlock(identifier string, consensusStart int64, consensusEnd int64) (*types.Transaction, *rTypes.Error)
 	FindBetween(start int64, end int64) ([]*types.Transaction, *rTypes.Error)
-	Types() (map[int]string, *rTypes.Error)
+	Types() (*sync.Map, *rTypes.Error)
 	TypesAsArray() ([]string, *rTypes.Error)
-	Statuses() (map[int]string, *rTypes.Error)
+	Statuses() (*sync.Map, *rTypes.Error)
 }

--- a/hedera-mirror-rosetta/app/domain/repositories/transaction.go
+++ b/hedera-mirror-rosetta/app/domain/repositories/transaction.go
@@ -23,14 +23,13 @@ package repositories
 import (
 	rTypes "github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/app/domain/types"
-	"sync"
 )
 
 // TransactionRepository Interface that all TransactionRepository structs must implement
 type TransactionRepository interface {
 	FindByHashInBlock(identifier string, consensusStart int64, consensusEnd int64) (*types.Transaction, *rTypes.Error)
 	FindBetween(start int64, end int64) ([]*types.Transaction, *rTypes.Error)
-	Types() (*sync.Map, *rTypes.Error)
-	TypesAsArray() ([]string, *rTypes.Error)
-	Statuses() (*sync.Map, *rTypes.Error)
+	Types() map[int]string
+	TypesAsArray() []string
+	Statuses() map[int]string
 }

--- a/hedera-mirror-rosetta/app/domain/repositories/transaction.go
+++ b/hedera-mirror-rosetta/app/domain/repositories/transaction.go
@@ -29,7 +29,7 @@ import (
 type TransactionRepository interface {
 	FindByHashInBlock(identifier string, consensusStart int64, consensusEnd int64) (*types.Transaction, *rTypes.Error)
 	FindBetween(start int64, end int64) ([]*types.Transaction, *rTypes.Error)
-	Types() map[int]string
-	TypesAsArray() []string
-	Statuses() map[int]string
+	Types() (map[int]string, *rTypes.Error)
+	TypesAsArray() ([]string, *rTypes.Error)
+	Statuses() (map[int]string, *rTypes.Error)
 }

--- a/hedera-mirror-rosetta/app/errors/errors.go
+++ b/hedera-mirror-rosetta/app/errors/errors.go
@@ -38,14 +38,16 @@ var Errors = map[string]*types.Error{
 	MultipleOperationTypesPresent:  New(MultipleOperationTypesPresent, 109, false),
 	MultipleSignaturesPresent:      New(MultipleSignaturesPresent, 110, false),
 	NotImplemented:                 New(NotImplemented, 111, false),
-	StartMustNotBeAfterEnd:         New(StartMustNotBeAfterEnd, 112, false),
-	TransactionBuildFailed:         New(TransactionBuildFailed, 113, false),
-	TransactionDecodeFailed:        New(TransactionDecodeFailed, 114, false),
-	TransactionRecordFetchFailed:   New(TransactionRecordFetchFailed, 115, false),
-	TransactionMarshallingFailed:   New(TransactionMarshallingFailed, 116, false),
-	TransactionUnmarshallingFailed: New(TransactionUnmarshallingFailed, 117, false),
-	TransactionSubmissionFailed:    New(TransactionSubmissionFailed, 118, false),
-	TransactionNotFound:            New(TransactionNotFound, 119, true),
+	OperationStatusesNotFound:      New(OperationStatusesNotFound, 112, true),
+	OperationTypesNotFound:         New(OperationTypesNotFound, 113, true),
+	StartMustNotBeAfterEnd:         New(StartMustNotBeAfterEnd, 114, false),
+	TransactionBuildFailed:         New(TransactionBuildFailed, 115, false),
+	TransactionDecodeFailed:        New(TransactionDecodeFailed, 116, false),
+	TransactionRecordFetchFailed:   New(TransactionRecordFetchFailed, 117, false),
+	TransactionMarshallingFailed:   New(TransactionMarshallingFailed, 118, false),
+	TransactionUnmarshallingFailed: New(TransactionUnmarshallingFailed, 119, false),
+	TransactionSubmissionFailed:    New(TransactionSubmissionFailed, 120, false),
+	TransactionNotFound:            New(TransactionNotFound, 121, true),
 	InternalServerError:            New(InternalServerError, 500, true),
 }
 
@@ -63,6 +65,8 @@ const (
 	MultipleOperationTypesPresent  string = "Only one Operation Type must be present"
 	MultipleSignaturesPresent      string = "Only one signature must be present"
 	NotImplemented                 string = "Not implemented"
+	OperationStatusesNotFound      string = "Operation Statuses not found"
+	OperationTypesNotFound         string = "Operation Types not found"
 	StartMustNotBeAfterEnd         string = "Start must not be after end"
 	TransactionBuildFailed         string = "Transaction build failed"
 	TransactionDecodeFailed        string = "Transaction Decode failed"

--- a/hedera-mirror-rosetta/app/persistence/transaction/transaction.go
+++ b/hedera-mirror-rosetta/app/persistence/transaction/transaction.go
@@ -90,6 +90,8 @@ func (t *transaction) getHashString() string {
 // TransactionRepository struct that has connection to the Database
 type TransactionRepository struct {
 	dbClient *gorm.DB
+	statuses map[int]string
+	types    map[int]string
 }
 
 // NewTransactionRepository creates an instance of a TransactionRepository struct
@@ -98,29 +100,49 @@ func NewTransactionRepository(dbClient *gorm.DB) *TransactionRepository {
 }
 
 // Types returns map of all Transaction Types
-// TODO implement cache instead of retrieving this everytime form DB
-func (tr *TransactionRepository) Types() map[int]string {
-	typesArray := tr.retrieveTransactionTypes()
-	tMap := make(map[int]string)
-	for _, t := range typesArray {
-		tMap[t.ProtoID] = t.Name
+func (tr *TransactionRepository) Types() (map[int]string, *rTypes.Error) {
+	if tr.types != nil {
+		return tr.types, nil
 	}
-	return tMap
+
+	typesArray := tr.retrieveTransactionTypes()
+	if len(typesArray) == 0 {
+		log.Println("No Transaction Types were found in the database.")
+		return nil, errors.Errors[errors.OperationTypesNotFound]
+	}
+
+	tr.types = make(map[int]string)
+	for _, t := range typesArray {
+		tr.types[t.ProtoID] = t.Name
+	}
+	return tr.types, nil
 }
 
 // Statuses returns map of all Transaction Results
-// TODO implement cache instead of retrieving this everytime form DB
-func (tr *TransactionRepository) Statuses() map[int]string {
-	rArray := tr.retrieveTransactionResults()
-	rMap := make(map[int]string)
-	for _, s := range rArray {
-		rMap[s.ProtoID] = s.Result
+func (tr *TransactionRepository) Statuses() (map[int]string, *rTypes.Error) {
+	if tr.statuses != nil {
+		return tr.statuses, nil
 	}
-	return rMap
+
+	rArray := tr.retrieveTransactionResults()
+	if len(rArray) == 0 {
+		log.Println("No Transaction Results were found in the database.")
+		return nil, errors.Errors[errors.OperationStatusesNotFound]
+	}
+
+	tr.statuses = make(map[int]string)
+	for _, s := range rArray {
+		tr.statuses[s.ProtoID] = s.Result
+	}
+	return tr.statuses, nil
 }
 
-func (tr *TransactionRepository) TypesAsArray() []string {
-	return maphelper.GetStringValuesFromIntStringMap(tr.Types())
+func (tr *TransactionRepository) TypesAsArray() ([]string, *rTypes.Error) {
+	transactionTypes, err := tr.Types()
+	if err != nil {
+		return nil, err
+	}
+	return maphelper.GetStringValuesFromIntStringMap(transactionTypes), nil
 }
 
 // FindBetween retrieves all Transactions between the provided start and end timestamp
@@ -206,8 +228,15 @@ func (tr *TransactionRepository) constructTransaction(sameHashTransactions []tra
 }
 
 func (tr *TransactionRepository) constructOperations(cryptoTransfers []dbTypes.CryptoTransfer, transactionsMap map[int64]transaction) ([]*types.Operation, *rTypes.Error) {
-	transactionTypes := tr.Types()
-	transactionStatuses := tr.Statuses()
+	transactionTypes, err := tr.Types()
+	if err != nil {
+		return nil, err
+	}
+
+	transactionStatuses, err := tr.Statuses()
+	if err != nil {
+		return nil, err
+	}
 
 	operations := make([]*types.Operation, len(cryptoTransfers))
 	for i, ct := range cryptoTransfers {

--- a/hedera-mirror-rosetta/app/persistence/transaction/transaction.go
+++ b/hedera-mirror-rosetta/app/persistence/transaction/transaction.go
@@ -102,13 +102,13 @@ func NewTransactionRepository(dbClient *gorm.DB) *TransactionRepository {
 
 // Types returns map of all Transaction Types
 func (tr *TransactionRepository) Types() map[int]string {
-	tr.retrieveTransactionResults()
+	tr.retrieveTransactionTypesAndStatuses()
 	return tr.types
 }
 
 // Statuses returns map of all Transaction Results
 func (tr *TransactionRepository) Statuses() map[int]string {
-	tr.retrieveTransactionResults()
+	tr.retrieveTransactionTypesAndStatuses()
 	return tr.statuses
 }
 
@@ -217,7 +217,7 @@ func (tr *TransactionRepository) constructOperations(cryptoTransfers []dbTypes.C
 	return operations, nil
 }
 
-func (tr *TransactionRepository) retrieveTypesAndStatuses() {
+func (tr *TransactionRepository) retrieveTransactionTypesAndStatuses() {
 	tr.once.Do(func() {
 		typesArray := tr.retrieveTransactionTypes()
 		rArray := tr.retrieveTransactionResults()

--- a/hedera-mirror-rosetta/app/persistence/transaction/transaction.go
+++ b/hedera-mirror-rosetta/app/persistence/transaction/transaction.go
@@ -102,13 +102,13 @@ func NewTransactionRepository(dbClient *gorm.DB) *TransactionRepository {
 
 // Types returns map of all Transaction Types
 func (tr *TransactionRepository) Types() map[int]string {
-	tr.fetchTypesAndStatuses()
+	tr.retrieveTransactionResults()
 	return tr.types
 }
 
 // Statuses returns map of all Transaction Results
 func (tr *TransactionRepository) Statuses() map[int]string {
-	tr.fetchTypesAndStatuses()
+	tr.retrieveTransactionResults()
 	return tr.statuses
 }
 
@@ -217,7 +217,7 @@ func (tr *TransactionRepository) constructOperations(cryptoTransfers []dbTypes.C
 	return operations, nil
 }
 
-func (tr *TransactionRepository) fetchTypesAndStatuses() {
+func (tr *TransactionRepository) retrieveTypesAndStatuses() {
 	tr.once.Do(func() {
 		typesArray := tr.retrieveTransactionTypes()
 		rArray := tr.retrieveTransactionResults()

--- a/hedera-mirror-rosetta/app/persistence/transaction/transaction.go
+++ b/hedera-mirror-rosetta/app/persistence/transaction/transaction.go
@@ -224,12 +224,12 @@ func (tr *TransactionRepository) retrieveTransactionTypesAndStatuses() {
 
 		if len(typesArray) == 0 {
 			log.Println("No Transaction Types were found in the database.")
-			panic(errors.Errors[errors.OperationTypesNotFound])
+			panic(errors.OperationTypesNotFound)
 		}
 
 		if len(rArray) == 0 {
 			log.Println("No Transaction Results were found in the database.")
-			panic(errors.Errors[errors.OperationStatusesNotFound])
+			panic(errors.OperationStatusesNotFound)
 		}
 
 		tr.types = make(map[int]string)

--- a/hedera-mirror-rosetta/app/services/network_service.go
+++ b/hedera-mirror-rosetta/app/services/network_service.go
@@ -49,10 +49,19 @@ func (n *NetworkAPIService) NetworkList(ctx context.Context, request *types.Meta
 
 // NetworkOptions implements the /network/options endpoint.
 func (n *NetworkAPIService) NetworkOptions(ctx context.Context, request *types.NetworkRequest) (*types.NetworkOptionsResponse, *types.Error) {
-	statuses := maphelper.GetStringValuesFromIntStringMap(n.transactionRepo.Statuses())
-	operationStatuses := make([]*types.OperationStatus, 0, len(statuses))
+	operationTypes, err := n.transactionRepo.TypesAsArray()
+	if err != nil {
+		return nil, err
+	}
 
-	for _, v := range statuses {
+	statuses, err := n.transactionRepo.Statuses()
+	if err != nil {
+		return nil, err
+	}
+
+	statusesArray := maphelper.GetStringValuesFromIntStringMap(statuses)
+	operationStatuses := make([]*types.OperationStatus, 0, len(statusesArray))
+	for _, v := range statusesArray {
 		operationStatuses = append(operationStatuses, &types.OperationStatus{
 			Status:     v,
 			Successful: true,
@@ -63,7 +72,7 @@ func (n *NetworkAPIService) NetworkOptions(ctx context.Context, request *types.N
 		Version: n.version,
 		Allow: &types.Allow{
 			OperationStatuses:       operationStatuses,
-			OperationTypes:          n.transactionRepo.TypesAsArray(),
+			OperationTypes:          operationTypes,
 			Errors:                  maphelper.GetErrorValuesFromStringErrorMap(errors.Errors),
 			HistoricalBalanceLookup: true,
 		},

--- a/hedera-mirror-rosetta/app/services/network_service.go
+++ b/hedera-mirror-rosetta/app/services/network_service.go
@@ -49,15 +49,8 @@ func (n *NetworkAPIService) NetworkList(ctx context.Context, request *types.Meta
 
 // NetworkOptions implements the /network/options endpoint.
 func (n *NetworkAPIService) NetworkOptions(ctx context.Context, request *types.NetworkRequest) (*types.NetworkOptionsResponse, *types.Error) {
-	operationTypes, err := n.transactionRepo.TypesAsArray()
-	if err != nil {
-		return nil, err
-	}
-
-	statuses, err := n.transactionRepo.Statuses()
-	if err != nil {
-		return nil, err
-	}
+	operationTypes := n.transactionRepo.TypesAsArray()
+	statuses := n.transactionRepo.Statuses()
 
 	statusesArray := maphelper.GetStringValuesFromIntStringMap(statuses)
 	operationStatuses := make([]*types.OperationStatus, 0, len(statusesArray))

--- a/hedera-mirror-rosetta/app/services/network_service.go
+++ b/hedera-mirror-rosetta/app/services/network_service.go
@@ -49,8 +49,14 @@ func (n *NetworkAPIService) NetworkList(ctx context.Context, request *types.Meta
 
 // NetworkOptions implements the /network/options endpoint.
 func (n *NetworkAPIService) NetworkOptions(ctx context.Context, request *types.NetworkRequest) (*types.NetworkOptionsResponse, *types.Error) {
-	operationTypes := n.transactionRepo.TypesAsArray()
-	statuses := n.transactionRepo.Statuses()
+	operationTypes, err := n.transactionRepo.TypesAsArray()
+	if err != nil {
+		return nil, err
+	}
+	statuses, err := n.transactionRepo.Statuses()
+	if err != nil {
+		return nil, err
+	}
 
 	statusesArray := maphelper.GetStringValuesFromIntStringMap(statuses)
 	operationStatuses := make([]*types.OperationStatus, 0, len(statusesArray))

--- a/hedera-mirror-rosetta/tools/maphelper/maphelper.go
+++ b/hedera-mirror-rosetta/tools/maphelper/maphelper.go
@@ -20,14 +20,18 @@
 
 package maphelper
 
-import "github.com/coinbase/rosetta-sdk-go/types"
+import (
+	"github.com/coinbase/rosetta-sdk-go/types"
+	"sync"
+)
 
-func GetStringValuesFromIntStringMap(mapping map[int]string) []string {
-	values := make([]string, 0, len(mapping))
+func GetStringValuesFromIntStringMap(mapping *sync.Map) []string {
+	var values []string
 
-	for _, v := range mapping {
-		values = append(values, v)
-	}
+	mapping.Range(func(key, value interface{}) bool {
+		values = append(values, value.(string))
+		return true
+	})
 
 	return values
 }

--- a/hedera-mirror-rosetta/tools/maphelper/maphelper.go
+++ b/hedera-mirror-rosetta/tools/maphelper/maphelper.go
@@ -22,16 +22,14 @@ package maphelper
 
 import (
 	"github.com/coinbase/rosetta-sdk-go/types"
-	"sync"
 )
 
-func GetStringValuesFromIntStringMap(mapping *sync.Map) []string {
+func GetStringValuesFromIntStringMap(mapping map[int]string) []string {
 	var values []string
 
-	mapping.Range(func(key, value interface{}) bool {
-		values = append(values, value.(string))
-		return true
-	})
+	for _, v := range mapping {
+		values = append(values, v)
+	}
 
 	return values
 }


### PR DESCRIPTION
**Detailed description**:
* Types and Statuses can be retrieved once because their tables are only updated in flyway migrations
* Memory cached on the first related query

**Which issue(s) this PR fixes**:
Fixes #None

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

