### PR TITLE
Exclude fee-free transactions in monitor check

### DIFF
--- a/hedera-mirror-rest/monitoring/monitor_apis/transaction_tests.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/transaction_tests.js
@@ -91,7 +91,13 @@ const getTransactionsWithAccountCheck = async (server) => {
     return {url, ...result};
   }
 
-  const highestAccount = _.max(_.map(transactions[0].transfers, (xfer) => xfer.account));
+  const highestAccount = _.max(
+    _.map(
+      _.filter(transactions[0].transfers, (xfer) => xfer.amount > 0),
+      (xfer) => xfer.account
+    )
+  );
+
   if (highestAccount === undefined) {
     return {
       url,

--- a/hedera-mirror-rest/monitoring/monitor_apis/transaction_tests.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/transaction_tests.js
@@ -72,7 +72,7 @@ const checkTransactionTransfers = (transactions, option) => {
  * @param {String} server API host endpoint
  */
 const getTransactionsWithAccountCheck = async (server) => {
-  let url = getUrl(server, transactionsPath, {limit: resourceLimit});
+  let url = getUrl(server, transactionsPath, {limit: resourceLimit, type: 'credit'});
   const transactions = await getAPIResponse(url, jsonRespKey);
 
   let result = new CheckRunner()

--- a/hedera-mirror-rest/monitoring/monitor_apis/transaction_tests.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/transaction_tests.js
@@ -91,13 +91,7 @@ const getTransactionsWithAccountCheck = async (server) => {
     return {url, ...result};
   }
 
-  const highestAccount = _.max(
-    _.map(
-      _.filter(transactions[0].transfers, (xfer) => xfer.amount > 0),
-      (xfer) => xfer.account
-    )
-  );
-
+  const highestAccount = _.max(_.map(transactions[0].transfers, (xfer) => xfer.account));
   if (highestAccount === undefined) {
     return {
       url,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
-->

**Detailed description**:
Add `type=credit` filter to exclude fee-free transactions so selecting an account id from the account ids of the transfers will not fail.

**Which issue(s) this PR fixes**:
Fixes #1829 

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

