### PR TITLE
Add a platform not active alert

### DIFF
--- a/charts/hedera-mirror-common/values.yaml
+++ b/charts/hedera-mirror-common/values.yaml
@@ -219,10 +219,12 @@ prometheus:
       requests:
         cpu: 5m
         memory: 16Mi
+  kubeApiServer:
+    enabled: false
   kubeControllerManager:
     enabled: false
   kubeDns:
-    enabled: true
+    enabled: false
   kubeEtcd:
     enabled: false
   kubeProxy:

--- a/charts/hedera-mirror-common/values.yaml
+++ b/charts/hedera-mirror-common/values.yaml
@@ -219,6 +219,7 @@ prometheus:
       requests:
         cpu: 5m
         memory: 16Mi
+  # We disable these exporters because they either don't work in GKE or produce too many time series
   kubeApiServer:
     enabled: false
   kubeControllerManager:

--- a/charts/hedera-mirror-importer/values.yaml
+++ b/charts/hedera-mirror-importer/values.yaml
@@ -297,10 +297,10 @@ prometheusRules:
 
   ImporterNoBalanceFile:
     annotations:
-      description: Have not processed a balance stream file in {{ $labels.namespace }} for the last 10 min
+      description: Have not processed a balance stream file in {{ $labels.namespace }} for the last 15 min
       summary: Missing balance stream files
     enabled: true
-    expr: sum(increase(hedera_mirror_parse_latency_seconds_count{application="hedera-mirror-importer",type="BALANCE"}[11m])) by (namespace) < 1
+    expr: sum(increase(hedera_mirror_parse_latency_seconds_count{application="hedera-mirror-importer",type="BALANCE"}[16m])) by (namespace) < 1
     for: 5m
     labels:
       application: hedera-mirror-importer

--- a/charts/hedera-mirror-monitor/values.yaml
+++ b/charts/hedera-mirror-monitor/values.yaml
@@ -181,9 +181,9 @@ prometheusRules:
   MonitorPublishErrors:
     annotations:
       description: "Averaging {{ $value | humanizePercentage }} error rate publishing '{{ $labels.scenario }}' scenario from {{ $labels.namespace }}/{{ $labels.pod }}"
-      summary: "Publish error rate exceeds 5%"
+      summary: "Publish error rate exceeds 15%"
     enabled: true
-    expr: sum(rate(hedera_mirror_monitor_publish_submit_seconds_sum{application="hedera-mirror-monitor",status!="SUCCESS"}[2m])) by (namespace, pod, scenario) / sum(rate(hedera_mirror_monitor_publish_submit_seconds_count{application="hedera-mirror-monitor"}[2m])) by (namespace, pod, scenario) > 0.05
+    expr: sum(rate(hedera_mirror_monitor_publish_submit_seconds_sum{application="hedera-mirror-monitor",status!="SUCCESS"}[2m])) by (namespace, pod, scenario) / sum(rate(hedera_mirror_monitor_publish_submit_seconds_count{application="hedera-mirror-monitor"}[2m])) by (namespace, pod, scenario) > 0.15
     for: 2m
     labels:
       severity: critical
@@ -201,6 +201,18 @@ prometheusRules:
       severity: critical
       application: hedera-mirror-monitor
       mode: publish
+
+  MonitorPublishPlatformNotActive:
+    annotations:
+      description: "Averaging {{ $value | humanizePercentage }} PLATFORM_NOT_ACTIVE error rate while attempting to publish in {{ $labels.namespace }}"
+      summary: "Platform is not active"
+    enabled: true
+    expr: sum(rate(hedera_mirror_monitor_publish_submit_seconds_count{application="hedera-mirror-monitor",status="PLATFORM_NOT_ACTIVE"}[2m])) by (namespace) / sum(rate(hedera_mirror_monitor_publish_submit_seconds_count{application="hedera-mirror-monitor"}[2m])) by (namespace) > 0
+    for: 1m
+    labels:
+      application: hedera-mirror-monitor
+      mode: publish
+      severity: warning
 
   MonitorPublishStopped:
     annotations:

--- a/charts/hedera-mirror/values.yaml
+++ b/charts/hedera-mirror/values.yaml
@@ -1,6 +1,18 @@
 alertmanager:
   inhibitRules:
     enabled: false
+    InhibitAllWhenPlatformNotActive:
+      enabled: true
+      matches:
+        - sourceMatch:
+            - name: alertname
+              value: MonitorPublishPlatformNotActive
+          targetMatch:
+            - name: application
+              regex: true
+              value: .*
+          equal:
+            - namespace
     InhibitGrpcAndMonitorHighLatencyWhenImporterRecordFileIssues:
       enabled: true
       matches:

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/service/TopicMessageServiceImpl.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/service/TopicMessageServiceImpl.java
@@ -82,7 +82,7 @@ public class TopicMessageServiceImpl implements TopicMessageService {
         }
 
         if (filter.hasLimit()) {
-            flux = flux.limitRequest(filter.getLimit());
+            flux = flux.take(filter.getLimit());
         }
 
         return topicExists(filter).thenMany(flux.doOnNext(topicContext::onNext)

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/MirrorNodeProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/MirrorNodeProperties.java
@@ -51,6 +51,9 @@ public class MirrorNodeProperties {
         private int port = 5600;
 
         public String getEndpoint() {
+            if (host.startsWith("in-process:")) {
+                return host;
+            }
             return host + ":" + port;
         }
     }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/grpc/GrpcSubscription.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/grpc/GrpcSubscription.java
@@ -48,7 +48,7 @@ class GrpcSubscription extends AbstractSubscription<GrpcSubscriberProperties, To
 
         TopicMessageQuery topicMessageQuery = new TopicMessageQuery();
         topicMessageQuery.setEndTime(properties.getEndTime());
-        topicMessageQuery.setLimit(limit > 0 ? limit - count.get() : 0);
+        topicMessageQuery.setLimit(limit > 0 ? limit - counter.get() : 0);
         topicMessageQuery.setStartTime(startTime);
         topicMessageQuery.setTopicId(TopicId.fromString(properties.getTopicId()));
         return topicMessageQuery;

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/grpc/GrpcClientSDKTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/grpc/GrpcClientSDKTest.java
@@ -238,7 +238,8 @@ class GrpcClientSDKTest {
                                    StreamObserver<ConsensusTopicResponse> streamObserver) {
             log.debug("subscribeTopic: {}", consensusTopicQuery);
             assertThat(consensusTopicQuery).isEqualTo(request.build());
-            responses.doOnComplete(streamObserver::onCompleted)
+            responses.delayElements(Duration.ofMillis(200L))
+                    .doOnComplete(streamObserver::onCompleted)
                     .doOnError(streamObserver::onError)
                     .doOnNext(streamObserver::onNext)
                     .doOnNext(t -> log.trace("Next: {}", t))

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/grpc/GrpcClientSDKTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/grpc/GrpcClientSDKTest.java
@@ -24,9 +24,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.protobuf.ByteString;
 import io.grpc.Server;
-import io.grpc.ServerBuilder;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
+import io.grpc.inprocess.InProcessServerBuilder;
 import io.grpc.stub.StreamObserver;
 import java.time.Duration;
 import java.time.Instant;
@@ -69,11 +69,11 @@ class GrpcClientSDKTest {
         properties.setTopicId("0.0.1000");
         subscription = new GrpcSubscription(1, properties);
         monitorProperties = new MonitorProperties();
-        monitorProperties.getMirrorNode().getGrpc().setHost("127.0.0.1");
+        monitorProperties.getMirrorNode().getGrpc().setHost("in-process:test");
         grpcClientSDK = new GrpcClientSDK(monitorProperties, new SubscribeProperties());
 
         consensusServiceStub = new ConsensusServiceStub();
-        server = ServerBuilder.forPort(5600)
+        server = InProcessServerBuilder.forName("test")
                 .addService(consensusServiceStub)
                 .build()
                 .start();


### PR DESCRIPTION
**Description**:
- Add a platform not active alert and inhibit all other application alerts when active
- Change balance alert back to 15 min to reflect adjustment in main node
- Change `GrpcClientSDKTest` to in-process channel to reduce flaky tests
- Disable kube API server and kube DNS metric exporters to reduce overall time series count
- Fix monitor showing a generic `Exception` publish error by getting root throwable
- Fix monitor interval rate calculation by using Micrometer utility
- Fix use of deprecated `Flux::limitRequest`
- Increase monitor publish error alert threshold

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
