### PR TITLE
Deduplicate NFT transfers

### DIFF
--- a/hedera-mirror-rest/__tests__/specs/accounts-14-account-transactions-transactiontype.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/accounts-14-account-transactions-transactiontype.spec.json
@@ -183,13 +183,13 @@
         ],
         "token_transfers": [
           {
-            "account": "0.0.9",
-            "amount": 1200,
+            "account": "0.0.8",
+            "amount": -1200,
             "token_id": "0.0.90000"
           },
           {
-            "account": "0.0.8",
-            "amount": -1200,
+            "account": "0.0.9",
+            "amount": 1200,
             "token_id": "0.0.90000"
           }
         ],

--- a/hedera-mirror-rest/__tests__/specs/accounts-19-account-transactions-timestamp.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/accounts-19-account-transactions-timestamp.spec.json
@@ -142,13 +142,13 @@
         "scheduled": false,
         "token_transfers": [
           {
-            "account": "0.0.1679",
-            "amount": 200,
+            "account": "0.0.8",
+            "amount": -200,
             "token_id": "0.0.90000"
           },
           {
-            "account": "0.0.8",
-            "amount": -200,
+            "account": "0.0.1679",
+            "amount": 200,
             "token_id": "0.0.90000"
           }
         ],
@@ -200,13 +200,13 @@
         ],
         "token_transfers": [
           {
-            "account": "0.0.9",
-            "amount": 1200,
+            "account": "0.0.8",
+            "amount": -1200,
             "token_id": "0.0.90000"
           },
           {
-            "account": "0.0.8",
-            "amount": -1200,
+            "account": "0.0.9",
+            "amount": 1200,
             "token_id": "0.0.90000"
           }
         ],

--- a/hedera-mirror-rest/__tests__/specs/transactions-01-no-args.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-01-no-args.spec.json
@@ -150,13 +150,13 @@
         "token_transfers": [
           {
             "token_id": "0.0.90000",
-            "account": "0.0.200",
-            "amount": 200
+            "account": "0.0.10",
+            "amount": -200
           },
           {
             "token_id": "0.0.90000",
-            "account": "0.0.10",
-            "amount": -200
+            "account": "0.0.200",
+            "amount": 200
           }
         ]
       },

--- a/hedera-mirror-rest/__tests__/specs/transactions-16-specific-id-tokentransfer.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-16-specific-id-tokentransfer.spec.json
@@ -78,13 +78,13 @@
         ],
         "token_transfers": [
           {
-            "account": "0.0.200",
-            "amount": 200,
+            "account": "0.0.300",
+            "amount": -1200,
             "token_id": "0.0.90000"
           },
           {
-            "account": "0.0.300",
-            "amount": -1200,
+            "account": "0.0.200",
+            "amount": 200,
             "token_id": "0.0.90000"
           },
           {

--- a/hedera-mirror-rest/__tests__/specs/transactions-17-transaction-type.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-17-transaction-type.spec.json
@@ -103,13 +103,13 @@
         ],
         "token_transfers": [
           {
-            "account": "0.0.10",
-            "amount": 1200,
+            "account": "0.0.9",
+            "amount": -1200,
             "token_id": "0.0.90000"
           },
           {
-            "account": "0.0.9",
-            "amount": -1200,
+            "account": "0.0.10",
+            "amount": 1200,
             "token_id": "0.0.90000"
           }
         ]

--- a/hedera-mirror-rest/__tests__/specs/transactions-28-account-id-only-token-transfers.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-28-account-id-only-token-transfers.spec.json
@@ -76,11 +76,6 @@
         "transfers": [],
         "token_transfers": [
           {
-            "account": "0.0.9",
-            "amount": 1000,
-            "token_id": "0.0.90000"
-          },
-          {
             "account": "0.0.8",
             "amount": -1200,
             "token_id": "0.0.90000"
@@ -88,6 +83,11 @@
           {
             "account": "0.0.3",
             "amount": 200,
+            "token_id": "0.0.90000"
+          },
+          {
+            "account": "0.0.9",
+            "amount": 1000,
             "token_id": "0.0.90000"
           }
         ]

--- a/hedera-mirror-rest/__tests__/specs/transactions-31-credit-type-only-token-transfers.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-31-credit-type-only-token-transfers.spec.json
@@ -100,11 +100,6 @@
         "transfers": [],
         "token_transfers": [
           {
-            "account": "0.0.9",
-            "amount": 1000,
-            "token_id": "0.0.90000"
-          },
-          {
             "account": "0.0.8",
             "amount": -1200,
             "token_id": "0.0.90000"
@@ -112,6 +107,11 @@
           {
             "account": "0.0.3",
             "amount": 200,
+            "token_id": "0.0.90000"
+          },
+          {
+            "account": "0.0.9",
+            "amount": 1000,
             "token_id": "0.0.90000"
           }
         ]

--- a/hedera-mirror-rest/__tests__/specs/transactions-32-debit-type-only-token-transfers.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-32-debit-type-only-token-transfers.spec.json
@@ -105,13 +105,13 @@
             "token_id": "0.0.90000"
           },
           {
-            "account": "0.0.8",
-            "amount": 1000,
+            "account": "0.0.3",
+            "amount": 200,
             "token_id": "0.0.90000"
           },
           {
-            "account": "0.0.3",
-            "amount": 200,
+            "account": "0.0.8",
+            "amount": 1000,
             "token_id": "0.0.90000"
           }
         ]

--- a/hedera-mirror-rest/__tests__/specs/transactions-33-credit-type-crypto-and-token-transfers.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-33-credit-type-crypto-and-token-transfers.spec.json
@@ -150,11 +150,6 @@
         ],
         "token_transfers": [
           {
-            "account": "0.0.9",
-            "amount": 1000,
-            "token_id": "0.0.90000"
-          },
-          {
             "account": "0.0.8",
             "amount": -1200,
             "token_id": "0.0.90000"
@@ -162,6 +157,11 @@
           {
             "account": "0.0.3",
             "amount": 200,
+            "token_id": "0.0.90000"
+          },
+          {
+            "account": "0.0.9",
+            "amount": 1000,
             "token_id": "0.0.90000"
           }
         ]
@@ -214,11 +214,6 @@
         "transfers": [],
         "token_transfers": [
           {
-            "account": "0.0.9",
-            "amount": 1000,
-            "token_id": "0.0.90000"
-          },
-          {
             "account": "0.0.8",
             "amount": -1200,
             "token_id": "0.0.90000"
@@ -226,6 +221,11 @@
           {
             "account": "0.0.3",
             "amount": 200,
+            "token_id": "0.0.90000"
+          },
+          {
+            "account": "0.0.9",
+            "amount": 1000,
             "token_id": "0.0.90000"
           }
         ]

--- a/hedera-mirror-rest/__tests__/specs/transactions-34-debit-type-crypto-and-token-transfers.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-34-debit-type-crypto-and-token-transfers.spec.json
@@ -155,13 +155,13 @@
             "token_id": "0.0.90000"
           },
           {
-            "account": "0.0.8",
-            "amount": 1000,
+            "account": "0.0.3",
+            "amount": 200,
             "token_id": "0.0.90000"
           },
           {
-            "account": "0.0.3",
-            "amount": 200,
+            "account": "0.0.8",
+            "amount": 1000,
             "token_id": "0.0.90000"
           }
         ]
@@ -219,13 +219,13 @@
             "token_id": "0.0.90000"
           },
           {
-            "account": "0.0.8",
-            "amount": 1000,
+            "account": "0.0.3",
+            "amount": 200,
             "token_id": "0.0.90000"
           },
           {
-            "account": "0.0.3",
-            "amount": 200,
+            "account": "0.0.8",
+            "amount": 1000,
             "token_id": "0.0.90000"
           }
         ]

--- a/hedera-mirror-rest/__tests__/specs/transactions-35-duplicate-token-transfers-bug.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-35-duplicate-token-transfers-bug.spec.json
@@ -102,12 +102,6 @@
             "sender_account_id": "0.0.11200",
             "serial_number": 1,
             "token_id": "0.0.90000"
-          },
-          {
-            "receiver_account_id": "0.0.12500",
-            "sender_account_id": "0.0.11200",
-            "serial_number": 1,
-            "token_id": "0.0.90000"
           }
         ],
         "node": "0.0.3",

--- a/hedera-mirror-rest/__tests__/specs/transactions-35-duplicate-token-transfers-bug.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-35-duplicate-token-transfers-bug.spec.json
@@ -109,13 +109,13 @@
         "scheduled": false,
         "token_transfers": [
           {
-            "account": "0.0.12500",
-            "amount": 1200,
+            "account": "0.0.11200",
+            "amount": -1200,
             "token_id": "0.0.30000"
           },
           {
-            "account": "0.0.11200",
-            "amount": -1200,
+            "account": "0.0.12500",
+            "amount": 1200,
             "token_id": "0.0.30000"
           }
         ],

--- a/hedera-mirror-rest/__tests__/specs/transactions-38-account-id-only-nft-transfers.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-38-account-id-only-nft-transfers.spec.json
@@ -79,9 +79,9 @@
         "transfers": [],
         "nft_transfers": [
           {
-            "receiver_account_id": "0.0.10",
+            "receiver_account_id": "0.0.8",
             "sender_account_id": "0.0.3",
-            "serial_number": 3,
+            "serial_number": 1,
             "token_id": "0.0.90000"
           },
           {
@@ -91,9 +91,9 @@
             "token_id": "0.0.90000"
           },
           {
-            "receiver_account_id": "0.0.8",
+            "receiver_account_id": "0.0.10",
             "sender_account_id": "0.0.3",
-            "serial_number": 1,
+            "serial_number": 3,
             "token_id": "0.0.90000"
           }
         ]

--- a/hedera-mirror-rest/__tests__/specs/transactions-39-nft-transfers-multiple-tokens.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-39-nft-transfers-multiple-tokens.spec.json
@@ -48,6 +48,18 @@
             "sender_account_id": null,
             "serial_number": 3,
             "token_id": "0.0.90000"
+          },
+          {
+            "receiver_account_id": "0.0.9",
+            "sender_account_id": null,
+            "serial_number": 1,
+            "token_id": "0.0.100000"
+          },
+          {
+            "receiver_account_id": "0.0.98",
+            "sender_account_id": "0.0.9",
+            "serial_number": 2,
+            "token_id": "0.0.100000"
           }
         ]
       }
@@ -74,6 +86,18 @@
         "max_fee": "33",
         "transfers": [],
         "nft_transfers": [
+          {
+            "receiver_account_id": "0.0.9",
+            "sender_account_id": null,
+            "serial_number": 1,
+            "token_id": "0.0.100000"
+          },
+          {
+            "receiver_account_id": "0.0.98",
+            "sender_account_id": "0.0.9",
+            "serial_number": 2,
+            "token_id": "0.0.100000"
+          },
           {
             "receiver_account_id": "0.0.8",
             "sender_account_id": "0.0.3",

--- a/hedera-mirror-rest/transactions.js
+++ b/hedera-mirror-rest/transactions.js
@@ -45,13 +45,11 @@ const getSelectClauseWithTokenTransferOrder = (order) => {
        ctl.entity_id AS ctl_entity_id,
        ctl.amount AS amount,
        json_agg(
-         json_build_object(
+         distinct jsonb_build_object(
            'token_id', ttl.token_id::text,
            'account_id', ttl.account_id::text,
            'amount', ttl.amount
-         ) ORDER BY
-             ttl.token_id ${order || ''},
-             ttl.account_id ${order || ''}
+         )
        ) FILTER (WHERE ttl.token_id IS NOT NULL) AS token_transfer_list,
        json_agg(
          distinct jsonb_build_object(

--- a/hedera-mirror-rest/transactions.js
+++ b/hedera-mirror-rest/transactions.js
@@ -54,15 +54,12 @@ const getSelectClauseWithTokenTransferOrder = (order) => {
              ttl.account_id ${order || ''}
        ) FILTER (WHERE ttl.token_id IS NOT NULL) AS token_transfer_list,
        json_agg(
-         json_build_object(
+         distinct jsonb_build_object(
            'receiver_account_id', ntl.receiver_account_id::text,
            'sender_account_id', ntl.sender_account_id::text,
            'serial_number', ntl.serial_number,
            'token_id', ntl.token_id::text
-         ) ORDER BY
-             ntl.token_id ${order || ''},
-             ntl.sender_account_id ${order || ''},
-             ntl.serial_number ${order || ''}
+         )
        ) FILTER (WHERE ntl.token_id IS NOT NULL) AS nft_transfer_list,
        t.charged_tx_fee,
        t.valid_duration_seconds,


### PR DESCRIPTION
**Detailed description**:
A duplicate nft transfer entry exists when the /api/v1/transactions?account.id={account} is called and the account in question is the recipient.

- Update aggregation to use `distinct jsonb_build_object`
- Add an extra test for multiple nft transfers across different tokens in one transaction

**Which issue(s) this PR fixes**:
Fixes #2139 

**Special notes for your reviewer**:
Postgres doesn't support distinct and order by for json. This should be okay though as the rows are mostly ordered prior to aggregation

**Checklist**

- [ ] Documentation added
- [x] Tests updated

