### PR TITLE
Port fix service endpoint migration (#1974)

### DIFF
--- a/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.37.1__add_address_book_service_endpoints.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.37.1__add_address_book_service_endpoints.sql
@@ -19,7 +19,7 @@ create table if not exists address_book_service_endpoint
     consensus_timestamp bigint      not null,
     ip_address_v4       varchar(15) not null,
     node_id             bigint      not null,
-    port                integer     not null
+    port                integer     default -1 not null
 );
 comment on table address_book_service_endpoint is 'Network address book node service endpoints';
 
@@ -31,7 +31,7 @@ alter table address_book_service_endpoint
 insert into address_book_service_endpoint (consensus_timestamp, ip_address_v4, port, node_id)
 select consensus_timestamp,
        ip,
-       port,
+       case when port is null then -1 else port end,
        node_id
 from address_book_entry
 where node_id is not null

--- a/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.0__time_scale_init.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.0__time_scale_init.sql
@@ -56,7 +56,7 @@ create table if not exists address_book_service_endpoint
     consensus_timestamp bigint      not null,
     ip_address_v4       varchar(15) not null,
     node_id             bigint      not null,
-    port                integer     not null
+    port                integer     default -1 not null
 );
 comment on table address_book_service_endpoint is 'Network address book node service endpoints';
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/AddAddressBookServiceEndpointsMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/AddAddressBookServiceEndpointsMigrationTest.java
@@ -305,6 +305,62 @@ class AddAddressBookServiceEndpointsMigrationTest extends IntegrationTest {
                 .isEmpty();
     }
 
+    @Test
+    void verifyAddressBookWithValidIpAndInvalidPortMigration() throws IOException {
+        long consensusTimestamp = 1;
+        AddressBookEntry.AddressBookEntryBuilder builder = AddressBookEntry.builder()
+                .nodeCertHash("nodeCertHash".getBytes())
+                .publicKey("rsa+public/key");
+
+        List<Long> nodeIds = List.of(0L, 1L, 2L, 3L);
+        insertAddressBook(AddressBookServiceImpl.ADDRESS_BOOK_102_ENTITY_ID, consensusTimestamp, nodeIds.size());
+        insertAddressBookEntry(
+                builder.memo(baseAccountId + (nodeIds.get(0) + nodeAccountOffset))
+                        .id(new AddressBookEntry.Id(consensusTimestamp, nodeIds.get(0)))
+                        .build(), "127.0.0.1", null);
+        insertAddressBookEntry(builder.memo(baseAccountId + (nodeIds.get(1) + nodeAccountOffset))
+                .id(new AddressBookEntry.Id(consensusTimestamp, nodeIds.get(1)))
+                .build(), "127.0.0.2", 0);
+        insertAddressBookEntry(builder.memo(baseAccountId + (nodeIds.get(2) + nodeAccountOffset))
+                .id(new AddressBookEntry.Id(consensusTimestamp, nodeIds.get(2)))
+                .build(), "127.0.0.3", null);
+        insertAddressBookEntry(builder.memo(baseAccountId + (nodeIds.get(3) + nodeAccountOffset))
+                .id(new AddressBookEntry.Id(consensusTimestamp, nodeIds.get(3)))
+                .build(), "127.0.0.4", 50211);
+
+        runMigration();
+
+        IterableAssert<AddressBookEntry> listAssert =
+                assertThat(addressBookEntryRepository
+                        .findAll())
+                        .isNotEmpty()
+                        .hasSize(nodeIds.size());
+
+        listAssert.extracting(AddressBookEntry::getId).extracting(AddressBookEntry.Id::getNodeId)
+                .containsExactlyInAnyOrderElementsOf(nodeIds);
+        listAssert.extracting(AddressBookEntry::getNodeAccountId)
+                .containsExactlyInAnyOrder(
+                        EntityId.of(baseAccountId + (nodeIds.get(0) + nodeAccountOffset), EntityTypeEnum.ACCOUNT),
+                        EntityId.of(baseAccountId + (nodeIds.get(1) + nodeAccountOffset), EntityTypeEnum.ACCOUNT),
+                        EntityId.of(baseAccountId + (nodeIds.get(2) + nodeAccountOffset), EntityTypeEnum.ACCOUNT),
+                        EntityId.of(baseAccountId + (nodeIds.get(3) + nodeAccountOffset), EntityTypeEnum.ACCOUNT));
+
+        IterableAssert<AddressBookServiceEndpoint> serviceListAssert =
+                assertThat(addressBookServiceEndpointRepository
+                        .findAll())
+                        .isNotEmpty()
+                        .hasSize(nodeIds.size());
+
+        serviceListAssert.extracting(AddressBookServiceEndpoint::getId)
+                .extracting(AddressBookServiceEndpoint.Id::getNodeId)
+                .extracting(EntityId::getId)
+                .containsExactlyInAnyOrder(0L, 1L, 2L, 3L);
+
+        serviceListAssert.extracting(AddressBookServiceEndpoint::getId)
+                .extracting(AddressBookServiceEndpoint.Id::getPort)
+                .containsExactlyInAnyOrder(-1, 0, -1, 50211);
+    }
+
     private List<AddressBookEntry> getAndSaveAddressBookEntries(boolean deprecatedIp, long consensusTimestamp,
                                                                 int nodeCount, int endPointCount) {
         List<AddressBookEntry> addressBookEntries = new ArrayList<>();
@@ -388,7 +444,7 @@ class AddAddressBookServiceEndpointsMigrationTest extends IntegrationTest {
      * @param ip               service endpoint ip
      * @param port             service endpoint  port
      */
-    private void insertAddressBookEntry(AddressBookEntry addressBookEntry, String ip, int port) {
+    private void insertAddressBookEntry(AddressBookEntry addressBookEntry, String ip, Integer port) {
         Long nodeAccountId = EntityId.isEmpty(addressBookEntry.getNodeAccountId()) ? null :
                 addressBookEntry.getNodeAccountId().getId();
         jdbcOperations


### PR DESCRIPTION
**Detailed description**:
Port
Migration was failing when 0.33.0-rc1 was deployed to dev cluster. 
It seems like there was a historic testnet address book where the ports were not set even though the entries had valid IPs. Likely a deployment issue

- Add a default value for port as -1 going forward
- Update migration to set historic address_book_entry values with no port but valid IP to -1. This leaves the window to address this in a future migration. Note this matches the default value when no IP is set in the proto
Signed-off-by: Nana-EC <nana.essilfie-conduah@hedera.com>

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

