### PR TITLE
Support NFT treasury account updates

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/NftRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/NftRepository.java
@@ -41,4 +41,15 @@ public interface NftRepository extends CrudRepository<Nft, NftId> {
     @Modifying
     @Query("update Nft set deleted = true, modifiedTimestamp = :timestamp where id = :id")
     void burnOrWipeNft(@Param("id") NftId nftId, @Param("timestamp") long modifiedTimestamp);
+
+    @Modifying
+    @Query(value = "with nft_updated as (" +
+            "  update nft set account_id = ?3, modified_timestamp = ?4 " +
+            "  where token_id = ?1 and account_id = ?2" +
+            "  returning serial_number) " +
+            "insert into nft_transfer " +
+            "(token_id, sender_account_id, receiver_account_id, consensus_timestamp, serial_number) " +
+            "select ?1, ?2, ?3, ?4, nft_updated.serial_number " +
+            "from nft_updated", nativeQuery = true)
+    void updateTreasury(long tokenId, long previousAccountId, long newAccountId, long consensusTimestamp);
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/AbstractDeleteOrUndeleteTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/AbstractDeleteOrUndeleteTransactionHandlerTest.java
@@ -47,7 +47,8 @@ abstract class AbstractDeleteOrUndeleteTransactionHandlerTest extends AbstractTr
                         .description(description)
                         .expected(expected)
                         .input(input)
-                        .recordItem(getRecordItem(getDefaultTransactionBody().build()))
+                        .recordItem(getRecordItem(getDefaultTransactionBody().build(),
+                                getDefaultTransactionRecord().build()))
                         .build()
         );
     }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/ConsensusCreateTopicTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/ConsensusCreateTopicTransactionHandlerTest.java
@@ -43,7 +43,7 @@ class ConsensusCreateTopicTransactionHandlerTest extends AbstractTransactionHand
 
     @Override
     protected TransactionRecord.Builder getDefaultTransactionRecord() {
-        return TransactionRecord.newBuilder()
+        return super.getDefaultTransactionRecord()
                 .setReceipt(TransactionReceipt.newBuilder()
                         .setTopicID(TopicID.newBuilder().setTopicNum(DEFAULT_ENTITY_NUM).build()));
     }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractCreateTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractCreateTransactionHandlerTest.java
@@ -43,7 +43,7 @@ class ContractCreateTransactionHandlerTest extends AbstractTransactionHandlerTes
 
     @Override
     protected TransactionRecord.Builder getDefaultTransactionRecord() {
-        return TransactionRecord.newBuilder()
+        return super.getDefaultTransactionRecord()
                 .setReceipt(TransactionReceipt.newBuilder()
                         .setContractID(ContractID.newBuilder().setContractNum(DEFAULT_ENTITY_NUM).build()));
     }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoCreateTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoCreateTransactionHandlerTest.java
@@ -43,7 +43,7 @@ class CryptoCreateTransactionHandlerTest extends AbstractTransactionHandlerTest 
 
     @Override
     protected TransactionRecord.Builder getDefaultTransactionRecord() {
-        return TransactionRecord.newBuilder()
+        return super.getDefaultTransactionRecord()
                 .setReceipt(TransactionReceipt.newBuilder()
                         .setAccountID(AccountID.newBuilder().setAccountNum(DEFAULT_ENTITY_NUM).build()));
     }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/FileCreateTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/FileCreateTransactionHandlerTest.java
@@ -49,7 +49,7 @@ class FileCreateTransactionHandlerTest extends AbstractTransactionHandlerTest {
 
     @Override
     protected TransactionRecord.Builder getDefaultTransactionRecord() {
-        return TransactionRecord.newBuilder()
+        return super.getDefaultTransactionRecord()
                 .setReceipt(TransactionReceipt.newBuilder()
                         .setFileID(FileID.newBuilder().setFileNum(DEFAULT_ENTITY_NUM).build()));
     }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/ScheduleCreateTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/ScheduleCreateTransactionHandlerTest.java
@@ -54,7 +54,7 @@ class ScheduleCreateTransactionHandlerTest extends AbstractTransactionHandlerTes
 
     @Override
     protected TransactionRecord.Builder getDefaultTransactionRecord() {
-        return TransactionRecord.newBuilder()
+        return super.getDefaultTransactionRecord()
                 .setReceipt(TransactionReceipt.newBuilder()
                         .setScheduleID(ScheduleID.newBuilder().setScheduleNum(DEFAULT_ENTITY_NUM).build()));
     }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/ScheduleSignTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/ScheduleSignTransactionHandlerTest.java
@@ -42,7 +42,6 @@ public class ScheduleSignTransactionHandlerTest extends AbstractTransactionHandl
         return TransactionBody.newBuilder()
                 .setScheduleSign(ScheduleSignTransactionBody.newBuilder()
                         .setScheduleID(ScheduleID.newBuilder().setScheduleNum(DEFAULT_ENTITY_NUM).build()));
-
     }
 
     @Override
@@ -61,7 +60,7 @@ public class ScheduleSignTransactionHandlerTest extends AbstractTransactionHandl
 
     @Override
     protected TransactionRecord.Builder getDefaultTransactionRecord() {
-        return TransactionRecord.newBuilder()
+        return super.getDefaultTransactionRecord()
                 .setReceipt(TransactionReceipt.newBuilder()
                         .setScheduleID(ScheduleID.newBuilder().setScheduleNum(DEFAULT_ENTITY_NUM).build()));
     }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenCreateTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenCreateTransactionHandlerTest.java
@@ -62,7 +62,7 @@ public class TokenCreateTransactionHandlerTest extends AbstractTransactionHandle
 
     @Override
     protected TransactionRecord.Builder getDefaultTransactionRecord() {
-        return TransactionRecord.newBuilder()
+        return super.getDefaultTransactionRecord()
                 .setReceipt(TransactionReceipt.newBuilder()
                         .setTokenID(TokenID.newBuilder().setTokenNum(DEFAULT_ENTITY_NUM).build()));
     }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenUpdateTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenUpdateTransactionHandlerTest.java
@@ -94,9 +94,10 @@ public class TokenUpdateTransactionHandlerTest extends AbstractTransactionHandle
         TransactionRecord record = getDefaultTransactionRecord().addTokenTransferLists(tokenTransferList).build();
         RecordItem recordItem = getRecordItem(getDefaultTransactionBody().build(), record);
 
-        nftRepository.updateTreasury(tokenID.getTokenNum(), previousAccountId.getAccountNum(),
-                newAccountId.getAccountNum(), consensusTimestamp);
         transactionHandler.updateEntity(entity, recordItem);
+
+        Mockito.verify(nftRepository).updateTreasury(tokenID.getTokenNum(), previousAccountId.getAccountNum(),
+                newAccountId.getAccountNum(), consensusTimestamp);
     }
 
     @Test
@@ -113,7 +114,8 @@ public class TokenUpdateTransactionHandlerTest extends AbstractTransactionHandle
         TransactionRecord record = getDefaultTransactionRecord().addTokenTransferLists(tokenTransferList).build();
         RecordItem recordItem = getRecordItem(getDefaultTransactionBody().build(), record);
 
-        Mockito.verifyNoInteractions(nftRepository);
         transactionHandler.updateEntity(entity, recordItem);
+
+        Mockito.verifyNoInteractions(nftRepository);
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenUpdateTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenUpdateTransactionHandlerTest.java
@@ -22,18 +22,34 @@ package com.hedera.mirror.importer.parser.record.transactionhandler;
 
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.Duration;
+import com.hederahashgraph.api.proto.java.NftTransfer;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TokenID;
+import com.hederahashgraph.api.proto.java.TokenTransferList;
 import com.hederahashgraph.api.proto.java.TokenUpdateTransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionBody;
+import com.hederahashgraph.api.proto.java.TransactionRecord;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.hedera.mirror.importer.domain.Entity;
 import com.hedera.mirror.importer.domain.EntityTypeEnum;
+import com.hedera.mirror.importer.parser.domain.RecordItem;
+import com.hedera.mirror.importer.repository.NftRepository;
+import com.hedera.mirror.importer.util.Utility;
 
+@ExtendWith(MockitoExtension.class)
 public class TokenUpdateTransactionHandlerTest extends AbstractTransactionHandlerTest {
+
+    @Mock
+    private NftRepository nftRepository;
 
     @Override
     protected TransactionHandler getTransactionHandler() {
-        return new TokenUpdateTransactionHandler();
+        return new TokenUpdateTransactionHandler(nftRepository);
     }
 
     @Override
@@ -58,5 +74,46 @@ public class TokenUpdateTransactionHandlerTest extends AbstractTransactionHandle
     @Override
     protected EntityTypeEnum getExpectedEntityIdType() {
         return EntityTypeEnum.TOKEN;
+    }
+
+    @Test
+    void updateTreasury() {
+        Entity entity = getExpectedUpdatedEntity();
+        AccountID previousAccountId = AccountID.newBuilder().setAccountNum(1L).build();
+        AccountID newAccountId = AccountID.newBuilder().setAccountNum(2L).build();
+        TokenID tokenID = TokenID.newBuilder().setTokenNum(3L).build();
+        long consensusTimestamp = Utility.timestampInNanosMax(MODIFIED_TIMESTAMP);
+        TokenTransferList tokenTransferList = TokenTransferList.newBuilder()
+                .setToken(tokenID)
+                .addNftTransfers(NftTransfer.newBuilder()
+                        .setReceiverAccountID(newAccountId)
+                        .setSenderAccountID(previousAccountId)
+                        .setSerialNumber(TokenUpdateTransactionHandler.WILDCARD_SERIAL_NUMBER)
+                        .build())
+                .build();
+        TransactionRecord record = getDefaultTransactionRecord().addTokenTransferLists(tokenTransferList).build();
+        RecordItem recordItem = getRecordItem(getDefaultTransactionBody().build(), record);
+
+        nftRepository.updateTreasury(tokenID.getTokenNum(), previousAccountId.getAccountNum(),
+                newAccountId.getAccountNum(), consensusTimestamp);
+        transactionHandler.updateEntity(entity, recordItem);
+    }
+
+    @Test
+    void noTreasuryUpdate() {
+        Entity entity = getExpectedUpdatedEntity();
+        TokenTransferList tokenTransferList = TokenTransferList.newBuilder()
+                .setToken(TokenID.newBuilder().setTokenNum(3L).build())
+                .addNftTransfers(NftTransfer.newBuilder()
+                        .setReceiverAccountID(AccountID.newBuilder().setAccountNum(2L).build())
+                        .setSenderAccountID(AccountID.newBuilder().setAccountNum(1L).build())
+                        .setSerialNumber(1L) // Not wildcard
+                        .build())
+                .build();
+        TransactionRecord record = getDefaultTransactionRecord().addTokenTransferLists(tokenTransferList).build();
+        RecordItem recordItem = getRecordItem(getDefaultTransactionBody().build(), record);
+
+        Mockito.verifyNoInteractions(nftRepository);
+        transactionHandler.updateEntity(entity, recordItem);
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/NftRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/NftRepositoryTest.java
@@ -22,65 +22,110 @@ package com.hedera.mirror.importer.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
 import javax.annotation.Resource;
+import org.assertj.core.api.AbstractObjectAssert;
+import org.assertj.core.api.IterableAssert;
 import org.junit.jupiter.api.Test;
 
 import com.hedera.mirror.importer.domain.EntityId;
 import com.hedera.mirror.importer.domain.EntityTypeEnum;
 import com.hedera.mirror.importer.domain.Nft;
 import com.hedera.mirror.importer.domain.NftId;
+import com.hedera.mirror.importer.domain.NftTransfer;
 
 class NftRepositoryTest extends AbstractRepositoryTest {
 
     @Resource
-    protected NftRepository repository;
+    private NftRepository nftRepository;
+
+    @Resource
+    private NftTransferRepository nftTransferRepository;
 
     @Test
     void save() {
-        Nft savedNft = repository.save(nft("0.0.2", 1, 1));
-        assertThat(repository.findById(savedNft.getId())).contains(savedNft);
+        Nft savedNft = nftRepository.save(nft("0.0.2", 1, 1));
+        assertThat(nftRepository.findById(savedNft.getId())).contains(savedNft);
     }
 
     @Test
     void updateDeleted() {
-        Nft savedNft = repository.save(nft("0.0.3", 2, 2));
-        repository.burnOrWipeNft(savedNft.getId(), 3L);
+        Nft savedNft = nftRepository.save(nft("0.0.3", 2, 2));
+        nftRepository.burnOrWipeNft(savedNft.getId(), 3L);
         savedNft.setDeleted(true);
         savedNft.setModifiedTimestamp(3L);
-        assertThat(repository.findById(savedNft.getId())).contains(savedNft);
+        assertThat(nftRepository.findById(savedNft.getId())).contains(savedNft);
     }
 
     @Test
     void updateDeletedMissingNft() {
         NftId nftId = new NftId(1L, EntityId.of("0.0.1", EntityTypeEnum.TOKEN));
-        repository.burnOrWipeNft(nftId, 1L);
-        assertThat(repository.findById(nftId)).isNotPresent();
+        nftRepository.burnOrWipeNft(nftId, 1L);
+        assertThat(nftRepository.findById(nftId)).isNotPresent();
     }
 
     @Test
     void updateAccountId() {
-        Nft savedNft = repository.save(nft("0.0.3", 2, 2));
+        Nft savedNft = nftRepository.save(nft("0.0.3", 2, 2));
         EntityId accountId = EntityId.of("0.0.10", EntityTypeEnum.ACCOUNT);
-        repository.transferNftOwnership(savedNft.getId(), accountId, 3L);
+        nftRepository.transferNftOwnership(savedNft.getId(), accountId, 3L);
         savedNft.setAccountId(accountId);
         savedNft.setModifiedTimestamp(3L);
-        assertThat(repository.findById(savedNft.getId())).contains(savedNft);
+        assertThat(nftRepository.findById(savedNft.getId())).contains(savedNft);
     }
 
     @Test
     void updateAccountIdMissingNft() {
         NftId nftId = new NftId(1L, EntityId.of("0.0.1", EntityTypeEnum.TOKEN));
         EntityId accountId = EntityId.of("0.0.10", EntityTypeEnum.ACCOUNT);
-        repository.transferNftOwnership(nftId, accountId, 3L);
-        assertThat(repository.findById(nftId)).isNotPresent();
+        nftRepository.transferNftOwnership(nftId, accountId, 3L);
+        assertThat(nftRepository.findById(nftId)).isNotPresent();
+    }
+
+    @Test
+    void updateTreasury() {
+        long consensusTimestamp = 6L;
+        EntityId newAccountId = EntityId.of("0.0.2", EntityTypeEnum.ACCOUNT);
+        Nft nft1 = nft("0.0.100", 1, 1);
+        Nft nft2 = nft("0.0.100", 2, 2);
+        Nft nft3 = nft("0.0.100", 3, 3);
+        Nft nft4 = nft("0.0.101", 1, 4); // Not updated since wrong token
+        Nft nft5 = nft("0.0.100", 4, 5); // Not updated since wrong account
+        nft5.setAccountId(newAccountId);
+        nftRepository.saveAll(List.of(nft1, nft2, nft3, nft4, nft5));
+
+        EntityId tokenId = nft1.getId().getTokenId();
+        EntityId previousAccountId = nft1.getAccountId();
+        nftRepository
+                .updateTreasury(tokenId.getId(), previousAccountId.getId(), newAccountId.getId(), consensusTimestamp);
+
+        assertAccountUpdated(nft1, newAccountId);
+        assertAccountUpdated(nft2, newAccountId);
+        assertAccountUpdated(nft3, newAccountId);
+        assertThat(nftRepository.findById(nft4.getId())).get().isEqualTo(nft4);
+        assertThat(nftRepository.findById(nft5.getId())).get().isEqualTo(nft5);
+
+        IterableAssert<NftTransfer> nftTransfers = assertThat(nftTransferRepository.findAll()).hasSize(3);
+        nftTransfers.extracting(NftTransfer::getReceiverAccountId).containsOnly(newAccountId);
+        nftTransfers.extracting(NftTransfer::getSenderAccountId).containsOnly(previousAccountId);
+        nftTransfers.extracting(n -> n.getId().getTokenId()).containsOnly(tokenId);
+        nftTransfers.extracting(n -> n.getId().getConsensusTimestamp()).containsOnly(consensusTimestamp);
+        nftTransfers.extracting(n -> n.getId().getSerialNumber()).containsExactlyInAnyOrder(1L, 2L, 3L);
+    }
+
+    private void assertAccountUpdated(Nft nft, EntityId accountId) {
+        AbstractObjectAssert<?, Nft> nftAssert = assertThat(nftRepository.findById(nft.getId())).get();
+        nftAssert.extracting(Nft::getAccountId).isEqualTo(accountId);
+        nftAssert.extracting(Nft::getModifiedTimestamp).isNotEqualTo(nft.getModifiedTimestamp());
     }
 
     private Nft nft(String tokenId, long serialNumber, long consensusTimestamp) {
         Nft nft = new Nft();
-        nft.setCreatedTimestamp(consensusTimestamp);
-        nft.setMetadata(new byte[] {1});
-        nft.setId(new NftId(serialNumber, EntityId.of(tokenId, EntityTypeEnum.TOKEN)));
         nft.setAccountId(EntityId.of("0.0.1", EntityTypeEnum.ACCOUNT));
+        nft.setCreatedTimestamp(consensusTimestamp);
+        nft.setId(new NftId(serialNumber, EntityId.of(tokenId, EntityTypeEnum.TOKEN)));
+        nft.setMetadata(new byte[] {1});
+        nft.setModifiedTimestamp(consensusTimestamp);
         return nft;
     }
 }


### PR DESCRIPTION
**Description**:
- Add support for updating NFT treasury accounts
- Create new NFT transfers not present in the record to materialize the transfer of ownership

**Related issue(s)**:

Fixes #2215

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
