### PR TITLE
Move Sonar to separate job & fix chart test

### DIFF
--- a/.github/workflows/charts.yml
+++ b/.github/workflows/charts.yml
@@ -33,19 +33,16 @@ jobs:
       - name: Build images
         run: ./mvnw ${MAVEN_CLI_OPTS} install -pl hedera-mirror-grpc,hedera-mirror-importer,hedera-mirror-rest --also-make -Dskip.npm -DskipTests
 
-      - name: Install k3s
-        id: k3s
-        uses: debianmaster/actions-k3s@master
-        with:
-          version: v1.17.4-k3s1
+      - name: Create k3d cluster
+        run: |
+          set -ex
+          version=$(docker images gcr.io/mirrornode/hedera-mirror-importer --format "{{.Tag}}" | head -n 1)
+          curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash
+          k3d cluster create mirror --agents 1 --timeout 5m
+          k3d image import -c mirror "gcr.io/mirrornode/hedera-mirror-grpc:${version}" "gcr.io/mirrornode/hedera-mirror-importer:${version}" "gcr.io/mirrornode/hedera-mirror-rest:${version}"
 
       - name: Install ct
         uses: helm/chart-testing-action@v2.0.1
-
-      - name: Copy kube config
-        run: |
-          mkdir -p "${HOME}/.kube"
-          cp ${{ steps.k3s.outputs.kubeconfig }} "${HOME}/.kube/config"
 
       - name: Install chart
         run: ct install --config .github/ct.yaml --charts=charts/hedera-mirror

--- a/.github/workflows/grpc-api.yml
+++ b/.github/workflows/grpc-api.yml
@@ -30,25 +30,15 @@ jobs:
         with:
           java-version: 11
 
-      - name: Cache Maven dependencies
+      - name: Cache dependencies
         uses: actions/cache@v2
         with:
-          key: ${{ runner.os }}-m2-${{ secrets.CACHE_VERSION }}-${{ hashFiles('./pom.xml') }}
+          key: ${{ runner.os }}-m2-${{ hashFiles('./pom.xml') }}
           path: ~/.m2
           restore-keys: ${{ runner.os }}-m2
 
-      - name: Cache SonarCloud dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/.sonar/cache
-          key: ${{ runner.os }}-sonar-${{ secrets.CACHE_VERSION }}
-          restore-keys: ${{ runner.os }}-sonar
-
       - name: Maven verify
