### PR TITLE
Bump swagger-stats to 0.99.1 and add its peer dependency prom-client 13.1.0

### DIFF
--- a/hedera-mirror-rest/package-lock.json
+++ b/hedera-mirror-rest/package-lock.json
@@ -7005,9 +7005,9 @@
       "dev": true
     },
     "prom-client": {
-      "version": "11.5.3",
-      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-11.5.3.tgz",
-      "integrity": "sha512-iz22FmTbtkyL2vt0MdDFY+kWof+S9UB/NACxSn2aJcewtw+EERsen0urSkZ2WrHseNdydsvcxCTAnPcSMZZv4Q==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-13.1.0.tgz",
+      "integrity": "sha512-jT9VccZCWrJWXdyEtQddCDszYsiuWj5T0ekrPszi/WEegj3IZy6Mm09iOOVM86A4IKMWq8hZkT2dD9MaSe+sng==",
       "requires": {
         "tdigest": "^0.1.1"
       }
@@ -8363,26 +8363,25 @@
       }
     },
     "swagger-stats": {
-      "version": "0.95.18",
-      "resolved": "https://registry.npmjs.org/swagger-stats/-/swagger-stats-0.95.18.tgz",
-      "integrity": "sha512-SRq7I+VUMZVm4WR2sZbMXEuB+Cu8sp3bJVeI3UltNQmismU+uswP6gA8MCPLs5t3oBzrn+wrCE8OVh4USjtZQw==",
+      "version": "0.99.1",
+      "resolved": "https://registry.npmjs.org/swagger-stats/-/swagger-stats-0.99.1.tgz",
+      "integrity": "sha512-IMi4vl0qqu9ygqdFZ3KWCWqPIucj0kWa4ZFN/9yaEtRKQjqnFrv9Yld9SbkYUx8b8BSrQyhJkJNaHVlRS+86qg==",
       "requires": {
         "basic-auth": "^2.0.1",
         "cookies": "^0.8.0",
-        "debug": "^4.1.1",
-        "moment": "^2.24.0",
-        "path-to-regexp": "^6.1.0",
-        "prom-client": "^11.5.3",
-        "qs": "^6.9.1",
-        "request": "^2.88.0",
+        "debug": "^4.3.1",
+        "moment": "^2.29.1",
+        "path-to-regexp": "^6.2.0",
+        "qs": "^6.10.1",
+        "request": "^2.88.2",
         "send": "^0.17.1",
-        "uuid": "^3.4.0"
+        "uuid": "^8.3.2"
       },
       "dependencies": {
         "debug": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "requires": {
             "ms": "2.1.2"
           }
@@ -8398,9 +8397,9 @@
           "integrity": "sha512-f66KywYG6+43afgE/8j/GoiNyygk/bnoCbps++3ErRKsIYkGGupyv07R2Ok5m9i67Iqc+T2g1eAUGUPzWhYTyg=="
         },
         "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
         }
       }
     },

--- a/hedera-mirror-rest/package.json
+++ b/hedera-mirror-rest/package.json
@@ -35,8 +35,9 @@
     "mathjs": "^9.3.2",
     "node-fetch": "^2.6.1",
     "pg": "~8.6.0",
+    "prom-client": "^13.1.0",
     "qs": "^6.10.1",
-    "swagger-stats": "^0.95.18",
+    "swagger-stats": "^0.99.1",
     "swagger-ui-express": "^4.1.6"
   },
   "bundledDependencies": [
@@ -57,6 +58,7 @@
     "mathjs",
     "node-fetch",
     "pg",
+    "prom-client",
     "qs",
     "swagger-stats",
     "swagger-ui-express"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
-->

**Detailed description**:

- Bump swagger-stats to 0.99.1
- Add prom-client 13.1.0

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
`swagger-stats` 0.98.19 changed `prom-client` to a peer dependency so it will not be automatically installed by npm. Add prom-client 13.1.0 to `package.json` as a precautionary step.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

