### PR TITLE
Update sdk to 1.3.3 to support hts changes

### DIFF
--- a/charts/hedera-mirror-common/Chart.yaml
+++ b/charts/hedera-mirror-common/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.23.0
+appVersion: 0.23.1
 description: Hedera Mirror Node common components installed globally for use across namespaces
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
@@ -11,4 +11,4 @@ maintainers:
 name: hedera-mirror-common
 sources:
   - https://github.com/hashgraph/hedera-mirror-node
-version: 0.10.0
+version: 0.10.1

--- a/charts/hedera-mirror-grpc/Chart.yaml
+++ b/charts/hedera-mirror-grpc/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.23.0
+appVersion: 0.23.1
 description: GRPC API for the Hedera Mirror Node
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
@@ -11,4 +11,4 @@ maintainers:
 name: hedera-mirror-grpc
 sources:
   - https://github.com/hashgraph/hedera-mirror-node
-version: 0.10.0
+version: 0.10.1

--- a/charts/hedera-mirror-importer/Chart.yaml
+++ b/charts/hedera-mirror-importer/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.23.0
+appVersion: 0.23.1
 description: Hedera Mirror Importer downloads and validates file streams from the cloud and imports them into the database
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
@@ -11,4 +11,4 @@ maintainers:
 name: hedera-mirror-importer
 sources:
   - https://github.com/hashgraph/hedera-mirror-node
-version: 0.10.0
+version: 0.10.1

--- a/charts/hedera-mirror-monitor/Chart.yaml
+++ b/charts/hedera-mirror-monitor/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.23.0
+appVersion: 0.23.1
 description: End to End Monitor for the Hedera Mirror Node
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
@@ -11,4 +11,4 @@ maintainers:
 name: hedera-mirror-monitor
 sources:
   - https://github.com/hashgraph/hedera-mirror-node
-version: 0.10.0
+version: 0.10.1

--- a/charts/hedera-mirror-rest/Chart.yaml
+++ b/charts/hedera-mirror-rest/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.23.0
+appVersion: 0.23.1
 description: REST API for the Hedera Mirror Node
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
@@ -11,4 +11,4 @@ maintainers:
 name: hedera-mirror-rest
 sources:
   - https://github.com/hashgraph/hedera-mirror-node
-version: 0.10.0
+version: 0.10.1

--- a/charts/hedera-mirror/Chart.yaml
+++ b/charts/hedera-mirror/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.23.0
+appVersion: 0.23.1
 description: Hedera Mirror Node mirrors data from Hedera nodes and serves it via an API
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
@@ -11,4 +11,4 @@ maintainers:
 name: hedera-mirror
 sources:
   - https://github.com/hashgraph/hedera-mirror-node
-version: 0.10.0
+version: 0.10.1

--- a/charts/hedera-mirror/requirements.lock
+++ b/charts/hedera-mirror/requirements.lock
@@ -1,13 +1,13 @@
 dependencies:
 - name: hedera-mirror-grpc
   repository: file://../hedera-mirror-grpc
-  version: 0.10.0
+  version: 0.10.1
 - name: hedera-mirror-importer
   repository: file://../hedera-mirror-importer
-  version: 0.10.0
+  version: 0.10.1
 - name: hedera-mirror-monitor
   repository: file://../hedera-mirror-monitor
-  version: 0.10.0
+  version: 0.10.1
 - name: postgresql-ha
   repository: https://charts.bitnami.com/bitnami
   version: 5.0.1
@@ -16,6 +16,6 @@ dependencies:
   version: 11.1.3
 - name: hedera-mirror-rest
   repository: file://../hedera-mirror-rest
-  version: 0.10.0
-digest: sha256:6c3d68597ffd2a89881dea865a6a7b36c642a6270b28a51e97854e56889ba445
-generated: "2020-11-19T10:38:56.520954-06:00"
+  version: 0.10.1
+digest: sha256:dc32b1bdaa5d8ca6a72016577988f5184fa0ebc18c5a498ced3e7f4cbca225d4
+generated: "2020-11-21T23:55:12.306198-06:00"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - 5432:5432
 
   grpc:
-    image: gcr.io/mirrornode/hedera-mirror-grpc:0.23.0
+    image: gcr.io/mirrornode/hedera-mirror-grpc:0.23.1
     restart: unless-stopped
     environment:
       HEDERA_MIRROR_GRPC_DB_HOST: db
@@ -29,7 +29,7 @@ services:
       - 5600:5600
 
   importer:
-    image: gcr.io/mirrornode/hedera-mirror-importer:0.23.0
+    image: gcr.io/mirrornode/hedera-mirror-importer:0.23.1
     restart: unless-stopped
     environment:
       HEDERA_MIRROR_IMPORTER_DATAPATH: /var/lib/hedera-mirror-importer
@@ -60,7 +60,7 @@ services:
       - 6379:6379
 
   rest:
-    image: gcr.io/mirrornode/hedera-mirror-rest:0.23.0
+    image: gcr.io/mirrornode/hedera-mirror-rest:0.23.1
     environment:
       HEDERA_MIRROR_REST_DB_HOST: db
     restart: unless-stopped

--- a/hedera-mirror-coverage/pom.xml
+++ b/hedera-mirror-coverage/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.23.0</version>
+        <version>0.23.1</version>
     </parent>
 
     <dependencies>

--- a/hedera-mirror-datagenerator/pom.xml
+++ b/hedera-mirror-datagenerator/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.23.0</version>
+        <version>0.23.1</version>
     </parent>
 
     <properties>

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenUpdateTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenUpdateTransactionSupplier.java
@@ -74,7 +74,7 @@ public class TokenUpdateTransactionSupplier implements TransactionSupplier<Token
                 .setExpirationTime(expirationTime)
                 .setMaxTransactionFee(maxTransactionFee)
                 .setName(symbol + "_name")
-                .setSybmol(symbol)
+                .setSymbol(symbol)
                 .setTokenId(TokenId.fromString(tokenId))
                 .setTransactionMemo(Utility.getMemo("Mirror node updated test token"));
 

--- a/hedera-mirror-grpc/pom.xml
+++ b/hedera-mirror-grpc/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.23.0</version>
+        <version>0.23.1</version>
     </parent>
 
     <properties>

--- a/hedera-mirror-importer/pom.xml
+++ b/hedera-mirror-importer/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.23.0</version>
+        <version>0.23.1</version>
     </parent>
 
     <properties>

--- a/hedera-mirror-monitor/pom.xml
+++ b/hedera-mirror-monitor/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.23.0</version>
+        <version>0.23.1</version>
     </parent>
 
     <dependencies>

--- a/hedera-mirror-protobuf/pom.xml
+++ b/hedera-mirror-protobuf/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.23.0</version>
+        <version>0.23.1</version>
     </parent>
 
     <properties>

--- a/hedera-mirror-rest/monitoring/monitor_apis/package-lock.json
+++ b/hedera-mirror-rest/monitoring/monitor_apis/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-mirror-monitor",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hedera-mirror-rest/monitoring/monitor_apis/package.json
+++ b/hedera-mirror-rest/monitoring/monitor_apis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-mirror-monitor",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "description": "Hedera Mirror Node Monitor",
   "main": "server.js",
   "private": true,

--- a/hedera-mirror-rest/package-lock.json
+++ b/hedera-mirror-rest/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-mirror-rest",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hedera-mirror-rest/package.json
+++ b/hedera-mirror-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-mirror-rest",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "description": "Hedera Mirror Node REST API",
   "main": "server.js",
   "private": true,

--- a/hedera-mirror-rest/pom.xml
+++ b/hedera-mirror-rest/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.23.0</version>
+        <version>0.23.1</version>
     </parent>
 
     <properties>

--- a/hedera-mirror-test/pom.xml
+++ b/hedera-mirror-test/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.23.0</version>
+        <version>0.23.1</version>
     </parent>
 
     <properties>

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TokenClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TokenClient.java
@@ -20,6 +20,7 @@ package com.hedera.mirror.test.e2e.acceptance.client;
  * ‍
  */
 
