### PR TITLE
Expose entity_id in transactions REST API

### DIFF
--- a/hedera-mirror-rest/__tests__/integrationDomainOps.js
+++ b/hedera-mirror-rest/__tests__/integrationDomainOps.js
@@ -236,7 +236,7 @@ const addTransaction = async (transaction) => {
 
   const payerAccount = EntityId.fromString(transaction.payerAccountId);
   const nodeAccount = EntityId.fromString(transaction.nodeAccountId, 'nodeAccountId', true);
-  const entityAccount = EntityId.fromString(transaction.entity_id, 'entity_id', true);
+  const entityId = EntityId.fromString(transaction.entity_id, 'entity_id', true);
   await sqlConnection.query(
     `INSERT INTO transaction (consensus_ns, valid_start_ns, payer_account_id, node_account_id, result, type,
                                 valid_duration_seconds, max_fee, charged_tx_fee, transaction_hash, scheduled, entity_id)
@@ -253,7 +253,7 @@ const addTransaction = async (transaction) => {
       transaction.charged_tx_fee,
       transaction.transaction_hash,
       transaction.scheduled,
-      entityAccount.getEncodedId(),
+      entityId.getEncodedId(),
     ]
   );
   await insertTransfers('crypto_transfer', transaction.consensus_timestamp, transaction.transfers);

--- a/hedera-mirror-rest/__tests__/integrationDomainOps.js
+++ b/hedera-mirror-rest/__tests__/integrationDomainOps.js
@@ -160,10 +160,9 @@ const addEntity = async (defaults, entity) => {
   };
 
   await sqlConnection.query(
-    `INSERT INTO t_entities (
-      id, fk_entity_type_id, entity_shard, entity_realm, entity_num, exp_time_ns, deleted, ed25519_public_key_hex,
-      auto_renew_period, key, memo)
-    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11);`,
+    `INSERT INTO t_entities (id, fk_entity_type_id, entity_shard, entity_realm, entity_num, exp_time_ns, deleted,
+                               ed25519_public_key_hex, auto_renew_period, key, memo)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11);`,
     [
       EntityId.of(entity.entity_shard, entity.entity_realm, entity.entity_num).getEncodedId(),
       entity.entity_type,
@@ -195,7 +194,7 @@ const setAccountBalance = async (balance) => {
   const accountId = EntityId.of(config.shard, balance.realm_num, balance.id).getEncodedId();
   await sqlConnection.query(
     `INSERT INTO account_balance (consensus_timestamp, account_id, balance)
-    VALUES ($1, $2, $3);`,
+       VALUES ($1, $2, $3);`,
     [balance.timestamp, accountId, balance.balance]
   );
 
@@ -226,6 +225,7 @@ const addTransaction = async (transaction) => {
     transaction_hash: 'hash',
     type: 14,
     valid_duration_seconds: 11,
+    entity_id: null,
     ...transaction,
   };
 
