### PR TITLE
Add support for alerts in Kubernetes

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -41,9 +41,10 @@ jobs:
           ref: deploy
       - name: Update dev tag
         run: |-
+          sed -i "s/ref: .*/ref: ${GITHUB_SHA}/" ./common/helmrelease.yaml
           sed -i "s/ref: .*/ref: ${GITHUB_SHA}/" ./dev/helmrelease.yaml
           sed -i "s/tag: .*/tag: master-${GITHUB_SHA}/" ./dev/helmrelease.yaml
         shell: bash
-      - uses: stefanzweifel/git-auto-commit-action@v4.4.0
+      - uses: stefanzweifel/git-auto-commit-action@v4.5.1
         with:
           commit_message: Upgrade dev to master-${{ github.sha }}

--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -36,3 +36,4 @@ jobs:
           config: .github/ct-install.yaml
           image: quay.io/helmpack/chart-testing:v3.0.0
           kubeconfig: ${{ steps.k8s.outputs.kubeconfig }}
+

--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -25,7 +25,7 @@ jobs:
         uses: debianmaster/actions-k3s@master
         if: steps.lint.outputs.changed == 'true' # Only create cluster if there are chart changes
         with:
-          version: v1.17.4-k3s1
+          version: v1.16.9-k3s1
 
       - name: Helm install
         uses: helm/chart-testing-action@v1.1.0

--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Helm lint
         id: lint
-        uses: helm/chart-testing-action@v1.0.0
+        uses: helm/chart-testing-action@v1.1.0
         with:
           command: lint
           config: .github/ct-lint.yaml
@@ -25,10 +25,10 @@ jobs:
         uses: debianmaster/actions-k3s@master
         if: steps.lint.outputs.changed == 'true' # Only create cluster if there are chart changes
         with:
-          version: v1.16.9-k3s1
+          version: v1.17.4-k3s1
 
       - name: Helm install
-        uses: helm/chart-testing-action@v1.0.0
+        uses: helm/chart-testing-action@v1.1.0
         if: steps.lint.outputs.changed == 'true'
         with:
           command: install

--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Helm lint
         id: lint
-        uses: helm/chart-testing-action@v1.1.0
+        uses: helm/chart-testing-action@v1.0.0
         with:
           command: lint
           config: .github/ct-lint.yaml
@@ -25,10 +25,10 @@ jobs:
         uses: debianmaster/actions-k3s@master
         if: steps.lint.outputs.changed == 'true' # Only create cluster if there are chart changes
         with:
-          version: v1.16.9-k3s1
+          version: v1.17.4-k3s1
 
       - name: Helm install
-        uses: helm/chart-testing-action@v1.1.0
+        uses: helm/chart-testing-action@v1.0.0
         if: steps.lint.outputs.changed == 'true'
         with:
           command: install

--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -35,3 +35,4 @@ jobs:
           command: install
           config: .github/ct-install.yaml
           image: quay.io/helmpack/chart-testing:v3.1.1
+          kubeconfig: ${{ steps.k8s.outputs.kubeconfig }}

--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -15,10 +15,11 @@ jobs:
 
       - name: Helm lint
         id: lint
-        uses: helm/chart-testing-action@v1.0.0
+        uses: helm/chart-testing-action@v1.1.0
         with:
           command: lint
           config: .github/ct-lint.yaml
+          image: quay.io/helmpack/chart-testing:v3.0.0
 
       - name: Create Kubernetes cluster
         id: k8s
@@ -28,9 +29,10 @@ jobs:
           version: v1.17.4-k3s1
 
       - name: Helm install
-        uses: helm/chart-testing-action@v1.0.0
+        uses: helm/chart-testing-action@v1.1.0
         if: steps.lint.outputs.changed == 'true'
         with:
           command: install
           config: .github/ct-install.yaml
+          image: quay.io/helmpack/chart-testing:v3.0.0
           kubeconfig: ${{ steps.k8s.outputs.kubeconfig }}

--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -15,11 +15,11 @@ jobs:
 
       - name: Helm lint
         id: lint
-        uses: helm/chart-testing-action@v1.1.0
+        uses: helm/chart-testing-action@v1.0.0
         with:
           command: lint
           config: .github/ct-lint.yaml
-          image: quay.io/helmpack/chart-testing:v3.0.0
+          image: quay.io/helmpack/chart-testing:v3.1.1
 
       - name: Create Kubernetes cluster
         id: k8s
@@ -29,11 +29,9 @@ jobs:
           version: v1.17.4-k3s1
 
       - name: Helm install
-        uses: helm/chart-testing-action@v1.1.0
+        uses: helm/chart-testing-action@v1.0.0
         if: steps.lint.outputs.changed == 'true'
         with:
           command: install
           config: .github/ct-install.yaml
-          image: quay.io/helmpack/chart-testing:v3.0.0
-          kubeconfig: ${{ steps.k8s.outputs.kubeconfig }}
-
+          image: quay.io/helmpack/chart-testing:v3.1.1

--- a/charts/README.md
+++ b/charts/README.md
@@ -47,12 +47,12 @@ To access the GRPC API (using [grpcurl](https://github.com/fullstorydev/grpcurl)
 
 To access the REST API:
 ```shell script
-  curl -s "http://${SERVICE_IP}:80/api/v1/transactions?limit=1"
+  curl -s "http://${SERVICE_IP}/api/v1/transactions?limit=1"
 ```
 
 To view the Grafana dashboard:
 ```shell script
-  open "http://${SERVICE_IP}:80/grafana"
+  open "http://${SERVICE_IP}/grafana"
 ```
 
 ## Uninstall
@@ -90,14 +90,23 @@ $ echo "logging.level.com.hedera.mirror.grpc=TRACE" > application.properties
 $ kubectl create configmap hedera-mirror-grpc --from-file=application.properties
 ```
 
-Dashboard and metrics can be viewed via [Grafana](https://grafana.com). To access, get the external IP and open it in a browser:
-
-```shell script
-$ open "http://$(kubectl get service "${RELEASE}-grafana" -o jsonpath='{.status.loadBalancer.ingress[0].ip}')"
-```
+Dashboard, metrics and alerts can be viewed via [Grafana](https://grafana.com). See the [Using](#using) section for how
+to connect to Grafana.
 
 To connect to the database and run queries:
 
 ```shell script
 $ kubectl exec -it "${RELEASE}-postgres-postgresql-0" -c postgresql -- psql -d mirror_node -U mirror_node
+```
+
+### Alerts
+
+Prometheus AlertManager is used to monitor and alert for ongoing issues in the cluster. If an alert is received via
+a notification mechanism like Slack or PagerDuty, it should contain enough details to know where to start the
+investigation. Active alerts can be viewed via the `AlertManager` dashboard in Grafana that is exposed by the load
+balancer. To see further details or to silence or suppress the alert it will need to be done via the AlertManager UI.
+To access the AlertManager UI, expose it via kubectl:
+
+```shell script
+kubectl port-forward service/${RELEASE}-prometheus-alertmanager 9093:9093
 ```

--- a/charts/hedera-mirror-common/dashboards/alertmanager.json
+++ b/charts/hedera-mirror-common/dashboards/alertmanager.json
@@ -1,0 +1,934 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 25,
+  "iteration": 1602715438463,
+  "links": [],
+  "panels": [
+    {
+      "datasource": "Prometheus",
+      "description": "The number of AlertManager pods",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 5,
+        "y": 0
+      },
+      "id": 8,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.2.0",
+      "targets": [
+        {
+          "expr": "count(alertmanager_build_info{instance=~\"$instance\"})",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "AlertManager Instances",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Current number of active alerts.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 8,
+        "y": 0
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.2.0",
+      "targets": [
+        {
+          "expr": "avg(alertmanager_alerts{state=\"active\", instance=~\"$instance\"})",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Active Alerts",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Current number of suppressed alerts.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 11,
+        "y": 0
+      },
+      "id": 7,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.2.0",
+      "targets": [
+        {
+          "expr": "avg(alertmanager_alerts{state=\"suppressed\", instance=~\"$instance\"})",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Suppressed Alerts",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Current number of silenced alerts.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 14,
+        "y": 0
+      },
+      "id": 9,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.2.0",
+      "targets": [
+        {
+          "expr": "avg(alertmanager_silences{state=\"active\", instance=~\"$instance\"})",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Silenced Alerts",
+      "type": "stat"
+    },
+    {
+      "datasource": "AlertManager",
+      "description": "Alerts that are currently firing that are not specific to a namespace",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": null,
+            "displayMode": "color-background",
+            "filterable": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Time"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 141
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "alertname"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 196
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "severity"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 76
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "job"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 228
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "summary"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 445
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "message"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 503
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "description"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 637
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "namespace"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 152
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 3,
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "Time"
+          }
+        ]
+      },
+      "pluginVersion": "7.2.0",
+      "repeatDirection": "v",
+      "targets": [
+        {
+          "annotations": false,
+          "expr": "namespace=~\"$namespace\",severity=~\"critical\"",
+          "labelSelector": "alertname, summary, description, message,job,namespace",
+          "legendFormat": "",
+          "refId": "A",
+          "target": "Query",
+          "type": "table"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Critical Alerts",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": false,
+              "Value": true,
+              "severity": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "Time": "",
+              "message": "",
+              "severity": ""
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": "AlertManager",
+      "description": "Alerts that are currently firing that are not specific to a namespace",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": null,
+            "displayMode": "color-background",
+            "filterable": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "orange",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Time"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 141
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "alertname"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 197
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "severity"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 76
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "job"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 228
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "summary"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 445
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "message"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 503
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "description"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 637
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "namespace"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 152
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "id": 4,
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "Time"
+          }
+        ]
+      },
+      "pluginVersion": "7.2.0",
+      "repeatDirection": "v",
+      "targets": [
+        {
+          "annotations": false,
+          "expr": "namespace=~\"$namespace\",severity=~\"warning\"",
+          "labelSelector": "alertname, summary, description, message,job,namespace",
+          "legendFormat": "",
+          "refId": "A",
+          "target": "Query",
+          "type": "table"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Warning Alerts",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": false,
+              "Value": true,
+              "severity": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "Time": "",
+              "message": "",
+              "severity": ""
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": "AlertManager",
+      "description": "Alerts that are currently firing that are not specific to a namespace",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": null,
+            "displayMode": "color-background",
+            "filterable": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "semi-dark-yellow",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Time"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 141
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "alertname"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 197
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "severity"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 76
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "job"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 262
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "summary"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 469
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 24,
+        "x": 0,
+        "y": 15
+      },
+      "id": 2,
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "Time"
+          }
+        ]
+      },
+      "pluginVersion": "7.2.0",
+      "repeat": null,
+      "repeatDirection": "v",
+      "targets": [
+        {
+          "annotations": false,
+          "expr": "namespace=~\"\",severity=~\"critical|warning\"",
+          "labelSelector": "alertname, summary, description, message,",
+          "legendFormat": "",
+          "refId": "A",
+          "target": "Query",
+          "type": "table"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Cluster Wide Alerts",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": false,
+              "Value": true,
+              "severity": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "Time": "",
+              "message": "",
+              "severity": ""
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 19
+      },
+      "hiddenSeries": false,
+      "id": 11,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.2.0",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(alertmanager_notifications_total{instance=~\"$instance\"}[5m])) by (integration) > 0",
+          "interval": "",
+          "legendFormat": "{{integration}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Notification Rate",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "schemaVersion": 26,
+  "style": "dark",
+  "tags": [
+    "alertmanager",
+    "alerts",
+    "prometheus"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": [
+            "common"
+          ],
+          "value": [
+            "common"
+          ]
+        },
+        "datasource": "AlertManager",
+        "definition": "label_values(severity!=\"\",namespace) ",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Namespace",
+        "multi": true,
+        "name": "namespace",
+        "options": [],
+        "query": "label_values(severity!=\"\",namespace) ",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [
+          {
+            "text": "{\"labels\":{\"alertname\":\"PrometheusRuleFailures\",\"container\":\"prometheus\",\"endpoint\":\"web\",\"instance\":\"10.42.0.81:9090\",\"job\":\"mirror-prometheus-prometheus\",\"namespace\":\"common\",\"pod\":\"prometheus-mirror-prometheus-prometheus-0\",\"prometheus\":\"common/mirror-prometheus-prometheus\",\"rule_group\":\"/etc/prometheus/rules/prometheus-mirror-prometheus-prometheus-rulefiles-0/common-mirror-prometheus-kubernetes-system-kubelet.yaml;kubernetes-system-kubelet\",\"service\":\"mirror-prometheus-prometheus\",\"severity\":\"critical\"},\"annotations\":{\"description\":\"Prometheus common/prometheus-mirror-prometheus-prometheus-0 has failed to evaluate 10 rules in the last 5m.\",\"summary\":\"Prometheus is failing rule evaluations.\"},\"startsAt\":\"2020-10-13T20:32:27.753Z\",\"endsAt\":\"2020-10-13T22:12:27.753Z\",\"generatorURL\":\"http://mirror-prometheus-prometheus.common:9090/graph?g0.expr=increase%28prometheus_rule_evaluation_failures_total%7Bjob%3D%22mirror-prometheus-prometheus%22%2Cnamespace%3D%22common%22%7D%5B5m%5D%29+%3E+0&g0.tab=1\",\"status\":{\"state\":\"active\",\"silencedBy\":[],\"inhibitedBy\":[]},\"receivers\":[\"slack\"],\"fingerprint\":\"03e4c53cc7a64c71\"}"
+          },
+          {
+            "text": "{\"labels\":{\"alertname\":\"KubeCPUOvercommit\",\"prometheus\":\"common/mirror-prometheus-prometheus\",\"severity\":\"warning\"},\"annotations\":{\"description\":\"Cluster has overcommitted CPU resource requests for Pods and cannot tolerate node failure.\",\"runbook_url\":\"https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecpuovercommit\",\"summary\":\"Cluster has overcommitted CPU resource requests.\"},\"startsAt\":\"2020-10-13T20:20:51.551Z\",\"endsAt\":\"2020-10-13T22:12:51.551Z\",\"generatorURL\":\"http://mirror-prometheus-prometheus.common:9090/graph?g0.expr=sum%28namespace%3Akube_pod_container_resource_requests_cpu_cores%3Asum%29+%2F+sum%28kube_node_status_allocatable_cpu_cores%29+%3E+%28count%28kube_node_status_allocatable_cpu_cores%29+-+1%29+%2F+count%28kube_node_status_allocatable_cpu_cores%29&g0.tab=1\",\"status\":{\"state\":\"active\",\"silencedBy\":[],\"inhibitedBy\":[]},\"receivers\":[\"slack\"],\"fingerprint\":\"099865e4e2a79e3e\"}"
+          },
+          {
+            "text": "{\"labels\":{\"alertname\":\"NodeClockNotSynchronising\",\"container\":\"node-exporter\",\"endpoint\":\"metrics\",\"instance\":\"10.42.0.82:9100\",\"job\":\"node-exporter\",\"namespace\":\"common\",\"pod\":\"mirror-prometheus-node-exporter-65kmj\",\"prometheus\":\"common/mirror-prometheus-prometheus\",\"service\":\"mirror-prometheus-node-exporter\",\"severity\":\"warning\"},\"annotations\":{\"message\":\"Clock on 10.42.0.82:9100 is not synchronising. Ensure NTP is configured on this host.\",\"runbook_url\":\"https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-nodeclocknotsynchronising\",\"summary\":\"Clock not synchronising.\"},\"startsAt\":\"2020-10-13T20:26:16.559Z\",\"endsAt\":\"2020-10-13T22:12:16.559Z\",\"generatorURL\":\"http://mirror-prometheus-prometheus.common:9090/graph?g0.expr=min_over_time%28node_timex_sync_status%5B5m%5D%29+%3D%3D+0&g0.tab=1\",\"status\":{\"state\":\"active\",\"silencedBy\":[],\"inhibitedBy\":[]},\"receivers\":[\"slack\"],\"fingerprint\":\"0e7775828c80cb31\"}"
+          },
+          {
+            "text": "{\"labels\":{\"alertname\":\"Watchdog\",\"prometheus\":\"common/mirror-prometheus-prometheus\",\"severity\":\"none\"},\"annotations\":{\"message\":\"This is an alert meant to ensure that the entire alerting pipeline is functional.\\nThis alert is always firing, therefore it should always be firing in Alertmanager\\nand always fire against a receiver. There are integrations with various notification\\nmechanisms that send a notification when this alert is not firing. For example the\\n\\\"DeadMansSnitch\\\" integration in PagerDuty.\\n\"},\"startsAt\":\"2020-10-13T20:15:15.342Z\",\"endsAt\":\"2020-10-13T22:11:45.342Z\",\"generatorURL\":\"http://mirror-prometheus-prometheus.common:9090/graph?g0.expr=vector%281%29&g0.tab=1\",\"status\":{\"state\":\"active\",\"silencedBy\":[],\"inhibitedBy\":[]},\"receivers\":[\"null\"],\"fingerprint\":\"884f08421bf0f6e5\"}"
+          },
+          {
+            "text": "{\"labels\":{\"alertname\":\"PrometheusRuleFailures\",\"container\":\"prometheus\",\"endpoint\":\"web\",\"instance\":\"10.42.0.81:9090\",\"job\":\"mirror-prometheus-prometheus\",\"namespace\":\"common\",\"pod\":\"prometheus-mirror-prometheus-prometheus-0\",\"prometheus\":\"common/mirror-prometheus-prometheus\",\"rule_group\":\"/etc/prometheus/rules/prometheus-mirror-prometheus-prometheus-rulefiles-0/common-mirror-prometheus-kubelet.rules.yaml;kubelet.rules\",\"service\":\"mirror-prometheus-prometheus\",\"severity\":\"critical\"},\"annotations\":{\"description\":\"Prometheus common/prometheus-mirror-prometheus-prometheus-0 has failed to evaluate 30 rules in the last 5m.\",\"summary\":\"Prometheus is failing rule evaluations.\"},\"startsAt\":\"2020-10-13T20:32:27.753Z\",\"endsAt\":\"2020-10-13T22:12:27.753Z\",\"generatorURL\":\"http://mirror-prometheus-prometheus.common:9090/graph?g0.expr=increase%28prometheus_rule_evaluation_failures_total%7Bjob%3D%22mirror-prometheus-prometheus%22%2Cnamespace%3D%22common%22%7D%5B5m%5D%29+%3E+0&g0.tab=1\",\"status\":{\"state\":\"active\",\"silencedBy\":[],\"inhibitedBy\":[]},\"receivers\":[\"slack\"],\"fingerprint\":\"8f5725baf5912df5\"}"
+          },
+          {
+            "text": "{\"labels\":{\"alertname\":\"KubeMemoryOvercommit\",\"prometheus\":\"common/mirror-prometheus-prometheus\",\"severity\":\"warning\"},\"annotations\":{\"description\":\"Cluster has overcommitted memory resource requests for Pods and cannot tolerate node failure.\",\"runbook_url\":\"https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubememoryovercommit\",\"summary\":\"Cluster has overcommitted memory resource requests.\"},\"startsAt\":\"2020-10-13T20:20:51.551Z\",\"endsAt\":\"2020-10-13T22:12:51.551Z\",\"generatorURL\":\"http://mirror-prometheus-prometheus.common:9090/graph?g0.expr=sum%28namespace%3Akube_pod_container_resource_requests_memory_bytes%3Asum%29+%2F+sum%28kube_node_status_allocatable_memory_bytes%29+%3E+%28count%28kube_node_status_allocatable_memory_bytes%29+-+1%29+%2F+count%28kube_node_status_allocatable_memory_bytes%29&g0.tab=1\",\"status\":{\"state\":\"active\",\"silencedBy\":[],\"inhibitedBy\":[]},\"receivers\":[\"slack\"],\"fingerprint\":\"abf173bbd2fc874d\"}"
+          },
+          {
+            "text": "{\"labels\":{\"alertname\":\"TargetDown\",\"job\":\"kube-dns\",\"namespace\":\"kube-system\",\"prometheus\":\"common/mirror-prometheus-prometheus\",\"service\":\"mirror-prometheus-kube-dns\",\"severity\":\"warning\"},\"annotations\":{\"message\":\"100% of the kube-dns/mirror-prometheus-kube-dns targets in kube-system namespace are down.\"},\"startsAt\":\"2020-10-13T20:26:15.342Z\",\"endsAt\":\"2020-10-13T22:12:15.342Z\",\"generatorURL\":\"http://mirror-prometheus-prometheus.common:9090/graph?g0.expr=100+%2A+%28count+by%28job%2C+namespace%2C+service%29+%28up+%3D%3D+0%29+%2F+count+by%28job%2C+namespace%2C+service%29+%28up%29%29+%3E+10&g0.tab=1\",\"status\":{\"state\":\"active\",\"silencedBy\":[],\"inhibitedBy\":[]},\"receivers\":[\"slack\"],\"fingerprint\":\"aece28aedf23b2bc\"}"
+          }
+        ],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": "Prometheus",
+        "definition": "query_result(alertmanager_build_info)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Instance",
+        "multi": true,
+        "name": "instance",
+        "options": [],
+        "query": "query_result(alertmanager_build_info)",
+        "refresh": 2,
+        "regex": "/.*instance=\"([^\"]+)\".*/",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "AlertManager",
+  "uid": "eea-9_sik",
+  "version": 1
+}

--- a/charts/hedera-mirror-common/dashboards/kubernetes-cluster-monitoring-via-prometheus_rev2.json
+++ b/charts/hedera-mirror-common/dashboards/kubernetes-cluster-monitoring-via-prometheus_rev2.json
@@ -16,8 +16,8 @@
   "editable": true,
   "gnetId": 3119,
   "graphTooltip": 0,
-  "id": 28,
-  "iteration": 1586272639061,
+  "id": 20,
+  "iteration": 1602616214182,
   "links": [],
   "panels": [
     {
@@ -47,6 +47,12 @@
       "datasource": "$datasource",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "percent",
       "gauge": {
         "maxValue": 100,
@@ -79,7 +85,6 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
-      "options": {},
       "postfix": "",
       "postfixFontSize": "50%",
       "prefix": "",
@@ -134,6 +139,12 @@
       "decimals": 2,
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "percent",
       "gauge": {
         "maxValue": 100,
@@ -166,7 +177,6 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
-      "options": {},
       "postfix": "",
       "postfixFontSize": "50%",
       "prefix": "",
@@ -222,6 +232,12 @@
       "decimals": 2,
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "percent",
       "gauge": {
         "maxValue": 100,
@@ -254,7 +270,6 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
-      "options": {},
       "postfix": "",
       "postfixFontSize": "50%",
       "prefix": "",
@@ -311,6 +326,12 @@
       "decimals": 2,
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "bytes",
       "gauge": {
         "maxValue": 100,
@@ -343,7 +364,6 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
-      "options": {},
       "postfix": "",
       "postfixFontSize": "20%",
       "prefix": "",
@@ -398,6 +418,12 @@
       "decimals": 2,
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "bytes",
       "gauge": {
         "maxValue": 100,
@@ -430,7 +456,6 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
-      "options": {},
       "postfix": "",
       "postfixFontSize": "50%",
       "prefix": "",
@@ -485,6 +510,12 @@
       "decimals": 2,
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -517,7 +548,6 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
-      "options": {},
       "postfix": " cores",
       "postfixFontSize": "30%",
       "prefix": "",
@@ -573,6 +603,12 @@
       "decimals": 2,
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -605,7 +641,6 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
-      "options": {},
       "postfix": " cores",
       "postfixFontSize": "30%",
       "prefix": "",
@@ -660,6 +695,12 @@
       "decimals": 2,
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "bytes",
       "gauge": {
         "maxValue": 100,
@@ -692,7 +733,6 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
-      "options": {},
       "postfix": "",
       "postfixFontSize": "50%",
       "prefix": "",
@@ -748,6 +788,12 @@
       "decimals": 2,
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "bytes",
       "gauge": {
         "maxValue": 100,
@@ -780,7 +826,6 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
-      "options": {},
       "postfix": "",
       "postfixFontSize": "50%",
       "prefix": "",
@@ -832,21 +877,6 @@
         "x": 0,
         "y": 9
       },
-      "id": 33,
-      "panels": [],
-      "repeat": null,
-      "title": "Network I/O pressure",
-      "type": "row"
-    },
-    {
-      "collapsed": false,
-      "datasource": null,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 10
-      },
       "id": 35,
       "panels": [],
       "repeat": null,
@@ -862,6 +892,13 @@
       "decimals": 2,
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 5,
       "grid": {},
@@ -869,7 +906,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 11
+        "y": 10
       },
       "height": "",
       "hiddenSeries": false,
@@ -892,9 +929,10 @@
       "links": [],
       "nullPointMode": "connected",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.2.0",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -904,7 +942,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (rate (container_cpu_usage_seconds_total{image!=\"\",name=~\"^k8s_.*\",kubernetes_io_hostname=~\"^$Node$\"}[$interval])) by (pod)",
+          "expr": "sum (rate (container_cpu_usage_seconds_total{image!=\"\",kubernetes_io_hostname=~\"^$Node$\"}[$interval])) by (pod)",
           "format": "time_series",
           "interval": "10s",
           "intervalFactor": 1,
@@ -966,6 +1004,13 @@
       "description": "",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 5,
       "grid": {},
@@ -973,7 +1018,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 18
+        "y": 17
       },
       "height": "",
       "hiddenSeries": false,
@@ -988,7 +1033,7 @@
         "rightSide": true,
         "show": true,
         "sideWidth": null,
-        "sort": "current",
+        "sort": "avg",
         "sortDesc": true,
         "total": false,
         "values": true
@@ -998,9 +1043,10 @@
       "links": [],
       "nullPointMode": "connected",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.2.0",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1065,9 +1111,17 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "decimals": 2,
+      "decimals": 0,
+      "description": "",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 5,
       "grid": {},
@@ -1075,7 +1129,117 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 25
+        "y": 24
+      },
+      "height": "",
+      "hiddenSeries": false,
+      "id": 46,
+      "interval": "",
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sideWidth": null,
+        "sort": "avg",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.2.0",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(container_cpu_cfs_throttled_seconds_total{kubernetes_io_hostname=~\"^$Node$\", container!=\"\"}[$interval])) by (container, pod)",
+          "interval": "10s",
+          "legendFormat": "{{ pod }}/{{container}}",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Container CPU Utilization",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 2,
+        "value_type": "cumulative"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 1,
+          "format": "percentunit",
+          "label": "Utilization",
+          "logBase": 1,
+          "max": "1",
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "decimals": 2,
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 5,
+      "grid": {},
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 31
       },
       "height": "",
       "hiddenSeries": false,
@@ -1091,7 +1255,7 @@
         "rightSide": true,
         "show": true,
         "sideWidth": null,
-        "sort": "current",
+        "sort": "avg",
         "sortDesc": true,
         "total": false,
         "values": true
@@ -1101,9 +1265,10 @@
       "links": [],
       "nullPointMode": "connected",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.2.0",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1113,7 +1278,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(container_cpu_usage_seconds_total{image!=\"\",name=~\"^k8s_.*\",container!=\"POD\",kubernetes_io_hostname=~\"^$Node$\"}[$interval])) by (container, pod)",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{image!=\"\",container!=\"POD\",kubernetes_io_hostname=~\"^$Node$\"}[$interval])) by (container, pod)",
           "format": "time_series",
           "hide": false,
           "interval": "10s",
@@ -1173,7 +1338,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 32
+        "y": 38
       },
       "id": 39,
       "panels": [],
@@ -1190,6 +1355,13 @@
       "decimals": 0,
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "grid": {},
@@ -1197,7 +1369,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 33
+        "y": 39
       },
       "hiddenSeries": false,
       "id": 25,
@@ -1220,9 +1392,10 @@
       "links": [],
       "nullPointMode": "connected",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.2.0",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1232,7 +1405,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (container_memory_working_set_bytes{image!=\"\",name=~\"^k8s_.*\",kubernetes_io_hostname=~\"^$Node$\"}) by (pod)",
+          "expr": "sum (container_memory_working_set_bytes{image!=\"\",kubernetes_io_hostname=~\"^$Node$\"}) by (pod)",
           "format": "time_series",
           "interval": "10s",
           "intervalFactor": 1,
@@ -1294,6 +1467,13 @@
       "description": "",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 5,
       "grid": {},
@@ -1301,7 +1481,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 40
+        "y": 46
       },
       "height": "",
       "hiddenSeries": false,
@@ -1316,7 +1496,7 @@
         "rightSide": true,
         "show": true,
         "sideWidth": null,
-        "sort": "current",
+        "sort": "avg",
         "sortDesc": true,
         "total": false,
         "values": true
@@ -1326,9 +1506,10 @@
       "links": [],
       "nullPointMode": "connected",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.2.0",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1396,6 +1577,13 @@
       "decimals": 2,
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 0,
       "fillGradient": 0,
       "grid": {},
@@ -1403,7 +1591,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 47
+        "y": 53
       },
       "hiddenSeries": false,
       "id": 27,
@@ -1426,9 +1614,10 @@
       "links": [],
       "nullPointMode": "connected",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.2.0",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1438,7 +1627,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (container_memory_working_set_bytes{image!=\"\",name=~\"^k8s_.*\",container!=\"POD\",kubernetes_io_hostname=~\"^$Node$\"}) by (container, pod)",
+          "expr": "sum (container_memory_working_set_bytes{image!=\"\",container!=\"POD\",kubernetes_io_hostname=~\"^$Node$\"}) by (container, pod)",
           "format": "time_series",
           "interval": "10s",
           "intervalFactor": 1,
@@ -1497,7 +1686,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 54
+        "y": 60
       },
       "id": 43,
       "panels": [],
@@ -1514,6 +1703,13 @@
       "decimals": 2,
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "grid": {},
@@ -1521,7 +1717,7 @@
         "h": 6,
         "w": 24,
         "x": 0,
-        "y": 55
+        "y": 61
       },
       "height": "200px",
       "hiddenSeries": false,
@@ -1545,9 +1741,10 @@
       "links": [],
       "nullPointMode": "connected",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.2.0",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1628,6 +1825,13 @@
       "decimals": 0,
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "grid": {},
@@ -1635,7 +1839,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 61
+        "y": 67
       },
       "hiddenSeries": false,
       "id": 16,
@@ -1658,9 +1862,10 @@
       "links": [],
       "nullPointMode": "connected",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.2.0",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1670,7 +1875,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (rate (container_network_receive_bytes_total{image!=\"\",name=~\"^k8s_.*\",kubernetes_io_hostname=~\"^$Node$\"}[$interval])) by (pod)",
+          "expr": "sum (rate (container_network_receive_bytes_total{image!=\"\",kubernetes_io_hostname=~\"^$Node$\"}[$interval])) by (pod)",
           "format": "time_series",
           "interval": "10s",
           "intervalFactor": 1,
@@ -1680,7 +1885,7 @@
           "step": 10
         },
         {
-          "expr": "- sum (rate (container_network_transmit_bytes_total{image!=\"\",name=~\"^k8s_.*\",kubernetes_io_hostname=~\"^$Node$\"}[$interval])) by (pod)",
+          "expr": "- sum (rate (container_network_transmit_bytes_total{image!=\"\",kubernetes_io_hostname=~\"^$Node$\"}[$interval])) by (pod)",
           "format": "time_series",
           "interval": "10s",
           "intervalFactor": 1,
@@ -1734,7 +1939,7 @@
     }
   ],
   "refresh": "1m",
-  "schemaVersion": 22,
+  "schemaVersion": 26,
   "style": "dark",
   "tags": [
     "kubernetes"
@@ -1817,6 +2022,7 @@
       },
       {
         "current": {
+          "selected": true,
           "text": "default",
           "value": "default"
         },
@@ -1827,6 +2033,7 @@
         "name": "datasource",
         "options": [],
         "query": "prometheus",
+        "queryValue": "",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -1835,7 +2042,7 @@
       {
         "allValue": ".*",
         "current": {
-          "selected": false,
+          "selected": true,
           "text": "All",
           "value": "$__all"
         },
@@ -1892,5 +2099,5 @@
   "timezone": "browser",
   "title": "Kubernetes / Pods / USE",
   "uid": "oAjYZcCZz",
-  "version": 5
+  "version": 1
 }

--- a/charts/hedera-mirror-common/dashboards/swagger-stats-dashboard-v3_rev4.json
+++ b/charts/hedera-mirror-common/dashboards/swagger-stats-dashboard-v3_rev4.json
@@ -1,0 +1,1269 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "7.2.0"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "singlestat",
+      "name": "Singlestat",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Swagger-Stats Main Dashboard Revision  3",
+  "editable": true,
+  "gnetId": 3091,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "rgba(245, 54, 54, 0.9)",
+        "rgba(237, 129, 40, 0.89)",
+        "rgba(50, 172, 45, 0.97)"
+      ],
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "api_all_request_total",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "refId": "A",
+          "step": 20
+        }
+      ],
+      "thresholds": "",
+      "title": "Requests",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "rgba(245, 54, 54, 0.9)",
+        "rgba(237, 129, 40, 0.89)",
+        "rgba(50, 172, 45, 0.97)"
+      ],
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 4,
+        "y": 0
+      },
+      "id": 2,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": true
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "(\n  sum(rate(api_request_duration_milliseconds_bucket{le=\"25\",code=~\"^2..$\"}[1m]))\n+\n  sum(rate(api_request_duration_milliseconds_bucket{le=\"100\",code=~\"^2..$\"}[1m]))\n) / 2 / sum(rate(api_request_duration_milliseconds_count[1m]))",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "",
+          "refId": "A",
+          "step": 20
+        }
+      ],
+      "thresholds": "",
+      "title": "Apdex Score",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "rgba(50, 172, 45, 0.97)",
+        "rgba(237, 129, 40, 0.89)",
+        "rgba(245, 54, 54, 0.9)"
+      ],
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": true,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 8,
+        "y": 0
+      },
+      "id": 3,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "( api_all_errors_total / api_all_request_total ) * 100",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "",
+          "refId": "A",
+          "step": 20
+        }
+      ],
+      "thresholds": "10,40,50",
+      "title": "Errors %",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "rgba(245, 54, 54, 0.9)",
+        "rgba(237, 129, 40, 0.89)",
+        "rgba(50, 172, 45, 0.97)"
+      ],
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 12,
+        "y": 0
+      },
+      "id": 4,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": true
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "api_all_request_in_processing_total",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "refId": "A",
+          "step": 20
+        }
+      ],
+      "thresholds": "",
+      "title": "Requests in Processing",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "rgba(50, 172, 45, 0.97)",
+        "rgba(237, 129, 40, 0.89)",
+        "rgba(245, 54, 54, 0.9)"
+      ],
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": true,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 16,
+        "y": 0
+      },
+      "id": 6,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": true
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "nodejs_process_cpu_usage_percentage",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "refId": "A",
+          "step": 20
+        }
+      ],
+      "thresholds": "5,10,20",
+      "title": "CPU %",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "rgba(245, 54, 54, 0.9)",
+        "rgba(237, 129, 40, 0.89)",
+        "rgba(50, 172, 45, 0.97)"
+      ],
+      "datasource": "${DS_PROMETHEUS}",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 20,
+        "y": 0
+      },
+      "id": 5,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": true
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "(nodejs_process_memory_heap_used_bytes)/1048576",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "refId": "A",
+          "step": 20
+        }
+      ],
+      "thresholds": "",
+      "title": "Heap Used, Mb",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 5
+      },
+      "hiddenSeries": false,
+      "id": 7,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.2.0",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum (irate(api_request_total[1m]))",
+          "format": "time_series",
+          "intervalFactor": 4,
+          "legendFormat": "Request Rate",
+          "refId": "A",
+          "step": 4
+        },
+        {
+          "expr": "sum (irate(api_request_total{code=~\"^5..$\"}[1m]))",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 4,
+          "legendFormat": "5XX Errors Rate",
+          "refId": "B",
+          "step": 4
+        },
+        {
+          "expr": "sum (irate(api_request_total{code=~\"^4..$\"}[1m]))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "4XX Errors Rate",
+          "refId": "C",
+          "step": 2
+        },
+        {
+          "expr": "sum (irate(api_request_total{code=~\"^2..$\"}[1m]))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "2XX Success Rate",
+          "refId": "D",
+          "step": 2
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Request and Error Rates (per sec)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 5
+      },
+      "hiddenSeries": false,
+      "id": 8,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": false,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.2.0",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum by(method) (irate(api_request_total[1m]))",
+          "format": "time_series",
+          "intervalFactor": 10,
+          "refId": "A",
+          "step": 10
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Request rate by Method (per sec)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
+      "hiddenSeries": false,
+      "id": 10,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.2.0",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "(\n  sum(irate(api_request_duration_milliseconds_bucket{le=\"25\",code=~\"^2..$\"}[1m]))\n+\n  (sum(irate(api_request_duration_milliseconds_bucket{le=\"100\",code=~\"^2..$\"}[1m]))/2)\n) / sum(irate(api_request_duration_milliseconds_count[1m]))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "",
+          "refId": "A",
+          "step": 2
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Apdex Score: target 25ms, tolerated: 100ms",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
+      "hiddenSeries": false,
+      "id": 9,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": true,
+      "pluginVersion": "7.2.0",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "( sum(irate(api_request_duration_milliseconds_bucket{le=\"5\"}[1m])) /  sum(irate(api_request_duration_milliseconds_count[1m])) ) * 100",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Duration < 5ms (%)",
+          "refId": "A",
+          "step": 2
+        },
+        {
+          "expr": "( sum(irate(api_request_duration_milliseconds_bucket{le=\"10\"}[1m])) /  sum(irate(api_request_duration_milliseconds_count[1m])) ) * 100",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Duration < 10ms (%)",
+          "refId": "B",
+          "step": 2
+        },
+        {
+          "expr": "( sum(irate(api_request_duration_milliseconds_bucket{le=\"50\"}[1m])) /  sum(irate(api_request_duration_milliseconds_count[1m])) ) * 100",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Duration < 50ms (%)",
+          "refId": "C",
+          "step": 2
+        },
+        {
+          "expr": "( sum(irate(api_request_duration_milliseconds_bucket{le=\"100\"}[1m])) /  sum(irate(api_request_duration_milliseconds_count[1m])) ) * 100",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Duration < 100ms (%)",
+          "refId": "D",
+          "step": 2
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Request Duration (%)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 19
+      },
+      "hiddenSeries": false,
+      "id": 11,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.2.0",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "topk(3, sum(irate(api_request_total[1m])) by (path))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "",
+          "refId": "A",
+          "step": 2
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Top 3 API calls (by path)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": true,
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 19
+      },
+      "hiddenSeries": false,
+      "id": 12,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": false,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.2.0",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "topk(3, sum(irate(api_request_total{code=~\"^5..$\"}[1m])) by (path))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "",
+          "refId": "A",
+          "step": 2
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Top 3 API Error Calls ( 5XX, by path)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": true,
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 26,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "swagger-stats dashboard v3",
+  "uid": "IcqsUmcGz",
+  "version": 3
+}

--- a/charts/hedera-mirror-common/requirements.lock
+++ b/charts/hedera-mirror-common/requirements.lock
@@ -1,15 +1,15 @@
 dependencies:
 - name: loki-stack
   repository: https://grafana.github.io/loki/charts
-  version: 0.40.1
+  version: 0.41.2
 - name: prometheus-adapter
   repository: https://prometheus-community.github.io/helm-charts
   version: 2.7.0
 - name: kube-prometheus-stack
   repository: https://prometheus-community.github.io/helm-charts
-  version: 9.4.5
+  version: 10.1.0
 - name: traefik
   repository: https://helm.traefik.io/traefik
-  version: 9.3.0
-digest: sha256:1679e55b8047dc99f54a6feec29a09f8f693588fee2d364df2e61063b7233bb1
-generated: "2020-10-02T09:49:42.965864-05:00"
+  version: 9.5.1
+digest: sha256:89ea57c56c007d7c115568b7d6377fa3390330d0ade1f9bdfe708749bce7fef2
+generated: "2020-10-14T10:25:56.114612-05:00"

--- a/charts/hedera-mirror-common/requirements.yaml
+++ b/charts/hedera-mirror-common/requirements.yaml
@@ -2,7 +2,7 @@ dependencies:
   - alias: loki
     condition: loki.enabled
     name: loki-stack
-    version: ~0.40.1
+    version: ~0.41.2
     repository: https://grafana.github.io/loki/charts
   - condition: prometheus-adapter.enabled
     name: prometheus-adapter
@@ -12,8 +12,8 @@ dependencies:
     condition: prometheus.enabled
     name: kube-prometheus-stack
     repository: https://prometheus-community.github.io/helm-charts
-    version: ~9.4.4
+    version: ~10.1.0
   - condition: traefik.enabled
     name: traefik
     repository: https://helm.traefik.io/traefik
-    version: ~9.3.0
+    version: ~9.5.1

--- a/charts/hedera-mirror-common/templates/NOTES.txt
+++ b/charts/hedera-mirror-common/templates/NOTES.txt
@@ -4,12 +4,6 @@ Hedera Mirror Node {{ .Chart.AppVersion }} successfully installed.
 To get the load balancer IP:
   export SERVICE_IP=$(kubectl get svc -n {{ include "hedera-mirror-common.namespace" . }} {{ printf "%s-traefik" .Release.Name }} -o jsonpath="{.status.loadBalancer.ingress[0].ip}")
 
-To access the GRPC API:
-  grpcurl -plaintext ${SERVICE_IP}:{{ .Values.traefik.ports.web.exposedPort }} list
-
-To access the REST API:
-  curl -s "http://${SERVICE_IP}:{{ .Values.traefik.ports.web.exposedPort }}/api/v1/transactions?limit=1"
-
 {{ if and .Values.prometheus.enabled .Values.prometheus.grafana.enabled -}}
 To view the Grafana dashboard:
   open "http://${SERVICE_IP}:{{ .Values.traefik.ports.web.exposedPort }}/grafana"

--- a/charts/hedera-mirror-common/values.yaml
+++ b/charts/hedera-mirror-common/values.yaml
@@ -50,7 +50,7 @@ prometheus-adapter:
   enabled: true
   priorityClassName: low
   prometheus:
-    url: http://prometheus-prometheus
+    url: http://common-mirror-prometheus-prometheus
   resources:
     limits:
       cpu: 50m
@@ -72,17 +72,53 @@ prometheus:
         requests:
           cpu: 30m
           memory: 30Mi
+    config:
+      receivers:
+        - name: 'null'
+      route:
+        group_by:
+          - namespace
+          - alertname
+        group_wait: 30s
+        receiver: 'null'
+        repeat_interval: 30m
+        routes: []
+      templates:
+        - '/etc/alertmanager/config/slack.tmpl'
+    enabled: true
+    templateFiles:
+      slack.tmpl: |-
+        {{- define "slack.title" -}}
+        {{- .Status | title }} {{ .CommonLabels.alertname }}{{ if .CommonLabels.namespace }} in {{ .CommonLabels.namespace }}{{ end }}
+        {{- end -}}
+
+        {{- define "slack.text" -}}
+        {{ range .Alerts -}}
+        *Summary:* {{ if .Annotations.summary }}{{ .Annotations.summary }}{{ else }}{{ .Annotations.message }}{{ end }}{{"\n"}}
+        {{- if .Annotations.description }} *Description:* {{ .Annotations.description }}{{"\n"}}{{ end }}
+        *Prometheus:* *<{{ .GeneratorURL }}|:fire:>* {{- if .Annotations.dashboard_url }}     *Grafana:* *<{{ .Annotations.dashboard_url }}|:chart_with_upwards_trend:>*{{ end }}{{- if .Annotations.runbook_url }}      *Runbook:* *<{{ .Annotations.runbook_url }}|:notebook:>*{{ end }}
+
+        *Labels:*
+          {{ range .Labels.SortedPairs }} • *{{ .Name }}:* `{{ .Value }}`
+          {{ end }}
+        {{ end }}
+        {{- end -}}
+  coreDns:
     enabled: false
   enabled: true
   grafana:
     additionalDataSources:
+      - name: AlertManager
+        type: camptocamp-prometheus-alertmanager-datasource
+        access: proxy
+        url: http://{{ .Release.Name }}-prometheus-alertmanager:9093
       - name: Loki
         type: loki
         access: proxy
         url: http://{{ .Release.Name }}-loki:3100
         jsonData:
           maxLines: 500
-    adminPassword: password
+    adminPassword: ""
     defaultDashboardsEnabled: true
     grafana.ini:
       server:
@@ -102,6 +138,8 @@ prometheus:
           average: 50
           burst: 100
       path: "/grafana"
+    plugins:
+      - camptocamp-prometheus-alertmanager-datasource
     rbac:
       pspEnabled: false
     resources:
@@ -121,17 +159,27 @@ prometheus:
       requests:
         cpu: 5m
         memory: 16Mi
+  kubeApiserver:
+    enabled: false
+  kubeControllerManager:
+    enabled: false
+  kubeEtcd:
+    enabled: false
+  kubeDns:
+    enabled: true
+  kubeScheduler:
+    enabled: false
   prometheus-node-exporter:
     hostNetwork: false
     rbac:
       pspEnabled: false
     resources:
       limits:
-        cpu: 50m
-        memory: 30Mi
+        cpu: 100m
+        memory: 50Mi
       requests:
-        cpu: 20m
-        memory: 10Mi
+        cpu: 50m
+        memory: 20Mi
   prometheus:
     additionalPodMonitors:
       - name: traefik

--- a/charts/hedera-mirror-rest/values.yaml
+++ b/charts/hedera-mirror-rest/values.yaml
@@ -17,8 +17,7 @@ config:
         db: {}
         metrics:
           config:
-            authentication:
-              enabled: false
+            authentication: false
 
 fullnameOverride: ""
 

--- a/charts/hedera-mirror/requirements.lock
+++ b/charts/hedera-mirror/requirements.lock
@@ -7,12 +7,12 @@ dependencies:
   version: 0.7.0-alpha1
 - name: postgresql-ha
   repository: https://charts.bitnami.com/bitnami
-  version: 3.8.2
+  version: 5.0.0
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 11.0.7
+  version: 11.1.3
 - name: hedera-mirror-rest
   repository: file://../hedera-mirror-rest
   version: 0.7.0-alpha1
-digest: sha256:4be7e03c995e8c8c131af8771a04cccf1de0b953826612e8653fe7494984df86
-generated: "2020-10-08T13:23:13.819794-05:00"
+digest: sha256:c61346450e3b0e087ee348aa56d62e35bac154eafb00ed4f7ddd5f7d7d581458
+generated: "2020-10-14T17:14:55.890202-05:00"

--- a/charts/hedera-mirror/requirements.yaml
+++ b/charts/hedera-mirror/requirements.yaml
@@ -13,12 +13,12 @@ dependencies:
     condition: postgresql.enabled
     name: postgresql-ha
     repository: https://charts.bitnami.com/bitnami
-    version: ~3.8.0
+    version: ~5.0.0
   - alias: redis
     condition: redis.enabled
     name: redis
     repository: https://charts.bitnami.com/bitnami
-    version: ~11.0.6
+    version: ~11.1.3
   - alias: rest
     condition: rest.enabled
     name: hedera-mirror-rest

--- a/charts/hedera-mirror/values-prod.yaml
+++ b/charts/hedera-mirror/values-prod.yaml
@@ -23,6 +23,8 @@ postgresql:
     priorityClassName: critical
 
 redis:
+  cluster:
+    slaveCount: 3
   metrics:
     enabled: true
   slave:

--- a/charts/hedera-mirror/values-prod.yaml
+++ b/charts/hedera-mirror/values-prod.yaml
@@ -19,8 +19,10 @@ postgresql:
       enabled: true
   pgpool:
     priorityClassName: critical
+    replicaCount: 2
   postgresql:
     priorityClassName: critical
+    replicaCount: 2
 
 redis:
   cluster:

--- a/charts/hedera-mirror/values.yaml
+++ b/charts/hedera-mirror/values.yaml
@@ -74,7 +74,6 @@ postgresql:
       role: db
     pdb:
       create: true
-    replicaCount: 2
     resources:
       limits:
         cpu: 200m
@@ -86,7 +85,7 @@ postgresql:
     debug: true
   postgresqlImage:
     debug: true
-    tag: 12.4.0-debian-10-r49
+    tag: 12.4.0-debian-10-r61
   postgresql:
     affinity:
       podAntiAffinity:

--- a/charts/hedera-mirror/values.yaml
+++ b/charts/hedera-mirror/values.yaml
@@ -99,6 +99,7 @@ postgresql:
                   app.kubernetes.io/component: postgresql
     initdbScriptsSecret: '{{ printf "%s-postgresql-init" .Release.Name }}'
     password: password
+    replicaCount: 1
     repmgrPassword: password
     resources:
       limits:
@@ -111,7 +112,7 @@ postgresql:
 
 redis:
   cluster:
-    slaveCount: 3
+    slaveCount: 1
   enabled: true
   metrics:
     resources:

--- a/charts/hedera-mirror/values.yaml
+++ b/charts/hedera-mirror/values.yaml
@@ -110,28 +110,33 @@ postgresql:
     repmgrLogLevel: DEBUG
 
 redis:
+  cluster:
+    slaveCount: 3
   enabled: true
   metrics:
     resources:
       limits:
-        cpu: 50m
+        cpu: 100m
         memory: 50Mi
       requests:
-        cpu: 20m
+        cpu: 50m
         memory: 25Mi
     serviceMonitor:
       enabled: true
   podDisruptionBudget:
     enabled: true
+  securityContext:
+    runAsGroup: 1001
+    runAsUser: 1001
   sentinel:
     enabled: true
     masterSet: mirror
     resources:
       limits:
-        cpu: 50m
+        cpu: 100m
         memory: 50Mi
       requests:
-        cpu: 20m
+        cpu: 50m
         memory: 25Mi
   serviceAccount:
     create: true

--- a/charts/marketplace/gcp/release.sh
+++ b/charts/marketplace/gcp/release.sh
@@ -21,7 +21,7 @@ fi
 target_tag="${target_tag#v}" # Strip v prefix if present
 target_tag_minor="${target_tag%\.*}"
 bats_tag="1.2.1"
-postgresql_tag="12.4.0-debian-10-r49"
+postgresql_tag="12.4.0-debian-10-r61"
 registry="gcr.io/mirror-node-public/hedera-mirror-node"
 
 function retag() {

--- a/charts/marketplace/gcp/values.yaml
+++ b/charts/marketplace/gcp/values.yaml
@@ -51,8 +51,6 @@ importer:
 postgresql:
   pgpool:
     replicaCount: 0
-  postgresql:
-    replicaCount: 1
 
 redis:
   enabled: false


### PR DESCRIPTION
**Detailed description**:
- Add [AlertManager](https://prometheus.io/docs/alerting/latest/alertmanager/) to common chart
- Add an AlertManager Grafana dashboard
- Add a Swagger REST API dashboard
- Fix existing Kubernetes dashboard showing blank graphs
- Fix REST API metrics not being collected due to incorrect authentication flag
- Fix Grafana using a hardcoded password instead of a random password
- Fix Redis not using an odd number of replicas to maintain a quorum
- Fix Redis running with root group permissions
- Fix some containers being CPU throttled
- Fix CI not working with HA PostgreSQL and Redis by moving HA to `values-prod.yaml`
- Fix incorrect Prometheus Adapter URL (full fix via upstream [PR](https://github.com/prometheus-community/helm-charts/pull/205))
- Change common chart to re-deploy on commit to master
- Change Helm GitHub Action to use Kubernetes 1.17 to match our recently upgraded GKE version
- Bump chart dependencies

**Which issue(s) this PR fixes**:
Fixes #658 

**Special notes for your reviewer**:
- Mirror node specific alerts will be added in a follow up
- Slack notification configuration will be stored separately in encrypted secret in deploy branch

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

