### PR TITLE
Skip rest test in test module docker build

### DIFF
--- a/hedera-mirror-test/src/main/resources/Dockerfile
+++ b/hedera-mirror-test/src/main/resources/Dockerfile
@@ -4,9 +4,6 @@ FROM adoptopenjdk:11-jdk-hotspot
 WORKDIR /usr/etc/hedera-mirror-node
 COPY . .
 
-# copy licenses out of target folder as they'll be cleared on performance test runs
-RUN mv hedera-mirror-test/target/container hedera-mirror-test/container
-
 ENV testProfile acceptance
 ENV cucumberFlags "@BalanceCheck"
 ENV subscribeThreadCount 30
@@ -15,7 +12,11 @@ ENV jmeterPropsDirectory "/usr/etc/hedera-mirror-test"
 ENV publishThreadCount 1
 
 # ensure all maven dependecies are placed ahead of test run
-RUN ./mvnw install -DskipTests -Djib.skip -Ddocker.skip --no-transfer-progress \
-    --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+RUN ./mvnw install -DskipTests -Djib.skip -Ddocker.skip -Dskip.npm --no-transfer-progress \
+    --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
+    -pl hedera-mirror-protobuf,hedera-mirror-grpc,hedera-mirror-test
+
+# copy licenses out of target folder as they'll be cleared on performance test runs
+RUN mv hedera-mirror-test/target/container hedera-mirror-test/container
 
 ENTRYPOINT hedera-mirror-test/src/main/resources/run-tests.sh


### PR DESCRIPTION
Dev Deployment is currently failing as it's attempting to run the rest integration tests during the Dockerfile build of the test module.
All other module tests are skipped so we should skip this too

**Detailed description**:
- Add `-Dskip.npm` flag to `./mvnw install` command to skip rest tests

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

