### PR TITLE
 Stream account balances to the database

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,7 +71,7 @@ value, it is recommended to only populate overridden properties in the custom `a
 | `hedera.mirror.importer.importHistoricalAccountInfo`                 | true                    | Import historical account information that occurred before the last stream reset. Skipped if `startDate` is unset or after 2019-09-14T00:00:10Z. |
 | `hedera.mirror.importer.initialAddressBook`                          | ""                      | The path to the bootstrap address book used to override the built-in address book              |
 | `hedera.mirror.importer.network`                                     | DEMO                    | Which Hedera network to use. Can be either `DEMO`, `MAINNET`, `TESTNET`, `PREVIEWNET` or `OTHER` |
-| `hedera.mirror.importer.parser.balance.batchSize`                    | 2000                    | The number of balances to insert before committing                                             |
+| `hedera.mirror.importer.parser.balance.batchSize`                    | 200000                  | The number of balances to store in memory before saving to the database                        |
 | `hedera.mirror.importer.parser.balance.bufferSize`                   | 32768                   | The size of the byte buffer to allocate for each batch                                         |
 | `hedera.mirror.importer.parser.balance.enabled`                      | true                    | Whether to enable balance file parsing                                                         |
 | `hedera.mirror.importer.parser.balance.fileBufferSize`               | 200000                  | The size of the buffer to use when reading in the balance file                                 |

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/AccountBalanceFile.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/AccountBalanceFile.java
@@ -20,8 +20,6 @@ package com.hedera.mirror.importer.domain;
  * ‍
  */
 
-import java.util.ArrayList;
-import java.util.List;
 import javax.persistence.Convert;
 import javax.persistence.Entity;
 import javax.persistence.Id;
@@ -32,6 +30,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import reactor.core.publisher.Flux;
 
 import com.hedera.mirror.importer.converter.AccountIdConverter;
 
@@ -56,7 +55,7 @@ public class AccountBalanceFile implements StreamFile<AccountBalance> {
     @EqualsAndHashCode.Exclude
     @ToString.Exclude
     @Transient
-    private List<AccountBalance> items = new ArrayList<>();
+    private Flux<AccountBalance> items = Flux.empty();
 
     private Long loadEnd;
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/EventFile.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/EventFile.java
@@ -20,8 +20,6 @@ package com.hedera.mirror.importer.domain;
  * ‍
  */
 
-import java.util.ArrayList;
-import java.util.List;
 import javax.persistence.Convert;
 import javax.persistence.Entity;
 import javax.persistence.Enumerated;
@@ -31,6 +29,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import reactor.core.publisher.Flux;
 
 import com.hedera.mirror.importer.converter.AccountIdConverter;
 import com.hedera.mirror.importer.parser.domain.EventItem;
@@ -62,7 +61,7 @@ public class EventFile implements StreamFile<EventItem> {
     @EqualsAndHashCode.Exclude
     @ToString.Exclude
     @Transient
-    private List<EventItem> items = new ArrayList<>();
+    private Flux<EventItem> items = Flux.empty();
 
     private Long loadEnd;
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/RecordFile.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/RecordFile.java
@@ -20,8 +20,6 @@ package com.hedera.mirror.importer.domain;
  * ‍
  */
 
-import java.util.ArrayList;
-import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.Convert;
 import javax.persistence.Entity;
@@ -34,6 +32,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import reactor.core.publisher.Flux;
 
 import com.hedera.mirror.importer.converter.AccountIdConverter;
 import com.hedera.mirror.importer.parser.domain.RecordItem;
@@ -75,7 +74,7 @@ public class RecordFile implements StreamFile<RecordItem> {
     @EqualsAndHashCode.Exclude
     @ToString.Exclude
     @Transient
-    private List<RecordItem> items = new ArrayList<>();
+    private Flux<RecordItem> items = Flux.empty();
 
     private Long loadEnd;
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamFile.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamFile.java
@@ -20,8 +20,8 @@ package com.hedera.mirror.importer.domain;
  * ‍
  */
 
-import java.util.List;
 import lombok.NonNull;
+import reactor.core.publisher.Flux;
 
 import com.hedera.mirror.importer.parser.domain.StreamItem;
 
@@ -46,7 +46,7 @@ public interface StreamFile<T extends StreamItem> {
         return null;
     }
 
-    List<T> getItems();
+    Flux<T> getItems();
 
     Long getLoadEnd();
 
@@ -72,7 +72,7 @@ public interface StreamFile<T extends StreamItem> {
 
     void setBytes(byte[] bytes);
 
-    void setItems(List<T> items);
+    void setItems(Flux<T> items);
 
     void setName(String name);
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamFileData.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamFileData.java
@@ -68,7 +68,7 @@ public class StreamFileData {
         try {
             InputStream is = new ByteArrayInputStream(bytes);
             String compressor = streamFilename.getCompressor();
-            if (!StringUtils.isBlank(compressor)) {
+            if (StringUtils.isNotBlank(compressor)) {
                 is = compressorStreamFactory.createCompressorInputStream(compressor, is);
             }
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/balance/AccountBalanceFileParser.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/balance/AccountBalanceFileParser.java
@@ -25,8 +25,8 @@ import static com.hedera.mirror.importer.config.MirrorDateRangePropertiesProcess
 import io.micrometer.core.instrument.MeterRegistry;
 import java.sql.Connection;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 import javax.inject.Named;
 import javax.sql.DataSource;
 import org.springframework.jdbc.datasource.DataSourceUtils;
@@ -86,19 +86,31 @@ public class AccountBalanceFileParser extends AbstractStreamFileParser<AccountBa
         log.info("Starting processing account balances file {}", accountBalanceFile.getName());
         DateRangeFilter filter = mirrorDateRangePropertiesProcessor.getDateRangeFilter(StreamType.BALANCE);
         Connection connection = DataSourceUtils.getConnection(dataSource);
+        int batchSize = ((BalanceParserProperties) parserProperties).getBatchSize();
+
         long count = 0L;
+        List<AccountBalance> accountBalances = new ArrayList<>(batchSize);
+        List<TokenBalance> tokenBalances = new ArrayList<>(batchSize);
 
         try {
             if (filter.filter(accountBalanceFile.getConsensusTimestamp())) {
-                List<AccountBalance> accountBalances = accountBalanceFile.getItems();
-                List<TokenBalance> tokenBalances = accountBalances
-                        .stream()
-                        .flatMap(a -> a.getTokenBalances().stream())
-                        .collect(Collectors.toList());
+                count = accountBalanceFile.getItems().doOnNext(accountBalance -> {
+                    accountBalances.add(accountBalance);
+                    tokenBalances.addAll(accountBalance.getTokenBalances());
+
+                    if (accountBalances.size() >= batchSize) {
+                        pgCopyAccountBalance.copy(accountBalances, connection);
+                        accountBalances.clear();
+                    }
+
+                    if (tokenBalances.size() >= batchSize) {
+                        pgCopyTokenBalance.copy(tokenBalances, connection);
+                        tokenBalances.clear();
+                    }
+                }).count().block();
 
                 pgCopyAccountBalance.copy(accountBalances, connection);
                 pgCopyTokenBalance.copy(tokenBalances, connection);
-                count = accountBalances.size();
             }
 
             Instant loadEnd = Instant.now();

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/balance/BalanceParserProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/balance/BalanceParserProperties.java
@@ -43,7 +43,7 @@ public class BalanceParserProperties extends AbstractParserProperties {
     }
 
     @Min(1)
-    private int batchSize = 2000;
+    private int batchSize = 200_000;
 
     @Min(1)
     private int fileBufferSize = 200_000;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordFileParser.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordFileParser.java
@@ -29,7 +29,6 @@ import io.micrometer.core.instrument.Timer;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
 import javax.inject.Named;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
@@ -114,16 +113,18 @@ public class RecordFileParser extends AbstractStreamFileParser<RecordFile> {
     protected void doParse(RecordFile recordFile) {
         DateRangeFilter dateRangeFilter = mirrorDateRangePropertiesProcessor
                 .getDateRangeFilter(parserProperties.getStreamType());
-        AtomicInteger counter = new AtomicInteger(0);
 
         try {
             recordStreamFileListener.onStart();
-            recordFile.getItems().forEach(recordItem -> {
-                if (processRecordItem(recordItem, dateRangeFilter)) {
-                    counter.incrementAndGet();
-                }
-            });
+            long count = recordFile.getItems()
+                    .doOnNext(this::logItem)
+                    .filter(r -> dateRangeFilter.filter(r.getConsensusTimestamp()))
+                    .doOnNext(recordItemListener::onItem)
+                    .doOnNext(this::recordMetrics)
+                    .count()
+                    .block();
 
+            recordFile.setCount(count);
             recordFile.setLoadEnd(Instant.now().getEpochSecond());
             recordStreamFileListener.onEnd(recordFile);
         } catch (Exception ex) {
@@ -132,7 +133,7 @@ public class RecordFileParser extends AbstractStreamFileParser<RecordFile> {
         }
     }
 
-    private boolean processRecordItem(RecordItem recordItem, DateRangeFilter dateRangeFilter) {
+    private void logItem(RecordItem recordItem) {
         if (log.isTraceEnabled()) {
             log.trace("Transaction = {}, Record = {}",
                     Utility.printProtoMessage(recordItem.getTransaction()),
@@ -140,19 +141,14 @@ public class RecordFileParser extends AbstractStreamFileParser<RecordFile> {
         } else if (log.isDebugEnabled()) {
             log.debug("Storing transaction with consensus timestamp {}", recordItem.getConsensusTimestamp());
         }
+    }
 
-        if (dateRangeFilter != null && !dateRangeFilter.filter(recordItem.getConsensusTimestamp())) {
-            return false;
-        }
-
-        recordItemListener.onItem(recordItem);
-
+    private void recordMetrics(RecordItem recordItem) {
         sizeMetrics.getOrDefault(recordItem.getTransactionType(), unknownSizeMetric)
                 .record(recordItem.getTransactionBytes().length);
 
         Instant consensusTimestamp = Utility.convertToInstant(recordItem.getRecord().getConsensusTimestamp());
         latencyMetrics.getOrDefault(recordItem.getTransactionType(), unknownLatencyMetric)
                 .record(Duration.between(consensusTimestamp, Instant.now()));
-        return true;
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/StreamFileReader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/StreamFileReader.java
@@ -20,10 +20,6 @@ package com.hedera.mirror.importer.reader;
  * ‍
  */
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.function.Consumer;
-
 import com.hedera.mirror.importer.domain.StreamFile;
 import com.hedera.mirror.importer.domain.StreamFileData;
 import com.hedera.mirror.importer.parser.domain.StreamItem;
@@ -32,18 +28,11 @@ public interface StreamFileReader<S extends StreamFile, I extends StreamItem> {
 
     /**
      * Reads a stream file. This method takes ownership of the {@link java.io.InputStream} provided by {@code
-     * streamFileData} and will close it when it's done processing the data.
+     * streamFileData} and will close it when it's done processing the data. Depending upon the implementation, the
+     * StreamFile::getItems may return a lazily parsed list of items.
      *
      * @param streamFileData {@link StreamFileData} object for the record file.
-     * @param itemConsumer   consumer to handle individual {@link StreamItem} objects.
      * @return {@link StreamFile} object
      */
-    S read(StreamFileData streamFileData, Consumer<I> itemConsumer);
-
-    default S read(StreamFileData streamFileData) {
-        List<I> items = new ArrayList<>();
-        S streamFile = read(streamFileData, items::add);
-        streamFile.getItems().addAll(items);
-        return streamFile;
-    }
+    S read(StreamFileData streamFileData);
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/balance/CompositeBalanceFileReader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/balance/CompositeBalanceFileReader.java
@@ -21,13 +21,11 @@ package com.hedera.mirror.importer.reader.balance;
  */
 
 import com.google.common.base.Stopwatch;
-import java.util.function.Consumer;
 import javax.inject.Named;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.context.annotation.Primary;
 
-import com.hedera.mirror.importer.domain.AccountBalance;
 import com.hedera.mirror.importer.domain.AccountBalanceFile;
 import com.hedera.mirror.importer.domain.StreamFileData;
 
@@ -47,19 +45,18 @@ public class CompositeBalanceFileReader implements BalanceFileReader {
     }
 
     @Override
-    public AccountBalanceFile read(StreamFileData streamFileData, Consumer<AccountBalance> itemConsumer) {
-        long count = 0;
+    public AccountBalanceFile read(StreamFileData streamFileData) {
         Stopwatch stopwatch = Stopwatch.createStarted();
+        boolean success = false;
 
         try {
             BalanceFileReader balanceFileReader = getReader(streamFileData);
-            AccountBalanceFile accountBalanceFile = balanceFileReader.read(streamFileData, itemConsumer);
-            count = accountBalanceFile.getCount();
+            AccountBalanceFile accountBalanceFile = balanceFileReader.read(streamFileData);
+            success = true;
             return accountBalanceFile;
         } finally {
-            boolean success = count != 0;
-            log.info("Read {} items {}successfully from account balance file {} in {}",
-                    count, success ? "" : "un", streamFileData.getFilename(), stopwatch);
+            log.info("Read account balance file {} {}successfully in {}",
+                    streamFileData.getFilename(), success ? "" : "un", stopwatch);
         }
     }
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/balance/ProtoBalanceFileReader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/balance/ProtoBalanceFileReader.java
@@ -69,11 +69,11 @@ public class ProtoBalanceFileReader implements BalanceFileReader {
                 .map(AccountBalance.Id::getConsensusTimestamp)
                 .blockFirst();
 
-        try {
+        try (InputStream inputStream = streamFileData.getInputStream()) {
             AccountBalanceFile accountBalanceFile = new AccountBalanceFile();
             accountBalanceFile.setBytes(streamFileData.getBytes());
             accountBalanceFile.setConsensusTimestamp(consensusTimestamp);
-            accountBalanceFile.setFileHash(DigestUtils.sha384Hex(streamFileData.getInputStream()));
+            accountBalanceFile.setFileHash(DigestUtils.sha384Hex(inputStream));
             accountBalanceFile.setItems(items);
             accountBalanceFile.setLoadStart(loadStart.getEpochSecond());
             accountBalanceFile.setName(streamFileData.getFilename());

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/balance/ProtoBalanceFileReader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/balance/ProtoBalanceFileReader.java
@@ -126,9 +126,8 @@ public class ProtoBalanceFileReader implements BalanceFileReader {
     private String getHash(StreamFileData streamFileData) {
         byte[] buffer = new byte[8192];
         MessageDigest messageDigest = DigestUtils.getSha384Digest();
-        InputStream inputStream = new DigestInputStream(streamFileData.getInputStream(), messageDigest);
 
-        try {
+        try (InputStream inputStream = new DigestInputStream(streamFileData.getInputStream(), messageDigest)) {
             while (inputStream.read(buffer) >= 0) {
             }
         } catch (Exception e) {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/event/EventFileReaderV3.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/event/EventFileReaderV3.java
@@ -25,7 +25,6 @@ import com.google.common.primitives.Ints;
 import java.io.DataInputStream;
 import java.security.MessageDigest;
 import java.time.Instant;
-import java.util.function.Consumer;
 import javax.inject.Named;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.codec.binary.Hex;
@@ -34,7 +33,6 @@ import com.hedera.mirror.importer.domain.DigestAlgorithm;
 import com.hedera.mirror.importer.domain.EventFile;
 import com.hedera.mirror.importer.domain.StreamFileData;
 import com.hedera.mirror.importer.exception.InvalidEventFileException;
-import com.hedera.mirror.importer.parser.domain.EventItem;
 import com.hedera.mirror.importer.util.Utility;
 
 @Log4j2
@@ -48,7 +46,7 @@ public class EventFileReaderV3 implements EventFileReader {
     public static final byte EVENT_STREAM_FILE_VERSION_3 = 3;
 
     @Override
-    public EventFile read(StreamFileData streamFileData, Consumer<EventItem> itemConsumer) {
+    public EventFile read(StreamFileData streamFileData) {
         String filename = streamFileData.getFilename();
         int fileVersion = 0;
         Stopwatch stopwatch = Stopwatch.createStarted();

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/record/CompositeRecordFileReader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/record/CompositeRecordFileReader.java
@@ -23,7 +23,6 @@ package com.hedera.mirror.importer.reader.record;
 import com.google.common.base.Stopwatch;
 import java.io.DataInputStream;
 import java.io.IOException;
-import java.util.function.Consumer;
 import javax.inject.Named;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -34,7 +33,6 @@ import com.hedera.mirror.importer.domain.RecordFile;
 import com.hedera.mirror.importer.domain.StreamFileData;
 import com.hedera.mirror.importer.exception.InvalidStreamFileException;
 import com.hedera.mirror.importer.exception.StreamFileReaderException;
-import com.hedera.mirror.importer.parser.domain.RecordItem;
 
 @Log4j2
 @Named
@@ -47,7 +45,7 @@ public class CompositeRecordFileReader implements RecordFileReader {
     private final RecordFileReaderImplV5 version5Reader;
 
     @Override
-    public RecordFile read(@NonNull StreamFileData streamFileData, Consumer<RecordItem> itemConsumer) {
+    public RecordFile read(@NonNull StreamFileData streamFileData) {
         long count = 0;
         Stopwatch stopwatch = Stopwatch.createStarted();
         String filename = streamFileData.getFilename();
@@ -72,7 +70,7 @@ public class CompositeRecordFileReader implements RecordFileReader {
                             version, filename));
             }
 
-            RecordFile recordFile = reader.read(streamFileData, itemConsumer);
+            RecordFile recordFile = reader.read(streamFileData);
             count = recordFile.getCount();
             return recordFile;
         } catch (IOException e) {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/balance/AccountBalanceFileParserTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/balance/AccountBalanceFileParserTest.java
@@ -22,15 +22,14 @@ package com.hedera.mirror.importer.parser.balance;
 
 import static com.hedera.mirror.importer.domain.StreamFilename.FileType.DATA;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 import com.google.common.primitives.Longs;
 import java.time.Instant;
 import java.util.List;
 import javax.annotation.Resource;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
 
 import com.hedera.mirror.importer.IntegrationTest;
 import com.hedera.mirror.importer.domain.AccountBalance;
@@ -40,7 +39,6 @@ import com.hedera.mirror.importer.domain.EntityTypeEnum;
 import com.hedera.mirror.importer.domain.StreamFilename;
 import com.hedera.mirror.importer.domain.StreamType;
 import com.hedera.mirror.importer.domain.TokenBalance;
-import com.hedera.mirror.importer.exception.ParserException;
 import com.hedera.mirror.importer.parser.StreamFileParser;
 import com.hedera.mirror.importer.repository.AccountBalanceFileRepository;
 import com.hedera.mirror.importer.repository.AccountBalanceRepository;
@@ -95,7 +93,6 @@ class AccountBalanceFileParserTest extends IntegrationTest {
         assertPostParseAccountBalanceFile(accountBalanceFile, true);
     }
 
-    @Disabled("Fails in CI")
     @Test
     void success() {
         AccountBalanceFile accountBalanceFile = accountBalanceFile(1);
@@ -103,19 +100,18 @@ class AccountBalanceFileParserTest extends IntegrationTest {
         assertPostParseAccountBalanceFile(accountBalanceFile, true);
     }
 
-    @Disabled("Fails in CI")
     @Test
     void duplicateFile() {
         AccountBalanceFile accountBalanceFile = accountBalanceFile(1);
         AccountBalanceFile duplicate = accountBalanceFile(1);
 
         accountBalanceFileParser.parse(accountBalanceFile);
-        assertThrows(ParserException.class, () -> accountBalanceFileParser.parse(duplicate));
+        accountBalanceFileParser.parse(duplicate); // Will be ignored
 
+        assertThat(accountBalanceFileRepository.count()).isEqualTo(1L);
         assertPostParseAccountBalanceFile(accountBalanceFile, true);
     }
 
-    @Disabled("Fails in CI")
     @Test
     void keepFiles() {
         AccountBalanceFile accountBalanceFile = accountBalanceFile(1);
@@ -152,17 +148,17 @@ class AccountBalanceFileParserTest extends IntegrationTest {
         assertThat(accountBalanceFileRepository.count()).isEqualTo(accountBalanceFiles.length);
 
         for (AccountBalanceFile accountBalanceFile : accountBalanceFiles) {
-            for (AccountBalance accountBalance : accountBalanceFile.getItems()) {
+            accountBalanceFile.getItems().doOnNext(accountBalance -> {
                 assertThat(accountBalanceRepository.findById(accountBalance.getId())).get().isEqualTo(accountBalance);
 
                 for (TokenBalance tokenBalance : accountBalance.getTokenBalances()) {
                     assertThat(tokenBalanceRepository.findById(tokenBalance.getId())).get().isEqualTo(tokenBalance);
                 }
-            }
+            }).blockLast();
 
             assertThat(accountBalanceRepository.findByIdConsensusTimestamp(accountBalanceFile.getConsensusTimestamp()))
                     .hasSize(accountBalanceFile.getCount().intValue())
-                    .hasSize(accountBalanceFile.getItems().size());
+                    .hasSize(Math.toIntExact(accountBalanceFile.getItems().count().block()));
 
             assertThat(accountBalanceFileRepository.findById(accountBalanceFile.getConsensusTimestamp()))
                     .get()
@@ -181,7 +177,7 @@ class AccountBalanceFileParserTest extends IntegrationTest {
                 .consensusTimestamp(timestamp)
                 .count(2L)
                 .fileHash("fileHash" + timestamp)
-                .items(List.of(accountBalance(timestamp, 1), accountBalance(timestamp, 2)))
+                .items(Flux.just(accountBalance(timestamp, 1), accountBalance(timestamp, 2)))
                 .loadEnd(null)
                 .loadStart(timestamp)
                 .name(filename)

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/balance/AccountBalanceFileParserTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/balance/AccountBalanceFileParserTest.java
@@ -80,20 +80,6 @@ class AccountBalanceFileParserTest extends IntegrationTest {
     }
 
     @Test
-    void alreadyExists() {
-        // given
-        AccountBalanceFile accountBalanceFile = accountBalanceFile(1);
-        accountBalanceFile.setLoadEnd(1L);
-        accountBalanceFileRepository.save(accountBalanceFile);
-
-        // when
-        accountBalanceFileParser.parse(accountBalanceFile);
-
-        // then
-        assertPostParseAccountBalanceFile(accountBalanceFile, true);
-    }
-
-    @Test
     void success() {
         AccountBalanceFile accountBalanceFile = accountBalanceFile(1);
         accountBalanceFileParser.parse(accountBalanceFile);

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/event/EventFileParserTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/event/EventFileParserTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.verify;
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Instant;
+import reactor.core.publisher.Flux;
 
 import com.hedera.mirror.importer.domain.DigestAlgorithm;
 import com.hedera.mirror.importer.domain.EntityId;
@@ -82,7 +83,7 @@ class EventFileParserTest extends AbstractStreamFileParserTest<EventFileParser> 
         eventFile.setNodeAccountId(EntityId.of("0.0.3", EntityTypeEnum.ACCOUNT));
         eventFile.setPreviousHash("previousHash" + (id - 1));
         eventFile.setVersion(1);
-        eventFile.getItems().add(new EventItem());
+        eventFile.setItems(Flux.just(new EventItem()));
         return eventFile;
     }
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileParserTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileParserTest.java
@@ -26,6 +26,8 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 import com.hederahashgraph.api.proto.java.CryptoTransferTransactionBody;
 import com.hederahashgraph.api.proto.java.SignatureMap;
@@ -36,9 +38,11 @@ import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionRecord;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Instant;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Mock;
+import reactor.core.publisher.Flux;
 
 import com.hedera.mirror.importer.config.MirrorDateRangePropertiesProcessor;
 import com.hedera.mirror.importer.config.MirrorDateRangePropertiesProcessor.DateRangeFilter;
@@ -60,7 +64,7 @@ class RecordFileParserTest extends AbstractStreamFileParserTest<RecordFileParser
     @Mock(lenient = true)
     private RecordStreamFileListener recordStreamFileListener;
 
-    @Mock
+    @Mock(lenient = true)
     private MirrorDateRangePropertiesProcessor mirrorDateRangePropertiesProcessor;
 
     private long count = 0;
@@ -88,6 +92,8 @@ class RecordFileParserTest extends AbstractStreamFileParserTest<RecordFileParser
     @Override
     protected RecordFileParser getParser() {
         RecordParserProperties parserProperties = new RecordParserProperties();
+        when(mirrorDateRangePropertiesProcessor.getDateRangeFilter(parserProperties.getStreamType()))
+                .thenReturn(DateRangeFilter.all());
         return new RecordFileParser(new SimpleMeterRegistry(), parserProperties, streamFileRepository,
                 recordItemListener, recordStreamFileListener, mirrorDateRangePropertiesProcessor);
     }
@@ -114,7 +120,7 @@ class RecordFileParserTest extends AbstractStreamFileParserTest<RecordFileParser
         recordFile.setNodeAccountId(EntityId.of("0.0.3", EntityTypeEnum.ACCOUNT));
         recordFile.setPreviousHash("previousHash" + (id - 1));
         recordFile.setVersion(1);
-        recordFile.getItems().add(recordItem);
+        recordFile.setItems(Flux.just(recordItem));
 
         return recordFile;
     }
@@ -124,12 +130,23 @@ class RecordFileParserTest extends AbstractStreamFileParserTest<RecordFileParser
         doThrow(ParserSQLException.class).when(recordItemListener).onItem(any());
     }
 
+    @Test
+    void filtered() {
+        RecordFile recordFile = (RecordFile) getStreamFile();
+        when(mirrorDateRangePropertiesProcessor.getDateRangeFilter(parserProperties.getStreamType()))
+                .thenReturn(DateRangeFilter.empty());
+        parser.parse(recordFile);
+        verifyNoInteractions(recordItemListener);
+        verify(recordStreamFileListener).onEnd(recordFile);
+        assertPostParseStreamFile(recordFile, true);
+    }
+
     @ParameterizedTest(name = "endDate with offset {0}ns")
     @CsvSource({"-1", "0", "1"})
     void endDate(long offset) {
         // given
         RecordFile recordFile = (RecordFile) getStreamFile();
-        RecordItem firstItem = recordFile.getItems().get(0);
+        RecordItem firstItem = recordFile.getItems().blockFirst();
         long end = recordFile.getConsensusStart() + offset;
         DateRangeFilter filter = new DateRangeFilter(Instant.EPOCH, Instant.ofEpochSecond(0, end));
         doReturn(filter).when(mirrorDateRangePropertiesProcessor).getDateRangeFilter(parserProperties.getStreamType());
@@ -151,7 +168,7 @@ class RecordFileParserTest extends AbstractStreamFileParserTest<RecordFileParser
     void startDate(long offset) {
         // given
         RecordFile recordFile = (RecordFile) getStreamFile();
-        RecordItem firstItem = recordFile.getItems().get(0);
+        RecordItem firstItem = recordFile.getItems().blockFirst();
         long start = recordFile.getConsensusStart() + offset;
         DateRangeFilter filter = new DateRangeFilter(Instant.ofEpochSecond(0, start), null);
         doReturn(filter).when(mirrorDateRangePropertiesProcessor).getDateRangeFilter(parserProperties.getStreamType());

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileParserTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileParserTest.java
@@ -131,7 +131,7 @@ class RecordFileParserTest extends AbstractStreamFileParserTest<RecordFileParser
     }
 
     @Test
-    void filtered() {
+    void allFiltered() {
         RecordFile recordFile = (RecordFile) getStreamFile();
         when(mirrorDateRangePropertiesProcessor.getDateRangeFilter(parserProperties.getStreamType()))
                 .thenReturn(DateRangeFilter.empty());

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/balance/BalanceFileReaderImplV1Test.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/balance/BalanceFileReaderImplV1Test.java
@@ -23,13 +23,11 @@ package com.hedera.mirror.importer.reader.balance;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Test;
 
-import com.hedera.mirror.importer.domain.AccountBalance;
 import com.hedera.mirror.importer.domain.AccountBalanceFile;
 import com.hedera.mirror.importer.domain.StreamFileData;
 import com.hedera.mirror.importer.reader.balance.line.AccountBalanceLineParserV1;
@@ -56,10 +54,9 @@ class BalanceFileReaderImplV1Test extends CsvBalanceFileReaderTest {
         copy.add("");
         copy.addAll(lines);
         FileUtils.writeLines(testFile, copy);
-        List<AccountBalance> accountBalances = new ArrayList<>();
         StreamFileData streamFileData = StreamFileData.from(testFile);
-        AccountBalanceFile accountBalanceFile = balanceFileReader.read(streamFileData, accountBalances::add);
+        AccountBalanceFile accountBalanceFile = balanceFileReader.read(streamFileData);
         assertAccountBalanceFile(accountBalanceFile);
-        verifySuccess(testFile, accountBalances, 2);
+        verifySuccess(testFile, accountBalanceFile, 2);
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/balance/CompositeBalanceFileReaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/balance/CompositeBalanceFileReaderTest.java
@@ -25,14 +25,12 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.function.Consumer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.hedera.mirror.importer.domain.AccountBalance;
 import com.hedera.mirror.importer.domain.AccountBalanceFile;
 import com.hedera.mirror.importer.domain.StreamFileData;
 
@@ -53,9 +51,6 @@ public class CompositeBalanceFileReaderTest {
     @InjectMocks
     private CompositeBalanceFileReader compositeBalanceFileReader;
 
-    private final Consumer<AccountBalance> consumer = accountBalance -> {
-    };
-
     private final AccountBalanceFile accountBalanceFile = AccountBalanceFile.builder().count(1L).build();
 
     @Test
@@ -64,11 +59,11 @@ public class CompositeBalanceFileReaderTest {
         configMockReader(protoBalanceFileReader, streamFileData, false);
         configMockReader(readerImplV1, streamFileData, true);
 
-        compositeBalanceFileReader.read(streamFileData, consumer);
+        compositeBalanceFileReader.read(streamFileData);
 
-        verify(readerImplV1, times(1)).read(streamFileData, consumer);
-        verify(readerImplV2, never()).read(streamFileData, consumer);
-        verify(protoBalanceFileReader, never()).read(streamFileData, consumer);
+        verify(readerImplV1, times(1)).read(streamFileData);
+        verify(readerImplV2, never()).read(streamFileData);
+        verify(protoBalanceFileReader, never()).read(streamFileData);
     }
 
     @Test
@@ -77,29 +72,30 @@ public class CompositeBalanceFileReaderTest {
         configMockReader(protoBalanceFileReader, streamFileData, false);
         configMockReader(readerImplV2, streamFileData, true);
 
-        compositeBalanceFileReader.read(streamFileData, consumer);
+        compositeBalanceFileReader.read(streamFileData);
 
-        verify(readerImplV2, times(1)).read(streamFileData, consumer);
-        verify(readerImplV1, never()).read(streamFileData, consumer);
-        verify(protoBalanceFileReader, never()).read(streamFileData, consumer);
+        verify(readerImplV2, times(1)).read(streamFileData);
+        verify(readerImplV1, never()).read(streamFileData);
+        verify(protoBalanceFileReader, never()).read(streamFileData);
     }
 
     @Test
     void usesProtoBalanceFileReader() {
-        StreamFileData streamFileData = StreamFileData.from(BALANCE_FILENAME_PREFIX + ".pb.gz", "proto-based balance file");
+        StreamFileData streamFileData = StreamFileData
+                .from(BALANCE_FILENAME_PREFIX + ".pb.gz", "proto-based balance file");
         configMockReader(protoBalanceFileReader, streamFileData, true);
 
-        compositeBalanceFileReader.read(streamFileData, consumer);
+        compositeBalanceFileReader.read(streamFileData);
 
-        verify(protoBalanceFileReader, times(1)).read(streamFileData, consumer);
-        verify(readerImplV1, never()).read(streamFileData, consumer);
-        verify(readerImplV2, never()).read(streamFileData, consumer);
+        verify(protoBalanceFileReader, times(1)).read(streamFileData);
+        verify(readerImplV1, never()).read(streamFileData);
+        verify(readerImplV2, never()).read(streamFileData);
     }
 
     private void configMockReader(BalanceFileReader reader, StreamFileData streamFileData, boolean supports) {
         if (supports) {
             when(reader.supports(streamFileData)).thenReturn(true);
-            when(reader.read(streamFileData, consumer)).thenReturn(accountBalanceFile);
+            when(reader.read(streamFileData)).thenReturn(accountBalanceFile);
         } else {
             when(reader.supports(streamFileData)).thenReturn(false);
         }


### PR DESCRIPTION
**Detailed description**:
- Change `ProtoBalanceFileReader` to calculate hash using raw input stream instead of proto parsing
- Change `ProtoBalanceFileReader` to return a lazy, streaming `Flux` of `AccountBalance` items to reduce memory usage
- Fix record file count not taking into account filtered items
- Remove unused reader item consumer

**Which issue(s) this PR fixes**:
Fixes #1927 
Fixes #1947

**Special notes for your reviewer**:
Improves reading `2021-05-04T14_00_00.844472Z_Balances.pb.gz` on my machine from infinity (due to not having as much memory as our server) to 3s
Improves parsing `2021-05-04T14_00_00.844472Z_Balances.pb.gz` on my machine to ~1.8m
It took `9.937 min` in perf for the same file, though my database is pretty much empty so not exact comparison.

**Checklist**

- [x] Documentation added
- [x] Tests updated

