### PR TITLE
Add multi node validation support to Acceptance tests

### DIFF
--- a/hedera-mirror-datagenerator/pom.xml
+++ b/hedera-mirror-datagenerator/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>com.hedera.hashgraph</groupId>
             <artifactId>sdk</artifactId>
-            <version>2.0.5-beta.7</version>
+            <version>${hedera-sdk.version}</version>
         </dependency>
         <dependency>
             <groupId>com.hedera</groupId>

--- a/hedera-mirror-grpc/pom.xml
+++ b/hedera-mirror-grpc/pom.xml
@@ -211,7 +211,7 @@
         <dependency>
             <groupId>com.hedera.hashgraph</groupId>
             <artifactId>sdk</artifactId>
-            <version>${hedera-sdk.version}</version>
+            <version>1.3.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/hedera-mirror-monitor/pom.xml
+++ b/hedera-mirror-monitor/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>com.hedera.hashgraph</groupId>
             <artifactId>sdk</artifactId>
-            <version>2.0.5-beta.7</version>
+            <version>${hedera-sdk.version}</version>
         </dependency>
         <dependency>
             <groupId>com.lmax</groupId>

--- a/hedera-mirror-test/README.md
+++ b/hedera-mirror-test/README.md
@@ -37,11 +37,11 @@ Tests can be compiled and run by running the following command from the root fol
     -   maxTinyBarTransactionFee - The maximum transaction fee you're willing to pay on a transaction
     -   messageTimeout - number of seconds to wait on messages representing transactions (default is 20)
     -   mirrorNodeAddress - mirror node grpc server (refer to https://docs.hedera.com/guides/docs/mirror-node-api/hedera-consensus-service-api-1)
-    -   network - The desired Hedera netowrk to point to. Options currently include MAINNET, OTHER, PREVIEWNET and TESTNET (default). Set to OTHER to point to a custom environment
-    -   nodes - A map of custom nodes to point to. This is made up of accountId and host key-value pairs
+    -   network - The desired Hedera network environment to point to. Options currently include MAINNET, OTHER, PREVIEWNET and TESTNET (default). Set to OTHER to point to a custom environment.
+    -   nodes - A map of custom nodes to be used by SDK. This is made up of accountId (e.g. 0.0.1000) and host (e.g. 127.0.0.1) key-value pairs
     -   operatorId - account id on network 'x.y.z' format
     -   operatorKey - account private key, to be used for signing transaction and client identification #Be careful with showing this, do not check this value in.
-    -   pullAddressBookNodes - Whether to download the address book from the network and use those nodes over the default nodes. Populating `nodes` will take priority over this.
+    -   pullAddressBookNodes - Whether to download the address book from the network and use those nodes over the default nodes. Populating `hedera.mirror.test.acceptancenodes` will take priority over this.
     -   restPollingProperties
         -   baseUrl - The host url to the mirrorNode e.g. https://testnet.mirrornode.hedera.com/api/v1
         -   delay - The time to wait in between failed REST API calls

--- a/hedera-mirror-test/README.md
+++ b/hedera-mirror-test/README.md
@@ -37,7 +37,7 @@ Tests can be compiled and run by running the following command from the root fol
     -   maxTinyBarTransactionFee - The maximum transaction fee you're willing to pay on a transaction
     -   messageTimeout - number of seconds to wait on messages representing transactions (default is 20)
     -   mirrorNodeAddress - mirror node grpc server (refer to https://docs.hedera.com/guides/docs/mirror-node-api/hedera-consensus-service-api-1)
-    -   network - The desired Hedera network environment to point to. Options currently include MAINNET, PREVIEWNET, TESTNET(default) and OTHER. Set to OTHER to point to a custom environment.
+    -   network - The desired Hedera network environment to point to. Options currently include MAINNET, PREVIEWNET, TESTNET (default) and OTHER. Set to OTHER to point to a custom environment.
     -   nodes - A map of custom nodes to be used by SDK. This is made up of accountId (e.g. 0.0.1000) and host (e.g. 127.0.0.1) key-value pairs
     -   operatorId - account id on network 'x.y.z' format
     -   operatorKey - account private key, to be used for signing transaction and client identification #Be careful with showing this, do not check this value in.
@@ -45,7 +45,7 @@ Tests can be compiled and run by running the following command from the root fol
         -   baseUrl - The host url to the mirrorNode e.g. https://testnet.mirrornode.hedera.com/api/v1
         -   delay - The time to wait in between failed REST API calls
         -   maxAttempts - The maximum number of attempts when calling a REST API endpoint and receiving a 404
-    -   retrieveAddressBook - Whether to download the address book from the network and use those nodes over the default nodes. Populating `hedera.mirror.test.acceptancenodes` will take priority over this.
+    -   retrieveAddressBook - Whether to download the address book from the network and use those nodes over the default nodes. Populating `hedera.mirror.test.acceptance.nodes` will take priority over this.
     -   subscribeRetries - number of times client should retryable on supported failures
     -   subscribeRetryOffPeriod - number of milliseconds client should wait before retrying on a retryable failure
 

--- a/hedera-mirror-test/README.md
+++ b/hedera-mirror-test/README.md
@@ -30,22 +30,22 @@ Tests can be compiled and run by running the following command from the root fol
 
 ### Test Configuration
 
--   Test run Config Properties: Configuration properties are set in the `application-default.yml` file located under `/src/test/resources` utilizing the spring boot application context for DI logic. Properties include
+-   Test Run Config Properties: Configuration properties are set in the `application-default.yml` file located under `/src/test/resources` utilizing the spring boot application context for DI logic. Properties include
 
     -   emitBackgroundMessages - Flag to set if background messages should be emitted. For OPS use in non production environments
-    -   existingTopicNum - a pre existing default topic number that can be used when no topicId is specified in a test. Used initially by @SubscribeOnly test
+    -   existingTopicNum - a preexisting default topic number that can be used when no topicId is specified in a test. Used initially by @SubscribeOnly test
     -   maxTinyBarTransactionFee - The maximum transaction fee you're willing to pay on a transaction
     -   messageTimeout - number of seconds to wait on messages representing transactions (default is 20)
     -   mirrorNodeAddress - mirror node grpc server (refer to https://docs.hedera.com/guides/docs/mirror-node-api/hedera-consensus-service-api-1)
-    -   network - The desired Hedera network environment to point to. Options currently include MAINNET, OTHER, PREVIEWNET and TESTNET (default). Set to OTHER to point to a custom environment.
+    -   network - The desired Hedera network environment to point to. Options currently include MAINNET, PREVIEWNET, TESTNET(default) and OTHER. Set to OTHER to point to a custom environment.
     -   nodes - A map of custom nodes to be used by SDK. This is made up of accountId (e.g. 0.0.1000) and host (e.g. 127.0.0.1) key-value pairs
     -   operatorId - account id on network 'x.y.z' format
     -   operatorKey - account private key, to be used for signing transaction and client identification #Be careful with showing this, do not check this value in.
-    -   pullAddressBookNodes - Whether to download the address book from the network and use those nodes over the default nodes. Populating `hedera.mirror.test.acceptancenodes` will take priority over this.
     -   restPollingProperties
         -   baseUrl - The host url to the mirrorNode e.g. https://testnet.mirrornode.hedera.com/api/v1
         -   delay - The time to wait in between failed REST API calls
         -   maxAttempts - The maximum number of attempts when calling a REST API endpoint and receiving a 404
+    -   retrieveAddressBook - Whether to download the address book from the network and use those nodes over the default nodes. Populating `hedera.mirror.test.acceptancenodes` will take priority over this.
     -   subscribeRetries - number of times client should retryable on supported failures
     -   subscribeRetryOffPeriod - number of milliseconds client should wait before retrying on a retryable failure
 
@@ -57,9 +57,9 @@ Options can also be set through the command line as follows
     `./mvnw integration-test --projects hedera-mirror-test/ -P=acceptance-tests -Dhedera.mirror.test.acceptance.nodeId=0.0.4 -Dhedera.mirror.test.acceptance.nodeAddress=1.testnet.hedera.com:50211`
 
 #### Custom nodes
-In some scenarios you may want to point to nodes not yet captured by the SDK, a subset of published nodes or custom nodes for a test environment.
+In some scenarios you may want to point to nodes not yet captured by the SDK, a subset of published nodes, or custom nodes for a test environment.
 To achieve this you can specify a list of accountId and host key-value pairs in the `hedera.mirror.test.acceptance.nodes` value of the config.
-These values will always take precedence over the default network map used by teh SDK for an environment.
+These values will always take precedence over the default network map used by the SDK for an environment.
 Refer to [Mainnet Nodes](https://docs.hedera.com/guides/mainnet/mainnet-nodes) and [Testnet Nodes](https://docs.hedera.com/guides/testnet/testnet-nodes) for the published list of nodes.
 
 The following example shows how you might specify a set of hosts to point to. Modify the accountId and host values as needed

--- a/hedera-mirror-test/README.md
+++ b/hedera-mirror-test/README.md
@@ -30,16 +30,22 @@ Tests can be compiled and run by running the following command from the root fol
 
 ### Test Configuration
 
--   Test run Config Properties: Configuration properties are set in the application-default.yml file located under /src/test/resources utilizing the spring boot application context for DI logic. Properties include
+-   Test run Config Properties: Configuration properties are set in the `application-default.yml` file located under `/src/test/resources` utilizing the spring boot application context for DI logic. Properties include
 
-    -   messageTimeout - number of seconds to wait on messages representing transactions (default is 20)
-    -   nodeId - main node id to submit transactions to in 'x.y.z' format (refer to https://docs.hedera.com/guides/testnet/nodes or https://docs.hedera.com/guides/mainnet/address-book)
-    -   nodeAddress - node domain or IP address (refer to https://docs.hedera.com/guides/testnet/nodes or https://docs.hedera.com/guides/mainnet/address-book or set to 'testnet' or 'mainnet' for automatic sdk handling)
-    -   mirrorNodeAddress - mirror node grpc server (refer to https://docs.hedera.com/guides/docs/mirror-node-api/hedera-consensus-service-api-1)
-    -   operatorId - account id on network 'x.y.z' format
-    -   operatorKey - account private key, to be used for signing transaction and client identification #Be careful with showing this, do not check this value in.
     -   emitBackgroundMessages - Flag to set if background messages should be emitted. For OPS use in non production environments
     -   existingTopicNum - a pre existing default topic number that can be used when no topicId is specified in a test. Used initially by @SubscribeOnly test
+    -   maxTinyBarTransactionFee - The maximum transaction fee you're willing to pay on a transaction
+    -   messageTimeout - number of seconds to wait on messages representing transactions (default is 20)
+    -   mirrorNodeAddress - mirror node grpc server (refer to https://docs.hedera.com/guides/docs/mirror-node-api/hedera-consensus-service-api-1)
+    -   network - The desired Hedera netowrk to point to. Options currently include MAINNET, OTHER, PREVIEWNET and TESTNET (default). Set to OTHER to point to a custom environment
+    -   nodes - A map of custom nodes to point to. This is made up of accountId and host key-value pairs
+    -   operatorId - account id on network 'x.y.z' format
+    -   operatorKey - account private key, to be used for signing transaction and client identification #Be careful with showing this, do not check this value in.
+    -   pullAddressBookNodes - Whether to download the address book from the network and use those nodes over the default nodes. Populating `nodes` will take priority over this.
+    -   restPollingProperties
+        -   baseUrl - The host url to the mirrorNode e.g. https://testnet.mirrornode.hedera.com/api/v1
+        -   delay - The time to wait in between failed REST API calls
+        -   maxAttempts - The maximum number of attempts when calling a REST API endpoint and receiving a 404
     -   subscribeRetries - number of times client should retryable on supported failures
     -   subscribeRetryOffPeriod - number of milliseconds client should wait before retrying on a retryable failure
 
@@ -50,6 +56,32 @@ Options can also be set through the command line as follows
 
     `./mvnw integration-test --projects hedera-mirror-test/ -P=acceptance-tests -Dhedera.mirror.test.acceptance.nodeId=0.0.4 -Dhedera.mirror.test.acceptance.nodeAddress=1.testnet.hedera.com:50211`
 
+#### Custom nodes
+In some scenarios you may want to point to nodes not yet captured by the SDK, a subset of published nodes or custom nodes for a test environment.
+To achieve this you can specify a list of accountId and host key-value pairs in the `hedera.mirror.test.acceptance.nodes` value of the config.
+These values will always take precedence over the default network map used by teh SDK for an environment.
+Refer to [Mainnet Nodes](https://docs.hedera.com/guides/mainnet/mainnet-nodes) and [Testnet Nodes](https://docs.hedera.com/guides/testnet/testnet-nodes) for the published list of nodes.
+
+The following example shows how you might specify a set of hosts to point to. Modify the accountId and host values as needed
+
+```yaml
+hedera:
+  mirror:
+    test:
+      acceptance:
+        network: OTHER
+        nodes:
+          - accountId: 0.0.3
+            host: 127.0.0.1
+          - accountId: 0.0.4
+            host: 127.0.0.2
+          - accountId: 0.0.5
+            host: 127.0.0.3
+          - accountId: 0.0.6
+            host: 127.0.0.4
+```
+
+#### Feature Tags
 -   Tags : Tags allow you to filter which cucumber scenarios and files are run. By default tests marked with the @Sanity tag are run. To run a different set of files different tags can be specified
     -   Acceptance test cases
 

--- a/hedera-mirror-test/pom.xml
+++ b/hedera-mirror-test/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>com.hedera.hashgraph</groupId>
             <artifactId>sdk</artifactId>
-            <version>2.0.5-beta.9</version>
+            <version>${hedera-sdk.version}</version>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>

--- a/hedera-mirror-test/pom.xml
+++ b/hedera-mirror-test/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>com.hedera.hashgraph</groupId>
             <artifactId>sdk</artifactId>
-            <version>2.0.5-beta.7</version>
+            <version>2.0.5-beta.9</version>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/AcceptanceTest.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/AcceptanceTest.java
@@ -32,7 +32,7 @@ import org.springframework.boot.test.context.SpringBootTest;
         glue = "com.hedera.mirror.test.e2e.acceptance",
         plugin = {"pretty", "de.monochromata.cucumber.report.PrettyReports:target/cucumber",
                 "timeline:target/cucumber/thread-report"},
-        tags = "@Sanity"
+        tags = "@basicsubscribe"
 )
 @SpringBootTest
 @CucumberContextConfiguration

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/AcceptanceTest.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/AcceptanceTest.java
@@ -32,7 +32,7 @@ import org.springframework.boot.test.context.SpringBootTest;
         glue = "com.hedera.mirror.test.e2e.acceptance",
         plugin = {"pretty", "de.monochromata.cucumber.report.PrettyReports:target/cucumber",
                 "timeline:target/cucumber/thread-report"},
-        tags = "@basicsubscribe"
+        tags = "@Sanity"
 )
 @SpringBootTest
 @CucumberContextConfiguration

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/SDKClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/SDKClient.java
@@ -116,13 +116,6 @@ public class SDKClient {
         client.close();
     }
 
-    private Client toClient(Map<String, AccountId> network) throws InterruptedException {
-        Client client = Client.forNetwork(network);
-        client.setOperator(operatorId, operatorKey);
-        client.setMirrorNetwork(List.of(mirrorNodeAddress));
-        return client;
-    }
-
     private Map<String, AccountId> getNetworkMap(Set<NodeProperties> nodes) {
         return nodes.stream()
                 .collect(Collectors.toMap(NodeProperties::getEndpoint, p -> AccountId.fromString(p.getAccountId())));

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/SDKClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/SDKClient.java
@@ -84,7 +84,7 @@ public class SDKClient {
             try {
                 networkMapToValidate = getAddressBookNetworkMap(client);
             } catch (Exception e) {
-                //
+                log.warn("Error retrieving address book", e);
             }
         }
 

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/SDKClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/SDKClient.java
@@ -20,12 +20,19 @@ package com.hedera.mirror.test.e2e.acceptance.client;
  * ‍
  */
 
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
 import lombok.Value;
 import lombok.extern.log4j.Log4j2;
 
+import com.hedera.hashgraph.sdk.AccountBalanceQuery;
 import com.hedera.hashgraph.sdk.AccountId;
 import com.hedera.hashgraph.sdk.Client;
 import com.hedera.hashgraph.sdk.Hbar;
@@ -33,6 +40,7 @@ import com.hedera.hashgraph.sdk.PrivateKey;
 import com.hedera.hashgraph.sdk.PublicKey;
 import com.hedera.mirror.test.e2e.acceptance.config.AcceptanceTestProperties;
 import com.hedera.mirror.test.e2e.acceptance.props.ExpandedAccountId;
+import com.hedera.mirror.test.e2e.acceptance.props.NodeProperties;
 
 @Log4j2
 @Value
@@ -43,7 +51,7 @@ public class SDKClient {
     private final AccountId operatorId;
     private final String mirrorNodeAddress;
     private final long messageTimeoutSeconds;
-    private final AccountId nodeId;
+    private final List<AccountId> singletonNodeId;
     private final Hbar maxTransactionFee;
 
     public SDKClient(AcceptanceTestProperties acceptanceTestProperties) throws InterruptedException {
@@ -54,29 +62,41 @@ public class SDKClient {
         payerPublicKey = operatorKey.getPublicKey();
         mirrorNodeAddress = acceptanceTestProperties.getMirrorNodeAddress();
         messageTimeoutSeconds = acceptanceTestProperties.getMessageTimeout().toSeconds();
-        nodeId = AccountId.fromString(acceptanceTestProperties.getNodeId());
         maxTransactionFee = Hbar.fromTinybars(acceptanceTestProperties.getMaxTinyBarTransactionFee());
 
         Client client;
-        var nodeAddress = acceptanceTestProperties.getNodeAddress();
-        if (nodeAddress.equalsIgnoreCase("testnet")) {
-            log.debug("Creating SDK client for TestNet");
-            client = Client.forTestnet();
-        } else if (nodeAddress.equalsIgnoreCase("mainnet")) {
-            log.debug("Creating SDK client for MainNet");
-            client = Client.forMainnet();
-        } else {
-            var nodeId = AccountId.fromString(acceptanceTestProperties.getNodeId());
-            log.debug("Creating SDK client for node {} at {}", nodeId, nodeAddress);
-
-            // Build client
-            client = Client.forNetwork(Map.of(nodeAddress, nodeId));
+        var network = acceptanceTestProperties.getNetwork();
+        switch (network) {
+            case TESTNET:
+                log.debug("Creating SDK client for TestNet");
+                client = Client.forTestnet();
+                break;
+            case MAINNET:
+                log.debug("Creating SDK client for MainNet");
+                client = Client.forMainnet();
+                break;
+            default:
+//                Set<NodeProperties> validNodes = validateNodes(acceptanceTestProperties);
+//                log.debug("Creating SDK client using {} valid nodes", validNodes.size());
+//                client = toClient(getNetworkMap(validNodes));
+                log.debug("Creating SDK client for OTHER");
+                client = toClient(getNetworkMap(acceptanceTestProperties.getNodes()));
         }
 
-        client.setOperator(operatorId, operatorKey);
-        client.setMirrorNetwork(List.of(acceptanceTestProperties.getMirrorNodeAddress()));
+//        Set<NodeProperties> validNodes = validateNodes(client.getNetwork());
+//        log.debug("Creating SDK client using {} valid nodes", validNodes.size());
+//        client = toClient(getNetworkMap(validNodes));
 
-        this.client = client;
+//        client.setOperator(operatorId, operatorKey);
+//        client.setMirrorNetwork(List.of(acceptanceTestProperties.getMirrorNodeAddress()));
+
+        // if prod environment, get current address book and use those nodes
+
+        // only use validated nodes for tests
+        this.client = getValidatedClient(client.getNetwork());
+
+        // set nodeId to first valid node
+        singletonNodeId = Collections.singletonList(this.client.getNetwork().values().iterator().next());
     }
 
     public ExpandedAccountId getExpandedOperatorAccountId() {
@@ -85,5 +105,95 @@ public class SDKClient {
 
     public void close() throws TimeoutException {
         client.close();
+    }
+
+    private Client toClient(Map<String, AccountId> network) throws InterruptedException {
+        Client client = Client.forNetwork(network);
+        client.setOperator(operatorId, operatorKey);
+        client.setMirrorNetwork(List.of(mirrorNodeAddress));
+        return client;
+    }
+
+    private Map<String, AccountId> getNetworkMap(Set<NodeProperties> nodes) {
+        return nodes.stream()
+                .collect(Collectors.toMap(NodeProperties::getEndpoint, p -> AccountId.fromString(p.getAccountId())));
+    }
+
+    private Set<NodeProperties> validateNodes(AcceptanceTestProperties acceptanceTestProperties) {
+        Set<NodeProperties> nodes = acceptanceTestProperties.getNodes();
+        Set<NodeProperties> validNodes = new HashSet<>();
+        try {
+            for (NodeProperties node : nodes) {
+                if (validateNode(node)) {
+                    validNodes.add(node);
+                    log.trace("Added node {} at endpoint {} to list of valid nodes", node.getAccountId(), node
+                            .getEndpoint());
+                }
+            }
+        } catch (Exception e) {
+            //
+        }
+
+        if (validNodes.size() == 0) {
+            throw new IllegalStateException("All provided nodes are unreachable!");
+        }
+
+        log.info("{} of {} nodes are functional", validNodes.size(), nodes.size());
+        return validNodes;
+    }
+
+    private Client getValidatedClient(Map<String, AccountId> currentNetworkMap) throws InterruptedException {
+        Map<String, AccountId> validNodes = new HashMap<>();
+//        AccountId firstValidNodeId = null;
+        for (var nodeEntry : currentNetworkMap.entrySet()) {
+            try {
+                NodeProperties node = new NodeProperties(nodeEntry.getValue().toString(), nodeEntry.getKey());
+                if (validateNode(node)) {
+                    validNodes.putIfAbsent(nodeEntry.getKey(), nodeEntry.getValue());
+                    log.trace("Added node {} at endpoint {} to list of valid nodes", node.getAccountId(), node
+                            .getHost());
+
+                    // set nodeId to first valid node
+//                    if (singletonNodeId == null) {
+//                        firstValidNodeId = nodeEntry.getValue();
+//                        singletonNodeId = Collections.singletonList(nodeEntry.getValue());
+//                    }
+                }
+            } catch (Exception e) {
+                //
+            }
+        }
+
+//        if (firstValidNodeId != null) {
+//            singletonNodeId = Collections.singletonList(firstValidNodeId);
+//        }
+
+        if (validNodes.size() == 0) {
+            throw new IllegalStateException("All provided nodes are unreachable!");
+        }
+
+        log.info("{} of {} nodes are functional", validNodes.size(), currentNetworkMap.size());
+        return toClient(validNodes);
+    }
+
+    private boolean validateNode(NodeProperties node) {
+        boolean valid = false;
+        try {
+            AccountId nodeAccountId = AccountId.fromString(node.getAccountId());
+            new AccountBalanceQuery()
+                    .setAccountId(nodeAccountId)
+                    .setNodeAccountIds(List.of(nodeAccountId))
+                    .execute(client, Duration.ofSeconds(10L));
+            log.info("Validated node: {}", node);
+            valid = true;
+        } catch (Exception e) {
+            log.warn("Unable to validate node {}: ", node, e);
+        }
+
+        return valid;
+    }
+
+    private Client getNodesFromCurrentAddressBook() {
+        return null;
     }
 }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/ScheduleClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/ScheduleClient.java
@@ -20,7 +20,6 @@ package com.hedera.mirror.test.e2e.acceptance.client;
  * ‍
  */
 
-import java.util.Collections;
 import java.util.concurrent.TimeoutException;
 import lombok.Value;
 import lombok.extern.log4j.Log4j2;
@@ -64,7 +63,7 @@ public class ScheduleClient extends AbstractNetworkClient {
                 .setTransactionMemo(memo);
 
         if (signatureKeyList != null) {
-            scheduleCreateTransaction.setNodeAccountIds(Collections.singletonList(sdkClient.getNodeId()));
+            scheduleCreateTransaction.setNodeAccountIds(sdkClient.getSingletonNodeId());
 
             // add initial set of required signatures to ScheduleCreate transaction
             signatureKeyList.forEach(k -> {

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/ScheduleClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/ScheduleClient.java
@@ -20,6 +20,7 @@ package com.hedera.mirror.test.e2e.acceptance.client;
  * ‍
  */
 
+import java.util.List;
 import java.util.concurrent.TimeoutException;
 import lombok.Value;
 import lombok.extern.log4j.Log4j2;
@@ -63,7 +64,7 @@ public class ScheduleClient extends AbstractNetworkClient {
                 .setTransactionMemo(memo);
 
         if (signatureKeyList != null) {
-            scheduleCreateTransaction.setNodeAccountIds(sdkClient.getRandomSingleNodeAccountIdList());
+            scheduleCreateTransaction.setNodeAccountIds(List.of(sdkClient.getRandomNodeAccountId()));
 
             // add initial set of required signatures to ScheduleCreate transaction
             signatureKeyList.forEach(k -> {

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/ScheduleClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/ScheduleClient.java
@@ -63,7 +63,7 @@ public class ScheduleClient extends AbstractNetworkClient {
                 .setTransactionMemo(memo);
 
         if (signatureKeyList != null) {
-            scheduleCreateTransaction.setNodeAccountIds(sdkClient.getSingletonNodeId());
+            scheduleCreateTransaction.setNodeAccountIds(sdkClient.getRandomSingleNodeAccountIdList());
 
             // add initial set of required signatures to ScheduleCreate transaction
             signatureKeyList.forEach(k -> {

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
@@ -21,6 +21,8 @@ package com.hedera.mirror.test.e2e.acceptance.config;
  */
 
 import java.time.Duration;
+import java.util.LinkedHashSet;
+import java.util.Set;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
@@ -29,6 +31,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.annotation.Validated;
 
+import com.hedera.mirror.test.e2e.acceptance.props.NodeProperties;
+
 @Component
 @ConfigurationProperties(prefix = "hedera.mirror.test.acceptance")
 @Data
@@ -36,10 +40,10 @@ import org.springframework.validation.annotation.Validated;
 public class AcceptanceTestProperties {
     private final RestPollingProperties restPollingProperties;
 
-    @NotBlank
-    private String nodeAddress;
-    @NotBlank
-    private String nodeId;
+    @NotNull
+    private Set<NodeProperties> nodes = new LinkedHashSet<>();
+    @NotNull
+    private HederaNetwork network = HederaNetwork.TESTNET;
     @NotBlank
     private String mirrorNodeAddress;
     @NotBlank
@@ -61,4 +65,18 @@ public class AcceptanceTestProperties {
 
     @NotNull
     private Long maxTinyBarTransactionFee = 1_000_000_000L;
+
+    public Set<NodeProperties> getNodes() {
+        if (network == HederaNetwork.OTHER && nodes.isEmpty()) {
+            throw new IllegalArgumentException("nodes must not be empty");
+        }
+        return nodes;
+    }
+
+    public enum HederaNetwork {
+        MAINNET,
+        PREVIEWNET,
+        TESTNET,
+        OTHER
+    }
 }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
@@ -64,9 +64,9 @@ public class AcceptanceTestProperties {
     @NotBlank
     private String operatorKey;
 
-    private boolean pullAddressBookNodes = true;
-
     private final RestPollingProperties restPollingProperties;
+
+    private boolean retrieveAddressBook = true;
 
     @Max(5)
     private int subscribeRetries = 5;

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
@@ -64,6 +64,8 @@ public class AcceptanceTestProperties {
     @NotBlank
     private String operatorKey;
 
+    private boolean pullAddressBookNodes = true;
+
     private final RestPollingProperties restPollingProperties;
 
     @Max(5)

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
@@ -38,33 +38,39 @@ import com.hedera.mirror.test.e2e.acceptance.props.NodeProperties;
 @Data
 @Validated
 public class AcceptanceTestProperties {
-    private final RestPollingProperties restPollingProperties;
 
-    @NotNull
-    private Set<NodeProperties> nodes = new LinkedHashSet<>();
-    @NotNull
-    private HederaNetwork network = HederaNetwork.TESTNET;
-    @NotBlank
-    private String mirrorNodeAddress;
-    @NotBlank
-    private String operatorId;
-    @NotBlank
-    private String operatorKey;
-    @NotNull
-    private Duration messageTimeout = Duration.ofSeconds(20);
+    private boolean emitBackgroundMessages = false;
+
     @NotNull
     private Long existingTopicNum;
 
-    private boolean emitBackgroundMessages = false;
+    @NotNull
+    private Long maxTinyBarTransactionFee = 1_000_000_000L;
+
+    @NotNull
+    private Duration messageTimeout = Duration.ofSeconds(20);
+
+    @NotBlank
+    private String mirrorNodeAddress;
+
+    @NotNull
+    private HederaNetwork network = HederaNetwork.TESTNET;
+
+    private Set<NodeProperties> nodes = new LinkedHashSet<>();
+
+    @NotBlank
+    private String operatorId;
+
+    @NotBlank
+    private String operatorKey;
+
+    private final RestPollingProperties restPollingProperties;
 
     @Max(5)
     private int subscribeRetries = 5;
 
     @NotNull
     private Duration subscribeRetryBackoffPeriod = Duration.ofMillis(5000);
-
-    @NotNull
-    private Long maxTinyBarTransactionFee = 1_000_000_000L;
 
     public Set<NodeProperties> getNodes() {
         if (network == HederaNetwork.OTHER && nodes.isEmpty()) {

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/ClientConfiguration.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/ClientConfiguration.java
@@ -23,11 +23,13 @@ package com.hedera.mirror.test.e2e.acceptance.config;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.google.protobuf.InvalidProtocolBufferException;
 import io.netty.channel.ChannelOption;
 import io.netty.handler.timeout.ReadTimeoutHandler;
 import io.netty.handler.timeout.WriteTimeoutHandler;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Bean;
@@ -46,6 +48,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 import reactor.netty.http.client.HttpClient;
 import reactor.netty.tcp.TcpClient;
 
+import com.hedera.hashgraph.sdk.PrecheckStatusException;
 import com.hedera.mirror.test.e2e.acceptance.client.AccountClient;
 import com.hedera.mirror.test.e2e.acceptance.client.MirrorNodeClient;
 import com.hedera.mirror.test.e2e.acceptance.client.SDKClient;
@@ -62,37 +65,43 @@ class ClientConfiguration {
 
     @Bean
     @Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE)
-    SDKClient sdkClient() throws InterruptedException {
+    SDKClient sdkClient() throws InterruptedException, InvalidProtocolBufferException, PrecheckStatusException,
+            TimeoutException {
         return new SDKClient(acceptanceTestProperties);
     }
 
     @Bean
     @Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE)
-    MirrorNodeClient mirrorNodeClient() throws InterruptedException {
+    MirrorNodeClient mirrorNodeClient() throws InterruptedException, InvalidProtocolBufferException,
+            PrecheckStatusException, TimeoutException {
         return new MirrorNodeClient(sdkClient());
     }
 
     @Bean
     @Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE)
-    TopicClient topicClient() throws InterruptedException {
+    TopicClient topicClient() throws InterruptedException, InvalidProtocolBufferException, PrecheckStatusException,
+            TimeoutException {
         return new TopicClient(sdkClient());
     }
 
     @Bean
     @Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE)
-    AccountClient accountClient() throws InterruptedException {
+    AccountClient accountClient() throws InterruptedException, InvalidProtocolBufferException,
+            PrecheckStatusException, TimeoutException {
         return new AccountClient(sdkClient());
     }
 
     @Bean
     @Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE)
-    TokenClient tokenClient() throws InterruptedException {
+    TokenClient tokenClient() throws InterruptedException, InvalidProtocolBufferException, PrecheckStatusException,
+            TimeoutException {
         return new TokenClient(sdkClient());
     }
 
     @Bean
     @Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE)
-    ScheduleClient scheduleClient() throws InterruptedException {
+    ScheduleClient scheduleClient() throws InterruptedException, InvalidProtocolBufferException,
+            PrecheckStatusException, TimeoutException {
         return new ScheduleClient(sdkClient());
     }
 

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/NodeProperties.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/NodeProperties.java
@@ -1,0 +1,52 @@
+package com.hedera.mirror.test.e2e.acceptance.props;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+
+@Data
+@NoArgsConstructor
+@Validated
+public class NodeProperties {
+
+    public NodeProperties(String accountId, String host) {
+        this.accountId = accountId;
+        this.host = host;
+    }
+
+    @NotBlank
+    private String accountId;
+
+    @NotBlank
+    private String host;
+
+    @Min(0)
+    private int port = 50211;
+
+    public String getEndpoint() {
+        return host + ":" + port;
+    }
+}
+

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ScheduleFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ScheduleFeature.java
@@ -391,7 +391,7 @@ public class ScheduleFeature {
             ReceiptStatusException {
         scheduleInfo = new ScheduleInfoQuery()
                 .setScheduleId(scheduleId)
-                .setNodeAccountIds(scheduleClient.getSdkClient().getSingletonNodeId())
+                .setNodeAccountIds(scheduleClient.getSdkClient().getRandomSingleNodeAccountIdList())
                 .execute(scheduleClient.getClient());
 
         // verify executed from 3 min record, set scheduled=true on scheduleCreateTransactionId and get receipt
@@ -424,7 +424,7 @@ public class ScheduleFeature {
             PrecheckStatusException {
         scheduleInfo = new ScheduleInfoQuery()
                 .setScheduleId(scheduleId)
-                .setNodeAccountIds(scheduleClient.getSdkClient().getSingletonNodeId())
+                .setNodeAccountIds(scheduleClient.getSdkClient().getRandomSingleNodeAccountIdList())
                 .execute(scheduleClient.getClient());
 
         assertNotNull(scheduleInfo);

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ScheduleFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ScheduleFeature.java
@@ -391,7 +391,7 @@ public class ScheduleFeature {
             ReceiptStatusException {
         scheduleInfo = new ScheduleInfoQuery()
                 .setScheduleId(scheduleId)
-                .setNodeAccountIds(scheduleClient.getSdkClient().getRandomSingleNodeAccountIdList())
+                .setNodeAccountIds(List.of(scheduleClient.getSdkClient().getRandomNodeAccountId()))
                 .execute(scheduleClient.getClient());
 
         // verify executed from 3 min record, set scheduled=true on scheduleCreateTransactionId and get receipt
@@ -424,7 +424,7 @@ public class ScheduleFeature {
             PrecheckStatusException {
         scheduleInfo = new ScheduleInfoQuery()
                 .setScheduleId(scheduleId)
-                .setNodeAccountIds(scheduleClient.getSdkClient().getRandomSingleNodeAccountIdList())
+                .setNodeAccountIds(List.of(scheduleClient.getSdkClient().getRandomNodeAccountId()))
                 .execute(scheduleClient.getClient());
 
         assertNotNull(scheduleInfo);

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ScheduleFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ScheduleFeature.java
@@ -30,7 +30,6 @@ import io.cucumber.java.en.When;
 import io.cucumber.junit.platform.engine.Cucumber;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -46,7 +45,6 @@ import org.springframework.retry.annotation.Recover;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 
-import com.hedera.hashgraph.sdk.AccountId;
 import com.hedera.hashgraph.sdk.Hbar;
 import com.hedera.hashgraph.sdk.KeyList;
 import com.hedera.hashgraph.sdk.PrecheckStatusException;
@@ -393,7 +391,7 @@ public class ScheduleFeature {
             ReceiptStatusException {
         scheduleInfo = new ScheduleInfoQuery()
                 .setScheduleId(scheduleId)
-                .setNodeAccountIds(Collections.singletonList(AccountId.fromString(acceptanceProps.getNodeId())))
+                .setNodeAccountIds(scheduleClient.getSdkClient().getSingletonNodeId())
                 .execute(scheduleClient.getClient());
 
         // verify executed from 3 min record, set scheduled=true on scheduleCreateTransactionId and get receipt
@@ -426,7 +424,7 @@ public class ScheduleFeature {
             PrecheckStatusException {
         scheduleInfo = new ScheduleInfoQuery()
                 .setScheduleId(scheduleId)
-                .setNodeAccountIds(Collections.singletonList(AccountId.fromString(acceptanceProps.getNodeId())))
+                .setNodeAccountIds(scheduleClient.getSdkClient().getSingletonNodeId())
                 .execute(scheduleClient.getClient());
 
         assertNotNull(scheduleInfo);

--- a/hedera-mirror-test/src/test/resources/application-default.yml
+++ b/hedera-mirror-test/src/test/resources/application-default.yml
@@ -8,10 +8,6 @@ hedera:
         # grpc endpoint
         mirrorNodeAddress: hcs.testnet.mirrornode.hedera.com:5600
         network: testnet
-        # list of nodes to bootstrap with when network is other
-        nodes:
-          - accountId:
-            host:
         # Do not use use 0.0.2 or 0.0.50 for operator to ensure crypto transfers are not waived
         operatorId:
         operatorKey:

--- a/hedera-mirror-test/src/test/resources/application-default.yml
+++ b/hedera-mirror-test/src/test/resources/application-default.yml
@@ -8,7 +8,7 @@ hedera:
         # grpc endpoint
         mirrorNodeAddress: hcs.testnet.mirrornode.hedera.com:5600
         network: testnet
-        # list of nodes to be set with network is other
+        # list of nodes to bootstrap with when network is other
         nodes:
           - accountId:
             host:

--- a/hedera-mirror-test/src/test/resources/application-default.yml
+++ b/hedera-mirror-test/src/test/resources/application-default.yml
@@ -7,8 +7,11 @@ hedera:
         messageTimeout: 20s
         # grpc endpoint
         mirrorNodeAddress: hcs.testnet.mirrornode.hedera.com:5600
-        nodeAddress: testnet
-        nodeId: 0.0.3
+        network: testnet
+        # list of nodes to be set with network is other
+        nodes:
+          - accountId:
+            host:
         # Do not use use 0.0.2 or 0.0.50 for operator to ensure crypto transfers are not waived
         operatorId:
         operatorKey:

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <grpc.version>1.37.0</grpc.version>
         <guava.version>30.1.1-jre</guava.version>
         <hedera-protobuf.version>0.13.0-alpha.2</hedera-protobuf.version>
-        <hedera-sdk.version>1.3.3</hedera-sdk.version>
+        <hedera-sdk.version>2.0.5</hedera-sdk.version>
         <jacoco.version>0.8.6</jacoco.version>
         <java.version>11</java.version>
         <javax.version>1</javax.version>


### PR DESCRIPTION
**Detailed description**:
Occasionally a node IP may change or go down.
In test environment this can be cumbersome with the current limitation of only 1 node in the acceptance test.

- Updated application yaml to accept list of nodes and value for network 
- Update SDKClient class to validate nodes. 
- Add config to pull in addressBook when desired

**Which issue(s) this PR fixes**:
Fixes #1852 

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

