### PR TITLE
Increase gRPC server keepalive

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -166,10 +166,11 @@ value, it is recommended to only populate overridden properties in the custom `a
 | `hedera.mirror.grpc.listener.type`                          | REDIS            | The type of listener to use for incoming messages. Accepts either NOTIFY, POLL, REDIS or SHARED_POLL |
 | `hedera.mirror.grpc.netty.executorCoreThreadCount`          | 10               | The number of core threads                                                                     |
 | `hedera.mirror.grpc.netty.executorMaxThreadCount`           | 1000             | The maximum allowed number of threads                                                          |
-| `hedera.mirror.grpc.netty.keepAliveTime`                    | 60               | The seconds limit for which threads may remain idle before being terminated                    |
+| `hedera.mirror.grpc.netty.maxConnectionIdle`                | 10m              | The max amount of time a connection can be idle before it will be gracefully terminated        |
 | `hedera.mirror.grpc.netty.maxConcurrentCallsPerConnection`  | 5                | The maximum number of concurrent calls permitted for each incoming connection                  |
-| `hedera.mirror.grpc.netty.maxInboundMessageSize`            | 6 \* 1024        | The maximum message size allowed to be received on the server                                  |
+| `hedera.mirror.grpc.netty.maxInboundMessageSize`            | 1024             | The maximum message size allowed to be received on the server                                  |
 | `hedera.mirror.grpc.netty.maxInboundMetadataSize`           | 1024             | The maximum size of metadata allowed to be received                                            |
+| `hedera.mirror.grpc.netty.threadKeepAliveTime`              | 1m               | The amount of time for which threads may remain idle before being terminated                   |
 | `hedera.mirror.grpc.port`                                   | 5600             | The GRPC API port                                                                              |
 | `hedera.mirror.grpc.retriever.enabled`                      | true             | Whether to retrieve historical massages or not                                                 |
 | `hedera.mirror.grpc.retriever.maxPageSize`                  | 1000             | The maximum number of messages the retriever can return in a single call to the database       |

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/config/GrpcConfiguration.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/config/GrpcConfiguration.java
@@ -62,7 +62,7 @@ public class GrpcConfiguration {
         Executor executor = new ThreadPoolExecutor(
                 nettyProperties.getExecutorCoreThreadCount(),
                 nettyProperties.getExecutorMaxThreadCount(),
-                nettyProperties.getThreadKeepAliveTime(),
+                nettyProperties.getThreadKeepAliveTime().toSeconds(),
                 TimeUnit.SECONDS,
                 new SynchronousQueue<>(),
                 new ThreadFactoryBuilder()
@@ -72,6 +72,7 @@ public class GrpcConfiguration {
 
         return serverBuilder -> ((NettyServerBuilder) serverBuilder)
                 .executor(executor)
+                .maxConnectionIdle(nettyProperties.getMaxConnectionIdle().toSeconds(), TimeUnit.SECONDS)
                 .maxConcurrentCallsPerConnection(nettyProperties.getMaxConcurrentCallsPerConnection())
                 .maxInboundMessageSize(nettyProperties.getMaxInboundMessageSize())
                 .maxInboundMetadataSize(nettyProperties.getMaxInboundMetadataSize());

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/config/NettyProperties.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/config/NettyProperties.java
@@ -20,22 +20,18 @@ package com.hedera.mirror.grpc.config;
  * ‍
  */
 
+import java.time.Duration;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
 import lombok.Data;
+import org.hibernate.validator.constraints.time.DurationMax;
+import org.hibernate.validator.constraints.time.DurationMin;
 import org.springframework.validation.annotation.Validated;
 
 @Data
 @Validated
 public class NettyProperties {
-    @Min(1)
-    private int maxConcurrentCallsPerConnection = 5;
-
-    @Min(8) // 6 kb
-    private int maxInboundMessageSize = 6 * 1024;
-
-    @Min(8) // 1 kb
-    private int maxInboundMetadataSize = 1024;
 
     @Min(1)
     private int executorCoreThreadCount = 10;
@@ -43,6 +39,21 @@ public class NettyProperties {
     @Max(10000)
     private int executorMaxThreadCount = 1000;
 
-    @Max(60)
-    private long threadKeepAliveTime = 60;
+    @DurationMin(minutes = 1L)
+    @NotNull
+    private Duration maxConnectionIdle = Duration.ofMinutes(10L);
+
+    @Min(1)
+    private int maxConcurrentCallsPerConnection = 5;
+
+    @Min(8) // 1 kb
+    private int maxInboundMessageSize = 1024;
+
+    @Min(8) // 1 kb
+    private int maxInboundMetadataSize = 1024;
+
+    @DurationMin(minutes = 0L)
+    @DurationMax(minutes = 5L)
+    @NotNull
+    private Duration threadKeepAliveTime = Duration.ofMinutes(1L);
 }

--- a/hedera-mirror-grpc/src/main/resources/application.yml
+++ b/hedera-mirror-grpc/src/main/resources/application.yml
@@ -10,11 +10,15 @@ hedera:
       port: 5600
 grpc:
   server:
+    enableKeepAlive: true
+    keepAliveTime: 5m
+    permitKeepAliveTime: 90s
     port: ${hedera.mirror.grpc.port}
 logging:
   level:
     root: warn
     com.hedera.mirror.grpc: info
+    # io.grpc: debug
     # org.hibernate.SQL: debug
     # org.hibernate.type.descriptor.sql.BasicBinder: trace
 management:

--- a/hedera-mirror-grpc/src/test/resources/config/application.yml
+++ b/hedera-mirror-grpc/src/test/resources/config/application.yml
@@ -5,6 +5,7 @@ grpc:
     local:
       address: in-process:local
   server:
+    enableKeepAlive: false
     inProcessName: local
 hedera:
   mirror:


### PR DESCRIPTION
**Detailed description**:
- Add a `maxConnectionIdle` property to cleanup unused resources on idle connections (idle being defined as without a RPC)
- Change `threadKeepAliveTime` to a Duration and fix its documentation
- Decrease `maxInboundMessageSize` to 1K since MAPI doesn't have large request payloads
- Set server `keepAliveTime` to 5m
- Set `permitKeepAliveTime` to 90s to limit how often clients can send pings

**Which issue(s) this PR fixes**:
Fixes #802 

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

