### PR TITLE
Rosetta: Unit tests for domain types and tools

### DIFF
--- a/hedera-mirror-rosetta/app/domain/types/account_test.go
+++ b/hedera-mirror-rosetta/app/domain/types/account_test.go
@@ -1,0 +1,171 @@
+/*-
+ * ‌
+ * Hedera Mirror Node
+ *
+ * Copyright (C) 2019 - 2020 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+package types
+
+import (
+	"github.com/coinbase/rosetta-sdk-go/types"
+	entityid "github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/app/domain/services/encoding"
+	"github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/app/errors"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func exampleAccount() *Account {
+	return &Account{
+		entityid.EntityId{
+			ShardNum:  0,
+			RealmNum:  0,
+			EntityNum: 0,
+		},
+	}
+}
+
+func exampleAccountWith(shard, realm, entity int64) *Account {
+	return &Account{
+		entityid.EntityId{
+			ShardNum:  shard,
+			RealmNum:  realm,
+			EntityNum: entity,
+		},
+	}
+}
+
+func expectedAccount() *types.AccountIdentifier {
+	return &types.AccountIdentifier{
+		Address:    "0.0.0",
+		SubAccount: nil,
+		Metadata:   nil,
+	}
+}
+
+func expectedAccountWith(shard int64, realm int64, number int64) *Account {
+	return &Account{
+		entityid.EntityId{
+			ShardNum:  shard,
+			RealmNum:  realm,
+			EntityNum: number,
+		},
+	}
+}
+
+func TestToRosettaAccount(t *testing.T) {
+	// when:
+	rosettaAccount := exampleAccount().ToRosetta()
+
+	// then:
+	assert.Equal(t, expectedAccount(), rosettaAccount)
+}
+
+func TestNewAccountFromEncodedID(t *testing.T) {
+	// given:
+	var testData = []struct {
+		input, shard, realm, number int64
+	}{
+		{0, 0, 0, 0},
+		{10, 0, 0, 10},
+		{4294967295, 0, 0, 4294967295},
+		{2814792716779530, 10, 10, 10},
+		{9223372036854775807, 32767, 65535, 4294967295},
+		{9223090561878065152, 32767, 0, 0},
+	}
+
+	for _, tt := range testData {
+		// when:
+		res, _ := NewAccountFromEncodedID(tt.input)
+
+		// then:
+		assert.Equal(t, expectedAccountWith(tt.shard, tt.realm, tt.number), res)
+	}
+}
+
+func TestComputeEncodedID(t *testing.T) {
+	var testData = []struct {
+		shard, realm, number int64
+	}{
+		{-1, 123, 246},
+		{123, -123, 246},
+		{123, 23, -246},
+	}
+
+	for _, tt := range testData {
+		res, e := exampleAccountWith(tt.shard, tt.realm, tt.number).ComputeEncodedID()
+		assert.Zero(t, res)
+		assert.NotNil(t, e)
+	}
+}
+
+func TestNewAccountFromEncodedIDThrows(t *testing.T) {
+	// given:
+	testData := int64(-1)
+
+	// when:
+	res, err := NewAccountFromEncodedID(testData)
+
+	// then:
+	assert.Nil(t, res)
+	assert.NotNil(t, err)
+}
+
+func TestAccountFromString(t *testing.T) {
+	// given:
+	var testData = []struct {
+		input                string
+		shard, realm, number int64
+	}{
+		{"0.0.0", 0, 0, 0},
+		{"0.0.10", 0, 0, 10},
+		{"0.0.4294967295", 0, 0, 4294967295},
+		{"10.10.10", 10, 10, 10},
+		{"32767.65535.4294967295", 32767, 65535, 4294967295},
+		{"32767.0.0", 32767, 0, 0},
+	}
+
+	for _, tt := range testData {
+		// when:
+		res, _ := AccountFromString(tt.input)
+
+		// then:
+		assert.Equal(t, expectedAccountWith(tt.shard, tt.realm, tt.number), res)
+	}
+}
+
+func TestAccountFromStringThrows(t *testing.T) {
+	// given:
+	var testData = []struct {
+		input string
+	}{
+		{"a.0.0"},
+		{"0.b.0"},
+		{"0.0c"},
+		{"0.0.c"},
+	}
+
+	var expectedNil *Account = nil
+
+	for _, tt := range testData {
+		// when:
+		res, err := AccountFromString(tt.input)
+
+		// then:
+		assert.Equal(t, expectedNil, res)
+		assert.Equal(t, errors.Errors[errors.InvalidAccount], err)
+	}
+}

--- a/hedera-mirror-rosetta/app/domain/types/account_test.go
+++ b/hedera-mirror-rosetta/app/domain/types/account_test.go
@@ -89,14 +89,43 @@ func TestNewAccountFromEncodedID(t *testing.T) {
 
 	for _, tt := range testData {
 		// when:
-		res, _ := NewAccountFromEncodedID(tt.input)
+		res, e := NewAccountFromEncodedID(tt.input)
 
 		// then:
 		assert.Equal(t, expectedAccountWith(tt.shard, tt.realm, tt.number), res)
+		assert.Nil(t, e)
 	}
 }
 
+func TestNewAccountFromEncodedIDThrows(t *testing.T) {
+	// given:
+	testData := int64(-1)
+
+	// when:
+	res, err := NewAccountFromEncodedID(testData)
+
+	// then:
+	assert.Nil(t, res)
+	assert.NotNil(t, err)
+}
+
 func TestComputeEncodedID(t *testing.T) {
+	var testData = []struct {
+		shard, realm, number, result int64
+	}{
+		{0, 0, 1, 1},
+		{0, 1, 1, 4294967297},
+		{123, 123, 123, 34621950416388219},
+	}
+
+	for _, tt := range testData {
+		res, e := exampleAccountWith(tt.shard, tt.realm, tt.number).ComputeEncodedID()
+		assert.Equal(t, tt.result, res)
+		assert.Nil(t, e)
+	}
+}
+
+func TestComputeEncodedIDThrows(t *testing.T) {
 	var testData = []struct {
 		shard, realm, number int64
 	}{
@@ -112,16 +141,22 @@ func TestComputeEncodedID(t *testing.T) {
 	}
 }
 
-func TestNewAccountFromEncodedIDThrows(t *testing.T) {
-	// given:
-	testData := int64(-1)
+func TestAccountString(t *testing.T) {
+	var testData = []struct {
+		shard  int64
+		realm  int64
+		number int64
+		result string
+	}{
+		{0, 0, 1, "0.0.1"},
+		{0, 1, 1, "0.1.1"},
+		{123, 123, 123, "123.123.123"},
+	}
 
-	// when:
-	res, err := NewAccountFromEncodedID(testData)
-
-	// then:
-	assert.Nil(t, res)
-	assert.NotNil(t, err)
+	for _, tt := range testData {
+		res := exampleAccountWith(tt.shard, tt.realm, tt.number).String()
+		assert.Equal(t, tt.result, res)
+	}
 }
 
 func TestAccountFromString(t *testing.T) {
@@ -140,10 +175,11 @@ func TestAccountFromString(t *testing.T) {
 
 	for _, tt := range testData {
 		// when:
-		res, _ := AccountFromString(tt.input)
+		res, e := AccountFromString(tt.input)
 
 		// then:
 		assert.Equal(t, expectedAccountWith(tt.shard, tt.realm, tt.number), res)
+		assert.Nil(t, e)
 	}
 }
 

--- a/hedera-mirror-rosetta/app/domain/types/address_book_entry_test.go
+++ b/hedera-mirror-rosetta/app/domain/types/address_book_entry_test.go
@@ -1,0 +1,55 @@
+package types
+
+import (
+	"github.com/coinbase/rosetta-sdk-go/types"
+	entityid "github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/app/domain/services/encoding"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func exampleAddressBookEntries() *AddressBookEntries {
+	return &AddressBookEntries{
+		[]*AddressBookEntry{
+			{
+				PeerId: &Account{
+					entityid.EntityId{
+						ShardNum:  0,
+						RealmNum:  0,
+						EntityNum: 0,
+					},
+				},
+				Metadata: map[string]interface{}{
+					"ip":   "123",
+					"port": "20514",
+				},
+			},
+		},
+	}
+}
+
+func expectedRosettaPeers() []*types.Peer {
+	return []*types.Peer{
+		{
+			PeerID: (&Account{
+				entityid.EntityId{
+					ShardNum:  0,
+					RealmNum:  0,
+					EntityNum: 0,
+				},
+			}).String(),
+			Metadata: map[string]interface{}{
+				"ip":   "123",
+				"port": "20514",
+			},
+		},
+	}
+}
+
+func TestToRosettaPeers(t *testing.T) {
+	// when:
+	result := exampleAddressBookEntries().ToRosetta()
+
+	// then:
+	assert.Equal(t, expectedRosettaPeers(), result)
+	assert.Len(t, result, 1)
+}

--- a/hedera-mirror-rosetta/app/domain/types/address_book_entry_test.go
+++ b/hedera-mirror-rosetta/app/domain/types/address_book_entry_test.go
@@ -1,47 +1,50 @@
+/*-
+ * ‌
+ * Hedera Mirror Node
+ *
+ * Copyright (C) 2019 - 2020 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
 package types
 
 import (
 	"github.com/coinbase/rosetta-sdk-go/types"
 	entityid "github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/app/domain/services/encoding"
 	"github.com/stretchr/testify/assert"
+	"reflect"
 	"testing"
 )
 
 func exampleAddressBookEntries() *AddressBookEntries {
 	return &AddressBookEntries{
 		[]*AddressBookEntry{
-			{
-				PeerId: &Account{
-					entityid.EntityId{
-						ShardNum:  0,
-						RealmNum:  0,
-						EntityNum: 0,
-					},
-				},
-				Metadata: map[string]interface{}{
-					"ip":   "123",
-					"port": "20514",
-				},
-			},
+			newDummyAddressBookEntry(0, 0, 1, dummyMetadata("someip", "someport")),
+			newDummyAddressBookEntry(0, 0, 2, dummyMetadata("someip2", "someport2")),
+			newDummyAddressBookEntry(0, 1, 3, dummyMetadata("someip3", "someport3")),
+			newDummyAddressBookEntry(10, 1, 3, dummyMetadata("someip3", "someport3")),
 		},
 	}
 }
 
 func expectedRosettaPeers() []*types.Peer {
 	return []*types.Peer{
-		{
-			PeerID: (&Account{
-				entityid.EntityId{
-					ShardNum:  0,
-					RealmNum:  0,
-					EntityNum: 0,
-				},
-			}).String(),
-			Metadata: map[string]interface{}{
-				"ip":   "123",
-				"port": "20514",
-			},
-		},
+		newDummyPeer(0, 0, 1, dummyMetadata("someip", "someport")),
+		newDummyPeer(0, 0, 2, dummyMetadata("someip2", "someport2")),
+		newDummyPeer(0, 1, 3, dummyMetadata("someip3", "someport3")),
+		newDummyPeer(10, 1, 3, dummyMetadata("someip3", "someport3")),
 	}
 }
 
@@ -50,6 +53,51 @@ func TestToRosettaPeers(t *testing.T) {
 	result := exampleAddressBookEntries().ToRosetta()
 
 	// then:
-	assert.Equal(t, expectedRosettaPeers(), result)
-	assert.Len(t, result, 1)
+	assert.Equal(t, len(expectedRosettaPeers()), len(result))
+
+	// and:
+	for _, a := range result {
+		found := false
+		for _, e := range result {
+			if reflect.DeepEqual(a, e) {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found)
+	}
+}
+
+func newDummyPeer(shard, realm, entity int64, metadata map[string]interface{}) *types.Peer {
+	return &types.Peer{
+		PeerID: (&Account{
+			entityid.EntityId{
+				ShardNum:  shard,
+				RealmNum:  realm,
+				EntityNum: entity,
+			},
+		}).String(),
+		Metadata: metadata,
+	}
+}
+
+func newDummyAddressBookEntry(shard, realm, entity int64, metadata map[string]interface{}) *AddressBookEntry {
+	return &AddressBookEntry{
+		PeerId: &Account{
+			entityid.EntityId{
+				ShardNum:  shard,
+				RealmNum:  realm,
+				EntityNum: entity,
+			},
+		},
+		Metadata: metadata,
+	}
+}
+
+func dummyMetadata(ip, port string) map[string]interface{} {
+	return map[string]interface {
+	}{
+		"ip":   ip,
+		"port": port,
+	}
 }

--- a/hedera-mirror-rosetta/app/domain/types/amount_test.go
+++ b/hedera-mirror-rosetta/app/domain/types/amount_test.go
@@ -1,0 +1,48 @@
+/*-
+ * ‌
+ * Hedera Mirror Node
+ *
+ * Copyright (C) 2019 - 2020 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+package types
+
+import (
+	"github.com/coinbase/rosetta-sdk-go/types"
+	"github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/config"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func expectedAmount() *types.Amount {
+	return &types.Amount{
+		Value:    "400",
+		Currency: config.CurrencyHbar,
+		Metadata: nil,
+	}
+}
+
+func exampleAmount() *Amount {
+	return &Amount{Value: int64(400)}
+}
+
+func TestToRosettaAmount(t *testing.T) {
+	// when:
+	result := exampleAmount().ToRosetta()
+
+	// then:
+	assert.Equal(t, expectedAmount(), result)
+}

--- a/hedera-mirror-rosetta/app/domain/types/block_test.go
+++ b/hedera-mirror-rosetta/app/domain/types/block_test.go
@@ -75,7 +75,6 @@ func TestToRosettaBlock(t *testing.T) {
 func TestGetTimestampMillis(t *testing.T) {
 	// given:
 	exampleBlock := exampleBlock()
-	exampleBlock.ConsensusStartNanos = 10000000
 
 	// when:
 	resultMillis := exampleBlock.GetTimestampMillis()

--- a/hedera-mirror-rosetta/app/domain/types/block_test.go
+++ b/hedera-mirror-rosetta/app/domain/types/block_test.go
@@ -1,0 +1,85 @@
+/*-
+ * ‌
+ * Hedera Mirror Node
+ *
+ * Copyright (C) 2019 - 2020 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+package types
+
+import (
+	"github.com/coinbase/rosetta-sdk-go/types"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func exampleBlock() *Block {
+	return &Block{
+		Index:               2,
+		Hash:                "somehash",
+		ConsensusStartNanos: 10000000,
+		ConsensusEndNanos:   12300000,
+		ParentIndex:         1,
+		ParentHash:          "someparenthash",
+		Transactions: []*Transaction{
+			{
+				Hash:       "somehash",
+				Operations: []*Operation{},
+			},
+		},
+	}
+}
+
+func expectedBlock() *types.Block {
+	return &types.Block{
+		BlockIdentifier: &types.BlockIdentifier{
+			Index: 2,
+			Hash:  "0xsomehash",
+		},
+		ParentBlockIdentifier: &types.BlockIdentifier{
+			Index: 1,
+			Hash:  "0xsomeparenthash",
+		},
+		Timestamp: int64(10),
+		Transactions: []*types.Transaction{
+			{
+				TransactionIdentifier: &types.TransactionIdentifier{Hash: "somehash"},
+				Operations:            []*types.Operation{},
+				Metadata:              nil,
+			},
+		},
+	}
+}
+
+func TestToRosettaBlock(t *testing.T) {
+	// when:
+	rosettaBlockResult := exampleBlock().ToRosetta()
+
+	// then:
+	assert.Equal(t, expectedBlock(), rosettaBlockResult)
+}
+
+func TestGetTimestampMillis(t *testing.T) {
+	// given:
+	exampleBlock := exampleBlock()
+	exampleBlock.ConsensusStartNanos = 10000000
+
+	// when:
+	resultMillis := exampleBlock.GetTimestampMillis()
+
+	// then:
+	assert.Equal(t, int64(10), resultMillis)
+}

--- a/hedera-mirror-rosetta/app/domain/types/operation_test.go
+++ b/hedera-mirror-rosetta/app/domain/types/operation_test.go
@@ -1,0 +1,75 @@
+/*-
+ * ‌
+ * Hedera Mirror Node
+ *
+ * Copyright (C) 2019 - 2020 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+package types
+
+import (
+	"github.com/coinbase/rosetta-sdk-go/types"
+	entityid "github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/app/domain/services/encoding"
+	"github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/config"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func exampleOperation() *Operation {
+	return &Operation{
+		Index:  1,
+		Type:   "transfer",
+		Status: "pending",
+		Account: &Account{
+			entityid.EntityId{
+				ShardNum:  0,
+				RealmNum:  0,
+				EntityNum: 0,
+			},
+		},
+		Amount: &Amount{Value: int64(400)},
+	}
+}
+
+func expectedOperation() *types.Operation {
+	return &types.Operation{
+		OperationIdentifier: &types.OperationIdentifier{
+			Index:        1,
+			NetworkIndex: nil,
+		},
+		RelatedOperations: []*types.OperationIdentifier{},
+		Type:              "transfer",
+		Status:            "pending",
+		Account: &types.AccountIdentifier{
+			Address:    "0.0.0",
+			SubAccount: nil,
+			Metadata:   nil,
+		},
+		Amount: &types.Amount{
+			Value:    "400",
+			Currency: config.CurrencyHbar,
+			Metadata: nil,
+		},
+	}
+}
+
+func TestToRosettaOperation(t *testing.T) {
+	// when:
+	rosettaOperation := exampleOperation().ToRosetta()
+
+	// then:
+	assert.Equal(t, expectedOperation(), rosettaOperation)
+}

--- a/hedera-mirror-rosetta/app/domain/types/transaction_test.go
+++ b/hedera-mirror-rosetta/app/domain/types/transaction_test.go
@@ -1,0 +1,89 @@
+/*-
+ * ‌
+ * Hedera Mirror Node
+ *
+ * Copyright (C) 2019 - 2020 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+package types
+
+import (
+	"github.com/coinbase/rosetta-sdk-go/types"
+	entityid "github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/app/domain/services/encoding"
+	"github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/config"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func exampleTransaction() *Transaction {
+	return &Transaction{
+		Hash: "somehash",
+		Operations: []*Operation{
+			{
+				Index:  1,
+				Type:   "transfer",
+				Status: "pending",
+				Account: &Account{
+					entityid.EntityId{
+						ShardNum:  0,
+						RealmNum:  0,
+						EntityNum: 0,
+					},
+				},
+				Amount: &Amount{Value: int64(400)},
+			},
+		},
+	}
+}
+
+func expectedTransaction() *types.Transaction {
+	return &types.Transaction{
+		TransactionIdentifier: &types.TransactionIdentifier{Hash: "somehash"},
+		Operations: []*types.Operation{
+			{
+				OperationIdentifier: &types.OperationIdentifier{
+					Index:        1,
+					NetworkIndex: nil,
+				},
+				RelatedOperations: []*types.OperationIdentifier{},
+				Type:              "transfer",
+				Status:            "pending",
+				Account: &types.AccountIdentifier{
+					Address:    "0.0.0",
+					SubAccount: nil,
+					Metadata:   nil,
+				},
+				Amount: &types.Amount{
+					Value:    "400",
+					Currency: config.CurrencyHbar,
+					Metadata: nil,
+				},
+			},
+		},
+		Metadata: nil,
+	}
+}
+
+func TestToRosettaTransaction(t *testing.T) {
+	// given:
+	expectedTransaction := expectedTransaction()
+
+	// when:
+	rosettaTransaction := exampleTransaction().ToRosetta()
+
+	// then:
+	assert.Equal(t, expectedTransaction, rosettaTransaction)
+}

--- a/hedera-mirror-rosetta/go.mod
+++ b/hedera-mirror-rosetta/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/jinzhu/gorm v1.9.16
 	github.com/lib/pq v1.8.0 // indirect
 	github.com/sqs/goreturns v0.0.0-20181028201513-538ac6014518 // indirect
+	github.com/stretchr/testify v1.6.1
 	golang.org/x/crypto v0.0.0-20201002094018-c90954cbb977 // indirect
 	golang.org/x/net v0.0.0-20200930145003-4acb6c075d10 // indirect
 	golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f // indirect

--- a/hedera-mirror-rosetta/tools/hex/hex_test.go
+++ b/hedera-mirror-rosetta/tools/hex/hex_test.go
@@ -54,7 +54,7 @@ func TestAddsPrefixCorrectly(t *testing.T) {
 		result := SafeAddHexPrefix(tt.string)
 
 		// then:
-		assert.Equal(t, result, expectedData[i].result)
+		assert.Equal(t, expectedData[i].result, result)
 	}
 }
 
@@ -66,7 +66,6 @@ func TestRemovesPrefixCorrectly(t *testing.T) {
 		{"0xaddprefix"},
 		{"0x"},
 		{"0x123"},
-		{"0x"},
 		{"0x "},
 		{"0x123aasd"},
 		{"0xaasd"},
@@ -79,7 +78,6 @@ func TestRemovesPrefixCorrectly(t *testing.T) {
 		{"addprefix"},
 		{""},
 		{"123"},
-		{""},
 		{" "},
 		{"123aasd"},
 		{"aasd"},
@@ -90,6 +88,6 @@ func TestRemovesPrefixCorrectly(t *testing.T) {
 		// when:
 		result := SafeRemoveHexPrefix(tt.string)
 		// then:
-		assert.Equal(t, result, expectedData[i].result)
+		assert.Equal(t, expectedData[i].result, result)
 	}
 }

--- a/hedera-mirror-rosetta/tools/hex/hex_test.go
+++ b/hedera-mirror-rosetta/tools/hex/hex_test.go
@@ -1,0 +1,95 @@
+/*-
+ * ‌
+ * Hedera Mirror Node
+ *
+ * Copyright (C) 2019 - 2020 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+package hex
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestAddsPrefixCorrectly(t *testing.T) {
+	// given:
+	var testData = []struct {
+		string string
+	}{
+		{"addprefix"},
+		{""},
+		{"123"},
+		{"0x"},
+		{"0x "},
+		{"0x123aasd"},
+	}
+
+	var expectedData = []struct {
+		result string
+	}{
+		{"0xaddprefix"},
+		{"0x"},
+		{"0x123"},
+		{"0x"},
+		{"0x "},
+		{"0x123aasd"},
+	}
+
+	for i, tt := range testData {
+		// when:
+		result := SafeAddHexPrefix(tt.string)
+
+		// then:
+		assert.Equal(t, result, expectedData[i].result)
+	}
+}
+
+func TestRemovesPrefixCorrectly(t *testing.T) {
+	// given:
+	var testData = []struct {
+		string string
+	}{
+		{"0xaddprefix"},
+		{"0x"},
+		{"0x123"},
+		{"0x"},
+		{"0x "},
+		{"0x123aasd"},
+		{"0xaasd"},
+		{"234123"},
+	}
+
+	var expectedData = []struct {
+		result string
+	}{
+		{"addprefix"},
+		{""},
+		{"123"},
+		{""},
+		{" "},
+		{"123aasd"},
+		{"aasd"},
+		{"234123"},
+	}
+
+	for i, tt := range testData {
+		// when:
+		result := SafeRemoveHexPrefix(tt.string)
+		// then:
+		assert.Equal(t, result, expectedData[i].result)
+	}
+}

--- a/hedera-mirror-rosetta/tools/maphelper/maphelper_test.go
+++ b/hedera-mirror-rosetta/tools/maphelper/maphelper_test.go
@@ -30,32 +30,50 @@ import (
 
 func TestGetsCorrectStringValuesFromMap(t *testing.T) {
 	// given:
-	testData := map[int]string{
+	inputData := map[int]string{
 		1: "abc",
+		2: "asd",
+		3: "aaaa",
+		4: "1",
 	}
-
 	// when:
-	result := GetStringValuesFromIntStringMap(testData)
-
+	result := GetStringValuesFromIntStringMap(inputData)
 	// then:
-	assert.Equal(t, 1, len(result))
-	assert.Equal(t, "abc", result[0])
+	assert.Equal(t, len(inputData), len(result))
+	for _, v := range inputData {
+		found := false
+		for _, e := range result {
+			if e == v {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found)
+	}
 }
 
 func TestGetsCorrectErrorValuesFromMap(t *testing.T) {
 	// given:
-	error := newErrorDummy(32, true)
-
-	testData := map[string]*types.Error{
-		"error": error,
+	inputData := map[string]*types.Error{
+		"error1":  newErrorDummy(32, true),
+		"error2":  newErrorDummy(64, false),
+		"error3":  newErrorDummy(128, true),
+		"error64": newErrorDummy(12341, false),
 	}
-
 	// when:
-	result := GetErrorValuesFromStringErrorMap(testData)
-
+	result := GetErrorValuesFromStringErrorMap(inputData)
 	// then:
-	assert.Equal(t, 1, len(result))
-	assert.Equal(t, error, result[0])
+	assert.Equal(t, len(inputData), len(result))
+	for _, v := range inputData {
+		found := false
+		for _, e := range result {
+			if e == v {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found)
+	}
 }
 
 func newErrorDummy(code int32, retryable bool) *types.Error {

--- a/hedera-mirror-rosetta/tools/maphelper/maphelper_test.go
+++ b/hedera-mirror-rosetta/tools/maphelper/maphelper_test.go
@@ -1,0 +1,63 @@
+/*-
+ * ‌
+ * Hedera Mirror Node
+ *
+ * Copyright (C) 2019 - 2020 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+package maphelper
+
+import (
+	"fmt"
+	"github.com/coinbase/rosetta-sdk-go/types"
+	"github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/app/errors"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestGetsCorrectStringValuesFromMap(t *testing.T) {
+	// given:
+	testData := map[int]string{
+		1: "abc",
+	}
+
+	// when:
+	result := GetStringValuesFromIntStringMap(testData)
+
+	// then:
+	assert.Equal(t, 1, len(result))
+	assert.Equal(t, "abc", result[0])
+}
+
+func TestGetsCorrectErrorValuesFromMap(t *testing.T) {
+	// given:
+	error := newErrorDummy(32, true)
+
+	testData := map[string]*types.Error{
+		"error": error,
+	}
+
+	// when:
+	result := GetErrorValuesFromStringErrorMap(testData)
+
+	// then:
+	assert.Equal(t, 1, len(result))
+	assert.Equal(t, error, result[0])
+}
+
+func newErrorDummy(code int32, retryable bool) *types.Error {
+	return errors.New(fmt.Sprintf("error_dummy_%d", code), code, retryable)
+}

--- a/hedera-mirror-rosetta/tools/validator/validator_test.go
+++ b/hedera-mirror-rosetta/tools/validator/validator_test.go
@@ -1,0 +1,72 @@
+/*-
+ * ‌
+ * Hedera Mirror Node
+ *
+ * Copyright (C) 2019 - 2020 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+package validator
+
+import (
+	"github.com/coinbase/rosetta-sdk-go/types"
+	"github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/app/errors"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestValidateOperationsSum(t *testing.T) {
+	// given:
+	operationDummy := newOperationDummy("100")
+	operationDummy2 := newOperationDummy("-100")
+	invalidOperationDummy := newOperationDummy("-100H")
+
+	testData := []*types.Operation{
+		operationDummy,
+		operationDummy2,
+	}
+
+	var nil *types.Error = nil
+	expectedInvalidOperationsTotalAmountError := errors.Errors[errors.InvalidOperationsTotalAmount]
+	expectedInvalidAmountError := errors.Errors[errors.InvalidAmount]
+
+	// when:
+	result := ValidateOperationsSum(testData)
+
+	// then:
+	assert.Equal(t, nil, result)
+
+	// and:
+	testData = append(testData, operationDummy2)
+
+	// then:
+	result = ValidateOperationsSum(testData)
+	assert.Equal(t, expectedInvalidOperationsTotalAmountError, result)
+
+	// and:
+	testData = append(testData, invalidOperationDummy)
+
+	// then:
+	result = ValidateOperationsSum(testData)
+	assert.Equal(t, expectedInvalidAmountError, result)
+}
+
+func newOperationDummy(amount string) *types.Operation {
+	return &types.Operation{
+		Amount: &types.Amount{
+			Value: amount,
+		},
+	}
+}

--- a/hedera-mirror-rosetta/tools/validator/validator_test.go
+++ b/hedera-mirror-rosetta/tools/validator/validator_test.go
@@ -30,37 +30,29 @@ import (
 func TestValidateOperationsSum(t *testing.T) {
 	// given:
 	operationDummy := newOperationDummy("100")
-	operationDummy2 := newOperationDummy("-100")
+	operationDummyNegative := newOperationDummy("-100")
 	invalidOperationDummy := newOperationDummy("-100H")
 
-	testData := []*types.Operation{
-		operationDummy,
-		operationDummy2,
+	var testData = []struct {
+		operations []*types.Operation
+		expected   *types.Error
+	}{
+		{[]*types.Operation{
+			operationDummy,
+			operationDummyNegative,
+		}, nil},
+		{[]*types.Operation{
+			operationDummyNegative,
+		}, errors.Errors[errors.InvalidOperationsTotalAmount]},
+		{[]*types.Operation{
+			invalidOperationDummy,
+		}, errors.Errors[errors.InvalidAmount]},
 	}
 
-	var nil *types.Error = nil
-	expectedInvalidOperationsTotalAmountError := errors.Errors[errors.InvalidOperationsTotalAmount]
-	expectedInvalidAmountError := errors.Errors[errors.InvalidAmount]
-
-	// when:
-	result := ValidateOperationsSum(testData)
-
-	// then:
-	assert.Equal(t, nil, result)
-
-	// and:
-	testData = append(testData, operationDummy2)
-
-	// then:
-	result = ValidateOperationsSum(testData)
-	assert.Equal(t, expectedInvalidOperationsTotalAmountError, result)
-
-	// and:
-	testData = append(testData, invalidOperationDummy)
-
-	// then:
-	result = ValidateOperationsSum(testData)
-	assert.Equal(t, expectedInvalidAmountError, result)
+	for _, tt := range testData {
+		result := ValidateOperationsSum(tt.operations)
+		assert.Equal(t, tt.expected, result)
+	}
 }
 
 func newOperationDummy(amount string) *types.Operation {


### PR DESCRIPTION
**Detailed description**:
- Add unit tests for all of the domain types: `account.go`, `address_book_entry.go`, `amount.go`, `block.go`, `operation.go`, `transaction.go`
- Add unit tests for the `tools` package

**Which issue(s) this PR fixes**:
Related to LimeChain [#103](https://github.com/LimeChain/hedera-mirror-node/issues/103)

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [X] Tests updated

