### PR TITLE
Rename maxRetries to maxAttempts to better fit sdk logic

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -229,7 +229,7 @@ Name                                                        | Default    | Descr
 `hedera.mirror.monitor.publish.scenarios[].limit`           | 0          | How many transactions to publish before halting. 0 for unlimited
 `hedera.mirror.monitor.publish.scenarios[].logResponse`     | false      | Whether to log the response from HAPI
 `hedera.mirror.monitor.publish.scenarios[].name`            | ""         | The publish scenario name. Used to tag logs and metrics
-`hedera.mirror.monitor.publish.scenarios[].maxRetries`      | 0          | The maximum number of times a scenario transaction attempt will be retried
+`hedera.mirror.monitor.publish.scenarios[].maxAttempts`     | 1          | The maximum number of times a scenario transaction will be attempted
 `hedera.mirror.monitor.publish.scenarios[].properties`      | {}         | Key/value pairs used to configure the [`TransactionSupplier`](/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier) associated with this scenario type
 `hedera.mirror.monitor.publish.scenarios[].receipt`         | 0.0        | The percentage of receipts to retrieve from HAPI. Accepts values between 0-1
 `hedera.mirror.monitor.publish.scenarios[].record`          | 0.0        | The percentage of records to retrieve from HAPI. Accepts values between 0-1

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/generator/ConfigurableTransactionGenerator.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/generator/ConfigurableTransactionGenerator.java
@@ -84,7 +84,7 @@ public class ConfigurableTransactionGenerator implements TransactionGenerator {
                 .record(shouldGenerate(properties.getRecord()))
                 .timestamp(Instant.now())
                 .transaction(transactionSupplier.get().get()
-                        .setMaxRetry(properties.getMaxRetries())) // set scenario transaction maxRetry
+                        .setMaxRetry(properties.getMaxAttempts())) // set scenario transaction maxRetry
                 .build();
     }
 

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/generator/ConfigurableTransactionGenerator.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/generator/ConfigurableTransactionGenerator.java
@@ -84,7 +84,7 @@ public class ConfigurableTransactionGenerator implements TransactionGenerator {
                 .record(shouldGenerate(properties.getRecord()))
                 .timestamp(Instant.now())
                 .transaction(transactionSupplier.get().get()
-                        .setMaxRetry(properties.getMaxAttempts())) // set scenario transaction maxRetry
+                        .setMaxRetry(properties.getMaxAttempts())) // set scenario transaction maxAttempts
                 .build();
     }
 

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/generator/ScenarioProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/generator/ScenarioProperties.java
@@ -76,8 +76,8 @@ public class ScenarioProperties {
         return limit > 0 ? limit : Long.MAX_VALUE;
     }
 
-    @Min(0)
-    private int maxRetries = 0;
+    @Min(1)
+    private int maxAttempts = 1;
 }
 
 


### PR DESCRIPTION
**Detailed description**:
Despite the name, `maxRetries` in the sdk v2 is actually a count of the number of attempts a transaction should make (so initial attempt + retries).  The sdk team has agreed to rename it.  For the time being, the minimum number of attempts should be set to 1, for one attempt and no retries.  Also renaming our config in anticipation of the sdk renaming.

**Checklist**
- [x] Documentation added
- [ ] Tests updated

