### PR TITLE
Fix NPE parsing token transactions

### DIFF
--- a/charts/hedera-mirror-common/Chart.yaml
+++ b/charts/hedera-mirror-common/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.20.0-rc1
+appVersion: 0.20.0-rc2
 description: Hedera Mirror Node common components installed globally for use across namespaces
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
@@ -11,4 +11,4 @@ maintainers:
 name: hedera-mirror-common
 sources:
   - https://github.com/hashgraph/hedera-mirror-node
-version: 0.7.0-rc1
+version: 0.7.0-rc2

--- a/charts/hedera-mirror-grpc/Chart.yaml
+++ b/charts/hedera-mirror-grpc/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.20.0-rc1
+appVersion: 0.20.0-rc2
 description: GRPC API for the Hedera Mirror Node
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
@@ -11,4 +11,4 @@ maintainers:
 name: hedera-mirror-grpc
 sources:
   - https://github.com/hashgraph/hedera-mirror-node
-version: 0.7.0-rc1
+version: 0.7.0-rc2

--- a/charts/hedera-mirror-importer/Chart.yaml
+++ b/charts/hedera-mirror-importer/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.20.0-rc1
+appVersion: 0.20.0-rc2
 description: Hedera Mirror Importer downloads and validates file streams from the cloud and imports them into the database
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
@@ -11,4 +11,4 @@ maintainers:
 name: hedera-mirror-importer
 sources:
   - https://github.com/hashgraph/hedera-mirror-node
-version: 0.7.0-rc1
+version: 0.7.0-rc2

--- a/charts/hedera-mirror-rest/Chart.yaml
+++ b/charts/hedera-mirror-rest/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.20.0-rc1
+appVersion: 0.20.0-rc2
 description: REST API for the Hedera Mirror Node
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
@@ -11,4 +11,4 @@ maintainers:
 name: hedera-mirror-rest
 sources:
   - https://github.com/hashgraph/hedera-mirror-node
-version: 0.7.0-rc1
+version: 0.7.0-rc2

--- a/charts/hedera-mirror/Chart.yaml
+++ b/charts/hedera-mirror/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.20.0-rc1
+appVersion: 0.20.0-rc2
 description: Hedera Mirror Node mirrors data from Hedera nodes and serves it via an API
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
@@ -11,4 +11,4 @@ maintainers:
 name: hedera-mirror
 sources:
   - https://github.com/hashgraph/hedera-mirror-node
-version: 0.7.0-rc1
+version: 0.7.0-rc2

--- a/charts/hedera-mirror/requirements.lock
+++ b/charts/hedera-mirror/requirements.lock
@@ -1,10 +1,10 @@
 dependencies:
 - name: hedera-mirror-grpc
   repository: file://../hedera-mirror-grpc
-  version: 0.7.0-rc1
+  version: 0.7.0-rc2
 - name: hedera-mirror-importer
   repository: file://../hedera-mirror-importer
-  version: 0.7.0-rc1
+  version: 0.7.0-rc2
 - name: postgresql-ha
   repository: https://charts.bitnami.com/bitnami
   version: 3.8.2
@@ -13,6 +13,6 @@ dependencies:
   version: 11.0.7
 - name: hedera-mirror-rest
   repository: file://../hedera-mirror-rest
-  version: 0.7.0-rc1
-digest: sha256:f05448b85355b14a4dd7d8237a138de3c0a574d03677f452ca31623fd90eefcf
-generated: "2020-10-16T12:52:30.383086-05:00"
+  version: 0.7.0-rc2
+digest: sha256:3da0c955a466b6b6199d7d56c9dca645919516ff9b58ef311fbd29af0a74514f
+generated: "2020-10-20T16:45:23.877335-05:00"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - 5432:5432
 
   grpc:
-    image: gcr.io/mirrornode/hedera-mirror-grpc:0.20.0-rc1
+    image: gcr.io/mirrornode/hedera-mirror-grpc:0.20.0-rc2
     restart: unless-stopped
     environment:
       HEDERA_MIRROR_GRPC_DB_HOST: db
@@ -28,7 +28,7 @@ services:
       - 5600:5600
 
   importer:
-    image: gcr.io/mirrornode/hedera-mirror-importer:0.20.0-rc1
+    image: gcr.io/mirrornode/hedera-mirror-importer:0.20.0-rc2
     restart: unless-stopped
     environment:
       HEDERA_MIRROR_IMPORTER_DATAPATH: /var/lib/hedera-mirror-importer
@@ -39,7 +39,7 @@ services:
       - ./application.yml:/usr/etc/hedera-mirror-importer/application.yml
 
   rest:
-    image: gcr.io/mirrornode/hedera-mirror-rest:0.20.0-rc1
+    image: gcr.io/mirrornode/hedera-mirror-rest:0.20.0-rc2
     environment:
       HEDERA_MIRROR_REST_DB_HOST: db
     restart: unless-stopped

--- a/hedera-mirror-coverage/pom.xml
+++ b/hedera-mirror-coverage/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.20.0-rc1</version>
+        <version>0.20.0-rc2</version>
     </parent>
 
     <dependencies>

--- a/hedera-mirror-datagenerator/pom.xml
+++ b/hedera-mirror-datagenerator/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.20.0-rc1</version>
+        <version>0.20.0-rc2</version>
     </parent>
 
     <properties>

--- a/hedera-mirror-grpc/pom.xml
+++ b/hedera-mirror-grpc/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.20.0-rc1</version>
+        <version>0.20.0-rc2</version>
     </parent>
 
     <properties>

