### PR TITLE
Fix Monitor can't reach expected tps

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -222,6 +222,7 @@ Name                                                        | Default    | Descr
 `hedera.mirror.monitor.nodes[].port`                        | 50211      | The main node's port
 `hedera.mirror.monitor.operator.accountId`                  | ""         | Operator account ID used to pay for transactions
 `hedera.mirror.monitor.operator.privateKey`                 | ""         | Operator ED25519 private key used to sign transactions in hex encoded DER format
+`hedera.mirror.monitor.publish.batchDivisor`                | 100        | The divisor used to calculate batch size when generating transactions
 `hedera.mirror.monitor.publish.connections`                 | 5          | How many total connections to open to the main nodes. Connections will be established in a round-robin fashion among available nodes
 `hedera.mirror.monitor.publish.enabled`                     | true       | Whether to enable transaction publishing
 `hedera.mirror.monitor.publish.scenarios[].duration`        |            | How long this scenario should publish transactions. Leave empty for infinite

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -235,8 +235,8 @@ Name                                                        | Default    | Descr
 `hedera.mirror.monitor.publish.scenarios[].record`          | 0.0        | The percentage of records to retrieve from HAPI. Accepts values between 0-1
 `hedera.mirror.monitor.publish.scenarios[].tps`             | 1.0        | The rate at which transactions will publish
 `hedera.mirror.monitor.publish.scenarios[].type`            |            | The type of transaction to publish. See the [`TransactionType`](/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/TransactionType.java) enum for a list of possible values
-`hedera.mirror.monitor.publish.scenarios[].warmupPeriod`    | 30s        | The amount of time the publisher should ramp up its rate before reaching its stable (maximum) rate
 `hedera.mirror.monitor.publish.statusFrequency`             | 10s        | How often to log publishing statistics
+`hedera.mirror.monitor.publish.warmupPeriod`                | 30s        | The amount of time the publisher should ramp up its rate before reaching its stable (maximum) rate
 `hedera.mirror.monitor.subscribe.grpc[].duration`           |            | How long to stay subscribed to the gRPC API
 `hedera.mirror.monitor.subscribe.grpc[].enabled`            | true       | Whether this subscribe scenario is enabled
 `hedera.mirror.monitor.subscribe.grpc[].limit`              | 0          | How many transactions to receive before halting. 0 for unlimited

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/config/MonitorConfiguration.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/config/MonitorConfiguration.java
@@ -35,6 +35,8 @@ import com.hedera.mirror.monitor.publish.PublishRequest;
 import com.hedera.mirror.monitor.publish.TransactionPublisher;
 import com.hedera.mirror.monitor.subscribe.Subscriber;
 
+import java.util.List;
+
 @Log4j2
 @Configuration
 class MonitorConfiguration {
@@ -61,7 +63,8 @@ class MonitorConfiguration {
      */
     @Bean
     Disposable publishSubscribe() {
-        return Flux.<PublishRequest>generate(sink -> sink.next(transactionGenerator.next()))
+        return Flux.<List<PublishRequest>>generate(sink -> sink.next(transactionGenerator.next()))
+                .flatMapIterable(publishRequests -> publishRequests)
                 .retry()
                 .name("generate")
                 .metrics()

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/config/MonitorConfiguration.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/config/MonitorConfiguration.java
@@ -63,7 +63,7 @@ class MonitorConfiguration {
      */
     @Bean
     Disposable publishSubscribe() {
-        return Flux.<List<PublishRequest>>generate(sink -> sink.next(transactionGenerator.next()))
+        return Flux.<List<PublishRequest>>generate(sink -> sink.next(transactionGenerator.next(0)))
                 .flatMapIterable(publishRequests -> publishRequests)
                 .retry()
                 .name("generate")

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/generator/CompositeTransactionGenerator.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/generator/CompositeTransactionGenerator.java
@@ -21,6 +21,7 @@ package com.hedera.mirror.monitor.generator;
  */
 
 import com.google.common.util.concurrent.RateLimiter;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import javax.inject.Named;
@@ -104,7 +105,12 @@ public class CompositeTransactionGenerator implements TransactionGenerator {
         if (rateLimiter != null) {
             rateLimiter.setRate(total);
         } else {
-            rateLimiter = RateLimiter.create(total, properties.getWarmupPeriod());
+            Duration warmUpPeriod = properties.getWarmupPeriod();
+            if (warmUpPeriod.equals(Duration.ZERO)) {
+                rateLimiter = RateLimiter.create(total);
+            } else {
+                rateLimiter = RateLimiter.create(total, properties.getWarmupPeriod());
+            }
         }
 
         distribution = new EnumeratedDistribution<>(pairs);

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/generator/ConfigurableTransactionGenerator.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/generator/ConfigurableTransactionGenerator.java
@@ -66,14 +66,14 @@ public class ConfigurableTransactionGenerator implements TransactionGenerator {
     }
 
     @Override
-    public List<PublishRequest> next(long count) {
+    public List<PublishRequest> next(int count) {
         if (count <= 0) {
             count = 1;
         }
 
         long left = remaining.getAndAdd(-count);
-        count = Math.min(count, left);
-        if (count <= 0) {
+        long actual = Math.min(left, count);
+        if (actual <= 0) {
             throw new ScenarioException(properties, "Reached publish limit of " + properties.getLimit());
         }
 
@@ -82,7 +82,7 @@ public class ConfigurableTransactionGenerator implements TransactionGenerator {
         }
 
         List<PublishRequest> publishRequests = new ArrayList<>();
-        for (long i = 0; i < count; i++) {
+        for (long i = 0; i < actual; i++) {
             PublishRequest publishRequest = builder.receipt(shouldGenerate(properties.getReceipt()))
                     .record(shouldGenerate(properties.getRecord()))
                     .timestamp(Instant.now())

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/generator/ScenarioProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/generator/ScenarioProperties.java
@@ -68,10 +68,6 @@ public class ScenarioProperties {
     @NotNull
     private TransactionType type;
 
-    @DurationMin(seconds = 0)
-    @NotNull
-    private Duration warmupPeriod = Duration.ofSeconds(30L);
-
     public long getLimit() {
         return limit > 0 ? limit : Long.MAX_VALUE;
     }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/generator/TransactionGenerator.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/generator/TransactionGenerator.java
@@ -22,7 +22,20 @@ package com.hedera.mirror.monitor.generator;
 
 import com.hedera.mirror.monitor.publish.PublishRequest;
 
+import java.util.List;
+
 public interface TransactionGenerator {
 
-    PublishRequest next();
+    /**
+     * Gets the next count publish requests. If count > 0, up to count publish requests will be generated;
+     * if count <= 0, the generator will determine the actual count.
+     *
+     * @param count
+     * @return
+     */
+    List<PublishRequest> next(long count);
+
+    default List<PublishRequest> next() {
+        return next(1);
+    }
 }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/generator/TransactionGenerator.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/generator/TransactionGenerator.java
@@ -20,9 +20,9 @@ package com.hedera.mirror.monitor.generator;
  * ‍
  */
 
-import com.hedera.mirror.monitor.publish.PublishRequest;
-
 import java.util.List;
+
+import com.hedera.mirror.monitor.publish.PublishRequest;
 
 public interface TransactionGenerator {
 
@@ -33,7 +33,7 @@ public interface TransactionGenerator {
      * @param count
      * @return
      */
-    List<PublishRequest> next(long count);
+    List<PublishRequest> next(int count);
 
     default List<PublishRequest> next() {
         return next(1);

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishMetrics.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishMetrics.java
@@ -56,6 +56,8 @@ public class PublishMetrics {
     private final Map<Tags, Timer> submitTimers = new ConcurrentHashMap<>();
     private final Map<Tags, TimeGauge> durationGauges = new ConcurrentHashMap<>();
     private final MeterRegistry meterRegistry;
+    private long lastCount = 0;
+    private long lastElapsed = 0;
 
     @FunctionalInterface
     interface CheckedFunction<T, R> {
@@ -137,10 +139,25 @@ public class PublishMetrics {
     public void status() {
         long count = counter.get();
         long elapsed = stopwatch.elapsed(TimeUnit.MICROSECONDS);
-        double rate = Precision.round(elapsed > 0 ? (1000000.0 * count) / elapsed : 0.0, 1);
+        double averageRate = getRate(count, elapsed);
+        long instantCount = count - lastCount;
+        long instantElapsed = elapsed - lastElapsed;
+        double instantRate = getRate(instantCount, instantElapsed);
         Map<String, Integer> errorCounts = new HashMap<>();
         errors.forEachEntry((k, v) -> errorCounts.put(k, v));
-        log.info("Published {} transactions in {} at {}/s. Errors: {}", count, stopwatch, rate, errorCounts);
+        log.info("Published {} transactions in {} at {}/s, {} transactions in last {} s at {}/s. Errors: {}",
+                count, stopwatch, averageRate, instantCount, toSeconds(instantElapsed), instantRate, errorCounts);
+
+        lastCount = count;
+        lastElapsed = elapsed;
+    }
+
+    private double getRate(long count, long elapsedMicros) {
+        return Precision.round(elapsedMicros > 0 ? (count * 1000000.0) / elapsedMicros : 0.0, 1);
+    }
+
+    private double toSeconds(long micros) {
+        return Precision.round(micros * 1.0 / 1_000_000, 2);
     }
 
     @Value

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishProperties.java
@@ -23,6 +23,7 @@ package com.hedera.mirror.monitor.publish;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
@@ -37,6 +38,9 @@ import com.hedera.mirror.monitor.generator.ScenarioProperties;
 @Validated
 @ConfigurationProperties("hedera.mirror.monitor.publish")
 public class PublishProperties {
+
+    @Min(100)
+    private int batchDivisor = 100;
 
     @Min(1)
     private int connections = 5;

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishProperties.java
@@ -23,7 +23,6 @@ package com.hedera.mirror.monitor.publish;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishProperties.java
@@ -49,4 +49,8 @@ public class PublishProperties {
     @DurationMin(seconds = 1L)
     @NotNull
     private Duration statusFrequency = Duration.ofSeconds(10L);
+
+    @DurationMin(seconds = 0)
+    @NotNull
+    private Duration warmupPeriod = Duration.ofSeconds(30L);
 }

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/generator/CompositeTransactionGeneratorTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/generator/CompositeTransactionGeneratorTest.java
@@ -119,9 +119,6 @@ class CompositeTransactionGeneratorTest {
     }
 
     private void assertInactive() {
-        assertThat(supplier.get().distribution.getPmf())
-                .hasSize(1)
-                .first()
-                .isEqualTo(CompositeTransactionGenerator.INACTIVE);
+        assertThat(supplier.get().rateLimiter).isEqualTo(CompositeTransactionGenerator.INACTIVE_RATE_LIMITER);
     }
 }

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/generator/CompositeTransactionGeneratorTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/generator/CompositeTransactionGeneratorTest.java
@@ -43,111 +43,111 @@ import com.hedera.mirror.monitor.publish.PublishRequest;
 @Log4j2
 class CompositeTransactionGeneratorTest {
 
-    private PublishProperties properties;
-    private Supplier<CompositeTransactionGenerator> supplier;
-    private double totalTps;
-
-    @BeforeEach
-    void init() {
-        double tps = 750;
-        ScenarioProperties scenarioProperties1 = new ScenarioProperties();
-        scenarioProperties1.setName("test1");
-        scenarioProperties1.setProperties(Map.of("topicId", "0.0.1000"));
-        scenarioProperties1.setTps(tps);
-        scenarioProperties1.setType(TransactionType.CONSENSUS_SUBMIT_MESSAGE);
-        totalTps = tps;
-
-        tps = 250;
-        ScenarioProperties scenarioProperties2 = new ScenarioProperties();
-        scenarioProperties2.setName("test2");
-        scenarioProperties2.setTps(tps);
-        scenarioProperties2.setType(TransactionType.ACCOUNT_CREATE);
-        totalTps += tps;
-
-        properties = new PublishProperties();
-        properties.getScenarios().add(scenarioProperties1);
-        properties.getScenarios().add(scenarioProperties2);
-        supplier = Suppliers.memoize(() -> new CompositeTransactionGenerator(p -> p, properties));
-    }
-
-    @Test
-    void distribution() {
-        properties.setWarmupPeriod(Duration.ZERO);
-        CompositeTransactionGenerator generator = supplier.get();
-        assertThat(generator.distribution.getPmf())
-                .hasSize(properties.getScenarios().size())
-                .extracting(Pair::getValue)
-                .containsExactly(0.75, 0.25);
-
-        Multiset<TransactionType> types = HashMultiset.create();
-        double seconds = 5;
-        for (int i = 0; i < totalTps * seconds; ++i) {
-            PublishRequest request = generator.next();
-            types.add(request.getType());
-        }
-
-        for (ScenarioProperties scenarioProperties : properties.getScenarios()) {
-            assertThat(types.count(scenarioProperties.getType()))
-                    .isNotNegative()
-                    .isNotZero()
-                    .isCloseTo((int) (scenarioProperties.getTps() * seconds), withinPercentage(10));
-        }
-    }
-
-    @Test
-    void disabledScenario() {
-        properties.getScenarios().get(0).setEnabled(false);
-        CompositeTransactionGenerator generator = supplier.get();
-        assertThat(generator.distribution.getPmf())
-                .hasSize(1)
-                .extracting(Pair::getValue)
-                .containsExactly(1.0);
-    }
-
-    @Test
-    void noScenario() {
-        properties.getScenarios().clear();
-        assertInactive();
-    }
-
-    @Test
-    void noWarmup() {
-        properties.setWarmupPeriod(Duration.ZERO);
-        CompositeTransactionGenerator generator = supplier.get();
-        Stopwatch stopwatch = Stopwatch.createStarted();
-        double seconds = 4.0;
-        int total = (int) (totalTps * seconds);
-        for (int i = 0; i < total; i++) {
-            generator.next();
-        }
-
-        assertThat(stopwatch.elapsed().toMillis() * 1.0 / 1000).isCloseTo(seconds, withinPercentage(5));
-    }
-
-    @Test
-    void publishDisabled() {
-        properties.setEnabled(false);
-        assertInactive();
-    }
-
-    @Test
-    void scenariosComplete() {
-        properties.getScenarios().remove(properties.getScenarios().size() - 1);
-        properties.getScenarios().get(0).setLimit(1L);
-        CompositeTransactionGenerator generator = supplier.get();
-        assertThat(generator.next()).isNotNull();
-        assertThatThrownBy(() -> generator.next()).isInstanceOf(ScenarioException.class);
-        assertInactive();
-        assertThat(properties.getScenarios())
-                .extracting(ScenarioProperties::isEnabled)
-                .containsExactly(false);
-    }
-
-    private void assertInactive() {
-        assertThat(supplier.get().rateLimiter).isEqualTo(CompositeTransactionGenerator.INACTIVE_RATE_LIMITER);
-    }
-
-    private double getTps(int count, Duration elapsed) {
-        return count * 1.0 / (elapsed.toNanos() * 1.0 / 1_000_000_000L);
-    }
+//    private PublishProperties properties;
+//    private Supplier<CompositeTransactionGenerator> supplier;
+//    private double totalTps;
+//
+//    @BeforeEach
+//    void init() {
+//        double tps = 750;
+//        ScenarioProperties scenarioProperties1 = new ScenarioProperties();
+//        scenarioProperties1.setName("test1");
+//        scenarioProperties1.setProperties(Map.of("topicId", "0.0.1000"));
+//        scenarioProperties1.setTps(tps);
+//        scenarioProperties1.setType(TransactionType.CONSENSUS_SUBMIT_MESSAGE);
+//        totalTps = tps;
+//
+//        tps = 250;
+//        ScenarioProperties scenarioProperties2 = new ScenarioProperties();
+//        scenarioProperties2.setName("test2");
+//        scenarioProperties2.setTps(tps);
+//        scenarioProperties2.setType(TransactionType.ACCOUNT_CREATE);
+//        totalTps += tps;
+//
+//        properties = new PublishProperties();
+//        properties.getScenarios().add(scenarioProperties1);
+//        properties.getScenarios().add(scenarioProperties2);
+//        supplier = Suppliers.memoize(() -> new CompositeTransactionGenerator(p -> p, properties));
+//    }
+//
+//    @Test
+//    void distribution() {
+//        properties.setWarmupPeriod(Duration.ZERO);
+//        CompositeTransactionGenerator generator = supplier.get();
+//        assertThat(generator.distribution.getPmf())
+//                .hasSize(properties.getScenarios().size())
+//                .extracting(Pair::getValue)
+//                .containsExactly(0.75, 0.25);
+//
+//        Multiset<TransactionType> types = HashMultiset.create();
+//        double seconds = 5;
+//        for (int i = 0; i < totalTps * seconds; ++i) {
+//            PublishRequest request = generator.next();
+//            types.add(request.getType());
+//        }
+//
+//        for (ScenarioProperties scenarioProperties : properties.getScenarios()) {
+//            assertThat(types.count(scenarioProperties.getType()))
+//                    .isNotNegative()
+//                    .isNotZero()
+//                    .isCloseTo((int) (scenarioProperties.getTps() * seconds), withinPercentage(10));
+//        }
+//    }
+//
+//    @Test
+//    void disabledScenario() {
+//        properties.getScenarios().get(0).setEnabled(false);
+//        CompositeTransactionGenerator generator = supplier.get();
+//        assertThat(generator.distribution.getPmf())
+//                .hasSize(1)
+//                .extracting(Pair::getValue)
+//                .containsExactly(1.0);
+//    }
+//
+//    @Test
+//    void noScenario() {
+//        properties.getScenarios().clear();
+//        assertInactive();
+//    }
+//
+//    @Test
+//    void noWarmup() {
+//        properties.setWarmupPeriod(Duration.ZERO);
+//        CompositeTransactionGenerator generator = supplier.get();
+//        Stopwatch stopwatch = Stopwatch.createStarted();
+//        double seconds = 4.0;
+//        int total = (int) (totalTps * seconds);
+//        for (int i = 0; i < total; i++) {
+//            generator.next();
+//        }
+//
+//        assertThat(stopwatch.elapsed().toMillis() * 1.0 / 1000).isCloseTo(seconds, withinPercentage(5));
+//    }
+//
+//    @Test
+//    void publishDisabled() {
+//        properties.setEnabled(false);
+//        assertInactive();
+//    }
+//
+//    @Test
+//    void scenariosComplete() {
+//        properties.getScenarios().remove(properties.getScenarios().size() - 1);
+//        properties.getScenarios().get(0).setLimit(1L);
+//        CompositeTransactionGenerator generator = supplier.get();
+//        assertThat(generator.next()).isNotNull();
+//        assertThatThrownBy(() -> generator.next()).isInstanceOf(ScenarioException.class);
+//        assertInactive();
+//        assertThat(properties.getScenarios())
+//                .extracting(ScenarioProperties::isEnabled)
+//                .containsExactly(false);
+//    }
+//
+//    private void assertInactive() {
+//        assertThat(supplier.get().rateLimiter).isEqualTo(CompositeTransactionGenerator.INACTIVE_RATE_LIMITER);
+//    }
+//
+//    private double getTps(int count, Duration elapsed) {
+//        return count * 1.0 / (elapsed.toNanos() * 1.0 / 1_000_000_000L);
+//    }
 }

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/generator/CompositeTransactionGeneratorTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/generator/CompositeTransactionGeneratorTest.java
@@ -50,20 +50,18 @@ class CompositeTransactionGeneratorTest {
 
     @BeforeEach
     void init() {
-        double tps = 750;
         ScenarioProperties scenarioProperties1 = new ScenarioProperties();
         scenarioProperties1.setName("test1");
         scenarioProperties1.setProperties(Map.of("topicId", "0.0.1000"));
-        scenarioProperties1.setTps(tps);
+        scenarioProperties1.setTps(750);
         scenarioProperties1.setType(TransactionType.CONSENSUS_SUBMIT_MESSAGE);
-        totalTps = tps;
+        totalTps = scenarioProperties1.getTps();
 
-        tps = 250;
         ScenarioProperties scenarioProperties2 = new ScenarioProperties();
         scenarioProperties2.setName("test2");
-        scenarioProperties2.setTps(tps);
+        scenarioProperties2.setTps(250);
         scenarioProperties2.setType(TransactionType.ACCOUNT_CREATE);
-        totalTps += tps;
+        totalTps += scenarioProperties2.getTps();
 
         properties = new PublishProperties();
         properties.getScenarios().add(scenarioProperties1);

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/generator/CompositeTransactionGeneratorTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/generator/CompositeTransactionGeneratorTest.java
@@ -21,7 +21,6 @@ package com.hedera.mirror.monitor.generator;
  */
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.withinPercentage;
 
 import com.google.common.base.Stopwatch;
@@ -29,12 +28,16 @@ import com.google.common.base.Suppliers;
 import com.google.common.collect.HashMultiset;
 import com.google.common.collect.Multiset;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.math3.util.Pair;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import com.hedera.datagenerator.sdk.supplier.TransactionType;
 import com.hedera.mirror.monitor.publish.PublishProperties;
@@ -43,111 +46,172 @@ import com.hedera.mirror.monitor.publish.PublishRequest;
 @Log4j2
 class CompositeTransactionGeneratorTest {
 
-//    private PublishProperties properties;
-//    private Supplier<CompositeTransactionGenerator> supplier;
-//    private double totalTps;
-//
-//    @BeforeEach
-//    void init() {
-//        double tps = 750;
-//        ScenarioProperties scenarioProperties1 = new ScenarioProperties();
-//        scenarioProperties1.setName("test1");
-//        scenarioProperties1.setProperties(Map.of("topicId", "0.0.1000"));
-//        scenarioProperties1.setTps(tps);
-//        scenarioProperties1.setType(TransactionType.CONSENSUS_SUBMIT_MESSAGE);
-//        totalTps = tps;
-//
-//        tps = 250;
-//        ScenarioProperties scenarioProperties2 = new ScenarioProperties();
-//        scenarioProperties2.setName("test2");
-//        scenarioProperties2.setTps(tps);
-//        scenarioProperties2.setType(TransactionType.ACCOUNT_CREATE);
-//        totalTps += tps;
-//
-//        properties = new PublishProperties();
-//        properties.getScenarios().add(scenarioProperties1);
-//        properties.getScenarios().add(scenarioProperties2);
-//        supplier = Suppliers.memoize(() -> new CompositeTransactionGenerator(p -> p, properties));
-//    }
-//
-//    @Test
-//    void distribution() {
-//        properties.setWarmupPeriod(Duration.ZERO);
-//        CompositeTransactionGenerator generator = supplier.get();
-//        assertThat(generator.distribution.getPmf())
-//                .hasSize(properties.getScenarios().size())
-//                .extracting(Pair::getValue)
-//                .containsExactly(0.75, 0.25);
-//
-//        Multiset<TransactionType> types = HashMultiset.create();
-//        double seconds = 5;
-//        for (int i = 0; i < totalTps * seconds; ++i) {
-//            PublishRequest request = generator.next();
-//            types.add(request.getType());
-//        }
-//
-//        for (ScenarioProperties scenarioProperties : properties.getScenarios()) {
-//            assertThat(types.count(scenarioProperties.getType()))
-//                    .isNotNegative()
-//                    .isNotZero()
-//                    .isCloseTo((int) (scenarioProperties.getTps() * seconds), withinPercentage(10));
-//        }
-//    }
-//
-//    @Test
-//    void disabledScenario() {
-//        properties.getScenarios().get(0).setEnabled(false);
-//        CompositeTransactionGenerator generator = supplier.get();
-//        assertThat(generator.distribution.getPmf())
-//                .hasSize(1)
-//                .extracting(Pair::getValue)
-//                .containsExactly(1.0);
-//    }
-//
-//    @Test
-//    void noScenario() {
-//        properties.getScenarios().clear();
-//        assertInactive();
-//    }
-//
-//    @Test
-//    void noWarmup() {
-//        properties.setWarmupPeriod(Duration.ZERO);
-//        CompositeTransactionGenerator generator = supplier.get();
-//        Stopwatch stopwatch = Stopwatch.createStarted();
-//        double seconds = 4.0;
-//        int total = (int) (totalTps * seconds);
-//        for (int i = 0; i < total; i++) {
-//            generator.next();
-//        }
-//
-//        assertThat(stopwatch.elapsed().toMillis() * 1.0 / 1000).isCloseTo(seconds, withinPercentage(5));
-//    }
-//
-//    @Test
-//    void publishDisabled() {
-//        properties.setEnabled(false);
-//        assertInactive();
-//    }
-//
-//    @Test
-//    void scenariosComplete() {
-//        properties.getScenarios().remove(properties.getScenarios().size() - 1);
-//        properties.getScenarios().get(0).setLimit(1L);
-//        CompositeTransactionGenerator generator = supplier.get();
-//        assertThat(generator.next()).isNotNull();
-//        assertThatThrownBy(() -> generator.next()).isInstanceOf(ScenarioException.class);
-//        assertInactive();
-//        assertThat(properties.getScenarios())
-//                .extracting(ScenarioProperties::isEnabled)
-//                .containsExactly(false);
-//    }
-//
-//    private void assertInactive() {
-//        assertThat(supplier.get().rateLimiter).isEqualTo(CompositeTransactionGenerator.INACTIVE_RATE_LIMITER);
-//    }
-//
-//    private double getTps(int count, Duration elapsed) {
-//        return count * 1.0 / (elapsed.toNanos() * 1.0 / 1_000_000_000L);
-//    }
+    private PublishProperties properties;
+    private Supplier<CompositeTransactionGenerator> supplier;
+    private double totalTps;
+
+    @BeforeEach
+    void init() {
+        double tps = 750;
+        ScenarioProperties scenarioProperties1 = new ScenarioProperties();
+        scenarioProperties1.setName("test1");
+        scenarioProperties1.setProperties(Map.of("topicId", "0.0.1000"));
+        scenarioProperties1.setTps(tps);
+        scenarioProperties1.setType(TransactionType.CONSENSUS_SUBMIT_MESSAGE);
+        totalTps = tps;
+
+        tps = 250;
+        ScenarioProperties scenarioProperties2 = new ScenarioProperties();
+        scenarioProperties2.setName("test2");
+        scenarioProperties2.setTps(tps);
+        scenarioProperties2.setType(TransactionType.ACCOUNT_CREATE);
+        totalTps += tps;
+
+        properties = new PublishProperties();
+        properties.getScenarios().add(scenarioProperties1);
+        properties.getScenarios().add(scenarioProperties2);
+        supplier = Suppliers.memoize(() -> new CompositeTransactionGenerator(p -> p, properties));
+
+        warmup();
+    }
+
+    @ParameterizedTest(name = "batch request count {0}")
+    @ValueSource(ints = {0, -1})
+    void batchRequestDefault(int count) {
+        CompositeTransactionGenerator generator = supplier.get();
+
+        List<PublishRequest> publishRequests = generator.next(count);
+        assertThat(publishRequests).hasSize(generator.batchSize);
+    }
+
+    @Test
+    void batchRequestTwo() {
+        CompositeTransactionGenerator generator = supplier.get();
+
+        List<PublishRequest> publishRequests = generator.next(2);
+        assertThat(publishRequests).hasSize(2);
+    }
+
+    @Test
+    void batchRequestGreaterThanDefault() {
+        CompositeTransactionGenerator generator = supplier.get();
+        int count = generator.batchSize + 1;
+
+        List<PublishRequest> publishRequests = generator.next(count);
+        assertThat(publishRequests).hasSize(count);
+    }
+
+    @Test
+    void distribution() {
+        properties.setWarmupPeriod(Duration.ZERO);
+        CompositeTransactionGenerator generator = supplier.get();
+        assertThat(generator.distribution.getPmf())
+                .hasSize(properties.getScenarios().size())
+                .extracting(Pair::getValue)
+                .containsExactly(0.75, 0.25);
+
+        Multiset<TransactionType> types = HashMultiset.create();
+        double seconds = 5;
+        for (int i = 0; i < totalTps * seconds;) {
+            List<PublishRequest> requests = generator.next();
+            requests.stream().map(PublishRequest::getType).forEach(types::add);
+            i += requests.size();
+        }
+
+        for (ScenarioProperties scenarioProperties : properties.getScenarios()) {
+            assertThat(types.count(scenarioProperties.getType()))
+                    .isNotNegative()
+                    .isNotZero()
+                    .isCloseTo((int) (scenarioProperties.getTps() * seconds), withinPercentage(10));
+        }
+    }
+
+    @Test
+    void disabledScenario() {
+        properties.getScenarios().get(0).setEnabled(false);
+        CompositeTransactionGenerator generator = supplier.get();
+        assertThat(generator.distribution.getPmf())
+                .hasSize(1)
+                .extracting(Pair::getValue)
+                .containsExactly(1.0);
+    }
+
+    @Test
+    void noScenario() {
+        properties.getScenarios().clear();
+        assertInactive();
+    }
+
+    @Test
+    void noWarmup() {
+        properties.setWarmupPeriod(Duration.ZERO);
+        CompositeTransactionGenerator generator = supplier.get();
+        Stopwatch stopwatch = Stopwatch.createStarted();
+        double seconds = 4.0;
+        int total = (int) (totalTps * seconds);
+        for (int i = 0; i < total; i++) {
+            generator.next();
+        }
+
+        assertThat(stopwatch.elapsed().toMillis() * 1.0 / 1000).isCloseTo(seconds, withinPercentage(5));
+    }
+
+    @Test
+    void publishDisabled() {
+        properties.setEnabled(false);
+        assertInactive();
+    }
+
+    @Test
+    void scenariosComplete() {
+        properties.getScenarios().remove(properties.getScenarios().size() - 1);
+        properties.getScenarios().get(0).setLimit(1L);
+        CompositeTransactionGenerator generator = supplier.get();
+        assertThat(generator.next()).hasSize(1);
+        assertThat(generator.next()).hasSize(0);
+        assertInactive();
+        assertThat(properties.getScenarios())
+                .extracting(ScenarioProperties::isEnabled)
+                .containsExactly(false);
+    }
+
+    @Test
+    void warmupBatchRequest() {
+        int warmUpSeconds = 4;
+        properties.setWarmupPeriod(Duration.ofSeconds(warmUpSeconds));
+        CompositeTransactionGenerator generator = supplier.get();
+
+        long begin = System.currentTimeMillis();
+        long elapsed = 0;
+        long lastElapsed = 0;
+        int count = 0;
+        List<Integer> counts = new ArrayList<>();
+        while (elapsed < (warmUpSeconds + 3) * 1000) {
+            List<PublishRequest> publishRequests = generator.next(0);
+            count += publishRequests.size();
+
+            elapsed = System.currentTimeMillis() - begin;
+            if (elapsed - lastElapsed >= 1000) {
+                counts.add(count);
+                count = 0;
+                lastElapsed = elapsed;
+            }
+        }
+
+        List<Integer> warmupCounts = counts.subList(0, warmUpSeconds);
+        List<Integer> stableCounts = counts.subList(warmUpSeconds, counts.size());
+        assertThat(warmupCounts).isSorted().allSatisfy(n -> assertThat(n * 1.0).isLessThan(totalTps));
+        assertThat(stableCounts).allSatisfy(n -> assertThat(n * 1.0).isCloseTo(totalTps, withinPercentage(5)));
+    }
+
+    private void assertInactive() {
+        assertThat(supplier.get().rateLimiter).isEqualTo(CompositeTransactionGenerator.INACTIVE_RATE_LIMITER);
+    }
+
+    private void warmup() {
+        TransactionGenerator generator = Suppliers
+                .synchronizedSupplier(() -> new CompositeTransactionGenerator(p -> p, properties)).get();
+        // warmup so in tests the timing will be accurate
+        generator.next(0);
+    }
 }

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/generator/ConfigurableTransactionGeneratorTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/generator/ConfigurableTransactionGeneratorTest.java
@@ -41,143 +41,143 @@ import com.hedera.mirror.monitor.publish.PublishRequest;
 
 class ConfigurableTransactionGeneratorTest {
 
-    private static final int SAMPLE_SIZE = 10_000;
-    private static final String TOPIC_ID = "0.0.1000";
-
-    private ScenarioProperties properties;
-    private Supplier<ConfigurableTransactionGenerator> generator;
-
-    @BeforeEach
-    void init() {
-        properties = new ScenarioProperties();
-        properties.setReceipt(1);
-        properties.setRecord(1);
-        properties.setName("test");
-        properties.setProperties(Map.of("topicId", TOPIC_ID));
-        properties.setTps(100_000);
-        properties.setType(TransactionType.CONSENSUS_SUBMIT_MESSAGE);
-        generator = Suppliers.memoize(() -> new ConfigurableTransactionGenerator(p -> p, properties));
-    }
-
-    @Test
-    void next() {
-        assertRequest(generator.get().next());
-    }
-
-    @Test
-    void logResponse() {
-        properties.setLogResponse(true);
-        assertRequest(generator.get().next());
-    }
-
-    @Test
-    void unknownField() {
-        properties.setProperties(Map.of("foo", "bar", "topicId", TOPIC_ID));
-        assertThatThrownBy(() -> generator.get().next())
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("Unrecognized field");
-    }
-
-    @Test
-    void reachedLimit() {
-        properties.setLimit(1);
-        assertRequest(generator.get().next());
-        assertThatThrownBy(() -> generator.get().next())
-                .isInstanceOf(ScenarioException.class)
-                .hasMessageContaining("Reached publish limit");
-    }
-
-    @Test
-    void reachedDuration() {
-        properties.setDuration(Duration.ofSeconds(-5L));
-        assertThatThrownBy(() -> generator.get().next())
-                .isInstanceOf(ScenarioException.class)
-                .hasMessageContaining("Reached publish duration");
-    }
-
-    @Test
-    void receiptDisabled() {
-        properties.setReceipt(0);
-        for (int i = 0; i < SAMPLE_SIZE; ++i) {
-            assertThat(generator.get().next())
-                    .extracting(PublishRequest::isReceipt)
-                    .isEqualTo(false);
-        }
-    }
-
-    @Test
-    void receiptEnabled() {
-        properties.setReceipt(1);
-        for (int i = 0; i < SAMPLE_SIZE; ++i) {
-            assertThat(generator.get().next())
-                    .extracting(PublishRequest::isReceipt)
-                    .isEqualTo(true);
-        }
-    }
-
-    @Test
-    void receiptPercent() {
-        properties.setReceipt(0.1);
-        Multiset<Boolean> receipts = HashMultiset.create();
-
-        for (int i = 0; i < SAMPLE_SIZE; ++i) {
-            receipts.add(generator.get().next().isReceipt());
-        }
-
-        assertThat((double) receipts.count(true) / SAMPLE_SIZE)
-                .isNotNegative()
-                .isNotZero()
-                .isCloseTo(properties.getReceipt(), within(properties.getReceipt() * 0.2));
-    }
-
-    @Test
-    void recordDisabled() {
-        properties.setRecord(0);
-        for (int i = 0; i < SAMPLE_SIZE; ++i) {
-            assertThat(generator.get().next())
-                    .extracting(PublishRequest::isRecord)
-                    .isEqualTo(false);
-        }
-    }
-
-    @Test
-    void recordEnabled() {
-        properties.setRecord(1);
-        for (int i = 0; i < SAMPLE_SIZE; ++i) {
-            assertThat(generator.get().next())
-                    .extracting(PublishRequest::isRecord)
-                    .isEqualTo(true);
-        }
-    }
-
-    @Test
-    void recordPercent() {
-        properties.setRecord(0.75);
-        Multiset<Boolean> records = HashMultiset.create();
-
-        for (int i = 0; i < SAMPLE_SIZE; ++i) {
-            records.add(generator.get().next().isRecord());
-        }
-
-        assertThat((double) records.count(true) / SAMPLE_SIZE)
-                .isNotNegative()
-                .isNotZero()
-                .isCloseTo(properties.getRecord(), within(properties.getRecord() * 0.2));
-    }
-
-    @Test
-    void missingRequiredField() {
-        properties.setProperties(Collections.emptyMap());
-        assertThatThrownBy(() -> generator.get().next()).isInstanceOf(ConstraintViolationException.class);
-    }
-
-    private void assertRequest(PublishRequest publishRequest) {
-        assertThat(publishRequest).isNotNull()
-                .hasNoNullFieldsOrProperties()
-                .hasFieldOrPropertyWithValue("logResponse", properties.isLogResponse())
-                .hasFieldOrPropertyWithValue("receipt", true)
-                .hasFieldOrPropertyWithValue("record", true)
-                .hasFieldOrPropertyWithValue("type", properties.getType())
-                .hasFieldOrPropertyWithValue("transaction.topicId", TopicId.fromString(TOPIC_ID));
-    }
+//    private static final int SAMPLE_SIZE = 10_000;
+//    private static final String TOPIC_ID = "0.0.1000";
+//
+//    private ScenarioProperties properties;
+//    private Supplier<ConfigurableTransactionGenerator> generator;
+//
+//    @BeforeEach
+//    void init() {
+//        properties = new ScenarioProperties();
+//        properties.setReceipt(1);
+//        properties.setRecord(1);
+//        properties.setName("test");
+//        properties.setProperties(Map.of("topicId", TOPIC_ID));
+//        properties.setTps(100_000);
+//        properties.setType(TransactionType.CONSENSUS_SUBMIT_MESSAGE);
+//        generator = Suppliers.memoize(() -> new ConfigurableTransactionGenerator(p -> p, properties));
+//    }
+//
+//    @Test
+//    void next() {
+//        assertRequest(generator.get().next());
+//    }
+//
+//    @Test
+//    void logResponse() {
+//        properties.setLogResponse(true);
+//        assertRequest(generator.get().next());
+//    }
+//
+//    @Test
+//    void unknownField() {
+//        properties.setProperties(Map.of("foo", "bar", "topicId", TOPIC_ID));
+//        assertThatThrownBy(() -> generator.get().next())
+//                .isInstanceOf(IllegalArgumentException.class)
+//                .hasMessageContaining("Unrecognized field");
+//    }
+//
+//    @Test
+//    void reachedLimit() {
+//        properties.setLimit(1);
+//        assertRequest(generator.get().next());
+//        assertThatThrownBy(() -> generator.get().next())
+//                .isInstanceOf(ScenarioException.class)
+//                .hasMessageContaining("Reached publish limit");
+//    }
+//
+//    @Test
+//    void reachedDuration() {
+//        properties.setDuration(Duration.ofSeconds(-5L));
+//        assertThatThrownBy(() -> generator.get().next())
+//                .isInstanceOf(ScenarioException.class)
+//                .hasMessageContaining("Reached publish duration");
+//    }
+//
+//    @Test
+//    void receiptDisabled() {
+//        properties.setReceipt(0);
+//        for (int i = 0; i < SAMPLE_SIZE; ++i) {
+//            assertThat(generator.get().next())
+//                    .extracting(PublishRequest::isReceipt)
+//                    .isEqualTo(false);
+//        }
+//    }
+//
+//    @Test
+//    void receiptEnabled() {
+//        properties.setReceipt(1);
+//        for (int i = 0; i < SAMPLE_SIZE; ++i) {
+//            assertThat(generator.get().next())
+//                    .extracting(PublishRequest::isReceipt)
+//                    .isEqualTo(true);
+//        }
+//    }
+//
+//    @Test
+//    void receiptPercent() {
+//        properties.setReceipt(0.1);
+//        Multiset<Boolean> receipts = HashMultiset.create();
+//
+//        for (int i = 0; i < SAMPLE_SIZE; ++i) {
+//            receipts.add(generator.get().next().isReceipt());
+//        }
+//
+//        assertThat((double) receipts.count(true) / SAMPLE_SIZE)
+//                .isNotNegative()
+//                .isNotZero()
+//                .isCloseTo(properties.getReceipt(), within(properties.getReceipt() * 0.2));
+//    }
+//
+//    @Test
+//    void recordDisabled() {
+//        properties.setRecord(0);
+//        for (int i = 0; i < SAMPLE_SIZE; ++i) {
+//            assertThat(generator.get().next())
+//                    .extracting(PublishRequest::isRecord)
+//                    .isEqualTo(false);
+//        }
+//    }
+//
+//    @Test
+//    void recordEnabled() {
+//        properties.setRecord(1);
+//        for (int i = 0; i < SAMPLE_SIZE; ++i) {
+//            assertThat(generator.get().next())
+//                    .extracting(PublishRequest::isRecord)
+//                    .isEqualTo(true);
+//        }
+//    }
+//
+//    @Test
+//    void recordPercent() {
+//        properties.setRecord(0.75);
+//        Multiset<Boolean> records = HashMultiset.create();
+//
+//        for (int i = 0; i < SAMPLE_SIZE; ++i) {
+//            records.add(generator.get().next().isRecord());
+//        }
+//
+//        assertThat((double) records.count(true) / SAMPLE_SIZE)
+//                .isNotNegative()
+//                .isNotZero()
+//                .isCloseTo(properties.getRecord(), within(properties.getRecord() * 0.2));
+//    }
+//
+//    @Test
+//    void missingRequiredField() {
+//        properties.setProperties(Collections.emptyMap());
+//        assertThatThrownBy(() -> generator.get().next()).isInstanceOf(ConstraintViolationException.class);
+//    }
+//
+//    private void assertRequest(PublishRequest publishRequest) {
+//        assertThat(publishRequest).isNotNull()
+//                .hasNoNullFieldsOrProperties()
+//                .hasFieldOrPropertyWithValue("logResponse", properties.isLogResponse())
+//                .hasFieldOrPropertyWithValue("receipt", true)
+//                .hasFieldOrPropertyWithValue("record", true)
+//                .hasFieldOrPropertyWithValue("type", properties.getType())
+//                .hasFieldOrPropertyWithValue("transaction.topicId", TopicId.fromString(TOPIC_ID));
+//    }
 }

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/generator/ConfigurableTransactionGeneratorTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/generator/ConfigurableTransactionGeneratorTest.java
@@ -29,11 +29,14 @@ import com.google.common.collect.HashMultiset;
 import com.google.common.collect.Multiset;
 import java.time.Duration;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 import javax.validation.ConstraintViolationException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import com.hedera.datagenerator.sdk.supplier.TransactionType;
 import com.hedera.hashgraph.sdk.TopicId;
@@ -41,143 +44,169 @@ import com.hedera.mirror.monitor.publish.PublishRequest;
 
 class ConfigurableTransactionGeneratorTest {
 
-//    private static final int SAMPLE_SIZE = 10_000;
-//    private static final String TOPIC_ID = "0.0.1000";
-//
-//    private ScenarioProperties properties;
-//    private Supplier<ConfigurableTransactionGenerator> generator;
-//
-//    @BeforeEach
-//    void init() {
-//        properties = new ScenarioProperties();
-//        properties.setReceipt(1);
-//        properties.setRecord(1);
-//        properties.setName("test");
-//        properties.setProperties(Map.of("topicId", TOPIC_ID));
-//        properties.setTps(100_000);
-//        properties.setType(TransactionType.CONSENSUS_SUBMIT_MESSAGE);
-//        generator = Suppliers.memoize(() -> new ConfigurableTransactionGenerator(p -> p, properties));
-//    }
-//
-//    @Test
-//    void next() {
-//        assertRequest(generator.get().next());
-//    }
-//
-//    @Test
-//    void logResponse() {
-//        properties.setLogResponse(true);
-//        assertRequest(generator.get().next());
-//    }
-//
-//    @Test
-//    void unknownField() {
-//        properties.setProperties(Map.of("foo", "bar", "topicId", TOPIC_ID));
-//        assertThatThrownBy(() -> generator.get().next())
-//                .isInstanceOf(IllegalArgumentException.class)
-//                .hasMessageContaining("Unrecognized field");
-//    }
-//
-//    @Test
-//    void reachedLimit() {
-//        properties.setLimit(1);
-//        assertRequest(generator.get().next());
-//        assertThatThrownBy(() -> generator.get().next())
-//                .isInstanceOf(ScenarioException.class)
-//                .hasMessageContaining("Reached publish limit");
-//    }
-//
-//    @Test
-//    void reachedDuration() {
-//        properties.setDuration(Duration.ofSeconds(-5L));
-//        assertThatThrownBy(() -> generator.get().next())
-//                .isInstanceOf(ScenarioException.class)
-//                .hasMessageContaining("Reached publish duration");
-//    }
-//
-//    @Test
-//    void receiptDisabled() {
-//        properties.setReceipt(0);
-//        for (int i = 0; i < SAMPLE_SIZE; ++i) {
-//            assertThat(generator.get().next())
-//                    .extracting(PublishRequest::isReceipt)
-//                    .isEqualTo(false);
-//        }
-//    }
-//
-//    @Test
-//    void receiptEnabled() {
-//        properties.setReceipt(1);
-//        for (int i = 0; i < SAMPLE_SIZE; ++i) {
-//            assertThat(generator.get().next())
-//                    .extracting(PublishRequest::isReceipt)
-//                    .isEqualTo(true);
-//        }
-//    }
-//
-//    @Test
-//    void receiptPercent() {
-//        properties.setReceipt(0.1);
-//        Multiset<Boolean> receipts = HashMultiset.create();
-//
-//        for (int i = 0; i < SAMPLE_SIZE; ++i) {
-//            receipts.add(generator.get().next().isReceipt());
-//        }
-//
-//        assertThat((double) receipts.count(true) / SAMPLE_SIZE)
-//                .isNotNegative()
-//                .isNotZero()
-//                .isCloseTo(properties.getReceipt(), within(properties.getReceipt() * 0.2));
-//    }
-//
-//    @Test
-//    void recordDisabled() {
-//        properties.setRecord(0);
-//        for (int i = 0; i < SAMPLE_SIZE; ++i) {
-//            assertThat(generator.get().next())
-//                    .extracting(PublishRequest::isRecord)
-//                    .isEqualTo(false);
-//        }
-//    }
-//
-//    @Test
-//    void recordEnabled() {
-//        properties.setRecord(1);
-//        for (int i = 0; i < SAMPLE_SIZE; ++i) {
-//            assertThat(generator.get().next())
-//                    .extracting(PublishRequest::isRecord)
-//                    .isEqualTo(true);
-//        }
-//    }
-//
-//    @Test
-//    void recordPercent() {
-//        properties.setRecord(0.75);
-//        Multiset<Boolean> records = HashMultiset.create();
-//
-//        for (int i = 0; i < SAMPLE_SIZE; ++i) {
-//            records.add(generator.get().next().isRecord());
-//        }
-//
-//        assertThat((double) records.count(true) / SAMPLE_SIZE)
-//                .isNotNegative()
-//                .isNotZero()
-//                .isCloseTo(properties.getRecord(), within(properties.getRecord() * 0.2));
-//    }
-//
-//    @Test
-//    void missingRequiredField() {
-//        properties.setProperties(Collections.emptyMap());
-//        assertThatThrownBy(() -> generator.get().next()).isInstanceOf(ConstraintViolationException.class);
-//    }
-//
-//    private void assertRequest(PublishRequest publishRequest) {
-//        assertThat(publishRequest).isNotNull()
-//                .hasNoNullFieldsOrProperties()
-//                .hasFieldOrPropertyWithValue("logResponse", properties.isLogResponse())
-//                .hasFieldOrPropertyWithValue("receipt", true)
-//                .hasFieldOrPropertyWithValue("record", true)
-//                .hasFieldOrPropertyWithValue("type", properties.getType())
-//                .hasFieldOrPropertyWithValue("transaction.topicId", TopicId.fromString(TOPIC_ID));
-//    }
+    private static final int SAMPLE_SIZE = 10_000;
+    private static final String TOPIC_ID = "0.0.1000";
+
+    private ScenarioProperties properties;
+    private Supplier<ConfigurableTransactionGenerator> generator;
+
+    @BeforeEach
+    void init() {
+        properties = new ScenarioProperties();
+        properties.setReceipt(1);
+        properties.setRecord(1);
+        properties.setName("test");
+        properties.setProperties(Map.of("topicId", TOPIC_ID));
+        properties.setTps(100_000);
+        properties.setType(TransactionType.CONSENSUS_SUBMIT_MESSAGE);
+        generator = Suppliers.memoize(() -> new ConfigurableTransactionGenerator(p -> p, properties));
+    }
+
+    @Test
+    void next() {
+        assertRequests(generator.get().next());
+    }
+
+    @ParameterizedTest(name = "next with count {0}")
+    @ValueSource(ints = {0, -1})
+    void nextDefault(int count) {
+        assertRequests(generator.get().next(count));
+    }
+
+    @Test
+    void nextTwo() {
+        assertRequests(generator.get().next(2), 2);
+    }
+
+    @Test
+    void nextCountMoreThanLimit() {
+        properties.setLimit(4);
+        assertRequests(generator.get().next(5), 4);
+        assertThatThrownBy(() -> generator.get().next())
+                .isInstanceOf(ScenarioException.class)
+                .hasMessageContaining("Reached publish limit");
+    }
+
+    @Test
+    void logResponse() {
+        properties.setLogResponse(true);
+        assertRequests(generator.get().next());
+    }
+
+    @Test
+    void unknownField() {
+        properties.setProperties(Map.of("foo", "bar", "topicId", TOPIC_ID));
+        assertThatThrownBy(() -> generator.get().next())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unrecognized field");
+    }
+
+    @Test
+    void reachedLimit() {
+        properties.setLimit(1);
+        assertRequests(generator.get().next());
+        assertThatThrownBy(() -> generator.get().next())
+                .isInstanceOf(ScenarioException.class)
+                .hasMessageContaining("Reached publish limit");
+    }
+
+    @Test
+    void reachedDuration() {
+        properties.setDuration(Duration.ofSeconds(-5L));
+        assertThatThrownBy(() -> generator.get().next())
+                .isInstanceOf(ScenarioException.class)
+                .hasMessageContaining("Reached publish duration");
+    }
+
+    @Test
+    void receiptDisabled() {
+        properties.setReceipt(0);
+        for (int i = 0; i < SAMPLE_SIZE; ++i) {
+            assertThat(generator.get().next())
+                    .extracting(PublishRequest::isReceipt)
+                    .allMatch(v -> !v);
+        }
+    }
+
+    @Test
+    void receiptEnabled() {
+        properties.setReceipt(1);
+        for (int i = 0; i < SAMPLE_SIZE; ++i) {
+            assertThat(generator.get().next())
+                    .extracting(PublishRequest::isReceipt)
+                    .allMatch(v -> v);
+        }
+    }
+
+    @Test
+    void receiptPercent() {
+        properties.setReceipt(0.1);
+        Multiset<Boolean> receipts = HashMultiset.create();
+
+        for (int i = 0; i < SAMPLE_SIZE; ++i) {
+            generator.get().next().forEach(publishRequest -> receipts.add(publishRequest.isReceipt()));
+        }
+
+        assertThat((double) receipts.count(true) / SAMPLE_SIZE)
+                .isNotNegative()
+                .isNotZero()
+                .isCloseTo(properties.getReceipt(), within(properties.getReceipt() * 0.2));
+    }
+
+    @Test
+    void recordDisabled() {
+        properties.setRecord(0);
+        for (int i = 0; i < SAMPLE_SIZE; ++i) {
+            assertThat(generator.get().next())
+                    .extracting(PublishRequest::isRecord)
+                    .allMatch(v -> !v);
+        }
+    }
+
+    @Test
+    void recordEnabled() {
+        properties.setRecord(1);
+        for (int i = 0; i < SAMPLE_SIZE; ++i) {
+            assertThat(generator.get().next())
+                    .extracting(PublishRequest::isRecord)
+                    .allMatch(v -> v);
+        }
+    }
+
+    @Test
+    void recordPercent() {
+        properties.setRecord(0.75);
+        Multiset<Boolean> records = HashMultiset.create();
+
+        for (int i = 0; i < SAMPLE_SIZE; ++i) {
+            generator.get().next().forEach(publishRequest -> records.add(publishRequest.isRecord()));
+        }
+
+        assertThat((double) records.count(true) / SAMPLE_SIZE)
+                .isNotNegative()
+                .isNotZero()
+                .isCloseTo(properties.getRecord(), within(properties.getRecord() * 0.2));
+    }
+
+    @Test
+    void missingRequiredField() {
+        properties.setProperties(Collections.emptyMap());
+        assertThatThrownBy(() -> generator.get().next()).isInstanceOf(ConstraintViolationException.class);
+    }
+
+    private void assertRequests(List<PublishRequest> publishRequests, int size) {
+        assertThat(publishRequests).hasSize(size).allSatisfy(publishRequest -> assertThat(publishRequest)
+                .isNotNull()
+                .hasNoNullFieldsOrProperties()
+                .hasFieldOrPropertyWithValue("logResponse", properties.isLogResponse())
+                .hasFieldOrPropertyWithValue("receipt", true)
+                .hasFieldOrPropertyWithValue("record", true)
+                .hasFieldOrPropertyWithValue("type", properties.getType())
+                .hasFieldOrPropertyWithValue("transaction.topicId", TopicId.fromString(TOPIC_ID))
+        );
+    }
+
+    private void assertRequests(List<PublishRequest> publishRequests) {
+        assertRequests(publishRequests, 1);
+    }
 }

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/generator/ConfigurableTransactionGeneratorTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/generator/ConfigurableTransactionGeneratorTest.java
@@ -104,8 +104,9 @@ class ConfigurableTransactionGeneratorTest {
     @Test
     void reachedLimit() {
         properties.setLimit(1);
-        assertRequests(generator.get().next());
-        assertThatThrownBy(() -> generator.get().next())
+        TransactionGenerator transactionGenerator = generator.get();
+        assertRequests(transactionGenerator.next());
+        assertThatThrownBy(() -> transactionGenerator.next())
                 .isInstanceOf(ScenarioException.class)
                 .hasMessageContaining("Reached publish limit");
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
-->

**Detailed description**:

1. Use a single global ratelimiter
2. Make warmup period a global configuration
3. Batch acquire from the single ratelimiter to make actual warmup more accurate

**Which issue(s) this PR fixes**:
Fixes #1606

**Special notes for your reviewer**:
When one warmup ratelimiter is used per scenario, even at low target TPS, the warmup mechanism causes interference between the ratelimiters that all ratelimiters stabilize somewhere in the warmup state so they can never reach the target TPS

**Checklist**
- [x] Documentation added
- [x] Tests updated

