### PR TITLE
Fix master deploy failing

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -26,7 +26,7 @@ jobs:
         run: ./mvnw ${MAVEN_CLI_OPTS} dependency-check:aggregate
 
   sonar:
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.pull_request.head.repo.full_name == github.repository && !contains(github.head_ref, 'dependabot/')
     name: SonarCloud
     runs-on: ubuntu-latest
     steps:

--- a/hedera-mirror-rosetta/pom.xml
+++ b/hedera-mirror-rosetta/pom.xml
@@ -15,6 +15,8 @@
     </parent>
 
     <properties>
+        <go.dir>${user.home}/.m2/repository/com/igormaznitsa/mvn-golang-wrapper</go.dir>
+        <maven.install.skip>true</maven.install.skip>
         <sonar.exclusions>pom.xml</sonar.exclusions>
         <sonar.sources>${project.basedir}</sonar.sources>
         <sonar.go.coverage.reportPaths>${project.basedir}/coverage.txt</sonar.go.coverage.reportPaths>
@@ -22,7 +24,7 @@
 
     <build>
         <defaultGoal>clean package</defaultGoal>
-        <directory>${basedir}${file.separator}bin</directory>
+        <directory>${basedir}/bin</directory>
         <finalName>${project.artifactId}</finalName>
         <sourceDirectory>${project.basedir}</sourceDirectory>
         <plugins>
@@ -35,9 +37,10 @@
                 <artifactId>mvn-golang-wrapper</artifactId>
                 <version>2.3.8</version>
                 <configuration>
+                    <goPath>${go.dir}/path</goPath>
                     <goVersion>1.16</goVersion>
                     <hideBanner>true</hideBanner>
-                    <storeFolder>${user.home}/.m2/repository/com/igormaznitsa/mvn-golang-wrapper</storeFolder>
+                    <storeFolder>${go.dir}/store</storeFolder>
                     <useEnvVars>true</useEnvVars>
                 </configuration>
                 <extensions>true</extensions>
@@ -63,7 +66,13 @@
                                 <flag>-i</flag>
                                 <flag>-race</flag>
                             </buildFlags>
-                            <sources>${project.basedir}${file.separator}cmd</sources>
+                            <sources>${project.basedir}/cmd</sources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>default-install</id>
+                        <configuration>
+                            <sources>${project.basedir}/cmd</sources>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
**Detailed description**:
- Fix image push [failing](https://github.com/hashgraph/hedera-mirror-node/runs/2233544994?check_suite_focus=true) due to Go deploy task failure
- Fix Dependabot PRs [failing](https://github.com/hashgraph/hedera-mirror-node/runs/2239832143?check_suite_focus=true) on SonarCloud task
- Fix `mvn-golang-wrapper` not storing go modules in cached m2 folder
- Fix slow `mvn-golang-wrapper:mvninstall` task by disabling it

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:
Haven't confirmed since I don't run Windows, but apparently using forward slashes in Maven instead of `${file.separator}` works fine on Windows.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

