### PR TITLE
Fix token_account primary index

### DIFF
--- a/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.33.0__drop_token_account_id.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.33.0__drop_token_account_id.sql
@@ -6,7 +6,7 @@
 alter table if exists token_account
     drop constraint token_account_pkey;
 alter table if exists token_account
-    add primary key (created_timestamp);
+    add primary key (created_timestamp, token_id);
 alter table if exists token_account
     drop column if exists id;
 

--- a/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.2__time_scale_index_init.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.2__time_scale_index_init.sql
@@ -103,7 +103,7 @@ create unique index if not exists token__id_timestamp
 
 -- token_account
 alter table token_account
-    add primary key (created_timestamp);
+    add primary key (created_timestamp, token_id);
 create unique index if not exists token_account__token_account_timestamp
     on token_account (token_id, account_id, created_timestamp);
 

--- a/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.3__time_scale_compression.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.3__time_scale_compression.sql
@@ -79,7 +79,7 @@ alter table token
     set (timescaledb.compress, timescaledb.compress_segmentby = 'token_id');
 
 alter table token_account
-    set (timescaledb.compress, timescaledb.compress_segmentby = 'account_id');
+    set (timescaledb.compress, timescaledb.compress_segmentby = 'account_id, token_id');
 
 alter table token_balance
     set (timescaledb.compress, timescaledb.compress_segmentby = 'account_id, token_id');

--- a/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.3__time_scale_compression.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.3__time_scale_compression.sql
@@ -79,7 +79,7 @@ alter table token
     set (timescaledb.compress, timescaledb.compress_segmentby = 'token_id');
 
 alter table token_account
-    set (timescaledb.compress, timescaledb.compress_segmentby = 'account_id, token_id');
+    set (timescaledb.compress, timescaledb.compress_segmentby = 'token_id');
 
 alter table token_balance
     set (timescaledb.compress, timescaledb.compress_segmentby = 'account_id, token_id');

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListenerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListenerTest.java
@@ -47,6 +47,7 @@ import com.hedera.mirror.importer.domain.FileData;
 import com.hedera.mirror.importer.domain.LiveHash;
 import com.hedera.mirror.importer.domain.NonFeeTransfer;
 import com.hedera.mirror.importer.domain.RecordFile;
+import com.hedera.mirror.importer.domain.StreamFileData;
 import com.hedera.mirror.importer.domain.Token;
 import com.hedera.mirror.importer.domain.TokenAccount;
 import com.hedera.mirror.importer.domain.TokenFreezeStatusEnum;
@@ -56,7 +57,6 @@ import com.hedera.mirror.importer.domain.TopicMessage;
 import com.hedera.mirror.importer.domain.Transaction;
 import com.hedera.mirror.importer.domain.TransactionTypeEnum;
 import com.hedera.mirror.importer.exception.MissingFileException;
-import com.hedera.mirror.importer.domain.StreamFileData;
 import com.hedera.mirror.importer.repository.ContractResultRepository;
 import com.hedera.mirror.importer.repository.CryptoTransferRepository;
 import com.hedera.mirror.importer.repository.EntityRepository;
@@ -240,7 +240,7 @@ public class SqlEntityListenerTest extends IntegrationTest {
         sqlEntityListener.onEntityId(entityId); // duplicate within file
         completeFileAndCommit();
 
-        recordFile = insertRecordFileRecord(UUID.randomUUID().toString(), null, null, 1L);
+        recordFile = insertRecordFileRecord(UUID.randomUUID().toString(), null, null, 2L);
         sqlEntityListener.onStart(new StreamFileData(fileName, null));
         sqlEntityListener.onEntityId(entityId); // duplicate across files
         completeFileAndCommit();

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/TokenAccountRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/TokenAccountRepositoryTest.java
@@ -1,6 +1,5 @@
 package com.hedera.mirror.importer.repository;
 
-import java.util.Optional;
 import javax.annotation.Resource;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -41,7 +40,7 @@ public class TokenAccountRepositoryTest extends AbstractRepositoryTest {
 
         Assertions.assertThat(tokenAccountRepository
                 .findByTokenIdAndAccountId(EntityId.of("1.2.3", EntityTypeEnum.TOKEN).getId(), EntityId
-                        .of("0.2.44", EntityTypeEnum.ACCOUNT).getId())).isEqualTo(Optional.empty());
+                        .of("0.2.44", EntityTypeEnum.ACCOUNT).getId())).isNotPresent();
     }
 
     @Test
@@ -63,7 +62,7 @@ public class TokenAccountRepositoryTest extends AbstractRepositoryTest {
 
         Assertions.assertThat(tokenAccountRepository
                 .findByTokenIdAndAccountId(EntityId.of(tokenId2, EntityTypeEnum.TOKEN).getId(), EntityId
-                        .of(accountId2, EntityTypeEnum.ACCOUNT).getId())).isEqualTo(Optional.empty());
+                        .of(accountId2, EntityTypeEnum.ACCOUNT).getId())).isNotPresent();
     }
 
     private TokenAccount tokenAccount(String tokenId, String accountId, long createdTimestamp) {


### PR DESCRIPTION
**Detailed description**:
#1364 updated the token_account table to have a primary index on the timestamp.
However, an account can be associated with multiple tokens in a single TokenAssociate transaction.

- Update `V1.33.0__drop_token_account_id.sql` migration file to set `token_account` primary index to use `created_timestamp, token_id`
- Update `V2.0.2__time_scale_index_init.sql` file to set `token_account` primary index to use `created_timestamp, token_id`
- Update `TokenAccountRepositoryTest` with test to capture scenario

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated

