### PR TITLE
Fix ConfigurableTransactionGeneratorTest.receiptPercent

### DIFF
--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/generator/ConfigurableTransactionGeneratorTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/generator/ConfigurableTransactionGeneratorTest.java
@@ -117,7 +117,7 @@ class ConfigurableTransactionGeneratorTest {
 
     @Test
     void receiptPercent() {
-        properties.setReceipt(0.001);
+        properties.setReceipt(0.1);
         Multiset<Boolean> receipts = HashMultiset.create();
 
         for (int i = 0; i < SAMPLE_SIZE; ++i) {
@@ -127,7 +127,7 @@ class ConfigurableTransactionGeneratorTest {
         assertThat((double) receipts.count(true) / SAMPLE_SIZE)
                 .isNotNegative()
                 .isNotZero()
-                .isCloseTo(properties.getReceipt(), within(0.001));
+                .isCloseTo(properties.getReceipt(), within(properties.getReceipt() * 0.2));
     }
 
     @Test
@@ -162,7 +162,7 @@ class ConfigurableTransactionGeneratorTest {
         assertThat((double) records.count(true) / SAMPLE_SIZE)
                 .isNotNegative()
                 .isNotZero()
-                .isCloseTo(properties.getRecord(), within(SAMPLE_SIZE * 0.05));
+                .isCloseTo(properties.getRecord(), within(properties.getRecord() * 0.2));
     }
 
     @Test


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
-->

**Detailed description**:

- Increase receipt percentage in the test case to be large enough w.r.t. the sample size
- Adjust the actual percentage to be within 20% difference

**Which issue(s) this PR fixes**:
Fixes #1566 

**Special notes for your reviewer**:
The other option of increasing sample size to be large enough for the target percentage `0.001` would take too long to run.

**Checklist**
- [ ] Documentation added
- [x] Tests updated

