### PR TITLE
Update NFT design doc to remove nft_transfers from transactions endpoint

### DIFF
--- a/docs/design/nft.md
+++ b/docs/design/nft.md
@@ -88,7 +88,9 @@ create table if not exists nft_transfer
 
 #### Get Transaction
 
-- Update `/api/v1/transactions` and `/api/v1/transactions/{id}` response to add nft_transfers
+- Update `/api/v1/transactions/{id}` response to add nft_transfers
+  - `/api/v1/transactions` should not contain nft_transfers, as moving forward we wish to not add more joins to this
+    endpoint.
 
 ```json
 {


### PR DESCRIPTION
**Detailed description**:
Clarify the nft design doc section about transactions to not have `/transactions` contain nft_transfers
- nft_transfers can still be found in `/transactions/{id}`.


- [ ] Documentation added
- [ ] Tests updated

