### PR TITLE
Add rest percentage check to monitor

### DIFF
--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/RestSubscriber.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/RestSubscriber.java
@@ -74,7 +74,6 @@ public class RestSubscriber implements Subscriber {
                         r.totalRetries() + 1, r.failure()));
 
         directProcessor.doOnSubscribe(s -> log.info("Connecting to mirror node {}", url))
-                //Randomly filter out transactions to only validate a set percentage.
                 .filter(publishResponse -> shouldFilter(publishResponse, properties.getValidationPercentage()))
                 .doOnNext(publishResponse -> log.trace("Querying REST API: {}", publishResponse))
                 .doFinally(s -> log.warn("Received {} signal", s))
@@ -103,6 +102,7 @@ public class RestSubscriber implements Subscriber {
                 ((WebClientResponseException) t).getStatusCode() == HttpStatus.NOT_FOUND;
     }
 
+    //Randomly filter out transactions to only validate a set percentage
     private boolean shouldFilter(PublishResponse publishResponse, double validationPercentage) {
         boolean filterOut = Double
                 .compare(RANDOM.nextDouble(), validationPercentage) != -1;

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/RestSubscriberProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/RestSubscriberProperties.java
@@ -41,5 +41,5 @@ public class RestSubscriberProperties extends AbstractSubscriberProperties {
     }
 
     @PositiveOrZero
-    private double validationPercentage = .2;
+    private double validationPercentage = 1.0;
 }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/RestSubscriberProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/RestSubscriberProperties.java
@@ -22,6 +22,7 @@ package com.hedera.mirror.monitor.subscribe;
 
 import java.time.Duration;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.PositiveOrZero;
 import lombok.Data;
 import org.hibernate.validator.constraints.time.DurationMin;
 import org.springframework.validation.annotation.Validated;
@@ -38,4 +39,7 @@ public class RestSubscriberProperties extends AbstractSubscriberProperties {
     public long getLimit() {
         return limit > 0 ? limit : Long.MAX_VALUE;
     }
+
+    @PositiveOrZero
+    private double validationPercentage = .2;
 }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/RestSubscriberProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/RestSubscriberProperties.java
@@ -21,8 +21,9 @@ package com.hedera.mirror.monitor.subscribe;
  */
 
 import java.time.Duration;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
-import javax.validation.constraints.PositiveOrZero;
 import lombok.Data;
 import org.hibernate.validator.constraints.time.DurationMin;
 import org.springframework.validation.annotation.Validated;
@@ -40,6 +41,7 @@ public class RestSubscriberProperties extends AbstractSubscriberProperties {
         return limit > 0 ? limit : Long.MAX_VALUE;
     }
 
-    @PositiveOrZero
-    private double validationPercentage = 1.0;
+    @Min(0)
+    @Max(1)
+    private double samplePercent = 1.0;
 }

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/RestSubscriberTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/RestSubscriberTest.java
@@ -74,12 +74,14 @@ class RestSubscriberTest {
         monitorProperties = new MonitorProperties();
         monitorProperties.setMirrorNode(new MirrorNodeProperties());
         monitorProperties.getMirrorNode().getRest().setHost("127.0.0.1");
+        monitorProperties.getMirrorNode().getRest().setHost("127.0.0.1");
 
         subscriberProperties = new RestSubscriberProperties();
         subscriberProperties.setLimit(2L);
         subscriberProperties.getRetry().setMaxAttempts(2L);
         subscriberProperties.getRetry().setMinBackoff(Duration.ofNanos(1L));
         subscriberProperties.getRetry().setMaxBackoff(Duration.ofNanos(2L));
+        subscriberProperties.setValidationPercentage(1.0);
 
         builder = WebClient.builder().exchangeFunction(exchangeFunction);
         this.restSubscriber = new RestSubscriber(meterRegistry, monitorProperties, subscriberProperties, builder);

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/RestSubscriberTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/RestSubscriberTest.java
@@ -74,14 +74,12 @@ class RestSubscriberTest {
         monitorProperties = new MonitorProperties();
         monitorProperties.setMirrorNode(new MirrorNodeProperties());
         monitorProperties.getMirrorNode().getRest().setHost("127.0.0.1");
-        monitorProperties.getMirrorNode().getRest().setHost("127.0.0.1");
 
         subscriberProperties = new RestSubscriberProperties();
         subscriberProperties.setLimit(2L);
         subscriberProperties.getRetry().setMaxAttempts(2L);
         subscriberProperties.getRetry().setMinBackoff(Duration.ofNanos(1L));
         subscriberProperties.getRetry().setMaxBackoff(Duration.ofNanos(2L));
-        subscriberProperties.setValidationPercentage(1.0);
 
         builder = WebClient.builder().exchangeFunction(exchangeFunction);
         this.restSubscriber = new RestSubscriber(meterRegistry, monitorProperties, subscriberProperties, builder);
@@ -169,6 +167,19 @@ class RestSubscriberTest {
 
         countDownLatch.await(1000, TimeUnit.MILLISECONDS);
         verify(exchangeFunction, times(3)).exchange(Mockito.isA(ClientRequest.class));
+        assertMetric(0L);
+    }
+
+    @Test
+    void zeroValidationPercentage() throws InterruptedException {
+        countDownLatch = new CountDownLatch(2);
+        subscriberProperties.setValidationPercentage(0);
+
+        restSubscriber.onPublish(publishResponse());
+        restSubscriber.onPublish(publishResponse());
+
+        countDownLatch.await(500, TimeUnit.MILLISECONDS);
+        verify(exchangeFunction, times(0)).exchange(Mockito.isA(ClientRequest.class));
         assertMetric(0L);
     }
 


### PR DESCRIPTION
**Detailed description**:
- Add property `samplePercent` to monitor to only validate certain transactions via REST.

**Which issue(s) this PR fixes**:
Fixes #1315 

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated

