### PR TITLE
Remove payer account id in transaction assessed custom fee response

### DIFF
--- a/docs/design/custom-fees.md
+++ b/docs/design/custom-fees.md
@@ -135,7 +135,7 @@ Both new domain objects are insert-only.
         "memo_base64": null,
         "result": "SUCCESS",
         "transaction_hash": "aGFzaA==",
-        "name": "TOKENTRANSFER",
+        "name": "CRYPTOTRANSFER",
         "node": "0.0.3",
         "transaction_id": "0.0.10-1234567890-000000000",
         "valid_duration_seconds": "11",
@@ -184,13 +184,11 @@ Both new domain objects are insert-only.
           {
             "amount": 150,
             "collector_account_id": "0.0.87501",
-            "payer_account_id": "0.0.10",
             "token_id": null
           },
           {
             "amount": 10,
             "collector_account_id": "0.0.87502",
-            "payer_account_id": "0.0.10",
             "token_id": "0.0.90000"
           }
         ]

--- a/docs/design/hts.md
+++ b/docs/design/hts.md
@@ -422,7 +422,7 @@ To achieve the goals and for easy integration with existing users the REST API s
           "memo_base64": null,
           "result": "SUCCESS",
           "transaction_hash": "aGFzaA==",
-          "name": "TOKENTRANSFER",
+          "name": "CRYPTOTRANSFER",
           "node": "0.0.3",
           "transaction_id": "0.0.10-1234567890-000000000",
           "valid_duration_seconds": "11",

--- a/hedera-mirror-rest/__tests__/specs/transactions-39-specific-id-assessed-custom-fees.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-39-specific-id-assessed-custom-fees.spec.json
@@ -121,19 +121,16 @@
           {
             "amount": 11,
             "collector_account_id": "0.0.8901",
-            "payer_account_id": "0.0.300",
             "token_id": null
           },
           {
             "amount": 13,
             "collector_account_id": "0.0.8902",
-            "payer_account_id": "0.0.300",
             "token_id": "0.0.10015"
           },
           {
             "amount": 17,
             "collector_account_id": "0.0.8903",
-            "payer_account_id": "0.0.300",
             "token_id": "0.0.90000"
           }
         ]

--- a/hedera-mirror-rest/__tests__/transactions.test.js
+++ b/hedera-mirror-rest/__tests__/transactions.test.js
@@ -412,7 +412,6 @@ describe('createAssessedCustomFeeList', () => {
   });
 
   test('Simple createAssessedCustomFeeList', () => {
-    const payerAccountId = '0.0.8001';
     const rowsFromDb = [
       {
         amount: 8,
@@ -434,24 +433,21 @@ describe('createAssessedCustomFeeList', () => {
       {
         amount: 8,
         collector_account_id: '0.0.9901',
-        payer_account_id: payerAccountId,
         token_id: null,
       },
       {
         amount: 9,
         collector_account_id: '0.0.9901',
-        payer_account_id: payerAccountId,
         token_id: '0.0.10001',
       },
       {
         amount: 29,
         collector_account_id: '0.0.9902',
-        payer_account_id: payerAccountId,
         token_id: '0.0.10002',
       },
     ];
 
-    expect(createAssessedCustomFeeList(rowsFromDb, payerAccountId)).toEqual(expected);
+    expect(createAssessedCustomFeeList(rowsFromDb)).toEqual(expected);
   });
 });
 

--- a/hedera-mirror-rest/__tests__/viewmodel/assessedCustomFeeViewModel.test.js
+++ b/hedera-mirror-rest/__tests__/viewmodel/assessedCustomFeeViewModel.test.js
@@ -24,8 +24,6 @@ const AssessedCustomFee = require('../../model/assessedCustomFee');
 const AssessedCustomFeeViewModel = require('../../viewmodel/assessedCustomFeeViewModel');
 
 describe('AssessedCustomFeeViewModel', () => {
-  const payer = '0.0.8702';
-
   test('fee charged in hbar', () => {
     const model = new AssessedCustomFee({
       amount: 13,
@@ -35,11 +33,10 @@ describe('AssessedCustomFeeViewModel', () => {
     const expected = {
       amount: 13,
       collector_account_id: '0.0.8901',
-      payer_account_id: payer,
       token_id: null,
     };
 
-    expect(new AssessedCustomFeeViewModel(model, payer)).toEqual(expected);
+    expect(new AssessedCustomFeeViewModel(model)).toEqual(expected);
   });
 
   test('fee charged in token', () => {
@@ -52,10 +49,9 @@ describe('AssessedCustomFeeViewModel', () => {
     const expected = {
       amount: 13,
       collector_account_id: '0.0.8901',
-      payer_account_id: payer,
       token_id: '0.0.10013',
     };
 
-    expect(new AssessedCustomFeeViewModel(model, payer)).toEqual(expected);
+    expect(new AssessedCustomFeeViewModel(model)).toEqual(expected);
   });
 });

--- a/hedera-mirror-rest/transactions.js
+++ b/hedera-mirror-rest/transactions.js
@@ -106,17 +106,16 @@ const getSelectClauseWithTransfers = (includeExtraInfo) => {
  * Creates an assessed custom fee list from aggregated array of JSON objects in the query result
  *
  * @param assessedCustomFees assessed custom fees
- * @param {string} payerAccountId the transaction payer account id
  * @return {undefined|{amount: Number, collector_account_id: string, payer_account_id: string, token_id: string}[]}
  */
-const createAssessedCustomFeeList = (assessedCustomFees, payerAccountId) => {
+const createAssessedCustomFeeList = (assessedCustomFees) => {
   if (!assessedCustomFees) {
     return undefined;
   }
 
   return assessedCustomFees.map((assessedCustomFee) => {
     const model = new AssessedCustomFee(assessedCustomFee);
-    return new AssessedCustomFeeViewModel(model, payerAccountId);
+    return new AssessedCustomFeeViewModel(model);
   });
 };
 
@@ -207,7 +206,7 @@ const createTransferLists = (rows) => {
       transfers: createCryptoTransferList(row.crypto_transfer_list),
       valid_duration_seconds: utils.getNullableNumber(row.valid_duration_seconds),
       valid_start_timestamp: utils.nsToSecNs(validStartTimestamp),
-      assessed_custom_fees: createAssessedCustomFeeList(row.assessed_custom_fees, payerAccountId),
+      assessed_custom_fees: createAssessedCustomFeeList(row.assessed_custom_fees),
     };
   });
 

--- a/hedera-mirror-rest/viewmodel/assessedCustomFeeViewModel.js
+++ b/hedera-mirror-rest/viewmodel/assessedCustomFeeViewModel.js
@@ -30,12 +30,10 @@ class AssessedCustomFeeViewModel {
    * Constructs the assessed custom fee view model
    *
    * @param {AssessedCustomFee} assessedCustomFee
-   * @param {String} payerAccountId
    */
-  constructor(assessedCustomFee, payerAccountId) {
+  constructor(assessedCustomFee) {
     this.amount = assessedCustomFee.amount;
     this.collector_account_id = EntityId.fromEncodedId(assessedCustomFee.collectorAccountId).toString();
-    this.payer_account_id = payerAccountId;
     this.token_id = EntityId.fromEncodedId(assessedCustomFee.tokenId, true).toString();
   }
 }


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR removes the `payer_account_id` in `assessed_custom_fee` of transaction rest api response.

- Remove `payer_account_id` in rest api response
- Update design doc

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
This is one of the services changes introduced lately. Specifically, the custom fees are now charged from the account(s)  who send the triggering tokens, not necessarily the payer of the transaction.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
