### PR TITLE
Show rosetta container log when validation fails

### DIFF
--- a/.github/workflows/rosetta-api.yml
+++ b/.github/workflows/rosetta-api.yml
@@ -75,10 +75,12 @@ jobs:
 
       - name: Run Mirror Node
         run: |
-          docker run -d -e HEDERA_MIRROR_IMPORTER_STARTDATE=$STARTDATE \
+          CONTAINER_ID=$(docker run -d -e HEDERA_MIRROR_IMPORTER_STARTDATE=$STARTDATE \
             -e NETWORK=testnet \
             -v /tmp/application.yml:/var/importer/application.yml \
-            -p 5432:5432 -p 5700:5700 "${MODULE}"
+            -p 5432:5432 -p 5700:5700 "${MODULE}")
+
+          echo "CONTAINER_ID=$CONTAINER_ID" >> $GITHUB_ENV
 
       - name: Wait for Mirror Node to start syncing
         run: ./scripts/wait-for-mirror-node.sh
@@ -99,6 +101,10 @@ jobs:
           [[ $code -eq 0 ]] && { wait $pid || code=$?; }
           cat /tmp/construction-validation.log
           exit $code
+
+      - name: Show Container Log
+        if: ${{ failure() && env.CONTAINER_ID != "" }}
+        run: docker logs $CONTAINER_ID
 
   gosec:
     runs-on: ubuntu-latest

--- a/.github/workflows/rosetta-api.yml
+++ b/.github/workflows/rosetta-api.yml
@@ -81,16 +81,10 @@ jobs:
             -p 5432:5432 -p 5700:5700 "${MODULE}"
 
       - name: Wait for Mirror Node to start syncing
-        run: |
-          ./scripts/wait-for-mirror-node.sh && code=0 || code=$?
-          [[ $code -ne 0 ]] && docker logs $(docker container ls -l -q -a)
-          exit $code
+        run: ./scripts/wait-for-mirror-node.sh
 
       - name: Get Genesis Account Balances
-        run: |
-          ./scripts/validation/get-genesis-balance.sh testnet && code=0 || code=$?
-          [[ $code -ne 0 ]] && docker logs $(docker container ls -l -q -a)
-          exit $code
+        run: ./scripts/validation/get-genesis-balance.sh testnet
 
       - name: Run Rosetta CLI Validation
         working-directory: ./hedera-mirror-rosetta/scripts/validation
@@ -104,8 +98,6 @@ jobs:
           ./run-validation.sh testnet data && code=0 || code=$?
           [[ $code -eq 0 ]] && { wait $pid || code=$?; }
           cat /tmp/construction-validation.log
-
-          [[ $code -ne 0 ]] && docker logs $(docker container ls -l -q -a)
           exit $code
 
   gosec:

--- a/.github/workflows/rosetta-api.yml
+++ b/.github/workflows/rosetta-api.yml
@@ -81,10 +81,16 @@ jobs:
             -p 5432:5432 -p 5700:5700 "${MODULE}"
 
       - name: Wait for Mirror Node to start syncing
-        run: ./scripts/wait-for-mirror-node.sh
+        run: |
+          ./scripts/wait-for-mirror-node.sh && code=0 || code=$?
+          [[ $code -ne 0 ]] && docker logs $(docker container ls -l -q -a)
+          exit $code
 
       - name: Get Genesis Account Balances
-        run: ./scripts/validation/get-genesis-balance.sh testnet
+        run: |
+          ./scripts/validation/get-genesis-balance.sh testnet && code=0 || code=$?
+          [[ $code -ne 0 ]] && docker logs $(docker container ls -l -q -a)
+          exit $code
 
       - name: Run Rosetta CLI Validation
         working-directory: ./hedera-mirror-rosetta/scripts/validation
@@ -98,6 +104,8 @@ jobs:
           ./run-validation.sh testnet data && code=0 || code=$?
           [[ $code -eq 0 ]] && { wait $pid || code=$?; }
           cat /tmp/construction-validation.log
+
+          [[ $code -ne 0 ]] && docker logs $(docker container ls -l -q -a)
           exit $code
 
   gosec:

--- a/.github/workflows/rosetta-api.yml
+++ b/.github/workflows/rosetta-api.yml
@@ -103,7 +103,7 @@ jobs:
           exit $code
 
       - name: Show Container Log
-        if: ${{ failure() && env.CONTAINER_ID != "" }}
+        if: ${{ failure() && env.CONTAINER_ID != '' }}
         run: docker logs $CONTAINER_ID
 
   gosec:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with master
-->

**Detailed description**:
Rosetta validation fails sometimes, without the log from the rosetta all-in-one container, it's hard to tell the cause. The PR adds the functionality to dump the container log when any step fails.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

