### PR TITLE
Bump versions for v0.27.0-rc1

### DIFF
--- a/charts/hedera-mirror-common/Chart.yaml
+++ b/charts/hedera-mirror-common/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.26.0
+appVersion: 0.27.0-rc1
 description: Hedera Mirror Node common components installed globally for use across namespaces
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
@@ -11,4 +11,4 @@ maintainers:
 name: hedera-mirror-common
 sources:
   - https://github.com/hashgraph/hedera-mirror-node
-version: 0.13.0
+version: 0.14.0-rc1

--- a/charts/hedera-mirror-grpc/Chart.yaml
+++ b/charts/hedera-mirror-grpc/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.26.0
+appVersion: 0.27.0-rc1
 description: GRPC API for the Hedera Mirror Node
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
@@ -11,4 +11,4 @@ maintainers:
 name: hedera-mirror-grpc
 sources:
   - https://github.com/hashgraph/hedera-mirror-node
-version: 0.13.0
+version: 0.14.0-rc1

--- a/charts/hedera-mirror-importer/Chart.yaml
+++ b/charts/hedera-mirror-importer/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.26.0
+appVersion: 0.27.0-rc1
 description: Hedera Mirror Importer downloads and validates file streams from the cloud and imports them into the database
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
@@ -11,4 +11,4 @@ maintainers:
 name: hedera-mirror-importer
 sources:
   - https://github.com/hashgraph/hedera-mirror-node
-version: 0.13.0
+version: 0.14.0-rc1

--- a/charts/hedera-mirror-monitor/Chart.yaml
+++ b/charts/hedera-mirror-monitor/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.26.0
+appVersion: 0.27.0-rc1
 description: End to End Monitor for the Hedera Mirror Node
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
@@ -11,4 +11,4 @@ maintainers:
 name: hedera-mirror-monitor
 sources:
   - https://github.com/hashgraph/hedera-mirror-node
-version: 0.13.0
+version: 0.14.0-rc1

--- a/charts/hedera-mirror-rest/Chart.yaml
+++ b/charts/hedera-mirror-rest/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.26.0
+appVersion: 0.27.0-rc1
 description: REST API for the Hedera Mirror Node
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
@@ -11,4 +11,4 @@ maintainers:
 name: hedera-mirror-rest
 sources:
   - https://github.com/hashgraph/hedera-mirror-node
-version: 0.13.0
+version: 0.14.0-rc1

--- a/charts/hedera-mirror/Chart.yaml
+++ b/charts/hedera-mirror/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.26.0
+appVersion: 0.27.0-rc1
 description: Hedera Mirror Node mirrors data from Hedera nodes and serves it via an API
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
@@ -11,4 +11,4 @@ maintainers:
 name: hedera-mirror
 sources:
   - https://github.com/hashgraph/hedera-mirror-node
-version: 0.13.0
+version: 0.14.0-rc1

--- a/charts/hedera-mirror/requirements.lock
+++ b/charts/hedera-mirror/requirements.lock
@@ -1,13 +1,13 @@
 dependencies:
 - name: hedera-mirror-grpc
   repository: file://../hedera-mirror-grpc
-  version: 0.13.0
+  version: 0.14.0-rc1
 - name: hedera-mirror-importer
   repository: file://../hedera-mirror-importer
-  version: 0.13.0
+  version: 0.14.0-rc1
 - name: hedera-mirror-monitor
   repository: file://../hedera-mirror-monitor
-  version: 0.13.0
+  version: 0.14.0-rc1
 - name: postgresql-ha
   repository: https://charts.bitnami.com/bitnami
   version: 6.3.7
@@ -16,9 +16,9 @@ dependencies:
   version: 12.2.4
 - name: hedera-mirror-rest
   repository: file://../hedera-mirror-rest
-  version: 0.13.0
+  version: 0.14.0-rc1
 - name: timescaledb-multinode
   repository: https://raw.githubusercontent.com/timescale/timescaledb-kubernetes/master/charts/repo/
   version: 0.8.0
