### PR TITLE
Fix stale accounts REST API

### DIFF
--- a/hedera-mirror-rest/__tests__/accounts.test.js
+++ b/hedera-mirror-rest/__tests__/accounts.test.js
@@ -154,7 +154,7 @@ const validateOrder = function (accounts, order) {
 const singletests = {
   accountid_lowerlimit: {
     urlparam: 'account.id=gte:0.0.1111',
-    checks: [{field: 'account_id', operator: '>=', value: 1111}],
+    checks: [{field: 'id', operator: '>=', value: 1111}],
     checkFunctions: [
       {func: validateAccNumRange, args: [1111, Number.MAX_SAFE_INTEGER]},
       {func: validateFields, args: []},
@@ -162,7 +162,7 @@ const singletests = {
   },
   accountid_higherlimit: {
     urlparam: 'account.id=lt:0.0.2222',
-    checks: [{field: 'account_id', operator: '<', value: 2222}],
+    checks: [{field: 'id', operator: '<', value: 2222}],
     checkFunctions: [
       {func: validateAccNumRange, args: [0, 2222]},
       {func: validateFields, args: []},
@@ -170,7 +170,7 @@ const singletests = {
   },
   accountid_equal: {
     urlparam: 'account.id=0.0.3333',
-    checks: [{field: 'account_id', operator: '=', value: 3333}],
+    checks: [{field: 'id', operator: '=', value: 3333}],
     checkFunctions: [
       {func: validateAccNumRange, args: [3333, 3333]},
       {func: validateFields, args: []},

--- a/hedera-mirror-rest/__tests__/accounts.test.js
+++ b/hedera-mirror-rest/__tests__/accounts.test.js
@@ -154,7 +154,7 @@ const validateOrder = function (accounts, order) {
 const singletests = {
   accountid_lowerlimit: {
     urlparam: 'account.id=gte:0.0.1111',
-    checks: [{field: 'id', operator: '>=', value: 1111}],
+    checks: [{field: 'account_id', operator: '>=', value: 1111}],
     checkFunctions: [
       {func: validateAccNumRange, args: [1111, Number.MAX_SAFE_INTEGER]},
       {func: validateFields, args: []},
@@ -162,7 +162,7 @@ const singletests = {
   },
   accountid_higherlimit: {
     urlparam: 'account.id=lt:0.0.2222',
-    checks: [{field: 'id', operator: '<', value: 2222}],
+    checks: [{field: 'account_id', operator: '<', value: 2222}],
     checkFunctions: [
       {func: validateAccNumRange, args: [0, 2222]},
       {func: validateFields, args: []},
@@ -170,7 +170,7 @@ const singletests = {
   },
   accountid_equal: {
     urlparam: 'account.id=0.0.3333',
-    checks: [{field: 'id', operator: '=', value: 3333}],
+    checks: [{field: 'account_id', operator: '=', value: 3333}],
     checkFunctions: [
       {func: validateAccNumRange, args: [3333, 3333]},
       {func: validateFields, args: []},

--- a/hedera-mirror-rest/__tests__/mockpool.js
+++ b/hedera-mirror-rest/__tests__/mockpool.js
@@ -86,7 +86,7 @@ class Pool {
         orderprefix = 'account_id';
         break;
       case 'accounts':
-        orderprefix = 'e.id';
+        orderprefix = 'coalesce\\(ab.account_id, e.id\\)';
         break;
       default:
         break;
@@ -297,7 +297,7 @@ class Pool {
     // Adjust the low/high values based on the SQL query parameters
     for (const param of parsedparams) {
       switch (param.field) {
-        case 'id':
+        case 'account_id':
           accountNum = this.adjustRangeBasedOnConstraints(param, accountNum);
           break;
         case 'balance':

--- a/hedera-mirror-rest/__tests__/mockpool.js
+++ b/hedera-mirror-rest/__tests__/mockpool.js
@@ -86,7 +86,7 @@ class Pool {
         orderprefix = 'account_id';
         break;
       case 'accounts':
-        orderprefix = 'coalesce\\(ab.account_id, e.id\\)';
+        orderprefix = 'e.id';
         break;
       default:
         break;
@@ -186,8 +186,7 @@ class Pool {
         0,
         0,
         Number(accountNum.low) + (accountNum.high == accountNum.low ? 0 : i % (accountNum.high - accountNum.low))
-      )
-        .getEncodedId();
+      ).getEncodedId();
       row.amount = i * 1000;
       row.charged_tx_fee = 100 + i;
       row.transaction_hash = '';
@@ -260,8 +259,9 @@ class Pool {
     for (let i = 0; i < limit.high; i++) {
       const row = {};
       row.consensus_timestamp = this.toNs(Math.floor((timestamp.low + timestamp.high) / 2));
-      row.account_id =
-        `${Number(accountNum.high) - (accountNum.high === accountNum.low ? 0 : i % (accountNum.high - accountNum.low))}`;
+      row.account_id = `${
+        Number(accountNum.high) - (accountNum.high === accountNum.low ? 0 : i % (accountNum.high - accountNum.low))
+      }`;
       row.balance = balance.low + Math.floor((balance.high - balance.low) / limit.high);
 
       rows.push(row);
@@ -297,7 +297,7 @@ class Pool {
     // Adjust the low/high values based on the SQL query parameters
     for (const param of parsedparams) {
       switch (param.field) {
-        case 'account_id':
+        case 'id':
           accountNum = this.adjustRangeBasedOnConstraints(param, accountNum);
           break;
         case 'balance':
@@ -324,8 +324,9 @@ class Pool {
 
       row.account_balance = balance.low + Math.floor((balance.high - balance.low) / limit.high);
       row.consensus_timestamp = this.toNs(this.timeNow);
-      row.entity_id =
-        `${Number(accountNum.high) - (accountNum.high == accountNum.low ? 0 : i % (accountNum.high - accountNum.low))}`;
+      row.entity_id = `${
+        Number(accountNum.high) - (accountNum.high == accountNum.low ? 0 : i % (accountNum.high - accountNum.low))
+      }`;
       row.exp_time_ns = this.toNs(this.timeNow + 1000);
       row.auto_renew_period = i * 1000;
       row.key = Buffer.from(`Key for row ${i}`);

--- a/hedera-mirror-rest/__tests__/specs/accounts-16-no-balances.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/accounts-16-no-balances.spec.json
@@ -105,8 +105,20 @@
         ]
       }
     ],
-    "transactions": [],
-    "cryptotransfers": []
+    "entities": [
+      {
+        "entity_num": 6,
+        "entity_type": 3
+      },
+      {
+        "entity_num": 7,
+        "entity_type": 4
+      },
+      {
+        "entity_num": 8,
+        "entity_type": 5
+      }
+    ]
   },
   "url": "/api/v1/accounts",
   "responseStatus": 200,

--- a/hedera-mirror-rest/__tests__/specs/accounts-16-no-balances.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/accounts-16-no-balances.spec.json
@@ -1,0 +1,207 @@
+{
+  "description": "Account api calls for all accounts, some with no balances",
+  "setup": {
+    "accounts": [
+      {
+        "entity_num": 1
+      },
+      {
+        "entity_num": 2
+      },
+      {
+        "entity_num": 3
+      },
+      {
+        "entity_num": 4
+      },
+      {
+        "entity_num": 5
+      }
+    ],
+    "balances": [
+      {
+        "timestamp": 1000,
+        "id": 1,
+        "balance": 5,
+        "tokens": [
+          {
+            "token_realm": 0,
+            "token_num": 90000,
+            "balance": 1
+          },
+          {
+            "token_realm": 0,
+            "token_num": 90001,
+            "balance": 5
+          }
+        ]
+      },
+      {
+        "timestamp": 2000,
+        "id": 1,
+        "balance": 10,
+        "tokens": [
+          {
+            "token_realm": 0,
+            "token_num": 90000,
+            "balance": 6
+          },
+          {
+            "token_realm": 0,
+            "token_num": 90001,
+            "balance": 11
+          }
+        ]
+      },
+      {
+        "timestamp": 1000,
+        "id": 2,
+        "balance": 10,
+        "tokens": [
+          {
+            "token_realm": 0,
+            "token_num": 90001,
+            "balance": 1
+          },
+          {
+            "token_realm": 0,
+            "token_num": 90010,
+            "balance": 12
+          }
+        ]
+      },
+      {
+        "timestamp": 2000,
+        "id": 2,
+        "balance": 20,
+        "tokens": [
+          {
+            "token_realm": 0,
+            "token_num": 90001,
+            "balance": 2
+          },
+          {
+            "token_realm": 0,
+            "token_num": 90010,
+            "balance": 22
+          }
+        ]
+      },
+      {
+        "timestamp": 2000,
+        "id": 5,
+        "balance": 50,
+        "tokens": [
+          {
+            "token_realm": 0,
+            "token_num": 100001,
+            "balance": 5
+          },
+          {
+            "token_realm": 0,
+            "token_num": 100002,
+            "balance": 55
+          }
+        ]
+      }
+    ],
+    "transactions": [],
+    "cryptotransfers": []
+  },
+  "url": "/api/v1/accounts",
+  "responseStatus": 200,
+  "responseJson": {
+    "accounts": [
+      {
+        "balance": {
+          "timestamp": "0.000002000",
+          "balance": 10,
+          "tokens": [
+            {
+              "token_id": "0.0.90000",
+              "balance": 6
+            },
+            {
+              "token_id": "0.0.90001",
+              "balance": 11
+            }
+          ]
+        },
+        "account": "0.0.1",
+        "expiry_timestamp": null,
+        "auto_renew_period": null,
+        "key": null,
+        "deleted": false
+      },
+      {
+        "balance": {
+          "timestamp": "0.000002000",
+          "balance": 20,
+          "tokens": [
+            {
+              "token_id": "0.0.90001",
+              "balance": 2
+            },
+            {
+              "token_id": "0.0.90010",
+              "balance": 22
+            }
+          ]
+        },
+        "account": "0.0.2",
+        "expiry_timestamp": null,
+        "auto_renew_period": null,
+        "key": null,
+        "deleted": false
+      },
+      {
+        "balance": {
+          "timestamp": null,
+          "balance": null,
+          "tokens": []
+        },
+        "account": "0.0.3",
+        "expiry_timestamp": null,
+        "auto_renew_period": null,
+        "key": null,
+        "deleted": false
+      },
+      {
+        "balance": {
+          "timestamp": null,
+          "balance": null,
+          "tokens": []
+        },
+        "account": "0.0.4",
+        "expiry_timestamp": null,
+        "auto_renew_period": null,
+        "key": null,
+        "deleted": false
+      },
+      {
+        "balance": {
+          "timestamp": "0.000002000",
+          "balance": 50,
+          "tokens": [
+            {
+              "token_id": "0.0.100001",
+              "balance": 5
+            },
+            {
+              "token_id": "0.0.100002",
+              "balance": 55
+            }
+          ]
+        },
+        "account": "0.0.5",
+        "expiry_timestamp": null,
+        "auto_renew_period": null,
+        "key": null,
+        "deleted": false
+      }
+    ],
+    "links": {
+      "next": null
+    }
+  }
+}

--- a/hedera-mirror-rest/__tests__/specs/accounts-17-specific-id-no-balance.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/accounts-17-specific-id-no-balance.spec.json
@@ -58,8 +58,20 @@
         "balance": 45
       }
     ],
-    "transactions": [],
-    "cryptotransfers": []
+    "entities": [
+      {
+        "entity_num": 10,
+        "entity_type": 3
+      },
+      {
+        "entity_num": 11,
+        "entity_type": 4
+      },
+      {
+        "entity_num": 12,
+        "entity_type": 5
+      }
+    ]
   },
   "url": "/api/v1/accounts?account.id=0.0.8",
   "responseStatus": 200,

--- a/hedera-mirror-rest/__tests__/specs/accounts-17-specific-id-no-balance.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/accounts-17-specific-id-no-balance.spec.json
@@ -1,0 +1,85 @@
+{
+  "description": "Account api calls for specific account using query param with no balance",
+  "setup": {
+    "accounts": [
+      {
+        "entity_num": 7
+      },
+      {
+        "entity_num": 8
+      },
+      {
+        "entity_num": 9
+      }
+    ],
+    "balances": [
+      {
+        "timestamp": 123,
+        "id": 7,
+        "balance": 20,
+        "tokens": [
+          {
+            "token_realm": 0,
+            "token_num": 100001,
+            "balance": 2
+          },
+          {
+            "token_realm": 0,
+            "token_num": 100002,
+            "balance": 7
+          }
+        ]
+      },
+      {
+        "timestamp": 2345,
+        "id": 7,
+        "balance": 70,
+        "tokens": [
+          {
+            "token_realm": 0,
+            "token_num": 100001,
+            "balance": 7
+          },
+          {
+            "token_realm": 0,
+            "token_num": 100002,
+            "balance": 77
+          }
+        ]
+      },
+      {
+        "timestamp": 2345,
+        "id": 9,
+        "balance": 90
+      },
+      {
+        "timestamp": 12,
+        "id": 9,
+        "balance": 45
+      }
+    ],
+    "transactions": [],
+    "cryptotransfers": []
+  },
+  "url": "/api/v1/accounts?account.id=0.0.8",
+  "responseStatus": 200,
+  "responseJson": {
+    "accounts": [
+      {
+        "balance": {
+          "timestamp": null,
+          "balance": null,
+          "tokens": []
+        },
+        "account": "0.0.8",
+        "expiry_timestamp": null,
+        "auto_renew_period": null,
+        "key": null,
+        "deleted": false
+      }
+    ],
+    "links": {
+      "next": null
+    }
+  }
+}

--- a/hedera-mirror-rest/__tests__/specs/accounts-18-account-transactions-no-balances.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/accounts-18-account-transactions-no-balances.spec.json
@@ -1,0 +1,160 @@
+{
+  "description": "Account api calls for specific account using path for account with no balance",
+  "setup": {
+    "accounts": [
+      {
+        "entity_num": 3
+      },
+      {
+        "entity_num": 7
+      },
+      {
+        "entity_num": 8
+      },
+      {
+        "entity_num": 9
+      },
+      {
+        "entity_num": 98
+      }
+    ],
+    "balances": [
+      {
+        "timestamp": 123,
+        "id": 7,
+        "balance": 20,
+        "tokens": [
+          {
+            "token_realm": 0,
+            "token_num": 99998,
+            "balance": 2
+          },
+          {
+            "token_realm": 0,
+            "token_num": 99999,
+            "balance": 20
+          }
+        ]
+      },
+      {
+        "timestamp": 2345,
+        "id": 7,
+        "balance": 70,
+        "tokens": [
+          {
+            "token_realm": 0,
+            "token_num": 99998,
+            "balance": 7
+          },
+          {
+            "token_realm": 0,
+            "token_num": 99999,
+            "balance": 77
+          }
+        ]
+      },
+      {
+        "timestamp": 123,
+        "id": 9,
+        "balance": 20
+      },
+      {
+        "timestamp": 2345,
+        "id": 9,
+        "balance": 90
+      }
+    ],
+    "transactions": [],
+    "cryptotransfers": [
+      {
+        "consensus_timestamp": "1234567890000000001",
+        "payerAccountId": "0.0.7",
+        "recipientAccountId": "0.0.8",
+        "amount": 25,
+        "nodeAccountId": "0.0.3",
+        "treasuryAccountId": "0.0.98"
+      },
+      {
+        "consensus_timestamp": "1234567890000000005",
+        "payerAccountId": "0.0.8",
+        "recipientAccountId": "0.0.9",
+        "amount": 10,
+        "nodeAccountId": "0.0.3",
+        "treasuryAccountId": "0.0.98"
+      }
+    ]
+  },
+  "url": "/api/v1/accounts/0.0.8",
+  "responseStatus": 200,
+  "responseJson": {
+    "transactions": [
+      {
+        "charged_tx_fee": 7,
+        "consensus_timestamp": "1234567890.000000005",
+        "max_fee": "33",
+        "memo_base64": null,
+        "name": "CRYPTOTRANSFER",
+        "node": "0.0.3",
+        "result": "SUCCESS",
+        "transaction_hash": "aGFzaA==",
+        "transaction_id": "0.0.8-1234567890-000000004",
+        "transfers": [
+          {
+            "account": "0.0.8",
+            "amount": -11
+          },
+          {
+            "account": "0.0.9",
+            "amount": 10
+          },
+          {
+            "account": "0.0.98",
+            "amount": 1
+          }
+        ],
+        "valid_duration_seconds": "11",
+        "valid_start_timestamp": "1234567890.000000004"
+      },
+      {
+        "charged_tx_fee": 7,
+        "consensus_timestamp": "1234567890.000000001",
+        "max_fee": "33",
+        "memo_base64": null,
+        "name": "CRYPTOTRANSFER",
+        "node": "0.0.3",
+        "result": "SUCCESS",
+        "transaction_hash": "aGFzaA==",
+        "transaction_id": "0.0.7-1234567890-000000000",
+        "transfers": [
+          {
+            "account": "0.0.7",
+            "amount": -26
+          },
+          {
+            "account": "0.0.8",
+            "amount": 25
+          },
+          {
+            "account": "0.0.98",
+            "amount": 1
+          }
+        ],
+        "valid_duration_seconds": "11",
+        "valid_start_timestamp": "1234567890.000000000"
+      }
+    ],
+    "balance": {
+      "timestamp": null,
+      "balance": null,
+      "tokens": []
+    },
+    "account": "0.0.8",
+    "expiry_timestamp": null,
+    "auto_renew_period": null,
+    "key": null,
+    "deleted": false,
+    "links": {
+      "next": null
+    }
+  }
+}

--- a/hedera-mirror-rest/__tests__/specs/accounts-18-account-transactions-no-balances.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/accounts-18-account-transactions-no-balances.spec.json
@@ -64,7 +64,6 @@
         "balance": 90
       }
     ],
-    "transactions": [],
     "cryptotransfers": [
       {
         "consensus_timestamp": "1234567890000000001",
@@ -81,6 +80,20 @@
         "amount": 10,
         "nodeAccountId": "0.0.3",
         "treasuryAccountId": "0.0.98"
+      }
+    ],
+    "entities": [
+      {
+        "entity_num": 10,
+        "entity_type": 3
+      },
+      {
+        "entity_num": 11,
+        "entity_type": 4
+      },
+      {
+        "entity_num": 12,
+        "entity_type": 5
       }
     ]
   },

--- a/hedera-mirror-rest/accounts.js
+++ b/hedera-mirror-rest/accounts.js
@@ -64,7 +64,7 @@ const getAccountQuery = (extraWhereCondition, orderClause, order, query) => {
   return `
     select ab.balance as account_balance,
        ab.consensus_timestamp as consensus_timestamp,
-       coalesce(ab.account_id, e.id) as entity_id,
+       e.id as entity_id,
        e.exp_time_ns,
        e.auto_renew_period,
        e.key,
@@ -110,7 +110,7 @@ const getAccounts = async (req, res) => {
 
   const entitySql = getAccountQuery(
     `${[entityAccountQuery, balanceQuery, pubKeyQuery].filter((x) => !!x).join(' and ')}`,
-    `order by coalesce(ab.account_id, e.id) ${order}`,
+    `order by e.id ${order}`,
     order,
     query
   );

--- a/hedera-mirror-rest/accounts.js
+++ b/hedera-mirror-rest/accounts.js
@@ -59,6 +59,8 @@ const processRow = (row) => {
  */
 const getAccountQuery = (extraWhereCondition, orderClause, order, query) => {
   // token balances pairs are aggregated as an array of json objects {token_id, balance}
+  const startWhereCondition = extraWhereCondition ? `${extraWhereCondition} and` : '';
+
   return `
     select ab.balance as account_balance,
        ab.consensus_timestamp as consensus_timestamp,
@@ -80,12 +82,11 @@ const getAccountQuery = (extraWhereCondition, orderClause, order, query) => {
            ab.consensus_timestamp = tb.consensus_timestamp
            and ab.account_id = tb.account_id
        ) as token_balances
-    from account_balance ab
-    full outer join t_entities e on (
-      ab.account_id = e.id
-      and e.fk_entity_type_id < ${utils.ENTITY_TYPE_FILE}
-    )
-    where ab.consensus_timestamp = (select max(consensus_timestamp) from account_balance) ${extraWhereCondition || ''}
+    from (select id, fk_entity_type_id, exp_time_ns, auto_renew_period, key, deleted, ed25519_public_key_hex from t_entities where fk_entity_type_id < ${
+      utils.ENTITY_TYPE_FILE
+    }) as e
+    left outer join account_balance ab on ab.account_id = e.id
+    where ${startWhereCondition} (ab.consensus_timestamp = (select max(consensus_timestamp) from account_balance) or ab.consensus_timestamp is null)
     ${orderClause || ''}
     ${query || ''}`;
 };
@@ -102,31 +103,19 @@ const getAccounts = async (req, res) => {
   utils.validateReq(req);
 
   // Parse the filter parameters for account-numbers, balances, publicKey and pagination
-
-  // Because of the outer join on the 'account_balance ab' and 't_entities e' below, we
-  // need to look  for the given account.id in both account_balance and t_entities table and combine with an 'or'
-  const [balancesAccountQuery, balancesAccountParams] = utils.parseAccountIdQueryParam(req.query, 'ab.account_id');
   const [entityAccountQuery, entityAccountParams] = utils.parseAccountIdQueryParam(req.query, 'e.id');
-  const accountQuery =
-    balancesAccountQuery === ''
-      ? ''
-      : `(${balancesAccountQuery} or (${entityAccountQuery} and e.fk_entity_type_id < ${utils.ENTITY_TYPE_FILE}))`;
   const [balanceQuery, balanceParams] = utils.parseBalanceQueryParam(req.query, 'ab.balance');
   const [pubKeyQuery, pubKeyParams] = utils.parsePublicKeyQueryParam(req.query, 'e.ed25519_public_key_hex');
   const {query, params, order, limit} = utils.parseLimitAndOrderParams(req, 'asc');
 
   const entitySql = getAccountQuery(
-    `and ${[accountQuery, balanceQuery, pubKeyQuery].map((q) => (q === '' ? '1=1' : q)).join(' and ')}`,
+    `${[entityAccountQuery, balanceQuery, pubKeyQuery].filter((x) => !!x).join(' and ')}`,
     `order by coalesce(ab.account_id, e.id) ${order}`,
     order,
     query
   );
 
-  const entityParams = balancesAccountParams
-    .concat(entityAccountParams)
-    .concat(balanceParams)
-    .concat(pubKeyParams)
-    .concat(params);
+  const entityParams = entityAccountParams.concat(balanceParams).concat(pubKeyParams).concat(params);
 
   const pgEntityQuery = utils.convertMySqlStyleQueryToPostgres(entitySql, entityParams);
 
@@ -191,15 +180,9 @@ const getOneAccount = async (req, res) => {
 
   // Because of the outer join on the 'account_balance ab' and 't_entities e' below, we
   // need to look  for the given account.id in both account_balance and t_entities table and combine with an 'or'
-  const entitySql = getAccountQuery(` and (
-      (ab.account_id  =  ?)
-      or (e.id = ?
-          and e.fk_entity_type_id < ${utils.ENTITY_TYPE_FILE}
-          )
-       )`);
-
+  const entitySql = getAccountQuery(`e.id = ? `);
   const encodedAccountId = accountId.getEncodedId();
-  const entityParams = [encodedAccountId, encodedAccountId];
+  const entityParams = [encodedAccountId];
   const pgEntityQuery = utils.convertMySqlStyleQueryToPostgres(entitySql, entityParams);
 
   if (logger.isTraceEnabled()) {


### PR DESCRIPTION
**Detailed description**:
Initial balance inner joins used by account rest api's resulted in info being stale.
In some cases there would be no balance and therefore new accounts were accidentally filter out.

- Rearrange join to start with entity filter to get all accounts then pick up balances
- Add 3 integration spec files to cover cases were accounts had no balance yet
- Remove cases of doubling up on entity and account_id filter 

**Which issue(s) this PR fixes**:
Fixes #1177 

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated

