### PR TITLE
Add multi batch support to upsert pgcopy flow

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/AbstractUpsertQueryGenerator.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/AbstractUpsertQueryGenerator.java
@@ -79,7 +79,7 @@ public abstract class AbstractUpsertQueryGenerator<T> implements UpsertQueryGene
 
     @Override
     public String getCreateTempTableQuery() {
-        return String.format("create temporary table %s on commit drop as table %s limit 0",
+        return String.format("create temporary table if not exists %s on commit drop as table %s limit 0",
                 getTemporaryTableName(), getFinalTableName());
     }
 


### PR DESCRIPTION
**Detailed description**:
When batch inserts occur within the same record file the Upsert flow attempt to recreate the temporary table that already exists

- Update Create table query to with `if not exists`
- Add a `truncate table` regardless to ensure insert and update don't utilize previously inserted information


**Which issue(s) this PR fixes**:
Addresses #2154 

**Special notes for your reviewer**:
Will port to 0.36

**Checklist**
- [ ] Documentation added
- [x] Tests updated