-        run: ./mvnw ${MAVEN_CLI_OPTS} verify sonar:sonar -pl "${MODULE}" --also-make -Dsonar.login=$SONAR_TOKEN -Dspring.profiles.active=${{ matrix.schema }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ./mvnw ${MAVEN_CLI_OPTS} verify -pl "${MODULE}" --also-make -Dspring.profiles.active=${{ matrix.schema }}
         working-directory: .
 
       - name: Upload coverage report

--- a/.github/workflows/importer.yml
+++ b/.github/workflows/importer.yml
@@ -30,29 +30,19 @@ jobs:
         with:
           java-version: 11
 
-      - name: Cache Maven dependencies
+      - name: Cache dependencies
         uses: actions/cache@v2
         with:
-          key: ${{ runner.os }}-m2-${{ secrets.CACHE_VERSION }}-${{ hashFiles('./pom.xml') }}
+          key: ${{ runner.os }}-m2-${{ hashFiles('./pom.xml') }}
           path: ~/.m2
           restore-keys: ${{ runner.os }}-m2
-
-      - name: Cache SonarCloud dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/.sonar/cache
-          key: ${{ runner.os }}-sonar-${{ secrets.CACHE_VERSION }}
-          restore-keys: ${{ runner.os }}-sonar
 
       - name: Set environment
         if: matrix.schema == 'v2'
         run: echo 'groups=!v1' >> $GITHUB_ENV
 
       - name: Maven verify
-        run: ./mvnw ${MAVEN_CLI_OPTS} verify sonar:sonar -pl "${MODULE}" --also-make -Dsonar.login=$SONAR_TOKEN -Dspring.profiles.active=${{ matrix.schema }} -Dgroups='${{ env.groups }}'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ./mvnw ${MAVEN_CLI_OPTS} verify -pl "${MODULE}" --also-make -Dspring.profiles.active=${{ matrix.schema }} -Dgroups='${{ env.groups }}'
         working-directory: .
 
       - name: Upload coverage report

--- a/.github/workflows/monitor.yml
+++ b/.github/workflows/monitor.yml
@@ -27,25 +27,15 @@ jobs:
         with:
           java-version: 11
 
-      - name: Cache Maven dependencies
+      - name: Cache dependencies
         uses: actions/cache@v2
         with:
-          key: ${{ runner.os }}-m2-${{ secrets.CACHE_VERSION }}-${{ hashFiles('./pom.xml') }}
+          key: ${{ runner.os }}-m2-${{ hashFiles('./pom.xml') }}
           path: ~/.m2
           restore-keys: ${{ runner.os }}-m2
 
-      - name: Cache SonarCloud dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/.sonar/cache
-          key: ${{ runner.os }}-sonar-${{ secrets.CACHE_VERSION }}
-          restore-keys: ${{ runner.os }}-sonar
-
       - name: Maven verify
-        run: ./mvnw ${MAVEN_CLI_OPTS} verify sonar:sonar -pl "${MODULE}" --also-make -Dtest='!com.hedera.mirror.importer.**' -DfailIfNoTests=false -Dsonar.login=$SONAR_TOKEN
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ./mvnw ${MAVEN_CLI_OPTS} verify -pl "${MODULE}" --also-make -Dtest='!com.hedera.mirror.importer.**' -DfailIfNoTests=false
         working-directory: .
 
       - name: Upload coverage report

--- a/.github/workflows/release-development.yml
+++ b/.github/workflows/release-development.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Cache Maven packages
         uses: actions/cache@v2
         with:
-          key: ${{ runner.os }}-m2-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           path: ~/.m2
           restore-keys: ${{ runner.os }}-m2
 

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Cache Maven packages
         uses: actions/cache@v2
         with:
-          key: ${{ runner.os }}-m2-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           path: ~/.m2
           restore-keys: ${{ runner.os }}-m2
 
@@ -30,7 +30,7 @@ jobs:
         run: gcloud auth configure-docker gcr.io,marketplace.gcr.io
 
       - name: Build and push images
-        run: ./mvnw ${MAVEN_CLI_OPTS} deploy -DskipTests
+        run: ./mvnw ${MAVEN_CLI_OPTS} dependency:copy-dependencies license:download-licenses deploy -DskipTests
 
   chart:
     name: Publish charts

--- a/.github/workflows/rest-api.yml
+++ b/.github/workflows/rest-api.yml
@@ -25,27 +25,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Cache npm dependencies
+      - name: Cache dependencies
         uses: actions/cache@v2
         with:
-          key: ${{ runner.os }}-node-${{ secrets.CACHE_VERSION }}-${{ hashFiles('./package-lock.json', './check-state-proof/package-lock.json', 'monitoring/monitor_apis/package-lock.json') }}
+          key: ${{ runner.os }}-node-${{ hashFiles('./package-lock.json', './check-state-proof/package-lock.json', 'monitoring/monitor_apis/package-lock.json') }}
           path: |
             ~/.npm
             .node-flywaydb
           restore-keys: ${{ runner.os }}-node-
 
-      - name: Cache SonarCloud dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/.sonar/cache
-          key: ${{ runner.os }}-sonar-${{ secrets.CACHE_VERSION }}
-          restore-keys: ${{ runner.os }}-sonar
-
       - name: Test
-        run: MIRROR_NODE_SCHEMA=${{ matrix.schema}} ./mvnw ${MAVEN_CLI_OPTS} verify sonar:sonar -pl "${MODULE}" --also-make -Dsonar.login=$SONAR_TOKEN
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: MIRROR_NODE_SCHEMA=${{ matrix.schema}} ./mvnw ${MAVEN_CLI_OPTS} verify -pl "${MODULE}" --also-make
         working-directory: .
 
       - name: Upload coverage report

--- a/.github/workflows/rosetta-api.yml
+++ b/.github/workflows/rosetta-api.yml
@@ -25,14 +25,11 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: ${{ runner.os }}-go-
 
       - name: Maven verify
-        run: ./mvnw ${MAVEN_CLI_OPTS} verify sonar:sonar -pl "${MODULE}" --also-make -Dsonar.login=$SONAR_TOKEN
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ./mvnw ${MAVEN_CLI_OPTS} verify -pl "${MODULE}" --also-make
         working-directory: .
 
       - name: Upload coverage report
@@ -74,13 +71,13 @@ jobs:
       - uses: actions/setup-go@v2
         name: Setup GO Env
         with:
-          go-version: '1.14'
+          go-version: '1.16'
 
       - name: Cache dependencies
         uses: actions/cache@v2
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: ${{ runner.os }}-go-
 
       - name: Install Gosec

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -18,9 +18,37 @@ jobs:
       - name: Cache Maven dependencies
         uses: actions/cache@v2
         with:
-          key: ${{ runner.os }}-m2-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           path: ~/.m2
           restore-keys: ${{ runner.os }}-m2
 
       - name: Vulnerability check
         run: ./mvnw ${MAVEN_CLI_OPTS} dependency-check:aggregate
+
+  sonar:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    name: SonarCloud
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Cache Maven dependencies
+        uses: actions/cache@v2
+        with:
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          path: ~/.m2
+          restore-keys: ${{ runner.os }}-m2
+
+      - name: Cache SonarCloud dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
+      - name: Maven Sonar
+        run: ./mvnw ${MAVEN_CLI_OPTS} compile sonar:sonar -Dsonar.login=$SONAR_TOKEN
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/charts/hedera-mirror/ci/default-values.yaml
+++ b/charts/hedera-mirror/ci/default-values.yaml
@@ -2,5 +2,7 @@
 global:
   db:
     host: pgdb-pgpool
+monitor:
+  enabled: false
 postgresql:
   fullnameOverride: pgdb

--- a/hedera-mirror-rosetta/Dockerfile
+++ b/hedera-mirror-rosetta/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14 as build
+FROM golang:1.16 as build
 WORKDIR /tmp/src/hedera-mirror-rosetta
 COPY . .
 RUN go build -o main ./cmd

--- a/hedera-mirror-rosetta/build/Dockerfile
+++ b/hedera-mirror-rosetta/build/Dockerfile
@@ -10,7 +10,7 @@ RUN git clone https://github.com/hashgraph/hedera-mirror-node.git
 RUN cd hedera-mirror-node && git checkout "${GIT_BRANCH}"
 
 # ------------------------------  Rosetta  ------------------------------- #
-FROM golang:1.14 as rosetta-builder
+FROM golang:1.16 as rosetta-builder
 WORKDIR /tmp
 COPY --from=cloner /hedera-mirror-node ./hedera-mirror-node
 WORKDIR /tmp/hedera-mirror-node/hedera-mirror-rosetta

--- a/hedera-mirror-rosetta/go.mod
+++ b/hedera-mirror-rosetta/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta
 
-go 1.14
+go 1.16
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0

--- a/hedera-mirror-rosetta/pom.xml
+++ b/hedera-mirror-rosetta/pom.xml
@@ -24,7 +24,7 @@
         <defaultGoal>clean package</defaultGoal>
         <directory>${basedir}${file.separator}bin</directory>
         <finalName>${project.artifactId}</finalName>
-        <sourceDirectory>${project.basedir}${file.separator}cmd</sourceDirectory>
+        <sourceDirectory>${project.basedir}</sourceDirectory>
         <plugins>
             <plugin>
                 <groupId>io.fabric8</groupId>
@@ -34,6 +34,12 @@
                 <groupId>com.igormaznitsa</groupId>
                 <artifactId>mvn-golang-wrapper</artifactId>
                 <version>2.3.8</version>
+                <configuration>
+                    <goVersion>1.16</goVersion>
+                    <hideBanner>true</hideBanner>
+                    <storeFolder>${user.home}/.m2/repository/com/igormaznitsa/mvn-golang-wrapper</storeFolder>
+                    <useEnvVars>true</useEnvVars>
+                </configuration>
                 <extensions>true</extensions>
                 <executions>
                     <execution>
@@ -47,8 +53,6 @@
                                 <flag>-v</flag>
                             </buildFlags>
                             <skip>${skipTests}</skip>
-                            <sources>${project.basedir}${file.separator}</sources>
-                            <useEnvVars>true</useEnvVars>
                         </configuration>
                     </execution>
                     <execution>
@@ -59,7 +63,7 @@
                                 <flag>-i</flag>
                                 <flag>-race</flag>
                             </buildFlags>
-                            <useEnvVars>true</useEnvVars>
+                            <sources>${project.basedir}${file.separator}cmd</sources>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
         <docker.resources>${project.build.directory}/container</docker.resources>
         <docker.tag.version>${release.version}</docker.tag.version>
         <embedded.testcontainers.version>2.0.5</embedded.testcontainers.version>
+        <git-commit-id-plugin.version>4.0.4</git-commit-id-plugin.version>
         <grpc-spring-boot.version>2.11.0.RELEASE</grpc-spring-boot.version>
         <grpc.version>1.36.1</grpc.version>
         <guava.version>30.1.1-jre</guava.version>
@@ -110,7 +111,7 @@
             <dependency>
                 <groupId>com.google.cloud</groupId>
                 <artifactId>spring-cloud-gcp-dependencies</artifactId>
-                <version>2.0.1</version>
+                <version>2.0.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -131,20 +132,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <executions>
-                        <execution>
-                            <phase>verify</phase>
-                            <goals>
-                                <goal>copy-dependencies</goal>
-                            </goals>
-                            <configuration>
-                                <classifier>sources</classifier>
-                                <includeScope>runtime</includeScope>
-                                <outputDirectory>${docker.resources}/third_party/sources</outputDirectory>
-                                <prependGroupId>true</prependGroupId>
-                            </configuration>
-                        </execution>
-                    </executions>
+                    <configuration>
+                        <classifier>sources</classifier>
+                        <includeScope>runtime</includeScope>
+                        <outputDirectory>${docker.resources}/third_party/sources</outputDirectory>
+                        <prependGroupId>true</prependGroupId>
+                    </configuration>
                 </plugin>
                 <!-- antlr 2.x (Hibernate dependency) is so old it doesn't have sources in Maven Central -->
                 <plugin>
@@ -306,6 +299,14 @@
                             <licenseMerge><![CDATA[MIT License|MIT|MIT license|The MIT License]]></licenseMerge>
                         </licenseMerges>
                         <licenseName>apache_v2</licenseName>
+                        <licensesOutputDirectory>${docker.resources}/third_party/licenses</licensesOutputDirectory>
+                        <licenseUrlReplacements>
+                            <licenseUrlReplacement>
+                                <regexp>\Qhttps://glassfish.dev.java.net/nonav/public/CDDL+GPL.html\E</regexp>
+                                <replacement>https://oss.oracle.com/licenses/CDDL+GPL-1.1</replacement>
+                            </licenseUrlReplacement>
+                        </licenseUrlReplacements>
+                        <organizeLicensesByDependencies>true</organizeLicensesByDependencies>
                         <!-- These contain unprintable characters to suppress showing the delimiters -->
                         <processEndTag>‍</processEndTag>
                         <processStartTag>‌</processStartTag>
@@ -314,26 +315,6 @@
                         </roots>
                         <sectionDelimiter>​</sectionDelimiter>
                     </configuration>
-                    <executions>
-                        <execution>
-                            <id>download-licenses-for-container</id>
-                            <phase>verify</phase>
-                            <goals>
-                                <goal>download-licenses</goal>
-                            </goals>
-                            <configuration>
-                                <licensesOutputDirectory>${docker.resources}/third_party/licenses
-                                </licensesOutputDirectory>
-                                <licenseUrlReplacements>
-                                    <licenseUrlReplacement>
-                                        <regexp>\Qhttps://glassfish.dev.java.net/nonav/public/CDDL+GPL.html\E</regexp>
-                                        <replacement>https://oss.oracle.com/licenses/CDDL+GPL-1.1</replacement>
-                                    </licenseUrlReplacement>
-                                </licenseUrlReplacements>
-                                <organizeLicensesByDependencies>true</organizeLicensesByDependencies>
-                            </configuration>
-                        </execution>
-                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>io.fabric8</groupId>
@@ -384,6 +365,7 @@
                     <injectAllReactorProjects>true</injectAllReactorProjects>
                     <runOnlyOnce>true</runOnlyOnce>
                     <skipPoms>false</skipPoms>
+                    <verbose>false</verbose>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
**Detailed description**:
- Bump Rosetta to Go 1.16
- Change test Kubernetes cluster from one to two nodes
- Change SonarCloud plugin to run once per commit instead of per module
- Fix chart test not using images built from the latest code
- Fix copying source jars every build unnecessarily
- Fix downloading licenses every build unnecessarily
- Fix forks failing to run checks due to unavailable GitHub secrets
- Fix verbose git commit plugin logs

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

