### PR TITLE
Add support for case insensitive query params to REST API

### DIFF
--- a/hedera-mirror-rest/__tests__/requestHandler.test.js
+++ b/hedera-mirror-rest/__tests__/requestHandler.test.js
@@ -38,8 +38,23 @@ describe('qs tests', () => {
     expect(val.transactiontype).toStrictEqual('bar');
   });
 
-  test('requestQueryParser for repeated query param of different case', () => {
+  test('requestQueryParser for repeated query params of different cases', () => {
     var val = requestQueryParser('transactiontype=bar&transactionType=xyz');
     expect(val).toStrictEqual({transactiontype: ['bar', 'xyz']});
+  });
+
+  test('requestQueryParser for repeated query params of different cases with matching repetitions', () => {
+    var val = requestQueryParser('transactiontype=bar&transactionType=xyz&transactionType=ppp');
+    expect(val).toStrictEqual({transactiontype: ['bar', 'xyz', 'ppp']});
+  });
+
+  test('requestQueryParser for repeated query params of different cases with matching repetitions of account and token ids', () => {
+    var val = requestQueryParser(
+      'account.id=1&token.id=2&account.Id=lt:3&token.Id=gt:4&account.Id=lte:5&token.Id=gte:6&account.id=7&token.id=8&account.ID=9&token.ID=10'
+    );
+    expect(val).toStrictEqual({
+      'account.id': ['1', '7', 'lt:3', 'lte:5', '9'],
+      'token.id': ['2', '8', 'gt:4', 'gte:6', '10'],
+    });
   });
 });

--- a/hedera-mirror-rest/__tests__/requestHandler.test.js
+++ b/hedera-mirror-rest/__tests__/requestHandler.test.js
@@ -1,0 +1,45 @@
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+'use strict';
+
+const {requestQueryParser} = require('../middleware/requestHandler');
+
+describe('qs tests', () => {
+  test('requestQueryParser for empty', () => {
+    var val = requestQueryParser('');
+    expect(val).toStrictEqual({});
+  });
+
+  test('requestQueryParser for null', () => {
+    var val = requestQueryParser(null);
+    expect(val).toStrictEqual({});
+  });
+
+  test('requestQueryParser for single query param', () => {
+    var val = requestQueryParser('transactiontype=bar');
+    expect(val.transactiontype).toStrictEqual('bar');
+  });
+
+  test('requestQueryParser for repeated query param of different case', () => {
+    var val = requestQueryParser('transactiontype=bar&transactionType=xyz');
+    expect(val).toStrictEqual({transactiontype: ['bar', 'xyz']});
+  });
+});

--- a/hedera-mirror-rest/__tests__/specs/accounts-06-all-params.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/accounts-06-all-params.spec.json
@@ -107,7 +107,7 @@
     "transactions": [],
     "cryptotransfers": []
   },
-  "url": "/api/v1/accounts?account.id=gte:0.1.18&account.id=lt:0.1.20&account.balance=gt:45&account.publickey=3c3d546321ff6f63d701d2ec5c277095874e19f4a235bee1e6bb19258bf362be&order=desc",
+  "url": "/api/v1/accounts?account.id=gte:0.1.18&account.id=lt:0.1.20&account.balance=gt:45&account.publicKey=3c3d546321ff6f63d701d2ec5c277095874e19f4a235bee1e6bb19258bf362be&order=desc",
   "responseStatus": 200,
   "responseJson": {
     "accounts": [

--- a/hedera-mirror-rest/__tests__/specs/balances-06-all-params.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/balances-06-all-params.spec.json
@@ -107,7 +107,7 @@
     "transactions": [],
     "cryptotransfers": []
   },
-  "url": "/api/v1/balances?account.id=gte:0.1.18&account.id=lt:0.1.20&account.balance=gt:45&account.publickey=3c3d546321ff6f63d701d2ec5c277095874e19f4a235bee1e6bb19258bf362be&timestamp=1566560003.000000000&order=asc",
+  "url": "/api/v1/balances?account.id=gte:0.1.18&account.id=lt:0.1.20&account.balance=gt:45&account.publicKey=3c3d546321ff6f63d701d2ec5c277095874e19f4a235bee1e6bb19258bf362be&timestamp=1566560003.000000000&order=asc",
   "responseStatus": 200,
   "responseJson": {
     "timestamp": "1566560003.000000000",

--- a/hedera-mirror-rest/__tests__/specs/token-balances-06-all-params.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/token-balances-06-all-params.spec.json
@@ -237,7 +237,7 @@
     "transactions": [],
     "cryptotransfers": []
   },
-  "url": "/api/v1/tokens/0.20.1/balances?account.id=gte:0.1.18&account.id=lt:0.1.20&account.balance=gt:45&account.publickey=3c3d546321ff6f63d701d2ec5c277095874e19f4a235bee1e6bb19258bf362be&timestamp=1566560003.000000000&order=asc",
+  "url": "/api/v1/tokens/0.20.1/balances?account.id=gte:0.1.18&account.id=lt:0.1.20&account.balance=gt:45&account.publicKey=3c3d546321ff6f63d701d2ec5c277095874e19f4a235bee1e6bb19258bf362be&timestamp=1566560003.000000000&order=asc",
   "responseStatus": 200,
   "responseJson": {
     "timestamp": "1566560003.000000000",

--- a/hedera-mirror-rest/__tests__/specs/token-info-02-invalid-id.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/token-info-02-invalid-id.spec.json
@@ -50,7 +50,7 @@
     "_status": {
       "messages": [
         {
-          "message": "Invalid parameter: tokenId"
+          "message": "Invalid parameter: tokenid"
         }
       ]
     }

--- a/hedera-mirror-rest/__tests__/specs/topicmessages-05-all-params.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/topicmessages-05-all-params.spec.json
@@ -43,7 +43,7 @@
       }
     ]
   },
-  "url": "/api/v1/topics/7/messages?sequencenumber=gt:3&timestamp=lte:1234567890.000000005&encoding=base64",
+  "url": "/api/v1/topics/7/messages?sequenceNumber=gt:3&timestamp=lte:1234567890.000000005&encoding=base64",
   "responseStatus": 200,
   "responseJson": {
     "messages": [

--- a/hedera-mirror-rest/__tests__/specs/transactions-13-invalid-param-values.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-13-invalid-param-values.spec.json
@@ -24,7 +24,7 @@
           "message": "Invalid parameter: result"
         },
         {
-          "message": "Invalid parameter: transactionType"
+          "message": "Invalid parameter: transactiontype"
         }
       ]
     }

--- a/hedera-mirror-rest/constants.js
+++ b/hedera-mirror-rest/constants.js
@@ -32,7 +32,7 @@ const filterKeys = {
   RESULT: 'result',
   SEQUENCE_NUMBER: 'sequencenumber',
   TIMESTAMP: 'timestamp',
-  TOKENID: 'tokenId',
+  TOKENID: 'tokenid',
   TOKEN_ID: 'token.id',
   CREDIT_TYPE: 'type',
   TRANSACTION_TYPE: 'transactiontype',

--- a/hedera-mirror-rest/constants.js
+++ b/hedera-mirror-rest/constants.js
@@ -35,7 +35,7 @@ const filterKeys = {
   TOKENID: 'tokenId',
   TOKEN_ID: 'token.id',
   CREDIT_TYPE: 'type',
-  TRANSACTION_TYPE: 'transactionType',
+  TRANSACTION_TYPE: 'transactiontype',
 };
 
 // sql table columns

--- a/hedera-mirror-rest/middleware/requestHandler.js
+++ b/hedera-mirror-rest/middleware/requestHandler.js
@@ -41,14 +41,16 @@ const requestQueryParser = (queryString) => {
   const caseInsensitiveQueryString = {};
   for (const key of Object.keys(parsedQueryString)) {
     const lowerKey = key.toLowerCase();
-    const currentValue = caseInsensitiveQueryString[lowerKey];
+    let currentValue = caseInsensitiveQueryString[lowerKey];
     if (currentValue) {
-      // handle repeated values. Add to array if applicable of convert to array
-      if (Array.isArray(currentValue)) {
-        caseInsensitiveQueryString[lowerKey].push(parsedQueryString[key]);
-      } else {
-        caseInsensitiveQueryString[lowerKey] = [currentValue, parsedQueryString[key]];
+      // handle repeated values. Add to array if applicable or convert to array
+      if (!Array.isArray(currentValue)) {
+        // create a new array of current value
+        currentValue = [currentValue];
       }
+
+      // assign value as concat of current value array and new value which may also be an array
+      caseInsensitiveQueryString[lowerKey] = currentValue.concat(parsedQueryString[key]);
     } else {
       caseInsensitiveQueryString[lowerKey] = parsedQueryString[key];
     }

--- a/hedera-mirror-rest/middleware/requestHandler.js
+++ b/hedera-mirror-rest/middleware/requestHandler.js
@@ -25,6 +25,22 @@ const requestLogger = function (req, res, next) {
   return next();
 };
 
+/**
+ * Support case insensitive retrieval from request parameters
+ * @param req
+ * @param res
+ * @param next
+ * @returns Query param value
+ */
+const requestQueryKeyFormatter = function (req, res, next) {
+  req.query = new Proxy(req.query, {
+    get: (target, name) => target[Object.keys(target).find((key) => key.toLowerCase() === name.toLowerCase())],
+  });
+
+  return next();
+};
+
 module.exports = {
   requestLogger,
+  requestQueryKeyFormatter,
 };

--- a/hedera-mirror-rest/package-lock.json
+++ b/hedera-mirror-rest/package-lock.json
@@ -1636,6 +1636,13 @@
         "qs": "6.7.0",
         "raw-body": "2.4.0",
         "type-is": "~1.6.17"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.7.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+        }
       }
     },
     "boxen": {
@@ -3140,6 +3147,13 @@
         "type-is": "~1.6.18",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.7.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+        }
       }
     },
     "extend": {
@@ -6657,9 +6671,9 @@
       "integrity": "sha512-wLHYUQxWaXVQvKnwIDWFVKDJku9XDCvyhhxoq8dc5MFdIlRenyPI9eSfEtcvgHgD7FlvCyGAlWgOzRnZD99GZQ=="
     },
     "qs": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-      "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
