### PR TITLE
Change monitor scenario properties from list to map

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -233,7 +233,7 @@ Name                                                            | Default    | D
 `hedera.mirror.monitor.publish.clients`                         | 4          | How many total SDK clients to publish transactions. Clients will be used in a round-robin fashion
 `hedera.mirror.monitor.publish.enabled`                         | true       | Whether to enable transaction publishing
 `hedera.mirror.monitor.publish.responseThreads`                 | 40         | How many threads to use to resolve the asynchronous responses
-`hedera.mirror.monitor.publish.scenarios.<name>`                | ""         | The unique publisher scenario name. Used as a unique identifier in logs, metrics, and the REST API
+`hedera.mirror.monitor.publish.scenarios`                       |            | A map of scenario name to publish scenarios. The name is used as a unique identifier in logs, metrics, and the REST API
 `hedera.mirror.monitor.publish.scenarios.<name>.duration`       |            | How long this scenario should publish transactions. Leave empty for infinite
 `hedera.mirror.monitor.publish.scenarios.<name>.enabled`        | true       | Whether this publish scenario is enabled
 `hedera.mirror.monitor.publish.scenarios.<name>.limit`          | 0          | How many transactions to publish before halting. 0 for unlimited
@@ -249,7 +249,7 @@ Name                                                            | Default    | D
 `hedera.mirror.monitor.publish.warmupPeriod`                    | 30s        | The amount of time the publisher should ramp up its rate before reaching its stable (maximum) rate
 `hedera.mirror.monitor.subscribe.clients`                       | 1          | How many SDK clients should be created to subscribe to mirror node APIs. Clients will be used in a round-robin fashion
 `hedera.mirror.monitor.subscribe.enabled`                       | true       | Whether to enable subscribing to mirror node APIs to verify published transactions
-`hedera.mirror.monitor.subscribe.grpc.<name>`                   | ""         | The unique gRPC subscriber scenario name. Used as a unique identifier in logs, metrics, and the REST API
+`hedera.mirror.monitor.subscribe.grpc`                          |            | A map of scenario name to gRPC subscriber scenarios. The name is used as a unique identifier in logs, metrics, and the REST API
 `hedera.mirror.monitor.subscribe.grpc.<name>.duration`          |            | How long to stay subscribed to the API
 `hedera.mirror.monitor.subscribe.grpc.<name>.enabled`           | true       | Whether this subscribe scenario is enabled
 `hedera.mirror.monitor.subscribe.grpc.<name>.limit`             | 0          | How many transactions to receive before halting. 0 for unlimited
@@ -259,7 +259,7 @@ Name                                                            | Default    | D
 `hedera.mirror.monitor.subscribe.grpc.<name>.startTime`         |            | The start time passed to the gRPC API. Defaults to current time if not set
 `hedera.mirror.monitor.subscribe.grpc.<name>.subscribers`       | 1          | How many concurrent subscribers should be instantiated for this scenario
 `hedera.mirror.monitor.subscribe.grpc.<name>.topicId`           |            | Which topic to subscribe to
-`hedera.mirror.monitor.subscribe.rest.<name>`                   | ""         | The unique REST subscriber scenario name. Used as a unique identifier in logs, metrics, and the REST API
+`hedera.mirror.monitor.subscribe.rest`                          |            | A map of scenario name to REST subscriber scenarios. The name is used as a unique identifier in logs, metrics, and the REST API
 `hedera.mirror.monitor.subscribe.rest.<name>.duration`          |            | How long to stay subscribed to the API
 `hedera.mirror.monitor.subscribe.rest.<name>.enabled`           | true       | Whether this subscribe scenario is enabled
 `hedera.mirror.monitor.subscribe.rest.<name>.limit`             | 0          | How many transactions to receive before halting. 0 for unlimited

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -217,59 +217,60 @@ value, it is recommended to only populate overridden properties in the custom `a
 
 See the monitor [documentation](monitor.md) for more general information about configuring and using the monitor.
 
-Name                                                        | Default    | Description
-------------------------------------------------------------| -----------| ---------------------------------------
-`hedera.mirror.monitor.mirrorNode.grpc.host`                | ""         | The hostname of the mirror node's gRPC API
-`hedera.mirror.monitor.mirrorNode.grpc.port`                | 5600       | The port of the mirror node's gRPC API
-`hedera.mirror.monitor.mirrorNode.rest.host`                | ""         | The hostname of the mirror node's REST API
-`hedera.mirror.monitor.mirrorNode.rest.port`                | 443        | The port of the mirror node's REST API
-`hedera.mirror.monitor.network`                             | TESTNET    | Which network to connect to. Automatically populates the main node & mirror node endpoints. Can be `MAINNET`, `PREVIEWNET`, `TESTNET` or `OTHER`
-`hedera.mirror.monitor.nodes[].accountId`                   | ""         | The main node's account ID
-`hedera.mirror.monitor.nodes[].host`                        | ""         | The main node's hostname
-`hedera.mirror.monitor.nodes[].port`                        | 50211      | The main node's port
-`hedera.mirror.monitor.operator.accountId`                  | ""         | Operator account ID used to pay for transactions
-`hedera.mirror.monitor.operator.privateKey`                 | ""         | Operator ED25519 private key used to sign transactions in hex encoded DER format
-`hedera.mirror.monitor.publish.batchDivisor`                | 100        | The divisor used to calculate batch size when generating transactions
-`hedera.mirror.monitor.publish.clients`                     | 4          | How many total SDK clients to publish transactions. Clients will be used in a round-robin fashion
-`hedera.mirror.monitor.publish.enabled`                     | true       | Whether to enable transaction publishing
-`hedera.mirror.monitor.publish.responseThreads`             | 40         | How many threads to use to resolve the asynchronous responses
-`hedera.mirror.monitor.publish.scenarios[].duration`        |            | How long this scenario should publish transactions. Leave empty for infinite
-`hedera.mirror.monitor.publish.scenarios[].enabled`         | true       | Whether this publish scenario is enabled
-`hedera.mirror.monitor.publish.scenarios[].limit`           | 0          | How many transactions to publish before halting. 0 for unlimited
-`hedera.mirror.monitor.publish.scenarios[].logResponse`     | false      | Whether to log the response from HAPI
-`hedera.mirror.monitor.publish.scenarios[].name`            | ""         | The publish scenario name. Used to tag logs and metrics
-`hedera.mirror.monitor.publish.scenarios[].maxAttempts`     | 1          | The maximum number of times a scenario transaction will be attempted
-`hedera.mirror.monitor.publish.scenarios[].properties`      | {}         | Key/value pairs used to configure the [`TransactionSupplier`](/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier) associated with this scenario type
-`hedera.mirror.monitor.publish.scenarios[].receiptPercent`  | 0.0        | The percentage of receipts to retrieve from HAPI. Accepts values between 0-1
-`hedera.mirror.monitor.publish.scenarios[].recordPercent`   | 0.0        | The percentage of records to retrieve from HAPI. Accepts values between 0-1
-`hedera.mirror.monitor.publish.scenarios[].timeout`         | 12s        | How long to wait for the transaction result
-`hedera.mirror.monitor.publish.scenarios[].tps`             | 1.0        | The rate at which transactions will publish
-`hedera.mirror.monitor.publish.scenarios[].type`            |            | The type of transaction to publish. See the [`TransactionType`](/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/TransactionType.java) enum for a list of possible values
-`hedera.mirror.monitor.publish.statusFrequency`             | 10s        | How often to log publishing statistics
-`hedera.mirror.monitor.publish.warmupPeriod`                | 30s        | The amount of time the publisher should ramp up its rate before reaching its stable (maximum) rate
-`hedera.mirror.monitor.subscribe.clients`                   | 1          | How many SDK clients should be created to subscribe to mirror node APIs. Clients will be used in a round-robin fashion
-`hedera.mirror.monitor.subscribe.enabled`                   | true       | Whether to enable subscribing to mirror node APIs to verify published transactions
-`hedera.mirror.monitor.subscribe.grpc[].duration`           |            | How long to stay subscribed to the API
-`hedera.mirror.monitor.subscribe.grpc[].enabled`            | true       | Whether this subscribe scenario is enabled
-`hedera.mirror.monitor.subscribe.grpc[].limit`              | 0          | How many transactions to receive before halting. 0 for unlimited
-`hedera.mirror.monitor.subscribe.grpc[].name`               | ""         | The subscribe scenario name. Used to tag logs and metrics
-`hedera.mirror.monitor.subscribe.grpc[].retry.maxAttempts`  | 16         | How many consecutive retry attempts before giving up connecting to the API
-`hedera.mirror.monitor.subscribe.grpc[].retry.maxBackoff`   | 8s         | The maximum amount of time to wait between retry attempts
-`hedera.mirror.monitor.subscribe.grpc[].retry.minBackoff`   | 250ms      | The initial amount of time to wait between retry attempts
-`hedera.mirror.monitor.subscribe.grpc[].startTime`          |            | The start time passed to the gRPC API. Defaults to current time if not set
-`hedera.mirror.monitor.subscribe.grpc[].subscribers`        | 1          | How many concurrent subscribers should be instantiated for this scenario
-`hedera.mirror.monitor.subscribe.grpc[].topicId`            |            | Which topic to subscribe to
-`hedera.mirror.monitor.subscribe.rest[].duration`           |            | How long to stay subscribed to the API
-`hedera.mirror.monitor.subscribe.rest[].enabled`            | true       | Whether this subscribe scenario is enabled
-`hedera.mirror.monitor.subscribe.rest[].limit`              | 0          | How many transactions to receive before halting. 0 for unlimited
-`hedera.mirror.monitor.subscribe.rest[].name`               | ""         | The subscribe scenario name. Used to tag logs and metrics
-`hedera.mirror.monitor.subscribe.rest[].retry.maxAttempts`  | 16         | How many consecutive retry attempts before giving up connecting to the API
-`hedera.mirror.monitor.subscribe.rest[].retry.maxBackoff`   | 8s         | The maximum amount of time to wait between retry attempts
-`hedera.mirror.monitor.subscribe.rest[].retry.minBackoff`   | 250ms      | The initial amount of time to wait between retry attempts
-`hedera.mirror.monitor.subscribe.rest[].samplePercent`      | 1.0        | The percentage of transactions to verify against the API. Accepts values between 0-1
-`hedera.mirror.monitor.subscribe.rest[].timeout`            | 5s         | Maximum amount of time to wait for a API call to retrieve data
-`hedera.mirror.monitor.subscribe.statusFrequency`           | 10s        | How often to log subscription statistics
-`hedera.mirror.monitor.validateNodes`                       | true       | Whether to validate and remove invalid or down nodes permanently before publishing
+Name                                                            | Default    | Description
+----------------------------------------------------------------| -----------| ---------------------------------------
+`hedera.mirror.monitor.mirrorNode.grpc.host`                    | ""         | The hostname of the mirror node's gRPC API
+`hedera.mirror.monitor.mirrorNode.grpc.port`                    | 5600       | The port of the mirror node's gRPC API
+`hedera.mirror.monitor.mirrorNode.rest.host`                    | ""         | The hostname of the mirror node's REST API
+`hedera.mirror.monitor.mirrorNode.rest.port`                    | 443        | The port of the mirror node's REST API
+`hedera.mirror.monitor.network`                                 | TESTNET    | Which network to connect to. Automatically populates the main node & mirror node endpoints. Can be `MAINNET`, `PREVIEWNET`, `TESTNET` or `OTHER`
+`hedera.mirror.monitor.nodes[].accountId`                       | ""         | The main node's account ID
+`hedera.mirror.monitor.nodes[].host`                            | ""         | The main node's hostname
+`hedera.mirror.monitor.nodes[].port`                            | 50211      | The main node's port
+`hedera.mirror.monitor.operator.accountId`                      | ""         | Operator account ID used to pay for transactions
+`hedera.mirror.monitor.operator.privateKey`                     | ""         | Operator ED25519 private key used to sign transactions in hex encoded DER format
+`hedera.mirror.monitor.publish.batchDivisor`                    | 100        | The divisor used to calculate batch size when generating transactions
+`hedera.mirror.monitor.publish.clients`                         | 4          | How many total SDK clients to publish transactions. Clients will be used in a round-robin fashion
+`hedera.mirror.monitor.publish.enabled`                         | true       | Whether to enable transaction publishing
+`hedera.mirror.monitor.publish.responseThreads`                 | 40         | How many threads to use to resolve the asynchronous responses
+`hedera.mirror.monitor.publish.scenarios.<name>`                | ""         | The unique publisher scenario name. Used as a unique identifier in logs, metrics, and the REST API
+`hedera.mirror.monitor.publish.scenarios.<name>.duration`       |            | How long this scenario should publish transactions. Leave empty for infinite
+`hedera.mirror.monitor.publish.scenarios.<name>.enabled`        | true       | Whether this publish scenario is enabled
+`hedera.mirror.monitor.publish.scenarios.<name>.limit`          | 0          | How many transactions to publish before halting. 0 for unlimited
+`hedera.mirror.monitor.publish.scenarios.<name>.logResponse`    | false      | Whether to log the response from HAPI
+`hedera.mirror.monitor.publish.scenarios.<name>.maxAttempts`    | 1          | The maximum number of times a scenario transaction will be attempted
+`hedera.mirror.monitor.publish.scenarios.<name>.properties`     | {}         | Key/value pairs used to configure the [`TransactionSupplier`](/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier) associated with this scenario type
+`hedera.mirror.monitor.publish.scenarios.<name>.receiptPercent` | 0.0        | The percentage of receipts to retrieve from HAPI. Accepts values between 0-1
+`hedera.mirror.monitor.publish.scenarios.<name>.recordPercent`  | 0.0        | The percentage of records to retrieve from HAPI. Accepts values between 0-1
+`hedera.mirror.monitor.publish.scenarios.<name>.timeout`        | 12s        | How long to wait for the transaction result
+`hedera.mirror.monitor.publish.scenarios.<name>.tps`            | 1.0        | The rate at which transactions will publish
+`hedera.mirror.monitor.publish.scenarios.<name>.type`           |            | The type of transaction to publish. See the [`TransactionType`](/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/TransactionType.java) enum for a list of possible values
+`hedera.mirror.monitor.publish.statusFrequency`                 | 10s        | How often to log publishing statistics
+`hedera.mirror.monitor.publish.warmupPeriod`                    | 30s        | The amount of time the publisher should ramp up its rate before reaching its stable (maximum) rate
+`hedera.mirror.monitor.subscribe.clients`                       | 1          | How many SDK clients should be created to subscribe to mirror node APIs. Clients will be used in a round-robin fashion
+`hedera.mirror.monitor.subscribe.enabled`                       | true       | Whether to enable subscribing to mirror node APIs to verify published transactions
+`hedera.mirror.monitor.subscribe.grpc.<name>`                   | ""         | The unique gRPC subscriber scenario name. Used as a unique identifier in logs, metrics, and the REST API
+`hedera.mirror.monitor.subscribe.grpc.<name>.duration`          |            | How long to stay subscribed to the API
+`hedera.mirror.monitor.subscribe.grpc.<name>.enabled`           | true       | Whether this subscribe scenario is enabled
+`hedera.mirror.monitor.subscribe.grpc.<name>.limit`             | 0          | How many transactions to receive before halting. 0 for unlimited
+`hedera.mirror.monitor.subscribe.grpc.<name>.retry.maxAttempts` | 16         | How many consecutive retry attempts before giving up connecting to the API
+`hedera.mirror.monitor.subscribe.grpc.<name>.retry.maxBackoff`  | 8s         | The maximum amount of time to wait between retry attempts
+`hedera.mirror.monitor.subscribe.grpc.<name>.retry.minBackoff`  | 250ms      | The initial amount of time to wait between retry attempts
+`hedera.mirror.monitor.subscribe.grpc.<name>.startTime`         |            | The start time passed to the gRPC API. Defaults to current time if not set
+`hedera.mirror.monitor.subscribe.grpc.<name>.subscribers`       | 1          | How many concurrent subscribers should be instantiated for this scenario
+`hedera.mirror.monitor.subscribe.grpc.<name>.topicId`           |            | Which topic to subscribe to
+`hedera.mirror.monitor.subscribe.rest.<name>`                   | ""         | The unique REST subscriber scenario name. Used as a unique identifier in logs, metrics, and the REST API
+`hedera.mirror.monitor.subscribe.rest.<name>.duration`          |            | How long to stay subscribed to the API
+`hedera.mirror.monitor.subscribe.rest.<name>.enabled`           | true       | Whether this subscribe scenario is enabled
+`hedera.mirror.monitor.subscribe.rest.<name>.limit`             | 0          | How many transactions to receive before halting. 0 for unlimited
+`hedera.mirror.monitor.subscribe.rest.<name>.publishers`        | []         | A list of publisher scenario names to consider for sampling
+`hedera.mirror.monitor.subscribe.rest.<name>.retry.maxAttempts` | 16         | How many consecutive retry attempts before giving up connecting to the API
+`hedera.mirror.monitor.subscribe.rest.<name>.retry.maxBackoff`  | 8s         | The maximum amount of time to wait between retry attempts
+`hedera.mirror.monitor.subscribe.rest.<name>.retry.minBackoff`  | 250ms      | The initial amount of time to wait between retry attempts
+`hedera.mirror.monitor.subscribe.rest.<name>.samplePercent`     | 1.0        | The percentage of transactions to verify against the API. Accepts values between 0-1
+`hedera.mirror.monitor.subscribe.rest.<name>.timeout`           | 5s         | Maximum amount of time to wait for a API call to retrieve data
+`hedera.mirror.monitor.subscribe.statusFrequency`               | 10s        | How often to log subscription statistics
+`hedera.mirror.monitor.validateNodes`                           | true       | Whether to validate and remove invalid or down nodes permanently before publishing
 
 ## REST API
 

--- a/docs/monitor.md
+++ b/docs/monitor.md
@@ -84,7 +84,7 @@ hedera:
     monitor:
       publish:
         scenarios:
-          - name: HCS Pinger
+          pinger: # Scenario name
             properties:
               maxTransactionFee: 1000000
               message: Hello world!
@@ -103,7 +103,7 @@ inner transaction must be signed by all required signatories as part of the `Sch
 transactions. Due to this the monitor by default will initially support only `ScheduleCreate` scenarios in which the
 inner transaction is a `CryptoCreate` with `receiverSignatureRequired` set to true.
 
-By default all required signatures will be provided. However, this can be modified by
+By default, all required signatures will be provided. However, this can be modified by
 setting `hedera.mirror.monitor.publish.scenarios.properties.signatoryCount` to be a number greater than 0 but smaller
 than `hedera.mirror.monitor.publish.scenarios.properties.totalSignatoryCount`
 To execute a scheduled scenario set the `hedera.mirror.monitor.publish.scenarios` properties similar to the following
@@ -115,7 +115,7 @@ hedera:
     monitor:
       publish:
         scenarios:
-          - name: Scheduled Crypto Create
+          scheduledCryptoCreate:
             properties:
               nodeAccountId: 0.0.3
               operatorAccountId: 0.0.1018
@@ -145,14 +145,14 @@ hedera:
     monitor:
       publish:
         scenarios:
-          - name: HTS associate
+          htsAssociate:
             limit: 1
             properties:
               accountId: ${account.them}
               tokenId: ${token.foobar}
             tps: 1
             type: TOKEN_ASSOCIATE
-          - name: HTS transfer
+          htsTransfer:
             properties:
               recipientAccountId: ${account.them}
               senderAccountId: ${account.me}
@@ -179,12 +179,12 @@ hedera:
       subscribe:
         clients: 4
         grpc:
-          - name: HCS Subscribe
+          hcs:
             enabled: true
             subscribers: 10
             topicId: ${topic.ping}
         rest:
-          - name: REST
+          transactionId:
             enabled: false
             samplePercent: 1.0
 ```
@@ -234,7 +234,7 @@ Example response:
     "errors": {
       "TimeoutException": 1
     },
-    "elapsed": "PT12M13.303710674S",
+    "elapsed": "2d3h3s",
     "rate": 0.1,
     "name": "HCS REST",
     "id": 1,
@@ -260,7 +260,7 @@ Example response:
     "errors": {
       "TimeoutException": 1
     },
-    "elapsed": "PT12M13.303710674S",
+    "elapsed": "1h2m57s",
     "rate": 0.1,
     "name": "HCS REST",
     "id": 1,
@@ -285,7 +285,7 @@ Example response:
   "errors": {
     "TimeoutException": 1
   },
-  "elapsed": "PT12M13.303710674S",
+  "elapsed": "12m13s",
   "rate": 0.1,
   "name": "HCS REST",
   "id": 1,

--- a/hedera-mirror-grpc/src/main/resources/log4j2.xml
+++ b/hedera-mirror-grpc/src/main/resources/log4j2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="WARN">
+<Configuration shutdownHook="disable" status="WARN">
     <Appenders>
         <Console name="console" target="SYSTEM_OUT">
             <PatternLayout>

--- a/hedera-mirror-importer/src/main/resources/log4j2.xml
+++ b/hedera-mirror-importer/src/main/resources/log4j2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="WARN">
+<Configuration shutdownHook="disable" status="WARN">
     <Appenders>
         <Console name="console" target="SYSTEM_OUT">
             <PatternLayout>

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/config/LoggingFilter.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/config/LoggingFilter.java
@@ -23,8 +23,10 @@ package com.hedera.mirror.monitor.config;
 import java.net.InetSocketAddress;
 import javax.inject.Named;
 import lombok.extern.log4j.Log4j2;
+import org.apache.commons.lang3.StringUtils;
 import org.reactivestreams.Publisher;
 import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.util.CollectionUtils;
 import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.server.WebFilter;
 import org.springframework.web.server.WebFilterChain;
@@ -35,6 +37,7 @@ import reactor.core.publisher.Mono;
 public class LoggingFilter implements WebFilter {
 
     private static final String LOCALHOST = "127.0.0.1";
+    private static final String X_FORWARDED_FOR = "X-Forwarded-For";
 
     @Override
     public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
@@ -62,6 +65,12 @@ public class LoggingFilter implements WebFilter {
     }
 
     private String getClient(ServerHttpRequest request) {
+        String xForwardedFor = CollectionUtils.firstElement(request.getHeaders().get(X_FORWARDED_FOR));
+
+        if (StringUtils.isNotBlank(xForwardedFor)) {
+            return xForwardedFor;
+        }
+
         InetSocketAddress remoteAddress = request.getRemoteAddress();
 
         if (remoteAddress != null && remoteAddress.getAddress() != null) {

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/converter/DurationToStringSerializer.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/converter/DurationToStringSerializer.java
@@ -1,0 +1,67 @@
+package com.hedera.mirror.monitor.converter;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import java.io.IOException;
+import java.time.Duration;
+
+public class DurationToStringSerializer extends StdSerializer<Duration> {
+
+    private static final long serialVersionUID = 5848583700556532429L;
+
+    protected DurationToStringSerializer() {
+        super(Duration.class);
+    }
+
+    @Override
+    public void serialize(Duration duration, JsonGenerator jsonGenerator, SerializerProvider provider) throws IOException {
+        jsonGenerator.writeString(convert(duration));
+    }
+
+    public static String convert(Duration duration) {
+        if (duration == null) {
+            return null;
+        }
+
+        StringBuilder s = new StringBuilder();
+
+        if (duration.toDaysPart() > 0) {
+            s.append(duration.toDaysPart()).append("d");
+        }
+
+        if (duration.toHoursPart() > 0) {
+            s.append(duration.toHoursPart()).append("h");
+        }
+
+        if (duration.toMinutesPart() > 0) {
+            s.append(duration.toMinutesPart()).append("m");
+        }
+
+        if (duration.toSecondsPart() > 0 || s.length() == 0) {
+            s.append(duration.toSecondsPart()).append("s");
+        }
+
+        return s.toString();
+    }
+}

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/converter/StringToDurationDeserializer.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/converter/StringToDurationDeserializer.java
@@ -1,0 +1,78 @@
+package com.hedera.mirror.monitor.converter;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.commons.lang3.StringUtils;
+
+public class StringToDurationDeserializer extends StdDeserializer<Duration> {
+
+    private static final Pattern PATTERN = Pattern.compile("(\\d+d)?(\\d+h)?(\\d+m)?(\\d+s)?");
+    private static final long serialVersionUID = 3690958538780466689L;
+
+    protected StringToDurationDeserializer() {
+        super(Duration.class);
+    }
+
+    @Override
+    public Duration deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+        String text = p.getValueAsString();
+        if (StringUtils.isBlank(text)) {
+            return null;
+        }
+
+        Matcher matcher = PATTERN.matcher(text);
+
+        if (matcher.matches() && matcher.groupCount() > 0) {
+            Duration duration = Duration.ZERO;
+            String days = matcher.group(1);
+            if (StringUtils.isNotBlank(days)) {
+                duration = duration.plusDays(Long.valueOf(days.replace("d", "")));
+            }
+
+            String hours = matcher.group(2);
+            if (StringUtils.isNotBlank(hours)) {
+                duration = duration.plusHours(Long.valueOf(hours.replace("h", "")));
+            }
+
+            String minutes = matcher.group(3);
+            if (StringUtils.isNotBlank(minutes)) {
+                duration = duration.plusMinutes(Long.valueOf(minutes.replace("m", "")));
+            }
+
+            String seconds = matcher.group(4);
+            if (StringUtils.isNotBlank(seconds)) {
+                duration = duration.plusSeconds(Long.valueOf(seconds.replace("s", "")));
+            }
+
+            return duration;
+        }
+
+        return null;
+    }
+}

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/generator/CompositeTransactionGenerator.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/generator/CompositeTransactionGenerator.java
@@ -58,6 +58,7 @@ public class CompositeTransactionGenerator implements TransactionGenerator {
     public CompositeTransactionGenerator(ExpressionConverter expressionConverter, PublishProperties properties) {
         this.properties = properties;
         this.transactionGenerators = properties.getScenarios()
+                .values()
                 .stream()
                 .filter(ScenarioProperties::isEnabled)
                 .map(scenarioProperties -> new ConfigurableTransactionGenerator(expressionConverter,

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/generator/ScenarioProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/generator/ScenarioProperties.java
@@ -25,7 +25,6 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
-import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import lombok.Data;
 import org.hibernate.validator.constraints.time.DurationMin;
@@ -51,7 +50,6 @@ public class ScenarioProperties {
     @Min(1)
     private int maxAttempts = 1;
 
-    @NotBlank
     private String name;
 
     @NotNull

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishMetrics.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishMetrics.java
@@ -44,6 +44,7 @@ import com.hedera.datagenerator.sdk.supplier.TransactionType;
 import com.hedera.hashgraph.sdk.AccountId;
 import com.hedera.hashgraph.sdk.PrecheckStatusException;
 import com.hedera.hashgraph.sdk.ReceiptStatusException;
+import com.hedera.mirror.monitor.converter.DurationToStringSerializer;
 
 @Log4j2
 @Named
@@ -163,7 +164,8 @@ public class PublishMetrics {
         double instantRate = getRate(instantCount, instantElapsed);
         Map<String, Integer> errorCounts = new HashMap<>();
         errors.forEachEntry((k, v) -> errorCounts.put(k, v));
-        log.info("Published {} transactions in {} at {}/s. Errors: {}", count, stopwatch, instantRate, errorCounts);
+        String elapsedStr = DurationToStringSerializer.convert(stopwatch.elapsed());
+        log.info("Published {} transactions in {} at {}/s. Errors: {}", count, elapsedStr, instantRate, errorCounts);
     }
 
     private double getRate(long count, long elapsedMicros) {

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/AbstractSubscriberProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/AbstractSubscriberProperties.java
@@ -23,7 +23,6 @@ package com.hedera.mirror.monitor.subscribe;
 import java.time.Duration;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
-import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import lombok.Data;
 import org.hibernate.validator.constraints.time.DurationMin;
@@ -42,7 +41,6 @@ public abstract class AbstractSubscriberProperties {
     @Min(0)
     protected long limit = 0; // 0 for unlimited
 
-    @NotBlank
     protected String name;
 
     @NotNull

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/SubscribeMetrics.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/SubscribeMetrics.java
@@ -33,6 +33,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.scheduling.annotation.Scheduled;
 
+import com.hedera.mirror.monitor.converter.DurationToStringSerializer;
+
 @Log4j2
 @Named
 @RequiredArgsConstructor
@@ -88,8 +90,9 @@ public class SubscribeMetrics {
 
     private void status(Subscription s) {
         if (s.getStatus() == SubscriptionStatus.RUNNING) {
+            String elapsed = DurationToStringSerializer.convert(s.getElapsed());
             log.info("{} {}: {} transactions in {} at {}/s. Errors: {}",
-                    s.getProtocol(), s, s.getCount(), s.getElapsed(), s.getRate(), s.getErrors());
+                    s.getProtocol(), s, s.getCount(), elapsed, s.getRate(), s.getErrors());
         }
     }
 }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/SubscribeProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/SubscribeProperties.java
@@ -20,19 +20,17 @@ package com.hedera.mirror.monitor.subscribe;
  * ‍
  */
 
+import com.google.common.collect.Sets;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import javax.annotation.PostConstruct;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import lombok.Data;
+import org.apache.commons.lang3.StringUtils;
 import org.hibernate.validator.constraints.time.DurationMin;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
@@ -52,10 +50,10 @@ public class SubscribeProperties {
     private boolean enabled = true;
 
     @NotNull
-    private List<GrpcSubscriberProperties> grpc = new ArrayList<>();
+    private Map<String, GrpcSubscriberProperties> grpc = new LinkedHashMap<>();
 
     @NotNull
-    private List<RestSubscriberProperties> rest = new ArrayList<>();
+    private Map<String, RestSubscriberProperties> rest = new LinkedHashMap<>();
 
     @DurationMin(seconds = 1L)
     @NotNull
@@ -67,17 +65,16 @@ public class SubscribeProperties {
             throw new IllegalArgumentException("There must be at least one subscribe scenario");
         }
 
-        Set<String> names = Stream.concat(grpc.stream(), rest.stream())
-                .map(AbstractSubscriberProperties::getName)
-                .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()))
-                .entrySet()
-                .stream()
-                .filter(e -> e.getValue() > 1)
-                .map(Map.Entry::getKey)
-                .collect(Collectors.toSet());
+        if (Sets.union(grpc.keySet(), rest.keySet()).stream().anyMatch(StringUtils::isBlank)) {
+            throw new IllegalArgumentException("Subscribe scenario name cannot be empty");
+        }
 
+        Set<String> names = Sets.intersection(grpc.keySet(), rest.keySet());
         if (!names.isEmpty()) {
             throw new IllegalArgumentException("More than one subscribe scenario with the same name: " + names);
         }
+
+        grpc.forEach((name, property) -> property.setName(name));
+        rest.forEach((name, property) -> property.setName(name));
     }
 }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/Subscription.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/Subscription.java
@@ -21,17 +21,20 @@ package com.hedera.mirror.monitor.subscribe;
  */
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.time.Duration;
 import java.util.Map;
 
 import com.hedera.mirror.monitor.converter.DurationToStringSerializer;
+import com.hedera.mirror.monitor.converter.StringToDurationDeserializer;
 
 @JsonSerialize(as = Subscription.class)
 public interface Subscription {
 
     long getCount();
 
+    @JsonDeserialize(using = StringToDurationDeserializer.class)
     @JsonSerialize(using = DurationToStringSerializer.class)
     Duration getElapsed();
 

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/Subscription.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/Subscription.java
@@ -25,11 +25,14 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.time.Duration;
 import java.util.Map;
 
+import com.hedera.mirror.monitor.converter.DurationToStringSerializer;
+
 @JsonSerialize(as = Subscription.class)
 public interface Subscription {
 
     long getCount();
 
+    @JsonSerialize(using = DurationToStringSerializer.class)
     Duration getElapsed();
 
     Map<String, Integer> getErrors();

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/grpc/GrpcSubscriber.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/grpc/GrpcSubscriber.java
@@ -62,7 +62,7 @@ class GrpcSubscriber implements MirrorSubscriber {
     private Flux<GrpcSubscription> createSubscriptions() {
         Collection<GrpcSubscription> subscriptionList = new ArrayList<>();
 
-        for (GrpcSubscriberProperties properties : subscribeProperties.getGrpc()) {
+        for (GrpcSubscriberProperties properties : subscribeProperties.getGrpc().values()) {
             if (subscribeProperties.isEnabled() && properties.isEnabled()) {
                 String topicId = expressionConverter.convert(properties.getTopicId());
                 properties.setTopicId(topicId);

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/rest/RestSubscriberProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/rest/RestSubscriberProperties.java
@@ -21,6 +21,8 @@ package com.hedera.mirror.monitor.subscribe.rest;
  */
 
 import java.time.Duration;
+import java.util.LinkedHashSet;
+import java.util.Set;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
@@ -35,12 +37,15 @@ import com.hedera.mirror.monitor.subscribe.AbstractSubscriberProperties;
 public class RestSubscriberProperties extends AbstractSubscriberProperties {
 
     @NotNull
-    @DurationMin(millis = 500)
-    private Duration timeout = Duration.ofSeconds(5);
+    private Set<String> publishers = new LinkedHashSet<>();
 
     @Min(0)
     @Max(1)
     private double samplePercent = 1.0;
+
+    @NotNull
+    @DurationMin(millis = 500)
+    private Duration timeout = Duration.ofSeconds(5);
 
     @Override
     public long getLimit() {

--- a/hedera-mirror-monitor/src/main/resources/application.yml
+++ b/hedera-mirror-monitor/src/main/resources/application.yml
@@ -3,7 +3,7 @@ hedera:
     monitor:
       publish:
         scenarios:
-          - name: HCS Pinger
+          pinger:
             properties:
               topicId: ${topic.ping}
             receiptPercent: 1.0
@@ -11,10 +11,11 @@ hedera:
             type: CONSENSUS_SUBMIT_MESSAGE
       subscribe:
         grpc:
-          - name: HCS Subscribe
+          hcs:
             topicId: ${topic.ping}
         rest:
-          - name: HCS REST
+          transactionId:
+            publishers: [ "pinger" ]
             samplePercent: 1.0
 logging:
   level:

--- a/hedera-mirror-monitor/src/main/resources/log4j2.xml
+++ b/hedera-mirror-monitor/src/main/resources/log4j2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="WARN">
+<Configuration shutdownHook="disable" status="WARN">
     <Appenders>
         <Console name="console" target="SYSTEM_OUT">
             <PatternLayout>

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/converter/DurationToStringSerializerTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/converter/DurationToStringSerializerTest.java
@@ -1,0 +1,70 @@
+package com.hedera.mirror.monitor.converter;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import java.time.Duration;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DurationToStringSerializerTest {
+
+    private final DurationToStringSerializer serializer = new DurationToStringSerializer();
+
+    @Mock
+    private JsonGenerator jsonGenerator;
+
+    @Test
+    void serialize() throws Exception {
+        Duration duration = Duration.ofSeconds(5L);
+        serializer.serialize(duration, jsonGenerator, null);
+        jsonGenerator.writeString("5s");
+    }
+
+    @DisplayName("Convert Duration to String")
+    @ParameterizedTest(name = "{0} => {1}")
+    @CsvSource({
+            ",",
+            "0, 0s",
+            "1, 1s",
+            "60, 1m",
+            "61, 1m1s",
+            "3600, 1h",
+            "3660, 1h1m",
+            "3661, 1h1m1s",
+            "86400, 1d",
+            "90000, 1d1h",
+            "90060, 1d1h1m",
+            "90061, 1d1h1m1s"
+    })
+    void convert(Long input, String text) {
+        Duration duration = input != null ? Duration.ofSeconds(input) : null;
+        assertThat(DurationToStringSerializer.convert(duration)).isEqualTo(text);
+    }
+}

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/converter/StringToDurationDeserializerTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/converter/StringToDurationDeserializerTest.java
@@ -1,0 +1,64 @@
+package com.hedera.mirror.monitor.converter;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.core.JsonParser;
+import java.time.Duration;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class StringToDurationDeserializerTest {
+
+    private final StringToDurationDeserializer deserializer = new StringToDurationDeserializer();
+
+    @Mock
+    private JsonParser jsonParser;
+
+    @DisplayName("Convert Duration to String")
+    @ParameterizedTest(name = "{0} => {1}")
+    @CsvSource({
+            ",",
+            "0s, 0",
+            "1s, 1",
+            "1m, 60",
+            "1m1s, 61",
+            "1h, 3600",
+            "1h1m, 3660",
+            "1h1m1s, 3661",
+            "1d, 86400",
+            "1d1h, 90000",
+            "1d1h1m, 90060",
+            "1d1h1m1s, 90061"
+    })
+    void deserialize(String input, Long expected) throws Exception {
+        when(jsonParser.getValueAsString()).thenReturn(input);
+        Duration duration = expected != null ? Duration.ofSeconds(expected) : null;
+        assertThat(deserializer.deserialize(jsonParser, null)).isEqualTo(duration);
+    }
+}

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/PublishPropertiesTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/PublishPropertiesTest.java
@@ -20,10 +20,13 @@ package com.hedera.mirror.monitor.publish;
  * ‍
  */
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import com.hedera.mirror.monitor.generator.ScenarioProperties;
 
@@ -35,22 +38,26 @@ class PublishPropertiesTest {
     @BeforeEach
     void setup() {
         scenarioProperties = new ScenarioProperties();
-        scenarioProperties.setName("test1");
-
         publishProperties = new PublishProperties();
-        publishProperties.getScenarios().add(scenarioProperties);
+        publishProperties.getScenarios().put("test1", scenarioProperties);
     }
 
     @Test
     void validate() {
         publishProperties.validate();
+        assertThat(scenarioProperties.getName()).isEqualTo("test1");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", " "})
+    void emptyName(String name) {
+        publishProperties.getScenarios().put(name, scenarioProperties);
+        assertThrows(IllegalArgumentException.class, publishProperties::validate);
     }
 
     @Test
-    void duplicateName() {
-        ScenarioProperties scenarioProperties2 = new ScenarioProperties();
-        scenarioProperties2.setName(scenarioProperties.getName());
-        publishProperties.getScenarios().add(scenarioProperties2);
+    void nullName() {
+        publishProperties.getScenarios().put(null, scenarioProperties);
         assertThrows(IllegalArgumentException.class, publishProperties::validate);
     }
 

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/grpc/GrpcSubscriberTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/grpc/GrpcSubscriberTest.java
@@ -60,7 +60,7 @@ class GrpcSubscriberTest {
     void setup() {
         grpcSubscriberProperties.setName("Test");
         grpcSubscriberProperties.setTopicId("0.0.1000");
-        subscribeProperties.getGrpc().add(grpcSubscriberProperties);
+        subscribeProperties.getGrpc().put(grpcSubscriberProperties.getName(), grpcSubscriberProperties);
         grpcSubscriber = new GrpcSubscriber(expressionConverter, grpcClient, subscribeProperties);
     }
 
@@ -106,7 +106,7 @@ class GrpcSubscriberTest {
         GrpcSubscriberProperties grpcSubscriberProperties2 = new GrpcSubscriberProperties();
         grpcSubscriberProperties2.setName("Test2");
         grpcSubscriberProperties2.setTopicId("0.0.1001");
-        subscribeProperties.getGrpc().add(grpcSubscriberProperties2);
+        subscribeProperties.getGrpc().put(grpcSubscriberProperties2.getName(), grpcSubscriberProperties2);
 
         when(grpcClient.subscribe(any())).thenReturn(Flux.just(response(), response()));
         grpcSubscriber.subscribe()


### PR DESCRIPTION
**Detailed description**:
- Add a `hedera.mirror.monitor.subscribe.rest.publishers` property to target slow sampling to specific publishers
- Change `hedera.mirror.monitor.publish.scenarios` from a list to a map
- Change `hedera.mirror.monitor.subscribe.grpc` from a list to a map
- Change `hedera.mirror.monitor.subscribe.rest` from a list to a map
- Change monitor log and REST API elapsed duration to a prettier format (follow up of https://github.com/hashgraph/hedera-mirror-node/pull/2065#discussion_r644278330)
- Fix logging stacktrace on shutdown due to [conflict](https://github.com/spring-projects/spring-boot/issues/26953) between Spring Boot and Log4j2's logging shutdown mechanism
- Fix monitor REST API client IP detection by relying upon standard `X-Forwarded-For` header, if available

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Checklist**

- [x] Documentation added
- [x] Tests updated

