### PR TITLE
Fix release artifact & bump to v0.31.0-alpha2

### DIFF
--- a/charts/hedera-mirror-common/Chart.yaml
+++ b/charts/hedera-mirror-common/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "0.31.0-alpha1"
+appVersion: "0.31.0-alpha2"
 dependencies:
   - alias: loki
     condition: loki.enabled
@@ -30,4 +30,4 @@ maintainers:
 name: hedera-mirror-common
 sources:
   - https://github.com/hashgraph/hedera-mirror-node
-version: 0.18.0-alpha1
+version: 0.18.0-alpha2

--- a/charts/hedera-mirror-grpc/Chart.yaml
+++ b/charts/hedera-mirror-grpc/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "0.31.0-alpha1"
+appVersion: "0.31.0-alpha2"
 description: GRPC API for the Hedera Mirror Node
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
@@ -11,4 +11,4 @@ maintainers:
 name: hedera-mirror-grpc
 sources:
   - https://github.com/hashgraph/hedera-mirror-node
-version: 0.18.0-alpha1
+version: 0.18.0-alpha2

--- a/charts/hedera-mirror-importer/Chart.yaml
+++ b/charts/hedera-mirror-importer/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "0.31.0-alpha1"
+appVersion: "0.31.0-alpha2"
 description: Hedera Mirror Importer downloads and validates file streams from the cloud and imports them into the database
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
@@ -11,4 +11,4 @@ maintainers:
 name: hedera-mirror-importer
 sources:
   - https://github.com/hashgraph/hedera-mirror-node
-version: 0.18.0-alpha1
+version: 0.18.0-alpha2

--- a/charts/hedera-mirror-monitor/Chart.yaml
+++ b/charts/hedera-mirror-monitor/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "0.31.0-alpha1"
+appVersion: "0.31.0-alpha2"
 description: End to End Monitor for the Hedera Mirror Node
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
@@ -11,4 +11,4 @@ maintainers:
 name: hedera-mirror-monitor
 sources:
   - https://github.com/hashgraph/hedera-mirror-node
-version: 0.18.0-alpha1
+version: 0.18.0-alpha2

--- a/charts/hedera-mirror-rest/Chart.yaml
+++ b/charts/hedera-mirror-rest/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "0.31.0-alpha1"
+appVersion: "0.31.0-alpha2"
 description: REST API for the Hedera Mirror Node
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
@@ -11,4 +11,4 @@ maintainers:
 name: hedera-mirror-rest
 sources:
   - https://github.com/hashgraph/hedera-mirror-node
-version: 0.18.0-alpha1
+version: 0.18.0-alpha2

--- a/charts/hedera-mirror/Chart.lock
+++ b/charts/hedera-mirror/Chart.lock
@@ -1,13 +1,13 @@
 dependencies:
 - name: hedera-mirror-grpc
   repository: file://../hedera-mirror-grpc
-  version: 0.18.0-alpha1
+  version: 0.18.0-alpha2
 - name: hedera-mirror-importer
   repository: file://../hedera-mirror-importer
-  version: 0.18.0-alpha1
+  version: 0.18.0-alpha2
 - name: hedera-mirror-monitor
   repository: file://../hedera-mirror-monitor
-  version: 0.18.0-alpha1
+  version: 0.18.0-alpha2
 - name: postgresql-ha
   repository: https://charts.bitnami.com/bitnami
   version: 6.3.7
@@ -16,9 +16,9 @@ dependencies:
   version: 12.2.4
 - name: hedera-mirror-rest
   repository: file://../hedera-mirror-rest
-  version: 0.18.0-alpha1
+  version: 0.18.0-alpha2
 - name: timescaledb-multinode
   repository: https://raw.githubusercontent.com/timescale/timescaledb-kubernetes/master/charts/repo/
   version: 0.8.0
-digest: sha256:8480d1ab7ae875157aadbebfa4bb8f3c95e82fbbd878740af751a267d79ac817
-generated: "2021-03-30T14:58:10.973291-05:00"
+digest: sha256:1d3b608fda6d85eb74b0d623bac7c1b68f9365592c9c2abaf883ba6831e9d9ab
+generated: "2021-03-30T16:37:23.12195-05:00"

--- a/charts/hedera-mirror/Chart.yaml
+++ b/charts/hedera-mirror/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "0.31.0-alpha1"
+appVersion: "0.31.0-alpha2"
 dependencies:
   - alias: grpc
     condition: grpc.enabled
@@ -57,4 +57,4 @@ maintainers:
 name: hedera-mirror
 sources:
   - https://github.com/hashgraph/hedera-mirror-node
-version: 0.18.0-alpha1
+version: 0.18.0-alpha2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - 5432:5432
 
   grpc:
-    image: gcr.io/mirrornode/hedera-mirror-grpc:0.31.0-alpha1
+    image: gcr.io/mirrornode/hedera-mirror-grpc:0.31.0-alpha2
     restart: unless-stopped
     environment:
       HEDERA_MIRROR_GRPC_DB_HOST: db
@@ -29,7 +29,7 @@ services:
       - 5600:5600
 
   importer:
-    image: gcr.io/mirrornode/hedera-mirror-importer:0.31.0-alpha1
+    image: gcr.io/mirrornode/hedera-mirror-importer:0.31.0-alpha2
     restart: unless-stopped
     environment:
       HEDERA_MIRROR_IMPORTER_DB_HOST: db
@@ -41,7 +41,7 @@ services:
   monitor:
     deploy:
       replicas: 0
-    image: gcr.io/mirrornode/hedera-mirror-monitor:0.31.0-alpha1
+    image: gcr.io/mirrornode/hedera-mirror-monitor:0.31.0-alpha2
     restart: unless-stopped
     environment:
       SPRING_CONFIG_ADDITIONAL_LOCATION: file:/usr/etc/hedera-mirror-monitor/
@@ -58,7 +58,7 @@ services:
       - 6379:6379
 
   rest:
-    image: gcr.io/mirrornode/hedera-mirror-rest:0.31.0-alpha1
+    image: gcr.io/mirrornode/hedera-mirror-rest:0.31.0-alpha2
     environment:
       HEDERA_MIRROR_REST_DB_HOST: db
     restart: unless-stopped
@@ -67,7 +67,7 @@ services:
       - 5551:5551
 
   rosetta:
-    image: gcr.io/mirrornode/hedera-mirror-rosetta:0.31.0-alpha1
+    image: gcr.io/mirrornode/hedera-mirror-rosetta:0.31.0-alpha2
     environment:
       HEDERA_MIRROR_ROSETTA_DB_HOST: db
     restart: unless-stopped

--- a/hedera-mirror-rest/api/v1/openapi.yml
+++ b/hedera-mirror-rest/api/v1/openapi.yml
@@ -550,7 +550,7 @@ tags:
     description: The tokens object represents the information associated with a token entity and returns a list of token information.
 info:
   title: Hedera Mirror Node REST API
-  version: 0.31.0-alpha1
+  version: 0.31.0-alpha2
   license:
     name: Apache-2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0.html'

--- a/hedera-mirror-rest/monitoring/monitor_apis/package-lock.json
+++ b/hedera-mirror-rest/monitoring/monitor_apis/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-mirror-monitor",
-  "version": "0.31.0-alpha1",
+  "version": "0.31.0-alpha2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hedera-mirror-rest/monitoring/monitor_apis/package.json
+++ b/hedera-mirror-rest/monitoring/monitor_apis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-mirror-monitor",
-  "version": "0.31.0-alpha1",
+  "version": "0.31.0-alpha2",
   "description": "Hedera Mirror Node Monitor",
   "main": "server.js",
   "private": true,

--- a/hedera-mirror-rest/package-lock.json
+++ b/hedera-mirror-rest/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-mirror-rest",
-  "version": "0.31.0-alpha1",
+  "version": "0.31.0-alpha2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hedera-mirror-rest/package.json
+++ b/hedera-mirror-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-mirror-rest",
-  "version": "0.31.0-alpha1",
+  "version": "0.31.0-alpha2",
   "description": "Hedera Mirror Node REST API",
   "main": "server.js",
   "private": true,

--- a/hedera-mirror-rosetta/config/application.yml
+++ b/hedera-mirror-rosetta/config/application.yml
@@ -15,4 +15,4 @@ hedera:
       port: 5700
       realm: 0
       shard: 0
-      version: 0.31.0-alpha1
+      version: 0.31.0-alpha2

