### PR TITLE
Fix V2 test failures related with timescaledb compression

### DIFF
--- a/hedera-mirror-grpc/src/test/resources/config/application.yml
+++ b/hedera-mirror-grpc/src/test/resources/config/application.yml
@@ -39,7 +39,7 @@ spring:
       api-user: mirror_api
       chunkIdInterval: 10000
       chunkTimeInterval: 604800000000000
-      compressionAge: 40000000000000000000 # use a large number to avoid compression during test
+      compressionAge: 9223372036854775807 # use long max to avoid compression during test
       db-name: ${hedera.mirror.grpc.db.name}
       db-user: ${hedera.mirror.grpc.db.username}
       topicRunningHashV2AddedTimestamp: 0

--- a/hedera-mirror-grpc/src/test/resources/config/application.yml
+++ b/hedera-mirror-grpc/src/test/resources/config/application.yml
@@ -39,7 +39,7 @@ spring:
       api-user: mirror_api
       chunkIdInterval: 10000
       chunkTimeInterval: 604800000000000
-      compressionAge: 604800000000000
+      compressionAge: 40000000000000000000 # use a large number to avoid compression during test
       db-name: ${hedera.mirror.grpc.db.name}
       db-user: ${hedera.mirror.grpc.db.username}
       topicRunningHashV2AddedTimestamp: 0

--- a/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.3__time_scale_compression.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.3__time_scale_compression.sql
@@ -4,7 +4,7 @@
 
 -- hyper tables with integer based time_column_name require a function that returns the now() value (current time) in
 -- the units of the time column. This is needed for policies. Return the latest record file's consensus end timestamp
--- to avoid inert/update on compressed chunks in catch-up mode
+-- to avoid insert/update on compressed chunks in catch-up mode
 create or replace function latest_consensus_timestamp() returns bigint
     language sql
     stable as
@@ -97,8 +97,8 @@ select add_compression_policy('file_data', bigint '${compressionAge}');
 select add_compression_policy('live_hash', bigint '${compressionAge}');
 select add_compression_policy('non_fee_transfer', bigint '${compressionAge}');
 select add_compression_policy('record_file', bigint '${compressionAge}');
-select add_compression_policy('token_balance', bigint '${compressionAge}');
 select add_compression_policy('schedule_signature', bigint '${compressionAge}');
+select add_compression_policy('token_balance', bigint '${compressionAge}');
 select add_compression_policy('token_transfer', bigint '${compressionAge}');
 select add_compression_policy('topic_message', bigint '${compressionAge}');
 select add_compression_policy('transaction', bigint '${compressionAge}');

--- a/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.3__time_scale_compression.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.3__time_scale_compression.sql
@@ -48,6 +48,8 @@ alter table account_balance_file
 alter table account_balance_sets
     set (timescaledb.compress);
 
+-- address_book skipped as update (end_consensus_timestamp) on compressed chunk is not allowed
+
 alter table address_book_entry
     set (timescaledb.compress, timescaledb.compress_segmentby = 'consensus_timestamp, memo');
 
@@ -72,14 +74,22 @@ alter table non_fee_transfer
 alter table record_file
     set (timescaledb.compress, timescaledb.compress_segmentby = 'node_account_id');
 
+-- schedule skipped as update (executed_timestamp) on compressed chunk is not allowed
+
 alter table schedule_signature
     set (timescaledb.compress, timescaledb.compress_segmentby = 'schedule_id');
+
+-- t_entities skipped as update on compressed chunk is not allowed
 
 -- t_entity_types skipped as not a hyper table
 
 -- t_transaction_results skipped as not a hyper table
 
 -- t_transaction_types skipped as not a hyper table
+
+-- token skipped as update on compressed chunk is not allowed
+
+-- token_account skipped as update on compressed chunk is not allowed
 
 alter table token_balance
     set (timescaledb.compress, timescaledb.compress_segmentby = 'account_id, token_id');

--- a/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.3__time_scale_compression.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.3__time_scale_compression.sql
@@ -2,42 +2,33 @@
 -- Add compression policies to larger tables
 -------------------
 
