### PR TITLE
Add high availability to importer

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -29,11 +29,6 @@ $ helm upgrade --install "${RELEASE}" charts/hedera-mirror
 
 ## Configure
 
-### Scaling
-
-At most one Importer pod can be run at time due to the potential to cause data inconsistencies. All other modules
-support scaling up to more than one replica.
-
 ### TimescaleDB
 
 In an effort to increase performance and reduce storage costs, the mirror node is switching to

--- a/charts/hedera-mirror/values-prod.yaml
+++ b/charts/hedera-mirror/values-prod.yaml
@@ -25,6 +25,10 @@ importer:
   priorityClassName: high
   prometheusRules:
     enabled: true
+  replicas: 2
+  updateStrategy:
+    rollingUpdate:
+      maxSurge: 0
 
 monitor:
   alertmanager:

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/MessagingConfiguration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/MessagingConfiguration.java
@@ -22,6 +22,8 @@ package com.hedera.mirror.importer.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.integration.channel.NullChannel;
+import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.dsl.IntegrationFlows;
 import org.springframework.integration.dsl.MessageChannels;
@@ -44,14 +46,9 @@ public class MessagingConfiguration {
 
     // Shared channel containing all stream types until they're routed to the individual channels
     public static final String CHANNEL_STREAM = "stream";
-
     private static final String CHANNEL_BALANCE = CHANNEL_STREAM + ".balance";
     private static final String CHANNEL_EVENT = CHANNEL_STREAM + ".event";
     private static final String CHANNEL_RECORD = CHANNEL_STREAM + ".record";
-    private static final String INTEGRATION_FLOW_PREFIX = "flow.";
-    private static final String INTEGRATION_FLOW_BALANCE = INTEGRATION_FLOW_PREFIX + CHANNEL_BALANCE;
-    private static final String INTEGRATION_FLOW_EVENT = INTEGRATION_FLOW_PREFIX + CHANNEL_EVENT;
-    private static final String INTEGRATION_FLOW_RECORD = INTEGRATION_FLOW_PREFIX + CHANNEL_RECORD;
 
     @Bean(CHANNEL_BALANCE)
     MessageChannel channelBalance(BalanceParserProperties properties) {
@@ -68,17 +65,22 @@ public class MessagingConfiguration {
         return channel(properties);
     }
 
-    @Bean(INTEGRATION_FLOW_BALANCE)
+    @Bean(IntegrationContextUtils.ERROR_CHANNEL_BEAN_NAME)
+    MessageChannel errorChannel() {
+        return new NullChannel();
+    }
+
+    @Bean
     IntegrationFlow integrationFlowBalance(AccountBalanceFileParser parser) {
         return integrationFlow(parser);
     }
 
-    @Bean(INTEGRATION_FLOW_EVENT)
+    @Bean
     IntegrationFlow integrationFlowEvent(EventFileParser parser) {
         return integrationFlow(parser);
     }
 
-    @Bean(INTEGRATION_FLOW_RECORD)
+    @Bean
     IntegrationFlow integrationFlowRecord(RecordFileParser parser) {
         return integrationFlow(parser);
     }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/StreamFileHealthIndicator.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/StreamFileHealthIndicator.java
@@ -21,7 +21,7 @@ package com.hedera.mirror.importer.config;
  */
 
 import static com.hedera.mirror.importer.downloader.Downloader.STREAM_CLOSE_LATENCY_METRIC_NAME;
-import static com.hedera.mirror.importer.parser.StreamFileParser.STREAM_PARSE_DURATION_METRIC_NAME;
+import static com.hedera.mirror.importer.parser.AbstractStreamFileParser.STREAM_PARSE_DURATION_METRIC_NAME;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/AbstractStreamFileParser.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/AbstractStreamFileParser.java
@@ -20,21 +20,76 @@ package com.hedera.mirror.importer.parser;
  * ‍
  */
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import com.google.common.base.Stopwatch;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.time.Duration;
+import java.time.Instant;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import com.hedera.mirror.importer.domain.StreamFile;
+import com.hedera.mirror.importer.repository.StreamFileRepository;
 
-@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public abstract class AbstractStreamFileParser<T extends StreamFile> implements StreamFileParser<T> {
 
-    @Getter
-    protected final ParserProperties properties;
+    public static final String STREAM_PARSE_DURATION_METRIC_NAME = "hedera.mirror.parse.duration";
 
+    protected final Logger log = LogManager.getLogger(getClass());
+    protected final MeterRegistry meterRegistry;
+    protected final ParserProperties parserProperties;
+    protected final StreamFileRepository<T, Long> streamFileRepository;
+
+    private final Timer parseDurationMetricFailure;
+    private final Timer parseDurationMetricSuccess;
+    private final Timer parseLatencyMetric;
+
+    protected AbstractStreamFileParser(MeterRegistry meterRegistry, ParserProperties parserProperties,
+                                       StreamFileRepository<T, Long> streamFileRepository) {
+        this.meterRegistry = meterRegistry;
+        this.parserProperties = parserProperties;
+        this.streamFileRepository = streamFileRepository;
+
+        // Metrics
+        Timer.Builder parseDurationTimerBuilder = Timer.builder(STREAM_PARSE_DURATION_METRIC_NAME)
+                .description("The duration in seconds it took to parse the file and store it in the database")
+                .tag("type", parserProperties.getStreamType().toString());
+        parseDurationMetricFailure = parseDurationTimerBuilder.tag("success", "false").register(meterRegistry);
+        parseDurationMetricSuccess = parseDurationTimerBuilder.tag("success", "true").register(meterRegistry);
+
+        parseLatencyMetric = Timer.builder("hedera.mirror.parse.latency")
+                .description("The difference in ms between the consensus time of the last transaction in the file " +
+                        "and the time at which the file was processed successfully")
+                .tag("type", parserProperties.getStreamType().toString())
+                .register(meterRegistry);
+    }
+
+    @Override
+    public ParserProperties getProperties() {
+        return parserProperties;
+    }
+
+    @Override
     public void parse(T streamFile) {
-        if (properties.isEnabled()) {
-            doParse(streamFile);
+        Stopwatch stopwatch = Stopwatch.createStarted();
+        boolean success = false;
+
+        if (shouldParse(streamFile)) {
+            try {
+                doParse(streamFile);
+
+                log.info("Successfully processed {} items from {} in {}",
+                        streamFile.getCount(), streamFile.getName(), stopwatch);
+                success = true;
+                Instant consensusInstant = Instant.ofEpochSecond(0L, streamFile.getConsensusEnd());
+                parseLatencyMetric.record(Duration.between(consensusInstant, Instant.now()));
+            } catch (Exception e) {
+                log.error("Error parsing file {} after {}", streamFile.getName(), stopwatch, e);
+                throw e;
+            } finally {
+                Timer timer = success ? parseDurationMetricSuccess : parseDurationMetricFailure;
+                timer.record(stopwatch.elapsed());
+            }
         }
 
         postParse(streamFile);
@@ -45,5 +100,19 @@ public abstract class AbstractStreamFileParser<T extends StreamFile> implements 
     private void postParse(T streamFile) {
         streamFile.setBytes(null);
         streamFile.setItems(null);
+    }
+
+    private boolean shouldParse(T streamFile) {
+        if (!parserProperties.isEnabled()) {
+            return false;
+        }
+
+        boolean exists = streamFileRepository.existsById(streamFile.getConsensusEnd());
+
+        if (exists) {
+            log.warn("Skipping existing stream file {}", streamFile.getName());
+        }
+
+        return !exists;
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/StreamFileParser.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/StreamFileParser.java
@@ -23,7 +23,6 @@ package com.hedera.mirror.importer.parser;
 import com.hedera.mirror.importer.domain.StreamFile;
 
 public interface StreamFileParser<T extends StreamFile> {
-    String STREAM_PARSE_DURATION_METRIC_NAME = "hedera.mirror.parse.duration";
 
     void parse(T streamFile);
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListener.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import javax.inject.Named;
 import javax.sql.DataSource;
 import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.BeanCreationNotAllowedException;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.core.annotation.Order;
 import org.springframework.jdbc.datasource.DataSourceUtils;
@@ -182,20 +183,24 @@ public class SqlEntityListener implements EntityListener, RecordStreamFileListen
     }
 
     private void cleanup() {
-        contractResults.clear();
-        cryptoTransfers.clear();
-        entities.clear();
-        fileData.clear();
-        liveHashes.clear();
-        nonFeeTransfers.clear();
-        schedules.clear();
-        topicMessages.clear();
-        transactions.clear();
-        tokenAccounts.clear();
-        tokens.clear();
-        tokenTransfers.clear();
-        transactionSignatures.clear();
-        eventPublisher.publishEvent(new EntityBatchCleanupEvent(this));
+        try {
+            contractResults.clear();
+            cryptoTransfers.clear();
+            entities.clear();
+            fileData.clear();
+            liveHashes.clear();
+            nonFeeTransfers.clear();
+            schedules.clear();
+            topicMessages.clear();
+            transactions.clear();
+            tokenAccounts.clear();
+            tokens.clear();
+            tokenTransfers.clear();
+            transactionSignatures.clear();
+            eventPublisher.publishEvent(new EntityBatchCleanupEvent(this));
+        } catch (BeanCreationNotAllowedException e) {
+            // This error can occur during shutdown
+        }
     }
 
     private void executeBatches() {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/balance/CompositeBalanceFileReader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/balance/CompositeBalanceFileReader.java
@@ -48,7 +48,7 @@ public class CompositeBalanceFileReader implements BalanceFileReader {
 
     @Override
     public AccountBalanceFile read(StreamFileData streamFileData, Consumer<AccountBalance> itemConsumer) {
-        long count = -1;
+        long count = 0;
         Stopwatch stopwatch = Stopwatch.createStarted();
 
         try {
@@ -57,9 +57,9 @@ public class CompositeBalanceFileReader implements BalanceFileReader {
             count = accountBalanceFile.getCount();
             return accountBalanceFile;
         } finally {
-            boolean success = count != -1;
-            log.info("Loaded {} items {}successfully from account balance file {} in {}", count, success ? "" : "un",
-                    streamFileData.getFilename(), stopwatch);
+            boolean success = count != 0;
+            log.info("Read {} items {}successfully from account balance file {} in {}",
+                    count, success ? "" : "un", streamFileData.getFilename(), stopwatch);
         }
     }
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/config/AbstractStreamFileHealthIndicatorTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/config/AbstractStreamFileHealthIndicatorTest.java
@@ -21,7 +21,7 @@ package com.hedera.mirror.importer.config;
  */
 
 import static com.hedera.mirror.importer.downloader.Downloader.STREAM_CLOSE_LATENCY_METRIC_NAME;
-import static com.hedera.mirror.importer.parser.StreamFileParser.STREAM_PARSE_DURATION_METRIC_NAME;
+import static com.hedera.mirror.importer.parser.AbstractStreamFileParser.STREAM_PARSE_DURATION_METRIC_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyIterable;

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/AbstractStreamFileParserTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/AbstractStreamFileParserTest.java
@@ -21,18 +21,24 @@ package com.hedera.mirror.importer.parser;
  */
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.hedera.mirror.importer.domain.StreamFile;
 import com.hedera.mirror.importer.exception.ParserException;
+import com.hedera.mirror.importer.repository.StreamFileRepository;
 
 @ExtendWith(MockitoExtension.class)
 public abstract class AbstractStreamFileParserTest<T extends StreamFileParser> {
+
+    @Mock
+    protected StreamFileRepository streamFileRepository;
 
     protected T parser;
 
@@ -71,6 +77,20 @@ public abstract class AbstractStreamFileParserTest<T extends StreamFileParser> {
         // given
         parserProperties.setEnabled(false);
         StreamFile streamFile = getStreamFile();
+
+        // when
+        parser.parse(streamFile);
+
+        // then
+        assertParsed(streamFile, false, false);
+        assertPostParseStreamFile(streamFile, true);
+    }
+
+    @Test
+    void alreadyExists() {
+        // given
+        StreamFile streamFile = getStreamFile();
+        when(streamFileRepository.existsById(streamFile.getConsensusEnd())).thenReturn(true);
 
         // when
         parser.parse(streamFile);

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/balance/AccountBalanceFileParserTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/balance/AccountBalanceFileParserTest.java
@@ -69,7 +69,7 @@ class AccountBalanceFileParserTest extends IntegrationTest {
     }
 
     @Test
-    void disabled() throws Exception {
+    void disabled() {
         // given
         parserProperties.setEnabled(false);
         AccountBalanceFile accountBalanceFile = accountBalanceFile(1);
@@ -81,9 +81,23 @@ class AccountBalanceFileParserTest extends IntegrationTest {
         assertPostParseAccountBalanceFile(accountBalanceFile, true);
     }
 
+    @Test
+    void alreadyExists() {
+        // given
+        AccountBalanceFile accountBalanceFile = accountBalanceFile(1);
+        accountBalanceFile.setLoadEnd(1L);
+        accountBalanceFileRepository.save(accountBalanceFile);
+
+        // when
+        accountBalanceFileParser.parse(accountBalanceFile);
+
+        // then
+        assertPostParseAccountBalanceFile(accountBalanceFile, true);
+    }
+
     @Disabled("Fails in CI")
     @Test
-    void success() throws Exception {
+    void success() {
         AccountBalanceFile accountBalanceFile = accountBalanceFile(1);
         accountBalanceFileParser.parse(accountBalanceFile);
         assertPostParseAccountBalanceFile(accountBalanceFile, true);
@@ -91,7 +105,7 @@ class AccountBalanceFileParserTest extends IntegrationTest {
 
     @Disabled("Fails in CI")
     @Test
-    void duplicateFile() throws Exception {
+    void duplicateFile() {
         AccountBalanceFile accountBalanceFile = accountBalanceFile(1);
         AccountBalanceFile duplicate = accountBalanceFile(1);
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileParserTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileParserTest.java
@@ -88,8 +88,8 @@ class RecordFileParserTest extends AbstractStreamFileParserTest<RecordFileParser
     @Override
     protected RecordFileParser getParser() {
         RecordParserProperties parserProperties = new RecordParserProperties();
-        return new RecordFileParser(parserProperties, new SimpleMeterRegistry(), recordItemListener,
-                recordStreamFileListener, mirrorDateRangePropertiesProcessor);
+        return new RecordFileParser(new SimpleMeterRegistry(), parserProperties, streamFileRepository,
+                recordItemListener, recordStreamFileListener, mirrorDateRangePropertiesProcessor);
     }
 
     @Override


### PR DESCRIPTION
**Detailed description**:
- Add `@Leader` around parsers
- Add a stream file existence check inside each parser and discard if it exists
- Add more details to reader logs
- Fix some stack traces that can occur when trying to create beans on shutdown
- Move more common logic to `AbstractStreamFileParser`
- Set `values-prod.yaml` to 2 importer replicas and `maxSurge` of 0

**Which issue(s) this PR fixes**:
Fixes #1899 

**Special notes for your reviewer**:
Tested in performance Kubernetes at 10K and randomly deleting/scaling pods.

There's a [bug](https://github.com/spring-cloud/spring-cloud-kubernetes/issues/804) in Spring Cloud Kubernetes that can cause leader election to fail when the pod in the configmap doesn't exist. This can occur whether it's 1 or 2 pods running, so it can occur without these changes so shouldn't block this PR.

**Checklist**
- [x] Documentation added
- [x] Tests updated