-digest: sha256:3fef15ed8c2cfa1f3a92802c6d1132388ef1c5a6bb8f423b7d17b8f6ac9d9ea8
-generated: "2021-01-22T10:50:17.771273-06:00"
+digest: sha256:c3d88922724b42c874f1a686043e846f5ef0b5b890038a025ffcfbeeed604c76
+generated: "2021-02-03T14:35:59.452345-06:00"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - 5432:5432
 
   grpc:
-    image: gcr.io/mirrornode/hedera-mirror-grpc:0.26.0
+    image: gcr.io/mirrornode/hedera-mirror-grpc:0.27.0-rc1
     restart: unless-stopped
     environment:
       HEDERA_MIRROR_GRPC_DB_HOST: db
@@ -29,7 +29,7 @@ services:
       - 5600:5600
 
   importer:
-    image: gcr.io/mirrornode/hedera-mirror-importer:0.26.0
+    image: gcr.io/mirrornode/hedera-mirror-importer:0.27.0-rc1
     restart: unless-stopped
     environment:
       HEDERA_MIRROR_IMPORTER_DATAPATH: /var/lib/hedera-mirror-importer
@@ -43,7 +43,7 @@ services:
   monitor:
     deploy:
       replicas: 0
-    image: gcr.io/mirrornode/hedera-mirror-monitor:0.26.0
+    image: gcr.io/mirrornode/hedera-mirror-monitor:0.27.0-rc1
     restart: unless-stopped
     environment:
       SPRING_CONFIG_ADDITIONAL_LOCATION: file:/usr/etc/hedera-mirror-monitor/
@@ -60,7 +60,7 @@ services:
       - 6379:6379
 
   rest:
-    image: gcr.io/mirrornode/hedera-mirror-rest:0.26.0
+    image: gcr.io/mirrornode/hedera-mirror-rest:0.27.0-rc1
     environment:
       HEDERA_MIRROR_REST_DB_HOST: db
     restart: unless-stopped
@@ -69,7 +69,7 @@ services:
       - 5551:5551
 
   rosetta:
-    image: gcr.io/mirrornode/hedera-mirror-rosetta:0.26.0
+    image: gcr.io/mirrornode/hedera-mirror-rosetta:0.27.0-rc1
     environment:
       HEDERA_MIRROR_ROSETTA_DB_HOST: db
     restart: unless-stopped

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -315,7 +315,7 @@ latter configuration overwriting (technically recursively merged into) the curre
 
 1. `./config/application.yml`
 2. `./application.yml`
-3. `${HEDERA_MIRROR_ROSETTA_API_CONFIG}/application.yml`
+3. `${HEDERA_MIRROR_ROSETTA_API_CONFIG}` environment variable to custom values file (e.g. `HEDERA_MIRROR_ROSETTA_API_CONFIG=/Users/Downloads/hedera-mirror-rosetta/application.yml`)
 4. Environment variables that start with `HEDERA_MIRROR_ROSETTA_` (e.g. `HEDERA_MIRROR_ROSETTA_API_VERSION=1.4.2`)
 
 The following table lists the available properties along with their default values.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -122,7 +122,7 @@ and secret keys in the config. This will also allow you to take advantage of alt
 to connect to an S3 bucket that requires authenticaion, and the static credentials are not provided in the config, the
 mirror node will default to using this provider. For more information and to see how you can set up your environment to
 take advantage of this, see
-[the AWS Credentials Documentation](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html)
+[the AWS Credentials Documentation](https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/credentials.html)
 When running in Docker or Kubernetes, credentials can be attached in a variety of ways, including by using volumes and
 secrets to directly add static credentials or an existing AWS credentials file, by using other tools such as Vault or
 AWS Secrets Manager, and many more.
@@ -310,29 +310,28 @@ hedera:
 ## Rosetta API
 
 The Rosetta API supports loading configuration from YAML. By default, it loads a file named
