### PR TITLE
fix test failure caused by timing precision

### DIFF
--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/generator/CompositeTransactionGeneratorTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/generator/CompositeTransactionGeneratorTest.java
@@ -244,7 +244,7 @@ class CompositeTransactionGeneratorTest {
 
         long elapsed = System.currentTimeMillis() - begin;
         assertThat(generator.transactionGenerators).isEmpty();
-        assertThat(elapsed).isBetween(5000L, 5100L);
+        assertThat(elapsed).isBetween(4950L, 5100L);
     }
 
     private void assertInactive() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
-->

**Detailed description**:

- Adjust the lower bound from 5000ms to 4950ms

**Which issue(s) this PR fixes**:
Fixes #1819 

**Special notes for your reviewer**:
It should be caused by the system time precision at milliseconds, so far when it tails, `elapsed` is always 4999ms. Adjusting the lower bound to 4950ms should suffice.

**Checklist**
- [ ] Documentation added
- [x] Tests updated

