### PR TITLE
Publish topic messages to redis in a separate thread

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/BatchEntityListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/BatchEntityListener.java
@@ -22,7 +22,7 @@ package com.hedera.mirror.importer.parser.record.entity;
 
 public interface BatchEntityListener extends EntityListener {
 
-    void onSave(EntityBatchSaveEvent event);
+    void onSave(EntityBatchSaveEvent event) throws InterruptedException;
 
     void onCleanup(EntityBatchCleanupEvent event);
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/redis/RedisEntityListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/redis/RedisEntityListener.java
@@ -89,7 +89,7 @@ public class RedisEntityListener implements BatchEntityListener {
                     publish(topicMessagesQueue.take());
                 }
             } catch (InterruptedException ex) {
-                //
+                Thread.currentThread().interrupt();
             }
         });
     }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/redis/RedisEntityListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/redis/RedisEntityListener.java
@@ -123,11 +123,11 @@ public class RedisEntityListener implements BatchEntityListener {
             Runtime.getRuntime().addShutdownHook(new Thread(() -> topicMessagesQueue.offer(new ArrayList<>())));
         }
 
-        List<TopicMessage> messages = topicMessages;
+        List<TopicMessage> latestMessageBatch = topicMessages;
         topicMessages = new ArrayList<>();
-        if (!topicMessagesQueue.offer(messages)) {
+        if (!topicMessagesQueue.offer(latestMessageBatch)) {
             log.warn("topicMessagesQueue is full, will block until space is available");
-            topicMessagesQueue.put(messages);
+            topicMessagesQueue.put(latestMessageBatch);
         }
     }
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListener.java
@@ -184,7 +184,7 @@ public class SqlEntityListener implements EntityListener, RecordStreamFileListen
         Connection connection = null;
 
         try {
-            // batch save action may run asynchronously, trigger it before other operations can reduce latency
+            // batch save action may run asynchronously, triggering it before other operations can reduce latency
             eventPublisher.publishEvent(new EntityBatchSaveEvent(this));
 
             connection = DataSourceUtils.getConnection(dataSource);

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/BatchEntityListenerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/BatchEntityListenerTest.java
@@ -40,6 +40,7 @@ public abstract class BatchEntityListenerTest extends IntegrationTest {
     protected final BatchEntityListener entityListener;
     protected final EntityListenerProperties properties;
 
+    private long consensusTimestamp = 1;
     private long sequenceNumber = 1;
 
     @BeforeEach
@@ -57,7 +58,7 @@ public abstract class BatchEntityListenerTest extends IntegrationTest {
     }
 
     @Test
-    void onTopicMessage() {
+    void onTopicMessage() throws InterruptedException {
         // given
         TopicMessage topicMessage1 = topicMessage();
         TopicMessage topicMessage2 = topicMessage();
@@ -77,7 +78,7 @@ public abstract class BatchEntityListenerTest extends IntegrationTest {
     }
 
     @Test
-    void onTopicMessageEmpty() {
+    void onTopicMessageEmpty() throws InterruptedException {
         // given
         Flux<TopicMessage> topicMessages = subscribe(1);
 
@@ -93,7 +94,7 @@ public abstract class BatchEntityListenerTest extends IntegrationTest {
     }
 
     @Test
-    void onTopicMessageDisabled() {
+    void onTopicMessageDisabled() throws InterruptedException {
         // given
         properties.setEnabled(false);
         TopicMessage topicMessage = topicMessage();
@@ -112,7 +113,7 @@ public abstract class BatchEntityListenerTest extends IntegrationTest {
     }
 
     @Test
-    void onCleanup() {
+    void onCleanup() throws InterruptedException {
         // given
         TopicMessage topicMessage = topicMessage();
         Flux<TopicMessage> topicMessages = subscribe(topicMessage.getTopicNum());
@@ -135,7 +136,7 @@ public abstract class BatchEntityListenerTest extends IntegrationTest {
         TopicMessage topicMessage = new TopicMessage();
         topicMessage.setChunkNum(1);
         topicMessage.setChunkTotal(2);
-        topicMessage.setConsensusTimestamp(1L);
+        topicMessage.setConsensusTimestamp(consensusTimestamp++);
         topicMessage.setMessage("test message".getBytes());
         topicMessage.setPayerAccountId(EntityId.of("0.1.1000", EntityTypeEnum.ACCOUNT));
         topicMessage.setRealmNum(0);

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/notify/NotifyingEntityListenerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/notify/NotifyingEntityListenerTest.java
@@ -25,7 +25,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import javax.sql.DataSource;
 import org.apache.commons.lang3.RandomUtils;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.postgresql.PGNotification;
 import org.postgresql.jdbc.PgConnection;
@@ -49,13 +48,8 @@ public class NotifyingEntityListenerTest extends BatchEntityListenerTest {
         this.dataSource = dataSource;
     }
 
-    @BeforeEach
-    void setup() {
-        properties.setEnabled(true);
-    }
-
     @Test
-    void onTopicMessagePayloadTooLong() {
+    void onTopicMessagePayloadTooLong() throws InterruptedException {
         // given
         TopicMessage topicMessage = topicMessage();
         topicMessage.setMessage(RandomUtils.nextBytes(5824)); // Just exceeds 8000B

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/redis/RedisEntityListenerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/redis/RedisEntityListenerTest.java
@@ -60,7 +60,7 @@ class RedisEntityListenerTest extends BatchEntityListenerTest {
 
     @Autowired
     public RedisEntityListenerTest(RedisEntityListener entityListener, RedisProperties properties,
-                               RedisOperations<String, StreamMessage> redisOperations) {
+                                   RedisOperations<String, StreamMessage> redisOperations) {
         super(entityListener, properties);
         this.redisOperations = redisOperations;
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
-->

**Detailed description**:
This PR changes `RedisEntityListener` to publish topic messages to redis in a separate thread so as to improve ingestion throughput and latency especially under heavy HCS traffic.

- Publish topic messages to redis in a separate thread
- Ignore duplicate topic messages, e.g., when parsing fails at the middle and the record file is reprocessed later

**Which issue(s) this PR fixes**:
Fixes #1308 

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated

