### PR TITLE
Add a property to override every child chart's tag

### DIFF
--- a/charts/hedera-mirror-grpc/templates/deployment.yaml
+++ b/charts/hedera-mirror-grpc/templates/deployment.yaml
@@ -32,7 +32,7 @@ spec:
             {{- end }}
             {{- end }}
           envFrom: {{ tpl (toYaml .Values.envFrom) . | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.global.image.tag | default .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           livenessProbe: {{ toYaml .Values.livenessProbe | nindent 12 }}
           ports:
@@ -48,7 +48,7 @@ spec:
           volumeMounts:
             {{- range $name, $config := .Values.volumeMounts }}
             - name: {{ $name }}
-            {{- tpl (toYaml $config) $ | nindent 14 }}
+            {{- toYaml $config | nindent 14 }}
             {{- end }}
       imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 8 }}
       nodeSelector: {{ toYaml .Values.nodeSelector | nindent 8 }}

--- a/charts/hedera-mirror-grpc/values.yaml
+++ b/charts/hedera-mirror-grpc/values.yaml
@@ -30,9 +30,8 @@ envFrom: []
 fullnameOverride: ""
 
 global:
+  image: {}
   namespaceOverride: ""
-  redis:
-    password: redis_password
 
 hpa:
   enabled: false
@@ -43,7 +42,7 @@ hpa:
 image:
   pullPolicy: IfNotPresent
   repository: gcr.io/mirrornode/hedera-mirror-grpc
-  tag: ""  # Default to the chart's app version
+  tag: ""  # Defaults to the chart's app version
 
 imagePullSecrets: []
 

--- a/charts/hedera-mirror-importer/templates/deployment.yaml
+++ b/charts/hedera-mirror-importer/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
             {{- end }}
             {{- end }}
           envFrom: {{ tpl (toYaml .Values.envFrom) . | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.global.image.tag | default .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           livenessProbe: {{ toYaml .Values.livenessProbe | nindent 12 }}
           ports:
@@ -43,7 +43,7 @@ spec:
           volumeMounts:
             {{- range $name, $config := .Values.volumeMounts }}
             - name: {{ $name }}
-            {{- tpl (toYaml $config) $ | nindent 14 }}
+            {{- toYaml $config | nindent 14 }}
             {{- end }}
       imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 8 }}
       nodeSelector: {{ toYaml .Values.nodeSelector | nindent 8 }}

--- a/charts/hedera-mirror-importer/values.yaml
+++ b/charts/hedera-mirror-importer/values.yaml
@@ -35,14 +35,13 @@ envFrom: []
 fullnameOverride: ""
 
 global:
+  image: {}
   namespaceOverride: ""
-  redis:
-    password: redis_password
 
 image:
   pullPolicy: IfNotPresent
   repository: gcr.io/mirrornode/hedera-mirror-importer
-  tag: ""  # Default to the chart's app version
+  tag: ""  # Defaults to the chart's app version
 
 imagePullSecrets: []
 

--- a/charts/hedera-mirror-monitor/templates/deployment.yaml
+++ b/charts/hedera-mirror-monitor/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
             {{- end }}
             {{- end }}
           envFrom: {{ tpl (toYaml .Values.envFrom) . | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.global.image.tag | default .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           livenessProbe: {{ toYaml .Values.livenessProbe | nindent 12 }}
           ports:
@@ -43,7 +43,7 @@ spec:
           volumeMounts:
             {{- range $name, $config := .Values.volumeMounts }}
             - name: {{ $name }}
-            {{- tpl (toYaml $config) $ | nindent 14 }}
+            {{- toYaml $config | nindent 14 }}
             {{- end }}
       imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 8 }}
       nodeSelector: {{ toYaml .Values.nodeSelector | nindent 8 }}

--- a/charts/hedera-mirror-monitor/values.yaml
+++ b/charts/hedera-mirror-monitor/values.yaml
@@ -36,12 +36,13 @@ envFrom: []
 fullnameOverride: ""
 
 global:
+  image: {}
   namespaceOverride: ""
 
 image:
   pullPolicy: IfNotPresent
   repository: gcr.io/mirrornode/hedera-mirror-monitor
-  tag: ""  # Default to the chart's app version
+  tag: ""  # Defaults to the chart's app version
 
 imagePullSecrets: []
 

