### PR TITLE
Add support to transactions REST API for finding transactions with only token transfers

### DIFF
--- a/hedera-mirror-rest/__tests__/specs/transactions-28-account-id-only-token-transfers.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-28-account-id-only-token-transfers.spec.json
@@ -1,0 +1,98 @@
+{
+  "description": "Transaction api calls for transactions via account id query filter",
+  "setup": {
+    "accounts": [
+      {
+        "entity_num": 3
+      },
+      {
+        "entity_num": 8
+      },
+      {
+        "entity_num": 9
+      },
+      {
+        "entity_num": 10
+      },
+      {
+        "entity_num": 98
+      }
+    ],
+    "balances": [],
+    "transactions": [
+      {
+        "name": "CRYPTOTRANSFER",
+        "type": "14",
+        "charged_tx_fee": 7,
+        "valid_start_timestamp": "1234567890000000000",
+        "consensus_timestamp": "1234567890000000001",
+        "payerAccountId": "0.0.8",
+        "nodeAccountId": "0.0.3",
+        "treasuryAccountId": "0.0.98",
+        "transfers": [],
+        "token_transfer_list": [
+          {
+            "token_id": "0.0.90000",
+            "account": "0.0.8",
+            "amount": -1200
+          },
+          {
+            "token_id": "0.0.90000",
+            "account": "0.0.3",
+            "amount": 200
+          },
+          {
+            "token_id": "0.0.90000",
+            "account": "0.0.9",
+            "amount": 1000
+          }
+        ]
+      }
+    ]
+  },
+  "urls": [
+    "/api/v1/transactions?account.id=0.0.9",
+    "/api/v1/transactions?account.id=0.9",
+    "/api/v1/transactions?account.id=9"
+  ],
+  "responseStatus": 200,
+  "responseJson": {
+    "transactions": [
+      {
+        "consensus_timestamp": "1234567890.000000001",
+        "valid_start_timestamp": "1234567890.000000000",
+        "charged_tx_fee": 7,
+        "memo_base64": null,
+        "result": "SUCCESS",
+        "scheduled": false,
+        "transaction_hash": "aGFzaA==",
+        "name": "CRYPTOTRANSFER",
+        "node": "0.0.3",
+        "transaction_id": "0.0.8-1234567890-000000000",
+        "valid_duration_seconds": "11",
+        "max_fee": "33",
+        "transfers": [],
+        "token_transfers": [
+          {
+            "account": "0.0.9",
+            "amount": 1000,
+            "token_id": "0.0.90000"
+          },
+          {
+            "account": "0.0.8",
+            "amount": -1200,
+            "token_id": "0.0.90000"
+          },
+          {
+            "account": "0.0.3",
+            "amount": 200,
+            "token_id": "0.0.90000"
+          }
+        ]
+      }
+    ],
+    "links": {
+      "next": null
+    }
+  }
+}

--- a/hedera-mirror-rest/__tests__/specs/transactions-28-account-id-only-token-transfers.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-28-account-id-only-token-transfers.spec.json
@@ -1,5 +1,5 @@
 {
-  "description": "Transaction api calls for transactions via account id query filter",
+  "description": "Transaction api calls for transactions via account id query filter where account only receives token transfer",
   "setup": {
     "accounts": [
       {

--- a/hedera-mirror-rest/transactions.js
+++ b/hedera-mirror-rest/transactions.js
@@ -344,7 +344,7 @@ const getTransferDistinctTimestampsQuery = function (
   const whereClause = buildWhereClause(namedAccountQuery, namedTransferTsQuery, resultTypeQuery, transactionTypeQuery);
 
   return `
-      SELECT DISTINCT ${tableAlias}.consensus_timestamp AS consensus_timestamp
+      SELECT DISTINCT ${tableAlias}.${timestampColumn} AS consensus_timestamp
         FROM ${tableName} AS ${tableAlias}
         ${joinClause}
         ${whereClause}

--- a/hedera-mirror-rest/transactions.js
+++ b/hedera-mirror-rest/transactions.js
@@ -272,7 +272,6 @@ const getGeneralTransactionsInnerQuery = function (
   if (namedAccountQuery) {
     // account filter applies to transaction.payer_account_id, crypto_transfer.entity_id, and token_transfer.account_id, a full outer join
     //between the three tables is needed to get rows that may only exist in one.
-
     const ctlQuery = getTransferDistinctTimestampsQuery(
       'crypto_transfer',
       'ctl',


### PR DESCRIPTION
**Detailed description**:
When querying the transactions REST API and filtering by account id, transactions where the account sent or received tokens, but did not send/receive HBARs and was not the payer for the transaction were not picked up.  This PR allows for that by doing a full outer join with the token_transfers table when searching the transactions and crypto_transfers tables for distinct timestamps.

**Which issue(s) this PR fixes**:
Fixes #1587 

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated

