### PR TITLE
Fix database initialization in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       POSTGRES_USER: mirror_node
     volumes:
       - ./db:/var/lib/postgresql/data
-      - ./hedera-mirror-importer/src/main/resources/db/scripts/init.sql:/docker-entrypoint-initdb.d/init_v1.sql
+      - ./hedera-mirror-importer/src/main/resources/db/scripts/init_v1.sql:/docker-entrypoint-initdb.d/init.sql
     ports:
       - 5432:5432
 


### PR DESCRIPTION
**Detailed description**:
Fix docker-compose not initializing the database properly:
```
db_1  #psql:/docker-entrypoint-initdb.d/init_v1.sql:0: could not read from input file: Is a directory
hedera-mirror-node_rosetta_1 exited with code 1
db_1           | FATAL:  password authentication failed for user "mirror_rosetta"
db_1           | DETAIL:  Role "mirror_rosetta" does not exist.
db_1           |        Connection matched pg_hba.conf line 95: "host all all all md5"
```

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

