### PR TITLE
Update Monitor and Data-Generator to use SDK v2

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -228,6 +228,7 @@ Name                                                        | Default    | Descr
 `hedera.mirror.monitor.publish.scenarios[].limit`           | 0          | How many transactions to publish before halting. 0 for unlimited
 `hedera.mirror.monitor.publish.scenarios[].logResponse`     | false      | Whether to log the response from HAPI
 `hedera.mirror.monitor.publish.scenarios[].name`            | ""         | The publish scenario name. Used to tag logs and metrics
+`hedera.mirror.monitor.publish.scenarios[].maxRetries`      | 0          | The maximum number of times a scenario transaction attempt will be retried
 `hedera.mirror.monitor.publish.scenarios[].properties`      | {}         | Key/value pairs used to configure the [`TransactionSupplier`](/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier) associated with this scenario type
 `hedera.mirror.monitor.publish.scenarios[].receipt`         | 0.0        | The percentage of receipts to retrieve from HAPI. Accepts values between 0-1
 `hedera.mirror.monitor.publish.scenarios[].record`          | 0.0        | The percentage of records to retrieve from HAPI. Accepts values between 0-1

--- a/hedera-mirror-datagenerator/pom.xml
+++ b/hedera-mirror-datagenerator/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>com.hedera.hashgraph</groupId>
             <artifactId>sdk</artifactId>
-            <version>${hedera-sdk.version}</version>
+            <version>2.0.4</version>
         </dependency>
         <dependency>
             <groupId>com.hedera</groupId>

--- a/hedera-mirror-datagenerator/pom.xml
+++ b/hedera-mirror-datagenerator/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>com.hedera.hashgraph</groupId>
             <artifactId>sdk</artifactId>
-            <version>2.0.4</version>
+            <version>2.0.5-beta.3</version>
         </dependency>
         <dependency>
             <groupId>com.hedera</groupId>

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/TransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/TransactionSupplier.java
@@ -22,9 +22,7 @@ package com.hedera.datagenerator.sdk.supplier;
 
 import java.util.function.Supplier;
 
-import com.hedera.hashgraph.sdk.TransactionBuilder;
-import com.hedera.hashgraph.sdk.TransactionId;
+import com.hedera.hashgraph.sdk.Transaction;
 
