### PR TITLE
Another attempt to fix monitor publishing

### DIFF
--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/config/MonitorConfiguration.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/config/MonitorConfiguration.java
@@ -20,7 +20,6 @@ package com.hedera.mirror.monitor.config;
  * ‍
  */
 
-import java.util.Objects;
 import javax.annotation.Resource;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.context.annotation.Bean;
@@ -30,6 +29,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.scheduler.Schedulers;
 
 import com.hedera.mirror.monitor.generator.TransactionGenerator;
+import com.hedera.mirror.monitor.publish.PublishException;
 import com.hedera.mirror.monitor.publish.PublishProperties;
 import com.hedera.mirror.monitor.publish.PublishRequest;
 import com.hedera.mirror.monitor.publish.TransactionPublisher;
@@ -63,14 +63,14 @@ class MonitorConfiguration {
     Disposable publishSubscribe() {
         return Flux.<PublishRequest>generate(sink -> sink.next(transactionGenerator.next()))
                 .retry()
-                .filter(Objects::nonNull)
-                .doFinally(s -> log.warn("Stopped after {} signal", s))
                 .subscribeOn(Schedulers.single())
                 .parallel(publishProperties.getConnections())
                 .runOn(Schedulers.newParallel("publisher", publishProperties.getConnections()))
                 .map(transactionPublisher::publish)
-                .filter(Objects::nonNull)
-                .doOnError(t -> log.error("Error during publish/subscribe flow: ", t))
+                .sequential()
+                .onErrorContinue(PublishException.class, (t, r) -> {})
+                .onErrorContinue((t, r) -> log.error("Unknown error during publish/subscribe flow: {}", t))
+                .doFinally(s -> log.warn("Stopped after {} signal", s))
                 .subscribe(subscriber::onPublish);
     }
 }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/config/MonitorConfiguration.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/config/MonitorConfiguration.java
@@ -69,8 +69,9 @@ class MonitorConfiguration {
                 .map(transactionPublisher::publish)
                 .sequential()
                 .onErrorContinue(PublishException.class, (t, r) -> {})
-                .onErrorContinue((t, r) -> log.error("Unknown error during publish/subscribe flow: {}", t))
                 .doFinally(s -> log.warn("Stopped after {} signal", s))
+                .doOnError(t -> log.error("Unexpected error during publish/subscribe flow:", t))
+                .doOnSubscribe(s -> log.info("Starting publisher flow"))
                 .subscribe(subscriber::onPublish);
     }
 }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishException.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishException.java
@@ -1,0 +1,29 @@
+package com.hedera.mirror.monitor.publish;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+public class PublishException extends RuntimeException {
+    private static final long serialVersionUID = 1405915869165326841L;
+
+    public PublishException(Throwable throwable) {
+        super(throwable);
+    }
+}

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishMetrics.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishMetrics.java
@@ -77,12 +77,15 @@ public class PublishMetrics {
             StatusRuntimeException sre = (StatusRuntimeException) e.getCause();
             status = sre.getStatus().getCode().name();
             log.debug("Network error {} submitting {} transaction: {}", status, type, sre.getStatus().getDescription());
+            throw new PublishException(e);
         } catch (HederaStatusException e) {
             status = e.status.name();
             log.debug("Hedera {} error submitting {} transaction: {}", status, type, e.getMessage());
+            throw new PublishException(e);
         } catch (Exception e) {
             status = e.getClass().getSimpleName();
             log.debug("{} submitting {} transaction: {}", status, type, e.getMessage());
+            throw new PublishException(e);
         } finally {
             long endTime = System.currentTimeMillis();
             Tags tags = new Tags(status, type);
@@ -93,8 +96,6 @@ public class PublishMetrics {
                 errors.add(status);
             }
         }
-
-        return null;
     }
 
     private Timer newTimer(Tags tags) {

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishMetrics.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishMetrics.java
@@ -71,7 +71,6 @@ public class PublishMetrics {
             counter.incrementAndGet();
             return response;
         } catch (LocalValidationException e) {
-            log.error("Local error. Halting thread", e);
             throw e;
         } catch (StatusRuntimeException e) {
             StatusRuntimeException sre = (StatusRuntimeException) e.getCause();


### PR DESCRIPTION
**Detailed description**:
- Fix `NullPointerException` halting the publish flow
- Change to throw exceptions in `PublishMetrics` and catch and ignore those errors after sequential merge of parallel flux

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

