### PR TITLE
Fix HistoricalAccountInfoMigration when ran as a jar

### DIFF
--- a/charts/hedera-mirror-common/Chart.yaml
+++ b/charts/hedera-mirror-common/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.29.0
+appVersion: 0.29.1
 description: Hedera Mirror Node common components installed globally for use across namespaces
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
@@ -11,4 +11,4 @@ maintainers:
 name: hedera-mirror-common
 sources:
   - https://github.com/hashgraph/hedera-mirror-node
-version: 0.16.0
+version: 0.16.1

--- a/charts/hedera-mirror-grpc/Chart.yaml
+++ b/charts/hedera-mirror-grpc/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.29.0
+appVersion: 0.29.1
 description: GRPC API for the Hedera Mirror Node
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
@@ -11,4 +11,4 @@ maintainers:
 name: hedera-mirror-grpc
 sources:
   - https://github.com/hashgraph/hedera-mirror-node
-version: 0.16.0
+version: 0.16.1

--- a/charts/hedera-mirror-importer/Chart.yaml
+++ b/charts/hedera-mirror-importer/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.29.0
+appVersion: 0.29.1
 description: Hedera Mirror Importer downloads and validates file streams from the cloud and imports them into the database
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
@@ -11,4 +11,4 @@ maintainers:
 name: hedera-mirror-importer
 sources:
   - https://github.com/hashgraph/hedera-mirror-node
-version: 0.16.0
+version: 0.16.1

--- a/charts/hedera-mirror-monitor/Chart.yaml
+++ b/charts/hedera-mirror-monitor/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.29.0
+appVersion: 0.29.1
 description: End to End Monitor for the Hedera Mirror Node
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
@@ -11,4 +11,4 @@ maintainers:
 name: hedera-mirror-monitor
 sources:
   - https://github.com/hashgraph/hedera-mirror-node
-version: 0.16.0
+version: 0.16.1

--- a/charts/hedera-mirror-rest/Chart.yaml
+++ b/charts/hedera-mirror-rest/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.29.0
+appVersion: 0.29.1
 description: REST API for the Hedera Mirror Node
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
@@ -11,4 +11,4 @@ maintainers:
 name: hedera-mirror-rest
 sources:
   - https://github.com/hashgraph/hedera-mirror-node
-version: 0.16.0
+version: 0.16.1

--- a/charts/hedera-mirror/Chart.yaml
+++ b/charts/hedera-mirror/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.29.0
+appVersion: 0.29.1
 description: Hedera Mirror Node mirrors data from Hedera nodes and serves it via an API
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
@@ -11,4 +11,4 @@ maintainers:
 name: hedera-mirror
 sources:
   - https://github.com/hashgraph/hedera-mirror-node
-version: 0.16.0
+version: 0.16.1

--- a/charts/hedera-mirror/requirements.lock
+++ b/charts/hedera-mirror/requirements.lock
@@ -1,13 +1,13 @@
 dependencies:
 - name: hedera-mirror-grpc
   repository: file://../hedera-mirror-grpc
-  version: 0.16.0
+  version: 0.16.1
 - name: hedera-mirror-importer
   repository: file://../hedera-mirror-importer
-  version: 0.16.0
+  version: 0.16.1
 - name: hedera-mirror-monitor
   repository: file://../hedera-mirror-monitor
-  version: 0.16.0
+  version: 0.16.1
 - name: postgresql-ha
   repository: https://charts.bitnami.com/bitnami
   version: 6.3.7
@@ -16,9 +16,9 @@ dependencies:
   version: 12.2.4
 - name: hedera-mirror-rest
   repository: file://../hedera-mirror-rest
-  version: 0.16.0
+  version: 0.16.1
 - name: timescaledb-multinode
   repository: https://raw.githubusercontent.com/timescale/timescaledb-kubernetes/master/charts/repo/
   version: 0.8.0
-digest: sha256:f51f300a98b7ff818e50c98ce0fed76a4454ee5ee099963e78afaaa092d49a20
-generated: "2021-03-23T13:27:50.173939-05:00"
+digest: sha256:03eecdaf877e1d11571955b64d6456f9213dcf353c0bb8ce9984cc601da620d1
+generated: "2021-03-23T18:47:40.179794-05:00"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - 5432:5432
 
   grpc:
-    image: gcr.io/mirrornode/hedera-mirror-grpc:0.29.0
+    image: gcr.io/mirrornode/hedera-mirror-grpc:0.29.1
     restart: unless-stopped
     environment:
       HEDERA_MIRROR_GRPC_DB_HOST: db
@@ -29,7 +29,7 @@ services:
       - 5600:5600
 
   importer:
-    image: gcr.io/mirrornode/hedera-mirror-importer:0.29.0
+    image: gcr.io/mirrornode/hedera-mirror-importer:0.29.1
     restart: unless-stopped
     environment:
       HEDERA_MIRROR_IMPORTER_DB_HOST: db
@@ -41,7 +41,7 @@ services:
   monitor:
     deploy:
       replicas: 0
-    image: gcr.io/mirrornode/hedera-mirror-monitor:0.29.0
+    image: gcr.io/mirrornode/hedera-mirror-monitor:0.29.1
     restart: unless-stopped
     environment:
       SPRING_CONFIG_ADDITIONAL_LOCATION: file:/usr/etc/hedera-mirror-monitor/
@@ -58,7 +58,7 @@ services:
       - 6379:6379
 
   rest:
-    image: gcr.io/mirrornode/hedera-mirror-rest:0.29.0
+    image: gcr.io/mirrornode/hedera-mirror-rest:0.29.1
     environment:
       HEDERA_MIRROR_REST_DB_HOST: db
     restart: unless-stopped
@@ -67,7 +67,7 @@ services:
       - 5551:5551
 
   rosetta:
-    image: gcr.io/mirrornode/hedera-mirror-rosetta:0.29.0
+    image: gcr.io/mirrornode/hedera-mirror-rosetta:0.29.1
     environment:
       HEDERA_MIRROR_ROSETTA_DB_HOST: db
     restart: unless-stopped

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/HistoricalAccountInfoMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/HistoricalAccountInfoMigration.java
@@ -23,9 +23,7 @@ package com.hedera.mirror.importer.migration;
 import com.google.common.base.Stopwatch;
 import com.hederahashgraph.api.proto.java.CryptoGetInfoResponse.AccountInfo;
 import java.io.BufferedReader;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
@@ -102,10 +100,8 @@ public class HistoricalAccountInfoMigration extends MirrorBaseJavaMigration {
         log.info("Importing historical account information");
         Stopwatch stopwatch = Stopwatch.createStarted();
 
-        try (
-                InputStream inputStream = new GZIPInputStream(new FileInputStream(accountInfoPath.getFile()));
-                BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))
-        ) {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(new GZIPInputStream(accountInfoPath
+                .getInputStream()), StandardCharsets.UTF_8))) {
             long count = reader.lines()
                     .map(this::parse)
                     .filter(Objects::nonNull)

--- a/hedera-mirror-rest/api/v1/openapi.yml
+++ b/hedera-mirror-rest/api/v1/openapi.yml
@@ -550,7 +550,7 @@ tags:
     description: The tokens object represents the information associated with a token entity and returns a list of token information.
 info:
   title: Hedera Mirror Node REST API
-  version: 0.29.0
+  version: 0.29.1
   license:
     name: Apache-2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0.html'

--- a/hedera-mirror-rest/monitoring/monitor_apis/package-lock.json
+++ b/hedera-mirror-rest/monitoring/monitor_apis/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-mirror-monitor",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hedera-mirror-rest/monitoring/monitor_apis/package.json
+++ b/hedera-mirror-rest/monitoring/monitor_apis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-mirror-monitor",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "description": "Hedera Mirror Node Monitor",
   "main": "server.js",
   "private": true,

--- a/hedera-mirror-rest/package-lock.json
+++ b/hedera-mirror-rest/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-mirror-rest",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hedera-mirror-rest/package.json
+++ b/hedera-mirror-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-mirror-rest",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "description": "Hedera Mirror Node REST API",
   "main": "server.js",
   "private": true,

--- a/hedera-mirror-rosetta/config/application.yml
+++ b/hedera-mirror-rosetta/config/application.yml
@@ -15,4 +15,4 @@ hedera:
       port: 5700
       realm: 0
       shard: 0
-      version: 0.29.0
+      version: 0.29.1

--- a/hedera-mirror-test/src/test/resources/k8s/hcs-perf-message-submit.yml
+++ b/hedera-mirror-test/src/test/resources/k8s/hcs-perf-message-submit.yml
@@ -41,7 +41,7 @@ spec:
                     app.kubernetes.io/name: test
       restartPolicy: Never
       containers:
-        - image: gcr.io/mirrornode/hedera-mirror-test:0.29.0
+        - image: gcr.io/mirrornode/hedera-mirror-test:0.29.1
           name: test
           env:
             - name: testProfile

--- a/hedera-mirror-test/src/test/resources/k8s/hcs-perf-publish-test.yml
+++ b/hedera-mirror-test/src/test/resources/k8s/hcs-perf-publish-test.yml
@@ -43,7 +43,7 @@ spec:
                     app.kubernetes.io/name: test
       restartPolicy: Never
       containers:
-        - image: gcr.io/mirrornode/hedera-mirror-test:0.29.0
+        - image: gcr.io/mirrornode/hedera-mirror-test:0.29.1
           name: test
           env:
             - name: testProfile

--- a/hedera-mirror-test/src/test/resources/k8s/hcs-perf-subscribe-test.yml
+++ b/hedera-mirror-test/src/test/resources/k8s/hcs-perf-subscribe-test.yml
@@ -46,7 +46,7 @@ spec:
                     app.kubernetes.io/name: test
       restartPolicy: Never
       containers:
-        - image: gcr.io/mirrornode/hedera-mirror-test:0.29.0
+        - image: gcr.io/mirrornode/hedera-mirror-test:0.29.1
           name: test
           env:
             - name: testProfile

--- a/hedera-mirror-test/src/test/resources/k8s/hts-perf-batch-publish-batch-validate.yml
+++ b/hedera-mirror-test/src/test/resources/k8s/hts-perf-batch-publish-batch-validate.yml
@@ -47,7 +47,7 @@ spec:
                     app.kubernetes.io/name: test
       restartPolicy: Never
       containers:
-        - image: gcr.io/mirrornode/hedera-mirror-test:0.29.0
+        - image: gcr.io/mirrornode/hedera-mirror-test:0.29.1
           name: test
           env:
             - name: testProfile

--- a/hedera-mirror-test/src/test/resources/k8s/hts-perf-publish-and-retrieve.yml
+++ b/hedera-mirror-test/src/test/resources/k8s/hts-perf-publish-and-retrieve.yml
@@ -46,7 +46,7 @@ spec:
                     app.kubernetes.io/name: test
       restartPolicy: Never
       containers:
-        - image: gcr.io/mirrornode/hedera-mirror-test:0.29.0
+        - image: gcr.io/mirrornode/hedera-mirror-test:0.29.1
           name: test
           env:
             - name: testProfile

--- a/pom.xml
+++ b/pom.xml
@@ -74,8 +74,8 @@
         <micrometer-jvm-extras.version>0.2.2</micrometer-jvm-extras.version>
         <msgpack.version>0.8.22</msgpack.version>
         <protobuf.version>3.15.5</protobuf.version>
-        <release.version>0.29.0</release.version> <!-- Used to replace release versions in all files -->
-        <release.chartVersion>0.16.0</release.chartVersion>
+        <release.version>0.29.1</release.version> <!-- Used to replace release versions in all files -->
+        <release.chartVersion>0.16.1</release.chartVersion>
         <replacer.version>1.5.3</replacer.version>
         <!--suppress UnresolvedMavenProperty -->
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>


### PR DESCRIPTION
**Detailed description**:
- Fix HistoricalAccountInfoMigration when ran as a jar by using `Resource::getInputStream()` since `Resource::getFile()` doesn't [work](https://stackoverflow.com/questions/25869428/classpath-resource-not-found-when-running-as-jar) except for in the IDE and exploded jars. 
- Bump versions to v0.29.1

**Which issue(s) this PR fixes**:
Fixes #1743 

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

