### PR TITLE
Fix issue with nft info REST API on deleted nfts (0.37)

### DIFF
--- a/hedera-mirror-rest/__tests__/integrationDomainOps.js
+++ b/hedera-mirror-rest/__tests__/integrationDomainOps.js
@@ -620,7 +620,7 @@ const addNft = async (nft) => {
     `INSERT INTO nft (account_id, created_timestamp, deleted, modified_timestamp, metadata, serial_number, token_id)
      VALUES ($1, $2, $3, $4, $5, $6, $7);`,
     [
-      EntityId.fromString(nft.account_id).getEncodedId(),
+      EntityId.fromString(nft.account_id, '', true).getEncodedId(),
       nft.created_timestamp,
       nft.deleted,
       nft.modified_timestamp,

--- a/hedera-mirror-rest/__tests__/specs/tokens-nfts-info-06-null-account-id.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/tokens-nfts-info-06-null-account-id.spec.json
@@ -1,0 +1,80 @@
+{
+  "description": "Token nft info api call for single nft with a null account id",
+  "setup": {
+    "entities": [
+      {
+        "num": 1001
+      },
+      {
+        "num": 2001
+      },
+      {
+        "num": 1500,
+        "type": 5
+      },
+      {
+        "num": 2500,
+        "type": 5
+      }
+    ],
+    "tokens": [
+      {
+        "token_id": "0.0.1500",
+        "symbol": "FIRSTMOVERLPDJH",
+        "created_timestamp": "1234567890000000003",
+        "type": "NON_FUNGIBLE_UNIQUE"
+      },
+      {
+        "token_id": "0.0.2500",
+        "symbol": "ORIGINALRDKSE",
+        "created_timestamp": "1234567890000000004",
+        "type": "NON_FUNGIBLE_UNIQUE"
+      }
+    ],
+    "balances": [],
+    "transactions": [],
+    "cryptotransfers": [],
+    "nfts": [
+      {
+        "account_id": "0.0.1001",
+        "created_timestamp": "1234567890000000005",
+        "metadata": "m1",
+        "serial_number": 1,
+        "token_id": "0.0.1500"
+      },
+      {
+        "account_id": null,
+        "created_timestamp": "1234567890000000006",
+        "deleted": true,
+        "metadata": "m2",
+        "serial_number": 2,
+        "token_id": "0.0.1500"
+      },
+      {
+        "account_id": "0.0.1001",
+        "created_timestamp": "1234567890000000007",
+        "metadata": "s1",
+        "serial_number": 1,
+        "token_id": "0.0.2500"
+      },
+      {
+        "account_id": "0.0.1001",
+        "created_timestamp": "1234567890000000008",
+        "metadata": "m3",
+        "serial_number": 3,
+        "token_id": "0.0.1500"
+      }
+    ]
+  },
+  "urls": ["/api/v1/tokens/1500/nfts/2", "/api/v1/tokens/0.1500/nfts/2", "/api/v1/tokens/0.0.1500/nfts/2"],
+  "responseStatus": 200,
+  "responseJson": {
+    "account_id": null,
+    "created_timestamp": "1234567890.000000006",
+    "deleted": true,
+    "metadata": "bTI=",
+    "modified_timestamp": "1234567890.000000006",
+    "serial_number": 2,
+    "token_id": "0.0.1500"
+  }
+}

--- a/hedera-mirror-rest/viewmodel/nftViewModel.js
+++ b/hedera-mirror-rest/viewmodel/nftViewModel.js
@@ -28,7 +28,7 @@ const EntityId = require('../entityId');
  */
 class NftViewModel {
   constructor(nftModel) {
-    this.account_id = EntityId.fromEncodedId(nftModel.accountId).toString();
+    this.account_id = EntityId.fromEncodedId(nftModel.accountId, true).toString();
     this.created_timestamp = utils.nsToSecNs(nftModel.createdTimestamp);
     this.deleted = nftModel.deleted;
     this.metadata = utils.encodeBase64(nftModel.metadata);


### PR DESCRIPTION
**Description**:
Cherry pick Fix issue with nft info REST API on deleted nfts #2275 

* Add boolean to check for null accountId before converting to an entity for the Nft logic.
* Add a test to confirm this behavior is fixed.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
