### PR TITLE
Add simple k6 Load Test for REST API

### DIFF
--- a/hedera-mirror-test/src/test/k6/allRESTEndpoints.js
+++ b/hedera-mirror-test/src/test/k6/allRESTEndpoints.js
@@ -1,0 +1,159 @@
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import http from "k6/http";
+import { check, group, sleep } from "k6";
+import { Rate } from "k6/metrics";
+
+export let errorRate = new Rate("errors");
+
+// options used by k6 framework
+export let options = {
+  vus: __ENV.DEFAULT_VUS,
+  duration: __ENV.DEFAULT_DURATION,
+  thresholds: {
+    errors: ["rate<0.1"], // threshold on a custom metric
+    http_req_duration: ["p(95)<500"], // threshold on a standard metric
+  },
+  insecureSkipTLSVerify: true,
+  noConnectionReuse: true,
+  noVUConnectionReuse: true,
+};
+
+const SLEEP_DURATION = 2;
+
+export default function () {
+  group("/api/v1/accounts", () => {
+    let url = __ENV.BASE_URL + `/api/v1/accounts?limit=${__ENV.DEFAULT_LIMIT}`;
+    let request = http.get(url);
+    console.log(`call : ${url}`);
+    check(request, {
+      "Accounts OK": (r) => r.status === 200,
+    });
+    errorRate.add(!request);
+    sleep(SLEEP_DURATION);
+  });
+  group("/api/v1/accounts/{id}", () => {
+    let url = __ENV.BASE_URL + `/api/v1/accounts/${__ENV.DEFAULT_ACCOUNT}`;
+    let request = http.get(url);
+    console.log(`call : ${url}`);
+    check(request, {
+      "Account Transactions OK": (r) => r.status === 200,
+    });
+    errorRate.add(!request);
+    sleep(SLEEP_DURATION);
+  });
+  group("/api/v1/balances", () => {
+    let url = __ENV.BASE_URL + `/api/v1/balances?limit=${__ENV.DEFAULT_LIMIT}`;
+    let request = http.get(url);
+    console.log(`call : ${url}`);
+    check(request, {
+      "Balances OK": (r) => r.status === 200,
+    });
+    errorRate.add(!request);
+    sleep(SLEEP_DURATION);
+  });
+  group("/api/v1/transactions", () => {
+    let url = __ENV.BASE_URL + `/api/v1/transactions?limit=${__ENV.DEFAULT_LIMIT}`;
+    let request = http.get(url);
+    console.log(`call : ${url}`);
+    check(request, {
+      "Transactions OK": (r) => r.status === 200,
+    });
+    errorRate.add(!request);
+    sleep(SLEEP_DURATION);
+  });
+  group("/api/v1/transactions/{id}", () => {
+    let url = __ENV.BASE_URL + `/api/v1/transactions/${__ENV.DEFAULT_TRANSACTION}`;
+    let request = http.get(url);
+    console.log(`call : ${url}`);
+    check(request, {
+      "Transaction Id OK": (r) => r.status === 200,
+    });
+    errorRate.add(!request);
+    sleep(SLEEP_DURATION);
+  });
+  // group("/api/v1/transactions/{id}/stateproof", () => {
+  //     let id = "TODO_EDIT_THE_ID";
+  //     let url = BASE_URL + `/api/v1/transactions/${id}/stateproof`;
+  //     // Request No. 1
+  //     let request = http.get(url);
+  //     sleep(SLEEP_DURATION);
+  // });
+  group("/api/v1/topics/{id}/messages", () => {
+    let url = __ENV.BASE_URL + `/api/v1/topics/${__ENV.DEFAULT_TOPIC}/messages?limit=${__ENV.DEFAULT_LIMIT}`;
+    let request = http.get(url);
+    console.log(`call : ${url}`);
+    check(request, {
+      "Topic Messages OK": (r) => r.status === 200,
+    });
+    errorRate.add(!request);
+    sleep(SLEEP_DURATION);
+  });
+  group("/api/v1/topics/{id}/messages/{sequencenumber}", () => {
+    let url =
+      __ENV.BASE_URL + `/api/v1/topics/${__ENV.DEFAULT_TOPIC}/messages?sequencenumber=${__ENV.DEFAULT_TOPIC_SEQUENCE}`;
+    let request = http.get(url);
+    console.log(`call : ${url}`);
+    check(request, {
+      "Topic Message OK": (r) => r.status === 200,
+    });
+    errorRate.add(!request);
+    sleep(SLEEP_DURATION);
+  });
+  group("/api/v1/topics/messages/{consensusTimestamp}", () => {
+    let url = __ENV.BASE_URL + `/api/v1/topics/messages/${__ENV.DEFAULT_TOPIC_TIMESTAMP}`;
+    let request = http.get(url);
+    check(request, {
+      "Topic messgae Timestamp OK": (r) => r.status === 200,
+    });
+    errorRate.add(!request);
+    sleep(SLEEP_DURATION);
+  });
+  group("/api/v1/tokens", () => {
+    let url = __ENV.BASE_URL + `/api/v1/tokens?limit=${__ENV.DEFAULT_LIMIT}`;
+    let request = http.get(url);
+    console.log(`call : ${url}`);
+    check(request, {
+      "Tokens OK": (r) => r.status === 200,
+    });
+    errorRate.add(!request);
+    sleep(SLEEP_DURATION);
+  });
+  group("/api/v1/tokens/{id}", () => {
+    let url = __ENV.BASE_URL + `/api/v1/tokens/${__ENV.DEFAULT_TOKEN}`;
+    let request = http.get(url);
+    console.log(`call : ${url}`);
+    check(request, {
+      "Token Id OK": (r) => r.status === 200,
+    });
+    errorRate.add(!request);
+    sleep(SLEEP_DURATION);
+  });
+  group("/api/v1/tokens/{id}/balances", () => {
+    let url = __ENV.BASE_URL + `/api/v1/tokens/${__ENV.DEFAULT_TOKEN}/balances`;
+    let request = http.get(url);
+    console.log(`call : ${url}`);
+    check(request, {
+      "Token Balance OK": (r) => r.status === 200,
+    });
+    errorRate.add(!request);
+    sleep(SLEEP_DURATION);
+  });
+}

