### PR TITLE
Fix jar name & bump to v0.31.0-alpha3

### DIFF
--- a/.github/workflows/rosetta-api.yml
+++ b/.github/workflows/rosetta-api.yml
@@ -57,7 +57,7 @@ jobs:
         run: echo "branch=${{ github.ref }}" >> $GITHUB_ENV
 
       - name: Set branch
-        if: ${{ github.head_ref != '' }}
+        if: !startsWith(github.ref, 'refs/tags/v')
         run: echo "branch=${{ github.head_ref }}" >> $GITHUB_ENV
 
       - name: Build Mirror Node All-in-One

--- a/.github/workflows/rosetta-api.yml
+++ b/.github/workflows/rosetta-api.yml
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Build Mirror Node All-in-One
-        run: docker build --tag="${MODULE}" --build-arg GIT_BRANCH=${{ github.head_ref }} build/
+        run: docker build --tag="${MODULE}" --build-arg GIT_BRANCH=${{ github.ref }} build/
 
       - name: Run Mirror Node
         run: docker run -d -p 5700:5700 "${MODULE}"

--- a/.github/workflows/rosetta-api.yml
+++ b/.github/workflows/rosetta-api.yml
@@ -52,16 +52,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set tag
-        if: startsWith(github.ref, 'refs/tags/v')
-        run: echo "branch=${{ git.ref }}" >> $GITHUB_ENV
-
-      - name: Set branch
-        if: ${{ github.head_ref != '' }}
-        run: echo "branch=${{ git.head_ref }}" >> $GITHUB_ENV
-
       - name: Build Mirror Node All-in-One
-        run: docker build --tag="${MODULE}" --build-arg GIT_BRANCH="${{ env.branch }}" build/
+        run: docker build --tag="${MODULE}" --build-arg GIT_BRANCH="${{ github.sha }}" build/
 
       - name: Run Mirror Node
         run: docker run -d -p 5700:5700 "${MODULE}"

--- a/.github/workflows/rosetta-api.yml
+++ b/.github/workflows/rosetta-api.yml
@@ -57,7 +57,7 @@ jobs:
         run: echo "branch=${{ github.ref }}" >> $GITHUB_ENV
 
       - name: Set branch
-        if: !startsWith(github.ref, 'refs/tags/v')
+        if: "!startsWith(github.ref, 'refs/tags/v')"
         run: echo "branch=${{ github.head_ref }}" >> $GITHUB_ENV
 
       - name: Build Mirror Node All-in-One

--- a/.github/workflows/rosetta-api.yml
+++ b/.github/workflows/rosetta-api.yml
@@ -52,8 +52,16 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Set tag
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: echo "branch=${{ git.ref }}" >> $GITHUB_ENV
+
+      - name: Set branch
+        if: ${{ github.head_ref != '' }}
+        run: echo "branch=${{ git.head_ref }}" >> $GITHUB_ENV
+
       - name: Build Mirror Node All-in-One
-        run: docker build --tag="${MODULE}" --build-arg GIT_BRANCH=${{ github.ref }} build/
+        run: docker build --tag="${MODULE}" --build-arg GIT_BRANCH="${{ env.branch }}" build/
 
       - name: Run Mirror Node
         run: docker run -d -p 5700:5700 "${MODULE}"

--- a/.github/workflows/rosetta-api.yml
+++ b/.github/workflows/rosetta-api.yml
@@ -52,8 +52,16 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Set tag
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: echo "branch=${{ github.ref }}" >> $GITHUB_ENV
+
+      - name: Set branch
+        if: ${{ github.head_ref != '' }}
+        run: echo "branch=${{ github.head_ref }}" >> $GITHUB_ENV
+
       - name: Build Mirror Node All-in-One
-        run: docker build --tag="${MODULE}" --build-arg GIT_BRANCH="${{ github.sha }}" build/
+        run: docker build --tag="${MODULE}" --build-arg GIT_BRANCH="${{ env.branch }}" build/
 
       - name: Run Mirror Node
         run: docker run -d -p 5700:5700 "${MODULE}"

--- a/charts/hedera-mirror-common/Chart.yaml
+++ b/charts/hedera-mirror-common/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "0.31.0-alpha2"
+appVersion: "0.31.0-alpha3"
 dependencies:
   - alias: loki
     condition: loki.enabled
@@ -30,4 +30,4 @@ maintainers:
 name: hedera-mirror-common
 sources:
   - https://github.com/hashgraph/hedera-mirror-node
-version: 0.18.0-alpha2
+version: 0.18.0-alpha3

--- a/charts/hedera-mirror-grpc/Chart.yaml
+++ b/charts/hedera-mirror-grpc/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "0.31.0-alpha2"
+appVersion: "0.31.0-alpha3"
 description: GRPC API for the Hedera Mirror Node
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
@@ -11,4 +11,4 @@ maintainers:
 name: hedera-mirror-grpc
 sources:
   - https://github.com/hashgraph/hedera-mirror-node
-version: 0.18.0-alpha2
+version: 0.18.0-alpha3

--- a/charts/hedera-mirror-importer/Chart.yaml
+++ b/charts/hedera-mirror-importer/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "0.31.0-alpha2"
+appVersion: "0.31.0-alpha3"
 description: Hedera Mirror Importer downloads and validates file streams from the cloud and imports them into the database
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
@@ -11,4 +11,4 @@ maintainers:
 name: hedera-mirror-importer
 sources:
   - https://github.com/hashgraph/hedera-mirror-node
-version: 0.18.0-alpha2
+version: 0.18.0-alpha3

--- a/charts/hedera-mirror-monitor/Chart.yaml
+++ b/charts/hedera-mirror-monitor/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "0.31.0-alpha2"
+appVersion: "0.31.0-alpha3"
 description: End to End Monitor for the Hedera Mirror Node
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
@@ -11,4 +11,4 @@ maintainers:
 name: hedera-mirror-monitor
 sources:
   - https://github.com/hashgraph/hedera-mirror-node
-version: 0.18.0-alpha2
+version: 0.18.0-alpha3

--- a/charts/hedera-mirror-rest/Chart.yaml
+++ b/charts/hedera-mirror-rest/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "0.31.0-alpha2"
+appVersion: "0.31.0-alpha3"
 description: REST API for the Hedera Mirror Node
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
@@ -11,4 +11,4 @@ maintainers:
 name: hedera-mirror-rest
 sources:
   - https://github.com/hashgraph/hedera-mirror-node
-version: 0.18.0-alpha2
+version: 0.18.0-alpha3

--- a/charts/hedera-mirror/Chart.lock
+++ b/charts/hedera-mirror/Chart.lock
@@ -1,13 +1,13 @@
 dependencies:
 - name: hedera-mirror-grpc
   repository: file://../hedera-mirror-grpc
-  version: 0.18.0-alpha2
+  version: 0.18.0-alpha3
 - name: hedera-mirror-importer
   repository: file://../hedera-mirror-importer
-  version: 0.18.0-alpha2
+  version: 0.18.0-alpha3
 - name: hedera-mirror-monitor
   repository: file://../hedera-mirror-monitor
-  version: 0.18.0-alpha2
+  version: 0.18.0-alpha3
 - name: postgresql-ha
   repository: https://charts.bitnami.com/bitnami
   version: 6.3.7
@@ -16,9 +16,9 @@ dependencies:
   version: 12.2.4
 - name: hedera-mirror-rest
   repository: file://../hedera-mirror-rest
-  version: 0.18.0-alpha2
+  version: 0.18.0-alpha3
 - name: timescaledb-multinode
   repository: https://raw.githubusercontent.com/timescale/timescaledb-kubernetes/master/charts/repo/
   version: 0.8.0
-digest: sha256:1d3b608fda6d85eb74b0d623bac7c1b68f9365592c9c2abaf883ba6831e9d9ab
-generated: "2021-03-30T16:37:23.12195-05:00"
+digest: sha256:033edab6ab9e4c4b17ff9510251a865abdab71fb698a51b340c5443649d4f7e7
+generated: "2021-03-30T17:18:17.318148-05:00"

--- a/charts/hedera-mirror/Chart.yaml
+++ b/charts/hedera-mirror/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "0.31.0-alpha2"
+appVersion: "0.31.0-alpha3"
 dependencies:
   - alias: grpc
     condition: grpc.enabled
@@ -57,4 +57,4 @@ maintainers:
 name: hedera-mirror
 sources:
   - https://github.com/hashgraph/hedera-mirror-node
-version: 0.18.0-alpha2
+version: 0.18.0-alpha3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - 5432:5432
 
   grpc:
-    image: gcr.io/mirrornode/hedera-mirror-grpc:0.31.0-alpha2
+    image: gcr.io/mirrornode/hedera-mirror-grpc:0.31.0-alpha3
     restart: unless-stopped
     environment:
       HEDERA_MIRROR_GRPC_DB_HOST: db
@@ -29,7 +29,7 @@ services:
       - 5600:5600
 
   importer:
-    image: gcr.io/mirrornode/hedera-mirror-importer:0.31.0-alpha2
+    image: gcr.io/mirrornode/hedera-mirror-importer:0.31.0-alpha3
     restart: unless-stopped
     environment:
       HEDERA_MIRROR_IMPORTER_DB_HOST: db
@@ -41,7 +41,7 @@ services:
   monitor:
     deploy:
       replicas: 0
-    image: gcr.io/mirrornode/hedera-mirror-monitor:0.31.0-alpha2
+    image: gcr.io/mirrornode/hedera-mirror-monitor:0.31.0-alpha3
     restart: unless-stopped
     environment:
       SPRING_CONFIG_ADDITIONAL_LOCATION: file:/usr/etc/hedera-mirror-monitor/
@@ -58,7 +58,7 @@ services:
       - 6379:6379
 
   rest:
-    image: gcr.io/mirrornode/hedera-mirror-rest:0.31.0-alpha2
+    image: gcr.io/mirrornode/hedera-mirror-rest:0.31.0-alpha3
     environment:
       HEDERA_MIRROR_REST_DB_HOST: db
     restart: unless-stopped
@@ -67,7 +67,7 @@ services:
       - 5551:5551
 
   rosetta:
-    image: gcr.io/mirrornode/hedera-mirror-rosetta:0.31.0-alpha2
+    image: gcr.io/mirrornode/hedera-mirror-rosetta:0.31.0-alpha3
     environment:
       HEDERA_MIRROR_ROSETTA_DB_HOST: db
     restart: unless-stopped

--- a/hedera-mirror-grpc/assembly.xml
+++ b/hedera-mirror-grpc/assembly.xml
@@ -5,7 +5,7 @@
     <files>
         <file>
             <source>${project.build.directory}/${project.artifactId}-${release.version}-exec.jar</source>
-            <destName>${project.artifactId}-${release.version}.jar</destName>
+            <destName>${project.artifactId}-v${release.version}.jar</destName>
         </file>
     </files>
     <fileSets>

--- a/hedera-mirror-importer/assembly.xml
+++ b/hedera-mirror-importer/assembly.xml
@@ -5,7 +5,7 @@
     <files>
         <file>
             <source>${project.build.directory}/${project.artifactId}-${release.version}-exec.jar</source>
-            <destName>${project.artifactId}-${release.version}.jar</destName>
+            <destName>${project.artifactId}-v${release.version}.jar</destName>
         </file>
     </files>
     <fileSets>

--- a/hedera-mirror-rest/api/v1/openapi.yml
+++ b/hedera-mirror-rest/api/v1/openapi.yml
@@ -550,7 +550,7 @@ tags:
     description: The tokens object represents the information associated with a token entity and returns a list of token information.
 info:
   title: Hedera Mirror Node REST API
-  version: 0.31.0-alpha2
+  version: 0.31.0-alpha3
   license:
     name: Apache-2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0.html'

--- a/hedera-mirror-rest/monitoring/monitor_apis/package-lock.json
+++ b/hedera-mirror-rest/monitoring/monitor_apis/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-mirror-monitor",
-  "version": "0.31.0-alpha2",
+  "version": "0.31.0-alpha3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hedera-mirror-rest/monitoring/monitor_apis/package.json
+++ b/hedera-mirror-rest/monitoring/monitor_apis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-mirror-monitor",
-  "version": "0.31.0-alpha2",
+  "version": "0.31.0-alpha3",
   "description": "Hedera Mirror Node Monitor",
   "main": "server.js",
   "private": true,

--- a/hedera-mirror-rest/package-lock.json
+++ b/hedera-mirror-rest/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-mirror-rest",
-  "version": "0.31.0-alpha2",
+  "version": "0.31.0-alpha3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hedera-mirror-rest/package.json
+++ b/hedera-mirror-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hedera-mirror-rest",
-  "version": "0.31.0-alpha2",
+  "version": "0.31.0-alpha3",
   "description": "Hedera Mirror Node REST API",
   "main": "server.js",
   "private": true,

--- a/hedera-mirror-rosetta/config/application.yml
+++ b/hedera-mirror-rosetta/config/application.yml
@@ -15,4 +15,4 @@ hedera:
       port: 5700
       realm: 0
       shard: 0
-      version: 0.31.0-alpha2
+      version: 0.31.0-alpha3

--- a/hedera-mirror-test/src/test/resources/k8s/hcs-perf-message-submit.yml
+++ b/hedera-mirror-test/src/test/resources/k8s/hcs-perf-message-submit.yml
@@ -41,7 +41,7 @@ spec:
                     app.kubernetes.io/name: test
       restartPolicy: Never
       containers:
-        - image: gcr.io/mirrornode/hedera-mirror-test:0.31.0-alpha2
+        - image: gcr.io/mirrornode/hedera-mirror-test:0.31.0-alpha3
           name: test
           env:
             - name: testProfile

--- a/hedera-mirror-test/src/test/resources/k8s/hcs-perf-publish-test.yml
+++ b/hedera-mirror-test/src/test/resources/k8s/hcs-perf-publish-test.yml
@@ -43,7 +43,7 @@ spec:
                     app.kubernetes.io/name: test
       restartPolicy: Never
       containers:
-        - image: gcr.io/mirrornode/hedera-mirror-test:0.31.0-alpha2
+        - image: gcr.io/mirrornode/hedera-mirror-test:0.31.0-alpha3
           name: test
           env:
             - name: testProfile

--- a/hedera-mirror-test/src/test/resources/k8s/hcs-perf-subscribe-test.yml
+++ b/hedera-mirror-test/src/test/resources/k8s/hcs-perf-subscribe-test.yml
@@ -46,7 +46,7 @@ spec:
                     app.kubernetes.io/name: test
       restartPolicy: Never
       containers:
-        - image: gcr.io/mirrornode/hedera-mirror-test:0.31.0-alpha2
+        - image: gcr.io/mirrornode/hedera-mirror-test:0.31.0-alpha3
           name: test
           env:
             - name: testProfile

--- a/hedera-mirror-test/src/test/resources/k8s/hts-perf-batch-publish-batch-validate.yml
+++ b/hedera-mirror-test/src/test/resources/k8s/hts-perf-batch-publish-batch-validate.yml
@@ -47,7 +47,7 @@ spec:
                     app.kubernetes.io/name: test
       restartPolicy: Never
       containers:
-        - image: gcr.io/mirrornode/hedera-mirror-test:0.31.0-alpha2
+        - image: gcr.io/mirrornode/hedera-mirror-test:0.31.0-alpha3
           name: test
           env:
             - name: testProfile

--- a/hedera-mirror-test/src/test/resources/k8s/hts-perf-publish-and-retrieve.yml
+++ b/hedera-mirror-test/src/test/resources/k8s/hts-perf-publish-and-retrieve.yml
@@ -46,7 +46,7 @@ spec:
                     app.kubernetes.io/name: test
       restartPolicy: Never
       containers:
-        - image: gcr.io/mirrornode/hedera-mirror-test:0.31.0-alpha2
+        - image: gcr.io/mirrornode/hedera-mirror-test:0.31.0-alpha3
           name: test
           env:
             - name: testProfile

--- a/pom.xml
+++ b/pom.xml
@@ -74,8 +74,8 @@
         <micrometer-jvm-extras.version>0.2.2</micrometer-jvm-extras.version>
         <msgpack.version>0.8.22</msgpack.version>
         <protobuf.version>3.15.6</protobuf.version>
-        <release.version>0.31.0-alpha2</release.version> <!-- Used to replace release versions in all files -->
-        <release.chartVersion>0.18.0-alpha2</release.chartVersion>
+        <release.version>0.31.0-alpha3</release.version> <!-- Used to replace release versions in all files -->
+        <release.chartVersion>0.18.0-alpha3</release.chartVersion>
         <replacer.version>1.5.3</replacer.version>
         <!--suppress UnresolvedMavenProperty -->
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>


### PR DESCRIPTION
**Detailed description**:
- Fix Rosetta validation failing on tags
- Fix release jar not prefixed with `v`
- Bump versions to v0.31.0-alpha3

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

