### PR TITLE
Add redis sentinel configuration for importer

### DIFF
--- a/charts/hedera-mirror-importer/templates/statefulset.yaml
+++ b/charts/hedera-mirror-importer/templates/statefulset.yaml
@@ -35,8 +35,17 @@ spec:
               value: "true"
             - name: SPRING_CONFIG_ADDITIONAL_LOCATION
               value: "file:/usr/etc/hedera-mirror-importer/"
+            {{- if not .Values.redis.sentinel.enabled }}
             - name: SPRING_REDIS_HOST
               value: {{ include "hedera-mirror-importer.redis-host" . }}
+            {{- else }}
+            - name: SPRING_REDIS_SENTINEL_MASTER
+              value: {{ .Values.redis.sentinel.masterSet }}
+            - name: SPRING_REDIS_SENTINEL_NODES
+              value: {{ print (include "hedera-mirror-importer.redis-host" .) ":" .Values.redis.sentinel.port }}
+            - name: SPRING_REDIS_SENTINEL_PASSWORD
+              value: {{ .Values.redis.sentinel.password | default .Values.global.redis.password }}
+            {{- end }}
             - name: SPRING_REDIS_PASSWORD
               value: {{ .Values.global.redis.password }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/hedera-mirror-importer/templates/statefulset.yaml
+++ b/charts/hedera-mirror-importer/templates/statefulset.yaml
@@ -35,10 +35,9 @@ spec:
               value: "true"
             - name: SPRING_CONFIG_ADDITIONAL_LOCATION
               value: "file:/usr/etc/hedera-mirror-importer/"
-            {{- if not .Values.redis.sentinel.enabled }}
             - name: SPRING_REDIS_HOST
               value: {{ include "hedera-mirror-importer.redis-host" . }}
-            {{- else }}
+            {{- if .Values.redis.sentinel.enabled }}
             - name: SPRING_REDIS_SENTINEL_MASTER
               value: {{ .Values.redis.sentinel.masterSet }}
             - name: SPRING_REDIS_SENTINEL_NODES

--- a/charts/hedera-mirror-importer/values.yaml
+++ b/charts/hedera-mirror-importer/values.yaml
@@ -86,7 +86,7 @@ readinessProbe:
 
 redis:
   sentinel:
-    enabled: false
+    enabled: true
     port: 26379
 
 replicas: 1

--- a/charts/hedera-mirror-importer/values.yaml
+++ b/charts/hedera-mirror-importer/values.yaml
@@ -84,6 +84,11 @@ readinessProbe:
   initialDelaySeconds: 60
   timeoutSeconds: 2
 
+redis:
+  sentinel:
+    enabled: false
+    port: 26379
+
 replicas: 1
 
 resources:

--- a/charts/hedera-mirror/values.yaml
+++ b/charts/hedera-mirror/values.yaml
@@ -38,7 +38,6 @@ importer:
   enabled: true
   redis:
     sentinel:
-      enabled: true
       masterSet: mirror
 
 labels: {}

--- a/charts/hedera-mirror/values.yaml
+++ b/charts/hedera-mirror/values.yaml
@@ -36,6 +36,10 @@ importer:
             password: mirror_node_pass
             username: mirror_node
   enabled: true
+  redis:
+    sentinel:
+      enabled: true
+      masterSet: mirror
 
 labels: {}
 


### PR DESCRIPTION
**Detailed description**:
Add redis sentinel configuration to importer so it can publish topic messages to the master node.

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:
By default, hedera-mirror charts configure redis chart to run in master-slave with sentinel enabled. However, hedera-mirror-importer charts configures importer to connect to the redis k8s service directly, which may route the topic messages to a read-only slave so all topic messages pubs are lost. The PR addresses the issue by configuring spring redis sentinel properties when needed. 

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

