### PR TITLE
Ensure entities are inserted only on create

### DIFF
--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/AbstractEntityRecordItemListenerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/AbstractEntityRecordItemListenerTest.java
@@ -77,6 +77,14 @@ public class AbstractEntityRecordItemListenerTest extends IntegrationTest {
     protected static final String KEY2 = "0a3312200aa8e21064c61eab86e2a9c164565b4e7a9a4146106e0a6cd03a8c395a110e92";
     protected static final AccountID PAYER =
             AccountID.newBuilder().setShardNum(0).setRealmNum(0).setAccountNum(2002).build();
+    protected static final AccountID NODE =
+            AccountID.newBuilder().setShardNum(0).setRealmNum(0).setAccountNum(3).build();
+    protected static final AccountID TREASURY =
+            AccountID.newBuilder().setShardNum(0).setRealmNum(0).setAccountNum(98).build();
+    protected static final AccountID PROXY =
+            AccountID.newBuilder().setShardNum(0).setRealmNum(0).setAccountNum(1003).build();
+    protected static final AccountID PROXY_UPDATE =
+            AccountID.newBuilder().setShardNum(0).setRealmNum(0).setAccountNum(3000).build();
     static final String TRANSACTION_MEMO = "transaction memo";
 
     @Resource
@@ -267,7 +275,7 @@ public class AbstractEntityRecordItemListenerTest extends IntegrationTest {
         recordBuilder.getReceiptBuilder().setStatusValue(status);
 
         // Give from payer to treasury and node
-        long[] transferAccounts = {PAYER.getAccountNum(), 98, 3};
+        long[] transferAccounts = {PAYER.getAccountNum(), TREASURY.getAccountNum(), NODE.getAccountNum()};
         long[] transferAmounts = {-2000, 1000, 1000};
         TransferList.Builder transferList = recordBuilder.getTransferListBuilder();
         for (int i = 0; i < transferAccounts.length; i++) {
@@ -349,6 +357,19 @@ public class AbstractEntityRecordItemListenerTest extends IntegrationTest {
         if (entityId != null) {
             assertThat(transaction)
                     .returns(entityId, t -> t.getEntityId().getId());
+        }
+    }
+
+    protected void assertEntities(EntityId... entityIds) {
+        if (entityIds == null) {
+            return;
+        }
+
+        assertEquals(entityIds.length, entityRepository.count());
+
+        // verify entities
+        for (EntityId entityId : entityIds) {
+            assertThat(entityRepository.findById(entityId.getId())).isPresent();
         }
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerContractTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerContractTest.java
@@ -20,10 +20,10 @@ package com.hedera.mirror.importer.parser.record.entity;
  * ‍
  */
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.google.protobuf.ByteString;
-import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ContractCallTransactionBody;
 import com.hederahashgraph.api.proto.java.ContractCreateTransactionBody;
 import com.hederahashgraph.api.proto.java.ContractDeleteTransactionBody;
@@ -36,7 +36,6 @@ import com.hederahashgraph.api.proto.java.FileID;
 import com.hederahashgraph.api.proto.java.RealmID;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.ShardID;
-import com.hederahashgraph.api.proto.java.SignedTransaction;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.Transaction;
 import com.hederahashgraph.api.proto.java.TransactionBody;
@@ -47,14 +46,15 @@ import org.junit.jupiter.api.Test;
 
 import com.hedera.mirror.importer.domain.ContractResult;
 import com.hedera.mirror.importer.domain.Entities;
+import com.hedera.mirror.importer.domain.EntityId;
 import com.hedera.mirror.importer.parser.domain.RecordItem;
 import com.hedera.mirror.importer.util.Utility;
 
 public class EntityRecordItemListenerContractTest extends AbstractEntityRecordItemListenerTest {
 
-    private static final ContractID contractId =
+    private static final ContractID CONTRACT_ID =
             ContractID.newBuilder().setShardNum(0).setRealmNum(0).setContractNum(1001).build();
-    private static final FileID fileId = FileID.newBuilder().setShardNum(0).setRealmNum(0).setFileNum(1002).build();
+    private static final FileID FILE_ID = FileID.newBuilder().setShardNum(0).setRealmNum(0).setFileNum(1002).build();
 
     @BeforeEach
     void before() throws Exception {
@@ -75,7 +75,8 @@ public class EntityRecordItemListenerContractTest extends AbstractEntityRecordIt
 
         assertAll(
                 () -> assertEquals(1, transactionRepository.count())
-                , () -> assertEquals(5, entityRepository.count())
+                , () -> assertEntities(EntityId.of(CONTRACT_ID), EntityId.of(PROXY), EntityId.of(PAYER), EntityId
+                        .of(NODE), EntityId.of(TREASURY))
                 , () -> assertEquals(1, contractResultRepository.count())
                 , () -> assertEquals(3, cryptoTransferRepository.count())
                 , () -> assertEquals(0, liveHashRepository.count())
@@ -100,7 +101,7 @@ public class EntityRecordItemListenerContractTest extends AbstractEntityRecordIt
 
         assertAll(
                 () -> assertEquals(1, transactionRepository.count()),
-                () -> assertEquals(3, entityRepository.count()),
+                () -> assertEntities(EntityId.of(PAYER), EntityId.of(NODE), EntityId.of(TREASURY)),
                 () -> assertEquals(1, contractResultRepository.count()),
                 () -> assertEquals(3, cryptoTransferRepository.count()),
                 () -> assertEquals(0, liveHashRepository.count()),
@@ -126,7 +127,7 @@ public class EntityRecordItemListenerContractTest extends AbstractEntityRecordIt
 
         assertAll(
                 () -> assertEquals(1, transactionRepository.count()),
-                () -> assertEquals(3, entityRepository.count()),
+                () -> assertEntities(EntityId.of(PAYER), EntityId.of(NODE), EntityId.of(TREASURY)),
                 () -> assertEquals(0, contractResultRepository.count()),
                 () -> assertEquals(3, cryptoTransferRepository.count()),
                 () -> assertEquals(0, liveHashRepository.count()),
@@ -148,7 +149,8 @@ public class EntityRecordItemListenerContractTest extends AbstractEntityRecordIt
 
         assertAll(
                 () -> assertEquals(1, transactionRepository.count())
-                , () -> assertEquals(5, entityRepository.count())
+                , () -> assertEntities(EntityId.of(CONTRACT_ID), EntityId.of(PROXY), EntityId.of(PAYER), EntityId
+                        .of(NODE), EntityId.of(TREASURY))
                 , () -> assertEquals(0, contractResultRepository.count())
                 , () -> assertEquals(3, cryptoTransferRepository.count())
                 , () -> assertEquals(0, liveHashRepository.count())
@@ -178,7 +180,8 @@ public class EntityRecordItemListenerContractTest extends AbstractEntityRecordIt
 
         assertAll(
                 () -> assertEquals(2, transactionRepository.count())
-                , () -> assertEquals(6, entityRepository.count())
+                , () -> assertEntities(EntityId.of(CONTRACT_ID), EntityId.of(PROXY), EntityId.of(PAYER), EntityId
+                        .of(NODE), EntityId.of(TREASURY), EntityId.of(PROXY_UPDATE))
                 , () -> assertEquals(1, contractResultRepository.count())
                 , () -> assertEquals(6, cryptoTransferRepository.count())
                 , () -> assertEquals(0, liveHashRepository.count())
@@ -199,7 +202,8 @@ public class EntityRecordItemListenerContractTest extends AbstractEntityRecordIt
 
         assertAll(
                 () -> assertEquals(1, transactionRepository.count())
-                , () -> assertEquals(5, entityRepository.count())
+                , () -> assertEntities(EntityId.of(CONTRACT_ID), EntityId.of(PROXY_UPDATE), EntityId.of(PAYER), EntityId
+                        .of(NODE), EntityId.of(TREASURY))
                 , () -> assertEquals(0, contractResultRepository.count())
                 , () -> assertEquals(3, cryptoTransferRepository.count())
                 , () -> assertEquals(0, liveHashRepository.count())
@@ -233,7 +237,8 @@ public class EntityRecordItemListenerContractTest extends AbstractEntityRecordIt
 
         assertAll(
                 () -> assertEquals(2, transactionRepository.count())
-                , () -> assertEquals(5, entityRepository.count())
+                , () -> assertEntities(EntityId.of(CONTRACT_ID), EntityId.of(PROXY), EntityId.of(PAYER), EntityId
+                        .of(NODE), EntityId.of(TREASURY))
                 , () -> assertEquals(1, contractResultRepository.count())
                 , () -> assertEquals(6, cryptoTransferRepository.count())
                 , () -> assertEquals(0, liveHashRepository.count())
@@ -270,7 +275,8 @@ public class EntityRecordItemListenerContractTest extends AbstractEntityRecordIt
 
         assertAll(
                 () -> assertEquals(2, transactionRepository.count())
-                , () -> assertEquals(5, entityRepository.count())
+                , () -> assertEntities(EntityId.of(CONTRACT_ID), EntityId.of(PROXY), EntityId.of(PAYER), EntityId
+                        .of(NODE), EntityId.of(TREASURY))
                 , () -> assertEquals(1, contractResultRepository.count())
                 , () -> assertEquals(6, cryptoTransferRepository.count())
                 , () -> assertEquals(0, liveHashRepository.count())
@@ -296,7 +302,8 @@ public class EntityRecordItemListenerContractTest extends AbstractEntityRecordIt
 
         assertAll(
                 () -> assertEquals(1, transactionRepository.count())
-                , () -> assertEquals(4, entityRepository.count())
+                , () -> assertEntities(EntityId.of(CONTRACT_ID), EntityId.of(PAYER), EntityId
+                        .of(NODE), EntityId.of(TREASURY))
                 , () -> assertEquals(0, contractResultRepository.count())
                 , () -> assertEquals(3, cryptoTransferRepository.count())
                 , () -> assertEquals(0, liveHashRepository.count())
@@ -317,13 +324,13 @@ public class EntityRecordItemListenerContractTest extends AbstractEntityRecordIt
 
         assertAll(
                 () -> assertEquals(1, transactionRepository.count())
-                , () -> assertEquals(4, entityRepository.count())
+                , () -> assertEntities(EntityId.of(PAYER), EntityId.of(NODE), EntityId.of(TREASURY))
                 , () -> assertEquals(0, contractResultRepository.count())
                 , () -> assertEquals(3, cryptoTransferRepository.count())
                 , () -> assertEquals(0, liveHashRepository.count())
                 , () -> assertEquals(0, fileDataRepository.count())
-                , () -> assertContractTransaction(transactionBody, record, false)
-                , () -> assertContractEntityHasNullFields(record.getConsensusTimestamp())
+                , () -> assertTransactionAndRecord(transactionBody, record)
+                , () -> assertThat(transactionBody.getContractDeleteInstance().getContractID()).isNotNull()
         );
     }
 
@@ -346,7 +353,8 @@ public class EntityRecordItemListenerContractTest extends AbstractEntityRecordIt
 
         assertAll(
                 () -> assertEquals(2, transactionRepository.count())
-                , () -> assertEquals(5, entityRepository.count())
+                , () -> assertEntities(EntityId.of(CONTRACT_ID), EntityId.of(PAYER), EntityId
+                        .of(NODE), EntityId.of(TREASURY), EntityId.of(PROXY))
                 , () -> assertEquals(2, contractResultRepository.count())
                 , () -> assertEquals(6, cryptoTransferRepository.count())
                 , () -> assertEquals(0, liveHashRepository.count())
@@ -367,7 +375,8 @@ public class EntityRecordItemListenerContractTest extends AbstractEntityRecordIt
 
         assertAll(
                 () -> assertEquals(1, transactionRepository.count())
-                , () -> assertEquals(4, entityRepository.count())
+                , () -> assertEntities(EntityId.of(CONTRACT_ID), EntityId.of(PAYER), EntityId
+                        .of(NODE), EntityId.of(TREASURY))
                 , () -> assertEquals(1, contractResultRepository.count())
                 , () -> assertEquals(3, cryptoTransferRepository.count())
                 , () -> assertEquals(0, liveHashRepository.count())
@@ -387,12 +396,12 @@ public class EntityRecordItemListenerContractTest extends AbstractEntityRecordIt
 
         assertAll(
                 () -> assertEquals(1, transactionRepository.count()),
-                () -> assertEquals(4, entityRepository.count()),
+                () -> assertEntities(EntityId.of(PAYER), EntityId.of(NODE), EntityId.of(TREASURY)),
                 () -> assertEquals(1, contractResultRepository.count()),
                 () -> assertEquals(3, cryptoTransferRepository.count()),
                 () -> assertEquals(0, liveHashRepository.count()),
                 () -> assertEquals(0, fileDataRepository.count()),
-                () -> assertContractTransaction(transactionBody, record, false)
+                () -> assertFailedContractCallTransaction(transactionBody, record)
         );
     }
 
@@ -407,12 +416,12 @@ public class EntityRecordItemListenerContractTest extends AbstractEntityRecordIt
 
         assertAll(
                 () -> assertEquals(1, transactionRepository.count()),
-                () -> assertEquals(4, entityRepository.count()),
+                () -> assertEntities(EntityId.of(PAYER), EntityId.of(NODE), EntityId.of(TREASURY)),
                 () -> assertEquals(0, contractResultRepository.count()),
                 () -> assertEquals(3, cryptoTransferRepository.count()),
                 () -> assertEquals(0, liveHashRepository.count()),
                 () -> assertEquals(0, fileDataRepository.count()),
-                () -> assertContractTransaction(transactionBody, record, false)
+                () -> assertFailedContractCallTransaction(transactionBody, record)
         );
     }
 
@@ -427,7 +436,8 @@ public class EntityRecordItemListenerContractTest extends AbstractEntityRecordIt
 
         assertAll(
                 () -> assertEquals(1, transactionRepository.count())
-                , () -> assertEquals(4, entityRepository.count())
+                , () -> assertEntities(EntityId.of(CONTRACT_ID), EntityId.of(PAYER), EntityId
+                        .of(NODE), EntityId.of(TREASURY))
                 , () -> assertEquals(0, contractResultRepository.count())
                 , () -> assertEquals(3, cryptoTransferRepository.count())
                 , () -> assertEquals(0, liveHashRepository.count())
@@ -449,7 +459,7 @@ public class EntityRecordItemListenerContractTest extends AbstractEntityRecordIt
 
         assertAll(
                 () -> assertEquals(1, transactionRepository.count()),
-                () -> assertEquals(3, entityRepository.count()), // payer, node, treasury
+                () -> assertEntities(EntityId.of(PAYER), EntityId.of(NODE), EntityId.of(TREASURY)),
                 () -> assertEquals(1, contractResultRepository.count()),
                 () -> assertEquals(3, cryptoTransferRepository.count()),
                 () -> assertEquals(0, liveHashRepository.count()),
@@ -474,6 +484,15 @@ public class EntityRecordItemListenerContractTest extends AbstractEntityRecordIt
                 () -> assertNull(dbTransaction.getEntityId()),
                 () -> assertEquals(transactionBody.getContractCreateInstance().getInitialBalance(),
                         dbTransaction.getInitialBalance()));
+    }
+
+    private void assertFailedContractCallTransaction(TransactionBody transactionBody, TransactionRecord record) {
+        var dbTransaction = getDbTransaction(record.getConsensusTimestamp());
+        assertAll(
+                () -> assertTransactionAndRecord(transactionBody, record),
+                () -> assertThat(dbTransaction.getEntityId()).isNotNull(),
+                () -> assertEquals(EntityId.of(transactionBody.getContractCall().getContractID()),
+                        dbTransaction.getEntityId()));
     }
 
     private void assertContractEntity(ContractCreateTransactionBody expected, Timestamp consensusTimestamp) {
@@ -536,7 +555,7 @@ public class EntityRecordItemListenerContractTest extends AbstractEntityRecordIt
 
     private TransactionRecord createOrUpdateRecord(TransactionBody transactionBody, ResponseCodeEnum status) {
         return buildTransactionRecord(recordBuilder -> {
-            recordBuilder.getReceiptBuilder().setContractID(contractId);
+            recordBuilder.getReceiptBuilder().setContractID(CONTRACT_ID);
             buildContractFunctionResult(recordBuilder.getContractCreateResultBuilder());
         }, transactionBody, status.getNumber());
     }
@@ -547,7 +566,7 @@ public class EntityRecordItemListenerContractTest extends AbstractEntityRecordIt
 
     private TransactionRecord callRecord(TransactionBody transactionBody, ResponseCodeEnum status) {
         return buildTransactionRecord(recordBuilder -> {
-            recordBuilder.getReceiptBuilder().setContractID(contractId);
+            recordBuilder.getReceiptBuilder().setContractID(CONTRACT_ID);
             buildContractFunctionResult(recordBuilder.getContractCallResultBuilder());
         }, transactionBody, status.getNumber());
     }
@@ -555,7 +574,7 @@ public class EntityRecordItemListenerContractTest extends AbstractEntityRecordIt
     private void buildContractFunctionResult(ContractFunctionResult.Builder builder) {
         builder.setBloom(ByteString.copyFromUtf8("bloom"));
         builder.setContractCallResult(ByteString.copyFromUtf8("call result"));
-        builder.setContractID(contractId);
+        builder.setContractID(CONTRACT_ID);
         builder.setErrorMessage("call error message");
         builder.setGasUsed(30);
         builder.addLogInfo(ContractLoginfo.newBuilder().addTopic(ByteString.copyFromUtf8("Topic")).build());
@@ -567,13 +586,12 @@ public class EntityRecordItemListenerContractTest extends AbstractEntityRecordIt
             contractCreate.setAdminKey(keyFromString(KEY));
             contractCreate.setAutoRenewPeriod(Duration.newBuilder().setSeconds(100).build());
             contractCreate.setConstructorParameters(ByteString.copyFromUtf8("Constructor Parameters"));
-            contractCreate.setFileID(fileId);
+            contractCreate.setFileID(FILE_ID);
             contractCreate.setGas(10000L);
             contractCreate.setInitialBalance(20000L);
             contractCreate.setMemo("Contract Memo");
             contractCreate.setNewRealmAdminKey(keyFromString(KEY2));
-            contractCreate.setProxyAccountID(
-                    AccountID.newBuilder().setShardNum(0).setRealmNum(0).setAccountNum(1003).build());
+            contractCreate.setProxyAccountID(PROXY);
             contractCreate.setRealmID(RealmID.newBuilder().setShardNum(0).setRealmNum(0).build());
             contractCreate.setShardID(ShardID.newBuilder().setShardNum(0));
         });
@@ -584,24 +602,23 @@ public class EntityRecordItemListenerContractTest extends AbstractEntityRecordIt
             ContractUpdateTransactionBody.Builder contractUpdate = builder.getContractUpdateInstanceBuilder();
             contractUpdate.setAdminKey(keyFromString(KEY));
             contractUpdate.setAutoRenewPeriod(Duration.newBuilder().setSeconds(400).build());
-            contractUpdate.setContractID(contractId);
+            contractUpdate.setContractID(CONTRACT_ID);
             contractUpdate.setExpirationTime(Timestamp.newBuilder().setSeconds(8000).setNanos(10).build());
             contractUpdate.setFileID(FileID.newBuilder().setShardNum(0).setRealmNum(0).setFileNum(2000).build());
             contractUpdate.setMemo("contract update memo");
-            contractUpdate.setProxyAccountID(
-                    AccountID.newBuilder().setShardNum(0).setRealmNum(0).setAccountNum(3000).build());
+            contractUpdate.setProxyAccountID(PROXY_UPDATE);
         });
     }
 
     private Transaction contractDeleteTransaction() {
         return buildTransaction(builder -> {
             ContractDeleteTransactionBody.Builder contractDelete = builder.getContractDeleteInstanceBuilder();
-            contractDelete.setContractID(contractId);
+            contractDelete.setContractID(CONTRACT_ID);
         });
     }
 
     private Transaction contractCallTransaction() {
-        return contractCallTransaction(contractId);
+        return contractCallTransaction(CONTRACT_ID);
     }
 
     private Transaction contractCallTransaction(ContractID contractId) {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerCryptoTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerCryptoTest.java
@@ -52,6 +52,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 import com.hedera.mirror.importer.domain.CryptoTransfer;
 import com.hedera.mirror.importer.domain.Entities;
 import com.hedera.mirror.importer.domain.EntityId;
+import com.hedera.mirror.importer.domain.EntityTypeEnum;
 import com.hedera.mirror.importer.domain.LiveHash;
 import com.hedera.mirror.importer.parser.domain.RecordItem;
 import com.hedera.mirror.importer.util.Utility;
@@ -82,7 +83,8 @@ public class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItem
 
         assertAll(
                 () -> assertEquals(1, transactionRepository.count())
-                , () -> assertEquals(5, entityRepository.count()) // accounts: node, treasury, payer, new crypto, proxy
+                , () -> assertEntities(EntityId.of(accountId), EntityId.of(PROXY), EntityId.of(PAYER), EntityId
+                        .of(NODE), EntityId.of(TREASURY))
                 , () -> assertEquals(5, cryptoTransferRepository.count())
                 , () -> assertEquals(0, contractResultRepository.count())
                 , () -> assertEquals(0, liveHashRepository.count())
@@ -107,7 +109,8 @@ public class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItem
 
         assertAll(
                 () -> assertEquals(1, transactionRepository.count()),
-                () -> assertEquals(5, entityRepository.count()),
+                () -> assertEntities(EntityId.of(accountId), EntityId.of(PROXY), EntityId.of(PAYER), EntityId
+                        .of(NODE), EntityId.of(TREASURY)),
                 () -> assertEquals(5, cryptoTransferRepository.count()),
                 () -> assertEquals(0, contractResultRepository.count()),
                 () -> assertEquals(0, liveHashRepository.count()),
@@ -136,7 +139,7 @@ public class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItem
 
         assertAll(
                 () -> assertEquals(1, transactionRepository.count())
-                , () -> assertEquals(3, entityRepository.count())
+                , () -> assertEntities(EntityId.of(PAYER), EntityId.of(NODE), EntityId.of(TREASURY))
                 , () -> assertEquals(3, cryptoTransferRepository.count())
                 , () -> assertEquals(0, contractResultRepository.count())
                 , () -> assertEquals(0, liveHashRepository.count())
@@ -168,7 +171,8 @@ public class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItem
 
         assertAll(
                 () -> assertEquals(1, transactionRepository.count())
-                , () -> assertEquals(5, entityRepository.count())
+                , () -> assertEntities(EntityId.of(accountId), EntityId.of(PROXY), EntityId.of(PAYER), EntityId
+                        .of(NODE), EntityId.of(TREASURY))
                 , () -> assertEquals(5, cryptoTransferRepository.count())
                 , () -> assertEquals(0, contractResultRepository.count())
                 , () -> assertEquals(0, liveHashRepository.count())
@@ -196,7 +200,8 @@ public class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItem
 
         assertAll(
                 () -> assertEquals(2, transactionRepository.count())
-                , () -> assertEquals(5, entityRepository.count())
+                , () -> assertEntities(EntityId.of(accountId), EntityId.of(PROXY), EntityId.of(PAYER), EntityId
+                        .of(NODE), EntityId.of(TREASURY))
                 , () -> assertEquals(10, cryptoTransferRepository.count())
                 , () -> assertEquals(0, contractResultRepository.count())
                 , () -> assertEquals(0, liveHashRepository.count())
@@ -223,7 +228,8 @@ public class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItem
 
         assertAll(
                 () -> assertEquals(2, transactionRepository.count())
-                , () -> assertEquals(6, entityRepository.count())
+                , () -> assertEntities(EntityId.of(accountId), EntityId.of(PROXY), EntityId.of(PAYER), EntityId
+                        .of(NODE), EntityId.of(TREASURY), EntityId.of(PROXY_UPDATE))
                 , () -> assertEquals(8, cryptoTransferRepository.count())
                 , () -> assertEquals(0, contractResultRepository.count())
                 , () -> assertEquals(0, liveHashRepository.count())
@@ -334,7 +340,8 @@ public class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItem
 
         assertAll(
                 () -> assertEquals(2, transactionRepository.count())
-                , () -> assertEquals(5, entityRepository.count())
+                , () -> assertEntities(EntityId.of(accountId), EntityId.of(PROXY), EntityId.of(PAYER), EntityId
+                        .of(NODE), EntityId.of(TREASURY))
                 , () -> assertEquals(8, cryptoTransferRepository.count()) // 3 + 3 fee transfers + 2 for initial balance
                 , () -> assertEquals(0, contractResultRepository.count())
                 , () -> assertEquals(0, liveHashRepository.count())
@@ -364,7 +371,8 @@ public class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItem
 
         assertAll(
                 () -> assertEquals(2, transactionRepository.count())
-                , () -> assertEquals(5, entityRepository.count())
+                , () -> assertEntities(EntityId.of(accountId), EntityId.of(PROXY), EntityId.of(PAYER), EntityId
+                        .of(NODE), EntityId.of(TREASURY))
                 , () -> assertEquals(8, cryptoTransferRepository.count()) // 3 + 3 fee transfers + 2 for initial balance
                 , () -> assertEquals(0, contractResultRepository.count())
                 , () -> assertEquals(0, liveHashRepository.count())
@@ -397,7 +405,8 @@ public class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItem
 
         assertAll(
                 () -> assertEquals(2, transactionRepository.count())
-                , () -> assertEquals(5, entityRepository.count())
+                , () -> assertEntities(EntityId.of(accountId), EntityId.of(PROXY), EntityId.of(PAYER), EntityId
+                        .of(NODE), EntityId.of(TREASURY))
                 , () -> assertEquals(8, cryptoTransferRepository.count()) // 3 + 3 fee transfers + 2 for initial balance
                 , () -> assertEquals(0, contractResultRepository.count())
                 , () -> assertEquals(0, liveHashRepository.count())
@@ -430,7 +439,8 @@ public class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItem
 
         assertAll(
                 () -> assertEquals(2, transactionRepository.count())
-                , () -> assertEquals(5, entityRepository.count())
+                , () -> assertEntities(EntityId.of(accountId), EntityId.of(PROXY), EntityId.of(PAYER), EntityId
+                        .of(NODE), EntityId.of(TREASURY))
                 , () -> assertEquals(8, cryptoTransferRepository.count()) // 3 + 3 fee transfers + 2 for initial balance
                 , () -> assertEquals(0, contractResultRepository.count())
                 , () -> assertEquals(1, liveHashRepository.count())
@@ -462,7 +472,8 @@ public class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItem
 
         assertAll(
                 () -> assertEquals(2, transactionRepository.count())
-                , () -> assertEquals(5, entityRepository.count())
+                , () -> assertEntities(EntityId.of(accountId), EntityId.of(PROXY), EntityId.of(PAYER), EntityId
+                        .of(NODE), EntityId.of(TREASURY))
                 , () -> assertEquals(8, cryptoTransferRepository.count()) // 3 + 3 fee transfers + 2 for initial balance
                 , () -> assertEquals(0, contractResultRepository.count())
                 , () -> assertEquals(0, liveHashRepository.count())
@@ -494,7 +505,8 @@ public class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItem
 
         assertAll(
                 () -> assertEquals(3, transactionRepository.count())
-                , () -> assertEquals(5, entityRepository.count())
+                , () -> assertEntities(EntityId.of(accountId), EntityId.of(PROXY), EntityId.of(PAYER), EntityId
+                        .of(NODE), EntityId.of(TREASURY))
                 , () -> assertEquals(11, cryptoTransferRepository.count())
                 , () -> assertEquals(0, contractResultRepository.count())
                 , () -> assertEquals(1, liveHashRepository.count())
@@ -519,7 +531,11 @@ public class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItem
 
         assertAll(
                 () -> assertEquals(1, transactionRepository.count())
-                , () -> assertEquals(5, entityRepository.count())
+                , () -> assertEntities(EntityId
+                        .of(String.format("0.0.%d", additionalTransfers[0]), EntityTypeEnum.ACCOUNT), EntityId
+                        .of(String.format("0.0.%d", additionalTransfers[1]), EntityTypeEnum.ACCOUNT), EntityId
+                        .of(PAYER), EntityId
+                        .of(NODE), EntityId.of(TREASURY))
                 , () -> assertEquals(5, cryptoTransferRepository.count())
                 , () -> assertEquals(0, contractResultRepository.count())
                 , () -> assertEquals(0, liveHashRepository.count())
@@ -540,6 +556,7 @@ public class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItem
 
         assertAll(
                 () -> assertEquals(1, transactionRepository.count()),
+                () -> assertEntities(EntityId.of(PAYER), EntityId.of(NODE)),
                 () -> assertEquals(2, entityRepository.count()),
                 () -> assertEquals(0, cryptoTransferRepository.count()),
                 () -> assertEquals(0, contractResultRepository.count()),
@@ -561,7 +578,7 @@ public class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItem
 
         assertAll(
                 () -> assertEquals(1, transactionRepository.count()),
-                () -> assertEquals(3, entityRepository.count(), "Payer, node and treasury"),
+                () -> assertEntities(EntityId.of(PAYER), EntityId.of(NODE), EntityId.of(TREASURY)),
                 () -> assertEquals(3, cryptoTransferRepository.count(), "Node and network fee"),
                 () -> assertEquals(0, nonFeeTransferRepository.count()),
                 () -> assertEquals(0, contractResultRepository.count()),
@@ -635,7 +652,7 @@ public class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItem
                 .setKey(keyFromString("0a2212200aa8e21064c61eab86e2a9c164565b4e7a9a4146106e0a6cd03a8c395a110e92"))
                 .setNewRealmAdminKey(keyFromString(
                         "0a3312200aa8e21064c61eab86e2a9c164565b4e7a9a4146106e0a6cd03a8c395a110e92"))
-                .setProxyAccountID(AccountID.newBuilder().setShardNum(1).setRealmNum(2).setAccountNum(3))
+                .setProxyAccountID(PROXY)
                 .setRealmID(RealmID.newBuilder().setShardNum(0).setRealmNum(0).build())
                 .setShardID(ShardID.newBuilder().setShardNum(0))
                 .setReceiveRecordThreshold(2000L)
@@ -649,7 +666,7 @@ public class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItem
                 .setInitialBalance(INITIAL_BALANCE)
                 .setKey(keyFromString(KEY))
                 .setNewRealmAdminKey(keyFromString(KEY2))
-                .setProxyAccountID(AccountID.newBuilder().setShardNum(1).setRealmNum(2).setAccountNum(3))
+                .setProxyAccountID(PROXY)
                 .setRealmID(RealmID.newBuilder().setShardNum(0).setRealmNum(0).build())
                 .setShardID(ShardID.newBuilder().setShardNum(0))
                 .setReceiveRecordThreshold(2000L)
@@ -663,7 +680,7 @@ public class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItem
                 .setAutoRenewPeriod(Duration.newBuilder().setSeconds(5001L))
                 .setExpirationTime(Utility.instantToTimestamp(Instant.now()))
                 .setKey(keyFromString(KEY))
-                .setProxyAccountID(AccountID.newBuilder().setShardNum(5).setRealmNum(6).setAccountNum(8))
+                .setProxyAccountID(PROXY_UPDATE)
                 .setReceiveRecordThreshold(5001L)
                 .setReceiverSigRequired(false)
                 .setSendRecordThreshold(6001L));


### PR DESCRIPTION
**Detailed description**:
Currently mirror node will create entities that don't exist even on failed transactions.
We should create entities only on the 5 create transactions and accounts in the record transfer list

- Add `createsEntity()` to transactionHandler interface
- Update crypto account.contract.file/topic/file create handlers to returns true with `createsEntity()`
- Update `EntityRecordItemListener` to create entities only when `transactionHandler.createsEntity()` is true
- Rearrange `EntityRecordItemListener.onItem()` inner calls to be easier to fall and move calls that should be only done on success into if successful statement 

**Which issue(s) this PR fixes**:
Partially addresses #1201

**Special notes for your reviewer**:
This prevents further issues but lacks migration logic, which will be added in a future PR.

**Checklist**
- [ ] Documentation added
- [x] Tests updated

