### PR TITLE
Upgrade Spring Boot to 2.4.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.4.5</version>
+        <version>2.4.6</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 


### PR DESCRIPTION
**Detailed description**:
Spring Boot 2.4.6 includes a fix to [CVE-2021-22118](https://tanzu.vmware.com/security/cve-2021-22118): Local Privilege Escalation within Spring Webflux Multipart Request Handling

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

