### PR TITLE
Fix test case fragmentedMessagesGroupAcrossHistoricAndIncoming

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -3,7 +3,7 @@ name: Deploy Development
 on:
   push:
     branches:
-      - master
+      - fix-grpc-test
 
 jobs:
   build:
@@ -22,29 +22,5 @@ jobs:
           key: ${{ runner.os }}-m2-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/pom.xml') }}
           path: ~/.m2
           restore-keys: ${{ runner.os }}-m2
-      - name: Login to Google Container Registry
-        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
-        with:
-          project_id: ${{ secrets.GCP_PROJECT_ID }}
-          service_account_key: ${{ secrets.GCR_KEY }}
-      - name: Configure Docker
-        run: gcloud auth configure-docker gcr.io,marketplace.gcr.io
       - name: Build and push images
-        run: ./mvnw ${MAVEN_CLI_OPTS} deploy -Ddocker.tag.version=master-${GITHUB_SHA} -Djib.to.tags=master-${GITHUB_SHA}
-
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          ref: deploy
-      - name: Update dev tag
-        run: |-
-          sed -i "s/ref: .*/ref: ${GITHUB_SHA}/" ./common/helmrelease.yaml
-          sed -i "s/ref: .*/ref: ${GITHUB_SHA}/" ./dev/helmrelease.yaml
-          sed -i "s/tag: .*/tag: master-${GITHUB_SHA}/" ./dev/helmrelease.yaml
-        shell: bash
-      - uses: stefanzweifel/git-auto-commit-action@v4.5.1
-        with:
-          commit_message: Upgrade dev to master-${{ github.sha }}
+        run: ./mvnw ${MAVEN_CLI_OPTS} package -Ddocker.tag.version=master-${GITHUB_SHA} -Djib.to.tags=master-${GITHUB_SHA} -pl hedera-mirror-protobuf,hedera-mirror-grpc

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -3,7 +3,7 @@ name: Deploy Development
 on:
   push:
     branches:
-      - fix-grpc-test
+      - master
 
 jobs:
   build:
@@ -22,5 +22,29 @@ jobs:
           key: ${{ runner.os }}-m2-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/pom.xml') }}
           path: ~/.m2
           restore-keys: ${{ runner.os }}-m2
+      - name: Login to Google Container Registry
+        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          service_account_key: ${{ secrets.GCR_KEY }}
+      - name: Configure Docker
+        run: gcloud auth configure-docker gcr.io,marketplace.gcr.io
       - name: Build and push images
-        run: ./mvnw ${MAVEN_CLI_OPTS} package -Ddocker.tag.version=master-${GITHUB_SHA} -Djib.to.tags=master-${GITHUB_SHA} -pl hedera-mirror-protobuf,hedera-mirror-grpc
+        run: ./mvnw ${MAVEN_CLI_OPTS} deploy -Ddocker.tag.version=master-${GITHUB_SHA} -Djib.to.tags=master-${GITHUB_SHA}
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: deploy
+      - name: Update dev tag
+        run: |-
+          sed -i "s/ref: .*/ref: ${GITHUB_SHA}/" ./common/helmrelease.yaml
+          sed -i "s/ref: .*/ref: ${GITHUB_SHA}/" ./dev/helmrelease.yaml
+          sed -i "s/tag: .*/tag: master-${GITHUB_SHA}/" ./dev/helmrelease.yaml
+        shell: bash
+      - uses: stefanzweifel/git-auto-commit-action@v4.5.1
+        with:
+          commit_message: Upgrade dev to master-${{ github.sha }}

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/controller/ConsensusControllerTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/controller/ConsensusControllerTest.java
@@ -249,13 +249,11 @@ public class ConsensusControllerTest extends GrpcIntegrationTest {
         grpcConsensusService.subscribeTopic(Mono.just(query))
                 // mapper doesn't handle null values so replace with 0's
                 .map(x -> x.hasChunkInfo() ? x.getChunkInfo().getNumber() : 0)
-                .doOnNext(x -> log.info("received {}", x))
                 .as(StepVerifier::create)
-//                .thenAwait(Duration.ofMillis(100))
+                .thenAwait(Duration.ofMillis(100))
                 .expectNext(0, 1, 2, 0, 1)
                 .then(generator::blockLast)
-//                .thenAwait(Duration.ofMillis(100))
-                .expectNext(2, 3, 0)
+                .expectNext(2, 3, 0) // incoming messages
                 .thenCancel()
                 .verify(Duration.ofMillis(800));
     }

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/controller/ConsensusControllerTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/controller/ConsensusControllerTest.java
@@ -252,8 +252,10 @@ public class ConsensusControllerTest extends GrpcIntegrationTest {
                 .doOnNext(x -> log.info("received {}", x))
                 .as(StepVerifier::create)
                 .thenAwait(Duration.ofMillis(100))
+                .expectNext(0, 1, 2, 0, 1)
                 .then(generator::blockLast)
-                .expectNext(0, 1, 2, 0, 1, 2, 3, 0)
+                .thenAwait(Duration.ofMillis(100))
+                .expectNext(2, 3, 0)
                 .thenCancel()
                 .verify(Duration.ofMillis(500));
     }

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/controller/ConsensusControllerTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/controller/ConsensusControllerTest.java
@@ -251,13 +251,13 @@ public class ConsensusControllerTest extends GrpcIntegrationTest {
                 .map(x -> x.hasChunkInfo() ? x.getChunkInfo().getNumber() : 0)
                 .doOnNext(x -> log.info("received {}", x))
                 .as(StepVerifier::create)
-                .thenAwait(Duration.ofMillis(100))
+//                .thenAwait(Duration.ofMillis(100))
                 .expectNext(0, 1, 2, 0, 1)
                 .then(generator::blockLast)
-                .thenAwait(Duration.ofMillis(100))
+//                .thenAwait(Duration.ofMillis(100))
                 .expectNext(2, 3, 0)
                 .thenCancel()
-                .verify(Duration.ofMillis(500));
+                .verify(Duration.ofMillis(800));
     }
 
     void assertException(Throwable t, Status.Code status, String message) {

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/controller/ConsensusControllerTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/controller/ConsensusControllerTest.java
@@ -28,6 +28,7 @@ import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Resource;
 import lombok.extern.log4j.Log4j2;
 import net.devh.boot.grpc.client.inject.GrpcClient;
@@ -220,38 +221,44 @@ public class ConsensusControllerTest extends GrpcIntegrationTest {
     @Test
     void fragmentedMessagesGroupAcrossHistoricAndIncoming() {
         Instant now = Instant.now();
-        domainBuilder.topicMessage(t -> t.sequenceNumber(1)).block();
-        domainBuilder.topicMessage(t -> t.sequenceNumber(2).chunkNum(1).chunkTotal(2)
-                .validStartTimestamp(now).payerAccountId(1L).consensusTimestamp(now.plusNanos(1))).block();
-        domainBuilder
-                .topicMessage(t -> t.sequenceNumber(3).chunkNum(2).chunkTotal(2).validStartTimestamp(now.plusNanos(1))
-                        .payerAccountId(1L).consensusTimestamp(now.plusNanos(2))).block();
-        domainBuilder.topicMessage(t -> t.sequenceNumber(4).consensusTimestamp(now.plusNanos(3))).block();
-        domainBuilder.topicMessage(t -> t.sequenceNumber(5).chunkNum(1).chunkTotal(3)
-                .validStartTimestamp(now.plusNanos(3)).payerAccountId(1L).consensusTimestamp(now.plusNanos(4))).block();
 
         // fragment message split across historic and incoming
-        Flux<TopicMessage> generator = Flux.concat(
-                domainBuilder.topicMessage(t -> t.sequenceNumber(6).chunkNum(2).chunkTotal(3)
-                        .validStartTimestamp(now.plusNanos(4)).payerAccountId(1L)
-                        .consensusTimestamp(now.plusSeconds(5))),
-                domainBuilder.topicMessage(t -> t.sequenceNumber(7).chunkNum(3).chunkTotal(3)
-                        .validStartTimestamp(now.plusNanos(5)).payerAccountId(1L)
-                        .consensusTimestamp(now.plusSeconds(6))),
-                domainBuilder.topicMessage(t -> t.sequenceNumber(8).consensusTimestamp(now.plusSeconds(7)))
-        );
+        final AtomicReference<Flux<TopicMessage>> generator = new AtomicReference<>();
 
-        ConsensusTopicQuery query = ConsensusTopicQuery.newBuilder()
-                .setConsensusStartTime(Timestamp.newBuilder().setSeconds(0).build())
-                .setTopicID(TopicID.newBuilder().setRealmNum(0).setTopicNum(0).build())
-                .build();
+        StepVerifier
+                .withVirtualTime(() -> {
+                    domainBuilder.topicMessage(t -> t.sequenceNumber(1)).block();
+                    domainBuilder.topicMessage(t -> t.sequenceNumber(2).chunkNum(1).chunkTotal(2)
+                            .validStartTimestamp(now).payerAccountId(1L).consensusTimestamp(now.plusNanos(1))).block();
+                    domainBuilder
+                            .topicMessage(t -> t.sequenceNumber(3).chunkNum(2).chunkTotal(2).validStartTimestamp(now.plusNanos(1))
+                                    .payerAccountId(1L).consensusTimestamp(now.plusNanos(2))).block();
+                    domainBuilder.topicMessage(t -> t.sequenceNumber(4).consensusTimestamp(now.plusNanos(3))).block();
+                    domainBuilder.topicMessage(t -> t.sequenceNumber(5).chunkNum(1).chunkTotal(3)
+                            .validStartTimestamp(now.plusNanos(3)).payerAccountId(1L).consensusTimestamp(now.plusNanos(4))).block();
 
-        grpcConsensusService.subscribeTopic(Mono.just(query))
-                // mapper doesn't handle null values so replace with 0's
-                .map(x -> x.hasChunkInfo() ? x.getChunkInfo().getNumber() : 0)
-                .as(StepVerifier::create)
+                    generator.set(Flux.concat(
+                            domainBuilder.topicMessage(t -> t.sequenceNumber(6).chunkNum(2).chunkTotal(3)
+                                    .validStartTimestamp(now.plusNanos(4)).payerAccountId(1L)
+                                    .consensusTimestamp(now.plusSeconds(5))),
+                            domainBuilder.topicMessage(t -> t.sequenceNumber(7).chunkNum(3).chunkTotal(3)
+                                    .validStartTimestamp(now.plusNanos(5)).payerAccountId(1L)
+                                    .consensusTimestamp(now.plusSeconds(6))),
+                            domainBuilder.topicMessage(t -> t.sequenceNumber(8).consensusTimestamp(now.plusSeconds(7)))
+                    ));
+
+                    ConsensusTopicQuery query = ConsensusTopicQuery.newBuilder()
+                            .setConsensusStartTime(Timestamp.newBuilder().setSeconds(0).build())
+                            .setTopicID(TopicID.newBuilder().setRealmNum(0).setTopicNum(0).build())
+                            .build();
+                    return grpcConsensusService
+                            .subscribeTopic(Mono.just(query))
+                            .map(x -> x.hasChunkInfo() ? x.getChunkInfo().getNumber() : 0)
+                            .doOnNext(x -> log.info("received {}", x));
+                })
+                .expectSubscription()
                 .thenAwait(Duration.ofMillis(100))
-                .then(generator::blockLast)
+                .then(() -> generator.get().blockLast())
                 .expectNext(0, 1, 2, 0, 1, 2, 3, 0)
                 .thenCancel()
                 .verify(Duration.ofMillis(500));

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/controller/ConsensusControllerTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/controller/ConsensusControllerTest.java
@@ -33,7 +33,6 @@ import lombok.extern.log4j.Log4j2;
 import net.devh.boot.grpc.client.inject.GrpcClient;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -218,7 +217,6 @@ public class ConsensusControllerTest extends GrpcIntegrationTest {
                 .verify(Duration.ofMillis(1000));
     }
 
-    @Disabled("This test fails in GitHub Action 'Deploy Development'")
     @Test
     void fragmentedMessagesGroupAcrossHistoricAndIncoming() {
         Instant now = Instant.now();


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
-->

**Detailed description**:
Fix the test case `fragmentedMessagesGroupAcrossHistoricAndIncoming` which consistently fails in github action

**Which issue(s) this PR fixes**:
Fixes #1178 

**Special notes for your reviewer**:
Github action environment appears to be slower than local / circleci, increasing the StepVerifier verification timeout solves the problem. Also adjusted the logic so some of the messages are now retrieved from `SharedPollingTopicListener` instead of all from `PollingTopicMessageRetriever`

**Checklist**
- [ ] Documentation added
- [x] Tests updated

