### PR TITLE
Add schema and domain support for scheduled transactions

### DIFF
--- a/docs/design/scheduled-transactions.md
+++ b/docs/design/scheduled-transactions.md
@@ -31,6 +31,7 @@ create table if not exists schedule
   consensus_timestamp bigint primary key not null,
   creator_account_id  bigint             not null,
   executed_timestamp  bigint             null,
+  memo                bytea              not null,
   payer_account_id    bigint             not null,
   schedule_id         bigint             not null,
   transaction_body    bytea              not null
@@ -86,6 +87,7 @@ Add a `ScheduleIdConverter`.
 - If the `scheduleID` does not exist, insert a `Schedule`:
   - Set `consensusTimestamp` to the `consensusTimestamp` in the transaction record.
   - Set `creatorAccountId` to the payer account from the transaction ID.
+  - Set `memo` to the `memo` field within the `ScheduleCreateTransactionBody`.
   - Set `payerAccountId` to the one in the transaction body else use the payer account from the transaction ID.
   - Set `scheduleId` to the `scheduleID` in the transaction receipt.
   - Set `transactionBody` to the `transactionBody` field within the `ScheduleCreateTransactionBody`.
@@ -208,6 +210,7 @@ GET `/api/v1/schedules`
       "consensus_timestamp": "1234567890.000000001",
       "creator_account_id": "0.0.100",
       "executed_timestamp": "1234567890.000000002",
+      "memo_base64": null,
       "payer_account_id": "0.0.101",
       "schedule_id": "0.0.102",
       "signatures": [
@@ -253,6 +256,7 @@ GET `/api/v1/schedules/{scheduleId}`
   "consensus_timestamp": "1234567890.000000001",
   "creator_account_id": "0.0.100",
   "executed_timestamp": "1234567890.000000002",
+  "memo_base64": null,
   "payer_account_id": "0.0.101",
   "schedule_id": "0.0.102",
   "signatures": [

--- a/docs/design/scheduled-transactions.md
+++ b/docs/design/scheduled-transactions.md
@@ -31,7 +31,6 @@ create table if not exists schedule
   consensus_timestamp bigint primary key not null,
   creator_account_id  bigint             not null,
   executed_timestamp  bigint             null,
-  memo                bytea              not null,
   payer_account_id    bigint             not null,
   schedule_id         bigint             not null,
   transaction_body    bytea              not null
@@ -209,7 +208,7 @@ GET `/api/v1/schedules`
       "consensus_timestamp": "1234567890.000000001",
       "creator_account_id": "0.0.100",
       "executed_timestamp": "1234567890.000000002",
-      "memo": null,
+      "memo": "Created per council decision dated 1/21/21",
       "payer_account_id": "0.0.101",
       "schedule_id": "0.0.102",
       "signatures": [
@@ -255,7 +254,7 @@ GET `/api/v1/schedules/{scheduleId}`
   "consensus_timestamp": "1234567890.000000001",
   "creator_account_id": "0.0.100",
   "executed_timestamp": "1234567890.000000002",
-  "memo_base64": null,
+  "memo": "Created per council decision dated 1/21/21",
   "payer_account_id": "0.0.101",
   "schedule_id": "0.0.102",
   "signatures": [

--- a/docs/design/scheduled-transactions.md
+++ b/docs/design/scheduled-transactions.md
@@ -87,7 +87,6 @@ Add a `ScheduleIdConverter`.
 - If the `scheduleID` does not exist, insert a `Schedule`:
   - Set `consensusTimestamp` to the `consensusTimestamp` in the transaction record.
   - Set `creatorAccountId` to the payer account from the transaction ID.
-  - Set `memo` to the `memo` field within the `ScheduleCreateTransactionBody`.
   - Set `payerAccountId` to the one in the transaction body else use the payer account from the transaction ID.
   - Set `scheduleId` to the `scheduleID` in the transaction receipt.
   - Set `transactionBody` to the `transactionBody` field within the `ScheduleCreateTransactionBody`.
@@ -210,7 +209,7 @@ GET `/api/v1/schedules`
       "consensus_timestamp": "1234567890.000000001",
       "creator_account_id": "0.0.100",
       "executed_timestamp": "1234567890.000000002",
-      "memo_base64": null,
+      "memo": null,
       "payer_account_id": "0.0.101",
       "schedule_id": "0.0.102",
       "signatures": [

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/converter/AbstractEntityIdConverter.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/converter/AbstractEntityIdConverter.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.importer.converter;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,6 +21,7 @@ package com.hedera.mirror.importer.converter;
  */
 
 import javax.persistence.AttributeConverter;
+import lombok.Getter;
 import org.springframework.core.convert.converter.Converter;
 
 import com.hedera.mirror.importer.domain.EntityId;
@@ -29,6 +30,7 @@ import com.hedera.mirror.importer.util.EntityIdEndec;
 
 public abstract class AbstractEntityIdConverter implements AttributeConverter<EntityId, Long>, Converter<String,
         EntityId> {
+    @Getter
     private final EntityTypeEnum entityTypeEnum;
 
     public AbstractEntityIdConverter(EntityTypeEnum entityTypeEnum) {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/converter/ScheduleIdConverter.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/converter/ScheduleIdConverter.java
@@ -1,4 +1,4 @@
-package com.hedera.mirror.grpc.domain;
+package com.hedera.mirror.importer.converter;
 
 /*-
  * ‌
@@ -20,18 +20,17 @@ package com.hedera.mirror.grpc.domain;
  * ‍
  */
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import javax.inject.Named;
+import org.springframework.boot.context.properties.ConfigurationPropertiesBinding;
 
-@Getter
-@RequiredArgsConstructor
-public enum EntityType {
+import com.hedera.mirror.importer.domain.EntityTypeEnum;
 
-    UNKNOWN, // Filler value to offset next values by one to match database values
-    ACCOUNT,
-    CONTRACT,
-    FILE,
-    TOPIC,
-    TOKEN,
-    SCHEDULE
+@Named
+@javax.persistence.Converter
+@ConfigurationPropertiesBinding
+public class ScheduleIdConverter extends AbstractEntityIdConverter {
+
+    public ScheduleIdConverter() {
+        super(EntityTypeEnum.SCHEDULE);
+    }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/EntityTypeEnum.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/EntityTypeEnum.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.importer.domain;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -31,7 +31,8 @@ public enum EntityTypeEnum {
     CONTRACT(2),
     FILE(3),
     TOPIC(4),
-    TOKEN(5);
+    TOKEN(5),
+    SCHEDULE(6);
 
     private final int id;
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/Schedule.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/Schedule.java
@@ -1,0 +1,60 @@
+package com.hedera.mirror.importer.domain;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import javax.persistence.Convert;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.extern.log4j.Log4j2;
+
+import com.hedera.mirror.importer.converter.AccountIdConverter;
+import com.hedera.mirror.importer.converter.EntityIdSerializer;
+import com.hedera.mirror.importer.converter.ScheduleIdConverter;
+
+@Data
+@Entity
+@Log4j2
+@NoArgsConstructor
+public class Schedule {
+    @Id
+    private Long consensusTimestamp;
+
+    @Convert(converter = AccountIdConverter.class)
+    @JsonSerialize(using = EntityIdSerializer.class)
+    private EntityId creatorAccountId;
+
+    private Long executedTimestamp;
+
+    @Convert(converter = AccountIdConverter.class)
+    @JsonSerialize(using = EntityIdSerializer.class)
+    private EntityId payerAccountId;
+
+    @Convert(converter = ScheduleIdConverter.class)
+    @JsonSerialize(using = EntityIdSerializer.class)
+    private EntityId scheduleId;
+
+    @ToString.Exclude
+    private byte[] transactionBody;
+}

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/Schedule.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/Schedule.java
@@ -35,7 +35,6 @@ import com.hedera.mirror.importer.converter.ScheduleIdConverter;
 @Data
 @Entity
 @NoArgsConstructor
-@ToString(exclude = {"memo", "transactionBody"})
 public class Schedule {
     @Id
     private Long consensusTimestamp;
@@ -54,5 +53,6 @@ public class Schedule {
     @JsonSerialize(using = EntityIdSerializer.class)
     private EntityId scheduleId;
 
+    @ToString.Exclude
     private byte[] transactionBody;
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/Schedule.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/Schedule.java
@@ -55,6 +55,6 @@ public class Schedule {
     @Convert(converter = ScheduleIdConverter.class)
     @JsonSerialize(using = EntityIdSerializer.class)
     private EntityId scheduleId;
-    
+
     private byte[] transactionBody;
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/Schedule.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/Schedule.java
@@ -27,7 +27,6 @@ import javax.persistence.Id;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
-import lombok.extern.log4j.Log4j2;
 
 import com.hedera.mirror.importer.converter.AccountIdConverter;
 import com.hedera.mirror.importer.converter.EntityIdSerializer;
@@ -35,8 +34,8 @@ import com.hedera.mirror.importer.converter.ScheduleIdConverter;
 
 @Data
 @Entity
-@Log4j2
 @NoArgsConstructor
+@ToString(exclude = {"memo", "transactionBody"})
 public class Schedule {
     @Id
     private Long consensusTimestamp;
@@ -47,6 +46,8 @@ public class Schedule {
 
     private Long executedTimestamp;
 
+    private byte[] memo;
+
     @Convert(converter = AccountIdConverter.class)
     @JsonSerialize(using = EntityIdSerializer.class)
     private EntityId payerAccountId;
@@ -54,7 +55,6 @@ public class Schedule {
     @Convert(converter = ScheduleIdConverter.class)
     @JsonSerialize(using = EntityIdSerializer.class)
     private EntityId scheduleId;
-
-    @ToString.Exclude
+    
     private byte[] transactionBody;
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/Schedule.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/Schedule.java
@@ -46,8 +46,6 @@ public class Schedule {
 
     private Long executedTimestamp;
 
-    private byte[] memo;
-
     @Convert(converter = AccountIdConverter.class)
     @JsonSerialize(using = EntityIdSerializer.class)
     private EntityId payerAccountId;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/ScheduleSignature.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/ScheduleSignature.java
@@ -1,0 +1,52 @@
+package com.hedera.mirror.importer.domain;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import javax.persistence.Convert;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.extern.log4j.Log4j2;
+
+import com.hedera.mirror.importer.converter.EntityIdSerializer;
+import com.hedera.mirror.importer.converter.ScheduleIdConverter;
+
+@Data
+@Entity
+@Log4j2
+@NoArgsConstructor
+public class ScheduleSignature {
+    @Id
+    private Long consensusTimestamp;
+
+    @ToString.Exclude
+    private byte[] publicKeyPrefix;
+
+    @Convert(converter = ScheduleIdConverter.class)
+    @JsonSerialize(using = EntityIdSerializer.class)
+    private EntityId scheduleId;
+
+    @ToString.Exclude
+    private byte[] signature;
+}

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/ScheduleSignature.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/ScheduleSignature.java
@@ -44,6 +44,10 @@ public class ScheduleSignature {
     @ToString.Exclude
     private byte[] signature;
 
+    @Convert(converter = ScheduleIdConverter.class)
+    @JsonSerialize(using = EntityIdSerializer.class)
+    private EntityId scheduleId;
+
     @Data
     @Embeddable
     @AllArgsConstructor
@@ -56,9 +60,5 @@ public class ScheduleSignature {
 
         @ToString.Exclude
         private byte[] publicKeyPrefix;
-
-        @Convert(converter = ScheduleIdConverter.class)
-        @JsonSerialize(using = EntityIdSerializer.class)
-        private EntityId scheduleId;
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/ScheduleSignature.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/ScheduleSignature.java
@@ -39,7 +39,7 @@ import com.hedera.mirror.importer.converter.ScheduleIdConverter;
 @NoArgsConstructor
 public class ScheduleSignature {
     @EmbeddedId
-    private ScheduleSignature.Id scheduleSignatureId;
+    private ScheduleSignature.Id id;
 
     @ToString.Exclude
     private byte[] signature;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/ScheduleSignature.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/ScheduleSignature.java
@@ -21,32 +21,44 @@ package com.hedera.mirror.importer.domain;
  */
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.io.Serializable;
 import javax.persistence.Convert;
+import javax.persistence.Embeddable;
+import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;
-import javax.persistence.Id;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
-import lombok.extern.log4j.Log4j2;
 
 import com.hedera.mirror.importer.converter.EntityIdSerializer;
 import com.hedera.mirror.importer.converter.ScheduleIdConverter;
 
 @Data
 @Entity
-@Log4j2
 @NoArgsConstructor
 public class ScheduleSignature {
-    @Id
-    private Long consensusTimestamp;
-
-    @ToString.Exclude
-    private byte[] publicKeyPrefix;
-
-    @Convert(converter = ScheduleIdConverter.class)
-    @JsonSerialize(using = EntityIdSerializer.class)
-    private EntityId scheduleId;
+    @EmbeddedId
+    private ScheduleSignature.Id scheduleSignatureId;
 
     @ToString.Exclude
     private byte[] signature;
+
+    @Data
+    @Embeddable
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Id implements Serializable {
+
+        private static final long serialVersionUID = -8758644338990079234L;
+
+        private Long consensusTimestamp;
+
+        @ToString.Exclude
+        private byte[] publicKeyPrefix;
+
+        @Convert(converter = ScheduleIdConverter.class)
+        @JsonSerialize(using = EntityIdSerializer.class)
+        private EntityId scheduleId;
+    }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/Token.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/Token.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.importer.domain;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -31,7 +31,6 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
-import lombok.extern.log4j.Log4j2;
 
 import com.hedera.mirror.importer.converter.AccountIdConverter;
 import com.hedera.mirror.importer.converter.EntityIdSerializer;
@@ -40,7 +39,6 @@ import com.hedera.mirror.importer.util.Utility;
 
 @Data
 @Entity
-@Log4j2
 @NoArgsConstructor
 public class Token {
     @EmbeddedId

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/TokenAccount.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/TokenAccount.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.importer.domain;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,7 +32,6 @@ import javax.persistence.Enumerated;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.extern.log4j.Log4j2;
 
 import com.hedera.mirror.importer.converter.AccountIdConverter;
 import com.hedera.mirror.importer.converter.EntityIdSerializer;
@@ -40,7 +39,6 @@ import com.hedera.mirror.importer.converter.TokenIdConverter;
 
 @Data
 @Entity
-@Log4j2
 @NoArgsConstructor
 public class TokenAccount {
     @EmbeddedId

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/TransactionTypeEnum.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/TransactionTypeEnum.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.importer.domain;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -65,7 +65,10 @@ public enum TransactionTypeEnum {
     TOKENBURN(38),
     TOKENWIPE(39),
     TOKENASSOCIATE(40),
-    TOKENDISSOCIATE(41);
+    TOKENDISSOCIATE(41),
+    SCHEDULECREATE(42),
+    SCHEDULEDELETE(43),
+    SCHEDULESIGN(44);
 
     private static final Map<Integer, TransactionTypeEnum> idMap = Arrays.stream(values())
             .collect(Collectors.toMap(TransactionTypeEnum::getProtoId, Function.identity()));

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/ScheduleRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/ScheduleRepository.java
@@ -1,0 +1,37 @@
+package com.hedera.mirror.importer.repository;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import javax.transaction.Transactional;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
+
+import com.hedera.mirror.importer.domain.EntityId;
+import com.hedera.mirror.importer.domain.Schedule;
+
+public interface ScheduleRepository extends CrudRepository<Schedule, Long> {
+    @Modifying
+    @Transactional
+    @Query("update Schedule set executedTimestamp = :timestamp where scheduleId = :schedule")
+    void updateExecutedTimestamp(@Param("schedule") EntityId scheduleId, @Param("timestamp") long executedTimestamp);
+}

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/ScheduleSignatureRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/ScheduleSignatureRepository.java
@@ -1,4 +1,4 @@
-package com.hedera.mirror.grpc.domain;
+package com.hedera.mirror.importer.repository;
 
 /*-
  * ‌
@@ -20,18 +20,9 @@ package com.hedera.mirror.grpc.domain;
  * ‍
  */
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import org.springframework.data.repository.CrudRepository;
 
-@Getter
-@RequiredArgsConstructor
-public enum EntityType {
+import com.hedera.mirror.importer.domain.ScheduleSignature;
 
-    UNKNOWN, // Filler value to offset next values by one to match database values
-    ACCOUNT,
-    CONTRACT,
-    FILE,
-    TOPIC,
-    TOKEN,
-    SCHEDULE
+public interface ScheduleSignatureRepository extends CrudRepository<ScheduleSignature, Long> {
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/ScheduleSignatureRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/ScheduleSignatureRepository.java
@@ -24,5 +24,5 @@ import org.springframework.data.repository.CrudRepository;
 
 import com.hedera.mirror.importer.domain.ScheduleSignature;
 
-public interface ScheduleSignatureRepository extends CrudRepository<ScheduleSignature, Long> {
+public interface ScheduleSignatureRepository extends CrudRepository<ScheduleSignature, ScheduleSignature.Id> {
 }

--- a/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.34.0__schedule_support.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.34.0__schedule_support.sql
@@ -36,7 +36,7 @@ create unique index if not exists schedule__schedule_id
     on schedule (schedule_id desc);
 
 create index if not exists schedule__consensus_timestamp
-    on schedule_signature (consensus_timestamp desc);
+    on schedule (consensus_timestamp desc);
 
 --- Add schedule_signature table to capture schedule signatories
 create table if not exists schedule_signature

--- a/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.34.0__schedule_support.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.34.0__schedule_support.sql
@@ -8,13 +8,17 @@ values (6, 'schedule');
 
 -- Add new schedule transaction body types
 insert into t_transaction_types (proto_id, name, entity_type)
-values (42, 'SCHEDULECREATE', 5),
-       (43, 'SCHEDULEDELETE', 5),
-       (44, 'SCHEDULESIGN', 5);
+values (42, 'SCHEDULECREATE', 6),
+       (43, 'SCHEDULEDELETE', 6),
+       (44, 'SCHEDULESIGN', 6);
 
 -- Add schedule transaction result types
 insert into t_transaction_results (proto_id, result)
-values (201, 'INVALID_SCHEDULE_ID');
+values (201, 'INVALID_SCHEDULE_ID'),
+       (202, 'SCHEDULE_IS_IMMUTABLE'),
+       (203, 'SCHEDULE_WAS_DELETED'),
+       (204, 'INVALID_SCHEDULE_PAYER_ID'),
+       (205, 'INVALID_SCHEDULE_ACCOUNT_ID');
 
 -- Add schedule table to hold schedule properties
 create table if not exists schedule
@@ -22,6 +26,7 @@ create table if not exists schedule
     consensus_timestamp bigint primary key not null,
     creator_account_id  bigint             not null,
     executed_timestamp  bigint             null,
+    memo                bytea              not null,
     payer_account_id    bigint             not null,
     schedule_id         bigint             not null,
     transaction_body    bytea              not null

--- a/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.34.0__schedule_support.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.34.0__schedule_support.sql
@@ -26,7 +26,6 @@ create table if not exists schedule
     consensus_timestamp bigint primary key not null,
     creator_account_id  bigint             not null,
     executed_timestamp  bigint             null,
-    memo                bytea              not null,
     payer_account_id    bigint             not null,
     schedule_id         bigint             not null,
     transaction_body    bytea              not null

--- a/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.34.0__schedule_support.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.34.0__schedule_support.sql
@@ -1,0 +1,45 @@
+-------------------
+-- Support schedule transactions
+-------------------
+
+-- Add new schedule entity type
+insert into t_entity_types (id, name)
+values (6, 'schedule');
+
+-- Add new schedule transaction body types
+insert into t_transaction_types (proto_id, name, entity_type)
+values (42, 'SCHEDULECREATE', 5),
+       (43, 'SCHEDULEDELETE', 5),
+       (44, 'SCHEDULESIGN', 5);
+
+-- Add schedule transaction result types
+insert into t_transaction_results (proto_id, result)
+values (201, 'INVALID_SCHEDULE_ID');
+
+-- Add schedule table to hold schedule properties
+create table if not exists schedule
+(
+    consensus_timestamp bigint primary key not null,
+    creator_account_id  bigint             not null,
+    executed_timestamp  bigint             null,
+    payer_account_id    bigint             not null,
+    schedule_id         bigint             not null,
+    transaction_body    bytea              not null
+);
+comment on table schedule is 'Schedule entity entries';
+
+create unique index if not exists schedule__schedule_id
+    on schedule (schedule_id);
+
+--- Add schedule_signature table to capture schedule signatories
+create table if not exists schedule_signature
+(
+    consensus_timestamp bigint not null,
+    public_key_prefix   bytea  not null,
+    schedule_id         bigint not null,
+    signature           bytea  not null
+);
+comment on table schedule is 'Schedule transaction signatories';
+
+create index if not exists schedule_signature__schedule_id
+    on schedule_signature (schedule_id desc);

--- a/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.34.0__schedule_support.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.34.0__schedule_support.sql
@@ -33,7 +33,10 @@ create table if not exists schedule
 comment on table schedule is 'Schedule entity entries';
 
 create unique index if not exists schedule__schedule_id
-    on schedule (schedule_id);
+    on schedule (schedule_id desc);
+
+create index if not exists schedule__consensus_timestamp
+    on schedule_signature (consensus_timestamp desc);
 
 --- Add schedule_signature table to capture schedule signatories
 create table if not exists schedule_signature
@@ -47,3 +50,6 @@ comment on table schedule is 'Schedule transaction signatories';
 
 create index if not exists schedule_signature__schedule_id
     on schedule_signature (schedule_id desc);
+
+create unique index if not exists schedule_signature__timestamp_public_key_prefix
+    on schedule_signature (consensus_timestamp desc, public_key_prefix);

--- a/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.34.0__schedule_support.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.34.0__schedule_support.sql
@@ -35,9 +35,6 @@ comment on table schedule is 'Schedule entity entries';
 create unique index if not exists schedule__schedule_id
     on schedule (schedule_id desc);
 
-create index if not exists schedule__consensus_timestamp
-    on schedule (consensus_timestamp desc);
-
 --- Add schedule_signature table to capture schedule signatories
 create table if not exists schedule_signature
 (

--- a/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.0__time_scale_init.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.0__time_scale_init.sql
@@ -135,6 +135,7 @@ create table if not exists schedule
     consensus_timestamp bigint primary key not null,
     creator_account_id  bigint             not null,
     executed_timestamp  bigint             null,
+    memo                bytea              not null,
     payer_account_id    bigint             not null,
     schedule_id         bigint             not null,
     transaction_body    bytea              not null
@@ -371,7 +372,11 @@ values ('OK', 0),
        ('TOKEN_TRANSFER_LIST_SIZE_LIMIT_EXCEEDED', 198),
        ('EMPTY_TOKEN_TRANSFER_BODY', 199),
        ('EMPTY_TOKEN_TRANSFER_ACCOUNT_AMOUNTS', 200),
-       ('INVALID_SCHEDULE_ID', 201);
+       ('INVALID_SCHEDULE_ID', 201),
+       ('SCHEDULE_IS_IMMUTABLE', 202),
+       ('SCHEDULE_WAS_DELETED', 203),
+       ('INVALID_SCHEDULE_PAYER_ID', 204),
+       ('INVALID_SCHEDULE_ACCOUNT_ID', 205);
 
 -- t_transaction_types
 create table if not exists t_transaction_types
@@ -417,9 +422,9 @@ values (7, 'CONTRACTCALL', 2),
        (39, 'TOKENWIPE', 5),
        (40, 'TOKENASSOCIATE', 1),
        (41, 'TOKENDISSOCIATE', 1),
-       (42, 'SCHEDULECREATE', 5),
-       (43, 'SCHEDULEDELETE', 5),
-       (44, 'SCHEDULESIGN', 5);
+       (42, 'SCHEDULECREATE', 6),
+       (43, 'SCHEDULEDELETE', 6),
+       (44, 'SCHEDULESIGN', 6);
 
 -- token
 create table if not exists token

--- a/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.0__time_scale_init.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.0__time_scale_init.sql
@@ -129,6 +129,28 @@ create table if not exists record_file
 );
 comment on table record_file is 'Network record file stream entries';
 
+-- schedule
+create table if not exists schedule
+(
+    consensus_timestamp bigint primary key not null,
+    creator_account_id  bigint             not null,
+    executed_timestamp  bigint             null,
+    payer_account_id    bigint             not null,
+    schedule_id         bigint             not null,
+    transaction_body    bytea              not null
+);
+comment on table schedule is 'Schedule entity entries';
+
+-- schedule_signature
+create table if not exists schedule_signature
+(
+    consensus_timestamp bigint not null,
+    public_key_prefix   bytea  not null,
+    schedule_id         bigint not null,
+    signature           bytea  not null
+);
+comment on table schedule is 'Schedule transaction signatories';
+
 -- t_application_status
 create table if not exists t_application_status
 (
@@ -182,7 +204,8 @@ values (1, 'account'),
        (2, 'contract'),
        (3, 'file'),
        (4, 'topic'),
-       (5, 'token');
+       (5, 'token'),
+       (6, 'schedule');
 
 -- t_transaction_results
 create table if not exists t_transaction_results
@@ -347,7 +370,8 @@ values ('OK', 0),
        ('TOKEN_ID_REPEATED_IN_TOKEN_LIST', 197),
        ('TOKEN_TRANSFER_LIST_SIZE_LIMIT_EXCEEDED', 198),
        ('EMPTY_TOKEN_TRANSFER_BODY', 199),
-       ('EMPTY_TOKEN_TRANSFER_ACCOUNT_AMOUNTS', 200);
+       ('EMPTY_TOKEN_TRANSFER_ACCOUNT_AMOUNTS', 200),
+       ('INVALID_SCHEDULE_ID', 201);
 
 -- t_transaction_types
 create table if not exists t_transaction_types
@@ -392,7 +416,10 @@ values (7, 'CONTRACTCALL', 2),
        (38, 'TOKENBURN', 5),
        (39, 'TOKENWIPE', 5),
        (40, 'TOKENASSOCIATE', 1),
-       (41, 'TOKENDISSOCIATE', 1);
+       (41, 'TOKENDISSOCIATE', 1),
+       (42, 'SCHEDULECREATE', 5),
+       (43, 'SCHEDULEDELETE', 5),
+       (44, 'SCHEDULESIGN', 5);
 
 -- token
 create table if not exists token

--- a/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.0__time_scale_init.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.0__time_scale_init.sql
@@ -135,7 +135,6 @@ create table if not exists schedule
     consensus_timestamp bigint primary key not null,
     creator_account_id  bigint             not null,
     executed_timestamp  bigint             null,
-    memo                bytea              not null,
     payer_account_id    bigint             not null,
     schedule_id         bigint             not null,
     transaction_body    bytea              not null

--- a/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.1__hyper_tables.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.1__hyper_tables.sql
@@ -7,53 +7,61 @@
 
 -- account_balance
 select create_hypertable('account_balance', 'consensus_timestamp', chunk_time_interval => ${chunkTimeInterval},
-                        create_default_indexes => false, if_not_exists => true);
+                         create_default_indexes => false, if_not_exists => true);
 
 -- account_balance_file
 select create_hypertable('account_balance_file', 'consensus_timestamp', chunk_time_interval => ${chunkTimeInterval},
-                        create_default_indexes => false, if_not_exists => true);
+                         create_default_indexes => false, if_not_exists => true);
 
 -- account_balance_sets
 select create_hypertable('account_balance_sets', 'consensus_timestamp', chunk_time_interval => ${chunkTimeInterval},
-                        create_default_indexes => false, if_not_exists => true);
+                         create_default_indexes => false, if_not_exists => true);
 
 -- address_book
 select create_hypertable('address_book', 'start_consensus_timestamp', chunk_time_interval => ${chunkTimeInterval},
-                        create_default_indexes => false, if_not_exists => true);
+                         create_default_indexes => false, if_not_exists => true);
 
 -- address_book_entry
 select create_hypertable('address_book_entry', 'consensus_timestamp', chunk_time_interval => ${chunkTimeInterval},
-                        create_default_indexes => false, if_not_exists => true);
+                         create_default_indexes => false, if_not_exists => true);
 
 -- contract_result
 select create_hypertable('contract_result', 'consensus_timestamp', chunk_time_interval => ${chunkTimeInterval},
-                        create_default_indexes => false, if_not_exists => true);
+                         create_default_indexes => false, if_not_exists => true);
 
 -- crypto_transfer
 select create_hypertable('crypto_transfer', 'consensus_timestamp', chunk_time_interval => ${chunkTimeInterval},
-                        create_default_indexes => false, if_not_exists => true);
+                         create_default_indexes => false, if_not_exists => true);
 
 -- file_data
 select create_hypertable('file_data', 'consensus_timestamp', chunk_time_interval => ${chunkTimeInterval},
-                        create_default_indexes => false, if_not_exists => true);
+                         create_default_indexes => false, if_not_exists => true);
 
 -- live_hash
 select create_hypertable('live_hash', 'consensus_timestamp', chunk_time_interval => ${chunkTimeInterval},
-                        create_default_indexes => false, if_not_exists => true);
+                         create_default_indexes => false, if_not_exists => true);
 
 -- non_fee_transfer
 select create_hypertable('non_fee_transfer', 'consensus_timestamp', chunk_time_interval => ${chunkTimeInterval},
-                        create_default_indexes => false, if_not_exists => true);
+                         create_default_indexes => false, if_not_exists => true);
+
+-- schedule
+select create_hypertable('schedule', 'consensus_timestamp', chunk_time_interval => ${chunkTimeInterval},
+                         create_default_indexes => false, if_not_exists => true);
+
+-- schedule_signature
+select create_hypertable('schedule_signature', 'consensus_timestamp', chunk_time_interval => ${chunkTimeInterval},
+                         create_default_indexes => false, if_not_exists => true);
 
 -- record_file
 select create_hypertable('record_file', 'consensus_start', chunk_time_interval => ${chunkTimeInterval},
-                        create_default_indexes => false, if_not_exists => true);
+                         create_default_indexes => false, if_not_exists => true);
 
 -- t_application_status hyper table creation skipped as it serves only as a reference table
 
 -- t_entities
 select create_hypertable('t_entities', 'id', chunk_time_interval => ${chunkIdInterval},
-                        create_default_indexes => false, if_not_exists => true);
+                         create_default_indexes => false, if_not_exists => true);
 
 -- t_entity_types hyper table creation skipped as it serves only as a reference table and rarely gets updated
 
@@ -63,24 +71,24 @@ select create_hypertable('t_entities', 'id', chunk_time_interval => ${chunkIdInt
 
 -- token
 select create_hypertable('token', 'created_timestamp', chunk_time_interval => ${chunkTimeInterval},
-                        create_default_indexes => false, if_not_exists => true);
+                         create_default_indexes => false, if_not_exists => true);
 
 -- token_account
 select create_hypertable('token_account', 'created_timestamp', chunk_time_interval => ${chunkTimeInterval},
-                        create_default_indexes => false, if_not_exists => true);
+                         create_default_indexes => false, if_not_exists => true);
 
 -- token_balance
 select create_hypertable('token_balance', 'consensus_timestamp', chunk_time_interval => ${chunkTimeInterval},
-                        create_default_indexes => false, if_not_exists => true);
+                         create_default_indexes => false, if_not_exists => true);
 
 -- token_transfer
 select create_hypertable('token_transfer', 'consensus_timestamp', chunk_time_interval => ${chunkTimeInterval},
-                        create_default_indexes => false, if_not_exists => true);
+                         create_default_indexes => false, if_not_exists => true);
 
 -- topic_message
 select create_hypertable('topic_message', 'consensus_timestamp', chunk_time_interval => ${chunkTimeInterval},
-                        create_default_indexes => false, if_not_exists => true);
+                         create_default_indexes => false, if_not_exists => true);
 
 -- transaction
 select create_hypertable('transaction', 'consensus_ns', chunk_time_interval => ${chunkTimeInterval},
-                        create_default_indexes => false, if_not_exists => true);
+                         create_default_indexes => false, if_not_exists => true);

--- a/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.2__time_scale_index_init.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.2__time_scale_index_init.sql
@@ -68,11 +68,11 @@ create index if not exists record_file__prev_hash
 
 -- schedule
 create unique index if not exists schedule__schedule_id
-    on schedule (schedule_id);
+    on schedule (schedule_id, consensus_timestamp);
 
 -- schedule_signature
 create index if not exists schedule_signature__schedule_id
-    on schedule_signature (schedule_id desc);
+    on schedule_signature (schedule_id desc, consensus_timestamp);
 
 -- t_entities
 alter table t_entities

--- a/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.2__time_scale_index_init.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.2__time_scale_index_init.sql
@@ -66,6 +66,14 @@ create index if not exists record_file__consensus_end
 create index if not exists record_file__prev_hash
     on record_file (prev_hash);
 
+-- schedule
+create unique index if not exists schedule__schedule_id
+    on schedule (schedule_id);
+
+-- schedule_signature
+create index if not exists schedule_signature__schedule_id
+    on schedule_signature (schedule_id desc);
+
 -- t_entities
 alter table t_entities
     add primary key (id);

--- a/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.2__time_scale_index_init.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.2__time_scale_index_init.sql
@@ -68,11 +68,17 @@ create index if not exists record_file__prev_hash
 
 -- schedule
 create unique index if not exists schedule__schedule_id
-    on schedule (schedule_id, consensus_timestamp);
+    on schedule (schedule_id desc, consensus_timestamp desc);
+
+create index if not exists schedule__consensus_timestamp
+    on schedule_signature (consensus_timestamp desc);
 
 -- schedule_signature
 create index if not exists schedule_signature__schedule_id
-    on schedule_signature (schedule_id desc, consensus_timestamp);
+    on schedule_signature (schedule_id desc, consensus_timestamp desc);
+
+create unique index if not exists schedule_signature__timestamp_public_key_prefix
+    on schedule_signature (consensus_timestamp desc, public_key_prefix);
 
 -- t_entities
 alter table t_entities

--- a/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.2__time_scale_index_init.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.2__time_scale_index_init.sql
@@ -70,9 +70,6 @@ create index if not exists record_file__prev_hash
 create unique index if not exists schedule__schedule_id
     on schedule (schedule_id desc, consensus_timestamp desc);
 
-create index if not exists schedule__consensus_timestamp
-    on schedule_signature (consensus_timestamp desc);
-
 -- schedule_signature
 create index if not exists schedule_signature__schedule_id
     on schedule_signature (schedule_id desc, consensus_timestamp desc);

--- a/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.3__time_scale_compression.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.3__time_scale_compression.sql
@@ -21,6 +21,8 @@ select set_integer_now_func('contract_result', 'unix_now');
 select set_integer_now_func('crypto_transfer', 'unix_now');
 select set_integer_now_func('file_data', 'unix_now');
 select set_integer_now_func('non_fee_transfer', 'unix_now');
+select set_integer_now_func('schedule', 'unix_now');
+select set_integer_now_func('schedule_signature', 'unix_now');
 select set_integer_now_func('record_file', 'unix_now');
 select set_integer_now_func('t_entities', 'unix_now');
 select set_integer_now_func('token', 'unix_now');
@@ -60,6 +62,12 @@ alter table live_hash
 
 alter table non_fee_transfer
     set (timescaledb.compress, timescaledb.compress_segmentby = 'entity_id');
+
+alter table schedule
+    set (timescaledb.compress, timescaledb.compress_segmentby = 'schedule_id');
+
+alter table schedule_signature
+    set (timescaledb.compress, timescaledb.compress_segmentby = 'schedule_id');
 
 alter table record_file
     set (timescaledb.compress, timescaledb.compress_segmentby = 'node_account_id');

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/converter/AbstractEntityConverterTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/converter/AbstractEntityConverterTest.java
@@ -25,27 +25,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 
 import com.hedera.mirror.importer.domain.EntityId;
-import com.hedera.mirror.importer.domain.EntityTypeEnum;
 
 public abstract class AbstractEntityConverterTest {
     protected static AbstractEntityIdConverter converter;
-    protected static EntityTypeEnum entityTypeEnum;
-
-    @Test
-    void testForNulls() {
-        assertThat(converter.convertToDatabaseColumn(null)).isNull();
-        assertThat(converter.convertToEntityAttribute(null)).isNull();
-    }
 
     @Test
     void testToDatabaseColumn() {
-        assertThat(converter.convertToDatabaseColumn(EntityId.of(10L, 10L, 10L, entityTypeEnum)))
+        assertThat(converter.convertToDatabaseColumn(null)).isNull();
+        assertThat(converter.convertToDatabaseColumn(EntityId.of(10L, 10L, 10L, converter.getEntityTypeEnum())))
                 .isEqualTo(2814792716779530L);
     }
 
     @Test
     void testToEntityAttribute() {
+        assertThat(converter.convertToEntityAttribute(null)).isNull();
         assertThat(converter.convertToEntityAttribute(9223372036854775807L))
-                .isEqualTo(EntityId.of(32767L, 65535L, 4294967295L, entityTypeEnum));
+                .isEqualTo(EntityId.of(32767L, 65535L, 4294967295L, converter.getEntityTypeEnum()));
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/converter/AbstractEntityConverterTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/converter/AbstractEntityConverterTest.java
@@ -1,0 +1,51 @@
+package com.hedera.mirror.importer.converter;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.hedera.mirror.importer.domain.EntityId;
+import com.hedera.mirror.importer.domain.EntityTypeEnum;
+
+class AbstractEntityConverterTest {
+    protected static AbstractEntityIdConverter converter;
+    protected static EntityTypeEnum entityTypeEnum;
+
+    @Test
+    void testForNulls() {
+        assertThat(converter.convertToDatabaseColumn(null)).isNull();
+        assertThat(converter.convertToEntityAttribute(null)).isNull();
+    }
+
+    @Test
+    void testToDatabaseColumn() {
+        assertThat(converter.convertToDatabaseColumn(EntityId.of(10L, 10L, 10L, entityTypeEnum)))
+                .isEqualTo(2814792716779530L);
+    }
+
+    @Test
+    void testToEntityAttribute() {
+        assertThat(converter.convertToEntityAttribute(9223372036854775807L))
+                .isEqualTo(EntityId.of(32767L, 65535L, 4294967295L, entityTypeEnum));
+    }
+}

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/converter/AbstractEntityConverterTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/converter/AbstractEntityConverterTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 
 import com.hedera.mirror.importer.domain.EntityId;
 
-public abstract class AbstractEntityConverterTest {
+abstract class AbstractEntityConverterTest {
     protected static AbstractEntityIdConverter converter;
 
     @Test

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/converter/AbstractEntityConverterTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/converter/AbstractEntityConverterTest.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 import com.hedera.mirror.importer.domain.EntityId;
 import com.hedera.mirror.importer.domain.EntityTypeEnum;
 
-class AbstractEntityConverterTest {
+public abstract class AbstractEntityConverterTest {
     protected static AbstractEntityIdConverter converter;
     protected static EntityTypeEnum entityTypeEnum;
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/converter/AccountIdConverterTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/converter/AccountIdConverterTest.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.importer.converter;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,30 +20,14 @@ package com.hedera.mirror.importer.converter;
  * ‍
  */
 
-import static com.hedera.mirror.importer.domain.EntityTypeEnum.ACCOUNT;
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.BeforeAll;
 
-import org.junit.jupiter.api.Test;
+import com.hedera.mirror.importer.domain.EntityTypeEnum;
 
-import com.hedera.mirror.importer.domain.EntityId;
-
-class AccountIdConverterTest {
-    AccountIdConverter converter = new AccountIdConverter();
-
-    @Test
-    void testForNulls() {
-        assertThat(converter.convertToDatabaseColumn(null)).isNull();
-        assertThat(converter.convertToEntityAttribute(null)).isNull();
-    }
-
-    @Test
-    void testToDatabaseColumn() {
-        assertThat(converter.convertToDatabaseColumn(EntityId.of(10L, 10L, 10L, ACCOUNT))).isEqualTo(2814792716779530L);
-    }
-
-    @Test
-    void testToEntityAttribute() {
-        assertThat(converter.convertToEntityAttribute(9223372036854775807L))
-                .isEqualTo(EntityId.of(32767L, 65535L, 4294967295L, ACCOUNT));
+class AccountIdConverterTest extends AbstractEntityConverterTest {
+    @BeforeAll
+    static void beforeAll() {
+        converter = new AccountIdConverter();
+        entityTypeEnum = EntityTypeEnum.ACCOUNT;
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/converter/AccountIdConverterTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/converter/AccountIdConverterTest.java
@@ -22,12 +22,9 @@ package com.hedera.mirror.importer.converter;
 
 import org.junit.jupiter.api.BeforeAll;
 
-import com.hedera.mirror.importer.domain.EntityTypeEnum;
-
 class AccountIdConverterTest extends AbstractEntityConverterTest {
     @BeforeAll
     static void beforeAll() {
         converter = new AccountIdConverter();
-        entityTypeEnum = EntityTypeEnum.ACCOUNT;
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/converter/FileIdConverterTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/converter/FileIdConverterTest.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.importer.converter;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,30 +20,14 @@ package com.hedera.mirror.importer.converter;
  * ‍
  */
 
-import static com.hedera.mirror.importer.domain.EntityTypeEnum.FILE;
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.BeforeAll;
 
-import org.junit.jupiter.api.Test;
+import com.hedera.mirror.importer.domain.EntityTypeEnum;
 
-import com.hedera.mirror.importer.domain.EntityId;
-
-class FileIdConverterTest {
-    FileIdConverter converter = new FileIdConverter();
-
-    @Test
-    void testForNulls() {
-        assertThat(converter.convertToDatabaseColumn(null)).isNull();
-        assertThat(converter.convertToEntityAttribute(null)).isNull();
-    }
-
-    @Test
-    void testToDatabaseColumn() {
-        assertThat(converter.convertToDatabaseColumn(EntityId.of(10L, 10L, 10L, FILE))).isEqualTo(2814792716779530L);
-    }
-
-    @Test
-    void testToEntityAttribute() {
-        assertThat(converter.convertToEntityAttribute(9223372036854775807L))
-                .isEqualTo(EntityId.of(32767L, 65535L, 4294967295L, FILE));
+class FileIdConverterTest extends AbstractEntityConverterTest {
+    @BeforeAll
+    static void beforeAll() {
+        converter = new FileIdConverter();
+        entityTypeEnum = EntityTypeEnum.FILE;
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/converter/FileIdConverterTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/converter/FileIdConverterTest.java
@@ -22,12 +22,9 @@ package com.hedera.mirror.importer.converter;
 
 import org.junit.jupiter.api.BeforeAll;
 
-import com.hedera.mirror.importer.domain.EntityTypeEnum;
-
 class FileIdConverterTest extends AbstractEntityConverterTest {
     @BeforeAll
     static void beforeAll() {
         converter = new FileIdConverter();
-        entityTypeEnum = EntityTypeEnum.FILE;
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/converter/ScheduleIdConverterTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/converter/ScheduleIdConverterTest.java
@@ -22,12 +22,9 @@ package com.hedera.mirror.importer.converter;
 
 import org.junit.jupiter.api.BeforeAll;
 
-import com.hedera.mirror.importer.domain.EntityTypeEnum;
-
 class ScheduleIdConverterTest extends AbstractEntityConverterTest {
     @BeforeAll
     static void beforeAll() {
         converter = new ScheduleIdConverter();
-        entityTypeEnum = EntityTypeEnum.SCHEDULE;
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/converter/ScheduleIdConverterTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/converter/ScheduleIdConverterTest.java
@@ -1,4 +1,4 @@
-package com.hedera.mirror.grpc.domain;
+package com.hedera.mirror.importer.converter;
 
 /*-
  * ‌
@@ -20,18 +20,14 @@ package com.hedera.mirror.grpc.domain;
  * ‍
  */
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.BeforeAll;
 
-@Getter
-@RequiredArgsConstructor
-public enum EntityType {
+import com.hedera.mirror.importer.domain.EntityTypeEnum;
 
-    UNKNOWN, // Filler value to offset next values by one to match database values
-    ACCOUNT,
-    CONTRACT,
-    FILE,
-    TOPIC,
-    TOKEN,
-    SCHEDULE
+class ScheduleIdConverterTest extends AbstractEntityConverterTest {
+    @BeforeAll
+    static void beforeAll() {
+        converter = new ScheduleIdConverter();
+        entityTypeEnum = EntityTypeEnum.SCHEDULE;
+    }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/converter/TokenIdConverterTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/converter/TokenIdConverterTest.java
@@ -22,12 +22,9 @@ package com.hedera.mirror.importer.converter;
 
 import org.junit.jupiter.api.BeforeAll;
 
-import com.hedera.mirror.importer.domain.EntityTypeEnum;
-
 class TokenIdConverterTest extends AbstractEntityConverterTest {
     @BeforeAll
     static void beforeAll() {
         converter = new TokenIdConverter();
-        entityTypeEnum = EntityTypeEnum.TOKEN;
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/converter/TokenIdConverterTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/converter/TokenIdConverterTest.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.importer.converter;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,31 +20,14 @@ package com.hedera.mirror.importer.converter;
  * ‍
  */
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.BeforeAll;
 
-import org.junit.jupiter.api.Test;
-
-import com.hedera.mirror.importer.domain.EntityId;
 import com.hedera.mirror.importer.domain.EntityTypeEnum;
 
-class TokenIdConverterTest {
-    TokenIdConverter converter = new TokenIdConverter();
-
-    @Test
-    void testForNulls() {
-        assertThat(converter.convertToDatabaseColumn(null)).isNull();
-        assertThat(converter.convertToEntityAttribute(null)).isNull();
-    }
-
-    @Test
-    void testToDatabaseColumn() {
-        assertThat(converter.convertToDatabaseColumn(EntityId.of(10L, 10L, 10L, EntityTypeEnum.TOKEN)))
-                .isEqualTo(2814792716779530L);
-    }
-
-    @Test
-    void testToEntityAttribute() {
-        assertThat(converter.convertToEntityAttribute(9223372036854775807L))
-                .isEqualTo(EntityId.of(32767L, 65535L, 4294967295L, EntityTypeEnum.TOKEN));
+class TokenIdConverterTest extends AbstractEntityConverterTest {
+    @BeforeAll
+    static void beforeAll() {
+        converter = new TokenIdConverter();
+        entityTypeEnum = EntityTypeEnum.TOKEN;
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/ScheduleRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/ScheduleRepositoryTest.java
@@ -46,7 +46,7 @@ public class ScheduleRepositoryTest extends AbstractRepositoryTest {
         Schedule schedule = scheduleRepository.save(schedule(1));
         long newExecutedTimestamp = 1000L;
         scheduleRepository.updateExecutedTimestamp(schedule.getScheduleId(), newExecutedTimestamp);
-        assertThat(scheduleRepository.findById(schedule.getConsensusTimestamp()).get())
+        assertThat(scheduleRepository.findById(schedule.getConsensusTimestamp())).get()
                 .returns(newExecutedTimestamp, from(Schedule::getExecutedTimestamp));
     }
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/ScheduleRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/ScheduleRepositoryTest.java
@@ -30,15 +30,15 @@ import com.hedera.mirror.importer.domain.EntityId;
 import com.hedera.mirror.importer.domain.EntityTypeEnum;
 import com.hedera.mirror.importer.domain.Schedule;
 
-public class ScheduleRepositoryTest extends AbstractRepositoryTest {
+class ScheduleRepositoryTest extends AbstractRepositoryTest {
     @Resource
     private ScheduleRepository scheduleRepository;
 
     @Test
     void save() {
         Schedule schedule = scheduleRepository.save(schedule(1));
-        assertThat(scheduleRepository.findById(schedule.getConsensusTimestamp())
-                .get()).isEqualTo(schedule);
+        assertThat(scheduleRepository.findById(schedule.getConsensusTimestamp()))
+                .get().isEqualTo(schedule);
     }
 
     @Test

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/ScheduleRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/ScheduleRepositoryTest.java
@@ -54,7 +54,6 @@ public class ScheduleRepositoryTest extends AbstractRepositoryTest {
         Schedule schedule = new Schedule();
         schedule.setConsensusTimestamp(consensusTimestamp);
         schedule.setCreatorAccountId(EntityId.of("0.0.123", EntityTypeEnum.ACCOUNT));
-        schedule.setMemo("schedule memo".getBytes());
         schedule.setPayerAccountId(EntityId.of("0.0.456", EntityTypeEnum.ACCOUNT));
         schedule.setScheduleId(EntityId.of("0.0.789", EntityTypeEnum.SCHEDULE));
         schedule.setTransactionBody("transaction body".getBytes());

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/ScheduleRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/ScheduleRepositoryTest.java
@@ -1,0 +1,67 @@
+package com.hedera.mirror.importer.repository;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.from;
+
+import javax.annotation.Resource;
+import org.junit.jupiter.api.Test;
+
+import com.hedera.mirror.importer.domain.EntityId;
+import com.hedera.mirror.importer.domain.EntityTypeEnum;
+import com.hedera.mirror.importer.domain.Schedule;
+
+public class ScheduleRepositoryTest extends AbstractRepositoryTest {
+    @Resource
+    protected ScheduleRepository scheduleRepository;
+
+    private static final EntityId CREATOR_ACCOUNT = EntityId.of("0.0.123", EntityTypeEnum.ACCOUNT);
+    private static final EntityId PAYER_ACCOUNT = EntityId.of("0.0.456", EntityTypeEnum.ACCOUNT);
+    private static final EntityId SCHEDULE_ID = EntityId.of("0.0.789", EntityTypeEnum.SCHEDULE);
+    private static final byte[] TRANSACTION_BODY = "transaction memo".getBytes();
+
+    @Test
+    void save() {
+        Schedule schedule = scheduleRepository.save(schedule(1));
+        assertThat(scheduleRepository.findById(schedule.getConsensusTimestamp())
+                .get()).isEqualTo(schedule);
+    }
+
+    @Test
+    void updateExecutedTimestamp() {
+        Schedule schedule = scheduleRepository.save(schedule(1));
+        long newExecutedTimestamp = 1000L;
+        scheduleRepository.updateExecutedTimestamp(schedule.getScheduleId(), newExecutedTimestamp);
+        assertThat(scheduleRepository.findById(schedule.getConsensusTimestamp()).get())
+                .returns(newExecutedTimestamp, from(Schedule::getExecutedTimestamp));
+    }
+
+    private Schedule schedule(long consensusTimestamp) {
+        Schedule schedule = new Schedule();
+        schedule.setConsensusTimestamp(consensusTimestamp);
+        schedule.setCreatorAccountId(CREATOR_ACCOUNT);
+        schedule.setPayerAccountId(PAYER_ACCOUNT);
+        schedule.setScheduleId(SCHEDULE_ID);
+        schedule.setTransactionBody(TRANSACTION_BODY);
+        return schedule;
+    }
+}

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/ScheduleRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/ScheduleRepositoryTest.java
@@ -32,12 +32,7 @@ import com.hedera.mirror.importer.domain.Schedule;
 
 public class ScheduleRepositoryTest extends AbstractRepositoryTest {
     @Resource
-    protected ScheduleRepository scheduleRepository;
-
-    private static final EntityId CREATOR_ACCOUNT = EntityId.of("0.0.123", EntityTypeEnum.ACCOUNT);
-    private static final EntityId PAYER_ACCOUNT = EntityId.of("0.0.456", EntityTypeEnum.ACCOUNT);
-    private static final EntityId SCHEDULE_ID = EntityId.of("0.0.789", EntityTypeEnum.SCHEDULE);
-    private static final byte[] TRANSACTION_BODY = "transaction memo".getBytes();
+    private ScheduleRepository scheduleRepository;
 
     @Test
     void save() {
@@ -58,10 +53,11 @@ public class ScheduleRepositoryTest extends AbstractRepositoryTest {
     private Schedule schedule(long consensusTimestamp) {
         Schedule schedule = new Schedule();
         schedule.setConsensusTimestamp(consensusTimestamp);
-        schedule.setCreatorAccountId(CREATOR_ACCOUNT);
-        schedule.setPayerAccountId(PAYER_ACCOUNT);
-        schedule.setScheduleId(SCHEDULE_ID);
-        schedule.setTransactionBody(TRANSACTION_BODY);
+        schedule.setCreatorAccountId(EntityId.of("0.0.123", EntityTypeEnum.ACCOUNT));
+        schedule.setMemo("schedule memo".getBytes());
+        schedule.setPayerAccountId(EntityId.of("0.0.456", EntityTypeEnum.ACCOUNT));
+        schedule.setScheduleId(EntityId.of("0.0.789", EntityTypeEnum.SCHEDULE));
+        schedule.setTransactionBody("transaction body".getBytes());
         return schedule;
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/ScheduleSignatureRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/ScheduleSignatureRepositoryTest.java
@@ -36,8 +36,8 @@ public class ScheduleSignatureRepositoryTest extends AbstractRepositoryTest {
     @Test
     void save() {
         ScheduleSignature scheduleSignature = scheduleSignatureRepository.save(scheduleSignature(1));
-        assertThat(scheduleSignatureRepository.findById(scheduleSignature.getScheduleSignatureId())
-                .get()).isEqualTo(scheduleSignature);
+        assertThat(scheduleSignatureRepository.findById(scheduleSignature.getScheduleSignatureId()))
+                .get().isEqualTo(scheduleSignature);
     }
 
     private ScheduleSignature scheduleSignature(long consensusTimestamp) {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/ScheduleSignatureRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/ScheduleSignatureRepositoryTest.java
@@ -36,13 +36,13 @@ class ScheduleSignatureRepositoryTest extends AbstractRepositoryTest {
     @Test
     void save() {
         ScheduleSignature scheduleSignature = scheduleSignatureRepository.save(scheduleSignature(1));
-        assertThat(scheduleSignatureRepository.findById(scheduleSignature.getScheduleSignatureId()))
+        assertThat(scheduleSignatureRepository.findById(scheduleSignature.getId()))
                 .get().isEqualTo(scheduleSignature);
     }
 
     private ScheduleSignature scheduleSignature(long consensusTimestamp) {
         ScheduleSignature scheduleSignature = new ScheduleSignature();
-        scheduleSignature.setScheduleSignatureId(new ScheduleSignature.Id(
+        scheduleSignature.setId(new ScheduleSignature.Id(
                 consensusTimestamp,
                 "signatory public key prefix".getBytes()));
         scheduleSignature.setScheduleId(EntityId.of("0.0.789", EntityTypeEnum.SCHEDULE));

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/ScheduleSignatureRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/ScheduleSignatureRepositoryTest.java
@@ -44,8 +44,8 @@ public class ScheduleSignatureRepositoryTest extends AbstractRepositoryTest {
         ScheduleSignature scheduleSignature = new ScheduleSignature();
         scheduleSignature.setScheduleSignatureId(new ScheduleSignature.Id(
                 consensusTimestamp,
-                "signatory public key prefix".getBytes(),
-                EntityId.of("0.0.789", EntityTypeEnum.SCHEDULE)));
+                "signatory public key prefix".getBytes()));
+        scheduleSignature.setScheduleId(EntityId.of("0.0.789", EntityTypeEnum.SCHEDULE));
         scheduleSignature.setSignature("scheduled transaction signature".getBytes());
         return scheduleSignature;
     }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/ScheduleSignatureRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/ScheduleSignatureRepositoryTest.java
@@ -1,0 +1,55 @@
+package com.hedera.mirror.importer.repository;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.annotation.Resource;
+import org.junit.jupiter.api.Test;
+
+import com.hedera.mirror.importer.domain.EntityId;
+import com.hedera.mirror.importer.domain.EntityTypeEnum;
+import com.hedera.mirror.importer.domain.ScheduleSignature;
+
+public class ScheduleSignatureRepositoryTest extends AbstractRepositoryTest {
+    @Resource
+    protected ScheduleSignatureRepository scheduleSignatureRepository;
+
+    private static final EntityId SCHEDULE_ID = EntityId.of("0.0.789", EntityTypeEnum.SCHEDULE);
+    private static final byte[] PUBLIC_KEY_PREFIX = "signatory public key prefix".getBytes();
+    private static final byte[] SIGNATURE = "scheduled transaction signature".getBytes();
+
+    @Test
+    void save() {
+        ScheduleSignature scheduleSignature = scheduleSignatureRepository.save(scheduleSignature(1));
+        assertThat(scheduleSignatureRepository.findById(scheduleSignature.getConsensusTimestamp())
+                .get()).isEqualTo(scheduleSignature);
+    }
+
+    private ScheduleSignature scheduleSignature(long consensusTimestamp) {
+        ScheduleSignature scheduleSignature = new ScheduleSignature();
+        scheduleSignature.setConsensusTimestamp(consensusTimestamp);
+        scheduleSignature.setPublicKeyPrefix(PUBLIC_KEY_PREFIX);
+        scheduleSignature.setScheduleId(SCHEDULE_ID);
+        scheduleSignature.setSignature(SIGNATURE);
+        return scheduleSignature;
+    }
+}

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/ScheduleSignatureRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/ScheduleSignatureRepositoryTest.java
@@ -31,25 +31,22 @@ import com.hedera.mirror.importer.domain.ScheduleSignature;
 
 public class ScheduleSignatureRepositoryTest extends AbstractRepositoryTest {
     @Resource
-    protected ScheduleSignatureRepository scheduleSignatureRepository;
-
-    private static final EntityId SCHEDULE_ID = EntityId.of("0.0.789", EntityTypeEnum.SCHEDULE);
-    private static final byte[] PUBLIC_KEY_PREFIX = "signatory public key prefix".getBytes();
-    private static final byte[] SIGNATURE = "scheduled transaction signature".getBytes();
+    private ScheduleSignatureRepository scheduleSignatureRepository;
 
     @Test
     void save() {
         ScheduleSignature scheduleSignature = scheduleSignatureRepository.save(scheduleSignature(1));
-        assertThat(scheduleSignatureRepository.findById(scheduleSignature.getConsensusTimestamp())
+        assertThat(scheduleSignatureRepository.findById(scheduleSignature.getScheduleSignatureId())
                 .get()).isEqualTo(scheduleSignature);
     }
 
     private ScheduleSignature scheduleSignature(long consensusTimestamp) {
         ScheduleSignature scheduleSignature = new ScheduleSignature();
-        scheduleSignature.setConsensusTimestamp(consensusTimestamp);
-        scheduleSignature.setPublicKeyPrefix(PUBLIC_KEY_PREFIX);
-        scheduleSignature.setScheduleId(SCHEDULE_ID);
-        scheduleSignature.setSignature(SIGNATURE);
+        scheduleSignature.setScheduleSignatureId(new ScheduleSignature.Id(
+                consensusTimestamp,
+                "signatory public key prefix".getBytes(),
+                EntityId.of("0.0.789", EntityTypeEnum.SCHEDULE)));
+        scheduleSignature.setSignature("scheduled transaction signature".getBytes());
         return scheduleSignature;
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/ScheduleSignatureRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/ScheduleSignatureRepositoryTest.java
@@ -29,7 +29,7 @@ import com.hedera.mirror.importer.domain.EntityId;
 import com.hedera.mirror.importer.domain.EntityTypeEnum;
 import com.hedera.mirror.importer.domain.ScheduleSignature;
 
-public class ScheduleSignatureRepositoryTest extends AbstractRepositoryTest {
+class ScheduleSignatureRepositoryTest extends AbstractRepositoryTest {
     @Resource
     private ScheduleSignatureRepository scheduleSignatureRepository;
 


### PR DESCRIPTION
**Detailed description**:
To support scheduled transactions 

- Add a v1 database migration
- Update v2 database migration
- Add necessary `Schedule` class
- Add necessary `ScheduleSignature` class
- Add necessary `ScheduleRepository` class
- Add necessary `ScheduleSignatureRepository` class
- Update grpc and importer modules `EntityTypeEnum` with `SCHEDULE(6)`
- Add `ScheduleIdConverter` to convert from `ScheduleId` to encodedEntityId long
- Add `AbstractEntityConverterTest` to consolidate ConverterTest logic
- Update existing ConverterTests to extend `AbstractEntityConverterTest`
- Add `ScheduleIdConverterTest` that extends `AbstractEntityConverterTest`
- Add `ScheduleRepositoryTest` and `ScheduleSignatureRepositoryTest`

**Which issue(s) this PR fixes**:
Fixes #1464 

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated

