### PR TITLE
Automatically create monitor entities

### DIFF
--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenCreateTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenCreateTransactionSupplier.java
@@ -20,10 +20,10 @@ package com.hedera.datagenerator.sdk.supplier.token;
  * ‍
  */
 
+import java.security.SecureRandom;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
 import lombok.Data;
-import org.apache.commons.lang3.RandomStringUtils;
 
 import com.hedera.datagenerator.common.Utility;
 import com.hedera.datagenerator.sdk.supplier.TransactionSupplier;
@@ -33,6 +33,8 @@ import com.hedera.hashgraph.sdk.token.TokenCreateTransaction;
 
 @Data
 public class TokenCreateTransactionSupplier implements TransactionSupplier<TokenCreateTransaction> {
+
+    private static final SecureRandom RANDOM = new SecureRandom();
 
     private String adminKey;
 
@@ -48,7 +50,9 @@ public class TokenCreateTransactionSupplier implements TransactionSupplier<Token
     private long maxTransactionFee = 1_000_000_000;
 
     @NotBlank
-    private String symbol = RandomStringUtils.randomAlphabetic(5);
+    private String symbol = RANDOM.ints(5, 'A', 'Z')
+            .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+            .toString();
 
     @NotBlank
     private String treasuryAccountId;

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenCreateTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenCreateTransactionSupplier.java
@@ -23,6 +23,7 @@ package com.hedera.datagenerator.sdk.supplier.token;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
 import lombok.Data;
+import org.apache.commons.lang3.RandomStringUtils;
 
 import com.hedera.datagenerator.common.Utility;
 import com.hedera.datagenerator.sdk.supplier.TransactionSupplier;
@@ -47,17 +48,16 @@ public class TokenCreateTransactionSupplier implements TransactionSupplier<Token
     private long maxTransactionFee = 1_000_000_000;
 
     @NotBlank
-    private String symbol = "HMNT";
+    private String symbol = RandomStringUtils.randomAlphabetic(5);
 
     @NotBlank
     private String treasuryAccountId;
 
     @Override
     public TokenCreateTransaction get() {
-
-        AccountId treasuryAccoundId = AccountId.fromString(treasuryAccountId);
+        AccountId treasuryAccount = AccountId.fromString(treasuryAccountId);
         TokenCreateTransaction tokenCreateTransaction = new TokenCreateTransaction()
-                .setAutoRenewAccount(treasuryAccoundId)
+                .setAutoRenewAccount(treasuryAccount)
                 .setDecimals(decimals)
                 .setInitialSupply(initialSupply)
                 .setFreezeDefault(freezeDefault)
@@ -65,7 +65,7 @@ public class TokenCreateTransactionSupplier implements TransactionSupplier<Token
                 .setName(symbol + "_name")
                 .setSymbol(symbol)
                 .setTransactionMemo(Utility.getMemo("Mirror node created test token"))
-                .setTreasury(treasuryAccoundId);
+                .setTreasury(treasuryAccount);
 
         if (adminKey != null) {
             Ed25519PublicKey key = Ed25519PublicKey.fromString(adminKey);

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/expression/ExpressionConverter.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/expression/ExpressionConverter.java
@@ -1,0 +1,35 @@
+package com.hedera.mirror.monitor.expression;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public interface ExpressionConverter {
+
+    default Map<String, String> convert(Map<String, String> properties) {
+        Map<String, String> converted = new LinkedHashMap<>();
+        properties.forEach((key, value) -> converted.put(key, convert(value)));
+        return converted;
+    }
+
+    String convert(String property);
+}

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/expression/ExpressionConverterImpl.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/expression/ExpressionConverterImpl.java
@@ -1,0 +1,142 @@
+package com.hedera.mirror.monitor.expression;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.inject.Named;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import lombok.extern.log4j.Log4j2;
+import org.apache.commons.lang3.StringUtils;
+
+import com.hedera.datagenerator.sdk.supplier.TransactionSupplier;
+import com.hedera.datagenerator.sdk.supplier.TransactionType;
+import com.hedera.datagenerator.sdk.supplier.token.TokenCreateTransactionSupplier;
+import com.hedera.hashgraph.sdk.TransactionReceipt;
+import com.hedera.mirror.monitor.publish.PublishRequest;
+import com.hedera.mirror.monitor.publish.PublishResponse;
+import com.hedera.mirror.monitor.publish.TransactionPublisher;
+
+@Log4j2
+@Named
+@RequiredArgsConstructor
+public class ExpressionConverterImpl implements ExpressionConverter {
+
+    private static final String EXPRESSION_START = "${";
+    private static final String EXPRESSION_END = "}";
+    private static final Pattern EXPRESSION_PATTERN = Pattern.compile("\\$\\{(account|token|topic)\\.([A-Za-z0-9_]+)}");
+
+    private final Map<Expression, String> expressions = new ConcurrentHashMap<>();
+    private final TransactionPublisher transactionPublisher;
+
+    @Override
+    public String convert(String property) {
+        if (!StringUtils.startsWith(property, EXPRESSION_START) || !StringUtils.endsWith(property, EXPRESSION_END)) {
+            return property;
+        }
+
+        Expression expression = parse(property);
+        String convertedProperty = expressions.computeIfAbsent(expression, this::doConvert);
+        log.info("Converted property {} to {}", property, convertedProperty);
+        return convertedProperty;
+    }
+
+    private synchronized String doConvert(Expression expression) {
+        if (expressions.containsKey(expression)) {
+            return expressions.get(expression);
+        }
+
+        return publish(expression);
+    }
+
+    private String publish(Expression expression) {
+        try {
+            ExpressionType type = expression.getType();
+            Class<? extends TransactionSupplier<?>> supplierClass = type.getTransactionType().getSupplier();
+            TransactionSupplier<?> transactionSupplier = supplierClass.getConstructor().newInstance();
+
+            if (transactionSupplier instanceof TokenCreateTransactionSupplier) {
+                String treasuryAccountId = publish(new Expression(ExpressionType.ACCOUNT, expression.getId()));
+                TokenCreateTransactionSupplier tokenSupplier = (TokenCreateTransactionSupplier) transactionSupplier;
+                tokenSupplier.setTreasuryAccountId(treasuryAccountId);
+            }
+
+            PublishRequest request = PublishRequest.builder()
+                    .logResponse(true)
+                    .receipt(true)
+                    .scenarioName(expression.toString())
+                    .timestamp(Instant.now())
+                    .transactionBuilder(transactionSupplier.get())
+                    .type(type.getTransactionType())
+                    .build();
+
+            PublishResponse publishResponse = transactionPublisher.publish(request);
+            String createdId = type.getIdExtractor().apply(publishResponse.getReceipt());
+            log.info("Created {} entity {}", type, createdId);
+            return createdId;
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Expression parse(String expression) {
+        Matcher matcher = EXPRESSION_PATTERN.matcher(expression);
+
+        if (!matcher.matches() || matcher.groupCount() != 2) {
+            throw new IllegalArgumentException("Not a valid property expression: " + expression);
+        }
+
+        ExpressionType type = ExpressionType.valueOf(matcher.group(1).toUpperCase());
+        String id = matcher.group(2);
+        return new Expression(type, id);
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    private enum ExpressionType {
+
+        ACCOUNT(TransactionType.ACCOUNT_CREATE, r -> r.getAccountId().toString()),
+        TOKEN(TransactionType.TOKEN_CREATE, r -> r.getTokenId().toString()),
+        TOPIC(TransactionType.CONSENSUS_CREATE_TOPIC, r -> r.getConsensusTopicId().toString());
+
+        private final TransactionType transactionType;
+        private final Function<TransactionReceipt, String> idExtractor;
+    }
+
+    @Value
+    private class Expression {
+        private ExpressionType type;
+        private String id;
+
+        @Override
+        public String toString() {
+            return type.name().toLowerCase() + "." + id;
+        }
+    }
+}

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/generator/ScenarioProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/generator/ScenarioProperties.java
@@ -52,7 +52,7 @@ public class ScenarioProperties {
     private String name;
 
     @NotNull
-    private Map<String, Object> properties = new LinkedHashMap<>();
+    private Map<String, String> properties = new LinkedHashMap<>();
 
     @Min(0)
     @Max(1)

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishMetrics.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishMetrics.java
@@ -137,7 +137,7 @@ public class PublishMetrics {
                 .register(meterRegistry);
     }
 
-    @Scheduled(fixedDelay = 5000)
+    @Scheduled(fixedDelayString = "${hedera.mirror.monitor.publish.statusFrequency:10000}")
     public void status() {
         long count = counter.get();
         long elapsed = stopwatch.elapsed(TimeUnit.MICROSECONDS);

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishProperties.java
@@ -20,11 +20,14 @@ package com.hedera.mirror.monitor.publish;
  * ‍
  */
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 import lombok.Data;
+import org.hibernate.validator.constraints.time.DurationMin;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
@@ -42,4 +45,8 @@ public class PublishProperties {
 
     @NotEmpty
     private List<ScenarioProperties> scenarios = new ArrayList<>();
+
+    @DurationMin(seconds = 1L)
+    @NotNull
+    private Duration statusFrequency = Duration.ofSeconds(10L);
 }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/AbstractSubscriberProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/AbstractSubscriberProperties.java
@@ -49,7 +49,7 @@ public abstract class AbstractSubscriberProperties {
 
     @DurationMin(seconds = 1L)
     @NotNull
-    protected Duration statusFrequency = Duration.ofSeconds(5L);
+    protected Duration statusFrequency = Duration.ofSeconds(10L);
 
     @Data
     @Validated

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/CompositeSubscriber.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/CompositeSubscriber.java
@@ -34,6 +34,7 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import com.hedera.mirror.monitor.MonitorProperties;
+import com.hedera.mirror.monitor.expression.ExpressionConverter;
 import com.hedera.mirror.monitor.publish.PublishResponse;
 
 @Named
@@ -41,6 +42,7 @@ import com.hedera.mirror.monitor.publish.PublishResponse;
 @RequiredArgsConstructor
 public class CompositeSubscriber implements Subscriber {
 
+    private final ExpressionConverter expressionConverter;
     private final MonitorProperties monitorProperties;
     private final SubscribeProperties subscribeProperties;
     private final MeterRegistry meterRegistry;
@@ -67,7 +69,7 @@ public class CompositeSubscriber implements Subscriber {
                 subscribeProperties.getGrpc()
                         .stream()
                         .filter(AbstractSubscriberProperties::isEnabled)
-                        .map(p -> new GrpcSubscriber(meterRegistry, monitorProperties, p)),
+                        .map(p -> new GrpcSubscriber(expressionConverter, meterRegistry, monitorProperties, p)),
                 subscribeProperties.getRest()
                         .stream()
                         .filter(AbstractSubscriberProperties::isEnabled)

--- a/hedera-mirror-monitor/src/main/resources/application.yml
+++ b/hedera-mirror-monitor/src/main/resources/application.yml
@@ -1,3 +1,25 @@
+hedera:
+  mirror:
+    monitor:
+      publish:
+        scenarios:
+          - name: HCS Pinger
+            enabled: true
+            logResponse: false
+            properties:
+              topicId: ${topic.ping}
+            record: 1.0
+            tps: 0.1
+            type: CONSENSUS_SUBMIT_MESSAGE
+      subscribe:
+        grpc:
+          - name: HCS Subscribe
+            enabled: true
+            topicId: ${topic.ping}
+        rest:
+          - name: REST
+            enabled: false
+            samplePercent: 1.0
 logging:
   level:
     root: warn

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/expression/ExpressionConverterImplTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/expression/ExpressionConverterImplTest.java
@@ -1,0 +1,187 @@
+package com.hedera.mirror.monitor.expression;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2020 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import com.hedera.datagenerator.sdk.supplier.TransactionType;
+import com.hedera.hashgraph.proto.AccountID;
+import com.hedera.hashgraph.proto.TokenID;
+import com.hedera.hashgraph.proto.TopicID;
+import com.hedera.hashgraph.proto.TransactionReceipt;
+import com.hedera.hashgraph.sdk.TransactionRecord;
+import com.hedera.mirror.monitor.publish.PublishRequest;
+import com.hedera.mirror.monitor.publish.PublishResponse;
+import com.hedera.mirror.monitor.publish.TransactionPublisher;
+
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
+public class ExpressionConverterImplTest {
+
+    @Mock
+    private TransactionPublisher transactionPublisher;
+
+    @InjectMocks
+    private ExpressionConverterImpl expressionConverter;
+
+    @Captor
+    private ArgumentCaptor<PublishRequest> request;
+
+    @Test
+    void invalidExpression() {
+        assertThatThrownBy(() -> expressionConverter.convert("${foo.bar}"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Not a valid property expression");
+    }
+
+    @Test
+    void incompleteExpression() {
+        assertThat(expressionConverter.convert("${topic.bar")).isEqualTo("${topic.bar");
+    }
+
+    @Test
+    void withoutId() {
+        assertThatThrownBy(() -> expressionConverter.convert("${topic}"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Not a valid property expression");
+    }
+
+    @Test
+    void nullValue() {
+        assertThat(expressionConverter.convert((String) null)).isNull();
+    }
+
+    @Test
+    void empty() {
+        assertThat(expressionConverter.convert("")).isEqualTo("");
+    }
+
+    @Test
+    void regularString() {
+        assertThat(expressionConverter.convert("0.0.100")).isEqualTo("0.0.100");
+    }
+
+    @Test
+    void errorPublishing() {
+        when(transactionPublisher.publish(any())).thenThrow(new RuntimeException());
+        assertThatThrownBy(() -> expressionConverter.convert("${topic.foo}"))
+                .isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    void account() {
+        TransactionType type = TransactionType.ACCOUNT_CREATE;
+        when(transactionPublisher.publish(any())).thenReturn(response(type, 100));
+        assertThat(expressionConverter.convert("${account.foo}")).isEqualTo("0.0.100");
+
+        verify(transactionPublisher).publish(request.capture());
+        assertThat(request.getValue().getType()).isEqualTo(type);
+    }
+
+    @Test
+    void token() {
+        TransactionType type = TransactionType.TOKEN_CREATE;
+        when(transactionPublisher.publish(any()))
+                .thenReturn(response(TransactionType.ACCOUNT_CREATE, 100))
+                .thenReturn(response(type, 101));
+        assertThat(expressionConverter.convert("${token.foo}")).isEqualTo("0.0.101");
+
+        verify(transactionPublisher, times(2)).publish(request.capture());
+        assertThat(request.getAllValues())
+                .extracting(PublishRequest::getType)
+                .containsExactly(TransactionType.ACCOUNT_CREATE, type);
+    }
+
+    @Test
+    void topic() {
+        TransactionType type = TransactionType.CONSENSUS_CREATE_TOPIC;
+        when(transactionPublisher.publish(any())).thenReturn(response(type, 100));
+        assertThat(expressionConverter.convert("${topic.foo}")).isEqualTo("0.0.100");
+
+        verify(transactionPublisher).publish(request.capture());
+        assertThat(request.getValue().getType()).isEqualTo(type);
+    }
+
+    @Test
+    void cached() {
+        TransactionType type = TransactionType.CONSENSUS_CREATE_TOPIC;
+        when(transactionPublisher.publish(any()))
+                .thenReturn(response(type, 100));
+
+        assertThat(expressionConverter.convert("${topic.foo}")).isEqualTo("0.0.100");
+        assertThat(expressionConverter.convert("${topic.foo}")).isEqualTo("0.0.100");
+
+        verify(transactionPublisher).publish(request.capture());
+        assertThat(request.getValue().getType()).isEqualTo(type);
+    }
+
+    @Test
+    void map() {
+        Map<String, String> properties = Map.of("accountId", "0.0.100", "topicId", "${topic.fooBar_123}");
+        TransactionType type = TransactionType.CONSENSUS_CREATE_TOPIC;
+        when(transactionPublisher.publish(any())).thenReturn(response(type, 101));
+
+        assertThat(expressionConverter.convert(properties))
+                .hasSize(2)
+                .containsEntry("accountId", "0.0.100")
+                .containsEntry("topicId", "0.0.101");
+
+        verify(transactionPublisher).publish(request.capture());
+        assertThat(request.getValue().getType()).isEqualTo(type);
+    }
+
+    private PublishResponse response(TransactionType type, long id) {
+        TransactionReceipt.Builder receipt = TransactionReceipt.newBuilder();
+
+        switch (type) {
+            case ACCOUNT_CREATE:
+                receipt.setAccountID(AccountID.newBuilder().setAccountNum(id).build());
+                break;
+            case CONSENSUS_CREATE_TOPIC:
+                receipt.setTopicID(TopicID.newBuilder().setTopicNum(id).build());
+                break;
+            case TOKEN_CREATE:
+                receipt.setTokenID(TokenID.newBuilder().setTokenNum(id).build());
+                break;
+        }
+
+        TransactionRecord record = new TransactionRecord(com.hedera.hashgraph.proto.TransactionRecord.newBuilder()
+                .setReceipt(receipt)
+                .build());
+        return PublishResponse.builder()
+                .record(record)
+                .receipt(record.receipt)
+                .build();
+    }
+}

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/generator/CompositeTransactionGeneratorTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/generator/CompositeTransactionGeneratorTest.java
@@ -58,7 +58,7 @@ class CompositeTransactionGeneratorTest {
         properties = new PublishProperties();
         properties.getScenarios().add(scenarioProperties1);
         properties.getScenarios().add(scenarioProperties2);
-        supplier = Suppliers.memoize(() -> new CompositeTransactionGenerator(properties));
+        supplier = Suppliers.memoize(() -> new CompositeTransactionGenerator(p -> p, properties));
     }
 
     @Test

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/generator/ConfigurableTransactionGeneratorTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/generator/ConfigurableTransactionGeneratorTest.java
@@ -56,7 +56,7 @@ class ConfigurableTransactionGeneratorTest {
         properties.setProperties(Map.of("topicId", TOPIC_ID));
         properties.setTps(100_000);
         properties.setType(TransactionType.CONSENSUS_SUBMIT_MESSAGE);
-        generator = Suppliers.memoize(() -> new ConfigurableTransactionGenerator(properties));
+        generator = Suppliers.memoize(() -> new ConfigurableTransactionGenerator(p -> p, properties));
     }
 
     @Test

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/CompositeSubscriberTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/CompositeSubscriberTest.java
@@ -51,7 +51,8 @@ class CompositeSubscriberTest {
         subscribeProperties = new SubscribeProperties();
         meterRegistry = new SimpleMeterRegistry();
         webClient = WebClient.builder();
-        compositeSubscriber = new CompositeSubscriber(monitorProperties, subscribeProperties, meterRegistry, webClient);
+        compositeSubscriber = new CompositeSubscriber(p -> p, monitorProperties, subscribeProperties, meterRegistry,
+                webClient);
 
         grpcSubscriberProperties = new GrpcSubscriberProperties();
         grpcSubscriberProperties.setName("grpc");


### PR DESCRIPTION
**Detailed description**:
- Add ability to automatically create account, token or topic entities needed for monitoring
- Add property to control frequency of publish status log
- Add a default publish and subscribe scenario in `application.yml` both as an example and for less config for our deployments
- Change status frequency to every 10 seconds

**Which issue(s) this PR fixes**:
Fixes #1220 

**Special notes for your reviewer**:

Expression format is `${type.name}` where type is either `account`, `token` or `topic` and `name` is a descriptive label that allows it to be referenced in multiple places but only created once.

**Checklist**
- [ ] Documentation added
- [x] Tests updated

