### PR TITLE
Automate release process

### DIFF
--- a/.github/release-notes.yml
+++ b/.github/release-notes.yml
@@ -1,0 +1,16 @@
+changelog:
+  contributors:
+    title: "Contributors"
+  issues:
+    exclude:
+      labels: ["wontfix", "question", "duplicate", "invalid"]
+  repository: hashgraph/hedera-mirror-node
+  sections:
+  - title: "Enhancements"
+    labels: ["enhancement"]
+  - title: "Bug Fixes"
+    labels: ["bug"]
+  - title: "Documentation"
+    labels: ["documentation", "docs"]
+  - title: "Dependency Upgrades"
+    labels: ["dependency-upgrade", "dependencies"]

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,237 @@
+name: Automated Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version (semver)'
+        required: true
+      chartVersion:
+        description: 'Chart Version (semver)'
+        required: true
+      description:
+        description: 'Description'
+        required: false
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    env:
+      CHANGELOG: CHANGELOG.md
+      RELEASE_NOTES_FILENAME: release_notes
+      RELEASE_NOTES_FULLNAME: release_notes.md
+    outputs:
+      create_pr: ${{ env.CREATE_PR }}
+      next_chart_version_snapshot: ${{ env.NEXT_CHART_VERSION_SNAPSHOT }}
+      next_version_snapshot: ${{ env.NEXT_VERSION_SNAPSHOT }}
+      pr_title: ${{ env.PR_TITLE }}
+      release_branch: ${{ env.RELEASE_BRANCH }}
+
+    steps:
+      - name: Parse Version
+        id: version_parser
+        uses: terradatum/semver-action@v1
+        with:
+          bump: preminor
+          version: ${{ github.event.inputs.version }}
+
+      - name: Parse Chart Version
+        id: chart_version_parser
+        uses: terradatum/semver-action@v1
+        with:
+          bump: preminor
+          version: ${{ github.event.inputs.chartVersion }}
+
+      - name: Set Prerelease
+        if: ${{ contains(steps.version_parser.outputs.version, '-') }}
+        run: echo "PRERELEASE=true" >> $GITHUB_ENV
+
+      - name: Retrieve the milestone
+        id: milestone
+        if: ${{ env.PRERELEASE != 'true' }}
+        uses: julb/action-manage-milestone@v1
+        with:
+          title: Mirror ${{ steps.version_parser.outputs.version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set Release Environment Variables
+        run: |
+          NEXT_CHART_VERSION_SNAPSHOT=${{ format('{0}.{1}.0-SNAPSHOT', steps.chart_version_parser.outputs.major, steps.chart_version_parser.outputs.next-minor) }}
+          NEXT_VERSION_SNAPSHOT=${{ format('{0}.{1}.0-SNAPSHOT', steps.version_parser.outputs.major, steps.version_parser.outputs.next-minor) }}
+          RELEASE_BRANCH="release/${{ steps.version_parser.outputs.major }}.${{ steps.version_parser.outputs.minor }}"
+          RELEASE_TAG=v${{ steps.version_parser.outputs.version }}
+
+          if [ ! -z "${{ steps.milestone.outputs.number }}" ]; then
+            CREATE_PR=true
+            PR_TITLE="Merge changes from $RELEASE_BRANCH"
+          fi
+
+          cat >> $GITHUB_ENV <<EOF
+          CREATE_PR=$CREATE_PR
+          NEXT_CHART_VERSION_SNAPSHOT=$NEXT_CHART_VERSION_SNAPSHOT
+          NEXT_VERSION_SNAPSHOT=$NEXT_VERSION_SNAPSHOT
+          PR_TITLE=$PR_TITLE
+          RELEASE_BRANCH=$RELEASE_BRANCH
+          RELEASE_TAG=$RELEASE_TAG
+          EOF
+
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Import GPG Key
+        id: gpg_importer
+        uses: crazy-max/ghaction-import-gpg@v3.1.0
+        with:
+          git-commit-gpgsign: true
+          git-tag-gpgsign: true
+          git-user-signingkey: true
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: Cache Maven Packages
+        uses: actions/cache@v2
+        with:
+          key: ${{ runner.os }}-m2-${{ hashFiles('pom.xml') }}
+          path: ~/.m2
+          restore-keys: ${{ runner.os }}-m2
+
+      - name: Create and Switch to Release Branch
+        run: |
+          if ! git ls-remote --exit-code --heads --quiet origin refs/heads/${RELEASE_BRANCH}; then
+            git checkout -b ${RELEASE_BRANCH}
+            git push -u origin ${RELEASE_BRANCH}
+
+            if [ -z "${{ steps.milestone.outputs.number }}" ]; then
+              echo "CREATE_PR=true" >> $GITHUB_ENV
+              echo "PR_TITLE=Bump versions for v$NEXT_VERSION_SNAPSHOT" >> $GITHUB_ENV
+            fi
+          else
+            git checkout ${RELEASE_BRANCH}
+          fi
+
+      - name: Maven Release
+        run: ./mvnw clean package -Drelease.version=$VERSION -Drelease.chartVersion=$CHART_VERSION -N -P=release
+        env:
+          VERSION: ${{ steps.version_parser.outputs.version }}
+          CHART_VERSION: ${{ steps.chart_version_parser.outputs.version }}
+
+      - name: Create Release Notes
+        if: ${{ steps.milestone.outputs.number != '' }}
+        uses: xin-hedera/release-notes-generator-action@v3.1.5-rc1
+        env:
+          FILENAME: ${{ env.RELEASE_NOTES_FILENAME }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MILESTONE_NUMBER: ${{ steps.milestone.outputs.number }}
+
+      - name: Update Changelog
+        if: ${{ steps.milestone.outputs.number != '' }}
+        run: |
+          RELEASE_DATE=$(date +%Y-%m-%d)
+
+          GITHUB_RELEASE_NOTES=$(mktemp --suffix .md)
+          TMP_CHANGELOG=$(mktemp --suffix .md)
+          TMP_RELEASE_NOTES=$(mktemp --suffix .md)
+
+          # copy to a temporary file for modification due to lack of write permsision
+          echo -e "${{ github.event.inputs.description }}\n" | cat - $RELEASE_NOTES_FULLNAME > $GITHUB_RELEASE_NOTES
+          RELEASE_NOTES=$(sed -r 's/^(#+) /\1# /g' $GITHUB_RELEASE_NOTES)
+
+          CHANGELOG_TITLE="# Hedera Mirror Node Changelog"
+          CHANGELOG_PREVIOUS=$(sed 'N; N; 0,/^'"$CHANGELOG_TITLE"'\n.*\n/s///' $CHANGELOG)
+          cat > $CHANGELOG <<EOF
+          $CHANGELOG_TITLE
+
+          ## ${{ steps.version_parser.outputs.version }} ($RELEASE_DATE)
+
+          $RELEASE_NOTES
+
+          $CHANGELOG_PREVIOUS
+          EOF
+
+          echo "GITHUB_RELEASE_NOTES=$GITHUB_RELEASE_NOTES" >> $GITHUB_ENV
+
+      - name: Commit and Tag
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Bump versions for ${{ env.RELEASE_TAG }}
+          commit_options: '--no-verify --signoff'
+          commit_user_name: ${{ steps.gpg_importer.outputs.name }}
+          commit_user_email: ${{ steps.gpg_importer.outputs.email }}
+          tagging_message: ${{ env.RELEASE_TAG }}
+
+      - name: Create Github Release
+        uses: ncipollo/release-action@v1
+        with:
+          bodyFile: ${{ env.GITHUB_RELEASE_NOTES }}
+          commit: ${{ env.RELEASE_BRANCH }}
+          draft: true
+          name: ${{ env.RELEASE_TAG }}
+          prerelease: ${{ env.PRERELEASE == 'true' }}
+          tag: ${{ env.RELEASE_TAG }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Close the Milestone
+        if: ${{ steps.milestone.outputs.number != '' }}
+        uses: julb/action-manage-milestone@v1
+        with:
+          title: Mirror ${{ steps.version_parser.outputs.version }}
+          state: closed
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  create_pr:
+    name: Create PR
+    runs-on: ubuntu-latest
+    needs: release
+    if: ${{ needs.release.outputs.create_pr == 'true' }}
+    env:
+      NEXT_CHART_VERSION_SNAPSHOT: ${{ needs.release.outputs.next_chart_version_snapshot }}
+      NEXT_VERSION_SNAPSHOT: ${{ needs.release.outputs.next_version_snapshot }}
+      RELEASE_BRANCH: ${{ needs.release.outputs.release_branch }}
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Import GPG Key
+        id: gpg_importer
+        uses: crazy-max/ghaction-import-gpg@v3.1.0
+        with:
+          git-commit-gpgsign: true
+          git-tag-gpgsign: true
+          git-user-signingkey: true
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: Cache Maven Packages
+        uses: actions/cache@v2
+        with:
+          key: ${{ runner.os }}-m2-${{ hashFiles('pom.xml') }}
+          path: ~/.m2
+          restore-keys: ${{ runner.os }}-m2
+
+      - name: Reset Master to Release Branch
+        run: |
+          git fetch origin $RELEASE_BRANCH:$RELEASE_BRANCH
+          git reset --hard $RELEASE_BRANCH
+
+      - name: Maven Release for Next Minor Snapshot
+        run: ./mvnw clean package -Drelease.version=$NEXT_VERSION_SNAPSHOT -Drelease.chartVersion=$NEXT_CHART_VERSION_SNAPSHOT -N -P=release
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          body: ''
+          branch: create-pull-request/${{ env.RELEASE_BRANCH }}
+          commit-message: Bump versions for v${{ env.NEXT_VERSION_SNAPSHOT }}
+          committer: ${{ steps.gpg_importer.outputs.name }} <${{ steps.gpg_importer.outputs.email }}>
+          author: ${{ steps.gpg_importer.outputs.name }} <${{ steps.gpg_importer.outputs.email }}>
+          delete-branch: true
+          signoff: true
+          title: ${{ needs.release.outputs.pr_title }}

--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,6 @@ hedera-mirror-rest/check-state-proof/output
 # Rosetta
 hedera-mirror-rosetta/scripts/validation/rosetta-cli
 coverage.txt
+
+# Auto-generated release notes
+release_notes.md

--- a/pom.xml
+++ b/pom.xml
@@ -452,6 +452,27 @@
                         </configuration>
                         <executions>
                             <execution>
+                                <id>pom</id>
+                                <goals>
+                                    <goal>replace</goal>
+                                </goals>
+                                <inherited>false</inherited>
+                                <phase>prepare-package</phase>
+                                <configuration>
+                                    <file>pom.xml</file>
+                                    <replacements>
+                                        <replacement>
+                                            <token><![CDATA[(?<=<release.version>)[0-9a-zA-Z.-]+(?=</release.version>)]]></token>
+                                            <value>${release.version}</value>
+                                        </replacement>
+                                        <replacement>
+                                            <token><![CDATA[(?<=<release.chartVersion>)[0-9a-zA-Z.-]+(?=</release.chartVersion>)]]></token>
+                                            <value>${release.chartVersion}</value>
+                                        </replacement>
+                                    </replacements>
+                                </configuration>
+                            </execution>
+                            <execution>
                                 <id>chart</id>
                                 <goals>
                                     <goal>replace</goal>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
-->

**Detailed description**:
This PR adds a github actions workflow for the release process. It implements the steps described in #344.

The workflow is triggered by `workflow_dispatch` event with `version` and `chartVersion` as the required input params. It runs a job to:

- Create the `release/{major}.{minor}` branch if not exists and switch to the release branch for all subsequent steps
- Bump versions specified by `version` and `chartVersion`
- Tag the HEAD of the release branch with `version`
- Optionally generate a release note for GA version
- Create a PR request with `version` and `chartVersion` bumps to the next minor snapshot for either when the release branch is created or a GA version
- Create draft github prerelease or draft github release with release notes
- Optionally close the matching milestone for GA version

In case the job creates the release branch or it's a GA version, the workflow will run the create PR job to merge changes from the release branch to the master branch.

**Which issue(s) this PR fixes**:
Fixes #344 

**Special notes for your reviewer**:
1. Menu to manually run the workflow for pre release:

![Screen Shot 2021-05-03 at 10 02 56 AM](https://user-images.githubusercontent.com/59580070/116893692-e491d880-abf6-11eb-8ef0-ad8025f32167.png)

2. Github prerelease and draft release, since they are draft, non-collaborators can't see them:

![Screen Shot 2021-05-03 at 10 03 25 AM](https://user-images.githubusercontent.com/59580070/116893741-ed82aa00-abf6-11eb-955a-22c25b6827c3.png)

3. The PRs to merge changes to master from the release branch:
     - From the rc1 version when the release branch is created, https://github.com/xin-hedera/hedera-mirror-node/pull/23
     - From 0.34.0 GA version, https://github.com/xin-hedera/hedera-mirror-node/pull/28
     - From 0.34.1 patch version, https://github.com/xin-hedera/hedera-mirror-node/pull/30

4. gpg signing: https://github.com/xin-hedera/hedera-mirror-node/pull/31/commits

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

