### PR TITLE
Acceptance test miscellaneous  improvements

### DIFF
--- a/hedera-mirror-test/pom.xml
+++ b/hedera-mirror-test/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>com.hedera.hashgraph</groupId>
             <artifactId>sdk</artifactId>
-            <version>2.0.5-beta.3</version>
+            <version>2.0.5-beta.4</version>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AccountClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AccountClient.java
@@ -127,9 +127,10 @@ public class AccountClient extends AbstractNetworkClient {
                 .setInitialBalance(initialBalance)
                 // The only _required_ property here is `key`
                 .setKey(publicKeys)
-                .setTransactionMemo(memo)
+                .setAccountMemo(memo)
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
-                .setReceiverSignatureRequired(receiverSigRequired);
+                .setReceiverSignatureRequired(receiverSigRequired)
+                .setTransactionMemo(memo);
     }
 
     public ExpandedAccountId createNewAccount(long initialBalance) throws TimeoutException, PrecheckStatusException,

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/MirrorNodeClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/MirrorNodeClient.java
@@ -118,7 +118,7 @@ public class MirrorNodeClient extends AbstractNetworkClient {
     public MirrorBalancesResponse getAccountBalances(String accountId) {
         log.debug("Verify balance for account '{}' is returned by Mirror Node", accountId);
         // build /balances?account.id=<accountId>
-        return (MirrorBalancesResponse) callRestEndpoint("/{endpoint}?{key}={accountId}",
+        return callRestEndpoint("/{endpoint}?{key}={accountId}",
                 MirrorBalancesResponse.class, BALANCES_ENDPOINT,
                 ACCOUNTS_ID_QUERY, accountId);
     }
@@ -126,7 +126,7 @@ public class MirrorNodeClient extends AbstractNetworkClient {
     public MirrorTransactionsResponse getTransactionInfoByTimestamp(String timestamp) {
         log.debug("Verify transaction with consensus timestamp '{}' is returned by Mirror Node", timestamp);
         // build /transactions/<timestamp>
-        return (MirrorTransactionsResponse) callRestEndpoint("/{endpoint}?timestamp={timestamp}",
+        return callRestEndpoint("/{endpoint}?timestamp={timestamp}",
                 MirrorTransactionsResponse.class, TRANSACTIONS_ENDPOINT,
                 timestamp);
     }
@@ -134,7 +134,7 @@ public class MirrorNodeClient extends AbstractNetworkClient {
     public MirrorTransactionsResponse getTransactions(String transactionId) {
         log.debug("Verify transaction '{}' is returned by Mirror Node", transactionId);
         // build /transactions/<transactionId>
-        return (MirrorTransactionsResponse) callRestEndpoint("/{endpoint}/{transactionId}",
+        return callRestEndpoint("/{endpoint}/{transactionId}",
                 MirrorTransactionsResponse.class, TRANSACTIONS_ENDPOINT,
                 transactionId);
     }
@@ -142,7 +142,7 @@ public class MirrorNodeClient extends AbstractNetworkClient {
     public MirrorTokenResponse getTokenInfo(String tokenId) {
         log.debug("Verify token '{}' is returned by Mirror Node", tokenId);
         // build /tokens/<tokenId>
-        return (MirrorTokenResponse) callRestEndpoint("/{endpoint}/{tokenId}", MirrorTokenResponse.class,
+        return callRestEndpoint("/{endpoint}/{tokenId}", MirrorTokenResponse.class,
                 TOKENS_ENDPOINT, tokenId);
     }
 

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/MirrorNodeClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/MirrorNodeClient.java
@@ -154,8 +154,8 @@ public class MirrorNodeClient extends AbstractNetworkClient {
                 scheduleId);
     }
 
-    public Object callRestEndpoint(String uri, Class<?> classType, Object... uriVariables) {
-        Object response = webClient.get()
+    public <T> T callRestEndpoint(String uri, Class<T> classType, Object... uriVariables) {
+        T response = webClient.get()
                 .uri(uri, uriVariables)
                 .accept(MediaType.APPLICATION_JSON)
                 .retrieve()

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/MirrorNodeClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/MirrorNodeClient.java
@@ -28,7 +28,6 @@ import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.retry.annotation.Recover;
-import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import com.hedera.hashgraph.sdk.SubscriptionHandle;
@@ -116,78 +115,54 @@ public class MirrorNodeClient extends AbstractNetworkClient {
         return subscriptionResponse;
     }
 
-    public ClientResponse getAccount(String accountId) {
-        log.debug("Verify account '{}' is returned by Mirror Node", accountId);
-        // build /accounts?account.id=<accountId>
-        return callRestEndpoint("/{endpoint}?{key}={accountId}", ACCOUNTS_ENDPOINT, ACCOUNTS_ID_QUERY, accountId);
-    }
-
-    public ClientResponse getAccountTransactions(String accountId, int lastCount) {
-        log.debug("Verify account '{}' is returned by Mirror Node", accountId);
-        // build /accounts/<accountId>?order=desc&limit=50
-        return callRestEndpoint("/{endpoint}/{accountId}?order=desc&limit={limit}", ACCOUNTS_ENDPOINT, accountId,
-                lastCount);
-    }
-
     public MirrorBalancesResponse getAccountBalances(String accountId) {
         log.debug("Verify balance for account '{}' is returned by Mirror Node", accountId);
         // build /balances?account.id=<accountId>
-        ClientResponse clientResponse = callRestEndpoint("/{endpoint}?{key}={accountId}", BALANCES_ENDPOINT,
+        return (MirrorBalancesResponse) callRestEndpoint("/{endpoint}?{key}={accountId}",
+                MirrorBalancesResponse.class, BALANCES_ENDPOINT,
                 ACCOUNTS_ID_QUERY, accountId);
-        return clientResponse.bodyToMono(MirrorBalancesResponse.class)
-                .block();
     }
 
     public MirrorTransactionsResponse getTransactionInfoByTimestamp(String timestamp) {
         log.debug("Verify transaction with consensus timestamp '{}' is returned by Mirror Node", timestamp);
         // build /transactions/<timestamp>
-        ClientResponse clientResponse = callRestEndpoint("/{endpoint}?timestamp={timestamp}", TRANSACTIONS_ENDPOINT,
+        return (MirrorTransactionsResponse) callRestEndpoint("/{endpoint}?timestamp={timestamp}",
+                MirrorTransactionsResponse.class, TRANSACTIONS_ENDPOINT,
                 timestamp);
-        return clientResponse.bodyToMono(MirrorTransactionsResponse.class)
-                .block();
     }
 
     public MirrorTransactionsResponse getTransactions(String transactionId) {
         log.debug("Verify transaction '{}' is returned by Mirror Node", transactionId);
         // build /transactions/<transactionId>
-        ClientResponse clientResponse = callRestEndpoint("/{endpoint}/{transactionId}", TRANSACTIONS_ENDPOINT,
+        return (MirrorTransactionsResponse) callRestEndpoint("/{endpoint}/{transactionId}",
+                MirrorTransactionsResponse.class, TRANSACTIONS_ENDPOINT,
                 transactionId);
-        return clientResponse.bodyToMono(MirrorTransactionsResponse.class)
-                .block();
     }
 
     public MirrorTokenResponse getTokenInfo(String tokenId) {
         log.debug("Verify token '{}' is returned by Mirror Node", tokenId);
         // build /tokens/<tokenId>
-        ClientResponse clientResponse = callRestEndpoint("/{endpoint}/{tokenId}", TOKENS_ENDPOINT, tokenId);
-        return clientResponse.bodyToMono(MirrorTokenResponse.class)
-                .block();
-    }
-
-    public ClientResponse getTokenBalances(String tokenId, String accountId) {
-        log.debug("Verify token balance for token '{}' and account '{}' is returned by Mirror Node", tokenId,
-                accountId);
-        // build /tokens/<tokenId>/balances?account.id=<accountId>
-        return callRestEndpoint("/{endpoint}/{tokenId}/{path}?{key}={accountId}", TOKENS_ENDPOINT, tokenId,
-                BALANCES_ENDPOINT, ACCOUNTS_ID_QUERY, accountId);
+        return (MirrorTokenResponse) callRestEndpoint("/{endpoint}/{tokenId}", MirrorTokenResponse.class,
+                TOKENS_ENDPOINT, tokenId);
     }
 
     public MirrorScheduleResponse getScheduleInfo(String scheduleId) {
         log.debug("Verify schedule '{}' is returned by Mirror Node", scheduleId);
         // build /schedules/<scheduleId>
-        ClientResponse clientResponse = callRestEndpoint("/{endpoint}/{scheduleId}", SCHEDULES_ENDPOINT, scheduleId);
-        return clientResponse.bodyToMono(MirrorScheduleResponse.class)
-                .block();
+        return (MirrorScheduleResponse) callRestEndpoint("/{endpoint}/{scheduleId}", MirrorScheduleResponse.class,
+                SCHEDULES_ENDPOINT,
+                scheduleId);
     }
 
-    public ClientResponse callRestEndpoint(String uri, Object... uriVariables) {
-        ClientResponse response = webClient.get()
+    public Object callRestEndpoint(String uri, Class<?> classType, Object... uriVariables) {
+        Object response = webClient.get()
                 .uri(uri, uriVariables)
                 .accept(MediaType.APPLICATION_JSON)
-                .exchange()
+                .retrieve()
+                .bodyToMono(classType)
+                .doOnNext(x -> log.debug("Endpoint call successfully returned a 200"))
+                .doOnError(x -> log.debug("Endpoint failed, returning: {}", x.getMessage()))
                 .block();
-
-        log.debug("Endpoint {} returned {}", uri, response.statusCode());
 
         return response;
     }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/ScheduleClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/ScheduleClient.java
@@ -58,8 +58,9 @@ public class ScheduleClient extends AbstractNetworkClient {
         ScheduleCreateTransaction scheduleCreateTransaction = transaction.schedule()
                 .setAdminKey(payerAccountId.getPublicKey())
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
-                .setMemo(memo)
-                .setPayerAccountId(payerAccountId.getAccountId());
+                .setPayerAccountId(payerAccountId.getAccountId())
+                .setScheduleMemo(memo)
+                .setTransactionMemo(memo);
 
         if (innerSignatureKeyList != null) {
             // add initial set of required signatures to ScheduleCreate transaction

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TokenClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TokenClient.java
@@ -69,6 +69,7 @@ public class TokenClient extends AbstractNetworkClient {
 
         log.debug("Create new token {}", symbol);
         Instant refInstant = Instant.now();
+        String memo = String.format("Create token {}_{}", symbol, refInstant);
         PublicKey adminKey = expandedAccountId.getPublicKey();
         TokenCreateTransaction tokenCreateTransaction = new TokenCreateTransaction()
                 .setAutoRenewAccountId(expandedAccountId.getAccountId())
@@ -76,11 +77,12 @@ public class TokenClient extends AbstractNetworkClient {
                 .setDecimals(10)
                 .setFreezeDefault(false)
                 .setInitialSupply(initialSupply)
+                .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
+                .setTokenMemo(memo)
                 .setTokenName(symbol + "_name")
                 .setTokenSymbol(symbol)
                 .setTreasuryAccountId(treasuryAccount.getAccountId())
-                .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
-                .setTransactionMemo("Create token_" + refInstant);
+                .setTransactionMemo(memo);
 
         if (adminKey != null) {
             tokenCreateTransaction

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TopicClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TopicClient.java
@@ -64,11 +64,13 @@ public class TopicClient extends AbstractNetworkClient {
             PrecheckStatusException, TimeoutException {
 
         Instant refInstant = Instant.now();
+        String memo = "HCS Topic_" + refInstant;
         TopicCreateTransaction consensusTopicCreateTransaction = new TopicCreateTransaction()
                 .setAdminKey(adminAccount.getPublicKey())
                 .setAutoRenewAccountId(sdkClient.getOperatorId())
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
-                .setTopicMemo("HCS Topic_" + refInstant)
+                .setTopicMemo(memo)
+                .setTransactionMemo(memo)
                 .setAutoRenewPeriod(autoRenewPeriod); // INSUFFICIENT_TX_FEE, also unsupported
 
         if (submitKey != null) {

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ScheduleFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ScheduleFeature.java
@@ -42,6 +42,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Recover;
 import org.springframework.retry.annotation.Retryable;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 
 import com.hedera.hashgraph.sdk.AccountId;
 import com.hedera.hashgraph.sdk.Hbar;
@@ -365,7 +366,7 @@ public class ScheduleFeature {
     }
 
     @Then("the mirror node REST API should return status {int} for the schedule transaction")
-    @Retryable(value = {AssertionError.class, AssertionFailedError.class},
+    @Retryable(value = {AssertionError.class, AssertionFailedError.class, WebClientResponseException.class},
             backoff = @Backoff(delayExpression = "#{@restPollingProperties.delay.toMillis()}"),
             maxAttemptsExpression = "#{@restPollingProperties.maxAttempts}")
     public void verifyMirrorAPIResponses(int status) {
@@ -381,7 +382,7 @@ public class ScheduleFeature {
     }
 
     @Then("the mirror node REST API should verify the executed schedule entity")
-    @Retryable(value = {AssertionError.class, AssertionFailedError.class},
+    @Retryable(value = {AssertionError.class, AssertionFailedError.class, WebClientResponseException.class},
             backoff = @Backoff(delayExpression = "#{@restPollingProperties.delay.toMillis()}"),
             maxAttemptsExpression = "#{@restPollingProperties.maxAttempts}")
     public void verifyExecutedScheduleFromMirror() {
@@ -391,7 +392,7 @@ public class ScheduleFeature {
     }
 
     @Then("the mirror node REST API should verify the non executed schedule entity")
-    @Retryable(value = {AssertionError.class, AssertionFailedError.class},
+    @Retryable(value = {AssertionError.class, AssertionFailedError.class, WebClientResponseException.class},
             backoff = @Backoff(delayExpression = "#{@restPollingProperties.delay.toMillis()}"),
             maxAttemptsExpression = "#{@restPollingProperties.maxAttempts}")
     public void verifyNonExecutedScheduleFromMirror() {

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TokenFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TokenFeature.java
@@ -38,6 +38,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Recover;
 import org.springframework.retry.annotation.Retryable;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 
 import com.hedera.hashgraph.sdk.AccountId;
 import com.hedera.hashgraph.sdk.PrecheckStatusException;
@@ -217,7 +218,7 @@ public class TokenFeature {
     }
 
     @Then("the mirror node REST API should return status {int}")
-    @Retryable(value = {AssertionError.class, AssertionFailedError.class},
+    @Retryable(value = {AssertionError.class, AssertionFailedError.class, WebClientResponseException.class},
             backoff = @Backoff(delayExpression = "#{@restPollingProperties.delay.toMillis()}"),
             maxAttemptsExpression = "#{@restPollingProperties.maxAttempts}")
     public void verifyMirrorAPIResponses(int status) {
@@ -225,7 +226,7 @@ public class TokenFeature {
     }
 
     @Then("the mirror node REST API should return status {int} for token fund flow")
-    @Retryable(value = {AssertionError.class, AssertionFailedError.class},
+    @Retryable(value = {AssertionError.class, AssertionFailedError.class, WebClientResponseException.class},
             backoff = @Backoff(delayExpression = "#{@restPollingProperties.delay.toMillis()}"),
             maxAttemptsExpression = "#{@restPollingProperties.maxAttempts}")
     public void verifyMirrorTokenFundFlow(int status) {
@@ -236,7 +237,7 @@ public class TokenFeature {
     }
 
     @Then("the mirror node REST API should confirm token update")
-    @Retryable(value = {AssertionError.class, AssertionFailedError.class},
+    @Retryable(value = {AssertionError.class, AssertionFailedError.class, WebClientResponseException.class},
             backoff = @Backoff(delayExpression = "#{@restPollingProperties.delay.toMillis()}"),
             maxAttemptsExpression = "#{@restPollingProperties.maxAttempts}")
     public void verifyMirrorTokenUpdateFlow() {
@@ -244,7 +245,7 @@ public class TokenFeature {
     }
 
     @Then("the mirror node REST API should return status {int} for transaction {string}")
-    @Retryable(value = {AssertionError.class, AssertionFailedError.class},
+    @Retryable(value = {AssertionError.class, AssertionFailedError.class, WebClientResponseException.class},
             backoff = @Backoff(delayExpression = "#{@restPollingProperties.delay.toMillis()}"),
             maxAttemptsExpression = "#{@restPollingProperties.maxAttempts}")
     public void verifyMirrorRestTransactionIsPresent(int status, String transactionIdString) {

--- a/hedera-mirror-test/src/test/resources/features/account/account.feature
+++ b/hedera-mirror-test/src/test/resources/features/account/account.feature
@@ -1,7 +1,7 @@
-@Accounts @FullSuite
+@accounts @fullsuite
 Feature: Account Coverage Feature
 
-    @BalanceCheck @Sanity @Acceptance
+    @balancecheck @sanity @acceptance @Acceptance
     Scenario Outline: Validate account balance check scenario
         When I request balance info for this account
         Then the crypto balance should be greater than or equal to <threshold>
@@ -9,7 +9,7 @@ Feature: Account Coverage Feature
             | threshold |
             | 1000000   |
 
-    @CreateCryptoAccount
+    @createcryptoaccount
     Scenario Outline: Create crypto account
         When I create a new account with balance <amount> tℏ
         Then the new balance should reflect cryptotransfer of <amount>

--- a/hedera-mirror-test/src/test/resources/features/hcs/hcs.feature
+++ b/hedera-mirror-test/src/test/resources/features/hcs/hcs.feature
@@ -1,7 +1,7 @@
-@TopicMessagesBase @FullSuite
+@topicmessagesbase @fullsuite
 Feature: HCS Base Coverage Feature
 
-    @Sanity @BasicSubscribe @Acceptance
+    @sanity @basicsubscribe @acceptance @Acceptance
     Scenario Outline: Validate Topic message submission
         Given I successfully create a new topic id
         And I publish and verify <numMessages> messages sent
@@ -12,7 +12,7 @@ Feature: HCS Base Coverage Feature
             | numMessages |
             | 10          |
 
-    @OpenSubscribe @Acceptance
+    @opensubscribe @acceptance @Acceptance
     Scenario Outline: Validate Topic message submission to an open submit topic
         Given I successfully create a new open topic
         And I publish and verify <numMessages> messages sent
@@ -23,7 +23,7 @@ Feature: HCS Base Coverage Feature
             | numMessages |
             | 2           |
 
-    @SubscribeOnly
+    @subscribeonly @SubscribeOnly
     Scenario Outline: Validate topic message subscription only
         Given I provide a topic id <topicId>
         And I provide a starting timestamp <startTimestamp> and a number of messages <numMessages> I want to receive
@@ -33,7 +33,7 @@ Feature: HCS Base Coverage Feature
             | topicId | startTimestamp | numMessages |
             | ""      | "-86400"       | 5           |
 
-    @PublishOnly
+    @publishonly
     Scenario Outline: Validate topic message subscription
         Given I provide a topic id <topicId>
         And I publish <numBatches> batches of <numMessages> messages every <milliSleep> milliseconds
@@ -43,7 +43,7 @@ Feature: HCS Base Coverage Feature
             | topicId | numBatches | numMessages | milliSleep |
             | ""      | 2          | 3           | 2000       |
 
-    @PublishAndVerify
+    @publishandverify
     Scenario Outline: Validate topic message subscription
         Given I provide a topic id <topicId>
         And I publish and verify <numMessages> messages sent
@@ -53,17 +53,17 @@ Feature: HCS Base Coverage Feature
             | topicId  | numMessages |
             | "171231" | 340         |
 
-    @UpdateTopic @Acceptance
+    @updatetopic @acceptance @Acceptance
     Scenario: Validate Topic Updates
         Given I successfully create a new topic id
         Then I successfully update an existing topic
 
-    @DeleteTopic @Acceptance
+    @deletetopic @acceptance @Acceptance
     Scenario: Validate topic deletion
         Given I successfully create a new topic id
         Then I successfully delete the topic
 
-    @Acceptance @Latency
+    @acceptance @latency @Acceptance
     Scenario Outline: Validate Topic message listener latency
         Given I successfully create a new topic id
         And I publish and verify <numMessages> messages sent
@@ -75,7 +75,7 @@ Feature: HCS Base Coverage Feature
             | 2           | 30      |
             | 5           | 30      |
 
-    @Negative @Acceptance
+    @negative @acceptance @Acceptance
     Scenario Outline: Validate topic subscription with missing topic id
         Given I provide a topic id <topicId>
         Then the network should observe an error <errorCode>

--- a/hedera-mirror-test/src/test/resources/features/hts/hts.feature
+++ b/hedera-mirror-test/src/test/resources/features/hts/hts.feature
@@ -1,7 +1,7 @@
-@TokenBase @FullSuite
+@tokenbase @fullsuite @TokenBase
 Feature: HTS Base Coverage Feature
 
-    @Acceptance @Sanity
+    @acceptance @sanity @Acceptance
     Scenario Outline: Validate Base Token Flow - Create, Associate, Fund
         Given I successfully create a new token
         Then the mirror node REST API should return status <httpStatusCode>
@@ -13,7 +13,7 @@ Feature: HTS Base Coverage Feature
             | amount | httpStatusCode |
             | 2350   | 200            |
 
-    @Acceptance
+    @acceptance @Acceptance
     Scenario Outline: Validate Freeze and KYC Flow - Create, Unfreeze, GrantKyc
         Given I successfully onboard a new token account with freeze status <initialFreezeStatus> and kyc status <initialKycStatus>
         When I associate a new recipient account with token
@@ -25,7 +25,7 @@ Feature: HTS Base Coverage Feature
             | initialFreezeStatus | initialKycStatus | newFreezeStatus | newKycStatus | httpStatusCode |
             | 1                   | 2                | 2               | 1            | 200            |
 
-    @Acceptance
+    @acceptance @Acceptance
     Scenario Outline: Validate Token Modification Flow - Create, Associate, Transfer, Update, Burn, Mint and Wipe
         Given I successfully onboard a new token account
         When I associate a new recipient account with token
@@ -43,7 +43,7 @@ Feature: HTS Base Coverage Feature
             | amount | httpStatusCode | modifySupplyAmount |
             | 2350   | 200            | 100                |
 
-    @Acceptance
+    @acceptance @Acceptance
     Scenario Outline: Validate Token ramp down Flow - Create, Associate, Dissociate, Delete
         Given I successfully onboard a new token account
         When I associate a new recipient account with token

--- a/hedera-mirror-test/src/test/resources/features/schedule/schedule.feature
+++ b/hedera-mirror-test/src/test/resources/features/schedule/schedule.feature
@@ -34,7 +34,7 @@ Feature: Schedule Base Coverage Feature
             | 200            |
 
     @acceptance @Acceptance
-    Scenario Outline: Validate Base Schedule Flow - MultiSig ScheduleCreate of CryptoAccountCreate and ScheduleDelete
+    Scenario Outline: Validate Base Schedule Flow - MultiSig ScheduleCreate of CryptoAccountCreate and ScheduleSign
         Given I schedule a crypto transfer with <initialSignatureCount> initial signatures but require an additional signature from <accountName>
         When the network confirms schedule presence
         And the mirror node REST API should return status <httpStatusCode> for the schedule transaction
@@ -66,7 +66,7 @@ Feature: Schedule Base Coverage Feature
             | sender  | receiver | httpStatusCode |
             | "ALICE" | "DAVE"   | 200            |
 
-#    @acceptance @Acceptance - sdk bug exists where executed HCS submit message fails
+    @acceptance @Acceptance
     Scenario Outline: Validate scheduled HCS message - ScheduleCreate of TopicMessageSubmit and ScheduleSign
         Given I successfully schedule a topic message submit with <accountName>'s submit key
         And the network confirms schedule presence

--- a/hedera-mirror-test/src/test/resources/features/schedule/schedule.feature
+++ b/hedera-mirror-test/src/test/resources/features/schedule/schedule.feature
@@ -1,7 +1,7 @@
-@schedulebase @FullSuite
+@schedulebase @fullsuite
 Feature: Schedule Base Coverage Feature
 
-    @Acceptance @Sanity
+    @acceptance @sanity @Acceptance
     Scenario Outline: Validate Base Schedule Flow - ScheduleCreate of CryptoTransfer and ScheduleSign
         Given I successfully schedule a treasury HBAR disbursement to <accountName>
         When the network confirms schedule presence
@@ -19,7 +19,7 @@ Feature: Schedule Base Coverage Feature
             | accountName | httpStatusCode |
             | "CAROL"     | 200            |
 
-    @Acceptance
+    @acceptance @Acceptance
     Scenario Outline: Validate Base Schedule Flow - ScheduleCreate of CryptoAccountCreate and ScheduleDelete
         Given I successfully schedule a crypto account create
         When the network confirms schedule presence
@@ -33,7 +33,7 @@ Feature: Schedule Base Coverage Feature
             | httpStatusCode |
             | 200            |
 
-    @Acceptance
+    @acceptance @Acceptance
     Scenario Outline: Validate Base Schedule Flow - MultiSig ScheduleCreate of CryptoAccountCreate and ScheduleDelete
         Given I schedule a crypto transfer with <initialSignatureCount> initial signatures but require an additional signature from <accountName>
         When the network confirms schedule presence
@@ -48,7 +48,7 @@ Feature: Schedule Base Coverage Feature
             | 3                     | "ALICE"     | 200            |
             | 10                    | "DAVE"      | 200            |
 
-    @Acceptance
+    @acceptance @Acceptance
     Scenario Outline: Validate scheduled Hbar and Token transfer - ScheduleCreate of TokenTransfer and multi ScheduleSign
         Given I successfully schedule a token transfer from <sender> to <receiver>
         And the network confirms schedule presence
@@ -66,7 +66,7 @@ Feature: Schedule Base Coverage Feature
             | sender  | receiver | httpStatusCode |
             | "ALICE" | "DAVE"   | 200            |
 
-#    @Acceptance - sdk bug exists where executed HCS submit message fails
+#    @acceptance @Acceptance - sdk bug exists where executed HCS submit message fails
     Scenario Outline: Validate scheduled HCS message - ScheduleCreate of TopicMessageSubmit and ScheduleSign
         Given I successfully schedule a topic message submit with <accountName>'s submit key
         And the network confirms schedule presence

--- a/hedera-mirror-test/src/test/resources/features/setup/setup.feature
+++ b/hedera-mirror-test/src/test/resources/features/setup/setup.feature
@@ -1,7 +1,7 @@
-@Setup
+@setup
 Feature: Setup entities for various features
 
-    @SetupTokenAccounts
+    @setuptokenaccounts
     Scenario Outline: Setup 2 new accounts for token transfers
         Given I successfully onboard a new token account
         When I associate a new recipient account with token
@@ -10,7 +10,7 @@ Feature: Setup entities for various features
             | amount |
             | 250000 |
 
-    @FundAccount
+    @fundaccount
     Scenario Outline: Fund account
         When I send <amount> ℏ to account <account>
         Then the new balance should reflect cryptotransfer of <amount>

--- a/hedera-mirror-test/src/test/resources/features/topicfilter/hcstopicfilter.feature
+++ b/hedera-mirror-test/src/test/resources/features/topicfilter/hcstopicfilter.feature
@@ -1,7 +1,7 @@
-@TopicMessagesFilter @FullSuite
+@topicmessagesfilter @fullsuite
 Feature: HCS Message Filter Coverage Feature
 
-    @Sanity @Acceptance @Filter
+    @sanity @acceptance @filter @Acceptance
     Scenario Outline: Validate topic filtering with past date and get X previous
         Given I successfully create a new topic id
         And I publish and verify <numMessages> messages sent
@@ -26,7 +26,7 @@ Feature: HCS Message Filter Coverage Feature
             | "1970-01-01T00:00:00.00Z" | 2           |
             | "2000-01-01T00:00:00.00Z" | 5           |
 
-    @Edge
+    @edge
     Scenario Outline: Validate topic filtering with start and end time in between min and max messages (e.g. if 100 messages get 25-30)
         Given I successfully create a new topic id
         And I publish and verify <publishCount> messages sent
@@ -37,7 +37,7 @@ Feature: HCS Message Filter Coverage Feature
             | publishCount | startSequence | endSequence | numMessages |
             | 50           | 25            | 30          | 5           |
 
-    @Acceptance
+    @acceptance @Acceptance
     Scenario Outline: Validate topic filtering with past date and a specified limit
         Given I successfully create a new topic id
         And I publish and verify <numMessages> messages sent


### PR DESCRIPTION
**Detailed description**:
A few improvements to acceptances tests

- Update `MirrorNodeClient` webclient to use `retrieve()` instead of `exchange()`
- Updated feature files to use lower case tags. Leave Initial `@Aceptance`, `@TokenBase` and `@SubscribeOnly` references to not immediately break OPS
- Pull in new 2.0.5-beta.4
- Uncomment schedule hcs message submit test 
- Update entity clients create methods to set both entity memo and transaction memo

**Which issue(s) this PR fixes**:
Fixes #1665 

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated

