### PR TITLE
Use property for versions in child poms

### DIFF
--- a/.github/workflows/v2-schema.yml
+++ b/.github/workflows/v2-schema.yml
@@ -33,11 +33,8 @@ jobs:
           path: ~/.m2
           restore-keys: ${{ runner.os }}-m2
 
-      - name: Maven Install
-        run: ./mvnw ${MAVEN_CLI_OPTS} ${MAVEN_SPRING_OPTS} install -DskipTests
-
       - name: Maven Verify
-        run: ./mvnw ${MAVEN_CLI_OPTS} ${MAVEN_SPRING_OPTS} verify -pl hedera-mirror-grpc/
+        run: ./mvnw ${MAVEN_CLI_OPTS} ${MAVEN_SPRING_OPTS} verify -pl hedera-mirror-protobuf,hedera-mirror-grpc
 
       - name: Upload grpc test results
         if: always()

--- a/README.md
+++ b/README.md
@@ -251,10 +251,10 @@ documentation for directions on where and how to view logs.
 
 ## Releasing
 
-To prepare for a new release:
+To prepare for a new release, first update `release.version` and `release.chartVersion` in the root `pom.xml`. Then run:
 
 ```
-./mvnw clean package -N -P=release -Drelease.version=x.y.z -Drelease.chartVersion=x.y.z
+./mvnw clean package -N -P=release
 helm dependency update charts/hedera-mirror
 ```
 

--- a/hedera-mirror-coverage/pom.xml
+++ b/hedera-mirror-coverage/pom.xml
@@ -11,14 +11,14 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.26.0</version>
+        <version>${release.version}</version>
     </parent>
 
     <dependencies>
         <dependency>
             <groupId>com.hedera</groupId>
             <artifactId>hedera-mirror-importer</artifactId>
-            <version>${project.version}</version>
+            <version>${release.version}</version>
         </dependency>
     </dependencies>
 

--- a/hedera-mirror-datagenerator/pom.xml
+++ b/hedera-mirror-datagenerator/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.26.0</version>
+        <version>${release.version}</version>
     </parent>
 
     <properties>
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>com.hedera</groupId>
             <artifactId>hedera-mirror-importer</artifactId>
-            <version>${project.version}</version>
+            <version>${release.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.springframework.cloud</groupId>

--- a/hedera-mirror-grpc/pom.xml
+++ b/hedera-mirror-grpc/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.26.0</version>
+        <version>${release.version}</version>
     </parent>
 
     <properties>
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>com.hedera</groupId>
             <artifactId>hedera-mirror-protobuf</artifactId>
-            <version>${project.version}</version>
+            <version>${release.version}</version>
         </dependency>
         <dependency>
             <groupId>com.lmax</groupId>

--- a/hedera-mirror-importer/pom.xml
+++ b/hedera-mirror-importer/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.26.0</version>
+        <version>${release.version}</version>
     </parent>
 
     <properties>

--- a/hedera-mirror-monitor/pom.xml
+++ b/hedera-mirror-monitor/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.26.0</version>
+        <version>${release.version}</version>
     </parent>
 
     <properties>
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>com.hedera</groupId>
             <artifactId>hedera-mirror-datagenerator</artifactId>
-            <version>${project.version}</version>
+            <version>${release.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.hedera</groupId>

--- a/hedera-mirror-protobuf/pom.xml
+++ b/hedera-mirror-protobuf/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.26.0</version>
+        <version>${release.version}</version>
     </parent>
 
     <properties>

--- a/hedera-mirror-rest/pom.xml
+++ b/hedera-mirror-rest/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.26.0</version>
+        <version>${release.version}</version>
     </parent>
 
     <properties>

--- a/hedera-mirror-test/pom.xml
+++ b/hedera-mirror-test/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.hedera</groupId>
         <artifactId>hedera-mirror-node</artifactId>
-        <version>0.26.0</version>
+        <version>${release.version}</version>
     </parent>
 
     <properties>
@@ -258,8 +258,8 @@
                             <jmeterExtensions>
                                 <jmeterExtension>io.perfmark:perfmark-api:0.20.1</jmeterExtension>
                                 <jmeterExtension>io.opencensus:opencensus-api:0.24.0</jmeterExtension>
-                                <jmeterExtension>com.hedera:hedera-mirror-grpc:${project.version}</jmeterExtension>
-                                <jmeterExtension>com.hedera:hedera-mirror-grpc:jar:tests:${project.version}
+                                <jmeterExtension>com.hedera:hedera-mirror-grpc:${release.version}</jmeterExtension>
+                                <jmeterExtension>com.hedera:hedera-mirror-grpc:jar:tests:${release.version}
                                 </jmeterExtension>
                                 <jmeterExtension>com.google.guava:guava:29.0-jre</jmeterExtension>
                             </jmeterExtensions>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <micrometer-jvm-extras.version>0.2.1</micrometer-jvm-extras.version>
         <msgpack.version>0.8.22</msgpack.version>
         <protobuf.version>3.14.0</protobuf.version>
-        <release.version>0.27.0-SNAPSHOT</release.version> <!-- Used to replace release versions in all files -->
+        <release.version>0.27.0-SNAPSHOT2</release.version> <!-- Used to replace release versions in all files -->
         <release.chartVersion>0.13.0</release.chartVersion>
         <!--suppress UnresolvedMavenProperty -->
         <sonar.coverage.jacoco.xmlReportPaths>
@@ -169,6 +169,32 @@
                         <!--suppress UnresolvedMavenProperty -->
                         <argLine>${argLine} -Xms512m -Xmx1024m</argLine>
                     </configuration>
+                </plugin>
+                <!-- This plugin allows us to use properties in children poms to control versioning -->
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>flatten-maven-plugin</artifactId>
+                    <version>1.2.5</version>
+                    <configuration>
+                        <updatePomFile>true</updatePomFile>
+                        <flattenMode>resolveCiFriendliesOnly</flattenMode>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>flatten</id>
+                            <phase>process-resources</phase>
+                            <goals>
+                                <goal>flatten</goal>
+                            </goals>
+                        </execution>
+                        <execution>
+                            <id>flatten.clean</id>
+                            <phase>clean</phase>
+                            <goals>
+                                <goal>clean</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.jacoco</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -170,32 +170,6 @@
                         <argLine>${argLine} -Xms512m -Xmx1024m</argLine>
                     </configuration>
                 </plugin>
-                <!-- This plugin allows us to use properties in children poms to control versioning -->
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>flatten-maven-plugin</artifactId>
-                    <version>1.2.5</version>
-                    <configuration>
-                        <updatePomFile>true</updatePomFile>
-                        <flattenMode>resolveCiFriendliesOnly</flattenMode>
-                    </configuration>
-                    <executions>
-                        <execution>
-                            <id>flatten</id>
-                            <phase>process-resources</phase>
-                            <goals>
-                                <goal>flatten</goal>
-                            </goals>
-                        </execution>
-                        <execution>
-                            <id>flatten.clean</id>
-                            <phase>clean</phase>
-                            <goals>
-                                <goal>clean</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <micrometer-jvm-extras.version>0.2.1</micrometer-jvm-extras.version>
         <msgpack.version>0.8.22</msgpack.version>
         <protobuf.version>3.14.0</protobuf.version>
-        <release.version>0.27.0-SNAPSHOT2</release.version> <!-- Used to replace release versions in all files -->
+        <release.version>0.27.0-SNAPSHOT</release.version> <!-- Used to replace release versions in all files -->
         <release.chartVersion>0.13.0</release.chartVersion>
         <!--suppress UnresolvedMavenProperty -->
         <sonar.coverage.jacoco.xmlReportPaths>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.hedera</groupId>
     <artifactId>hedera-mirror-node</artifactId>
-    <version>0.26.0</version>
+    <version>${release.version}</version>
     <description>Hedera Mirror Node mirrors data from Hedera nodes and serves it via an API</description>
     <inceptionYear>2019</inceptionYear>
     <modelVersion>4.0.0</modelVersion>
@@ -58,7 +58,7 @@
         <docker-maven-plugin.version>0.34.1</docker-maven-plugin.version>
         <docker.push.repository>gcr.io/mirrornode</docker.push.repository>
         <docker.resources>${project.build.directory}/container</docker.resources>
-        <docker.tag.version>${project.version}</docker.tag.version>
+        <docker.tag.version>${release.version}</docker.tag.version>
         <embedded.testcontainers.version>2.0.0</embedded.testcontainers.version>
         <grpc-spring-boot.version>2.10.1.RELEASE</grpc-spring-boot.version>
         <grpc.version>1.35.0</grpc.version>
@@ -72,7 +72,7 @@
         <micrometer-jvm-extras.version>0.2.1</micrometer-jvm-extras.version>
         <msgpack.version>0.8.22</msgpack.version>
         <protobuf.version>3.14.0</protobuf.version>
-        <release.version>${project.version}</release.version> <!-- Used to replace release versions in all files -->
+        <release.version>0.27.0-SNAPSHOT</release.version> <!-- Used to replace release versions in all files -->
         <release.chartVersion>0.13.0</release.chartVersion>
         <!--suppress UnresolvedMavenProperty -->
         <sonar.coverage.jacoco.xmlReportPaths>
@@ -367,8 +367,6 @@
                                 <include>hedera-mirror-rest/**/openapi.yml</include>
                                 <include>hedera-mirror-rest/package*.json</include>
                                 <include>hedera-mirror-rest/monitoring/monitor_apis/package*.json</include>
-                                <include>*/pom.xml</include>
-                                <include>pom.xml</include>
                                 <include>hedera-mirror-test/src/test/resources/k8s/*.yml</include>
                             </includes>
                             <replacements>
@@ -378,20 +376,15 @@
                                     <value>${release.version}</value>
                                 </replacement>
                                 <replacement>
-                                    <token>
-                                        <![CDATA[(?<=hedera-mirror-node</artifactId>(\s{9}|\s{5})<version>)[^<]+]]></token>
+                                    <token><![CDATA[(?<=appVersion: )[0-9a-zA-Z.-]+]]></token>
                                     <value>${release.version}</value>
                                 </replacement>
                                 <replacement>
-                                    <token><![CDATA[(?<=appVersion: )[0-9a-z.-]+]]></token>
-                                    <value>${release.version}</value>
-                                </replacement>
-                                <replacement>
-                                    <token><![CDATA[(?<=version: )[0-9a-z.-]+]]></token>
+                                    <token><![CDATA[(?<=version: )[0-9a-zA-Z.-]+]]></token>
                                     <value>${release.chartVersion}</value>
                                 </replacement>
                                 <replacement>
-                                    <token><![CDATA[(?<=(\s{3})version: )[0-9a-z.-]+]]></token>
+                                    <token><![CDATA[(?<=(\s{3})version: )[0-9a-zA-Z.-]+]]></token>
                                     <value>${release.version}</value>
                                 </replacement>
                                 <replacement>


### PR DESCRIPTION
**Detailed description**:
- Change children `pom.xml` to use `${release.version}` [property](https://maven.apache.org/maven-ci-friendly.html#Multi_Module_Setup) instead of hardcoded versions
- Change current version to `0.27.0-SNAPSHOT`
- Change replacer to not modify `pom.xml`
- Fix replacer not allowing uppercase characters like `SNAPSHOT`

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
This change cuts down on the number of files that have to be committed every release to bump the versions.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

