### PR TITLE
Ignore Sonar false positives

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/Downloader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/Downloader.java
@@ -300,8 +300,7 @@ public abstract class Downloader<T extends StreamFile> {
                 .collect(Collectors.toList());
     }
 
-    private Optional<FileStreamSignature> parseSignatureFile(PendingDownload pendingDownload, EntityId nodeAccountId)
-            throws Exception {
+    private Optional<FileStreamSignature> parseSignatureFile(PendingDownload pendingDownload, EntityId nodeAccountId) throws InterruptedException, ExecutionException {
         String s3Key = pendingDownload.getS3key();
         Stopwatch stopwatch = pendingDownload.getStopwatch();
 
@@ -474,7 +473,8 @@ public abstract class Downloader<T extends StreamFile> {
         return downloaderProperties.getPrefix() + nodeAccountId + "/";
     }
 
-    protected void onVerified(PendingDownload pendingDownload, T streamFile) throws Exception {
+    protected void onVerified(PendingDownload pendingDownload, T streamFile) throws ExecutionException,
+            InterruptedException {
         setStreamFileIndex(streamFile);
         streamFileNotifier.verified(streamFile);
         lastStreamFile.set(Optional.of(streamFile));

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/generator/ConfigurableTransactionGenerator.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/generator/ConfigurableTransactionGenerator.java
@@ -89,8 +89,7 @@ public class ConfigurableTransactionGenerator implements TransactionGenerator {
             PublishRequest publishRequest = builder.receipt(shouldGenerate(properties.getReceipt()))
                     .record(shouldGenerate(properties.getRecord()))
                     .timestamp(Instant.now())
-                    .transaction(transactionSupplier.get().get()
-                            .setMaxRetry(properties.getMaxAttempts())) // set scenario transaction maxAttempts
+                    .transaction(transactionSupplier.get().get().setMaxAttempts(properties.getMaxAttempts()))
                     .build();
             publishRequests.add(publishRequest);
         }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/TransactionPublisher.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/TransactionPublisher.java
@@ -98,7 +98,7 @@ public class TransactionPublisher {
     }
 
     private Mono<TransactionResponse> getTransactionResponse(PublishRequest request, Client client) {
-        Transaction transaction = request.getTransaction();
+        Transaction<?> transaction = request.getTransaction();
 
         // set transaction node where applicable
         if (transaction.getNodeAccountIds() == null) {
@@ -121,7 +121,7 @@ public class TransactionPublisher {
 
         if (request.isRecord()) {
             return Mono.fromFuture(transactionId.getRecordAsync(client))
-                    .map(record -> builder.record(record).receipt(record.receipt));
+                    .map(r -> builder.record(r).receipt(r.receipt));
         } else if (request.isReceipt()) {
             // TODO: Implement a faster retry for get receipt for more accurate metrics
             return Mono.fromFuture(transactionId.getReceiptAsync(client))

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,11 @@
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.organization>hashgraph</sonar.organization>
         <sonar.projectKey>${project.artifactId}</sonar.projectKey>
+        <sonar.issue.ignore.multicriteria>e1,e2</sonar.issue.ignore.multicriteria>
+        <sonar.issue.ignore.multicriteria.e1.resourceKey>**/*.java</sonar.issue.ignore.multicriteria.e1.resourceKey>
+        <sonar.issue.ignore.multicriteria.e1.ruleKey>java:S6212</sonar.issue.ignore.multicriteria.e1.ruleKey>
+        <sonar.issue.ignore.multicriteria.e2.resourceKey>**/*.java</sonar.issue.ignore.multicriteria.e2.resourceKey>
+        <sonar.issue.ignore.multicriteria.e2.ruleKey>java:S125</sonar.issue.ignore.multicriteria.e2.ruleKey>
     </properties>
 
     <scm>


### PR DESCRIPTION
**Detailed description**:
- Add ignore rule configuration to ignore Sonar false positives
- Fix some code smells

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
Sonar was showing 200+ code smells in every PR just because they added a rule that recommended using `var`. Using `var` is a personal preference and in my opinion not appropriate for every variable as it hides the type and makes code harder to understand.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

