### PR TITLE
Dissociate accounts from tokens post run

### DIFF
--- a/hedera-mirror-test/README.md
+++ b/hedera-mirror-test/README.md
@@ -117,23 +117,24 @@ hedera:
 Tags: Tags allow you to filter which Cucumber scenarios and files are run. By default, tests marked with the `@critical`
 tag are run. To run a different set of files different tags can be specified
 
-`@critical` - Test cases to ensure the network is up and running and satisfies base scenarios.
+Test Suite Tags
 
-    `./mvnw clean integration-test --projects hedera-mirror-test/ -P=acceptance-tests -Dcucumber.filter.tags="@acceptance"`
+- `@critical` - Test cases to ensure the network is up and running and satisfies base scenarios.
+- `@release` - Test cases to verify a new deployed version satisfies core scenarios and is release worthy.
+- `@acceptance` - Test cases to verify most feature scenarios meet customer acceptance criteria.
+- `@fullsuite` - All cases - this will require some configuration of feature files.
 
-`@release` - Test cases to verify a new deployed version satisfies core scenarios and is release worthy.
+Feature based Tags
 
-    `./mvnw clean integration-test --projects hedera-mirror-test/ -P=acceptance-tests -Dcucumber.filter.tags="@acceptance"`
+- `@accounts` - Crypto account focused tests.
+- `@topicmessagesbase` - Simple HCS focused tests.
+- `@topicmessagesfilter` - HCS focused tests wth varied subscription filters.
+- `@tokenbase` - HTS focused tests.
+- `@schedulebase` - Scheduled transactions focused tests.
 
-`@acceptance` - Test cases to verify most feature scenarios meet customer acceptance criteria.
+To execute run
 
-    `./mvnw clean integration-test --projects hedera-mirror-test/ -P=acceptance-tests -Dcucumber.filter.tags="@acceptance"`
-
-`@fullsuite` - All cases - this will require some configuration of feature files.
-
-    `./mvnw clean integration-test --projects hedera-mirror-test/ -P=acceptance-tests -Dcucumber.filter.tags="@fullsuite"`
-
-Search for @? tags within the .feature files for other applicable tags.
+    ./mvnw clean integration-test --projects hedera-mirror-test/ -P=acceptance-tests -Dcucumber.filter.tags="<tag name>"
 
 > **_NOTE:_** Feature tags can be combined - See [Tag expressions](https://cucumber.io/docs/cucumber/api/). To run a subset of tags
 > - `@acceptance and @topicmessagesbase` - all token acceptance scenarios

--- a/hedera-mirror-test/README.md
+++ b/hedera-mirror-test/README.md
@@ -119,10 +119,17 @@ tag are run. To run a different set of files different tags can be specified
 
 Test Suite Tags
 
-- `@critical` - Test cases to ensure the network is up and running and satisfies base scenarios.
-- `@release` - Test cases to verify a new deployed version satisfies core scenarios and is release worthy.
-- `@acceptance` - Test cases to verify most feature scenarios meet customer acceptance criteria.
-- `@fullsuite` - All cases - this will require some configuration of feature files.
+- `@critical` - Test cases to ensure the network is up and running and satisfies base scenarios. Total cost to run 31.6
+  ℏ.
+- `@release` - Test cases to verify a new deployed version satisfies core scenarios and is release worthy. Total cost to
+  run 19.2 ℏ.
+- `@acceptance` - Test cases to verify most feature scenarios meet customer acceptance criteria. Total cost to run 6.5
+  ℏ.
+- `@fullsuite` - All cases - this will require some configuration of feature files and may include some disabled tests
+  that will fail on execution. Total cost to run 33.9 ℏ.
+
+> **_NOTE:_** Any noted total costs are estimates.
+> They will fluctuate with test coverage expansion, improvements and network fee schedule changes.
 
 Feature based Tags
 

--- a/hedera-mirror-test/README.md
+++ b/hedera-mirror-test/README.md
@@ -114,28 +114,30 @@ hedera:
 
 #### Feature Tags
 
-Tags: Tags allow you to filter which Cucumber scenarios and files are run. By default, tests marked with the @sanity tag
-are run. To run a different set of files different tags can be specified
+Tags: Tags allow you to filter which Cucumber scenarios and files are run. By default, tests marked with the `@critical`
+tag are run. To run a different set of files different tags can be specified
 
-Acceptance test cases
+`@critical` - Test cases to ensure the network is up and running and satisfies base scenarios.
 
-`./mvnw clean integration-test --projects hedera-mirror-test/ -P=acceptance-tests -Dcucumber.filter.tags="@acceptance"`
+    `./mvnw clean integration-test --projects hedera-mirror-test/ -P=acceptance-tests -Dcucumber.filter.tags="@acceptance"`
 
-All cases
+`@release` - Test cases to verify a new deployed version satisfies core scenarios and is release worthy.
 
-`./mvnw clean integration-test --projects hedera-mirror-test/ -P=acceptance-tests -Dcucumber.filter.tags="@fullsuite"`
+    `./mvnw clean integration-test --projects hedera-mirror-test/ -P=acceptance-tests -Dcucumber.filter.tags="@acceptance"`
 
-Negative cases
+`@acceptance` - Test cases to verify most feature scenarios meet customer acceptance criteria.
 
-`./mvnw clean integration-test --projects hedera-mirror-test/ -P=acceptance-tests -Dcucumber.filter.tags="@negative"`
+    `./mvnw clean integration-test --projects hedera-mirror-test/ -P=acceptance-tests -Dcucumber.filter.tags="@acceptance"`
 
-Edge cases
+`@fullsuite` - All cases - this will require some configuration of feature files.
 
-`./mvnw clean integration-test --projects hedera-mirror-test/ -P=acceptance-tests -Dcucumber.filter.tags="@edge"`
+    `./mvnw clean integration-test --projects hedera-mirror-test/ -P=acceptance-tests -Dcucumber.filter.tags="@fullsuite"`
 
-Other (search for @? tags within the .feature files for further tags)
+Search for @? tags within the .feature files for other applicable tags.
 
-`./mvnw integration-test --projects hedera-mirror-test/ -P=acceptance-tests -Dcucumber.filter.tags="@balancecheck"`
+> **_NOTE:_** Feature tags can be combined - See [Tag expressions](https://cucumber.io/docs/cucumber/api/). To run a subset of tags
+> - `@acceptance and @topicmessagesbase` - all token acceptance scenarios
+> - `@acceptance and not @tokenbase` - all acceptance except token scenarios
 
 ### Test Layout
 

--- a/hedera-mirror-test/src/main/resources/Dockerfile
+++ b/hedera-mirror-test/src/main/resources/Dockerfile
@@ -1,6 +1,6 @@
 FROM adoptopenjdk:11-jdk-hotspot
 
-ENV cucumberFlags "@balancecheck"
+ENV cucumberFlags "@critical"
 WORKDIR /usr/etc/hedera-mirror-node
 
 COPY .mvn/ .mvn/

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/AcceptanceTest.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/AcceptanceTest.java
@@ -32,7 +32,7 @@ import org.springframework.boot.test.context.SpringBootTest;
         glue = "com.hedera.mirror.test.e2e.acceptance",
         plugin = {"pretty", "de.monochromata.cucumber.report.PrettyReports:target/cucumber",
                 "timeline:target/cucumber/thread-report"},
-        tags = "@Sanity"
+        tags = "@critical"
 )
 @SpringBootTest
 @CucumberContextConfiguration

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AccountClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AccountClient.java
@@ -48,7 +48,8 @@ import com.hedera.mirror.test.e2e.acceptance.props.ExpandedAccountId;
 @Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE)
 public class AccountClient extends AbstractNetworkClient {
 
-    private static final long DEFAULT_INITIAL_BALANCE = 1_000_000_000L;
+    private static final long DEFAULT_INITIAL_BALANCE = 50_000_000L; // 0.5 ℏ
+    private static final long SMALL_INITIAL_BALANCE = 1_000L; // 1000 tℏ
 
     private ExpandedAccountId tokenTreasuryAccount = null;
 
@@ -74,7 +75,7 @@ public class AccountClient extends AbstractNetworkClient {
         ExpandedAccountId accountId = accountMap
                 .computeIfAbsent(accountNameEnum, x -> {
                     try {
-                        return createNewAccount(DEFAULT_INITIAL_BALANCE,
+                        return createNewAccount(SMALL_INITIAL_BALANCE,
                                 accountNameEnum);
                     } catch (Exception e) {
                         log.trace("Issue creating additional account: {}, ex: {}", accountNameEnum, e);

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TokenClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TokenClient.java
@@ -31,6 +31,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Scope;
 
+import com.hedera.hashgraph.sdk.AccountBalanceQuery;
 import com.hedera.hashgraph.sdk.AccountId;
 import com.hedera.hashgraph.sdk.KeyList;
 import com.hedera.hashgraph.sdk.PrecheckStatusException;
@@ -345,5 +346,16 @@ public class TokenClient extends AbstractNetworkClient {
         log.debug("Deleted token {}", accountId, token);
 
         return networkTransactionResponse;
+    }
+
+    public long getTokenBalance(AccountId accountId, TokenId tokenId) throws TimeoutException, PrecheckStatusException {
+        long balance = new AccountBalanceQuery()
+                .setAccountId(accountId)
+                .execute(client)
+                .token.get(tokenId);
+
+        log.debug("{}'s token balance is {} {} tokens", accountId, balance, tokenId);
+
+        return balance;
     }
 }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ScheduleFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ScheduleFeature.java
@@ -381,6 +381,7 @@ public class ScheduleFeature {
             tokenClient.delete(tokenClient.getSdkClient().getExpandedOperatorAccountId(), tokenId);
             dissociateAccount(tokenTreasuryAccount);
             dissociateAccount(tokenClient.getSdkClient().getExpandedOperatorAccountId());
+            tokenId = null;
         }
     }
 

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ScheduleFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ScheduleFeature.java
@@ -237,7 +237,7 @@ public class ScheduleFeature {
         // create topic w submit key
         log.debug("Create new topic with {}'s submit key", accountName);
         networkTransactionResponse = topicClient
-                .createTopic(accountClient.getTokenTreasuryAccount(), submitAdmin.getPublicKey());
+                .createTopic(scheduleClient.getSdkClient().getExpandedOperatorAccountId(), submitAdmin.getPublicKey());
         assertNotNull(networkTransactionResponse.getTransactionId());
         assertNotNull(networkTransactionResponse.getReceipt());
         TopicId topicId = networkTransactionResponse.getReceipt().topicId;

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ScheduleFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ScheduleFeature.java
@@ -23,6 +23,7 @@ package com.hedera.mirror.test.e2e.acceptance.steps;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
+import io.cucumber.java.After;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
@@ -77,30 +78,27 @@ public class ScheduleFeature {
     private final static int DEFAULT_TINY_HBAR = 1_000;
 
     @Autowired
-    private ScheduleClient scheduleClient;
-    @Autowired
     private AccountClient accountClient;
+    @Autowired
+    private MirrorNodeClient mirrorClient;
+    @Autowired
+    private TokenClient tokenClient;
     @Autowired
     private TopicClient topicClient;
     @Autowired
-    private TokenClient tokenClient;
+    private ScheduleClient scheduleClient;
 
-    private ScheduleId scheduleId;
-
-    @Autowired
-    private MirrorNodeClient mirrorClient;
-
-    private NetworkTransactionResponse networkTransactionResponse;
-    private TransactionId scheduledTransactionId;
-
-    private ScheduleInfo scheduleInfo;
-
-    private Transaction scheduledTransaction;
-
-    private int expectedSignersCount;
     private int currentSignersCount;
+    private int expectedSignersCount;
+    private NetworkTransactionResponse networkTransactionResponse;
+    private ScheduleId scheduleId;
+    private ScheduleInfo scheduleInfo;
+    private Transaction scheduledTransaction;
+    private TransactionId scheduledTransactionId;
     private final int signatoryCountOffset = 1; // Schedule map includes payer account which may not be a required
     // signatory
+    private TokenId tokenId;
+    private ExpandedAccountId tokenTreasuryAccount;
 
     @Given("I successfully schedule a treasury HBAR disbursement to {string}")
     @Retryable(value = {PrecheckStatusException.class}, exceptionExpression = "#{message.contains('BUSY')}")
@@ -187,7 +185,7 @@ public class ScheduleFeature {
             TimeoutException {
         expectedSignersCount = 2;
         currentSignersCount = 0 + signatoryCountOffset;
-        ExpandedAccountId sender = accountClient.getAccount(AccountClient.AccountNameEnum.valueOf(senderName));
+        tokenTreasuryAccount = accountClient.getAccount(AccountClient.AccountNameEnum.valueOf(senderName));
         ExpandedAccountId receiver = accountClient.getAccount(AccountClient.AccountNameEnum.valueOf(receiverName));
 
         // create token
@@ -200,11 +198,11 @@ public class ScheduleFeature {
                 RandomStringUtils.randomAlphabetic(4).toUpperCase(),
                 TokenFreezeStatus.FreezeNotApplicable_VALUE,
                 TokenKycStatus.KycNotApplicable_VALUE,
-                sender,
+                tokenTreasuryAccount,
                 DEFAULT_TINY_HBAR);
         assertNotNull(networkTransactionResponse.getTransactionId());
         assertNotNull(networkTransactionResponse.getReceipt());
-        TokenId tokenId = networkTransactionResponse.getReceipt().tokenId;
+        tokenId = networkTransactionResponse.getReceipt().tokenId;
         assertNotNull(tokenId);
 
         // associate new account, sender as treasury is auto associated
@@ -216,12 +214,12 @@ public class ScheduleFeature {
         scheduledTransaction = tokenClient
                 .getTokenTransferTransaction(
                         tokenId,
-                        sender.getAccountId(),
+                        tokenTreasuryAccount.getAccountId(),
                         receiver.getAccountId(),
                         10)
                 // add Hbar transfer logic
-                .addHbarTransfer(receiver.getAccountId(), hbarAmount.negated())
-                .addHbarTransfer(sender.getAccountId(), hbarAmount);
+                .addHbarTransfer(receiver.getAccountId(), hbarAmount)
+                .addHbarTransfer(tokenTreasuryAccount.getAccountId(), hbarAmount.negated());
 
         createNewSchedule(scheduledTransaction, null);
     }
@@ -371,6 +369,30 @@ public class ScheduleFeature {
             maxAttemptsExpression = "#{@restPollingProperties.maxAttempts}")
     public void verifyDeletedScheduleFromMirror() {
         verifyScheduleFromMirror(ScheduleStatus.DELETED);
+    }
+
+    @After
+    public void cleanup() throws ReceiptStatusException, PrecheckStatusException, TimeoutException {
+        // dissociate all applicable accounts from token to reduce likelihood of max token association error
+        if (tokenId != null) {
+            // a nonzero balance will result in a TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES error
+            // not possible to wipe a treasury account as it results in CANNOT_WIPE_TOKEN_TREASURY_ACCOUNT error
+            // as a result to dissociate first delete token
+            tokenClient.delete(tokenClient.getSdkClient().getExpandedOperatorAccountId(), tokenId);
+            dissociateAccount(tokenTreasuryAccount);
+            dissociateAccount(tokenClient.getSdkClient().getExpandedOperatorAccountId());
+        }
+    }
+
+    private void dissociateAccount(ExpandedAccountId accountId) {
+        if (accountId != null) {
+            try {
+                tokenClient.disssociate(accountId, tokenId);
+                log.info("Successfully dissociated account {} from token {}", accountId, tokenId);
+            } catch (Exception ex) {
+                log.warn("Error dissociating account {} from token {}, error: {}", accountId, tokenId, ex);
+            }
+        }
     }
 
     private void validateScheduleInfo(ScheduleInfo scheduleInfo) {

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TokenFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TokenFeature.java
@@ -276,14 +276,14 @@ public class TokenFeature {
     }
 
     @After
-    public void dissociateAccountsPostTests() throws ReceiptStatusException, PrecheckStatusException, TimeoutException {
+    public void dissociateAccounts() throws ReceiptStatusException, PrecheckStatusException, TimeoutException {
         // dissociate all applicable accounts from token to reduce likelihood of max token association error
-        dissociateAccountPostTests(accountClient.getTokenTreasuryAccount());
-        dissociateAccountPostTests(sender);
-        dissociateAccountPostTests(recipient);
+        dissociateAccount(accountClient.getTokenTreasuryAccount());
+        dissociateAccount(sender);
+        dissociateAccount(recipient);
     }
 
-    private void dissociateAccountPostTests(ExpandedAccountId accountId) {
+    private void dissociateAccount(ExpandedAccountId accountId) {
         if (accountId != null) {
             try {
                 tokenClient.disssociate(accountId, tokenId);

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TokenFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TokenFeature.java
@@ -23,6 +23,7 @@ package com.hedera.mirror.test.e2e.acceptance.steps;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
+import io.cucumber.java.After;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
@@ -272,6 +273,24 @@ public class TokenFeature {
 
         // publish background message to network to reduce possibility of stale info in low TPS environment
         topicClient.publishMessageToDefaultTopic();
+    }
+
+    @After
+    public void dissociateAccountsPostTests() throws ReceiptStatusException, PrecheckStatusException, TimeoutException {
+        // dissociate all applicable accounts from token to reduce likelihood of max token association error
+        dissociateAccountPostTests(accountClient.getTokenTreasuryAccount());
+        dissociateAccountPostTests(sender);
+        dissociateAccountPostTests(recipient);
+    }
+
+    private void dissociateAccountPostTests(ExpandedAccountId accountId) {
+        if (accountId != null) {
+            try {
+                tokenClient.disssociate(accountId, tokenId);
+                log.info("Successfully dissociated account {} from token {}", accountId, tokenId);
+            } catch (Exception ex) {
+            }
+        }
     }
 
     private void createNewToken(String symbol, int freezeStatus, int kycStatus) throws PrecheckStatusException,

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TokenFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TokenFeature.java
@@ -279,9 +279,9 @@ public class TokenFeature {
             // as a result to dissociate first delete token
             try {
                 tokenClient.delete(tokenClient.getSdkClient().getExpandedOperatorAccountId(), tokenId);
-                tokenId = null;
                 dissociateAccount(sender);
                 dissociateAccount(recipient);
+                tokenId = null;
             } catch (Exception ex) {
                 log.warn("Error cleaning up token {} and associations error: {}", tokenId, ex);
             }

--- a/hedera-mirror-test/src/test/resources/features/account/account.feature
+++ b/hedera-mirror-test/src/test/resources/features/account/account.feature
@@ -1,7 +1,7 @@
 @accounts @fullsuite
 Feature: Account Coverage Feature
 
-    @balancecheck @sanity @acceptance @Acceptance
+    @critical @release @acceptance @balancecheck
     Scenario Outline: Validate account balance check scenario
         When I request balance info for this account
         Then the crypto balance should be greater than or equal to <threshold>

--- a/hedera-mirror-test/src/test/resources/features/hcs/hcs.feature
+++ b/hedera-mirror-test/src/test/resources/features/hcs/hcs.feature
@@ -1,7 +1,7 @@
 @topicmessagesbase @fullsuite
 Feature: HCS Base Coverage Feature
 
-    @sanity @basicsubscribe @acceptance @extended
+    @critical @release @acceptance @basicsubscribe
     Scenario Outline: Validate Topic message submission
         Given I successfully create a new topic id
         And I publish and verify <numMessages> messages sent
@@ -12,7 +12,7 @@ Feature: HCS Base Coverage Feature
             | numMessages |
             | 10          |
 
-    @opensubscribe @extended
+    @opensubscribe @acceptance
     Scenario Outline: Validate Topic message submission to an open submit topic
         Given I successfully create a new open topic
         And I publish and verify <numMessages> messages sent
@@ -23,7 +23,7 @@ Feature: HCS Base Coverage Feature
             | numMessages |
             | 2           |
 
-    @subscribeonly @SubscribeOnly
+    @subscribeonly
     Scenario Outline: Validate topic message subscription only
         Given I provide a topic id <topicId>
         And I provide a starting timestamp <startTimestamp> and a number of messages <numMessages> I want to receive
@@ -53,17 +53,17 @@ Feature: HCS Base Coverage Feature
             | topicId  | numMessages |
             | "171231" | 340         |
 
-    @updatetopic @acceptance @extended
+    @release @acceptance @updatetopic
     Scenario: Validate Topic Updates
         Given I successfully create a new topic id
         Then I successfully update an existing topic
 
-    @deletetopic @acceptance @extended
+    @acceptance @deletetopic
     Scenario: Validate topic deletion
         Given I successfully create a new topic id
         Then I successfully delete the topic
 
-    @latency @extended
+    @acceptance @latency
     Scenario Outline: Validate Topic message listener latency
         Given I successfully create a new topic id
         And I publish and verify <numMessages> messages sent
@@ -75,7 +75,7 @@ Feature: HCS Base Coverage Feature
             | 2           | 30      |
             | 5           | 30      |
 
-    @negative @extended
+    @acceptance @negative
     Scenario Outline: Validate topic subscription with missing topic id
         Given I provide a topic id <topicId>
         Then the network should observe an error <errorCode>

--- a/hedera-mirror-test/src/test/resources/features/hcs/hcs.feature
+++ b/hedera-mirror-test/src/test/resources/features/hcs/hcs.feature
@@ -1,7 +1,7 @@
 @topicmessagesbase @fullsuite
 Feature: HCS Base Coverage Feature
 
-    @sanity @basicsubscribe @acceptance @Acceptance
+    @sanity @basicsubscribe @acceptance @extended
     Scenario Outline: Validate Topic message submission
         Given I successfully create a new topic id
         And I publish and verify <numMessages> messages sent
@@ -12,7 +12,7 @@ Feature: HCS Base Coverage Feature
             | numMessages |
             | 10          |
 
-    @opensubscribe @acceptance @Acceptance
+    @opensubscribe @extended
     Scenario Outline: Validate Topic message submission to an open submit topic
         Given I successfully create a new open topic
         And I publish and verify <numMessages> messages sent
@@ -53,17 +53,17 @@ Feature: HCS Base Coverage Feature
             | topicId  | numMessages |
             | "171231" | 340         |
 
-    @updatetopic @acceptance @Acceptance
+    @updatetopic @acceptance @extended
     Scenario: Validate Topic Updates
         Given I successfully create a new topic id
         Then I successfully update an existing topic
 
-    @deletetopic @acceptance @Acceptance
+    @deletetopic @acceptance @extended
     Scenario: Validate topic deletion
         Given I successfully create a new topic id
         Then I successfully delete the topic
 
-    @acceptance @latency @Acceptance
+    @latency @extended
     Scenario Outline: Validate Topic message listener latency
         Given I successfully create a new topic id
         And I publish and verify <numMessages> messages sent
@@ -75,7 +75,7 @@ Feature: HCS Base Coverage Feature
             | 2           | 30      |
             | 5           | 30      |
 
-    @negative @acceptance @Acceptance
+    @negative @extended
     Scenario Outline: Validate topic subscription with missing topic id
         Given I provide a topic id <topicId>
         Then the network should observe an error <errorCode>

--- a/hedera-mirror-test/src/test/resources/features/hts/hts.feature
+++ b/hedera-mirror-test/src/test/resources/features/hts/hts.feature
@@ -1,7 +1,7 @@
 @tokenbase @fullsuite @TokenBase
 Feature: HTS Base Coverage Feature
 
-    @acceptance @sanity @Acceptance
+    @sanity @extended
     Scenario Outline: Validate Base Token Flow - Create, Associate, Fund
         Given I successfully create a new token
         Then the mirror node REST API should return status <httpStatusCode>
@@ -13,7 +13,7 @@ Feature: HTS Base Coverage Feature
             | amount | httpStatusCode |
             | 2350   | 200            |
 
-    @acceptance @Acceptance
+    @acceptance @extended
     Scenario Outline: Validate Freeze and KYC Flow - Create, Unfreeze, GrantKyc
         Given I successfully onboard a new token account with freeze status <initialFreezeStatus> and kyc status <initialKycStatus>
         When I associate a new recipient account with token
@@ -25,7 +25,7 @@ Feature: HTS Base Coverage Feature
             | initialFreezeStatus | initialKycStatus | newFreezeStatus | newKycStatus | httpStatusCode |
             | 1                   | 2                | 2               | 1            | 200            |
 
-    @acceptance @Acceptance
+    @acceptance @extended
     Scenario Outline: Validate Token Modification Flow - Create, Associate, Transfer, Update, Burn, Mint and Wipe
         Given I successfully onboard a new token account
         When I associate a new recipient account with token
@@ -43,7 +43,7 @@ Feature: HTS Base Coverage Feature
             | amount | httpStatusCode | modifySupplyAmount |
             | 2350   | 200            | 100                |
 
-    @acceptance @Acceptance
+    @extended
     Scenario Outline: Validate Token ramp down Flow - Create, Associate, Dissociate, Delete
         Given I successfully onboard a new token account
         When I associate a new recipient account with token

--- a/hedera-mirror-test/src/test/resources/features/hts/hts.feature
+++ b/hedera-mirror-test/src/test/resources/features/hts/hts.feature
@@ -1,7 +1,7 @@
-@tokenbase @fullsuite @TokenBase
+@tokenbase @fullsuite
 Feature: HTS Base Coverage Feature
 
-    @sanity @extended
+    @critical @release @acceptance
     Scenario Outline: Validate Base Token Flow - Create, Associate, Fund
         Given I successfully create a new token
         Then the mirror node REST API should return status <httpStatusCode>
@@ -13,7 +13,7 @@ Feature: HTS Base Coverage Feature
             | amount | httpStatusCode |
             | 2350   | 200            |
 
-    @acceptance @extended
+    @release @acceptance
     Scenario Outline: Validate Freeze and KYC Flow - Create, Unfreeze, GrantKyc
         Given I successfully onboard a new token account with freeze status <initialFreezeStatus> and kyc status <initialKycStatus>
         When I associate a new recipient account with token
@@ -25,7 +25,7 @@ Feature: HTS Base Coverage Feature
             | initialFreezeStatus | initialKycStatus | newFreezeStatus | newKycStatus | httpStatusCode |
             | 1                   | 2                | 2               | 1            | 200            |
 
-    @acceptance @extended
+    @acceptance
     Scenario Outline: Validate Token Modification Flow - Create, Associate, Transfer, Update, Burn, Mint and Wipe
         Given I successfully onboard a new token account
         When I associate a new recipient account with token
@@ -43,7 +43,7 @@ Feature: HTS Base Coverage Feature
             | amount | httpStatusCode | modifySupplyAmount |
             | 2350   | 200            | 100                |
 
-    @extended
+    @acceptance
     Scenario Outline: Validate Token ramp down Flow - Create, Associate, Dissociate, Delete
         Given I successfully onboard a new token account
         When I associate a new recipient account with token

--- a/hedera-mirror-test/src/test/resources/features/hts/hts.feature
+++ b/hedera-mirror-test/src/test/resources/features/hts/hts.feature
@@ -5,9 +5,9 @@ Feature: HTS Base Coverage Feature
     Scenario Outline: Validate Base Token Flow - Create, Associate, Fund
         Given I successfully create a new token
         Then the mirror node REST API should return status <httpStatusCode>
-        When I associate with token
+        When I associate a new recipient account with token
         Then the mirror node REST API should return status <httpStatusCode>
-        Then I transfer <amount> tokens to payer
+        Then I transfer <amount> tokens to recipient
         Then the mirror node REST API should return status <httpStatusCode> for token fund flow
         Examples:
             | amount | httpStatusCode |
@@ -15,7 +15,7 @@ Feature: HTS Base Coverage Feature
 
     @release @acceptance
     Scenario Outline: Validate Freeze and KYC Flow - Create, Unfreeze, GrantKyc
-        Given I successfully onboard a new token account with freeze status <initialFreezeStatus> and kyc status <initialKycStatus>
+        Given I successfully create a new token account with freeze status <initialFreezeStatus> and kyc status <initialKycStatus>
         When I associate a new recipient account with token
         And I set new account freeze status to <newFreezeStatus>
         Then the mirror node REST API should return status <httpStatusCode>
@@ -27,7 +27,8 @@ Feature: HTS Base Coverage Feature
 
     @acceptance
     Scenario Outline: Validate Token Modification Flow - Create, Associate, Transfer, Update, Burn, Mint and Wipe
-        Given I successfully onboard a new token account
+        Given I successfully create a new token
+        Then the mirror node REST API should return status <httpStatusCode>
         When I associate a new recipient account with token
         And I transfer <amount> tokens to recipient
         Then the mirror node REST API should return status <httpStatusCode> for token fund flow
@@ -45,7 +46,7 @@ Feature: HTS Base Coverage Feature
 
     @acceptance
     Scenario Outline: Validate Token ramp down Flow - Create, Associate, Dissociate, Delete
-        Given I successfully onboard a new token account
+        Given I successfully create a new token
         When I associate a new recipient account with token
         And the mirror node REST API should return status <httpStatusCode>
         Then I dissociate the account from the token

--- a/hedera-mirror-test/src/test/resources/features/schedule/schedule.feature
+++ b/hedera-mirror-test/src/test/resources/features/schedule/schedule.feature
@@ -1,7 +1,7 @@
 @schedulebase @fullsuite
 Feature: Schedule Base Coverage Feature
 
-    @acceptance @sanity @Acceptance
+    @acceptance @sanity @extended
     Scenario Outline: Validate Base Schedule Flow - ScheduleCreate of CryptoTransfer and ScheduleSign
         Given I successfully schedule a treasury HBAR disbursement to <accountName>
         When the network confirms schedule presence
@@ -32,7 +32,7 @@ Feature: Schedule Base Coverage Feature
             | httpStatusCode |
             | 200            |
 
-    @acceptance @Acceptance
+    @extended
     Scenario Outline: Validate Base Schedule Flow - MultiSig ScheduleCreate of CryptoAccountCreate and ScheduleSign
         Given I schedule a crypto transfer with <initialSignatureCount> initial signatures but require an additional signature from <accountName>
         When the network confirms schedule presence
@@ -47,7 +47,7 @@ Feature: Schedule Base Coverage Feature
             | 3                     | "ALICE"     | 200            |
 #            | 10                    | "DAVE"      | 200            |
 
-    @acceptance @Acceptance
+    @acceptance @extended
     Scenario Outline: Validate scheduled Hbar and Token transfer - ScheduleCreate of TokenTransfer and multi ScheduleSign
         Given I successfully schedule a token transfer from <sender> to <receiver>
         And the network confirms schedule presence
@@ -65,7 +65,7 @@ Feature: Schedule Base Coverage Feature
             | sender  | receiver | httpStatusCode |
             | "ALICE" | "DAVE"   | 200            |
 
-    @acceptance @Acceptance
+    @acceptance @extended
     Scenario Outline: Validate scheduled HCS message - ScheduleCreate of TopicMessageSubmit and ScheduleSign
         Given I successfully schedule a topic message submit with <accountName>'s submit key
         And the network confirms schedule presence

--- a/hedera-mirror-test/src/test/resources/features/schedule/schedule.feature
+++ b/hedera-mirror-test/src/test/resources/features/schedule/schedule.feature
@@ -1,7 +1,7 @@
 @schedulebase @fullsuite
 Feature: Schedule Base Coverage Feature
 
-    @acceptance @sanity @extended
+    @critical @release @acceptance
     Scenario Outline: Validate Base Schedule Flow - ScheduleCreate of CryptoTransfer and ScheduleSign
         Given I successfully schedule a treasury HBAR disbursement to <accountName>
         When the network confirms schedule presence
@@ -32,7 +32,7 @@ Feature: Schedule Base Coverage Feature
             | httpStatusCode |
             | 200            |
 
-    @extended
+    @acceptance
     Scenario Outline: Validate Base Schedule Flow - MultiSig ScheduleCreate of CryptoAccountCreate and ScheduleSign
         Given I schedule a crypto transfer with <initialSignatureCount> initial signatures but require an additional signature from <accountName>
         When the network confirms schedule presence
@@ -44,10 +44,9 @@ Feature: Schedule Base Coverage Feature
         And the network confirms the schedule is executed
         Examples:
             | initialSignatureCount | accountName | httpStatusCode |
-            | 3                     | "ALICE"     | 200            |
-#            | 10                    | "DAVE"      | 200            |
+            | 10                    | "ALICE"     | 200            |
 
-    @acceptance @extended
+    @release @acceptance
     Scenario Outline: Validate scheduled Hbar and Token transfer - ScheduleCreate of TokenTransfer and multi ScheduleSign
         Given I successfully schedule a token transfer from <sender> to <receiver>
         And the network confirms schedule presence
@@ -65,7 +64,7 @@ Feature: Schedule Base Coverage Feature
             | sender  | receiver | httpStatusCode |
             | "ALICE" | "DAVE"   | 200            |
 
-    @acceptance @extended
+    @acceptance
     Scenario Outline: Validate scheduled HCS message - ScheduleCreate of TopicMessageSubmit and ScheduleSign
         Given I successfully schedule a topic message submit with <accountName>'s submit key
         And the network confirms schedule presence

--- a/hedera-mirror-test/src/test/resources/features/topicfilter/hcstopicfilter.feature
+++ b/hedera-mirror-test/src/test/resources/features/topicfilter/hcstopicfilter.feature
@@ -1,7 +1,7 @@
 @topicmessagesfilter @fullsuite
 Feature: HCS Message Filter Coverage Feature
 
-    @sanity @acceptance @filter @extended
+    @critical @release @acceptance @filter
     Scenario Outline: Validate topic filtering with past date and get X previous
         Given I successfully create a new topic id
         And I publish and verify <numMessages> messages sent
@@ -37,7 +37,7 @@ Feature: HCS Message Filter Coverage Feature
             | publishCount | startSequence | endSequence | numMessages |
             | 50           | 25            | 30          | 5           |
 
-    @extended
+    @acceptance
     Scenario Outline: Validate topic filtering with past date and a specified limit
         Given I successfully create a new topic id
         And I publish and verify <numMessages> messages sent

--- a/hedera-mirror-test/src/test/resources/features/topicfilter/hcstopicfilter.feature
+++ b/hedera-mirror-test/src/test/resources/features/topicfilter/hcstopicfilter.feature
@@ -1,7 +1,7 @@
 @topicmessagesfilter @fullsuite
 Feature: HCS Message Filter Coverage Feature
 
-    @sanity @acceptance @filter @Acceptance
+    @sanity @acceptance @filter @extended
     Scenario Outline: Validate topic filtering with past date and get X previous
         Given I successfully create a new topic id
         And I publish and verify <numMessages> messages sent
@@ -37,7 +37,7 @@ Feature: HCS Message Filter Coverage Feature
             | publishCount | startSequence | endSequence | numMessages |
             | 50           | 25            | 30          | 5           |
 
-    @acceptance @Acceptance
+    @extended
     Scenario Outline: Validate topic filtering with past date and a specified limit
         Given I successfully create a new topic id
         And I publish and verify <numMessages> messages sent


### PR DESCRIPTION
**Detailed description**:
Many of the HTS acceptance tests associate the payer account with the newly created token.
Overtime this may build up and the account may hit the TOKENS_PER_ACCOUNT_LIMIT_EXCEEDED error.

Full `@acceptance` runs are also expensive and it might be worth being a bit more selective on tests included for every post deployment run

- Dissociate accounts from tokens post run
- Add `@critical` and `@release` flags for acceptance tests, refine tag distribution accordingly
- Update README
- Where possible use payer account as treasury as it avoids the cost of creating and funding a new treasury account
- Reduce funding amounts for created accounts to cut costs
- Remove camel case tag variants

**Which issue(s) this PR fixes**:
Fixes #2069 

**Special notes for your reviewer**:
A full `@acceptance` run was costing about 150  ℏ, with these updates I was able to cut it down to 36  ℏ

```
@acceptance - total cost 31.6  ℏ
@release - total cost 19.2  ℏ
@critical -  total cost 6.5  ℏ
```

**Checklist**
- [x] Documentation added
- [x] Tests updated

