### PR TITLE
Optimize AccountBalanceRepository queries

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/AccountBalance.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/AccountBalance.java
@@ -29,9 +29,10 @@ import javax.persistence.Convert;
 import javax.persistence.Embeddable;
 import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinColumns;
+import javax.persistence.NamedAttributeNode;
+import javax.persistence.NamedEntityGraph;
 import javax.persistence.OneToMany;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -45,11 +46,12 @@ import com.hedera.mirror.importer.converter.EntityIdSerializer;
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity
+@NamedEntityGraph(name = "AccountBalance.tokenBalances", attributeNodes = @NamedAttributeNode("tokenBalances"))
 public class AccountBalance implements Persistable<AccountBalance.Id> {
 
     private long balance;
 
-    @OneToMany(cascade = {CascadeType.ALL}, orphanRemoval = true, fetch = FetchType.EAGER)
+    @OneToMany(cascade = {CascadeType.ALL}, orphanRemoval = true)
     @JoinColumns({
             @JoinColumn(name = "accountId"),
             @JoinColumn(name = "consensusTimestamp")

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/AccountBalanceRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/AccountBalanceRepository.java
@@ -21,11 +21,17 @@ package com.hedera.mirror.importer.repository;
  */
 
 import java.util.List;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.repository.CrudRepository;
 
 import com.hedera.mirror.importer.domain.AccountBalance;
 
 public interface AccountBalanceRepository extends CrudRepository<AccountBalance, AccountBalance.Id> {
 
+    @Override
+    @EntityGraph(attributePaths = {"tokenBalances"})
+    List<AccountBalance> findAll();
+
+    @EntityGraph(attributePaths = {"tokenBalances"})
     List<AccountBalance> findByIdConsensusTimestamp(long consensusTimestamp);
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/AccountBalanceRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/AccountBalanceRepository.java
@@ -29,9 +29,9 @@ import com.hedera.mirror.importer.domain.AccountBalance;
 public interface AccountBalanceRepository extends CrudRepository<AccountBalance, AccountBalance.Id> {
 
     @Override
-    @EntityGraph(attributePaths = {"tokenBalances"})
+    @EntityGraph("AccountBalance.tokenBalances")
     List<AccountBalance> findAll();
 
-    @EntityGraph(attributePaths = {"tokenBalances"})
+    @EntityGraph("AccountBalance.tokenBalances")
     List<AccountBalance> findByIdConsensusTimestamp(long consensusTimestamp);
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/AccountBalanceRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/AccountBalanceRepositoryTest.java
@@ -23,6 +23,7 @@ package com.hedera.mirror.importer.repository;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import javax.annotation.Resource;
 import org.junit.jupiter.api.Test;
@@ -36,14 +37,16 @@ public class AccountBalanceRepositoryTest extends AbstractRepositoryTest {
 
     @Resource
     private AccountBalanceRepository accountBalanceRepository;
-    
+
     @Test
     void findByConsensusTimestamp() {
         AccountBalance accountBalance1 = create(1L, 1, 100, 0);
         AccountBalance accountBalance2 = create(1L, 2, 200, 3);
         create(2L, 1, 50, 1);
 
-        assertThat(accountBalanceRepository.findByIdConsensusTimestamp(1L))
+        List<AccountBalance> result = accountBalanceRepository.findByIdConsensusTimestamp(1);
+        result.forEach(ab -> ab.getTokenBalances().sort(Comparator.comparing(o -> o.getId().getTokenId())));
+        assertThat(result)
                 .usingRecursiveFieldByFieldElementComparator()
                 .containsExactlyInAnyOrder(accountBalance1, accountBalance2);
     }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/AccountBalanceRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/AccountBalanceRepositoryTest.java
@@ -72,7 +72,7 @@ public class AccountBalanceRepositoryTest extends AbstractRepositoryTest {
             TokenBalance.Id id = new TokenBalance.Id();
             id.setAccountId(EntityId.of(0, 0, accountNum, EntityTypeEnum.ACCOUNT));
             id.setConsensusTimestamp(consensusTimestamp);
-            id.setTokenId(EntityId.of(0, 0, i, EntityTypeEnum.TOKEN));
+            id.setTokenId(EntityId.of(0, 1, i, EntityTypeEnum.TOKEN));
             tokenBalance.setBalance(balance);
             tokenBalance.setId(id);
             tokenBalanceList.add(tokenBalance);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
-->

**Detailed description**:
Optimize the queries for the find* methods in `AccountBalanceRepository` so hibernate generate select statement with left join.

**Which issue(s) this PR fixes**:
Fixes #1162 

**Special notes for your reviewer**:
Without the optimization, for example, the findAll method will run N+1 select queries: 1 to select all rows from account_balance table, and N to select token balances from token_balance table for each account.

**Checklist**
- [ ] Documentation added
- [x] Tests updated

