### PR TITLE
Fix incorrect base64 encoding in stateproof

### DIFF
--- a/hedera-mirror-rest/__tests__/stateproof.test.js
+++ b/hedera-mirror-rest/__tests__/stateproof.test.js
@@ -273,6 +273,8 @@ describe('getAddressBooksAndNodeAccountIdsByConsensusNs', () => {
 
 describe('downloadRecordStreamFilesFromObjectStorage', () => {
   const partialFilePaths = _.map([3, 4, 5, 6], (num) => `0.0.${num}/2020-02-09T18_30_25.001721Z.rcd_sig`);
+  const extraFileContent = '123456790123456789012345678901234';
+  const sliceSize = 5;
 
   beforeEach(() => {
     config.stateproof = {
@@ -288,7 +290,13 @@ describe('downloadRecordStreamFilesFromObjectStorage', () => {
     });
   };
 
-  const verifyGetObjectStubAndReturnedFileObjects = (getObjectStub, fileObjects, partialFilePaths, failedNodes) => {
+  const verifyGetObjectStubAndReturnedFileObjects = (
+    getObjectStub,
+    fileObjects,
+    partialFilePaths,
+    failedNodes,
+    extraFileContent
+  ) => {
     let succeededPartialFilePaths = partialFilePaths;
     if (failedNodes) {
       succeededPartialFilePaths = _.filter(partialFilePaths, (partialFilePath) =>
@@ -298,9 +306,8 @@ describe('downloadRecordStreamFilesFromObjectStorage', () => {
 
     expect(_.map(fileObjects, (file) => file.partialFilePath).sort()).toEqual(succeededPartialFilePaths.sort());
     for (const fileObject of fileObjects) {
-      expect(fileObject.base64Data).toEqual(
-        Buffer.from(constants.recordStreamPrefix + fileObject.partialFilePath).toString('base64')
-      );
+      const data = constants.recordStreamPrefix + fileObject.partialFilePath + extraFileContent || '';
+      expect(fileObject.base64Data).toEqual(Buffer.from(data).toString('base64'));
     }
     expect(getObjectStub.callCount).toEqual(partialFilePaths.length);
     for (const args of getObjectStub.args) {
@@ -318,6 +325,12 @@ describe('downloadRecordStreamFilesFromObjectStorage', () => {
         });
         stream._read = function (size) {
           this.push(params.Key);
+          let start = 0;
+          while (start < extraFileContent.length) {
+            const end = start + sliceSize;
+            this.push(extraFileContent.slice(start, end));
+            start = end;
+          }
           this.push(null);
         };
         return stream;
@@ -326,7 +339,13 @@ describe('downloadRecordStreamFilesFromObjectStorage', () => {
     stubS3ClientGetObject(getObjectStub);
 
     const fileObjects = await stateproof.downloadRecordStreamFilesFromObjectStorage(...partialFilePaths);
-    verifyGetObjectStubAndReturnedFileObjects(getObjectStub, fileObjects, partialFilePaths);
+    verifyGetObjectStubAndReturnedFileObjects(
+      getObjectStub,
+      fileObjects,
+      partialFilePaths,
+      undefined,
+      extraFileContent
+    );
   });
 
   test('with all files failed to download', async () => {
@@ -369,6 +388,12 @@ describe('downloadRecordStreamFilesFromObjectStorage', () => {
             }
           } else {
             this.push(params.Key);
+            let start = 0;
+            while (start < extraFileContent.length) {
+              const end = start + sliceSize;
+              this.push(extraFileContent.slice(start, end));
+              start = end;
+            }
             this.push(null);
           }
         };
@@ -378,7 +403,13 @@ describe('downloadRecordStreamFilesFromObjectStorage', () => {
     stubS3ClientGetObject(getObjectStub);
 
     const fileObjects = await stateproof.downloadRecordStreamFilesFromObjectStorage(...partialFilePaths);
-    verifyGetObjectStubAndReturnedFileObjects(getObjectStub, fileObjects, partialFilePaths, ['0.0.3']);
+    verifyGetObjectStubAndReturnedFileObjects(
+      getObjectStub,
+      fileObjects,
+      partialFilePaths,
+      ['0.0.3'],
+      extraFileContent
+    );
   });
 });
 

--- a/hedera-mirror-rest/__tests__/stateproof.test.js
+++ b/hedera-mirror-rest/__tests__/stateproof.test.js
@@ -290,13 +290,7 @@ describe('downloadRecordStreamFilesFromObjectStorage', () => {
     });
   };
 
-  const verifyGetObjectStubAndReturnedFileObjects = (
-    getObjectStub,
-    fileObjects,
-    partialFilePaths,
-    failedNodes,
-    extraFileContent
-  ) => {
+  const verifyGetObjectStubAndReturnedFileObjects = (getObjectStub, fileObjects, failedNodes) => {
     let succeededPartialFilePaths = partialFilePaths;
     if (failedNodes) {
       succeededPartialFilePaths = _.filter(partialFilePaths, (partialFilePath) =>
@@ -306,7 +300,7 @@ describe('downloadRecordStreamFilesFromObjectStorage', () => {
 
     expect(_.map(fileObjects, (file) => file.partialFilePath).sort()).toEqual(succeededPartialFilePaths.sort());
     for (const fileObject of fileObjects) {
-      const data = constants.recordStreamPrefix + fileObject.partialFilePath + extraFileContent || '';
+      const data = constants.recordStreamPrefix + fileObject.partialFilePath + extraFileContent;
       expect(fileObject.base64Data).toEqual(Buffer.from(data).toString('base64'));
     }
     expect(getObjectStub.callCount).toEqual(partialFilePaths.length);
@@ -339,13 +333,7 @@ describe('downloadRecordStreamFilesFromObjectStorage', () => {
     stubS3ClientGetObject(getObjectStub);
 
     const fileObjects = await stateproof.downloadRecordStreamFilesFromObjectStorage(...partialFilePaths);
-    verifyGetObjectStubAndReturnedFileObjects(
-      getObjectStub,
-      fileObjects,
-      partialFilePaths,
-      undefined,
-      extraFileContent
-    );
+    verifyGetObjectStubAndReturnedFileObjects(getObjectStub, fileObjects);
   });
 
   test('with all files failed to download', async () => {
@@ -366,12 +354,8 @@ describe('downloadRecordStreamFilesFromObjectStorage', () => {
     stubS3ClientGetObject(getObjectStub);
 
     const fileObjects = await stateproof.downloadRecordStreamFilesFromObjectStorage(...partialFilePaths);
-    verifyGetObjectStubAndReturnedFileObjects(
-      getObjectStub,
-      fileObjects,
-      partialFilePaths,
-      _.map([3, 4, 5, 6], (num) => `0.0.${num}`)
-    );
+    const failedNodes = _.map([3, 4, 5, 6], (num) => `0.0.${num}`);
+    verifyGetObjectStubAndReturnedFileObjects(getObjectStub, fileObjects, failedNodes);
   });
 
   test('with download failed for 0.0.3', async () => {
@@ -403,13 +387,7 @@ describe('downloadRecordStreamFilesFromObjectStorage', () => {
     stubS3ClientGetObject(getObjectStub);
 
     const fileObjects = await stateproof.downloadRecordStreamFilesFromObjectStorage(...partialFilePaths);
-    verifyGetObjectStubAndReturnedFileObjects(
-      getObjectStub,
-      fileObjects,
-      partialFilePaths,
-      ['0.0.3'],
-      extraFileContent
-    );
+    verifyGetObjectStubAndReturnedFileObjects(getObjectStub, fileObjects, ['0.0.3']);
   });
 });
 

--- a/hedera-mirror-rest/stateproof.js
+++ b/hedera-mirror-rest/stateproof.js
@@ -187,17 +187,17 @@ let downloadRecordStreamFilesFromObjectStorage = async (...partialFilePaths) => 
       };
 
       return new Promise((resolve) => {
-        let base64Data = '';
+        const buffers = [];
         s3Client
           .getObject(params)
           .createReadStream()
           .on('data', (chunk) => {
-            base64Data += Buffer.from(chunk).toString('base64');
+            buffers.push(Buffer.from(chunk));
           })
           .on('end', () => {
             resolve({
               partialFilePath,
-              base64Data,
+              base64Data: Buffer.concat(buffers).toString('base64'),
             });
           })
           // error may happen for a couple of reasons: 1. the node does not have the requested file, 2. s3 transient


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
-->

**Detailed description**:
Base64 encode the complete record file content, instead of encoding individual chunks of the file received from object storage service then concatenating the encoded string.

**Which issue(s) this PR fixes**:
Fixes #1261 

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated

