### PR TITLE
Refactor CryptoTransferTransactionSupplier to only add crypto or token transfers

### DIFF
--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/account/CryptoTransferTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/account/CryptoTransferTransactionSupplier.java
@@ -22,6 +22,7 @@ package com.hedera.datagenerator.sdk.supplier.account;
 
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import lombok.Data;
 
 import com.hedera.datagenerator.common.Utility;
@@ -47,6 +48,7 @@ public class CryptoTransferTransactionSupplier implements TransactionSupplier<Tr
 
     private String tokenId;
 
+    @NotNull
     private TransferType transferType = TransferType.CRYPTO;
 
     @Override

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/account/CryptoTransferTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/account/CryptoTransferTransactionSupplier.java
@@ -55,12 +55,15 @@ public class CryptoTransferTransactionSupplier implements TransactionSupplier<Tr
         AccountId senderId = AccountId.fromString(senderAccountId);
 
         TransferTransaction transferTransaction = new TransferTransaction()
-                .addHbarTransfer(recipientId, amount)
-                .addHbarTransfer(senderId, Math.negateExact(amount))
                 .setMaxTransactionFee(maxTransactionFee)
                 .setTransactionMemo(Utility.getMemo("Mirror node created test crypto transfer"));
 
-        if (StringUtils.isNotBlank(tokenId)) {
+        //Only add an Hbar transfer or a token transfer, never both
+        if (StringUtils.isBlank(tokenId)) {
+            transferTransaction
+                    .addHbarTransfer(recipientId, amount)
+                    .addHbarTransfer(senderId, Math.negateExact(amount));
+        } else {
             TokenId token = TokenId.fromString(tokenId);
             transferTransaction
                     .addTokenTransfer(token, recipientId, amount)

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/account/CryptoTransferTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/account/CryptoTransferTransactionSupplier.java
@@ -55,19 +55,20 @@ public class CryptoTransferTransactionSupplier implements TransactionSupplier<Tr
         AccountId senderId = AccountId.fromString(senderAccountId);
 
         TransferTransaction transferTransaction = new TransferTransaction()
-                .setMaxTransactionFee(maxTransactionFee)
-                .setTransactionMemo(Utility.getMemo("Mirror node created test crypto transfer"));
+                .setMaxTransactionFee(maxTransactionFee);
 
         //Only add an Hbar transfer or a token transfer, never both
         if (StringUtils.isBlank(tokenId)) {
             transferTransaction
                     .addHbarTransfer(recipientId, amount)
-                    .addHbarTransfer(senderId, Math.negateExact(amount));
+                    .addHbarTransfer(senderId, Math.negateExact(amount))
+                    .setTransactionMemo(Utility.getMemo("Mirror node created test crypto transfer"));
         } else {
             TokenId token = TokenId.fromString(tokenId);
             transferTransaction
                     .addTokenTransfer(token, recipientId, amount)
-                    .addTokenTransfer(token, senderId, Math.negateExact(amount));
+                    .addTokenTransfer(token, senderId, Math.negateExact(amount))
+                    .setTransactionMemo(Utility.getMemo("Mirror node created test token transfer"));
         }
         return transferTransaction;
     }


### PR DESCRIPTION
**Detailed description**:
The CryptoTransferTransactionSupplier is adding an unnecessary crypto transfer when attempting to submit a token transfer, which could negatively effect the performance.
- Refactor CryptoTransferTransactionSupplier to only add a crypto transfer or a token transfer, instead of both.

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

