### PR TITLE
Add Transaction Suppliers to generate HAPI transactions

### DIFF
--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/TransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/TransactionSupplier.java
@@ -1,0 +1,10 @@
+package com.hedera.datagenerator.sdk.supplier;
+
+import java.util.function.Supplier;
+
+import com.hedera.hashgraph.sdk.TransactionBuilder;
+import com.hedera.hashgraph.sdk.TransactionId;
+
+public interface TransactionSupplier<T extends TransactionBuilder<TransactionId, ?, T>>
+        extends Supplier<TransactionBuilder<TransactionId, ?, T>> {
+}

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/account/AccountCreateTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/account/AccountCreateTransactionSupplier.java
@@ -1,0 +1,44 @@
+package com.hedera.datagenerator.sdk.supplier.account;
+
+import java.time.Instant;
+import lombok.Builder;
+import lombok.Value;
+import lombok.extern.log4j.Log4j2;
+
+import com.hedera.datagenerator.sdk.supplier.TransactionSupplier;
+import com.hedera.hashgraph.sdk.account.AccountCreateTransaction;
+import com.hedera.hashgraph.sdk.crypto.ed25519.Ed25519PrivateKey;
+import com.hedera.hashgraph.sdk.crypto.ed25519.Ed25519PublicKey;
+
+@Builder
+@Value
+@Log4j2
+public class AccountCreateTransactionSupplier implements TransactionSupplier<AccountCreateTransaction> {
+
+    //Required
+    private final Ed25519PublicKey publicKey;
+
+    //Optional
+    @Builder.Default
+    private final long initialBalance = 10_000_000;
+    @Builder.Default
+    private final long maxTransactionFee = 1_000_000_000;
+
+    @Override
+    public AccountCreateTransaction get() {
+        return new AccountCreateTransaction()
+                .setKey(publicKey != null ? publicKey : generateKeys())
+                .setInitialBalance(initialBalance)
+                .setMaxTransactionFee(maxTransactionFee)
+                .setTransactionMemo("Supplier create account_" + Instant.now());
+    }
+
+    private Ed25519PublicKey generateKeys() {
+        Ed25519PrivateKey privateKey = Ed25519PrivateKey.generate();
+        Ed25519PublicKey publicKey = privateKey.publicKey;
+
+        log.debug("Private key = {}", privateKey);
+        log.debug("Public key = {}", publicKey);
+        return publicKey;
+    }
+}

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/account/AccountCryptoTransferTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/account/AccountCryptoTransferTransactionSupplier.java
@@ -1,0 +1,34 @@
+package com.hedera.datagenerator.sdk.supplier.account;
+
+import java.time.Instant;
+import lombok.Builder;
+import lombok.Value;
+
+import com.hedera.datagenerator.sdk.supplier.TransactionSupplier;
+import com.hedera.hashgraph.sdk.account.AccountId;
+import com.hedera.hashgraph.sdk.account.CryptoTransferTransaction;
+
+@Builder
+@Value
+public class AccountCryptoTransferTransactionSupplier implements TransactionSupplier<CryptoTransferTransaction> {
+
+    //Required
+    private final AccountId senderId;
+    private final AccountId recipientId;
+
+    //Optional
+    @Builder.Default
+    private final long amount = 1;
+    @Builder.Default
+    private final long maxTransactionFee = 1_000_000;
+
+    @Override
+    public CryptoTransferTransaction get() {
+        return new CryptoTransferTransaction()
+                .addSender(senderId, amount)
+                .addRecipient(recipientId, amount)
+                .setTransactionMemo("transfer test")
+                .setMaxTransactionFee(maxTransactionFee)
+                .setTransactionMemo("Supplier crypto transfer_" + Instant.now());
+    }
+}

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/account/AccountDeleteTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/account/AccountDeleteTransactionSupplier.java
@@ -1,0 +1,34 @@
+package com.hedera.datagenerator.sdk.supplier.account;
+
+import java.time.Instant;
+import lombok.Builder;
+import lombok.Value;
+import lombok.extern.log4j.Log4j2;
+
+import com.hedera.datagenerator.sdk.supplier.TransactionSupplier;
+import com.hedera.hashgraph.sdk.account.AccountDeleteTransaction;
+import com.hedera.hashgraph.sdk.account.AccountId;
+
+@Builder
+@Value
+@Log4j2
+public class AccountDeleteTransactionSupplier implements TransactionSupplier<AccountDeleteTransaction> {
+
+    //Required
+    private final AccountId accountId;
+
+    //Optional
+    @Builder.Default
+    private final AccountId transferAccountId = AccountId.fromString("0.0.2");
+    @Builder.Default
+    private final long maxTransactionFee = 1_000_000_000;
+
+    @Override
+    public AccountDeleteTransaction get() {
+        return new AccountDeleteTransaction()
+                .setDeleteAccountId(accountId)
+                .setTransferAccountId(transferAccountId)
+                .setMaxTransactionFee(maxTransactionFee)
+                .setTransactionMemo("Supplier delete account_" + Instant.now());
+    }
+}

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/account/AccountUpdateTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/account/AccountUpdateTransactionSupplier.java
@@ -1,0 +1,52 @@
+package com.hedera.datagenerator.sdk.supplier.account;
+
+import java.time.Duration;
+import java.time.Instant;
+import lombok.Builder;
+import lombok.Value;
+import lombok.extern.log4j.Log4j2;
+
+import com.hedera.datagenerator.sdk.supplier.TransactionSupplier;
+import com.hedera.hashgraph.sdk.account.AccountId;
+import com.hedera.hashgraph.sdk.account.AccountUpdateTransaction;
+import com.hedera.hashgraph.sdk.crypto.ed25519.Ed25519PublicKey;
+
+@Builder
+@Value
+@Log4j2
+public class AccountUpdateTransactionSupplier implements TransactionSupplier<AccountUpdateTransaction> {
+
+    //Required
+    private final AccountId accountId;
+    private final Ed25519PublicKey newPublicKey;
+
+    //Optional
+    private final Instant expirationTime;
+    private final Duration autoRenewPeriod;
+    private final AccountId proxyAccountId;
+    @Builder.Default
+    private final boolean receiverSignatureRequired = false;
+    @Builder.Default
+    private final long maxTransactionFee = 1_000_000_000;
+
+    @Override
+    public AccountUpdateTransaction get() {
+        AccountUpdateTransaction transaction = new AccountUpdateTransaction()
+                .setAccountId(accountId)
+                .setKey(newPublicKey)
+                .setReceiverSignatureRequired(receiverSignatureRequired)
+                .setMaxTransactionFee(maxTransactionFee)
+                .setTransactionMemo("Supplier update account_" + Instant.now());
+
+        if (autoRenewPeriod != null) {
+            transaction.setAutoRenewPeriod(autoRenewPeriod);
+        }
+        if (expirationTime != null) {
+            transaction.setExpirationTime(expirationTime);
+        }
+        if (proxyAccountId != null) {
+            transaction.setProxyAccountId(proxyAccountId);
+        }
+        return transaction;
+    }
+}

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/hcs/ConsensusCreateTopicTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/hcs/ConsensusCreateTopicTransactionSupplier.java
@@ -1,0 +1,47 @@
+package com.hedera.datagenerator.sdk.supplier.hcs;
+
+import java.time.Duration;
+import java.time.Instant;
+import lombok.Builder;
+import lombok.Value;
+
+import com.hedera.datagenerator.sdk.supplier.TransactionSupplier;
+import com.hedera.hashgraph.sdk.account.AccountId;
+import com.hedera.hashgraph.sdk.consensus.ConsensusTopicCreateTransaction;
+import com.hedera.hashgraph.sdk.crypto.ed25519.Ed25519PublicKey;
+
+@Builder
+@Value
+public class ConsensusCreateTopicTransactionSupplier implements TransactionSupplier<ConsensusTopicCreateTransaction> {
+
+    //Optional
+    //TODO Do we care about having this much customization?
+    private final Ed25519PublicKey adminKey;
+    private final Ed25519PublicKey submitKey;
+    private final AccountId autoRenewAccountId;
+    private final Duration autoRenewPeriod;
+
+    @Builder.Default
+    private final long maxTransactionFee = 1_000_000_000;
+
+    @Override
+    public ConsensusTopicCreateTransaction get() {
+        ConsensusTopicCreateTransaction consensusTopicCreateTransaction = new ConsensusTopicCreateTransaction()
+                .setMaxTransactionFee(maxTransactionFee)
+                .setTopicMemo("Supplier HCS Topic Create_" + Instant.now());
+
+        if (submitKey != null) {
+            consensusTopicCreateTransaction.setSubmitKey(submitKey);
+        }
+        if (adminKey != null) {
+            consensusTopicCreateTransaction.setAdminKey(adminKey);
+        }
+        if (autoRenewAccountId != null) {
+            consensusTopicCreateTransaction.setAutoRenewAccountId(autoRenewAccountId);
+        }
+        if (autoRenewPeriod != null) {
+            consensusTopicCreateTransaction.setAutoRenewPeriod(autoRenewPeriod);
+        }
+        return consensusTopicCreateTransaction;
+    }
+}

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/hcs/ConsensusDeleteTopicTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/hcs/ConsensusDeleteTopicTransactionSupplier.java
@@ -1,0 +1,29 @@
+package com.hedera.datagenerator.sdk.supplier.hcs;
+
+import java.time.Instant;
+import lombok.Builder;
+import lombok.Value;
+
+import com.hedera.datagenerator.sdk.supplier.TransactionSupplier;
+import com.hedera.hashgraph.sdk.consensus.ConsensusTopicDeleteTransaction;
+import com.hedera.hashgraph.sdk.consensus.ConsensusTopicId;
+
+@Builder
+@Value
+public class ConsensusDeleteTopicTransactionSupplier implements TransactionSupplier<ConsensusTopicDeleteTransaction> {
+
+    //Required
+    private final ConsensusTopicId topicId;
+
+    //Optional
+    @Builder.Default
+    private final long maxTransactionFee = 1_000_000_000;
+
+    @Override
+    public ConsensusTopicDeleteTransaction get() {
+        return new ConsensusTopicDeleteTransaction()
+                .setTopicId(topicId)
+                .setMaxTransactionFee(maxTransactionFee)
+                .setTransactionMemo("Supplier HCS Topic Create_" + Instant.now());
+    }
+}

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/hcs/ConsensusSubmitMessageTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/hcs/ConsensusSubmitMessageTransactionSupplier.java
@@ -1,0 +1,44 @@
+package com.hedera.datagenerator.sdk.supplier.hcs;
+
+import com.google.common.primitives.Longs;
+import java.time.Instant;
+import lombok.Builder;
+import lombok.Value;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.lang3.RandomStringUtils;
+
+import com.hedera.datagenerator.sdk.supplier.TransactionSupplier;
+import com.hedera.hashgraph.sdk.consensus.ConsensusMessageSubmitTransaction;
+import com.hedera.hashgraph.sdk.consensus.ConsensusTopicId;
+
+@Builder
+@Value
+public class ConsensusSubmitMessageTransactionSupplier implements TransactionSupplier<ConsensusMessageSubmitTransaction> {
+
+    //Required
+    private final ConsensusTopicId topicId;
+
+    //Optional
+    private final String message;
+    @Builder.Default
+    private final int messageSize = 256;
+    //TODO is it worthwhile to add Chunk data?
+    @Builder.Default
+    private final long maxTransactionFee = 1_000_000;
+
+    @Override
+    public ConsensusMessageSubmitTransaction get() {
+        return new ConsensusMessageSubmitTransaction()
+                .setTopicId(topicId)
+                .setMessage(message != null ? message : getMessage())
+                .setTransactionMemo("Supplier HCS Topic Message_" + Instant.now())
+                .setMaxTransactionFee(maxTransactionFee);
+    }
+
+    private String getMessage() {
+        byte[] timeRefBytes = Longs.toByteArray(Instant.now().toEpochMilli());
+        int additionalBytes = messageSize <= timeRefBytes.length ? 0 : messageSize - timeRefBytes.length;
+        String randomAlphanumeric = RandomStringUtils.randomAlphanumeric(additionalBytes);
+        return Base64.encodeBase64String(timeRefBytes) + randomAlphanumeric;
+    }
+}

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/hcs/ConsensusUpdateTopicTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/hcs/ConsensusUpdateTopicTransactionSupplier.java
@@ -1,0 +1,60 @@
+package com.hedera.datagenerator.sdk.supplier.hcs;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import lombok.Builder;
+import lombok.Value;
+
+import com.hedera.datagenerator.sdk.supplier.TransactionSupplier;
+import com.hedera.hashgraph.sdk.account.AccountId;
+import com.hedera.hashgraph.sdk.consensus.ConsensusTopicId;
+import com.hedera.hashgraph.sdk.consensus.ConsensusTopicUpdateTransaction;
+import com.hedera.hashgraph.sdk.crypto.ed25519.Ed25519PublicKey;
+
+@Builder
+@Value
+public class ConsensusUpdateTopicTransactionSupplier implements TransactionSupplier<ConsensusTopicUpdateTransaction> {
+
+    //Required
+    private final ConsensusTopicId topicId;
+
+    //Optional
+    private final Ed25519PublicKey adminKey;
+    private final Ed25519PublicKey submitKey;
+    private final AccountId autoRenewAccountId;
+    @Builder.Default
+    private final Duration autoRenewPeriod = Duration.ofSeconds(8000000);
+    @Builder.Default
+    private final Instant expirationTime = Instant.now().plus(120, ChronoUnit.DAYS);
+
+    @Builder.Default
+    private final long maxTransactionFee = 1_000_000_000;
+
+    @Override
+    public ConsensusTopicUpdateTransaction get() {
+        ConsensusTopicUpdateTransaction consensusTopicUpdateTransaction = new ConsensusTopicUpdateTransaction()
+                .setTopicId(topicId)
+                .setTopicMemo("Supplier HCS Topic Update_" + Instant.now())
+                .setExpirationTime(expirationTime)
+                .setAutoRenewPeriod(autoRenewPeriod)
+                .clearTopicMemo()
+                .clearAutoRenewAccountId();
+        if (submitKey != null) {
+            consensusTopicUpdateTransaction.setSubmitKey(submitKey);
+        } else {
+            consensusTopicUpdateTransaction.clearSubmitKey();
+        }
+        if (adminKey != null) {
+            consensusTopicUpdateTransaction.setAdminKey(adminKey);
+        } else {
+            consensusTopicUpdateTransaction.clearAdminKey();
+        }
+        if (autoRenewAccountId != null) {
+            consensusTopicUpdateTransaction.setAutoRenewAccountId(autoRenewAccountId);
+        } else {
+            consensusTopicUpdateTransaction.clearAutoRenewAccountId();
+        }
+        return consensusTopicUpdateTransaction;
+    }
+}


### PR DESCRIPTION
**Detailed description**:
Add TransactionSupplier classes, which allow for a centralized place to quickly generate HAPI transactions. 
**Which issue(s) this PR fixes**:
Fixes #1151 

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