--- a/hedera-mirror-importer/pom.xml
+++ b/hedera-mirror-importer/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.20.0-rc1</version>
+        <version>0.20.0-rc2</version>
     </parent>
 
     <properties>

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/EntityId.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/EntityId.java
@@ -28,6 +28,7 @@ import com.hederahashgraph.api.proto.java.FileID;
 import com.hederahashgraph.api.proto.java.TokenID;
 import com.hederahashgraph.api.proto.java.TopicID;
 import java.io.Serializable;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -45,7 +46,10 @@ import com.hedera.mirror.importer.util.EntityIdEndec;
  */
 @Value
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
-public class EntityId implements Serializable {
+public class EntityId implements Serializable, Comparable<EntityId> {
+
+    private static final Comparator<EntityId> COMPARATOR = Comparator
+            .nullsFirst(Comparator.comparingLong(EntityId::getId));
 
     private static final Splitter SPLITTER = Splitter.on('.').omitEmptyStrings().trimResults();
     private static final long serialVersionUID = 1427649605832330197L;
@@ -121,5 +125,10 @@ public class EntityId implements Serializable {
         entity.setEntityNum(entityNum);
         entity.setEntityTypeId(type);
         return entity;
+    }
+
+    @Override
+    public int compareTo(EntityId other) {
+        return COMPARATOR.compare(this, other);
     }
 }

--- a/hedera-mirror-protobuf/pom.xml
+++ b/hedera-mirror-protobuf/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.20.0-rc1</version>
+        <version>0.20.0-rc2</version>
     </parent>
 
     <properties>

--- a/hedera-mirror-rest/monitoring/monitor_apis/package-lock.json
+++ b/hedera-mirror-rest/monitoring/monitor_apis/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-mirror-monitor",
-  "version": "0.20.0-rc1",
+  "version": "0.20.0-rc2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hedera-mirror-rest/monitoring/monitor_apis/package.json
+++ b/hedera-mirror-rest/monitoring/monitor_apis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-mirror-monitor",
-  "version": "0.20.0-rc1",
+  "version": "0.20.0-rc2",
   "description": "Hedera Mirror Node Monitor",
   "main": "server.js",
   "private": true,

--- a/hedera-mirror-rest/package-lock.json
+++ b/hedera-mirror-rest/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-mirror-rest",
-  "version": "0.20.0-rc1",
+  "version": "0.20.0-rc2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hedera-mirror-rest/package.json
+++ b/hedera-mirror-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-mirror-rest",
-  "version": "0.20.0-rc1",
+  "version": "0.20.0-rc2",
   "description": "Hedera Mirror Node REST API",
   "main": "server.js",
   "private": true,

--- a/hedera-mirror-rest/pom.xml
+++ b/hedera-mirror-rest/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.20.0-rc1</version>
+        <version>0.20.0-rc2</version>
     </parent>
 
     <build>

--- a/hedera-mirror-test/pom.xml
+++ b/hedera-mirror-test/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.20.0-rc1</version>
+        <version>0.20.0-rc2</version>
     </parent>
 
     <properties>

--- a/hedera-mirror-test/src/test/resources/k8s/hcs-perf-message-submit.yml
+++ b/hedera-mirror-test/src/test/resources/k8s/hcs-perf-message-submit.yml
@@ -41,7 +41,7 @@ spec:
                     app.kubernetes.io/name: test
       restartPolicy: Never
       containers:
-        - image: gcr.io/mirrornode/hedera-mirror-test:0.20.0-rc1
+        - image: gcr.io/mirrornode/hedera-mirror-test:0.20.0-rc2
           name: test
           env:
             - name: testProfile

--- a/hedera-mirror-test/src/test/resources/k8s/hcs-perf-publish-test.yml
+++ b/hedera-mirror-test/src/test/resources/k8s/hcs-perf-publish-test.yml
@@ -43,7 +43,7 @@ spec:
                     app.kubernetes.io/name: test
       restartPolicy: Never
       containers:
-        - image: gcr.io/mirrornode/hedera-mirror-test:0.20.0-rc1
+        - image: gcr.io/mirrornode/hedera-mirror-test:0.20.0-rc2
           name: test
           env:
             - name: testProfile

--- a/hedera-mirror-test/src/test/resources/k8s/hcs-perf-subscribe-test.yml
+++ b/hedera-mirror-test/src/test/resources/k8s/hcs-perf-subscribe-test.yml
@@ -46,7 +46,7 @@ spec:
                     app.kubernetes.io/name: test
       restartPolicy: Never
       containers:
-        - image: gcr.io/mirrornode/hedera-mirror-test:0.20.0-rc1
+        - image: gcr.io/mirrornode/hedera-mirror-test:0.20.0-rc2
           name: test
           env:
             - name: testProfile

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.hedera</groupId>
     <artifactId>hedera-mirror-node</artifactId>
-    <version>0.20.0-rc1</version>
+    <version>0.20.0-rc2</version>
     <description>Hedera Mirror Node mirrors data from Hedera nodes and serves it via an API</description>
     <inceptionYear>2019</inceptionYear>
     <modelVersion>4.0.0</modelVersion>
@@ -70,7 +70,7 @@
         <msgpack.version>0.8.20</msgpack.version>
         <protobuf.version>3.13.0</protobuf.version>
         <release.version>${project.version}</release.version> <!-- Used to replace release versions in all files -->
-        <release.chartVersion>0.7.0-rc1</release.chartVersion>
+        <release.chartVersion>0.7.0-rc2</release.chartVersion>
         <embedded.testcontainers.version>1.82</embedded.testcontainers.version>
     </properties>
 


### PR DESCRIPTION
**Detailed description**:
- Fix NPE parsing token transactions
- Bump versions for 0.20.0-rc2

**Which issue(s) this PR fixes**:
Fixes #1156

**Special notes for your reviewer**:
This seems to be a gotcha with Hibernate that only appears in rare scenarios. As far as I can tell, Hibernate is attempting to sort multiple `TokenAccount`'s in memory by their `TokenAccount.id` and failing since the fields within that ID doesn't implement `Comparable`. I verified this fixes the issue by copying the affected rcd file and running an integration test against it before and after the fix. I was unable to find the exact scenario that caused this to occur with a narrow test case in `EntityRecordItemListenerTokenTest`.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

