### PR TITLE
Change elastic index format to yyyy-MM-dd

### DIFF
--- a/hedera-mirror-grpc/src/main/resources/application.yml
+++ b/hedera-mirror-grpc/src/main/resources/application.yml
@@ -32,6 +32,7 @@ management:
         autoCreateIndex: false
         enabled: false
         index: mirror
+        indexDateFormat: yyyy-MM-dd
         step: 30s
       prometheus:
         step: 30s

--- a/hedera-mirror-importer/src/main/resources/application.yml
+++ b/hedera-mirror-importer/src/main/resources/application.yml
@@ -35,6 +35,7 @@ management:
         autoCreateIndex: false
         enabled: false
         index: mirror
+        indexDateFormat: yyyy-MM-dd
         step: 30s
       prometheus:
         step: 30s

--- a/hedera-mirror-monitor/src/main/resources/application.yml
+++ b/hedera-mirror-monitor/src/main/resources/application.yml
@@ -37,6 +37,7 @@ management:
         autoCreateIndex: false
         enabled: false
         index: mirror
+        indexDateFormat: yyyy-MM-dd
         step: 30s
       prometheus:
         step: 30s


### PR DESCRIPTION
**Detailed description**:
As requested by Ops, adjust our elastic index to `yyyy-MM-dd` to generate a new index every day to avoid reaching the limit on entries per index as we did in prod.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

