### PR TITLE
Update js-sdk version and fix columns in entity updater

### DIFF
--- a/hedera-mirror-rest/entity-info-updater/dbEntityService.js
+++ b/hedera-mirror-rest/entity-info-updater/dbEntityService.js
@@ -94,8 +94,8 @@ const updateEntity = async (entity) => {
   const paramValues = [
     entity.auto_renew_period,
     entity.deleted,
-    entity.ed25519_public_key_hex,
-    entity.exp_time_ns,
+    entity.public_key,
+    entity.expiration_timestamp,
     entity.key,
     entity.memo,
     entity.proxy_account_id,
@@ -115,9 +115,9 @@ const updateEntity = async (entity) => {
          where id = $8`,
       paramValues
     );
-  }
 
-  logger.trace(`Updated entity ${entity.id}`);
+    logger.trace(`Updated entity ${entity.id}`);
+  }
 };
 
 module.exports = {

--- a/hedera-mirror-rest/entity-info-updater/package-lock.json
+++ b/hedera-mirror-rest/entity-info-updater/package-lock.json
@@ -393,9 +393,9 @@
       }
     },
     "@grpc/grpc-js": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.2.11.tgz",
-      "integrity": "sha512-DZqx3nHBm2OGY7NKq4sppDEfx4nBAsQH/d/H/yxo/+BwpVLWLGs+OorpwQ+Fqd6EgpDEoi4MhqndjGUeLl/5GA==",
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.2.12.tgz",
+      "integrity": "sha512-+gPCklP1eqIgrNPyzddYQdt9+GvZqPlLpIjIo+TveE+gbtp74VV1A2ju8ExeO8ma8f7MbpaGZx/KJPYVWL9eDw==",
       "requires": {
         "@types/node": ">=12.12.47",
         "google-auth-library": "^6.1.1",
@@ -403,18 +403,24 @@
       }
     },
     "@hashgraph/cryptography": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@hashgraph/cryptography/-/cryptography-1.0.12.tgz",
-      "integrity": "sha512-uX0IzuOoE1LxAuc6+SVrc9WCEJWnRJNurAgEfycGKqfwUbCEWXHqTzUc/hDlB2NEv0M6g/cRVwtzatCHPGaJwQ==",
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@hashgraph/cryptography/-/cryptography-1.0.14.tgz",
+      "integrity": "sha512-qtlBzCCzePm9KOuy1GJ9FtEU8L7dNPrL4iAaFOlCn1UmDa0u4tPwYHDKcsuDhZetS47QJl0y+Vzgpo+b968WMg==",
       "requires": {
+        "@stablelib/utf8": "^1.0.0",
+        "@types/crypto-js": "^4.0.1",
         "bignumber.js": "^9.0.1",
+        "crypto-js": "^4.0.0",
+        "expo-crypto": "^9.1.0",
+        "expo-random": "^11.1.2",
+        "js-base64": "^3.6.0",
         "tweetnacl": "^1.0.3"
       }
     },
     "@hashgraph/proto": {
-      "version": "1.0.22",
-      "resolved": "https://registry.npmjs.org/@hashgraph/proto/-/proto-1.0.22.tgz",
-      "integrity": "sha512-09Q31V1Bqc9098fu4kwDJoJXqdks75HlfkM9z2HTq46eVlOHEEWGEat5fVmJeJOR+NCh2hBw4UQ4u/XRLlMtmA==",
+      "version": "1.0.24",
+      "resolved": "https://registry.npmjs.org/@hashgraph/proto/-/proto-1.0.24.tgz",
+      "integrity": "sha512-ARc+wom2K/b4X0XYuQJiy4PUcJy5IbSFXVS7UD1g2T0xTRrYmhKbyDpZ/CdSGB8iep1YNCCkKIBhIyMN+s5egw==",
       "requires": {
         "@hashgraph/protobufjs": "^6.10.1-hashgraph.2"
       }
@@ -447,15 +453,30 @@
       }
     },
     "@hashgraph/sdk": {
-      "version": "2.0.17-beta.2",
-      "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.0.17-beta.2.tgz",
-      "integrity": "sha512-KuvDQq3Y1I9LvbAhyR1E0mNoRsoptNby8hwk5OxI0NZzRwI3Hg+1AYifBvBwC9wGZbsy/hXmY/FZM93iDs7jYQ==",
+      "version": "2.0.17-beta.7",
+      "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.0.17-beta.7.tgz",
+      "integrity": "sha512-ERfWLOzXJ/0AcE7q1hBl62LJg2/ioQCcgDMjjpAd50Qw0kb3dPyMjK1KffwuVNY+SpGYAx8v2uJ5k9kCZq3L8w==",
       "requires": {
         "@grpc/grpc-js": "^1.2.2",
-        "@hashgraph/cryptography": "^1.0.12",
-        "@hashgraph/proto": "^1.0.22",
+        "@hashgraph/cryptography": "^1.0.14",
+        "@hashgraph/proto": "^1.0.24",
+        "@types/crypto-js": "^4.0.1",
+        "@types/utf8": "^2.1.6",
         "bignumber.js": "^9.0.1",
-        "long": "^4.0.0"
+        "crypto-js": "^4.0.0",
+        "js-base64": "^3.6.0",
+        "long": "^4.0.0",
+        "utf8": "^3.0.0"
+      },
+      "dependencies": {
+        "@hashgraph/proto": {
+          "version": "1.0.24",
+          "resolved": "https://registry.npmjs.org/@hashgraph/proto/-/proto-1.0.24.tgz",
+          "integrity": "sha512-ARc+wom2K/b4X0XYuQJiy4PUcJy5IbSFXVS7UD1g2T0xTRrYmhKbyDpZ/CdSGB8iep1YNCCkKIBhIyMN+s5egw==",
+          "requires": {
+            "@hashgraph/protobufjs": "^6.10.1-hashgraph.2"
+          }
+        }
       }
     },
     "@istanbuljs/load-nyc-config": {
@@ -737,6 +758,11 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "@stablelib/utf8": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@stablelib/utf8/-/utf8-1.0.0.tgz",
+      "integrity": "sha512-Y8QWrK4T0yW0HMFfSI3ZaMHKV37q27hX5ilsmKV358x01mzYfj5fwIf2LjzTlF+UIemHEXSlSN9XJnv1ML4znQ=="
+    },
     "@types/babel__core": {
       "version": "7.1.12",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.12.tgz",
@@ -773,6 +799,11 @@
       "requires": {
         "@babel/types": "^7.3.0"
       }
+    },
+    "@types/crypto-js": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/crypto-js/-/crypto-js-4.0.1.tgz",
+      "integrity": "sha512-6+OPzqhKX/cx5xh+yO8Cqg3u3alrkhoxhE5ZOdSEv0DOzJ13lwJ6laqGU0Kv6+XDMFmlnGId04LtY22PsFLQUw=="
     },
     "@types/graceful-fs": {
       "version": "4.1.5",
@@ -827,6 +858,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
       "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw=="
+    },
+    "@types/utf8": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@types/utf8/-/utf8-2.1.6.tgz",
+      "integrity": "sha512-pRs2gYF5yoKYrgSaira0DJqVg2tFuF+Qjp838xS7K+mJyY2jJzjsrl6y17GbIa4uMRogMbxs+ghNCvKg6XyNrA=="
     },
     "@types/yargs": {
       "version": "15.0.13",
@@ -1413,6 +1449,11 @@
         }
       }
     },
+    "crypto-js": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.0.0.tgz",
+      "integrity": "sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg=="
+    },
     "cssom": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
@@ -1738,6 +1779,19 @@
         "jest-matcher-utils": "^26.6.2",
         "jest-message-util": "^26.6.2",
         "jest-regex-util": "^26.0.0"
+      }
+    },
+    "expo-crypto": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/expo-crypto/-/expo-crypto-9.1.0.tgz",
+      "integrity": "sha512-5N3W/B4L7sx8IT/DhUjkSlbAfY0eQXo9ApiQ/67n2VjUNW/NKna4b1kCvAIjetPuqugAR2CFLltcYIc8PinRmA=="
+    },
+    "expo-random": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/expo-random/-/expo-random-11.1.2.tgz",
+      "integrity": "sha512-JaNqoYwFWJnyRSsMPpFjjSsm09wrEv+Uoif6IExfR8v6K3m/tIySoVjzS47tD6YVdxLtL/I8RmqmB6Nwh1p6AQ==",
+      "requires": {
+        "base64-js": "^1.3.0"
       }
     },
     "extend": {
@@ -2911,6 +2965,11 @@
         "merge-stream": "^2.0.0",
         "supports-color": "^7.0.0"
       }
+    },
+    "js-base64": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.6.0.tgz",
+      "integrity": "sha512-wVdUBYQeY2gY73RIlPrysvpYx+2vheGo8Y1SNQv/BzHToWpAZzJU7Z6uheKMAe+GLSBig5/Ps2nxg/8tRB73xg=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -4661,6 +4720,11 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
+    },
+    "utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
+      "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
     },
     "util": {
       "version": "0.10.4",

--- a/hedera-mirror-rest/entity-info-updater/package.json
+++ b/hedera-mirror-rest/entity-info-updater/package.json
@@ -26,8 +26,8 @@
     "entity-info-updater": "./index.js"
   },
   "dependencies": {
-    "@hashgraph/proto": "^1.0.22",
-    "@hashgraph/sdk": "^2.0.17-beta.2",
+    "@hashgraph/proto": "^1.0.24",
+    "@hashgraph/sdk": "^2.0.17-beta.7",
     "fs": "0.0.2",
     "jest": "^26.6.3",
     "js-yaml": "^4.0.0",


### PR DESCRIPTION
**Detailed description**:
JS-sdk [updated the node ports](https://github.com/hashgraph/hedera-sdk-js/commit/506a28415a3c45f9c38462fa8b05850fe6e029cd#diff-a2a697fa33ac2bde4b90372114a354e8675964672fb36d31472d2dc6208b67ad), this was contributing to the `Error: 13 INTERNAL: Received RST_STREAM` errors I was seeing. 

Additionally, I realized 2 of the entity table columns weren't updated and so they weren't getting updated

- Updated `@hashgraph/sdk` to `^2.0.17-beta.7`
- Updated `@hashgraph/proto` to `^1.0.24`
- Updated `entity.ed25519_public_key_hex` to `entity.public_key` and `entity.exp_time_ns` to `entity.expiration_timestamp`


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:
Ran module multiple times to verify after successful runs no new changes are attempted


**Checklist**
- [ ] Documentation added
- [ ] Tests updated

