### PR TITLE
fix semantic error for openapi.yml

### DIFF
--- a/hedera-mirror-rest/api/v1/openapi.yml
+++ b/hedera-mirror-rest/api/v1/openapi.yml
@@ -216,7 +216,7 @@ paths:
                     - message: "Invalid parameter: timestamp"
       tags:
         - transactions
-  /api/v1/transactions/{id}:
+  /api/v1/transactions/{transactionId}:
     get:
       summary: Get transaction by id
       description: Returns transaction information based on the given transaction id
@@ -254,7 +254,7 @@ paths:
           $ref: '#/components/responses/NotFoundError'
       tags:
         - transactions
-  /api/v1/transactions/{id}/stateproof:
+  /api/v1/transactions/{transactionId}/stateproof:
     get:
       summary: Get stateproof information
       description: Returns the  contents of the address book file, signature files, and record file that can be used to validate the transaction occurred on the Hedera network given transaction id.
@@ -1074,7 +1074,6 @@ components:
       name: account.id
       in: query
       description: The ID of the account to return information for
-      example: 0.0.8
       explode: true
       examples:
         entityNumNoOperator:


### PR DESCRIPTION
**Detailed description**:

see https://editor.swagger.io/?url=https://raw.githubusercontent.com/hashgraph/hedera-mirror-node/master/hedera-mirror-rest/api/v1/openapi.yml

Semantic error at paths./api/v1/transactions/{id}
Declared path parameter "id" needs to be defined as a path parameter at either the path or operation level

Semantic error at paths./api/v1/transactions/{id}.get.parameters.0.name
Path parameter "transactionId" must have the corresponding {transactionId} segment in the "/api/v1/transactions/{id}" path

Semantic error at paths./api/v1/transactions/{id}/stateproof
Declared path parameter "id" needs to be defined as a path parameter at either the path or operation level

Structural error at components.parameters.accountIdQueryParam
should not have both `example` and `examples`, as they are mutually exclusive

**Which issue(s) this PR fixes**:
no related issue

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

