### PR TITLE
Support additional pg pool config params

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -187,9 +187,9 @@ value, it is recommended to only populate overridden properties in the custom `a
 | `hedera.mirror.rest.db.host`                             | 127.0.0.1               | The IP or hostname used to connect to the database                                             |
 | `hedera.mirror.rest.db.name`                             | mirror_node             | The name of the database                                                                       |
 | `hedera.mirror.rest.db.password`                         | mirror_api_pass         | The database password the processor uses to connect. **Should be changed from default**        |
-| `hedera.mirror.rest.db.pool.connectionTimeout`           | 1000                    | The number of milliseconds to wait before timing out when connecting a new database client     |
+| `hedera.mirror.rest.db.pool.connectionTimeout`           | 3000                    | The number of milliseconds to wait before timing out when connecting a new database client     |
 | `hedera.mirror.rest.db.pool.maxConnections`              | 10                      | The maximum number of clients the database pool can contain                                    |
-| `hedera.mirror.rest.db.pool.statementTimeout`            | 500                     | The number of milliseconds to wait before timing out a query statement                         |
+| `hedera.mirror.rest.db.pool.statementTimeout`            | 5000                    | The number of milliseconds to wait before timing out a query statement                         |
 | `hedera.mirror.rest.db.port`                             | 5432                    | The port used to connect to the database                                                       |
 | `hedera.mirror.rest.db.username`                         | mirror_api              | The username the processor uses to connect to the database                                     |
 | `hedera.mirror.rest.includeHostInLink`                   | false                   | Whether to include the hostname and port in the next link in the response                      |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -187,6 +187,9 @@ value, it is recommended to only populate overridden properties in the custom `a
 | `hedera.mirror.rest.db.host`                             | 127.0.0.1               | The IP or hostname used to connect to the database                                             |
 | `hedera.mirror.rest.db.name`                             | mirror_node             | The name of the database                                                                       |
 | `hedera.mirror.rest.db.password`                         | mirror_api_pass         | The database password the processor uses to connect. **Should be changed from default**        |
+| `hedera.mirror.rest.db.pool.connectionTimeout`           | 1000                    | The number of milliseconds to wait before timing out when connecting a new database client     |
+| `hedera.mirror.rest.db.pool.maxConnections`              | 10                      | The maximum number of clients the database pool can contain                                    |
+| `hedera.mirror.rest.db.pool.statementTimeout`            | 500                     | The number of milliseconds to wait before timing out a query statement                         |
 | `hedera.mirror.rest.db.port`                             | 5432                    | The port used to connect to the database                                                       |
 | `hedera.mirror.rest.db.username`                         | mirror_api              | The username the processor uses to connect to the database                                     |
 | `hedera.mirror.rest.includeHostInLink`                   | false                   | Whether to include the hostname and port in the next link in the response                      |

--- a/hedera-mirror-rest/__tests__/config.test.js
+++ b/hedera-mirror-rest/__tests__/config.test.js
@@ -151,7 +151,6 @@ describe('Custom CONFIG_NAME:', () => {
 
     expect(config.shard).toBe(custom.hedera.mirror.rest.shard);
     expect(config.maxLimit).toBe(custom.hedera.mirror.rest.maxLimit);
-    expect(config.log).toBeUndefined();
   });
 });
 

--- a/hedera-mirror-rest/__tests__/config.test.js
+++ b/hedera-mirror-rest/__tests__/config.test.js
@@ -276,6 +276,90 @@ describe('Override stateproof config', () => {
   });
 });
 
+describe('Override db pool config', () => {
+  const loadConfigWithCustomDbPoolConfig = (customDbPoolConfig) => {
+    if (customDbPoolConfig) {
+      const customConfig = {
+        hedera: {
+          mirror: {
+            rest: {
+              db: {
+                pool: customDbPoolConfig,
+              },
+            },
+          },
+        },
+      };
+      fs.writeFileSync(path.join(tempDir, 'application.yml'), yaml.safeDump(customConfig));
+      process.env = {CONFIG_PATH: tempDir};
+    }
+
+    return require('../config');
+  };
+
+  const testSpecs = [
+    {
+      name: 'the default values should be valid',
+      expectThrow: false,
+    },
+    {
+      name: 'override with valid integer values',
+      override: {
+        connectionTimeout: 200,
+        maxConnections: 5,
+        statementTimeout: 100,
+      },
+      expected: {
+        connectionTimeout: 200,
+        maxConnections: 5,
+        statementTimeout: 100,
+      },
+    },
+    {
+      name: 'override with valid string values',
+      override: {
+        connectionTimeout: '200',
+        maxConnections: '5',
+        statementTimeout: '100',
+      },
+      expected: {
+        connectionTimeout: 200,
+        maxConnections: 5,
+        statementTimeout: 100,
+      },
+    },
+    ..._.flattenDeep(
+      [-1, 0, true, false, '', 'NaN'].map((value) => {
+        return ['connectionTimeout', 'maxConnections', 'statementTimeout'].map((configKey) => {
+          return {
+            name: `override ${configKey} with invalid value ${JSON.stringify(value)}`,
+            override: {
+              [configKey]: value,
+            },
+            expectThrow: true,
+          };
+        });
+      })
+    ),
+  ];
+
+  testSpecs.forEach((testSpec) => {
+    const {name, override, expected, expectThrow} = testSpec;
+    test(name, () => {
+      if (!expectThrow) {
+        const config = loadConfigWithCustomDbPoolConfig(override);
+        if (expected) {
+          expect(config.db.pool).toEqual(expected);
+        }
+      } else {
+        expect(() => {
+          loadConfigWithCustomDbPoolConfig(override);
+        }).toThrow();
+      }
+    });
+  });
+});
+
 function unlink(file) {
   if (fs.existsSync(file)) {
     fs.unlinkSync(file);

--- a/hedera-mirror-rest/config.js
+++ b/hedera-mirror-rest/config.js
@@ -27,15 +27,11 @@ const path = require('path');
 const {InvalidConfigError} = require('./errors/invalidConfigError');
 const {cloudProviders, networks, defaultBucketNames} = require('./constants');
 
-let configName = 'application';
-if (process.env.CONFIG_NAME) {
-  configName = process.env.CONFIG_NAME;
-}
-
+const defaultConfigName = 'application';
 const config = {};
 let loaded = false;
 
-function load(configPath) {
+function load(configPath, configName) {
   if (!configPath) {
     return;
   }
@@ -160,9 +156,11 @@ function parseStateProofStreamsConfig() {
 }
 
 if (!loaded) {
-  load(path.join(__dirname, 'config'));
-  load(__dirname);
-  load(process.env.CONFIG_PATH);
+  const configName = process.env.CONFIG_NAME || defaultConfigName;
+  // always load the default configuration
+  load(path.join(__dirname, 'config'), defaultConfigName);
+  load(__dirname, configName);
+  load(process.env.CONFIG_PATH, configName);
   loadEnvironment();
   parseDbPoolConfig();
   parseStateProofStreamsConfig();

--- a/hedera-mirror-rest/config.js
+++ b/hedera-mirror-rest/config.js
@@ -70,18 +70,18 @@ function loadEnvironment() {
  */
 function setConfigValue(propertyPath, value) {
   let current = config;
-  let properties = propertyPath.toLowerCase().split('_');
+  const properties = propertyPath.toLowerCase().split('_');
 
   // Ignore properties that don't start with HEDERA_MIRROR_REST
   if (properties.length < 4 || properties[0] !== 'hedera' || properties[1] !== 'mirror' || properties[2] !== 'rest') {
     return;
   }
 
-  for (let i in properties) {
-    let property = properties[i];
+  for (let i = 0; i < properties.length; i += 1) {
+    const property = properties[i];
     let found = false;
 
-    for (let [k, v] of Object.entries(current)) {
+    for (const [k, v] of Object.entries(current)) {
       if (property === k.toLowerCase()) {
         if (i < properties.length - 1) {
           current = v;

--- a/hedera-mirror-rest/config.js
+++ b/hedera-mirror-rest/config.js
@@ -108,7 +108,7 @@ function setConfigValue(propertyPath, value) {
 function convertType(value) {
   let parsedValue = value;
 
-  if (value !== null && value !== '' && !isNaN(value)) {
+  if (value !== null && value !== '' && !Number.isNaN(value)) {
     parsedValue = +value;
   } else if (value === 'true' || value === 'false') {
     parsedValue = value === 'true';
@@ -119,6 +119,19 @@ function convertType(value) {
 
 function getConfig() {
   return config.hedera && config.hedera.mirror ? config.hedera.mirror.rest : config;
+}
+
+function parseDbPoolConfig() {
+  const {pool} = getConfig().db;
+  const configKeys = ['connectionTimeout', 'maxConnections', 'statementTimeout'];
+  configKeys.forEach((configKey) => {
+    const value = pool[configKey];
+    const parsed = parseInt(value, 10);
+    if (Number.isNaN(parsed) || parsed <= 0) {
+      throw new InvalidConfigError(`invalid value set for db.pool.${configKey}: ${value}`);
+    }
+    pool[configKey] = parsed;
+  });
 }
 
 function parseStateProofStreamsConfig() {
@@ -151,6 +164,7 @@ if (!loaded) {
   load(__dirname);
   load(process.env.CONFIG_PATH);
   loadEnvironment();
+  parseDbPoolConfig();
   parseStateProofStreamsConfig();
   loaded = true;
 }

--- a/hedera-mirror-rest/config.js
+++ b/hedera-mirror-rest/config.js
@@ -108,7 +108,7 @@ function setConfigValue(propertyPath, value) {
 function convertType(value) {
   let parsedValue = value;
 
-  if (value !== null && value !== '' && !Number.isNaN(value)) {
+  if (value !== null && value !== '' && !isNaN(value)) {
     parsedValue = +value;
   } else if (value === 'true' || value === 'false') {
     parsedValue = value === 'true';

--- a/hedera-mirror-rest/config/application.yml
+++ b/hedera-mirror-rest/config/application.yml
@@ -7,9 +7,9 @@ hedera:
         name: mirror_node
         password: mirror_api_pass
         pool:
-          connectionTimeout: 1000
+          connectionTimeout: 3000
           maxConnections: 10
-          statementTimeout: 500
+          statementTimeout: 5000
         port: 5432
         username: mirror_api
       includeHostInLink: false

--- a/hedera-mirror-rest/config/application.yml
+++ b/hedera-mirror-rest/config/application.yml
@@ -6,6 +6,10 @@ hedera:
         host: 127.0.0.1
         name: mirror_node
         password: mirror_api_pass
+        pool:
+          connectionTimeout: 1000
+          maxConnections: 10
+          statementTimeout: 500
         port: 5432
         username: mirror_api
       includeHostInLink: false

--- a/hedera-mirror-rest/server.js
+++ b/hedera-mirror-rest/server.js
@@ -90,6 +90,9 @@ const pool = new Pool({
   database: config.db.name,
   password: config.db.password,
   port: config.db.port,
+  connectionTimeoutMillis: config.db.pool.connectionTimeout,
+  max: config.db.pool.maxConnections,
+  statement_timeout: config.db.pool.statementTimeout,
 });
 global.pool = pool;
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
-->

**Detailed description**:

- Support pg pool configuration params connectionTimeoutMillis, max, and statement_timeout
- Fix the issue that customizing configuration file name would skip loading the default `application.yml` file

**Which issue(s) this PR fixes**:
Relates to #1295 

**Special notes for your reviewer**:

**Checklist**
- [x] Documentation added
- [x] Tests updated

