### PR TITLE
Fix failure when building hedera-mirror-rest docker image

### DIFF
--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/AbstractDeleteOrUndeleteTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/AbstractDeleteOrUndeleteTransactionHandlerTest.java
@@ -1,23 +1,23 @@
 package com.hedera.mirror.importer.parser.record.transactionhandler;
 
-/*
- *
+/*-
+ * ‌
  * Hedera Mirror Node
- *  ​
+ * ​
  * Copyright (C) 2019 - 2021 Hedera Hashgraph, LLC
- *  ​
+ * ​
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
+ * ‍
  */
 
 import java.util.List;

--- a/hedera-mirror-rest/__tests__/schedules.test.js
+++ b/hedera-mirror-rest/__tests__/schedules.test.js
@@ -1,21 +1,21 @@
 /*-
- *
+ * ‌
  * Hedera Mirror Node
- *  ​
+ * ​
  * Copyright (C) 2019 - 2021 Hedera Hashgraph, LLC
- *  ​
- * Licensed under the Apache License, Version 2.0 (the 'License');
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an 'AS IS' BASIS,
+ * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
+ * ‍
  */
 
 'use strict';

--- a/hedera-mirror-rest/check-state-proof/constants.js
+++ b/hedera-mirror-rest/check-state-proof/constants.js
@@ -1,9 +1,9 @@
 /*-
- *
+ * ‌
  * Hedera Mirror Node
- *  ​
+ * ​
  * Copyright (C) 2019 - 2021 Hedera Hashgraph, LLC
- *  ​
+ * ​
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -15,7 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
+ * ‍
  */
 
 'use strict';

--- a/hedera-mirror-rest/check-state-proof/tests/testUtils.js
+++ b/hedera-mirror-rest/check-state-proof/tests/testUtils.js
@@ -1,9 +1,9 @@
 /*-
- *
+ * ‌
  * Hedera Mirror Node
- *  ​
+ * ​
  * Copyright (C) 2019 - 2021 Hedera Hashgraph, LLC
- *  ​
+ * ​
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -15,7 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
+ * ‍
  */
 
 'use strict';

--- a/hedera-mirror-rest/npm_scripts/postinstall.js
+++ b/hedera-mirror-rest/npm_scripts/postinstall.js
@@ -1,0 +1,36 @@
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+'use strict';
+
+const {execSync} = require('child_process');
+const path = require('path');
+
+if (
+  process.env.NODE_ENV === 'production' ||
+  process.env.npm_config_only === 'prod' ||
+  process.env.npm_config_only === 'production'
+) {
+  process.exit(0);
+}
+
+// run "husky install" only when dev dependencies are installed
+const huskyPath = ['hedera-mirror-rest', '.husky'].join(path.sep);
+console.log(execSync(`cd .. && husky install ${huskyPath}`, {encoding: 'utf8'}));

--- a/hedera-mirror-rest/package.json
+++ b/hedera-mirror-rest/package.json
@@ -12,7 +12,7 @@
     "integrationtest": "jest --testPathPattern='__tests__/integration.test.js' --collectCoverage=false",
     "lint": "eslint \"**/*.js\"",
     "perftest": "__performancetests__/perfTest.js",
-    "postinstall": "cd .. && husky install hedera-mirror-rest/.husky",
+    "postinstall": "[ \"${npm_config_only}\" = prod -o \"${npm_config_only}\" = production ] || (cd .. && husky install hedera-mirror-rest/.husky)",
     "test": "jest --testPathPattern='__tests__/*'"
   },
   "author": "Hedera Mirror Node Team",

--- a/hedera-mirror-rest/package.json
+++ b/hedera-mirror-rest/package.json
@@ -12,7 +12,7 @@
     "integrationtest": "jest --testPathPattern='__tests__/integration.test.js' --collectCoverage=false",
     "lint": "eslint \"**/*.js\"",
     "perftest": "__performancetests__/perfTest.js",
-    "postinstall": "[ \"${npm_config_only}\" = prod -o \"${npm_config_only}\" = production ] || (cd .. && husky install hedera-mirror-rest/.husky)",
+    "postinstall": "node ./npm_scripts/postinstall.js",
     "test": "jest --testPathPattern='__tests__/*'"
   },
   "author": "Hedera Mirror Node Team",

--- a/hedera-mirror-rest/schedules.js
+++ b/hedera-mirror-rest/schedules.js
@@ -1,9 +1,9 @@
-/*
- *
+/*-
+ * ‌
  * Hedera Mirror Node
- *  ​
+ * ​
  * Copyright (C) 2019 - 2021 Hedera Hashgraph, LLC
- *  ​
+ * ​
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -15,7 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
+ * ‍
  */
 
 'use strict';


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
-->

**Detailed description**:
In our github action `build` job (https://github.com/hashgraph/hedera-mirror-node/actions/runs/579279458), `npm -ci --only=production` is used. The command skips dev dependencies, so the `postinstall` script fails because `husky` does not exist, which then fails the whole job. To fix it, in `postinstall`, `huksy install` will only run when --only=(prod|production) is not specified.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

