### PR TITLE
Disable stream file health indicator for 0.37 release

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/HealthCheckConfiguration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/HealthCheckConfiguration.java
@@ -29,12 +29,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.boot.actuate.health.CompositeHealthContributor;
 import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
 import com.hedera.mirror.importer.MirrorProperties;
 import com.hedera.mirror.importer.parser.ParserProperties;
 
-@Configuration
+// @Configuration, disable it now as it causes health check issue in k8s
 @RequiredArgsConstructor
 public class HealthCheckConfiguration {
     private final MirrorProperties mirrorProperties;

--- a/hedera-mirror-importer/src/main/resources/application.yml
+++ b/hedera-mirror-importer/src/main/resources/application.yml
@@ -45,9 +45,9 @@ management:
     health:
       group:
         liveness:
-          include: ping, streamFileActivity
+          include: ping
         readiness:
-          include: db, diskSpace, ping, redis, streamFileActivity
+          include: db, diskSpace, ping, redis
 server:
   shutdown: graceful
 spring:

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/IntegrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/IntegrationTest.java
@@ -25,11 +25,8 @@ import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInfo;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.jdbc.Sql;
-
-import com.hedera.mirror.importer.config.MeterRegistryConfiguration;
 
 @TestExecutionListeners(value = {ResetCacheTestExecutionListener.class},
         mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
@@ -37,7 +34,7 @@ import com.hedera.mirror.importer.config.MeterRegistryConfiguration;
 @Sql(executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD, scripts = "classpath:db/scripts/cleanup.sql")
 @Sql(executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD, scripts = "classpath:db/scripts/cleanup.sql")
 @SpringBootTest
-@Import(MeterRegistryConfiguration.class)
+//@Import(MeterRegistryConfiguration.class)
 public abstract class IntegrationTest {
 
     protected final Logger log = LogManager.getLogger(getClass());


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
Disable stream file health indicators.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
The stream file health checks cause failure in integration deployment to k8s. The possible cause includes the health check disregards leader/follower status in k8s and perhaps other issues. Disable it now since we need to roll out a release. We should address it and bring it back in 0.38.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
