### PR TITLE
Bump Java SDK v2 to 2.0.9-beta.2 (0.37)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <grpc.version>1.39.0</grpc.version>
         <guava.version>30.1.1-jre</guava.version>
         <hedera-protobuf.version>0.16.0-alpha.4</hedera-protobuf.version>
-        <hedera-sdk.version>2.0.8</hedera-sdk.version>
+        <hedera-sdk.version>2.0.9-beta.2</hedera-sdk.version>
         <jacoco.version>0.8.7</jacoco.version>
         <java.version>11</java.version>
         <javax.version>1</javax.version>


### PR DESCRIPTION
**Description**:
Bump Java SDK v2 to 2.0.9-beta.2

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
