### PR TITLE
Retry monitor entity creation

### DIFF
--- a/charts/hedera-mirror-common/values.yaml
+++ b/charts/hedera-mirror-common/values.yaml
@@ -260,7 +260,7 @@ prometheus:
         requests:
           cpu: 250m
           memory: 250Mi
-      retention: 30d
+      retention: 60d
       ruleSelectorNilUsesHelmValues: false
       scrapeInterval: 30s
       serviceMonitorSelectorNilUsesHelmValues: false
@@ -272,9 +272,6 @@ prometheus:
                 storage: 50Gi
       walCompression: true
   prometheusOperator:
-    namespaces:
-      additional: []
-      releaseNamespace: true
     resources:
       limits:
         cpu: 100m

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/expression/ExpressionConverterImpl.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/expression/ExpressionConverterImpl.java
@@ -34,6 +34,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.Value;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.StringUtils;
+import reactor.core.publisher.Mono;
+import reactor.util.retry.RetrySpec;
 
 import com.hedera.datagenerator.sdk.supplier.AdminKeyable;
 import com.hedera.datagenerator.sdk.supplier.TransactionSupplier;
@@ -116,13 +118,13 @@ public class ExpressionConverterImpl implements ExpressionConverter {
                     .type(type.getTransactionType())
                     .build();
 
-            PublishResponse publishResponse = transactionPublisher.publish(request).toFuture().join();
+            PublishResponse publishResponse = Mono.defer(() -> transactionPublisher.publish(request))
+                    .retryWhen(RetrySpec.backoff(Long.MAX_VALUE, Duration.ofMillis(500L))
+                            .maxBackoff(Duration.ofSeconds(8L)))
+                    .toFuture().join();
             String createdId = type.getIdExtractor().apply(publishResponse.getReceipt());
             log.info("Created {} entity {}", type, createdId);
             return createdId;
-        } catch (RuntimeException e) {
-            log.error("Error converting expression {}:", expression, e);
-            throw e;
         } catch (Exception e) {
             log.error("Error converting expression {}:", expression, e);
             throw new RuntimeException(e);

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/expression/ExpressionConverterImplTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/expression/ExpressionConverterImplTest.java
@@ -108,10 +108,19 @@ class ExpressionConverterImplTest {
     }
 
     @Test
-    void errorPublishing() {
-        when(transactionPublisher.publish(any())).thenThrow(new RuntimeException());
+    void error() throws InvalidProtocolBufferException {
+        TransactionType type = TransactionType.CONSENSUS_SUBMIT_MESSAGE;
+        when(transactionPublisher.publish(any())).thenReturn(response(type, 100));
         assertThatThrownBy(() -> expressionConverter.convert("${topic.foo}"))
                 .isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    void errorPublishing() throws InvalidProtocolBufferException {
+        TransactionType type = TransactionType.CONSENSUS_CREATE_TOPIC;
+        when(transactionPublisher.publish(any())).thenReturn(Mono.error(new RuntimeException()))
+                .thenReturn(response(type, 100));
+        assertThat(expressionConverter.convert("${topic.foo}")).isEqualTo("0.0.100");
     }
 
     @Test


### PR DESCRIPTION
**Description**:
- Change Prometheus retention to 60 days
- Change Prometheus to watch all namespaces to avoid manual flux configuration of namespaces
- Retry monitor entity creation indefinitely

**Related issue(s)**:

**Notes for reviewer**:
Monitor doesn't have a good health check currently so if entity creation fails it doesn't publish and doesn't restart.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