--- a/hedera-mirror-test/src/test/resources/k8s/hcs-perf-message-submit.yml
+++ b/hedera-mirror-test/src/test/resources/k8s/hcs-perf-message-submit.yml
@@ -41,7 +41,7 @@ spec:
                     app.kubernetes.io/name: test
       restartPolicy: Never
       containers:
-        - image: gcr.io/mirrornode/hedera-mirror-test:0.31.0-alpha1
+        - image: gcr.io/mirrornode/hedera-mirror-test:0.31.0-alpha2
           name: test
           env:
             - name: testProfile

--- a/hedera-mirror-test/src/test/resources/k8s/hcs-perf-publish-test.yml
+++ b/hedera-mirror-test/src/test/resources/k8s/hcs-perf-publish-test.yml
@@ -43,7 +43,7 @@ spec:
                     app.kubernetes.io/name: test
       restartPolicy: Never
       containers:
-        - image: gcr.io/mirrornode/hedera-mirror-test:0.31.0-alpha1
+        - image: gcr.io/mirrornode/hedera-mirror-test:0.31.0-alpha2
           name: test
           env:
             - name: testProfile

--- a/hedera-mirror-test/src/test/resources/k8s/hcs-perf-subscribe-test.yml
+++ b/hedera-mirror-test/src/test/resources/k8s/hcs-perf-subscribe-test.yml
@@ -46,7 +46,7 @@ spec:
                     app.kubernetes.io/name: test
       restartPolicy: Never
       containers:
-        - image: gcr.io/mirrornode/hedera-mirror-test:0.31.0-alpha1
+        - image: gcr.io/mirrornode/hedera-mirror-test:0.31.0-alpha2
           name: test
           env:
             - name: testProfile

--- a/hedera-mirror-test/src/test/resources/k8s/hts-perf-batch-publish-batch-validate.yml
+++ b/hedera-mirror-test/src/test/resources/k8s/hts-perf-batch-publish-batch-validate.yml
@@ -47,7 +47,7 @@ spec:
                     app.kubernetes.io/name: test
       restartPolicy: Never
       containers:
-        - image: gcr.io/mirrornode/hedera-mirror-test:0.31.0-alpha1
+        - image: gcr.io/mirrornode/hedera-mirror-test:0.31.0-alpha2
           name: test
           env:
             - name: testProfile

--- a/hedera-mirror-test/src/test/resources/k8s/hts-perf-publish-and-retrieve.yml
+++ b/hedera-mirror-test/src/test/resources/k8s/hts-perf-publish-and-retrieve.yml
@@ -46,7 +46,7 @@ spec:
                     app.kubernetes.io/name: test
       restartPolicy: Never
       containers:
-        - image: gcr.io/mirrornode/hedera-mirror-test:0.31.0-alpha1
+        - image: gcr.io/mirrornode/hedera-mirror-test:0.31.0-alpha2
           name: test
           env:
             - name: testProfile

--- a/pom.xml
+++ b/pom.xml
@@ -74,8 +74,8 @@
         <micrometer-jvm-extras.version>0.2.2</micrometer-jvm-extras.version>
         <msgpack.version>0.8.22</msgpack.version>
         <protobuf.version>3.15.6</protobuf.version>
-        <release.version>0.31.0-alpha1</release.version> <!-- Used to replace release versions in all files -->
-        <release.chartVersion>0.18.0-alpha1</release.chartVersion>
+        <release.version>0.31.0-alpha2</release.version> <!-- Used to replace release versions in all files -->
+        <release.chartVersion>0.18.0-alpha2</release.chartVersion>
         <replacer.version>1.5.3</replacer.version>
         <!--suppress UnresolvedMavenProperty -->
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>

--- a/pom.xml
+++ b/pom.xml
@@ -213,7 +213,7 @@
                     <artifactId>maven-assembly-plugin</artifactId>
                     <configuration>
                         <appendAssemblyId>false</appendAssemblyId>
-                        <finalName>${project.artifactId}-${release.version}</finalName>
+                        <finalName>${project.artifactId}-v${release.version}</finalName>
                         <formats>tgz</formats>
                         <descriptors>
                             <descriptor>assembly.xml</descriptor>


### PR DESCRIPTION
**Detailed description**:
- Fix release artifacts missing v prefix that devops scripts require
- Bump version to v0.31.0-alpha2

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:
Will backport fix to 0.30

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

