### PR TITLE
Add monitor dashboard

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -377,6 +377,8 @@ jobs:
       - gcloud_image_untag:
           imagepath: "importer"
       - gcloud_image_untag:
+          imagepath: "monitor"
+      - gcloud_image_untag:
           imagepath: "rest"
       - gcloud_image_untag:
           imagepath: "test"
@@ -384,6 +386,8 @@ jobs:
           imagepath: "grpc"
       - gcloud_image_delete:
           imagepath: "importer"
+      - gcloud_image_delete:
+          imagepath: "monitor"
       - gcloud_image_delete:
           imagepath: "rest"
       - gcloud_image_delete:

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -23,7 +23,7 @@ jobs:
           path: ~/.m2
           restore-keys: ${{ runner.os }}-m2
       - name: Login to Google Container Registry
-        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@master
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           service_account_key: ${{ secrets.GCR_KEY }}

--- a/charts/hedera-mirror-common/dashboards/hedera-mirror-monitor.json
+++ b/charts/hedera-mirror-common/dashboards/hedera-mirror-monitor.json
@@ -1,0 +1,2966 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 30,
+  "iteration": 1607121556805,
+  "links": [],
+  "panels": [
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "The average publish TPS",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "0",
+              "type": 1,
+              "value": "null"
+            }
+          ],
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.01
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 0,
+        "y": 0
+      },
+      "id": 13,
+      "links": [],
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "targets": [
+        {
+          "expr": "sum(rate(hedera_mirror_monitor_publish_submit_seconds_count{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval]))",
+          "interval": "1m",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Publish TPS",
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "The average gRPC subscribe TPS",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "0",
+              "type": 1,
+              "value": "null"
+            }
+          ],
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.01
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 3,
+        "y": 0
+      },
+      "id": 74,
+      "links": [],
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "targets": [
+        {
+          "expr": "sum(rate(hedera_mirror_monitor_subscribe_e2e_seconds_count{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\",subscriber=\"GrpcSubscriber\"}[$__rate_interval]))",
+          "interval": "1m",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Subscribe TPS",
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "The average amount of time all scenarios have been actively publishing transactions",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 2,
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "0",
+              "type": 1,
+              "value": "null"
+            }
+          ],
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 0.1
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 6,
+        "y": 0
+      },
+      "id": 58,
+      "links": [],
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "targets": [
+        {
+          "expr": "avg(hedera_mirror_monitor_publish_duration_seconds{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "interval": "1m",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Publish Duration",
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "The average amount of time all clients have been subscribed",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 2,
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "0",
+              "type": 1,
+              "value": "null"
+            }
+          ],
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 0.1
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 9,
+        "y": 0
+      },
+      "id": 73,
+      "links": [],
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "targets": [
+        {
+          "expr": "avg(hedera_mirror_monitor_subscribe_duration_seconds{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "interval": "1m",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Subscribe Duration",
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "The average time from submit to handle transaction",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "0",
+              "type": 1,
+              "value": "null"
+            }
+          ],
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 6
+              },
+              {
+                "color": "orange",
+                "value": 8
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 12,
+        "y": 0
+      },
+      "id": 82,
+      "links": [],
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "targets": [
+        {
+          "expr": "sum(rate(hedera_mirror_monitor_publish_handle_seconds_sum{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) / sum(rate(hedera_mirror_monitor_publish_handle_seconds_count{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval]))",
+          "interval": "1m",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Submit to Handle",
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "The average end to end latency of the entire system",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "0",
+              "type": 1,
+              "value": "null"
+            }
+          ],
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 8
+              },
+              {
+                "color": "orange",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 15
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 15,
+        "y": 0
+      },
+      "id": 83,
+      "links": [],
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.3",
+      "targets": [
+        {
+          "expr": "sum(rate(hedera_mirror_monitor_subscribe_e2e_seconds_sum{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) / sum(rate(hedera_mirror_monitor_subscribe_e2e_seconds_count{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval]))",
+          "interval": "1m",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "E2E",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 4
+      },
+      "id": 21,
+      "panels": [],
+      "title": "Publish",
+      "type": "row"
+    },
+    {
+      "aliasColors": {
+        "success=false": "semi-dark-red",
+        "success=true": "green"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "decimals": 1,
+      "description": "The number of transactions per second published broken down by type",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 2,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "hiddenSeries": false,
+      "id": 56,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sideWidth": null,
+        "sort": "avg",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(hedera_mirror_monitor_publish_submit_seconds_count{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (type)",
+          "interval": "1m",
+          "legendFormat": "{{ type }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Publish TPS",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "none",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "s",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {
+        "success=false": "semi-dark-red",
+        "success=true": "green"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "decimals": 1,
+      "description": "How long the publish scenario has been active",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": [],
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "fill": 2,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
+      "hiddenSeries": false,
+      "id": 76,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sideWidth": null,
+        "sort": "avg",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(hedera_mirror_monitor_publish_duration_seconds{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}) by (scenario)",
+          "interval": "1m",
+          "legendFormat": "{{ scenario }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Publish Duration",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "s",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "s",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {
+        "CRYPTOTRANSFER": "green"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "decimals": 1,
+      "description": "The number of errors per second when submitting transactions",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 21
+      },
+      "hiddenSeries": false,
+      "id": 71,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sideWidth": null,
+        "sort": "avg",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(hedera_mirror_monitor_publish_submit_seconds_count{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\",status!=\"SUCCESS\"}[$__rate_interval])) by (status)",
+          "interval": "1m",
+          "legendFormat": "{{ status }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Publish Error Rate",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "decimals": null,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "description": "How long it took to submit the transaction to the main node",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 29
+      },
+      "hiddenSeries": false,
+      "id": 29,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sort": "avg",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(hedera_mirror_monitor_publish_submit_seconds_sum{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (scenario) / sum(rate(hedera_mirror_monitor_publish_submit_seconds_count{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (scenario)",
+          "interval": "1m",
+          "legendFormat": "{{scenario}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Submit Latency",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "s",
+          "label": "Time",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "dtdurationms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "description": "The time it takes from submit to being handled by the main nodes",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 37
+      },
+      "hiddenSeries": false,
+      "id": 75,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sort": "avg",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(hedera_mirror_monitor_publish_handle_seconds_sum{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (scenario) / sum(rate(hedera_mirror_monitor_publish_handle_seconds_count{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (scenario)",
+          "interval": "1m",
+          "legendFormat": "{{scenario}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Submit to Handle Latency",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "s",
+          "label": "Time",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "dtdurationms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 45
+      },
+      "id": 78,
+      "panels": [],
+      "title": "Subscribe",
+      "type": "row"
+    },
+    {
+      "aliasColors": {
+        "success=false": "semi-dark-red",
+        "success=true": "green"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "decimals": 1,
+      "description": "The number of transactions per second received broken down by scenario",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 2,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 46
+      },
+      "hiddenSeries": false,
+      "id": 79,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sideWidth": null,
+        "sort": "avg",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(hedera_mirror_monitor_subscribe_e2e_seconds_count{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (scenario)",
+          "interval": "1m",
+          "legendFormat": "{{ scenario }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Subscribe TPS",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "none",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "s",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {
+        "success=false": "semi-dark-red",
+        "success=true": "green"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "decimals": 1,
+      "description": "How long it took to submit the transaction to the main node and receive it back from the mirror node",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 2,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 54
+      },
+      "hiddenSeries": false,
+      "id": 80,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sideWidth": null,
+        "sort": "avg",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(hedera_mirror_monitor_subscribe_e2e_seconds_sum{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (scenario) / sum(rate(hedera_mirror_monitor_subscribe_e2e_seconds_count{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (scenario)",
+          "interval": "1m",
+          "legendFormat": "{{ scenario }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "End to End Latency",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "none",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "s",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {
+        "success=false": "semi-dark-red",
+        "success=true": "green"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "decimals": 1,
+      "description": "How long the subscribe scenario has been active",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": [],
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "fill": 2,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 62
+      },
+      "hiddenSeries": false,
+      "id": 81,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sideWidth": null,
+        "sort": "avg",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(hedera_mirror_monitor_subscribe_duration_seconds{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}) by (scenario)",
+          "interval": "1m",
+          "legendFormat": "{{ scenario }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Subscribe Duration",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "s",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "s",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 70
+      },
+      "id": 61,
+      "panels": [],
+      "title": "Reactor",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "decimals": 1,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 71
+      },
+      "hiddenSeries": false,
+      "id": 69,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": false,
+        "max": true,
+        "min": true,
+        "rightSide": true,
+        "show": true,
+        "sideWidth": null,
+        "sort": "avg",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(reactor_subscribed_subscribers_total{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (flow)",
+          "interval": "1m",
+          "legendFormat": "{{ flow }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Subscription Rate",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "none",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "description": "The number of requests per second for more data",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 79
+      },
+      "hiddenSeries": false,
+      "id": 63,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": false,
+        "max": true,
+        "min": true,
+        "rightSide": true,
+        "show": true,
+        "sort": "avg",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(reactor_requested_requested_amount_count{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (flow)",
+          "interval": "1m",
+          "legendFormat": "{{ flow }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Request Rate",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "decimals": 0,
+      "description": "Times the duration elapsed between a subscription and the termination or cancellation of the sequence",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 87
+      },
+      "hiddenSeries": false,
+      "id": 64,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": false,
+        "max": true,
+        "min": true,
+        "rightSide": true,
+        "show": true,
+        "sort": "avg",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(reactor_flow_duration_seconds_sum{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (flow) / sum(rate(reactor_flow_duration_seconds_count{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (flow)",
+          "interval": "1m",
+          "legendFormat": "{{ flow }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Flow Duration",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "s",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "decimals": 0,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 95
+      },
+      "hiddenSeries": false,
+      "id": 65,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "sort": "avg",
+        "sortDesc": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(executor_pool_size_threads{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\"}) by (reactor_scheduler_id)",
+          "interval": "1m",
+          "legendFormat": "{{ reactor_scheduler_id }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Executor Pool",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "none",
+          "label": "Threads",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "decimals": 0,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 103
+      },
+      "hiddenSeries": false,
+      "id": 66,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "sort": "avg",
+        "sortDesc": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "\nsum(executor_queued_tasks{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\"} >= 0) by (reactor_scheduler_id)",
+          "interval": "1m",
+          "legendFormat": "{{ reactor_scheduler_id }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Queued Tasks",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "none",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "decimals": 0,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 111
+      },
+      "hiddenSeries": false,
+      "id": 67,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "sort": "avg",
+        "sortDesc": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "max(executor_seconds_max{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\"}) by (reactor_scheduler_id)",
+          "interval": "1m",
+          "legendFormat": "{{ reactor_scheduler_id }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Task Execution Latency",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "s",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "decimals": 0,
+      "description": "Measures delays between onNext signals (or between onSubscribe and first onNext)",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 119
+      },
+      "hiddenSeries": false,
+      "id": 68,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": false,
+        "max": true,
+        "min": true,
+        "rightSide": true,
+        "show": true,
+        "sideWidth": null,
+        "sort": "avg",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(reactor_onNext_delay_seconds_sum{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (flow) / sum(rate(reactor_onNext_delay_seconds_count{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (flow)",
+          "interval": "1m",
+          "legendFormat": "{{ flow }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "onNext Delay",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "s",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 127
+      },
+      "id": 25,
+      "panels": [],
+      "title": "Resources",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 128
+      },
+      "hiddenSeries": false,
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(jvm_memory_committed_bytes{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "interval": "1m",
+          "legendFormat": "committed",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(jvm_memory_used_bytes{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "hide": false,
+          "interval": "1m",
+          "legendFormat": "used",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(jvm_memory_max_bytes{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "hide": false,
+          "interval": "1m",
+          "legendFormat": "max",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Memory Usage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "bytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 128
+      },
+      "hiddenSeries": false,
+      "id": 3,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(system_cpu_count{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "hide": false,
+          "interval": "1m",
+          "legendFormat": "max",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(process_cpu_usage{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "hide": false,
+          "interval": "1m",
+          "legendFormat": "usage",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "CPU Usage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {
+        "new": "dark-blue",
+        "runnable": "green",
+        "timed-waiting": "light-yellow",
+        "waiting": "dark-yellow"
+      },
+      "bars": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "decimals": 0,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 137
+      },
+      "hiddenSeries": false,
+      "id": 7,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": false,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(jvm_threads_states_threads{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}) by (state)",
+          "interval": "1m",
+          "legendFormat": "{{ state }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Threads",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {
+        "new": "dark-blue",
+        "runnable": "green",
+        "timed-waiting": "light-yellow",
+        "waiting": "dark-yellow"
+      },
+      "bars": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "decimals": 0,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 137
+      },
+      "hiddenSeries": false,
+      "id": 59,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": false,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(process_files_open_files{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "interval": "1m",
+          "legendFormat": "open",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(process_files_max_files{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "interval": "1m",
+          "legendFormat": "max",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "File Descriptors",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 2,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "decimals": 1,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 145
+      },
+      "hiddenSeries": false,
+      "id": 27,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "sort": "avg",
+        "sortDesc": true,
+        "total": true,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(http_server_requests_seconds_count{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (pod, method, uri)",
+          "interval": "1m",
+          "legendFormat": "{{ method}} {{uri}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "HTTP Requests",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 153
+      },
+      "id": 35,
+      "panels": [],
+      "title": "Logs",
+      "type": "row"
+    },
+    {
+      "aliasColors": {
+        "debug": "blue",
+        "error": "red",
+        "fatal": "red",
+        "info": "light-green",
+        "trace": "semi-dark-purple",
+        "warn": "light-orange"
+      },
+      "bars": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 154
+      },
+      "hiddenSeries": false,
+      "id": 5,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": false,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(log4j2_events_total{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (level)",
+          "interval": "1m",
+          "legendFormat": "{{ level }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Logs",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "datasource": "Loki",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 162
+      },
+      "id": 54,
+      "options": {
+        "showLabels": false,
+        "showTime": false,
+        "sortOrder": "Descending",
+        "wrapLogMessage": false
+      },
+      "targets": [
+        {
+          "expr": "{pod=~\"$pod\"}",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "",
+      "type": "logs"
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 26,
+  "style": "dark",
+  "tags": [
+    "hedera",
+    "mirror",
+    "application",
+    "monitor"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "hedera-mirror-monitor",
+          "value": "hedera-mirror-monitor"
+        },
+        "error": null,
+        "hide": 2,
+        "label": null,
+        "name": "application",
+        "options": [
+          {
+            "selected": true,
+            "text": "hedera-mirror-monitor",
+            "value": "hedera-mirror-monitor"
+          }
+        ],
+        "query": "hedera-mirror-monitor",
+        "skipUrlSync": false,
+        "type": "constant"
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": "Prometheus",
+        "definition": "label_values(system_cpu_count{application=\"$application\"},namespace)",
+        "error": null,
+        "hide": 0,
+        "includeAll": true,
+        "label": "Namespace",
+        "multi": false,
+        "name": "namespace",
+        "options": [],
+        "query": "label_values(system_cpu_count{application=\"$application\"},namespace)",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": "Prometheus",
+        "definition": "label_values(system_cpu_count{application=\"$application\",namespace=~\"$namespace\"},pod)",
+        "error": null,
+        "hide": 0,
+        "includeAll": true,
+        "label": "Pod",
+        "multi": false,
+        "name": "pod",
+        "options": [],
+        "query": "label_values(system_cpu_count{application=\"$application\",namespace=~\"$namespace\"},pod)",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-3h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "",
+  "title": "Hedera / Mirror / Monitor",
+  "uid": "63jQE_AGk",
+  "version": 6
+}

--- a/charts/hedera-mirror-grpc/values.yaml
+++ b/charts/hedera-mirror-grpc/values.yaml
@@ -79,7 +79,7 @@ prometheusRules:
   enabled: false
   GrpcErrors:
     annotations:
-      description: '{{ $value | humanizePercentage }}% gRPC {{ $labels.statusCode }} error rate for {{ $labels.namespace }}/{{ $labels.pod }}'
+      description: '{{ $value | humanizePercentage }} gRPC {{ $labels.statusCode }} error rate for {{ $labels.namespace }}/{{ $labels.pod }}'
       summary: "Mirror gRPC API error rate exceeds 5%"
     enabled: true
     expr: sum(rate(grpc_server_processing_duration_seconds_count{application="hedera-mirror-grpc", statusCode!~"DEADLINE_EXCEEDED|INVALID_ARGUMENT|NOT_FOUND|OK|RESOURCE_EXHAUSTED"}[5m])) by (namespace, pod, statusCode) / sum(rate(grpc_server_processing_duration_seconds_count{application="hedera-mirror-grpc"}[5m])) by (namespace, pod, statusCode) > 0.05
@@ -89,7 +89,7 @@ prometheusRules:
 
   GrpcHighCPU:
     annotations:
-      description: "{{ $labels.namespace }}/{{ $labels.pod }} CPU usage reached {{ $value | humanizePercentage }}%"
+      description: "{{ $labels.namespace }}/{{ $labels.pod }} CPU usage reached {{ $value | humanizePercentage }}"
       summary: "Mirror gRPC API CPU usage exceeds 80%"
     enabled: true
     expr: sum(process_cpu_usage{application="hedera-mirror-grpc"}) by (namespace, pod) / sum(system_cpu_count{application="hedera-mirror-grpc"}) by (namespace, pod) > 0.8
@@ -99,7 +99,7 @@ prometheusRules:
 
   GrpcHighDBConnections:
     annotations:
-      description: "{{ $labels.namespace }}/{{ $labels.pod }} is using {{ $value | humanizePercentage }}% of available database connections"
+      description: "{{ $labels.namespace }}/{{ $labels.pod }} is using {{ $value | humanizePercentage }} of available database connections"
       summary: "Mirror gRPC API database connection utilization exceeds 75%"
     enabled: true
     expr: sum(hikaricp_connections_active{application="hedera-mirror-grpc"}) by (namespace, pod) / sum(hikaricp_connections_max{application="hedera-mirror-grpc"}) by (namespace, pod) > 0.75
@@ -109,7 +109,7 @@ prometheusRules:
 
   GrpcHighFileDescriptors:
     annotations:
-      description: "{{ $labels.namespace }}/{{ $labels.pod }} file descriptor usage reached {{ $value | humanizePercentage }}%"
+      description: "{{ $labels.namespace }}/{{ $labels.pod }} file descriptor usage reached {{ $value | humanizePercentage }}"
       summary: "Mirror gRPC API file descriptor usage exceeds 80%"
     enabled: true
     expr: sum(process_files_open_files{application="hedera-mirror-grpc"}) by (namespace, pod) / sum(process_files_max_files{application="hedera-mirror-grpc"}) by (namespace, pod) > 0.8
@@ -129,7 +129,7 @@ prometheusRules:
 
   GrpcHighMemory:
     annotations:
-      description: "{{ $labels.namespace }}/{{ $labels.pod }} memory usage reached {{ $value | humanizePercentage }}%"
+      description: "{{ $labels.namespace }}/{{ $labels.pod }} memory usage reached {{ $value | humanizePercentage }}"
       summary: "Mirror gRPC API memory usage exceeds 80%"
     enabled: true
     expr: sum(jvm_memory_used_bytes{application="hedera-mirror-grpc"}) by (namespace, pod) / sum(jvm_memory_max_bytes{application="hedera-mirror-grpc"}) by (namespace, pod) > 0.8

--- a/charts/hedera-mirror-importer/values.yaml
+++ b/charts/hedera-mirror-importer/values.yaml
@@ -125,7 +125,7 @@ prometheusRules:
 
   ImporterCloudStorageErrors:
     annotations:
-      description: '{{ $value | humanizePercentage }}% Error rate trying to {{ if ne $labels.action "list" }} retrieve{{ end }} {{ $labels.action }} {{ $labels.type }} files from cloud storage for {{ $labels.namespace }}/{{ $labels.pod }}'
+      description: '{{ $value | humanizePercentage }} Error rate trying to {{ if ne $labels.action "list" }} retrieve{{ end }} {{ $labels.action }} {{ $labels.type }} files from cloud storage for {{ $labels.namespace }}/{{ $labels.pod }}'
       summary: "Cloud storage error rate exceeds 5%"
     enabled: true
     expr: (sum(rate(hedera_mirror_download_request_seconds_count{application="hedera-mirror-importer", status!~"^2.*"}[2m])) by (namespace, pod, type, action) / sum(rate(hedera_mirror_download_request_seconds_count{application="hedera-mirror-importer"}[2m])) by (namespace, pod, type, action)) > 0.05
@@ -145,7 +145,7 @@ prometheusRules:
 
   ImporterFileVerificationErrors:
     annotations:
-      description: "Error rate of {{ $value | humanizePercentage }}% trying to download and verify {{ $labels.type }} stream files for {{ $labels.namespace }}/{{ $labels.pod }}"
+      description: "Error rate of {{ $value | humanizePercentage }} trying to download and verify {{ $labels.type }} stream files for {{ $labels.namespace }}/{{ $labels.pod }}"
       summary: "{{ $labels.type }} file verification error rate exceeds 5%"
     enabled: true
     expr: sum(rate(hedera_mirror_download_stream_verification_seconds_count{application="hedera-mirror-importer", success="false"}[3m])) by (namespace, pod, type) / sum(rate(hedera_mirror_download_stream_verification_seconds_count{application="hedera-mirror-importer"}[3m])) by (namespace, pod, type) > 0.05
@@ -155,7 +155,7 @@ prometheusRules:
 
   ImporterHighCPU:
     annotations:
-      description: "{{ $labels.namespace }}/{{ $labels.pod }} CPU usage reached {{ $value | humanizePercentage }}%"
+      description: "{{ $labels.namespace }}/{{ $labels.pod }} CPU usage reached {{ $value | humanizePercentage }}"
       summary: "Mirror Importer CPU usage exceeds 80%"
     enabled: true
     expr: sum(process_cpu_usage{application="hedera-mirror-importer"}) by (namespace, pod) / sum(system_cpu_count{application="hedera-mirror-importer"}) by (namespace, pod) > 0.8
@@ -165,7 +165,7 @@ prometheusRules:
 
   ImporterHighDBConnections:
     annotations:
-      description: "{{ $labels.namespace }}/{{ $labels.pod }} is using {{ $value | humanizePercentage }}% of available database connections"
+      description: "{{ $labels.namespace }}/{{ $labels.pod }} is using {{ $value | humanizePercentage }} of available database connections"
       summary: "Mirror Importer database connection utilization exceeds 75%"
     enabled: true
     expr: sum(hikaricp_connections_active{application="hedera-mirror-importer"}) by (namespace, pod) / sum(hikaricp_connections_max{application="hedera-mirror-importer"}) by (namespace, pod) > 0.75
@@ -175,7 +175,7 @@ prometheusRules:
 
   ImporterHighFileDescriptors:
     annotations:
-      description: "{{ $labels.namespace }}/{{ $labels.pod }} file descriptor usage reached {{ $value | humanizePercentage }}%"
+      description: "{{ $labels.namespace }}/{{ $labels.pod }} file descriptor usage reached {{ $value | humanizePercentage }}"
       summary: "Mirror Importer file descriptor usage exceeds 80%"
     enabled: true
     expr: sum(process_files_open_files{application="hedera-mirror-importer"}) by (namespace, pod) / sum(process_files_max_files{application="hedera-mirror-importer"}) by (namespace, pod) > 0.8
@@ -185,7 +185,7 @@ prometheusRules:
 
   ImporterHighMemory:
     annotations:
-      description: "{{ $labels.namespace }}/{{ $labels.pod }} memory usage reached {{ $value | humanizePercentage }}%"
+      description: "{{ $labels.namespace }}/{{ $labels.pod }} memory usage reached {{ $value | humanizePercentage }}"
       summary: "Mirror Importer memory usage exceeds 80%"
     enabled: true
     expr: sum(jvm_memory_used_bytes{application="hedera-mirror-importer"}) by (namespace, pod) / sum(jvm_memory_max_bytes{application="hedera-mirror-importer"}) by (namespace, pod) > 0.8
@@ -205,7 +205,7 @@ prometheusRules:
 
   ImporterNoConsensus:
     annotations:
-      description: "{{ $labels.namespace }}/{{ $labels.pod }} only able to achieve {{ $value | humanizePercentage }}% consensus during {{ $labels.type }} stream signature verification"
+      description: "{{ $labels.namespace }}/{{ $labels.pod }} only able to achieve {{ $value | humanizePercentage }} consensus during {{ $labels.type }} stream signature verification"
       summary: Unable to verify {{ $labels.type }} stream signatures
     enabled: true
     expr: sum(rate(hedera_mirror_download_signature_verification_total{application="hedera-mirror-importer", status="CONSENSUS_REACHED"}[2m])) by (namespace, pod, type) / sum(rate(hedera_mirror_download_signature_verification_total{application="hedera-mirror-importer"}[2m])) by (namespace, pod, type) < 0.33
@@ -225,7 +225,7 @@ prometheusRules:
 
   ImporterParseErrors:
     annotations:
-      description: "Encountered {{ $value | humanizePercentage }}% errors trying to parse {{ $labels.type }} stream files for {{ $labels.namespace }}/{{ $labels.pod }}"
+      description: "Encountered {{ $value | humanizePercentage }} errors trying to parse {{ $labels.type }} stream files for {{ $labels.namespace }}/{{ $labels.pod }}"
       summary: "Error rate parsing {{ $labels.type }} exceeds 5%"
     enabled: true
     expr: sum(rate(hedera_mirror_parse_duration_seconds_count{application="hedera-mirror-importer", success="false"}[3m])) by (namespace, pod, type) / sum(rate(hedera_mirror_parse_duration_seconds_count{application="hedera-mirror-importer"}[3m])) by (namespace, pod, type) > 0.05

--- a/charts/hedera-mirror-monitor/values.yaml
+++ b/charts/hedera-mirror-monitor/values.yaml
@@ -52,7 +52,7 @@ prometheusRules:
   enabled: false
   MonitorHighCPU:
     annotations:
-      description: "{{ $labels.namespace }}/{{ $labels.pod }} CPU usage reached {{ $value | humanizePercentage }}%"
+      description: "{{ $labels.namespace }}/{{ $labels.pod }} CPU usage reached {{ $value | humanizePercentage }}"
       summary: "Mirror Monitor CPU usage exceeds 80%"
     enabled: true
     expr: sum(process_cpu_usage{application="hedera-mirror-monitor"}) by (namespace, pod) / sum(system_cpu_count{application="hedera-mirror-monitor"}) by (namespace, pod) > 0.8
@@ -62,7 +62,7 @@ prometheusRules:
 
   MonitorHighMemory:
     annotations:
-      description: "{{ $labels.namespace }}/{{ $labels.pod }} memory usage reached {{ $value | humanizePercentage }}%"
+      description: "{{ $labels.namespace }}/{{ $labels.pod }} memory usage reached {{ $value | humanizePercentage }}"
       summary: "Mirror Monitor memory usage exceeds 80%"
     enabled: true
     expr: sum(jvm_memory_used_bytes{application="hedera-mirror-monitor"}) by (namespace, pod) / sum(jvm_memory_max_bytes{application="hedera-mirror-monitor"}) by (namespace, pod) > 0.8
@@ -82,20 +82,60 @@ prometheusRules:
 
   MonitorPublishErrors:
     annotations:
-      description: "{{ $value | humanizePercentage }}% Error rate publishing {{ $labels.type }} transactions from {{ $labels.namespace }}/{{ $labels.pod }}"
+      description: "{{ $value | humanizePercentage }} Error rate publishing '{{ $labels.scenario }}' scenario from {{ $labels.namespace }}/{{ $labels.pod }}"
       summary: "Publish error rate exceeds 5%"
     enabled: true
-    expr: sum(rate(hedera_mirror_monitor_publish_seconds_sum{application="hedera-mirror-monitor",status!="SUCCESS"}[2m])) by (namespace, pod, type) / sum(rate(hedera_mirror_monitor_publish_seconds_count{application="hedera-mirror-monitor"}[2m])) by (namespace, pod, type) > 0.05
+    expr: sum(rate(hedera_mirror_monitor_publish_submit_seconds_sum{application="hedera-mirror-monitor",status!="SUCCESS"}[2m])) by (namespace, pod, scenario) / sum(rate(hedera_mirror_monitor_publish_submit_seconds_count{application="hedera-mirror-monitor"}[2m])) by (namespace, pod, scenario) > 0.05
     for: 2m
     labels:
       severity: critical
 
   MonitorPublishLatency:
     annotations:
-      description: "Publish latency exceeded {{ $value | humanizeDuration }} for {{ $labels.type }} transaction for {{ $labels.namespace }}/{{ $labels.pod }}"
-      summary: "Publish latency exceeds 4s"
+      description: "Publish latency exceeded {{ $value | humanizeDuration }} for '{{ $labels.scenario }}' scenario for {{ $labels.namespace }}/{{ $labels.pod }}"
+      summary: "Publish latency exceeds 2s"
     enabled: true
-    expr: sum(rate(hedera_mirror_monitor_publish_seconds_sum{application="hedera-mirror-monitor"}[2m])) by (namespace, pod, type) / sum(rate(hedera_mirror_monitor_publish_seconds_count{application="hedera-mirror-monitor"}[2m])) by (namespace, pod, type) > 4
+    expr: sum(rate(hedera_mirror_monitor_publish_submit_seconds_sum{application="hedera-mirror-monitor"}[2m])) by (namespace, pod, scenario) / sum(rate(hedera_mirror_monitor_publish_submit_seconds_count{application="hedera-mirror-monitor"}[2m])) by (namespace, pod, scenario) > 2
+    for: 2m
+    labels:
+      severity: critical
+
+  MonitorPublishStopped:
+    annotations:
+      description: "Publish TPS dropped to {{ $value }} for '{{ $labels.scenario }}' scenario for {{ $labels.namespace }}/{{ $labels.pod }}"
+      summary: "Publishing stopped"
+    enabled: true
+    expr: sum(rate(hedera_mirror_monitor_publish_submit_seconds_sum{application="hedera-mirror-monitor"}[2m])) by (namespace, pod, scenario) / sum(rate(hedera_mirror_monitor_publish_submit_seconds_count{application="hedera-mirror-monitor"}[2m])) by (namespace, pod, scenario) <= 0
+    for: 2m
+    labels:
+      severity: critical
+
+  MonitorPublishToHandleLatency:
+    annotations:
+      description: "Transaction latency exceeded {{ $value | humanizeDuration }} for '{{ $labels.scenario }}' scenario for {{ $labels.namespace }}/{{ $labels.pod }}"
+      summary: "Submit to transaction being handled latency exceeds 8s"
+    enabled: true
+    expr: sum(rate(hedera_mirror_monitor_publish_handle_seconds_sum{application="hedera-mirror-monitor"}[2m])) by (namespace, pod, scenario) / sum(rate(hedera_mirror_monitor_publish_handle_seconds_count{application="hedera-mirror-monitor"}[2m])) by (namespace, pod, scenario) > 8
+    for: 2m
+    labels:
+      severity: warning
+
+  MonitorSubscribeLatency:
+    annotations:
+      description: "{{ $labels.subscriber }} latency exceeded {{ $value | humanizeDuration }} for '{{ $labels.scenario }}' scenario for {{ $labels.namespace }}/{{ $labels.pod }}"
+      summary: "End to end latency exceeds 10s"
+    enabled: true
+    expr: sum(rate(hedera_mirror_monitor_subscribe_e2e_seconds_sum{application="hedera-mirror-monitor"}[2m])) by (namespace, pod, scenario, subscriber) / sum(rate(hedera_mirror_monitor_subscribe_e2e_seconds_count{application="hedera-mirror-monitor"}[2m])) by (namespace, pod, scenario, subscriber) > 10
+    for: 2m
+    labels:
+      severity: critical
+
+  MonitorSubscribeStopped:
+    annotations:
+      description: "{{ $labels.subscriber }} TPS dropped to {{ $value }} for '{{ $labels.scenario }}' scenario for {{ $labels.namespace }}/{{ $labels.pod }}"
+      summary: "Subscription stopped"
+    enabled: true
+    expr: sum(rate(hedera_mirror_monitor_subscribe_e2e_seconds_sum{application="hedera-mirror-monitor"}[2m])) by (namespace, pod, subscriber, scenario) / sum(rate(hedera_mirror_monitor_subscribe_e2e_seconds_count{application="hedera-mirror-monitor"}[2m])) by (namespace, pod, subscriber, scenario) <= 0
     for: 2m
     labels:
       severity: critical

--- a/charts/hedera-mirror-rest/values.yaml
+++ b/charts/hedera-mirror-rest/values.yaml
@@ -77,7 +77,7 @@ prometheusRules:
   enabled: false
   RestErrors:
     annotations:
-      description: "REST API 5xx error rate for {{ $labels.namespace }}/{{ $labels.pod }} is {{ $value | humanizePercentage }}%"
+      description: "REST API 5xx error rate for {{ $labels.namespace }}/{{ $labels.pod }} is {{ $value | humanizePercentage }}"
       summary: "Mirror REST API error rate exceeds 5%"
     enabled: true
     expr: sum(rate(api_request_total{container="rest",code=~"^5.."}[5m])) by (namespace, pod) / sum(rate(api_request_total{container="rest"}[5m])) by (namespace, pod) > 0.05
@@ -87,7 +87,7 @@ prometheusRules:
 
   RestHighCPU:
     annotations:
-      description: "{{ $labels.namespace }}/{{ $labels.pod }} CPU usage reached {{ $value | humanizePercentage }}%"
+      description: "{{ $labels.namespace }}/{{ $labels.pod }} CPU usage reached {{ $value | humanizePercentage }}"
       summary: "Mirror REST API CPU usage exceeds 80%"
     enabled: true
     expr: sum(nodejs_process_cpu_usage_percentage{container="rest"}) by (namespace, pod) > 80

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/MonitorApplication.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/MonitorApplication.java
@@ -24,6 +24,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import reactor.core.scheduler.Schedulers;
 
 @ConfigurationPropertiesScan
 @EnableScheduling
@@ -31,6 +32,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 public class MonitorApplication {
 
     public static void main(String[] args) {
+        Schedulers.enableMetrics();
         SpringApplication.run(MonitorApplication.class, args);
     }
 }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/config/MonitorConfiguration.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/config/MonitorConfiguration.java
@@ -63,6 +63,8 @@ class MonitorConfiguration {
     Disposable publishSubscribe() {
         return Flux.<PublishRequest>generate(sink -> sink.next(transactionGenerator.next()))
                 .retry()
+                .name("generate")
+                .metrics()
                 .subscribeOn(Schedulers.single())
                 .parallel(publishProperties.getConnections())
                 .runOn(Schedulers.newParallel("publisher", publishProperties.getConnections()))

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/generator/ScenarioProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/generator/ScenarioProperties.java
@@ -55,12 +55,12 @@ public class ScenarioProperties {
     private Map<String, Object> properties = new LinkedHashMap<>();
 
     @Min(0)
-    @Max(100)
-    private int receipt = 0;
+    @Max(1)
+    private double receipt = 0.0;
 
     @Min(0)
-    @Max(100)
-    private int record = 0;
+    @Max(1)
+    private double record = 0.0;
 
     @Min(0)
     private double tps = 10.0;

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishMetrics.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishMetrics.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ConcurrentHashMultiset;
 import com.google.common.collect.Multiset;
 import io.grpc.StatusRuntimeException;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.TimeGauge;
 import io.micrometer.core.instrument.Timer;
 import java.util.HashMap;
 import java.util.Map;
@@ -52,7 +53,9 @@ public class PublishMetrics {
     private final AtomicLong counter = new AtomicLong(0L);
     private final Multiset<String> errors = ConcurrentHashMultiset.create();
     private final Stopwatch stopwatch = Stopwatch.createStarted();
-    private final Map<Tags, Timer> timers = new ConcurrentHashMap<>();
+    private final Map<Tags, Timer> handleTimers = new ConcurrentHashMap<>();
+    private final Map<Tags, Timer> submitTimers = new ConcurrentHashMap<>();
+    private final Map<Tags, TimeGauge> durationGauges = new ConcurrentHashMap<>();
     private final MeterRegistry meterRegistry;
 
     @FunctionalInterface
@@ -65,10 +68,12 @@ public class PublishMetrics {
         long startTime = System.currentTimeMillis();
         String status = SUCCESS;
         TransactionType type = publishRequest.getType();
+        PublishResponse response = null;
 
         try {
-            PublishResponse response = function.apply(publishRequest);
+            response = function.apply(publishRequest);
             counter.incrementAndGet();
+
             return response;
         } catch (LocalValidationException e) {
             throw e;
@@ -86,10 +91,18 @@ public class PublishMetrics {
             log.debug("{} submitting {} transaction: {}", status, type, e.getMessage());
             throw new PublishException(e);
         } finally {
-            long endTime = System.currentTimeMillis();
-            Tags tags = new Tags(status, type);
-            Timer timer = timers.computeIfAbsent(tags, this::newTimer);
-            timer.record(endTime - startTime, TimeUnit.MILLISECONDS);
+            long endTime = response != null ? response.getTimestamp().toEpochMilli() : System.currentTimeMillis();
+            String scenarioName = publishRequest.getScenarioName();
+            Tags tags = new Tags(scenarioName, status, type);
+            Timer submitTimer = submitTimers.computeIfAbsent(tags, this::newSubmitMetric);
+            submitTimer.record(endTime - startTime, TimeUnit.MILLISECONDS);
+            durationGauges.computeIfAbsent(tags, this::newDurationMetric);
+
+            if (response != null && response.getReceipt() != null) {
+                long elapsed = System.currentTimeMillis() - startTime;
+                Timer handleTimer = handleTimers.computeIfAbsent(tags, this::newHandleMetric);
+                handleTimer.record(elapsed, TimeUnit.MILLISECONDS);
+            }
 
             if (!SUCCESS.equals(status)) {
                 errors.add(status);
@@ -97,9 +110,28 @@ public class PublishMetrics {
         }
     }
 
-    private Timer newTimer(Tags tags) {
-        return Timer.builder("hedera.mirror.monitor.publish")
-                .description("The time it takes to publish a transaction")
+    private TimeGauge newDurationMetric(Tags tags) {
+        TimeUnit unit = TimeUnit.NANOSECONDS;
+        return TimeGauge.builder("hedera.mirror.monitor.publish.duration", stopwatch, unit, s -> s.elapsed(unit))
+                .description("The amount of time this scenario has been publishing transactions")
+                .tag("scenario", tags.getScenarioName())
+                .tag("type", tags.getType().toString())
+                .register(meterRegistry);
+    }
+
+    private Timer newHandleMetric(Tags tags) {
+        return Timer.builder("hedera.mirror.monitor.publish.handle")
+                .description("The time it takes from submit to being handled by the main nodes")
+                .tag("scenario", tags.getScenarioName())
+                .tag("status", tags.getStatus())
+                .tag("type", tags.getType().toString())
+                .register(meterRegistry);
+    }
+
+    private Timer newSubmitMetric(Tags tags) {
+        return Timer.builder("hedera.mirror.monitor.publish.submit")
+                .description("The time it takes to submit a transaction")
+                .tag("scenario", tags.getScenarioName())
                 .tag("status", tags.getStatus())
                 .tag("type", tags.getType().toString())
                 .register(meterRegistry);
@@ -117,6 +149,7 @@ public class PublishMetrics {
 
     @Value
     private class Tags {
+        private final String scenarioName;
         private final String status;
         private final TransactionType type;
     }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishMetrics.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishMetrics.java
@@ -114,26 +114,26 @@ public class PublishMetrics {
         TimeUnit unit = TimeUnit.NANOSECONDS;
         return TimeGauge.builder("hedera.mirror.monitor.publish.duration", stopwatch, unit, s -> s.elapsed(unit))
                 .description("The amount of time this scenario has been publishing transactions")
-                .tag("scenario", tags.getScenarioName())
-                .tag("type", tags.getType().toString())
+                .tag(Tags.TAG_SCENARIO, tags.getScenarioName())
+                .tag(Tags.TAG_TYPE, tags.getType().toString())
                 .register(meterRegistry);
     }
 
     private Timer newHandleMetric(Tags tags) {
         return Timer.builder("hedera.mirror.monitor.publish.handle")
                 .description("The time it takes from submit to being handled by the main nodes")
-                .tag("scenario", tags.getScenarioName())
-                .tag("status", tags.getStatus())
-                .tag("type", tags.getType().toString())
+                .tag(Tags.TAG_SCENARIO, tags.getScenarioName())
+                .tag(Tags.TAG_STATUS, tags.getStatus())
+                .tag(Tags.TAG_TYPE, tags.getType().toString())
                 .register(meterRegistry);
     }
 
     private Timer newSubmitMetric(Tags tags) {
         return Timer.builder("hedera.mirror.monitor.publish.submit")
                 .description("The time it takes to submit a transaction")
-                .tag("scenario", tags.getScenarioName())
-                .tag("status", tags.getStatus())
-                .tag("type", tags.getType().toString())
+                .tag(Tags.TAG_SCENARIO, tags.getScenarioName())
+                .tag(Tags.TAG_STATUS, tags.getStatus())
+                .tag(Tags.TAG_TYPE, tags.getType().toString())
                 .register(meterRegistry);
     }
 
@@ -149,6 +149,10 @@ public class PublishMetrics {
 
     @Value
     private class Tags {
+        private static final String TAG_SCENARIO = "scenario";
+        private static final String TAG_STATUS = "status";
+        private static final String TAG_TYPE = "type";
+
         private final String scenarioName;
         private final String status;
         private final TransactionType type;

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishRequest.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishRequest.java
@@ -32,9 +32,10 @@ import com.hedera.hashgraph.sdk.TransactionId;
 @Value
 public class PublishRequest {
     private final boolean logResponse;
+    private final String scenarioName;
     private final boolean receipt;
     private final boolean record;
-    private final Instant timestamp = Instant.now();
+    private final Instant timestamp;
     private final TransactionBuilder<TransactionId, ?, ?> transactionBuilder;
     private final TransactionType type;
 }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishResponse.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishResponse.java
@@ -37,7 +37,7 @@ public class PublishResponse {
     private final PublishRequest request;
     private final TransactionRecord record;
     private final TransactionReceipt receipt;
-    private final Instant timestamp = Instant.now();
+    private final Instant timestamp;
     private final TransactionId transactionId;
 
     // Needed since the SDK doesn't implement toString() or have actual fields to use with reflection

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/AbstractSubscriber.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/AbstractSubscriber.java
@@ -1,0 +1,105 @@
+package com.hedera.mirror.monitor.subscribe;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.google.common.base.Stopwatch;
+import com.google.common.collect.ConcurrentHashMultiset;
+import com.google.common.collect.Multiset;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.TimeGauge;
+import io.micrometer.core.instrument.Timer;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.commons.math3.util.Precision;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import com.hedera.datagenerator.sdk.supplier.TransactionType;
+
+public abstract class AbstractSubscriber<P extends AbstractSubscriberProperties> implements Subscriber {
+
+    static final String METRIC_DURATION = "hedera.mirror.monitor.subscribe.duration";
+    static final String METRIC_E2E = "hedera.mirror.monitor.subscribe.e2e";
+
+    protected final Logger log = LogManager.getLogger(getClass());
+
+    protected final AtomicLong counter;
+    protected final Multiset<String> errors;
+    protected final Stopwatch stopwatch;
+    protected final P subscriberProperties;
+
+    private final TimeGauge durationMetric;
+    private final Map<TransactionType, Timer> latencyMetrics;
+    private final MeterRegistry meterRegistry;
+    private final ScheduledFuture<?> statusThread;
+
+    protected AbstractSubscriber(MeterRegistry meterRegistry, P subscriberProperties) {
+        this.counter = new AtomicLong(0L);
+        this.errors = ConcurrentHashMultiset.create();
+        this.stopwatch = Stopwatch.createStarted();
+        this.subscriberProperties = subscriberProperties;
+        this.durationMetric = TimeGauge
+                .builder(METRIC_DURATION, stopwatch, TimeUnit.NANOSECONDS, s -> s.elapsed(TimeUnit.NANOSECONDS))
+                .description("How long the subscriber has been running")
+                .tag("scenario", subscriberProperties.getName())
+                .tag("subscriber", getClass().getSimpleName())
+                .register(meterRegistry);
+        this.latencyMetrics = new ConcurrentHashMap<>();
+        this.meterRegistry = meterRegistry;
+        long frequency = subscriberProperties.getStatusFrequency().toMillis();
+        this.statusThread = Executors.newSingleThreadScheduledExecutor()
+                .scheduleWithFixedDelay(this::status, frequency, frequency, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public void close() {
+        meterRegistry.remove(durationMetric);
+        statusThread.cancel(true);
+    }
+
+    protected final Timer getLatencyTimer(TransactionType type) {
+        return latencyMetrics.computeIfAbsent(type, t -> Timer.builder(METRIC_E2E)
+                .description("The end to end transaction latency starting from publish and ending at receive")
+                .tag("scenario", subscriberProperties.getName())
+                .tag("subscriber", getClass().getSimpleName())
+                .tag("type", t.name())
+                .register(meterRegistry)
+        );
+    }
+
+    protected abstract void onError(Throwable t);
+
+    protected abstract boolean shouldRetry(Throwable t);
+
+    private void status() {
+        long count = counter.get();
+        long elapsed = stopwatch.elapsed(TimeUnit.MICROSECONDS);
+        double rate = Precision.round(elapsed > 0 ? (1_000_000.0 * count) / elapsed : 0.0, 1);
+        Map<String, Integer> errorCounts = new HashMap<>();
+        errors.forEachEntry(errorCounts::put);
+        log.info("Received {} transactions in {} at {}/s. Errors: {}", count, stopwatch, rate, errorCounts);
+    }
+}

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/AbstractSubscriberProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/AbstractSubscriberProperties.java
@@ -47,6 +47,10 @@ public abstract class AbstractSubscriberProperties {
     @NotNull
     protected RetryProperties retry = new RetryProperties();
 
+    @DurationMin(seconds = 1L)
+    @NotNull
+    protected Duration statusFrequency = Duration.ofSeconds(5L);
+
     @Data
     @Validated
     public static class RetryProperties {

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/CompositeSubscriber.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/CompositeSubscriber.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import javax.annotation.PreDestroy;
 import javax.inject.Named;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Primary;
@@ -45,6 +46,12 @@ public class CompositeSubscriber implements Subscriber {
     private final MeterRegistry meterRegistry;
     private final WebClient.Builder webClientBuilder;
     final Supplier<List<Subscriber>> subscribers = Suppliers.memoize(this::subscribers);
+
+    @Override
+    @PreDestroy
+    public void close() {
+        subscribers.get().forEach(Subscriber::close);
+    }
 
     @Override
     public void onPublish(PublishResponse response) {

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/RestSubscriber.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/RestSubscriber.java
@@ -39,7 +39,7 @@ import com.hedera.hashgraph.sdk.TransactionId;
 import com.hedera.mirror.monitor.MonitorProperties;
 import com.hedera.mirror.monitor.publish.PublishResponse;
 
-public class RestSubscriber extends AbstractSubscriber {
+public class RestSubscriber extends AbstractSubscriber<RestSubscriberProperties> {
 
     private final FluxSink<PublishResponse> restProcessor;
     private static final SecureRandom RANDOM = new SecureRandom();

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/RestSubscriber.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/RestSubscriber.java
@@ -26,10 +26,6 @@ import java.security.SecureRandom;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -39,24 +35,18 @@ import reactor.core.publisher.FluxSink;
 import reactor.util.retry.Retry;
 import reactor.util.retry.RetryBackoffSpec;
 
-import com.hedera.datagenerator.sdk.supplier.TransactionType;
 import com.hedera.hashgraph.sdk.TransactionId;
 import com.hedera.mirror.monitor.MonitorProperties;
 import com.hedera.mirror.monitor.publish.PublishResponse;
 
-@Log4j2
-@RequiredArgsConstructor
-public class RestSubscriber implements Subscriber {
+public class RestSubscriber extends AbstractSubscriber {
 
-    private final MeterRegistry meterRegistry;
     private final FluxSink<PublishResponse> restProcessor;
-    private final Map<TransactionType, Timer> timers;
     private static final SecureRandom RANDOM = new SecureRandom();
 
-    public RestSubscriber(MeterRegistry meterRegistry, MonitorProperties monitorProperties,
-                          RestSubscriberProperties properties, WebClient.Builder webClientBuilder) {
-        this.meterRegistry = meterRegistry;
-        this.timers = new ConcurrentHashMap<>();
+    RestSubscriber(MeterRegistry meterRegistry, MonitorProperties monitorProperties,
+                   RestSubscriberProperties properties, WebClient.Builder webClientBuilder) {
+        super(meterRegistry, properties);
 
         String url = monitorProperties.getMirrorNode().getRest().getBaseUrl();
         WebClient webClient = webClientBuilder.baseUrl(url)
@@ -79,6 +69,7 @@ public class RestSubscriber implements Subscriber {
                 .filter(r -> RANDOM.nextDouble() < samplePercent)
                 .doOnNext(publishResponse -> log.trace("Querying REST API: {}", publishResponse))
                 .doFinally(s -> log.warn("Received {} signal", s))
+                .doFinally(s -> close())
                 .limitRequest(properties.getLimit())
                 .take(properties.getDuration())
                 .flatMap(publishResponse -> webClient.get()
@@ -86,20 +77,37 @@ public class RestSubscriber implements Subscriber {
                                 .getTransactionId()))
                         .retrieve()
                         .bodyToMono(String.class)
+                        .name("rest")
+                        .metrics()
                         .doOnNext(json -> log.trace("Response: {}", json))
                         .timeout(properties.getTimeout())
                         .retryWhen(retrySpec)
-                        .onErrorContinue((t, o) -> log.warn("Error subscribing to REST API: {}", t))
+                        .onErrorContinue((t, o) -> onError(t))
                         .doOnNext(clientResponse -> record(publishResponse)))
                 .subscribe();
     }
 
     @Override
     public void onPublish(PublishResponse response) {
-        restProcessor.next(response);
+        if (!restProcessor.isCancelled()) {
+            restProcessor.next(response);
+        }
     }
 
-    private boolean shouldRetry(Throwable t) {
+    @Override
+    protected void onError(Throwable t) {
+        log.warn("Error subscribing to REST API: {}", t.getMessage());
+        String error = t.getClass().getSimpleName();
+
+        if (t instanceof WebClientResponseException) {
+            error = ((WebClientResponseException) t).getStatusCode().toString();
+        }
+
+        errors.add(error);
+    }
+
+    @Override
+    protected boolean shouldRetry(Throwable t) {
         return t instanceof WebClientResponseException &&
                 ((WebClientResponseException) t).getStatusCode() == HttpStatus.NOT_FOUND;
     }
@@ -107,15 +115,9 @@ public class RestSubscriber implements Subscriber {
     private void record(PublishResponse r) {
         Duration latency = Duration.between(r.getRequest().getTimestamp(), Instant.now());
         log.debug("Transaction retrieved with a latency of {}s", latency.toSeconds());
-        Timer timer = timers.computeIfAbsent(r.getRequest().getType(), this::newTimer);
+        Timer timer = getLatencyTimer(r.getRequest().getType());
         timer.record(latency);
-    }
-
-    private Timer newTimer(TransactionType type) {
-        return Timer.builder(METRIC_NAME)
-                .tag("api", "rest")
-                .tag("type", type.name())
-                .register(meterRegistry);
+        counter.incrementAndGet();
     }
 
     private String toString(TransactionId tid) {

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/Subscriber.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/Subscriber.java
@@ -24,7 +24,7 @@ import com.hedera.mirror.monitor.publish.PublishResponse;
 
 public interface Subscriber {
 
-    String METRIC_NAME = "hedera.mirror.monitor.subscribe";
+    void close();
 
     void onPublish(PublishResponse response);
 }

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/generator/ConfigurableTransactionGeneratorTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/generator/ConfigurableTransactionGeneratorTest.java
@@ -41,7 +41,7 @@ import com.hedera.mirror.monitor.publish.PublishRequest;
 
 class ConfigurableTransactionGeneratorTest {
 
-    private static final int SAMPLE_SIZE = 1000;
+    private static final int SAMPLE_SIZE = 10_000;
     private static final String TOPIC_ID = "0.0.1000";
 
     private ScenarioProperties properties;
@@ -50,11 +50,11 @@ class ConfigurableTransactionGeneratorTest {
     @BeforeEach
     void init() {
         properties = new ScenarioProperties();
-        properties.setReceipt(100);
-        properties.setRecord(100);
+        properties.setReceipt(1);
+        properties.setRecord(1);
         properties.setName("test");
         properties.setProperties(Map.of("topicId", TOPIC_ID));
-        properties.setTps(10000);
+        properties.setTps(100_000);
         properties.setType(TransactionType.CONSENSUS_SUBMIT_MESSAGE);
         generator = Suppliers.memoize(() -> new ConfigurableTransactionGenerator(properties));
     }
@@ -107,7 +107,7 @@ class ConfigurableTransactionGeneratorTest {
 
     @Test
     void receiptEnabled() {
-        properties.setReceipt(100);
+        properties.setReceipt(1);
         for (int i = 0; i < SAMPLE_SIZE; ++i) {
             assertThat(generator.get().next())
                     .extracting(PublishRequest::isReceipt)
@@ -117,17 +117,17 @@ class ConfigurableTransactionGeneratorTest {
 
     @Test
     void receiptPercent() {
-        properties.setReceipt(1);
+        properties.setReceipt(0.001);
         Multiset<Boolean> receipts = HashMultiset.create();
 
         for (int i = 0; i < SAMPLE_SIZE; ++i) {
             receipts.add(generator.get().next().isReceipt());
         }
 
-        assertThat((int) (receipts.count(true) * 100.0 / SAMPLE_SIZE))
+        assertThat((double) receipts.count(true) / SAMPLE_SIZE)
                 .isNotNegative()
                 .isNotZero()
-                .isCloseTo(properties.getReceipt(), within((int) (SAMPLE_SIZE * 0.05)));
+                .isCloseTo(properties.getReceipt(), within(0.001));
     }
 
     @Test
@@ -142,7 +142,7 @@ class ConfigurableTransactionGeneratorTest {
 
     @Test
     void recordEnabled() {
-        properties.setRecord(100);
+        properties.setRecord(1);
         for (int i = 0; i < SAMPLE_SIZE; ++i) {
             assertThat(generator.get().next())
                     .extracting(PublishRequest::isRecord)
@@ -152,17 +152,17 @@ class ConfigurableTransactionGeneratorTest {
 
     @Test
     void recordPercent() {
-        properties.setRecord(75);
+        properties.setRecord(0.75);
         Multiset<Boolean> records = HashMultiset.create();
 
         for (int i = 0; i < SAMPLE_SIZE; ++i) {
             records.add(generator.get().next().isRecord());
         }
 
-        assertThat((int) (records.count(true) * 100.0 / SAMPLE_SIZE))
+        assertThat((double) records.count(true) / SAMPLE_SIZE)
                 .isNotNegative()
                 .isNotZero()
-                .isCloseTo(properties.getRecord(), within((int) (SAMPLE_SIZE * 0.05)));
+                .isCloseTo(properties.getRecord(), within(SAMPLE_SIZE * 0.05));
     }
 
     @Test

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/CompositeSubscriberTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/CompositeSubscriberTest.java
@@ -54,8 +54,10 @@ class CompositeSubscriberTest {
         compositeSubscriber = new CompositeSubscriber(monitorProperties, subscribeProperties, meterRegistry, webClient);
 
         grpcSubscriberProperties = new GrpcSubscriberProperties();
+        grpcSubscriberProperties.setName("grpc");
         grpcSubscriberProperties.setTopicId("0.0.1000");
         restSubscriberProperties = new RestSubscriberProperties();
+        restSubscriberProperties.setName("rest");
         subscribeProperties.getGrpc().add(grpcSubscriberProperties);
         subscribeProperties.getRest().add(restSubscriberProperties);
     }

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/RestSubscriberTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/RestSubscriberTest.java
@@ -205,14 +205,13 @@ class RestSubscriberTest {
         int sampleSize = 1000;
         countDownLatch = new CountDownLatch(sampleSize);
         subscriberProperties.setLimit(sampleSize);
-        this.restSubscriber = new RestSubscriber(meterRegistry, monitorProperties, subscriberProperties, builder);
 
         for (int i = 0; i < sampleSize; ++i) {
-            restSubscriber.onPublish(publishResponse());
+            restSubscriber.get().onPublish(publishResponse());
         }
 
         verify(exchangeFunction, times(0)).exchange(Mockito.isA(ClientRequest.class));
-        assertMetric(0L);
+        assertE2EMetric(0L);
     }
 
     @Test
@@ -222,11 +221,10 @@ class RestSubscriberTest {
         int sampleSize = 1000;
         countDownLatch = new CountDownLatch(700);
         subscriberProperties.setLimit(sampleSize);
-        this.restSubscriber = new RestSubscriber(meterRegistry, monitorProperties, subscriberProperties, builder);
         Mockito.when(exchangeFunction.exchange(Mockito.any(ClientRequest.class))).thenReturn(response(HttpStatus.OK));
 
         for (int i = 0; i < sampleSize; ++i) {
-            restSubscriber.onPublish(publishResponse());
+            restSubscriber.get().onPublish(publishResponse());
         }
 
         countDownLatch.await(500, TimeUnit.MILLISECONDS);
@@ -241,17 +239,16 @@ class RestSubscriberTest {
         int sampleSize = 1000;
         countDownLatch = new CountDownLatch(700);
         subscriberProperties.setLimit(sampleSize);
-        this.restSubscriber = new RestSubscriber(meterRegistry, monitorProperties, subscriberProperties, builder);
         Mockito.when(exchangeFunction.exchange(Mockito.any(ClientRequest.class))).thenReturn(response(HttpStatus.OK));
 
         for (int i = 0; i < sampleSize; ++i) {
-            restSubscriber.onPublish(publishResponse());
+            restSubscriber.get().onPublish(publishResponse());
         }
 
         countDownLatch.await(500, TimeUnit.MILLISECONDS);
         verify(exchangeFunction, times(1000)).exchange(Mockito.isA(ClientRequest.class));
 
-        assertMetric(1000L);
+        assertE2EMetric(1000L);
     }
 
     private PublishResponse publishResponse() {

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/RestSubscriberTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/RestSubscriberTest.java
@@ -20,13 +20,15 @@ package com.hedera.mirror.monitor.subscribe;
  * ‍
  */
 
-import static com.hedera.mirror.monitor.subscribe.Subscriber.METRIC_NAME;
+import static com.hedera.mirror.monitor.subscribe.AbstractSubscriber.METRIC_DURATION;
+import static com.hedera.mirror.monitor.subscribe.AbstractSubscriber.METRIC_E2E;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import com.google.common.base.Suppliers;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -34,11 +36,13 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.reactive.function.client.ClientRequest;
@@ -56,17 +60,17 @@ import com.hedera.mirror.monitor.MonitorProperties;
 import com.hedera.mirror.monitor.publish.PublishRequest;
 import com.hedera.mirror.monitor.publish.PublishResponse;
 
-@MockitoSettings
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
 class RestSubscriberTest {
 
-    @Mock()
+    @Mock
     private ExchangeFunction exchangeFunction;
 
     private MeterRegistry meterRegistry;
     private MonitorProperties monitorProperties;
     private RestSubscriberProperties subscriberProperties;
     private WebClient.Builder builder;
-    private RestSubscriber restSubscriber;
+    private Supplier<RestSubscriber> restSubscriber;
     private CountDownLatch countDownLatch;
 
     @BeforeEach
@@ -78,13 +82,15 @@ class RestSubscriberTest {
         monitorProperties.getMirrorNode().getRest().setHost("127.0.0.1");
 
         subscriberProperties = new RestSubscriberProperties();
-        subscriberProperties.setLimit(2L);
+        subscriberProperties.setLimit(3L);
+        subscriberProperties.setName("test");
         subscriberProperties.getRetry().setMaxAttempts(2L);
         subscriberProperties.getRetry().setMinBackoff(Duration.ofNanos(1L));
         subscriberProperties.getRetry().setMaxBackoff(Duration.ofNanos(2L));
 
         builder = WebClient.builder().exchangeFunction(exchangeFunction);
-        this.restSubscriber = new RestSubscriber(meterRegistry, monitorProperties, subscriberProperties, builder);
+        this.restSubscriber = Suppliers
+                .memoize(() -> new RestSubscriber(meterRegistry, monitorProperties, subscriberProperties, builder));
     }
 
     @Test
@@ -92,43 +98,60 @@ class RestSubscriberTest {
         countDownLatch = new CountDownLatch(2);
         Mockito.when(exchangeFunction.exchange(Mockito.any(ClientRequest.class))).thenReturn(response(HttpStatus.OK));
 
-        restSubscriber.onPublish(publishResponse());
-        restSubscriber.onPublish(publishResponse());
+        restSubscriber.get().onPublish(publishResponse());
+        restSubscriber.get().onPublish(publishResponse());
 
         countDownLatch.await(500, TimeUnit.MILLISECONDS);
         verify(exchangeFunction, times(2)).exchange(Mockito.isA(ClientRequest.class));
-        assertMetric(2L);
+        assertE2EMetric(2L);
+        assertThat(meterRegistry.find(METRIC_DURATION).timeGauges()).isNotEmpty();
     }
 
     @Test
     void duration() throws Exception {
         countDownLatch = new CountDownLatch(1);
         subscriberProperties.setDuration(Duration.ofSeconds(1));
-        this.restSubscriber = new RestSubscriber(meterRegistry, monitorProperties, subscriberProperties, builder);
         Mono<ClientResponse> delay = response(HttpStatus.OK)
                 .delayElement(Duration.ofSeconds(5L))
                 .doOnSubscribe(s -> countDownLatch.countDown());
         Mockito.when(exchangeFunction.exchange(Mockito.any(ClientRequest.class))).thenReturn(delay);
 
-        restSubscriber.onPublish(publishResponse());
+        restSubscriber.get().onPublish(publishResponse());
 
         countDownLatch.await(2, TimeUnit.SECONDS);
         verify(exchangeFunction).exchange(Mockito.isA(ClientRequest.class));
-        assertMetric(0L);
+        assertE2EMetric(0L);
     }
 
     @Test
-    void limit() throws Exception {
+    void limitReached() throws Exception {
         countDownLatch = new CountDownLatch(3);
         Mockito.when(exchangeFunction.exchange(Mockito.any(ClientRequest.class))).thenReturn(response(HttpStatus.OK));
 
-        restSubscriber.onPublish(publishResponse());
-        restSubscriber.onPublish(publishResponse());
-        restSubscriber.onPublish(publishResponse());
+        restSubscriber.get().onPublish(publishResponse());
+        restSubscriber.get().onPublish(publishResponse());
+        restSubscriber.get().onPublish(publishResponse());
 
         countDownLatch.await(500, TimeUnit.MILLISECONDS);
-        verify(exchangeFunction, times(2)).exchange(Mockito.isA(ClientRequest.class));
-        assertMetric(2L);
+        verify(exchangeFunction, times(3)).exchange(Mockito.isA(ClientRequest.class));
+        assertE2EMetric(3L);
+        assertThat(meterRegistry.find(METRIC_DURATION).timeGauges()).isEmpty();
+    }
+
+    @Test
+    void limitExceeded() throws Exception {
+        countDownLatch = new CountDownLatch(3);
+        Mockito.when(exchangeFunction.exchange(Mockito.any(ClientRequest.class))).thenReturn(response(HttpStatus.OK));
+
+        restSubscriber.get().onPublish(publishResponse());
+        restSubscriber.get().onPublish(publishResponse());
+        restSubscriber.get().onPublish(publishResponse());
+        restSubscriber.get().onPublish(publishResponse());
+
+        countDownLatch.await(500, TimeUnit.MILLISECONDS);
+        verify(exchangeFunction, times(3)).exchange(Mockito.isA(ClientRequest.class));
+        assertE2EMetric(3L);
+        assertThat(meterRegistry.find(METRIC_DURATION).timeGauges()).isEmpty();
     }
 
     @Test
@@ -136,11 +159,12 @@ class RestSubscriberTest {
         countDownLatch = new CountDownLatch(1);
         Mockito.when(exchangeFunction.exchange(Mockito.any(ClientRequest.class)))
                 .thenReturn(response(HttpStatus.INTERNAL_SERVER_ERROR));
-        restSubscriber.onPublish(publishResponse());
+        restSubscriber.get().onPublish(publishResponse());
 
         countDownLatch.await(500, TimeUnit.MILLISECONDS);
         verify(exchangeFunction).exchange(Mockito.isA(ClientRequest.class));
-        assertMetric(0L);
+        assertE2EMetric(0L);
+        assertThat(meterRegistry.find(METRIC_DURATION).timeGauges()).isNotEmpty();
     }
 
     @Test
@@ -150,11 +174,12 @@ class RestSubscriberTest {
                 .thenReturn(response(HttpStatus.NOT_FOUND))
                 .thenReturn(response(HttpStatus.OK));
 
-        restSubscriber.onPublish(publishResponse());
+        restSubscriber.get().onPublish(publishResponse());
 
         countDownLatch.await(1000, TimeUnit.MILLISECONDS);
         verify(exchangeFunction, times(2)).exchange(Mockito.isA(ClientRequest.class));
-        assertMetric(1L);
+        assertE2EMetric(1L);
+        assertThat(meterRegistry.find(METRIC_DURATION).timeGauges()).isNotEmpty();
     }
 
     @Test
@@ -165,11 +190,12 @@ class RestSubscriberTest {
                 .thenReturn(response(HttpStatus.NOT_FOUND))
                 .thenReturn(response(HttpStatus.NOT_FOUND));
 
-        restSubscriber.onPublish(publishResponse());
+        restSubscriber.get().onPublish(publishResponse());
 
         countDownLatch.await(1000, TimeUnit.MILLISECONDS);
         verify(exchangeFunction, times(3)).exchange(Mockito.isA(ClientRequest.class));
-        assertMetric(0L);
+        assertE2EMetric(0L);
+        assertThat(meterRegistry.find(METRIC_DURATION).timeGauges()).isNotEmpty();
     }
 
     @Test
@@ -230,7 +256,11 @@ class RestSubscriberTest {
 
     private PublishResponse publishResponse() {
         return PublishResponse.builder()
-                .request(PublishRequest.builder().type(TransactionType.CONSENSUS_SUBMIT_MESSAGE).build())
+                .request(PublishRequest.builder()
+                        .timestamp(Instant.now())
+                        .type(TransactionType.CONSENSUS_SUBMIT_MESSAGE)
+                        .build())
+                .timestamp(Instant.now())
                 .transactionId(TransactionId.withValidStart(AccountId.fromString("0.0.1000"), Instant.ofEpochSecond(1)))
                 .build();
     }
@@ -248,15 +278,15 @@ class RestSubscriberTest {
                 .doFinally(s -> countDownLatch.countDown());
     }
 
-    private void assertMetric(long count) {
+    private void assertE2EMetric(long count) {
         if (count > 0) {
-            assertThat(meterRegistry.find(METRIC_NAME).timers())
+            assertThat(meterRegistry.find(METRIC_E2E).timers())
                     .hasSize(1)
                     .element(0)
                     .extracting(Timer::takeSnapshot)
                     .hasFieldOrPropertyWithValue("count", count);
         } else {
-            assertThat(meterRegistry.find(METRIC_NAME).timers()).isEmpty();
+            assertThat(meterRegistry.find(METRIC_E2E).timers()).isEmpty();
         }
     }
 }


### PR DESCRIPTION
**Detailed description**:
- Add a monitor Grafana dashboard
- Add additional Prometheus alerts for monitor
- Add scenario name tag to metrics
- Add status logs to REST subscriber and make the frequency configurable
- Add project reactor metrics
- Add `hedera.mirror.monitor.publish.handle` metric to track the how long it takes to submit a transaction and be handled
- Add `hedera.mirror.monitor.publish.duration` metric to track how long transaction publishing has been active
- Add `hedera.mirror.monitor.subscribe.duration` metric to track how long a subscription scenario has been active
- Rename `hedera.mirror.monitor.publish` to `hedera.mirror.monitor.publish.submit` for clarity
- Change publish receipt and record percentages from integer to double for finer grained configuration
- Fix deprecated `setup-gcloud` GitHub action
- Fix extra `%` in alert messages using `humanizePercentage`
- Fix gRPC subscriber not retrying
- Fix monitor images not being cleaned up
- Fix not closing subscriber resources
- Refactor subscribers into a common base class

**Which issue(s) this PR fixes**:
Fixes #1314 

**Special notes for your reviewer**:
![Screen Shot 2020-12-10 at 22 41 24](https://user-images.githubusercontent.com/17552371/101863000-e4eee180-3b38-11eb-88b8-7841718db2f7.png)

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

