### PR TITLE
Add rosetta module to maven cycle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,7 +239,7 @@ jobs:
       - write_spring_override_config
       - run:
           name: Running maven (validate, compile, test, package)
-          command: ./mvnw ${MAVEN_CLI_OPTS} ${MAVEN_SPRING_OPTS} package
+          command: ./mvnw ${MAVEN_CLI_OPTS} ${MAVEN_SPRING_OPTS} package -pl '!hedera-mirror-rosetta'
       - store_artifacts:
           path: hedera-mirror-importer/target/surefire-reports
           destination: /importer-surefire

--- a/.github/workflows/rosetta-api.yml
+++ b/.github/workflows/rosetta-api.yml
@@ -24,14 +24,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       - name: Build hedera-mirror-rosetta
-        run: go build -i -o rosetta cmd/*
-        working-directory: ${{env.working-directory}}
-      - name: Upload Binary as artifact
-        uses: actions/upload-artifact@master
-        with:
-          name: hedera-mirror-rosetta
-          path: ${{ env.working-directory }}/rosetta
-          if-no-files-found: error
+        run: ./mvnw clean package -pl hedera-mirror-rosetta
       - name: Get current version
         id: get_version
         run: |

--- a/hedera-mirror-rosetta/pom.xml
+++ b/hedera-mirror-rosetta/pom.xml
@@ -44,7 +44,6 @@
                             <packages>
                                 <package>${project.basedir}/...</package>
                             </packages>
-                            <outLogFile>${project.artifactId}-test.log</outLogFile>
                         </configuration>
                     </execution>
                     <execution>

--- a/hedera-mirror-rosetta/pom.xml
+++ b/hedera-mirror-rosetta/pom.xml
@@ -20,7 +20,7 @@
     </properties>
 
     <build>
-        <sourceDirectory>${project.basedir}/cmd</sourceDirectory>
+        <sourceDirectory>${project.basedir}${file.separator}cmd</sourceDirectory>
         <directory>${basedir}${file.separator}bin</directory>
         <defaultGoal>clean package</defaultGoal>
         <finalName>${project.artifactId}</finalName>
@@ -42,7 +42,7 @@
                                 <flag>-v</flag>
                             </buildFlags>
                             <packages>
-                                <package>${project.basedir}/...</package>
+                                <package>${project.basedir}${file.separator}...</package>
                             </packages>
                         </configuration>
                     </execution>
@@ -53,7 +53,7 @@
                                 <flag>-a</flag>
                                 <flag>-i</flag>
                             </buildFlags>
-                            <sources>${project.basedir}/cmd</sources>
+                            <sources>${project.basedir}${file.separator}cmd</sources>
                         </configuration>
                     </execution>
                 </executions>

--- a/hedera-mirror-rosetta/pom.xml
+++ b/hedera-mirror-rosetta/pom.xml
@@ -6,7 +6,7 @@
     <description>Rosetta REST API for the Hedera Mirror Node</description>
     <modelVersion>4.0.0</modelVersion>
     <name>Hedera Mirror Node Rosetta REST API</name>
-    <packaging>pom</packaging>
+    <packaging>mvn-golang</packaging>
 
     <parent>
         <groupId>com.hedera</groupId>
@@ -20,10 +20,44 @@
     </properties>
 
     <build>
+        <sourceDirectory>${project.basedir}/cmd</sourceDirectory>
+        <directory>${basedir}${file.separator}bin</directory>
+        <defaultGoal>clean package</defaultGoal>
+        <finalName>${project.artifactId}</finalName>
         <plugins>
             <plugin>
                 <groupId>io.fabric8</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>com.igormaznitsa</groupId>
+                <artifactId>mvn-golang-wrapper</artifactId>
+                <version>2.3.6</version>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <id>default-test</id>
+                        <configuration>
+                            <buildFlags>
+                                <flag>-v</flag>
+                            </buildFlags>
+                            <packages>
+                                <package>${project.basedir}/...</package>
+                            </packages>
+                            <outLogFile>${project.artifactId}-test.log</outLogFile>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>default-build</id>
+                        <configuration>
+                            <buildFlags>
+                                <flag>-a</flag>
+                                <flag>-i</flag>
+                            </buildFlags>
+                            <sources>${project.basedir}/cmd</sources>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
**Detailed description**:
Rosetta module isn't currently included in the mane build cycle

- Add `mvn-golang-wrapper` plugin to add maven cycle support to rosetta module
- Update`rosetta-api.yml` GitHub action to run maven package

**Which issue(s) this PR fixes**:
Fixes #1523 

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

