### PR TITLE
Fix timescaledb init job failure

### DIFF
--- a/charts/hedera-mirror/templates/job-timescaledb-init.yaml
+++ b/charts/hedera-mirror/templates/job-timescaledb-init.yaml
@@ -24,11 +24,14 @@ spec:
               # wait for the access node to allow connections
               while ! pg_isready -U postgres -h {{ include "hedera-mirror.dbHost" . }}; do sleep 1; done;
 
-              # wait for all data nodes to be added to access node
-              while true; do
-                count=$(echo "${GET_DATA_NODES_COUNT_COMMAND}" | psql -d "${ACCESS_SVC_CONNSTR_POSTGRES}" --file=- --set ON_ERROR_STOP=1 -At)
-                [ "$count" -eq "{{ .Values.timescaledb.dataNodes }}" ] && break || sleep 1
+              # wait for all data nodes to be added to the access node
+              seconds=0
+              until [ "$(psql -d "${ACCESS_SVC_CONNSTR_POSTGRES}" --set ON_ERROR_STOP=1 -At -c 'select count(*) from pg_foreign_server')" = "{{ .Values.timescaledb.dataNodes }}" ]; do
+                sleep 1
+                seconds=$((seconds+1))
+                [ $((seconds % 10)) -eq 0 ] && echo "${seconds} seconds elapsed, still waiting for all data nodes to be added to the access node"
               done
+              echo 'All {{ .Values.timescaledb.dataNodes }} data nodes have been added to the access node'
 
               psql --echo-queries -d "${ACCESS_SVC_CONNSTR_POSTGRES}" --set ON_ERROR_STOP=1 -f ${DB_INIT_DIR}/users_v2.sql
               echo 'Completed db initialization and user creation for mirror node'
@@ -47,8 +50,6 @@ spec:
               value: host={{ include "hedera-mirror.dbHost" . }} dbname={{ .Values.importer.config.hedera.mirror.importer.db.name }} user={{ .Values.importer.config.hedera.mirror.importer.db.owner }} connect_timeout=3 sslmode=disable password={{ .Values.importer.config.hedera.mirror.importer.db.ownerPassword }}
             - name: DB_INIT_DIR
               value: /usr/etc/db-init
-            - name: GET_DATA_NODES_COUNT_COMMAND
-              value: select count(*) from pg_foreign_server
           volumeMounts:
             - name: timescaledb-init-volume
               mountPath: /usr/etc/db-init

--- a/charts/hedera-mirror/templates/job-timescaledb-init.yaml
+++ b/charts/hedera-mirror/templates/job-timescaledb-init.yaml
@@ -21,7 +21,15 @@ spec:
             - |
               set -e
 
-              while ! pg_isready -U postgres -h {{ include "hedera-mirror.dbHost" . }}-data; do sleep 1; done;
+              # wait for the access node to allow connections
+              while ! pg_isready -U postgres -h {{ include "hedera-mirror.dbHost" . }}; do sleep 1; done;
+
+              # wait for all data nodes to be added to access node
+              while true; do
+                count=$(echo "${GET_DATA_NODES_COUNT_COMMAND}" | psql -d "${ACCESS_SVC_CONNSTR_POSTGRES}" --file=- --set ON_ERROR_STOP=1 -At)
+                [ "$count" -eq "{{ .Values.timescaledb.dataNodes }}" ] && break || sleep 1
+              done
+
               psql --echo-queries -d "${ACCESS_SVC_CONNSTR_POSTGRES}" --set ON_ERROR_STOP=1 -f ${DB_INIT_DIR}/users_v2.sql
               echo 'Completed db initialization and user creation for mirror node'
 
@@ -39,6 +47,8 @@ spec:
               value: host={{ include "hedera-mirror.dbHost" . }} dbname={{ .Values.importer.config.hedera.mirror.importer.db.name }} user={{ .Values.importer.config.hedera.mirror.importer.db.owner }} connect_timeout=3 sslmode=disable password={{ .Values.importer.config.hedera.mirror.importer.db.ownerPassword }}
             - name: DB_INIT_DIR
               value: /usr/etc/db-init
+            - name: GET_DATA_NODES_COUNT_COMMAND
+              value: select count(*) from pg_foreign_server
           volumeMounts:
             - name: timescaledb-init-volume
               mountPath: /usr/etc/db-init


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
-->

**Detailed description**:

- Fixes the timescaledb init job failure by checking the readiness of the access node service

**Which issue(s) this PR fixes**:
Fixes #1435 

**Special notes for your reviewer**:
The added step to ensure all data nodes have been added to the access node is in consideration of distributed hypertable. Quote from [timescaledb doc](https://docs.timescale.com/latest/getting-started/setup-multi-node-basic):

Once logged in on the access node, it is necessary to add data nodes to the local database before creating distributed hypertables. This will make the data node available for use by distributed hypertables and the access node will also connect to the data node and initialize it. 

However, this increases the time to finish the init job to > 1 minute for a 3 data nodes scenario, and `helm install` blocks until the init job finishes.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

