### PR TITLE
Bump protobuf to 0.16.0-alpha.4 and add new response codes

### DIFF
--- a/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.41.0__response_codes.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.41.0__response_codes.sql
@@ -1,0 +1,9 @@
+-------------------
+-- Add new response codes
+-------------------
+
+insert into t_transaction_results (result, proto_id)
+values ('ACCOUNT_STILL_OWNS_NFTS', 251),
+       ('TREASURY_MUST_OWN_BURNED_NFT', 252),
+       ('ACCOUNT_DOES_NOT_OWN_WIPED_NFT', 253),
+       ('ACCOUNT_AMOUNT_TRANSFERS_ONLY_ALLOWED_FOR_FUNGIBLE_COMMON', 254);

--- a/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.4__reference_table_inserts.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.4__reference_table_inserts.sql
@@ -217,7 +217,11 @@ values ('OK', 0),
        ('INVALID_CUSTOM_FEE_SCHEDULE_KEY', 247),
        ('INVALID_TOKEN_MINT_METADATA', 248),
        ('INVALID_TOKEN_BURN_METADATA', 249),
-       ('CURRENT_TREASURY_STILL_OWNS_NFTS', 250);
+       ('CURRENT_TREASURY_STILL_OWNS_NFTS', 250),
+       ('ACCOUNT_STILL_OWNS_NFTS', 251),
+       ('TREASURY_MUST_OWN_BURNED_NFT', 252),
+       ('ACCOUNT_DOES_NOT_OWN_WIPED_NFT', 253),
+       ('ACCOUNT_AMOUNT_TRANSFERS_ONLY_ALLOWED_FOR_FUNGIBLE_COMMON', 254);
 
 -- t_transaction_types
 insert into t_transaction_types (proto_id, name, entity_type)

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <grpc-spring-boot.version>2.11.0.RELEASE</grpc-spring-boot.version>
         <grpc.version>1.39.0</grpc.version>
         <guava.version>30.1.1-jre</guava.version>
-        <hedera-protobuf.version>0.16.0-alpha.3</hedera-protobuf.version>
+        <hedera-protobuf.version>0.16.0-alpha.4</hedera-protobuf.version>
         <hedera-sdk.version>2.0.8</hedera-sdk.version>
         <jacoco.version>0.8.7</jacoco.version>
         <java.version>11</java.version>


### PR DESCRIPTION
Signed-off-by: Ian Jungmann <ian.jungmann@hedera.com>

**Description**:

- Bump protobuf to 0.16.0-alpha.4
- Add new response codes

**Additional Details**

See new response codes [here](https://github.com/hashgraph/hedera-protobufs/pull/54/files)

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