+      "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
     },
     "querystring": {
       "version": "0.2.0",

--- a/hedera-mirror-rest/package.json
+++ b/hedera-mirror-rest/package.json
@@ -17,13 +17,13 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@awaitjs/express": "^0.6.1",
+    "@godaddy/terminus": "^4.4.1",
     "asn1js": "^2.0.26",
     "aws-sdk": "^2.773.0",
     "body-parser": "^1.19.0",
     "compression": "^1.7.4",
     "cors": "^2.8.5",
     "express": "^4.17.1",
-    "@godaddy/terminus": "^4.4.1",
     "extend": "^3.0.2",
     "js-yaml": "^3.14.0",
     "lodash": "^4.17.20",
@@ -33,6 +33,7 @@
     "node-cache": "^5.1.2",
     "node-fetch": "^2.6.1",
     "pg": "~8.4.1",
+    "qs": "^6.9.4",
     "swagger-stats": "^0.95.17"
   },
   "bundledDependencies": [
@@ -53,6 +54,7 @@
     "node-cache",
     "node-fetch",
     "pg",
+    "qs",
     "swagger-stats"
   ],
   "devDependencies": {

--- a/hedera-mirror-rest/server.js
+++ b/hedera-mirror-rest/server.js
@@ -41,7 +41,7 @@ const transactions = require('./transactions');
 const {handleError} = require('./middleware/httpErrorHandler');
 const {responseHandler} = require('./middleware/responseHandler');
 const {metricsHandler} = require('./middleware/metricsHandler');
-const {requestLogger} = require('./middleware/requestLogger');
+const {requestLogger, requestQueryKeyFormatter} = require('./middleware/requestHandler');
 
 // Logger
 const logger = log4js.getLogger();
@@ -102,6 +102,7 @@ app.use(cors());
 
 // logging middleware
 app.use(requestLogger);
+app.use(requestQueryKeyFormatter);
 
 // metrics middleware
 if (config.metrics.enabled) {

--- a/hedera-mirror-rest/server.js
+++ b/hedera-mirror-rest/server.js
@@ -41,7 +41,7 @@ const transactions = require('./transactions');
 const {handleError} = require('./middleware/httpErrorHandler');
 const {responseHandler} = require('./middleware/responseHandler');
 const {metricsHandler} = require('./middleware/metricsHandler');
-const {requestLogger, requestQueryKeyFormatter} = require('./middleware/requestHandler');
+const {requestLogger, requestQueryParser} = require('./middleware/requestHandler');
 
 // Logger
 const logger = log4js.getLogger();
@@ -87,10 +87,13 @@ const pool = new Pool({
 });
 global.pool = pool;
 
-// Express configuration
+// Express configuration. Prior to v0.5 all sets should be configured before use or they won't be picked up
 const app = addAsync(express());
 app.set('trust proxy', true);
 app.set('port', port);
+app.set('query parser', requestQueryParser);
+
+// middleware functions, Prior to v0.5 define after sets
 app.use(
   bodyParser.urlencoded({
     extended: false,
@@ -102,7 +105,6 @@ app.use(cors());
 
 // logging middleware
 app.use(requestLogger);
-app.use(requestQueryKeyFormatter);
 
 // metrics middleware
 if (config.metrics.enabled) {

--- a/hedera-mirror-rest/utils.js
+++ b/hedera-mirror-rest/utils.js
@@ -141,7 +141,7 @@ const filterValidityChecks = (param, op, val) => {
   }
 
   // Validate the value
-  switch (param.toLowerCase()) {
+  switch (param) {
     case constants.filterKeys.ACCOUNT_BALANCE:
       // Accepted forms: Upto 50 billion
       ret = isValidAccountBalanceQuery(val);
@@ -624,7 +624,8 @@ const buildFilterObject = (filters) => {
     return null;
   }
 
-  for (const [key, values] of Object.entries(filters)) {
+  for (const key in filters) {
+    const values = filters[key];
     // for repeated params val will be an array
     if (Array.isArray(values)) {
       for (const val of values) {
@@ -643,7 +644,7 @@ const buildComparatorFilter = (name, filter) => {
   let opVal = splitVal.length === 1 ? ['eq', filter] : splitVal;
 
   return {
-    key: name.toLowerCase(),
+    key: name,
     operator: opVal[0],
     value: opVal[1],
   };

--- a/hedera-mirror-rest/utils.js
+++ b/hedera-mirror-rest/utils.js
@@ -141,7 +141,7 @@ const filterValidityChecks = (param, op, val) => {
   }
 
   // Validate the value
-  switch (param) {
+  switch (param.toLowerCase()) {
     case constants.filterKeys.ACCOUNT_BALANCE:
       // Accepted forms: Upto 50 billion
       ret = isValidAccountBalanceQuery(val);
@@ -643,7 +643,7 @@ const buildComparatorFilter = (name, filter) => {
   let opVal = splitVal.length === 1 ? ['eq', filter] : splitVal;
 
   return {
-    key: name,
+    key: name.toLowerCase(),
     operator: opVal[0],
     value: opVal[1],
   };


### PR DESCRIPTION
**Detailed description**:
REST API should support query params regardless of case

- Add a middleware function using Proxy object to support lookup of values regardless of case
- Convert filter query name to lower case on creation
- Update a few test specs with camel case variations of query keys
- Set filter keys to lowercase for easy comparison

**Which issue(s) this PR fixes**:
Fixes #1159

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated

