### PR TITLE
Always create redis secret

### DIFF
--- a/charts/hedera-mirror/templates/secret-redis.yaml
+++ b/charts/hedera-mirror/templates/secret-redis.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.redis.enabled -}}
 {{- $name := "mirror-redis" -}}  # redis chart doesn't support template names
 apiVersion: v1
 kind: Secret
@@ -17,4 +16,4 @@ stringData:
   SPRING_REDIS_SENTINEL_MASTER: "{{ .Values.redis.sentinel.masterSet }}"
   SPRING_REDIS_SENTINEL_NODES: "{{ print $redisHost ":" .Values.redis.sentinel.port }}"
   SPRING_REDIS_SENTINEL_PASSWORD: "{{ $redisPassword }}"
-{{- end -}}
+


### PR DESCRIPTION
**Detailed description**:
Other environment variables in `values.yaml` depend upon the existence of this secret and they are not conditionally enabled. Without this deploys will get a `CreateContainerConfigError` when redis is disabled.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

