### PR TITLE
Update REST monitor to check for valid balances in reference account

### DIFF
--- a/hedera-mirror-rest/monitoring/monitor_apis/account_tests.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/account_tests.js
@@ -105,7 +105,10 @@ const getAccountsWithAccountCheck = async (server) => {
  * @param {Object} server API host endpoint
  */
 const getAccountsWithTimeAndLimitParams = async (server) => {
-  let url = getUrl(server, accountsPath, {limit: 1});
+  let url = getUrl(server, accountsPath, {
+    'account.balance': 'gte:0',
+    limit: 1,
+  });
   let accounts = await getAPIResponse(url, jsonRespKey);
 
   const checkRunnder = new CheckRunner()


### PR DESCRIPTION
**Detailed description**:
Monitor `getAccountsWithTimeAndLimitParams()` is broken with v0.23.1 changes

- Add account.balance=gte:0 to the url call that pull the reference account that timestamps are pulled from 

**Which issue(s) this PR fixes**:
Fixes #1316 

**Special notes for your reviewer**:
Note, this has been tested locally and also patched for our deployed monitor tests

**Checklist**
- [ ] Documentation added
- [x] Tests updated

