### PR TITLE
Address audit static analysis problems

### DIFF
--- a/charts/hedera-mirror-importer/values.yaml
+++ b/charts/hedera-mirror-importer/values.yaml
@@ -106,9 +106,9 @@ prometheusRules:
   ImporterBalanceParseLatency:
     annotations:
       description: Averaging {{ $value | humanizeDuration }} trying to parse balance stream files for {{ $labels.namespace }}/{{ $labels.pod }}
-      summary: Took longer than 5s to parse balance stream files
+      summary: Took longer than 6.5s to parse balance stream files
     enabled: true
-    expr: sum(rate(hedera_mirror_parse_duration_seconds_sum{application="hedera-mirror-importer",type="BALANCE"}[3m])) by (namespace, pod) / sum(rate(hedera_mirror_parse_duration_seconds_count{application="hedera-mirror-importer",type="BALANCE"}[3m])) by (namespace, pod) > 5
+    expr: sum(rate(hedera_mirror_parse_duration_seconds_sum{application="hedera-mirror-importer",type="BALANCE"}[3m])) by (namespace, pod) / sum(rate(hedera_mirror_parse_duration_seconds_count{application="hedera-mirror-importer",type="BALANCE"}[3m])) by (namespace, pod) > 6.5
     for: 1m
     labels:
       severity: critical
@@ -125,7 +125,7 @@ prometheusRules:
 
   ImporterCloudStorageErrors:
     annotations:
-      description: '{{ $value | humanizePercentage }} Error rate trying to {{ if ne $labels.action "list" }} retrieve{{ end }} {{ $labels.action }} {{ $labels.type }} files from cloud storage for {{ $labels.namespace }}/{{ $labels.pod }}'
+      description: 'Averaging {{ $value | humanizePercentage }} error rate trying to {{ if ne $labels.action "list" }} retrieve{{ end }} {{ $labels.action }} {{ $labels.type }} files from cloud storage for {{ $labels.namespace }}/{{ $labels.pod }}'
       summary: "Cloud storage error rate exceeds 5%"
     enabled: true
     expr: (sum(rate(hedera_mirror_download_request_seconds_count{application="hedera-mirror-importer", status!~"^2.*"}[2m])) by (namespace, pod, type, action) / sum(rate(hedera_mirror_download_request_seconds_count{application="hedera-mirror-importer"}[2m])) by (namespace, pod, type, action)) > 0.05
@@ -135,7 +135,7 @@ prometheusRules:
 
   ImporterCloudStorageLatency:
     annotations:
-      description: Cloud storage latency exceeded {{ $value | humanizeDuration }} trying to {{ if ne $labels.action "list" }} retrieve{{ end }} {{ $labels.action }} {{ $labels.type }} files from cloud storage for {{ $labels.namespace }}/{{ $labels.pod }}
+      description: Averaging {{ $value | humanizeDuration }} cloud storage latency trying to {{ if ne $labels.action "list" }} retrieve{{ end }} {{ $labels.action }} {{ $labels.type }} files from cloud storage for {{ $labels.namespace }}/{{ $labels.pod }}
       summary: Cloud storage latency exceeds 1s
     enabled: true
     expr: sum(rate(hedera_mirror_download_request_seconds_sum{application="hedera-mirror-importer", status=~"^2.*"}[2m])) by (namespace, pod, type, action) / sum(rate(hedera_mirror_download_request_seconds_count{application="hedera-mirror-importer", status=~"^2.*"}[2m])) by (namespace, pod, type, action) > 1

--- a/charts/hedera-mirror-monitor/values.yaml
+++ b/charts/hedera-mirror-monitor/values.yaml
@@ -82,7 +82,7 @@ prometheusRules:
 
   MonitorPublishErrors:
     annotations:
-      description: "{{ $value | humanizePercentage }} Error rate publishing '{{ $labels.scenario }}' scenario from {{ $labels.namespace }}/{{ $labels.pod }}"
+      description: "Averaging {{ $value | humanizePercentage }} error rate publishing '{{ $labels.scenario }}' scenario from {{ $labels.namespace }}/{{ $labels.pod }}"
       summary: "Publish error rate exceeds 5%"
     enabled: true
     expr: sum(rate(hedera_mirror_monitor_publish_submit_seconds_sum{application="hedera-mirror-monitor",status!="SUCCESS"}[2m])) by (namespace, pod, scenario) / sum(rate(hedera_mirror_monitor_publish_submit_seconds_count{application="hedera-mirror-monitor"}[2m])) by (namespace, pod, scenario) > 0.05
