### PR TITLE
Add cloud storage metrics

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/MetricsExecutionInterceptor.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/MetricsExecutionInterceptor.java
@@ -121,7 +121,7 @@ public class MetricsExecutionInterceptor implements ExecutionInterceptor {
     private String getAction(String uri) {
         if (uri.contains("marker")) {
             return "list";
-        } else if (uri.endsWith("_sig")) {
+        } else if (uri.contains(StreamType.SIGNATURE_SUFFIX)) {
             return "signature";
         } else {
             return "signed";

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/MetricsExecutionInterceptor.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/MetricsExecutionInterceptor.java
@@ -53,7 +53,7 @@ import com.hedera.mirror.importer.domain.StreamType;
 @RequiredArgsConstructor
 public class MetricsExecutionInterceptor implements ExecutionInterceptor {
 
-    private static final Pattern ENTITY_ID_PATTERN = Pattern.compile("(\\d+\\.\\d+\\.\\d+)");
+    private static final Pattern ENTITY_ID_PATTERN = Pattern.compile("(\\d{1,10}\\.\\d{1,10}\\.\\d{1,10})");
     private static final ExecutionAttribute<ResponseSizeSubscriber> SIZE = new ExecutionAttribute("size");
     private static final ExecutionAttribute<Instant> START_TIME = new ExecutionAttribute("start-time");
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/PendingDownload.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/PendingDownload.java
@@ -62,8 +62,8 @@ class PendingDownload {
         return future.get().asByteArrayUnsafe();
     }
 
-    String getFilename() {
-        return streamFilename.getFilename();
+    GetObjectResponse getObjectResponse() throws Exception {
+        return future.get().response();
     }
 
     /**

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/PendingDownload.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/PendingDownload.java
@@ -58,11 +58,11 @@ class PendingDownload {
         this.s3key = s3key;
     }
 
-    byte[] getBytes() throws Exception {
+    byte[] getBytes() throws ExecutionException, InterruptedException {
         return future.get().asByteArrayUnsafe();
     }
 
-    GetObjectResponse getObjectResponse() throws Exception {
+    GetObjectResponse getObjectResponse() throws ExecutionException, InterruptedException {
         return future.get().response();
     }
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/record/RecordFileDownloader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/record/RecordFileDownloader.java
@@ -21,10 +21,6 @@ package com.hedera.mirror.importer.downloader.record;
  */
 
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Timer;
-import java.time.Duration;
-import java.time.Instant;
-import java.util.concurrent.TimeUnit;
 import javax.inject.Named;
 import org.springframework.scheduling.annotation.Scheduled;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
@@ -42,9 +38,6 @@ import com.hedera.mirror.importer.reader.signature.SignatureFileReader;
 @Named
 public class RecordFileDownloader extends Downloader<RecordFile> {
 
-    private final Timer downloadLatencyMetric;
-    private final Timer streamCloseMetric;
-
     public RecordFileDownloader(
             S3AsyncClient s3Client, AddressBookService addressBookService,
             RecordDownloaderProperties downloaderProperties,
@@ -55,18 +48,6 @@ public class RecordFileDownloader extends Downloader<RecordFile> {
         super(s3Client, addressBookService, downloaderProperties, meterRegistry,
                 nodeSignatureVerifier, signatureFileReader, recordFileReader, streamFileNotifier,
                 mirrorDateRangePropertiesProcessor);
-
-        downloadLatencyMetric = Timer.builder("hedera.mirror.download.latency")
-                .description("The difference in ms between the consensus time of the last transaction in the file " +
-                        "and the time at which the file was downloaded and verified")
-                .tag("type", downloaderProperties.getStreamType().toString())
-                .register(meterRegistry);
-
-        streamCloseMetric = Timer.builder("hedera.mirror.stream.close.latency")
-                .description("The difference between the consensus time of the last and first transaction in the " +
-                        "stream file")
-                .tag("type", downloaderProperties.getStreamType().toString())
-                .register(meterRegistry);
     }
 
     @Override
@@ -74,14 +55,5 @@ public class RecordFileDownloader extends Downloader<RecordFile> {
     @Scheduled(fixedDelayString = "${hedera.mirror.importer.downloader.record.frequency:500}")
     public void download() {
         downloadNextBatch();
-    }
-
-    @Override
-    protected void onVerified(RecordFile recordFile) {
-        Instant consensusEnd = Instant.ofEpochSecond(0, recordFile.getConsensusEnd());
-        downloadLatencyMetric.record(Duration.between(consensusEnd, Instant.now()));
-
-        long streamClose = recordFile.getConsensusEnd() - recordFile.getConsensusStart();
-        streamCloseMetric.record(streamClose, TimeUnit.NANOSECONDS);
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/event/EventFileReaderV3.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/event/EventFileReaderV3.java
@@ -47,9 +47,11 @@ public class EventFileReaderV3 implements EventFileReader {
     @Override
     public EventFile read(StreamFileData streamFileData, Consumer<EventItem> itemConsumer) {
         String fileName = streamFileData.getFilename();
+        long consensusStart = Utility.convertToNanosMax(streamFileData.getInstant());
         EventFile eventFile = new EventFile();
         eventFile.setBytes(streamFileData.getBytes());
-        eventFile.setConsensusStart(Utility.convertToNanosMax(streamFileData.getInstant()));
+        eventFile.setConsensusEnd(consensusStart); // TODO: Extract last consensus timestamp from transactions
+        eventFile.setConsensusStart(consensusStart);
         eventFile.setCount(0L);
         eventFile.setDigestAlgorithm(DIGEST_ALGORITHM);
         eventFile.setLoadStart(Instant.now().getEpochSecond());

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/event/EventFileReaderV3.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/event/EventFileReaderV3.java
@@ -50,7 +50,7 @@ public class EventFileReaderV3 implements EventFileReader {
         long consensusStart = Utility.convertToNanosMax(streamFileData.getInstant());
         EventFile eventFile = new EventFile();
         eventFile.setBytes(streamFileData.getBytes());
-        eventFile.setConsensusEnd(consensusStart); // TODO: Extract last consensus timestamp from transactions
+        eventFile.setConsensusEnd(consensusStart);
         eventFile.setConsensusStart(consensusStart);
         eventFile.setCount(0L);
         eventFile.setDigestAlgorithm(DIGEST_ALGORITHM);

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/event/EventFileReaderV3Test.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/event/EventFileReaderV3Test.java
@@ -21,22 +21,18 @@ package com.hedera.mirror.importer.reader.event;
  */
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.google.common.primitives.Ints;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
-import java.util.UUID;
-
-import com.hedera.mirror.importer.util.Utility;
-
 import org.apache.commons.codec.binary.Hex;
 import org.junit.jupiter.api.Test;
 
 import com.hedera.mirror.importer.domain.EventFile;
 import com.hedera.mirror.importer.domain.StreamFileData;
 import com.hedera.mirror.importer.exception.InvalidEventFileException;
+import com.hedera.mirror.importer.util.Utility;
 
 class EventFileReaderV3Test {
 
@@ -121,9 +117,11 @@ class EventFileReaderV3Test {
 
     private void verifyForSuccess(EventFile eventFile, StreamFileData inputFile, int expectedFileVersion,
                                   byte[] expectedPrevHash) {
+        long consensusStart = Utility.convertToNanosMax(inputFile.getInstant());
         assertThat(eventFile).isNotNull();
         assertThat(eventFile.getBytes()).isNotEmpty().isEqualTo(inputFile.getBytes());
-        assertThat(eventFile.getConsensusStart()).isEqualTo(Utility.convertToNanosMax(inputFile.getInstant()));
+        assertThat(eventFile.getConsensusStart()).isEqualTo(consensusStart);
+        assertThat(eventFile.getConsensusEnd()).isEqualTo(consensusStart);
         assertThat(eventFile.getLoadStart()).isNotNull().isPositive();
         assertThat(eventFile.getName()).isEqualTo(inputFile.getFilename());
         assertThat(eventFile.getVersion()).isEqualTo(expectedFileVersion);


### PR DESCRIPTION
**Detailed description**:
- Add `hedera.mirror.importer.cloud.latency` metric to compare consensus time against cloud storage creation time
- Add `hedera.mirror.download.latency` metric to all stream types
- Add `hedera.mirror.stream.close.latency` metric to all stream types
- Fix event file not persisting due to missing required consensus end field
- Fix cloud storage response size and time metrics not counting `_sig.gz` files as signature files

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated

