### PR TITLE
Replace null character on insert

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/Entities.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/Entities.java
@@ -77,6 +77,10 @@ public class Entities {
         ed25519PublicKeyHex = Utility.convertSimpleKeyToHex(key);
     }
 
+    public void setMemo(String memo) {
+        this.memo = Utility.sanitize(memo);
+    }
+
     public EntityId toEntityId() {
         return new EntityId(entityShard, entityRealm, entityNum, entityTypeId);
     }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/Token.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/Token.java
@@ -41,6 +41,7 @@ import com.hedera.mirror.importer.util.Utility;
 @Entity
 @NoArgsConstructor
 public class Token {
+
     @EmbeddedId
     private Token.Id tokenId;
 
@@ -146,6 +147,14 @@ public class Token {
         }
 
         return TokenKycStatusEnum.REVOKED;
+    }
+
+    public void setName(String name) {
+        this.name = Utility.sanitize(name);
+    }
+
+    public void setSymbol(String symbol) {
+        this.symbol = Utility.sanitize(symbol);
     }
 
     @Data

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/util/Utility.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/util/Utility.java
@@ -50,8 +50,9 @@ import com.hedera.mirror.importer.domain.StreamType;
 public class Utility {
 
     public static final Instant MAX_INSTANT_LONG = Instant.ofEpochSecond(0, Long.MAX_VALUE);
-
-    private static final Long NANOS_PER_SECOND = 1_000_000_000L;
+    private static final long NANOS_PER_SECOND = 1_000_000_000L;
+    private static final char NULL_CHARACTER = (char) 0;
+    private static final char NULL_REPLACEMENT = '�'; // Standard replacement character 0xFFFD
 
     /**
      * @return Timestamp from an instant
@@ -226,5 +227,16 @@ public class Utility {
     public static TransactionID getTransactionId(AccountID payerAccountId) {
         Timestamp validStart = Utility.instantToTimestamp(Instant.now());
         return TransactionID.newBuilder().setAccountID(payerAccountId).setTransactionValidStart(validStart).build();
+    }
+
+    /**
+     * Cleans a string of invalid characters that would cause it to fail when inserted into the database. In particular,
+     * PostgreSQL does not allow the null character (0x0000) to be inserted.
+     *
+     * @param input string containing potentially invalid characters
+     * @return the cleaned string
+     */
+    public static String sanitize(String input) {
+        return input != null ? input.replace(NULL_CHARACTER, NULL_REPLACEMENT) : null;
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/EntitiesTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/EntitiesTest.java
@@ -1,0 +1,35 @@
+package com.hedera.mirror.importer.domain;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class EntitiesTest {
+
+    @Test
+    void nullCharacters() {
+        Entities entities = new Entities();
+        entities.setMemo("abc" + (char) 0);
+        assertThat(entities.getMemo()).isEqualTo("abc�");
+    }
+}

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/TokenTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/TokenTest.java
@@ -20,6 +20,7 @@ package com.hedera.mirror.importer.domain;
  * ‍
  */
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.google.protobuf.ByteString;
@@ -95,6 +96,15 @@ public class TokenTest {
         Token token = new Token();
         token.setKycKey("kyckey".getBytes());
         assertEquals(token.getNewAccountKycStatus(), TokenKycStatusEnum.REVOKED);
+    }
+
+    @Test
+    void nullCharacters() {
+        Token token = new Token();
+        token.setName("abc" + (char) 0);
+        token.setSymbol("abc" + (char) 0);
+        assertThat(token.getName()).isEqualTo("abc�");
+        assertThat(token.getSymbol()).isEqualTo("abc�");
     }
 
     private Token token(long consensusTimestamp) throws DecoderException {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/EntityRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/EntityRepositoryTest.java
@@ -25,6 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import javax.annotation.Resource;
 import org.junit.jupiter.api.Test;
 
+import com.hedera.mirror.importer.domain.Entities;
 import com.hedera.mirror.importer.domain.EntityId;
 import com.hedera.mirror.importer.domain.EntityTypeEnum;
 
@@ -32,6 +33,19 @@ public class EntityRepositoryTest extends AbstractRepositoryTest {
 
     @Resource
     private EntityRepository entityRepository;
+
+    @Test
+    void nullCharacter() {
+        Entities entities = new Entities();
+        entities.setId(1L);
+        entities.setEntityNum(1L);
+        entities.setEntityRealm(0L);
+        entities.setEntityShard(0L);
+        entities.setEntityTypeId(1);
+        entities.setMemo("abc" + (char) 0);
+        entityRepository.save(entities);
+        assertThat(entityRepository.findById(entities.getId())).get().isEqualTo(entities);
+    }
 
     @Test
     void insertEntityId() {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/TokenRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/TokenRepositoryTest.java
@@ -51,6 +51,15 @@ public class TokenRepositoryTest extends AbstractRepositoryTest {
     }
 
     @Test
+    void nullCharacter() throws DecoderException {
+        Token token = token(1);
+        token.setName("abc" + (char) 0);
+        token.setSymbol("abc" + (char) 0);
+        tokenRepository.save(token);
+        assertThat(tokenRepository.findById(token.getTokenId())).get().isEqualTo(token);
+    }
+
+    @Test
     void updateSupply() throws DecoderException {
         Token token = tokenRepository.save(token(1));
         long newTotalSupply = INITIAL_SUPPLY - 1000;

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/util/UtilityTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/util/UtilityTest.java
@@ -259,5 +259,13 @@ class UtilityTest {
             Utility.timeStampInNanos(timestamp);
         });
     }
+
+    @Test
+    void sanitize() {
+        assertThat(Utility.sanitize(null)).isNull();
+        assertThat(Utility.sanitize("")).isEmpty();
+        assertThat(Utility.sanitize("abc")).isEqualTo("abc");
+        assertThat(Utility.sanitize("abc" + (char) 0 + "123" + (char) 0)).isEqualTo("abc�123�");
+    }
 }
 


### PR DESCRIPTION
**Detailed description**:
- Fix failing on insert of tokens with null character (0x0000) in symbol or name

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
Will backport to 0.29 and tag rc2 to unblock previewnet. I don't unescape replacement character in REST API as this is just a temporary fix until services blocks null char in strings in v0.13

**Checklist**
- [ ] Documentation added
- [x] Tests updated

