### PR TITLE
Fix address_book_entry table update on compressed chunk issue

### DIFF
--- a/charts/hedera-mirror/values.yaml
+++ b/charts/hedera-mirror/values.yaml
@@ -302,7 +302,7 @@ timescaledb:
   enabled: false
   image:
     pullPolicy: IfNotPresent
-    tag: pg13.3-ts2.3.0-p0
+    tag: pg13.3-ts2.3.1-p1
   loadBalancer:
     enabled: false
   patroni:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 version: "3.7"
 services:
   db:
-    image: postgres:13.3-alpine # Or timescale/timescaledb-ha:pg13.3-ts2.3.0-p0
+    image: postgres:13.3-alpine # Or timescale/timescaledb-ha:pg13.3-ts2.3.1-p1
     restart: unless-stopped
     stop_grace_period: 2m
     stop_signal: SIGTERM

--- a/hedera-mirror-grpc/src/test/resources/config/bootstrap-v2.yml
+++ b/hedera-mirror-grpc/src/test/resources/config/bootstrap-v2.yml
@@ -1,6 +1,6 @@
 embedded:
   postgresql:
-    docker-image: timescale/timescaledb-ha:pg13.3-ts2.3.0-p0
+    docker-image: timescale/timescaledb-ha:pg13.3-ts2.3.1-p1
 spring:
   flyway:
     baselineVersion: 1.999.999

--- a/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.1__hyper_tables.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.1__hyper_tables.sql
@@ -17,18 +17,11 @@ select create_hypertable('account_balance', 'consensus_timestamp', chunk_time_in
 select create_hypertable('account_balance_file', 'consensus_timestamp', chunk_time_interval => ${chunkTimeInterval},
                          create_default_indexes => false, if_not_exists => true);
 
--- address_book
-select create_hypertable('address_book', 'start_consensus_timestamp', chunk_time_interval => ${chunkTimeInterval},
-                         create_default_indexes => false, if_not_exists => true);
+-- address_book hyper table creation skipped as small tables won't benefit from timescaledb scalability
 
--- address_book_entry
-select create_hypertable('address_book_entry', 'consensus_timestamp', chunk_time_interval => ${chunkTimeInterval},
-                         create_default_indexes => false, if_not_exists => true);
+-- address_book_entry hyper table creation skipped as small tables won't benefit from timescaledb scalability
 
--- address_book_service_endpoint
-select create_hypertable('address_book_service_endpoint', 'consensus_timestamp',
-                         chunk_time_interval => ${chunkTimeInterval},
-                         create_default_indexes => false, if_not_exists => true);
+-- address_book_service_endpoint hyper table creation skipped as small tables won't benefit from timescaledb scalability
 
 -- contract_result
 select create_hypertable('contract_result', 'consensus_timestamp', chunk_time_interval => ${chunkTimeInterval},

--- a/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.3__time_scale_compression.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.3__time_scale_compression.sql
@@ -24,8 +24,6 @@ $$ language plpgsql;
 select set_integer_now_func('assessed_custom_fee', 'latest_consensus_timestamp');
 select set_integer_now_func('account_balance', 'latest_consensus_timestamp');
 select set_integer_now_func('account_balance_file', 'latest_consensus_timestamp');
-select set_integer_now_func('address_book_entry', 'latest_consensus_timestamp');
-select set_integer_now_func('address_book_service_endpoint', 'latest_consensus_timestamp');
 select set_integer_now_func('contract_result', 'latest_consensus_timestamp');
 select set_integer_now_func('crypto_transfer', 'latest_consensus_timestamp');
 select set_integer_now_func('custom_fee', 'latest_consensus_timestamp');
@@ -51,13 +49,11 @@ alter table account_balance
 alter table account_balance_file
     set (timescaledb.compress, timescaledb.compress_segmentby = 'node_account_id');
 
--- address_book skipped as update (end_consensus_timestamp) on compressed chunk is not allowed
+-- address_book skipped as not a hyper table
 
-alter table address_book_entry
-    set (timescaledb.compress, timescaledb.compress_segmentby = 'consensus_timestamp, node_id');
+-- address_book_entry skipped as not a hyper table
 
-alter table address_book_service_endpoint
-    set (timescaledb.compress, timescaledb.compress_segmentby = 'consensus_timestamp, node_id, ip_address_v4, port');
+-- address_book_service_endpoint skipped as not a hyper table
 
 alter table contract_result
     set (timescaledb.compress);
@@ -121,7 +117,6 @@ alter table transaction_signature
 select add_compression_policy('assessed_custom_fee', bigint '${compressionAge}');
 select add_compression_policy('account_balance', bigint '${compressionAge}');
 select add_compression_policy('account_balance_file', bigint '${compressionAge}');
-select add_compression_policy('address_book_entry', bigint '${compressionAge}');
 select add_compression_policy('contract_result', bigint '${compressionAge}');
 select add_compression_policy('crypto_transfer', bigint '${compressionAge}');
 select add_compression_policy('custom_fee', bigint '${compressionAge}');

--- a/hedera-mirror-importer/src/test/resources/config/bootstrap-v2.yml
+++ b/hedera-mirror-importer/src/test/resources/config/bootstrap-v2.yml
@@ -1,3 +1,3 @@
 embedded:
   postgresql:
-    docker-image: timescale/timescaledb-ha:pg13.3-ts2.3.0-p0
+    docker-image: timescale/timescaledb-ha:pg13.3-ts2.3.1-p1

--- a/hedera-mirror-rest/__tests__/integrationDbOps.js
+++ b/hedera-mirror-rest/__tests__/integrationDbOps.js
@@ -54,7 +54,7 @@ const v1SchemaConfigs = {
 const v2SchemaConfigs = {
   docker: {
     imageName: 'timescale/timescaledb-ha',
-    tagName: 'pg13.3-ts2.3.0-p0',
+    tagName: 'pg13.3-ts2.3.1-p1',
   },
   flyway: {
     baselineVersion: '1.999.999',


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR fixes the address_book_entry update on compressed timescaledb chunk issue.

- Change address book related tables to be vanilla postgres tables
- Upgrade to pg13.3-ts2.3.1-p1 image
 
**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
Update data in compressed chunks is not allowed. In addition, there is no benefit in making the address book tables hypertables, taken how small those tables are and how infrequently they get updates.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
