### PR TITLE
Increase downloader threads and Bump version for v0.27.0

### DIFF
--- a/charts/hedera-mirror-common/Chart.yaml
+++ b/charts/hedera-mirror-common/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.27.0-rc2
+appVersion: 0.27.0
 description: Hedera Mirror Node common components installed globally for use across namespaces
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
@@ -11,4 +11,4 @@ maintainers:
 name: hedera-mirror-common
 sources:
   - https://github.com/hashgraph/hedera-mirror-node
-version: 0.14.0-rc2
+version: 0.14.0

--- a/charts/hedera-mirror-grpc/Chart.yaml
+++ b/charts/hedera-mirror-grpc/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.27.0-rc2
+appVersion: 0.27.0
 description: GRPC API for the Hedera Mirror Node
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
@@ -11,4 +11,4 @@ maintainers:
 name: hedera-mirror-grpc
 sources:
   - https://github.com/hashgraph/hedera-mirror-node
-version: 0.14.0-rc2
+version: 0.14.0

--- a/charts/hedera-mirror-importer/Chart.yaml
+++ b/charts/hedera-mirror-importer/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.27.0-rc2
+appVersion: 0.27.0
 description: Hedera Mirror Importer downloads and validates file streams from the cloud and imports them into the database
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
@@ -11,4 +11,4 @@ maintainers:
 name: hedera-mirror-importer
 sources:
   - https://github.com/hashgraph/hedera-mirror-node
-version: 0.14.0-rc2
+version: 0.14.0

--- a/charts/hedera-mirror-monitor/Chart.yaml
+++ b/charts/hedera-mirror-monitor/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.27.0-rc2
+appVersion: 0.27.0
 description: End to End Monitor for the Hedera Mirror Node
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
@@ -11,4 +11,4 @@ maintainers:
 name: hedera-mirror-monitor
 sources:
   - https://github.com/hashgraph/hedera-mirror-node
-version: 0.14.0-rc2
+version: 0.14.0

--- a/charts/hedera-mirror-rest/Chart.yaml
+++ b/charts/hedera-mirror-rest/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.27.0-rc2
+appVersion: 0.27.0
 description: REST API for the Hedera Mirror Node
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
@@ -11,4 +11,4 @@ maintainers:
 name: hedera-mirror-rest
 sources:
   - https://github.com/hashgraph/hedera-mirror-node
-version: 0.14.0-rc2
+version: 0.14.0

--- a/charts/hedera-mirror/Chart.yaml
+++ b/charts/hedera-mirror/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.27.0-rc2
+appVersion: 0.27.0
 description: Hedera Mirror Node mirrors data from Hedera nodes and serves it via an API
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
@@ -11,4 +11,4 @@ maintainers:
 name: hedera-mirror
 sources:
   - https://github.com/hashgraph/hedera-mirror-node
-version: 0.14.0-rc2
+version: 0.14.0

--- a/charts/hedera-mirror/requirements.lock
+++ b/charts/hedera-mirror/requirements.lock
@@ -1,13 +1,13 @@
 dependencies:
 - name: hedera-mirror-grpc
   repository: file://../hedera-mirror-grpc
-  version: 0.14.0-rc2
+  version: 0.14.0
 - name: hedera-mirror-importer
   repository: file://../hedera-mirror-importer
-  version: 0.14.0-rc2
+  version: 0.14.0
 - name: hedera-mirror-monitor
   repository: file://../hedera-mirror-monitor
-  version: 0.14.0-rc2
+  version: 0.14.0
 - name: postgresql-ha
   repository: https://charts.bitnami.com/bitnami
   version: 6.3.7
@@ -16,9 +16,9 @@ dependencies:
   version: 12.2.4
 - name: hedera-mirror-rest
   repository: file://../hedera-mirror-rest
-  version: 0.14.0-rc2
+  version: 0.14.0
 - name: timescaledb-multinode
   repository: https://raw.githubusercontent.com/timescale/timescaledb-kubernetes/master/charts/repo/
   version: 0.8.0
-digest: sha256:89b1c17cb7617cd30dbbb6568ed38a498d03542a268e8f04f04e1e3dd0eb9bd2
-generated: "2021-02-03T16:43:49.234707-06:00"
+digest: sha256:05a3cc8f709494cf5784753123bf1f850ea27a9cddc5875de220e67694293de1
+generated: "2021-02-10T13:24:32.378517-06:00"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - 5432:5432
 
   grpc:
-    image: gcr.io/mirrornode/hedera-mirror-grpc:0.27.0-rc2
+    image: gcr.io/mirrornode/hedera-mirror-grpc:0.27.0
     restart: unless-stopped
     environment:
       HEDERA_MIRROR_GRPC_DB_HOST: db
@@ -29,7 +29,7 @@ services:
       - 5600:5600
 
   importer:
-    image: gcr.io/mirrornode/hedera-mirror-importer:0.27.0-rc2
+    image: gcr.io/mirrornode/hedera-mirror-importer:0.27.0
     restart: unless-stopped
     environment:
       HEDERA_MIRROR_IMPORTER_DATAPATH: /var/lib/hedera-mirror-importer
@@ -43,7 +43,7 @@ services:
   monitor:
     deploy:
       replicas: 0
-    image: gcr.io/mirrornode/hedera-mirror-monitor:0.27.0-rc2
+    image: gcr.io/mirrornode/hedera-mirror-monitor:0.27.0
     restart: unless-stopped
     environment:
       SPRING_CONFIG_ADDITIONAL_LOCATION: file:/usr/etc/hedera-mirror-monitor/
@@ -60,7 +60,7 @@ services:
       - 6379:6379
 
   rest:
-    image: gcr.io/mirrornode/hedera-mirror-rest:0.27.0-rc2
+    image: gcr.io/mirrornode/hedera-mirror-rest:0.27.0
     environment:
       HEDERA_MIRROR_REST_DB_HOST: db
     restart: unless-stopped
@@ -69,7 +69,7 @@ services:
       - 5551:5551
 
   rosetta:
-    image: gcr.io/mirrornode/hedera-mirror-rosetta:0.27.0-rc2
+    image: gcr.io/mirrornode/hedera-mirror-rosetta:0.27.0
     environment:
       HEDERA_MIRROR_ROSETTA_DB_HOST: db
     restart: unless-stopped

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -40,7 +40,7 @@ value, it is recommended to only populate overridden properties in the custom `a
 | `hedera.mirror.importer.downloader.balance.frequency`                | 30s                     | The fixed period between invocations. Can accept duration units like `10s`, `2m` etc.          |
 | `hedera.mirror.importer.downloader.balance.keepSignatures`           | false                   | Whether to keep balance signature files after successful verification. If false, files are deleted. |
 | `hedera.mirror.importer.downloader.balance.prefix`                   | accountBalances/balance | The prefix to search cloud storage for balance files                                           |
-| `hedera.mirror.importer.downloader.balance.threads`                  | 13                      | The number of threads to search for new files to download                                      |
+| `hedera.mirror.importer.downloader.balance.threads`                  | 15                      | The number of threads to search for new files to download                                      |
 | `hedera.mirror.importer.downloader.bucketName`                       |                         | The cloud storage bucket name to download streamed files. This value takes priority over network hardcoded bucket names regardless of `hedera.mirror.importer.network` value.|
 | `hedera.mirror.importer.downloader.cloudProvider`                    | S3                      | The cloud provider to download files from. Either `S3` or `GCP`                                |
 | `hedera.mirror.importer.downloader.endpointOverride`                 |                         | Can be specified to download streams from a source other than S3 and GCP. Should be S3 compatible |
@@ -49,7 +49,7 @@ value, it is recommended to only populate overridden properties in the custom `a
 | `hedera.mirror.importer.downloader.event.frequency`                  | 5s                      | The fixed period between invocations. Can accept duration units like `10s`, `2m` etc.          |
 | `hedera.mirror.importer.downloader.event.keepSignatures`             | false                   | Whether to keep event signature files after successful verification. If false, files are deleted. |
 | `hedera.mirror.importer.downloader.event.prefix`                     | eventsStreams/events\_  | The prefix to search cloud storage for event files                                             |
-| `hedera.mirror.importer.downloader.event.threads`                    | 13                      | The number of threads to search for new files to download                                      |
+| `hedera.mirror.importer.downloader.event.threads`                    | 15                      | The number of threads to search for new files to download                                      |
 | `hedera.mirror.importer.downloader.gcpProjectId`                     |                         | GCP project id to bill for requests to GCS bucket which has Requester Pays enabled.            |
 | `hedera.mirror.importer.downloader.maxConcurrency`                   | 1000                    | The maximum number of allowed open HTTP connections. Used by AWS SDK directly.                 |
 | `hedera.mirror.importer.downloader.record.batchSize`                 | 40                      | The number of signature files to download per node before downloading the signed files         |
