### PR TITLE
Add HTTPS support to Monitor API 

### DIFF
--- a/hedera-mirror-rest/monitoring/monitor_apis/common.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/common.js
@@ -124,18 +124,17 @@ const getStatusByName = (name) => {
  * @return {Number} PID of the test process running for the given server
  */
 const getProcess = (server) => {
-  const key = `${server.ip}_${server.port}`;
-  return pids[key];
+  return pids[server.baseUrl];
 };
 
 /**
  * Stores the process pid for a given server
  * @param {Object} server the server for which the pid needs to be stored
- * @return {} None
+ * @param {number} count
+ * @return None
  */
 const saveProcess = (server, count) => {
-  const key = `${server.ip}_${server.port}`;
-  pids[key] = {
+  pids[server.baseUrl] = {
     id: server.name,
     encountered: count,
   };
@@ -144,11 +143,10 @@ const saveProcess = (server, count) => {
 /**
  * Deletes the process pid for a given server (when the test process returns)
  * @param {Object} server the server for which the pid needs to be deleted
- * @return {} None
+ * @return None
  */
 const deleteProcess = (server) => {
-  const key = `${server.ip}_${server.port}`;
-  delete pids[key];
+  delete pids[server.baseUrl];
 };
 
 module.exports = {

--- a/hedera-mirror-rest/monitoring/monitor_apis/config/default.serverlist.json
+++ b/hedera-mirror-rest/monitoring/monitor_apis/config/default.serverlist.json
@@ -2,12 +2,15 @@
   "port": 3000,
   "servers": [
     {
-      "ip": "127.0.0.1",
-      "port": 5551,
+      "baseUrl": "http://127.0.0.1:5551",
       "name": "local"
     }
   ],
   "interval": 60,
+  "retry": {
+    "max": 10,
+    "minMillisToWait": 50
+  },
   "shard": 0,
   "account": {
     "enabled": true,

--- a/hedera-mirror-rest/monitoring/monitor_apis/config/default.serverlist.json
+++ b/hedera-mirror-rest/monitoring/monitor_apis/config/default.serverlist.json
@@ -8,8 +8,8 @@
   ],
   "interval": 60,
   "retry": {
-    "max": 10,
-    "minMillisToWait": 50
+    "maxAttempts": 10,
+    "minBackoff": 50
   },
   "shard": 0,
   "account": {

--- a/hedera-mirror-rest/monitoring/monitor_apis/monitor.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/monitor.js
@@ -29,17 +29,15 @@ const retryCountMax = 3; // # of times a single process can retry
 /**
  * Main function to run the tests and save results
  * @param {Array} servers array of servers to test
- * @return {} None
+ * @return None
  */
 const runEverything = async (servers) => {
   try {
-    const restservers = undefined === servers ? common.getServerList().servers : servers;
-
-    if (restservers.length === 0) {
+    if (servers.length === 0) {
       return;
     }
 
-    for (const server of restservers) {
+    for (const server of servers) {
       const processObj = common.getProcess(server);
 
       if (processObj === undefined) {

--- a/hedera-mirror-rest/monitoring/monitor_apis/package-lock.json
+++ b/hedera-mirror-rest/monitoring/monitor_apis/package-lock.json
@@ -3654,6 +3654,11 @@
         }
       }
     },
+    "parse-duration": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-duration/-/parse-duration-1.0.0.tgz",
+      "integrity": "sha512-X4kUkCTHU1N/kEbwK9FpUJ0UZQa90VzeczfS704frR30gljxDG0pSziws06XlK+CGRSo/1wtG1mFIdBFQTMQNw=="
+    },
     "parse-ms": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-2.1.0.tgz",

--- a/hedera-mirror-rest/monitoring/monitor_apis/package.json
+++ b/hedera-mirror-rest/monitoring/monitor_apis/package.json
@@ -24,6 +24,7 @@
     "log4js": "^6.3.0",
     "mathjs": "^9.4.4",
     "node-fetch": "^2.6.1",
+    "parse-duration": "^1.0.0",
     "pretty-ms": "^7.0.1"
   },
   "devDependencies": {

--- a/hedera-mirror-rest/monitoring/monitor_dashboard/css/main.css
+++ b/hedera-mirror-rest/monitoring/monitor_dashboard/css/main.css
@@ -37,7 +37,7 @@
   display: inline-block;
 }
 
-.ip-addr {
+.base-url {
   font-size: 1.5em;
   color: grey;
   display: inline-block;

--- a/hedera-mirror-rest/monitoring/monitor_dashboard/js/main.js
+++ b/hedera-mirror-rest/monitoring/monitor_dashboard/js/main.js
@@ -110,7 +110,7 @@ const makeCard = (data, server) => {
         <div class="card my-card">
           <div class="card-body" data-toggle="modal" data-target="#modal-${server}">
             <div class="card-title">${server}</div>
-            <div class="ip-addr"> (${data.ip}:${data.port})</div>
+            <div class="base-url"> (${data.baseUrl})</div>
             <div class="card-text">
                <div class="results">
                  <span class="dot" style="background-color: ${dotcolor}"></span>


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

This PR adds https support to the js monitor API

- Replace `servers[].ip` and `servers[].port` with `servers[].baseUrl` in config
- Update dashboard to use the new format
- Add configurable retry on 429 HTTP response code

**Related issue(s)**:

Fixes #2243 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

This is the log with retry when running w/ mainnet-public:

```
2021-07-15T13:31:32.676-0500 INFO Running tests
2021-07-15T13:31:32.755-0500 WARN url: https://mainnet-public.mirrornode.hedera.com/api/v1/transactions?order=asc&limit=10, response status: 429, retry in 50ms
2021-07-15T13:31:32.756-0500 WARN url: https://mainnet-public.mirrornode.hedera.com/api/v1/balances?limit=10, response status: 429, retry in 50ms
2021-07-15T13:31:32.758-0500 WARN url: https://mainnet-public.mirrornode.hedera.com/api/v1/accounts?limit=10, response status: 429, retry in 50ms
2021-07-15T13:31:32.759-0500 WARN url: https://mainnet-public.mirrornode.hedera.com/api/v1/transactions?limit=1&order=desc, response status: 429, retry in 50ms
2021-07-15T13:31:32.759-0500 WARN url: https://mainnet-public.mirrornode.hedera.com/api/v1/transactions?limit=1, response status: 429, retry in 50ms
2021-07-15T13:31:32.760-0500 WARN url: https://mainnet-public.mirrornode.hedera.com/api/v1/accounts?account.balance=gte%3A0&limit=1, response status: 429, retry in 50ms
2021-07-15T13:31:32.760-0500 WARN url: https://mainnet-public.mirrornode.hedera.com/api/v1/balances?limit=10, response status: 429, retry in 50ms
2021-07-15T13:31:32.761-0500 WARN url: https://mainnet-public.mirrornode.hedera.com/api/v1/transactions?limit=1, response status: 429, retry in 50ms
2021-07-15T13:31:32.761-0500 WARN url: https://mainnet-public.mirrornode.hedera.com/api/v1/balances?limit=1&order=desc, response status: 429, retry in 50ms
2021-07-15T13:31:32.762-0500 WARN url: https://mainnet-public.mirrornode.hedera.com/api/v1/transactions?limit=10&type=credit, response status: 429, retry in 50ms
2021-07-15T13:31:32.815-0500 WARN url: https://mainnet-public.mirrornode.hedera.com/api/v1/accounts/0.0.9, response status: 429, retry in 50ms
2021-07-15T13:31:32.864-0500 WARN url: https://mainnet-public.mirrornode.hedera.com/api/v1/accounts?account.balance=gte%3A0&limit=1, response status: 429, retry in 50ms
2021-07-15T13:31:32.864-0500 WARN url: https://mainnet-public.mirrornode.hedera.com/api/v1/balances?limit=10, response status: 429, retry in 50ms
2021-07-15T13:31:32.865-0500 WARN url: https://mainnet-public.mirrornode.hedera.com/api/v1/transactions?order=asc&limit=10, response status: 429, retry in 50ms
2021-07-15T13:31:32.866-0500 WARN url: https://mainnet-public.mirrornode.hedera.com/api/v1/transactions?limit=10&type=credit, response status: 429, retry in 50ms
2021-07-15T13:31:32.867-0500 WARN url: https://mainnet-public.mirrornode.hedera.com/api/v1/transactions?limit=1, response status: 429, retry in 50ms
2021-07-15T13:31:32.868-0500 WARN url: https://mainnet-public.mirrornode.hedera.com/api/v1/balances?limit=1&order=desc, response status: 429, retry in 50ms
2021-07-15T13:31:32.869-0500 WARN url: https://mainnet-public.mirrornode.hedera.com/api/v1/balances?limit=10, response status: 429, retry in 50ms
2021-07-15T13:31:32.924-0500 WARN url: https://mainnet-public.mirrornode.hedera.com/api/v1/accounts?account.id=0.0.9&type=credit&limit=1, response status: 429, retry in 50ms
2021-07-15T13:31:32.965-0500 WARN url: https://mainnet-public.mirrornode.hedera.com/api/v1/transactions?order=asc&limit=10, response status: 429, retry in 55ms
2021-07-15T13:31:32.968-0500 WARN url: https://mainnet-public.mirrornode.hedera.com/api/v1/transactions?limit=10&type=credit, response status: 429, retry in 52ms
2021-07-15T13:31:32.969-0500 WARN url: https://mainnet-public.mirrornode.hedera.com/api/v1/transactions?limit=1, response status: 429, retry in 50ms
2021-07-15T13:31:32.979-0500 WARN url: https://mainnet-public.mirrornode.hedera.com/api/v1/balances?limit=1&order=desc, response status: 429, retry in 50ms
2021-07-15T13:31:32.985-0500 WARN url: https://mainnet-public.mirrornode.hedera.com/api/v1/balances?limit=10, response status: 429, retry in 50ms
2021-07-15T13:31:33.078-0500 WARN url: https://mainnet-public.mirrornode.hedera.com/api/v1/transactions?limit=10&type=credit, response status: 429, retry in 50ms
2021-07-15T13:31:33.081-0500 WARN url: https://mainnet-public.mirrornode.hedera.com/api/v1/balances?limit=1&order=desc, response status: 429, retry in 50ms
2021-07-15T13:31:33.083-0500 WARN url: https://mainnet-public.mirrornode.hedera.com/api/v1/balances?limit=10, response status: 429, retry in 50ms
2021-07-15T13:31:33.243-0500 WARN url: https://mainnet-public.mirrornode.hedera.com/api/v1/balances?account.id=0.0.319008, response status: 429, retry in 50ms
2021-07-15T13:31:33.349-0500 INFO Completed tests run for mainnet-public with 14/14 tests passed
```

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
