### PR TITLE
Add retry configuration support to HTS acceptance tests

### DIFF
--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/jmeter/handler/SDKClientHandler.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/jmeter/handler/SDKClientHandler.java
@@ -100,7 +100,7 @@ public class SDKClientHandler {
         return topicId;
     }
 
-    public List<TransactionId> submitTopicMessage(ConsensusTopicId topicId, String message) throws HederaStatusException {
+    public List<TransactionId> submitTopicMessage(ConsensusTopicId topicId, byte[] message) throws HederaStatusException {
         ConsensusMessageSubmitTransaction consensusMessageSubmitTransaction = new ConsensusMessageSubmitTransaction()
                 .setTopicId(topicId)
                 .setMessage(message);

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/jmeter/props/TopicMessagePublishRequest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/jmeter/props/TopicMessagePublishRequest.java
@@ -51,7 +51,7 @@ public class TopicMessagePublishRequest {
 
     public byte[] getMessage() {
         if (randomBytes == null) {
-            randomBytes = new byte[messageByteSize > 8 ? messageByteSize - Long.BYTES : 0];
+            randomBytes = new byte[messageByteSize > Long.BYTES ? messageByteSize - Long.BYTES : 0];
             new SecureRandom().nextBytes(randomBytes);
         }
 

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/jmeter/props/TopicMessagePublishRequest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/jmeter/props/TopicMessagePublishRequest.java
@@ -47,15 +47,15 @@ public class TopicMessagePublishRequest {
     @ToString.Exclude
     private Ed25519PrivateKey operatorPrivateKey;
 
-    private byte[] randomAlphanumeric;
+    private byte[] randomBytes;
 
     public byte[] getMessage() {
-        if (randomAlphanumeric == null) {
-            randomAlphanumeric = new byte[messageByteSize > 8 ? messageByteSize - Long.BYTES : 0];
-            new SecureRandom().nextBytes(randomAlphanumeric);
+        if (randomBytes == null) {
+            randomBytes = new byte[messageByteSize > 8 ? messageByteSize - Long.BYTES : 0];
+            new SecureRandom().nextBytes(randomBytes);
         }
 
-        // set current time stamp to first 8 bytes of message and random message after
-        return ArrayUtils.addAll(Longs.toByteArray(System.currentTimeMillis()), randomAlphanumeric);
+        // set current time stamp to first 8 bytes of message and random bytes message after
+        return ArrayUtils.addAll(Longs.toByteArray(System.currentTimeMillis()), randomBytes);
     }
 }

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/jmeter/sampler/result/HCSSamplerResult.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/jmeter/sampler/result/HCSSamplerResult.java
@@ -23,12 +23,10 @@ package com.hedera.mirror.grpc.jmeter.sampler.result;
 import com.google.common.base.Stopwatch;
 import com.google.common.primitives.Longs;
 import java.time.Instant;
-import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 import lombok.Data;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.log4j.Log4j2;
-import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
 
 @SuperBuilder
@@ -163,16 +161,10 @@ public abstract class HCSSamplerResult<T> {
 
         byte[] message = getMessageByteArray(currentResponse);
         try {
-            byte[] decodedMessage = Base64.decodeBase64(message);
-            publishInstant = retrieveInstantFromArray(decodedMessage);
+            publishInstant = retrieveInstantFromArray(message);
             if (isInstantOutOfRange(publishInstant)) {
-                publishInstant = retrieveInstantFromArray(message);
-
-                // support non encoded version
-                if (isInstantOutOfRange(publishInstant)) {
-                    log.debug("publishInstant is out of range: {}", publishInstant);
-                    publishInstant = null;
-                }
+                log.debug("publishInstant is out of range: {}", publishInstant);
+                publishInstant = null;
             }
         } catch (Exception ex) {
             log.debug("response message contains invalid publish millisecond value: {}", message);
@@ -183,7 +175,7 @@ public abstract class HCSSamplerResult<T> {
     }
 
     private Instant retrieveInstantFromArray(byte[] message) {
-        Long publishMillis = Longs.fromByteArray(Arrays.copyOfRange(message, 0, 8));
+        Long publishMillis = Longs.fromByteArray(message);
         return Instant.ofEpochMilli(publishMillis);
     }
 

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/jmeter/sampler/result/HCSSamplerResult.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/jmeter/sampler/result/HCSSamplerResult.java
@@ -22,6 +22,7 @@ package com.hedera.mirror.grpc.jmeter.sampler.result;
 
 import com.google.common.base.Stopwatch;
 import com.google.common.primitives.Longs;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
 import lombok.Data;
@@ -167,7 +168,8 @@ public abstract class HCSSamplerResult<T> {
                 publishInstant = null;
             }
         } catch (Exception ex) {
-            log.debug("response message contains invalid publish millisecond value: {}", message);
+            log.debug("response message contains invalid publish millisecond value: '{}', ex: {}",
+                    new String(message, StandardCharsets.UTF_8), ex.getMessage());
             publishInstant = null;
         }
 
@@ -175,6 +177,10 @@ public abstract class HCSSamplerResult<T> {
     }
 
     private Instant retrieveInstantFromArray(byte[] message) {
+        if (message == null || message.length < Long.BYTES) {
+            return Instant.MAX;
+        }
+
         Long publishMillis = Longs.fromByteArray(message);
         return Instant.ofEpochMilli(publishMillis);
     }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/SubscriptionResponse.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/SubscriptionResponse.java
@@ -28,7 +28,6 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.Data;
 import lombok.extern.log4j.Log4j2;
-import org.apache.commons.codec.binary.Base64;
 
 import com.hedera.hashgraph.sdk.mirror.MirrorConsensusTopicResponse;
 import com.hedera.hashgraph.sdk.mirror.MirrorSubscriptionHandle;
@@ -65,8 +64,7 @@ public class SubscriptionResponse {
             MirrorConsensusTopicResponse mirrorConsensusTopicResponse = mirrorHCSResponseResponse
                     .getMirrorConsensusTopicResponse();
 
-            Instant publishInstant = Instant
-                    .ofEpochMilli(Longs.fromByteArray(Base64.decodeBase64(mirrorConsensusTopicResponse.message)));
+            Instant publishInstant = Instant.ofEpochMilli(Longs.fromByteArray(mirrorConsensusTopicResponse.message));
 
             long publishSeconds = publishInstant.getEpochSecond();
             long consensusSeconds = mirrorConsensusTopicResponse.consensusTimestamp.getEpochSecond();

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TopicClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TopicClient.java
@@ -21,6 +21,7 @@ package com.hedera.mirror.test.e2e.acceptance.client;
  */
 
 import com.google.common.primitives.Longs;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -111,14 +112,13 @@ public class TopicClient extends AbstractNetworkClient {
     }
 
     public List<TransactionReceipt> publishMessagesToTopic(ConsensusTopicId topicId, String baseMessage,
-                                                           Ed25519PrivateKey submitKey,
-                                                           int numMessages, boolean verify) throws HederaStatusException
-            , InterruptedException {
+                                                           Ed25519PrivateKey submitKey, int numMessages,
+                                                           boolean verify) throws HederaStatusException {
         log.debug("Publishing {} message(s) to topicId : {}.", numMessages, topicId);
         List<TransactionReceipt> transactionReceiptList = new ArrayList<>();
         for (int i = 0; i < numMessages; i++) {
             byte[] publishTimestampByteArray = Longs.toByteArray(System.currentTimeMillis());
-            byte[] suffixByteArray = ("_" + baseMessage + "_" + (i + 1)).getBytes();
+            byte[] suffixByteArray = ("_" + baseMessage + "_" + (i + 1)).getBytes(StandardCharsets.UTF_8);
             byte[] message = ArrayUtils.addAll(publishTimestampByteArray, suffixByteArray);
 
             if (verify) {
@@ -145,8 +145,10 @@ public class TopicClient extends AbstractNetworkClient {
             recordPublishInstants.put(0L, transactionRecord.consensusTimestamp);
         }
 
-        log.trace("Published message : '{}' to topicId : {} with consensusTimestamp: {}", new String(message), topicId,
-                transactionRecord.consensusTimestamp);
+        if (log.isTraceEnabled()) {
+            log.trace("Published message : '{}' to topicId : {} with consensusTimestamp: {}",
+                    new String(message, StandardCharsets.UTF_8), topicId, transactionRecord.consensusTimestamp);
+        }
 
         return transactionIdList;
     }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TopicClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TopicClient.java
@@ -118,7 +118,7 @@ public class TopicClient extends AbstractNetworkClient {
         List<TransactionReceipt> transactionReceiptList = new ArrayList<>();
         for (int i = 0; i < numMessages; i++) {
             byte[] publishTimestampByteArray = Longs.toByteArray(System.currentTimeMillis());
-            byte[] suffixByteArray = ("_" + baseMessage + "_" + i + 1).getBytes();
+            byte[] suffixByteArray = ("_" + baseMessage + "_" + (i + 1)).getBytes();
             byte[] message = ArrayUtils.addAll(publishTimestampByteArray, suffixByteArray);
 
             if (verify) {

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
@@ -22,6 +22,7 @@ package com.hedera.mirror.test.e2e.acceptance.config;
 
 import java.time.Duration;
 import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import lombok.Data;
@@ -58,4 +59,11 @@ public class AcceptanceTestProperties {
 
     @NotNull
     private Duration subscribeRetryBackoffPeriod = Duration.ofMillis(5000);
+
+    @Min(1)
+    @Max(60)
+    private int restPollRetries = 60;
+
+    @NotNull
+    private Duration restRetryBackoffPeriod = Duration.ofMillis(1000);
 }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/ClientConfiguration.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/ClientConfiguration.java
@@ -125,7 +125,7 @@ public class ClientConfiguration {
         Jackson2JsonEncoder jackson2JsonEncoder = new Jackson2JsonEncoder(objectMapper, MediaType.APPLICATION_JSON);
 
         return WebClient.builder()
-                .baseUrl(acceptanceTestProperties.getMirrorRestAddress())
+                .baseUrl(acceptanceTestProperties.getRestPollingProperties().getBaseUrl())
                 .clientConnector(new ReactorClientHttpConnector(HttpClient.from(tcpClient)))
                 .codecs(clientCodecConfigurer -> {
                     clientCodecConfigurer.defaultCodecs().jackson2JsonDecoder(jackson2JsonDecoder);

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/RestPollingProperties.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/RestPollingProperties.java
@@ -26,6 +26,8 @@ import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import lombok.Data;
+import org.hibernate.validator.constraints.time.DurationMax;
+import org.hibernate.validator.constraints.time.DurationMin;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.annotation.Validated;
@@ -39,6 +41,8 @@ public class RestPollingProperties {
     @NotBlank
     private String baseUrl;
 
+    @DurationMin(seconds = 0L)
+    @DurationMax(seconds = 10L)
     @NotNull
     private Duration delay = Duration.ofMillis(1000);
 

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/RestPollingProperties.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/RestPollingProperties.java
@@ -22,6 +22,7 @@ package com.hedera.mirror.test.e2e.acceptance.config;
 
 import java.time.Duration;
 import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import lombok.Data;
@@ -30,32 +31,18 @@ import org.springframework.stereotype.Component;
 import org.springframework.validation.annotation.Validated;
 
 @Component
-@ConfigurationProperties(prefix = "hedera.mirror.test.acceptance")
+@ConfigurationProperties(prefix = "hedera.mirror.test.acceptance.rest")
 @Data
 @Validated
-public class AcceptanceTestProperties {
-    private final RestPollingProperties restPollingProperties;
+public class RestPollingProperties {
 
     @NotBlank
-    private String nodeAddress;
-    @NotBlank
-    private String nodeId;
-    @NotBlank
-    private String mirrorNodeAddress;
-    @NotBlank
-    private String operatorId;
-    @NotBlank
-    private String operatorKey;
-    @NotNull
-    private Duration messageTimeout = Duration.ofSeconds(20);
-    @NotNull
-    private Long existingTopicNum;
-
-    private boolean emitBackgroundMessages = false;
-
-    @Max(5)
-    private int subscribeRetries = 5;
+    private String baseUrl;
 
     @NotNull
-    private Duration subscribeRetryBackoffPeriod = Duration.ofMillis(5000);
+    private Duration delay = Duration.ofMillis(1000);
+
+    @Min(1)
+    @Max(60)
+    private int maxAttempts = 60;
 }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TokenFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TokenFeature.java
@@ -272,16 +272,16 @@ public class TokenFeature {
 
     @Then("the mirror node REST API should return status {int}")
     @Retryable(value = {AssertionError.class, AssertionFailedError.class},
-            backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.restRetryBackoffPeriod.toMillis()}"),
-            maxAttemptsExpression = "#{@acceptanceTestProperties.restPollRetries}")
+            backoff = @Backoff(delayExpression = "#{@restPollingProperties.delay.toMillis()}"),
+            maxAttemptsExpression = "#{@restPollingProperties.maxAttempts}")
     public void verifyMirrorAPIResponses(int status) {
         verifyTransactions(status);
     }
 
     @Then("the mirror node REST API should return status {int} for token fund flow")
     @Retryable(value = {AssertionError.class, AssertionFailedError.class},
-            backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.restRetryBackoffPeriod.toMillis()}"),
-            maxAttemptsExpression = "#{@acceptanceTestProperties.restPollRetries}")
+            backoff = @Backoff(delayExpression = "#{@restPollingProperties.delay.toMillis()}"),
+            maxAttemptsExpression = "#{@restPollingProperties.maxAttempts}")
     public void verifyMirrorTokenFundFlow(int status) {
         verifyBalances();
         verifyTransactions(status);
@@ -291,16 +291,16 @@ public class TokenFeature {
 
     @Then("the mirror node REST API should confirm token update")
     @Retryable(value = {AssertionError.class, AssertionFailedError.class},
-            backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.restRetryBackoffPeriod.toMillis()}"),
-            maxAttemptsExpression = "#{@acceptanceTestProperties.restPollRetries}")
+            backoff = @Backoff(delayExpression = "#{@restPollingProperties.delay.toMillis()}"),
+            maxAttemptsExpression = "#{@restPollingProperties.maxAttempts}")
     public void verifyMirrorTokenUpdateFlow() {
         verifyTokenUpdate();
     }
 
     @Then("the mirror node REST API should return status {int} for transaction {string}")
     @Retryable(value = {AssertionError.class, AssertionFailedError.class},
-            backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.restRetryBackoffPeriod.toMillis()}"),
-            maxAttemptsExpression = "#{@acceptanceTestProperties.restPollRetries}")
+            backoff = @Backoff(delayExpression = "#{@restPollingProperties.delay.toMillis()}"),
+            maxAttemptsExpression = "#{@restPollingProperties.maxAttempts}")
     public void verifyMirrorRestTransactionIsPresent(int status, String transactionIdString) {
         MirrorTransactionsResponse mirrorTransactionsResponse = mirrorClient.getTransactions(transactionIdString);
 
@@ -466,7 +466,7 @@ public class TokenFeature {
     @Recover
     public void recover(AssertionError t) {
         log.error("REST API response verification failed after {} retries w: {}",
-                acceptanceProps.getRestPollRetries(), t.getMessage());
+                acceptanceProps.getRestPollingProperties().getMaxAttempts(), t.getMessage());
         throw t;
     }
 }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TokenFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TokenFeature.java
@@ -191,15 +191,11 @@ public class TokenFeature {
     }
 
     @Then("I transfer {int} tokens to recipient")
-    @Retryable(value = {StatusRuntimeException.class}, exceptionExpression = "#{message.contains('UNAVAILABLE') || " +
-            "message.contains('RESOURCE_EXHAUSTED')}")
     public void transferTokensToRecipient(int amount) throws HederaStatusException {
         transferTokens(tokenId, amount, tokenClient.getSdkClient().getOperatorId(), recipient.getAccountId());
     }
 
     @Then("I transfer {int} tokens of {int} to {int}")
-    @Retryable(value = {StatusRuntimeException.class}, exceptionExpression = "#{message.contains('UNAVAILABLE') || " +
-            "message.contains('RESOURCE_EXHAUSTED')}")
     public void transferTokens(int amount, int token, int recipient) throws HederaStatusException {
         transferTokens(new TokenId(token), amount, tokenClient.getSdkClient()
                 .getOperatorId(), new AccountId(recipient));
@@ -275,13 +271,17 @@ public class TokenFeature {
     }
 
     @Then("the mirror node REST API should return status {int}")
-    @Retryable(value = {AssertionError.class, AssertionFailedError.class}, backoff = @Backoff(delay = 5000))
+    @Retryable(value = {AssertionError.class, AssertionFailedError.class},
+            backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.restRetryBackoffPeriod.toMillis()}"),
+            maxAttemptsExpression = "#{@acceptanceTestProperties.restPollRetries}")
     public void verifyMirrorAPIResponses(int status) {
         verifyTransactions(status);
     }
 
     @Then("the mirror node REST API should return status {int} for token fund flow")
-    @Retryable(value = {AssertionError.class, AssertionFailedError.class}, backoff = @Backoff(delay = 5000))
+    @Retryable(value = {AssertionError.class, AssertionFailedError.class},
+            backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.restRetryBackoffPeriod.toMillis()}"),
+            maxAttemptsExpression = "#{@acceptanceTestProperties.restPollRetries}")
     public void verifyMirrorTokenFundFlow(int status) {
         verifyBalances();
         verifyTransactions(status);
@@ -290,13 +290,17 @@ public class TokenFeature {
     }
 
     @Then("the mirror node REST API should confirm token update")
-    @Retryable(value = {AssertionError.class, AssertionFailedError.class}, backoff = @Backoff(delay = 5000))
+    @Retryable(value = {AssertionError.class, AssertionFailedError.class},
+            backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.restRetryBackoffPeriod.toMillis()}"),
+            maxAttemptsExpression = "#{@acceptanceTestProperties.restPollRetries}")
     public void verifyMirrorTokenUpdateFlow() {
         verifyTokenUpdate();
     }
 
     @Then("the mirror node REST API should return status {int} for transaction {string}")
-    @Retryable(value = {AssertionError.class, AssertionFailedError.class}, backoff = @Backoff(delay = 5000))
+    @Retryable(value = {AssertionError.class, AssertionFailedError.class},
+            backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.restRetryBackoffPeriod.toMillis()}"),
+            maxAttemptsExpression = "#{@acceptanceTestProperties.restPollRetries}")
     public void verifyMirrorRestTransactionIsPresent(int status, String transactionIdString) {
         MirrorTransactionsResponse mirrorTransactionsResponse = mirrorClient.getTransactions(transactionIdString);
 
@@ -442,15 +446,14 @@ public class TokenFeature {
     }
 
     /**
-     * Recover method for REST verify operations. Method parameters of retry method must match this method after
-     * exception parameter
+     * Recover method for token transaction retry operations. Method parameters of retry method must match this method
+     * after exception parameter
      *
      * @param t
      */
     @Recover
-    public void recover(AssertionError t, int status) {
-        log.error("Received {} from REST API, failed verification after {} retries w: {}",
-                status, acceptanceProps.getSubscribeRetries(), t.getMessage());
+    public void recover(StatusRuntimeException t) {
+        log.error("Transaction submissions for token transaction failed after retries w: {}", t.getMessage());
         throw t;
     }
 
@@ -461,9 +464,9 @@ public class TokenFeature {
      * @param t
      */
     @Recover
-    public void recover(AssertionError t, String endpoint, int status) {
-        log.error("Received {} response from {}. Failed verification after {} retries w:" +
-                " {}", status, endpoint, acceptanceProps.getSubscribeRetries(), t.getMessage());
+    public void recover(AssertionError t) {
+        log.error("REST API response verification failed after {} retries w: {}",
+                acceptanceProps.getRestPollRetries(), t.getMessage());
         throw t;
     }
 }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TopicFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TopicFeature.java
@@ -28,6 +28,7 @@ import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import io.cucumber.junit.platform.engine.Cucumber;
 import io.grpc.StatusRuntimeException;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.Executors;
@@ -364,7 +365,10 @@ public class TopicFeature {
             scheduler = Executors.newSingleThreadScheduledExecutor();
             scheduler.scheduleAtFixedRate(() -> {
                 try {
-                    topicClient.publishMessageToTopic(consensusTopicId, "backgroundMessage".getBytes(), submitKey);
+                    topicClient.publishMessageToTopic(
+                            consensusTopicId,
+                            "backgroundMessage".getBytes(StandardCharsets.UTF_8),
+                            submitKey);
                 } catch (HederaStatusException e) {
                     e.printStackTrace();
                 }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TopicFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TopicFeature.java
@@ -364,7 +364,7 @@ public class TopicFeature {
             scheduler = Executors.newSingleThreadScheduledExecutor();
             scheduler.scheduleAtFixedRate(() -> {
                 try {
-                    topicClient.publishMessageToTopic(consensusTopicId, "backgroundMessage", submitKey);
+                    topicClient.publishMessageToTopic(consensusTopicId, "backgroundMessage".getBytes(), submitKey);
                 } catch (HederaStatusException e) {
                     e.printStackTrace();
                 }

--- a/hedera-mirror-test/src/test/resources/application-default.yml
+++ b/hedera-mirror-test/src/test/resources/application-default.yml
@@ -7,10 +7,11 @@ hedera:
         messageTimeout: 20s
         # grpc endpoint
         mirrorNodeAddress: hcs.testnet.mirrornode.hedera.com:5600
-        # REST endpoint
-        mirrorRestAddress: http://testnet.mirrornode.hedera.com/api/v1
         nodeAddress: testnet
         nodeId: 0.0.3
         # Do not use use 0.0.2 or 0.0.50 for operator to ensure crypto transfers are not waived
         operatorId:
         operatorKey:
+        rest:
+          # REST endpoint
+          baseUrl: http://testnet.mirrornode.hedera.com/api/v1


### PR DESCRIPTION
**Detailed description**:
- Add retry configuration support to HTS REST calls
- Simplify acceptance and performance publish time write and reads for latency calculations
- Add a new properties class for REST API related configs

**Which issue(s) this PR fixes**:
Fixes #1294 
**Special notes for your reviewer**:
Usage of new configs would look like. Example contains the 
```yaml
hedera:
  mirror:
    test:
      acceptance:
        rest:
          # REST endpoint
          baseUrl: http://testnet.mirrornode.hedera.com/api/v1
          delay: 1s
          maxAttempts: 60
```
Defaults are as above and don't need to be specified unless changed.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