@@ -236,11 +236,11 @@ const addTransaction = async (transaction) => {
 
   const payerAccount = EntityId.fromString(transaction.payerAccountId);
   const nodeAccount = EntityId.fromString(transaction.nodeAccountId, 'nodeAccountId', true);
+  const entityAccount = EntityId.fromString(transaction.entity_id, 'entity_id', true);
   await sqlConnection.query(
-    `INSERT INTO transaction (
-      consensus_ns, valid_start_ns, payer_account_id, node_account_id,
-      result, type, valid_duration_seconds, max_fee, charged_tx_fee, transaction_hash, scheduled)
-    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11);`,
+    `INSERT INTO transaction (consensus_ns, valid_start_ns, payer_account_id, node_account_id, result, type,
+                                valid_duration_seconds, max_fee, charged_tx_fee, transaction_hash, scheduled, entity_id)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12);`,
     [
       transaction.consensus_timestamp.toString(),
       transaction.valid_start_timestamp.toString(),
@@ -253,6 +253,7 @@ const addTransaction = async (transaction) => {
       transaction.charged_tx_fee,
       transaction.transaction_hash,
       transaction.scheduled,
+      entityAccount.getEncodedId(),
     ]
   );
   await insertTransfers('crypto_transfer', transaction.consensus_timestamp, transaction.transfers);
@@ -320,9 +321,9 @@ const addTopicMessage = async (message) => {
   };
 
   await sqlConnection.query(
-    `INSERT INTO topic_message (
-       consensus_timestamp, realm_num, topic_num, message, running_hash, sequence_number, running_hash_version)
-    VALUES ($1, $2, $3, $4, $5, $6, $7);`,
+    `INSERT INTO topic_message (consensus_timestamp, realm_num, topic_num, message, running_hash, sequence_number,
+                                  running_hash_version)
+       VALUES ($1, $2, $3, $4, $5, $6, $7);`,
     [
       message.timestamp,
       message.realm_num,
@@ -344,14 +345,13 @@ const addSchedule = async (schedule) => {
   };
 
   await sqlConnection.query(
-    `INSERT INTO schedule (
-      consensus_timestamp,
-      creator_account_id,
-      executed_timestamp,
-      payer_account_id,
-      schedule_id,
-      transaction_body)
-     VALUES($1, $2, $3, $4, $5, $6)`,
+    `INSERT INTO schedule (consensus_timestamp,
+                             creator_account_id,
+                             executed_timestamp,
+                             payer_account_id,
+                             schedule_id,
+                             transaction_body)
+       VALUES ($1, $2, $3, $4, $5, $6)`,
     [
       schedule.consensus_timestamp,
       EntityId.fromString(schedule.creator_account_id).getEncodedId().toString(),
@@ -365,12 +365,11 @@ const addSchedule = async (schedule) => {
 
 const addTransactionSignature = async (transactionSignature) => {
   await sqlConnection.query(
-    `INSERT INTO transaction_signature (
-      consensus_timestamp,
-      public_key_prefix,
-      entity_id,
-      signature)
-     VALUES($1, $2, $3, $4)`,
+    `INSERT INTO transaction_signature (consensus_timestamp,
+                                          public_key_prefix,
+                                          entity_id,
+                                          signature)
+       VALUES ($1, $2, $3, $4)`,
     [
       transactionSignature.consensus_timestamp,
       Buffer.from(transactionSignature.public_key_prefix),
@@ -465,9 +464,9 @@ const addTokenAccount = async (tokenAccount) => {
   }
 
   await sqlConnection.query(
-    `INSERT INTO token_account (
-      account_id, associated, created_timestamp, freeze_status, kyc_status, modified_timestamp, token_id)
-    VALUES ($1, $2, $3, $4, $5, $6, $7);`,
+    `INSERT INTO token_account (account_id, associated, created_timestamp, freeze_status, kyc_status,
+                                  modified_timestamp, token_id)
+       VALUES ($1, $2, $3, $4, $5, $6, $7);`,
     [
       EntityId.fromString(tokenAccount.account_id).getEncodedId(),
       tokenAccount.associated,

--- a/hedera-mirror-rest/__tests__/mockpool.js
+++ b/hedera-mirror-rest/__tests__/mockpool.js
@@ -199,7 +199,7 @@ class Pool {
       row.charged_tx_fee = 100 + i;
       row.transaction_hash = '';
       row.scheduled = false;
-      row.entity_id = EntityId.of(0, 0, accountNumValue).getEncodedId();
+      row.entity_id = null;
       rows.push(row);
     }
     if (['asc', 'ASC'].includes(order)) {

--- a/hedera-mirror-rest/__tests__/mockpool.js
+++ b/hedera-mirror-rest/__tests__/mockpool.js
@@ -199,6 +199,7 @@ class Pool {
       row.charged_tx_fee = 100 + i;
       row.transaction_hash = '';
       row.scheduled = false;
+      row.entity_id = EntityId.of(0, 0, accountNumValue).getEncodedId();
       rows.push(row);
     }
     if (['asc', 'ASC'].includes(order)) {

--- a/hedera-mirror-rest/__tests__/specs/accounts-10-account-transactions.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/accounts-10-account-transactions.spec.json
@@ -95,6 +95,7 @@
       {
         "charged_tx_fee": 0,
         "consensus_timestamp": "1234567890.000000006",
+        "entity_id": null,
         "max_fee": "33",
         "memo_base64": null,
         "name": "CRYPTOUPDATEACCOUNT",
@@ -110,6 +111,7 @@
       {
         "charged_tx_fee": 7,
         "consensus_timestamp": "1234567890.000000005",
+        "entity_id": null,
         "max_fee": "33",
         "memo_base64": null,
         "name": "CRYPTOTRANSFER",
@@ -138,6 +140,7 @@
       {
         "charged_tx_fee": 7,
         "consensus_timestamp": "1234567890.000000001",
+        "entity_id": null,
         "max_fee": "33",
         "memo_base64": null,
         "name": "CRYPTOTRANSFER",

--- a/hedera-mirror-rest/__tests__/specs/accounts-10-account-transactions.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/accounts-10-account-transactions.spec.json
@@ -66,7 +66,8 @@
         "nodeAccountId": "0.0.3",
         "consensus_timestamp": "1234567890000000006",
         "name": "CRYPTOUPDATEACCOUNT",
-        "type": "15"
+        "type": "15",
+        "entity_id": "0.0.9"
       }
     ],
     "cryptotransfers": [
@@ -95,7 +96,7 @@
       {
         "charged_tx_fee": 0,
         "consensus_timestamp": "1234567890.000000006",
-        "entity_id": null,
+        "entity_id": "0.0.9",
         "max_fee": "33",
         "memo_base64": null,
         "name": "CRYPTOUPDATEACCOUNT",

--- a/hedera-mirror-rest/__tests__/specs/accounts-14-account-transactions-transactiontype.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/accounts-14-account-transactions-transactiontype.spec.json
@@ -128,6 +128,7 @@
       {
         "charged_tx_fee": 0,
         "consensus_timestamp": "1234567891.000000007",
+        "entity_id": null,
         "max_fee": "33",
         "memo_base64": null,
         "name": "CRYPTOTRANSFER",
@@ -152,6 +153,7 @@
       {
         "charged_tx_fee": 7,
         "consensus_timestamp": "1234567890.000000007",
+        "entity_id": null,
         "max_fee": "33",
         "memo_base64": null,
         "name": "CRYPTOTRANSFER",

--- a/hedera-mirror-rest/__tests__/specs/accounts-14-account-transactions-transactiontype.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/accounts-14-account-transactions-transactiontype.spec.json
@@ -65,14 +65,16 @@
         "nodeAccountId": "0.0.3",
         "consensus_timestamp": "1565779555711927001",
         "name": "TOKENCREATION",
-        "type": "29"
+        "type": "29",
+        "entity_id": "0.0.90000"
       },
       {
         "payerAccountId": "0.0.9",
         "nodeAccountId": "0.0.3",
         "consensus_timestamp": "1234567890000000005",
         "name": "CRYPTODELETE",
-        "type": "12"
+        "type": "12",
+        "entity_id": "0.0.117"
       },
       {
         "charged_tx_fee": 0,
@@ -80,7 +82,8 @@
         "nodeAccountId": "0.0.3",
         "consensus_timestamp": "1234567890000000015",
         "name": "CRYPTOUPDATEACCOUNT",
-        "type": "15"
+        "type": "15",
+        "entity_id": "0.0.7"
       }
     ],
     "cryptotransfers": [

--- a/hedera-mirror-rest/__tests__/specs/accounts-18-account-transactions-no-balances.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/accounts-18-account-transactions-no-balances.spec.json
@@ -114,6 +114,7 @@
       {
         "charged_tx_fee": 0,
         "consensus_timestamp": "1234567890.000000031",
+        "entity_id": null,
         "max_fee": "33",
         "memo_base64": null,
         "name": "CRYPTOUPDATEACCOUNT",
@@ -129,6 +130,7 @@
       {
         "charged_tx_fee": 7,
         "consensus_timestamp": "1234567890.000000005",
+        "entity_id": null,
         "max_fee": "33",
         "memo_base64": null,
         "name": "CRYPTOTRANSFER",
@@ -157,6 +159,7 @@
       {
         "charged_tx_fee": 7,
         "consensus_timestamp": "1234567890.000000001",
+        "entity_id": null,
         "max_fee": "33",
         "memo_base64": null,
         "name": "CRYPTOTRANSFER",

--- a/hedera-mirror-rest/__tests__/specs/accounts-18-account-transactions-no-balances.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/accounts-18-account-transactions-no-balances.spec.json
@@ -71,7 +71,8 @@
         "nodeAccountId": "0.0.3",
         "consensus_timestamp": "1234567890000000031",
         "name": "CRYPTOUPDATEACCOUNT",
-        "type": "15"
+        "type": "15",
+        "entity_id": "0.0.9"
       }
     ],
     "cryptotransfers": [
@@ -114,7 +115,7 @@
       {
         "charged_tx_fee": 0,
         "consensus_timestamp": "1234567890.000000031",
-        "entity_id": null,
+        "entity_id": "0.0.9",
         "max_fee": "33",
         "memo_base64": null,
         "name": "CRYPTOUPDATEACCOUNT",

--- a/hedera-mirror-rest/__tests__/specs/accounts-19-account-transactions-timestamp.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/accounts-19-account-transactions-timestamp.spec.json
@@ -129,6 +129,7 @@
       {
         "charged_tx_fee": 7,
         "consensus_timestamp": "1234567890.300000007",
+        "entity_id": null,
         "max_fee": "33",
         "memo_base64": null,
         "name": "CRYPTOTRANSFER",
@@ -169,6 +170,7 @@
       {
         "charged_tx_fee": 7,
         "consensus_timestamp": "1234567890.000000007",
+        "entity_id": null,
         "max_fee": "33",
         "memo_base64": null,
         "name": "CRYPTOTRANSFER",

--- a/hedera-mirror-rest/__tests__/specs/accounts-19-account-transactions-timestamp.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/accounts-19-account-transactions-timestamp.spec.json
@@ -65,14 +65,16 @@
         "nodeAccountId": "0.0.3",
         "consensus_timestamp": "1565779555711927001",
         "name": "TOKENCREATION",
-        "type": "29"
+        "type": "29",
+        "entity_id": "0.0.90000"
       },
       {
         "payerAccountId": "0.0.9",
         "nodeAccountId": "0.0.3",
         "consensus_timestamp": "1234567890000000005",
         "name": "CRYPTODELETE",
-        "type": "12"
+        "type": "12",
+        "entity_id": "0.0.7"
       },
       {
         "charged_tx_fee": 0,
@@ -80,7 +82,8 @@
         "nodeAccountId": "0.0.3",
         "consensus_timestamp": "1234567890000000015",
         "name": "CRYPTOUPDATEACCOUNT",
-        "type": "15"
+        "type": "15",
+        "entity_id": "0.0.8"
       }
     ],
     "cryptotransfers": [

--- a/hedera-mirror-rest/__tests__/specs/transactions-01-no-args.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-01-no-args.spec.json
@@ -90,6 +90,7 @@
       {
         "consensus_timestamp": "1234567890.000000005",
         "valid_start_timestamp": "1234567890.000000004",
+        "entity_id": null,
         "charged_tx_fee": 7,
         "memo_base64": null,
         "result": "SUCCESS",
@@ -118,6 +119,7 @@
       {
         "consensus_timestamp": "1234567890.000000004",
         "valid_start_timestamp": "1234567890.000000003",
+        "entity_id": null,
         "charged_tx_fee": 7,
         "memo_base64": null,
         "result": "SUCCESS",
@@ -158,6 +160,7 @@
       {
         "consensus_timestamp": "1234567890.000000003",
         "valid_start_timestamp": "1234567890.000000002",
+        "entity_id": null,
         "charged_tx_fee": 7,
         "memo_base64": null,
         "result": "SUCCESS",
@@ -186,6 +189,7 @@
       {
         "consensus_timestamp": "1234567890.000000002",
         "valid_start_timestamp": "1234567890.000000001",
+        "entity_id": null,
         "charged_tx_fee": 7,
         "memo_base64": null,
         "result": "SUCCESS",
@@ -214,6 +218,7 @@
       {
         "consensus_timestamp": "1234567890.000000001",
         "valid_start_timestamp": "1234567890.000000000",
+        "entity_id": null,
         "charged_tx_fee": 7,
         "memo_base64": null,
         "result": "SUCCESS",
@@ -242,6 +247,7 @@
       {
         "charged_tx_fee": 0,
         "consensus_timestamp": "1234567800.000000009",
+        "entity_id": null,
         "max_fee": "33",
         "memo_base64": null,
         "name": "CRYPTOUPDATEACCOUNT",

--- a/hedera-mirror-rest/__tests__/specs/transactions-01-no-args.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-01-no-args.spec.json
@@ -26,7 +26,8 @@
         "nodeAccountId": null,
         "consensus_timestamp": "1234567800000000009",
         "name": "CRYPTOUPDATEACCOUNT",
-        "type": "15"
+        "type": "15",
+        "entity_id": "0.0.10"
       }
     ],
     "cryptotransfers": [
@@ -247,7 +248,7 @@
       {
         "charged_tx_fee": 0,
         "consensus_timestamp": "1234567800.000000009",
-        "entity_id": null,
+        "entity_id": "0.0.10",
         "max_fee": "33",
         "memo_base64": null,
         "name": "CRYPTOUPDATEACCOUNT",

--- a/hedera-mirror-rest/__tests__/specs/transactions-02-specific-id.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-02-specific-id.spec.json
@@ -77,6 +77,7 @@
       {
         "consensus_timestamp": "1234567890.000000002",
         "charged_tx_fee": 7,
+        "entity_id": null,
         "max_fee": "33",
         "memo_base64": null,
         "name": "SCHEDULECREATE",
@@ -101,6 +102,7 @@
       {
         "charged_tx_fee": 7,
         "consensus_timestamp": "1234567890.000000003",
+        "entity_id": null,
         "max_fee": "33",
         "memo_base64": null,
         "name": "CRYPTOTRANSFER",
@@ -129,6 +131,7 @@
       {
         "charged_tx_fee": 7,
         "consensus_timestamp": "1234567890.000000040",
+        "entity_id": null,
         "max_fee": "33",
         "memo_base64": null,
         "name": "CRYPTOTRANSFER",

--- a/hedera-mirror-rest/__tests__/specs/transactions-02-specific-id.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-02-specific-id.spec.json
@@ -15,6 +15,15 @@
         "entity_num": 98
       }
     ],
+    "entities": [
+      {
+        "entity_num": 100,
+        "entity_type": 6,
+        "memo": "Created per council decision dated 02/01/21",
+        "public_key": "7a3c7a3c5477bdf4a63742647d7cfc4544acc1899d07141caf4cd9fea2f75b28a5cc",
+        "key": [1, 1, 1]
+      }
+    ],
     "balances": [],
     "transactions": [
       {
@@ -25,6 +34,7 @@
         "valid_start_timestamp": "1234567890000000001",
         "name": "SCHEDULECREATE",
         "type": 42,
+        "entity_id": "0.0.100",
         "transfers": [
           {
             "account": "0.0.9",
@@ -77,7 +87,7 @@
       {
         "consensus_timestamp": "1234567890.000000002",
         "charged_tx_fee": 7,
-        "entity_id": null,
+        "entity_id": "0.0.100",
         "max_fee": "33",
         "memo_base64": null,
         "name": "SCHEDULECREATE",

--- a/hedera-mirror-rest/__tests__/specs/transactions-04-timestamp.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-04-timestamp.spec.json
@@ -53,6 +53,7 @@
     "transactions": [
       {
         "consensus_timestamp": "1565779209.711927001",
+        "entity_id": null,
         "valid_start_timestamp": "1565779209.711927000",
         "charged_tx_fee": 7,
         "memo_base64": null,

--- a/hedera-mirror-rest/__tests__/specs/transactions-05-success-result.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-05-success-result.spec.json
@@ -63,6 +63,7 @@
     "transactions": [
       {
         "consensus_timestamp": "1565779666.711927001",
+        "entity_id": null,
         "valid_start_timestamp": "1565779666.711927000",
         "charged_tx_fee": 7,
         "memo_base64": null,
@@ -91,6 +92,7 @@
       },
       {
         "consensus_timestamp": "1565779209.711927001",
+        "entity_id": null,
         "valid_start_timestamp": "1565779209.711927000",
         "charged_tx_fee": 7,
         "memo_base64": null,

--- a/hedera-mirror-rest/__tests__/specs/transactions-06-fail-result.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-06-fail-result.spec.json
@@ -63,6 +63,7 @@
     "transactions": [
       {
         "consensus_timestamp": "1565779333.711927001",
+        "entity_id": null,
         "valid_start_timestamp": "1565779333.711927000",
         "charged_tx_fee": 7,
         "memo_base64": null,
@@ -91,6 +92,7 @@
       },
       {
         "consensus_timestamp": "1565779111.711927001",
+        "entity_id": null,
         "valid_start_timestamp": "1565779111.711927000",
         "charged_tx_fee": 7,
         "memo_base64": null,

--- a/hedera-mirror-rest/__tests__/specs/transactions-07-credit-type.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-07-credit-type.spec.json
@@ -26,7 +26,8 @@
         "nodeAccountId": "0.0.3",
         "consensus_timestamp": "1565779444711927001",
         "name": "CRYPTOUPDATEACCOUNT",
-        "type": "15"
+        "type": "15",
+        "entity_id": "0.0.8"
       }
     ],
     "cryptotransfers": [

--- a/hedera-mirror-rest/__tests__/specs/transactions-07-credit-type.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-07-credit-type.spec.json
@@ -72,6 +72,7 @@
     "transactions": [
       {
         "consensus_timestamp": "1565779333.711927001",
+        "entity_id": null,
         "valid_start_timestamp": "1565779333.711927000",
         "charged_tx_fee": 7,
         "memo_base64": null,
@@ -100,6 +101,7 @@
       },
       {
         "consensus_timestamp": "1565779209.711927001",
+        "entity_id": null,
         "valid_start_timestamp": "1565779209.711927000",
         "charged_tx_fee": 7,
         "memo_base64": null,
@@ -128,6 +130,7 @@
       },
       {
         "consensus_timestamp": "1565779111.711927001",
+        "entity_id": null,
         "valid_start_timestamp": "1565779111.711927000",
         "charged_tx_fee": 7,
         "memo_base64": null,

--- a/hedera-mirror-rest/__tests__/specs/transactions-08-debit-type.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-08-debit-type.spec.json
@@ -26,7 +26,8 @@
         "nodeAccountId": "0.0.3",
         "consensus_timestamp": "1565779444711927001",
         "name": "CRYPTOUPDATEACCOUNT",
-        "type": "15"
+        "type": "15",
+        "entity_id": "0.0.8"
       }
     ],
     "cryptotransfers": [

--- a/hedera-mirror-rest/__tests__/specs/transactions-08-debit-type.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-08-debit-type.spec.json
@@ -73,6 +73,7 @@
       {
         "charged_tx_fee": 7,
         "consensus_timestamp": "1565779209.711927001",
+        "entity_id": null,
         "max_fee": "33",
         "memo_base64": null,
         "name": "CRYPTOTRANSFER",
@@ -101,6 +102,7 @@
       {
         "charged_tx_fee": 7,
         "consensus_timestamp": "1565779111.711927001",
+        "entity_id": null,
         "max_fee": "33",
         "memo_base64": null,
         "name": "CRYPTOTRANSFER",

--- a/hedera-mirror-rest/__tests__/specs/transactions-09-account-id.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-09-account-id.spec.json
@@ -26,7 +26,8 @@
         "nodeAccountId": "0.0.3",
         "consensus_timestamp": "1565779444711927001",
         "name": "CRYPTOUPDATEACCOUNT",
-        "type": "15"
+        "type": "15",
+        "entity_id": "0.0.8"
       }
     ],
     "cryptotransfers": [
@@ -67,7 +68,7 @@
       {
         "charged_tx_fee": 0,
         "consensus_timestamp": "1565779444.711927001",
-        "entity_id": null,
+        "entity_id": "0.0.8",
         "max_fee": "33",
         "memo_base64": null,
         "name": "CRYPTOUPDATEACCOUNT",

--- a/hedera-mirror-rest/__tests__/specs/transactions-09-account-id.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-09-account-id.spec.json
@@ -67,6 +67,7 @@
       {
         "charged_tx_fee": 0,
         "consensus_timestamp": "1565779444.711927001",
+        "entity_id": null,
         "max_fee": "33",
         "memo_base64": null,
         "name": "CRYPTOUPDATEACCOUNT",
@@ -82,6 +83,7 @@
       {
         "charged_tx_fee": 7,
         "consensus_timestamp": "1565779333.711927001",
+        "entity_id": null,
         "max_fee": "33",
         "memo_base64": null,
         "name": "CRYPTOTRANSFER",
@@ -110,6 +112,7 @@
       {
         "charged_tx_fee": 7,
         "consensus_timestamp": "1565779209.711927001",
+        "entity_id": null,
         "max_fee": "33",
         "memo_base64": null,
         "name": "CRYPTOTRANSFER",

--- a/hedera-mirror-rest/__tests__/specs/transactions-10-all-params.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-10-all-params.spec.json
@@ -72,6 +72,7 @@
     "transactions": [
       {
         "consensus_timestamp": "1565779209.711927001",
+        "entity_id": null,
         "valid_start_timestamp": "1565779209.711927000",
         "charged_tx_fee": 7,
         "memo_base64": null,

--- a/hedera-mirror-rest/__tests__/specs/transactions-10-all-params.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-10-all-params.spec.json
@@ -26,7 +26,8 @@
         "nodeAccountId": "0.0.3",
         "consensus_timestamp": "1565779444711927001",
         "name": "CRYPTOUPDATEACCOUNT",
-        "type": "15"
+        "type": "15",
+        "entity_id": "0.0.8"
       }
     ],
     "cryptotransfers": [

--- a/hedera-mirror-rest/__tests__/specs/transactions-11-not-found.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-11-not-found.spec.json
@@ -23,7 +23,8 @@
         "nodeAccountId": "0.0.3",
         "consensus_timestamp": "1234567890000000008",
         "name": "CRYPTOUPDATEACCOUNT",
-        "type": "15"
+        "type": "15",
+        "entity_id": "0.0.8"
       }
     ],
     "cryptotransfers": [

--- a/hedera-mirror-rest/__tests__/specs/transactions-14-repeated-valid-params.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-14-repeated-valid-params.spec.json
@@ -26,7 +26,8 @@
         "nodeAccountId": "0.0.3",
         "consensus_timestamp": "1565779444711927001",
         "name": "CRYPTOUPDATEACCOUNT",
-        "type": "15"
+        "type": "15",
+        "entity_id": "0.0.8"
       }
     ],
     "cryptotransfers": [

--- a/hedera-mirror-rest/__tests__/specs/transactions-15-limit.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-15-limit.spec.json
@@ -94,6 +94,7 @@
       {
         "charged_tx_fee": 7,
         "consensus_timestamp": "1565779666.711927001",
+        "entity_id": null,
         "max_fee": "33",
         "memo_base64": null,
         "name": "CRYPTOTRANSFER",
@@ -122,6 +123,7 @@
       {
         "charged_tx_fee": 0,
         "consensus_timestamp": "1565779600.711927001",
+        "entity_id": null,
         "max_fee": "33",
         "memo_base64": null,
         "name": "CRYPTOUPDATEACCOUNT",

--- a/hedera-mirror-rest/__tests__/specs/transactions-15-limit.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-15-limit.spec.json
@@ -26,7 +26,8 @@
         "nodeAccountId": "0.0.3",
         "consensus_timestamp": "1565779600711927001",
         "name": "CRYPTOUPDATEACCOUNT",
-        "type": "15"
+        "type": "15",
+        "entity_id": "0.0.8"
       }
     ],
     "cryptotransfers": [
@@ -123,7 +124,7 @@
       {
         "charged_tx_fee": 0,
         "consensus_timestamp": "1565779600.711927001",
-        "entity_id": null,
+        "entity_id": "0.0.8",
         "max_fee": "33",
         "memo_base64": null,
         "name": "CRYPTOUPDATEACCOUNT",

--- a/hedera-mirror-rest/__tests__/specs/transactions-16-specific-id-tokentransfer.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-16-specific-id-tokentransfer.spec.json
@@ -49,6 +49,7 @@
     "transactions": [
       {
         "consensus_timestamp": "1565779555.711927001",
+        "entity_id": null,
         "valid_start_timestamp": "1565779555.711927000",
         "charged_tx_fee": 7,
         "memo_base64": null,

--- a/hedera-mirror-rest/__tests__/specs/transactions-17-transaction-type.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-17-transaction-type.spec.json
@@ -71,6 +71,7 @@
     "transactions": [
       {
         "consensus_timestamp": "1565779555.711927002",
+        "entity_id": null,
         "valid_start_timestamp": "1565779555.711927001",
         "charged_tx_fee": 7,
         "memo_base64": null,

--- a/hedera-mirror-rest/__tests__/specs/transactions-17-transaction-type.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-17-transaction-type.spec.json
@@ -26,14 +26,16 @@
         "nodeAccountId": "0.0.3",
         "consensus_timestamp": "1565779555711927001",
         "name": "TOKENCREATION",
-        "type": "29"
+        "type": "29",
+        "entity_id": "0.0.90000"
       },
       {
         "payerAccountId": "0.0.9",
         "nodeAccountId": "0.0.3",
         "consensus_timestamp": "1565779555711927003",
         "name": "CRYPTODELETE",
-        "type": "12"
+        "type": "12",
+        "entity_id": "0.0.7"
       },
       {
         "charged_tx_fee": 0,
@@ -41,7 +43,8 @@
         "nodeAccountId": "0.0.3",
         "consensus_timestamp": "1565779444711927001",
         "name": "CRYPTOUPDATEACCOUNT",
-        "type": "15"
+        "type": "15",
+        "entity_id": "0.0.10"
       }
     ],
     "cryptotransfers": [

--- a/hedera-mirror-rest/__tests__/specs/transactions-18-specific-id-no-transfers.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-18-specific-id-no-transfers.spec.json
@@ -34,6 +34,7 @@
     "transactions": [
       {
         "consensus_timestamp": "1234567890.999999999",
+        "entity_id": null,
         "valid_start_timestamp": "1234567890.999999998",
         "charged_tx_fee": 0,
         "memo_base64": null,

--- a/hedera-mirror-rest/__tests__/specs/transactions-18-specific-id-no-transfers.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-18-specific-id-no-transfers.spec.json
@@ -23,7 +23,8 @@
         "nodeAccountId": "0.0.3",
         "consensus_timestamp": "1234567890999999999",
         "name": "CRYPTOUPDATEACCOUNT",
-        "type": "15"
+        "type": "15",
+        "entity_id": "0.0.9"
       }
     ],
     "cryptotransfers": []
@@ -34,7 +35,7 @@
     "transactions": [
       {
         "consensus_timestamp": "1234567890.999999999",
-        "entity_id": null,
+        "entity_id": "0.0.9",
         "valid_start_timestamp": "1234567890.999999998",
         "charged_tx_fee": 0,
         "memo_base64": null,

--- a/hedera-mirror-rest/__tests__/specs/transactions-19-timestamp-no-transfers.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-19-timestamp-no-transfers.spec.json
@@ -26,7 +26,8 @@
         "nodeAccountId": "0.0.3",
         "consensus_timestamp": "1565779209711927001",
         "name": "CRYPTOUPDATEACCOUNT",
-        "type": "15"
+        "type": "15",
+        "entity_id": "0.0.8"
       }
     ],
     "cryptotransfers": [
@@ -54,7 +55,7 @@
     "transactions": [
       {
         "consensus_timestamp": "1565779209.711927001",
-        "entity_id": null,
+        "entity_id": "0.0.8",
         "valid_start_timestamp": "1565779209.711927000",
         "charged_tx_fee": 0,
         "memo_base64": null,

--- a/hedera-mirror-rest/__tests__/specs/transactions-19-timestamp-no-transfers.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-19-timestamp-no-transfers.spec.json
@@ -54,6 +54,7 @@
     "transactions": [
       {
         "consensus_timestamp": "1565779209.711927001",
+        "entity_id": null,
         "valid_start_timestamp": "1565779209.711927000",
         "charged_tx_fee": 0,
         "memo_base64": null,

--- a/hedera-mirror-rest/__tests__/specs/transactions-20-specific-id-scheduled-true.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-20-specific-id-scheduled-true.spec.json
@@ -77,6 +77,7 @@
       {
         "charged_tx_fee": 7,
         "consensus_timestamp": "1234567890.000000003",
+        "entity_id": null,
         "max_fee": "33",
         "memo_base64": null,
         "name": "CRYPTOTRANSFER",

--- a/hedera-mirror-rest/__tests__/specs/transactions-20-specific-id-scheduled-true.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-20-specific-id-scheduled-true.spec.json
@@ -34,7 +34,8 @@
             "account": "0.0.98",
             "amount": 1
           }
-        ]
+        ],
+        "entity_id": "0.0.1000"
       },
       {
         "charged_tx_fee": 7,

--- a/hedera-mirror-rest/__tests__/specs/transactions-21-specific-id-scheduled-true-not-found.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-21-specific-id-scheduled-true-not-found.spec.json
@@ -34,7 +34,8 @@
             "account": "0.0.98",
             "amount": 1
           }
-        ]
+        ],
+        "entity_id": "0.0.1000"
       },
       {
         "charged_tx_fee": 7,

--- a/hedera-mirror-rest/__tests__/specs/transactions-22-specific-id-scheduled-false.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-22-specific-id-scheduled-false.spec.json
@@ -34,7 +34,8 @@
             "account": "0.0.98",
             "amount": 1
           }
-        ]
+        ],
+        "entity_id": "0.0.1000"
       },
       {
         "charged_tx_fee": 7,
@@ -76,7 +77,7 @@
     "transactions": [
       {
         "consensus_timestamp": "1234567890.000000002",
-        "entity_id": null,
+        "entity_id": "0.0.1000",
         "charged_tx_fee": 7,
         "max_fee": "33",
         "memo_base64": null,

--- a/hedera-mirror-rest/__tests__/specs/transactions-22-specific-id-scheduled-false.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-22-specific-id-scheduled-false.spec.json
@@ -76,6 +76,7 @@
     "transactions": [
       {
         "consensus_timestamp": "1234567890.000000002",
+        "entity_id": null,
         "charged_tx_fee": 7,
         "max_fee": "33",
         "memo_base64": null,
@@ -101,6 +102,7 @@
       {
         "charged_tx_fee": 7,
         "consensus_timestamp": "1234567890.000000040",
+        "entity_id": null,
         "max_fee": "33",
         "memo_base64": null,
         "name": "CRYPTOTRANSFER",

--- a/hedera-mirror-rest/__tests__/specs/transactions-24-specific-id-repeated-valid-params-schedule-false.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-24-specific-id-repeated-valid-params-schedule-false.spec.json
@@ -34,7 +34,8 @@
             "account": "0.0.98",
             "amount": 1
           }
-        ]
+        ],
+        "entity_id": "0.0.1000"
       },
       {
         "charged_tx_fee": 7,
@@ -77,7 +78,7 @@
       {
         "charged_tx_fee": 7,
         "consensus_timestamp": "1234567890.000000002",
-        "entity_id": null,
+        "entity_id": "0.0.1000",
         "max_fee": "33",
         "memo_base64": null,
         "name": "SCHEDULECREATE",

--- a/hedera-mirror-rest/__tests__/specs/transactions-24-specific-id-repeated-valid-params-schedule-false.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-24-specific-id-repeated-valid-params-schedule-false.spec.json
@@ -77,6 +77,7 @@
       {
         "charged_tx_fee": 7,
         "consensus_timestamp": "1234567890.000000002",
+        "entity_id": null,
         "max_fee": "33",
         "memo_base64": null,
         "name": "SCHEDULECREATE",
@@ -101,6 +102,7 @@
       {
         "charged_tx_fee": 7,
         "consensus_timestamp": "1234567890.000000040",
+        "entity_id": null,
         "max_fee": "33",
         "memo_base64": null,
         "name": "CRYPTOTRANSFER",

--- a/hedera-mirror-rest/__tests__/specs/transactions-25-specific-id-repeated-valid-params-schedule-true.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-25-specific-id-repeated-valid-params-schedule-true.spec.json
@@ -77,6 +77,7 @@
       {
         "charged_tx_fee": 7,
         "consensus_timestamp": "1234567890.000000003",
+        "entity_id": null,
         "max_fee": "33",
         "memo_base64": null,
         "name": "CRYPTOTRANSFER",

--- a/hedera-mirror-rest/__tests__/specs/transactions-25-specific-id-repeated-valid-params-schedule-true.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-25-specific-id-repeated-valid-params-schedule-true.spec.json
@@ -34,7 +34,8 @@
             "account": "0.0.98",
             "amount": 1
           }
-        ]
+        ],
+        "entity_id": "0.0.1000"
       },
       {
         "charged_tx_fee": 7,

--- a/hedera-mirror-rest/__tests__/specs/transactions-27-multiple-account-ids.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-27-multiple-account-ids.spec.json
@@ -74,6 +74,7 @@
       {
         "charged_tx_fee": 0,
         "consensus_timestamp": "1565779444.711927001",
+        "entity_id": null,
         "max_fee": "33",
         "memo_base64": null,
         "name": "CRYPTOUPDATEACCOUNT",
@@ -89,6 +90,7 @@
       {
         "charged_tx_fee": 7,
         "consensus_timestamp": "1565779333.711927001",
+        "entity_id": null,
         "max_fee": "33",
         "memo_base64": null,
         "name": "CRYPTOTRANSFER",
@@ -117,6 +119,7 @@
       {
         "charged_tx_fee": 7,
         "consensus_timestamp": "1565779209.711927001",
+        "entity_id": null,
         "max_fee": "33",
         "memo_base64": null,
         "name": "CRYPTOTRANSFER",
@@ -145,6 +148,7 @@
       {
         "charged_tx_fee": 7,
         "consensus_timestamp": "1565779111.711927001",
+        "entity_id": null,
         "max_fee": "33",
         "memo_base64": null,
         "name": "CRYPTOTRANSFER",

--- a/hedera-mirror-rest/__tests__/specs/transactions-27-multiple-account-ids.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-27-multiple-account-ids.spec.json
@@ -29,7 +29,8 @@
         "nodeAccountId": "0.0.3",
         "consensus_timestamp": "1565779444711927001",
         "name": "CRYPTOUPDATEACCOUNT",
-        "type": "15"
+        "type": "15",
+        "entity_id": "0.0.11"
       }
     ],
     "cryptotransfers": [
@@ -74,7 +75,7 @@
       {
         "charged_tx_fee": 0,
         "consensus_timestamp": "1565779444.711927001",
-        "entity_id": null,
+        "entity_id": "0.0.11",
         "max_fee": "33",
         "memo_base64": null,
         "name": "CRYPTOUPDATEACCOUNT",

--- a/hedera-mirror-rest/__tests__/specs/transactions-28-account-id-only-token-transfers.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-28-account-id-only-token-transfers.spec.json
@@ -60,6 +60,7 @@
     "transactions": [
       {
         "consensus_timestamp": "1234567890.000000001",
+        "entity_id": null,
         "valid_start_timestamp": "1234567890.000000000",
         "charged_tx_fee": 7,
         "memo_base64": null,

--- a/hedera-mirror-rest/__tests__/specs/transactions-29-tokenwipe.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-29-tokenwipe.spec.json
@@ -33,7 +33,9 @@
             "account": "0.0.9",
             "amount": -20
           }
-        ]
+        ],
+        "name": "TOKENWIPE",
+        "entity_id": "0.0.90000"
       }
     ]
   },
@@ -43,7 +45,7 @@
     "transactions": [
       {
         "consensus_timestamp": "1234567890.000000001",
-        "entity_id": null,
+        "entity_id": "0.0.90000",
         "valid_start_timestamp": "1234567890.000000000",
         "charged_tx_fee": 7,
         "memo_base64": null,

--- a/hedera-mirror-rest/__tests__/specs/transactions-29-tokenwipe.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-29-tokenwipe.spec.json
@@ -43,6 +43,7 @@
     "transactions": [
       {
         "consensus_timestamp": "1234567890.000000001",
+        "entity_id": null,
         "valid_start_timestamp": "1234567890.000000000",
         "charged_tx_fee": 7,
         "memo_base64": null,

--- a/hedera-mirror-rest/__tests__/specs/transactions-30-specific-id-tokenwipe.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-30-specific-id-tokenwipe.spec.json
@@ -27,7 +27,9 @@
             "account": "0.0.9",
             "amount": -20
           }
-        ]
+        ],
+        "name": "TOKENWIPE",
+        "entity_id": "0.0.90000"
       }
     ]
   },
@@ -37,7 +39,7 @@
     "transactions": [
       {
         "consensus_timestamp": "1234567890.000000001",
-        "entity_id": null,
+        "entity_id": "0.0.90000",
         "valid_start_timestamp": "1234567890.000000000",
         "charged_tx_fee": 7,
         "memo_base64": null,

--- a/hedera-mirror-rest/__tests__/specs/transactions-30-specific-id-tokenwipe.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-30-specific-id-tokenwipe.spec.json
@@ -37,6 +37,7 @@
     "transactions": [
       {
         "consensus_timestamp": "1234567890.000000001",
+        "entity_id": null,
         "valid_start_timestamp": "1234567890.000000000",
         "charged_tx_fee": 7,
         "memo_base64": null,

--- a/hedera-mirror-rest/__tests__/specs/transactions-31-credit-type-only-token-transfers.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-31-credit-type-only-token-transfers.spec.json
@@ -84,6 +84,7 @@
     "transactions": [
       {
         "consensus_timestamp": "1234567890.000000001",
+        "entity_id": null,
         "valid_start_timestamp": "1234567890.000000000",
         "charged_tx_fee": 7,
         "memo_base64": null,

--- a/hedera-mirror-rest/__tests__/specs/transactions-32-debit-type-only-token-transfers.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-32-debit-type-only-token-transfers.spec.json
@@ -84,6 +84,7 @@
     "transactions": [
       {
         "consensus_timestamp": "1234567890.000000001",
+        "entity_id": null,
         "valid_start_timestamp": "1234567890.000000000",
         "charged_tx_fee": 7,
         "memo_base64": null,

--- a/hedera-mirror-rest/__tests__/specs/transactions-33-credit-type-crypyo-and-token-transfers.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-33-credit-type-crypyo-and-token-transfers.spec.json
@@ -121,6 +121,7 @@
     "transactions": [
       {
         "consensus_timestamp": "1234567890.000000005",
+        "entity_id": null,
         "valid_start_timestamp": "1234567890.000000004",
         "charged_tx_fee": 7,
         "memo_base64": null,
@@ -166,6 +167,7 @@
       },
       {
         "consensus_timestamp": "1234567890.000000003",
+        "entity_id": null,
         "valid_start_timestamp": "1234567890.000000002",
         "charged_tx_fee": 7,
         "memo_base64": null,
@@ -194,6 +196,7 @@
       },
       {
         "consensus_timestamp": "1234567890.000000001",
+        "entity_id": null,
         "valid_start_timestamp": "1234567890.000000000",
         "charged_tx_fee": 7,
         "memo_base64": null,

--- a/hedera-mirror-rest/__tests__/specs/transactions-34-debit-type-crypyo-and-token-transfers.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-34-debit-type-crypyo-and-token-transfers.spec.json
@@ -121,6 +121,7 @@
     "transactions": [
       {
         "consensus_timestamp": "1234567890.000000005",
+        "entity_id": null,
         "valid_start_timestamp": "1234567890.000000004",
         "charged_tx_fee": 7,
         "memo_base64": null,
@@ -166,6 +167,7 @@
       },
       {
         "consensus_timestamp": "1234567890.000000003",
+        "entity_id": null,
         "valid_start_timestamp": "1234567890.000000002",
         "charged_tx_fee": 7,
         "memo_base64": null,
@@ -194,6 +196,7 @@
       },
       {
         "consensus_timestamp": "1234567890.000000001",
+        "entity_id": null,
         "valid_start_timestamp": "1234567890.000000000",
         "charged_tx_fee": 7,
         "memo_base64": null,

--- a/hedera-mirror-rest/__tests__/transactions.test.js
+++ b/hedera-mirror-rest/__tests__/transactions.test.js
@@ -140,6 +140,7 @@ const validateFields = function (transactions) {
     'max_fee',
     'transaction_hash',
     'scheduled',
+    'entity_id',
   ].forEach((field) => {
     if (!(field in transaction)) {
       errors.push(`missing field "${field}"`);

--- a/hedera-mirror-rest/transactions.js
+++ b/hedera-mirror-rest/transactions.js
@@ -57,7 +57,8 @@ const getSelectClauseWithTokenTransferOrder = (order) => {
        t.valid_duration_seconds,
        t.max_fee,
        t.transaction_hash,
-       t.scheduled`;
+       t.scheduled,
+       t.entity_id`;
 };
 
 /**
@@ -101,6 +102,7 @@ const createTransferLists = (rows) => {
       transactions[row.consensus_ns] = {
         charged_tx_fee: Number(row.charged_tx_fee),
         consensus_timestamp: utils.nsToSecNs(row.consensus_ns),
+        entity_id: EntityId.fromEncodedId(row.entity_id, true).toString(),
         id: row.id,
         max_fee: utils.getNullableNumber(row.max_fee),
         memo_base64: utils.encodeBase64(row.memo),


### PR DESCRIPTION
**Detailed description**:
Currently there's no way to know from an entity impacting transaction what the entity_id is e.g. a transaction that creates a crypto account doesn't say what the entityId is

- Add `entity_id` from transaction into select statement for transactions
- Update spec test files with new column
- Update mock pool file to support new column

**Which issue(s) this PR fixes**:
Fixes #1639 

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated

