### PR TITLE
Update Acceptance Tests to Use SDK v2

### DIFF
--- a/hedera-mirror-test/pom.xml
+++ b/hedera-mirror-test/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>com.hedera.hashgraph</groupId>
             <artifactId>sdk</artifactId>
-            <version>${hedera-sdk.version}</version>
+            <version>2.0.4</version>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TopicClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TopicClient.java
@@ -24,26 +24,28 @@ import com.google.common.primitives.Longs;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeoutException;
 import lombok.Value;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.ArrayUtils;
 
-import com.hedera.hashgraph.sdk.HederaStatusException;
+import com.hedera.hashgraph.sdk.Hbar;
+import com.hedera.hashgraph.sdk.PrecheckStatusException;
+import com.hedera.hashgraph.sdk.PrivateKey;
+import com.hedera.hashgraph.sdk.PublicKey;
+import com.hedera.hashgraph.sdk.ReceiptStatusException;
+import com.hedera.hashgraph.sdk.TopicCreateTransaction;
+import com.hedera.hashgraph.sdk.TopicDeleteTransaction;
+import com.hedera.hashgraph.sdk.TopicId;
+import com.hedera.hashgraph.sdk.TopicMessageSubmitTransaction;
+import com.hedera.hashgraph.sdk.TopicUpdateTransaction;
 import com.hedera.hashgraph.sdk.TransactionId;
 import com.hedera.hashgraph.sdk.TransactionReceipt;
 import com.hedera.hashgraph.sdk.TransactionRecord;
-import com.hedera.hashgraph.sdk.consensus.ConsensusMessageSubmitTransaction;
-import com.hedera.hashgraph.sdk.consensus.ConsensusTopicCreateTransaction;
-import com.hedera.hashgraph.sdk.consensus.ConsensusTopicDeleteTransaction;
-import com.hedera.hashgraph.sdk.consensus.ConsensusTopicId;
-import com.hedera.hashgraph.sdk.consensus.ConsensusTopicUpdateTransaction;
-import com.hedera.hashgraph.sdk.crypto.ed25519.Ed25519PrivateKey;
-import com.hedera.hashgraph.sdk.crypto.ed25519.Ed25519PublicKey;
 
 @Log4j2
 @Value
@@ -56,13 +58,14 @@ public class TopicClient extends AbstractNetworkClient {
         log.debug("Creating Topic Client");
     }
 
-    public TransactionReceipt createTopic(Ed25519PublicKey adminKey, Ed25519PublicKey submitKey) throws HederaStatusException {
+    public TransactionReceipt createTopic(PublicKey adminKey, PublicKey submitKey) throws ReceiptStatusException,
+            PrecheckStatusException, TimeoutException {
 
         Instant refInstant = Instant.now();
-        ConsensusTopicCreateTransaction consensusTopicCreateTransaction = new ConsensusTopicCreateTransaction()
+        TopicCreateTransaction consensusTopicCreateTransaction = new TopicCreateTransaction()
                 .setAdminKey(adminKey)
                 .setAutoRenewAccountId(sdkClient.getOperatorId())
-                .setMaxTransactionFee(1_000_000_000)
+                .setMaxTransactionFee(Hbar.fromTinybars(1_000_000_000))
                 .setTopicMemo("HCS Topic_" + refInstant);
 //                .setAutoRenewPeriod(Duration.ofDays(7000000)) // INSUFFICIENT_TX_FEE, also unsupported
 //                .setAutoRenewAccountId()
@@ -74,23 +77,23 @@ public class TopicClient extends AbstractNetworkClient {
         TransactionReceipt transactionReceipt = executeTransactionAndRetrieveReceipt(consensusTopicCreateTransaction,
                 null).getReceipt();
 
-        ConsensusTopicId topicId = transactionReceipt.getConsensusTopicId();
+        TopicId topicId = transactionReceipt.topicId;
         log.debug("Created new topic {}", topicId);
 
         return transactionReceipt;
     }
 
-    public TransactionReceipt updateTopic(ConsensusTopicId topicId) throws HederaStatusException {
+    public TransactionReceipt updateTopic(TopicId topicId) throws ReceiptStatusException, PrecheckStatusException,
+            TimeoutException {
         String newMemo = "HCS UpdatedTopic__" + Instant.now().getNano();
-        ConsensusTopicUpdateTransaction consensusTopicUpdateTransaction = new ConsensusTopicUpdateTransaction()
+        TopicUpdateTransaction consensusTopicUpdateTransaction = new TopicUpdateTransaction()
                 .setTopicId(topicId)
                 .setTopicMemo(newMemo)
-                .setExpirationTime(Instant.now().plus(120, ChronoUnit.DAYS))
                 .setAutoRenewPeriod(Duration.ofSeconds(8000000))
                 .clearAdminKey()
                 .clearSubmitKey()
                 .clearTopicMemo()
-                .clearAutoRenewAccountId();
+                .clearAutoRenewAccountId(sdkClient.getOperatorId());
 
         TransactionReceipt transactionReceipt = executeTransactionAndRetrieveReceipt(consensusTopicUpdateTransaction,
                 null).getReceipt();
@@ -99,8 +102,9 @@ public class TopicClient extends AbstractNetworkClient {
         return transactionReceipt;
     }
 
-    public TransactionReceipt deleteTopic(ConsensusTopicId topicId) throws HederaStatusException {
-        ConsensusTopicDeleteTransaction consensusTopicDeleteTransaction = new ConsensusTopicDeleteTransaction()
+    public TransactionReceipt deleteTopic(TopicId topicId) throws ReceiptStatusException, PrecheckStatusException,
+            TimeoutException {
+        TopicDeleteTransaction consensusTopicDeleteTransaction = new TopicDeleteTransaction()
                 .setTopicId(topicId);
 
         TransactionReceipt transactionReceipt = executeTransactionAndRetrieveReceipt(consensusTopicDeleteTransaction,
@@ -111,9 +115,10 @@ public class TopicClient extends AbstractNetworkClient {
         return transactionReceipt;
     }
 
-    public List<TransactionReceipt> publishMessagesToTopic(ConsensusTopicId topicId, String baseMessage,
-                                                           Ed25519PrivateKey submitKey, int numMessages,
-                                                           boolean verify) throws HederaStatusException {
+    public List<TransactionReceipt> publishMessagesToTopic(TopicId topicId, String baseMessage,
+                                                           PrivateKey submitKey, int numMessages,
+                                                           boolean verify) throws PrecheckStatusException,
+            ReceiptStatusException, TimeoutException {
         log.debug("Publishing {} message(s) to topicId : {}.", numMessages, topicId);
         List<TransactionReceipt> transactionReceiptList = new ArrayList<>();
         for (int i = 0; i < numMessages; i++) {
@@ -122,7 +127,7 @@ public class TopicClient extends AbstractNetworkClient {
             byte[] message = ArrayUtils.addAll(publishTimestampByteArray, suffixByteArray);
 
             if (verify) {
-                transactionReceiptList.addAll(publishMessageToTopicAndVerify(topicId, message, submitKey));
+                transactionReceiptList.add(publishMessageToTopicAndVerify(topicId, message, submitKey));
             } else {
                 publishMessageToTopic(topicId, message, submitKey);
             }
@@ -131,15 +136,14 @@ public class TopicClient extends AbstractNetworkClient {
         return transactionReceiptList;
     }
 
-    public List<TransactionId> publishMessageToTopic(ConsensusTopicId topicId, byte[] message,
-                                                     Ed25519PrivateKey submitKey) throws HederaStatusException {
-        ConsensusMessageSubmitTransaction consensusMessageSubmitTransaction = new ConsensusMessageSubmitTransaction()
+    public TransactionId publishMessageToTopic(TopicId topicId, byte[] message, PrivateKey submitKey) throws TimeoutException, PrecheckStatusException, ReceiptStatusException {
+        TopicMessageSubmitTransaction consensusMessageSubmitTransaction = new TopicMessageSubmitTransaction()
                 .setTopicId(topicId)
                 .setMessage(message);
 
-        List<TransactionId> transactionIdList = executeTransactionList(consensusMessageSubmitTransaction, submitKey);
+        TransactionId transactionId = executeTransaction(consensusMessageSubmitTransaction, submitKey);
 
-        TransactionRecord transactionRecord = transactionIdList.get(0).getRecord(client);
+        TransactionRecord transactionRecord = transactionId.getRecord(client);
         // get only the 1st sequence number
         if (recordPublishInstants.size() == 0) {
             recordPublishInstants.put(0L, transactionRecord.consensusTimestamp);
@@ -150,32 +154,26 @@ public class TopicClient extends AbstractNetworkClient {
                     new String(message, StandardCharsets.UTF_8), topicId, transactionRecord.consensusTimestamp);
         }
 
-        return transactionIdList;
+        return transactionId;
     }
 
-    public List<TransactionReceipt> publishMessageToTopicAndVerify(ConsensusTopicId topicId, byte[] message,
-                                                                   Ed25519PrivateKey submitKey) throws HederaStatusException {
-        List<TransactionId> transactionIdList = publishMessageToTopic(topicId, message, submitKey);
-        List<TransactionReceipt> transactionReceipts = new ArrayList<>();
-        transactionIdList.forEach((transactionId -> {
-            TransactionReceipt transactionReceipt = null;
-            try {
-                transactionReceipt = transactionId.getReceipt(client);
+    public TransactionReceipt publishMessageToTopicAndVerify(TopicId topicId, byte[] message, PrivateKey submitKey) throws ReceiptStatusException, PrecheckStatusException, TimeoutException {
+        TransactionId transactionId = publishMessageToTopic(topicId, message, submitKey);
+        TransactionReceipt transactionReceipt = null;
+        try {
+            transactionReceipt = transactionId.getReceipt(client);
 
-                // note time stamp
-                recordPublishInstants.put(transactionReceipt.getConsensusTopicSequenceNumber(), transactionId
-                        .getRecord(client).consensusTimestamp);
-            } catch (HederaStatusException e) {
-                e.printStackTrace();
-            }
+            // note time stamp
+            recordPublishInstants.put(transactionReceipt.topicSequenceNumber, transactionId
+                    .getRecord(client).consensusTimestamp);
+        } catch (TimeoutException | PrecheckStatusException | ReceiptStatusException e) {
+            e.printStackTrace();
+        }
 
-            log.trace("Verified message published : '{}' to topicId : {} with sequence number : {}", message, topicId,
-                    transactionReceipt.getConsensusTopicSequenceNumber());
+        log.trace("Verified message published : '{}' to topicId : {} with sequence number : {}", message, topicId,
+                transactionReceipt.topicSequenceNumber);
 
-            transactionReceipts.add(transactionReceipt);
-        }));
-
-        return transactionReceipts;
+        return transactionReceipt;
     }
 
     public Instant getInstantOfPublishedMessage(long sequenceNumber) {

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/ClientConfiguration.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/ClientConfiguration.java
@@ -64,31 +64,31 @@ public class ClientConfiguration {
 
     @Bean
     @Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE)
-    public SDKClient sdkClient() {
+    public SDKClient sdkClient() throws InterruptedException {
         return new SDKClient(acceptanceTestProperties);
     }
 
     @Bean
     @Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE)
-    public MirrorNodeClient mirrorNodeClient() {
-        return new MirrorNodeClient(acceptanceTestProperties);
+    public MirrorNodeClient mirrorNodeClient() throws InterruptedException {
+        return new MirrorNodeClient(sdkClient());
     }
 
     @Bean
     @Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE)
-    public TopicClient topicClient() {
+    public TopicClient topicClient() throws InterruptedException {
         return new TopicClient(sdkClient());
     }
 
     @Bean
     @Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE)
-    public AccountClient accountClient() {
+    public AccountClient accountClient() throws InterruptedException {
         return new AccountClient(sdkClient());
     }
 
     @Bean
     @Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE)
-    public TokenClient tokenClient() {
+    public TokenClient tokenClient() throws InterruptedException {
         return new TokenClient(sdkClient());
     }
 

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/ExpandedAccountId.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/ExpandedAccountId.java
@@ -23,15 +23,15 @@ package com.hedera.mirror.test.e2e.acceptance.props;
 import lombok.Data;
 import lombok.ToString;
 
-import com.hedera.hashgraph.sdk.account.AccountId;
-import com.hedera.hashgraph.sdk.crypto.ed25519.Ed25519PrivateKey;
-import com.hedera.hashgraph.sdk.crypto.ed25519.Ed25519PublicKey;
+import com.hedera.hashgraph.sdk.AccountId;
+import com.hedera.hashgraph.sdk.PrivateKey;
+import com.hedera.hashgraph.sdk.PublicKey;
 
 @Data
 public class ExpandedAccountId {
     private final AccountId accountId;
     @ToString.Exclude
-    private final Ed25519PrivateKey privateKey;
+    private final PrivateKey privateKey;
     @ToString.Exclude
-    private final Ed25519PublicKey publicKey;
+    private final PublicKey publicKey;
 }

--- a/hedera-mirror-test/src/test/resources/features/account/account.feature
+++ b/hedera-mirror-test/src/test/resources/features/account/account.feature
@@ -1,7 +1,7 @@
 @Accounts @FullSuite
 Feature: Account Coverage Feature
 
-    @BalanceCheck @Sanity @Acceptance
+    @BalanceCheck @Sanity @Acceptance @TokenSanity
     Scenario Outline: Validate account balance check scenario
         When I request balance info for this account
         Then the crypto balance should be greater than or equal to <threshold>
@@ -12,7 +12,7 @@ Feature: Account Coverage Feature
     @CreateCryptoAccount
     Scenario Outline: Create crypto account
         When I create a new account with balance <amount> tℏ
-        Then the crypto balance should be greater than or equal to <amount>
+        Then the new balance should reflect cryptotransfer of <amount>
         Examples:
-            | amount     |
-            | 1000000000 |
+            | amount    |
+            | 100000000 |

--- a/hedera-mirror-test/src/test/resources/features/account/account.feature
+++ b/hedera-mirror-test/src/test/resources/features/account/account.feature
@@ -1,7 +1,7 @@
 @Accounts @FullSuite
 Feature: Account Coverage Feature
 
-    @BalanceCheck @Sanity @Acceptance @TokenSanity
+    @BalanceCheck @Sanity @Acceptance
     Scenario Outline: Validate account balance check scenario
         When I request balance info for this account
         Then the crypto balance should be greater than or equal to <threshold>

--- a/hedera-mirror-test/src/test/resources/features/setup/setup.feature
+++ b/hedera-mirror-test/src/test/resources/features/setup/setup.feature
@@ -12,8 +12,8 @@ Feature: Setup entities for various features
 
     @FundAccount
     Scenario Outline: Fund account
-        When I send <amount> tℏ to account <account>
+        When I send <amount> ℏ to account <account>
         Then the new balance should reflect cryptotransfer of <amount>
         Examples:
-            | amount     | account |
-            | 1000000000 | 1562    |
+            | amount | account |
+            | 1000   | 1043    |


### PR DESCRIPTION
**Detailed description**:
Acceptance tests currently use SDK v1.
This will eventually lose support over the next year.

- Updated test module `pom.xml` to use latest v2 release
- Update `TokenClient`, `AccountClient`, `MirrorClient` and `TopicClient` to use new Transaction type classes 
- Update `TokenFeature`, `AccountFeature` and `TopicFeature` tests cases to use new objects 
- Update `setup.feature` and `AccountFeature` to support transfer of wholes HBARs

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:
The priority on this was hastened to make it easier to support testing of scheduled transactions, since SDK has support in develop right now for v2 but not yet in master for v1

**Checklist**
- [ ] Documentation added
- [x] Tests updated