--- a/charts/hedera-mirror-rest/templates/deployment.yaml
+++ b/charts/hedera-mirror-rest/templates/deployment.yaml
@@ -32,7 +32,7 @@ spec:
             {{- end }}
             {{- end }}
           envFrom: {{ tpl (toYaml .Values.envFrom) . | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.global.image.tag | default .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           livenessProbe: {{- toYaml .Values.livenessProbe | nindent 12 }}
           ports:
@@ -45,7 +45,7 @@ spec:
           volumeMounts:
             {{- range $name, $config := .Values.volumeMounts }}
             - name: {{ $name }}
-            {{- tpl (toYaml $config) $ | nindent 14 }}
+            {{- toYaml $config | nindent 14 }}
             {{- end }}
       imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 8 }}
       nodeSelector: {{ toYaml .Values.nodeSelector | nindent 8 }}

--- a/charts/hedera-mirror-rest/templates/tests/configmap.yaml
+++ b/charts/hedera-mirror-rest/templates/tests/configmap.yaml
@@ -38,6 +38,7 @@ data:
       has_data "balances"
     }
 
+    {{ if .Values.test.checkRecent -}}
     @test "Has recent transactions" {
       has_data "transactions"
       local timestamp=$(curl -s "${URI}/transactions?limit=1" | jq -re '.transactions[0].consensus_timestamp')
@@ -47,4 +48,5 @@ data:
         sleep 1
       done
     }
+    {{- end }}
 {{- end -}}

--- a/charts/hedera-mirror-rest/templates/tests/configmap.yaml
+++ b/charts/hedera-mirror-rest/templates/tests/configmap.yaml
@@ -3,8 +3,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   annotations:
-    helm.sh/hook: test-success
-    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook: test
+    helm.sh/hook-delete-policy: hook-failed,hook-succeeded
   labels:
     {{- include "hedera-mirror-rest.labels" . | nindent 4 }}
   name: {{ include "hedera-mirror-rest.fullname" . }}-test
@@ -38,13 +38,16 @@ data:
       has_data "balances"
     }
 
+    @test "Has transactions" {
+      has_data "transactions"
+    }
+
     {{ if .Values.test.checkRecent -}}
     @test "Has recent transactions" {
-      has_data "transactions"
       local timestamp=$(curl -s "${URI}/transactions?limit=1" | jq -re '.transactions[0].consensus_timestamp')
 
       until [[ $(curl -s "${URI}/transactions?limit=1" | jq -re '.transactions[0].consensus_timestamp') > "${timestamp}" ]]; do
-        echo "Waiting for new data" >&3
+        echo "Waiting for new transactions" >&3
         sleep 1
       done
     }

--- a/charts/hedera-mirror-rest/templates/tests/pod.yaml
+++ b/charts/hedera-mirror-rest/templates/tests/pod.yaml
@@ -3,8 +3,8 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
-    helm.sh/hook: test-success
-    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook: test
+    helm.sh/hook-delete-policy: hook-failed,hook-succeeded
   labels:
     {{- include "hedera-mirror-rest.labels" . | nindent 4 }}
   name: {{ include "hedera-mirror-rest.fullname" . }}-test

--- a/charts/hedera-mirror-rest/values.yaml
+++ b/charts/hedera-mirror-rest/values.yaml
@@ -174,6 +174,7 @@ serviceMonitor:
 terminationGracePeriodSeconds: 60
 
 test:
+  checkRecent: true
   enabled: true
   image:
     pullPolicy: IfNotPresent

--- a/charts/hedera-mirror-rest/values.yaml
+++ b/charts/hedera-mirror-rest/values.yaml
@@ -35,6 +35,7 @@ envFrom: []
 fullnameOverride: ""
 
 global:
+  image: {}
   namespaceOverride: ""
 
 hpa:
@@ -46,7 +47,7 @@ hpa:
 image:
   pullPolicy: IfNotPresent
   repository: gcr.io/mirrornode/hedera-mirror-rest
-  tag: ""  # Default to the chart's app version
+  tag: ""  # Defaults to the chart's app version
 
 imagePullSecrets: []
 


### PR DESCRIPTION
**Detailed description**:
- Add a `global.image.tag` that overrides the tag in each child chart
- Add a `rest.test.checkRecent` flag to disable checks for recent transaction data
- Change to Helm 3 test hook
- Change to always delete test pod so it doesn't run forever on failure
- Fix accidentally templating `volumeMounts` unnecessarily in the last round of refactoring
- Remove an unused `global.redis.password` property

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
The global tag will make it easier to override the version in one place for continuous deployment. It also makes it easier to try out different app versions with a chart.

The recent check will be used to disable this check in environments that don't have recent data like demo and integration. Integration has recent data only during working hours so deploys during nights and weekends would fail and attempt rollback.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

