### PR TITLE
Fix address book update always updating 102 file

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/addressbook/AddressBookServiceImpl.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/addressbook/AddressBookServiceImpl.java
@@ -91,7 +91,7 @@ public class AddressBookServiceImpl implements AddressBookService {
      * @return returns AddressBook containing network node details
      */
     @Override
-    @Cacheable(key = "#root.target.ADDRESS_BOOK_102_ENTITY_ID.getId()")
+    @Cacheable
     public AddressBook getCurrent() {
         Instant now = Instant.now();
         long consensusTimestamp = Utility.convertToNanosMax(now.getEpochSecond(), now.getNano());

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/util/Utility.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/util/Utility.java
@@ -80,7 +80,7 @@ public class Utility {
             return null;
         }
 
-        try (DataInputStream dis = new DataInputStream(new FileInputStream(file))) {
+        try (DataInputStream dis = new DataInputStream(new BufferedInputStream(new FileInputStream(file)))) {
             byte[] fileHash = new byte[48];
 
             while (dis.available() != 0) {

--- a/hedera-mirror-importer/src/main/resources/db/migration/V1.31.0__fix_address_book_102.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/V1.31.0__fix_address_book_102.sql
@@ -1,0 +1,7 @@
+-- Recalculate all end timestamps since we accidentally set the 0.0.102 end timestamp instead of the 0.0.101's in GH1229
+update address_book as ab
+set end_consensus_timestamp = (
+  select min(next.start_consensus_timestamp) - 1
+  from address_book as next
+  where next.file_id = ab.file_id and next.start_consensus_timestamp > ab.start_consensus_timestamp
+);

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/addressbook/AddressBookServiceImplTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/addressbook/AddressBookServiceImplTest.java
@@ -340,7 +340,7 @@ class AddressBookServiceImplTest extends IntegrationTest {
     }
 
     @Test
-    void verifyAddressBookEndPointsAreSet() {
+    void verify102AddressBookEndPointsAreSet() {
         byte[] addressBookBytes = UPDATED.toByteArray();
         update(addressBookBytes, 0L, true);
 
@@ -354,6 +354,32 @@ class AddressBookServiceImplTest extends IntegrationTest {
 
         update(newAddressBookBytes, 10L, true);
         AddressBook newAddressBook = addressBookService.getCurrent();
+        assertAddressBook(newAddressBook, FINAL);
+        assertAddressBookData(newAddressBookBytes, 10);
+
+        assertEquals(2, addressBookRepository.count());
+        assertEquals(UPDATED.getNodeAddressCount() + FINAL.getNodeAddressCount(), addressBookEntryRepository.count());
+
+        // verify end consensus timestamp was set for previous address book
+        AddressBook prevAddressBook = addressBookRepository.findById(1L).get();
+        assertThat(prevAddressBook.getStartConsensusTimestamp()).isNotNull();
+        assertThat(prevAddressBook.getEndConsensusTimestamp()).isNotNull();
+    }
+
+    @Test
+    void verify101AddressBookEndPointsAreSet() {
+        byte[] addressBookBytes = UPDATED.toByteArray();
+        update(addressBookBytes, 0L, false);
+
+        // assert current addressBook is updated
+        AddressBook addressBook = addressBookRepository.findLatestAddressBook(1L, 101L).get();
+        assertThat(addressBook.getEntries()).hasSize(UPDATED.getNodeAddressCount());
+        assertThat(addressBook.getStartConsensusTimestamp()).isNotNull();
+        assertThat(addressBook.getEndConsensusTimestamp()).isNull();
+
+        byte[] newAddressBookBytes = FINAL.toByteArray();
+        update(newAddressBookBytes, 10L, false);
+        AddressBook newAddressBook = addressBookRepository.findLatestAddressBook(11L, 101L).get();
         assertAddressBook(newAddressBook, FINAL);
         assertAddressBookData(newAddressBookBytes, 10);
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/addressbook/AddressBookServiceImplTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/addressbook/AddressBookServiceImplTest.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.cache.CacheManager;
+import org.springframework.cache.interceptor.SimpleKey;
 
 import com.hedera.mirror.importer.IntegrationTest;
 import com.hedera.mirror.importer.MirrorProperties;
@@ -152,20 +153,20 @@ class AddressBookServiceImplTest extends IntegrationTest {
 
         //verify cache is empty to start
         assertNull(cacheManager.getCache(AddressBookServiceImpl.ADDRESS_BOOK_102_CACHE_NAME)
-                .get(AddressBookServiceImpl.ADDRESS_BOOK_102_ENTITY_ID.getId()));
+                .get(SimpleKey.EMPTY));
 
         //verify getCurrent() adds an entry to the cache
         AddressBook addressBookDb = addressBookService.getCurrent();
         AddressBook addressBookCache = (AddressBook) cacheManager
                 .getCache(AddressBookServiceImpl.ADDRESS_BOOK_102_CACHE_NAME)
-                .get(AddressBookServiceImpl.ADDRESS_BOOK_102_ENTITY_ID.getId()).get();
+                .get(SimpleKey.EMPTY).get();
         assertNotNull(addressBookCache);
         assertThat(addressBookCache).isEqualTo(addressBookDb);
 
         //verify updating the address book evicts the cache.
         update(addressBookBytes, 2L, true);
         assertNull(cacheManager.getCache(AddressBookServiceImpl.ADDRESS_BOOK_102_CACHE_NAME)
-                .get(AddressBookServiceImpl.ADDRESS_BOOK_102_ENTITY_ID.getId()));
+                .get(SimpleKey.EMPTY));
     }
 
     @Test

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/V1_31_0_fix_address_book_102Test.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/V1_31_0_fix_address_book_102Test.java
@@ -1,0 +1,112 @@
+package com.hedera.mirror.importer.migration;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import javax.annotation.Resource;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.jdbc.core.JdbcOperations;
+
+import com.hedera.mirror.importer.IntegrationTest;
+import com.hedera.mirror.importer.domain.AddressBook;
+import com.hedera.mirror.importer.domain.EntityId;
+import com.hedera.mirror.importer.domain.EntityTypeEnum;
+import com.hedera.mirror.importer.repository.AddressBookRepository;
+
+public class V1_31_0_fix_address_book_102Test extends IntegrationTest {
+
+    @Resource
+    private AddressBookRepository addressBookRepository;
+
+    @Resource
+    private JdbcOperations jdbcOperations;
+
+    @Value("classpath:db/migration/V1.31.0__fix_address_book_102.sql")
+    private File sql;
+
+    @Test
+    void latest102WithNonNullTimestamp() throws IOException {
+        AddressBook addressBook1 = addressBook(102, 1, 100L);
+        AddressBook addressBook2 = addressBook(101, 101, null);
+        AddressBook addressBook3 = addressBook(101, 201, null);
+
+        runMigration();
+
+        assertEndTimestamp(addressBook1, null);
+        assertEndTimestamp(addressBook2, 200L);
+        assertEndTimestamp(addressBook3, null);
+    }
+
+    @Test
+    void previous102WithIncorrectTimestamp() throws IOException {
+        AddressBook addressBook1 = addressBook(102, 1, 200L);
+        AddressBook addressBook2 = addressBook(102, 101, 300L);
+        AddressBook addressBook3 = addressBook(101, 201, null);
+        AddressBook addressBook4 = addressBook(101, 301, null);
+
+        runMigration();
+
+        assertEndTimestamp(addressBook1, 100L);
+        assertEndTimestamp(addressBook2, null);
+        assertEndTimestamp(addressBook3, 300L);
+        assertEndTimestamp(addressBook4, null);
+    }
+
+    @Test
+    void noChanges() throws IOException {
+        AddressBook addressBook1 = addressBook(102, 1, 100L);
+        AddressBook addressBook2 = addressBook(102, 101, null);
+        AddressBook addressBook3 = addressBook(101, 201, 300L);
+        AddressBook addressBook4 = addressBook(101, 301, null);
+
+        runMigration();
+
+        assertEndTimestamp(addressBook1, 100L);
+        assertEndTimestamp(addressBook2, null);
+        assertEndTimestamp(addressBook3, 300L);
+        assertEndTimestamp(addressBook4, null);
+    }
+
+    private AddressBook addressBook(long fileId, long startConsensusTimestamp, Long endConsensusTimestamp) {
+        AddressBook addressBook = new AddressBook();
+        addressBook.setEndConsensusTimestamp(endConsensusTimestamp);
+        addressBook.setFileData(new byte[] {});
+        addressBook.setFileId(EntityId.of(0, 0, fileId, EntityTypeEnum.FILE));
+        addressBook.setStartConsensusTimestamp(startConsensusTimestamp);
+        return addressBookRepository.save(addressBook);
+    }
+
+    private void runMigration() throws IOException {
+        jdbcOperations.update(FileUtils.readFileToString(sql, "UTF-8"));
+    }
+
+    private void assertEndTimestamp(AddressBook addressBook, Long endConsensusTimestamp) {
+        assertThat(addressBookRepository.findById(addressBook.getStartConsensusTimestamp()))
+                .get()
+                .extracting(AddressBook::getEndConsensusTimestamp)
+                .isEqualTo(endConsensusTimestamp);
+    }
+}

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishMetrics.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishMetrics.java
@@ -61,7 +61,7 @@ public class PublishMetrics {
     }
 
     public PublishResponse record(PublishRequest publishRequest,
-                                  CheckedFunction<PublishRequest, PublishResponse> function) {
+            CheckedFunction<PublishRequest, PublishResponse> function) {
         long startTime = System.currentTimeMillis();
         String status = SUCCESS;
         TransactionType type = publishRequest.getType();
@@ -75,15 +75,14 @@ public class PublishMetrics {
             throw e;
         } catch (StatusRuntimeException e) {
             StatusRuntimeException sre = (StatusRuntimeException) e.getCause();
-            String code = sre.getStatus().getCode().name();
-            log.debug("Network error {} submitting {} transaction: {}", code, type, sre.getStatus().getDescription());
-            status = code;
+            status = sre.getStatus().getCode().name();
+            log.debug("Network error {} submitting {} transaction: {}", status, type, sre.getStatus().getDescription());
         } catch (HederaStatusException e) {
-            log.debug("Hedera status error submitting {} transaction: {}", type, e.getMessage());
             status = e.status.name();
+            log.debug("Hedera {} error submitting {} transaction: {}", status, type, e.getMessage());
         } catch (Exception e) {
-            log.debug("Unknown error submitting {} transaction: {}", type, e.getMessage());
             status = e.getClass().getSimpleName();
+            log.debug("{} submitting {} transaction: {}", status, type, e.getMessage());
         } finally {
             long endTime = System.currentTimeMillis();
             Tags tags = new Tags(status, type);


### PR DESCRIPTION
**Detailed description**:
- Fix address book service always updating 0.0.102 end timestamp regardless of file ID
- Add a migration that recalculates all end timestamps to fix both the 102 rows with incorrect timestamps and 101 rows missing correct timestamps
- Fix signature file not buffering the input stream

**Which issue(s) this PR fixes**:
Fixes #1229

**Special notes for your reviewer**:
Working on database migration

**Checklist**
- [ ] Documentation added
- [x] Tests updated