--- a/hedera-mirror-test/src/test/resources/k8s/mirror-rest-benchmark.yml
+++ b/hedera-mirror-test/src/test/resources/k8s/mirror-rest-benchmark.yml
@@ -1,0 +1,57 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mirror-rest-benchmark
+  labels:
+    app.kubernetes.io/name: test
+spec:
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      name: mirror-rest-benchmark
+      labels:
+        app.kubernetes.io/name: test
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: test
+      restartPolicy: Never
+      containers:
+        - image: loadimpact/k6:master
+          command: ["k6", "run", "/usr/etc/k6-config/script.js"]
+          name: test
+          env:
+            - name: DEFAULT_VUS
+              value: "50"
+            - name: DEFAULT_DURATION
+              value: "300s"
+            - name: BASE_URL
+              value: "https://testnet.mirrornode.hedera.com"
+            - name: DEFAULT_ACCOUNT
+              value: "0.0.119036"
+            - name: DEFAULT_TOPIC
+              value: "1017"
+            - name: DEFAULT_TOPIC_SEQUENCE
+              value: "85022971"
+            - name: DEFAULT_TOPIC_TIMESTAMP
+              value: "1604093439.107103006"
+            - name: DEFAULT_TOKEN
+              value: "0.0.1646"
+            - name: DEFAULT_TRANSACTION
+              value: "0.0.11161-1605908678-269629000"
+            - name: DEFAULT_LIMIT
+              value: "100"
+          volumeMounts:
+            - name: benchmark-config-volume
+              mountPath: /usr/etc/k6-config
+      volumes:
+        - name: benchmark-config-volume
+          configMap:
+            name: k6-config


### PR DESCRIPTION
**Detailed description**:
The Mirror node code base currently has performance testing for the importer and grpc modules but is missing pure load testing for the REST API that can show latency numbers.
k6 seems to have good support and extensibility for this

- Add k6 js script with tests groups for all endpoints with basic 200 checks and error rate. Generate using openapi.yml spec and modify.
- Add k8s job yaml script to test path for easy running

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:
To run locally
- `docker pull loadimpact/k6`
- `docker run --rm --env BASE_URL="<host_url>" --env DEFAULT_LIMIT=100 -i loadimpact/k6 run - <hedera-mirror-test/src/test/k6/allRESTEndpoints.js`

To run in k8s
- `kubectl create configmap k6-config --from-file=script.js=hedera-mirror-test/src/test/k6/allRESTEndpoints.js`
- `kubectl apply -f hedera-mirror-test/src/test/resources/k8s/mirror-rest-benchmark.yml`
- `kubectl logs -f job/mirror-rest-benchmark | less`

Note
-This is just a POC, we can do more and should have more test files utilizing scenarios and other checks
- Is currently missing documentation updates

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