-/*
- completely disable compression until timescaledb release 2.1 which should support adding/renaming columns of compressed
- hypertables as well as updating compressed chunks
- */
-
--- hyper tables with integer based time_column_name require a function that returns the now() value (current time) in the units of the time column
--- This is needed for policies
-create or replace function unix_now() returns bigint
+-- hyper tables with integer based time_column_name require a function that returns the now() value (current time) in
+-- the units of the time column. This is needed for policies. Return the latest record file's consensus end timestamp
+-- to avoid inert/update on compressed chunks in catch-up mode
+create or replace function latest_consensus_timestamp() returns bigint
     language sql
     stable as
 $$
-select extract(epoch from now())::bigint * 1000000000
+select coalesce(consensus_end, 0) from record_file order by consensus_end desc limit 1;
 $$;
 
 -- set integer now functions for tables
-select set_integer_now_func('account_balance', 'unix_now');
-select set_integer_now_func('account_balance_file', 'unix_now');
-select set_integer_now_func('account_balance_sets', 'unix_now');
-select set_integer_now_func('address_book', 'unix_now');
-select set_integer_now_func('address_book_entry', 'unix_now');
-select set_integer_now_func('contract_result', 'unix_now');
-select set_integer_now_func('crypto_transfer', 'unix_now');
-select set_integer_now_func('event_file', 'unix_now');
-select set_integer_now_func('file_data', 'unix_now');
-select set_integer_now_func('live_hash', 'unix_now');
-select set_integer_now_func('non_fee_transfer', 'unix_now');
-select set_integer_now_func('record_file', 'unix_now');
-select set_integer_now_func('schedule', 'unix_now');
-select set_integer_now_func('schedule_signature', 'unix_now');
-select set_integer_now_func('t_entities', 'unix_now');
-select set_integer_now_func('token', 'unix_now');
-select set_integer_now_func('token_account', 'unix_now');
-select set_integer_now_func('token_balance', 'unix_now');
-select set_integer_now_func('token_transfer', 'unix_now');
-select set_integer_now_func('topic_message', 'unix_now');
-select set_integer_now_func('transaction', 'unix_now');
+select set_integer_now_func('account_balance', 'latest_consensus_timestamp');
+select set_integer_now_func('account_balance_file', 'latest_consensus_timestamp');
+select set_integer_now_func('account_balance_sets', 'latest_consensus_timestamp');
+select set_integer_now_func('address_book_entry', 'latest_consensus_timestamp');
+select set_integer_now_func('contract_result', 'latest_consensus_timestamp');
+select set_integer_now_func('crypto_transfer', 'latest_consensus_timestamp');
+select set_integer_now_func('event_file', 'latest_consensus_timestamp');
+select set_integer_now_func('file_data', 'latest_consensus_timestamp');
+select set_integer_now_func('live_hash', 'latest_consensus_timestamp');
+select set_integer_now_func('non_fee_transfer', 'latest_consensus_timestamp');
+select set_integer_now_func('record_file', 'latest_consensus_timestamp');
+select set_integer_now_func('schedule_signature', 'latest_consensus_timestamp');
+select set_integer_now_func('token_balance', 'latest_consensus_timestamp');
+select set_integer_now_func('token_transfer', 'latest_consensus_timestamp');
+select set_integer_now_func('topic_message', 'latest_consensus_timestamp');
+select set_integer_now_func('transaction', 'latest_consensus_timestamp');
 
 -- turn compression on
 alter table account_balance
@@ -48,9 +39,6 @@ alter table account_balance_file
 
 alter table account_balance_sets
     set (timescaledb.compress);
-
-alter table address_book
-    set (timescaledb.compress, timescaledb.compress_segmentby = 'start_consensus_timestamp, file_id');
 
 alter table address_book_entry
     set (timescaledb.compress, timescaledb.compress_segmentby = 'consensus_timestamp, memo');
@@ -76,26 +64,14 @@ alter table non_fee_transfer
 alter table record_file
     set (timescaledb.compress, timescaledb.compress_segmentby = 'node_account_id');
 
-alter table schedule
-    set (timescaledb.compress, timescaledb.compress_segmentby = 'schedule_id');
-
 alter table schedule_signature
     set (timescaledb.compress, timescaledb.compress_segmentby = 'schedule_id');
-
-alter table t_entities
-    set (timescaledb.compress, timescaledb.compress_segmentby = 'fk_entity_type_id');
 
 -- t_entity_types skipped as not a hyper table
 
 -- t_transaction_results skipped as not a hyper table
 
 -- t_transaction_types skipped as not a hyper table
-
-alter table token
-    set (timescaledb.compress, timescaledb.compress_segmentby = 'token_id');
-
-alter table token_account
-    set (timescaledb.compress, timescaledb.compress_segmentby = 'token_id');
 
 alter table token_balance
     set (timescaledb.compress, timescaledb.compress_segmentby = 'account_id, token_id');
@@ -109,12 +85,10 @@ alter table topic_message
 alter table transaction
     set (timescaledb.compress, timescaledb.compress_segmentby = 'payer_account_id, type');
 
-
 -- add compression policy
 select add_compression_policy('account_balance', bigint '${compressionAge}');
 select add_compression_policy('account_balance_file', bigint '${compressionAge}');
 select add_compression_policy('account_balance_sets', bigint '${compressionAge}');
-select add_compression_policy('address_book', bigint '${compressionAge}');
 select add_compression_policy('address_book_entry', bigint '${compressionAge}');
 select add_compression_policy('contract_result', bigint '${compressionAge}');
 select add_compression_policy('crypto_transfer', bigint '${compressionAge}');
@@ -123,12 +97,8 @@ select add_compression_policy('file_data', bigint '${compressionAge}');
 select add_compression_policy('live_hash', bigint '${compressionAge}');
 select add_compression_policy('non_fee_transfer', bigint '${compressionAge}');
 select add_compression_policy('record_file', bigint '${compressionAge}');
-select add_compression_policy('schedule', bigint '${compressionAge}');
-select add_compression_policy('schedule_signature', bigint '${compressionAge}');
-select add_compression_policy('t_entities', bigint '${compressionAge}');
-select add_compression_policy('token', bigint '${compressionAge}');
-select add_compression_policy('token_account', bigint '${compressionAge}');
 select add_compression_policy('token_balance', bigint '${compressionAge}');
+select add_compression_policy('schedule_signature', bigint '${compressionAge}');
 select add_compression_policy('token_transfer', bigint '${compressionAge}');
 select add_compression_policy('topic_message', bigint '${compressionAge}');
 select add_compression_policy('transaction', bigint '${compressionAge}');

--- a/hedera-mirror-importer/src/main/resources/db/migration/v2/_V2.0.3__time_scale_compression.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v2/_V2.0.3__time_scale_compression.sql
@@ -2,6 +2,11 @@
 -- Add compression policies to larger tables
 -------------------
 
+/*
+ completely disable compression until timescaledb release 2.1 which should support adding/renaming columns of compressed
+ hypertables as well as updating compressed chunks
+ */
+
 -- hyper tables with integer based time_column_name require a function that returns the now() value (current time) in the units of the time column
 -- This is needed for policies
 create or replace function unix_now() returns bigint
@@ -21,10 +26,11 @@ select set_integer_now_func('contract_result', 'unix_now');
 select set_integer_now_func('crypto_transfer', 'unix_now');
 select set_integer_now_func('event_file', 'unix_now');
 select set_integer_now_func('file_data', 'unix_now');
+select set_integer_now_func('live_hash', 'unix_now');
 select set_integer_now_func('non_fee_transfer', 'unix_now');
+select set_integer_now_func('record_file', 'unix_now');
 select set_integer_now_func('schedule', 'unix_now');
 select set_integer_now_func('schedule_signature', 'unix_now');
-select set_integer_now_func('record_file', 'unix_now');
 select set_integer_now_func('t_entities', 'unix_now');
 select set_integer_now_func('token', 'unix_now');
 select set_integer_now_func('token_account', 'unix_now');

--- a/hedera-mirror-importer/src/test/resources/config/application.yml
+++ b/hedera-mirror-importer/src/test/resources/config/application.yml
@@ -25,6 +25,8 @@ hedera:
 spring:
   flyway:
     password: ${hedera.mirror.importer.db.password}
+    placeholders:
+      compressionAge: 40000000000000000000 # use a large number to avoid compression during test
     user: ${hedera.mirror.importer.db.username}
   redis:
     host: ${embedded.redis.host}

--- a/hedera-mirror-importer/src/test/resources/config/application.yml
+++ b/hedera-mirror-importer/src/test/resources/config/application.yml
@@ -26,7 +26,7 @@ spring:
   flyway:
     password: ${hedera.mirror.importer.db.password}
     placeholders:
-      compressionAge: 40000000000000000000 # use a large number to avoid compression during test
+      compressionAge: 9223372036854775807 # use long max to avoid compression during test
     user: ${hedera.mirror.importer.db.username}
   redis:
     host: ${embedded.redis.host}

--- a/hedera-mirror-rest/__tests__/integrationDbOps.js
+++ b/hedera-mirror-rest/__tests__/integrationDbOps.js
@@ -129,7 +129,7 @@ const flywayMigrate = () => {
     "placeholders.api-user": "${dbConfig.username}",
     "placeholders.chunkIdInterval": 10000,
     "placeholders.chunkTimeInterval": 604800000000000,
-    "placeholders.compressionAge": 40000000000000000000,
+    "placeholders.compressionAge": 9223372036854775807,
     "placeholders.db-name": "${dbConfig.name}",
     "placeholders.db-user": "${dbAdminUser}",
     "placeholders.topicRunningHashV2AddedTimestamp": 0,

--- a/hedera-mirror-rest/__tests__/integrationDbOps.js
+++ b/hedera-mirror-rest/__tests__/integrationDbOps.js
@@ -129,7 +129,7 @@ const flywayMigrate = () => {
     "placeholders.api-user": "${dbConfig.username}",
     "placeholders.chunkIdInterval": 10000,
     "placeholders.chunkTimeInterval": 604800000000000,
-    "placeholders.compressionAge": 9223372036854775807,
+    "placeholders.compressionAge": 9007199254740991,
     "placeholders.db-name": "${dbConfig.name}",
     "placeholders.db-user": "${dbAdminUser}",
     "placeholders.topicRunningHashV2AddedTimestamp": 0,

--- a/hedera-mirror-rest/__tests__/integrationDbOps.js
+++ b/hedera-mirror-rest/__tests__/integrationDbOps.js
@@ -129,7 +129,7 @@ const flywayMigrate = () => {
     "placeholders.api-user": "${dbConfig.username}",
     "placeholders.chunkIdInterval": 10000,
     "placeholders.chunkTimeInterval": 604800000000000,
-    "placeholders.compressionAge": 604800000000000,
+    "placeholders.compressionAge": 40000000000000000000,
     "placeholders.db-name": "${dbConfig.name}",
     "placeholders.db-user": "${dbAdminUser}",
     "placeholders.topicRunningHashV2AddedTimestamp": 0,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
-->

**Detailed description**:
- Don't enable compression on `address_book`, `schedule`, `t_entities`, `token`, and `token_account`
- Use latest record file's consensus_end as `now` for compression
- Set `compressionAge` to long max during tests to avoid compression

**Which issue(s) this PR fixes**:
Fixes #1584 

**Special notes for your reviewer**:
timescaledb 2.0 does not support insert/update/delete on compressed chunks. Per our hypertable compression configuration, we use time_now in precision of nanos as the current time, any data inserted during tests is far older than 7 days (the compression policy) and will be compressed when the timescaledb compression job runs.

The compression jobs by default are scheduled daily. In local environment, they tend to all fail at timescaledb startup due to out of background workers so the error rarely happens. In CI environment, the compression job has a higher possibility to succeed at startup and if there is still data to insert into the chunk which is already compressed, we will see the error.

We should also upgrade to timescaledb 2.1 when its docker image becomes available as it adds support to alter hypertable with compression enabled.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

