### PR TITLE
Improve acceptance accountId and retry logic

### DIFF
--- a/hedera-mirror-test/README.md
+++ b/hedera-mirror-test/README.md
@@ -50,10 +50,12 @@ Configuration properties are set in the `application.yml` file located under `sr
 uses [Spring Boot](https://spring.io/projects/spring-boot) properties to configure the application. Available properties
 under `hedera.mirror.test.acceptance` include:
 
+- `backOffPeriod` - The number of milliseconds client should wait before retrying a retryable failure.
 - `emitBackgroundMessages` - Flag to set if background messages should be emitted. For operations use in non-production
   `environments.
 - `existingTopicNum` - A pre-existing default topic number that can be used when no topicId is specified in a test. Used
   initially by `@subscribeonly` test.
+- `maxRetries` - The number of times client should retryable on supported failures.
 - `maxTinyBarTransactionFee` - The maximum transaction fee you're willing to pay on a transaction.
 - `messageTimeout` - The number of seconds to wait on messages representing transactions (default is 20).
 - `mirrorNodeAddress` - The mirror node grpc server endpoint including IP address and port. Refer to
@@ -69,10 +71,12 @@ under `hedera.mirror.test.acceptance` include:
   - `baseUrl` - The host URL to the mirror node. For example, https://testnet.mirrornode.hedera.com/api/v1
   - `delay` - The time to wait in between failed REST API calls.
   - `maxAttempts` - The maximum number of attempts when calling a REST API endpoint and receiving a 404.
+  - `maxBackoff` - The maximum backoff duration the mirror grpc subscriber will wait between attempts.
+  - `minBackoff` - The minimum backoff duration the mirror grpc subscriber will wait between attempts.
 - `retrieveAddressBook` - Whether to download the address book from the network and use those nodes over the default
   nodes. Populating `hedera.mirror.test.acceptance.nodes` will take priority over this.
-- `subscribeRetries` - The number of times client should retryable on supported failures.
-- `subscribeRetryOffPeriod` - The number of milliseconds client should wait before retrying a retryable failure.
+- `sdkProperties`
+  - `maxAttempts` - The maximum number of times the sdk should try to submit a transaction to the network.
 
 (Recommended) Options can be set by creating your own configuration file with the above properties. This allows for
 multiple files per env. The following command will help to point out which file to use:

--- a/hedera-mirror-test/README.md
+++ b/hedera-mirror-test/README.md
@@ -65,7 +65,7 @@ under `hedera.mirror.test.acceptance` include:
 - `operatorId` - Account ID on the network in 'x.y.z' format.
 - `operatorKey` - Account private key to be used for signing transaction and client identification. Please do not check
   in.
-- `restPollingProperties`
+- `rest`
   - `baseUrl` - The host URL to the mirror node. For example, https://testnet.mirrornode.hedera.com/api/v1
   - `delay` - The time to wait in between failed REST API calls.
   - `maxAttempts` - The maximum number of attempts when calling a REST API endpoint and receiving a 404.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AccountClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AccountClient.java
@@ -23,7 +23,6 @@ package com.hedera.mirror.test.e2e.acceptance.client;
 import java.time.Instant;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicReference;
 import javax.inject.Named;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
@@ -72,21 +71,11 @@ public class AccountClient extends AbstractNetworkClient {
 
     public ExpandedAccountId getAccount(AccountNameEnum accountNameEnum) {
         // retrieve account, setting if it doesn't exist
-        AtomicReference<Exception> encounteredException = new AtomicReference<>();
         ExpandedAccountId accountId = accountMap
-                .computeIfAbsent(accountNameEnum, x -> {
-                    try {
-                        return createNewAccount(SMALL_INITIAL_BALANCE,
-                                accountNameEnum);
-                    } catch (Exception e) {
-                        encounteredException.set(e);
-                        log.trace("Issue creating additional account: {}, ex: {}", accountNameEnum, e);
-                    }
-                    return null;
-                });
+                .computeIfAbsent(accountNameEnum, x -> createNewAccount(SMALL_INITIAL_BALANCE, accountNameEnum));
 
         if (accountId == null) {
-            throw new NetworkException(encounteredException.get().getMessage());
+            throw new NetworkException("Null accountId retrieved from receipt");
         }
 
         log.debug("Retrieve Account: {}, {}", accountId, accountNameEnum);

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AccountClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AccountClient.java
@@ -72,7 +72,14 @@ public class AccountClient extends AbstractNetworkClient {
     public ExpandedAccountId getAccount(AccountNameEnum accountNameEnum) {
         // retrieve account, setting if it doesn't exist
         ExpandedAccountId accountId = accountMap
-                .computeIfAbsent(accountNameEnum, x -> createNewAccount(SMALL_INITIAL_BALANCE, accountNameEnum));
+                .computeIfAbsent(accountNameEnum, x -> {
+                    try {
+                        return createNewAccount(SMALL_INITIAL_BALANCE, accountNameEnum);
+                    } catch (Exception e) {
+                        log.trace("Issue creating additional account: {}, ex: {}", accountNameEnum, e);
+                        return null;
+                    }
+                });
 
         if (accountId == null) {
             throw new NetworkException("Null accountId retrieved from receipt");

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AccountClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AccountClient.java
@@ -29,6 +29,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Scope;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 
 import com.hedera.hashgraph.sdk.AccountBalanceQuery;
 import com.hedera.hashgraph.sdk.AccountCreateTransaction;
@@ -154,6 +156,9 @@ public class AccountClient extends AbstractNetworkClient {
                 accountNameEnum.toString());
     }
 
+    @Retryable(value = {PrecheckStatusException.class, TimeoutException.class},
+            backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.backOffPeriod.toMillis()}"),
+            maxAttemptsExpression = "#{@acceptanceTestProperties.maxRetries}")
     public ExpandedAccountId createCryptoAccount(Hbar initialBalance, boolean receiverSigRequired, KeyList keyList,
                                                  String memo)
             throws TimeoutException, PrecheckStatusException, ReceiptStatusException {

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/MirrorNodeClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/MirrorNodeClient.java
@@ -21,6 +21,7 @@ package com.hedera.mirror.test.e2e.acceptance.client;
  */
 
 import com.google.common.base.Stopwatch;
+import io.grpc.netty.shaded.io.netty.handler.timeout.ReadTimeoutException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -159,7 +160,9 @@ public class MirrorNodeClient extends AbstractNetworkClient {
     }
 
     protected boolean shouldRetryRestCall(Throwable t) {
-        return t instanceof TimeoutException || t instanceof PrematureCloseException ||
+        return t instanceof PrematureCloseException ||
+                t instanceof ReadTimeoutException ||
+                t instanceof TimeoutException ||
                 (t instanceof WebClientResponseException &&
                         ((WebClientResponseException) t).getStatusCode() == HttpStatus.NOT_FOUND);
     }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/NetworkException.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/NetworkException.java
@@ -1,0 +1,30 @@
+package com.hedera.mirror.test.e2e.acceptance.client;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+public class NetworkException extends RuntimeException {
+
+    private static final long serialVersionUID = 4080400972797042474L;
+
+    public NetworkException(String message) {
+        super(message);
+    }
+}

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/ScheduleClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/ScheduleClient.java
@@ -26,6 +26,8 @@ import javax.inject.Named;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Scope;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 
 import com.hedera.hashgraph.sdk.KeyList;
 import com.hedera.hashgraph.sdk.PrecheckStatusException;
@@ -50,6 +52,9 @@ public class ScheduleClient extends AbstractNetworkClient {
         log.debug("Creating Schedule Client");
     }
 
+    @Retryable(value = {PrecheckStatusException.class, TimeoutException.class},
+            backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.backOffPeriod.toMillis()}"),
+            maxAttemptsExpression = "#{@acceptanceTestProperties.maxRetries}")
     public NetworkTransactionResponse createSchedule(ExpandedAccountId payerAccountId, Transaction transaction,
                                                      String memo, KeyList signatureKeyList) throws ReceiptStatusException,
             PrecheckStatusException, TimeoutException {
@@ -87,6 +92,9 @@ public class ScheduleClient extends AbstractNetworkClient {
         return networkTransactionResponse;
     }
 
+    @Retryable(value = {PrecheckStatusException.class, TimeoutException.class},
+            backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.backOffPeriod.toMillis()}"),
+            maxAttemptsExpression = "#{@acceptanceTestProperties.maxRetries}")
     public NetworkTransactionResponse signSchedule(ExpandedAccountId expandedAccountId,
                                                    ScheduleId scheduleId) throws ReceiptStatusException,
             PrecheckStatusException, TimeoutException {
@@ -103,6 +111,9 @@ public class ScheduleClient extends AbstractNetworkClient {
         return networkTransactionResponse;
     }
 
+    @Retryable(value = {PrecheckStatusException.class, TimeoutException.class},
+            backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.backOffPeriod.toMillis()}"),
+            maxAttemptsExpression = "#{@acceptanceTestProperties.maxRetries}")
     public NetworkTransactionResponse deleteSchedule(ScheduleId scheduleId) throws ReceiptStatusException,
             PrecheckStatusException, TimeoutException {
 

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/ScheduleClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/ScheduleClient.java
@@ -22,6 +22,7 @@ package com.hedera.mirror.test.e2e.acceptance.client;
 
 import java.util.List;
 import javax.inject.Named;
+import lombok.SneakyThrows;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Scope;
@@ -51,7 +52,7 @@ public class ScheduleClient extends AbstractNetworkClient {
     }
 
     public NetworkTransactionResponse createSchedule(ExpandedAccountId payerAccountId, Transaction transaction,
-                                                     String memo, KeyList signatureKeyList) throws Exception {
+                                                     String memo, KeyList signatureKeyList) {
 
         log.debug("Create new schedule");
         TransactionId transactionId = TransactionId.generate(sdkClient.getExpandedOperatorAccountId().getAccountId())
@@ -88,7 +89,7 @@ public class ScheduleClient extends AbstractNetworkClient {
     }
 
     public NetworkTransactionResponse signSchedule(ExpandedAccountId expandedAccountId,
-                                                   ScheduleId scheduleId) throws Exception {
+                                                   ScheduleId scheduleId) {
 
         ScheduleSignTransaction scheduleSignTransaction = new ScheduleSignTransaction()
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
@@ -102,7 +103,7 @@ public class ScheduleClient extends AbstractNetworkClient {
         return networkTransactionResponse;
     }
 
-    public NetworkTransactionResponse deleteSchedule(ScheduleId scheduleId) throws Exception {
+    public NetworkTransactionResponse deleteSchedule(ScheduleId scheduleId) {
 
         log.debug("Delete schedule {}", scheduleId);
         ScheduleDeleteTransaction scheduleDeleteTransaction = new ScheduleDeleteTransaction()
@@ -116,7 +117,8 @@ public class ScheduleClient extends AbstractNetworkClient {
         return networkTransactionResponse;
     }
 
-    public ScheduleInfo getScheduleInfo(ScheduleId scheduleId) throws Exception {
+    @SneakyThrows
+    public ScheduleInfo getScheduleInfo(ScheduleId scheduleId) {
         return retryTemplate.execute(x ->
                 new ScheduleInfoQuery()
                         .setScheduleId(scheduleId)

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TokenClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TokenClient.java
@@ -30,6 +30,8 @@ import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Scope;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 
 import com.hedera.hashgraph.sdk.AccountBalanceQuery;
 import com.hedera.hashgraph.sdk.AccountId;
@@ -66,6 +68,9 @@ public class TokenClient extends AbstractNetworkClient {
         log.debug("Creating Token Client");
     }
 
+    @Retryable(value = {PrecheckStatusException.class, TimeoutException.class},
+            backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.backOffPeriod.toMillis()}"),
+            maxAttemptsExpression = "#{@acceptanceTestProperties.maxRetries}")
     public NetworkTransactionResponse createToken(ExpandedAccountId expandedAccountId, String symbol, int freezeStatus,
                                                   int kycStatus, ExpandedAccountId treasuryAccount,
                                                   int initialSupply) throws ReceiptStatusException,
@@ -115,6 +120,9 @@ public class TokenClient extends AbstractNetworkClient {
         return networkTransactionResponse;
     }
 
+    @Retryable(value = {PrecheckStatusException.class, TimeoutException.class},
+            backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.backOffPeriod.toMillis()}"),
+            maxAttemptsExpression = "#{@acceptanceTestProperties.maxRetries}")
     public NetworkTransactionResponse asssociate(ExpandedAccountId accountId, TokenId token) throws ReceiptStatusException, PrecheckStatusException, TimeoutException {
 
         log.debug("Associate account {} with token {}", accountId.getAccountId(), token);
@@ -134,6 +142,9 @@ public class TokenClient extends AbstractNetworkClient {
         return networkTransactionResponse;
     }
 
+    @Retryable(value = {PrecheckStatusException.class, TimeoutException.class},
+            backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.backOffPeriod.toMillis()}"),
+            maxAttemptsExpression = "#{@acceptanceTestProperties.maxRetries}")
     public NetworkTransactionResponse mint(TokenId tokenId, long amount) throws ReceiptStatusException,
             PrecheckStatusException, TimeoutException {
 
@@ -153,6 +164,9 @@ public class TokenClient extends AbstractNetworkClient {
         return networkTransactionResponse;
     }
 
+    @Retryable(value = {PrecheckStatusException.class, TimeoutException.class},
+            backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.backOffPeriod.toMillis()}"),
+            maxAttemptsExpression = "#{@acceptanceTestProperties.maxRetries}")
     public NetworkTransactionResponse freeze(TokenId tokenId, AccountId accountId, PrivateKey freezeKey) throws ReceiptStatusException, PrecheckStatusException, TimeoutException {
 
         Instant refInstant = Instant.now();
@@ -171,6 +185,9 @@ public class TokenClient extends AbstractNetworkClient {
         return networkTransactionResponse;
     }
 
+    @Retryable(value = {PrecheckStatusException.class, TimeoutException.class},
+            backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.backOffPeriod.toMillis()}"),
+            maxAttemptsExpression = "#{@acceptanceTestProperties.maxRetries}")
     public NetworkTransactionResponse unfreeze(TokenId tokenId, AccountId accountId, PrivateKey freezeKey) throws ReceiptStatusException, PrecheckStatusException, TimeoutException {
 
         Instant refInstant = Instant.now();
@@ -189,6 +206,9 @@ public class TokenClient extends AbstractNetworkClient {
         return networkTransactionResponse;
     }
 
+    @Retryable(value = {PrecheckStatusException.class, TimeoutException.class},
+            backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.backOffPeriod.toMillis()}"),
+            maxAttemptsExpression = "#{@acceptanceTestProperties.maxRetries}")
     public NetworkTransactionResponse grantKyc(TokenId tokenId, AccountId accountId, PrivateKey kycKey) throws ReceiptStatusException, PrecheckStatusException, TimeoutException {
 
         log.debug("Grant account {} with KYC for token {}", accountId, tokenId);
@@ -207,6 +227,9 @@ public class TokenClient extends AbstractNetworkClient {
         return networkTransactionResponse;
     }
 
+    @Retryable(value = {PrecheckStatusException.class, TimeoutException.class},
+            backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.backOffPeriod.toMillis()}"),
+            maxAttemptsExpression = "#{@acceptanceTestProperties.maxRetries}")
     public NetworkTransactionResponse revokeKyc(TokenId tokenId, AccountId accountId, PrivateKey kycKey) throws ReceiptStatusException, PrecheckStatusException, TimeoutException {
 
         log.debug("Grant account {} with KYC for token {}", accountId, tokenId);
@@ -225,6 +248,9 @@ public class TokenClient extends AbstractNetworkClient {
         return networkTransactionResponse;
     }
 
+    @Retryable(value = {PrecheckStatusException.class, TimeoutException.class},
+            backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.backOffPeriod.toMillis()}"),
+            maxAttemptsExpression = "#{@acceptanceTestProperties.maxRetries}")
     public TransferTransaction getTokenTransferTransaction(TokenId tokenId, AccountId sender, AccountId recipient,
                                                            long amount) {
         Instant refInstant = Instant.now();
@@ -235,6 +261,9 @@ public class TokenClient extends AbstractNetworkClient {
                 .setTransactionMemo("Transfer token_" + refInstant);
     }
 
+    @Retryable(value = {PrecheckStatusException.class, TimeoutException.class},
+            backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.backOffPeriod.toMillis()}"),
+            maxAttemptsExpression = "#{@acceptanceTestProperties.maxRetries}")
     public NetworkTransactionResponse transferToken(TokenId tokenId, ExpandedAccountId sender, AccountId recipient,
                                                     long amount) throws ReceiptStatusException,
             PrecheckStatusException, TimeoutException {
@@ -252,6 +281,9 @@ public class TokenClient extends AbstractNetworkClient {
         return networkTransactionResponse;
     }
 
+    @Retryable(value = {PrecheckStatusException.class, TimeoutException.class},
+            backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.backOffPeriod.toMillis()}"),
+            maxAttemptsExpression = "#{@acceptanceTestProperties.maxRetries}")
     public NetworkTransactionResponse updateToken(TokenId tokenId, ExpandedAccountId expandedAccountId) throws ReceiptStatusException, PrecheckStatusException, TimeoutException {
         PublicKey publicKey = expandedAccountId.getPublicKey();
         String newSymbol = RandomStringUtils.randomAlphabetic(4).toUpperCase();
@@ -276,6 +308,9 @@ public class TokenClient extends AbstractNetworkClient {
         return networkTransactionResponse;
     }
 
+    @Retryable(value = {PrecheckStatusException.class, TimeoutException.class},
+            backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.backOffPeriod.toMillis()}"),
+            maxAttemptsExpression = "#{@acceptanceTestProperties.maxRetries}")
     public NetworkTransactionResponse burn(TokenId tokenId, long amount) throws ReceiptStatusException,
             PrecheckStatusException, TimeoutException {
 
@@ -295,6 +330,9 @@ public class TokenClient extends AbstractNetworkClient {
         return networkTransactionResponse;
     }
 
+    @Retryable(value = {PrecheckStatusException.class, TimeoutException.class},
+            backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.backOffPeriod.toMillis()}"),
+            maxAttemptsExpression = "#{@acceptanceTestProperties.maxRetries}")
     public NetworkTransactionResponse wipe(TokenId tokenId, long amount, ExpandedAccountId expandedAccountId) throws ReceiptStatusException, PrecheckStatusException, TimeoutException {
 
         log.debug("Wipe {} tokens from {}", amount, tokenId);
@@ -314,6 +352,9 @@ public class TokenClient extends AbstractNetworkClient {
         return networkTransactionResponse;
     }
 
+    @Retryable(value = {PrecheckStatusException.class, TimeoutException.class},
+            backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.backOffPeriod.toMillis()}"),
+            maxAttemptsExpression = "#{@acceptanceTestProperties.maxRetries}")
     public NetworkTransactionResponse disssociate(ExpandedAccountId accountId, TokenId token) throws ReceiptStatusException, PrecheckStatusException, TimeoutException {
 
         log.debug("Dissociate account {} with token {}", accountId.getAccountId(), token);
@@ -330,6 +371,9 @@ public class TokenClient extends AbstractNetworkClient {
         return networkTransactionResponse;
     }
 
+    @Retryable(value = {PrecheckStatusException.class, TimeoutException.class},
+            backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.backOffPeriod.toMillis()}"),
+            maxAttemptsExpression = "#{@acceptanceTestProperties.maxRetries}")
     public NetworkTransactionResponse delete(ExpandedAccountId accountId, TokenId token) throws ReceiptStatusException, PrecheckStatusException, TimeoutException {
 
         log.debug("Delete token {}", token);
@@ -348,6 +392,9 @@ public class TokenClient extends AbstractNetworkClient {
         return networkTransactionResponse;
     }
 
+    @Retryable(value = {PrecheckStatusException.class, TimeoutException.class},
+            backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.backOffPeriod.toMillis()}"),
+            maxAttemptsExpression = "#{@acceptanceTestProperties.maxRetries}")
     public long getTokenBalance(AccountId accountId, TokenId tokenId) throws TimeoutException, PrecheckStatusException {
         long balance = new AccountBalanceQuery()
                 .setAccountId(accountId)

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TokenClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TokenClient.java
@@ -352,7 +352,7 @@ public class TokenClient extends AbstractNetworkClient {
         long balance = new AccountBalanceQuery()
                 .setAccountId(accountId)
                 .execute(client)
-                .token.get(tokenId);
+                .tokens.get(tokenId);
 
         log.debug("{}'s token balance is {} {} tokens", accountId, balance, tokenId);
 

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TokenClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TokenClient.java
@@ -30,8 +30,7 @@ import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Scope;
-import org.springframework.retry.annotation.Backoff;
-import org.springframework.retry.annotation.Retryable;
+import org.springframework.retry.support.RetryTemplate;
 
 import com.hedera.hashgraph.sdk.AccountBalanceQuery;
 import com.hedera.hashgraph.sdk.AccountId;
@@ -39,7 +38,6 @@ import com.hedera.hashgraph.sdk.KeyList;
 import com.hedera.hashgraph.sdk.PrecheckStatusException;
 import com.hedera.hashgraph.sdk.PrivateKey;
 import com.hedera.hashgraph.sdk.PublicKey;
-import com.hedera.hashgraph.sdk.ReceiptStatusException;
 import com.hedera.hashgraph.sdk.TokenAssociateTransaction;
 import com.hedera.hashgraph.sdk.TokenBurnTransaction;
 import com.hedera.hashgraph.sdk.TokenCreateTransaction;
@@ -63,18 +61,14 @@ import com.hedera.mirror.test.e2e.acceptance.response.NetworkTransactionResponse
 @Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE)
 public class TokenClient extends AbstractNetworkClient {
 
-    public TokenClient(SDKClient sdkClient) {
-        super(sdkClient);
+    public TokenClient(SDKClient sdkClient, RetryTemplate retryTemplate) {
+        super(sdkClient, retryTemplate);
         log.debug("Creating Token Client");
     }
 
-    @Retryable(value = {PrecheckStatusException.class, TimeoutException.class},
-            backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.backOffPeriod.toMillis()}"),
-            maxAttemptsExpression = "#{@acceptanceTestProperties.maxRetries}")
     public NetworkTransactionResponse createToken(ExpandedAccountId expandedAccountId, String symbol, int freezeStatus,
                                                   int kycStatus, ExpandedAccountId treasuryAccount,
-                                                  int initialSupply) throws ReceiptStatusException,
-            PrecheckStatusException, TimeoutException {
+                                                  int initialSupply) throws Exception {
 
         log.debug("Create new token {}", symbol);
         Instant refInstant = Instant.now();
@@ -120,10 +114,7 @@ public class TokenClient extends AbstractNetworkClient {
         return networkTransactionResponse;
     }
 
-    @Retryable(value = {PrecheckStatusException.class, TimeoutException.class},
-            backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.backOffPeriod.toMillis()}"),
-            maxAttemptsExpression = "#{@acceptanceTestProperties.maxRetries}")
-    public NetworkTransactionResponse asssociate(ExpandedAccountId accountId, TokenId token) throws ReceiptStatusException, PrecheckStatusException, TimeoutException {
+    public NetworkTransactionResponse associate(ExpandedAccountId accountId, TokenId token) throws Exception {
 
         log.debug("Associate account {} with token {}", accountId.getAccountId(), token);
         Instant refInstant = Instant.now();
@@ -142,11 +133,7 @@ public class TokenClient extends AbstractNetworkClient {
         return networkTransactionResponse;
     }
 
-    @Retryable(value = {PrecheckStatusException.class, TimeoutException.class},
-            backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.backOffPeriod.toMillis()}"),
-            maxAttemptsExpression = "#{@acceptanceTestProperties.maxRetries}")
-    public NetworkTransactionResponse mint(TokenId tokenId, long amount) throws ReceiptStatusException,
-            PrecheckStatusException, TimeoutException {
+    public NetworkTransactionResponse mint(TokenId tokenId, long amount) throws Exception {
 
         log.debug("Mint {} tokens from {}", amount, tokenId);
         Instant refInstant = Instant.now();
@@ -164,10 +151,7 @@ public class TokenClient extends AbstractNetworkClient {
         return networkTransactionResponse;
     }
 
-    @Retryable(value = {PrecheckStatusException.class, TimeoutException.class},
-            backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.backOffPeriod.toMillis()}"),
-            maxAttemptsExpression = "#{@acceptanceTestProperties.maxRetries}")
-    public NetworkTransactionResponse freeze(TokenId tokenId, AccountId accountId, PrivateKey freezeKey) throws ReceiptStatusException, PrecheckStatusException, TimeoutException {
+    public NetworkTransactionResponse freeze(TokenId tokenId, AccountId accountId, PrivateKey freezeKey) throws Exception {
 
         Instant refInstant = Instant.now();
         TokenFreezeTransaction tokenFreezeAccountTransaction = new TokenFreezeTransaction()
@@ -185,10 +169,7 @@ public class TokenClient extends AbstractNetworkClient {
         return networkTransactionResponse;
     }
 
-    @Retryable(value = {PrecheckStatusException.class, TimeoutException.class},
-            backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.backOffPeriod.toMillis()}"),
-            maxAttemptsExpression = "#{@acceptanceTestProperties.maxRetries}")
-    public NetworkTransactionResponse unfreeze(TokenId tokenId, AccountId accountId, PrivateKey freezeKey) throws ReceiptStatusException, PrecheckStatusException, TimeoutException {
+    public NetworkTransactionResponse unfreeze(TokenId tokenId, AccountId accountId, PrivateKey freezeKey) throws Exception {
 
         Instant refInstant = Instant.now();
         TokenUnfreezeTransaction tokenUnfreezeTransaction = new TokenUnfreezeTransaction()
@@ -206,10 +187,7 @@ public class TokenClient extends AbstractNetworkClient {
         return networkTransactionResponse;
     }
 
-    @Retryable(value = {PrecheckStatusException.class, TimeoutException.class},
-            backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.backOffPeriod.toMillis()}"),
-            maxAttemptsExpression = "#{@acceptanceTestProperties.maxRetries}")
-    public NetworkTransactionResponse grantKyc(TokenId tokenId, AccountId accountId, PrivateKey kycKey) throws ReceiptStatusException, PrecheckStatusException, TimeoutException {
+    public NetworkTransactionResponse grantKyc(TokenId tokenId, AccountId accountId, PrivateKey kycKey) throws Exception {
 
         log.debug("Grant account {} with KYC for token {}", accountId, tokenId);
         Instant refInstant = Instant.now();
@@ -227,10 +205,7 @@ public class TokenClient extends AbstractNetworkClient {
         return networkTransactionResponse;
     }
 
-    @Retryable(value = {PrecheckStatusException.class, TimeoutException.class},
-            backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.backOffPeriod.toMillis()}"),
-            maxAttemptsExpression = "#{@acceptanceTestProperties.maxRetries}")
-    public NetworkTransactionResponse revokeKyc(TokenId tokenId, AccountId accountId, PrivateKey kycKey) throws ReceiptStatusException, PrecheckStatusException, TimeoutException {
+    public NetworkTransactionResponse revokeKyc(TokenId tokenId, AccountId accountId, PrivateKey kycKey) throws Exception {
 
         log.debug("Grant account {} with KYC for token {}", accountId, tokenId);
         Instant refInstant = Instant.now();
@@ -248,9 +223,6 @@ public class TokenClient extends AbstractNetworkClient {
         return networkTransactionResponse;
     }
 
-    @Retryable(value = {PrecheckStatusException.class, TimeoutException.class},
-            backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.backOffPeriod.toMillis()}"),
-            maxAttemptsExpression = "#{@acceptanceTestProperties.maxRetries}")
     public TransferTransaction getTokenTransferTransaction(TokenId tokenId, AccountId sender, AccountId recipient,
                                                            long amount) {
         Instant refInstant = Instant.now();
@@ -261,12 +233,8 @@ public class TokenClient extends AbstractNetworkClient {
                 .setTransactionMemo("Transfer token_" + refInstant);
     }
 
-    @Retryable(value = {PrecheckStatusException.class, TimeoutException.class},
-            backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.backOffPeriod.toMillis()}"),
-            maxAttemptsExpression = "#{@acceptanceTestProperties.maxRetries}")
     public NetworkTransactionResponse transferToken(TokenId tokenId, ExpandedAccountId sender, AccountId recipient,
-                                                    long amount) throws ReceiptStatusException,
-            PrecheckStatusException, TimeoutException {
+                                                    long amount) throws Exception {
 
         log.debug("Transfer {} of token {} from {} to {}", amount, tokenId, sender, recipient);
         TransferTransaction tokenTransferTransaction = getTokenTransferTransaction(tokenId, sender
@@ -281,10 +249,7 @@ public class TokenClient extends AbstractNetworkClient {
         return networkTransactionResponse;
     }
 
-    @Retryable(value = {PrecheckStatusException.class, TimeoutException.class},
-            backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.backOffPeriod.toMillis()}"),
-            maxAttemptsExpression = "#{@acceptanceTestProperties.maxRetries}")
-    public NetworkTransactionResponse updateToken(TokenId tokenId, ExpandedAccountId expandedAccountId) throws ReceiptStatusException, PrecheckStatusException, TimeoutException {
+    public NetworkTransactionResponse updateToken(TokenId tokenId, ExpandedAccountId expandedAccountId) throws Exception {
         PublicKey publicKey = expandedAccountId.getPublicKey();
         String newSymbol = RandomStringUtils.randomAlphabetic(4).toUpperCase();
         TokenUpdateTransaction tokenUpdateTransaction = new TokenUpdateTransaction()
@@ -308,11 +273,7 @@ public class TokenClient extends AbstractNetworkClient {
         return networkTransactionResponse;
     }
 
-    @Retryable(value = {PrecheckStatusException.class, TimeoutException.class},
-            backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.backOffPeriod.toMillis()}"),
-            maxAttemptsExpression = "#{@acceptanceTestProperties.maxRetries}")
-    public NetworkTransactionResponse burn(TokenId tokenId, long amount) throws ReceiptStatusException,
-            PrecheckStatusException, TimeoutException {
+    public NetworkTransactionResponse burn(TokenId tokenId, long amount) throws Exception {
 
         log.debug("Burn {} tokens from {}", amount, tokenId);
         Instant refInstant = Instant.now();
@@ -330,10 +291,7 @@ public class TokenClient extends AbstractNetworkClient {
         return networkTransactionResponse;
     }
 
-    @Retryable(value = {PrecheckStatusException.class, TimeoutException.class},
-            backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.backOffPeriod.toMillis()}"),
-            maxAttemptsExpression = "#{@acceptanceTestProperties.maxRetries}")
-    public NetworkTransactionResponse wipe(TokenId tokenId, long amount, ExpandedAccountId expandedAccountId) throws ReceiptStatusException, PrecheckStatusException, TimeoutException {
+    public NetworkTransactionResponse wipe(TokenId tokenId, long amount, ExpandedAccountId expandedAccountId) throws Exception {
 
         log.debug("Wipe {} tokens from {}", amount, tokenId);
         Instant refInstant = Instant.now();
@@ -352,10 +310,7 @@ public class TokenClient extends AbstractNetworkClient {
         return networkTransactionResponse;
     }
 
-    @Retryable(value = {PrecheckStatusException.class, TimeoutException.class},
-            backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.backOffPeriod.toMillis()}"),
-            maxAttemptsExpression = "#{@acceptanceTestProperties.maxRetries}")
-    public NetworkTransactionResponse disssociate(ExpandedAccountId accountId, TokenId token) throws ReceiptStatusException, PrecheckStatusException, TimeoutException {
+    public NetworkTransactionResponse dissociate(ExpandedAccountId accountId, TokenId token) throws Exception {
 
         log.debug("Dissociate account {} with token {}", accountId.getAccountId(), token);
         TokenDissociateTransaction tokenDissociateTransaction = new TokenDissociateTransaction()
@@ -371,10 +326,7 @@ public class TokenClient extends AbstractNetworkClient {
         return networkTransactionResponse;
     }
 
-    @Retryable(value = {PrecheckStatusException.class, TimeoutException.class},
-            backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.backOffPeriod.toMillis()}"),
-            maxAttemptsExpression = "#{@acceptanceTestProperties.maxRetries}")
-    public NetworkTransactionResponse delete(ExpandedAccountId accountId, TokenId token) throws ReceiptStatusException, PrecheckStatusException, TimeoutException {
+    public NetworkTransactionResponse delete(ExpandedAccountId accountId, TokenId token) throws Exception {
 
         log.debug("Delete token {}", token);
         Instant refInstant = Instant.now();
@@ -392,9 +344,6 @@ public class TokenClient extends AbstractNetworkClient {
         return networkTransactionResponse;
     }
 
-    @Retryable(value = {PrecheckStatusException.class, TimeoutException.class},
-            backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.backOffPeriod.toMillis()}"),
-            maxAttemptsExpression = "#{@acceptanceTestProperties.maxRetries}")
     public long getTokenBalance(AccountId accountId, TokenId tokenId) throws TimeoutException, PrecheckStatusException {
         long balance = new AccountBalanceQuery()
                 .setAccountId(accountId)

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TokenClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TokenClient.java
@@ -24,8 +24,8 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
-import java.util.concurrent.TimeoutException;
 import javax.inject.Named;
+import lombok.SneakyThrows;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
@@ -35,7 +35,6 @@ import org.springframework.retry.support.RetryTemplate;
 import com.hedera.hashgraph.sdk.AccountBalanceQuery;
 import com.hedera.hashgraph.sdk.AccountId;
 import com.hedera.hashgraph.sdk.KeyList;
-import com.hedera.hashgraph.sdk.PrecheckStatusException;
 import com.hedera.hashgraph.sdk.PrivateKey;
 import com.hedera.hashgraph.sdk.PublicKey;
 import com.hedera.hashgraph.sdk.TokenAssociateTransaction;
@@ -68,7 +67,7 @@ public class TokenClient extends AbstractNetworkClient {
 
     public NetworkTransactionResponse createToken(ExpandedAccountId expandedAccountId, String symbol, int freezeStatus,
                                                   int kycStatus, ExpandedAccountId treasuryAccount,
-                                                  int initialSupply) throws Exception {
+                                                  int initialSupply) {
 
         log.debug("Create new token {}", symbol);
         Instant refInstant = Instant.now();
@@ -114,7 +113,7 @@ public class TokenClient extends AbstractNetworkClient {
         return networkTransactionResponse;
     }
 
-    public NetworkTransactionResponse associate(ExpandedAccountId accountId, TokenId token) throws Exception {
+    public NetworkTransactionResponse associate(ExpandedAccountId accountId, TokenId token) {
 
         log.debug("Associate account {} with token {}", accountId.getAccountId(), token);
         Instant refInstant = Instant.now();
@@ -133,7 +132,7 @@ public class TokenClient extends AbstractNetworkClient {
         return networkTransactionResponse;
     }
 
-    public NetworkTransactionResponse mint(TokenId tokenId, long amount) throws Exception {
+    public NetworkTransactionResponse mint(TokenId tokenId, long amount) {
 
         log.debug("Mint {} tokens from {}", amount, tokenId);
         Instant refInstant = Instant.now();
@@ -151,7 +150,7 @@ public class TokenClient extends AbstractNetworkClient {
         return networkTransactionResponse;
     }
 
-    public NetworkTransactionResponse freeze(TokenId tokenId, AccountId accountId, PrivateKey freezeKey) throws Exception {
+    public NetworkTransactionResponse freeze(TokenId tokenId, AccountId accountId, PrivateKey freezeKey) {
 
         Instant refInstant = Instant.now();
         TokenFreezeTransaction tokenFreezeAccountTransaction = new TokenFreezeTransaction()
@@ -169,7 +168,7 @@ public class TokenClient extends AbstractNetworkClient {
         return networkTransactionResponse;
     }
 
-    public NetworkTransactionResponse unfreeze(TokenId tokenId, AccountId accountId, PrivateKey freezeKey) throws Exception {
+    public NetworkTransactionResponse unfreeze(TokenId tokenId, AccountId accountId, PrivateKey freezeKey) {
 
         Instant refInstant = Instant.now();
         TokenUnfreezeTransaction tokenUnfreezeTransaction = new TokenUnfreezeTransaction()
@@ -187,7 +186,7 @@ public class TokenClient extends AbstractNetworkClient {
         return networkTransactionResponse;
     }
 
-    public NetworkTransactionResponse grantKyc(TokenId tokenId, AccountId accountId, PrivateKey kycKey) throws Exception {
+    public NetworkTransactionResponse grantKyc(TokenId tokenId, AccountId accountId, PrivateKey kycKey) {
 
         log.debug("Grant account {} with KYC for token {}", accountId, tokenId);
         Instant refInstant = Instant.now();
@@ -205,7 +204,7 @@ public class TokenClient extends AbstractNetworkClient {
         return networkTransactionResponse;
     }
 
-    public NetworkTransactionResponse revokeKyc(TokenId tokenId, AccountId accountId, PrivateKey kycKey) throws Exception {
+    public NetworkTransactionResponse revokeKyc(TokenId tokenId, AccountId accountId, PrivateKey kycKey) {
 
         log.debug("Grant account {} with KYC for token {}", accountId, tokenId);
         Instant refInstant = Instant.now();
@@ -234,7 +233,7 @@ public class TokenClient extends AbstractNetworkClient {
     }
 
     public NetworkTransactionResponse transferToken(TokenId tokenId, ExpandedAccountId sender, AccountId recipient,
-                                                    long amount) throws Exception {
+                                                    long amount) {
 
         log.debug("Transfer {} of token {} from {} to {}", amount, tokenId, sender, recipient);
         TransferTransaction tokenTransferTransaction = getTokenTransferTransaction(tokenId, sender
@@ -249,7 +248,7 @@ public class TokenClient extends AbstractNetworkClient {
         return networkTransactionResponse;
     }
 
-    public NetworkTransactionResponse updateToken(TokenId tokenId, ExpandedAccountId expandedAccountId) throws Exception {
+    public NetworkTransactionResponse updateToken(TokenId tokenId, ExpandedAccountId expandedAccountId) {
         PublicKey publicKey = expandedAccountId.getPublicKey();
         String newSymbol = RandomStringUtils.randomAlphabetic(4).toUpperCase();
         TokenUpdateTransaction tokenUpdateTransaction = new TokenUpdateTransaction()
@@ -273,7 +272,7 @@ public class TokenClient extends AbstractNetworkClient {
         return networkTransactionResponse;
     }
 
-    public NetworkTransactionResponse burn(TokenId tokenId, long amount) throws Exception {
+    public NetworkTransactionResponse burn(TokenId tokenId, long amount) {
 
         log.debug("Burn {} tokens from {}", amount, tokenId);
         Instant refInstant = Instant.now();
@@ -291,7 +290,7 @@ public class TokenClient extends AbstractNetworkClient {
         return networkTransactionResponse;
     }
 
-    public NetworkTransactionResponse wipe(TokenId tokenId, long amount, ExpandedAccountId expandedAccountId) throws Exception {
+    public NetworkTransactionResponse wipe(TokenId tokenId, long amount, ExpandedAccountId expandedAccountId) {
 
         log.debug("Wipe {} tokens from {}", amount, tokenId);
         Instant refInstant = Instant.now();
@@ -310,7 +309,7 @@ public class TokenClient extends AbstractNetworkClient {
         return networkTransactionResponse;
     }
 
-    public NetworkTransactionResponse dissociate(ExpandedAccountId accountId, TokenId token) throws Exception {
+    public NetworkTransactionResponse dissociate(ExpandedAccountId accountId, TokenId token) {
 
         log.debug("Dissociate account {} with token {}", accountId.getAccountId(), token);
         TokenDissociateTransaction tokenDissociateTransaction = new TokenDissociateTransaction()
@@ -326,7 +325,7 @@ public class TokenClient extends AbstractNetworkClient {
         return networkTransactionResponse;
     }
 
-    public NetworkTransactionResponse delete(ExpandedAccountId accountId, TokenId token) throws Exception {
+    public NetworkTransactionResponse delete(ExpandedAccountId accountId, TokenId token) {
 
         log.debug("Delete token {}", token);
         Instant refInstant = Instant.now();
@@ -344,7 +343,8 @@ public class TokenClient extends AbstractNetworkClient {
         return networkTransactionResponse;
     }
 
-    public long getTokenBalance(AccountId accountId, TokenId tokenId) throws TimeoutException, PrecheckStatusException {
+    @SneakyThrows
+    public long getTokenBalance(AccountId accountId, TokenId tokenId) {
         long balance = new AccountBalanceQuery()
                 .setAccountId(accountId)
                 .execute(client)

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TopicClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TopicClient.java
@@ -43,6 +43,8 @@ import com.hedera.hashgraph.sdk.ReceiptStatusException;
 import com.hedera.hashgraph.sdk.TopicCreateTransaction;
 import com.hedera.hashgraph.sdk.TopicDeleteTransaction;
 import com.hedera.hashgraph.sdk.TopicId;
+import com.hedera.hashgraph.sdk.TopicInfo;
+import com.hedera.hashgraph.sdk.TopicInfoQuery;
 import com.hedera.hashgraph.sdk.TopicMessageSubmitTransaction;
 import com.hedera.hashgraph.sdk.TopicUpdateTransaction;
 import com.hedera.hashgraph.sdk.TransactionId;
@@ -212,5 +214,13 @@ public class TopicClient extends AbstractNetworkClient {
 
     public Instant getInstantOfFirstPublishedMessage() {
         return recordPublishInstants.get(0L);
+    }
+
+    public TopicInfo getTopicInfo(TopicId topicId) throws Exception {
+        return retryTemplate.execute(x ->
+                new TopicInfoQuery()
+                        .setTopicId(topicId)
+                        .setNodeAccountIds(List.of(sdkClient.getRandomNodeAccountId()))
+                        .execute(client));
     }
 }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TopicClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TopicClient.java
@@ -34,6 +34,8 @@ import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.ArrayUtils;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Scope;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 
 import com.hedera.hashgraph.sdk.KeyList;
 import com.hedera.hashgraph.sdk.PrecheckStatusException;
@@ -64,6 +66,9 @@ public class TopicClient extends AbstractNetworkClient {
         log.debug("Creating Topic Client");
     }
 
+    @Retryable(value = {PrecheckStatusException.class, TimeoutException.class},
+            backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.backOffPeriod.toMillis()}"),
+            maxAttemptsExpression = "#{@acceptanceTestProperties.maxRetries}")
     public NetworkTransactionResponse createTopic(ExpandedAccountId adminAccount, PublicKey submitKey) throws ReceiptStatusException,
             PrecheckStatusException, TimeoutException {
 
@@ -90,6 +95,9 @@ public class TopicClient extends AbstractNetworkClient {
         return networkTransactionResponse;
     }
 
+    @Retryable(value = {PrecheckStatusException.class, TimeoutException.class},
+            backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.backOffPeriod.toMillis()}"),
+            maxAttemptsExpression = "#{@acceptanceTestProperties.maxRetries}")
     public NetworkTransactionResponse updateTopic(TopicId topicId) throws ReceiptStatusException,
             PrecheckStatusException,
             TimeoutException {
@@ -112,6 +120,9 @@ public class TopicClient extends AbstractNetworkClient {
         return networkTransactionResponse;
     }
 
+    @Retryable(value = {PrecheckStatusException.class, TimeoutException.class},
+            backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.backOffPeriod.toMillis()}"),
+            maxAttemptsExpression = "#{@acceptanceTestProperties.maxRetries}")
     public NetworkTransactionResponse deleteTopic(TopicId topicId) throws ReceiptStatusException,
             PrecheckStatusException,
             TimeoutException {
@@ -128,6 +139,9 @@ public class TopicClient extends AbstractNetworkClient {
         return networkTransactionResponse;
     }
 
+    @Retryable(value = {PrecheckStatusException.class, TimeoutException.class},
+            backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.backOffPeriod.toMillis()}"),
+            maxAttemptsExpression = "#{@acceptanceTestProperties.maxRetries}")
     public List<TransactionReceipt> publishMessagesToTopic(TopicId topicId, String baseMessage,
                                                            KeyList submitKeys, int numMessages,
                                                            boolean verify) throws PrecheckStatusException,
@@ -155,6 +169,9 @@ public class TopicClient extends AbstractNetworkClient {
                 .setMessage(message);
     }
 
+    @Retryable(value = {PrecheckStatusException.class, TimeoutException.class},
+            backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.backOffPeriod.toMillis()}"),
+            maxAttemptsExpression = "#{@acceptanceTestProperties.maxRetries}")
     public TopicId getDefaultTopicId() throws PrecheckStatusException, ReceiptStatusException, TimeoutException {
         if (defaultTopicId == null) {
             NetworkTransactionResponse networkTransactionResponse = createTopic(sdkClient
@@ -166,11 +183,17 @@ public class TopicClient extends AbstractNetworkClient {
         return defaultTopicId;
     }
 
+    @Retryable(value = {PrecheckStatusException.class, TimeoutException.class},
+            backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.backOffPeriod.toMillis()}"),
+            maxAttemptsExpression = "#{@acceptanceTestProperties.maxRetries}")
     public void publishMessageToDefaultTopic() throws ReceiptStatusException, PrecheckStatusException,
             TimeoutException {
         publishMessagesToTopic(getDefaultTopicId(), "Background message", null, 1, false);
     }
 
+    @Retryable(value = {PrecheckStatusException.class, TimeoutException.class},
+            backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.backOffPeriod.toMillis()}"),
+            maxAttemptsExpression = "#{@acceptanceTestProperties.maxRetries}")
     public TransactionId publishMessageToTopic(TopicId topicId, byte[] message, KeyList submitKeys) throws TimeoutException, PrecheckStatusException, ReceiptStatusException {
         TopicMessageSubmitTransaction consensusMessageSubmitTransaction = new TopicMessageSubmitTransaction()
                 .setTopicId(topicId)

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
@@ -69,10 +69,10 @@ public class AcceptanceTestProperties {
     private boolean retrieveAddressBook = true;
 
     @Max(5)
-    private int subscribeRetries = 5;
+    private int maxRetries = 5;
 
     @NotNull
-    private Duration subscribeRetryBackoffPeriod = Duration.ofMillis(5000);
+    private Duration backOffPeriod = Duration.ofMillis(5000);
 
     public Set<NodeProperties> getNodes() {
         if (network == HederaNetwork.OTHER && nodes.isEmpty()) {

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
@@ -68,8 +68,8 @@ public class AcceptanceTestProperties {
 
     private boolean retrieveAddressBook = true;
 
-    @Max(5)
-    private int maxRetries = 5;
+    @Max(10)
+    private int maxRetries = 10;
 
     @NotNull
     private Duration backOffPeriod = Duration.ofMillis(5000);

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
@@ -46,8 +46,8 @@ public class AcceptanceTestProperties {
     @NotNull
     private Long existingTopicNum;
 
-    @Max(10)
-    private int maxRetries = 3;
+    @Max(5)
+    private int maxRetries = 2;
 
     @NotNull
     private Long maxTinyBarTransactionFee = 1_000_000_000L;

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
@@ -47,7 +47,7 @@ public class AcceptanceTestProperties {
     private Long existingTopicNum;
 
     @Max(10)
-    private int maxRetries = 10;
+    private int maxRetries = 3;
 
     @NotNull
     private Long maxTinyBarTransactionFee = 1_000_000_000L;

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
@@ -38,17 +38,22 @@ import com.hedera.mirror.test.e2e.acceptance.props.NodeProperties;
 @Data
 @Validated
 public class AcceptanceTestProperties {
+    @NotNull
+    private Duration backOffPeriod = Duration.ofMillis(5000);
 
     private boolean emitBackgroundMessages = false;
 
     @NotNull
     private Long existingTopicNum;
 
+    @Max(10)
+    private int maxRetries = 10;
+
     @NotNull
     private Long maxTinyBarTransactionFee = 1_000_000_000L;
 
     @NotNull
-    private Duration messageTimeout = Duration.ofSeconds(20);
+    private Duration messageTimeout = Duration.ofSeconds(60);
 
     @NotBlank
     private String mirrorNodeAddress;
@@ -68,11 +73,7 @@ public class AcceptanceTestProperties {
 
     private boolean retrieveAddressBook = true;
 
-    @Max(10)
-    private int maxRetries = 10;
-
-    @NotNull
-    private Duration backOffPeriod = Duration.ofMillis(5000);
+    private final SdkProperties sdkProperties;
 
     public Set<NodeProperties> getNodes() {
         if (network == HederaNetwork.OTHER && nodes.isEmpty()) {

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/ClientConfiguration.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/ClientConfiguration.java
@@ -54,10 +54,10 @@ class ClientConfiguration {
     @Bean
     RetryTemplate retryTemplate() {
         FixedBackOffPolicy fixedBackOffPolicy = new FixedBackOffPolicy();
-        fixedBackOffPolicy.setBackOffPeriod(acceptanceTestProperties.getSubscribeRetryBackoffPeriod().toMillis());
+        fixedBackOffPolicy.setBackOffPeriod(acceptanceTestProperties.getBackOffPeriod().toMillis());
 
         SimpleRetryPolicy simpleRetryPolicy = new SimpleRetryPolicy();
-        simpleRetryPolicy.setMaxAttempts(acceptanceTestProperties.getSubscribeRetries());
+        simpleRetryPolicy.setMaxAttempts(acceptanceTestProperties.getMaxRetries());
 
         RetryTemplate retryTemplate = new RetryTemplate();
         retryTemplate.setBackOffPolicy(fixedBackOffPolicy);

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/RestPollingProperties.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/RestPollingProperties.java
@@ -26,7 +26,6 @@ import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import lombok.Data;
-import org.hibernate.validator.constraints.time.DurationMax;
 import org.hibernate.validator.constraints.time.DurationMin;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
@@ -41,12 +40,15 @@ public class RestPollingProperties {
     @NotBlank
     private String baseUrl;
 
-    @DurationMin(seconds = 0L)
-    @DurationMax(seconds = 10L)
-    @NotNull
-    private Duration delay = Duration.ofMillis(3000);
-
     @Min(1)
     @Max(60)
     private int maxAttempts = 60;
+
+    @NotNull
+    @DurationMin(millis = 500L)
+    private Duration maxBackoff = Duration.ofSeconds(8L);
+
+    @NotNull
+    @DurationMin(millis = 100L)
+    private Duration minBackoff = Duration.ofMillis(250L);
 }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/SdkProperties.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/SdkProperties.java
@@ -36,5 +36,5 @@ public class SdkProperties {
 
     @Min(1)
     @Max(60)
-    private int maxAttempts = 20;
+    private int maxAttempts = 10;
 }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/SdkProperties.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/SdkProperties.java
@@ -1,4 +1,4 @@
-package com.hedera.mirror.test.e2e.acceptance.props;
+package com.hedera.mirror.test.e2e.acceptance.config;
 
 /*-
  * ‌
@@ -20,26 +20,21 @@ package com.hedera.mirror.test.e2e.acceptance.props;
  * ‍
  */
 
-import lombok.AllArgsConstructor;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
 import lombok.Data;
-import lombok.ToString;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
 
-import com.hedera.hashgraph.sdk.AccountId;
-import com.hedera.hashgraph.sdk.PrivateKey;
-import com.hedera.hashgraph.sdk.PublicKey;
-
+@Component
+@ConfigurationProperties(prefix = "hedera.mirror.test.acceptance.sdk")
 @Data
-@AllArgsConstructor
-public class ExpandedAccountId {
-    private final AccountId accountId;
-    @ToString.Exclude
-    private final PrivateKey privateKey;
-    @ToString.Exclude
-    private final PublicKey publicKey;
+@Validated
+public class SdkProperties {
+    // To-do: move sdk related properties from AcceptanceTestProperties here
 
-    public ExpandedAccountId(String operatorId, String operatorKey) {
-        accountId = AccountId.fromString(operatorId);
-        privateKey = PrivateKey.fromString(operatorKey);
-        publicKey = privateKey.getPublicKey();
-    }
+    @Min(1)
+    @Max(60)
+    private int maxAttempts = 20;
 }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AccountFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AccountFeature.java
@@ -25,14 +25,12 @@ import static org.junit.jupiter.api.Assertions.*;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import io.cucumber.junit.platform.engine.Cucumber;
-import java.util.concurrent.TimeoutException;
 import lombok.Data;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import com.hedera.hashgraph.sdk.AccountId;
 import com.hedera.hashgraph.sdk.Hbar;
-import com.hedera.hashgraph.sdk.PrecheckStatusException;
 import com.hedera.hashgraph.sdk.TransactionReceipt;
 import com.hedera.mirror.test.e2e.acceptance.client.AccountClient;
 
@@ -48,7 +46,7 @@ public class AccountFeature {
     private AccountClient accountClient;
 
     @When("I request balance info for this account")
-    public void getAccountBalance() throws TimeoutException, PrecheckStatusException {
+    public void getAccountBalance() {
         balance = accountClient.getBalance();
     }
 
@@ -58,20 +56,20 @@ public class AccountFeature {
     }
 
     @When("I create a new account with balance {long} tℏ")
-    public void createNewAccount(long initialBalance) throws Exception {
+    public void createNewAccount(long initialBalance) {
         accountId = accountClient.createNewAccount(initialBalance).getAccountId();
         assertNotNull(accountId);
     }
 
     @When("I send {long} tℏ to newly created account")
-    public void sendTinyHbars(long amount) throws Exception {
+    public void sendTinyHbars(long amount) {
         startingBalance = accountClient.getBalance(accountId);
         TransactionReceipt receipt = accountClient.sendCryptoTransfer(accountId, Hbar.fromTinybars(amount));
         assertNotNull(receipt);
     }
 
     @When("I send {long} tℏ to account {int}")
-    public void sendTinyHbars(long amount, int accountNum) throws Exception {
+    public void sendTinyHbars(long amount, int accountNum) {
         accountId = new AccountId(accountNum);
         startingBalance = accountClient.getBalance(accountId);
         TransactionReceipt receipt = accountClient.sendCryptoTransfer(accountId, Hbar.fromTinybars(amount));
@@ -79,7 +77,7 @@ public class AccountFeature {
     }
 
     @When("I send {int} ℏ to account {int}")
-    public void sendHbars(int amount, int accountNum) throws Exception {
+    public void sendHbars(int amount, int accountNum) {
         accountId = new AccountId(accountNum);
         startingBalance = accountClient.getBalance(accountId);
         TransactionReceipt receipt = accountClient.sendCryptoTransfer(accountId, Hbar.from(amount));
@@ -87,7 +85,7 @@ public class AccountFeature {
     }
 
     @Then("the new balance should reflect cryptotransfer of {long}")
-    public void accountReceivedFunds(long amount) throws TimeoutException, PrecheckStatusException {
+    public void accountReceivedFunds(long amount) {
         assertTrue(accountClient.getBalance(accountId) >= startingBalance + amount);
     }
 }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AccountFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AccountFeature.java
@@ -33,7 +33,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import com.hedera.hashgraph.sdk.AccountId;
 import com.hedera.hashgraph.sdk.Hbar;
 import com.hedera.hashgraph.sdk.PrecheckStatusException;
-import com.hedera.hashgraph.sdk.ReceiptStatusException;
 import com.hedera.hashgraph.sdk.TransactionReceipt;
 import com.hedera.mirror.test.e2e.acceptance.client.AccountClient;
 
@@ -59,23 +58,20 @@ public class AccountFeature {
     }
 
     @When("I create a new account with balance {long} tℏ")
-    public void createNewAccount(long initialBalance) throws ReceiptStatusException, PrecheckStatusException,
-            TimeoutException {
+    public void createNewAccount(long initialBalance) throws Exception {
         accountId = accountClient.createNewAccount(initialBalance).getAccountId();
         assertNotNull(accountId);
     }
 
     @When("I send {long} tℏ to newly created account")
-    public void sendTinyHbars(long amount) throws TimeoutException, PrecheckStatusException,
-            ReceiptStatusException {
+    public void sendTinyHbars(long amount) throws Exception {
         startingBalance = accountClient.getBalance(accountId);
         TransactionReceipt receipt = accountClient.sendCryptoTransfer(accountId, Hbar.fromTinybars(amount));
         assertNotNull(receipt);
     }
 
     @When("I send {long} tℏ to account {int}")
-    public void sendTinyHbars(long amount, int accountNum) throws TimeoutException, PrecheckStatusException,
-            ReceiptStatusException {
+    public void sendTinyHbars(long amount, int accountNum) throws Exception {
         accountId = new AccountId(accountNum);
         startingBalance = accountClient.getBalance(accountId);
         TransactionReceipt receipt = accountClient.sendCryptoTransfer(accountId, Hbar.fromTinybars(amount));
@@ -83,8 +79,7 @@ public class AccountFeature {
     }
 
     @When("I send {int} ℏ to account {int}")
-    public void sendHbars(int amount, int accountNum) throws TimeoutException, PrecheckStatusException,
-            ReceiptStatusException {
+    public void sendHbars(int amount, int accountNum) throws Exception {
         accountId = new AccountId(accountNum);
         startingBalance = accountClient.getBalance(accountId);
         TransactionReceipt receipt = accountClient.sendCryptoTransfer(accountId, Hbar.from(amount));

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ScheduleFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ScheduleFeature.java
@@ -95,7 +95,7 @@ public class ScheduleFeature {
     private ExpandedAccountId tokenTreasuryAccount;
 
     @Given("I successfully schedule a treasury HBAR disbursement to {string}")
-    public void createNewHBarTransferSchedule(String accountName) throws Exception {
+    public void createNewHBarTransferSchedule(String accountName) {
         expectedSignersCount = 2;
         currentSignersCount = 0 + signatoryCountOffset;
         ExpandedAccountId recipient = accountClient
@@ -110,7 +110,7 @@ public class ScheduleFeature {
     }
 
     @Given("I successfully schedule a crypto account create")
-    public void createNewCryptoAccountSchedule() throws Exception {
+    public void createNewCryptoAccountSchedule() {
         expectedSignersCount = 1;
         currentSignersCount = 0 + signatoryCountOffset;
 
@@ -127,7 +127,7 @@ public class ScheduleFeature {
 
     @Given("I schedule a crypto transfer with {int} initial signatures but require an additional signature from " +
             "{string}")
-    public void createNewCryptoAccountSchedule(int initSignatureCount, String accountName) throws Exception {
+    public void createNewCryptoAccountSchedule(int initSignatureCount, String accountName) {
         expectedSignersCount = 2 + initSignatureCount; // new account, accountName and initSignatureCount
         currentSignersCount = initSignatureCount + signatoryCountOffset;
         ExpandedAccountId finalSignatory = accountClient.getAccount(AccountClient.AccountNameEnum.valueOf(accountName));
@@ -165,7 +165,7 @@ public class ScheduleFeature {
     }
 
     @Given("I successfully schedule a token transfer from {string} to {string}")
-    public void createNewTokenTransferSchedule(String senderName, String receiverName) throws Exception {
+    public void createNewTokenTransferSchedule(String senderName, String receiverName) {
         expectedSignersCount = 2;
         currentSignersCount = 0 + signatoryCountOffset;
         tokenTreasuryAccount = accountClient.getAccount(AccountClient.AccountNameEnum.valueOf(senderName));
@@ -208,7 +208,7 @@ public class ScheduleFeature {
     }
 
     @Given("I successfully schedule a topic message submit with {string}'s submit key")
-    public void createNewHCSSchedule(String accountName) throws Exception {
+    public void createNewHCSSchedule(String accountName) {
         expectedSignersCount = 1;
         currentSignersCount = 0 + signatoryCountOffset;
         ExpandedAccountId submitAdmin = accountClient.getAccount(AccountClient.AccountNameEnum.valueOf(accountName));
@@ -230,7 +230,7 @@ public class ScheduleFeature {
         createNewSchedule(scheduledTransaction, null);
     }
 
-    private void createNewSchedule(Transaction transaction, KeyList innerSignatureKeyList) throws Exception {
+    private void createNewSchedule(Transaction transaction, KeyList innerSignatureKeyList) {
         log.debug("Schedule creation ");
 
         // create signatures list
@@ -250,7 +250,7 @@ public class ScheduleFeature {
         assertNotNull(scheduledTransactionId);
     }
 
-    public void signSignature(ExpandedAccountId signatoryAccount) throws Exception {
+    public void signSignature(ExpandedAccountId signatoryAccount) {
         currentSignersCount++; // add signatoryAccount and payer
         networkTransactionResponse = scheduleClient.signSchedule(
                 signatoryAccount,
@@ -348,7 +348,7 @@ public class ScheduleFeature {
     @Retryable(value = {AssertionError.class, AssertionFailedError.class},
             backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.backOffPeriod.toMillis()}"),
             maxAttemptsExpression = "#{@acceptanceTestProperties.maxRetries}")
-    public void verifyNetworkScheduleStatus(ScheduleStatus scheduleStatus) throws Exception {
+    public void verifyNetworkScheduleStatus(ScheduleStatus scheduleStatus) {
         scheduleInfo = scheduleClient.getScheduleInfo(scheduleId);
 
         // verify executed from 3 min record, set scheduled=true on scheduleCreateTransactionId and get receipt
@@ -397,7 +397,7 @@ public class ScheduleFeature {
                 .isEqualTo(accountClient.getSdkClient().getExpandedOperatorAccountId().getAccountId());
     }
 
-    private void verifyScheduleInfoFromNetwork(int expectedSignatoriesCount) throws Exception {
+    private void verifyScheduleInfoFromNetwork(int expectedSignatoriesCount) {
         scheduleInfo = scheduleClient.getScheduleInfo(scheduleId);
 
         assertNotNull(scheduleInfo);

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ScheduleFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ScheduleFeature.java
@@ -376,7 +376,7 @@ public class ScheduleFeature {
 
         log.info("Schedule {} status was confirmed by network state", scheduleId);
     }
-    
+
     private void dissociateAccount(ExpandedAccountId accountId) {
         if (accountId != null) {
             try {

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ScheduleFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ScheduleFeature.java
@@ -42,7 +42,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
-import org.springframework.web.reactive.function.client.WebClientResponseException;
 
 import com.hedera.hashgraph.sdk.Hbar;
 import com.hedera.hashgraph.sdk.KeyList;
@@ -325,7 +324,7 @@ public class ScheduleFeature {
     }
 
     @Then("the mirror node REST API should return status {int} for the schedule transaction")
-    @Retryable(value = {AssertionError.class, AssertionFailedError.class, WebClientResponseException.class},
+    @Retryable(value = {AssertionError.class, AssertionFailedError.class},
             backoff = @Backoff(delayExpression = "#{@restPollingProperties.delay.toMillis()}"),
             maxAttemptsExpression = "#{@restPollingProperties.maxAttempts}")
     public void verifyMirrorAPIResponses(int status) {
@@ -341,7 +340,7 @@ public class ScheduleFeature {
     }
 
     @Then("the mirror node REST API should verify the executed schedule entity")
-    @Retryable(value = {AssertionError.class, AssertionFailedError.class, WebClientResponseException.class},
+    @Retryable(value = {AssertionError.class, AssertionFailedError.class},
             backoff = @Backoff(delayExpression = "#{@restPollingProperties.delay.toMillis()}"),
             maxAttemptsExpression = "#{@restPollingProperties.maxAttempts}")
     public void verifyExecutedScheduleFromMirror() {
@@ -350,7 +349,7 @@ public class ScheduleFeature {
     }
 
     @Then("the mirror node REST API should verify the non executed schedule entity")
-    @Retryable(value = {AssertionError.class, AssertionFailedError.class, WebClientResponseException.class},
+    @Retryable(value = {AssertionError.class, AssertionFailedError.class},
             backoff = @Backoff(delayExpression = "#{@restPollingProperties.delay.toMillis()}"),
             maxAttemptsExpression = "#{@restPollingProperties.maxAttempts}")
     public void verifyNonExecutedScheduleFromMirror() {
@@ -358,7 +357,7 @@ public class ScheduleFeature {
     }
 
     @Then("the mirror node REST API should verify the deleted schedule entity")
-    @Retryable(value = {AssertionError.class, AssertionFailedError.class, WebClientResponseException.class},
+    @Retryable(value = {AssertionError.class, AssertionFailedError.class},
             backoff = @Backoff(delayExpression = "#{@restPollingProperties.delay.toMillis()}"),
             maxAttemptsExpression = "#{@restPollingProperties.maxAttempts}")
     public void verifyDeletedScheduleFromMirror() {

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ScheduleFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ScheduleFeature.java
@@ -41,7 +41,6 @@ import org.opentest4j.AssertionFailedError;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.retry.annotation.Backoff;
-import org.springframework.retry.annotation.Recover;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 
@@ -101,7 +100,6 @@ public class ScheduleFeature {
     private ExpandedAccountId tokenTreasuryAccount;
 
     @Given("I successfully schedule a treasury HBAR disbursement to {string}")
-    @Retryable(value = {PrecheckStatusException.class}, exceptionExpression = "#{message.contains('BUSY')}")
     public void createNewHBarTransferSchedule(String accountName) throws ReceiptStatusException,
             PrecheckStatusException,
             TimeoutException {
@@ -119,7 +117,6 @@ public class ScheduleFeature {
     }
 
     @Given("I successfully schedule a crypto account create")
-    @Retryable(value = {PrecheckStatusException.class}, exceptionExpression = "#{message.contains('BUSY')}")
     public void createNewCryptoAccountSchedule() throws ReceiptStatusException, PrecheckStatusException,
             TimeoutException {
         expectedSignersCount = 1;
@@ -138,7 +135,6 @@ public class ScheduleFeature {
 
     @Given("I schedule a crypto transfer with {int} initial signatures but require an additional signature from " +
             "{string}")
-    @Retryable(value = {PrecheckStatusException.class}, exceptionExpression = "#{message.contains('BUSY')}")
     public void createNewCryptoAccountSchedule(int initSignatureCount, String accountName) throws ReceiptStatusException,
             PrecheckStatusException,
             TimeoutException {
@@ -179,7 +175,6 @@ public class ScheduleFeature {
     }
 
     @Given("I successfully schedule a token transfer from {string} to {string}")
-    @Retryable(value = {PrecheckStatusException.class}, exceptionExpression = "#{message.contains('BUSY')}")
     public void createNewTokenTransferSchedule(String senderName, String receiverName) throws ReceiptStatusException,
             PrecheckStatusException,
             TimeoutException {
@@ -225,7 +220,6 @@ public class ScheduleFeature {
     }
 
     @Given("I successfully schedule a topic message submit with {string}'s submit key")
-    @Retryable(value = {PrecheckStatusException.class}, exceptionExpression = "#{message.contains('BUSY')}")
     public void createNewHCSSchedule(String accountName) throws ReceiptStatusException, PrecheckStatusException,
             TimeoutException {
         expectedSignersCount = 1;
@@ -508,18 +502,6 @@ public class ScheduleFeature {
         assertThat(mirrorTransaction.getConsensusTimestamp()).isNotNull();
 
         return mirrorTransaction;
-    }
-
-    /**
-     * Recover method for token transaction retry operations. Method parameters of retry method must match this method
-     * after exception parameter
-     *
-     * @param t
-     */
-    @Recover
-    public void recover(PrecheckStatusException t) throws PrecheckStatusException {
-        log.error("Transaction submissions for token transaction failed after retries w: {}", t.getMessage());
-        throw t;
     }
 
     @RequiredArgsConstructor

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ScheduleFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ScheduleFeature.java
@@ -33,11 +33,10 @@ import java.time.Instant;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.TimeoutException;
+import junit.framework.AssertionFailedError;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.opentest4j.AssertionFailedError;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.retry.annotation.Backoff;
@@ -45,13 +44,10 @@ import org.springframework.retry.annotation.Retryable;
 
 import com.hedera.hashgraph.sdk.Hbar;
 import com.hedera.hashgraph.sdk.KeyList;
-import com.hedera.hashgraph.sdk.PrecheckStatusException;
 import com.hedera.hashgraph.sdk.PrivateKey;
 import com.hedera.hashgraph.sdk.PublicKey;
-import com.hedera.hashgraph.sdk.ReceiptStatusException;
 import com.hedera.hashgraph.sdk.ScheduleId;
 import com.hedera.hashgraph.sdk.ScheduleInfo;
-import com.hedera.hashgraph.sdk.ScheduleInfoQuery;
 import com.hedera.hashgraph.sdk.TokenId;
 import com.hedera.hashgraph.sdk.TopicId;
 import com.hedera.hashgraph.sdk.Transaction;
@@ -99,9 +95,7 @@ public class ScheduleFeature {
     private ExpandedAccountId tokenTreasuryAccount;
 
     @Given("I successfully schedule a treasury HBAR disbursement to {string}")
-    public void createNewHBarTransferSchedule(String accountName) throws ReceiptStatusException,
-            PrecheckStatusException,
-            TimeoutException {
+    public void createNewHBarTransferSchedule(String accountName) throws Exception {
         expectedSignersCount = 2;
         currentSignersCount = 0 + signatoryCountOffset;
         ExpandedAccountId recipient = accountClient
@@ -116,8 +110,7 @@ public class ScheduleFeature {
     }
 
     @Given("I successfully schedule a crypto account create")
-    public void createNewCryptoAccountSchedule() throws ReceiptStatusException, PrecheckStatusException,
-            TimeoutException {
+    public void createNewCryptoAccountSchedule() throws Exception {
         expectedSignersCount = 1;
         currentSignersCount = 0 + signatoryCountOffset;
 
@@ -134,9 +127,7 @@ public class ScheduleFeature {
 
     @Given("I schedule a crypto transfer with {int} initial signatures but require an additional signature from " +
             "{string}")
-    public void createNewCryptoAccountSchedule(int initSignatureCount, String accountName) throws ReceiptStatusException,
-            PrecheckStatusException,
-            TimeoutException {
+    public void createNewCryptoAccountSchedule(int initSignatureCount, String accountName) throws Exception {
         expectedSignersCount = 2 + initSignatureCount; // new account, accountName and initSignatureCount
         currentSignersCount = initSignatureCount + signatoryCountOffset;
         ExpandedAccountId finalSignatory = accountClient.getAccount(AccountClient.AccountNameEnum.valueOf(accountName));
@@ -163,7 +154,7 @@ public class ScheduleFeature {
         scheduledTransaction = accountClient
                 .getCryptoTransferTransaction(
                         newAccountId.getAccountId(),
-                        accountClient.getSdkClient().getOperatorId(),
+                        accountClient.getSdkClient().getExpandedOperatorAccountId().getAccountId(),
                         Hbar.fromTinybars(DEFAULT_TINY_HBAR));
 
         // add sender private key to ensure only Alice's signature is the only signature left that is required
@@ -174,9 +165,7 @@ public class ScheduleFeature {
     }
 
     @Given("I successfully schedule a token transfer from {string} to {string}")
-    public void createNewTokenTransferSchedule(String senderName, String receiverName) throws ReceiptStatusException,
-            PrecheckStatusException,
-            TimeoutException {
+    public void createNewTokenTransferSchedule(String senderName, String receiverName) throws Exception {
         expectedSignersCount = 2;
         currentSignersCount = 0 + signatoryCountOffset;
         tokenTreasuryAccount = accountClient.getAccount(AccountClient.AccountNameEnum.valueOf(senderName));
@@ -201,7 +190,7 @@ public class ScheduleFeature {
 
         // associate new account, sender as treasury is auto associated
         log.debug("Associate receiver: {} with token: {}", receiverName, tokenId);
-        networkTransactionResponse = tokenClient.asssociate(receiver, tokenId);
+        networkTransactionResponse = tokenClient.associate(receiver, tokenId);
         assertNotNull(networkTransactionResponse.getTransactionId());
 
         Hbar hbarAmount = Hbar.fromTinybars(DEFAULT_TINY_HBAR);
@@ -219,8 +208,7 @@ public class ScheduleFeature {
     }
 
     @Given("I successfully schedule a topic message submit with {string}'s submit key")
-    public void createNewHCSSchedule(String accountName) throws ReceiptStatusException, PrecheckStatusException,
-            TimeoutException {
+    public void createNewHCSSchedule(String accountName) throws Exception {
         expectedSignersCount = 1;
         currentSignersCount = 0 + signatoryCountOffset;
         ExpandedAccountId submitAdmin = accountClient.getAccount(AccountClient.AccountNameEnum.valueOf(accountName));
@@ -242,8 +230,7 @@ public class ScheduleFeature {
         createNewSchedule(scheduledTransaction, null);
     }
 
-    private void createNewSchedule(Transaction transaction, KeyList innerSignatureKeyList) throws PrecheckStatusException,
-            ReceiptStatusException, TimeoutException {
+    private void createNewSchedule(Transaction transaction, KeyList innerSignatureKeyList) throws Exception {
         log.debug("Schedule creation ");
 
         // create signatures list
@@ -263,8 +250,7 @@ public class ScheduleFeature {
         assertNotNull(scheduledTransactionId);
     }
 
-    public void signSignature(ExpandedAccountId signatoryAccount) throws PrecheckStatusException,
-            ReceiptStatusException, TimeoutException {
+    public void signSignature(ExpandedAccountId signatoryAccount) throws Exception {
         currentSignersCount++; // add signatoryAccount and payer
         networkTransactionResponse = scheduleClient.signSchedule(
                 signatoryAccount,
@@ -277,21 +263,19 @@ public class ScheduleFeature {
     }
 
     @Then("the scheduled transaction is signed by {string}")
-    public void accountSignsSignature(String accountName) throws PrecheckStatusException, ReceiptStatusException,
-            TimeoutException {
+    public void accountSignsSignature(String accountName) throws Exception {
         log.debug("{} signs scheduledTransaction", accountName);
         signSignature(accountClient.getAccount(AccountClient.AccountNameEnum.valueOf(accountName)));
     }
 
     @Then("the scheduled transaction is signed by treasuryAccount")
-    public void treasurySignsSignature() throws PrecheckStatusException, ReceiptStatusException,
-            TimeoutException {
+    public void treasurySignsSignature() throws Exception {
         log.debug("treasuryAccount signs scheduledTransaction");
         signSignature(accountClient.getTokenTreasuryAccount());
     }
 
     @When("I successfully delete the schedule")
-    public void deleteSchedule() throws PrecheckStatusException, ReceiptStatusException, TimeoutException {
+    public void deleteSchedule() throws Exception {
         networkTransactionResponse = scheduleClient.deleteSchedule(scheduleId);
 
         assertNotNull(networkTransactionResponse.getTransactionId());
@@ -299,34 +283,26 @@ public class ScheduleFeature {
     }
 
     @Then("the network confirms schedule presence")
-    public void verifyNetworkScheduleResponse() throws TimeoutException, PrecheckStatusException,
-            ReceiptStatusException {
+    public void verifyNetworkScheduleResponse() throws Exception {
         verifyNetworkScheduleStatus(ScheduleStatus.NON_EXECUTED);
     }
 
     @Then("the network confirms the schedule is executed")
-    public void verifyNetworkScheduleExecutedResponse() throws TimeoutException,
-            PrecheckStatusException,
-            ReceiptStatusException {
+    public void verifyNetworkScheduleExecutedResponse() throws Exception {
         verifyNetworkScheduleStatus(ScheduleStatus.EXECUTED);
     }
 
     @Then("the network confirms the schedule is deleted")
-    public void verifyNetworkScheduleDeletedResponse() throws TimeoutException,
-            PrecheckStatusException,
-            ReceiptStatusException {
+    public void verifyNetworkScheduleDeletedResponse() throws Exception {
         verifyNetworkScheduleStatus(ScheduleStatus.DELETED);
     }
 
     @Then("the network confirms some signers have provided their signatures")
-    public void verifyPartialScheduleFromNetwork() throws TimeoutException, PrecheckStatusException {
+    public void verifyPartialScheduleFromNetwork() throws Exception {
         verifyScheduleInfoFromNetwork(currentSignersCount);
     }
 
     @Then("the mirror node REST API should return status {int} for the schedule transaction")
-    @Retryable(value = {AssertionError.class, AssertionFailedError.class},
-            backoff = @Backoff(delayExpression = "#{@restPollingProperties.delay.toMillis()}"),
-            maxAttemptsExpression = "#{@restPollingProperties.maxAttempts}")
     public void verifyMirrorAPIResponses(int status) {
         log.info("Verify schedule transaction");
         String transactionId = networkTransactionResponse.getTransactionIdString();
@@ -340,32 +316,23 @@ public class ScheduleFeature {
     }
 
     @Then("the mirror node REST API should verify the executed schedule entity")
-    @Retryable(value = {AssertionError.class, AssertionFailedError.class},
-            backoff = @Backoff(delayExpression = "#{@restPollingProperties.delay.toMillis()}"),
-            maxAttemptsExpression = "#{@restPollingProperties.maxAttempts}")
     public void verifyExecutedScheduleFromMirror() {
         MirrorScheduleResponse mirrorSchedule = verifyScheduleFromMirror(ScheduleStatus.EXECUTED);
         verifyScheduledTransaction(mirrorSchedule.getExecutedTimestamp());
     }
 
     @Then("the mirror node REST API should verify the non executed schedule entity")
-    @Retryable(value = {AssertionError.class, AssertionFailedError.class},
-            backoff = @Backoff(delayExpression = "#{@restPollingProperties.delay.toMillis()}"),
-            maxAttemptsExpression = "#{@restPollingProperties.maxAttempts}")
     public void verifyNonExecutedScheduleFromMirror() {
         verifyScheduleFromMirror(ScheduleStatus.NON_EXECUTED);
     }
 
     @Then("the mirror node REST API should verify the deleted schedule entity")
-    @Retryable(value = {AssertionError.class, AssertionFailedError.class},
-            backoff = @Backoff(delayExpression = "#{@restPollingProperties.delay.toMillis()}"),
-            maxAttemptsExpression = "#{@restPollingProperties.maxAttempts}")
     public void verifyDeletedScheduleFromMirror() {
         verifyScheduleFromMirror(ScheduleStatus.DELETED);
     }
 
     @After
-    public void cleanup() throws ReceiptStatusException, PrecheckStatusException, TimeoutException {
+    public void cleanup() throws Exception {
         // dissociate all applicable accounts from token to reduce likelihood of max token association error
         if (tokenId != null) {
             // a nonzero balance will result in a TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES error
@@ -378,10 +345,42 @@ public class ScheduleFeature {
         }
     }
 
+    @Retryable(value = {AssertionError.class, AssertionFailedError.class},
+            backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.backOffPeriod.toMillis()}"),
+            maxAttemptsExpression = "#{@acceptanceTestProperties.maxRetries}")
+    public void verifyNetworkScheduleStatus(ScheduleStatus scheduleStatus) throws Exception {
+        scheduleInfo = scheduleClient.getScheduleInfo(scheduleId);
+
+        // verify executed from 3 min record, set scheduled=true on scheduleCreateTransactionId and get receipt
+        validateScheduleInfo(scheduleInfo);
+
+        switch (scheduleStatus) {
+            case NON_EXECUTED:
+                assertThat(scheduleInfo.executedAt).isNull();
+                assertThat(scheduleInfo.deletedAt).isNull();
+                break;
+            case EXECUTED:
+                assertThat(scheduleInfo.deletedAt).isNull();
+                assertThat(scheduleInfo.executedAt).isNotNull();
+                TransactionReceipt transactionReceipt = scheduleClient.getTransactionReceipt(scheduledTransactionId);
+                assertNotNull(transactionReceipt);
+                log.debug("Executed transaction {} was confirmed", scheduledTransactionId);
+                break;
+            case DELETED:
+                assertThat(scheduleInfo.deletedAt).isNotNull();
+                assertThat(scheduleInfo.executedAt).isNull();
+                break;
+            default:
+                break;
+        }
+
+        log.info("Schedule {} status was confirmed by network state", scheduleId);
+    }
+    
     private void dissociateAccount(ExpandedAccountId accountId) {
         if (accountId != null) {
             try {
-                tokenClient.disssociate(accountId, tokenId);
+                tokenClient.dissociate(accountId, tokenId);
                 log.info("Successfully dissociated account {} from token {}", accountId, tokenId);
             } catch (Exception ex) {
                 log.warn("Error dissociating account {} from token {}, error: {}", accountId, tokenId, ex);
@@ -398,46 +397,8 @@ public class ScheduleFeature {
                 .isEqualTo(accountClient.getSdkClient().getExpandedOperatorAccountId().getAccountId());
     }
 
-    private void verifyNetworkScheduleStatus(ScheduleStatus scheduleStatus) throws TimeoutException,
-            PrecheckStatusException,
-            ReceiptStatusException {
-        scheduleInfo = new ScheduleInfoQuery()
-                .setScheduleId(scheduleId)
-                .setNodeAccountIds(List.of(scheduleClient.getSdkClient().getRandomNodeAccountId()))
-                .execute(scheduleClient.getClient());
-
-        // verify executed from 3 min record, set scheduled=true on scheduleCreateTransactionId and get receipt
-        validateScheduleInfo(scheduleInfo);
-
-        switch (scheduleStatus) {
-            case NON_EXECUTED:
-                assertThat(scheduleInfo.executedAt).isNull();
-                assertThat(scheduleInfo.deletedAt).isNull();
-                break;
-            case EXECUTED:
-                assertThat(scheduleInfo.deletedAt).isNull();
-                assertThat(scheduleInfo.executedAt).isNotNull();
-                TransactionReceipt transactionReceipt = scheduledTransactionId.getReceipt(scheduleClient.getClient());
-                assertNotNull(transactionReceipt);
-                log.debug("Executed transaction {} was confirmed", scheduledTransactionId);
-                break;
-            case DELETED:
-                assertThat(scheduleInfo.deletedAt).isNotNull();
-                assertThat(scheduleInfo.executedAt).isNull();
-                break;
-            default:
-                break;
-        }
-
-        log.info("Schedule {} status was confirmed by network state", scheduleId);
-    }
-
-    private void verifyScheduleInfoFromNetwork(int expectedSignatoriesCount) throws TimeoutException,
-            PrecheckStatusException {
-        scheduleInfo = new ScheduleInfoQuery()
-                .setScheduleId(scheduleId)
-                .setNodeAccountIds(List.of(scheduleClient.getSdkClient().getRandomNodeAccountId()))
-                .execute(scheduleClient.getClient());
+    private void verifyScheduleInfoFromNetwork(int expectedSignatoriesCount) throws Exception {
+        scheduleInfo = scheduleClient.getScheduleInfo(scheduleId);
 
         assertNotNull(scheduleInfo);
         assertThat(scheduleInfo.scheduleId).isEqualTo(scheduleId);

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TokenFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TokenFeature.java
@@ -74,7 +74,7 @@ public class TokenFeature {
     private NetworkTransactionResponse networkTransactionResponse;
 
     @Given("I successfully create a new token")
-    public void createNewToken() throws Exception {
+    public void createNewToken() {
         createNewToken(RandomStringUtils.randomAlphabetic(4).toUpperCase(), TokenFreezeStatus.FreezeNotApplicable_VALUE,
                 TokenKycStatus.KycNotApplicable_VALUE);
     }
@@ -86,7 +86,7 @@ public class TokenFeature {
     }
 
     @Given("I successfully create a new token account with freeze status {int} and kyc status {int}")
-    public void createNewToken(int freezeStatus, int kycStatus) throws Exception {
+    public void createNewToken(int freezeStatus, int kycStatus) {
         createNewToken(RandomStringUtils.randomAlphabetic(4).toUpperCase(), freezeStatus, kycStatus);
     }
 
@@ -98,43 +98,43 @@ public class TokenFeature {
     }
 
     @Given("I associate a new sender account with token")
-    public void associateSenderWithToken() throws Exception {
+    public void associateSenderWithToken() {
 
         sender = accountClient.createNewAccount(10_000_000);
         associateWithToken(sender);
     }
 
     @Given("I associate a new recipient account with token")
-    public void associateRecipientWithToken() throws Exception {
+    public void associateRecipientWithToken() {
 
         recipient = accountClient.createNewAccount(10_000_000);
         associateWithToken(recipient);
     }
 
     @When("I set new account freeze status to {int}")
-    public void setFreezeStatus(int freezeStatus) throws Exception {
+    public void setFreezeStatus(int freezeStatus) {
         setFreezeStatus(freezeStatus, recipient);
     }
 
     @When("I set new account kyc status to {int}")
-    public void setKycStatus(int kycStatus) throws Exception {
+    public void setKycStatus(int kycStatus) {
         setKycStatus(kycStatus, recipient);
     }
 
     @Then("I transfer {int} tokens to payer")
-    public void fundPayerAccountWithTokens(int amount) throws Exception {
+    public void fundPayerAccountWithTokens(int amount) {
         transferTokens(tokenId, amount, recipient, tokenClient.getSdkClient().getExpandedOperatorAccountId()
                 .getAccountId());
     }
 
     @Then("I transfer {int} tokens to recipient")
-    public void transferTokensToRecipient(int amount) throws Exception {
+    public void transferTokensToRecipient(int amount) {
         transferTokens(tokenId, amount, sender, recipient
                 .getAccountId());
     }
 
     @Given("I update the token")
-    public void updateToken() throws Exception {
+    public void updateToken() {
 
         networkTransactionResponse = tokenClient
                 .updateToken(tokenId, tokenClient.getSdkClient().getExpandedOperatorAccountId());
@@ -143,7 +143,7 @@ public class TokenFeature {
     }
 
     @Given("I burn {int} from the token")
-    public void burnToken(int amount) throws Exception {
+    public void burnToken(int amount) {
 
         networkTransactionResponse = tokenClient.burn(tokenId, amount);
         assertNotNull(networkTransactionResponse.getTransactionId());
@@ -151,7 +151,7 @@ public class TokenFeature {
     }
 
     @Given("I mint {int} from the token")
-    public void mintToken(int amount) throws Exception {
+    public void mintToken(int amount) {
 
         networkTransactionResponse = tokenClient.mint(tokenId, amount);
         assertNotNull(networkTransactionResponse.getTransactionId());
@@ -159,7 +159,7 @@ public class TokenFeature {
     }
 
     @Given("I wipe {int} from the token")
-    public void wipeToken(int amount) throws Exception {
+    public void wipeToken(int amount) {
 
         networkTransactionResponse = tokenClient.wipe(tokenId, amount, recipient);
         assertNotNull(networkTransactionResponse.getTransactionId());
@@ -167,14 +167,14 @@ public class TokenFeature {
     }
 
     @Given("I dissociate the account from the token")
-    public void dissociateNewAccountFromToken() throws Exception {
+    public void dissociateNewAccountFromToken() {
         networkTransactionResponse = tokenClient.dissociate(recipient, tokenId);
         assertNotNull(networkTransactionResponse.getTransactionId());
         assertNotNull(networkTransactionResponse.getReceipt());
     }
 
     @Given("I delete the token")
-    public void deleteToken() throws Exception {
+    public void deleteToken() {
 
         networkTransactionResponse = tokenClient
                 .delete(tokenClient.getSdkClient().getExpandedOperatorAccountId(), tokenId);
@@ -220,7 +220,7 @@ public class TokenFeature {
     @Retryable(value = {AssertionError.class, AssertionFailedError.class},
             backoff = @Backoff(delayExpression = "#{@restPollingProperties.minBackoff.toMillis()}"),
             maxAttemptsExpression = "#{@restPollingProperties.maxAttempts}")
-    public void verifyMirrorRestTransactionIsPresent(int status, String transactionIdString) throws Exception {
+    public void verifyMirrorRestTransactionIsPresent(int status, String transactionIdString) {
         MirrorTransactionsResponse mirrorTransactionsResponse = mirrorClient.getTransactions(transactionIdString);
 
         List<MirrorTransaction> transactions = mirrorTransactionsResponse.getTransactions();
@@ -266,7 +266,7 @@ public class TokenFeature {
         }
     }
 
-    private void createNewToken(String symbol, int freezeStatus, int kycStatus) throws Exception {
+    private void createNewToken(String symbol, int freezeStatus, int kycStatus) {
         tokenKey = PrivateKey.generate();
         PublicKey tokenPublicKey = tokenKey.getPublicKey();
         log.trace("Token creation PrivateKey : {}, PublicKey : {}", tokenKey, tokenPublicKey);
@@ -285,13 +285,13 @@ public class TokenFeature {
         assertNotNull(tokenId);
     }
 
-    private void associateWithToken(ExpandedAccountId accountId) throws Exception {
+    private void associateWithToken(ExpandedAccountId accountId) {
         networkTransactionResponse = tokenClient.associate(accountId, tokenId);
         assertNotNull(networkTransactionResponse.getTransactionId());
         assertNotNull(networkTransactionResponse.getReceipt());
     }
 
-    private void setFreezeStatus(int freezeStatus, ExpandedAccountId accountId) throws Exception {
+    private void setFreezeStatus(int freezeStatus, ExpandedAccountId accountId) {
         if (freezeStatus == TokenFreezeStatus.Frozen_VALUE) {
             networkTransactionResponse = tokenClient.freeze(tokenId, accountId.getAccountId(), tokenKey);
         } else if (freezeStatus == TokenFreezeStatus.Unfrozen_VALUE) {
@@ -304,7 +304,7 @@ public class TokenFeature {
         assertNotNull(networkTransactionResponse.getReceipt());
     }
 
-    private void setKycStatus(int kycStatus, ExpandedAccountId accountId) throws Exception {
+    private void setKycStatus(int kycStatus, ExpandedAccountId accountId) {
         if (kycStatus == TokenKycStatus.Granted_VALUE) {
             networkTransactionResponse = tokenClient.grantKyc(tokenId, accountId.getAccountId(), tokenKey);
         } else if (kycStatus == TokenKycStatus.Revoked_VALUE) {
@@ -320,7 +320,7 @@ public class TokenFeature {
     @Retryable(value = {AssertionError.class, AssertionFailedError.class},
             backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.backOffPeriod.toMillis()}"),
             maxAttemptsExpression = "#{@acceptanceTestProperties.maxRetries}")
-    private void transferTokens(TokenId tokenId, int amount, ExpandedAccountId sender, AccountId receiver) throws Exception {
+    private void transferTokens(TokenId tokenId, int amount, ExpandedAccountId sender, AccountId receiver) {
         long startingBalance = tokenClient.getTokenBalance(receiver, tokenId);
         networkTransactionResponse = tokenClient.transferToken(tokenId, sender, receiver, amount);
         assertNotNull(networkTransactionResponse.getTransactionId());

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TokenFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TokenFeature.java
@@ -36,7 +36,6 @@ import org.opentest4j.AssertionFailedError;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.retry.annotation.Backoff;
-import org.springframework.retry.annotation.Recover;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 
@@ -82,28 +81,24 @@ public class TokenFeature {
     private NetworkTransactionResponse networkTransactionResponse;
 
     @Given("I successfully create a new token")
-    @Retryable(value = {PrecheckStatusException.class}, exceptionExpression = "#{message.contains('BUSY')}")
     public void createNewToken() throws ReceiptStatusException, PrecheckStatusException, TimeoutException {
         createNewToken(RandomStringUtils.randomAlphabetic(4).toUpperCase(), TokenFreezeStatus.FreezeNotApplicable_VALUE,
                 TokenKycStatus.KycNotApplicable_VALUE);
     }
 
     @Given("I successfully create a new token {string}")
-    @Retryable(value = {PrecheckStatusException.class}, exceptionExpression = "#{message.contains('BUSY')}")
     public void createNewToken(String symbol) throws ReceiptStatusException, PrecheckStatusException, TimeoutException {
         createNewToken(symbol, TokenFreezeStatus.FreezeNotApplicable_VALUE,
                 TokenKycStatus.KycNotApplicable_VALUE);
     }
 
     @Given("I successfully create a new token account with freeze status {int} and kyc status {int}")
-    @Retryable(value = {PrecheckStatusException.class}, exceptionExpression = "#{message.contains('BUSY')}")
     public void createNewToken(int freezeStatus, int kycStatus) throws ReceiptStatusException,
             PrecheckStatusException, TimeoutException {
         createNewToken(RandomStringUtils.randomAlphabetic(4).toUpperCase(), freezeStatus, kycStatus);
     }
 
     @Given("I associate with token")
-    @Retryable(value = {PrecheckStatusException.class}, exceptionExpression = "#{message.contains('BUSY')}")
     public void associateWithToken() throws ReceiptStatusException, PrecheckStatusException, TimeoutException {
         // associate payer
         sender = tokenClient.getSdkClient().getExpandedOperatorAccountId();
@@ -111,7 +106,6 @@ public class TokenFeature {
     }
 
     @Given("I associate a new sender account with token")
-    @Retryable(value = {PrecheckStatusException.class}, exceptionExpression = "#{message.contains('BUSY')}")
     public void associateSenderWithToken() throws ReceiptStatusException, PrecheckStatusException, TimeoutException {
 
         sender = accountClient.createNewAccount(10_000_000);
@@ -119,7 +113,6 @@ public class TokenFeature {
     }
 
     @Given("I associate a new recipient account with token")
-    @Retryable(value = {PrecheckStatusException.class}, exceptionExpression = "#{message.contains('BUSY')}")
     public void associateRecipientWithToken() throws ReceiptStatusException, PrecheckStatusException, TimeoutException {
 
         recipient = accountClient.createNewAccount(10_000_000);
@@ -127,20 +120,17 @@ public class TokenFeature {
     }
 
     @When("I set new account freeze status to {int}")
-    @Retryable(value = {PrecheckStatusException.class}, exceptionExpression = "#{message.contains('BUSY')}")
     public void setFreezeStatus(int freezeStatus) throws ReceiptStatusException, PrecheckStatusException,
             TimeoutException {
         setFreezeStatus(freezeStatus, recipient);
     }
 
     @When("I set new account kyc status to {int}")
-    @Retryable(value = {PrecheckStatusException.class}, exceptionExpression = "#{message.contains('BUSY')}")
     public void setKycStatus(int kycStatus) throws ReceiptStatusException, PrecheckStatusException, TimeoutException {
         setKycStatus(kycStatus, recipient);
     }
 
     @Then("I transfer {int} tokens to payer")
-    @Retryable(value = {PrecheckStatusException.class}, exceptionExpression = "#{message.contains('BUSY')}")
     public void fundPayerAccountWithTokens(int amount) throws PrecheckStatusException, ReceiptStatusException,
             TimeoutException {
         transferTokens(tokenId, amount, recipient, tokenClient.getSdkClient()
@@ -148,7 +138,6 @@ public class TokenFeature {
     }
 
     @Then("I transfer {int} tokens to recipient")
-    @Retryable(value = {PrecheckStatusException.class}, exceptionExpression = "#{message.contains('BUSY')}")
     public void transferTokensToRecipient(int amount) throws ReceiptStatusException, PrecheckStatusException,
             TimeoutException {
         transferTokens(tokenId, amount, sender, recipient
@@ -156,7 +145,6 @@ public class TokenFeature {
     }
 
     @Given("I update the token")
-    @Retryable(value = {PrecheckStatusException.class}, exceptionExpression = "#{message.contains('BUSY')}")
     public void updateToken() throws PrecheckStatusException, ReceiptStatusException, TimeoutException {
 
         networkTransactionResponse = tokenClient
@@ -166,7 +154,6 @@ public class TokenFeature {
     }
 
     @Given("I burn {int} from the token")
-    @Retryable(value = {PrecheckStatusException.class}, exceptionExpression = "#{message.contains('BUSY')}")
     public void burnToken(int amount) throws PrecheckStatusException, ReceiptStatusException, TimeoutException {
 
         networkTransactionResponse = tokenClient.burn(tokenId, amount);
@@ -175,7 +162,6 @@ public class TokenFeature {
     }
 
     @Given("I mint {int} from the token")
-    @Retryable(value = {PrecheckStatusException.class}, exceptionExpression = "#{message.contains('BUSY')}")
     public void mintToken(int amount) throws PrecheckStatusException, ReceiptStatusException, TimeoutException {
 
         networkTransactionResponse = tokenClient.mint(tokenId, amount);
@@ -184,7 +170,6 @@ public class TokenFeature {
     }
 
     @Given("I wipe {int} from the token")
-    @Retryable(value = {PrecheckStatusException.class}, exceptionExpression = "#{message.contains('BUSY')}")
     public void wipeToken(int amount) throws PrecheckStatusException, ReceiptStatusException, TimeoutException {
 
         networkTransactionResponse = tokenClient.wipe(tokenId, amount, recipient);
@@ -193,7 +178,6 @@ public class TokenFeature {
     }
 
     @Given("I dissociate the account from the token")
-    @Retryable(value = {PrecheckStatusException.class}, exceptionExpression = "#{message.contains('BUSY')}")
     public void dissociateNewAccountFromToken() throws PrecheckStatusException, ReceiptStatusException,
             TimeoutException {
         networkTransactionResponse = tokenClient.disssociate(recipient, tokenId);
@@ -202,7 +186,6 @@ public class TokenFeature {
     }
 
     @Given("I delete the token")
-    @Retryable(value = {PrecheckStatusException.class}, exceptionExpression = "#{message.contains('BUSY')}")
     public void deleteToken() throws PrecheckStatusException, ReceiptStatusException, TimeoutException {
 
         networkTransactionResponse = tokenClient
@@ -216,26 +199,22 @@ public class TokenFeature {
     @Retryable(value = {AssertionError.class, AssertionFailedError.class, WebClientResponseException.class},
             backoff = @Backoff(delayExpression = "#{@restPollingProperties.delay.toMillis()}"),
             maxAttemptsExpression = "#{@restPollingProperties.maxAttempts}")
-    public void verifyMirrorAPIResponses(int status) throws PrecheckStatusException, ReceiptStatusException,
-            TimeoutException {
+    public void verifyMirrorAPIResponses(int status) {
         verifyTransactions(status);
 
-        // publish background message to network to reduce possibility of stale info in low TPS environment
-        topicClient.publishMessageToDefaultTopic();
+        publishBackgroundMessages();
     }
 
     @Then("the mirror node REST API should return status {int} for token fund flow")
     @Retryable(value = {AssertionError.class, AssertionFailedError.class, WebClientResponseException.class},
             backoff = @Backoff(delayExpression = "#{@restPollingProperties.delay.toMillis()}"),
             maxAttemptsExpression = "#{@restPollingProperties.maxAttempts}")
-    public void verifyMirrorTokenFundFlow(int status) throws PrecheckStatusException, ReceiptStatusException,
-            TimeoutException {
+    public void verifyMirrorTokenFundFlow(int status) {
         verifyTransactions(status);
         verifyToken();
         verifyTokenTransfers();
 
-        // publish background message to network to reduce possibility of stale info in low TPS environment
-        topicClient.publishMessageToDefaultTopic();
+        publishBackgroundMessages();
     }
 
     @Then("the mirror node REST API should confirm token update")
@@ -271,7 +250,7 @@ public class TokenFeature {
     }
 
     @After
-    public void cleanup() throws ReceiptStatusException, PrecheckStatusException, TimeoutException {
+    public void cleanup() {
         // dissociate all applicable accounts from token to reduce likelihood of max token association error
         if (tokenId != null) {
             // a nonzero balance will result in a TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES error
@@ -432,52 +411,12 @@ public class TokenFeature {
         assertThat(mirrorToken.getCreatedTimestamp()).isNotEqualTo(mirrorToken.getModifiedTimestamp());
     }
 
-    /**
-     * Recover method for token transaction retry operations. Method parameters of retry method must match this method
-     * after exception parameter
-     *
-     * @param t
-     */
-    @Recover
-    public void recover(PrecheckStatusException t) throws PrecheckStatusException {
-        log.error("Transaction submissions for token transaction failed after retries w: {}", t.getMessage());
-        throw t;
-    }
-
-    /**
-     * Recover method for token transaction retry operations. Method parameters of retry method must match this method
-     * after exception parameter
-     *
-     * @param t
-     */
-    @Recover
-    public void recover(PrecheckStatusException t, int count) throws PrecheckStatusException {
-        log.error("Transaction submissions for token transaction failed after retries w: {}", t.getMessage());
-        throw t;
-    }
-
-    /**
-     * Recover method for token transaction retry operations. Method parameters of retry method must match this method
-     * after exception parameter
-     *
-     * @param t
-     */
-    @Recover
-    public void recover(PrecheckStatusException t, String param) throws PrecheckStatusException {
-        log.error("Transaction submissions for token transaction failed after retries w: {}", t.getMessage());
-        throw t;
-    }
-
-    /**
-     * Recover method for REST verify operations. Method parameters of retry method must match this method after
-     * exception parameter
-     *
-     * @param t
-     */
-    @Recover
-    public void recover(AssertionError t) {
-        log.error("REST API response verification failed after {} retries w: {}",
-                acceptanceProps.getRestPollingProperties().getMaxAttempts(), t.getMessage());
-        throw t;
+    private void publishBackgroundMessages() {
+        // publish background message to network to reduce possibility of stale info in low TPS environment
+        try {
+            topicClient.publishMessageToDefaultTopic();
+        } catch (Exception ex) {
+            log.trace("Encountered issue published background messages to default topic", ex);
+        }
     }
 }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TokenFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TokenFeature.java
@@ -37,7 +37,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
-import org.springframework.web.reactive.function.client.WebClientResponseException;
 
 import com.hedera.hashgraph.sdk.AccountId;
 import com.hedera.hashgraph.sdk.PrecheckStatusException;
@@ -196,7 +195,7 @@ public class TokenFeature {
     }
 
     @Then("the mirror node REST API should return status {int}")
-    @Retryable(value = {AssertionError.class, AssertionFailedError.class, WebClientResponseException.class},
+    @Retryable(value = {AssertionError.class, AssertionFailedError.class},
             backoff = @Backoff(delayExpression = "#{@restPollingProperties.delay.toMillis()}"),
             maxAttemptsExpression = "#{@restPollingProperties.maxAttempts}")
     public void verifyMirrorAPIResponses(int status) {
@@ -206,7 +205,7 @@ public class TokenFeature {
     }
 
     @Then("the mirror node REST API should return status {int} for token fund flow")
-    @Retryable(value = {AssertionError.class, AssertionFailedError.class, WebClientResponseException.class},
+    @Retryable(value = {AssertionError.class, AssertionFailedError.class},
             backoff = @Backoff(delayExpression = "#{@restPollingProperties.delay.toMillis()}"),
             maxAttemptsExpression = "#{@restPollingProperties.maxAttempts}")
     public void verifyMirrorTokenFundFlow(int status) {
@@ -218,7 +217,7 @@ public class TokenFeature {
     }
 
     @Then("the mirror node REST API should confirm token update")
-    @Retryable(value = {AssertionError.class, AssertionFailedError.class, WebClientResponseException.class},
+    @Retryable(value = {AssertionError.class, AssertionFailedError.class},
             backoff = @Backoff(delayExpression = "#{@restPollingProperties.delay.toMillis()}"),
             maxAttemptsExpression = "#{@restPollingProperties.maxAttempts}")
     public void verifyMirrorTokenUpdateFlow() throws PrecheckStatusException, ReceiptStatusException, TimeoutException {
@@ -229,7 +228,7 @@ public class TokenFeature {
     }
 
     @Then("the mirror node REST API should return status {int} for transaction {string}")
-    @Retryable(value = {AssertionError.class, AssertionFailedError.class, WebClientResponseException.class},
+    @Retryable(value = {AssertionError.class, AssertionFailedError.class},
             backoff = @Backoff(delayExpression = "#{@restPollingProperties.delay.toMillis()}"),
             maxAttemptsExpression = "#{@restPollingProperties.maxAttempts}")
     public void verifyMirrorRestTransactionIsPresent(int status, String transactionIdString) throws PrecheckStatusException, ReceiptStatusException, TimeoutException {

--- a/hedera-mirror-test/src/test/resources/features/hcs/hcs.feature
+++ b/hedera-mirror-test/src/test/resources/features/hcs/hcs.feature
@@ -5,6 +5,7 @@ Feature: HCS Base Coverage Feature
     Scenario Outline: Validate Topic message submission
         Given I successfully create a new topic id
         And I publish and verify <numMessages> messages sent
+        Then the network should successfully observe the topic
         When I provide a number of messages <numMessages> I want to receive
         And I subscribe with a filter to retrieve messages
         Then the network should successfully observe these messages
@@ -16,6 +17,7 @@ Feature: HCS Base Coverage Feature
     Scenario Outline: Validate Topic message submission to an open submit topic
         Given I successfully create a new open topic
         And I publish and verify <numMessages> messages sent
+        Then the network should successfully observe the topic
         When I provide a number of messages <numMessages> I want to receive
         And I subscribe with a filter to retrieve messages
         Then the network should successfully observe these messages
@@ -37,6 +39,7 @@ Feature: HCS Base Coverage Feature
     Scenario Outline: Validate topic message subscription
         Given I provide a topic id <topicId>
         And I publish <numBatches> batches of <numMessages> messages every <milliSleep> milliseconds
+        Then the network should successfully observe the topic
         And I subscribe with a filter to retrieve these published messages
         Then the network should successfully observe these messages
         Examples:
@@ -47,6 +50,7 @@ Feature: HCS Base Coverage Feature
     Scenario Outline: Validate topic message subscription
         Given I provide a topic id <topicId>
         And I publish and verify <numMessages> messages sent
+        Then the network should successfully observe the topic
         And I subscribe with a filter to retrieve these published messages
         Then the network should successfully observe these messages
         Examples:
@@ -67,6 +71,7 @@ Feature: HCS Base Coverage Feature
     Scenario Outline: Validate Topic message listener latency
         Given I successfully create a new topic id
         And I publish and verify <numMessages> messages sent
+        Then the network should successfully observe the topic
         When I provide a number of messages <numMessages> I want to receive within <latency> seconds
         And I subscribe with a filter to retrieve messages
         Then the network should successfully observe these messages

--- a/hedera-mirror-test/src/test/resources/features/topicfilter/hcstopicfilter.feature
+++ b/hedera-mirror-test/src/test/resources/features/topicfilter/hcstopicfilter.feature
@@ -5,6 +5,7 @@ Feature: HCS Message Filter Coverage Feature
     Scenario Outline: Validate topic filtering with past date and get X previous
         Given I successfully create a new topic id
         And I publish and verify <numMessages> messages sent
+        Then the network should successfully observe the topic
         When I provide a starting timestamp <startTimestamp> and a number of messages <numMessages> I want to receive
         And I subscribe with a filter to retrieve messages
         Then the network should successfully observe these messages
@@ -16,6 +17,7 @@ Feature: HCS Message Filter Coverage Feature
     Scenario Outline: Validate resubscribe topic filtering
         Given I successfully create a new topic id
         And I publish and verify <numMessages> messages sent
+        Then the network should successfully observe the topic
         When I provide a starting timestamp <startTimestamp> and a number of messages <numMessages> I want to receive
         And I subscribe with a filter to retrieve messages
         And I unsubscribe from a topic
@@ -30,6 +32,7 @@ Feature: HCS Message Filter Coverage Feature
     Scenario Outline: Validate topic filtering with start and end time in between min and max messages (e.g. if 100 messages get 25-30)
         Given I successfully create a new topic id
         And I publish and verify <publishCount> messages sent
+        Then the network should successfully observe the topic
         When I provide a startSequence <startSequence> and endSequence <endSequence> and a number of messages <numMessages> I want to receive
         And I subscribe with a filter to retrieve messages
         Then the network should successfully observe <numMessages> messages
@@ -41,6 +44,7 @@ Feature: HCS Message Filter Coverage Feature
     Scenario Outline: Validate topic filtering with past date and a specified limit
         Given I successfully create a new topic id
         And I publish and verify <numMessages> messages sent
+        Then the network should successfully observe the topic
         When I provide a starting timestamp <startTimestamp> and ending timestamp <endTimestamp> and a limit of <limit> messages I want to receive
         And I subscribe with a filter to retrieve messages
         Then the network should successfully observe these messages


### PR DESCRIPTION
**Detailed description**:
Acceptance tests saw a bug where it encoutedred a busy network with valid GO AWAY errors. During this flow the tests were unable to created dependency accounts needed for tests. However, it didn't fail early and resulted in NullPointerExceptions.

- Add `NetworkExpection` class to capture exceptions when hitting network during dependency items setup
- Fail fast where any early issues are encountered
- Move retry logic around network interactions to abstract network client
- Move retry logic around mirror REST API calls to Mirror node client
- Utilize retryTemplate over annotation


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**

- [ ] Documentation added
- [ ] Tests updated

