### PR TITLE
Remove failing acceptance test

### DIFF
--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TokenFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TokenFeature.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.test.e2e.acceptance.steps;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -43,7 +43,6 @@ import com.hedera.hashgraph.proto.TokenFreezeStatus;
 import com.hedera.hashgraph.proto.TokenKycStatus;
 import com.hedera.hashgraph.sdk.HederaStatusException;
 import com.hedera.hashgraph.sdk.TransactionId;
-import com.hedera.hashgraph.sdk.TransactionReceipt;
 import com.hedera.hashgraph.sdk.account.AccountId;
 import com.hedera.hashgraph.sdk.crypto.ed25519.Ed25519PrivateKey;
 import com.hedera.hashgraph.sdk.crypto.ed25519.Ed25519PublicKey;
@@ -312,48 +311,6 @@ public class TokenFeature {
 
         if (status == HttpStatus.OK.value()) {
             assertThat(mirrorTransaction.getResult()).isEqualTo("SUCCESS");
-        }
-    }
-
-    @Then("the network should observe an error creating a token {string}")
-    public void verifyTokenCreation(String errorCode) throws Throwable {
-        try {
-            networkTransactionResponse = tokenClient.createToken(tokenClient.getSdkClient()
-                            .getExpandedOperatorAccountId(), symbol, TokenFreezeStatus.FreezeNotApplicable_VALUE,
-                    TokenKycStatus.KycNotApplicable_VALUE);
-            assertNotNull(networkTransactionResponse.getTransactionId());
-            TransactionReceipt receipt = networkTransactionResponse.getReceipt();
-            assertNotNull(receipt);
-            assertTrue(errorCode.isEmpty());
-            TokenId tokenId = receipt.getTokenId();
-            assertNotNull(tokenId);
-        } catch (Exception ex) {
-            if (!ex.getMessage().contains(errorCode)) {
-                log.info("Exception mismatch : {}", ex.getMessage());
-                throw new Exception("Unexpected error code returned");
-            } else {
-                log.warn("Expected error found");
-            }
-        }
-    }
-
-    @Then("the network should observe an error associating a token {string}")
-    public void verifyTokenAssociation(String errorCode) throws Throwable {
-        try {
-            ExpandedAccountId accountToAssociate = recipient == null ? tokenClient.getSdkClient()
-                    .getExpandedOperatorAccountId() : recipient;
-            networkTransactionResponse = tokenClient
-                    .asssociate(accountToAssociate, tokenId);
-            assertNotNull(networkTransactionResponse.getTransactionId());
-            assertNotNull(networkTransactionResponse.getReceipt());
-            assertTrue(errorCode.isEmpty());
-        } catch (Exception ex) {
-            if (!ex.getMessage().contains(errorCode)) {
-                log.info("Exception mismatch : {}", ex.getMessage());
-                throw new Exception("Unexpected error code returned");
-            } else {
-                log.warn("Expected error found");
-            }
         }
     }
 

--- a/hedera-mirror-test/src/test/resources/features/hts/hts.feature
+++ b/hedera-mirror-test/src/test/resources/features/hts/hts.feature
@@ -55,19 +55,3 @@ Feature: HTS Base Coverage Feature
         Examples:
             | httpStatusCode |
             | 200            |
-
-#    @Negative @Acceptance
-    Scenario Outline: Validate Negative Association
-        Given I successfully create a new token
-        Then the network should observe an error associating a token <errorCode>
-        Examples:
-            | errorCode                             |
-            | "TOKEN_ALREADY_ASSOCIATED_TO_ACCOUNT" |
-
-#    @Negative @Acceptance
-    Scenario Outline: Validate token creation with bad symbols
-        Given I provide a token symbol <tokenId>
-        Then the network should observe an error creating a token <errorCode>
-        Examples:
-            | tokenId | errorCode              |
-            | ""      | "MISSING_TOKEN_SYMBOL" |


### PR DESCRIPTION
**Detailed description**:
Acceptance tests are failing on mainnet with the below error for the `Validate Negative Association` flow:
```
2021-01-14T10:38:46.604-0600 DEBUG main c.h.m.t.e.a.c.TokenClient Create new token OHWD 
2021-01-14T10:38:46.941-0600 DEBUG main c.h.m.t.e.a.c.AbstractNetworkClient Executed transaction 0.0.950@1610642316.866285000. 
2021-01-14T10:38:50.957-0600 DEBUG main c.h.m.t.e.a.c.TokenClient Created new token 0.0.107629 
  Given I successfully create a new token                                                            # com.hedera.mirror.test.e2e.acceptance.steps.TokenFeature.createNewToken()
2021-01-14T10:38:50.959-0600 DEBUG main c.h.m.t.e.a.c.TokenClient Associate account 0.0.950 with token 0.0.107629 
2021-01-14T10:38:51.182-0600 INFO main c.h.m.t.e.a.s.TokenFeature Exception mismatch : transaction 0.0.950@1610642321.108028000 failed precheck with status INSUFFICIENT_TX_FEE 
  Then the network should observe an error associating a token "TOKEN_ALREADY_ASSOCIATED_TO_ACCOUNT" # com.hedera.mirror.test.e2e.acceptance.steps.TokenFeature.verifyTokenAssociation(java.lang.String)
      java.lang.Exception: Unexpected error code returned
	at com.hedera.mirror.test.e2e.acceptance.steps.TokenFeature.verifyTokenAssociation(TokenFeature.java:353)
	at ???.the network should observe an error associating a token "TOKEN_ALREADY_ASSOCIATED_TO_ACCOUNT"
```

Other token associates before this work fine. It's not clear why we are getting insufficient tx fee as 1_000_000_000 should be high enough for most token associates per fee calculator. However, I think it bad practice to be testing negative scenarios of HAPI as such tests don't touch any part of the mirror node. As such, I recommend we remove these two negative tests.

Another reason to remove this test is using the static payer account for token associate will eventually run into `TOKENS_PER_ACCOUNT_LIMIT_EXCEEDED` errors.

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated

