### PR TITLE
Add gRPC and REST subscriber to monitor

### DIFF
--- a/.github/workflows/code-scan.yml
+++ b/.github/workflows/code-scan.yml
@@ -16,13 +16,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-
-      # If this run was triggered by a pull request event, then checkout
-      # the head of the pull request instead of the merge commit.
-      - run: git checkout HEAD^2
-        if: ${{ github.event_name == 'pull_request' }}
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v1
@@ -64,13 +57,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 2
-
-      # If this run was triggered by a pull request event, then checkout
-      # the head of the pull request instead of the merge commit.
-      - run: git checkout HEAD^2
-        if: ${{ github.event_name == 'pull_request' }}
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v1

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/common/Utility.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/common/Utility.java
@@ -22,8 +22,6 @@ package com.hedera.datagenerator.common;
 
 import com.google.common.primitives.Longs;
 import java.time.Instant;
-import java.util.Arrays;
-import java.util.Base64;
 import lombok.experimental.UtilityClass;
 import lombok.extern.log4j.Log4j2;
 
@@ -31,25 +29,15 @@ import lombok.extern.log4j.Log4j2;
 @UtilityClass
 public class Utility {
 
-    public static Long getDecodedTimestamp(byte[] bytes) {
-        if (bytes == null || bytes.length < Long.BYTES) {
+    public static Long getTimestamp(byte[] message) {
+        if (message == null || message.length < Long.BYTES) {
             return null;
         }
 
-        byte[] decoded = Base64.getDecoder().decode(bytes);
-        if (decoded.length < Long.BYTES) {
-            return null;
-        }
-
-        byte[] timestampBytes = Arrays.copyOfRange(decoded, 0, Long.BYTES);
-        return Longs.fromByteArray(timestampBytes);
-    }
-
-    public static String getEncodedTimestamp() {
-        return Base64.getEncoder().encodeToString(Longs.toByteArray(System.currentTimeMillis()));
+        return Longs.fromByteArray(message);
     }
 
     public static String getMemo(String message) {
-        return getEncodedTimestamp() + "_" + message + " at " + Instant.now();
+        return System.currentTimeMillis() + "_" + message + " at " + Instant.now();
     }
 }

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/common/Utility.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/common/Utility.java
@@ -31,11 +31,10 @@ import lombok.extern.log4j.Log4j2;
 public class Utility {
 
     public static String getEncodedTimestamp() {
-        return Base64.getEncoder().encodeToString(Longs.toByteArray(Instant.now().toEpochMilli()));
+        return Base64.getEncoder().encodeToString(Longs.toByteArray(System.currentTimeMillis()));
     }
 
     public static String getMemo(String message) {
-        return getEncodedTimestamp() + "_" + message + " at " + Instant
-                .now();
+        return getEncodedTimestamp() + "_" + message + " at " + Instant.now();
     }
 }

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/common/Utility.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/common/Utility.java
@@ -22,6 +22,7 @@ package com.hedera.datagenerator.common;
 
 import com.google.common.primitives.Longs;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.Base64;
 import lombok.experimental.UtilityClass;
 import lombok.extern.log4j.Log4j2;
@@ -29,6 +30,20 @@ import lombok.extern.log4j.Log4j2;
 @Log4j2
 @UtilityClass
 public class Utility {
+
+    public static Long getDecodedTimestamp(byte[] bytes) {
+        if (bytes == null || bytes.length < Long.BYTES) {
+            return null;
+        }
+
+        byte[] decoded = Base64.getDecoder().decode(bytes);
+        if (decoded.length < Long.BYTES) {
+            return null;
+        }
+
+        byte[] timestampBytes = Arrays.copyOfRange(decoded, 0, Long.BYTES);
+        return Longs.fromByteArray(timestampBytes);
+    }
 
     public static String getEncodedTimestamp() {
         return Base64.getEncoder().encodeToString(Longs.toByteArray(System.currentTimeMillis()));

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/account/AccountCreateTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/account/AccountCreateTransactionSupplier.java
@@ -22,6 +22,7 @@ package com.hedera.datagenerator.sdk.supplier.account;
 
 import javax.validation.constraints.Min;
 import lombok.Data;
+import lombok.extern.log4j.Log4j2;
 
 import com.hedera.datagenerator.common.Utility;
 import com.hedera.datagenerator.sdk.supplier.TransactionSupplier;
@@ -30,10 +31,13 @@ import com.hedera.hashgraph.sdk.crypto.ed25519.Ed25519PrivateKey;
 import com.hedera.hashgraph.sdk.crypto.ed25519.Ed25519PublicKey;
 
 @Data
+@Log4j2
 public class AccountCreateTransactionSupplier implements TransactionSupplier<AccountCreateTransaction> {
 
     @Min(1)
     private long initialBalance = 10_000_000;
+
+    private boolean logKeys = false;
 
     @Min(1)
     private long maxTransactionFee = 1_000_000_000;
@@ -52,6 +56,13 @@ public class AccountCreateTransactionSupplier implements TransactionSupplier<Acc
     private Ed25519PublicKey generateKeys() {
         Ed25519PrivateKey privateKey = Ed25519PrivateKey.generate();
         Ed25519PublicKey publicKey = privateKey.publicKey;
+
+        // Since these keys will never be seen again, if we want to reuse this account provide an option to print them
+        if (logKeys) {
+            log.info("privateKey: {}", privateKey);
+            log.info("publicKey: {}", publicKey);
+        }
+
         return publicKey;
     }
 }

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/consensus/ConsensusSubmitMessageTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/consensus/ConsensusSubmitMessageTransactionSupplier.java
@@ -20,8 +20,8 @@ package com.hedera.datagenerator.sdk.supplier.consensus;
  * ‍
  */
 
-import com.google.common.base.Charsets;
 import com.google.common.primitives.Longs;
+import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
@@ -73,7 +73,7 @@ public class ConsensusSubmitMessageTransactionSupplier implements TransactionSup
 
     private byte[] randomByteArray() {
         if (StringUtils.isNotBlank(message)) {
-            return message.getBytes(Charsets.UTF_8);
+            return message.getBytes(StandardCharsets.UTF_8);
         }
 
         byte[] bytes = new byte[messageSize - Long.BYTES];

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/consensus/ConsensusSubmitMessageTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/consensus/ConsensusSubmitMessageTransactionSupplier.java
@@ -46,12 +46,12 @@ public class ConsensusSubmitMessageTransactionSupplier implements TransactionSup
     @Min(8)
     private int messageSize = 256;
 
+    private boolean retry = false;
+
     @NotBlank
     private String topicId;
 
-    private boolean retry = false;
-
-    // Cached for performance testing
+    // Internal variables that are cached for performance reasons
     @Getter(lazy = true)
     private final ConsensusTopicId consensusTopicId = ConsensusTopicId.fromString(topicId);
 

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/consensus/ConsensusSubmitMessageTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/consensus/ConsensusSubmitMessageTransactionSupplier.java
@@ -23,6 +23,7 @@ package com.hedera.datagenerator.sdk.supplier.consensus;
 import com.google.common.primitives.Longs;
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
+import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
 import lombok.Data;
@@ -44,6 +45,7 @@ public class ConsensusSubmitMessageTransactionSupplier implements TransactionSup
     private String message = StringUtils.EMPTY;
 
     @Min(8)
+    @Max(6144)
     private int messageSize = 256;
 
     private boolean retry = false;

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/consensus/ConsensusSubmitMessageTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/consensus/ConsensusSubmitMessageTransactionSupplier.java
@@ -60,7 +60,7 @@ public class ConsensusSubmitMessageTransactionSupplier implements TransactionSup
 
     @Override
     public ConsensusMessageSubmitTransaction get() {
-        return new NonRetryableConsensusMessageSubmitTransaction()
+        return new RetryConfigurableConsensusMessageSubmitTransaction()
                 .setMaxTransactionFee(maxTransactionFee)
                 .setMessage(generateMessage())
                 .setTopicId(getConsensusTopicId());
@@ -81,7 +81,7 @@ public class ConsensusSubmitMessageTransactionSupplier implements TransactionSup
         return bytes;
     }
 
-    private class NonRetryableConsensusMessageSubmitTransaction extends ConsensusMessageSubmitTransaction {
+    private class RetryConfigurableConsensusMessageSubmitTransaction extends ConsensusMessageSubmitTransaction {
 
         @Override
         protected boolean shouldRetry(HederaThrowable e) {

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/RedisTopicListener.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/RedisTopicListener.java
@@ -76,8 +76,7 @@ public class RedisTopicListener extends SharedTopicListener {
     @Override
     protected Flux<TopicMessage> getSharedListener(TopicMessageFilter filter) {
         Topic topic = getTopic(filter);
-        return topicMessages.computeIfAbsent(topic.getTopic(), key -> subscribe(topic))
-                .doOnSubscribe(s -> log.info("Subscribing: {}", filter));
+        return topicMessages.computeIfAbsent(topic.getTopic(), key -> subscribe(topic));
     }
 
     private Topic getTopic(TopicMessageFilter filter) {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListener.java
@@ -218,7 +218,7 @@ public class SqlEntityListener implements EntityListener, RecordStreamFileListen
     @Override
     public void onEntityId(EntityId entityId) throws ImporterException {
         // only insert entities not found in cache
-        if (entityCache.get(entityId.getId()) != null) {
+        if (entityId == null || entityCache.get(entityId.getId()) != null) {
             return;
         }
 

--- a/hedera-mirror-monitor/pom.xml
+++ b/hedera-mirror-monitor/pom.xml
@@ -127,10 +127,6 @@
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-kubernetes-config</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.integration</groupId>
-            <artifactId>spring-integration-core</artifactId>
-        </dependency>
         <!-- Test -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/hedera-mirror-monitor/pom.xml
+++ b/hedera-mirror-monitor/pom.xml
@@ -17,6 +17,10 @@
         <javax.el.version>3.0.0</javax.el.version>
     </properties>
 
+    <properties>
+        <commons-math3.version>3.6.1</commons-math3.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -83,7 +87,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-math3</artifactId>
-            <version>3.6.1</version>
+            <version>${commons-math3.version}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>

--- a/hedera-mirror-monitor/pom.xml
+++ b/hedera-mirror-monitor/pom.xml
@@ -13,9 +13,6 @@
         <artifactId>hedera-mirror-node</artifactId>
         <version>0.23.0-rc1</version>
     </parent>
-    <properties>
-        <javax.el.version>3.0.0</javax.el.version>
-    </properties>
 
     <properties>
         <commons-math3.version>3.6.1</commons-math3.version>
@@ -88,11 +85,6 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-math3</artifactId>
             <version>${commons-math3.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>javax.el</artifactId>
-            <version>${javax.el.version}</version>
         </dependency>
         <dependency>
             <groupId>org.hibernate.validator</groupId>

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/HederaNetwork.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/HederaNetwork.java
@@ -29,12 +29,13 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum HederaNetwork {
 
-    MAINNET(mainnet()),
-    PREVIEWNET(previewnet()),
-    TESTNET(testnet()),
-    OTHER(Collections.emptySet());
+    MAINNET(mainnet(), new MirrorNodeProperties("mainnet.mirrornode.hedera.com")),
+    PREVIEWNET(previewnet(), new MirrorNodeProperties("previewnet.mirrornode.hedera.com")),
+    TESTNET(testnet(), new MirrorNodeProperties("testnet.mirrornode.hedera.com")),
+    OTHER(Collections.emptySet(), null);
 
     private final Set<NodeProperties> nodes;
+    private final MirrorNodeProperties mirrorNode;
 
     private static Set<NodeProperties> mainnet() {
         return Set.of(

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/HederaNetwork.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/HederaNetwork.java
@@ -29,13 +29,21 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum HederaNetwork {
 
-    MAINNET(mainnet(), new MirrorNodeProperties("mainnet.mirrornode.hedera.com")),
-    PREVIEWNET(previewnet(), new MirrorNodeProperties("previewnet.mirrornode.hedera.com")),
-    TESTNET(testnet(), new MirrorNodeProperties("testnet.mirrornode.hedera.com")),
+    MAINNET(mainnet(), mirrorNode("mainnet")),
+    PREVIEWNET(previewnet(), mirrorNode("previewnet")),
+    TESTNET(testnet(), mirrorNode("testnet")),
     OTHER(Collections.emptySet(), null);
 
     private final Set<NodeProperties> nodes;
     private final MirrorNodeProperties mirrorNode;
+
+    private static MirrorNodeProperties mirrorNode(String environment) {
+        String host = environment + ".mirrornode.hedera.com";
+        MirrorNodeProperties mirrorNodeProperties = new MirrorNodeProperties();
+        mirrorNodeProperties.getGrpc().setHost("hcs." + host);
+        mirrorNodeProperties.getRest().setHost(host);
+        return mirrorNodeProperties;
+    }
 
     private static Set<NodeProperties> mainnet() {
         return Set.of(

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/HederaNetwork.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/HederaNetwork.java
@@ -65,7 +65,8 @@ public enum HederaNetwork {
                 new NodeProperties("0.0.3", "0.testnet.hedera.com"),
                 new NodeProperties("0.0.4", "1.testnet.hedera.com"),
                 new NodeProperties("0.0.5", "2.testnet.hedera.com"),
-                new NodeProperties("0.0.6", "3.testnet.hedera.com")
+                new NodeProperties("0.0.6", "3.testnet.hedera.com"),
+                new NodeProperties("0.0.7", "4.testnet.hedera.com")
         );
     }
 }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/MirrorNodeProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/MirrorNodeProperties.java
@@ -33,11 +33,6 @@ import org.springframework.validation.annotation.Validated;
 @Validated
 public class MirrorNodeProperties {
 
-    MirrorNodeProperties(String host) {
-        grpc.setHost("hcs." + host);
-        rest.setHost(host);
-    }
-
     @NotNull
     private GrpcProperties grpc = new GrpcProperties();
 

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/MirrorNodeProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/MirrorNodeProperties.java
@@ -1,0 +1,80 @@
+package com.hedera.mirror.monitor;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+
+@Data
+@NoArgsConstructor
+@Validated
+public class MirrorNodeProperties {
+
+    MirrorNodeProperties(String host) {
+        grpc.setHost("hcs." + host);
+        rest.setHost(host);
+    }
+
+    @NotNull
+    private GrpcProperties grpc = new GrpcProperties();
+
+    @NotNull
+    private RestProperties rest = new RestProperties();
+
+    @Data
+    @Validated
+    public static class GrpcProperties {
+
+        @NotBlank
+        private String host;
+
+        @Min(0)
+        @Max(65535)
+        private int port = 5600;
+
+        public String getEndpoint() {
+            return host + ":" + port;
+        }
+    }
+
+    @Data
+    @Validated
+    public static class RestProperties {
+
+        @NotBlank
+        private String host;
+
+        @Min(0)
+        @Max(65535)
+        private int port = 443;
+
+        public String getBaseUrl() {
+            String scheme = port == 443 ? "https://" : "http://";
+            return scheme + host + ":" + port + "/api/v1";
+        }
+    }
+}
+

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/MonitorProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/MonitorProperties.java
@@ -21,7 +21,9 @@ package com.hedera.mirror.monitor;
  */
 
 import java.util.LinkedHashSet;
+import java.util.Objects;
 import java.util.Set;
+import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -31,6 +33,9 @@ import org.springframework.validation.annotation.Validated;
 @Validated
 @ConfigurationProperties("hedera.mirror.monitor")
 public class MonitorProperties {
+
+    @Nullable
+    private MirrorNodeProperties mirrorNode;
 
     @NotNull
     private HederaNetwork network = HederaNetwork.TESTNET;
@@ -43,7 +48,15 @@ public class MonitorProperties {
 
     private boolean validateNodes = true;
 
+    public MirrorNodeProperties getMirrorNode() {
+        return Objects.requireNonNullElseGet(this.mirrorNode, network::getMirrorNode);
+    }
+
     public Set<NodeProperties> getNodes() {
-        return !nodes.isEmpty() ? nodes : network.getNodes();
+        Set<NodeProperties> n = !nodes.isEmpty() ? nodes : network.getNodes();
+        if (n.isEmpty()) {
+            throw new IllegalArgumentException("nodes must not be empty");
+        }
+        return n;
     }
 }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/config/MonitorConfiguration.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/config/MonitorConfiguration.java
@@ -25,9 +25,11 @@ import javax.annotation.Resource;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.integration.channel.NullChannel;
 import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.dsl.IntegrationFlows;
 import org.springframework.integration.endpoint.ReactiveMessageSourceProducer;
+import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.GenericMessage;
 
 import com.hedera.mirror.monitor.generator.TransactionGenerator;
@@ -55,5 +57,10 @@ class MonitorConfiguration {
                 .channel(c -> c.executor(Executors.newFixedThreadPool(publishProperties.getConnections())))
                 .handle(PublishRequest.class, (p, h) -> transactionPublisher.publish(p))
                 .nullChannel();
+    }
+
+    @Bean
+    MessageChannel errorChannel() {
+        return new NullChannel();
     }
 }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/config/MonitorConfiguration.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/config/MonitorConfiguration.java
@@ -51,6 +51,14 @@ class MonitorConfiguration {
     @Resource
     private Subscriber subscriber;
 
+    /**
+     * Constructs a reactive flow for publishing and subscribing to transactions. The transaction generator will run on
+     * a single thread and generate transactions as fast as possible. Next, a parallel Flux will concurrently publish
+     * those transactions to the main nodes. Finally, a subscriber will receive every published transaction response and
+     * validate whether that transaction was received by the mirror node APIs.
+     *
+     * @return the subscribed flux
+     */
     @Bean
     Disposable publishSubscribe() {
         return Flux.<PublishRequest>generate(sink -> sink.next(transactionGenerator.next()))

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/config/MonitorConfiguration.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/config/MonitorConfiguration.java
@@ -20,22 +20,20 @@ package com.hedera.mirror.monitor.config;
  * ‍
  */
 
-import java.util.concurrent.Executors;
+import java.util.Objects;
 import javax.annotation.Resource;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.integration.channel.NullChannel;
-import org.springframework.integration.dsl.IntegrationFlow;
-import org.springframework.integration.dsl.IntegrationFlows;
-import org.springframework.integration.endpoint.ReactiveMessageSourceProducer;
-import org.springframework.messaging.MessageChannel;
-import org.springframework.messaging.support.GenericMessage;
+import reactor.core.Disposable;
+import reactor.core.publisher.Flux;
+import reactor.core.scheduler.Schedulers;
 
 import com.hedera.mirror.monitor.generator.TransactionGenerator;
 import com.hedera.mirror.monitor.publish.PublishProperties;
 import com.hedera.mirror.monitor.publish.PublishRequest;
 import com.hedera.mirror.monitor.publish.TransactionPublisher;
+import com.hedera.mirror.monitor.subscribe.Subscriber;
 
 @Log4j2
 @Configuration
@@ -50,17 +48,17 @@ class MonitorConfiguration {
     @Resource
     private TransactionPublisher transactionPublisher;
 
-    @Bean
-    IntegrationFlow publishFlow() {
-        return IntegrationFlows
-                .from(new ReactiveMessageSourceProducer(() -> new GenericMessage<>(transactionGenerator.next())))
-                .channel(c -> c.executor(Executors.newFixedThreadPool(publishProperties.getConnections())))
-                .handle(PublishRequest.class, (p, h) -> transactionPublisher.publish(p))
-                .nullChannel();
-    }
+    @Resource
+    private Subscriber subscriber;
 
     @Bean
-    MessageChannel errorChannel() {
-        return new NullChannel();
+    Disposable publishSubscribe() {
+        return Flux.<PublishRequest>generate(sink -> sink.next(transactionGenerator.next()))
+                .subscribeOn(Schedulers.single())
+                .parallel(publishProperties.getConnections())
+                .runOn(Schedulers.newParallel("publisher", publishProperties.getConnections()))
+                .map(transactionPublisher::publish)
+                .filter(Objects::nonNull)
+                .subscribe(subscriber::onPublish);
     }
 }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/generator/CompositeTransactionGenerator.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/generator/CompositeTransactionGenerator.java
@@ -74,17 +74,19 @@ public class CompositeTransactionGenerator implements TransactionGenerator {
     private synchronized void rebuild() {
         List<Pair<TransactionGenerator, Double>> pairs = new ArrayList<>();
 
-        double total = properties.getScenarios()
-                .stream()
-                .filter(ScenarioProperties::isEnabled)
-                .map(ScenarioProperties::getTps)
-                .reduce(0.0, (x, y) -> x + y);
+        if (properties.isEnabled()) {
+            double total = properties.getScenarios()
+                    .stream()
+                    .filter(ScenarioProperties::isEnabled)
+                    .map(ScenarioProperties::getTps)
+                    .reduce(0.0, (x, y) -> x + y);
 
-        for (ScenarioProperties scenarioProperties : properties.getScenarios()) {
-            if (properties.isEnabled() && scenarioProperties.isEnabled()) {
-                double weight = total > 0 ? scenarioProperties.getTps() / total : 0.0;
-                pairs.add(Pair.create(new ConfigurableTransactionGenerator(scenarioProperties), weight));
-                log.info("Activated scenario: {}", scenarioProperties);
+            for (ScenarioProperties scenarioProperties : properties.getScenarios()) {
+                if (scenarioProperties.isEnabled()) {
+                    double weight = total > 0 ? scenarioProperties.getTps() / total : 0.0;
+                    pairs.add(Pair.create(new ConfigurableTransactionGenerator(scenarioProperties), weight));
+                    log.info("Activated scenario: {}", scenarioProperties);
+                }
             }
         }
 

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/generator/CompositeTransactionGenerator.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/generator/CompositeTransactionGenerator.java
@@ -22,6 +22,7 @@ package com.hedera.mirror.monitor.generator;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import javax.inject.Named;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.math3.distribution.EnumeratedDistribution;
@@ -40,6 +41,7 @@ public class CompositeTransactionGenerator implements TransactionGenerator {
     static {
         ScenarioProperties scenarioProperties = new ScenarioProperties();
         scenarioProperties.setName("Inactive");
+        scenarioProperties.setProperties(Map.of("topicId", "invalid"));
         scenarioProperties.setTps(Double.MIN_NORMAL); // Never retry
         scenarioProperties.setType(TransactionType.CONSENSUS_SUBMIT_MESSAGE);
         TransactionGenerator generator = new ConfigurableTransactionGenerator(scenarioProperties);

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/generator/ConfigurableTransactionGenerator.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/generator/ConfigurableTransactionGenerator.java
@@ -53,7 +53,7 @@ public class ConfigurableTransactionGenerator implements TransactionGenerator {
         builder = PublishRequest.builder()
                 .logResponse(properties.isLogResponse())
                 .type(properties.getType());
-        rateLimiter.acquire();
+        rateLimiter.acquire(); // The first acquire always succeeds, so do this so tps=Double.MIN_NORMAL won't acquire
     }
 
     @Override
@@ -90,12 +90,6 @@ public class ConfigurableTransactionGenerator implements TransactionGenerator {
     }
 
     private boolean shouldGenerate(int percent, long count) {
-        if (percent <= 0) {
-            return false;
-        } else if (percent >= 100) {
-            return true;
-        } else {
-            return (count % 100) <= percent;
-        }
+        return (count % 100) < percent;
     }
 }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/generator/ConfigurableTransactionGenerator.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/generator/ConfigurableTransactionGenerator.java
@@ -28,8 +28,8 @@ import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
 import javax.validation.Validation;
 import javax.validation.Validator;
-import javax.validation.ValidatorFactory;
 import lombok.extern.log4j.Log4j2;
+import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
 
 import com.hedera.datagenerator.sdk.supplier.TransactionSupplier;
 import com.hedera.mirror.monitor.publish.PublishRequest;
@@ -78,8 +78,11 @@ public class ConfigurableTransactionGenerator implements TransactionGenerator {
     private TransactionSupplier<?> convert(ScenarioProperties p) {
         TransactionSupplier<?> supplier = new ObjectMapper().convertValue(p.getProperties(), p.getType().getSupplier());
 
-        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
-        Validator validator = factory.getValidator();
+        Validator validator = Validation.byDefaultProvider()
+                .configure()
+                .messageInterpolator(new ParameterMessageInterpolator())
+                .buildValidatorFactory()
+                .getValidator();
         Set<ConstraintViolation<TransactionSupplier<?>>> validations = validator.validate(supplier);
 
         if (!validations.isEmpty()) {

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/generator/ScenarioException.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/generator/ScenarioException.java
@@ -20,11 +20,17 @@ package com.hedera.mirror.monitor.generator;
  * ‍
  */
 
+import lombok.Getter;
+
 public class ScenarioException extends RuntimeException {
 
-    private static final long serialVersionUID = 3538325614384119370L;
+    private static final long serialVersionUID = 1690349494197296387L;
 
-    public ScenarioException(String message) {
+    @Getter
+    private final ScenarioProperties properties;
+
+    public ScenarioException(ScenarioProperties properties, String message) {
         super(message);
+        this.properties = properties;
     }
 }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/generator/ScenarioException.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/generator/ScenarioException.java
@@ -27,7 +27,7 @@ public class ScenarioException extends RuntimeException {
     private static final long serialVersionUID = 1690349494197296387L;
 
     @Getter
-    private final ScenarioProperties properties;
+    private final transient ScenarioProperties properties;
 
     public ScenarioException(ScenarioProperties properties, String message) {
         super(message);

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/generator/ScenarioProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/generator/ScenarioProperties.java
@@ -23,9 +23,9 @@ package com.hedera.mirror.monitor.generator;
 import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import lombok.Data;
 import org.hibernate.validator.constraints.time.DurationMin;
@@ -37,29 +37,40 @@ import com.hedera.datagenerator.sdk.supplier.TransactionType;
 @Validated
 public class ScenarioProperties {
 
+    @NotNull
     @DurationMin(seconds = 30)
-    private Duration duration = Duration.ofMinutes(10L);
+    private Duration duration = Duration.ofNanos(Long.MAX_VALUE);
 
     private boolean enabled = true;
 
     @Min(0)
     private long limit = 0;
 
+    private boolean logResponse = false;
+
     @NotBlank
     private String name;
 
-    @NotEmpty
+    @NotNull
     private Map<String, Object> properties = new LinkedHashMap<>();
 
-    private boolean receipt = false; // TODO: Retrieve a percentage of receipts and records
+    @Min(0)
+    @Max(100)
+    private int receipt = 0;
 
-    private boolean record = false;
+    @Min(0)
+    @Max(100)
+    private int record = 0;
 
     @Min(0)
     private double tps = 10.0;
 
     @NotNull
     private TransactionType type;
+
+    public long getLimit() {
+        return limit > 0 ? limit : Long.MAX_VALUE;
+    }
 }
 
 

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishException.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishException.java
@@ -20,19 +20,10 @@ package com.hedera.mirror.monitor.publish;
  * ‍
  */
 
-import lombok.Builder;
-import lombok.Value;
+public class PublishException extends RuntimeException {
+    private static final long serialVersionUID = 1405915869165326841L;
 
-import com.hedera.datagenerator.sdk.supplier.TransactionType;
-import com.hedera.hashgraph.sdk.TransactionBuilder;
-import com.hedera.hashgraph.sdk.TransactionId;
-
-@Builder
-@Value
-public class PublishRequest {
-    private final boolean logResponse;
-    private final boolean receipt;
-    private final boolean record;
-    private final TransactionBuilder<TransactionId, ?, ?> transactionBuilder;
-    private final TransactionType type;
+    public PublishException(Throwable t) {
+        super(t);
+    }
 }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishMetrics.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishMetrics.java
@@ -61,7 +61,7 @@ public class PublishMetrics {
     }
 
     public PublishResponse record(PublishRequest publishRequest,
-            CheckedFunction<PublishRequest, PublishResponse> function) {
+                                  CheckedFunction<PublishRequest, PublishResponse> function) {
         long startTime = System.currentTimeMillis();
         String status = SUCCESS;
         TransactionType type = publishRequest.getType();
@@ -77,12 +77,15 @@ public class PublishMetrics {
             StatusRuntimeException sre = (StatusRuntimeException) e.getCause();
             status = sre.getStatus().getCode().name();
             log.debug("Network error {} submitting {} transaction: {}", status, type, sre.getStatus().getDescription());
+            throw e;
         } catch (HederaStatusException e) {
             status = e.status.name();
             log.debug("Hedera {} error submitting {} transaction: {}", status, type, e.getMessage());
+            throw new PublishException(e);
         } catch (Exception e) {
             status = e.getClass().getSimpleName();
             log.debug("{} submitting {} transaction: {}", status, type, e.getMessage());
+            throw new PublishException(e);
         } finally {
             long endTime = System.currentTimeMillis();
             Tags tags = new Tags(status, type);
@@ -93,8 +96,6 @@ public class PublishMetrics {
                 errors.add(status);
             }
         }
-
-        return null;
     }
 
     private Timer newTimer(Tags tags) {

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishMetrics.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishMetrics.java
@@ -77,15 +77,12 @@ public class PublishMetrics {
             StatusRuntimeException sre = (StatusRuntimeException) e.getCause();
             status = sre.getStatus().getCode().name();
             log.debug("Network error {} submitting {} transaction: {}", status, type, sre.getStatus().getDescription());
-            throw e;
         } catch (HederaStatusException e) {
             status = e.status.name();
             log.debug("Hedera {} error submitting {} transaction: {}", status, type, e.getMessage());
-            throw new PublishException(e);
         } catch (Exception e) {
             status = e.getClass().getSimpleName();
             log.debug("{} submitting {} transaction: {}", status, type, e.getMessage());
-            throw new PublishException(e);
         } finally {
             long endTime = System.currentTimeMillis();
             Tags tags = new Tags(status, type);
@@ -96,6 +93,8 @@ public class PublishMetrics {
                 errors.add(status);
             }
         }
+
+        return null;
     }
 
     private Timer newTimer(Tags tags) {

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishProperties.java
@@ -36,7 +36,7 @@ import com.hedera.mirror.monitor.generator.ScenarioProperties;
 public class PublishProperties {
 
     @Min(1)
-    private int connections = 4;
+    private int connections = 5;
 
     private boolean enabled = true;
 

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishProperties.java
@@ -36,7 +36,7 @@ import com.hedera.mirror.monitor.generator.ScenarioProperties;
 public class PublishProperties {
 
     @Min(1)
-    private int connections = 10;
+    private int connections = 4;
 
     private boolean enabled = true;
 

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishResponse.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishResponse.java
@@ -20,12 +20,12 @@ package com.hedera.mirror.monitor.publish;
  * ‍
  */
 
+import java.time.Instant;
 import lombok.Builder;
 import lombok.Value;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
-import com.hedera.datagenerator.sdk.supplier.TransactionType;
 import com.hedera.hashgraph.sdk.TransactionId;
 import com.hedera.hashgraph.sdk.TransactionReceipt;
 import com.hedera.hashgraph.sdk.TransactionRecord;
@@ -34,17 +34,19 @@ import com.hedera.hashgraph.sdk.TransactionRecord;
 @Value
 public class PublishResponse {
 
+    private final PublishRequest request;
     private final TransactionRecord record;
     private final TransactionReceipt receipt;
+    private final Instant timestamp = Instant.now();
     private final TransactionId transactionId;
-    private final TransactionType type;
 
     // Needed since the SDK doesn't implement toString() or have actual fields to use with reflection
     @Override
     public String toString() {
         ToStringBuilder toStringBuilder = new ToStringBuilder(this, ToStringStyle.NO_CLASS_NAME_STYLE);
+        toStringBuilder.append("timestamp", timestamp);
         toStringBuilder.append("transactionId", transactionId);
-        toStringBuilder.append("type", type);
+        toStringBuilder.append("type", request.getType());
 
         if (record != null) {
             toStringBuilder.append("consensusTimestamp", record.consensusTimestamp);

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishResponse.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishResponse.java
@@ -62,8 +62,8 @@ public class PublishResponse {
                 toStringBuilder.append("contractId", receiptProto.getContractID());
             } else if (receiptProto.hasFileID()) {
                 toStringBuilder.append("fileId", receiptProto.getFileID());
-            } else if (receiptProto.hasTokenId()) {
-                toStringBuilder.append("tokenId", receiptProto.getTokenId());
+            } else if (receiptProto.hasTokenID()) {
+                toStringBuilder.append("tokenId", receiptProto.getTokenID());
             } else if (receiptProto.hasTopicID()) {
                 toStringBuilder.append("topicId", receiptProto.getTopicID());
             }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishResponse.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishResponse.java
@@ -57,15 +57,15 @@ public class PublishResponse {
             toStringBuilder.append("status", receiptProto.getStatus());
 
             if (receiptProto.hasAccountID()) {
-                toStringBuilder.append("accountId", receiptProto.getAccountID());
+                toStringBuilder.append("accountId", receiptProto.getAccountID().getAccountNum());
             } else if (receiptProto.hasContractID()) {
-                toStringBuilder.append("contractId", receiptProto.getContractID());
+                toStringBuilder.append("contractId", receiptProto.getContractID().getContractNum());
             } else if (receiptProto.hasFileID()) {
-                toStringBuilder.append("fileId", receiptProto.getFileID());
+                toStringBuilder.append("fileId", receiptProto.getFileID().getFileNum());
             } else if (receiptProto.hasTokenID()) {
-                toStringBuilder.append("tokenId", receiptProto.getTokenID());
+                toStringBuilder.append("tokenId", receiptProto.getTokenID().getTokenNum());
             } else if (receiptProto.hasTopicID()) {
-                toStringBuilder.append("topicId", receiptProto.getTopicID());
+                toStringBuilder.append("topicId", receiptProto.getTopicID().getTopicNum());
             }
 
             if (receiptProto.getTopicSequenceNumber() > 0) {

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishResponse.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishResponse.java
@@ -22,6 +22,8 @@ package com.hedera.mirror.monitor.publish;
 
 import lombok.Builder;
 import lombok.Value;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 
 import com.hedera.datagenerator.sdk.supplier.TransactionType;
 import com.hedera.hashgraph.sdk.TransactionId;
@@ -31,8 +33,44 @@ import com.hedera.hashgraph.sdk.TransactionRecord;
 @Builder
 @Value
 public class PublishResponse {
+
     private final TransactionRecord record;
     private final TransactionReceipt receipt;
     private final TransactionId transactionId;
     private final TransactionType type;
+
+    // Needed since the SDK doesn't implement toString() or have actual fields to use with reflection
+    @Override
+    public String toString() {
+        ToStringBuilder toStringBuilder = new ToStringBuilder(this, ToStringStyle.NO_CLASS_NAME_STYLE);
+        toStringBuilder.append("transactionId", transactionId);
+        toStringBuilder.append("type", type);
+
+        if (record != null) {
+            toStringBuilder.append("consensusTimestamp", record.consensusTimestamp);
+        }
+
+        if (receipt != null) {
+            com.hedera.hashgraph.proto.TransactionReceipt receiptProto = receipt.toProto();
+            toStringBuilder.append("status", receiptProto.getStatus());
+
+            if (receiptProto.hasAccountID()) {
+                toStringBuilder.append("accountId", receiptProto.getAccountID());
+            } else if (receiptProto.hasContractID()) {
+                toStringBuilder.append("contractId", receiptProto.getContractID());
+            } else if (receiptProto.hasFileID()) {
+                toStringBuilder.append("fileId", receiptProto.getFileID());
+            } else if (receiptProto.hasTokenId()) {
+                toStringBuilder.append("tokenId", receiptProto.getTokenId());
+            } else if (receiptProto.hasTopicID()) {
+                toStringBuilder.append("topicId", receiptProto.getTopicID());
+            }
+
+            if (receiptProto.getTopicSequenceNumber() > 0) {
+                toStringBuilder.append("topicSequenceNumber", receiptProto.getTopicSequenceNumber());
+            }
+        }
+
+        return toStringBuilder.toString();
+    }
 }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/TransactionPublisher.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/TransactionPublisher.java
@@ -61,6 +61,7 @@ public class TransactionPublisher {
             try {
                 client.close(200, TimeUnit.MILLISECONDS);
             } catch (Exception e) {
+                // Ignore
             }
         }
     }
@@ -76,8 +77,8 @@ public class TransactionPublisher {
 
         var transactionId = request.getTransactionBuilder().execute(client);
         PublishResponse.PublishResponseBuilder responseBuilder = PublishResponse.builder()
-                .transactionId(transactionId)
-                .type(request.getType());
+                .request(request)
+                .transactionId(transactionId);
 
         if (request.isRecord()) {
             var record = transactionId.getRecord(client);

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/TransactionPublisher.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/TransactionPublisher.java
@@ -50,7 +50,7 @@ public class TransactionPublisher {
     private final MonitorProperties monitorProperties;
     private final PublishProperties publishProperties;
     private final PublishMetrics publishMetrics;
-    private final Supplier<List<Client>> clients = Suppliers.memoize(() -> getClients());
+    private final Supplier<List<Client>> clients = Suppliers.memoize(this::getClients);
     private final AtomicInteger counter = new AtomicInteger(0);
 
     @PreDestroy
@@ -104,15 +104,15 @@ public class TransactionPublisher {
             throw new IllegalArgumentException("No valid nodes found");
         }
 
-        List<Client> clients = new ArrayList<>();
+        List<Client> validatedClients = new ArrayList<>();
 
         for (int i = 0; i < publishProperties.getConnections(); ++i) {
             NodeProperties nodeProperties = validNodes.get(i % validNodes.size());
             Client client = toClient(nodeProperties);
-            clients.add(client);
+            validatedClients.add(client);
         }
 
-        return clients;
+        return validatedClients;
     }
 
     private List<NodeProperties> validateNodes() {

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/TransactionPublisher.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/TransactionPublisher.java
@@ -20,15 +20,15 @@ package com.hedera.mirror.monitor.publish;
  * ‍
  */
 
-import java.security.SecureRandom;
+import com.google.common.base.Suppliers;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.PostConstruct;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 import javax.annotation.PreDestroy;
 import javax.inject.Named;
 import lombok.RequiredArgsConstructor;
@@ -47,33 +47,17 @@ import com.hedera.mirror.monitor.NodeProperties;
 @RequiredArgsConstructor
 public class TransactionPublisher {
 
-    private static final Random RANDOM = new SecureRandom();
-
     private final MonitorProperties monitorProperties;
     private final PublishProperties publishProperties;
     private final PublishMetrics publishMetrics;
-    private final List<Client> clients = new ArrayList<>();
-
-    @PostConstruct
-    public void init() {
-        List<NodeProperties> validNodes = validateNodes();
-
-        if (validNodes.isEmpty()) {
-            throw new IllegalArgumentException("No valid nodes found");
-        }
-
-        for (int i = 0; i < publishProperties.getConnections(); ++i) {
-            NodeProperties nodeProperties = validNodes.get(i % validNodes.size());
-            Client client = toClient(nodeProperties);
-            clients.add(client);
-        }
-    }
+    private final Supplier<List<Client>> clients = Suppliers.memoize(() -> getClients());
+    private final AtomicInteger counter = new AtomicInteger(0);
 
     @PreDestroy
     public void close() {
-        log.info("Closing {} client connections", clients.size());
+        log.info("Closing {} client connections", clients.get().size());
 
-        for (Client client : clients) {
+        for (Client client : clients.get()) {
             try {
                 client.close(200, TimeUnit.MILLISECONDS);
             } catch (Exception e) {
@@ -82,17 +66,13 @@ public class TransactionPublisher {
     }
 
     public PublishResponse publish(PublishRequest request) {
-        if (clients.isEmpty() || !publishProperties.isEnabled()) {
-            return null;
-        }
-
         return publishMetrics.record(request, this::doPublish);
     }
 
     private PublishResponse doPublish(PublishRequest request) throws Exception {
         log.trace("Publishing: {}", request);
-        int index = RANDOM.nextInt(clients.size());
-        Client client = clients.get(index);
+        int index = counter.getAndUpdate(n -> (n + 1 < clients.get().size()) ? n + 1 : 0);
+        Client client = clients.get().get(index);
 
         var transactionId = request.getTransactionBuilder().execute(client);
         PublishResponse.PublishResponseBuilder responseBuilder = PublishResponse.builder()
@@ -108,8 +88,30 @@ public class TransactionPublisher {
         }
 
         PublishResponse response = responseBuilder.build();
-        log.trace("Received response: {}", response);
+
+        if (request.isLogResponse()) {
+            log.info("Received response: {}", response);
+        }
+
         return response;
+    }
+
+    private List<Client> getClients() {
+        List<NodeProperties> validNodes = validateNodes();
+
+        if (validNodes.isEmpty()) {
+            throw new IllegalArgumentException("No valid nodes found");
+        }
+
+        List<Client> clients = new ArrayList<>();
+
+        for (int i = 0; i < publishProperties.getConnections(); ++i) {
+            NodeProperties nodeProperties = validNodes.get(i % validNodes.size());
+            Client client = toClient(nodeProperties);
+            clients.add(client);
+        }
+
+        return clients;
     }
 
     private List<NodeProperties> validateNodes() {
@@ -128,7 +130,7 @@ public class TransactionPublisher {
             try {
                 new AccountInfoQuery().setAccountId(accountId).execute(client, Duration.ofSeconds(10L));
                 validNodes.add(node);
-                log.info("Added node {} to the list of valid nodes", node);
+                log.info("Validated node: {}", node);
             } catch (Exception e) {
                 log.warn("Unable to validate node {}: ", node, e);
             } finally {

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/AbstractSubscriberProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/AbstractSubscriberProperties.java
@@ -1,0 +1,51 @@
+package com.hedera.mirror.monitor.subscribe;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import java.time.Duration;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import lombok.Data;
+import org.hibernate.validator.constraints.time.DurationMin;
+import org.springframework.validation.annotation.Validated;
+
+@Data
+@Validated
+public abstract class AbstractSubscriberProperties {
+
+    @NotNull
+    @DurationMin(seconds = 30)
+    protected Duration duration = Duration.ofNanos(Long.MAX_VALUE);
+
+    protected boolean enabled = true;
+
+    @Min(0)
+    protected long limit = 0; // 0 for unlimited
+
+    @NotBlank
+    protected String name;
+
+    @Min(0)
+    protected long retries = 16L;
+}
+
+

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/AbstractSubscriberProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/AbstractSubscriberProperties.java
@@ -44,8 +44,24 @@ public abstract class AbstractSubscriberProperties {
     @NotBlank
     protected String name;
 
-    @Min(0)
-    protected long retries = 16L;
+    @NotNull
+    protected RetryProperties retry = new RetryProperties();
+
+    @Data
+    @Validated
+    public static class RetryProperties {
+
+        @Min(0)
+        private long maxAttempts = 16L;
+
+        @NotNull
+        @DurationMin(millis = 500L)
+        private Duration maxBackoff = Duration.ofSeconds(8L);
+
+        @NotNull
+        @DurationMin(millis = 100L)
+        private Duration minBackoff = Duration.ofMillis(250L);
+    }
 }
 
 

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/CompositeSubscriber.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/CompositeSubscriber.java
@@ -1,0 +1,70 @@
+package com.hedera.mirror.monitor.subscribe;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.google.common.base.Suppliers;
+import com.google.common.collect.Streams;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import javax.inject.Named;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Primary;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.hedera.mirror.monitor.MonitorProperties;
+import com.hedera.mirror.monitor.publish.PublishResponse;
+
+@Named
+@Primary
+@RequiredArgsConstructor
+public class CompositeSubscriber implements Subscriber {
+
+    private final MonitorProperties monitorProperties;
+    private final SubscribeProperties subscribeProperties;
+    private final MeterRegistry meterRegistry;
+    private final WebClient.Builder webClientBuilder;
+    final Supplier<List<Subscriber>> subscribers = Suppliers.memoize(this::subscribers);
+
+    @Override
+    public void onPublish(PublishResponse response) {
+        subscribers.get().forEach(s -> s.onPublish(response));
+    }
+
+    private List<Subscriber> subscribers() {
+        if (!subscribeProperties.isEnabled()) {
+            return Collections.emptyList();
+        }
+
+        return Streams.concat(
+                subscribeProperties.getGrpc()
+                        .stream()
+                        .filter(AbstractSubscriberProperties::isEnabled)
+                        .map(p -> new GrpcSubscriber(meterRegistry, monitorProperties, p)),
+                subscribeProperties.getRest()
+                        .stream()
+                        .filter(AbstractSubscriberProperties::isEnabled)
+                        .map(p -> new RestSubscriber(meterRegistry, monitorProperties, p, webClientBuilder))
+        ).collect(Collectors.toList());
+    }
+}

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/GrpcSubscriber.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/GrpcSubscriber.java
@@ -88,8 +88,9 @@ public class GrpcSubscriber implements Subscriber {
         statusThread = Executors.newSingleThreadScheduledExecutor()
                 .scheduleWithFixedDelay(this::status, 5, 5, TimeUnit.SECONDS);
 
-        log.info("Connecting to mirror node {}", monitorProperties.getMirrorNode().getGrpc().getEndpoint());
-        this.mirrorClient = new MirrorClient(monitorProperties.getMirrorNode().getGrpc().getEndpoint());
+        String endpoint = monitorProperties.getMirrorNode().getGrpc().getEndpoint();
+        log.info("Connecting to mirror node {}", endpoint);
+        this.mirrorClient = new MirrorClient(endpoint);
         resubscribe();
     }
 

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/GrpcSubscriber.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/GrpcSubscriber.java
@@ -1,0 +1,201 @@
+package com.hedera.mirror.monitor.subscribe;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import static io.grpc.Status.Code.INVALID_ARGUMENT;
+import static io.grpc.Status.Code.NOT_FOUND;
+
+import com.google.common.base.Stopwatch;
+import com.google.common.collect.ConcurrentHashMultiset;
+import com.google.common.collect.Multiset;
+import com.google.common.util.concurrent.Uninterruptibles;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import javax.annotation.PreDestroy;
+import lombok.extern.log4j.Log4j2;
+import org.apache.commons.math3.util.Precision;
+
+import com.hedera.datagenerator.common.Utility;
+import com.hedera.datagenerator.sdk.supplier.TransactionType;
+import com.hedera.hashgraph.sdk.consensus.ConsensusTopicId;
+import com.hedera.hashgraph.sdk.mirror.MirrorClient;
+import com.hedera.hashgraph.sdk.mirror.MirrorConsensusTopicQuery;
+import com.hedera.hashgraph.sdk.mirror.MirrorConsensusTopicResponse;
+import com.hedera.hashgraph.sdk.mirror.MirrorSubscriptionHandle;
+import com.hedera.mirror.monitor.MonitorProperties;
+import com.hedera.mirror.monitor.publish.PublishResponse;
+
+@Log4j2
+public class GrpcSubscriber implements Subscriber {
+
+    private final MonitorProperties monitorProperties;
+    private final GrpcSubscriberProperties subscriberProperties;
+    private final Timer timer;
+
+    private final MirrorClient mirrorClient;
+    private final AtomicLong counter;
+    private final AtomicLong retries;
+    private final Stopwatch stopwatch;
+    private final Multiset<String> errors;
+    private final ScheduledFuture<?> statusThread;
+
+    private MirrorSubscriptionHandle subscription;
+    private volatile MirrorConsensusTopicResponse lastReceived;
+    private Instant endTime;
+
+    GrpcSubscriber(MeterRegistry meterRegistry, MonitorProperties monitorProperties,
+                   GrpcSubscriberProperties subscriberProperties) {
+        this.monitorProperties = monitorProperties;
+        this.subscriberProperties = subscriberProperties;
+        this.counter = new AtomicLong(0L);
+        this.retries = new AtomicLong(0L);
+        stopwatch = Stopwatch.createStarted();
+        errors = ConcurrentHashMultiset.create();
+        this.timer = Timer.builder("hedera.mirror.monitor.subscribe")
+                .tag("api", "grpc")
+                .tag("type", TransactionType.CONSENSUS_SUBMIT_MESSAGE.toString())
+                .register(meterRegistry);
+
+        statusThread = Executors.newSingleThreadScheduledExecutor()
+                .scheduleWithFixedDelay(this::status, 5, 5, TimeUnit.SECONDS);
+
+        log.info("Connecting to mirror node {}", monitorProperties.getMirrorNode().getGrpc().getEndpoint());
+        this.mirrorClient = new MirrorClient(monitorProperties.getMirrorNode().getGrpc().getEndpoint());
+        resubscribe();
+    }
+
+    private void onNext(MirrorConsensusTopicResponse topicResponse) {
+        log.trace("Received message #{} with timestamp {}", topicResponse.sequenceNumber,
+                topicResponse.consensusTimestamp);
+
+        if (lastReceived != null) {
+            long expected = lastReceived.sequenceNumber + 1;
+            if (topicResponse.sequenceNumber != expected) {
+                log.warn("Expected sequence number {} but received {}", expected, topicResponse.sequenceNumber);
+            }
+        }
+
+        Long timestamp = Utility.getDecodedTimestamp(topicResponse.message);
+        if (timestamp == null || timestamp <= 0 || timestamp >= System.currentTimeMillis()) {
+            log.warn("Invalid timestamp in message: {}", timestamp);
+            return;
+        }
+
+        long latency = System.currentTimeMillis() - timestamp;
+        timer.record(latency, TimeUnit.MILLISECONDS);
+        this.lastReceived = topicResponse;
+        counter.incrementAndGet();
+    }
+
+    private void onError(Throwable t) {
+        log.error("Error subscribing: ", t);
+        errors.add(getStatusCode(t).name());
+
+        if (shouldRetry(t)) {
+            long delayMillis = retries.get() * subscriberProperties.getDelayMultiplier().toMillis();
+            Duration retry = Duration.ofMillis(Math.min(delayMillis, subscriberProperties.getDelayMax().toMillis()));
+            log.info("Retrying in {}s", retry.toSeconds());
+            Uninterruptibles.sleepUninterruptibly(retry);
+            resubscribe();
+        } else {
+            close();
+        }
+    }
+
+    private boolean shouldRetry(Throwable t) {
+        Status.Code code = getStatusCode(t);
+
+        if (code == INVALID_ARGUMENT || code == NOT_FOUND) {
+            return false;
+        }
+
+        return retries.incrementAndGet() < subscriberProperties.getRetries();
+    }
+
+    private Status.Code getStatusCode(Throwable t) {
+        if (t instanceof StatusRuntimeException) {
+            return ((StatusRuntimeException) t).getStatus().getCode();
+        }
+        return Status.Code.UNKNOWN;
+    }
+
+    @Override
+    public void onPublish(PublishResponse response) {
+        // Ignore for now
+    }
+
+    @PreDestroy
+    public void close() {
+        try {
+            log.info("Closing mirror node connection to {}", monitorProperties.getMirrorNode().getGrpc().getEndpoint());
+            subscription.unsubscribe();
+            mirrorClient.close(1, TimeUnit.SECONDS);
+            statusThread.cancel(true);
+        } catch (Exception e) {
+            // Ignore
+        }
+    }
+
+    private synchronized void resubscribe() {
+        MirrorConsensusTopicQuery mirrorConsensusTopicQuery = new MirrorConsensusTopicQuery();
+        mirrorConsensusTopicQuery.setTopicId(ConsensusTopicId.fromString(subscriberProperties.getTopicId()));
+        mirrorConsensusTopicQuery.setLimit(Math.min(0, subscriberProperties.getLimit() - counter.get()));
+
+        Instant startTime = lastReceived != null ? lastReceived.consensusTimestamp.plusNanos(1) : subscriberProperties
+                .getStartTime();
+        startTime = Objects.requireNonNullElseGet(startTime, Instant::now);
+        mirrorConsensusTopicQuery.setStartTime(startTime);
+
+        if (endTime != null) {
+            mirrorConsensusTopicQuery.setEndTime(endTime);
+        } else {
+            Duration duration = subscriberProperties.getDuration();
+            if (duration != null) {
+                endTime = startTime.plus(duration);
+                mirrorConsensusTopicQuery.setEndTime(endTime);
+            }
+        }
+
+        log.info("Starting subscriber: {}", subscriberProperties);
+        subscription = mirrorConsensusTopicQuery.subscribe(mirrorClient, this::onNext, this::onError);
+        retries.set(0L);
+    }
+
+    private void status() {
+        long count = counter.get();
+        long elapsed = stopwatch.elapsed(TimeUnit.MICROSECONDS);
+        double rate = Precision.round(elapsed > 0 ? (1_000_000.0 * count) / elapsed : 0.0, 1);
+        Map<String, Integer> errorCounts = new HashMap<>();
+        errors.forEachEntry((k, v) -> errorCounts.put(k, v));
+        log.info("Received {} transactions in {} at {}/s. Errors: {}", count, stopwatch, rate, errorCounts);
+    }
+}

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/GrpcSubscriber.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/GrpcSubscriber.java
@@ -91,7 +91,7 @@ public class GrpcSubscriber implements Subscriber {
         String endpoint = monitorProperties.getMirrorNode().getGrpc().getEndpoint();
         log.info("Connecting to mirror node {}", endpoint);
         this.mirrorClient = new MirrorClient(endpoint);
-        resubscribe();
+        subscribe();
     }
 
     private void onNext(MirrorConsensusTopicResponse topicResponse) {
@@ -129,7 +129,7 @@ public class GrpcSubscriber implements Subscriber {
             Duration retryDuration = Duration.ofMillis(Math.min(delayMillis, retry.getMaxBackoff().toMillis()));
             log.info("Retrying in {}s", retryDuration.toSeconds());
             Uninterruptibles.sleepUninterruptibly(retryDuration);
-            resubscribe();
+            subscribe();
         } else {
             close();
         }
@@ -168,7 +168,7 @@ public class GrpcSubscriber implements Subscriber {
         }
     }
 
-    private synchronized void resubscribe() {
+    private synchronized void subscribe() {
         long limit = subscriberProperties.getLimit();
         MirrorConsensusTopicQuery mirrorConsensusTopicQuery = new MirrorConsensusTopicQuery();
         mirrorConsensusTopicQuery.setTopicId(ConsensusTopicId.fromString(subscriberProperties.getTopicId()));

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/GrpcSubscriber.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/GrpcSubscriber.java
@@ -95,6 +95,7 @@ public class GrpcSubscriber implements Subscriber {
     }
 
     private void onNext(MirrorConsensusTopicResponse topicResponse) {
+        long endTimestamp = System.currentTimeMillis();
         counter.incrementAndGet();
         log.trace("Received message #{} with timestamp {}", topicResponse.sequenceNumber,
                 topicResponse.consensusTimestamp);
@@ -114,7 +115,7 @@ public class GrpcSubscriber implements Subscriber {
             return;
         }
 
-        long latency = System.currentTimeMillis() - timestamp;
+        long latency = endTimestamp - timestamp;
         timer.record(latency, TimeUnit.MILLISECONDS);
     }
 

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/GrpcSubscriberProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/GrpcSubscriberProperties.java
@@ -1,0 +1,49 @@
+package com.hedera.mirror.monitor.subscribe;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import java.time.Duration;
+import java.time.Instant;
+import javax.annotation.Nullable;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import lombok.Data;
+import org.hibernate.validator.constraints.time.DurationMin;
+import org.springframework.validation.annotation.Validated;
+
+@Data
+@Validated
+public class GrpcSubscriberProperties extends AbstractSubscriberProperties {
+
+    @NotNull
+    @DurationMin(millis = 500L)
+    private Duration delayMax = Duration.ofSeconds(8L);
+
+    @NotNull
+    @DurationMin(millis = 100L)
+    private Duration delayMultiplier = Duration.ofMillis(500L);
+
+    @Nullable
+    private Instant startTime;
+
+    @NotBlank
+    private String topicId;
+}

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/GrpcSubscriberProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/GrpcSubscriberProperties.java
@@ -20,26 +20,15 @@ package com.hedera.mirror.monitor.subscribe;
  * ‍
  */
 
-import java.time.Duration;
 import java.time.Instant;
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 import lombok.Data;
-import org.hibernate.validator.constraints.time.DurationMin;
 import org.springframework.validation.annotation.Validated;
 
 @Data
 @Validated
 public class GrpcSubscriberProperties extends AbstractSubscriberProperties {
-
-    @NotNull
-    @DurationMin(millis = 500L)
-    private Duration delayMax = Duration.ofSeconds(8L);
-
-    @NotNull
-    @DurationMin(millis = 100L)
-    private Duration delayMultiplier = Duration.ofMillis(500L);
 
     @Nullable
     private Instant startTime;

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/RestSubscriber.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/RestSubscriber.java
@@ -82,7 +82,7 @@ public class RestSubscriber implements Subscriber {
                         .doOnNext(json -> log.trace("Response: {}", json))
                         .timeout(properties.getTimeout())
                         .retryWhen(retrySpec)
-                        .onErrorContinue((t, o) -> log.info("Error subscribing to REST API: {}", t))
+                        .onErrorContinue((t, o) -> log.warn("Error subscribing to REST API: {}", t))
                         .doOnNext(clientResponse -> record(publishResponse)))
                 .subscribe();
     }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/RestSubscriber.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/RestSubscriber.java
@@ -1,0 +1,108 @@
+package com.hedera.mirror.monitor.subscribe;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.DirectProcessor;
+import reactor.core.publisher.FluxSink;
+import reactor.util.retry.Retry;
+
+import com.hedera.datagenerator.sdk.supplier.TransactionType;
+import com.hedera.hashgraph.sdk.TransactionId;
+import com.hedera.mirror.monitor.MonitorProperties;
+import com.hedera.mirror.monitor.publish.PublishResponse;
+
+@Log4j2
+@RequiredArgsConstructor
+public class RestSubscriber implements Subscriber {
+
+    private final MeterRegistry meterRegistry;
+    private final FluxSink<PublishResponse> restProcessor;
+    private final Map<TransactionType, Timer> timers;
+
+    public RestSubscriber(MeterRegistry meterRegistry, MonitorProperties monitorProperties,
+                          RestSubscriberProperties properties, WebClient.Builder webClientBuilder) {
+        this.meterRegistry = meterRegistry;
+        this.timers = new ConcurrentHashMap<>();
+
+        String url = monitorProperties.getMirrorNode().getRest().getBaseUrl();
+        WebClient webClient = webClientBuilder.baseUrl(url)
+                .defaultHeaders(h -> h.setAccept(List.of(MediaType.APPLICATION_JSON)))
+                .build();
+
+        DirectProcessor<PublishResponse> directProcessor = DirectProcessor.create();
+        restProcessor = directProcessor.sink();
+
+        directProcessor.doOnSubscribe(s -> log.info("Connecting to mirror node {}", url))
+                .doOnNext(publishResponse -> log.trace("Querying REST API: {}", publishResponse))
+                .doOnComplete(() -> log.info("Finished subscription"))
+                .limitRequest(properties.getLimit())
+                .take(properties.getDuration())
+                .onErrorContinue((t, o) -> log.info("Error: {}", t))
+                .flatMap(publishResponse -> webClient.get()
+                        .uri("/transactions/{transactionId}", toString(publishResponse.getTransactionId()))
+                        .retrieve()
+                        .bodyToMono(String.class)
+                        .doOnNext(json -> log.trace("Response: {}", json))
+                        .timeout(properties.getTimeout())
+                        .retryWhen(Retry.backoff(properties.getRetries(), properties.getFrequency())
+                                .filter(this::isClientError))
+                        .doOnNext(clientResponse -> record(publishResponse))
+                ).subscribe();
+    }
+
+    @Override
+    public void onPublish(PublishResponse response) {
+        restProcessor.next(response);
+    }
+
+    private boolean isClientError(Throwable t) {
+        return t instanceof WebClientResponseException &&
+                ((WebClientResponseException) t).getStatusCode().is4xxClientError();
+    }
+
+    private void record(PublishResponse r) {
+        Timer timer = timers.computeIfAbsent(r.getRequest().getType(), this::newTimer);
+        timer.record(Duration.between(r.getRequest().getTimestamp(), Instant.now()));
+    }
+
+    private Timer newTimer(TransactionType type) {
+        return Timer.builder("hedera.mirror.monitor.subscribe")
+                .tag("api", "rest")
+                .tag("type", type.name())
+                .register(meterRegistry);
+    }
+
+    private String toString(TransactionId tid) {
+        return tid.accountId + "-" + tid.validStart.getEpochSecond() + "-" + tid.validStart.getNano();
+    }
+}

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/RestSubscriberProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/RestSubscriberProperties.java
@@ -31,10 +31,6 @@ import org.springframework.validation.annotation.Validated;
 public class RestSubscriberProperties extends AbstractSubscriberProperties {
 
     @NotNull
-    @DurationMin(millis = 50)
-    private Duration frequency = Duration.ofMillis(100);
-
-    @NotNull
     @DurationMin(millis = 500)
     private Duration timeout = Duration.ofSeconds(2);
 
@@ -43,5 +39,3 @@ public class RestSubscriberProperties extends AbstractSubscriberProperties {
         return limit > 0 ? limit : Long.MAX_VALUE;
     }
 }
-
-

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/RestSubscriberProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/RestSubscriberProperties.java
@@ -1,4 +1,4 @@
-package com.hedera.mirror.monitor.publish;
+package com.hedera.mirror.monitor.subscribe;
 
 /*-
  * ‌
@@ -20,21 +20,28 @@ package com.hedera.mirror.monitor.publish;
  * ‍
  */
 
-import java.time.Instant;
-import lombok.Builder;
-import lombok.Value;
+import java.time.Duration;
+import javax.validation.constraints.NotNull;
+import lombok.Data;
+import org.hibernate.validator.constraints.time.DurationMin;
+import org.springframework.validation.annotation.Validated;
 
-import com.hedera.datagenerator.sdk.supplier.TransactionType;
-import com.hedera.hashgraph.sdk.TransactionBuilder;
-import com.hedera.hashgraph.sdk.TransactionId;
+@Data
+@Validated
+public class RestSubscriberProperties extends AbstractSubscriberProperties {
 
-@Builder
-@Value
-public class PublishRequest {
-    private final boolean logResponse;
-    private final boolean receipt;
-    private final boolean record;
-    private final Instant timestamp = Instant.now();
-    private final TransactionBuilder<TransactionId, ?, ?> transactionBuilder;
-    private final TransactionType type;
+    @NotNull
+    @DurationMin(millis = 50)
+    private Duration frequency = Duration.ofMillis(100);
+
+    @NotNull
+    @DurationMin(millis = 500)
+    private Duration timeout = Duration.ofSeconds(2);
+
+    @Override
+    public long getLimit() {
+        return limit > 0 ? limit : Long.MAX_VALUE;
+    }
 }
+
+

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/SubscribeProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/SubscribeProperties.java
@@ -1,4 +1,4 @@
-package com.hedera.mirror.monitor.publish;
+package com.hedera.mirror.monitor.subscribe;
 
 /*-
  * ‌
@@ -20,10 +20,23 @@ package com.hedera.mirror.monitor.publish;
  * ‍
  */
 
-public class PublishException extends RuntimeException {
-    private static final long serialVersionUID = 1405915869165326841L;
+import java.util.ArrayList;
+import java.util.List;
+import javax.validation.constraints.NotNull;
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
 
-    public PublishException(Throwable t) {
-        super(t);
-    }
+@Data
+@Validated
+@ConfigurationProperties("hedera.mirror.monitor.subscribe")
+public class SubscribeProperties {
+
+    private boolean enabled = true;
+
+    @NotNull
+    private List<GrpcSubscriberProperties> grpc = new ArrayList<>();
+
+    @NotNull
+    private List<RestSubscriberProperties> rest = new ArrayList<>();
 }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/Subscriber.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/Subscriber.java
@@ -1,4 +1,4 @@
-package com.hedera.mirror.monitor.publish;
+package com.hedera.mirror.monitor.subscribe;
 
 /*-
  * ‌
@@ -20,21 +20,8 @@ package com.hedera.mirror.monitor.publish;
  * ‍
  */
 
-import java.time.Instant;
-import lombok.Builder;
-import lombok.Value;
+import com.hedera.mirror.monitor.publish.PublishResponse;
 
-import com.hedera.datagenerator.sdk.supplier.TransactionType;
-import com.hedera.hashgraph.sdk.TransactionBuilder;
-import com.hedera.hashgraph.sdk.TransactionId;
-
-@Builder
-@Value
-public class PublishRequest {
-    private final boolean logResponse;
-    private final boolean receipt;
-    private final boolean record;
-    private final Instant timestamp = Instant.now();
-    private final TransactionBuilder<TransactionId, ?, ?> transactionBuilder;
-    private final TransactionType type;
+public interface Subscriber {
+    void onPublish(PublishResponse response);
 }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/Subscriber.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/Subscriber.java
@@ -23,5 +23,8 @@ package com.hedera.mirror.monitor.subscribe;
 import com.hedera.mirror.monitor.publish.PublishResponse;
 
 public interface Subscriber {
+
+    String METRIC_NAME = "hedera.mirror.monitor.subscribe";
+
     void onPublish(PublishResponse response);
 }

--- a/hedera-mirror-monitor/src/main/resources/application.yml
+++ b/hedera-mirror-monitor/src/main/resources/application.yml
@@ -1,6 +1,8 @@
 logging:
   level:
     root: warn
+    #org.springframework.web.reactive.function.client: trace
+    com.hedera.datagenerator: info
     com.hedera.mirror.monitor: info
 management:
   endpoints:

--- a/hedera-mirror-monitor/src/main/resources/application.yml
+++ b/hedera-mirror-monitor/src/main/resources/application.yml
@@ -1,19 +1,3 @@
-hedera:
-  mirror:
-    monitor:
-      network: TESTNET
-      operator:
-        accountId:
-        privateKey:
-      publish:
-        connections: 4
-        scenarios:
-          - name: HCS pinger
-            properties:
-              topicId:
-            record: true
-            tps: 0.1
-            type: CONSENSUS_SUBMIT_MESSAGE
 logging:
   level:
     root: warn

--- a/hedera-mirror-monitor/src/main/resources/application.yml
+++ b/hedera-mirror-monitor/src/main/resources/application.yml
@@ -1,7 +1,7 @@
 logging:
   level:
     root: warn
-    com.hedera.mirror.monitor: trace
+    com.hedera.mirror.monitor: info
 management:
   endpoints:
     web:

--- a/hedera-mirror-monitor/src/main/resources/application.yml
+++ b/hedera-mirror-monitor/src/main/resources/application.yml
@@ -1,7 +1,7 @@
 logging:
   level:
     root: warn
-    com.hedera.mirror.monitor: info
+    com.hedera.mirror.monitor: trace
 management:
   endpoints:
     web:

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/generator/CompositeTransactionGeneratorTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/generator/CompositeTransactionGeneratorTest.java
@@ -37,7 +37,7 @@ import com.hedera.datagenerator.sdk.supplier.TransactionType;
 import com.hedera.mirror.monitor.publish.PublishProperties;
 import com.hedera.mirror.monitor.publish.PublishRequest;
 
-public class CompositeTransactionGeneratorTest {
+class CompositeTransactionGeneratorTest {
 
     private PublishProperties properties;
     private Supplier<CompositeTransactionGenerator> supplier;

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/generator/CompositeTransactionGeneratorTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/generator/CompositeTransactionGeneratorTest.java
@@ -21,6 +21,7 @@ package com.hedera.mirror.monitor.generator;
  */
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.withinPercentage;
 
 import com.google.common.base.Suppliers;
@@ -90,5 +91,37 @@ public class CompositeTransactionGeneratorTest {
                 .hasSize(1)
                 .extracting(Pair::getValue)
                 .containsExactly(1.0);
+    }
+
+    @Test
+    void noScenario() {
+        properties.getScenarios().clear();
+        assertInactive();
+    }
+
+    @Test
+    void publishDisabled() {
+        properties.setEnabled(false);
+        assertInactive();
+    }
+
+    @Test
+    void scenariosComplete() {
+        properties.getScenarios().remove(properties.getScenarios().size() - 1);
+        properties.getScenarios().get(0).setLimit(1L);
+        CompositeTransactionGenerator generator = supplier.get();
+        assertThat(generator.next()).isNotNull();
+        assertThatThrownBy(() -> generator.next()).isInstanceOf(ScenarioException.class);
+        assertInactive();
+        assertThat(properties.getScenarios())
+                .extracting(ScenarioProperties::isEnabled)
+                .containsExactly(false);
+    }
+
+    private void assertInactive() {
+        assertThat(supplier.get().distribution.getPmf())
+                .hasSize(1)
+                .first()
+                .isEqualTo(CompositeTransactionGenerator.INACTIVE);
     }
 }

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/generator/ConfigurableTransactionGeneratorTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/generator/ConfigurableTransactionGeneratorTest.java
@@ -53,7 +53,7 @@ class ConfigurableTransactionGeneratorTest {
         properties.setReceipt(100);
         properties.setRecord(100);
         properties.setName("test");
-        properties.setProperties(Map.of("topicId", TOPIC_ID));
+        properties.setProperties(Map.of("messageSize", 8, "topicId", TOPIC_ID));
         properties.setTps(10000);
         properties.setType(TransactionType.CONSENSUS_SUBMIT_MESSAGE);
         generator = Suppliers.memoize(() -> new ConfigurableTransactionGenerator(properties));

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/generator/ConfigurableTransactionGeneratorTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/generator/ConfigurableTransactionGeneratorTest.java
@@ -39,7 +39,7 @@ import com.hedera.datagenerator.sdk.supplier.TransactionType;
 import com.hedera.hashgraph.sdk.consensus.ConsensusTopicId;
 import com.hedera.mirror.monitor.publish.PublishRequest;
 
-public class ConfigurableTransactionGeneratorTest {
+class ConfigurableTransactionGeneratorTest {
 
     private static final int SAMPLE_SIZE = 1000;
     private static final String TOPIC_ID = "0.0.1000";

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/generator/ConfigurableTransactionGeneratorTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/generator/ConfigurableTransactionGeneratorTest.java
@@ -53,7 +53,7 @@ class ConfigurableTransactionGeneratorTest {
         properties.setReceipt(100);
         properties.setRecord(100);
         properties.setName("test");
-        properties.setProperties(Map.of("messageSize", 8, "topicId", TOPIC_ID));
+        properties.setProperties(Map.of("topicId", TOPIC_ID));
         properties.setTps(10000);
         properties.setType(TransactionType.CONSENSUS_SUBMIT_MESSAGE);
         generator = Suppliers.memoize(() -> new ConfigurableTransactionGenerator(properties));

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/CompositeSubscriberTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/CompositeSubscriberTest.java
@@ -1,0 +1,96 @@
+package com.hedera.mirror.monitor.subscribe;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.hedera.mirror.monitor.MirrorNodeProperties;
+import com.hedera.mirror.monitor.MonitorProperties;
+
+class CompositeSubscriberTest {
+
+    private MonitorProperties monitorProperties;
+    private SubscribeProperties subscribeProperties;
+    private GrpcSubscriberProperties grpcSubscriberProperties;
+    private RestSubscriberProperties restSubscriberProperties;
+    private MeterRegistry meterRegistry;
+    private WebClient.Builder webClient;
+    private CompositeSubscriber compositeSubscriber;
+
+    @BeforeEach
+    void setup() {
+        monitorProperties = new MonitorProperties();
+        monitorProperties.setMirrorNode(new MirrorNodeProperties());
+        subscribeProperties = new SubscribeProperties();
+        meterRegistry = new SimpleMeterRegistry();
+        webClient = WebClient.builder();
+        compositeSubscriber = new CompositeSubscriber(monitorProperties, subscribeProperties, meterRegistry, webClient);
+
+        grpcSubscriberProperties = new GrpcSubscriberProperties();
+        grpcSubscriberProperties.setTopicId("0.0.1000");
+        restSubscriberProperties = new RestSubscriberProperties();
+        subscribeProperties.getGrpc().add(grpcSubscriberProperties);
+        subscribeProperties.getRest().add(restSubscriberProperties);
+    }
+
+    @Test
+    void allEnabled() {
+        assertThat(compositeSubscriber.subscribers.get())
+                .hasSize(2)
+                .hasAtLeastOneElementOfType(GrpcSubscriber.class)
+                .hasAtLeastOneElementOfType(RestSubscriber.class);
+    }
+
+    @Test
+    void restDisabled() {
+        restSubscriberProperties.setEnabled(false);
+        assertThat(compositeSubscriber.subscribers.get())
+                .hasSize(1)
+                .hasAtLeastOneElementOfType(GrpcSubscriber.class);
+    }
+
+    @Test
+    void grpcDisabled() {
+        grpcSubscriberProperties.setEnabled(false);
+        assertThat(compositeSubscriber.subscribers.get())
+                .hasSize(1)
+                .hasAtLeastOneElementOfType(RestSubscriber.class);
+    }
+
+    @Test
+    void allDisabled() {
+        grpcSubscriberProperties.setEnabled(false);
+        restSubscriberProperties.setEnabled(false);
+        assertThat(compositeSubscriber.subscribers.get()).isEmpty();
+    }
+
+    @Test
+    void subscribeDisabled() {
+        subscribeProperties.setEnabled(false);
+        assertThat(compositeSubscriber.subscribers.get()).isEmpty();
+    }
+}

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/CompositeSubscriberTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/CompositeSubscriberTest.java
@@ -43,8 +43,11 @@ class CompositeSubscriberTest {
 
     @BeforeEach
     void setup() {
+        MirrorNodeProperties mirrorNodeProperties = new MirrorNodeProperties();
+        mirrorNodeProperties.getGrpc().setHost("127.0.0.1");
+        mirrorNodeProperties.getRest().setHost("127.0.0.1");
         monitorProperties = new MonitorProperties();
-        monitorProperties.setMirrorNode(new MirrorNodeProperties());
+        monitorProperties.setMirrorNode(mirrorNodeProperties);
         subscribeProperties = new SubscribeProperties();
         meterRegistry = new SimpleMeterRegistry();
         webClient = WebClient.builder();

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/RestSubscriberTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/RestSubscriberTest.java
@@ -1,0 +1,189 @@
+package com.hedera.mirror.monitor.subscribe;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import static com.hedera.mirror.monitor.subscribe.Subscriber.METRIC_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.google.common.util.concurrent.Uninterruptibles;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Duration;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Mono;
+
+import com.hedera.datagenerator.sdk.supplier.TransactionType;
+import com.hedera.hashgraph.sdk.TransactionId;
+import com.hedera.hashgraph.sdk.account.AccountId;
+import com.hedera.mirror.monitor.MirrorNodeProperties;
+import com.hedera.mirror.monitor.MonitorProperties;
+import com.hedera.mirror.monitor.publish.PublishRequest;
+import com.hedera.mirror.monitor.publish.PublishResponse;
+
+@MockitoSettings
+class RestSubscriberTest {
+
+    @Mock()
+    private ExchangeFunction exchangeFunction;
+
+    private MeterRegistry meterRegistry;
+    private MonitorProperties monitorProperties;
+    private RestSubscriberProperties subscriberProperties;
+    private WebClient.Builder builder;
+    private RestSubscriber restSubscriber;
+
+    @BeforeEach
+    void setup() {
+        meterRegistry = new SimpleMeterRegistry();
+
+        monitorProperties = new MonitorProperties();
+        monitorProperties.setMirrorNode(new MirrorNodeProperties());
+        monitorProperties.getMirrorNode().getRest().setHost("127.0.0.1");
+
+        subscriberProperties = new RestSubscriberProperties();
+        subscriberProperties.setLimit(2L);
+        subscriberProperties.getRetry().setMaxAttempts(2L);
+        subscriberProperties.getRetry().setMinBackoff(Duration.ofNanos(1L));
+        subscriberProperties.getRetry().setMaxBackoff(Duration.ofNanos(2L));
+
+        builder = WebClient.builder().exchangeFunction(exchangeFunction);
+        this.restSubscriber = new RestSubscriber(meterRegistry, monitorProperties, subscriberProperties, builder);
+    }
+
+    @Test
+    void publish() {
+        Mockito.when(exchangeFunction.exchange(Mockito.any(ClientRequest.class))).thenReturn(response(HttpStatus.OK));
+
+        restSubscriber.onPublish(publishResponse());
+        restSubscriber.onPublish(publishResponse());
+
+        verify(exchangeFunction, times(2)).exchange(Mockito.isA(ClientRequest.class));
+        assertMetric(2L);
+    }
+
+    @Test
+    void duration() {
+        subscriberProperties.setDuration(Duration.ofMillis(500L));
+        this.restSubscriber = new RestSubscriber(meterRegistry, monitorProperties, subscriberProperties, builder);
+        Mono<ClientResponse> delay = Mono.delay(Duration.ofSeconds(5L)).then(response(HttpStatus.OK));
+        Mockito.when(exchangeFunction.exchange(Mockito.any(ClientRequest.class))).thenReturn(delay);
+
+        restSubscriber.onPublish(publishResponse());
+
+        Uninterruptibles.sleepUninterruptibly(Duration.ofSeconds(1));
+        verify(exchangeFunction).exchange(Mockito.isA(ClientRequest.class));
+        assertMetric(0L);
+    }
+
+    @Test
+    void limit() {
+        Mockito.when(exchangeFunction.exchange(Mockito.any(ClientRequest.class))).thenReturn(response(HttpStatus.OK));
+
+        restSubscriber.onPublish(publishResponse());
+        restSubscriber.onPublish(publishResponse());
+        restSubscriber.onPublish(publishResponse());
+
+        verify(exchangeFunction, times(2)).exchange(Mockito.isA(ClientRequest.class));
+        assertMetric(2L);
+    }
+
+    @Test
+    void clientError() {
+        Mockito.when(exchangeFunction.exchange(Mockito.any(ClientRequest.class)))
+                .thenReturn(response(HttpStatus.BAD_REQUEST));
+        restSubscriber.onPublish(publishResponse());
+
+        verify(exchangeFunction).exchange(Mockito.isA(ClientRequest.class));
+        assertMetric(0L);
+    }
+
+    @Test
+    void serverErrorRecovers() {
+        Mockito.when(exchangeFunction.exchange(Mockito.isA(ClientRequest.class)))
+                .thenReturn(response(HttpStatus.INTERNAL_SERVER_ERROR))
+                .thenReturn(response(HttpStatus.OK));
+
+        restSubscriber.onPublish(publishResponse());
+
+        Uninterruptibles.sleepUninterruptibly(Duration.ofSeconds(1));
+        verify(exchangeFunction, times(2)).exchange(Mockito.isA(ClientRequest.class));
+        assertMetric(1L);
+    }
+
+    @Test
+    void serverErrorNeverRecovers() {
+        Mockito.when(exchangeFunction.exchange(Mockito.isA(ClientRequest.class)))
+                .thenReturn(response(HttpStatus.INTERNAL_SERVER_ERROR))
+                .thenReturn(response(HttpStatus.INTERNAL_SERVER_ERROR))
+                .thenReturn(response(HttpStatus.INTERNAL_SERVER_ERROR));
+
+        restSubscriber.onPublish(publishResponse());
+
+        Uninterruptibles.sleepUninterruptibly(Duration.ofSeconds(1));
+        verify(exchangeFunction, times(3)).exchange(Mockito.isA(ClientRequest.class));
+        assertMetric(0L);
+    }
+
+    private PublishResponse publishResponse() {
+        return PublishResponse.builder()
+                .request(PublishRequest.builder().type(TransactionType.CONSENSUS_SUBMIT_MESSAGE).build())
+                .transactionId(TransactionId.withValidStart(AccountId.fromString("0.0.1000"), Instant.ofEpochSecond(1)))
+                .build();
+    }
+
+    private Mono<ClientResponse> response(HttpStatus httpStatus) {
+        if (!httpStatus.is2xxSuccessful()) {
+            return Mono.defer(() -> Mono
+                    .error(WebClientResponseException.create(httpStatus.value(), "", HttpHeaders.EMPTY, null, null)));
+        }
+        return Mono.just(ClientResponse.create(httpStatus)
+                .header("Content-Type", "application/json")
+                .body("{}")
+                .build());
+    }
+
+    private void assertMetric(long count) {
+        if (count > 0) {
+            assertThat(meterRegistry.find(METRIC_NAME).timers())
+                    .hasSize(1)
+                    .element(0)
+                    .extracting(Timer::takeSnapshot)
+                    .hasFieldOrPropertyWithValue("count", count);
+        } else {
+            assertThat(meterRegistry.find(METRIC_NAME).timers()).isEmpty();
+        }
+    }
+}

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/RestSubscriberTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/RestSubscriberTest.java
@@ -101,7 +101,7 @@ class RestSubscriberTest {
     @Test
     void duration() throws Exception {
         countDownLatch = new CountDownLatch(1);
-        subscriberProperties.setDuration(Duration.ofMillis(500));
+        subscriberProperties.setDuration(Duration.ofSeconds(1));
         this.restSubscriber = new RestSubscriber(meterRegistry, monitorProperties, subscriberProperties, builder);
         Mono<ClientResponse> delay = response(HttpStatus.OK)
                 .delayElement(Duration.ofSeconds(5L))
@@ -110,7 +110,7 @@ class RestSubscriberTest {
 
         restSubscriber.onPublish(publishResponse());
 
-        countDownLatch.await(1000, TimeUnit.MILLISECONDS);
+        countDownLatch.await(2, TimeUnit.SECONDS);
         verify(exchangeFunction).exchange(Mockito.isA(ClientRequest.class));
         assertMetric(0L);
     }

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/RestSubscriberTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/RestSubscriberTest.java
@@ -130,10 +130,10 @@ class RestSubscriberTest {
     }
 
     @Test
-    void clientError() throws Exception {
+    void nonRetryableError() throws Exception {
         countDownLatch = new CountDownLatch(1);
         Mockito.when(exchangeFunction.exchange(Mockito.any(ClientRequest.class)))
-                .thenReturn(response(HttpStatus.BAD_REQUEST));
+                .thenReturn(response(HttpStatus.INTERNAL_SERVER_ERROR));
         restSubscriber.onPublish(publishResponse());
 
         countDownLatch.await(500, TimeUnit.MILLISECONDS);
@@ -142,10 +142,10 @@ class RestSubscriberTest {
     }
 
     @Test
-    void serverErrorRecovers() throws Exception {
+    void recovers() throws Exception {
         countDownLatch = new CountDownLatch(2);
         Mockito.when(exchangeFunction.exchange(Mockito.isA(ClientRequest.class)))
-                .thenReturn(response(HttpStatus.INTERNAL_SERVER_ERROR))
+                .thenReturn(response(HttpStatus.NOT_FOUND))
                 .thenReturn(response(HttpStatus.OK));
 
         restSubscriber.onPublish(publishResponse());
@@ -156,12 +156,12 @@ class RestSubscriberTest {
     }
 
     @Test
-    void serverErrorNeverRecovers() throws Exception {
+    void neverRecovers() throws Exception {
         countDownLatch = new CountDownLatch(3);
         Mockito.when(exchangeFunction.exchange(Mockito.isA(ClientRequest.class)))
-                .thenReturn(response(HttpStatus.INTERNAL_SERVER_ERROR))
-                .thenReturn(response(HttpStatus.INTERNAL_SERVER_ERROR))
-                .thenReturn(response(HttpStatus.INTERNAL_SERVER_ERROR));
+                .thenReturn(response(HttpStatus.NOT_FOUND))
+                .thenReturn(response(HttpStatus.NOT_FOUND))
+                .thenReturn(response(HttpStatus.NOT_FOUND));
 
         restSubscriber.onPublish(publishResponse());
 

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/RestSubscriberTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/RestSubscriberTest.java
@@ -96,14 +96,15 @@ class RestSubscriberTest {
 
     @Test
     void duration() {
-        subscriberProperties.setDuration(Duration.ofMillis(500L));
+        subscriberProperties.setDuration(Duration.ofMillis(1000L));
+        subscriberProperties.getRetry().setMaxAttempts(0);
         this.restSubscriber = new RestSubscriber(meterRegistry, monitorProperties, subscriberProperties, builder);
         Mono<ClientResponse> delay = Mono.delay(Duration.ofSeconds(5L)).then(response(HttpStatus.OK));
         Mockito.when(exchangeFunction.exchange(Mockito.any(ClientRequest.class))).thenReturn(delay);
 
         restSubscriber.onPublish(publishResponse());
 
-        Uninterruptibles.sleepUninterruptibly(Duration.ofSeconds(1));
+        Uninterruptibles.sleepUninterruptibly(Duration.ofSeconds(2));
         verify(exchangeFunction).exchange(Mockito.isA(ClientRequest.class));
         assertMetric(0L);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -396,7 +396,7 @@
                                 </replacement>
                                 <replacement>
                                     <token>
-                                        <![CDATA[(?<=gcr.io/mirrornode/hedera-mirror-(grpc|importer|rest|test):)[0-9a-zA-Z.-]+]]></token>
+                                        <![CDATA[(?<=gcr.io/mirrornode/hedera-mirror-(grpc|importer|monitor|rest|test):)[0-9a-zA-Z.-]+]]></token>
                                     <value>${release.version}</value>
                                 </replacement>
                             </replacements>


### PR DESCRIPTION
**Detailed description**:
- Add gRPC API subscription to validate HCS message stream
- Add REST API subscription to validate transactions show up via `/api/v1/transactions/{transactionId}`
- Add `hedera.mirror.monitor.subscribe` metric to track end to end latency
- Add mirror node host configuration with defaults for common environments
- Add new testnet node 0.0.7
- Add support for completing a scenario while another continues
- Add support for retrieving a percentage of record or receipts
- Change monitor flow from Spring Integration to Project Reactor for backpressure support and easier development
- Fix busy loop when all publish scenarios complete
- Fix error prone timestamp extraction by removing unnecessary base64 encoding
- Fix inaccurate HCS message size generation
- Fix the GitHub Actions [warning](https://github.com/hashgraph/hedera-mirror-node/actions/runs/392159216) `git checkout HEAD^2 is no longer necessary`
- Fix gRPC topic subscription printing `Subscribing:` twice
- Fix replacer not updating monitor docker image
- Improve slow startup by deferring connection to main nodes until later
- Improve publisher performance by caching fields, disabling SDK retry and using round robin instead of random for connection selection

**Which issue(s) this PR fixes**:
Fixes #1217 

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated

