### PR TITLE
Fix some tests requiring v1 or v2 tags to pass

### DIFF
--- a/.github/workflows/importer.yml
+++ b/.github/workflows/importer.yml
@@ -39,16 +39,8 @@ jobs:
           path: ~/.m2
           restore-keys: ${{ runner.os }}-m2
 
-      - name: Set v1 environment
-        if: matrix.schema == 'v1'
-        run: echo 'groups=!v2' >> $GITHUB_ENV
-
-      - name: Set v2 environment
-        if: matrix.schema == 'v2'
-        run: echo 'groups=!v1' >> $GITHUB_ENV
-
       - name: Maven verify
-        run: ./mvnw ${MAVEN_CLI_OPTS} verify -pl "${MODULE}" --also-make -Dspring.profiles.active=${{ matrix.schema }} -Dgroups='${{ env.groups }}'
+        run: ./mvnw ${MAVEN_CLI_OPTS} verify -pl "${MODULE}" --also-make -Dspring.profiles.active=${{ matrix.schema }}
         working-directory: .
 
       - name: Upload coverage report

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -35,6 +35,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 
       - name: Cache Maven dependencies
         uses: actions/cache@v2

--- a/charts/hedera-mirror-monitor/values.yaml
+++ b/charts/hedera-mirror-monitor/values.yaml
@@ -204,10 +204,10 @@ prometheusRules:
 
   MonitorPublishPlatformNotActive:
     annotations:
-      description: "Averaging {{ $value | humanizePercentage }} PLATFORM_NOT_ACTIVE error rate while attempting to publish in {{ $labels.namespace }}"
+      description: "Averaging {{ $value | humanizePercentage }} PLATFORM_NOT_ACTIVE or UNAVAILABLE errors while attempting to publish in {{ $labels.namespace }}"
       summary: "Platform is not active"
     enabled: true
-    expr: sum(rate(hedera_mirror_monitor_publish_submit_seconds_count{application="hedera-mirror-monitor",status="PLATFORM_NOT_ACTIVE"}[2m])) by (namespace) / sum(rate(hedera_mirror_monitor_publish_submit_seconds_count{application="hedera-mirror-monitor"}[2m])) by (namespace) > 0
+    expr: sum(rate(hedera_mirror_monitor_publish_submit_seconds_count{application="hedera-mirror-monitor",status=~"(PLATFORM_NOT_ACTIVE|UNAVAILABLE)"}[2m])) by (namespace) / sum(rate(hedera_mirror_monitor_publish_submit_seconds_count{application="hedera-mirror-monitor"}[2m])) by (namespace) > 0
     for: 1m
     labels:
       application: hedera-mirror-monitor

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/PollingTopicListener.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/PollingTopicListener.java
@@ -23,6 +23,7 @@ package com.hedera.mirror.grpc.listener;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import javax.inject.Named;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
@@ -86,11 +87,15 @@ public class PollingTopicListener implements TopicListener {
 
         private final TopicMessageFilter filter;
         private final AtomicLong count = new AtomicLong(0L);
-        private volatile TopicMessage last;
+        private final AtomicReference<TopicMessage> last = new AtomicReference<>();
 
         void onNext(TopicMessage topicMessage) {
-            last = topicMessage;
+            last.set(topicMessage);
             count.incrementAndGet();
+        }
+
+        private TopicMessage getLast() {
+            return last.get();
         }
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/EnabledIfV1.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/EnabledIfV1.java
@@ -1,0 +1,33 @@
+package com.hedera.mirror.importer;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.test.context.junit.jupiter.EnabledIf;
+
+@EnabledIf("#{environment.acceptsProfiles('!v2')}")
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface EnabledIfV1 {
+}

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/EnabledIfV2.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/EnabledIfV2.java
@@ -1,0 +1,33 @@
+package com.hedera.mirror.importer;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.test.context.junit.jupiter.EnabledIf;
+
+@EnabledIf("#{environment.acceptsProfiles('v2')}")
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface EnabledIfV2 {
+}

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/AddAddressBookServiceEndpointsMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/AddAddressBookServiceEndpointsMigrationTest.java
@@ -38,6 +38,7 @@ import org.springframework.jdbc.core.JdbcOperations;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.jdbc.Sql;
 
+import com.hedera.mirror.importer.EnabledIfV1;
 import com.hedera.mirror.importer.IntegrationTest;
 import com.hedera.mirror.importer.addressbook.AddressBookServiceImpl;
 import com.hedera.mirror.importer.domain.AddressBook;
@@ -49,8 +50,8 @@ import com.hedera.mirror.importer.repository.AddressBookEntryRepository;
 import com.hedera.mirror.importer.repository.AddressBookRepository;
 import com.hedera.mirror.importer.repository.AddressBookServiceEndpointRepository;
 
+@EnabledIfV1
 @Tag("migration")
-@Tag("v1")
 @Sql(executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD, statements = {"truncate table address_book restart " +
         "identity cascade;"})
 @Sql(executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD, statements = {"truncate table address_book restart " +

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/CleanupEntityMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/CleanupEntityMigrationTest.java
@@ -40,6 +40,7 @@ import org.springframework.jdbc.core.JdbcOperations;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.jdbc.Sql;
 
+import com.hedera.mirror.importer.EnabledIfV1;
 import com.hedera.mirror.importer.IntegrationTest;
 import com.hedera.mirror.importer.MirrorProperties;
 import com.hedera.mirror.importer.domain.Entity;
@@ -51,12 +52,12 @@ import com.hedera.mirror.importer.repository.EntityRepository;
 import com.hedera.mirror.importer.repository.TransactionRepository;
 import com.hedera.mirror.importer.util.EntityIdEndec;
 
+@EnabledIfV1
 @Sql(executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD, statements = {"truncate table transaction restart " +
         "identity cascade"})
 @Sql(executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD, statements = {"truncate table transaction restart " +
         "identity cascade"})
 @Tag("migration")
-@Tag("v1")
 @TestPropertySource(properties = "spring.flyway.target=1.35.5")
 class CleanupEntityMigrationTest extends IntegrationTest {
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/EntityTimestampMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/EntityTimestampMigrationTest.java
@@ -36,6 +36,7 @@ import org.springframework.jdbc.core.JdbcOperations;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.jdbc.Sql;
 
+import com.hedera.mirror.importer.EnabledIfV1;
 import com.hedera.mirror.importer.IntegrationTest;
 import com.hedera.mirror.importer.domain.Entity;
 import com.hedera.mirror.importer.domain.EntityId;
@@ -46,8 +47,8 @@ import com.hedera.mirror.importer.repository.EntityRepository;
 import com.hedera.mirror.importer.repository.TransactionRepository;
 import com.hedera.mirror.importer.util.EntityIdEndec;
 
+@EnabledIfV1
 @Tag("migration")
-@Tag("v1")
 @TestPropertySource(properties = "spring.flyway.target=1.39.2")
 @Sql(executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD, scripts = "classpath:db/scripts/cleanup_v1.40.1.sql")
 @Sql(executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD, scripts = "classpath:db/scripts/cleanup_v1.40.1.sql")

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/Fix102AddressBookMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/Fix102AddressBookMigrationTest.java
@@ -31,14 +31,15 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jdbc.core.JdbcOperations;
 
+import com.hedera.mirror.importer.EnabledIfV1;
 import com.hedera.mirror.importer.IntegrationTest;
 import com.hedera.mirror.importer.domain.AddressBook;
 import com.hedera.mirror.importer.domain.EntityId;
 import com.hedera.mirror.importer.domain.EntityTypeEnum;
 import com.hedera.mirror.importer.repository.AddressBookRepository;
 
+@EnabledIfV1
 @Tag("migration")
-@Tag("v1")
 class Fix102AddressBookMigrationTest extends IntegrationTest {
 
     @Resource

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/RemoveInvalidEntityMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/RemoveInvalidEntityMigrationTest.java
@@ -41,6 +41,7 @@ import org.springframework.jdbc.core.JdbcOperations;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.jdbc.Sql;
 
+import com.hedera.mirror.importer.EnabledIfV1;
 import com.hedera.mirror.importer.IntegrationTest;
 import com.hedera.mirror.importer.MirrorProperties;
 import com.hedera.mirror.importer.domain.Entity;
@@ -51,10 +52,10 @@ import com.hedera.mirror.importer.domain.TransactionTypeEnum;
 import com.hedera.mirror.importer.repository.TransactionRepository;
 import com.hedera.mirror.importer.util.EntityIdEndec;
 
+@EnabledIfV1
 @Sql(executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD, scripts = "classpath:db/scripts/cleanup_v1.31.2.sql")
 @Sql(executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD, scripts = "classpath:db/scripts/cleanup_v1.31.2.sql")
 @Tag("migration")
-@Tag("v1")
 @TestPropertySource(properties = "spring.flyway.target=1.31.1")
 class RemoveInvalidEntityMigrationTest extends IntegrationTest {
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/signature/SignatureFileReaderV2Test.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/signature/SignatureFileReaderV2Test.java
@@ -68,6 +68,7 @@ class SignatureFileReaderV2Test extends AbstractSignatureFileReaderTest {
                 .getFileHashSignature());
     }
 
+    @SuppressWarnings("java:S2699")
     @TestFactory
     Iterable<DynamicTest> testReadCorruptSignatureFileV2() {
         SignatureFileSection hashDelimiter = new SignatureFileSection(

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/signature/SignatureFileReaderV5Test.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/signature/SignatureFileReaderV5Test.java
@@ -89,6 +89,7 @@ class SignatureFileReaderV5Test extends AbstractSignatureFileReaderTest {
                 .getMetadataHashSignature());
     }
 
+    @SuppressWarnings("java:S2699")
     @TestFactory
     Iterable<DynamicTest> testReadCorruptSignatureFileV5() {
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/AbstractUpsertQueryGeneratorTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/AbstractUpsertQueryGeneratorTest.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.Test;
 import com.hedera.mirror.importer.converter.NullableStringSerializer;
 import com.hedera.mirror.importer.repository.AbstractRepositoryTest;
 
-public abstract class AbstractUpsertQueryGeneratorTest extends AbstractRepositoryTest {
+abstract class AbstractUpsertQueryGeneratorTest extends AbstractRepositoryTest {
     @Resource
     private DataSource dataSource;
 
@@ -51,7 +51,7 @@ public abstract class AbstractUpsertQueryGeneratorTest extends AbstractRepositor
     }
 
     @Test
-    protected void insertContainsAllFields() {
+    void insertContainsAllFields() {
         // verify all fields in a domain are captured to ensure we don't miss schema updates
         String insertQuery = getUpdatableDomainRepositoryCustom().getInsertQuery()
                 .replaceAll(NullableStringSerializer.NULLABLE_STRING_REPLACEMENT, "<uuid>");

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/EntityUpsertQueryGeneratorTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/EntityUpsertQueryGeneratorTest.java
@@ -30,12 +30,12 @@ class EntityUpsertQueryGeneratorTest extends AbstractUpsertQueryGeneratorTest {
     private EntityUpsertQueryGenerator entityRepositoryCustom;
 
     @Override
-    public UpsertQueryGenerator getUpdatableDomainRepositoryCustom() {
+    protected UpsertQueryGenerator getUpdatableDomainRepositoryCustom() {
         return entityRepositoryCustom;
     }
 
     @Override
-    public String getInsertQuery() {
+    protected String getInsertQuery() {
         return "insert into entity (auto_renew_account_id, auto_renew_period, created_timestamp, deleted, " +
                 "expiration_timestamp, id, key, memo, modified_timestamp, num, proxy_account_id, public_key, realm, " +
                 "shard, submit_key, type) select entity_temp.auto_renew_account_id, entity_temp.auto_renew_period, " +
@@ -50,7 +50,7 @@ class EntityUpsertQueryGeneratorTest extends AbstractUpsertQueryGeneratorTest {
     }
 
     @Override
-    public String getUpdateQuery() {
+    protected String getUpdateQuery() {
         return "update entity set " +
                 "auto_renew_account_id = coalesce(entity_temp.auto_renew_account_id, entity.auto_renew_account_id), " +
                 "auto_renew_period = coalesce(entity_temp.auto_renew_period, entity.auto_renew_period), " +

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/NftUpsertQueryGeneratorTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/NftUpsertQueryGeneratorTest.java
@@ -23,21 +23,22 @@ package com.hedera.mirror.importer.repository.upsert;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import javax.annotation.Resource;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-@Tag("v1")
+import com.hedera.mirror.importer.EnabledIfV1;
+
+@EnabledIfV1
 class NftUpsertQueryGeneratorTest extends AbstractUpsertQueryGeneratorTest {
     @Resource
     private NftUpsertQueryGenerator nftUpsertQueryGenerator;
 
     @Override
-    public UpsertQueryGenerator getUpdatableDomainRepositoryCustom() {
+    protected UpsertQueryGenerator getUpdatableDomainRepositoryCustom() {
         return nftUpsertQueryGenerator;
     }
 
     @Override
-    public String getInsertQuery() {
+    protected String getInsertQuery() {
         return "insert into nft (account_id, created_timestamp, deleted, metadata, modified_timestamp, serial_number," +
                 " token_id) select nft_temp.account_id, nft_temp.created_timestamp, nft_temp.deleted, " +
                 "nft_temp.metadata, nft_temp.modified_timestamp, nft_temp.serial_number, nft_temp.token_id " +
@@ -48,7 +49,7 @@ class NftUpsertQueryGeneratorTest extends AbstractUpsertQueryGeneratorTest {
     }
 
     @Override
-    public String getUpdateQuery() {
+    protected String getUpdateQuery() {
         return "update nft set account_id = case when nft_temp.deleted = true then null " +
                 "else coalesce(nft_temp.account_id, nft.account_id) end, " +
                 "deleted = coalesce(nft_temp.deleted, nft.deleted), " +

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/NftUpsertQueryGeneratorV2Test.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/NftUpsertQueryGeneratorV2Test.java
@@ -23,6 +23,7 @@ package com.hedera.mirror.importer.repository.upsert;
 import com.hedera.mirror.importer.EnabledIfV2;
 
 @EnabledIfV2
+@SuppressWarnings("java:S2187")
 class NftUpsertQueryGeneratorV2Test extends NftUpsertQueryGeneratorTest {
     @Override
     protected String getInsertQuery() {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/NftUpsertQueryGeneratorV2Test.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/NftUpsertQueryGeneratorV2Test.java
@@ -20,18 +20,18 @@ package com.hedera.mirror.importer.repository.upsert;
  * ‍
  */
 
-import org.junit.jupiter.api.Tag;
+import com.hedera.mirror.importer.EnabledIfV2;
 
-@Tag("v2")
+@EnabledIfV2
 class NftUpsertQueryGeneratorV2Test extends NftUpsertQueryGeneratorTest {
     @Override
-    public String getInsertQuery() {
+    protected String getInsertQuery() {
         return "insert into nft (account_id, created_timestamp, deleted, metadata, modified_timestamp, serial_number," +
                 " token_id) select nft_temp.account_id, nft_temp.created_timestamp, nft_temp.deleted, " +
                 "nft_temp.metadata, nft_temp.modified_timestamp, nft_temp.serial_number, nft_temp.token_id " +
                 "from nft_temp " +
                 "join token on nft_temp.token_id = token.token_id " +
                 "where nft_temp.created_timestamp is not null " +
-                "on conflict (created_timestamp, token_id, serial_number) do nothing";
+                "on conflict (token_id, serial_number, created_timestamp) do nothing";
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/ScheduleUpsertQueryGeneratorTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/ScheduleUpsertQueryGeneratorTest.java
@@ -23,21 +23,22 @@ package com.hedera.mirror.importer.repository.upsert;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import javax.annotation.Resource;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-@Tag("v1")
+import com.hedera.mirror.importer.EnabledIfV1;
+
+@EnabledIfV1
 class ScheduleUpsertQueryGeneratorTest extends AbstractUpsertQueryGeneratorTest {
     @Resource
     private ScheduleUpsertQueryGenerator scheduleRepositoryCustom;
 
     @Override
-    public UpsertQueryGenerator getUpdatableDomainRepositoryCustom() {
+    protected UpsertQueryGenerator getUpdatableDomainRepositoryCustom() {
         return scheduleRepositoryCustom;
     }
 
     @Override
-    public String getInsertQuery() {
+    protected String getInsertQuery() {
         return "insert into schedule (consensus_timestamp, creator_account_id, executed_timestamp, payer_account_id, " +
                 "schedule_id, transaction_body) select schedule_temp.consensus_timestamp, schedule_temp" +
                 ".creator_account_id, schedule_temp.executed_timestamp, schedule_temp.payer_account_id, schedule_temp" +
@@ -46,7 +47,7 @@ class ScheduleUpsertQueryGeneratorTest extends AbstractUpsertQueryGeneratorTest 
     }
 
     @Override
-    public String getUpdateQuery() {
+    protected String getUpdateQuery() {
         return "update schedule set executed_timestamp = coalesce(schedule_temp.executed_timestamp, schedule" +
                 ".executed_timestamp) from schedule_temp where schedule.schedule_id = schedule_temp.schedule_id and " +
                 "schedule_temp.executed_timestamp is not null";

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/ScheduleUpsertQueryGeneratorV2Test.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/ScheduleUpsertQueryGeneratorV2Test.java
@@ -23,6 +23,7 @@ package com.hedera.mirror.importer.repository.upsert;
 import com.hedera.mirror.importer.EnabledIfV2;
 
 @EnabledIfV2
+@SuppressWarnings("java:S2187")
 class ScheduleUpsertQueryGeneratorV2Test extends ScheduleUpsertQueryGeneratorTest {
     @Override
     protected String getInsertQuery() {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/ScheduleUpsertQueryGeneratorV2Test.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/ScheduleUpsertQueryGeneratorV2Test.java
@@ -20,12 +20,12 @@ package com.hedera.mirror.importer.repository.upsert;
  * ‍
  */
 
-import org.junit.jupiter.api.Tag;
+import com.hedera.mirror.importer.EnabledIfV2;
 
-@Tag("v2")
+@EnabledIfV2
 class ScheduleUpsertQueryGeneratorV2Test extends ScheduleUpsertQueryGeneratorTest {
     @Override
-    public String getInsertQuery() {
+    protected String getInsertQuery() {
         return "insert into schedule (consensus_timestamp, creator_account_id, executed_timestamp, payer_account_id, " +
                 "schedule_id, transaction_body) select schedule_temp.consensus_timestamp, schedule_temp" +
                 ".creator_account_id, schedule_temp.executed_timestamp, schedule_temp.payer_account_id, schedule_temp" +

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/TokenAccountUpsertQueryGeneratorTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/TokenAccountUpsertQueryGeneratorTest.java
@@ -23,21 +23,22 @@ package com.hedera.mirror.importer.repository.upsert;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import javax.annotation.Resource;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-@Tag("v1")
-class TokenAccounUpsertQueryGeneratorTest extends AbstractUpsertQueryGeneratorTest {
+import com.hedera.mirror.importer.EnabledIfV1;
+
+@EnabledIfV1
+class TokenAccountUpsertQueryGeneratorTest extends AbstractUpsertQueryGeneratorTest {
     @Resource
     private TokenAccountUpsertQueryGenerator tokenAccountRepositoryCustom;
 
     @Override
-    public UpsertQueryGenerator getUpdatableDomainRepositoryCustom() {
+    protected UpsertQueryGenerator getUpdatableDomainRepositoryCustom() {
         return tokenAccountRepositoryCustom;
     }
 
     @Override
-    public String getInsertQuery() {
+    protected String getInsertQuery() {
         return "insert into token_account (account_id, associated, created_timestamp, freeze_status, kyc_status, " +
                 "modified_timestamp, token_id) select token_account_temp.account_id, token_account_temp.associated, " +
                 "token_account_temp.created_timestamp, case when token_account_temp.freeze_status is not null then " +
@@ -51,7 +52,7 @@ class TokenAccounUpsertQueryGeneratorTest extends AbstractUpsertQueryGeneratorTe
     }
 
     @Override
-    public String getUpdateQuery() {
+    protected String getUpdateQuery() {
         return "update token_account set associated = coalesce(token_account_temp.associated, token_account" +
                 ".associated), freeze_status = coalesce(token_account_temp.freeze_status, token_account" +
                 ".freeze_status), kyc_status = coalesce(token_account_temp.kyc_status, token_account.kyc_status), " +

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/TokenAccountUpsertQueryGeneratorV2Test.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/TokenAccountUpsertQueryGeneratorV2Test.java
@@ -23,6 +23,7 @@ package com.hedera.mirror.importer.repository.upsert;
 import com.hedera.mirror.importer.EnabledIfV2;
 
 @EnabledIfV2
+@SuppressWarnings("java:S2187")
 class TokenAccountUpsertQueryGeneratorV2Test extends TokenAccountUpsertQueryGeneratorTest {
     @Override
     protected String getInsertQuery() {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/TokenAccountUpsertQueryGeneratorV2Test.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/TokenAccountUpsertQueryGeneratorV2Test.java
@@ -20,12 +20,12 @@ package com.hedera.mirror.importer.repository.upsert;
  * ‍
  */
 
-import org.junit.jupiter.api.Tag;
+import com.hedera.mirror.importer.EnabledIfV2;
 
-@Tag("v2")
-class TokenAccounUpsertQueryGeneratorV2Test extends TokenAccounUpsertQueryGeneratorTest {
+@EnabledIfV2
+class TokenAccountUpsertQueryGeneratorV2Test extends TokenAccountUpsertQueryGeneratorTest {
     @Override
-    public String getInsertQuery() {
+    protected String getInsertQuery() {
         return "insert into token_account (account_id, associated, created_timestamp, freeze_status, kyc_status, " +
                 "modified_timestamp, token_id) select token_account_temp.account_id, token_account_temp.associated, " +
                 "token_account_temp.created_timestamp, case when token_account_temp.freeze_status is not null then " +

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/TokenUpsertQueryGeneratorTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/TokenUpsertQueryGeneratorTest.java
@@ -23,21 +23,22 @@ package com.hedera.mirror.importer.repository.upsert;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import javax.annotation.Resource;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-@Tag("v1")
+import com.hedera.mirror.importer.EnabledIfV1;
+
+@EnabledIfV1
 class TokenUpsertQueryGeneratorTest extends AbstractUpsertQueryGeneratorTest {
     @Resource
     private TokenUpsertQueryGenerator tokenRepositoryCustom;
 
     @Override
-    public UpsertQueryGenerator getUpdatableDomainRepositoryCustom() {
+    protected UpsertQueryGenerator getUpdatableDomainRepositoryCustom() {
         return tokenRepositoryCustom;
     }
 
     @Override
-    public String getInsertQuery() {
+    protected String getInsertQuery() {
         return "insert into token (created_timestamp, decimals, fee_schedule_key, fee_schedule_key_ed25519_hex, " +
                 "freeze_default, freeze_key, freeze_key_ed25519_hex, " +
                 "initial_supply, kyc_key, kyc_key_ed25519_hex, max_supply, modified_timestamp, name, supply_key, " +
@@ -61,10 +62,11 @@ class TokenUpsertQueryGeneratorTest extends AbstractUpsertQueryGeneratorTest {
     }
 
     @Override
-    public String getUpdateQuery() {
+    protected String getUpdateQuery() {
         return "update token set " +
                 "fee_schedule_key = coalesce(token_temp.fee_schedule_key, token.fee_schedule_key), " +
-                "fee_schedule_key_ed25519_hex = case when token_temp.fee_schedule_key_ed25519_hex = '<uuid>' then '' else " +
+                "fee_schedule_key_ed25519_hex = case when token_temp.fee_schedule_key_ed25519_hex = '<uuid>' then '' " +
+                "else " +
                 "coalesce(token_temp.fee_schedule_key_ed25519_hex, token.fee_schedule_key_ed25519_hex) end, " +
                 "freeze_key = coalesce(token_temp.freeze_key, token.freeze_key), " +
                 "freeze_key_ed25519_hex = case when token_temp.freeze_key_ed25519_hex = '<uuid>' then '' else " +
@@ -97,10 +99,5 @@ class TokenUpsertQueryGeneratorTest extends AbstractUpsertQueryGeneratorTest {
     void tempTableName() {
         String upsertQuery = getUpdatableDomainRepositoryCustom().getTemporaryTableName();
         assertThat(upsertQuery).isEqualTo("token_temp");
-    }
-
-    @Override
-    @Test
-    protected void insertContainsAllFields() {
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/TokenUpsertQueryGeneratorV2Test.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/TokenUpsertQueryGeneratorV2Test.java
@@ -20,12 +20,12 @@ package com.hedera.mirror.importer.repository.upsert;
  * ‍
  */
 
-import org.junit.jupiter.api.Tag;
+import com.hedera.mirror.importer.EnabledIfV2;
 
-@Tag("v2")
+@EnabledIfV2
 class TokenUpsertQueryGeneratorV2Test extends TokenUpsertQueryGeneratorTest {
     @Override
-    public String getInsertQuery() {
+    protected String getInsertQuery() {
         return "insert into token (created_timestamp, decimals, fee_schedule_key, fee_schedule_key_ed25519_hex, " +
                 "freeze_default, freeze_key, freeze_key_ed25519_hex, " +
                 "initial_supply, kyc_key, kyc_key_ed25519_hex, max_supply, modified_timestamp, name, supply_key, " +

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/TokenUpsertQueryGeneratorV2Test.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/TokenUpsertQueryGeneratorV2Test.java
@@ -23,6 +23,7 @@ package com.hedera.mirror.importer.repository.upsert;
 import com.hedera.mirror.importer.EnabledIfV2;
 
 @EnabledIfV2
+@SuppressWarnings("java:S2187")
 class TokenUpsertQueryGeneratorV2Test extends TokenUpsertQueryGeneratorTest {
     @Override
     protected String getInsertQuery() {

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/config/LoggingFilter.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/config/LoggingFilter.java
@@ -21,9 +21,11 @@ package com.hedera.mirror.monitor.config;
  */
 
 import java.net.InetSocketAddress;
+import java.net.URI;
 import javax.inject.Named;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.Level;
 import org.reactivestreams.Publisher;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.util.CollectionUtils;
@@ -36,6 +38,7 @@ import reactor.core.publisher.Mono;
 @Named
 public class LoggingFilter implements WebFilter {
 
+    private static final String ACTUATOR_PATH = "/actuator/";
     private static final String LOCALHOST = "127.0.0.1";
     private static final String X_FORWARDED_FOR = "X-Forwarded-For";
 
@@ -53,7 +56,9 @@ public class LoggingFilter implements WebFilter {
     private void onSuccess(ServerWebExchange exchange, long startTime) {
         long elapsed = System.currentTimeMillis() - startTime;
         ServerHttpRequest request = exchange.getRequest();
-        log.info("{} {} {} in {} ms: {}", getClient(request), request.getMethod(), request.getURI(), elapsed,
+        URI uri = request.getURI();
+        Level level = StringUtils.startsWith(uri.getPath(), ACTUATOR_PATH) ? Level.DEBUG : Level.INFO;
+        log.log(level, "{} {} {} in {} ms: {}", getClient(request), request.getMethod(), uri, elapsed,
                 exchange.getResponse().getStatusCode());
     }
 

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/grpc/GrpcSubscription.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/grpc/GrpcSubscription.java
@@ -43,7 +43,7 @@ class GrpcSubscription extends AbstractSubscription<GrpcSubscriberProperties, To
 
     TopicMessageQuery getTopicMessageQuery() {
         long limit = properties.getLimit();
-        Instant startTime = last.map(t -> t.consensusTimestamp.plusNanos(1))
+        Instant startTime = getLast().map(t -> t.consensusTimestamp.plusNanos(1))
                 .orElseGet(properties::getStartTime);
 
         TopicMessageQuery topicMessageQuery = new TopicMessageQuery();
@@ -59,7 +59,7 @@ class GrpcSubscription extends AbstractSubscription<GrpcSubscriberProperties, To
         log.trace("{}: Received message #{} with timestamp {}", this, topicResponse.sequenceNumber,
                 topicResponse.consensusTimestamp);
 
-        last.ifPresent(topicMessage -> {
+        getLast().ifPresent(topicMessage -> {
             long expected = topicMessage.sequenceNumber + 1;
             if (topicResponse.sequenceNumber != expected) {
                 log.warn("{}: Expected sequence number {} but received {}", this, expected,

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/converter/DurationToStringSerializerTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/converter/DurationToStringSerializerTest.java
@@ -21,14 +21,14 @@ package com.hedera.mirror.monitor.converter;
  */
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import java.time.Duration;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -40,31 +40,38 @@ class DurationToStringSerializerTest {
     @Mock
     private JsonGenerator jsonGenerator;
 
-    @Test
-    void serialize() throws Exception {
-        Duration duration = Duration.ofSeconds(5L);
+    @DisplayName("Serialize Duration to String")
+    @ParameterizedTest(name = "{0} => {1}")
+    @MethodSource("testCases")
+    void serialize(Long input, String text) throws Exception {
+        Duration duration = input != null ? Duration.ofSeconds(input) : null;
         serializer.serialize(duration, jsonGenerator, null);
-        jsonGenerator.writeString("5s");
+        verify(jsonGenerator).writeString(text);
     }
 
     @DisplayName("Convert Duration to String")
     @ParameterizedTest(name = "{0} => {1}")
-    @CsvSource({
-            ",",
-            "0, 0s",
-            "1, 1s",
-            "60, 1m",
-            "61, 1m1s",
-            "3600, 1h",
-            "3660, 1h1m",
-            "3661, 1h1m1s",
-            "86400, 1d",
-            "90000, 1d1h",
-            "90060, 1d1h1m",
-            "90061, 1d1h1m1s"
-    })
+    @MethodSource("testCases")
     void convert(Long input, String text) {
         Duration duration = input != null ? Duration.ofSeconds(input) : null;
         assertThat(DurationToStringSerializer.convert(duration)).isEqualTo(text);
+    }
+
+    @SuppressWarnings("unused")
+    private static String[][] testCases() {
+        String[][] testCases = {
+                {"0", "0s"},
+                {"1", "1s"},
+                {"60", "1m"},
+                {"61", "1m1s"},
+                {"3600", "1h"},
+                {"3660", "1h1m"},
+                {"3661", "1h1m1s"},
+                {"86400", "1d"},
+                {"90000", "1d1h"},
+                {"90060", "1d1h1m"},
+                {"90061", "1d1h1m1s"}
+        };
+        return testCases;
     }
 }

--- a/hedera-mirror-rest/__tests__/s3client.test.js
+++ b/hedera-mirror-rest/__tests__/s3client.test.js
@@ -128,7 +128,7 @@ describe('createS3Client with valid config', () => {
     },
     {
       name: 'valid config with endpointOverride',
-      override: {endpointOverride: 'http://universal-storage-service-provider.mars.universe'},
+      override: {endpointOverride: 'https://universal-storage-service-provider.mars.universe'},
     },
     {
       name: 'valid config with null region',


### PR DESCRIPTION
**Description**:
- Fix 4 sonar bugs, 4 blockers and 1 security hotspot
- Fix `MonitorPublishPlatformNotActive` still firing while platform is unavailable
- Fix monitor showing access logs for internal APIs and cluttering the logs
- Fix some tests requiring v1 or v2 tags to pass (`mvn verify` now works again)
- Fix sonar check not doing a deep clone for proper analysis
- Fix sonar always failing due to coverage

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
