### PR TITLE
Fix PostgreSQL chart

### DIFF
--- a/charts/hedera-mirror/values.yaml
+++ b/charts/hedera-mirror/values.yaml
@@ -99,7 +99,7 @@ postgresql:
     debug: true
   postgresqlImage:
     debug: true
-    tag: 13.0.0-debian-10-r35
+    tag: 13.1.0-debian-10-r74
   postgresql:
     affinity:
       podAntiAffinity:

--- a/charts/marketplace/gcp/release.sh
+++ b/charts/marketplace/gcp/release.sh
@@ -21,7 +21,7 @@ fi
 target_tag="${target_tag#v}" # Strip v prefix if present
 target_tag_minor="${target_tag%\.*}"
 bats_tag="1.2.1"
-postgresql_tag="13.0.0-debian-10-r35"
+postgresql_tag="13.1.0-debian-10-r74"
 registry="gcr.io/mirror-node-public/hedera-mirror-node"
 
 function retag() {


### PR DESCRIPTION
**Detailed description**:
Ops deployed mirror node chart and ran into this PostgreSQL 13 and repmgr conflict that's been fixed upstream: https://github.com/bitnami/charts/issues/4414

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

Second PostgreSQL pod never becomes ready:
```
[REPMGR EVENT::standby_follow] Node id: 1001; Event type: standby_follow; Success [1|0]: 0; Time: 2021-01-29 21:11:20.914202+00;  Details: slot "repmgr_slot_1001" already exists as an active slot
```

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

