### PR TITLE
Fix monitor chart's default mirror node hosts

### DIFF
--- a/charts/hedera-mirror-monitor/values.yaml
+++ b/charts/hedera-mirror-monitor/values.yaml
@@ -20,8 +20,6 @@ config:
 
 # Environment variables to add to the container. The value can either be a string or an EnvVarSource. Evaluated as a template.
 env:
-  HEDERA_MIRROR_MONITOR_MIRROR_NODE_HOST_GRPC: "{{ .Release.Name }}-grpc"
-  HEDERA_MIRROR_MONITOR_MIRROR_NODE_HOST_REST: "{{ .Release.Name }}-rest"
   SPRING_CLOUD_KUBERNETES_ENABLED: "true"
   SPRING_CONFIG_ADDITIONAL_LOCATION: "file:/usr/etc/hedera/"
   # FOO:

--- a/charts/hedera-mirror/values.yaml
+++ b/charts/hedera-mirror/values.yaml
@@ -68,6 +68,9 @@ labels: {}
 
 monitor:
   enabled: true
+  env:
+    HEDERA_MIRROR_MONITOR_MIRROR_NODE_GRPC_HOST: "{{ .Release.Name }}-grpc"
+    HEDERA_MIRROR_MONITOR_MIRROR_NODE_REST_HOST: "{{ .Release.Name }}-rest"
 
 networkPolicy:
   enabled: false


### PR DESCRIPTION
**Detailed description**:
- Fix monitor chart's default mirror node hosts using wrong environment variable
- Move monitor environment variable to parent chart since it only applies when deploying parent

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

