### PR TITLE
Fix pgpool admin password

### DIFF
--- a/charts/hedera-mirror/values.yaml
+++ b/charts/hedera-mirror/values.yaml
@@ -137,6 +137,7 @@ postgresql:
     size: 500Gi
   pgpool:
     adminPassword: ""  # Randomly generated if left blank
+    existingSecret: mirror-passwords
     extraEnvVars:
       - name: PGPOOL_POSTGRES_CUSTOM_PASSWORDS
         valueFrom:


### PR DESCRIPTION
**Detailed description**:
Previous fix did not take into account that pgpool uses a separate secret so we should pass our existing secret to pgpool.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

