### PR TITLE
Change token_transfer index

### DIFF
--- a/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.40.1__token_transfer_index.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.40.1__token_transfer_index.sql
@@ -1,0 +1,8 @@
+-------------------
+-- Change the index on token_transfer (account) to (account, consensus_timestamp) to speedup the query to get a list of
+-- consensus timestamps of token transfers for specific account(s).
+-------------------
+
+drop index if exists token_transfer_account;
+create index if not exists token_transfer__account_timestamp
+    on token_transfer (account_id, consensus_timestamp desc);

--- a/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.2__time_scale_index_init.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.2__time_scale_index_init.sql
@@ -131,6 +131,8 @@ alter table token_balance
 -- token_transfer
 create index if not exists token_transfer__token_account_timestamp
     on token_transfer (consensus_timestamp desc, token_id desc, account_id desc);
+create index if not exists token_transfer__account_timestamp
+    on token_transfer (account_id, consensus_timestamp desc);
 
 -- topic_message
 alter table if exists topic_message


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`
3. Rebase your PR if it gets out of sync with main
-->

**Detailed description**:
Replace the index on `token_transfer (account_id)` with `token_transfer (account_id, consensus_timestamp desc)`

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:
Some accounts query in perfnet times out, e.g., `/api/v1/accounts/1028`. The issue is perfnet has around 450 million token transfers, and account 0.0.1028 is only involved in less than 10 token transfers and the transfers are very old timestamp-wise. So the transactions query as part of the single account rest request gets stuck in sequentially scanning the token_transfer index (consensus_timestamp, token_id, account) to find the matching timestamps.

**Checklist**

- [ ] Documentation added
- [ ] Tests updated

