### PR TITLE
Add workflow for building on windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -9,6 +9,10 @@ jobs:
     runs-on: windows-2019
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: '11'
 
       - name: Cache Maven packages
         uses: actions/cache@v2

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,21 @@
+name: Windows
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: windows-2019
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          path: ~/.m2
+          restore-keys: ${{ runner.os }}-m2
+
+      - name: Maven package
+        run: ./mvnw.cmd package --batch-mode --no-transfer-progress -DskipTests


### PR DESCRIPTION
**Detailed description**:
Add workflow to build mirror node on Windows Server 2019 virtual environment for pull requests to master.

Tests are skipped as they are not supported in windows-2019 virtual environment.

**Which issue(s) this PR fixes**:
Fixes #2072 