### PR TITLE
Add a global hostname, pullPolicy and podAnnotations properties to chart

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -49,53 +49,37 @@ $ helm upgrade --install "${RELEASE}" charts/hedera-mirror --set postgresql.enab
 When running against a network other than a public network (demo/previewnet/testnet/mainnet), the network must be
 updated with an initial address book file prior to deploying the chart.
 
-1. First create the secret from the local address book file (`/Downloads/perf.bin` in this case):
+1. First acquire the address book file and encode its contents to Base64:
 
 ```shell
-$ kubectl create secret generic mirror-importer-addressbook --from-file=addressbook.bin=/Downloads/perf.bin
+$ base64 --input ~/addressbook.bin
 ```
 
-2. Then create a local values file (i.e. `custom.yaml`) to set the `network`, `initialAddressBook`, `volumes`,
-   and `volumeMounts` properties:
+2. Then populate the importer's `addressBook` property in the custom `values.yaml` with the Base64 output:
 
 ```yaml
 importer:
-  config:
-    hedera:
-      mirror:
-        importer:
-          initialAddressBook: "/usr/etc/addressbook/addressbook.bin"
-          network: "OTHER"
-  volumeMounts:
-    addressbook:
-      mountPath: /usr/etc/addressbook
-  volumes:
-    addressbook:
-      secret:
-        defaultMode: 420
-        secretName: mirror-importer-addressbook
-```
-
-> **_Note_** Ensure the configured `mountPath` matches the path in `initialAddressBook`
-
-The secret data will be mounted as a file by the importer StatefulSet and placed at the `mountPath` location on the
-importer filesystem. The `custom.yaml` should be referenced as a values file during chart deployment:
-
-```shell
-$ helm upgrade --install mirror charts/hedera-mirror -f charts/hedera-mirror/custom.yaml
+  addressBook: CtYGGgUwLjAuN...
 ```
 
 ### Production Environments
-In non production environments, the mirror node chart uses the [Traefik subchart](https://github.com/traefik/traefik-helm-chart) to manage access to cluster services through an [Ingress](https://doc.traefik.io/traefik/providers/kubernetes-ingress/) and to route traffic through [Load Balancing](https://doc.traefik.io/traefik/routing/overview/).
-The implemented configuration uses a [default self-signed certificate](https://doc.traefik.io/traefik/https/tls/#default-certificate) to secure traffic over the TLS protocol.
 
-In production it is advised to use a CA signed certificate and an external load balancer to allow for more secure and intricate load balancing needs.
-The following diagram illustrates a high level overview of the resources utilized in the recommended traffic flow.
+In non production environments, the mirror node chart uses
+the [Traefik subchart](https://github.com/traefik/traefik-helm-chart) to manage access to cluster services through
+an [Ingress](https://doc.traefik.io/traefik/providers/kubernetes-ingress/) and to route traffic
+through [Load Balancing](https://doc.traefik.io/traefik/routing/overview/). The implemented configuration uses
+a [default self-signed certificate](https://doc.traefik.io/traefik/https/tls/#default-certificate) to secure traffic
+over the TLS protocol.
+
+In production it is advised to use a CA signed certificate and an external load balancer to allow for more secure and
+intricate load balancing needs. The following diagram illustrates a high level overview of the resources utilized in the
+recommended traffic flow.
 ![Kubernetes deployed Hedera Mirror Node Resource Traffic Flow](images/mirror_traffic_resource_architecture.png)
 
 #### GCP
-When deploying in GCP, the following steps may be taken to use container-native load balancer through a [Standalone NEG](https://cloud.google.com/kubernetes-engine/docs/how-to/standalone-neg).
 
+When deploying in GCP, the following steps may be taken to use container-native load balancer through
+a [Standalone NEG](https://cloud.google.com/kubernetes-engine/docs/how-to/standalone-neg).
 
 1. Create a Kubernetes cluster utilizing a custom subnet.
 
@@ -112,8 +96,8 @@ When deploying in GCP, the following steps may be taken to use container-native 
 
 2. Configure the Traefik Subchart to use the external load balancer.
 
-   The following default production setup configures the Standalone NEG.
-   It exposes 2 ports (80 and 443) for http and TLS based traffic.
+   The following default production setup configures the Standalone NEG. It exposes 2 ports (80 and 443) for http and
+   TLS based traffic.
 
    Apply this config to your local values file (i.e. `custom.yaml`) for use in helm deployment.
    ```yaml
@@ -129,21 +113,25 @@ When deploying in GCP, the following steps may be taken to use container-native 
               }'
    ```
 
-    > **_Note:_** Ensure the NEG names are cluster unique to support shared NEGs across separate globally distributed clusters
+   > **_Note:_** Ensure the NEG names are cluster unique to support shared NEGs across separate globally distributed clusters
 
-   The annotation will ensure that a NEG is created for each name specified, with the endpoints pointing to the Traefik pod IPs in your cluster on the configured port.
-   These ports should match the ports exposed by Traefik in the common chart `.Values.traefik.ports`.
+   The annotation will ensure that a NEG is created for each name specified, with the endpoints pointing to the Traefik
+   pod IPs in your cluster on the configured port. These ports should match the ports exposed by Traefik in the common
+   chart `.Values.traefik.ports`.
 
-3. Create a [Google Managed Certificate](https://cloud.google.com/load-balancing/docs/ssl-certificates/google-managed-certs) for use by the Load Balancer
+3. Create
+   a [Google Managed Certificate](https://cloud.google.com/load-balancing/docs/ssl-certificates/google-managed-certs)
+   for use by the Load Balancer
 
-4. Create an [External HTTPS load balancer](https://cloud.google.com/load-balancing/docs/https/ext-https-lb-simple) and create a Backend Service(s) that utilizes the automatically created NEGs pointing to the traffic pods.
+4. Create an [External HTTPS load balancer](https://cloud.google.com/load-balancing/docs/https/ext-https-lb-simple) and
+   create a Backend Service(s) that utilizes the automatically created NEGs pointing to the traffic pods.
 
 ## Testing
 
 To verify the chart installation is successful, you can run the helm tests. These tests are not automatically executed
 by helm on install/upgrade, they have to be executed manually. The tests require the `existingTopicNum`,  `operatorId`,
-and `operatorKey` properties be set in a local values file in order to execute, as well as `network` if using an environment other
-than testnet, and `nodes` if using a custom environment.
+and `operatorKey` properties be set in a local values file in order to execute, as well as `network` if using an
+environment other than testnet, and `nodes` if using a custom environment.
 
 To configure:
 

--- a/charts/hedera-mirror-common/dashboards/hedera-mirror-monitor.json
+++ b/charts/hedera-mirror-common/dashboards/hedera-mirror-monitor.json
@@ -454,7 +454,7 @@
       "pluginVersion": "7.3.3",
       "targets": [
         {
-          "expr": "sum(rate(hedera_mirror_monitor_subscribe_e2e_seconds_sum{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) / sum(rate(hedera_mirror_monitor_subscribe_e2e_seconds_count{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval]))",
+          "expr": "sum(rate(hedera_mirror_monitor_subscribe_e2e_seconds_sum{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\",protocol=\"GRPC\"}[$__rate_interval])) / sum(rate(hedera_mirror_monitor_subscribe_e2e_seconds_count{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\",protocol=\"GRPC\"}[$__rate_interval]))",
           "interval": "1m",
           "legendFormat": "",
           "refId": "A"

--- a/charts/hedera-mirror-grpc/templates/deployment.yaml
+++ b/charts/hedera-mirror-grpc/templates/deployment.yaml
@@ -17,6 +17,9 @@ spec:
     metadata:
       annotations:
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- if or .Values.podAnnotations .Values.global.podAnnotations }}
+        {{- tpl (mergeOverwrite .Values.podAnnotations .Values.global.podAnnotations | toYaml) $ | nindent 8 }}
+        {{- end }}
       labels: {{ include "hedera-mirror-grpc.selectorLabels" . | nindent 8 }}
     spec:
       affinity: {{ toYaml .Values.affinity | nindent 8 }}
@@ -33,7 +36,7 @@ spec:
             {{- end }}
           envFrom: {{ tpl (toYaml .Values.envFrom) . | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.global.image.tag | default .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          imagePullPolicy: {{ .Values.global.image.pullPolicy | default .Values.image.pullPolicy }}
           livenessProbe: {{ toYaml .Values.livenessProbe | nindent 12 }}
           ports:
             - containerPort: 5600

--- a/charts/hedera-mirror-grpc/templates/ingress.yaml
+++ b/charts/hedera-mirror-grpc/templates/ingress.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "hedera-mirror-grpc.fullname" $ -}}
+{{- $hostname := .Values.global.hostname -}}
 {{- $servicePort := .Values.service.port -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -16,7 +17,7 @@ metadata:
 spec:
   rules:
   {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ $hostname | default .host | quote }}
       http:
         paths:
         {{- range .paths }}

--- a/charts/hedera-mirror-grpc/values.yaml
+++ b/charts/hedera-mirror-grpc/values.yaml
@@ -61,6 +61,7 @@ fullnameOverride: ""
 global:
   image: {}
   namespaceOverride: ""
+  podAnnotations: {}
 
 hpa:
   enabled: false
@@ -108,6 +109,8 @@ livenessProbe:
   timeoutSeconds: 2
 
 nodeSelector: {}
+
+podAnnotations: {}
 
 podSecurityContext:
   fsGroup: 1000
@@ -199,11 +202,11 @@ prometheusRules:
 
   GrpcNoPodsReady:
     annotations:
-      description: "No grpc instances are currently running in {{ $labels.namespace }}/{{ $labels.pod }}"
-      summary: No grpc instances running
+      description: "No gRPC API instances are currently running in {{ $labels.namespace }}"
+      summary: No gRPC API instances running
     enabled: true
-    expr: sum(kube_pod_container_status_ready{container="grpc"}) by (namespace, pod) < 1
-    for: 30s
+    expr: sum(kube_pod_container_status_ready{container="grpc"}) by (namespace) < 1
+    for: 2m
     labels:
       severity: critical
       application: hedera-mirror-grpc

--- a/charts/hedera-mirror-importer/templates/deployment.yaml
+++ b/charts/hedera-mirror-importer/templates/deployment.yaml
@@ -15,6 +15,9 @@ spec:
     metadata:
       annotations:
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- if or .Values.podAnnotations .Values.global.podAnnotations }}
+        {{- tpl (mergeOverwrite .Values.podAnnotations .Values.global.podAnnotations | toYaml) $ | nindent 8 }}
+        {{- end }}
       labels: {{ include "hedera-mirror-importer.selectorLabels" . | nindent 8 }}
     spec:
       affinity: {{ toYaml .Values.affinity | nindent 8 }}
@@ -31,7 +34,7 @@ spec:
             {{- end }}
           envFrom: {{ tpl (toYaml .Values.envFrom) . | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.global.image.tag | default .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          imagePullPolicy: {{ .Values.global.image.pullPolicy | default .Values.image.pullPolicy }}
           livenessProbe: {{ toYaml .Values.livenessProbe | nindent 12 }}
           ports:
             - containerPort: 8080

--- a/charts/hedera-mirror-importer/templates/secret.yaml
+++ b/charts/hedera-mirror-importer/templates/secret.yaml
@@ -5,6 +5,11 @@ metadata:
   name: {{ include "hedera-mirror-importer.fullname" . }}
   namespace: {{ include "hedera-mirror-importer.namespace" . }}
 type: Opaque
-stringData:
-  application.yaml: |-
-    {{- toYaml .Values.config | nindent 4 }}
+data:
+  {{- $config := deepCopy .Values.config }}
+  {{- if .Values.addressBook }}
+  {{- $addressBookConfig := dict "hedera" (dict "mirror" (dict "importer" (dict "initialAddressBook" "/usr/etc/hedera/addressbook.bin" ))) }}
+  {{- $config = merge $config $addressBookConfig }}
+  addressbook.bin: {{ .Values.addressBook }}
+  {{- end }}
+  application.yaml: {{ toYaml $config | b64enc }}

--- a/charts/hedera-mirror-importer/values.yaml
+++ b/charts/hedera-mirror-importer/values.yaml
@@ -1,3 +1,6 @@
+# Base64 encoded contents of a bootstrap address book
+addressBook: ""
+
 affinity:
   podAntiAffinity:
     preferredDuringSchedulingIgnoredDuringExecution:
@@ -126,6 +129,7 @@ fullnameOverride: ""
 global:
   image: {}
   namespaceOverride: ""
+  podAnnotations: {}
 
 image:
   pullPolicy: IfNotPresent
@@ -151,6 +155,8 @@ networkPolicy:
 
 nodeSelector: {}
 
+podAnnotations: {}
+
 podDisruptionBudget:
   enabled: false
   # maxUnavailable: 0
@@ -164,28 +170,6 @@ podSecurityContext:
   fsGroup: 1000
 
 priorityClassName: ""
-
-rbac:
-  enabled: true
-
-readinessProbe:
-  httpGet:
-    path: /actuator/health/readiness
-    port: http
-  initialDelaySeconds: 60
-  timeoutSeconds: 2
-
-replicas: 1
-
-resources:
-  limits:
-    cpu: 1.8
-    memory: 3072Mi
-  requests:
-    cpu: 200m
-    memory: 512Mi
-
-revisionHistoryLimit: 3
 
 prometheusRules:
   enabled: false
@@ -325,11 +309,11 @@ prometheusRules:
 
   ImporterNoPodsReady:
     annotations:
-      description: "No importer instances are currently ready in {{ $labels.namespace }}/{{ $labels.pod }}"
+      description: "No importer instances are currently ready in {{ $labels.namespace }}"
       summary: No importer instances are ready
     enabled: true
-    expr: sum(kube_pod_container_status_ready{container="importer"}) by (namespace, pod) < 1
-    for: 30s
+    expr: sum(kube_pod_container_status_ready{container="importer"}) by (namespace) < 1
+    for: 2m
     labels:
       severity: critical
       application: hedera-mirror-importer
@@ -410,6 +394,28 @@ prometheusRules:
       application: hedera-mirror-importer
       type: RECORD
       area: downloader
+
+rbac:
+  enabled: true
+
+readinessProbe:
+  httpGet:
+    path: /actuator/health/readiness
+    port: http
+  initialDelaySeconds: 60
+  timeoutSeconds: 2
+
+replicas: 1
+
+resources:
+  limits:
+    cpu: 1.8
+    memory: 3072Mi
+  requests:
+    cpu: 200m
+    memory: 512Mi
+
+revisionHistoryLimit: 3
 
 securityContext:
   capabilities:

--- a/charts/hedera-mirror-monitor/templates/deployment.yaml
+++ b/charts/hedera-mirror-monitor/templates/deployment.yaml
@@ -15,6 +15,9 @@ spec:
     metadata:
       annotations:
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- if or .Values.podAnnotations .Values.global.podAnnotations }}
+        {{- tpl (mergeOverwrite .Values.podAnnotations .Values.global.podAnnotations | toYaml) $ | nindent 8 }}
+        {{- end }}
       labels: {{ include "hedera-mirror-monitor.selectorLabels" . | nindent 8 }}
     spec:
       affinity: {{ toYaml .Values.affinity | nindent 8 }}
@@ -31,7 +34,7 @@ spec:
             {{- end }}
           envFrom: {{ tpl (toYaml .Values.envFrom) . | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.global.image.tag | default .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          imagePullPolicy: {{ .Values.global.image.pullPolicy | default .Values.image.pullPolicy }}
           livenessProbe: {{ toYaml .Values.livenessProbe | nindent 12 }}
           ports:
             - containerPort: 8082

--- a/charts/hedera-mirror-monitor/values.yaml
+++ b/charts/hedera-mirror-monitor/values.yaml
@@ -88,6 +88,7 @@ fullnameOverride: ""
 global:
   image: {}
   namespaceOverride: ""
+  podAnnotations: {}
 
 image:
   pullPolicy: IfNotPresent
@@ -107,6 +108,8 @@ livenessProbe:
   timeoutSeconds: 2
 
 nodeSelector: {}
+
+podAnnotations: {}
 
 podSecurityContext:
   fsGroup: 1000
@@ -152,10 +155,10 @@ prometheusRules:
 
   MonitorNoPodsReady:
     annotations:
-      description: "No monitor instances are currently running in {{ $labels.namespace }}/{{ $labels.pod }}"
+      description: "No monitor instances are currently running in {{ $labels.namespace }}"
       summary: No monitor instances running
     enabled: true
-    expr: sum(kube_pod_container_status_ready{container="monitor"}) by (namespace, pod) < 1
+    expr: sum(kube_pod_container_status_ready{container="monitor"}) by (namespace) < 1
     for: 2m
     labels:
       severity: critical

--- a/charts/hedera-mirror-rest/templates/deployment.yaml
+++ b/charts/hedera-mirror-rest/templates/deployment.yaml
@@ -17,6 +17,9 @@ spec:
     metadata:
       annotations:
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- if or .Values.podAnnotations .Values.global.podAnnotations }}
+        {{- tpl (mergeOverwrite .Values.podAnnotations .Values.global.podAnnotations | toYaml) $ | nindent 8 }}
+        {{- end }}
       labels: {{ include "hedera-mirror-rest.selectorLabels" . | nindent 8 }}
     spec:
       affinity: {{ toYaml .Values.affinity | nindent 8 }}
@@ -33,7 +36,7 @@ spec:
             {{- end }}
           envFrom: {{ tpl (toYaml .Values.envFrom) . | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.global.image.tag | default .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          imagePullPolicy: {{ .Values.global.image.pullPolicy | default .Values.image.pullPolicy }}
           livenessProbe: {{- toYaml .Values.livenessProbe | nindent 12 }}
           ports:
             - containerPort: 5551

--- a/charts/hedera-mirror-rest/templates/ingress.yaml
+++ b/charts/hedera-mirror-rest/templates/ingress.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "hedera-mirror-rest.fullname" $ -}}
+{{- $hostname := .Values.global.hostname -}}
 {{- $servicePort := .Values.service.port -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -16,7 +17,7 @@ metadata:
 spec:
   rules:
   {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ $hostname | default .host | quote }}
       http:
         paths:
         {{- range .paths }}

--- a/charts/hedera-mirror-rest/values.yaml
+++ b/charts/hedera-mirror-rest/values.yaml
@@ -53,6 +53,7 @@ fullnameOverride: ""
 global:
   image: {}
   namespaceOverride: ""
+  podAnnotations: {}
 
 hpa:
   enabled: true
@@ -98,6 +99,8 @@ livenessProbe:
 
 nodeSelector: {}
 
+podAnnotations: {}
+
 podSecurityContext:
   fsGroup: 1000
 
@@ -130,11 +133,11 @@ prometheusRules:
 
   RestNoPodsReady:
     annotations:
-      description: "No REST API instances are currently running in {{ $labels.namespace }}/{{ $labels.pod }}"
-      summary: No rest instances running
+      description: "No REST API instances are currently running in {{ $labels.namespace }}"
+      summary: No REST API instances running
     enabled: true
-    expr: sum(kube_pod_container_status_ready{container="rest"}) by (namespace, pod) < 1
-    for: 30s
+    expr: sum(kube_pod_container_status_ready{container="rest"}) by (namespace) < 1
+    for: 2m
     labels:
       severity: critical
       application: hedera-mirror-rest

--- a/charts/hedera-mirror/values.yaml
+++ b/charts/hedera-mirror/values.yaml
@@ -57,8 +57,10 @@ db:
     username: mirror_node
 
 global:
+  hostname: ""
   image: {}
   namespaceOverride: ""
+  podAnnotations: {}
   useReleaseForNameLabel: false  # Set the name label to the release name for Marketplace
 
 grpc:


### PR DESCRIPTION
**Detailed description**:
- Add an `importer.addressBook` property that takes a Base64 encoded bootstrap address book to simplify non-prod configuration
- Add a `global.hostname` property to simplify ingress configuration
- Add a `global.image.pullPolicy` property
- Add a `global.podAnnotations` property
- Add a `podAnnotations` property to each component
- Fix the monitor dashboard E2E subscriber single stat including REST latency
- Fix the no pods ready alert triggering when any single pod went unready

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
A follow up PR will use the `global.podAnnotations` and `global.image.pullPolicy` to automate deployments to integration.

**Checklist**
- [x] Documentation added
- [ ] Tests updated

