### PR TITLE
Upgrade Google Marketplace with support for v0.27

### DIFF
--- a/charts/marketplace/gcp/BUILDING.md
+++ b/charts/marketplace/gcp/BUILDING.md
@@ -79,7 +79,7 @@ Or you can simply delete the entire namespace if you created it during the insta
 
 # Releasing
 
-Once all local testing is completed succesfully and the images are tagged, run the below commands to republish the images
+Once all local testing is completed successfully and the images are tagged, run the below commands to republish the images
 to the staging registry:
 
     git checkout "tags/v${TAG}"

--- a/charts/marketplace/gcp/Dockerfile
+++ b/charts/marketplace/gcp/Dockerfile
@@ -27,7 +27,9 @@ RUN cat /tmp/schema.yaml \
 # Run helm template to render and verify templates
 RUN helm dependency update /tmp/charts/hedera-mirror
 RUN helm template /tmp/charts/hedera-mirror -f /tmp/charts/hedera-mirror/values.yaml
-RUN cd /tmp/charts && tar -czvf hedera-mirror-node.tar.gz hedera-mirror
+
+# Build chart archive, copy hedera-mirror contents to chart dir to comply with mpdev expectations
+RUN cd /tmp/charts && mv hedera-mirror chart && tar -czvf hedera-mirror-node.tar.gz chart
 
 # Setup marketplace structure on helm deployer image base
 FROM gcr.io/cloud-marketplace-tools/k8s/deployer_helm

--- a/charts/marketplace/gcp/README.md
+++ b/charts/marketplace/gcp/README.md
@@ -383,11 +383,11 @@ helm upgrade "${APP_NAME}" charts/hedera-mirror \
   -f custom-values.yaml
 ```
 
-## v0.13 -> v0.27+ (Includes breaking changes)
+## v0.13 to v0.27+
 
-Marketplace upgrade from v0.13 to v0.27 onwards include many noteworthy improvements and changes.
-Unfortunately 2 such changes include breaking stateful set changes from the mirror node and postgres sub chart.
-As such a few extra steps are necessary for a smooth transition.
+Marketplace upgrade from v0.13 to v0.27+ include many noteworthy improvements and changes.
+Unfortunately 2 such changes introduce breaking stateful set changes from the mirror node and postgres sub charts.
+As such, a few extra steps are necessary to ensure a smooth upgrade process.
 These steps draw inspiration from Bitnami's [Upgrade Steps To 9.0.0](https://artifacthub.io/packages/helm/bitnami/postgresql#to-9-0-0)
 
 1. From a v0.13 repo Stop importer downloading
@@ -408,7 +408,7 @@ These steps draw inspiration from Bitnami's [Upgrade Steps To 9.0.0](https://art
     From a newly checked out v0.27 or greater mirror node repo kickoff the upgrade
     ```shell script
     git checkout tags/v0.27.0
-    helm upgrade "${APP_NAME}" charts/hedera-mirror --namespace "${NAMESPACE}" -f charts/marketplace/gcp/values.yaml -f custom-values.yaml
+    helm upgrade "${APP_NAME}" charts/hedera-mirror --namespace "${NAMESPACE}" --install -f charts/marketplace/gcp/values.yaml -f custom-values.yaml
     ```
 
 4. Delete importer and postgres pods

--- a/charts/marketplace/gcp/README.md
+++ b/charts/marketplace/gcp/README.md
@@ -385,12 +385,12 @@ helm upgrade "${APP_NAME}" charts/hedera-mirror \
 
 ## v0.13 to v0.27+
 
-Marketplace upgrade from v0.13 to v0.27+ include many noteworthy improvements and changes.
-Unfortunately 2 such changes introduce breaking stateful set changes from the mirror node and postgres sub charts.
+The Marketplace solution update from v0.13 to v0.27+ includes many noteworthy improvements and changes.
+Unfortunately, 2 such changes introduce breaking stateful set changes from the mirror node and postgres sub charts.
 As such, a few extra steps are necessary to ensure a smooth upgrade process.
 These steps draw inspiration from Bitnami's [Upgrade Steps To 9.0.0](https://artifacthub.io/packages/helm/bitnami/postgresql#to-9-0-0)
 
-1. From a v0.13 repo Stop importer downloading
+1. From a v0.13 repo, stop stream file downloads on the importer
     > **Note:** It's important to run the following command from a v0.13 repo, to ensure additional charts and resources are not prematurely pushed to the existing application
     ```shell script
     helm upgrade "${APP_NAME}" charts/hedera-mirror --namespace "${NAMESPACE}" --install --reuse-values --set importer.config.hedera.mirror.importer.downloader.record.enabled=false --set importer.config.hedera.mirror.importer.downloader.balance.enabled=false
@@ -398,17 +398,17 @@ These steps draw inspiration from Bitnami's [Upgrade Steps To 9.0.0](https://art
 
     Observe the logs and ensure no record or balance stream files are being processed.
 
-2. Delete stateful sets
-    After verifying no record or balance stream files are being processed, remove the importer and postgres stateful sets
+2. Delete importer and postgres stateful sets
+    After verifying no record or balance stream files are being processed, remove the offending importer and postgres stateful sets
     ```shell script
     kubectl delete statefulsets.apps --cascade=false "${APP_NAME}-importer" "${APP_NAME}-postgres-postgresql"
     ```
 
-3. From a v0.27 repo Upgrade
+3. From a v0.27+ repo upgrade application
     From a newly checked out v0.27 or greater mirror node repo kickoff the upgrade
     ```shell script
     git checkout tags/v0.27.0
-    helm upgrade "${APP_NAME}" charts/hedera-mirror --namespace "${NAMESPACE}" --install -f charts/marketplace/gcp/values.yaml -f custom-values.yaml
+    helm upgrade "${APP_NAME}" charts/hedera-mirror --namespace "${NAMESPACE}" -f charts/marketplace/gcp/values.yaml -f custom-values.yaml
     ```
 
 4. Delete importer and postgres pods

--- a/charts/marketplace/gcp/README.md
+++ b/charts/marketplace/gcp/README.md
@@ -383,38 +383,15 @@ helm upgrade "${APP_NAME}" charts/hedera-mirror \
   -f custom-values.yaml
 ```
 
-## v0.13 to v0.27+
+## v0.27
 
 The Marketplace solution update from v0.13 to v0.27+ includes many noteworthy improvements and changes.
 Unfortunately, 2 such changes introduce breaking stateful set changes from the mirror node and postgres sub charts.
-As such, a few extra steps are necessary to ensure a smooth upgrade process.
-These steps draw inspiration from Bitnami's [Upgrade Steps To 9.0.0](https://artifacthub.io/packages/helm/bitnami/postgresql#to-9-0-0)
+To ensure a smooth upgrade process:
 
-1. From a v0.13 repo, stop stream file downloads on the importer
-    > **Note:** It's important to run the following command from a v0.13 repo, to ensure additional charts and resources are not prematurely pushed to the existing application
-    ```shell script
-    helm upgrade "${APP_NAME}" charts/hedera-mirror --namespace "${NAMESPACE}" --install --reuse-values --set importer.config.hedera.mirror.importer.downloader.record.enabled=false --set importer.config.hedera.mirror.importer.downloader.balance.enabled=false
-    ```
-
-    Observe the logs and ensure no record or balance stream files are being processed.
-
-2. Delete importer and postgres stateful sets
-    After verifying no record or balance stream files are being processed, remove the offending importer and postgres stateful sets
-    ```shell script
-    kubectl delete statefulsets.apps --cascade=false "${APP_NAME}-importer" "${APP_NAME}-postgres-postgresql"
-    ```
-
-3. From a v0.27+ repo upgrade application
-    From a newly checked out v0.27 or greater mirror node repo kickoff the upgrade
-    ```shell script
-    git checkout tags/v0.27.0
-    helm upgrade "${APP_NAME}" charts/hedera-mirror --namespace "${NAMESPACE}" -f charts/marketplace/gcp/values.yaml -f custom-values.yaml
-    ```
-
-4. Delete importer and postgres pods
-    ```shell script
-    kubectl delete pod "${APP_NAME}-importer-0" "${APP_NAME}-postgres-postgresql-0"
-    ```
+1. Verify your importer is up to date on file processing by inspecting logs before beginning.
+2. Delete the `${APP_NAME}-importer` and `${APP_NAME}-postgres` Stateful Set workloads.
+3. Install the v0.27 solution
 
 # Scaling
 

--- a/charts/marketplace/gcp/release.sh
+++ b/charts/marketplace/gcp/release.sh
@@ -2,47 +2,47 @@
 set -ex
 
 if [[ "$#" -lt 1 ]]; then
-  echo "You must provide the Mirror Node image tag (e.g. 0.14.0)"
-  exit 1
+    echo "You must provide the Mirror Node image tag (e.g. 0.14.0)"
+    exit 1
 fi
 
 # Same source and target tags
 if [[ "$#" -eq 1 ]]; then
-  source_tag="${1}"
-  target_tag="${source_tag}"
+    source_tag="${1}"
+    target_tag="${source_tag}"
 fi
 
 # Different source and target tags. Useful for testing chart changes with existing tags.
 if [[ "$#" -eq 2 ]]; then
-  source_tag="${1}"
-  target_tag="${2}"
+    source_tag="${1}"
+    target_tag="${2}"
 fi
 
 target_tag="${target_tag#v}" # Strip v prefix if present
 target_tag_minor="${target_tag%\.*}"
 bats_tag="1.2.1"
-postgresql_tag="13.1.0-debian-10-r74"
+postgresql_tag="12.5.0-debian-10-r79"
 registry="gcr.io/mirror-node-public/hedera-mirror-node"
 
 function retag() {
-  local source=${1}
-  local image=${2}
-  local target="${registry}/${image}"
+    local source=${1}
+    local image=${2}
+    local target="${registry}/${image}"
 
-  # Main image
-  if [[ -z "${image}" ]]; then
-    target="${registry}"
-  fi
+    # Main image
+    if [[ -z "${image}" ]]; then
+        target="${registry}"
+    fi
 
-  docker pull "${source}"
-  docker tag "${source}" "${target}:${target_tag}"
-  docker push "${target}:${target_tag}"
+    docker pull "${source}"
+    docker tag "${source}" "${target}:${target_tag}"
+    docker push "${target}:${target_tag}"
 
-  # Don't update minor tag for pre-release tags
-  if [[ ! "${target_tag}" =~ .*-.* ]]; then
-    docker tag "${source}" "${target}:${target_tag_minor}"
-    docker push "${target}:${target_tag_minor}"
-  fi
+    # Don't update minor tag for pre-release tags
+    if [[ ! "${target_tag}" =~ .*-.* ]]; then
+        docker tag "${source}" "${target}:${target_tag_minor}"
+        docker push "${target}:${target_tag_minor}"
+    fi
 }
 
 # Ensure chart app version matches schema.yaml version
@@ -63,4 +63,3 @@ retag "bitnami/postgresql-repmgr:${postgresql_tag}" "postgresql-repmgr"
 mv values.yaml.bak values.yaml
 echo "Successfully pushed all images"
 exit 0
-

--- a/charts/marketplace/gcp/release.sh
+++ b/charts/marketplace/gcp/release.sh
@@ -22,7 +22,6 @@ target_tag="${target_tag#v}" # Strip v prefix if present
 target_tag_minor="${target_tag%\.*}"
 bats_tag="1.2.1"
 postgresql_tag="11.10.0-debian-10-r83"
-redis_tag="6.0.10-debian-10-r22"
 registry="gcr.io/mirror-node-public/hedera-mirror-node"
 
 function retag() {
@@ -56,11 +55,9 @@ docker push "${registry}/deployer:${target_tag}"
 # Retag other images
 retag "bats/bats:${bats_tag}" "test"
 retag "bitnami/postgresql-repmgr:${postgresql_tag}" "postgresql-repmgr"
-retag "bitnami/redis:${redis_tag}" "redis"
 retag "${registry}/deployer:${target_tag}" "deployer"
 retag "gcr.io/mirrornode/hedera-mirror-grpc:${source_tag}" "grpc"
 retag "gcr.io/mirrornode/hedera-mirror-importer:${source_tag}" ""
-retag "gcr.io/mirrornode/hedera-mirror-monitor:${source_tag}" "monitor"
 retag "gcr.io/mirrornode/hedera-mirror-rest:${source_tag}" "rest"
 
 mv values.yaml.bak values.yaml

--- a/charts/marketplace/gcp/release.sh
+++ b/charts/marketplace/gcp/release.sh
@@ -21,7 +21,8 @@ fi
 target_tag="${target_tag#v}" # Strip v prefix if present
 target_tag_minor="${target_tag%\.*}"
 bats_tag="1.2.1"
-postgresql_tag="12.5.0-debian-10-r79"
+postgresql_tag="11.10.0-debian-10-r83"
+redis_tag="6.0.10-debian-10-r22"
 registry="gcr.io/mirror-node-public/hedera-mirror-node"
 
 function retag() {
@@ -53,12 +54,14 @@ docker build -f ./Dockerfile -t "${registry}/deployer:${target_tag}" --build-arg
 docker push "${registry}/deployer:${target_tag}"
 
 # Retag other images
-retag "${registry}/deployer:${target_tag}" "deployer"
-retag "gcr.io/mirrornode/hedera-mirror-importer:${source_tag}" ""
-retag "gcr.io/mirrornode/hedera-mirror-grpc:${source_tag}" "grpc"
-retag "gcr.io/mirrornode/hedera-mirror-rest:${source_tag}" "rest"
 retag "bats/bats:${bats_tag}" "test"
 retag "bitnami/postgresql-repmgr:${postgresql_tag}" "postgresql-repmgr"
+retag "bitnami/redis:${redis_tag}" "redis"
+retag "${registry}/deployer:${target_tag}" "deployer"
+retag "gcr.io/mirrornode/hedera-mirror-grpc:${source_tag}" "grpc"
+retag "gcr.io/mirrornode/hedera-mirror-importer:${source_tag}" ""
+retag "gcr.io/mirrornode/hedera-mirror-monitor:${source_tag}" "monitor"
+retag "gcr.io/mirrornode/hedera-mirror-rest:${source_tag}" "rest"
 
 mv values.yaml.bak values.yaml
 echo "Successfully pushed all images"

--- a/charts/marketplace/gcp/release.sh
+++ b/charts/marketplace/gcp/release.sh
@@ -21,7 +21,7 @@ fi
 target_tag="${target_tag#v}" # Strip v prefix if present
 target_tag_minor="${target_tag%\.*}"
 bats_tag="1.2.1"
-postgresql_tag="11.10.0-debian-10-r83"
+postgresql_tag="12.5.0-debian-10-r88"
 registry="gcr.io/mirror-node-public/hedera-mirror-node"
 
 function retag() {

--- a/charts/marketplace/gcp/schema.yaml
+++ b/charts/marketplace/gcp/schema.yaml
@@ -18,16 +18,19 @@ x-google-marketplace:
   publishedVersionMetadata:
     releaseNote: >-
       v0.27 brings many new features to the mirror node marketplace application since v0.13.
-      The largest of which is the support for the Hedera Token Service (HTS) which allows for the creation and management of custom tokens on the Hedera network.
-      Tokens entity types are now ingested to the DB and can be queried through new REST APIs.
-      Support for the new v5 record file and signature file formats was added to be able to parse additional detailed information made available by the network in HAPI v0.11.0.
-      Additionally topic fragmentation support was added to the ingestion process as well as the exposure through the appropriate REST and gRPC APIs
-      State Proof alpha REST API was added to enable Mirror node users who want to verify submitted transactions for themselves.
+      This upgrade includes breaking changes. Please refer to <a href"https://github.com/hashgraph/hedera-mirror-node/tree/master/charts/marketplace/gcp#v0.13-to-v0.27+">v0.13 to v0.27+ Upgrade</a> for additional upgrade steps.
+
+      The largest feature introduced since v0.13 is that of the Hedera Token Service (HTS) which allows for the creation and management of custom tokens on the Hedera network.
+      Token entity types are now ingested to the DB and can be queried through new REST APIs.
+      Support for the new v5 record file and signature file formats was added to be able to parse additional hash information made available by the network in HAPI v0.11.0.
+      Topic fragmentation support was added to the ingestion process as well as exposed through the appropriate REST and gRPC APIs
+      State Proof alpha REST API was added to enable Mirror node users who want to verify the cryptographic claims of submitted transactions for themselves.
       <a href"https://swagger.io/specification">OpenAPI 3.0</a> specification support was added to the REST API long with a docs endpoint for upto date documentation and REST API curl support.
-      Redis service was added to support at least 10,000 TPS ingestion while still remaining under 10 seconds from submitting the topic message and receiving it back via the mirror node's streaming API.
+      A Redis service was added to support ~10,000 TPS ingestion while still remaining under 10 seconds from submitting the topic message and receiving it back via the mirror node's streaming API.
       DB and process memory optimizations were made to improve the ingestion rate with at least 2x-3x improvements.
       `startDate` and `endDate` properties were added to enable Mirror node users the ability to specify a time range for data processing.
       <a href"https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS default credential provider chain</a> support was added to provide greater flexibility for mirror node operators.
+
       Many more features went into the release, for detailed release notes refer to <a href="https://github.com/hashgraph/hedera-mirror-node/releases">hedera-mirror-node releases</a>.
     # releaseTypes - Feature | BugFix | Security
     releaseTypes:
@@ -51,11 +54,11 @@ x-google-marketplace:
           type: REPO_WITH_REGISTRY
         grpc.image.tag:
           type: TAG
-    rest:
+    monitor:
       properties:
-        rest.image.repository:
+        monitor.image.repository:
           type: REPO_WITH_REGISTRY
-        rest.image.tag:
+        monitor.image.tag:
           type: TAG
     postgresql-repmgr:
       properties:
@@ -64,6 +67,18 @@ x-google-marketplace:
         postgresql.postgresqlImage.repository:
           type: REPO_WITHOUT_REGISTRY
         postgresql.postgresqlImage.tag:
+          type: TAG
+    rest:
+      properties:
+        rest.image.repository:
+          type: REPO_WITH_REGISTRY
+        rest.image.tag:
+          type: TAG
+    redis:
+      properties:
+        redis.image.repository:
+          type: REPO_WITH_REGISTRY
+        redis.image.tag:
           type: TAG
     test:
       properties:

--- a/charts/marketplace/gcp/schema.yaml
+++ b/charts/marketplace/gcp/schema.yaml
@@ -70,6 +70,24 @@ properties:
     type: string
     x-google-marketplace:
       type: NAMESPACE
+  global.redis.password:
+    type: string
+    description: The password used by the redis service to connect to the database
+    title: Redis database password
+    x-google-marketplace:
+      type: GENERATED_PASSWORD
+      generatedPassword:
+        length: 24
+        base64: False
+  global.rest.password:
+    type: string
+    description: The password used by the REST API to connect to the database
+    title: REST API database password
+    x-google-marketplace:
+      type: GENERATED_PASSWORD
+      generatedPassword:
+        length: 24
+        base64: False
   grpc.config.hedera.mirror.grpc.db.password:
     type: string
     description: The password used by the gRPC API to connect to the database
@@ -89,10 +107,10 @@ properties:
   grpc.serviceAccount.name:
     type: string
     title: gRPC API service account
-    description: The Kubernetes service account to assign to the gRPC API
     x-google-marketplace:
       type: SERVICE_ACCOUNT
       serviceAccount:
+        description: The Kubernetes service account to assign to the gRPC API
         roles:
           - type: Role
             rulesType: CUSTOM
@@ -120,14 +138,27 @@ properties:
     type: string
     description: The Google Cloud Storage bucket name to download streamed files. This value takes priority over network hardcoded bucket names regardless of `hedera.mirror.importer.network` value.
     title: Importer GCS bucket name
+  importer.config.hedera.mirror.importer.downloader.cloudProvider:
+    default: GCP
+    type: string
+    description: The cloud provider to download files from. Either S3 or GCP.
+    title: Importer cloud provider
   importer.config.hedera.mirror.importer.downloader.gcpProjectId:
     type: string
-    description: GCP project id to bill for requests to GCS bucket with requester pays enabled
+    description: GCP project id to bill for requests to GCS bucket with requester pays enabled.
     title: Importer GCP billing project ID
   importer.config.hedera.mirror.importer.downloader.secretKey:
     type: string
     description: The Google Cloud secret key used to pay for downloaded streamed files
     title: Importer GCP secret key
+  importer.config.hedera.mirror.importer.endDate:
+    type: string
+    description: The end date (inclusive) of the data to import. Items after this date will be ignored. Format - YYYY-MM-ddTHH:mm:ss.nnnnnnnnnZ
+    title: Importer data end date
+  importer.config.hedera.mirror.importer.initialAddressBook:
+    type: string
+    description: The path to the bootstrap address book used to override the built-in address book
+    title: Importer bootstrap address book
   importer.config.hedera.mirror.importer.network:
     default: MAINNET
     type: string
@@ -139,6 +170,29 @@ properties:
       - PREVIEWNET
       - DEMO
       - OTHER
+  importer.config.hedera.mirror.importer.startDate:
+    type: string
+    description: The start date (inclusive) of the data to import. Items before this date will be ignored. Format - YYYY-MM-ddTHH:mm:ss.nnnnnnnnnZ
+    title: Importer data start date
+  importer.config.hedera.mirror.importer.verifyHashAfter:
+    type: string
+    description: Skip hash verification for stream files linked by hash until after (and not including) this point of time. Format - YYYY-MM-ddTHH:mm:ss.nnnnnnnnnZ
+    title: Importer data verify hash after date
+  importer.config.spring.flyway.baselineVersion:
+    default: '0'
+    type: string
+    description: The version to tag an existing schema with when executing baseline.
+    title: Importer data migration baseline version
+  importer.config.spring.flyway.locations:
+    default: classpath:db/migration/v1
+    type: string
+    description: Comma-separated list of locations to scan recursively for migrations.
+    title: Importer data migration scripts location
+  importer.config.spring.flyway.target:
+    default: '1.999.999'
+    type: string
+    description: Skip hash verification for stream files linked by hash until after (and not including) this point of time. Format - YYYY-MM-ddTHH:mm:ss.nnnnnnnnnZ
+    title: Importer data migration target version
   importer.persistence.size:
     default: 10Gi
     description: The storage size for the importer persistent volume
@@ -147,10 +201,10 @@ properties:
   importer.serviceAccount.name:
     type: string
     title: Importer service account
-    description: The Kubernetes service account to assign to the importer
     x-google-marketplace:
       type: SERVICE_ACCOUNT
       serviceAccount:
+        description: The Kubernetes service account to assign to the importer
         roles:
           - type: Role
             rulesType: CUSTOM
@@ -179,15 +233,6 @@ properties:
     type: string
     description: The password used by the PostgreSQL Replication Manager to connect to the database
     title: PostgreSQL Repmgr password
-    x-google-marketplace:
-      type: GENERATED_PASSWORD
-      generatedPassword:
-        length: 24
-        base64: False
-  global.rest.password:
-    type: string
-    description: The password used by the REST API to connect to the database
-    title: REST API database password
     x-google-marketplace:
       type: GENERATED_PASSWORD
       generatedPassword:

--- a/charts/marketplace/gcp/schema.yaml
+++ b/charts/marketplace/gcp/schema.yaml
@@ -17,14 +17,25 @@ x-google-marketplace:
   publishedVersion: "$TAG"
   publishedVersionMetadata:
     releaseNote: >-
-      Initial release of the Hedera Mirror Node
+      v0.27 brings many new features to the mirror node marketplace application since v0.13.
+      The largest of which is the support for the Hedera Token Service (HTS) which allows for the creation and management of custom tokens on the Hedera network.
+      Tokens entity types are now ingested to the DB and can be queried through new REST APIs.
+      Support for the new v5 record file and signature file formats was added to be able to parse additional detailed information made available by the network in HAPI v0.11.0.
+      Additionally topic fragmentation support was added to the ingestion process as well as the exposure through the appropriate REST and gRPC APIs
+      State Proof alpha REST API was added to enable Mirror node users who want to verify submitted transactions for themselves.
+      <a href"https://swagger.io/specification">OpenAPI 3.0</a> specification support was added to the REST API long with a docs endpoint for upto date documentation and REST API curl support.
+      Redis service was added to support at least 10,000 TPS ingestion while still remaining under 10 seconds from submitting the topic message and receiving it back via the mirror node's streaming API.
+      DB and process memory optimizations were made to improve the ingestion rate with at least 2x-3x improvements.
+      `startDate` and `endDate` properties were added to enable Mirror node users the ability to specify a time range for data processing.
+      <a href"https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS default credential provider chain</a> support was added to provide greater flexibility for mirror node operators.
+      Many more features went into the release, for detailed release notes refer to <a href="https://github.com/hashgraph/hedera-mirror-node/releases">hedera-mirror-node releases</a>.
     # releaseTypes - Feature | BugFix | Security
     releaseTypes:
       - Feature
     # If "recommended" is "true", users using older releases are encouraged
     # to update as soon as possible. This is useful if, for example, this release
     # fixes a critical issue.
-    recommended: false
+    recommended: true
 
   # images for subcharts. Primary image is importer
   images:

--- a/charts/marketplace/gcp/schema.yaml
+++ b/charts/marketplace/gcp/schema.yaml
@@ -18,18 +18,16 @@ x-google-marketplace:
   publishedVersionMetadata:
     releaseNote: >-
       v0.27 brings many new features to the mirror node marketplace application since v0.13.
-      This upgrade includes breaking changes. Please refer to <a href"https://github.com/hashgraph/hedera-mirror-node/tree/master/charts/marketplace/gcp#v0.13-to-v0.27+">v0.13 to v0.27+ Upgrade</a> for additional upgrade steps.
+      This upgrade includes breaking changes. Please refer to <a href"https://github.com/hashgraph/hedera-mirror-node/tree/master/charts/marketplace/gcp#v0.27">v0.27 Upgrade</a> for additional upgrade steps.
 
       The largest feature introduced since v0.13 is that of the Hedera Token Service (HTS) which allows for the creation and management of custom tokens on the Hedera network.
       Token entity types are now ingested to the DB and can be queried through new REST APIs.
-      Support for the new v5 record file and signature file formats was added to be able to parse additional hash information made available by the network in HAPI v0.11.0.
-      Topic fragmentation support was added to the ingestion process as well as exposed through the appropriate REST and gRPC APIs
-      State Proof alpha REST API was added to enable Mirror node users who want to verify the cryptographic claims of submitted transactions for themselves.
-      <a href"https://swagger.io/specification">OpenAPI 3.0</a> specification support was added to the REST API long with a docs endpoint for upto date documentation and REST API curl support.
-      A Redis service was added to support ~10,000 TPS ingestion while still remaining under 10 seconds from submitting the topic message and receiving it back via the mirror node's streaming API.
+      Support for the new v5 <a href="https://docs.hedera.com/guides/docs/record-and-event-stream-file-formats">Record and Event Stream File Formats</a> introduced in HAPI v0.11.0 was added.
+      Topic fragmentation support was added to the ingestion process as well as exposed through the appropriate REST and gRPC APIs.
+      State Proof alpha REST API was added to support Mirror node users who want to verify the cryptographic claims of submitted transactions for themselves.
+      <a href"https://swagger.io/specification">OpenAPI 3.0</a> specification support was added to the REST API along with a docs endpoint for up to date documentation and REST API curl support.
       DB and process memory optimizations were made to improve the ingestion rate with at least 2x-3x improvements.
       `startDate` and `endDate` properties were added to enable Mirror node users the ability to specify a time range for data processing.
-      <a href"https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html">AWS default credential provider chain</a> support was added to provide greater flexibility for mirror node operators.
 
       Many more features went into the release, for detailed release notes refer to <a href="https://github.com/hashgraph/hedera-mirror-node/releases">hedera-mirror-node releases</a>.
     # releaseTypes - Feature | BugFix | Security
@@ -84,15 +82,6 @@ properties:
     type: string
     x-google-marketplace:
       type: NAMESPACE
-  global.redis.password:
-    type: string
-    description: The password used by the redis service to connect to the database
-    title: Redis database password
-    x-google-marketplace:
-      type: GENERATED_PASSWORD
-      generatedPassword:
-        length: 24
-        base64: False
   global.rest.password:
     type: string
     description: The password used by the REST API to connect to the database
@@ -152,11 +141,6 @@ properties:
     type: string
     description: The Google Cloud Storage bucket name to download streamed files. This value takes priority over network hardcoded bucket names regardless of `hedera.mirror.importer.network` value.
     title: Importer GCS bucket name
-  importer.config.hedera.mirror.importer.downloader.cloudProvider:
-    default: GCP
-    type: string
-    description: The cloud provider to download files from. Either S3 or GCP.
-    title: Importer cloud provider
   importer.config.hedera.mirror.importer.downloader.gcpProjectId:
     type: string
     description: GCP project id to bill for requests to GCS bucket with requester pays enabled.
@@ -165,14 +149,6 @@ properties:
     type: string
     description: The Google Cloud secret key used to pay for downloaded streamed files
     title: Importer GCP secret key
-  importer.config.hedera.mirror.importer.endDate:
-    type: string
-    description: The end date (inclusive) of the data to import. Items after this date will be ignored. Format - YYYY-MM-ddTHH:mm:ss.nnnnnnnnnZ
-    title: Importer data end date
-  importer.config.hedera.mirror.importer.initialAddressBook:
-    type: string
-    description: The path to the bootstrap address book used to override the built-in address book
-    title: Importer bootstrap address book
   importer.config.hedera.mirror.importer.network:
     default: MAINNET
     type: string
@@ -188,25 +164,6 @@ properties:
     type: string
     description: The start date (inclusive) of the data to import. Items before this date will be ignored. Format - YYYY-MM-ddTHH:mm:ss.nnnnnnnnnZ
     title: Importer data start date
-  importer.config.hedera.mirror.importer.verifyHashAfter:
-    type: string
-    description: Skip hash verification for stream files linked by hash until after (and not including) this point of time. Format - YYYY-MM-ddTHH:mm:ss.nnnnnnnnnZ
-    title: Importer data verify hash after date
-  importer.config.spring.flyway.baselineVersion:
-    default: '0'
-    type: string
-    description: The version to tag an existing schema with when executing baseline.
-    title: Importer data migration baseline version
-  importer.config.spring.flyway.locations:
-    default: classpath:db/migration/v1
-    type: string
-    description: Comma-separated list of locations to scan recursively for migrations.
-    title: Importer data migration scripts location
-  importer.config.spring.flyway.target:
-    default: '1.999.999'
-    type: string
-    description: Skip hash verification for stream files linked by hash until after (and not including) this point of time. Format - YYYY-MM-ddTHH:mm:ss.nnnnnnnnnZ
-    title: Importer data migration target version
   importer.persistence.size:
     default: 10Gi
     description: The storage size for the importer persistent volume

--- a/charts/marketplace/gcp/schema.yaml
+++ b/charts/marketplace/gcp/schema.yaml
@@ -54,12 +54,6 @@ x-google-marketplace:
           type: REPO_WITH_REGISTRY
         grpc.image.tag:
           type: TAG
-    monitor:
-      properties:
-        monitor.image.repository:
-          type: REPO_WITH_REGISTRY
-        monitor.image.tag:
-          type: TAG
     postgresql-repmgr:
       properties:
         postgresql.postgresqlImage.registry:
@@ -73,12 +67,6 @@ x-google-marketplace:
         rest.image.repository:
           type: REPO_WITH_REGISTRY
         rest.image.tag:
-          type: TAG
-    redis:
-      properties:
-        redis.image.repository:
-          type: REPO_WITH_REGISTRY
-        redis.image.tag:
           type: TAG
     test:
       properties:

--- a/charts/marketplace/gcp/values.yaml
+++ b/charts/marketplace/gcp/values.yaml
@@ -8,7 +8,6 @@ applicationResource:
 global:
   db:
     host: RELEASE-NAME-postgres-postgresql
-    schema: mirrornode
   rest:
     username: mirror_api
     password: mirror_api_pass

--- a/charts/marketplace/gcp/values.yaml
+++ b/charts/marketplace/gcp/values.yaml
@@ -71,6 +71,11 @@ monitor:
 postgresql:
   pgpool:
     replicaCount: 0
+  postgresql:
+    upgradeRepmgrExtension: true #upgrade repmgr version to 5.2 or else container spinup fails
+  postgresqlImage:
+    debug: true
+    tag: 11.10.0-debian-10-r78
 
 redis:
   cluster:

--- a/charts/marketplace/gcp/values.yaml
+++ b/charts/marketplace/gcp/values.yaml
@@ -8,9 +8,6 @@ applicationResource:
 global:
   db:
     host: RELEASE-NAME-postgres-postgresql
-  rest:
-    username: mirror_api
-    password: mirror_api_pass
   useReleaseForNameLabel: true
 
 grpc:
@@ -72,7 +69,7 @@ postgresql:
   postgresql:
     upgradeRepmgrExtension: true #upgrade repmgr version to 5.2 or else container spinup fails
   postgresqlImage:
-    tag: 11.10.0-debian-10-r83
+    tag: 12.5.0-debian-10-r88
 
 redis:
   enabled: false

--- a/charts/marketplace/gcp/values.yaml
+++ b/charts/marketplace/gcp/values.yaml
@@ -3,20 +3,22 @@ applicationResource:
   partnerId: mirror-node-public
   partnerName: mirror-node-public
   solutionId: hedera-mirror-node
-  version: ''
+  version: 0.27.0-rc2
 
 global:
   db:
     host: RELEASE-NAME-postgres-postgresql
+    schema: mirrornode
+  redis:
+    host: RELEASE-NAME-redis
+    password: redis_password
+  rest:
+    username: mirror_api
+    password: mirror_api_pass
   useReleaseForNameLabel: true
 
 grpc:
   config:
-    hedera:
-      mirror:
-        grpc:
-          listener:
-            type: NOTIFY
     management:
       endpoint:
         health:
@@ -56,16 +58,27 @@ importer:
               exclude: redis
   rbac:
     enabled: false
+  redis:
+    sentinel:
+      masterSet: mirror
   replicas: 1
   serviceAccount:
     create: false
+
+monitor:
+  enabled: false
 
 postgresql:
   pgpool:
     replicaCount: 0
 
 redis:
-  enabled: false
+  cluster:
+    slaveCount: 1
+  enabled: true
+  sentinel:
+    enabled: true
+    masterSet: mirror
 
 rest:
   config:

--- a/charts/marketplace/gcp/values.yaml
+++ b/charts/marketplace/gcp/values.yaml
@@ -9,9 +9,6 @@ global:
   db:
     host: RELEASE-NAME-postgres-postgresql
     schema: mirrornode
-  redis:
-    host: RELEASE-NAME-redis
-    password: redis_password
   rest:
     username: mirror_api
     password: mirror_api_pass
@@ -19,6 +16,11 @@ global:
 
 grpc:
   config:
+    hedera:
+      mirror:
+        grpc:
+          listener:
+            type: NOTIFY
     management:
       endpoint:
         health:
@@ -58,19 +60,12 @@ importer:
               exclude: redis
   rbac:
     enabled: false
-  redis:
-    sentinel:
-      masterSet: mirror
   replicas: 1
   serviceAccount:
     create: false
 
 monitor:
   enabled: false
-  rbac:
-    enabled: false
-  serviceAccount:
-    create: false
 
 postgresql:
   pgpool:
@@ -81,14 +76,7 @@ postgresql:
     tag: 11.10.0-debian-10-r83
 
 redis:
-  cluster:
-    slaveCount: 1
-  enabled: true
-  image:
-    tag: 6.0.10-debian-10-r22
-  sentinel:
-    enabled: true
-    masterSet: mirror
+  enabled: false
 
 rest:
   config:

--- a/charts/marketplace/gcp/values.yaml
+++ b/charts/marketplace/gcp/values.yaml
@@ -3,7 +3,7 @@ applicationResource:
   partnerId: mirror-node-public
   partnerName: mirror-node-public
   solutionId: hedera-mirror-node
-  version: 0.27.0-rc2
+  version: ''
 
 global:
   db:
@@ -67,6 +67,10 @@ importer:
 
 monitor:
   enabled: false
+  rbac:
+    enabled: false
+  serviceAccount:
+    create: false
 
 postgresql:
   pgpool:
@@ -74,13 +78,14 @@ postgresql:
   postgresql:
     upgradeRepmgrExtension: true #upgrade repmgr version to 5.2 or else container spinup fails
   postgresqlImage:
-    debug: true
-    tag: 11.10.0-debian-10-r78
+    tag: 11.10.0-debian-10-r83
 
 redis:
   cluster:
     slaveCount: 1
   enabled: true
+  image:
+    tag: 6.0.10-debian-10-r22
   sentinel:
     enabled: true
     masterSet: mirror


### PR DESCRIPTION
**Detailed description**:
Market place solution is still on v0.13. Current deployments will be broken by V5 stream file updates and thus require an upgrade.

- Update docker file to rename folder with charts to allow `mpdev` to pick up chart
- Update README with instructions on handling breaking changes due to Importer and Postgres StatefulSet changes
- Update schema with release notes and links. Also add missing default properties for importer. 
- Update schema with new location of descriptions
- Update `values.yml` with `monitor` and `redis` disabled defaults

**Which issue(s) this PR fixes**:
Fixes #1174 

**Special notes for your reviewer**:
- Verify and install tests were completed using `v0.27.0-rc2` in `minikube` and in a real GCP cluster
- Upgrade from `v0.11` to `v0.27-0-rc2` along with manual steps to handle StatefulSets was successfully attempted multiple times in a real `k8s` cluster. `importer`, `grpc` and `rest` features were verified
- pg 11 to pg 12 upgrade was considered but the manual steps were concluded to be potentially too much overhead for this ticket


**Checklist**
- [x] Documentation added
- [ ] Tests updated