@@ -57,7 +57,7 @@ value, it is recommended to only populate overridden properties in the custom `a
 | `hedera.mirror.importer.downloader.record.frequency`                 | 500ms                   | The fixed period between invocations. Can accept duration units like `10s`, `2m` etc.          |
 | `hedera.mirror.importer.downloader.record.keepSignatures`            | false                   | Whether to keep record signature files after successful verification. If false, files are deleted. |
 | `hedera.mirror.importer.downloader.record.prefix`                    | recordstreams/record    | The prefix to search cloud storage for record files                                            |
-| `hedera.mirror.importer.downloader.record.threads`                   | 13                      | The number of threads to search for new files to download                                      |
+| `hedera.mirror.importer.downloader.record.threads`                   | 15                      | The number of threads to search for new files to download                                      |
 | `hedera.mirror.importer.downloader.region`                           | us-east-1               | The region associated with the bucket                                                          |
 | `hedera.mirror.importer.downloader.secretKey`                        | ""                      | The cloud storage secret key                                                                   |
 | `hedera.mirror.importer.endDate`                                     | 2262-04-11T23:47:16.854775807Z | The end date (inclusive) of the data to import. Items after this date will be ignored. Format: YYYY-MM-ddTHH:mm:ss.nnnnnnnnnZ |
@@ -315,7 +315,8 @@ latter configuration overwriting (technically recursively merged into) the curre
 
 1. `./config/application.yml`
 2. `./application.yml`
-3. `${HEDERA_MIRROR_ROSETTA_API_CONFIG}` environment variable to custom values file (e.g. `HEDERA_MIRROR_ROSETTA_API_CONFIG=/Users/Downloads/hedera-mirror-rosetta/application.yml`)
+3. `${HEDERA_MIRROR_ROSETTA_API_CONFIG}` environment variable to custom values file (
+   e.g. `HEDERA_MIRROR_ROSETTA_API_CONFIG=/Users/Downloads/hedera-mirror-rosetta/application.yml`)
 4. Environment variables that start with `HEDERA_MIRROR_ROSETTA_` (e.g. `HEDERA_MIRROR_ROSETTA_API_VERSION=1.4.2`)
 
 The following table lists the available properties along with their default values.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/balance/BalanceDownloaderProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/balance/BalanceDownloaderProperties.java
@@ -58,7 +58,7 @@ public class BalanceDownloaderProperties implements DownloaderProperties {
     private String prefix = "accountBalances/balance";
 
     @Min(1)
-    private int threads = 13;
+    private int threads = 15;
 
     @NotNull
     private Duration startDateAdjustment = Duration.ofSeconds(1L);

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/event/EventDownloaderProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/event/EventDownloaderProperties.java
@@ -58,7 +58,7 @@ public class EventDownloaderProperties implements DownloaderProperties {
     private String prefix = "eventsStreams/events_";
 
     @Min(1)
-    private int threads = 13;
+    private int threads = 15;
 
     @NotNull
     private Duration startDateAdjustment = Duration.ofSeconds(30L);

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/record/RecordDownloaderProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/record/RecordDownloaderProperties.java
@@ -58,7 +58,7 @@ public class RecordDownloaderProperties implements DownloaderProperties {
     private String prefix = "recordstreams/record";
 
     @Min(1)
-    private int threads = 13;
+    private int threads = 15;
 
     @NotNull
     private Duration startDateAdjustment = Duration.ofSeconds(30L);

--- a/hedera-mirror-rest/api/v1/openapi.yml
+++ b/hedera-mirror-rest/api/v1/openapi.yml
@@ -486,7 +486,7 @@ tags:
     description: The tokens object represents the information associated with a token entity and returns a list of token information.
 info:
   title: Hedera Mirror Node REST API
-  version: 0.27.0-rc2
+  version: 0.27.0
   license:
     name: Apache-2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0.html'

--- a/hedera-mirror-rest/monitoring/monitor_apis/package-lock.json
+++ b/hedera-mirror-rest/monitoring/monitor_apis/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-mirror-monitor",
-  "version": "0.27.0-rc2",
+  "version": "0.27.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hedera-mirror-rest/monitoring/monitor_apis/package.json
+++ b/hedera-mirror-rest/monitoring/monitor_apis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-mirror-monitor",
-  "version": "0.27.0-rc2",
+  "version": "0.27.0",
   "description": "Hedera Mirror Node Monitor",
   "main": "server.js",
   "private": true,

--- a/hedera-mirror-rest/package-lock.json
+++ b/hedera-mirror-rest/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-mirror-rest",
-  "version": "0.27.0-rc2",
+  "version": "0.27.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hedera-mirror-rest/package.json
+++ b/hedera-mirror-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-mirror-rest",
-  "version": "0.27.0-rc2",
+  "version": "0.27.0",
   "description": "Hedera Mirror Node REST API",
   "main": "server.js",
   "private": true,

--- a/hedera-mirror-rosetta/config/application-deploy.yml
+++ b/hedera-mirror-rosetta/config/application-deploy.yml
@@ -15,4 +15,4 @@ hedera:
       port: ${apiPort}
       realm: 0
       shard: 0
-      version: 0.27.0-rc2
+      version: 0.27.0

--- a/hedera-mirror-rosetta/config/application.yml
+++ b/hedera-mirror-rosetta/config/application.yml
@@ -15,4 +15,4 @@ hedera:
       port: 5700
       realm: 0
       shard: 0
-      version: 0.27.0-rc2
+      version: 0.27.0

--- a/hedera-mirror-test/src/test/resources/k8s/hcs-perf-message-submit.yml
+++ b/hedera-mirror-test/src/test/resources/k8s/hcs-perf-message-submit.yml
@@ -41,7 +41,7 @@ spec:
                     app.kubernetes.io/name: test
       restartPolicy: Never
       containers:
-        - image: gcr.io/mirrornode/hedera-mirror-test:0.27.0-rc2
+        - image: gcr.io/mirrornode/hedera-mirror-test:0.27.0
           name: test
           env:
             - name: testProfile

--- a/hedera-mirror-test/src/test/resources/k8s/hcs-perf-publish-test.yml
+++ b/hedera-mirror-test/src/test/resources/k8s/hcs-perf-publish-test.yml
@@ -43,7 +43,7 @@ spec:
                     app.kubernetes.io/name: test
       restartPolicy: Never
       containers:
-        - image: gcr.io/mirrornode/hedera-mirror-test:0.27.0-rc2
+        - image: gcr.io/mirrornode/hedera-mirror-test:0.27.0
           name: test
           env:
             - name: testProfile

--- a/hedera-mirror-test/src/test/resources/k8s/hcs-perf-subscribe-test.yml
+++ b/hedera-mirror-test/src/test/resources/k8s/hcs-perf-subscribe-test.yml
@@ -46,7 +46,7 @@ spec:
                     app.kubernetes.io/name: test
       restartPolicy: Never
       containers:
-        - image: gcr.io/mirrornode/hedera-mirror-test:0.27.0-rc2
+        - image: gcr.io/mirrornode/hedera-mirror-test:0.27.0
           name: test
           env:
             - name: testProfile

--- a/hedera-mirror-test/src/test/resources/k8s/hts-perf-batch-publish-batch-validate.yml
+++ b/hedera-mirror-test/src/test/resources/k8s/hts-perf-batch-publish-batch-validate.yml
@@ -47,7 +47,7 @@ spec:
                     app.kubernetes.io/name: test
       restartPolicy: Never
       containers:
-        - image: gcr.io/mirrornode/hedera-mirror-test:0.27.0-rc2
+        - image: gcr.io/mirrornode/hedera-mirror-test:0.27.0
           name: test
           env:
             - name: testProfile

--- a/hedera-mirror-test/src/test/resources/k8s/hts-perf-publish-and-retrieve.yml
+++ b/hedera-mirror-test/src/test/resources/k8s/hts-perf-publish-and-retrieve.yml
@@ -46,7 +46,7 @@ spec:
                     app.kubernetes.io/name: test
       restartPolicy: Never
       containers:
-        - image: gcr.io/mirrornode/hedera-mirror-test:0.27.0-rc2
+        - image: gcr.io/mirrornode/hedera-mirror-test:0.27.0
           name: test
           env:
             - name: testProfile

--- a/pom.xml
+++ b/pom.xml
@@ -73,8 +73,8 @@
         <micrometer-jvm-extras.version>0.2.1</micrometer-jvm-extras.version>
         <msgpack.version>0.8.22</msgpack.version>
         <protobuf.version>3.14.0</protobuf.version>
-        <release.version>0.27.0-rc2</release.version> <!-- Used to replace release versions in all files -->
-        <release.chartVersion>0.14.0-rc2</release.chartVersion>
+        <release.version>0.27.0</release.version> <!-- Used to replace release versions in all files -->
+        <release.chartVersion>0.14.0</release.chartVersion>
         <replacer.version>1.5.3</replacer.version>
         <!--suppress UnresolvedMavenProperty -->
         <sonar.coverage.jacoco.xmlReportPaths>


### PR DESCRIPTION
**Detailed description**:
- Increase downloader threads from 13 to 15 to match the current number of main nodes
- Bump versions for v0.27.0

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [x] Documentation added
- [ ] Tests updated

