### PR TITLE
Support disabling pgpool load balancing in importer

### DIFF
--- a/charts/hedera-mirror-importer/values.yaml
+++ b/charts/hedera-mirror-importer/values.yaml
@@ -15,7 +15,8 @@ config:
     mirror:
       importer:
         dataPath: /var/lib/hedera-mirror-importer
-        db: {}
+        db:
+          loadBalance: false
 
 fullnameOverride: ""
 

--- a/charts/hedera-mirror/values.yaml
+++ b/charts/hedera-mirror/values.yaml
@@ -33,6 +33,7 @@ importer:
         importer:
           db:
             name: mirror_node
+            noLoadBalancing: true
             password: mirror_node_pass
             username: mirror_node
   enabled: true

--- a/charts/hedera-mirror/values.yaml
+++ b/charts/hedera-mirror/values.yaml
@@ -33,7 +33,6 @@ importer:
         importer:
           db:
             name: mirror_node
-            noLoadBalancing: true
             password: mirror_node_pass
             username: mirror_node
   enabled: true

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,6 +24,7 @@ value, it is recommended to only populate overridden properties in the custom `a
 | `hedera.mirror.importer.db.restUsername`                             | mirror_api              | The username the API uses to connect to the database                                           |
 | `hedera.mirror.importer.db.host`                                     | 127.0.0.1               | The IP or hostname used to connect to the database                                             |
 | `hedera.mirror.importer.db.name`                                     | mirror_node             | The name of the database                                                                       |
+| `hedera.mirror.importer.db.noLoadBalancing`                          | false                   | Whether to disable pgpool load balancing. If true, load balancing is disabled by prepending a comment to sql statements. |
 | `hedera.mirror.importer.db.password`                                 | mirror_node_pass        | The database password the processor uses to connect. **Should be changed from default**        |
 | `hedera.mirror.importer.db.port`                                     | 5432                    | The port used to connect to the database                                                       |
 | `hedera.mirror.importer.db.username`                                 | mirror_node             | The username the processor uses to connect to the database                                     |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,8 +23,8 @@ value, it is recommended to only populate overridden properties in the custom `a
 | `hedera.mirror.importer.db.restPassword`                             | mirror_api_pass         | The database password the API uses to connect. **Should be changed from default**              |
 | `hedera.mirror.importer.db.restUsername`                             | mirror_api              | The username the API uses to connect to the database                                           |
 | `hedera.mirror.importer.db.host`                                     | 127.0.0.1               | The IP or hostname used to connect to the database                                             |
+| `hedera.mirror.importer.db.loadBalance`                              | true                    | Whether to enable pgpool load balancing. If false, it sends all reads to the primary db backend instead of load balancing them across the primary and replicas. |
 | `hedera.mirror.importer.db.name`                                     | mirror_node             | The name of the database                                                                       |
-| `hedera.mirror.importer.db.noLoadBalancing`                          | false                   | Whether to disable pgpool load balancing. If true, load balancing is disabled by prepending a comment to sql statements. |
 | `hedera.mirror.importer.db.password`                                 | mirror_node_pass        | The database password the processor uses to connect. **Should be changed from default**        |
 | `hedera.mirror.importer.db.port`                                     | 5432                    | The port used to connect to the database                                                       |
 | `hedera.mirror.importer.db.username`                                 | mirror_node             | The username the processor uses to connect to the database                                     |

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/HibernateConfiguration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/HibernateConfiguration.java
@@ -1,0 +1,47 @@
+package com.hedera.mirror.importer.config;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import java.util.Map;
+import org.hibernate.EmptyInterceptor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernatePropertiesCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@ConditionalOnProperty(prefix = "hedera.mirror.importer.db", name = "noLoadBalancing", havingValue = "true")
+@Configuration
+public class HibernateConfiguration implements HibernatePropertiesCustomizer {
+    @Override
+    public void customize(final Map<String, Object> hibernateProperties) {
+        hibernateProperties.put("hibernate.session_factory.interceptor", hibernateInterceptor());
+    }
+
+    @Bean
+    public EmptyInterceptor hibernateInterceptor() {
+        return new EmptyInterceptor() {
+            @Override
+            public String onPrepareStatement(final String sql) {
+                return "/* NO PGPOOL LOAD BALANCE */\n" + sql;
+            }
+        };
+    }
+}

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/HibernateConfiguration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/HibernateConfiguration.java
@@ -22,12 +22,13 @@ package com.hedera.mirror.importer.config;
 
 import java.util.Map;
 import org.hibernate.EmptyInterceptor;
+import org.hibernate.Interceptor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernatePropertiesCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-@ConditionalOnProperty(prefix = "hedera.mirror.importer.db", name = "noLoadBalancing", havingValue = "true")
+@ConditionalOnProperty(prefix = "hedera.mirror.importer.db", name = "loadBalance", havingValue = "false")
 @Configuration
 public class HibernateConfiguration implements HibernatePropertiesCustomizer {
     @Override
@@ -36,7 +37,10 @@ public class HibernateConfiguration implements HibernatePropertiesCustomizer {
     }
 
     @Bean
-    public EmptyInterceptor hibernateInterceptor() {
+    public Interceptor hibernateInterceptor() {
+        // https://www.pgpool.net/docs/latest/en/html/runtime-config-load-balancing.html
+        // pgpool disables load balancing for SQL statements beginning with an arbitrary comment and sends them to the
+        // master / primary node. This is used to prevent the stale read-after-write issue.
         return new EmptyInterceptor() {
             @Override
             public String onPrepareStatement(final String sql) {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/db/DBProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/db/DBProperties.java
@@ -40,6 +40,8 @@ public class DBProperties {
     @NotBlank
     private String name = "";
 
+    private boolean noLoadBalancing = false;
+
     @NotBlank
     private String password = "";
 
@@ -54,4 +56,5 @@ public class DBProperties {
 
     @NotBlank
     private String username = "";
+
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/db/DBProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/db/DBProperties.java
@@ -37,10 +37,10 @@ public class DBProperties {
     @NotBlank
     private String host = "";
 
+    private boolean loadBalance = true;
+
     @NotBlank
     private String name = "";
-
-    private boolean noLoadBalancing = false;
 
     @NotBlank
     private String password = "";

--- a/hedera-mirror-importer/src/main/resources/application.yml
+++ b/hedera-mirror-importer/src/main/resources/application.yml
@@ -4,6 +4,7 @@ hedera:
       db:
         host: 127.0.0.1
         name: mirror_node
+        noLoadBalancing: false
         password: mirror_node_pass
         port: 5432
         restPassword: mirror_api_pass

--- a/hedera-mirror-importer/src/main/resources/application.yml
+++ b/hedera-mirror-importer/src/main/resources/application.yml
@@ -3,8 +3,8 @@ hedera:
     importer:
       db:
         host: 127.0.0.1
+        loadBalance: true
         name: mirror_node
-        noLoadBalancing: false
         password: mirror_node_pass
         port: 5432
         restPassword: mirror_api_pass


### PR DESCRIPTION
**Detailed description**:
pgpool II will disable load balancing for SQL statements beginning with a comment, this PR does so by prepends a comment to SQL statements generated by hibernate ORM.

- Add a Hibernate interceptor bean to prepend a comment to the generated sql statement
- Add `HibernateConfiguration` to set the hibernate property so hibernate session factory use the custom interceptor
- Add a configuration option `loadBalance` to enable / disable the configuration and interceptor
- Set `loadBalance` to false as default in hedera-mirror-importer charts

**Which issue(s) this PR fixes**:
Fixes #1154 

**Special notes for your reviewer**:
Verified it works by turning on `pgpool.logPerNodeStatement` and confirming all the sql statements with a leading comment are sent to the primary backend. Note `pgpool.logPerNodeStatement` is only supported in newer bitnami `postgresql-ha` releases, e.g., 5.1.0.

pgpool official documentation: https://www.pgpool.net/docs/latest/en/html/runtime-config-load-balancing.html

**Checklist**
- [x] Documentation added
- [ ] Tests updated

