### PR TITLE
Remove two no longer applicable HTS acceptance tests

### DIFF
--- a/hedera-mirror-test/src/test/resources/features/hts/hts.feature
+++ b/hedera-mirror-test/src/test/resources/features/hts/hts.feature
@@ -69,7 +69,5 @@ Feature: HTS Base Coverage Feature
         Given I provide a token symbol <tokenId>
         Then the network should observe an error creating a token <errorCode>
         Examples:
-            | tokenId     | errorCode              |
-            | ""          | "MISSING_TOKEN_SYMBOL" |
-            | "q1MG"      | "INVALID_TOKEN_SYMBOL" |
-            | "hashGRAPH" | "INVALID_TOKEN_SYMBOL" |
+            | tokenId | errorCode              |
+            | ""      | "MISSING_TOKEN_SYMBOL" |


### PR DESCRIPTION
**Detailed description**:
- HAPI was changed to allow upper or lower case characters and our tests expected an error for mixed case
- HAPI does not currently return `INVALID_TOKEN_SYMBOL` for any scenario

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
