### PR TITLE
Fix wrong API base URL on Swagger site

### DIFF
--- a/hedera-mirror-rest/api/v1/openapi.yml
+++ b/hedera-mirror-rest/api/v1/openapi.yml
@@ -124,12 +124,12 @@ paths:
           in: query
           description: The transaction success type.
           schema:
-            enum: [success, fail]
+            enum: [ success, fail ]
         - name: type
           in: query
           description: The transaction account balance modification type.
           schema:
-            enum: [credit, debit]
+            enum: [ credit, debit ]
       responses:
         200:
           description: OK
@@ -484,19 +484,19 @@ externalDocs:
   description: Hedera REST API Docs
   url: 'https://docs.hedera.com/guides/docs/mirror-node-api/cryptocurrency-api'
 servers:
-  - description: Current REST API server
-    url: '/api/v1'
+  - description: The current REST API server
+    url: ''
   - description: The production REST API servers
-    url: '{scheme}://{network}.mirrornode.hedera.com/api/v1'
+    url: '{scheme}://{network}.mirrornode.hedera.com'
     variables:
       scheme:
         default: https
         description: The URI scheme
-        enum: [http, https]
+        enum: [ http, https ]
       network:
         default: testnet
         description: The Hedera network in use
-        enum: [mainnet, previewnet, testnet]
+        enum: [ mainnet, previewnet, testnet ]
 components:
   schemas:
     Timestamp:
@@ -1020,7 +1020,7 @@ components:
       description: The order in which items are listed
       example: desc
       schema:
-        enum: [asc, desc]
+        enum: [ asc, desc ]
         default: asc
     accountPublicKeyQueryParam:
       name: account.publickey


### PR DESCRIPTION
**Detailed description**:
- Fix error "Not found" when executing queries via Swagger docs site due to generating URLs as "http://mainnet.mirrornode.hedera.com/api/v1/api/v1/..."

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
Can reproduce here: http://mainnet.mirrornode.hedera.com/api/v1/docs

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

