### PR TITLE
Add scheduled column to transaction table

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/Transaction.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/Transaction.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.importer.domain;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -44,37 +44,39 @@ public class Transaction implements Persistable<Long> {
     @Id
     private Long consensusNs;
 
-    @Convert(converter = AccountIdConverter.class)
-    @JsonSerialize(using = EntityIdSerializer.class)
-    private EntityId nodeAccountId;
-
-    private byte[] memo;
-
-    private Integer type;
-
-    private Integer result;
-
-    @Convert(converter = AccountIdConverter.class)
-    @JsonSerialize(using = EntityIdSerializer.class)
-    private EntityId payerAccountId;
-
     private Long chargedTxFee;
-
-    private Long initialBalance;
 
     @Convert(converter = AccountIdConverter.class)
     @JsonSerialize(using = EntityIdSerializer.class)
     private EntityId entityId;
 
-    private Long validStartNs;
+    private Long initialBalance;
 
-    private Long validDurationSeconds;
+    private byte[] memo;
 
     private Long maxFee;
 
-    private byte[] transactionHash;
+    @Convert(converter = AccountIdConverter.class)
+    @JsonSerialize(using = EntityIdSerializer.class)
+    private EntityId nodeAccountId;
+
+    @Convert(converter = AccountIdConverter.class)
+    @JsonSerialize(using = EntityIdSerializer.class)
+    private EntityId payerAccountId;
+
+    private Integer result;
+
+    private boolean scheduled;
 
     private byte[] transactionBytes;
+
+    private byte[] transactionHash;
+
+    private Integer type;
+
+    private Long validDurationSeconds;
+
+    private Long validStartNs;
 
     @JsonIgnore
     @Override

--- a/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.34.1__transaction_schedule.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.34.1__transaction_schedule.sql
@@ -1,0 +1,6 @@
+-------------------
+-- Add schedule to transaction table
+-------------------
+
+alter table if exists transaction
+    add column if not exists scheduled boolean not null default false;

--- a/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.34.1__transaction_schedule.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.34.1__transaction_schedule.sql
@@ -1,5 +1,5 @@
 -------------------
--- Add schedule to transaction table
+-- Add scheduled to transaction table
 -------------------
 
 alter table if exists transaction

--- a/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.0__time_scale_init.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.0__time_scale_init.sql
@@ -510,10 +510,11 @@ create table if not exists transaction
     valid_duration_seconds bigint,
     node_account_id        bigint   not null,
     entity_id              bigint,
-    initial_balance        bigint default 0,
+    initial_balance        bigint   default 0,
     max_fee                bigint,
     charged_tx_fee         bigint,
     memo                   bytea,
+    scheduled              boolean  null default false,
     transaction_hash       bytea,
     transaction_bytes      bytea
 );

--- a/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.0__time_scale_init.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.0__time_scale_init.sql
@@ -514,7 +514,7 @@ create table if not exists transaction
     max_fee                bigint,
     charged_tx_fee         bigint,
     memo                   bytea,
-    scheduled              boolean  null default false,
+    scheduled              boolean  not null default false,
     transaction_hash       bytea,
     transaction_bytes      bytea
 );

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/V_1_31_2__Remove_Invalid_EntitiesTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/V_1_31_2__Remove_Invalid_EntitiesTest.java
@@ -276,6 +276,11 @@ class V_1_31_2__Remove_Invalid_EntitiesTest extends IntegrationTest {
         jdbcOperations.update(FileUtils.readFileToString(migrationSql, "UTF-8"));
     }
 
+    /**
+     * Insert transaction object using only columns supported in V_1_31_2
+     *
+     * @param transaction transaction domain
+     */
     private void insertTransaction(Transaction transaction) {
         jdbcOperations
                 .update("insert into transaction (charged_tx_fee, entity_id, initial_balance, max_fee, memo, " +

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/V_1_31_2__Remove_Invalid_EntitiesTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/V_1_31_2__Remove_Invalid_EntitiesTest.java
@@ -109,7 +109,7 @@ class V_1_31_2__Remove_Invalid_EntitiesTest extends IntegrationTest {
         transactionList
                 .add(transaction(50, 5, EntityTypeEnum.TOKEN, ResponseCodeEnum.SUCCESS,
                         TransactionTypeEnum.TOKENCREATION));
-        transactionRepository.saveAll(transactionList);
+        transactionList.forEach(this::insertTransaction);
 
         // migration
         migrate();
@@ -152,7 +152,7 @@ class V_1_31_2__Remove_Invalid_EntitiesTest extends IntegrationTest {
         transactionList
                 .add(transaction(80, 100, EntityTypeEnum.TOPIC, ResponseCodeEnum.TOPIC_EXPIRED,
                         TransactionTypeEnum.CONSENSUSSUBMITMESSAGE));
-        transactionRepository.saveAll(transactionList);
+        transactionList.forEach(this::insertTransaction);
 
         // migration
         migrate();
@@ -228,7 +228,7 @@ class V_1_31_2__Remove_Invalid_EntitiesTest extends IntegrationTest {
         transactionList
                 .add(transaction(1000, 100, EntityTypeEnum.TOPIC, ResponseCodeEnum.TOPIC_EXPIRED,
                         TransactionTypeEnum.CONSENSUSSUBMITMESSAGE));
-        transactionRepository.saveAll(transactionList);
+        transactionList.forEach(this::insertTransaction);
 
         // migration
         migrate();
@@ -274,5 +274,27 @@ class V_1_31_2__Remove_Invalid_EntitiesTest extends IntegrationTest {
 
     private void migrate() throws IOException {
         jdbcOperations.update(FileUtils.readFileToString(migrationSql, "UTF-8"));
+    }
+
+    private void insertTransaction(Transaction transaction) {
+        jdbcOperations
+                .update("insert into transaction (charged_tx_fee, entity_id, initial_balance, max_fee, memo, " +
+                                "node_account_id, payer_account_id, result, transaction_bytes, " +
+                                "transaction_hash, type, valid_duration_seconds, valid_start_ns, consensus_ns) values" +
+                                " (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                        transaction.getChargedTxFee(),
+                        transaction.getEntityId().getId(),
+                        transaction.getInitialBalance(),
+                        transaction.getMaxFee(),
+                        transaction.getMemo(),
+                        transaction.getNodeAccountId().getId(),
+                        transaction.getPayerAccountId().getId(),
+                        transaction.getResult(),
+                        transaction.getTransactionBytes(),
+                        transaction.getTransactionHash(),
+                        transaction.getType(),
+                        transaction.getValidDurationSeconds(),
+                        transaction.getValidStartNs(),
+                        transaction.getConsensusNs());
     }
 }


### PR DESCRIPTION
**Detailed description**:
PR #1477 missed the addition of the scheduled column to the transaction table.

- Add `scheduled` boolean field to the `Transaction` domain
- Add a v1 sql migration to add the `scheduled` boolean column to the `transaction` table
- Update V2.0.0 sql migration to add the `scheduled` boolean column to the `transaction` table
- Update `V_1_31_2__Remove_Invalid_EntitiesTest` to handle the insertion of transactions without the newly added column

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated

