### PR TITLE
Fix charts workflow and ConsensusControllerTest

### DIFF
--- a/.github/workflows/charts.yml
+++ b/.github/workflows/charts.yml
@@ -22,23 +22,16 @@ jobs:
       - name: Run lint
         run: ct lint --config .github/ct.yaml --all
 
-  image:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Build images
-        run: ./mvnw ${MAVEN_CLI_OPTS} install -pl hedera-mirror-grpc,hedera-mirror-importer,hedera-mirror-rest --also-make -Dskip.npm -DskipTests
-
   install:
-    needs: image
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+
+      - name: Build images
+        run: ./mvnw ${MAVEN_CLI_OPTS} install -pl hedera-mirror-grpc,hedera-mirror-importer,hedera-mirror-rest --also-make -Dskip.npm -DskipTests
 
       - name: Install k3s
         id: k3s

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/controller/ConsensusControllerTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/controller/ConsensusControllerTest.java
@@ -135,7 +135,8 @@ public class ConsensusControllerTest extends GrpcIntegrationTest {
         assertThat(blockingService.subscribeTopic(query))
                 .toIterable()
                 .hasSize(3)
-                .containsSequence(topicMessage1.getResponse(), topicMessage2.getResponse(), topicMessage3.getResponse());
+                .containsSequence(topicMessage1.getResponse(), topicMessage2.getResponse(), topicMessage3
+                        .getResponse());
     }
 
     @Test
@@ -255,7 +256,7 @@ public class ConsensusControllerTest extends GrpcIntegrationTest {
                 .then(generator::blockLast)
                 .expectNext(2, 3, 0) // incoming messages
                 .thenCancel()
-                .verify(Duration.ofMillis(800));
+                .verify(Duration.ofMillis(2000));
     }
 
     void assertException(Throwable t, Status.Code status, String message) {


### PR DESCRIPTION
**Detailed description**:
- Fix charts install [not using](https://github.com/hashgraph/hedera-mirror-node/pull/1746/checks?check_run_id=2180620774) the newly built docker images
- Fix `ConsensusControllerTest.fragmentedMessagesGroupAcrossHistoricAndIncoming` [timing out
](https://github.com/hashgraph/hedera-mirror-node/runs/2180414105)


**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:
GitHub actions can't share artifacts/images across jobs

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

