### PR TITLE
Integrate gosec into rosetta

### DIFF
--- a/.github/workflows/rosetta-api.yml
+++ b/.github/workflows/rosetta-api.yml
@@ -16,11 +16,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Cache Maven packages
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           key: ${{ runner.os }}-m2-${{ secrets.CACHE_VERSION }}-${{ hashFiles('hedera-mirror-rosetta/pom.xml') }}
-          path: ~/.m2
-          restore-keys: ${{ runner.os }}-m2
+          path: ~/.m2/repository
+          restore-keys: ${{ runner.os }}-m2-
       - name: Cache Go modules
         uses: actions/cache@v2
         with:

--- a/.github/workflows/rosetta-api.yml
+++ b/.github/workflows/rosetta-api.yml
@@ -106,7 +106,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-gosec-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-gosec-
       - name: Install Gosec

--- a/.github/workflows/rosetta-api.yml
+++ b/.github/workflows/rosetta-api.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Cache Go modules
         uses: actions/cache@v2
         with:
-          path: ~/go/pkg/mod
+          path: ~/.mvnGoLang/.go_path/pkg/mod
           key: ${{ runner.os }}-go-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-

--- a/.github/workflows/rosetta-api.yml
+++ b/.github/workflows/rosetta-api.yml
@@ -13,18 +13,26 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v2
+      - name: Cache Maven packages
+        uses: actions/cache@v1
+        with:
+          key: ${{ runner.os }}-m2-${{ secrets.CACHE_VERSION }}-${{ hashFiles('hedera-mirror-rosetta/pom.xml') }}
+          path: ~/.m2
+          restore-keys: ${{ runner.os }}-m2
       - name: Cache Go modules
         uses: actions/cache@v2
         with:
-          path: ~/.mvnGoLang/.go_path/pkg/mod
+          path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
       - name: Build hedera-mirror-rosetta
         run: ./mvnw clean package -pl hedera-mirror-rosetta
+      - name: Upload Coverage report to CodeCov
+        run: bash <(curl -s https://codecov.io/bash)
+        working-directory: ${{env.working-directory}}
       - name: Get current version
         id: get_version
         run: |
@@ -52,27 +60,6 @@ jobs:
           name: hedera-mirror-rosetta
           path: hedera-mirror-rosetta-${{ steps.get_version.outputs.VERSION }}.tgz
           if-no-files-found: error
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
-        name: Setup GO Env
-        with:
-          go-version: '1.14'
-      - name: Cache Go modules
-        uses: actions/cache@v2
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-test-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-test-
-      - name: Run Unit Tests with Coverage
-        run: go test ./... -coverpkg=./... -race -coverprofile=coverage.txt -covermode=atomic
-        working-directory: ${{env.working-directory}}
-      - name: Upload Coverage report to CodeCov
-        run: bash <(curl -s https://codecov.io/bash)
-        working-directory: ${{env.working-directory}}
   cli-validation:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/rosetta-api.yml
+++ b/.github/workflows/rosetta-api.yml
@@ -94,11 +94,11 @@ jobs:
         working-directory: ${{env.working-directory}}/scripts
   go-security-check:
     runs-on: ubuntu-latest
-      env:
-        GO111MODULE: on
-      steps:
-        - uses: actions/checkout@v2
-        - name: Run Gosec Security Scanner
-          uses: securego/gosec@master
-          with:
-            args: ./...
+    env:
+      GO111MODULE: on
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run Gosec Security Scanner
+        uses: securego/gosec@master
+        with:
+          args: ./...

--- a/.github/workflows/rosetta-api.yml
+++ b/.github/workflows/rosetta-api.yml
@@ -102,3 +102,4 @@ jobs:
         uses: securego/gosec@master
         with:
           args: ./...
+        working-directory: ${{ env.working-directory }}

--- a/.github/workflows/rosetta-api.yml
+++ b/.github/workflows/rosetta-api.yml
@@ -98,8 +98,12 @@ jobs:
       GO111MODULE: on
     steps:
       - uses: actions/checkout@v2
-      - name: Run Gosec Security Scanner
-        uses: securego/gosec@master
+      - uses: actions/setup-go@v2
+        name: Setup GO Env
         with:
-          args: ./...
+          go-version: '1.14'
+      - name: Install Gosec
+        run: go get github.com/securego/gosec/v2/cmd/gosec
+      - name: Run Gosec Security Scanner
+        run: gosec ./...
         working-directory: ${{ env.working-directory }}

--- a/.github/workflows/rosetta-api.yml
+++ b/.github/workflows/rosetta-api.yml
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/setup-go@v2
         name: Setup GO Env
         with:
-          go-version: '1.13'
+          go-version: '1.14'
       - name: Cache Go modules
         uses: actions/cache@v2
         with:
@@ -92,3 +92,13 @@ jobs:
       - name: Run CLI Validation
         run: bash ./validation/run-validation.sh
         working-directory: ${{env.working-directory}}/scripts
+  go-security-check:
+    runs-on: ubuntu-latest
+      env:
+        GO111MODULE: on
+      steps:
+        - uses: actions/checkout@v2
+        - name: Run Gosec Security Scanner
+          uses: securego/gosec@master
+          with:
+            args: ./...

--- a/.github/workflows/rosetta-api.yml
+++ b/.github/workflows/rosetta-api.yml
@@ -102,6 +102,13 @@ jobs:
         name: Setup GO Env
         with:
           go-version: '1.14'
+      - name: Cache Go modules
+        uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-gosec-
       - name: Install Gosec
         run: go get github.com/securego/gosec/v2/cmd/gosec
       - name: Run Gosec Security Scanner

--- a/.github/workflows/rosetta-api.yml
+++ b/.github/workflows/rosetta-api.yml
@@ -16,10 +16,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
-        name: Setup GO Env
-        with:
-          go-version: '1.14'
       - name: Cache Go modules
         uses: actions/cache@v2
         with:

--- a/hedera-mirror-rosetta/cmd/config.go
+++ b/hedera-mirror-rosetta/cmd/config.go
@@ -54,7 +54,7 @@ func GetConfig(config *types.Config, path string) {
 	}
 
 	filename, _ := filepath.Abs(path)
-	yamlFile, err := ioutil.ReadFile(filename)
+	yamlFile, err := ioutil.ReadFile(filename) // #nosec
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/hedera-mirror-rosetta/pom.xml
+++ b/hedera-mirror-rosetta/pom.xml
@@ -20,10 +20,10 @@
     </properties>
 
     <build>
-        <sourceDirectory>${project.basedir}${file.separator}cmd</sourceDirectory>
-        <directory>${basedir}${file.separator}bin</directory>
         <defaultGoal>clean package</defaultGoal>
+        <directory>${basedir}${file.separator}bin</directory>
         <finalName>${project.artifactId}</finalName>
+        <sourceDirectory>${project.basedir}${file.separator}cmd</sourceDirectory>
         <plugins>
             <plugin>
                 <groupId>io.fabric8</groupId>
@@ -39,12 +39,14 @@
                         <id>default-test</id>
                         <configuration>
                             <buildFlags>
+                                <flag>-coverpkg=./...</flag>
+                                <flag>-coverprofile=coverage.txt</flag>
+                                <flag>-covermode=atomic</flag>
                                 <flag>-race</flag>
                                 <flag>-v</flag>
                             </buildFlags>
-                            <packages>
-                                <package>${project.basedir}${file.separator}...</package>
-                            </packages>
+                            <sources>${project.basedir}${file.separator}</sources>
+                            <useEnvVars>true</useEnvVars>
                         </configuration>
                     </execution>
                     <execution>
@@ -55,7 +57,7 @@
                                 <flag>-i</flag>
                                 <flag>-race</flag>
                             </buildFlags>
-                            <sources>${project.basedir}${file.separator}cmd</sources>
+                            <useEnvVars>true</useEnvVars>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
-->

**Detailed description**:

- Add go security check job using `gosec` to rosetta-api github action workflow
- Mark `ReadFile` in `config.go` as `#nosec` to suppress warning
- Fix rosetta-api `build` job's go module cache
- Add maven cache to `build` job
- Enable coverage analysis in `pom.xml` and add upload coverage step to `build` job
- Remove `test` job

**Which issue(s) this PR fixes**:
Fixes #1588 

**Special notes for your reviewer**:
Can't use gosec's official github action support as it follows common go project layout requirement that the project to be scanned should have a single `go.mod` file in its root directory.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