+import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import lombok.Value;
@@ -65,6 +66,7 @@ public class TokenClient extends AbstractNetworkClient {
         Ed25519PublicKey adminKey = expandedAccountId.getPublicKey();
         TokenCreateTransaction tokenCreateTransaction = new TokenCreateTransaction()
                 .setAutoRenewAccount(expandedAccountId.getAccountId())
+                .setAutoRenewPeriod(Duration.ofSeconds(6_999_999L))
                 .setDecimals(10)
                 .setFreezeDefault(false)
                 .setInitialSupply(1000000000)
@@ -236,10 +238,11 @@ public class TokenClient extends AbstractNetworkClient {
         TokenUpdateTransaction tokenUpdateTransaction = new TokenUpdateTransaction()
                 .setAdminKey(publicKey)
                 .setAutoRenewAccount(expandedAccountId.getAccountId())
+                .setAutoRenewPeriod(Duration.ofSeconds(8_000_001L))
                 .setExpirationTime(Instant.now().plus(120, ChronoUnit.DAYS))
                 .setName(newSymbol + "_name")
                 .setSupplyKey(publicKey)
-                .setSybmol(newSymbol)
+                .setSymbol(newSymbol)
                 .setTokenId(tokenId)
                 .setTreasury(client.getOperatorId())
                 .setWipeKey(publicKey);

--- a/hedera-mirror-test/src/test/resources/k8s/hcs-perf-message-submit.yml
+++ b/hedera-mirror-test/src/test/resources/k8s/hcs-perf-message-submit.yml
@@ -41,7 +41,7 @@ spec:
                     app.kubernetes.io/name: test
       restartPolicy: Never
       containers:
-        - image: gcr.io/mirrornode/hedera-mirror-test:0.23.0
+        - image: gcr.io/mirrornode/hedera-mirror-test:0.23.1
           name: test
           env:
             - name: testProfile

--- a/hedera-mirror-test/src/test/resources/k8s/hcs-perf-publish-test.yml
+++ b/hedera-mirror-test/src/test/resources/k8s/hcs-perf-publish-test.yml
@@ -43,7 +43,7 @@ spec:
                     app.kubernetes.io/name: test
       restartPolicy: Never
       containers:
-        - image: gcr.io/mirrornode/hedera-mirror-test:0.23.0
+        - image: gcr.io/mirrornode/hedera-mirror-test:0.23.1
           name: test
           env:
             - name: testProfile

--- a/hedera-mirror-test/src/test/resources/k8s/hcs-perf-subscribe-test.yml
+++ b/hedera-mirror-test/src/test/resources/k8s/hcs-perf-subscribe-test.yml
@@ -46,7 +46,7 @@ spec:
                     app.kubernetes.io/name: test
       restartPolicy: Never
       containers:
-        - image: gcr.io/mirrornode/hedera-mirror-test:0.23.0
+        - image: gcr.io/mirrornode/hedera-mirror-test:0.23.1
           name: test
           env:
             - name: testProfile

--- a/hedera-mirror-test/src/test/resources/k8s/hts-perf-batch-publish-batch-validate.yml
+++ b/hedera-mirror-test/src/test/resources/k8s/hts-perf-batch-publish-batch-validate.yml
@@ -47,7 +47,7 @@ spec:
                     app.kubernetes.io/name: test
       restartPolicy: Never
       containers:
-        - image: gcr.io/mirrornode/hedera-mirror-test:0.23.0
+        - image: gcr.io/mirrornode/hedera-mirror-test:0.23.1
           name: test
           env:
             - name: testProfile

--- a/hedera-mirror-test/src/test/resources/k8s/hts-perf-publish-and-retrieve.yml
+++ b/hedera-mirror-test/src/test/resources/k8s/hts-perf-publish-and-retrieve.yml
@@ -46,7 +46,7 @@ spec:
                     app.kubernetes.io/name: test
       restartPolicy: Never
       containers:
-        - image: gcr.io/mirrornode/hedera-mirror-test:0.23.0
+        - image: gcr.io/mirrornode/hedera-mirror-test:0.23.1
           name: test
           env:
             - name: testProfile

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.hedera</groupId>
     <artifactId>hedera-mirror-node</artifactId>
-    <version>0.23.0</version>
+    <version>0.23.1</version>
     <description>Hedera Mirror Node mirrors data from Hedera nodes and serves it via an API</description>
     <inceptionYear>2019</inceptionYear>
     <modelVersion>4.0.0</modelVersion>
@@ -63,7 +63,7 @@
         <grpc-spring-boot.version>2.10.1.RELEASE</grpc-spring-boot.version>
         <grpc.version>1.33.1</grpc.version>
         <hedera-protobuf.version>0.9.0-rc.3</hedera-protobuf.version>
-        <hedera-sdk.version>1.3.2</hedera-sdk.version>
+        <hedera-sdk.version>1.3.3</hedera-sdk.version>
         <jacoco.version>0.8.6</jacoco.version>
         <java.version>11</java.version>
         <javax.version>1</javax.version>
@@ -73,7 +73,7 @@
         <msgpack.version>0.8.21</msgpack.version>
         <protobuf.version>3.13.0</protobuf.version>
         <release.version>${project.version}</release.version> <!-- Used to replace release versions in all files -->
-        <release.chartVersion>0.10.0</release.chartVersion>
+        <release.chartVersion>0.10.1</release.chartVersion>
         <!--suppress UnresolvedMavenProperty -->
         <sonar.coverage.jacoco.xmlReportPaths>
             ${maven.multiModuleProjectDirectory}/hedera-mirror-coverage/target/site/jacoco-aggregate/jacoco.xml


### PR DESCRIPTION
**Detailed description**:
- Update sdk to v1.3.3 to support changes to auto renew and expiration in HAPI
- Bump version to v0.23.1
- Bump charts to v0.10.1

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

