### PR TITLE
Fix hedera-mirror-test Dockerfile pointing to tag that does not exist

### DIFF
--- a/hedera-mirror-test/src/main/resources/Dockerfile
+++ b/hedera-mirror-test/src/main/resources/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /usr/etc/hedera-mirror-node
 COPY . .
 
 ENV testProfile acceptance
-ENV cucumberFlags "@BalanceCheck"
+ENV cucumberFlags "@balancecheck"
 ENV subscribeThreadCount 30
 ENV jmeterTestPlan E2E_Subscribe_Only.jmx
 ENV jmeterPropsDirectory "/usr/etc/hedera-mirror-test"


### PR DESCRIPTION
**Detailed description**:

At some point many of the cucumber feature tags were updated to be all lowercase, however the Dockerfile default tag was not updated to reflect this.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

