### PR TITLE
Fix doc links and add HIP link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Major enhancement
+    url: https://github.com/hashgraph/hedera-improvement-proposal
+    about: Propose a major feature using our Hedera Improvement Proposal (HIP) process
+

--- a/README.md
+++ b/README.md
@@ -251,14 +251,23 @@ To manually verify the Rosetta API endpoints follow the [Operations](docs/operat
 
 To perform a new release, run the `Automated Release` GitHub workflow.
 
+## Support
+
+If you have a question on how to use the product, please see our
+[support guide](https://github.com/hashgraph/.github/blob/main/SUPPORT.md).
+
 ## Contributing
 
-Contributions are welcome. Please see the [contributing](CONTRIBUTING.md) guide to see how you can get involved.
+Contributions are welcome. Please see the
+[contributing guide](https://github.com/hashgraph/.github/blob/main/CONTRIBUTING.md)
+to see how you can get involved.
 
 ## Code of Conduct
 
-This project is governed by the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are
-expected to uphold this code of conduct. Please report unacceptable behavior to [oss@hedera.com](mailto:oss@hedera.com)
+This project is governed by the
+[Contributor Covenant Code of Conduct](https://github.com/hashgraph/.github/blob/main/CODE_OF_CONDUCT.md). By
+participating, you are expected to uphold this code of conduct. Please report unacceptable behavior
+to [oss@hedera.com](mailto:oss@hedera.com).
 
 ## License
 


### PR DESCRIPTION
**Description**:
With the move to organization level common docs we need to update our doc links.
- Add a link to `SUPPORT.md`
- Add issue template link to HIP
- Fix links to `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
