### PR TITLE
Change helm-gh-pages action to use GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -44,4 +44,4 @@ jobs:
         uses: stefanprodan/helm-gh-pages@master
         with:
           target_dir: charts
-          token: ${{ secrets.REPO_RW_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Detailed description**:
Change helm-gh-pages action to use GITHUB_TOKEN instead of a personal access token

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
It's better to use the standard GITHUB_TOKEN instead of a personal access token as the latter is associated with an account that won't necessarily work for the company forever. More importantly, codecov.io had a security [breach](https://about.codecov.io/security-update/) that may have exposed this old token.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