@@ -92,7 +92,7 @@ prometheusRules:
 
   MonitorPublishLatency:
     annotations:
-      description: "Publish latency exceeded {{ $value | humanizeDuration }} for '{{ $labels.scenario }}' scenario for {{ $labels.namespace }}/{{ $labels.pod }}"
+      description: "Averaging {{ $value | humanizeDuration }} publish latency for '{{ $labels.scenario }}' scenario for {{ $labels.namespace }}/{{ $labels.pod }}"
       summary: "Publish latency exceeds 2s"
     enabled: true
     expr: sum(rate(hedera_mirror_monitor_publish_submit_seconds_sum{application="hedera-mirror-monitor"}[2m])) by (namespace, pod, scenario) / sum(rate(hedera_mirror_monitor_publish_submit_seconds_count{application="hedera-mirror-monitor"}[2m])) by (namespace, pod, scenario) > 2
@@ -112,7 +112,7 @@ prometheusRules:
 
   MonitorPublishToHandleLatency:
     annotations:
-      description: "Transaction latency exceeded {{ $value | humanizeDuration }} for '{{ $labels.scenario }}' scenario for {{ $labels.namespace }}/{{ $labels.pod }}"
+      description: "Averaging {{ $value | humanizeDuration }} transaction latency for '{{ $labels.scenario }}' scenario for {{ $labels.namespace }}/{{ $labels.pod }}"
       summary: "Submit to transaction being handled latency exceeds 8s"
     enabled: true
     expr: sum(rate(hedera_mirror_monitor_publish_handle_seconds_sum{application="hedera-mirror-monitor"}[2m])) by (namespace, pod, scenario) / sum(rate(hedera_mirror_monitor_publish_handle_seconds_count{application="hedera-mirror-monitor"}[2m])) by (namespace, pod, scenario) > 8
@@ -122,7 +122,7 @@ prometheusRules:
 
   MonitorSubscribeLatency:
     annotations:
-      description: "{{ $labels.subscriber }} latency exceeded {{ $value | humanizeDuration }} for '{{ $labels.scenario }}' scenario for {{ $labels.namespace }}/{{ $labels.pod }}"
+      description: "{{ $labels.subscriber }} latency averaging {{ $value | humanizeDuration }} for '{{ $labels.scenario }}' scenario for {{ $labels.namespace }}/{{ $labels.pod }}"
       summary: "End to end latency exceeds 10s"
     enabled: true
     expr: sum(rate(hedera_mirror_monitor_subscribe_e2e_seconds_sum{application="hedera-mirror-monitor"}[2m])) by (namespace, pod, scenario, subscriber) / sum(rate(hedera_mirror_monitor_subscribe_e2e_seconds_count{application="hedera-mirror-monitor"}[2m])) by (namespace, pod, scenario, subscriber) > 10

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/jmeter/client/MultiTopicHCSClient.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/jmeter/client/MultiTopicHCSClient.java
@@ -141,11 +141,13 @@ public class MultiTopicHCSClient extends AbstractJavaSamplerClient {
                 }
             }
 
-            result.setResponseMessage("Successfully performed subscriptions");
-            result.setResponseCodeOK();
-            result.sampleEnd();
-            result.setResponseData(response.toString().getBytes());
-            result.setSuccessful(response.isSuccess());
+            if (response != null) {
+                result.setResponseMessage("Successfully performed subscriptions");
+                result.setResponseCodeOK();
+                result.sampleEnd();
+                result.setResponseData(response.toString().getBytes());
+                result.setSuccessful(response.isSuccess());
+            }
         } catch (Exception ex) {
             log.error("Error subscribing to topic", ex);
 
@@ -162,12 +164,6 @@ public class MultiTopicHCSClient extends AbstractJavaSamplerClient {
         }
 
         log.info("{} out of {} samples passed", successSamplesCount, clientCount);
-
-        return result;
-    }
-
-    private SampleResult concurrentRun() {
-        SampleResult result = new SampleResult();
 
         return result;
     }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/converter/AbstractEntityIdConverter.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/converter/AbstractEntityIdConverter.java
@@ -39,7 +39,7 @@ public abstract class AbstractEntityIdConverter implements AttributeConverter<En
 
     @Override
     public Long convertToDatabaseColumn(EntityId entityId) {
-        if (entityId == null) {
+        if (EntityId.isEmpty(entityId)) {
             return null;
         }
         return entityId.getId();

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/converter/EntityIdSerializer.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/converter/EntityIdSerializer.java
@@ -32,8 +32,10 @@ import com.hedera.mirror.importer.domain.EntityId;
 public class EntityIdSerializer extends JsonSerializer<EntityId> {
     @Override
     public void serialize(EntityId value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
-        if (value != null) {
+        if (!EntityId.isEmpty(value)) {
             gen.writeNumber(value.getId());
+        } else {
+            gen.writeNull();
         }
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/AccountBalance.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/AccountBalance.java
@@ -23,6 +23,7 @@ package com.hedera.mirror.importer.domain;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.CascadeType;
 import javax.persistence.Convert;
@@ -57,7 +58,7 @@ public class AccountBalance implements Persistable<AccountBalance.Id>, StreamIte
             @JoinColumn(name = "accountId"),
             @JoinColumn(name = "consensusTimestamp")
     })
-    private List<TokenBalance> tokenBalances;
+    private List<TokenBalance> tokenBalances = new ArrayList<>();
 
     @EmbeddedId
     @JsonUnwrapped

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/AddressBook.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/AddressBook.java
@@ -21,6 +21,7 @@ package com.hedera.mirror.importer.domain;
  */
 
 import java.security.PublicKey;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -73,7 +74,7 @@ public class AddressBook {
 
     @OneToMany(cascade = {CascadeType.ALL}, orphanRemoval = true, fetch = FetchType.EAGER)
     @JoinColumn(name = "consensusTimestamp")
-    private List<AddressBookEntry> entries;
+    private List<AddressBookEntry> entries = new ArrayList<>();
 
     public Set<EntityId> getNodeSet() {
         return entries.stream()

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/AddressBookEntry.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/AddressBookEntry.java
@@ -79,7 +79,7 @@ public class AddressBookEntry {
     }
 
     public EntityId getNodeAccountId() {
-        if (nodeAccountId == null) {
+        if (EntityId.isEmpty(nodeAccountId)) {
             return memo == null ? null : EntityId.of(memo, EntityTypeEnum.ACCOUNT);
         }
 
@@ -88,6 +88,6 @@ public class AddressBookEntry {
 
     @Transient
     public String getNodeAccountIdString() {
-        return nodeAccountId == null ? memo : nodeAccountId.entityIdToString();
+        return EntityId.isEmpty(nodeAccountId) ? memo : nodeAccountId.entityIdToString();
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/EntityId.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/EntityId.java
@@ -51,6 +51,7 @@ public class EntityId implements Serializable, Comparable<EntityId> {
 
     private static final Comparator<EntityId> COMPARATOR = Comparator
             .nullsFirst(Comparator.comparingLong(EntityId::getId));
+    public static final EntityId EMPTY = new EntityId(0L, 0L, 0L, EntityTypeEnum.ACCOUNT.getId());
 
     private static final Splitter SPLITTER = Splitter.on('.').omitEmptyStrings().trimResults();
     private static final long serialVersionUID = 1427649605832330197L;
@@ -58,11 +59,11 @@ public class EntityId implements Serializable, Comparable<EntityId> {
     // Ignored so not included in json serialization of PubSubMessage
     @JsonIgnore
     @EqualsAndHashCode.Include
-    private Long id;
-    private Long shardNum;
-    private Long realmNum;
-    private Long entityNum;
-    private Integer type;
+    private final Long id;
+    private final Long shardNum;
+    private final Long realmNum;
+    private final Long entityNum;
+    private final Integer type;
 
     public EntityId(Long shardNum, Long realmNum, Long entityNum, Integer type) {
         id = EntityIdEndec.encode(shardNum, realmNum, entityNum);
@@ -113,9 +114,13 @@ public class EntityId implements Serializable, Comparable<EntityId> {
 
     public static EntityId of(long entityShard, long entityRealm, long entityNum, EntityTypeEnum type) {
         if (entityNum == 0 && entityRealm == 0 && entityShard == 0) {
-            return null;
+            return EMPTY;
         }
         return new EntityId(entityShard, entityRealm, entityNum, type.getId());
+    }
+
+    public static boolean isEmpty(EntityId entityId) {
+        return entityId == null || EMPTY.equals(entityId);
     }
 
     public String entityIdToString() {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/domain/RecordItem.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/domain/RecordItem.java
@@ -27,6 +27,7 @@ import com.hederahashgraph.api.proto.java.SignedTransaction;
 import com.hederahashgraph.api.proto.java.Transaction;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionRecord;
+import java.util.Objects;
 import java.util.Set;
 import lombok.Getter;
 import lombok.Value;
@@ -87,6 +88,8 @@ public class RecordItem implements StreamItem {
     // There are many brittle RecordItemParser*Tests which rely on bytes being null. Those tests need to be fixed,
     // then this function can be removed.
     public RecordItem(Transaction transaction, TransactionRecord record) {
+        Objects.requireNonNull(transaction, "transaction is required");
+        Objects.requireNonNull(record, "record is required");
         this.transaction = transaction;
         transactionBodyAndSignatureMap = parseTransactionBodyAndSignatureMap(transaction);
         transactionType = getTransactionType(transactionBodyAndSignatureMap.getTransactionBody());

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListener.java
@@ -164,9 +164,7 @@ public class EntityRecordItemListener implements RecordItemListener {
         boolean isSuccessful = isSuccessful(txRecord);
         Transaction tx = buildTransaction(consensusNs, recordItem);
         transactionHandler.updateTransaction(tx, recordItem);
-        if (entityId != null) {
-            tx.setEntityId(entityId);
-        }
+        tx.setEntityId(entityId);
 
         if (txRecord.hasTransferList() && entityProperties.getPersist().isCryptoTransferAmounts()) {
             if (body.hasCryptoCreateAccount() && isSuccessful) {
@@ -190,7 +188,7 @@ public class EntityRecordItemListener implements RecordItemListener {
         }
 
         if (isSuccessful) {
-            if (entityId != null) {
+            if (!EntityId.isEmpty(entityId)) {
                 // Only insert entityId on successful transaction, as non null entityIds can be retrieved from
                 // transactionBody which may not yet exist on network. entityIds from successful transactions are
                 // guaranteed to be valid entities on network (validated to exist in pre-consensus checks).
@@ -451,14 +449,14 @@ public class EntityRecordItemListener implements RecordItemListener {
                 .orElseGet(entityId::toEntity);
         transactionHandler.updateEntity(entity, recordItem);
         EntityId autoRenewAccount = transactionHandler.getAutoRenewAccount(recordItem);
-        if (autoRenewAccount != null) {
+        if (!EntityId.isEmpty(autoRenewAccount)) {
             entityListener.onEntityId(autoRenewAccount);
             entity.setAutoRenewAccountId(autoRenewAccount);
         }
         // Stream contains transactions with proxyAccountID explicitly set to '0.0.0'. However it's not a valid entity,
         // so no need to persist it to repo.
         EntityId proxyAccount = transactionHandler.getProxyAccount(recordItem);
-        if (proxyAccount != null) {
+        if (!EntityId.isEmpty(proxyAccount)) {
             entityListener.onEntityId(proxyAccount);
             entity.setProxyAccountId(proxyAccount);
         }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListener.java
@@ -218,7 +218,7 @@ public class SqlEntityListener implements EntityListener, RecordStreamFileListen
     @Override
     public void onEntityId(EntityId entityId) throws ImporterException {
         // only insert entities not found in cache
-        if (entityId == null || entityCache.get(entityId.getId()) != null) {
+        if (EntityId.isEmpty(entityId) || entityCache.get(entityId.getId()) != null) {
             return;
         }
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/converter/EntityIdSerializerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/converter/EntityIdSerializerTest.java
@@ -21,7 +21,6 @@ package com.hedera.mirror.importer.converter;
  */
 
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import org.junit.jupiter.api.Test;
@@ -43,7 +42,16 @@ class EntityIdSerializerTest {
         new EntityIdSerializer().serialize(null, jsonGenerator, null);
 
         // then
-        verifyNoInteractions(jsonGenerator);
+        verify(jsonGenerator).writeNull();
+    }
+
+    @Test
+    void testEmpty() throws Exception {
+        // when
+        new EntityIdSerializer().serialize(EntityId.EMPTY, jsonGenerator, null);
+
+        // then
+        verify(jsonGenerator).writeNull();
     }
 
     @Test

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/EntityIdTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/EntityIdTest.java
@@ -43,6 +43,6 @@ public class EntityIdTest {
     void ofStringPositive() {
         EntityTypeEnum type = EntityTypeEnum.ACCOUNT;
         assertThat(EntityId.of("0.0.1", type)).isEqualTo(EntityId.of(0, 0, 1, type));
-        assertThat(EntityId.of("0.0.0", type)).isNull();
+        assertThat(EntityId.of("0.0.0", type)).isEqualTo(EntityId.EMPTY);
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/AbstractDownloaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/AbstractDownloaderTest.java
@@ -147,13 +147,15 @@ public abstract class AbstractDownloaderTest {
         try {
             File file = p.toFile();
             if (file.isFile()) {
-                FileChannel outChan = new FileOutputStream(file, true).getChannel();
-                if (outChan.size() <= 48) {
-                    outChan.truncate(outChan.size() / 2);
-                } else {
-                    outChan.truncate(48);
+                try (FileOutputStream fileOutputStream = new FileOutputStream(file, true);
+                     FileChannel channel = fileOutputStream.getChannel()
+                ) {
+                    if (channel.size() <= 48) {
+                        channel.truncate(channel.size() / 2);
+                    } else {
+                        channel.truncate(48);
+                    }
                 }
-                outChan.close();
             }
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/performance/RestoreClientIntegrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/performance/RestoreClientIntegrationTest.java
@@ -20,9 +20,7 @@ package com.hedera.mirror.importer.parser.performance;
  * ‍
  */
 
-import java.sql.SQLException;
 import lombok.extern.log4j.Log4j2;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -38,27 +36,16 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 public class RestoreClientIntegrationTest extends PerformanceIntegrationTest {
 
     @Container
-    GenericContainer customContainer;
+    private GenericContainer customContainer;
 
     @BeforeAll
-    void warmUp() throws SQLException {
+    void warmUp() {
         customContainer = createRestoreContainer("100k");
-
-        log.info("Start container {}", customContainer);
-        customContainer.start();
-
-        connection = dataSource.getConnection();
-        checkSeededTablesArePresent();
-    }
-
-    @AfterAll
-    void coolOff() {
-        log.info("Stop container {}", customContainer);
-        customContainer.stop();
     }
 
     @Test
     public void parseAndIngestTransactions() throws Exception {
+        checkSeededTablesArePresent();
         clearLastProcessedRecordHash();
         parse();
     }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/balance/line/AccountBalanceLineParserV1Test.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/balance/line/AccountBalanceLineParserV1Test.java
@@ -77,6 +77,7 @@ class AccountBalanceLineParserV1Test {
             var id = accountBalance.getId();
 
             assertThat(accountBalance.getBalance()).isEqualTo(expectedBalance);
+            assertThat(id).isNotNull();
             assertThat(id.getAccountId().getShardNum()).isEqualTo(mirrorProperties.getShard());
             assertThat(id.getAccountId().getRealmNum()).isEqualTo(expectedRealm);
             assertThat(id.getAccountId().getEntityNum()).isEqualTo(expectedAccount);

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/balance/line/AccountBalanceLineParserV2Test.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/balance/line/AccountBalanceLineParserV2Test.java
@@ -97,6 +97,7 @@ class AccountBalanceLineParserV2Test {
             var id = accountBalance.getId();
 
             assertThat(accountBalance.getBalance()).isEqualTo(expectedBalance);
+            assertThat(id).isNotNull();
             assertThat(id.getAccountId().getRealmNum()).isEqualTo(expectedRealm);
             assertThat(id.getAccountId().getEntityNum()).isEqualTo(expectedAccount);
             assertThat(id.getConsensusTimestamp()).isEqualTo(timestamp);
@@ -115,6 +116,7 @@ class AccountBalanceLineParserV2Test {
                     assertThat(expectedTokenBalances.containsKey(actualId.getTokenId().getEntityNum()));
                     assertThat(actualTokenBalance.getBalance())
                             .isEqualTo(expectedTokenBalances.get(actualId.getTokenId().getEntityNum()));
+                    assertThat(actualId).isNotNull();
                     assertThat(actualId.getConsensusTimestamp()).isEqualTo(timestamp);
                     assertThat(actualId.getAccountId().getShardNum()).isEqualTo(mirrorProperties.getShard());
                     assertThat(actualId.getAccountId().getRealmNum()).isEqualTo(expectedRealm);

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/util/UtilityTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/util/UtilityTest.java
@@ -242,7 +242,8 @@ class UtilityTest {
     void timeStampInNanosTimeStamp(long seconds, int nanos) {
         Timestamp timestamp = Timestamp.newBuilder().setSeconds(seconds).setNanos(nanos).build();
 
-        long timeStampInNanos = Utility.timeStampInNanos(timestamp);
+        Long timeStampInNanos = Utility.timeStampInNanos(timestamp);
+        assertThat(timeStampInNanos).isNotNull();
         Instant fromTimeStamp = Instant.ofEpochSecond(0, timeStampInNanos);
 
         assertAll(

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/ClientConfiguration.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/ClientConfiguration.java
@@ -29,8 +29,6 @@ import io.netty.handler.timeout.WriteTimeoutHandler;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -56,51 +54,50 @@ import com.hedera.mirror.test.e2e.acceptance.client.TokenClient;
 import com.hedera.mirror.test.e2e.acceptance.client.TopicClient;
 
 @Configuration
-@Log4j2
 @RequiredArgsConstructor
 @EnableRetry
-public class ClientConfiguration {
-    @Autowired
+class ClientConfiguration {
+
     private final AcceptanceTestProperties acceptanceTestProperties;
 
     @Bean
     @Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE)
-    public SDKClient sdkClient() throws InterruptedException {
+    SDKClient sdkClient() throws InterruptedException {
         return new SDKClient(acceptanceTestProperties);
     }
 
     @Bean
     @Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE)
-    public MirrorNodeClient mirrorNodeClient() throws InterruptedException {
+    MirrorNodeClient mirrorNodeClient() throws InterruptedException {
         return new MirrorNodeClient(sdkClient());
     }
 
     @Bean
     @Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE)
-    public TopicClient topicClient() throws InterruptedException {
+    TopicClient topicClient() throws InterruptedException {
         return new TopicClient(sdkClient());
     }
 
     @Bean
     @Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE)
-    public AccountClient accountClient() throws InterruptedException {
+    AccountClient accountClient() throws InterruptedException {
         return new AccountClient(sdkClient());
     }
 
     @Bean
     @Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE)
-    public TokenClient tokenClient() throws InterruptedException {
+    TokenClient tokenClient() throws InterruptedException {
         return new TokenClient(sdkClient());
     }
 
     @Bean
     @Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE)
-    public ScheduleClient scheduleClient() throws InterruptedException {
+    ScheduleClient scheduleClient() throws InterruptedException {
         return new ScheduleClient(sdkClient());
     }
 
     @Bean
-    public RetryTemplate retryTemplate() {
+    RetryTemplate retryTemplate() {
         RetryTemplate retryTemplate = new RetryTemplate();
 
         FixedBackOffPolicy fixedBackOffPolicy = new FixedBackOffPolicy();


### PR DESCRIPTION
**Detailed description**:
- Fix balance latency alert triggering too often
- Fix alerts showing exceeded the actual value
- Fix potential null dereferences by switching `EntityId.of()` to return an empty object for `0.0.0.`
- Fix potential null dereferences in domain objects by creating default lists
- Fix other potential null dereferences
- Fix `RestoreClientIntegrationTest` (image is still out of date, though)
- Fix potential resource leaks

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated

