### PR TITLE
Workaround lack of TLS support in SDK & acceptance test cleanup

### DIFF
--- a/hedera-mirror-monitor/src/main/java/com/hedera/hashgraph/sdk/ManagedNode.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/hashgraph/sdk/ManagedNode.java
@@ -1,0 +1,56 @@
+package com.hedera.hashgraph.sdk;
+
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+abstract class ManagedNode {
+    String address;
+    ManagedChannel channel;
+    final ExecutorService executor;
+    long lastUsed = 0;
+    long useCount = 0;
+
+    ManagedNode(String address, ExecutorService executor) {
+        this.executor = executor;
+        this.address = address;
+    }
+
+    void inUse() {
+        useCount++;
+        lastUsed = System.currentTimeMillis();
+    }
+
+    synchronized ManagedChannel getChannel() {
+        if (channel != null) {
+            return channel;
+        }
+
+        ManagedChannelBuilder builder = ManagedChannelBuilder.forTarget(address)
+                .userAgent(getUserAgent())
+                .executor(executor);
+
+        if (!address.endsWith(":443") && !address.endsWith(":50212")) {
+            builder.usePlaintext();
+        }
+
+        channel = builder.build();
+
+        return channel;
+    }
+
+    void close(long seconds) throws InterruptedException {
+        if (channel != null) {
+            channel.shutdown();
+            channel.awaitTermination(seconds, TimeUnit.SECONDS);
+            channel = null;
+        }
+    }
+
+    private String getUserAgent() {
+        var thePackage = getClass().getPackage();
+        var implementationVersion = thePackage != null ? thePackage.getImplementationVersion() : null;
+        return "hedera-sdk-java/" + ((implementationVersion != null) ? ("v" + implementationVersion) : "DEV");
+    }
+}

--- a/hedera-mirror-test/README.md
+++ b/hedera-mirror-test/README.md
@@ -30,7 +30,7 @@ complex code underneath.
 
 Tests can be compiled and run by running the following command from the root folder:
 
-`./mvnw clean integration-test --projects hedera-mirror-test/ -P=acceptance-tests`
+`./mvnw clean integration-test --projects hedera-mirror-test/ -P=acceptance-tests -Dcucumber.filter.tags=@acceptance`
 
 ### Image Execution
 

--- a/hedera-mirror-test/pom.xml
+++ b/hedera-mirror-test/pom.xml
@@ -57,6 +57,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <version>${javax.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <scope>compile</scope>

--- a/hedera-mirror-test/src/test/java/com/hedera/hashgraph/sdk/ManagedNode.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/hashgraph/sdk/ManagedNode.java
@@ -1,0 +1,56 @@
+package com.hedera.hashgraph.sdk;
+
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+abstract class ManagedNode {
+    String address;
+    ManagedChannel channel;
+    final ExecutorService executor;
+    long lastUsed = 0;
+    long useCount = 0;
+
+    ManagedNode(String address, ExecutorService executor) {
+        this.executor = executor;
+        this.address = address;
+    }
+
+    void inUse() {
+        useCount++;
+        lastUsed = System.currentTimeMillis();
+    }
+
+    synchronized ManagedChannel getChannel() {
+        if (channel != null) {
+            return channel;
+        }
+
+        ManagedChannelBuilder builder = ManagedChannelBuilder.forTarget(address)
+                .userAgent(getUserAgent())
+                .executor(executor);
+
+        if (!address.endsWith(":443") && !address.endsWith(":50212")) {
+            builder.usePlaintext();
+        }
+
+        channel = builder.build();
+
+        return channel;
+    }
+
+    void close(long seconds) throws InterruptedException {
+        if (channel != null) {
+            channel.shutdown();
+            channel.awaitTermination(seconds, TimeUnit.SECONDS);
+            channel = null;
+        }
+    }
+
+    private String getUserAgent() {
+        var thePackage = getClass().getPackage();
+        var implementationVersion = thePackage != null ? thePackage.getImplementationVersion() : null;
+        return "hedera-sdk-java/" + ((implementationVersion != null) ? ("v" + implementationVersion) : "DEV");
+    }
+}

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AbstractNetworkClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AbstractNetworkClient.java
@@ -83,12 +83,4 @@ public abstract class AbstractNetworkClient {
                 .hbars
                 .toTinybars();
     }
-
-    public void close() {
-        try {
-            sdkClient.close();
-        } catch (Exception ex) {
-            log.warn("Error closing client : {}", ex.getMessage());
-        }
-    }
 }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AccountClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AccountClient.java
@@ -24,8 +24,11 @@ import java.time.Instant;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeoutException;
+import javax.inject.Named;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.annotation.Scope;
 
 import com.hedera.hashgraph.sdk.AccountBalanceQuery;
 import com.hedera.hashgraph.sdk.AccountCreateTransaction;
@@ -41,6 +44,8 @@ import com.hedera.hashgraph.sdk.TransferTransaction;
 import com.hedera.mirror.test.e2e.acceptance.props.ExpandedAccountId;
 
 @Log4j2
+@Named
+@Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE)
 public class AccountClient extends AbstractNetworkClient {
 
     private static final long DEFAULT_INITIAL_BALANCE = 1_000_000_000L;

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/SDKClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/SDKClient.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
+import javax.inject.Named;
 import lombok.Value;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.RandomUtils;
@@ -52,8 +53,12 @@ import com.hedera.mirror.test.e2e.acceptance.props.ExpandedAccountId;
 import com.hedera.mirror.test.e2e.acceptance.props.NodeProperties;
 
 @Log4j2
+@Named
 @Value
-public class SDKClient {
+public class SDKClient implements AutoCloseable {
+
+    private static final FileId ADDRESS_BOOK_ID = new FileId(0L, 0L, 101L);
+
     private final Client client;
     private final PublicKey payerPublicKey;
     private final PrivateKey operatorKey;
@@ -62,11 +67,8 @@ public class SDKClient {
     private final long messageTimeoutSeconds;
     private final Hbar maxTransactionFee;
     private final Map<String, AccountId> validateNetworkMap;
-    private static final FileId ADDRESS_BOOK_IPS = new FileId(0L, 0L, 101L);
 
-    public SDKClient(AcceptanceTestProperties acceptanceTestProperties) throws InterruptedException,
-            InvalidProtocolBufferException, PrecheckStatusException, TimeoutException {
-
+    public SDKClient(AcceptanceTestProperties acceptanceTestProperties) throws InterruptedException {
         // Grab configuration variables from the .env file
         operatorId = AccountId.fromString(acceptanceTestProperties.getOperatorId());
         operatorKey = PrivateKey.fromString(acceptanceTestProperties.getOperatorKey());
@@ -102,6 +104,7 @@ public class SDKClient {
         return new ArrayList<>(validateNetworkMap.values()).get(randIndex);
     }
 
+    @Override
     public void close() throws TimeoutException {
         client.close();
     }
@@ -186,7 +189,7 @@ public class SDKClient {
     private NodeAddressBook getAddressBookFromNetwork(Client client) throws TimeoutException, PrecheckStatusException,
             InvalidProtocolBufferException {
         ByteString contents = new FileContentsQuery()
-                .setFileId(ADDRESS_BOOK_IPS)
+                .setFileId(ADDRESS_BOOK_ID)
                 .setMaxQueryPayment(new Hbar(1))
                 .execute(client);
 

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/ScheduleClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/ScheduleClient.java
@@ -22,8 +22,10 @@ package com.hedera.mirror.test.e2e.acceptance.client;
 
 import java.util.List;
 import java.util.concurrent.TimeoutException;
-import lombok.Value;
+import javax.inject.Named;
 import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.annotation.Scope;
 
 import com.hedera.hashgraph.sdk.KeyList;
 import com.hedera.hashgraph.sdk.PrecheckStatusException;
@@ -39,7 +41,8 @@ import com.hedera.mirror.test.e2e.acceptance.props.ExpandedAccountId;
 import com.hedera.mirror.test.e2e.acceptance.response.NetworkTransactionResponse;
 
 @Log4j2
-@Value
+@Named
+@Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE)
 public class ScheduleClient extends AbstractNetworkClient {
 
     public ScheduleClient(SDKClient sdkClient) {

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TokenClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TokenClient.java
@@ -25,9 +25,11 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
-import lombok.Value;
+import javax.inject.Named;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.annotation.Scope;
 
 import com.hedera.hashgraph.sdk.AccountId;
 import com.hedera.hashgraph.sdk.KeyList;
@@ -54,7 +56,8 @@ import com.hedera.mirror.test.e2e.acceptance.props.ExpandedAccountId;
 import com.hedera.mirror.test.e2e.acceptance.response.NetworkTransactionResponse;
 
 @Log4j2
-@Value
+@Named
+@Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE)
 public class TokenClient extends AbstractNetworkClient {
 
     public TokenClient(SDKClient sdkClient) {

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TopicClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TopicClient.java
@@ -29,8 +29,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
+import javax.inject.Named;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.ArrayUtils;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.annotation.Scope;
 
 import com.hedera.hashgraph.sdk.KeyList;
 import com.hedera.hashgraph.sdk.PrecheckStatusException;
@@ -48,6 +51,8 @@ import com.hedera.mirror.test.e2e.acceptance.props.ExpandedAccountId;
 import com.hedera.mirror.test.e2e.acceptance.response.NetworkTransactionResponse;
 
 @Log4j2
+@Named
+@Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE)
 public class TopicClient extends AbstractNetworkClient {
     private static final Duration autoRenewPeriod = Duration.ofSeconds(8000000);
     private final Map<Long, Instant> recordPublishInstants;
@@ -197,7 +202,7 @@ public class TopicClient extends AbstractNetworkClient {
             recordPublishInstants.put(transactionReceipt.topicSequenceNumber, transactionId
                     .getRecord(client).consensusTimestamp);
         } catch (TimeoutException | PrecheckStatusException | ReceiptStatusException e) {
-            e.printStackTrace();
+            log.error("Error publishing to topic", e);
         }
 
         log.trace("Verified message published : '{}' to topicId : {} with sequence number : {}", message, topicId,

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
@@ -23,17 +23,17 @@ package com.hedera.mirror.test.e2e.acceptance.config;
 import java.time.Duration;
 import java.util.LinkedHashSet;
 import java.util.Set;
+import javax.inject.Named;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.stereotype.Component;
 import org.springframework.validation.annotation.Validated;
 
 import com.hedera.mirror.test.e2e.acceptance.props.NodeProperties;
 
-@Component
+@Named
 @ConfigurationProperties(prefix = "hedera.mirror.test.acceptance")
 @Data
 @Validated

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/NodeProperties.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/NodeProperties.java
@@ -31,11 +31,6 @@ import org.springframework.validation.annotation.Validated;
 @Validated
 public class NodeProperties {
 
-    public NodeProperties(String accountId, String host) {
-        this.accountId = accountId;
-        this.host = host;
-    }
-
     @NotBlank
     private String accountId;
 

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AccountFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AccountFeature.java
@@ -22,7 +22,6 @@ package com.hedera.mirror.test.e2e.acceptance.steps;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import io.cucumber.java.After;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import io.cucumber.junit.platform.engine.Cucumber;
@@ -95,11 +94,5 @@ public class AccountFeature {
     @Then("the new balance should reflect cryptotransfer of {long}")
     public void accountReceivedFunds(long amount) throws TimeoutException, PrecheckStatusException {
         assertTrue(accountClient.getBalance(accountId) >= startingBalance + amount);
-    }
-
-    @After("@Accounts")
-    public void closeClients() {
-        log.debug("Closing account feature clients");
-        accountClient.close();
     }
 }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ScheduleFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ScheduleFeature.java
@@ -23,7 +23,6 @@ package com.hedera.mirror.test.e2e.acceptance.steps;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
-import io.cucumber.java.After;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
@@ -66,7 +65,6 @@ import com.hedera.mirror.test.e2e.acceptance.client.MirrorNodeClient;
 import com.hedera.mirror.test.e2e.acceptance.client.ScheduleClient;
 import com.hedera.mirror.test.e2e.acceptance.client.TokenClient;
 import com.hedera.mirror.test.e2e.acceptance.client.TopicClient;
-import com.hedera.mirror.test.e2e.acceptance.config.AcceptanceTestProperties;
 import com.hedera.mirror.test.e2e.acceptance.props.ExpandedAccountId;
 import com.hedera.mirror.test.e2e.acceptance.props.MirrorTransaction;
 import com.hedera.mirror.test.e2e.acceptance.response.MirrorScheduleResponse;
@@ -78,8 +76,6 @@ import com.hedera.mirror.test.e2e.acceptance.response.NetworkTransactionResponse
 public class ScheduleFeature {
     private final static int DEFAULT_TINY_HBAR = 1_000;
 
-    @Autowired
-    private AcceptanceTestProperties acceptanceProps;
     @Autowired
     private ScheduleClient scheduleClient;
     @Autowired
@@ -501,15 +497,6 @@ public class ScheduleFeature {
     public void recover(PrecheckStatusException t) throws PrecheckStatusException {
         log.error("Transaction submissions for token transaction failed after retries w: {}", t.getMessage());
         throw t;
-    }
-
-    @After("@schedulebase")
-    public void closeClients() {
-        log.debug("Closing schedule feature clients");
-        accountClient.close();
-        mirrorClient.close();
-        tokenClient.close();
-        topicClient.close();
     }
 
     @RequiredArgsConstructor

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TokenFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TokenFeature.java
@@ -23,7 +23,6 @@ package com.hedera.mirror.test.e2e.acceptance.steps;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
-import io.cucumber.java.After;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
@@ -452,13 +451,5 @@ public class TokenFeature {
         log.error("REST API response verification failed after {} retries w: {}",
                 acceptanceProps.getRestPollingProperties().getMaxAttempts(), t.getMessage());
         throw t;
-    }
-
-    @After("@TokenBase")
-    public void closeClients() {
-        log.debug("Closing token feature clients");
-        accountClient.close();
-        mirrorClient.close();
-        tokenClient.close();
     }
 }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TopicFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TopicFeature.java
@@ -22,7 +22,6 @@ package com.hedera.mirror.test.e2e.acceptance.steps;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import io.cucumber.java.After;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
@@ -36,7 +35,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.retry.annotation.Recover;
 import org.springframework.retry.annotation.Retryable;
 
 import com.hedera.hashgraph.sdk.KeyList;
@@ -354,7 +352,7 @@ public class TopicFeature {
                             "backgroundMessage".getBytes(StandardCharsets.UTF_8),
                             getSubmitKeys());
                 } catch (TimeoutException | PrecheckStatusException | ReceiptStatusException e) {
-                    e.printStackTrace();
+                    log.error("Error publishing to topic", e);
                 }
             }, 0, 1, TimeUnit.SECONDS);
         }
@@ -375,48 +373,5 @@ public class TopicFeature {
 
     private KeyList getSubmitKeys() {
         return submitKey == null ? null : KeyList.of(submitKey);
-    }
-
-    /**
-     * Recover method for retry operations Method parameters of retry method must match this method after exception
-     * parameter
-     *
-     * @param t
-     */
-    @Recover
-    public void recover(PrecheckStatusException t) throws PrecheckStatusException {
-        log.error("Transaction submissions for topic operation failed after retries w: {}", t.getMessage());
-        throw t;
-    }
-
-    /**
-     * Recover method for publishTopicMessages retry operations. Method parameters of retry method must match this
-     * method after exception parameter
-     *
-     * @param t
-     */
-    @Recover
-    public void recover(PrecheckStatusException t, int messageCount) throws PrecheckStatusException {
-        log.error("Transaction submissions for message publish failed after retries w: {}", t.getMessage());
-        throw t;
-    }
-
-    /**
-     * Recover method for publishTopicMessages retry operations. Method parameters of retry method must match this
-     * method after exception parameter
-     *
-     * @param t
-     */
-    @Recover
-    public void recover(PrecheckStatusException t, int numGroups, int messageCount, long milliSleep) throws PrecheckStatusException {
-        log.error("Transaction submissions for message publish failed after retries w: {}", t.getMessage());
-        throw t;
-    }
-
-    @After("@TopicMessagesBase or @TopicMessagesFilter")
-    public void closeClients() {
-        log.debug("Closing topic feature clients");
-        mirrorClient.close();
-        topicClient.close();
     }
 }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TopicFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TopicFeature.java
@@ -35,6 +35,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.retry.annotation.Recover;
 import org.springframework.retry.annotation.Retryable;
 
 import com.hedera.hashgraph.sdk.KeyList;
@@ -373,5 +374,41 @@ public class TopicFeature {
 
     private KeyList getSubmitKeys() {
         return submitKey == null ? null : KeyList.of(submitKey);
+    }
+
+    /**
+     * Recover method for retry operations Method parameters of retry method must match this method after exception
+     * parameter
+     *
+     * @param t
+     */
+    @Recover
+    public void recover(PrecheckStatusException t) throws PrecheckStatusException {
+        log.error("Transaction submissions for topic operation failed after retries w: {}", t.getMessage());
+        throw t;
+    }
+
+    /**
+     * Recover method for publishTopicMessages retry operations. Method parameters of retry method must match this
+     * method after exception parameter
+     *
+     * @param t
+     */
+    @Recover
+    public void recover(PrecheckStatusException t, int messageCount) throws PrecheckStatusException {
+        log.error("Transaction submissions for message publish failed after retries w: {}", t.getMessage());
+        throw t;
+    }
+
+    /**
+     * Recover method for publishTopicMessages retry operations. Method parameters of retry method must match this
+     * method after exception parameter
+     *
+     * @param t
+     */
+    @Recover
+    public void recover(PrecheckStatusException t, int numGroups, int messageCount, long milliSleep) throws PrecheckStatusException {
+        log.error("Transaction submissions for message publish failed after retries w: {}", t.getMessage());
+        throw t;
     }
 }


### PR DESCRIPTION
**Detailed description**:
- Change acceptance tests to component scanning
- Fix acceptance tests loading address book and validating nodes multiple times by switching to singleton
- Remove dead code in acceptance tests
- Workaround https://github.com/hashgraph/hedera-sdk-java/issues/494 by hacking SDK's `ManagedNode` to not use plaintext for ports 443 or 50212

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [x] Documentation added
- [x] Tests updated