-public interface TransactionSupplier<T extends TransactionBuilder<TransactionId, ?, T>>
-        extends Supplier<TransactionBuilder<TransactionId, ?, T>> {
+public interface TransactionSupplier<T extends Transaction> extends Supplier<Transaction> {
 }

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/TransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/TransactionSupplier.java
@@ -24,5 +24,5 @@ import java.util.function.Supplier;
 
 import com.hedera.hashgraph.sdk.Transaction;
 
-public interface TransactionSupplier<T extends Transaction<?>> extends Supplier<Transaction<?>> {
+public interface TransactionSupplier<T extends Transaction<T>> extends Supplier<Transaction<T>> {
 }

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/TransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/TransactionSupplier.java
@@ -24,5 +24,5 @@ import java.util.function.Supplier;
 
 import com.hedera.hashgraph.sdk.Transaction;
 
-public interface TransactionSupplier<T extends Transaction> extends Supplier<Transaction> {
+public interface TransactionSupplier<T extends Transaction<?>> extends Supplier<Transaction<?>> {
 }

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/account/AccountCreateTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/account/AccountCreateTransactionSupplier.java
@@ -47,7 +47,8 @@ public class AccountCreateTransactionSupplier implements TransactionSupplier<Acc
 
     @Override
     public AccountCreateTransaction get() {
-        return new AccountCreateTransaction().setInitialBalance(Hbar.fromTinybars(initialBalance))
+        return new AccountCreateTransaction()
+                .setInitialBalance(Hbar.fromTinybars(initialBalance))
                 .setKey(publicKey != null ? PublicKey.fromString(publicKey) : generateKeys())
                 .setMaxTransactionFee(Hbar.fromTinybars(maxTransactionFee))
                 .setTransactionMemo(Utility.getMemo("Mirror node created test account"));

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/account/AccountCreateTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/account/AccountCreateTransactionSupplier.java
@@ -56,15 +56,15 @@ public class AccountCreateTransactionSupplier implements TransactionSupplier<Acc
 
     private PublicKey generateKeys() {
         PrivateKey privateKey = PrivateKey.generate();
-        PublicKey publicKey = privateKey.getPublicKey();
+        privateKey.getPublicKey();
 
         // Since these keys will never be seen again, if we want to reuse this account
         // provide an option to print them
         if (logKeys) {
             log.info("privateKey: {}", privateKey);
-            log.info("publicKey: {}", publicKey);
+            log.info("publicKey: {}", privateKey.getPublicKey());
         }
 
-        return publicKey;
+        return privateKey.getPublicKey();
     }
 }

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/account/AccountCreateTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/account/AccountCreateTransactionSupplier.java
@@ -26,9 +26,10 @@ import lombok.extern.log4j.Log4j2;
 
 import com.hedera.datagenerator.common.Utility;
 import com.hedera.datagenerator.sdk.supplier.TransactionSupplier;
-import com.hedera.hashgraph.sdk.account.AccountCreateTransaction;
-import com.hedera.hashgraph.sdk.crypto.ed25519.Ed25519PrivateKey;
-import com.hedera.hashgraph.sdk.crypto.ed25519.Ed25519PublicKey;
+import com.hedera.hashgraph.sdk.AccountCreateTransaction;
+import com.hedera.hashgraph.sdk.Hbar;
+import com.hedera.hashgraph.sdk.PrivateKey;
+import com.hedera.hashgraph.sdk.PublicKey;
 
 @Data
 @Log4j2
@@ -46,18 +47,18 @@ public class AccountCreateTransactionSupplier implements TransactionSupplier<Acc
 
     @Override
     public AccountCreateTransaction get() {
-        return new AccountCreateTransaction()
-                .setInitialBalance(initialBalance)
-                .setKey(publicKey != null ? Ed25519PublicKey.fromString(publicKey) : generateKeys())
-                .setMaxTransactionFee(maxTransactionFee)
+        return new AccountCreateTransaction().setInitialBalance(Hbar.fromTinybars(initialBalance))
+                .setKey(publicKey != null ? PublicKey.fromString(publicKey) : generateKeys())
+                .setMaxTransactionFee(Hbar.fromTinybars(maxTransactionFee))
                 .setTransactionMemo(Utility.getMemo("Mirror node created test account"));
     }
 
-    private Ed25519PublicKey generateKeys() {
-        Ed25519PrivateKey privateKey = Ed25519PrivateKey.generate();
-        Ed25519PublicKey publicKey = privateKey.publicKey;
+    private PublicKey generateKeys() {
+        PrivateKey privateKey = PrivateKey.generate();
+        PublicKey publicKey = privateKey.getPublicKey();
 
-        // Since these keys will never be seen again, if we want to reuse this account provide an option to print them
+        // Since these keys will never be seen again, if we want to reuse this account
+        // provide an option to print them
         if (logKeys) {
             log.info("privateKey: {}", privateKey);
             log.info("publicKey: {}", publicKey);

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/account/AccountCreateTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/account/AccountCreateTransactionSupplier.java
@@ -56,7 +56,6 @@ public class AccountCreateTransactionSupplier implements TransactionSupplier<Acc
 
     private PublicKey generateKeys() {
         PrivateKey privateKey = PrivateKey.generate();
-        privateKey.getPublicKey();
 
         // Since these keys will never be seen again, if we want to reuse this account
         // provide an option to print them

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/account/AccountDeleteTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/account/AccountDeleteTransactionSupplier.java
@@ -26,8 +26,9 @@ import lombok.Data;
 
 import com.hedera.datagenerator.common.Utility;
 import com.hedera.datagenerator.sdk.supplier.TransactionSupplier;
-import com.hedera.hashgraph.sdk.account.AccountDeleteTransaction;
-import com.hedera.hashgraph.sdk.account.AccountId;
+import com.hedera.hashgraph.sdk.AccountDeleteTransaction;
+import com.hedera.hashgraph.sdk.AccountId;
+import com.hedera.hashgraph.sdk.Hbar;
 
 @Data
 public class AccountDeleteTransactionSupplier implements TransactionSupplier<AccountDeleteTransaction> {
@@ -44,9 +45,8 @@ public class AccountDeleteTransactionSupplier implements TransactionSupplier<Acc
     @Override
     public AccountDeleteTransaction get() {
 
-        return new AccountDeleteTransaction()
-                .setDeleteAccountId(AccountId.fromString(accountId))
-                .setMaxTransactionFee(maxTransactionFee)
+        return new AccountDeleteTransaction().setAccountId(AccountId.fromString(accountId))
+                .setMaxTransactionFee(Hbar.fromTinybars(maxTransactionFee))
                 .setTransactionMemo(Utility.getMemo("Mirror node deleted test account"))
                 .setTransferAccountId(AccountId.fromString(transferAccountId));
     }

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/account/AccountDeleteTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/account/AccountDeleteTransactionSupplier.java
@@ -45,7 +45,8 @@ public class AccountDeleteTransactionSupplier implements TransactionSupplier<Acc
     @Override
     public AccountDeleteTransaction get() {
 
-        return new AccountDeleteTransaction().setAccountId(AccountId.fromString(accountId))
+        return new AccountDeleteTransaction()
+                .setAccountId(AccountId.fromString(accountId))
                 .setMaxTransactionFee(Hbar.fromTinybars(maxTransactionFee))
                 .setTransactionMemo(Utility.getMemo("Mirror node deleted test account"))
                 .setTransferAccountId(AccountId.fromString(transferAccountId));

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/account/AccountUpdateTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/account/AccountUpdateTransactionSupplier.java
@@ -64,7 +64,8 @@ public class AccountUpdateTransactionSupplier implements TransactionSupplier<Acc
     public AccountUpdateTransaction get() {
 
         AccountUpdateTransaction transaction = new AccountUpdateTransaction()
-                .setAccountId(AccountId.fromString(accountId)).setExpirationTime(expirationTime)
+                .setAccountId(AccountId.fromString(accountId))
+                .setExpirationTime(expirationTime)
                 .setMaxTransactionFee(Hbar.fromTinybars(maxTransactionFee))
                 .setReceiverSignatureRequired(receiverSignatureRequired)
                 .setTransactionMemo(Utility.getMemo("Mirror node updated test account"));

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/account/AccountUpdateTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/account/AccountUpdateTransactionSupplier.java
@@ -32,9 +32,10 @@ import org.hibernate.validator.constraints.time.DurationMin;
 
 import com.hedera.datagenerator.common.Utility;
 import com.hedera.datagenerator.sdk.supplier.TransactionSupplier;
-import com.hedera.hashgraph.sdk.account.AccountId;
-import com.hedera.hashgraph.sdk.account.AccountUpdateTransaction;
-import com.hedera.hashgraph.sdk.crypto.ed25519.Ed25519PublicKey;
+import com.hedera.hashgraph.sdk.AccountId;
+import com.hedera.hashgraph.sdk.AccountUpdateTransaction;
+import com.hedera.hashgraph.sdk.Hbar;
+import com.hedera.hashgraph.sdk.PublicKey;
 
 @Data
 public class AccountUpdateTransactionSupplier implements TransactionSupplier<AccountUpdateTransaction> {
@@ -63,10 +64,8 @@ public class AccountUpdateTransactionSupplier implements TransactionSupplier<Acc
     public AccountUpdateTransaction get() {
 
         AccountUpdateTransaction transaction = new AccountUpdateTransaction()
-                .setAccountId(AccountId.fromString(accountId))
-                .setAutoRenewPeriod(autoRenewPeriod)
-                .setExpirationTime(expirationTime)
-                .setMaxTransactionFee(maxTransactionFee)
+                .setAccountId(AccountId.fromString(accountId)).setExpirationTime(expirationTime)
+                .setMaxTransactionFee(Hbar.fromTinybars(maxTransactionFee))
                 .setReceiverSignatureRequired(receiverSignatureRequired)
                 .setTransactionMemo(Utility.getMemo("Mirror node updated test account"));
 
@@ -74,7 +73,7 @@ public class AccountUpdateTransactionSupplier implements TransactionSupplier<Acc
             transaction.setProxyAccountId(AccountId.fromString(proxyAccountId));
         }
         if (publicKey != null) {
-            transaction.setKey(Ed25519PublicKey.fromString(publicKey));
+            transaction.setKey(PublicKey.fromString(publicKey));
         }
         return transaction;
     }

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/account/CryptoTransferTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/account/CryptoTransferTransactionSupplier.java
@@ -28,9 +28,10 @@ import lombok.Getter;
 
 import com.hedera.datagenerator.common.Utility;
 import com.hedera.datagenerator.sdk.supplier.TransactionSupplier;
-import com.hedera.hashgraph.sdk.account.AccountId;
-import com.hedera.hashgraph.sdk.account.TransferTransaction;
-import com.hedera.hashgraph.sdk.token.TokenId;
+import com.hedera.hashgraph.sdk.AccountId;
+import com.hedera.hashgraph.sdk.Hbar;
+import com.hedera.hashgraph.sdk.TransferTransaction;
+import com.hedera.hashgraph.sdk.TokenId;
 
 @Data
 public class CryptoTransferTransactionSupplier implements TransactionSupplier<TransferTransaction> {
@@ -65,7 +66,7 @@ public class CryptoTransferTransactionSupplier implements TransactionSupplier<Tr
     public TransferTransaction get() {
 
         TransferTransaction transferTransaction = new TransferTransaction()
-                .setMaxTransactionFee(maxTransactionFee);
+                .setMaxTransactionFee(Hbar.fromTinybars(maxTransactionFee));
 
         switch (transferType) {
             case CRYPTO:
@@ -87,17 +88,15 @@ public class CryptoTransferTransactionSupplier implements TransactionSupplier<Tr
     }
 
     private void addCryptoTransfers(TransferTransaction transferTransaction, AccountId recipientId,
-                                    AccountId senderId) {
-        transferTransaction
-                .addHbarTransfer(recipientId, amount)
-                .addHbarTransfer(senderId, Math.negateExact(amount));
+            AccountId senderId) {
+        Hbar hbarAmount = Hbar.fromTinybars(amount);
+        transferTransaction.addHbarTransfer(recipientId, hbarAmount).addHbarTransfer(senderId, hbarAmount.negated());
     }
 
     private void addTokenTransfers(TransferTransaction transferTransaction, TokenId token, AccountId recipientId,
-                                   AccountId senderId) {
-        transferTransaction
-                .addTokenTransfer(token, recipientId, amount)
-                .addTokenTransfer(token, senderId, Math.negateExact(amount));
+            AccountId senderId) {
+        transferTransaction.addTokenTransfer(token, recipientId, amount).addTokenTransfer(token, senderId,
+                Math.negateExact(amount));
     }
 
     public enum TransferType {

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/account/CryptoTransferTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/account/CryptoTransferTransactionSupplier.java
@@ -30,8 +30,8 @@ import com.hedera.datagenerator.common.Utility;
 import com.hedera.datagenerator.sdk.supplier.TransactionSupplier;
 import com.hedera.hashgraph.sdk.AccountId;
 import com.hedera.hashgraph.sdk.Hbar;
-import com.hedera.hashgraph.sdk.TransferTransaction;
 import com.hedera.hashgraph.sdk.TokenId;
+import com.hedera.hashgraph.sdk.TransferTransaction;
 
 @Data
 public class CryptoTransferTransactionSupplier implements TransactionSupplier<TransferTransaction> {
@@ -88,15 +88,18 @@ public class CryptoTransferTransactionSupplier implements TransactionSupplier<Tr
     }
 
     private void addCryptoTransfers(TransferTransaction transferTransaction, AccountId recipientId,
-            AccountId senderId) {
+                                    AccountId senderId) {
         Hbar hbarAmount = Hbar.fromTinybars(amount);
-        transferTransaction.addHbarTransfer(recipientId, hbarAmount).addHbarTransfer(senderId, hbarAmount.negated());
+        transferTransaction
+                .addHbarTransfer(recipientId, hbarAmount)
+                .addHbarTransfer(senderId, hbarAmount.negated());
     }
 
     private void addTokenTransfers(TransferTransaction transferTransaction, TokenId token, AccountId recipientId,
-            AccountId senderId) {
-        transferTransaction.addTokenTransfer(token, recipientId, amount).addTokenTransfer(token, senderId,
-                Math.negateExact(amount));
+                                   AccountId senderId) {
+        transferTransaction
+                .addTokenTransfer(token, recipientId, amount)
+                .addTokenTransfer(token, senderId, Math.negateExact(amount));
     }
 
     public enum TransferType {

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/consensus/ConsensusCreateTopicTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/consensus/ConsensusCreateTopicTransactionSupplier.java
@@ -25,12 +25,13 @@ import lombok.Data;
 
 import com.hedera.datagenerator.common.Utility;
 import com.hedera.datagenerator.sdk.supplier.TransactionSupplier;
-import com.hedera.hashgraph.sdk.account.AccountId;
-import com.hedera.hashgraph.sdk.consensus.ConsensusTopicCreateTransaction;
-import com.hedera.hashgraph.sdk.crypto.ed25519.Ed25519PublicKey;
+import com.hedera.hashgraph.sdk.AccountId;
+import com.hedera.hashgraph.sdk.Hbar;
+import com.hedera.hashgraph.sdk.TopicCreateTransaction;
+import com.hedera.hashgraph.sdk.PublicKey;
 
 @Data
-public class ConsensusCreateTopicTransactionSupplier implements TransactionSupplier<ConsensusTopicCreateTransaction> {
+public class ConsensusCreateTopicTransactionSupplier implements TransactionSupplier<TopicCreateTransaction> {
 
     private String adminKey;
 
@@ -40,22 +41,19 @@ public class ConsensusCreateTopicTransactionSupplier implements TransactionSuppl
     private long maxTransactionFee = 1_000_000_000;
 
     @Override
-    public ConsensusTopicCreateTransaction get() {
-        ConsensusTopicCreateTransaction consensusTopicCreateTransaction = new ConsensusTopicCreateTransaction()
-                .setMaxTransactionFee(maxTransactionFee)
+    public TopicCreateTransaction get() {
+        TopicCreateTransaction topicCreateTransaction = new TopicCreateTransaction()
+                .setMaxTransactionFee(Hbar.fromTinybars(maxTransactionFee))
                 .setTopicMemo(Utility.getMemo("Mirror node created test topic"))
                 .setTransactionMemo(Utility.getMemo("Mirror node created test topic"));
 
         if (adminKey != null) {
-            Ed25519PublicKey key = Ed25519PublicKey.fromString(adminKey);
-            consensusTopicCreateTransaction
-                    .setAdminKey(key)
-                    .setSubmitKey(key);
+            PublicKey key = PublicKey.fromString(adminKey);
+            topicCreateTransaction.setAdminKey(key).setSubmitKey(key);
         }
         if (autoRenewAccountId != null) {
-            consensusTopicCreateTransaction
-                    .setAutoRenewAccountId(AccountId.fromString(autoRenewAccountId));
+            topicCreateTransaction.setAutoRenewAccountId(AccountId.fromString(autoRenewAccountId));
         }
-        return consensusTopicCreateTransaction;
+        return topicCreateTransaction;
     }
 }

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/consensus/ConsensusCreateTopicTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/consensus/ConsensusCreateTopicTransactionSupplier.java
@@ -27,8 +27,8 @@ import com.hedera.datagenerator.common.Utility;
 import com.hedera.datagenerator.sdk.supplier.TransactionSupplier;
 import com.hedera.hashgraph.sdk.AccountId;
 import com.hedera.hashgraph.sdk.Hbar;
-import com.hedera.hashgraph.sdk.TopicCreateTransaction;
 import com.hedera.hashgraph.sdk.PublicKey;
+import com.hedera.hashgraph.sdk.TopicCreateTransaction;
 
 @Data
 public class ConsensusCreateTopicTransactionSupplier implements TransactionSupplier<TopicCreateTransaction> {
@@ -52,7 +52,8 @@ public class ConsensusCreateTopicTransactionSupplier implements TransactionSuppl
             topicCreateTransaction.setAdminKey(key).setSubmitKey(key);
         }
         if (autoRenewAccountId != null) {
-            topicCreateTransaction.setAutoRenewAccountId(AccountId.fromString(autoRenewAccountId));
+            topicCreateTransaction
+                    .setAutoRenewAccountId(AccountId.fromString(autoRenewAccountId));
         }
         return topicCreateTransaction;
     }

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/consensus/ConsensusDeleteTopicTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/consensus/ConsensusDeleteTopicTransactionSupplier.java
@@ -42,7 +42,8 @@ public class ConsensusDeleteTopicTransactionSupplier implements TransactionSuppl
     @Override
     public TopicDeleteTransaction get() {
 
-        return new TopicDeleteTransaction().setMaxTransactionFee(Hbar.fromTinybars(maxTransactionFee))
+        return new TopicDeleteTransaction()
+                .setMaxTransactionFee(Hbar.fromTinybars(maxTransactionFee))
                 .setTopicId(TopicId.fromString(topicId))
                 .setTransactionMemo(Utility.getMemo("Mirror node deleted test topic"));
     }

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/consensus/ConsensusDeleteTopicTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/consensus/ConsensusDeleteTopicTransactionSupplier.java
@@ -26,11 +26,12 @@ import lombok.Data;
 
 import com.hedera.datagenerator.common.Utility;
 import com.hedera.datagenerator.sdk.supplier.TransactionSupplier;
-import com.hedera.hashgraph.sdk.consensus.ConsensusTopicDeleteTransaction;
-import com.hedera.hashgraph.sdk.consensus.ConsensusTopicId;
+import com.hedera.hashgraph.sdk.Hbar;
+import com.hedera.hashgraph.sdk.TopicDeleteTransaction;
+import com.hedera.hashgraph.sdk.TopicId;
 
 @Data
-public class ConsensusDeleteTopicTransactionSupplier implements TransactionSupplier<ConsensusTopicDeleteTransaction> {
+public class ConsensusDeleteTopicTransactionSupplier implements TransactionSupplier<TopicDeleteTransaction> {
 
     @Min(1)
     private long maxTransactionFee = 1_000_000_000;
@@ -39,11 +40,10 @@ public class ConsensusDeleteTopicTransactionSupplier implements TransactionSuppl
     private String topicId;
 
     @Override
-    public ConsensusTopicDeleteTransaction get() {
+    public TopicDeleteTransaction get() {
 
-        return new ConsensusTopicDeleteTransaction()
-                .setMaxTransactionFee(maxTransactionFee)
-                .setTopicId(ConsensusTopicId.fromString(topicId))
+        return new TopicDeleteTransaction().setMaxTransactionFee(Hbar.fromTinybars(maxTransactionFee))
+                .setTopicId(TopicId.fromString(topicId))
                 .setTransactionMemo(Utility.getMemo("Mirror node deleted test topic"));
     }
 }

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/consensus/ConsensusSubmitMessageTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/consensus/ConsensusSubmitMessageTransactionSupplier.java
@@ -33,11 +33,11 @@ import org.apache.commons.lang3.StringUtils;
 
 import com.hedera.datagenerator.sdk.supplier.TransactionSupplier;
 import com.hedera.hashgraph.sdk.HederaThrowable;
-import com.hedera.hashgraph.sdk.consensus.ConsensusMessageSubmitTransaction;
-import com.hedera.hashgraph.sdk.consensus.ConsensusTopicId;
+import com.hedera.hashgraph.sdk.TopicId;
+import com.hedera.hashgraph.sdk.TopicMessageSubmitTransaction;
 
 @Data
-public class ConsensusSubmitMessageTransactionSupplier implements TransactionSupplier<ConsensusMessageSubmitTransaction> {
+public class ConsensusSubmitMessageTransactionSupplier implements TransactionSupplier<TopicMessageSubmitTransaction> {
 
     @Min(1)
     private long maxTransactionFee = 1_000_000;
@@ -55,22 +55,20 @@ public class ConsensusSubmitMessageTransactionSupplier implements TransactionSup
 
     // Internal variables that are cached for performance reasons
     @Getter(lazy = true)
-    private final ConsensusTopicId consensusTopicId = ConsensusTopicId.fromString(topicId);
+    private final TopicId consensusTopicId = TopicId.fromString(topicId);
 
     @Getter(lazy = true)
     private final byte[] messageSuffix = randomByteArray();
 
     @Override
-    public ConsensusMessageSubmitTransaction get() {
-        return new RetryConfigurableConsensusMessageSubmitTransaction()
-                .setMaxTransactionFee(maxTransactionFee)
-                .setMessage(generateMessage())
-                .setTopicId(getConsensusTopicId());
+    public TopicMessageSubmitTransaction get() {
+        return new RetryConfigurableConsensusMessageSubmitTransaction().setMessage(generateMessage())
+                .setTopicId(topicId);
     }
 
     private byte[] generateMessage() {
         byte[] timestamp = Longs.toByteArray(System.currentTimeMillis());
-        return ArrayUtils.addAll(timestamp, getMessageSuffix());
+        return ArrayUtils.addAll(timestamp, messageSuffix);
     }
 
     private byte[] randomByteArray() {
@@ -83,7 +81,7 @@ public class ConsensusSubmitMessageTransactionSupplier implements TransactionSup
         return bytes;
     }
 
-    private class RetryConfigurableConsensusMessageSubmitTransaction extends ConsensusMessageSubmitTransaction {
+    private class RetryConfigurableConsensusMessageSubmitTransaction extends TopicMessageSubmitTransaction {
 
         @Override
         protected boolean shouldRetry(HederaThrowable e) {
@@ -91,4 +89,3 @@ public class ConsensusSubmitMessageTransactionSupplier implements TransactionSup
         }
     }
 }
-

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/consensus/ConsensusSubmitMessageTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/consensus/ConsensusSubmitMessageTransactionSupplier.java
@@ -48,7 +48,7 @@ public class ConsensusSubmitMessageTransactionSupplier implements TransactionSup
     @Max(6144)
     private int messageSize = 256;
 
-    private boolean retry = false;
+    private int maxRetryCount = 3;
 
     @NotBlank
     private String topicId;
@@ -63,6 +63,7 @@ public class ConsensusSubmitMessageTransactionSupplier implements TransactionSup
     @Override
     public TopicMessageSubmitTransaction get() {
         return new TopicMessageSubmitTransaction()
+                .setMaxRetry(maxRetryCount)
                 .setMaxTransactionFee(Hbar.fromTinybars(maxTransactionFee))
                 .setMessage(generateMessage())
                 .setTopicId(getConsensusTopicId());
@@ -82,12 +83,4 @@ public class ConsensusSubmitMessageTransactionSupplier implements TransactionSup
         new SecureRandom().nextBytes(bytes);
         return bytes;
     }
-
-//    private class RetryConfigurableConsensusMessageSubmitTransaction extends TopicMessageSubmitTransaction {
-//
-//        @Override
-//        protected boolean shouldRetry(HederaThrowable e) {
-//            return retry;
-//        }
-//    }
 }

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/consensus/ConsensusSubmitMessageTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/consensus/ConsensusSubmitMessageTransactionSupplier.java
@@ -32,7 +32,7 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import com.hedera.datagenerator.sdk.supplier.TransactionSupplier;
-import com.hedera.hashgraph.sdk.HederaThrowable;
+import com.hedera.hashgraph.sdk.Hbar;
 import com.hedera.hashgraph.sdk.TopicId;
 import com.hedera.hashgraph.sdk.TopicMessageSubmitTransaction;
 
@@ -62,13 +62,15 @@ public class ConsensusSubmitMessageTransactionSupplier implements TransactionSup
 
     @Override
     public TopicMessageSubmitTransaction get() {
-        return new RetryConfigurableConsensusMessageSubmitTransaction().setMessage(generateMessage())
-                .setTopicId(topicId);
+        return new TopicMessageSubmitTransaction()
+                .setMaxTransactionFee(Hbar.fromTinybars(maxTransactionFee))
+                .setMessage(generateMessage())
+                .setTopicId(getConsensusTopicId());
     }
 
     private byte[] generateMessage() {
         byte[] timestamp = Longs.toByteArray(System.currentTimeMillis());
-        return ArrayUtils.addAll(timestamp, messageSuffix);
+        return ArrayUtils.addAll(timestamp, getMessageSuffix());
     }
 
     private byte[] randomByteArray() {
@@ -81,11 +83,11 @@ public class ConsensusSubmitMessageTransactionSupplier implements TransactionSup
         return bytes;
     }
 
-    private class RetryConfigurableConsensusMessageSubmitTransaction extends TopicMessageSubmitTransaction {
-
-        @Override
-        protected boolean shouldRetry(HederaThrowable e) {
-            return retry;
-        }
-    }
+//    private class RetryConfigurableConsensusMessageSubmitTransaction extends TopicMessageSubmitTransaction {
+//
+//        @Override
+//        protected boolean shouldRetry(HederaThrowable e) {
+//            return retry;
+//        }
+//    }
 }

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/consensus/ConsensusSubmitMessageTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/consensus/ConsensusSubmitMessageTransactionSupplier.java
@@ -48,8 +48,6 @@ public class ConsensusSubmitMessageTransactionSupplier implements TransactionSup
     @Max(6144)
     private int messageSize = 256;
 
-    private int maxRetryCount = 3;
-
     @NotBlank
     private String topicId;
 
@@ -63,7 +61,6 @@ public class ConsensusSubmitMessageTransactionSupplier implements TransactionSup
     @Override
     public TopicMessageSubmitTransaction get() {
         return new TopicMessageSubmitTransaction()
-                .setMaxRetry(maxRetryCount)
                 .setMaxTransactionFee(Hbar.fromTinybars(maxTransactionFee))
                 .setMessage(generateMessage())
                 .setTopicId(getConsensusTopicId());

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/consensus/ConsensusUpdateTopicTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/consensus/ConsensusUpdateTopicTransactionSupplier.java
@@ -32,13 +32,13 @@ import org.hibernate.validator.constraints.time.DurationMin;
 
 import com.hedera.datagenerator.common.Utility;
 import com.hedera.datagenerator.sdk.supplier.TransactionSupplier;
-import com.hedera.hashgraph.sdk.account.AccountId;
-import com.hedera.hashgraph.sdk.consensus.ConsensusTopicId;
-import com.hedera.hashgraph.sdk.consensus.ConsensusTopicUpdateTransaction;
-import com.hedera.hashgraph.sdk.crypto.ed25519.Ed25519PublicKey;
+import com.hedera.hashgraph.sdk.AccountId;
+import com.hedera.hashgraph.sdk.TopicId;
+import com.hedera.hashgraph.sdk.TopicUpdateTransaction;
+import com.hedera.hashgraph.sdk.PublicKey;
 
 @Data
-public class ConsensusUpdateTopicTransactionSupplier implements TransactionSupplier<ConsensusTopicUpdateTransaction> {
+public class ConsensusUpdateTopicTransactionSupplier implements TransactionSupplier<TopicUpdateTransaction> {
 
     private String adminKey;
 
@@ -59,25 +59,20 @@ public class ConsensusUpdateTopicTransactionSupplier implements TransactionSuppl
     private String topicId;
 
     @Override
-    public ConsensusTopicUpdateTransaction get() {
+    public TopicUpdateTransaction get() {
 
-        ConsensusTopicUpdateTransaction consensusTopicUpdateTransaction = new ConsensusTopicUpdateTransaction()
-                .setExpirationTime(expirationTime)
-                .setTopicId(ConsensusTopicId.fromString(topicId))
-                .setTopicMemo(Utility.getMemo("Mirror node created test topic"))
+        TopicUpdateTransaction topicUpdateTransaction = new TopicUpdateTransaction()
+                .setTopicId(TopicId.fromString(topicId)).setTopicMemo(Utility.getMemo("Mirror node created test topic"))
                 .setTransactionMemo(Utility.getMemo("Mirror node updated test topic"));
 
         if (adminKey != null) {
-            Ed25519PublicKey key = Ed25519PublicKey.fromString(adminKey);
-            consensusTopicUpdateTransaction
-                    .setAdminKey(key)
-                    .setSubmitKey(key);
+            PublicKey key = PublicKey.fromString(adminKey);
+            topicUpdateTransaction.setAdminKey(key).setSubmitKey(key);
         }
         if (autoRenewAccountId != null) {
-            consensusTopicUpdateTransaction
-                    .setAutoRenewAccountId(AccountId.fromString(autoRenewAccountId))
+            topicUpdateTransaction.setAutoRenewAccountId(AccountId.fromString(autoRenewAccountId))
                     .setAutoRenewPeriod(autoRenewPeriod);
         }
-        return consensusTopicUpdateTransaction;
+        return topicUpdateTransaction;
     }
 }

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/consensus/ConsensusUpdateTopicTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/consensus/ConsensusUpdateTopicTransactionSupplier.java
@@ -33,9 +33,9 @@ import org.hibernate.validator.constraints.time.DurationMin;
 import com.hedera.datagenerator.common.Utility;
 import com.hedera.datagenerator.sdk.supplier.TransactionSupplier;
 import com.hedera.hashgraph.sdk.AccountId;
+import com.hedera.hashgraph.sdk.PublicKey;
 import com.hedera.hashgraph.sdk.TopicId;
 import com.hedera.hashgraph.sdk.TopicUpdateTransaction;
-import com.hedera.hashgraph.sdk.PublicKey;
 
 @Data
 public class ConsensusUpdateTopicTransactionSupplier implements TransactionSupplier<TopicUpdateTransaction> {
@@ -62,7 +62,8 @@ public class ConsensusUpdateTopicTransactionSupplier implements TransactionSuppl
     public TopicUpdateTransaction get() {
 
         TopicUpdateTransaction topicUpdateTransaction = new TopicUpdateTransaction()
-                .setTopicId(TopicId.fromString(topicId)).setTopicMemo(Utility.getMemo("Mirror node created test topic"))
+                .setTopicId(TopicId.fromString(topicId))
+                .setTopicMemo(Utility.getMemo("Mirror node created test topic"))
                 .setTransactionMemo(Utility.getMemo("Mirror node updated test topic"));
 
         if (adminKey != null) {

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenAssociateTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenAssociateTransactionSupplier.java
@@ -1,5 +1,7 @@
 package com.hedera.datagenerator.sdk.supplier.token;
 
+import java.util.List;
+
 /*-
  * ‌
  * Hedera Mirror Node
@@ -26,9 +28,10 @@ import lombok.Data;
 
 import com.hedera.datagenerator.common.Utility;
 import com.hedera.datagenerator.sdk.supplier.TransactionSupplier;
-import com.hedera.hashgraph.sdk.account.AccountId;
-import com.hedera.hashgraph.sdk.token.TokenAssociateTransaction;
-import com.hedera.hashgraph.sdk.token.TokenId;
+import com.hedera.hashgraph.sdk.AccountId;
+import com.hedera.hashgraph.sdk.Hbar;
+import com.hedera.hashgraph.sdk.TokenAssociateTransaction;
+import com.hedera.hashgraph.sdk.TokenId;
 
 @Data
 public class TokenAssociateTransactionSupplier implements TransactionSupplier<TokenAssociateTransaction> {
@@ -45,10 +48,9 @@ public class TokenAssociateTransactionSupplier implements TransactionSupplier<To
     @Override
     public TokenAssociateTransaction get() {
 
-        return new TokenAssociateTransaction()
-                .addTokenId(TokenId.fromString(tokenId))
+        return new TokenAssociateTransaction().setTokenIds(List.of(TokenId.fromString(tokenId)))
                 .setAccountId(AccountId.fromString(accountId))
-                .setMaxTransactionFee(maxTransactionFee)
+                .setMaxTransactionFee(Hbar.fromTinybars(maxTransactionFee))
                 .setTransactionMemo(Utility.getMemo("Mirror node associated test token"));
     }
 }

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenAssociateTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenAssociateTransactionSupplier.java
@@ -1,6 +1,16 @@
 package com.hedera.datagenerator.sdk.supplier.token;
 
 import java.util.List;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
+import lombok.Data;
+
+import com.hedera.datagenerator.common.Utility;
+import com.hedera.datagenerator.sdk.supplier.TransactionSupplier;
+import com.hedera.hashgraph.sdk.AccountId;
+import com.hedera.hashgraph.sdk.Hbar;
+import com.hedera.hashgraph.sdk.TokenAssociateTransaction;
+import com.hedera.hashgraph.sdk.TokenId;
 
 /*-
  * ‌
@@ -22,17 +32,6 @@ import java.util.List;
  * ‍
  */
 
-import javax.validation.constraints.Min;
-import javax.validation.constraints.NotBlank;
-import lombok.Data;
-
-import com.hedera.datagenerator.common.Utility;
-import com.hedera.datagenerator.sdk.supplier.TransactionSupplier;
-import com.hedera.hashgraph.sdk.AccountId;
-import com.hedera.hashgraph.sdk.Hbar;
-import com.hedera.hashgraph.sdk.TokenAssociateTransaction;
-import com.hedera.hashgraph.sdk.TokenId;
-
 @Data
 public class TokenAssociateTransactionSupplier implements TransactionSupplier<TokenAssociateTransaction> {
 
@@ -48,9 +47,10 @@ public class TokenAssociateTransactionSupplier implements TransactionSupplier<To
     @Override
     public TokenAssociateTransaction get() {
 
-        return new TokenAssociateTransaction().setTokenIds(List.of(TokenId.fromString(tokenId)))
+        return new TokenAssociateTransaction()
                 .setAccountId(AccountId.fromString(accountId))
                 .setMaxTransactionFee(Hbar.fromTinybars(maxTransactionFee))
+                .setTokenIds(List.of(TokenId.fromString(tokenId)))
                 .setTransactionMemo(Utility.getMemo("Mirror node associated test token"));
     }
 }

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenBurnTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenBurnTransactionSupplier.java
@@ -26,8 +26,9 @@ import lombok.Data;
 
 import com.hedera.datagenerator.common.Utility;
 import com.hedera.datagenerator.sdk.supplier.TransactionSupplier;
-import com.hedera.hashgraph.sdk.token.TokenBurnTransaction;
-import com.hedera.hashgraph.sdk.token.TokenId;
+import com.hedera.hashgraph.sdk.Hbar;
+import com.hedera.hashgraph.sdk.TokenBurnTransaction;
+import com.hedera.hashgraph.sdk.TokenId;
 
 @Data
 public class TokenBurnTransactionSupplier implements TransactionSupplier<TokenBurnTransaction> {
@@ -44,9 +45,7 @@ public class TokenBurnTransactionSupplier implements TransactionSupplier<TokenBu
     @Override
     public TokenBurnTransaction get() {
 
-        return new TokenBurnTransaction()
-                .setAmount(amount)
-                .setMaxTransactionFee(maxTransactionFee)
+        return new TokenBurnTransaction().setAmount(amount).setMaxTransactionFee(Hbar.fromTinybars(maxTransactionFee))
                 .setTokenId(TokenId.fromString(tokenId))
                 .setTransactionMemo(Utility.getMemo("Mirror node burned test token"));
     }

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenBurnTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenBurnTransactionSupplier.java
@@ -45,7 +45,8 @@ public class TokenBurnTransactionSupplier implements TransactionSupplier<TokenBu
     @Override
     public TokenBurnTransaction get() {
 
-        return new TokenBurnTransaction().setAmount(amount).setMaxTransactionFee(Hbar.fromTinybars(maxTransactionFee))
+        return new TokenBurnTransaction().setAmount(amount)
+                .setMaxTransactionFee(Hbar.fromTinybars(maxTransactionFee))
                 .setTokenId(TokenId.fromString(tokenId))
                 .setTransactionMemo(Utility.getMemo("Mirror node burned test token"));
     }

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenCreateTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenCreateTransactionSupplier.java
@@ -27,9 +27,10 @@ import lombok.Data;
 
 import com.hedera.datagenerator.common.Utility;
 import com.hedera.datagenerator.sdk.supplier.TransactionSupplier;
-import com.hedera.hashgraph.sdk.account.AccountId;
-import com.hedera.hashgraph.sdk.crypto.ed25519.Ed25519PublicKey;
-import com.hedera.hashgraph.sdk.token.TokenCreateTransaction;
+import com.hedera.hashgraph.sdk.AccountId;
+import com.hedera.hashgraph.sdk.Hbar;
+import com.hedera.hashgraph.sdk.PublicKey;
+import com.hedera.hashgraph.sdk.TokenCreateTransaction;
 
 @Data
 public class TokenCreateTransactionSupplier implements TransactionSupplier<TokenCreateTransaction> {
@@ -51,8 +52,7 @@ public class TokenCreateTransactionSupplier implements TransactionSupplier<Token
 
     @NotBlank
     private String symbol = RANDOM.ints(5, 'A', 'Z')
-            .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
-            .toString();
+            .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append).toString();
 
     @NotBlank
     private String treasuryAccountId;
@@ -61,24 +61,15 @@ public class TokenCreateTransactionSupplier implements TransactionSupplier<Token
     public TokenCreateTransaction get() {
         AccountId treasuryAccount = AccountId.fromString(treasuryAccountId);
         TokenCreateTransaction tokenCreateTransaction = new TokenCreateTransaction()
-                .setAutoRenewAccount(treasuryAccount)
-                .setDecimals(decimals)
-                .setInitialSupply(initialSupply)
-                .setFreezeDefault(freezeDefault)
-                .setMaxTransactionFee(maxTransactionFee)
-                .setName(symbol + "_name")
-                .setSymbol(symbol)
+                .setAutoRenewAccountId(treasuryAccount).setDecimals(decimals).setInitialSupply(initialSupply)
+                .setFreezeDefault(freezeDefault).setMaxTransactionFee(Hbar.fromTinybars(maxTransactionFee))
+                .setTokenName(symbol + "_name").setTokenSymbol(symbol)
                 .setTransactionMemo(Utility.getMemo("Mirror node created test token"))
-                .setTreasury(treasuryAccount);
+                .setTreasuryAccountId(treasuryAccount);
 
         if (adminKey != null) {
-            Ed25519PublicKey key = Ed25519PublicKey.fromString(adminKey);
-            tokenCreateTransaction
-                    .setAdminKey(key)
-                    .setFreezeKey(key)
-                    .setKycKey(key)
-                    .setSupplyKey(key)
-                    .setWipeKey(key);
+            PublicKey key = PublicKey.fromString(adminKey);
+            tokenCreateTransaction.setAdminKey(key).setFreezeKey(key).setKycKey(key).setSupplyKey(key).setWipeKey(key);
         }
 
         return tokenCreateTransaction;

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenCreateTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenCreateTransactionSupplier.java
@@ -61,9 +61,12 @@ public class TokenCreateTransactionSupplier implements TransactionSupplier<Token
     public TokenCreateTransaction get() {
         AccountId treasuryAccount = AccountId.fromString(treasuryAccountId);
         TokenCreateTransaction tokenCreateTransaction = new TokenCreateTransaction()
-                .setAutoRenewAccountId(treasuryAccount).setDecimals(decimals).setInitialSupply(initialSupply)
-                .setFreezeDefault(freezeDefault).setMaxTransactionFee(Hbar.fromTinybars(maxTransactionFee))
-                .setTokenName(symbol + "_name").setTokenSymbol(symbol)
+                .setAutoRenewAccountId(treasuryAccount)
+                .setDecimals(decimals).setInitialSupply(initialSupply)
+                .setFreezeDefault(freezeDefault)
+                .setMaxTransactionFee(Hbar.fromTinybars(maxTransactionFee))
+                .setTokenName(symbol + "_name")
+                .setTokenSymbol(symbol)
                 .setTransactionMemo(Utility.getMemo("Mirror node created test token"))
                 .setTreasuryAccountId(treasuryAccount);
 

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenDeleteTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenDeleteTransactionSupplier.java
@@ -42,7 +42,8 @@ public class TokenDeleteTransactionSupplier implements TransactionSupplier<Token
     @Override
     public TokenDeleteTransaction get() {
 
-        return new TokenDeleteTransaction().setMaxTransactionFee(Hbar.fromTinybars(maxTransactionFee))
+        return new TokenDeleteTransaction()
+                .setMaxTransactionFee(Hbar.fromTinybars(maxTransactionFee))
                 .setTokenId(TokenId.fromString(tokenId))
                 .setTransactionMemo(Utility.getMemo("Mirror node deleted test token"));
     }

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenDeleteTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenDeleteTransactionSupplier.java
@@ -26,8 +26,9 @@ import lombok.Data;
 
 import com.hedera.datagenerator.common.Utility;
 import com.hedera.datagenerator.sdk.supplier.TransactionSupplier;
-import com.hedera.hashgraph.sdk.token.TokenDeleteTransaction;
-import com.hedera.hashgraph.sdk.token.TokenId;
+import com.hedera.hashgraph.sdk.Hbar;
+import com.hedera.hashgraph.sdk.TokenDeleteTransaction;
+import com.hedera.hashgraph.sdk.TokenId;
 
 @Data
 public class TokenDeleteTransactionSupplier implements TransactionSupplier<TokenDeleteTransaction> {
@@ -41,8 +42,7 @@ public class TokenDeleteTransactionSupplier implements TransactionSupplier<Token
     @Override
     public TokenDeleteTransaction get() {
 
-        return new TokenDeleteTransaction()
-                .setMaxTransactionFee(maxTransactionFee)
+        return new TokenDeleteTransaction().setMaxTransactionFee(Hbar.fromTinybars(maxTransactionFee))
                 .setTokenId(TokenId.fromString(tokenId))
                 .setTransactionMemo(Utility.getMemo("Mirror node deleted test token"));
     }

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenDissociateTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenDissociateTransactionSupplier.java
@@ -47,7 +47,8 @@ public class TokenDissociateTransactionSupplier implements TransactionSupplier<T
     @Override
     public TokenDissociateTransaction get() {
 
-        return new TokenDissociateTransaction().setTokenIds(List.of(TokenId.fromString(tokenId)))
+        return new TokenDissociateTransaction()
+                .setTokenIds(List.of(TokenId.fromString(tokenId)))
                 .setAccountId(AccountId.fromString(accountId))
                 .setMaxTransactionFee(Hbar.fromTinybars(maxTransactionFee))
                 .setTransactionMemo(Utility.getMemo("Mirror node dissociated test token"));

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenDissociateTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenDissociateTransactionSupplier.java
@@ -20,6 +20,7 @@ package com.hedera.datagenerator.sdk.supplier.token;
  * ‍
  */
 
+import java.util.List;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
 import lombok.Data;
@@ -46,7 +47,7 @@ public class TokenDissociateTransactionSupplier implements TransactionSupplier<T
     @Override
     public TokenDissociateTransaction get() {
 
-        return new TokenDissociateTransaction().addTokenId(TokenId.fromString(tokenId))
+        return new TokenDissociateTransaction().setTokenIds(List.of(TokenId.fromString(tokenId)))
                 .setAccountId(AccountId.fromString(accountId))
                 .setMaxTransactionFee(Hbar.fromTinybars(maxTransactionFee))
                 .setTransactionMemo(Utility.getMemo("Mirror node dissociated test token"));

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenDissociateTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenDissociateTransactionSupplier.java
@@ -26,9 +26,10 @@ import lombok.Data;
 
 import com.hedera.datagenerator.common.Utility;
 import com.hedera.datagenerator.sdk.supplier.TransactionSupplier;
-import com.hedera.hashgraph.sdk.account.AccountId;
-import com.hedera.hashgraph.sdk.token.TokenDissociateTransaction;
-import com.hedera.hashgraph.sdk.token.TokenId;
+import com.hedera.hashgraph.sdk.AccountId;
+import com.hedera.hashgraph.sdk.Hbar;
+import com.hedera.hashgraph.sdk.TokenDissociateTransaction;
+import com.hedera.hashgraph.sdk.TokenId;
 
 @Data
 public class TokenDissociateTransactionSupplier implements TransactionSupplier<TokenDissociateTransaction> {
@@ -45,10 +46,9 @@ public class TokenDissociateTransactionSupplier implements TransactionSupplier<T
     @Override
     public TokenDissociateTransaction get() {
 
-        return new TokenDissociateTransaction()
-                .addTokenId(TokenId.fromString(tokenId))
+        return new TokenDissociateTransaction().addTokenId(TokenId.fromString(tokenId))
                 .setAccountId(AccountId.fromString(accountId))
-                .setMaxTransactionFee(maxTransactionFee)
+                .setMaxTransactionFee(Hbar.fromTinybars(maxTransactionFee))
                 .setTransactionMemo(Utility.getMemo("Mirror node dissociated test token"));
     }
 }

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenFreezeTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenFreezeTransactionSupplier.java
@@ -26,9 +26,10 @@ import lombok.Data;
 
 import com.hedera.datagenerator.common.Utility;
 import com.hedera.datagenerator.sdk.supplier.TransactionSupplier;
-import com.hedera.hashgraph.sdk.account.AccountId;
-import com.hedera.hashgraph.sdk.token.TokenFreezeTransaction;
-import com.hedera.hashgraph.sdk.token.TokenId;
+import com.hedera.hashgraph.sdk.AccountId;
+import com.hedera.hashgraph.sdk.Hbar;
+import com.hedera.hashgraph.sdk.TokenFreezeTransaction;
+import com.hedera.hashgraph.sdk.TokenId;
 
 @Data
 public class TokenFreezeTransactionSupplier implements TransactionSupplier<TokenFreezeTransaction> {
@@ -45,10 +46,8 @@ public class TokenFreezeTransactionSupplier implements TransactionSupplier<Token
     @Override
     public TokenFreezeTransaction get() {
 
-        return new TokenFreezeTransaction()
-                .setAccountId(AccountId.fromString(accountId))
-                .setMaxTransactionFee(maxTransactionFee)
-                .setTokenId(TokenId.fromString(tokenId))
+        return new TokenFreezeTransaction().setAccountId(AccountId.fromString(accountId))
+                .setMaxTransactionFee(Hbar.fromTinybars(maxTransactionFee)).setTokenId(TokenId.fromString(tokenId))
                 .setTransactionMemo(Utility.getMemo("Mirror node froze test token"));
     }
 }

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenFreezeTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenFreezeTransactionSupplier.java
@@ -48,7 +48,8 @@ public class TokenFreezeTransactionSupplier implements TransactionSupplier<Token
 
         return new TokenFreezeTransaction()
                 .setAccountId(AccountId.fromString(accountId))
-                .setMaxTransactionFee(Hbar.fromTinybars(maxTransactionFee)).setTokenId(TokenId.fromString(tokenId))
+                .setMaxTransactionFee(Hbar.fromTinybars(maxTransactionFee))
+                .setTokenId(TokenId.fromString(tokenId))
                 .setTransactionMemo(Utility.getMemo("Mirror node froze test token"));
     }
 }

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenFreezeTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenFreezeTransactionSupplier.java
@@ -46,7 +46,8 @@ public class TokenFreezeTransactionSupplier implements TransactionSupplier<Token
     @Override
     public TokenFreezeTransaction get() {
 
-        return new TokenFreezeTransaction().setAccountId(AccountId.fromString(accountId))
+        return new TokenFreezeTransaction()
+                .setAccountId(AccountId.fromString(accountId))
                 .setMaxTransactionFee(Hbar.fromTinybars(maxTransactionFee)).setTokenId(TokenId.fromString(tokenId))
                 .setTransactionMemo(Utility.getMemo("Mirror node froze test token"));
     }

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenGrantKycTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenGrantKycTransactionSupplier.java
@@ -26,9 +26,10 @@ import lombok.Data;
 
 import com.hedera.datagenerator.common.Utility;
 import com.hedera.datagenerator.sdk.supplier.TransactionSupplier;
-import com.hedera.hashgraph.sdk.account.AccountId;
-import com.hedera.hashgraph.sdk.token.TokenGrantKycTransaction;
-import com.hedera.hashgraph.sdk.token.TokenId;
+import com.hedera.hashgraph.sdk.AccountId;
+import com.hedera.hashgraph.sdk.Hbar;
+import com.hedera.hashgraph.sdk.TokenGrantKycTransaction;
+import com.hedera.hashgraph.sdk.TokenId;
 
 @Data
 public class TokenGrantKycTransactionSupplier implements TransactionSupplier<TokenGrantKycTransaction> {
@@ -45,10 +46,8 @@ public class TokenGrantKycTransactionSupplier implements TransactionSupplier<Tok
     @Override
     public TokenGrantKycTransaction get() {
 
-        return new TokenGrantKycTransaction()
-                .setAccountId(AccountId.fromString(accountId))
-                .setMaxTransactionFee(maxTransactionFee)
-                .setTokenId(TokenId.fromString(tokenId))
+        return new TokenGrantKycTransaction().setAccountId(AccountId.fromString(accountId))
+                .setMaxTransactionFee(Hbar.fromTinybars(maxTransactionFee)).setTokenId(TokenId.fromString(tokenId))
                 .setTransactionMemo(Utility.getMemo("Mirror node granted kyc to test token"));
     }
 }

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenGrantKycTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenGrantKycTransactionSupplier.java
@@ -46,8 +46,10 @@ public class TokenGrantKycTransactionSupplier implements TransactionSupplier<Tok
     @Override
     public TokenGrantKycTransaction get() {
 
-        return new TokenGrantKycTransaction().setAccountId(AccountId.fromString(accountId))
-                .setMaxTransactionFee(Hbar.fromTinybars(maxTransactionFee)).setTokenId(TokenId.fromString(tokenId))
+        return new TokenGrantKycTransaction()
+                .setAccountId(AccountId.fromString(accountId))
+                .setMaxTransactionFee(Hbar.fromTinybars(maxTransactionFee))
+                .setTokenId(TokenId.fromString(tokenId))
                 .setTransactionMemo(Utility.getMemo("Mirror node granted kyc to test token"));
     }
 }

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenMintTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenMintTransactionSupplier.java
@@ -45,7 +45,9 @@ public class TokenMintTransactionSupplier implements TransactionSupplier<TokenMi
     @Override
     public TokenMintTransaction get() {
 
-        return new TokenMintTransaction().setAmount(amount).setMaxTransactionFee(Hbar.fromTinybars(maxTransactionFee))
+        return new TokenMintTransaction()
+                .setAmount(amount)
+                .setMaxTransactionFee(Hbar.fromTinybars(maxTransactionFee))
                 .setTokenId(TokenId.fromString(tokenId))
                 .setTransactionMemo(Utility.getMemo("Mirror node minted test token"));
     }

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenMintTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenMintTransactionSupplier.java
@@ -26,8 +26,9 @@ import lombok.Data;
 
 import com.hedera.datagenerator.common.Utility;
 import com.hedera.datagenerator.sdk.supplier.TransactionSupplier;
-import com.hedera.hashgraph.sdk.token.TokenId;
-import com.hedera.hashgraph.sdk.token.TokenMintTransaction;
+import com.hedera.hashgraph.sdk.Hbar;
+import com.hedera.hashgraph.sdk.TokenId;
+import com.hedera.hashgraph.sdk.TokenMintTransaction;
 
 @Data
 public class TokenMintTransactionSupplier implements TransactionSupplier<TokenMintTransaction> {
@@ -44,9 +45,7 @@ public class TokenMintTransactionSupplier implements TransactionSupplier<TokenMi
     @Override
     public TokenMintTransaction get() {
 
-        return new TokenMintTransaction()
-                .setAmount(amount)
-                .setMaxTransactionFee(maxTransactionFee)
+        return new TokenMintTransaction().setAmount(amount).setMaxTransactionFee(Hbar.fromTinybars(maxTransactionFee))
                 .setTokenId(TokenId.fromString(tokenId))
                 .setTransactionMemo(Utility.getMemo("Mirror node minted test token"));
     }

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenRevokeKycTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenRevokeKycTransactionSupplier.java
@@ -46,8 +46,10 @@ public class TokenRevokeKycTransactionSupplier implements TransactionSupplier<To
     @Override
     public TokenRevokeKycTransaction get() {
 
-        return new TokenRevokeKycTransaction().setAccountId(AccountId.fromString(accountId))
-                .setMaxTransactionFee(Hbar.fromTinybars(maxTransactionFee)).setTokenId(TokenId.fromString(tokenId))
+        return new TokenRevokeKycTransaction()
+                .setAccountId(AccountId.fromString(accountId))
+                .setMaxTransactionFee(Hbar.fromTinybars(maxTransactionFee))
+                .setTokenId(TokenId.fromString(tokenId))
                 .setTransactionMemo(Utility.getMemo("Mirror node revoked kyc for test token"));
     }
 }

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenRevokeKycTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenRevokeKycTransactionSupplier.java
@@ -26,9 +26,10 @@ import lombok.Data;
 
 import com.hedera.datagenerator.common.Utility;
 import com.hedera.datagenerator.sdk.supplier.TransactionSupplier;
-import com.hedera.hashgraph.sdk.account.AccountId;
-import com.hedera.hashgraph.sdk.token.TokenId;
-import com.hedera.hashgraph.sdk.token.TokenRevokeKycTransaction;
+import com.hedera.hashgraph.sdk.AccountId;
+import com.hedera.hashgraph.sdk.Hbar;
+import com.hedera.hashgraph.sdk.TokenId;
+import com.hedera.hashgraph.sdk.TokenRevokeKycTransaction;
 
 @Data
 public class TokenRevokeKycTransactionSupplier implements TransactionSupplier<TokenRevokeKycTransaction> {
@@ -45,10 +46,8 @@ public class TokenRevokeKycTransactionSupplier implements TransactionSupplier<To
     @Override
     public TokenRevokeKycTransaction get() {
 
-        return new TokenRevokeKycTransaction()
-                .setAccountId(AccountId.fromString(accountId))
-                .setMaxTransactionFee(maxTransactionFee)
-                .setTokenId(TokenId.fromString(tokenId))
+        return new TokenRevokeKycTransaction().setAccountId(AccountId.fromString(accountId))
+                .setMaxTransactionFee(Hbar.fromTinybars(maxTransactionFee)).setTokenId(TokenId.fromString(tokenId))
                 .setTransactionMemo(Utility.getMemo("Mirror node revoked kyc for test token"));
     }
 }

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenUnfreezeTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenUnfreezeTransactionSupplier.java
@@ -26,9 +26,10 @@ import lombok.Data;
 
 import com.hedera.datagenerator.common.Utility;
 import com.hedera.datagenerator.sdk.supplier.TransactionSupplier;
-import com.hedera.hashgraph.sdk.account.AccountId;
-import com.hedera.hashgraph.sdk.token.TokenId;
-import com.hedera.hashgraph.sdk.token.TokenUnfreezeTransaction;
+import com.hedera.hashgraph.sdk.AccountId;
+import com.hedera.hashgraph.sdk.Hbar;
+import com.hedera.hashgraph.sdk.TokenId;
+import com.hedera.hashgraph.sdk.TokenUnfreezeTransaction;
 
 @Data
 public class TokenUnfreezeTransactionSupplier implements TransactionSupplier<TokenUnfreezeTransaction> {
@@ -47,7 +48,7 @@ public class TokenUnfreezeTransactionSupplier implements TransactionSupplier<Tok
 
         return new TokenUnfreezeTransaction()
                 .setAccountId(AccountId.fromString(accountId))
-                .setMaxTransactionFee(maxTransactionFee)
+                .setMaxTransactionFee(Hbar.fromTinybars(maxTransactionFee))
                 .setTokenId(TokenId.fromString(tokenId))
                 .setTransactionMemo(Utility.getMemo("Mirror node unfroze test token"));
     }

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenUpdateTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenUpdateTransactionSupplier.java
@@ -65,18 +65,29 @@ public class TokenUpdateTransactionSupplier implements TransactionSupplier<Token
     @Override
     public TokenUpdateTransaction get() {
 
-        TokenUpdateTransaction tokenUpdateTransaction = new TokenUpdateTransaction().setAutoRenewPeriod(autoRenewPeriod)
-                .setExpirationTime(expirationTime).setMaxTransactionFee(Hbar.fromTinybars(maxTransactionFee))
-                .setTokenName(symbol + "_name").setTokenSymbol(symbol).setTokenId(TokenId.fromString(tokenId))
+        TokenUpdateTransaction tokenUpdateTransaction = new TokenUpdateTransaction()
+                .setAutoRenewPeriod(autoRenewPeriod)
+                .setExpirationTime(expirationTime)
+                .setMaxTransactionFee(Hbar.fromTinybars(maxTransactionFee))
+                .setTokenName(symbol + "_name")
+                .setTokenSymbol(symbol)
+                .setTokenId(TokenId.fromString(tokenId))
                 .setTransactionMemo(Utility.getMemo("Mirror node updated test token"));
 
         if (adminKey != null) {
             PublicKey key = PublicKey.fromString(adminKey);
-            tokenUpdateTransaction.setAdminKey(key).setFreezeKey(key).setKycKey(key).setSupplyKey(key).setWipeKey(key);
+            tokenUpdateTransaction
+                    .setAdminKey(key)
+                    .setFreezeKey(key)
+                    .setKycKey(key)
+                    .setSupplyKey(key)
+                    .setWipeKey(key);
         }
         if (treasuryAccountId != null) {
             AccountId treastury = AccountId.fromString(treasuryAccountId);
-            tokenUpdateTransaction.setAutoRenewAccountId(treastury).setTreasuryAccountId(treastury);
+            tokenUpdateTransaction
+                    .setAutoRenewAccountId(treastury)
+                    .setTreasuryAccountId(treastury);
         }
         return tokenUpdateTransaction;
     }

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenUpdateTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenUpdateTransactionSupplier.java
@@ -32,10 +32,11 @@ import org.hibernate.validator.constraints.time.DurationMin;
 
 import com.hedera.datagenerator.common.Utility;
 import com.hedera.datagenerator.sdk.supplier.TransactionSupplier;
-import com.hedera.hashgraph.sdk.account.AccountId;
-import com.hedera.hashgraph.sdk.crypto.ed25519.Ed25519PublicKey;
-import com.hedera.hashgraph.sdk.token.TokenId;
-import com.hedera.hashgraph.sdk.token.TokenUpdateTransaction;
+import com.hedera.hashgraph.sdk.AccountId;
+import com.hedera.hashgraph.sdk.Hbar;
+import com.hedera.hashgraph.sdk.PublicKey;
+import com.hedera.hashgraph.sdk.TokenId;
+import com.hedera.hashgraph.sdk.TokenUpdateTransaction;
 
 @Data
 public class TokenUpdateTransactionSupplier implements TransactionSupplier<TokenUpdateTransaction> {
@@ -64,29 +65,18 @@ public class TokenUpdateTransactionSupplier implements TransactionSupplier<Token
     @Override
     public TokenUpdateTransaction get() {
 
-        TokenUpdateTransaction tokenUpdateTransaction = new TokenUpdateTransaction()
-                .setAutoRenewPeriod(autoRenewPeriod)
-                .setExpirationTime(expirationTime)
-                .setMaxTransactionFee(maxTransactionFee)
-                .setName(symbol + "_name")
-                .setSymbol(symbol)
-                .setTokenId(TokenId.fromString(tokenId))
+        TokenUpdateTransaction tokenUpdateTransaction = new TokenUpdateTransaction().setAutoRenewPeriod(autoRenewPeriod)
+                .setExpirationTime(expirationTime).setMaxTransactionFee(Hbar.fromTinybars(maxTransactionFee))
+                .setTokenName(symbol + "_name").setTokenSymbol(symbol).setTokenId(TokenId.fromString(tokenId))
                 .setTransactionMemo(Utility.getMemo("Mirror node updated test token"));
 
         if (adminKey != null) {
-            Ed25519PublicKey key = Ed25519PublicKey.fromString(adminKey);
-            tokenUpdateTransaction
-                    .setAdminKey(key)
-                    .setFreezeKey(key)
-                    .setKycKey(key)
-                    .setSupplyKey(key)
-                    .setWipeKey(key);
+            PublicKey key = PublicKey.fromString(adminKey);
+            tokenUpdateTransaction.setAdminKey(key).setFreezeKey(key).setKycKey(key).setSupplyKey(key).setWipeKey(key);
         }
         if (treasuryAccountId != null) {
             AccountId treastury = AccountId.fromString(treasuryAccountId);
-            tokenUpdateTransaction
-                    .setAutoRenewAccount(treastury)
-                    .setTreasury(treastury);
+            tokenUpdateTransaction.setAutoRenewAccountId(treastury).setTreasuryAccountId(treastury);
         }
         return tokenUpdateTransaction;
     }

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenWipeTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenWipeTransactionSupplier.java
@@ -49,8 +49,11 @@ public class TokenWipeTransactionSupplier implements TransactionSupplier<TokenWi
     @Override
     public TokenWipeTransaction get() {
 
-        return new TokenWipeTransaction().setAccountId(AccountId.fromString(accountId)).setAmount(amount)
-                .setMaxTransactionFee(Hbar.fromTinybars(maxTransactionFee)).setTokenId(TokenId.fromString(tokenId))
+        return new TokenWipeTransaction()
+                .setAccountId(AccountId.fromString(accountId))
+                .setAmount(amount)
+                .setMaxTransactionFee(Hbar.fromTinybars(maxTransactionFee))
+                .setTokenId(TokenId.fromString(tokenId))
                 .setTransactionMemo(Utility.getMemo("Mirror node wiped test token"));
     }
 }

--- a/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenWipeTransactionSupplier.java
+++ b/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/token/TokenWipeTransactionSupplier.java
@@ -26,9 +26,10 @@ import lombok.Data;
 
 import com.hedera.datagenerator.common.Utility;
 import com.hedera.datagenerator.sdk.supplier.TransactionSupplier;
-import com.hedera.hashgraph.sdk.account.AccountId;
-import com.hedera.hashgraph.sdk.token.TokenId;
-import com.hedera.hashgraph.sdk.token.TokenWipeTransaction;
+import com.hedera.hashgraph.sdk.AccountId;
+import com.hedera.hashgraph.sdk.Hbar;
+import com.hedera.hashgraph.sdk.TokenId;
+import com.hedera.hashgraph.sdk.TokenWipeTransaction;
 
 @Data
 public class TokenWipeTransactionSupplier implements TransactionSupplier<TokenWipeTransaction> {
@@ -48,11 +49,8 @@ public class TokenWipeTransactionSupplier implements TransactionSupplier<TokenWi
     @Override
     public TokenWipeTransaction get() {
 
-        return new TokenWipeTransaction()
-                .setAccountId(AccountId.fromString(accountId))
-                .setAmount(amount)
-                .setMaxTransactionFee(maxTransactionFee)
-                .setTokenId(TokenId.fromString(tokenId))
+        return new TokenWipeTransaction().setAccountId(AccountId.fromString(accountId)).setAmount(amount)
+                .setMaxTransactionFee(Hbar.fromTinybars(maxTransactionFee)).setTokenId(TokenId.fromString(tokenId))
                 .setTransactionMemo(Utility.getMemo("Mirror node wiped test token"));
     }
 }

--- a/hedera-mirror-monitor/pom.xml
+++ b/hedera-mirror-monitor/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>com.hedera.hashgraph</groupId>
             <artifactId>sdk</artifactId>
-            <version>${hedera-sdk.version}</version>
+            <version>2.0.5-beta.3</version>
         </dependency>
         <dependency>
             <groupId>com.lmax</groupId>

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/expression/ExpressionConverterImpl.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/expression/ExpressionConverterImpl.java
@@ -122,9 +122,9 @@ public class ExpressionConverterImpl implements ExpressionConverter {
     @RequiredArgsConstructor
     private enum ExpressionType {
 
-        ACCOUNT(TransactionType.ACCOUNT_CREATE, r -> r.getAccountId().toString()),
-        TOKEN(TransactionType.TOKEN_CREATE, r -> r.getTokenId().toString()),
-        TOPIC(TransactionType.CONSENSUS_CREATE_TOPIC, r -> r.getConsensusTopicId().toString());
+        ACCOUNT(TransactionType.ACCOUNT_CREATE, r -> r.accountId.toString()),
+        TOKEN(TransactionType.TOKEN_CREATE, r -> r.tokenId.toString()),
+        TOPIC(TransactionType.CONSENSUS_CREATE_TOPIC, r -> r.topicId.toString());
 
         private final TransactionType transactionType;
         private final Function<TransactionReceipt, String> idExtractor;

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/expression/ExpressionConverterImpl.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/expression/ExpressionConverterImpl.java
@@ -89,7 +89,7 @@ public class ExpressionConverterImpl implements ExpressionConverter {
                     .receipt(true)
                     .scenarioName(expression.toString())
                     .timestamp(Instant.now())
-                    .transactionBuilder(transactionSupplier.get())
+                    .transaction(transactionSupplier.get())
                     .type(type.getTransactionType())
                     .build();
 

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/generator/ConfigurableTransactionGenerator.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/generator/ConfigurableTransactionGenerator.java
@@ -56,8 +56,8 @@ public class ConfigurableTransactionGenerator implements TransactionGenerator {
     public ConfigurableTransactionGenerator(ExpressionConverter expressionConverter, ScenarioProperties properties) {
         this.expressionConverter = expressionConverter;
         this.properties = properties;
-        this.transactionSupplier = Suppliers.memoize(this::convert);
-        this.rateLimiter = RateLimiter.create(properties.getTps(), properties.getWarmupPeriod());
+        transactionSupplier = Suppliers.memoize(this::convert);
+        rateLimiter = RateLimiter.create(properties.getTps(), properties.getWarmupPeriod());
         remaining = new AtomicLong(properties.getLimit());
         stopTime = System.nanoTime() + properties.getDuration().toNanos();
         builder = PublishRequest.builder()
@@ -83,7 +83,8 @@ public class ConfigurableTransactionGenerator implements TransactionGenerator {
         return builder.receipt(shouldGenerate(properties.getReceipt()))
                 .record(shouldGenerate(properties.getRecord()))
                 .timestamp(Instant.now())
-                .transactionBuilder(transactionSupplier.get().get())
+                .transaction(transactionSupplier.get().get()
+                        .setMaxRetry(properties.getMaxRetries())) // set scenario transaction maxRetry
                 .build();
     }
 

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/generator/ScenarioProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/generator/ScenarioProperties.java
@@ -75,6 +75,9 @@ public class ScenarioProperties {
     public long getLimit() {
         return limit > 0 ? limit : Long.MAX_VALUE;
     }
+
+    @Min(0)
+    private int maxRetries = 0;
 }
 
 

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishMetrics.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishMetrics.java
@@ -74,14 +74,14 @@ public class PublishMetrics {
             counter.incrementAndGet();
 
             return response;
-        } catch (PrecheckStatusException e) {
-            PrecheckStatusException sre = (PrecheckStatusException) e.getCause();
-            status = sre.status.name();
-            log.debug("Network error {} submitting {} transaction: {}", status, type, sre.getMessage());
-            throw new PublishException(e);
-        } catch (ReceiptStatusException e) {
-            log.debug("Hedera error for {} transaction {}: {}", type, e.transactionId, e.getMessage());
-            throw new PublishException(e);
+        } catch (PrecheckStatusException pse) {
+            status = pse.status.toString();
+            log.debug("Network error {} submitting {} transaction: {}", status, type, pse.getMessage());
+            throw new PublishException(pse);
+        } catch (ReceiptStatusException rse) {
+            status = rse.getClass().getSimpleName();
+            log.debug("Hedera error for {} transaction {}: {}", type, rse.transactionId, rse.getMessage());
+            throw new PublishException(rse);
         } catch (Exception e) {
             status = e.getClass().getSimpleName();
             log.debug("{} submitting {} transaction: {}", status, type, e.getMessage());

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishMetrics.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishMetrics.java
@@ -79,7 +79,7 @@ public class PublishMetrics {
             log.debug("Network error {} submitting {} transaction: {}", status, type, pse.getMessage());
             throw new PublishException(pse);
         } catch (ReceiptStatusException rse) {
-            status = rse.getClass().getSimpleName();
+            status = rse.receipt.status.toString();
             log.debug("Hedera error for {} transaction {}: {}", type, rse.transactionId, rse.getMessage());
             throw new PublishException(rse);
         } catch (Exception e) {

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishRequest.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishRequest.java
@@ -35,6 +35,6 @@ public class PublishRequest {
     private final boolean receipt;
     private final boolean record;
     private final Instant timestamp;
-    private final Transaction transactionBuilder;
+    private final Transaction<?> transactionBuilder;
     private final TransactionType type;
 }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishRequest.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishRequest.java
@@ -35,6 +35,6 @@ public class PublishRequest {
     private final boolean receipt;
     private final boolean record;
     private final Instant timestamp;
-    private final Transaction<?> transactionBuilder;
+    private final Transaction<?> transaction;
     private final TransactionType type;
 }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishRequest.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishRequest.java
@@ -25,8 +25,7 @@ import lombok.Builder;
 import lombok.Value;
 
 import com.hedera.datagenerator.sdk.supplier.TransactionType;
-import com.hedera.hashgraph.sdk.TransactionBuilder;
-import com.hedera.hashgraph.sdk.TransactionId;
+import com.hedera.hashgraph.sdk.Transaction;
 
 @Builder
 @Value
@@ -36,6 +35,6 @@ public class PublishRequest {
     private final boolean receipt;
     private final boolean record;
     private final Instant timestamp;
-    private final TransactionBuilder<TransactionId, ?, ?> transactionBuilder;
+    private final Transaction transactionBuilder;
     private final TransactionType type;
 }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishResponse.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishResponse.java
@@ -53,23 +53,22 @@ public class PublishResponse {
         }
 
         if (receipt != null) {
-            com.hedera.hashgraph.proto.TransactionReceipt receiptProto = receipt.toProto();
-            toStringBuilder.append("status", receiptProto.getStatus());
+            toStringBuilder.append("status", receipt.status);
 
-            if (receiptProto.hasAccountID()) {
-                toStringBuilder.append("accountId", receiptProto.getAccountID().getAccountNum());
-            } else if (receiptProto.hasContractID()) {
-                toStringBuilder.append("contractId", receiptProto.getContractID().getContractNum());
-            } else if (receiptProto.hasFileID()) {
-                toStringBuilder.append("fileId", receiptProto.getFileID().getFileNum());
-            } else if (receiptProto.hasTokenID()) {
-                toStringBuilder.append("tokenId", receiptProto.getTokenID().getTokenNum());
-            } else if (receiptProto.hasTopicID()) {
-                toStringBuilder.append("topicId", receiptProto.getTopicID().getTopicNum());
+            if (receipt.accountId != null) {
+                toStringBuilder.append("accountId", receipt.accountId.num);
+            } else if (receipt.contractId != null) {
+                toStringBuilder.append("contractId", receipt.contractId.num);
+            } else if (receipt.fileId != null) {
+                toStringBuilder.append("fileId", receipt.fileId.num);
+            } else if (receipt.tokenId != null) {
+                toStringBuilder.append("tokenId", receipt.tokenId.num);
+            } else if (receipt.topicId != null) {
+                toStringBuilder.append("topicId", receipt.topicId.num);
             }
 
-            if (receiptProto.getTopicSequenceNumber() > 0) {
-                toStringBuilder.append("topicSequenceNumber", receiptProto.getTopicSequenceNumber());
+            if (receipt.topicSequenceNumber > 0) {
+                toStringBuilder.append("topicSequenceNumber", receipt.topicSequenceNumber);
             }
         }
 

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/TransactionPublisher.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/TransactionPublisher.java
@@ -42,7 +42,6 @@ import com.hedera.hashgraph.sdk.PrecheckStatusException;
 import com.hedera.hashgraph.sdk.PrivateKey;
 import com.hedera.hashgraph.sdk.ReceiptStatusException;
 import com.hedera.hashgraph.sdk.TransactionId;
-import com.hedera.hashgraph.sdk.TransactionResponse;
 import com.hedera.mirror.monitor.MonitorProperties;
 import com.hedera.mirror.monitor.NodeProperties;
 
@@ -80,8 +79,7 @@ public class TransactionPublisher {
         int index = counter.getAndUpdate(n -> (n + 1 < clients.get().size()) ? n + 1 : 0);
         Client client = clients.get().get(index);
 
-        TransactionResponse transactionResponse = (TransactionResponse) request.getTransactionBuilder().execute(client);
-        TransactionId transactionId = transactionResponse.transactionId;
+        TransactionId transactionId = request.getTransactionBuilder().execute(client).transactionId;
         PublishResponse.PublishResponseBuilder responseBuilder = PublishResponse.builder()
                 .request(request)
                 .timestamp(Instant.now())

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/TransactionPublisher.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/TransactionPublisher.java
@@ -79,7 +79,7 @@ public class TransactionPublisher {
         int index = counter.getAndUpdate(n -> (n + 1 < clients.get().size()) ? n + 1 : 0);
         Client client = clients.get().get(index);
 
-        TransactionId transactionId = request.getTransactionBuilder().execute(client).transactionId;
+        TransactionId transactionId = request.getTransaction().execute(client).transactionId;
         PublishResponse.PublishResponseBuilder responseBuilder = PublishResponse.builder()
                 .request(request)
                 .timestamp(Instant.now())

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/CompositeSubscriber.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/CompositeSubscriber.java
@@ -25,6 +25,7 @@ import com.google.common.collect.Streams;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import javax.annotation.PreDestroy;
@@ -79,7 +80,8 @@ public class CompositeSubscriber implements Subscriber {
                                         .getMirrorNode().getGrpc().getEndpoint());
                             }
                             return null;
-                        }),
+                        })
+                        .filter(Objects::nonNull),
                 subscribeProperties.getRest()
                         .stream()
                         .filter(AbstractSubscriberProperties::isEnabled)

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/CompositeSubscriber.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/CompositeSubscriber.java
@@ -30,7 +30,6 @@ import java.util.stream.Collectors;
 import javax.annotation.PreDestroy;
 import javax.inject.Named;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
 import org.springframework.context.annotation.Primary;
 import org.springframework.web.reactive.function.client.WebClient;
 
@@ -38,7 +37,6 @@ import com.hedera.mirror.monitor.MonitorProperties;
 import com.hedera.mirror.monitor.expression.ExpressionConverter;
 import com.hedera.mirror.monitor.publish.PublishResponse;
 
-@Log4j2
 @Named
 @Primary
 @RequiredArgsConstructor

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/CompositeSubscriber.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/CompositeSubscriber.java
@@ -72,15 +72,7 @@ public class CompositeSubscriber implements Subscriber {
                 subscribeProperties.getGrpc()
                         .stream()
                         .filter(AbstractSubscriberProperties::isEnabled)
-                        .map(p -> {
-                            try {
-                                return new GrpcSubscriber(expressionConverter, meterRegistry, monitorProperties, p);
-                            } catch (InterruptedException e) {
-                                log.warn("Unable to retrieve mirror grpc subscriber to {}: ", monitorProperties
-                                        .getMirrorNode().getGrpc().getEndpoint());
-                            }
-                            return null;
-                        })
+                        .map(p -> new GrpcSubscriber(expressionConverter, meterRegistry, monitorProperties, p))
                         .filter(Objects::nonNull),
                 subscribeProperties.getRest()
                         .stream()

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/CompositeSubscriber.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/CompositeSubscriber.java
@@ -25,7 +25,6 @@ import com.google.common.collect.Streams;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import javax.annotation.PreDestroy;
@@ -72,8 +71,7 @@ public class CompositeSubscriber implements Subscriber {
                 subscribeProperties.getGrpc()
                         .stream()
                         .filter(AbstractSubscriberProperties::isEnabled)
-                        .map(p -> new GrpcSubscriber(expressionConverter, meterRegistry, monitorProperties, p))
-                        .filter(Objects::nonNull),
+                        .map(p -> new GrpcSubscriber(expressionConverter, meterRegistry, monitorProperties, p)),
                 subscribeProperties.getRest()
                         .stream()
                         .filter(AbstractSubscriberProperties::isEnabled)

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/GrpcSubscriber.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/GrpcSubscriber.java
@@ -78,6 +78,7 @@ public class GrpcSubscriber extends AbstractSubscriber<GrpcSubscriberProperties>
         } catch (InterruptedException e) {
             log.warn("Unable to retrieve mirror grpc subscriber to {}: ", monitorProperties
                     .getMirrorNode().getGrpc().getEndpoint());
+            Thread.currentThread().interrupt();
         }
     }
 

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/GrpcSubscriber.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/GrpcSubscriber.java
@@ -28,20 +28,23 @@ import io.grpc.StatusRuntimeException;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import com.hedera.datagenerator.common.Utility;
 import com.hedera.datagenerator.sdk.supplier.TransactionType;
+import com.hedera.hashgraph.sdk.AccountId;
 import com.hedera.hashgraph.sdk.Client;
 import com.hedera.hashgraph.sdk.SubscriptionHandle;
 import com.hedera.hashgraph.sdk.TopicId;
 import com.hedera.hashgraph.sdk.TopicMessage;
 import com.hedera.hashgraph.sdk.TopicMessageQuery;
 import com.hedera.mirror.monitor.MonitorProperties;
+import com.hedera.mirror.monitor.NodeProperties;
 import com.hedera.mirror.monitor.expression.ExpressionConverter;
 import com.hedera.mirror.monitor.publish.PublishResponse;
 
@@ -62,12 +65,12 @@ public class GrpcSubscriber extends AbstractSubscriber<GrpcSubscriberProperties>
         String topicId = expressionConverter.convert(subscriberProperties.getTopicId());
         subscriberProperties.setTopicId(topicId);
 
+        NodeProperties singleNodeProperty = new ArrayList<>(monitorProperties.getNodes()).get(0);
+        AccountId nodeAccount = AccountId.fromString(singleNodeProperty.getAccountId());
+        // though not used in mirror case you must set network nodes
+        client = Client.forNetwork(Map.of(singleNodeProperty.getEndpoint(), nodeAccount));
         String endpoint = monitorProperties.getMirrorNode().getGrpc().getEndpoint();
         log.info("Connecting to mirror node {}", endpoint);
-//        NodeProperties singleNodeProperty = new ArrayList<>(monitorProperties.getNodes()).get(0);
-//        AccountId nodeAccount = AccountId.fromString(singleNodeProperty.getAccountId());
-//        mirrorClient = Client.forNetwork(Map.of(singleNodeProperty.getEndpoint(), nodeAccount));
-        client = Client.forNetwork(new HashMap<>());
         client.setMirrorNetwork(List.of(endpoint));
         subscribe();
     }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/GrpcSubscriber.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/GrpcSubscriber.java
@@ -28,45 +28,51 @@ import io.grpc.StatusRuntimeException;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import com.hedera.datagenerator.common.Utility;
 import com.hedera.datagenerator.sdk.supplier.TransactionType;
-import com.hedera.hashgraph.sdk.consensus.ConsensusTopicId;
-import com.hedera.hashgraph.sdk.mirror.MirrorClient;
-import com.hedera.hashgraph.sdk.mirror.MirrorConsensusTopicQuery;
-import com.hedera.hashgraph.sdk.mirror.MirrorConsensusTopicResponse;
-import com.hedera.hashgraph.sdk.mirror.MirrorSubscriptionHandle;
+import com.hedera.hashgraph.sdk.Client;
+import com.hedera.hashgraph.sdk.SubscriptionHandle;
+import com.hedera.hashgraph.sdk.TopicId;
+import com.hedera.hashgraph.sdk.TopicMessage;
+import com.hedera.hashgraph.sdk.TopicMessageQuery;
 import com.hedera.mirror.monitor.MonitorProperties;
 import com.hedera.mirror.monitor.expression.ExpressionConverter;
 import com.hedera.mirror.monitor.publish.PublishResponse;
 
 public class GrpcSubscriber extends AbstractSubscriber<GrpcSubscriberProperties> {
 
-    private final MirrorClient mirrorClient;
+    private final Client client;
     private final AtomicLong retries;
 
-    private MirrorSubscriptionHandle subscription;
-    private volatile MirrorConsensusTopicResponse lastReceived;
+    private SubscriptionHandle subscription;
+    private volatile TopicMessage lastReceived;
     private Instant endTime;
 
     GrpcSubscriber(ExpressionConverter expressionConverter, MeterRegistry meterRegistry,
-                   MonitorProperties monitorProperties, GrpcSubscriberProperties subscriberProperties) {
+                   MonitorProperties monitorProperties, GrpcSubscriberProperties subscriberProperties) throws InterruptedException {
         super(meterRegistry, subscriberProperties);
-        this.retries = new AtomicLong(0L);
+        retries = new AtomicLong(0L);
 
         String topicId = expressionConverter.convert(subscriberProperties.getTopicId());
         subscriberProperties.setTopicId(topicId);
 
         String endpoint = monitorProperties.getMirrorNode().getGrpc().getEndpoint();
         log.info("Connecting to mirror node {}", endpoint);
-        this.mirrorClient = new MirrorClient(endpoint);
+//        NodeProperties singleNodeProperty = new ArrayList<>(monitorProperties.getNodes()).get(0);
+//        AccountId nodeAccount = AccountId.fromString(singleNodeProperty.getAccountId());
+//        mirrorClient = Client.forNetwork(Map.of(singleNodeProperty.getEndpoint(), nodeAccount));
+        client = Client.forNetwork(new HashMap<>());
+        client.setMirrorNetwork(List.of(endpoint));
         subscribe();
     }
 
-    private void onNext(MirrorConsensusTopicResponse topicResponse) {
+    private void onNext(TopicMessage topicResponse) {
         long endTimestamp = System.currentTimeMillis();
         counter.incrementAndGet();
         retries.set(0L);
@@ -80,8 +86,8 @@ public class GrpcSubscriber extends AbstractSubscriber<GrpcSubscriberProperties>
             }
         }
 
-        this.lastReceived = topicResponse;
-        Long timestamp = Utility.getTimestamp(topicResponse.message);
+        lastReceived = topicResponse;
+        Long timestamp = Utility.getTimestamp(topicResponse.contents);
 
         if (timestamp == null || timestamp <= 0 || timestamp >= System.currentTimeMillis()) {
             log.warn("Invalid timestamp in message: {}", timestamp);
@@ -140,7 +146,7 @@ public class GrpcSubscriber extends AbstractSubscriber<GrpcSubscriberProperties>
             super.close();
             log.info("Closing mirror node connection");
             subscription.unsubscribe();
-            mirrorClient.close(1, TimeUnit.SECONDS);
+            client.close();
         } catch (Exception e) {
             // Ignore
         }
@@ -148,8 +154,8 @@ public class GrpcSubscriber extends AbstractSubscriber<GrpcSubscriberProperties>
 
     private synchronized void subscribe() {
         long limit = subscriberProperties.getLimit();
-        MirrorConsensusTopicQuery mirrorConsensusTopicQuery = new MirrorConsensusTopicQuery();
-        mirrorConsensusTopicQuery.setTopicId(ConsensusTopicId.fromString(subscriberProperties.getTopicId()));
+        TopicMessageQuery mirrorConsensusTopicQuery = new TopicMessageQuery();
+        mirrorConsensusTopicQuery.setTopicId(TopicId.fromString(subscriberProperties.getTopicId()));
         mirrorConsensusTopicQuery.setLimit(limit > 0 ? limit - counter.get() : 0);
 
         Instant startTime = lastReceived != null ? lastReceived.consensusTimestamp.plusNanos(1) : subscriberProperties
@@ -168,6 +174,6 @@ public class GrpcSubscriber extends AbstractSubscriber<GrpcSubscriberProperties>
         }
 
         log.info("Starting subscriber: {}", subscriberProperties);
-        subscription = mirrorConsensusTopicQuery.subscribe(mirrorClient, this::onNext, this::onError);
+        subscription = mirrorConsensusTopicQuery.subscribe(client, this::onNext);
     }
 }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/GrpcSubscriber.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/GrpcSubscriber.java
@@ -58,7 +58,7 @@ public class GrpcSubscriber extends AbstractSubscriber<GrpcSubscriberProperties>
     private Instant endTime;
 
     GrpcSubscriber(ExpressionConverter expressionConverter, MeterRegistry meterRegistry,
-                   MonitorProperties monitorProperties, GrpcSubscriberProperties subscriberProperties) throws InterruptedException {
+                   MonitorProperties monitorProperties, GrpcSubscriberProperties subscriberProperties) {
         super(meterRegistry, subscriberProperties);
         retries = new AtomicLong(0L);
 
@@ -71,8 +71,14 @@ public class GrpcSubscriber extends AbstractSubscriber<GrpcSubscriberProperties>
         client = Client.forNetwork(Map.of(singleNodeProperty.getEndpoint(), nodeAccount));
         String endpoint = monitorProperties.getMirrorNode().getGrpc().getEndpoint();
         log.info("Connecting to mirror node {}", endpoint);
-        client.setMirrorNetwork(List.of(endpoint));
-        subscribe();
+
+        try {
+            client.setMirrorNetwork(List.of(endpoint));
+            subscribe();
+        } catch (InterruptedException e) {
+            log.warn("Unable to retrieve mirror grpc subscriber to {}: ", monitorProperties
+                    .getMirrorNode().getGrpc().getEndpoint());
+        }
     }
 
     private void onNext(TopicMessage topicResponse) {

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/generator/ConfigurableTransactionGeneratorTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/generator/ConfigurableTransactionGeneratorTest.java
@@ -178,6 +178,6 @@ class ConfigurableTransactionGeneratorTest {
                 .hasFieldOrPropertyWithValue("receipt", true)
                 .hasFieldOrPropertyWithValue("record", true)
                 .hasFieldOrPropertyWithValue("type", properties.getType())
-                .hasFieldOrPropertyWithValue("transactionBuilder.topicId", TopicId.fromString(TOPIC_ID));
+                .hasFieldOrPropertyWithValue("transaction.topicId", TopicId.fromString(TOPIC_ID));
     }
 }

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/generator/ConfigurableTransactionGeneratorTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/generator/ConfigurableTransactionGeneratorTest.java
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.hedera.datagenerator.sdk.supplier.TransactionType;
-import com.hedera.hashgraph.sdk.consensus.ConsensusTopicId;
+import com.hedera.hashgraph.sdk.TopicId;
 import com.hedera.mirror.monitor.publish.PublishRequest;
 
 class ConfigurableTransactionGeneratorTest {
@@ -178,6 +178,6 @@ class ConfigurableTransactionGeneratorTest {
                 .hasFieldOrPropertyWithValue("receipt", true)
                 .hasFieldOrPropertyWithValue("record", true)
                 .hasFieldOrPropertyWithValue("type", properties.getType())
-                .hasFieldOrPropertyWithValue("transactionBuilder.topicId", ConsensusTopicId.fromString(TOPIC_ID));
+                .hasFieldOrPropertyWithValue("transactionBuilder.topicId", TopicId.fromString(TOPIC_ID));
     }
 }

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/RestSubscriberTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/RestSubscriberTest.java
@@ -258,7 +258,7 @@ class RestSubscriberTest {
                         .type(TransactionType.CONSENSUS_SUBMIT_MESSAGE)
                         .build())
                 .timestamp(Instant.now())
-                .transactionId(new TransactionId(AccountId.fromString("0.0.1000"), Instant.ofEpochSecond(1)))
+                .transactionId(TransactionId.withValidStart(AccountId.fromString("0.0.1000"), Instant.ofEpochSecond(1)))
                 .build();
     }
 

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/RestSubscriberTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/RestSubscriberTest.java
@@ -53,8 +53,8 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 import reactor.core.publisher.Mono;
 
 import com.hedera.datagenerator.sdk.supplier.TransactionType;
+import com.hedera.hashgraph.sdk.AccountId;
 import com.hedera.hashgraph.sdk.TransactionId;
-import com.hedera.hashgraph.sdk.account.AccountId;
 import com.hedera.mirror.monitor.MirrorNodeProperties;
 import com.hedera.mirror.monitor.MonitorProperties;
 import com.hedera.mirror.monitor.publish.PublishRequest;
@@ -89,7 +89,7 @@ class RestSubscriberTest {
         subscriberProperties.getRetry().setMaxBackoff(Duration.ofNanos(2L));
 
         builder = WebClient.builder().exchangeFunction(exchangeFunction);
-        this.restSubscriber = Suppliers
+        restSubscriber = Suppliers
                 .memoize(() -> new RestSubscriber(meterRegistry, monitorProperties, subscriberProperties, builder));
     }
 
@@ -258,7 +258,7 @@ class RestSubscriberTest {
                         .type(TransactionType.CONSENSUS_SUBMIT_MESSAGE)
                         .build())
                 .timestamp(Instant.now())
-                .transactionId(TransactionId.withValidStart(AccountId.fromString("0.0.1000"), Instant.ofEpochSecond(1)))
+                .transactionId(new TransactionId(AccountId.fromString("0.0.1000"), Instant.ofEpochSecond(1)))
                 .build();
     }
 


### PR DESCRIPTION
**Detailed description**:
Update monitor to use sdk v2

- Update `TransactionSupplier` signature given removal of TransactionBuilder
- Update data generator and monitor to use sdk v2.0.5-beta.3
- Update classes to use new Key, Transaction, Entity id, record and receipt classes
- Update `PublishMetrics` exception cases as they've changed

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated

