### PR TITLE
Add ability for REST transaction queries with credit/debit parameter to retrieve token only transfers (0.29)

### DIFF
--- a/charts/hedera-mirror-common/Chart.yaml
+++ b/charts/hedera-mirror-common/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.29.0-rc2
+appVersion: 0.29.0-rc3
 description: Hedera Mirror Node common components installed globally for use across namespaces
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
@@ -11,4 +11,4 @@ maintainers:
 name: hedera-mirror-common
 sources:
   - https://github.com/hashgraph/hedera-mirror-node
-version: 0.16.0-rc2
+version: 0.16.0-rc3

--- a/charts/hedera-mirror-grpc/Chart.yaml
+++ b/charts/hedera-mirror-grpc/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.29.0-rc2
+appVersion: 0.29.0-rc3
 description: GRPC API for the Hedera Mirror Node
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
@@ -11,4 +11,4 @@ maintainers:
 name: hedera-mirror-grpc
 sources:
   - https://github.com/hashgraph/hedera-mirror-node
-version: 0.16.0-rc2
+version: 0.16.0-rc3

--- a/charts/hedera-mirror-importer/Chart.yaml
+++ b/charts/hedera-mirror-importer/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.29.0-rc2
+appVersion: 0.29.0-rc3
 description: Hedera Mirror Importer downloads and validates file streams from the cloud and imports them into the database
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
@@ -11,4 +11,4 @@ maintainers:
 name: hedera-mirror-importer
 sources:
   - https://github.com/hashgraph/hedera-mirror-node
-version: 0.16.0-rc2
+version: 0.16.0-rc3

--- a/charts/hedera-mirror-monitor/Chart.yaml
+++ b/charts/hedera-mirror-monitor/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.29.0-rc2
+appVersion: 0.29.0-rc3
 description: End to End Monitor for the Hedera Mirror Node
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
@@ -11,4 +11,4 @@ maintainers:
 name: hedera-mirror-monitor
 sources:
   - https://github.com/hashgraph/hedera-mirror-node
-version: 0.16.0-rc2
+version: 0.16.0-rc3

--- a/charts/hedera-mirror-rest/Chart.yaml
+++ b/charts/hedera-mirror-rest/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.29.0-rc2
+appVersion: 0.29.0-rc3
 description: REST API for the Hedera Mirror Node
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
@@ -11,4 +11,4 @@ maintainers:
 name: hedera-mirror-rest
 sources:
   - https://github.com/hashgraph/hedera-mirror-node
-version: 0.16.0-rc2
+version: 0.16.0-rc3

--- a/charts/hedera-mirror/Chart.yaml
+++ b/charts/hedera-mirror/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.29.0-rc2
+appVersion: 0.29.0-rc3
 description: Hedera Mirror Node mirrors data from Hedera nodes and serves it via an API
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
@@ -11,4 +11,4 @@ maintainers:
 name: hedera-mirror
 sources:
   - https://github.com/hashgraph/hedera-mirror-node
-version: 0.16.0-rc2
+version: 0.16.0-rc3

--- a/charts/hedera-mirror/requirements.lock
+++ b/charts/hedera-mirror/requirements.lock
@@ -1,13 +1,13 @@
 dependencies:
 - name: hedera-mirror-grpc
   repository: file://../hedera-mirror-grpc
-  version: 0.16.0-rc2
+  version: 0.16.0-rc3
 - name: hedera-mirror-importer
   repository: file://../hedera-mirror-importer
-  version: 0.16.0-rc2
+  version: 0.16.0-rc3
 - name: hedera-mirror-monitor
   repository: file://../hedera-mirror-monitor
-  version: 0.16.0-rc2
+  version: 0.16.0-rc3
 - name: postgresql-ha
   repository: https://charts.bitnami.com/bitnami
   version: 6.3.7
@@ -16,9 +16,9 @@ dependencies:
   version: 12.2.4
 - name: hedera-mirror-rest
   repository: file://../hedera-mirror-rest
-  version: 0.16.0-rc2
+  version: 0.16.0-rc3
 - name: timescaledb-multinode
   repository: https://raw.githubusercontent.com/timescale/timescaledb-kubernetes/master/charts/repo/
   version: 0.8.0
-digest: sha256:a2f448b403619fb878e590c8213d73ba5a699b964b0336c2a65f1d9a5b6ee970
-generated: "2021-03-15T21:53:12.557902-05:00"
+digest: sha256:e35ca8740a7eed4621027294360e2d16fe6f7240467511d31229b17b97b25287
+generated: "2021-03-17T17:44:40.255117-05:00"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - 5432:5432
 
   grpc:
-    image: gcr.io/mirrornode/hedera-mirror-grpc:0.29.0-rc2
+    image: gcr.io/mirrornode/hedera-mirror-grpc:0.29.0-rc3
     restart: unless-stopped
     environment:
       HEDERA_MIRROR_GRPC_DB_HOST: db
@@ -29,7 +29,7 @@ services:
       - 5600:5600
 
   importer:
-    image: gcr.io/mirrornode/hedera-mirror-importer:0.29.0-rc2
+    image: gcr.io/mirrornode/hedera-mirror-importer:0.29.0-rc3
     restart: unless-stopped
     environment:
       HEDERA_MIRROR_IMPORTER_DB_HOST: db
@@ -41,7 +41,7 @@ services:
   monitor:
     deploy:
       replicas: 0
-    image: gcr.io/mirrornode/hedera-mirror-monitor:0.29.0-rc2
+    image: gcr.io/mirrornode/hedera-mirror-monitor:0.29.0-rc3
     restart: unless-stopped
     environment:
       SPRING_CONFIG_ADDITIONAL_LOCATION: file:/usr/etc/hedera-mirror-monitor/
@@ -58,7 +58,7 @@ services:
       - 6379:6379
 
   rest:
-    image: gcr.io/mirrornode/hedera-mirror-rest:0.29.0-rc2
+    image: gcr.io/mirrornode/hedera-mirror-rest:0.29.0-rc3
     environment:
       HEDERA_MIRROR_REST_DB_HOST: db
     restart: unless-stopped
@@ -67,7 +67,7 @@ services:
       - 5551:5551
 
   rosetta:
-    image: gcr.io/mirrornode/hedera-mirror-rosetta:0.29.0-rc2
+    image: gcr.io/mirrornode/hedera-mirror-rosetta:0.29.0-rc3
     environment:
       HEDERA_MIRROR_ROSETTA_DB_HOST: db
     restart: unless-stopped

--- a/hedera-mirror-rest/__tests__/specs/transactions-31-credit-type-only-token-transfers.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-31-credit-type-only-token-transfers.spec.json
@@ -1,0 +1,122 @@
+{
+  "description": "Transaction api calls for transactions via credit type query filter where account only receives token transfer",
+  "setup": {
+    "accounts": [
+      {
+        "entity_num": 3
+      },
+      {
+        "entity_num": 8
+      },
+      {
+        "entity_num": 9
+      },
+      {
+        "entity_num": 10
+      },
+      {
+        "entity_num": 98
+      }
+    ],
+    "balances": [],
+    "transactions": [
+      {
+        "name": "CRYPTOTRANSFER",
+        "type": "14",
+        "charged_tx_fee": 7,
+        "valid_start_timestamp": "1234567890000000000",
+        "consensus_timestamp": "1234567890000000001",
+        "payerAccountId": "0.0.8",
+        "nodeAccountId": "0.0.3",
+        "treasuryAccountId": "0.0.98",
+        "transfers": [],
+        "token_transfer_list": [
+          {
+            "token_id": "0.0.90000",
+            "account": "0.0.8",
+            "amount": -1200
+          },
+          {
+            "token_id": "0.0.90000",
+            "account": "0.0.3",
+            "amount": 200
+          },
+          {
+            "token_id": "0.0.90000",
+            "account": "0.0.9",
+            "amount": 1000
+          }
+        ]
+      },
+      {
+        "name": "CRYPTOTRANSFER",
+        "type": "14",
+        "charged_tx_fee": 7,
+        "valid_start_timestamp": "1234567890000000002",
+        "consensus_timestamp": "1234567890000000003",
+        "payerAccountId": "0.0.8",
+        "nodeAccountId": "0.0.3",
+        "treasuryAccountId": "0.0.98",
+        "transfers": [],
+        "token_transfer_list": [
+          {
+            "token_id": "0.0.90000",
+            "account": "0.0.8",
+            "amount": 1000
+          },
+          {
+            "token_id": "0.0.90000",
+            "account": "0.0.3",
+            "amount": 200
+          },
+          {
+            "token_id": "0.0.90000",
+            "account": "0.0.9",
+            "amount": -1200
+          }
+        ]
+      }
+    ]
+  },
+  "urls": ["/api/v1/transactions?account.id=0.0.9&type=credit"],
+  "responseStatus": 200,
+  "responseJson": {
+    "transactions": [
+      {
+        "consensus_timestamp": "1234567890.000000001",
+        "valid_start_timestamp": "1234567890.000000000",
+        "charged_tx_fee": 7,
+        "memo_base64": null,
+        "result": "SUCCESS",
+        "scheduled": false,
+        "transaction_hash": "aGFzaA==",
+        "name": "CRYPTOTRANSFER",
+        "node": "0.0.3",
+        "transaction_id": "0.0.8-1234567890-000000000",
+        "valid_duration_seconds": "11",
+        "max_fee": "33",
+        "transfers": [],
+        "token_transfers": [
+          {
+            "account": "0.0.9",
+            "amount": 1000,
+            "token_id": "0.0.90000"
+          },
+          {
+            "account": "0.0.8",
+            "amount": -1200,
+            "token_id": "0.0.90000"
+          },
+          {
+            "account": "0.0.3",
+            "amount": 200,
+            "token_id": "0.0.90000"
+          }
+        ]
+      }
+    ],
+    "links": {
+      "next": null
+    }
+  }
+}

--- a/hedera-mirror-rest/__tests__/specs/transactions-32-debit-type-only-token-transfers.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-32-debit-type-only-token-transfers.spec.json
@@ -1,0 +1,122 @@
+{
+  "description": "Transaction api calls for transactions via debit type query filter where account only receives token transfer",
+  "setup": {
+    "accounts": [
+      {
+        "entity_num": 3
+      },
+      {
+        "entity_num": 8
+      },
+      {
+        "entity_num": 9
+      },
+      {
+        "entity_num": 10
+      },
+      {
+        "entity_num": 98
+      }
+    ],
+    "balances": [],
+    "transactions": [
+      {
+        "name": "CRYPTOTRANSFER",
+        "type": "14",
+        "charged_tx_fee": 7,
+        "valid_start_timestamp": "1234567890000000000",
+        "consensus_timestamp": "1234567890000000001",
+        "payerAccountId": "0.0.8",
+        "nodeAccountId": "0.0.3",
+        "treasuryAccountId": "0.0.98",
+        "transfers": [],
+        "token_transfer_list": [
+          {
+            "token_id": "0.0.90000",
+            "account": "0.0.9",
+            "amount": -1200
+          },
+          {
+            "token_id": "0.0.90000",
+            "account": "0.0.3",
+            "amount": 200
+          },
+          {
+            "token_id": "0.0.90000",
+            "account": "0.0.8",
+            "amount": 1000
+          }
+        ]
+      },
+      {
+        "name": "CRYPTOTRANSFER",
+        "type": "14",
+        "charged_tx_fee": 7,
+        "valid_start_timestamp": "1234567890000000002",
+        "consensus_timestamp": "1234567890000000003",
+        "payerAccountId": "0.0.8",
+        "nodeAccountId": "0.0.3",
+        "treasuryAccountId": "0.0.98",
+        "transfers": [],
+        "token_transfer_list": [
+          {
+            "token_id": "0.0.90000",
+            "account": "0.0.9",
+            "amount": 1000
+          },
+          {
+            "token_id": "0.0.90000",
+            "account": "0.0.3",
+            "amount": 200
+          },
+          {
+            "token_id": "0.0.90000",
+            "account": "0.0.8",
+            "amount": -1200
+          }
+        ]
+      }
+    ]
+  },
+  "urls": ["/api/v1/transactions?account.id=0.0.9&type=debit"],
+  "responseStatus": 200,
+  "responseJson": {
+    "transactions": [
+      {
+        "consensus_timestamp": "1234567890.000000001",
+        "valid_start_timestamp": "1234567890.000000000",
+        "charged_tx_fee": 7,
+        "memo_base64": null,
+        "result": "SUCCESS",
+        "scheduled": false,
+        "transaction_hash": "aGFzaA==",
+        "name": "CRYPTOTRANSFER",
+        "node": "0.0.3",
+        "transaction_id": "0.0.8-1234567890-000000000",
+        "valid_duration_seconds": "11",
+        "max_fee": "33",
+        "transfers": [],
+        "token_transfers": [
+          {
+            "account": "0.0.9",
+            "amount": -1200,
+            "token_id": "0.0.90000"
+          },
+          {
+            "account": "0.0.8",
+            "amount": 1000,
+            "token_id": "0.0.90000"
+          },
+          {
+            "account": "0.0.3",
+            "amount": 200,
+            "token_id": "0.0.90000"
+          }
+        ]
+      }
+    ],
+    "links": {
+      "next": null
+    }
+  }
+}

--- a/hedera-mirror-rest/__tests__/specs/transactions-33-credit-type-crypyo-and-token-transfers.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-33-credit-type-crypyo-and-token-transfers.spec.json
@@ -1,0 +1,232 @@
+{
+  "description": "Transaction api calls for transactions via credit type query filter where account receives crypto and token transfers",
+  "setup": {
+    "accounts": [
+      {
+        "entity_num": 3
+      },
+      {
+        "entity_num": 8
+      },
+      {
+        "entity_num": 9
+      },
+      {
+        "entity_num": 10
+      },
+      {
+        "entity_num": 98
+      }
+    ],
+    "balances": [],
+    "transactions": [
+      {
+        "name": "CRYPTOTRANSFER",
+        "type": "14",
+        "charged_tx_fee": 7,
+        "valid_start_timestamp": "1234567890000000000",
+        "consensus_timestamp": "1234567890000000001",
+        "payerAccountId": "0.0.8",
+        "nodeAccountId": "0.0.3",
+        "treasuryAccountId": "0.0.98",
+        "transfers": [],
+        "token_transfer_list": [
+          {
+            "token_id": "0.0.90000",
+            "account": "0.0.8",
+            "amount": -1200
+          },
+          {
+            "token_id": "0.0.90000",
+            "account": "0.0.3",
+            "amount": 200
+          },
+          {
+            "token_id": "0.0.90000",
+            "account": "0.0.9",
+            "amount": 1000
+          }
+        ]
+      },
+      {
+        "name": "CRYPTOTRANSFER",
+        "type": "14",
+        "charged_tx_fee": 7,
+        "valid_start_timestamp": "1234567890000000002",
+        "consensus_timestamp": "1234567890000000003",
+        "payerAccountId": "0.0.8",
+        "nodeAccountId": "0.0.3",
+        "treasuryAccountId": "0.0.98",
+        "transfers": [
+          {
+            "account": "0.0.8",
+            "amount": -1234
+          },
+          {
+            "account": "0.0.3",
+            "amount": 1
+          },
+          {
+            "account": "0.0.9",
+            "amount": 1233
+          }
+        ]
+      },
+      {
+        "name": "CRYPTOTRANSFER",
+        "type": "14",
+        "charged_tx_fee": 7,
+        "valid_start_timestamp": "1234567890000000004",
+        "consensus_timestamp": "1234567890000000005",
+        "payerAccountId": "0.0.8",
+        "nodeAccountId": "0.0.3",
+        "treasuryAccountId": "0.0.98",
+        "transfers": [
+          {
+            "account": "0.0.8",
+            "amount": -1234
+          },
+          {
+            "account": "0.0.3",
+            "amount": 1
+          },
+          {
+            "account": "0.0.9",
+            "amount": 1233
+          }
+        ],
+        "token_transfer_list": [
+          {
+            "token_id": "0.0.90000",
+            "account": "0.0.8",
+            "amount": -1200
+          },
+          {
+            "token_id": "0.0.90000",
+            "account": "0.0.3",
+            "amount": 200
+          },
+          {
+            "token_id": "0.0.90000",
+            "account": "0.0.9",
+            "amount": 1000
+          }
+        ]
+      }
+    ]
+  },
+  "urls": ["/api/v1/transactions?account.id=0.0.9&type=credit"],
+  "responseStatus": 200,
+  "responseJson": {
+    "transactions": [
+      {
+        "consensus_timestamp": "1234567890.000000005",
+        "valid_start_timestamp": "1234567890.000000004",
+        "charged_tx_fee": 7,
+        "memo_base64": null,
+        "result": "SUCCESS",
+        "scheduled": false,
+        "transaction_hash": "aGFzaA==",
+        "name": "CRYPTOTRANSFER",
+        "node": "0.0.3",
+        "transaction_id": "0.0.8-1234567890-000000004",
+        "valid_duration_seconds": "11",
+        "max_fee": "33",
+        "transfers": [
+          {
+            "account": "0.0.3",
+            "amount": 1
+          },
+          {
+            "account": "0.0.8",
+            "amount": -1234
+          },
+          {
+            "account": "0.0.9",
+            "amount": 1233
+          }
+        ],
+        "token_transfers": [
+          {
+            "account": "0.0.9",
+            "amount": 1000,
+            "token_id": "0.0.90000"
+          },
+          {
+            "account": "0.0.8",
+            "amount": -1200,
+            "token_id": "0.0.90000"
+          },
+          {
+            "account": "0.0.3",
+            "amount": 200,
+            "token_id": "0.0.90000"
+          }
+        ]
+      },
+      {
+        "consensus_timestamp": "1234567890.000000003",
+        "valid_start_timestamp": "1234567890.000000002",
+        "charged_tx_fee": 7,
+        "memo_base64": null,
+        "result": "SUCCESS",
+        "scheduled": false,
+        "transaction_hash": "aGFzaA==",
+        "name": "CRYPTOTRANSFER",
+        "node": "0.0.3",
+        "transaction_id": "0.0.8-1234567890-000000002",
+        "valid_duration_seconds": "11",
+        "max_fee": "33",
+        "transfers": [
+          {
+            "account": "0.0.3",
+            "amount": 1
+          },
+          {
+            "account": "0.0.8",
+            "amount": -1234
+          },
+          {
+            "account": "0.0.9",
+            "amount": 1233
+          }
+        ]
+      },
+      {
+        "consensus_timestamp": "1234567890.000000001",
+        "valid_start_timestamp": "1234567890.000000000",
+        "charged_tx_fee": 7,
+        "memo_base64": null,
+        "result": "SUCCESS",
+        "scheduled": false,
+        "transaction_hash": "aGFzaA==",
+        "name": "CRYPTOTRANSFER",
+        "node": "0.0.3",
+        "transaction_id": "0.0.8-1234567890-000000000",
+        "valid_duration_seconds": "11",
+        "max_fee": "33",
+        "transfers": [],
+        "token_transfers": [
+          {
+            "account": "0.0.9",
+            "amount": 1000,
+            "token_id": "0.0.90000"
+          },
+          {
+            "account": "0.0.8",
+            "amount": -1200,
+            "token_id": "0.0.90000"
+          },
+          {
+            "account": "0.0.3",
+            "amount": 200,
+            "token_id": "0.0.90000"
+          }
+        ]
+      }
+    ],
+    "links": {
+      "next": null
+    }
+  }
+}

--- a/hedera-mirror-rest/__tests__/specs/transactions-34-debit-type-crypyo-and-token-transfers.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-34-debit-type-crypyo-and-token-transfers.spec.json
@@ -1,0 +1,232 @@
+{
+  "description": "Transaction api calls for transactions via debit type query filter where account receives crypto and token transfers",
+  "setup": {
+    "accounts": [
+      {
+        "entity_num": 3
+      },
+      {
+        "entity_num": 8
+      },
+      {
+        "entity_num": 9
+      },
+      {
+        "entity_num": 10
+      },
+      {
+        "entity_num": 98
+      }
+    ],
+    "balances": [],
+    "transactions": [
+      {
+        "name": "CRYPTOTRANSFER",
+        "type": "14",
+        "charged_tx_fee": 7,
+        "valid_start_timestamp": "1234567890000000000",
+        "consensus_timestamp": "1234567890000000001",
+        "payerAccountId": "0.0.8",
+        "nodeAccountId": "0.0.3",
+        "treasuryAccountId": "0.0.98",
+        "transfers": [],
+        "token_transfer_list": [
+          {
+            "token_id": "0.0.90000",
+            "account": "0.0.9",
+            "amount": -1200
+          },
+          {
+            "token_id": "0.0.90000",
+            "account": "0.0.3",
+            "amount": 200
+          },
+          {
+            "token_id": "0.0.90000",
+            "account": "0.0.8",
+            "amount": 1000
+          }
+        ]
+      },
+      {
+        "name": "CRYPTOTRANSFER",
+        "type": "14",
+        "charged_tx_fee": 7,
+        "valid_start_timestamp": "1234567890000000002",
+        "consensus_timestamp": "1234567890000000003",
+        "payerAccountId": "0.0.8",
+        "nodeAccountId": "0.0.3",
+        "treasuryAccountId": "0.0.98",
+        "transfers": [
+          {
+            "account": "0.0.9",
+            "amount": -1234
+          },
+          {
+            "account": "0.0.3",
+            "amount": 1
+          },
+          {
+            "account": "0.0.8",
+            "amount": 1233
+          }
+        ]
+      },
+      {
+        "name": "CRYPTOTRANSFER",
+        "type": "14",
+        "charged_tx_fee": 7,
+        "valid_start_timestamp": "1234567890000000004",
+        "consensus_timestamp": "1234567890000000005",
+        "payerAccountId": "0.0.8",
+        "nodeAccountId": "0.0.3",
+        "treasuryAccountId": "0.0.98",
+        "transfers": [
+          {
+            "account": "0.0.9",
+            "amount": -1234
+          },
+          {
+            "account": "0.0.3",
+            "amount": 1
+          },
+          {
+            "account": "0.0.8",
+            "amount": 1233
+          }
+        ],
+        "token_transfer_list": [
+          {
+            "token_id": "0.0.90000",
+            "account": "0.0.9",
+            "amount": -1200
+          },
+          {
+            "token_id": "0.0.90000",
+            "account": "0.0.3",
+            "amount": 200
+          },
+          {
+            "token_id": "0.0.90000",
+            "account": "0.0.8",
+            "amount": 1000
+          }
+        ]
+      }
+    ]
+  },
+  "urls": ["/api/v1/transactions?account.id=0.0.9&type=debit"],
+  "responseStatus": 200,
+  "responseJson": {
+    "transactions": [
+      {
+        "consensus_timestamp": "1234567890.000000005",
+        "valid_start_timestamp": "1234567890.000000004",
+        "charged_tx_fee": 7,
+        "memo_base64": null,
+        "result": "SUCCESS",
+        "scheduled": false,
+        "transaction_hash": "aGFzaA==",
+        "name": "CRYPTOTRANSFER",
+        "node": "0.0.3",
+        "transaction_id": "0.0.8-1234567890-000000004",
+        "valid_duration_seconds": "11",
+        "max_fee": "33",
+        "transfers": [
+          {
+            "account": "0.0.3",
+            "amount": 1
+          },
+          {
+            "account": "0.0.8",
+            "amount": 1233
+          },
+          {
+            "account": "0.0.9",
+            "amount": -1234
+          }
+        ],
+        "token_transfers": [
+          {
+            "account": "0.0.9",
+            "amount": -1200,
+            "token_id": "0.0.90000"
+          },
+          {
+            "account": "0.0.8",
+            "amount": 1000,
+            "token_id": "0.0.90000"
+          },
+          {
+            "account": "0.0.3",
+            "amount": 200,
+            "token_id": "0.0.90000"
+          }
+        ]
+      },
+      {
+        "consensus_timestamp": "1234567890.000000003",
+        "valid_start_timestamp": "1234567890.000000002",
+        "charged_tx_fee": 7,
+        "memo_base64": null,
+        "result": "SUCCESS",
+        "scheduled": false,
+        "transaction_hash": "aGFzaA==",
+        "name": "CRYPTOTRANSFER",
+        "node": "0.0.3",
+        "transaction_id": "0.0.8-1234567890-000000002",
+        "valid_duration_seconds": "11",
+        "max_fee": "33",
+        "transfers": [
+          {
+            "account": "0.0.3",
+            "amount": 1
+          },
+          {
+            "account": "0.0.8",
+            "amount": 1233
+          },
+          {
+            "account": "0.0.9",
+            "amount": -1234
+          }
+        ]
+      },
+      {
+        "consensus_timestamp": "1234567890.000000001",
+        "valid_start_timestamp": "1234567890.000000000",
+        "charged_tx_fee": 7,
+        "memo_base64": null,
+        "result": "SUCCESS",
+        "scheduled": false,
+        "transaction_hash": "aGFzaA==",
+        "name": "CRYPTOTRANSFER",
+        "node": "0.0.3",
+        "transaction_id": "0.0.8-1234567890-000000000",
+        "valid_duration_seconds": "11",
+        "max_fee": "33",
+        "transfers": [],
+        "token_transfers": [
+          {
+            "account": "0.0.9",
+            "amount": -1200,
+            "token_id": "0.0.90000"
+          },
+          {
+            "account": "0.0.8",
+            "amount": 1000,
+            "token_id": "0.0.90000"
+          },
+          {
+            "account": "0.0.3",
+            "amount": 200,
+            "token_id": "0.0.90000"
+          }
+        ]
+      }
+    ],
+    "links": {
+      "next": null
+    }
+  }
+}

--- a/hedera-mirror-rest/api/v1/openapi.yml
+++ b/hedera-mirror-rest/api/v1/openapi.yml
@@ -550,7 +550,7 @@ tags:
     description: The tokens object represents the information associated with a token entity and returns a list of token information.
 info:
   title: Hedera Mirror Node REST API
-  version: 0.29.0-rc2
+  version: 0.29.0-rc3
   license:
     name: Apache-2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0.html'

--- a/hedera-mirror-rest/monitoring/monitor_apis/package-lock.json
+++ b/hedera-mirror-rest/monitoring/monitor_apis/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-mirror-monitor",
-  "version": "0.29.0-rc2",
+  "version": "0.29.0-rc3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hedera-mirror-rest/monitoring/monitor_apis/package.json
+++ b/hedera-mirror-rest/monitoring/monitor_apis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-mirror-monitor",
-  "version": "0.29.0-rc2",
+  "version": "0.29.0-rc3",
   "description": "Hedera Mirror Node Monitor",
   "main": "server.js",
   "private": true,

--- a/hedera-mirror-rest/package-lock.json
+++ b/hedera-mirror-rest/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-mirror-rest",
-  "version": "0.29.0-rc2",
+  "version": "0.29.0-rc3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hedera-mirror-rest/package.json
+++ b/hedera-mirror-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-mirror-rest",
-  "version": "0.29.0-rc2",
+  "version": "0.29.0-rc3",
   "description": "Hedera Mirror Node REST API",
   "main": "server.js",
   "private": true,

--- a/hedera-mirror-rest/transactions.js
+++ b/hedera-mirror-rest/transactions.js
@@ -191,128 +191,6 @@ const convertToNamedQuery = function (query, prefix) {
 };
 
 /**
- * Get the transactions inner query for transactions with a crypto transfer list matching the query filters.
- *
- * @param namedAccountQuery - Account query with named parameters
- * @param namedTsQuery - Transaction table timestamp query with named parameters
- * @param resultTypeQuery - Transaction result query
- * @param limitQuery - Limit query
- * @param creditDebitQuery - Credit or debit query
- * @param transactionTypeQuery - Transaction type query
- * @param order - Sorting order
- * @return {string} - The inner query string
- */
-const getCryptoTransferTransactionsInnerQuery = function (
-  namedAccountQuery,
-  namedTsQuery,
-  resultTypeQuery,
-  limitQuery,
-  namedCreditDebitQuery,
-  transactionTypeQuery,
-  order
-) {
-  const namedCtlTsQuery = namedTsQuery.replace(/t\.consensus_ns/g, 'ctl.consensus_timestamp');
-  const ctlWhereClause = buildWhereClause(namedAccountQuery, namedCtlTsQuery, namedCreditDebitQuery);
-  const ctlSubQuery = `
-    SELECT DISTINCT consensus_timestamp
-    FROM crypto_transfer ctl
-    ${ctlWhereClause}
-    ORDER BY consensus_timestamp ${order}`;
-
-  if (resultTypeQuery || transactionTypeQuery) {
-    const whereClause = buildWhereClause(namedTsQuery, resultTypeQuery, transactionTypeQuery);
-    return `
-      SELECT t.consensus_ns AS consensus_timestamp
-      FROM transaction t
-      JOIN (${ctlSubQuery}) AS ctl
-      ON t.consensus_ns = ctl.consensus_timestamp
-      ${whereClause}
-      ORDER BY t.consensus_ns ${order}
-      ${limitQuery}`;
-  }
-
-  // get consensus timestamps from crypto_transfer table directly when there are no transaction related filters
-  return `${ctlSubQuery}
-    ${limitQuery}`;
-};
-
-/**
- * Get the general transactions inner query for transactions matching the query filters.
- *
- * @param namedAccountQuery - Account query with named parameters
- * @param namedTsQuery - Transaction table timestamp query with named parameters
- * @param resultTypeQuery - Transaction result query
- * @param namedLimitQuery - Limit query with named parameters
- * @param transactionTypeQuery - Transaction type query
- * @param order - Sorting order
- * @return {string} - The inner query string
- */
-const getGeneralTransactionsInnerQuery = function (
-  namedAccountQuery,
-  namedTsQuery,
-  resultTypeQuery,
-  namedLimitQuery,
-  transactionTypeQuery,
-  order
-) {
-  const transactionAccountQuery = namedAccountQuery.replace(/ctl\.entity_id/g, 't.payer_account_id');
-  const transactionWhereClause = buildWhereClause(
-    transactionAccountQuery,
-    namedTsQuery,
-    resultTypeQuery,
-    transactionTypeQuery
-  );
-  const transactionOnlyQuery = `
-    SELECT consensus_ns AS consensus_timestamp
-    FROM transaction AS t
-    ${transactionWhereClause}
-    ORDER BY consensus_ns ${order}
-    ${namedLimitQuery}`;
-
-  if (namedAccountQuery) {
-    // account filter applies to transaction.payer_account_id, crypto_transfer.entity_id, and token_transfer.account_id, a full outer join
-    //between the three tables is needed to get rows that may only exist in one.
-    const ctlQuery = getTransferDistinctTimestampsQuery(
-      'crypto_transfer',
-      'ctl',
-      namedTsQuery,
-      'consensus_timestamp',
-      resultTypeQuery,
-      transactionTypeQuery,
-      namedAccountQuery,
-      order,
-      namedLimitQuery
-    );
-
-    const namedTtlAccountQuery = namedAccountQuery.replace(/ctl\.entity_id/g, 'ttl.account_id');
-    const ttlQuery = getTransferDistinctTimestampsQuery(
-      'token_transfer',
-      'ttl',
-      namedTsQuery,
-      'consensus_timestamp',
-      resultTypeQuery,
-      transactionTypeQuery,
-      namedTtlAccountQuery,
-      order,
-      namedLimitQuery
-    );
-
-    return `
-      SELECT coalesce(t.consensus_timestamp,ctl.consensus_timestamp,ttl.consensus_timestamp) AS consensus_timestamp
-      FROM (${transactionOnlyQuery}) AS t
-      FULL OUTER JOIN (${ctlQuery}) AS ctl
-      ON t.consensus_timestamp = ctl.consensus_timestamp
-      FULL OUTER JOIN (${ttlQuery}) AS ttl
-      ON t.consensus_timestamp = ttl.consensus_timestamp
-      ORDER BY consensus_timestamp ${order}
-      ${namedLimitQuery}`;
-  }
-
-  // no account filter, only need to query transaction table
-  return transactionOnlyQuery;
-};
-
-/**
  * Get the query to find distinct timestamps for transactions matching the query filters from a transfers table when filtering by an account id
  *
  * @param {string} tableName - Name of the transfers table to query
@@ -322,6 +200,7 @@ const getGeneralTransactionsInnerQuery = function (
  * @param resultTypeQuery - Transaction result query
  * @param transactionTypeQuery - Transaction type query
  * @param namedAccountQuery - Account query with named parameters
+ * @param namedCreditDebitQuery - Credit/debit query
  * @param order - Sorting order
  * @param namedLimitQuery - Limit query with named parameters
  * @return {string} - The distinct timestamp query for the given table name
@@ -334,6 +213,7 @@ const getTransferDistinctTimestampsQuery = function (
   resultTypeQuery,
   transactionTypeQuery,
   namedAccountQuery,
+  namedCreditDebitQuery,
   order,
   namedLimitQuery
 ) {
@@ -341,7 +221,13 @@ const getTransferDistinctTimestampsQuery = function (
   const joinClause =
     (resultTypeQuery || transactionTypeQuery) &&
     `JOIN transaction AS t ON ${tableAlias}.${timestampColumn} = t.consensus_ns`;
-  const whereClause = buildWhereClause(namedAccountQuery, namedTransferTsQuery, resultTypeQuery, transactionTypeQuery);
+  const whereClause = buildWhereClause(
+    namedAccountQuery,
+    namedTransferTsQuery,
+    resultTypeQuery,
+    transactionTypeQuery,
+    namedCreditDebitQuery
+  );
 
   return `
       SELECT DISTINCT ${tableAlias}.${timestampColumn} AS consensus_timestamp
@@ -385,27 +271,75 @@ const getTransactionsInnerQuery = function (
   const namedLimitQuery = convertToNamedQuery(limitQuery, 'limit');
   const namedCreditDebitQuery = convertToNamedQuery(creditDebitQuery, 'cd');
 
-  if (creditDebitQuery) {
-    // limit the query to transactions with cryptotransfer list
-    return getCryptoTransferTransactionsInnerQuery(
-      namedAccountQuery,
-      namedTsQuery,
-      resultTypeQuery,
-      namedLimitQuery,
-      namedCreditDebitQuery,
-      transactionTypeQuery,
-      order
-    );
-  }
-
-  return getGeneralTransactionsInnerQuery(
-    namedAccountQuery,
+  const transactionAccountQuery = namedAccountQuery.replace(/ctl\.entity_id/g, 't.payer_account_id');
+  const transactionWhereClause = buildWhereClause(
+    transactionAccountQuery,
     namedTsQuery,
     resultTypeQuery,
-    namedLimitQuery,
-    transactionTypeQuery,
-    order
+    transactionTypeQuery
   );
+  const transactionOnlyQuery = `
+    SELECT consensus_ns AS consensus_timestamp
+    FROM transaction AS t
+    ${transactionWhereClause}
+    ORDER BY consensus_ns ${order}
+    ${namedLimitQuery}`;
+
+  if (creditDebitQuery || namedAccountQuery) {
+    const ctlQuery = getTransferDistinctTimestampsQuery(
+      'crypto_transfer',
+      'ctl',
+      namedTsQuery,
+      'consensus_timestamp',
+      resultTypeQuery,
+      transactionTypeQuery,
+      namedAccountQuery,
+      namedCreditDebitQuery,
+      order,
+      namedLimitQuery
+    );
+
+    const namedTtlAccountQuery = namedAccountQuery.replace(/ctl\.entity_id/g, 'ttl.account_id');
+    const namedTtlCreditDebitQuery = namedCreditDebitQuery.replace(/ctl\.amount/g, 'ttl.amount');
+    const ttlQuery = getTransferDistinctTimestampsQuery(
+      'token_transfer',
+      'ttl',
+      namedTsQuery,
+      'consensus_timestamp',
+      resultTypeQuery,
+      transactionTypeQuery,
+      namedTtlAccountQuery,
+      namedTtlCreditDebitQuery,
+      order,
+      namedLimitQuery
+    );
+
+    if (creditDebitQuery) {
+      // credit/debit filter applies to crypto_transfer.amount and token_transfer.amount, a full outer join is needed to get
+      // transactions that only have a crypto_transfer or a token_transfer
+      return `
+        SELECT COALESCE(ctl.consensus_timestamp, ttl.consensus_timestamp) AS consensus_timestamp
+        FROM (${ctlQuery}) AS ctl
+        FULL OUTER JOIN (${ttlQuery}) as ttl
+        ON ctl.consensus_timestamp = ttl.consensus_timestamp
+        ORDER BY consensus_timestamp ${order}
+        ${namedLimitQuery}`;
+    } else {
+      // account filter applies to transaction.payer_account_id, crypto_transfer.entity_id, and token_transfer.account_id, a full outer join
+      //between the three tables is needed to get rows that may only exist in one.
+      return `
+        SELECT coalesce(t.consensus_timestamp,ctl.consensus_timestamp,ttl.consensus_timestamp) AS consensus_timestamp
+        FROM (${transactionOnlyQuery}) AS t
+        FULL OUTER JOIN (${ctlQuery}) AS ctl
+        ON t.consensus_timestamp = ctl.consensus_timestamp
+        FULL OUTER JOIN (${ttlQuery}) AS ttl
+        ON t.consensus_timestamp = ttl.consensus_timestamp
+        ORDER BY consensus_timestamp ${order}
+        ${namedLimitQuery}`;
+    }
+  }
+
+  return transactionOnlyQuery;
 };
 
 const reqToSql = async function (req) {

--- a/hedera-mirror-rosetta/config/application.yml
+++ b/hedera-mirror-rosetta/config/application.yml
@@ -15,4 +15,4 @@ hedera:
       port: 5700
       realm: 0
       shard: 0
-      version: 0.29.0-rc2
+      version: 0.29.0-rc3

--- a/hedera-mirror-test/src/test/resources/k8s/hcs-perf-message-submit.yml
+++ b/hedera-mirror-test/src/test/resources/k8s/hcs-perf-message-submit.yml
@@ -41,7 +41,7 @@ spec:
                     app.kubernetes.io/name: test
       restartPolicy: Never
       containers:
-        - image: gcr.io/mirrornode/hedera-mirror-test:0.29.0-rc2
+        - image: gcr.io/mirrornode/hedera-mirror-test:0.29.0-rc3
           name: test
           env:
             - name: testProfile

--- a/hedera-mirror-test/src/test/resources/k8s/hcs-perf-publish-test.yml
+++ b/hedera-mirror-test/src/test/resources/k8s/hcs-perf-publish-test.yml
@@ -43,7 +43,7 @@ spec:
                     app.kubernetes.io/name: test
       restartPolicy: Never
       containers:
-        - image: gcr.io/mirrornode/hedera-mirror-test:0.29.0-rc2
+        - image: gcr.io/mirrornode/hedera-mirror-test:0.29.0-rc3
           name: test
           env:
             - name: testProfile

--- a/hedera-mirror-test/src/test/resources/k8s/hcs-perf-subscribe-test.yml
+++ b/hedera-mirror-test/src/test/resources/k8s/hcs-perf-subscribe-test.yml
@@ -46,7 +46,7 @@ spec:
                     app.kubernetes.io/name: test
       restartPolicy: Never
       containers:
-        - image: gcr.io/mirrornode/hedera-mirror-test:0.29.0-rc2
+        - image: gcr.io/mirrornode/hedera-mirror-test:0.29.0-rc3
           name: test
           env:
             - name: testProfile

--- a/hedera-mirror-test/src/test/resources/k8s/hts-perf-batch-publish-batch-validate.yml
+++ b/hedera-mirror-test/src/test/resources/k8s/hts-perf-batch-publish-batch-validate.yml
@@ -47,7 +47,7 @@ spec:
                     app.kubernetes.io/name: test
       restartPolicy: Never
       containers:
-        - image: gcr.io/mirrornode/hedera-mirror-test:0.29.0-rc2
+        - image: gcr.io/mirrornode/hedera-mirror-test:0.29.0-rc3
           name: test
           env:
             - name: testProfile

--- a/hedera-mirror-test/src/test/resources/k8s/hts-perf-publish-and-retrieve.yml
+++ b/hedera-mirror-test/src/test/resources/k8s/hts-perf-publish-and-retrieve.yml
@@ -46,7 +46,7 @@ spec:
                     app.kubernetes.io/name: test
       restartPolicy: Never
       containers:
-        - image: gcr.io/mirrornode/hedera-mirror-test:0.29.0-rc2
+        - image: gcr.io/mirrornode/hedera-mirror-test:0.29.0-rc3
           name: test
           env:
             - name: testProfile

--- a/pom.xml
+++ b/pom.xml
@@ -74,8 +74,8 @@
         <micrometer-jvm-extras.version>0.2.2</micrometer-jvm-extras.version>
         <msgpack.version>0.8.22</msgpack.version>
         <protobuf.version>3.15.5</protobuf.version>
-        <release.version>0.29.0-rc2</release.version> <!-- Used to replace release versions in all files -->
-        <release.chartVersion>0.16.0-rc2</release.chartVersion>
+        <release.version>0.29.0-rc3</release.version> <!-- Used to replace release versions in all files -->
+        <release.chartVersion>0.16.0-rc3</release.chartVersion>
         <replacer.version>1.5.3</replacer.version>
         <!--suppress UnresolvedMavenProperty -->
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>


### PR DESCRIPTION
* Add a full outer join to token_transfer table to the transactions credit/debit query to get token transfers
* Refactor getTransactionsInnerQuery() to be easier to maintain

**Detailed description**:

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