-`application.yml` in each of the search paths (see below).
-The configuration is loaded in the following order with the latter configuration overwriting (technically recursively
-merged into) the current configuration:
+`application.yml` in each of the search paths (see below). The configuration is loaded in the following order with the
+latter configuration overwriting (technically recursively merged into) the current configuration:
 
 1. `./config/application.yml`
 2. `./application.yml`
-3. `${HEDERA_MIRROR_ROSETTA_API_CONFIG}` environment variable to custom values file (e.g. `HEDERA_MIRROR_ROSETTA_API_CONFIG=/Users/Downloads/hedera-mirror-rosetta/application.yml`)
+3. `${HEDERA_MIRROR_ROSETTA_API_CONFIG}/application.yml`
 4. Environment variables that start with `HEDERA_MIRROR_ROSETTA_` (e.g. `HEDERA_MIRROR_ROSETTA_API_VERSION=1.4.2`)
 
 The following table lists the available properties along with their default values.
 
-| Name                                                    | Default                 | Description                                                                                    |
-| ------------------------------------------------------- | ----------------------- | ---------------------------------------------------------------------------------------------- |
-| `hedera.mirror.rosetta.apiVersion`                      | 1.4.4                   | The version of the Rosetta interface the implementation adheres to                             |
-| `hedera.mirror.rosetta.db.host`                         | 127.0.0.1               | The IP or hostname used to connect to the database                                             |
-| `hedera.mirror.rosetta.db.name`                         | mirror_node             | The name of the database                                                                       |
-| `hedera.mirror.rosetta.db.password`                     | mirror_rosetta_pass     | The database password the processor uses to connect. **Should be changed from default**        |
-| `hedera.mirror.rosetta.db.port`                         | 5432                    | The port used to connect to the database                                                       |
-| `hedera.mirror.rosetta.db.username`                     | mirror_rosetta          | The username the processor uses to connect to the database                                     |
-| `hedera.mirror.rosetta.network`                         | DEMO                    | Which Hedera network to use. Can be either `DEMO`, `MAINNET`, `PREVIEWNET`, `TESTNET` or `OTHER`             |
-| `hedera.mirror.rosetta.nodeVersion`                     | 0                       | The default canonical version of the node runtime                                              |
-| `hedera.mirror.rosetta.online`                          | true                    | The default online mode of the Rosetta interface                                               |
-| `hedera.mirror.rosetta.port`                            | 5700                    | The REST API port                                                                              |
-| `hedera.mirror.rosetta.shard`                           | 0                       | The default shard number that this mirror node participates in                                 |
-| `hedera.mirror.rosetta.realm`                           | 0                       | The default realm number within the shard                                                      |
-| `hedera.mirror.rosetta.version`                         | 0.20.0                  | The version of the Hedera Mirror Node used to adhere to the Rosetta interface                  |
+Name                                                    | Default                 | Description
+------------------------------------------------------- | ----------------------- | ----------------------------------------------------------------------------------------------
+`hedera.mirror.rosetta.apiVersion`                      | 1.4.4                   | The version of the Rosetta interface the implementation adheres to
+`hedera.mirror.rosetta.db.host`                         | 127.0.0.1               | The IP or hostname used to connect to the database
+`hedera.mirror.rosetta.db.name`                         | mirror_node             | The name of the database
+`hedera.mirror.rosetta.db.password`                     | mirror_rosetta_pass     | The database password the processor uses to connect.
+`hedera.mirror.rosetta.db.port`                         | 5432                    | The port used to connect to the database
+`hedera.mirror.rosetta.db.username`                     | mirror_rosetta          | The username the processor uses to connect to the database
+`hedera.mirror.rosetta.network`                         | DEMO                    | Which Hedera network to use. Can be either `DEMO`, `MAINNET`, `PREVIEWNET`, `TESTNET` or `OTHER`
+`hedera.mirror.rosetta.nodeVersion`                     | 0                       | The default canonical version of the node runtime
+`hedera.mirror.rosetta.online`                          | true                    | The default online mode of the Rosetta interface
+`hedera.mirror.rosetta.port`                            | 5700                    | The REST API port
+`hedera.mirror.rosetta.shard`                           | 0                       | The default shard number that this mirror node participates in
+`hedera.mirror.rosetta.realm`                           | 0                       | The default realm number within the shard
+`hedera.mirror.rosetta.version`                         | Varies per release      | The version of the Hedera Mirror Node used to adhere to the Rosetta interface

--- a/hedera-mirror-rest/api/v1/openapi.yml
+++ b/hedera-mirror-rest/api/v1/openapi.yml
@@ -486,7 +486,7 @@ tags:
     description: The tokens object represents the information associated with a token entity and returns a list of token information.
 info:
   title: Hedera Mirror Node REST API
-  version: 0.26.0
+  version: 0.27.0-rc1
   license:
     name: Apache-2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
@@ -746,7 +746,7 @@ components:
         topic_id: 0.0.7
         message: bWVzc2FnZQ==
         running_hash: cnVubmluZ19oYXNo
-        running_hash_version: 0.13.0
+        running_hash_version: 2
         sequence_number: 1
     TopicMessages:
       type: array

--- a/hedera-mirror-rest/monitoring/monitor_apis/package-lock.json
+++ b/hedera-mirror-rest/monitoring/monitor_apis/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-mirror-monitor",
-  "version": "0.26.0",
+  "version": "0.27.0-rc1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hedera-mirror-rest/monitoring/monitor_apis/package.json
+++ b/hedera-mirror-rest/monitoring/monitor_apis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-mirror-monitor",
-  "version": "0.26.0",
+  "version": "0.27.0-rc1",
   "description": "Hedera Mirror Node Monitor",
   "main": "server.js",
   "private": true,

--- a/hedera-mirror-rest/package-lock.json
+++ b/hedera-mirror-rest/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-mirror-rest",
-  "version": "0.26.0",
+  "version": "0.27.0-rc1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hedera-mirror-rest/package.json
+++ b/hedera-mirror-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-mirror-rest",
-  "version": "0.26.0",
+  "version": "0.27.0-rc1",
   "description": "Hedera Mirror Node REST API",
   "main": "server.js",
   "private": true,

--- a/hedera-mirror-rosetta/config/application-deploy.yml
+++ b/hedera-mirror-rosetta/config/application-deploy.yml
@@ -15,4 +15,4 @@ hedera:
       port: ${apiPort}
       realm: 0
       shard: 0
-      version: 0.20.0
+      version: 0.27.0-rc1

--- a/hedera-mirror-rosetta/config/application.yml
+++ b/hedera-mirror-rosetta/config/application.yml
@@ -15,4 +15,4 @@ hedera:
       port: 5700
       realm: 0
       shard: 0
-      version: 0.20.0
+      version: 0.27.0-rc1

--- a/hedera-mirror-test/src/test/resources/k8s/hcs-perf-message-submit.yml
+++ b/hedera-mirror-test/src/test/resources/k8s/hcs-perf-message-submit.yml
@@ -41,7 +41,7 @@ spec:
                     app.kubernetes.io/name: test
       restartPolicy: Never
       containers:
-        - image: gcr.io/mirrornode/hedera-mirror-test:0.26.0
+        - image: gcr.io/mirrornode/hedera-mirror-test:0.27.0-rc1
           name: test
           env:
             - name: testProfile

--- a/hedera-mirror-test/src/test/resources/k8s/hcs-perf-publish-test.yml
+++ b/hedera-mirror-test/src/test/resources/k8s/hcs-perf-publish-test.yml
@@ -43,7 +43,7 @@ spec:
                     app.kubernetes.io/name: test
       restartPolicy: Never
       containers:
-        - image: gcr.io/mirrornode/hedera-mirror-test:0.26.0
+        - image: gcr.io/mirrornode/hedera-mirror-test:0.27.0-rc1
           name: test
           env:
             - name: testProfile

--- a/hedera-mirror-test/src/test/resources/k8s/hcs-perf-subscribe-test.yml
+++ b/hedera-mirror-test/src/test/resources/k8s/hcs-perf-subscribe-test.yml
@@ -46,7 +46,7 @@ spec:
                     app.kubernetes.io/name: test
       restartPolicy: Never
       containers:
-        - image: gcr.io/mirrornode/hedera-mirror-test:0.26.0
+        - image: gcr.io/mirrornode/hedera-mirror-test:0.27.0-rc1
           name: test
           env:
             - name: testProfile

--- a/hedera-mirror-test/src/test/resources/k8s/hts-perf-batch-publish-batch-validate.yml
+++ b/hedera-mirror-test/src/test/resources/k8s/hts-perf-batch-publish-batch-validate.yml
@@ -47,7 +47,7 @@ spec:
                     app.kubernetes.io/name: test
       restartPolicy: Never
       containers:
-        - image: gcr.io/mirrornode/hedera-mirror-test:0.26.0
+        - image: gcr.io/mirrornode/hedera-mirror-test:0.27.0-rc1
           name: test
           env:
             - name: testProfile

--- a/hedera-mirror-test/src/test/resources/k8s/hts-perf-publish-and-retrieve.yml
+++ b/hedera-mirror-test/src/test/resources/k8s/hts-perf-publish-and-retrieve.yml
@@ -46,7 +46,7 @@ spec:
                     app.kubernetes.io/name: test
       restartPolicy: Never
       containers:
-        - image: gcr.io/mirrornode/hedera-mirror-test:0.26.0
+        - image: gcr.io/mirrornode/hedera-mirror-test:0.27.0-rc1
           name: test
           env:
             - name: testProfile

--- a/pom.xml
+++ b/pom.xml
@@ -73,8 +73,8 @@
         <micrometer-jvm-extras.version>0.2.1</micrometer-jvm-extras.version>
         <msgpack.version>0.8.22</msgpack.version>
         <protobuf.version>3.14.0</protobuf.version>
-        <release.version>0.27.0-SNAPSHOT</release.version> <!-- Used to replace release versions in all files -->
-        <release.chartVersion>0.13.0</release.chartVersion>
+        <release.version>0.27.0-rc1</release.version> <!-- Used to replace release versions in all files -->
+        <release.chartVersion>0.14.0-rc1</release.chartVersion>
         <replacer.version>1.5.3</replacer.version>
         <!--suppress UnresolvedMavenProperty -->
         <sonar.coverage.jacoco.xmlReportPaths>
@@ -431,6 +431,7 @@
                                 <include>hedera-mirror-rest/**/openapi.yml</include>
                                 <include>hedera-mirror-rest/package*.json</include>
                                 <include>hedera-mirror-rest/monitoring/monitor_apis/package*.json</include>
+                                <include>hedera-mirror-rosetta/config/application*.yml</include>
                                 <include>hedera-mirror-test/src/test/resources/k8s/*.yml</include>
                             </includes>
                             <replacements>
@@ -444,7 +445,7 @@
                                     <value>${release.version}</value>
                                 </replacement>
                                 <replacement>
-                                    <token><![CDATA[(?<=version: )[0-9a-zA-Z.-]+]]></token>
+                                    <token><![CDATA[(?<=\sversion: )[0-9a-zA-Z.-]+]]></token>
                                     <value>${release.chartVersion}</value>
                                 </replacement>
                                 <replacement>


### PR DESCRIPTION
**Detailed description**:
- Bump versions for v0.27.0.rc1
- Fix `running_hash_version` in `openapi.yml` getting updated
- Fix Rosetta version in `application.yml` not getting updated
- Fix Rosetta version in configuration docs

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

