### PR TITLE
Bump hedera-protobuf.version to 0.12.0-rc.1

### DIFF
--- a/hedera-mirror-importer/pom.xml
+++ b/hedera-mirror-importer/pom.xml
@@ -45,8 +45,8 @@
             <artifactId>caffeine</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.hashgraph</groupId>
-            <artifactId>hedera-protobufs-java</artifactId>
+            <groupId>com.hedera.hashgraph</groupId>
+            <artifactId>hedera-protobuf-java-api</artifactId>
             <version>${hedera-protobuf.version}</version>
             <exclusions>
                 <exclusion>

--- a/hedera-mirror-protobuf/pom.xml
+++ b/hedera-mirror-protobuf/pom.xml
@@ -36,8 +36,8 @@
             <artifactId>grpc-protobuf</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.hashgraph</groupId>
-            <artifactId>hedera-protobufs-java</artifactId>
+            <groupId>com.hedera.hashgraph</groupId>
+            <artifactId>hedera-protobuf-java-api</artifactId>
             <version>${hedera-protobuf.version}</version>
             <exclusions>
                 <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <embedded.testcontainers.version>2.0.3</embedded.testcontainers.version>
         <grpc-spring-boot.version>2.10.1.RELEASE</grpc-spring-boot.version>
         <grpc.version>1.35.0</grpc.version>
-        <hedera-protobuf.version>master</hedera-protobuf.version>
+        <hedera-protobuf.version>0.12.0-rc.1</hedera-protobuf.version>
         <hedera-sdk.version>1.3.3</hedera-sdk.version>
         <jacoco.version>0.8.6</jacoco.version>
         <java.version>11</java.version>
@@ -84,14 +84,7 @@
         <sonar.organization>hashgraph</sonar.organization>
         <sonar.projectKey>${project.artifactId}</sonar.projectKey>
     </properties>
-
-    <repositories>
-        <repository>
-            <id>jitpack.io</id>
-            <url>https://jitpack.io</url>
-        </repository>
-    </repositories>
-
+    
     <scm>
         <connection>https://github.com/hashgraph/hedera-mirror-node.git</connection>
         <tag>master</tag>


### PR DESCRIPTION
**Detailed description**:

New 0.12.0 protobufs are in Maven as an rc.1 build.  Bump the hedera-protobuf.version to use that and remove the JitPack repo.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

