### PR TITLE
Port fix StreamFileHealthIndicator issue to release/0.37

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/HealthCheckConfiguration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/HealthCheckConfiguration.java
@@ -24,6 +24,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Collection;
 import java.util.Map;
 import java.util.stream.Collectors;
+import javax.inject.Named;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.actuate.health.CompositeHealthContributor;
 import org.springframework.boot.actuate.health.HealthIndicator;
@@ -39,7 +40,7 @@ public class HealthCheckConfiguration {
     private final MirrorProperties mirrorProperties;
 
     @Bean
-    CompositeHealthContributor streamFileActivity(MeterRegistry meterRegistry,
+    CompositeHealthContributor streamFileActivity(@Named("prometheusMeterRegistry") MeterRegistry meterRegistry,
                                                   Collection<ParserProperties> parserProperties) {
         Map<String, HealthIndicator> healthIndicators = parserProperties.stream().collect(Collectors.toMap(
                 k -> k.getStreamType().toString(),

--- a/hedera-mirror-importer/src/main/resources/application.yml
+++ b/hedera-mirror-importer/src/main/resources/application.yml
@@ -45,9 +45,9 @@ management:
     health:
       group:
         liveness:
-          include: ping, streamFile
+          include: ping, streamFileActivity
         readiness:
-          include: db, diskSpace, ping, redis, streamFile
+          include: db, diskSpace, ping, redis, streamFileActivity
 server:
   shutdown: graceful
 spring:

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/IntegrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/IntegrationTest.java
@@ -25,8 +25,11 @@ import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInfo;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.jdbc.Sql;
+
+import com.hedera.mirror.importer.config.MeterRegistryConfiguration;
 
 @TestExecutionListeners(value = {ResetCacheTestExecutionListener.class},
         mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
@@ -34,6 +37,7 @@ import org.springframework.test.context.jdbc.Sql;
 @Sql(executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD, scripts = "classpath:db/scripts/cleanup.sql")
 @Sql(executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD, scripts = "classpath:db/scripts/cleanup.sql")
 @SpringBootTest
+@Import(MeterRegistryConfiguration.class)
 public abstract class IntegrationTest {
 
     protected final Logger log = LogManager.getLogger(getClass());

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/config/MeterRegistryConfiguration.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/config/MeterRegistryConfiguration.java
@@ -1,0 +1,35 @@
+package com.hedera.mirror.importer.config;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class MeterRegistryConfiguration {
+
+    @Bean
+    public MeterRegistry prometheusMeterRegistry() {
+        return new SimpleMeterRegistry();
+    }
+}

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/AbstractDownloaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/AbstractDownloaderTest.java
@@ -95,6 +95,7 @@ import com.hedera.mirror.importer.reader.signature.CompositeSignatureFileReader;
 import com.hedera.mirror.importer.reader.signature.SignatureFileReader;
 import com.hedera.mirror.importer.reader.signature.SignatureFileReaderV2;
 import com.hedera.mirror.importer.reader.signature.SignatureFileReaderV5;
+import com.hedera.mirror.importer.util.Utility;
 
 @ExtendWith(MockitoExtension.class)
 @Log4j2
@@ -664,6 +665,7 @@ public abstract class AbstractDownloaderTest {
     protected void expectLastStreamFile(String hash, Long index, Instant instant) {
         StreamFile streamFile = (StreamFile) ReflectUtils.newInstance(streamType.getStreamFileClass());
         streamFile.setName(StreamFilename.getFilename(streamType, DATA, instant));
+        streamFile.setConsensusStart(Utility.convertToNanosMax(instant));
         streamFile.setHash(hash);
         streamFile.setIndex(index);
 


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
Port the fix to release/0.37

- Update streamCloseMetric to record stream file interval
- Use prometheus meter registry to work around the inaccurate timer count issue
- Fix incorrect bean name in application.yml

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
