### PR TITLE
Fix using wrapper chart without redis chart enabled

### DIFF
--- a/charts/hedera-mirror/Chart.yaml
+++ b/charts/hedera-mirror/Chart.yaml
@@ -22,11 +22,11 @@ dependencies:
     condition: postgresql.enabled
     name: postgresql-ha
     repository: https://charts.bitnami.com/bitnami
-    version: 6.9.0
+    version: 7.3.0
   - condition: redis.enabled
     name: redis
     repository: https://charts.bitnami.com/bitnami
-    version: 13.0.1
+    version: 14.1.1
   - alias: rest
     condition: rest.enabled
     name: hedera-mirror-rest
@@ -38,7 +38,7 @@ dependencies:
     condition: timescaledb.enabled
     name: timescaledb-single
     repository: https://raw.githubusercontent.com/timescale/timescaledb-kubernetes/master/charts/repo/
-    version: 0.8.2
+    version: 0.9.0
 description: Hedera Mirror Node mirrors data from Hedera nodes and serves it via an API
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067

--- a/charts/hedera-mirror/templates/secret-passwords.yaml
+++ b/charts/hedera-mirror/templates/secret-passwords.yaml
@@ -30,6 +30,7 @@ stringData:
   HEDERA_MIRROR_IMPORTER_DB_RESTUSERNAME: "{{ $restUsername }}"
 
   {{ if .Values.postgresql.enabled -}}
+  admin-password: {{ coalesce .Values.postgresql.pgpool.adminPassword (get $passwords "admin-password" | default "" | b64dec) (randAlphaNum 40) | quote }}
   PGPOOL_POSTGRES_CUSTOM_PASSWORDS: "{{ $grpcPassword }},{{ $importerPassword }},{{ $ownerPassword }},{{ $restPassword }}"
   PGPOOL_POSTGRES_CUSTOM_USERS: "{{ $grpcUsername }},{{ $importerUsername }},{{ $ownerUsername }},{{ $restUsername }}"
   postgresql-password: {{ coalesce .Values.postgresql.postgresql.password (get $passwords "postgresql-password" | default "" | b64dec) (randAlphaNum 40) | quote }}

--- a/charts/hedera-mirror/templates/secret-redis.yaml
+++ b/charts/hedera-mirror/templates/secret-redis.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.redis.enabled -}}
 {{- $name := "mirror-redis" -}}  # redis chart doesn't support template names
 apiVersion: v1
 kind: Secret
@@ -10,11 +9,13 @@ stringData:
   {{- $secret := lookup "v1" "Secret" .Release.Namespace $name | default (dict) -}}
   {{- $passwords := $secret.data | default (dict) -}}
   {{- $redisHost := tpl .Values.redis.host . -}}
-  {{- $redisPassword := coalesce .Values.redis.password ($passwords.SPRING_REDIS_PASSWORD | default "" | b64dec) (randAlphaNum 40) }}
+  {{- $redisPassword := coalesce .Values.redis.auth.password ($passwords.SPRING_REDIS_PASSWORD | default "" | b64dec) (randAlphaNum 40) }}
 
   SPRING_REDIS_HOST: "{{ $redisHost }}"
   SPRING_REDIS_PASSWORD: "{{ $redisPassword }}"
+
+  {{- if and .Values.redis.enabled .Values.redis.sentinel.enabled }}
   SPRING_REDIS_SENTINEL_MASTER: "{{ .Values.redis.sentinel.masterSet }}"
-  SPRING_REDIS_SENTINEL_NODES: "{{ print $redisHost ":" .Values.redis.sentinel.port }}"
+  SPRING_REDIS_SENTINEL_NODES: "{{ print $redisHost ":" .Values.redis.sentinel.service.sentinelPort }}"
   SPRING_REDIS_SENTINEL_PASSWORD: "{{ $redisPassword }}"
-{{- end -}}
+  {{- end -}}

--- a/charts/hedera-mirror/values-prod.yaml
+++ b/charts/hedera-mirror/values-prod.yaml
@@ -36,12 +36,13 @@ postgresql:
     replicaCount: 2
 
 redis:
-  cluster:
-    slaveCount: 3
   metrics:
     enabled: true
-  slave:
+    sentinel:
+      enabled: true
+  replica:
     priorityClassName: critical
+    replicaCount: 3
 
 rest:
   ingress:

--- a/charts/hedera-mirror/values.yaml
+++ b/charts/hedera-mirror/values.yaml
@@ -92,16 +92,7 @@ postgresql:
   persistence:
     size: 500Gi
   pgpool:
-    adminPassword: password
-    affinity:
-      podAntiAffinity:
-        preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              topologyKey: kubernetes.io/hostname
-              labelSelector:
-                matchLabels:
-                  app.kubernetes.io/component: pgpool
+    adminPassword: ""  # Randomly generated if left blank
     extraEnvVars:
       - name: PGPOOL_POSTGRES_CUSTOM_PASSWORDS
         valueFrom:
@@ -113,6 +104,7 @@ postgresql:
           secretKeyRef:
             name: mirror-passwords
             key: PGPOOL_POSTGRES_CUSTOM_USERS
+    podAntiAffinityPreset: soft
     podLabels:
       role: db
     pdb:
@@ -128,21 +120,13 @@ postgresql:
     debug: true
   postgresqlImage:
     debug: true
-    tag: 13.1.0-debian-10-r74
+    tag: 13.2.0-debian-10-r83
   postgresql:
-    affinity:
-      podAntiAffinity:
-        preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              topologyKey: kubernetes.io/hostname
-              labelSelector:
-                matchLabels:
-                  app.kubernetes.io/component: postgresql
     existingSecret: mirror-passwords
     extraEnvVarsSecret: mirror-passwords
     initdbScriptsSecret: db-init
     password: ""  # Randomly generated if left blank
+    podAntiAffinityPreset: soft
     replicaCount: 1
     repmgrPassword: ""  # Randomly generated if left blank
     resources:
@@ -157,13 +141,12 @@ postgresql:
     enabled: true
 
 redis:
-  cluster:
-    slaveCount: 1
+  auth:
+    existingSecret: mirror-redis
+    existingSecretPasswordKey: SPRING_REDIS_PASSWORD
+    password: ""  # Randomly generated if left blank
   enabled: true
-  existingSecret: mirror-redis
-  existingSecretPasswordKey: SPRING_REDIS_PASSWORD
   host: "{{ .Release.Name }}-redis"
-  password: ""  # Randomly generated if left blank
   metrics:
     resources:
       limits:
@@ -174,11 +157,23 @@ redis:
         memory: 25Mi
     serviceMonitor:
       enabled: true
-  podDisruptionBudget:
-    enabled: true
-  securityContext:
-    runAsGroup: 1001
-    runAsUser: 1001
+  pdb:
+    create: true
+  rbac:
+    create: true
+  replica:
+    podAntiAffinityPreset: soft
+    podSecurityContext:
+      runAsGroup: 1001
+      runAsUser: 1001
+    replicaCount: 1
+    resources:
+      limits:
+        cpu: 1500m
+        memory: 1000Mi
+      requests:
+        cpu: 250m
+        memory: 500Mi
   sentinel:
     enabled: true
     masterSet: mirror
@@ -191,25 +186,6 @@ redis:
         memory: 25Mi
   serviceAccount:
     create: true
-  slave:  # Both master and slave are configured via slave property when sentinel is enabled
-    affinity:
-      podAntiAffinity:
-        preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              topologyKey: kubernetes.io/hostname
-              labelSelector:
-                matchLabels:
-                  app: redis
-    resources:
-      limits:
-        cpu: 1500m
-        memory: 1000Mi
-      requests:
-        cpu: 250m
-        memory: 500Mi
-    statefulset:
-      updateStrategy: RollingUpdate
 
 rest:
   db:
@@ -242,7 +218,6 @@ timescaledb:
   enabled: false
   image:
     pullPolicy: IfNotPresent
-    repository: timescale/timescaledb-ha
     tag: pg13-ts2.2-latest
   loadBalancer:
     enabled: false

--- a/hedera-mirror-importer/src/main/resources/db/scripts/init_v1.sql
+++ b/hedera-mirror-importer/src/main/resources/db/scripts/init_v1.sql
@@ -1,69 +1,46 @@
 -- Change the values below if you are not installing via Docker
 
-\set db_name 'mirror_node'
-\set db_create 'create database mirror_node'
-\set db_user 'mirror_node'
-\set db_password 'mirror_node_pass'
-\set db_owner 'mirror_node'
-\set grpc_user 'mirror_grpc'
-\set grpc_password 'mirror_grpc_pass'
-\set rosetta_user 'mirror_rosetta'
-\set rosetta_password 'mirror_rosetta_pass'
+\set dbName 'mirror_node'
+\set dbSchema 'public'
+\set grpcPassword 'mirror_grpc_pass'
+\set grpcUsername 'mirror_grpc'
+\set importerPassword 'mirror_importer_pass'
+\set importerUsername 'mirror_importer'
+\set ownerPassword 'mirror_node_pass'
+\set ownerUsername 'mirror_node'
+\set rosettaUsername 'mirror_rosetta'
+\set rosettaPassword 'mirror_rosetta_pass'
 
-create function init_create_user(user_name text, user_pass text) returns void as
-$$
-begin
-    if not exists(select from pg_catalog.pg_roles where rolname = user_name) then
-        execute format(
-                'create user %I with
-                    createrole
-                    password %L'
-            , user_name
-            , user_pass
-            );
-        raise notice 'Created user "%" with create role', user_name;
-    else
-        raise notice 'User "%" already exists, not creating it', user_name;
-    end if;
-end
-$$ language plpgsql;
+create user :ownerUsername with createrole login password :'ownerPassword';
+grant :ownerUsername to postgres;
+create database :dbName with owner :ownerUsername;
+create extension if not exists pg_stat_statements;
 
-create function init_user(user_name text, user_pass text) returns void as
-$$
-begin
-    if not exists(select from pg_catalog.pg_roles where rolname = user_name) then
-        execute format(
-                'create user %I with
-                    login
-                    password %L'
-            , user_name
-            , user_pass
-            );
-        raise notice 'Created user "%"', user_name;
-    else
-        raise notice 'User "%" already exists, not creating it', user_name;
-    end if;
-end
-$$ language plpgsql;
+-- Create roles
+create role readonly;
+create role readwrite in role readonly;
 
-select :'db_create'
-where not exists(select from pg_database where datname = :'db_name')
-\gexec
+-- Create users
+create user :grpcUsername with login password :'grpcPassword' in role readonly;
+create user :importerUsername with login password :'importerPassword' in role readwrite;
+create user :rosettaUsername with login password :'rosettaPassword' in role readonly;
 
-select init_create_user(:'db_user', :'db_password');
-select init_user(:'grpc_user', :'grpc_password');
-select init_user(:'rosetta_user', :'rosetta_password');
+-- Create schema
+\connect :dbName
+create schema if not exists :dbSchema authorization :ownerUsername;
+grant usage on schema :dbSchema to public;
+revoke create on schema :dbSchema from readonly;
 
-grant connect on database :db_name to :grpc_user;
+-- Grant readonly privileges
+grant connect on database :dbName to readonly;
+grant select on all tables in schema :dbSchema to readonly;
+grant select on all sequences in schema :dbSchema to readonly;
+grant usage on schema :dbSchema to readonly;
+alter default privileges in schema :dbSchema grant select on tables to readonly;
+alter default privileges in schema :dbSchema grant select on sequences to readonly;
 
-grant connect on database :db_name to :rosetta_user;
-
-\c :db_name
-
-alter default privileges in schema public grant select on tables to :grpc_user;
-
-grant select on all tables in schema public to :grpc_user;
-
-alter default privileges in schema public grant select on tables to :rosetta_user;
-
-grant select on all tables in schema public to :rosetta_user;
+-- Grant readwrite privileges
+grant insert, update on all tables in schema :dbSchema to readwrite;
+grant usage on all sequences in schema :dbSchema to readwrite;
+alter default privileges in schema :dbSchema grant insert, update on tables to readwrite;
+alter default privileges in schema :dbSchema grant usage on sequences to readwrite;

--- a/hedera-mirror-importer/src/main/resources/db/scripts/init_v1.sql
+++ b/hedera-mirror-importer/src/main/resources/db/scripts/init_v1.sql
@@ -28,8 +28,9 @@ create user :rosettaUsername with login password :'rosettaPassword' in role read
 -- Create schema
 \connect :dbName
 create schema if not exists :dbSchema authorization :ownerUsername;
+revoke all privileges on schema :dbSchema from public;
 grant usage on schema :dbSchema to public;
-revoke create on schema :dbSchema from readonly;
+grant create on schema :dbSchema to :ownerUsername;
 
 -- Grant readonly privileges
 grant connect on database :dbName to readonly;

--- a/hedera-mirror-importer/src/main/resources/db/scripts/init_v1.sql
+++ b/hedera-mirror-importer/src/main/resources/db/scripts/init_v1.sql
@@ -1,5 +1,7 @@
 -- Change the values below if you are not installing via Docker
 
+\set dbHost '127.0.0.1'
+\set dbPort '5432'
 \set dbName 'mirror_node'
 \set dbSchema 'public'
 \set grpcPassword 'mirror_grpc_pass'
@@ -8,8 +10,8 @@
 \set importerUsername 'mirror_importer'
 \set ownerPassword 'mirror_node_pass'
 \set ownerUsername 'mirror_node'
-\set rosettaUsername 'mirror_rosetta'
 \set rosettaPassword 'mirror_rosetta_pass'
+\set rosettaUsername 'mirror_rosetta'
 
 create user :ownerUsername with createrole login password :'ownerPassword';
 grant :ownerUsername to postgres;
@@ -26,7 +28,7 @@ create user :importerUsername with login password :'importerPassword' in role re
 create user :rosettaUsername with login password :'rosettaPassword' in role readonly;
 
 -- Create schema
-\connect :dbName
+\connect postgresql://:ownerUsername::ownerPassword@:dbHost::dbPort/:dbName
 create schema if not exists :dbSchema authorization :ownerUsername;
 revoke all privileges on schema :dbSchema from public;
 grant usage on schema :dbSchema to public;


### PR DESCRIPTION
**Detailed description**:
- Bump postgresql-ha chart version
- Bump redis chart version (lots of breaking changes)
- Change `init_v1.sql` to match the chart database init with separate importer user and reduced permissions
- Fix pgpool admin password not auto generating a random password
- Fix `CreateContainerConfigError` due to missing Redis secret
- Fix Importer configured to use Redis sentinel (Google Redis doesn't support sentinel)

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

