### PR TITLE
Fix address book updates that occur within a single record file (0.38)

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/addressbook/AddressBookService.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/addressbook/AddressBookService.java
@@ -26,9 +26,11 @@ import com.hedera.mirror.importer.domain.FileData;
 
 public interface AddressBookService {
 
+    AddressBook getCurrent();
+
     boolean isAddressBook(EntityId entityId);
 
-    void update(FileData fileData);
+    AddressBook migrate();
 
-    AddressBook getCurrent();
+    void update(FileData fileData);
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/MirrorBaseJavaMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/MirrorBaseJavaMigration.java
@@ -20,6 +20,7 @@ package com.hedera.mirror.importer.migration;
  * ‍
  */
 
+import com.google.common.base.Stopwatch;
 import java.io.IOException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -42,7 +43,9 @@ public abstract class MirrorBaseJavaMigration implements JavaMigration {
             return;
         }
 
+        Stopwatch stopwatch = Stopwatch.createStarted();
         doMigrate();
+        log.info("Ran migration {} in {}.", getDescription(), stopwatch);
     }
 
     protected abstract void doMigrate() throws IOException;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/MissingAddressBooksMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/MissingAddressBooksMigration.java
@@ -1,0 +1,72 @@
+package com.hedera.mirror.importer.migration;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import javax.inject.Named;
+import lombok.RequiredArgsConstructor;
+import org.flywaydb.core.api.MigrationVersion;
+import org.flywaydb.core.api.configuration.Configuration;
+import org.springframework.context.annotation.Lazy;
+
+import com.hedera.mirror.importer.addressbook.AddressBookService;
+import com.hedera.mirror.importer.repository.AddressBookServiceEndpointRepository;
+
+@Named
+@RequiredArgsConstructor(onConstructor_ = {@Lazy})
+public class MissingAddressBooksMigration extends MirrorBaseJavaMigration {
+
+    private final AddressBookService addressBookService;
+    private final AddressBookServiceEndpointRepository addressBookServiceEndpointRepository;
+
+    @Override
+    public Integer getChecksum() {
+        return 1;
+    }
+
+    @Override
+    public String getDescription() {
+        return "Parse valid but unprocessed addressBook file_data rows into valid addressBooks";
+    }
+
+    @Override
+    public MigrationVersion getVersion() {
+        return null;
+    }
+
+    @Override
+    protected boolean skipMigration(Configuration configuration) {
+        // skip when no address books with service endpoint exist. Allow normal flow migration to do initial population
+        long serviceEndpointCount = 0;
+        try {
+            serviceEndpointCount = addressBookServiceEndpointRepository.count();
+        } catch (Exception ex) {
+            // catch ERROR: relation "address_book_service_endpoint" does not exist
+            // this will occur in migration version before v1.37.1 where service endpoints were not supported by proto
+            log.info("Error checking service endpoints: {}", ex.getMessage());
+        }
+        return serviceEndpointCount < 1;
+    }
+
+    @Override
+    protected void doMigrate() {
+        addressBookService.migrate();
+    }
+}

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/FileDataRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/FileDataRepository.java
@@ -37,7 +37,7 @@ public interface FileDataRepository extends CrudRepository<FileData, Long> {
     Optional<FileData> findLatestMatchingFile(long consensusTimestamp, long encodedEntityId,
                                               List<Integer> transactionTypes);
 
-    @Query(value = "select * from file_data where consensus_timestamp > ?1 and entity_id in (101, 102) order by " +
-            "consensus_timestamp asc limit ?2", nativeQuery = true)
-    List<FileData> findAddressBooksAfter(long consensusTimestamp, long limit);
+    @Query(value = "select * from file_data where consensus_timestamp > ?1 and consensus_timestamp < ?2 and " +
+            "entity_id in (101, 102) order by consensus_timestamp asc limit ?3", nativeQuery = true)
+    List<FileData> findAddressBooksBetween(long startConsensusTimestamp, long endConsensusTimestamp, long limit);
 }

--- a/hedera-mirror-importer/src/main/resources/db/scripts/timescaledb/csvBackupTables.sql
+++ b/hedera-mirror-importer/src/main/resources/db/scripts/timescaledb/csvBackupTables.sql
@@ -12,6 +12,8 @@
 
 \copy address_book_entry to address_book_entry.csv delimiter ',' csv;
 
+\copy address_book_service_endpoint to address_book_service_endpoint.csv delimiter ',' csv;
+
 \copy contract_result to contract_result.csv delimiter ',' csv;
 
 \copy crypto_transfer to crypto_transfer.csv delimiter ',' csv;

--- a/hedera-mirror-importer/src/main/resources/db/scripts/timescaledb/csvRestoreTables.sql
+++ b/hedera-mirror-importer/src/main/resources/db/scripts/timescaledb/csvRestoreTables.sql
@@ -10,7 +10,9 @@
 
 \copy address_book (start_consensus_timestamp, end_consensus_timestamp, file_id, node_count, file_data) from address_book.csv csv;
 
-\copy address_book_entry (id, consensus_timestamp, ip, port, memo, public_key, node_id, node_account_id, node_cert_hash) from address_book_entry.csv csv;
+\copy address_book_entry (consensus_timestamp, memo, public_key, node_id, node_account_id, node_cert_hash, description, stake) from address_book_entry.csv csv;
+
+\copy address_book_service_endpoint (consensus_timestamp, ip_address_v4, node_id, port) from address_book_service_endpoint.csv csv;
 
 \copy contract_result (function_parameters, gas_supplied, call_result, gas_used, consensus_timestamp) from contract_result.csv csv;
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/addressbook/AddressBookServiceImplTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/addressbook/AddressBookServiceImplTest.java
@@ -137,29 +137,26 @@ class AddressBookServiceImplTest extends IntegrationTest {
         return builder.build();
     }
 
-    private FileData createFileData(byte[] contents, long consensusTimeStamp, boolean is102) {
+    private FileData createFileData(byte[] contents, long consensusTimeStamp, boolean is102,
+                                    TransactionTypeEnum transactionTypeEnum) {
         EntityId entityId = is102 ? AddressBookServiceImpl.ADDRESS_BOOK_102_ENTITY_ID :
                 AddressBookServiceImpl.ADDRESS_BOOK_101_ENTITY_ID;
-        return new FileData(consensusTimeStamp, contents, entityId, TransactionTypeEnum.FILEUPDATE
-                .getProtoId());
+        return new FileData(consensusTimeStamp, contents, entityId, transactionTypeEnum.getProtoId());
     }
 
     private FileData store(byte[] contents, long consensusTimeStamp, boolean is102) {
-        FileData fileData = createFileData(contents, consensusTimeStamp, is102);
+        FileData fileData = createFileData(contents, consensusTimeStamp, is102, TransactionTypeEnum.FILEUPDATE);
         return fileDataRepository.save(fileData);
     }
 
     private void update(byte[] contents, long consensusTimeStamp, boolean is102) {
-        FileData fileData = createFileData(contents, consensusTimeStamp, is102);
+        FileData fileData = createFileData(contents, consensusTimeStamp, is102, TransactionTypeEnum.FILEUPDATE);
         addressBookService.update(fileData);
         fileDataRepository.save(fileData);
     }
 
     private void append(byte[] contents, long consensusTimeStamp, boolean is102) {
-        EntityId entityId = is102 ? AddressBookServiceImpl.ADDRESS_BOOK_102_ENTITY_ID :
-                AddressBookServiceImpl.ADDRESS_BOOK_101_ENTITY_ID;
-        FileData fileData = new FileData(consensusTimeStamp, contents, entityId, TransactionTypeEnum.FILEAPPEND
-                .getProtoId());
+        FileData fileData = createFileData(contents, consensusTimeStamp, is102, TransactionTypeEnum.FILEAPPEND);
         fileDataRepository.save(fileData);
         addressBookService.update(fileData);
     }
@@ -182,6 +179,19 @@ class AddressBookServiceImplTest extends IntegrationTest {
             customAddressBookService.getCurrent();
         });
         assertEquals(0, addressBookRepository.count());
+    }
+
+    @Test
+    void startupWithDefaultNetwork() {
+        // init address book and verify initial state
+        assertEquals(0, addressBookEntryRepository.count());
+        assertEquals(0, addressBookRepository.count());
+
+        AddressBook addressBook = addressBookService.getCurrent();
+
+        assertThat(addressBook.getStartConsensusTimestamp()).isEqualTo(1L);
+        assertEquals(1, addressBookRepository.count());
+        assertEquals(TEST_INITIAL_ADDRESS_BOOK_NODE_COUNT, addressBookEntryRepository.count());
     }
 
     @Test
@@ -631,7 +641,7 @@ class AddressBookServiceImplTest extends IntegrationTest {
         // migration
         int addressBook5NodeCount = 20;
         byte[] addressBookBytes5 = addressBook(addressBook5NodeCount, 0).toByteArray();
-        addressBookService.update(createFileData(addressBookBytes5, 6L, true));
+        addressBookService.update(createFileData(addressBookBytes5, 6L, true, TransactionTypeEnum.FILEUPDATE));
 
         assertEquals(4, fileDataRepository.count());
         assertEquals(6, addressBookRepository.count()); // initial plus 5 files
@@ -869,6 +879,89 @@ class AddressBookServiceImplTest extends IntegrationTest {
                 addressBookEntryRepository.count());
         assertEquals(addressBookEntries * numEndpointsPerNode,
                 addressBookServiceEndpointRepository.count());
+    }
+
+    @Test
+    void verifyAddressBookMigrationWithNewFileDataAfterCurrentAddressBook() {
+        byte[] addressBookBytes1 = UPDATED.toByteArray();
+        store(addressBookBytes1, 2L, false);
+
+        byte[] addressBookBytes2 = UPDATED.toByteArray();
+        store(addressBookBytes2, 3L, true);
+
+        // initial migration
+        AddressBook addressBook = addressBookService.getCurrent();
+        assertThat(addressBook.getStartConsensusTimestamp()).isEqualTo(4L);
+        assertAddressBook(addressBook, UPDATED);
+
+        // valid file data added but no address book produced
+        // file 101 update contents to be split over 1 update and 1 append operation
+        byte[] addressBook101Bytes = FINAL.toByteArray();
+        int index101 = addressBook101Bytes.length / 2;
+        byte[] addressBook101Bytes1 = Arrays.copyOfRange(addressBook101Bytes, 0, index101);
+        byte[] addressBook101Bytes2 = Arrays.copyOfRange(addressBook101Bytes, index101, addressBook101Bytes.length);
+        fileDataRepository.save(createFileData(addressBook101Bytes1, 4L, false, TransactionTypeEnum.FILEUPDATE));
+        fileDataRepository.save(createFileData(addressBook101Bytes2, 5L, false, TransactionTypeEnum.FILEAPPEND));
+
+        // file 102 update contents to be split over 1 update and 1 append operation
+        byte[] addressBook102Bytes = FINAL.toByteArray();
+        int index = addressBook102Bytes.length / 2;
+        byte[] addressBook102Bytes1 = Arrays.copyOfRange(addressBook102Bytes, 0, index);
+        byte[] addressBook102Bytes2 = Arrays.copyOfRange(addressBook102Bytes, index, addressBook102Bytes.length);
+        fileDataRepository.save(createFileData(addressBook102Bytes1, 6L, true, TransactionTypeEnum.FILEUPDATE));
+        fileDataRepository.save(createFileData(addressBook102Bytes2, 7L, true, TransactionTypeEnum.FILEAPPEND));
+
+        // migration on startup
+        AddressBook newAddressBook = addressBookService.migrate();
+        assertThat(newAddressBook.getStartConsensusTimestamp()).isEqualTo(8L);
+        assertAddressBook(newAddressBook, FINAL);
+
+        assertEquals(6, fileDataRepository.count());
+        assertEquals(5, addressBookRepository.count()); // initial plus 4 files
+        assertEquals(TEST_INITIAL_ADDRESS_BOOK_NODE_COUNT + (UPDATED.getNodeAddressCount() * 2) +
+                (FINAL.getNodeAddressCount() * 2), addressBookEntryRepository.count());
+    }
+
+    @Test
+    void verifyUpdateWithNewFileDataAfterCurrentAddressBook() {
+        byte[] addressBookBytes1 = UPDATED.toByteArray();
+        store(addressBookBytes1, 2L, false);
+
+        byte[] addressBookBytes2 = UPDATED.toByteArray();
+        store(addressBookBytes2, 3L, true);
+
+        // initial migration
+        AddressBook addressBook = addressBookService.getCurrent();
+        assertThat(addressBook.getStartConsensusTimestamp()).isEqualTo(4L);
+        assertAddressBook(addressBook, UPDATED);
+
+        // valid file data added but no address book produced
+        // file 101 update contents to be split over 1 update and 1 append operation
+        byte[] addressBook101Bytes = FINAL.toByteArray();
+        int index101 = addressBook101Bytes.length / 2;
+        byte[] addressBook101Bytes1 = Arrays.copyOfRange(addressBook101Bytes, 0, index101);
+        byte[] addressBook101Bytes2 = Arrays.copyOfRange(addressBook101Bytes, index101, addressBook101Bytes.length);
+        fileDataRepository.save(createFileData(addressBook101Bytes1, 4L, false, TransactionTypeEnum.FILEUPDATE));
+        fileDataRepository.save(createFileData(addressBook101Bytes2, 5L, false, TransactionTypeEnum.FILEAPPEND));
+
+        // file 102 update contents to be split over 1 update and 1 append operation
+        byte[] addressBook102Bytes = FINAL.toByteArray();
+        int index = addressBook102Bytes.length / 2;
+        byte[] addressBook102Bytes1 = Arrays.copyOfRange(addressBook102Bytes, 0, index);
+        byte[] addressBook102Bytes2 = Arrays.copyOfRange(addressBook102Bytes, index, addressBook102Bytes.length);
+        fileDataRepository.save(createFileData(addressBook102Bytes1, 6L, true, TransactionTypeEnum.FILEUPDATE));
+        fileDataRepository.save(createFileData(addressBook102Bytes2, 7L, true, TransactionTypeEnum.FILEAPPEND));
+
+        // migration on update, missing address books are created
+        addressBookService.update(createFileData(addressBook101Bytes1, 10L, false, TransactionTypeEnum.FILEUPDATE));
+        AddressBook newAddressBook = addressBookService.getCurrent(); // latest missing address book is current
+        assertThat(newAddressBook.getStartConsensusTimestamp()).isEqualTo(8L);
+        assertAddressBook(newAddressBook, FINAL);
+
+        assertEquals(6, fileDataRepository.count());
+        assertEquals(5, addressBookRepository.count()); // initial plus 4 files
+        assertEquals(TEST_INITIAL_ADDRESS_BOOK_NODE_COUNT + (UPDATED.getNodeAddressCount() * 2) +
+                (FINAL.getNodeAddressCount() * 2), addressBookEntryRepository.count());
     }
 
     private ServiceEndpoint getServiceEndpoint(String ip, int port) throws UnknownHostException {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/MissingAddressBooksMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/MissingAddressBooksMigrationTest.java
@@ -1,0 +1,235 @@
+package com.hedera.mirror.importer.migration;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.google.protobuf.ByteString;
+import com.hederahashgraph.api.proto.java.AccountID;
+import com.hederahashgraph.api.proto.java.NodeAddress;
+import com.hederahashgraph.api.proto.java.NodeAddressBook;
+import com.hederahashgraph.api.proto.java.ServiceEndpoint;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Consumer;
+import javax.annotation.Resource;
+import org.assertj.core.api.ListAssert;
+import org.flywaydb.core.api.configuration.ClassicConfiguration;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import com.hedera.mirror.importer.IntegrationTest;
+import com.hedera.mirror.importer.addressbook.AddressBookServiceImpl;
+import com.hedera.mirror.importer.domain.AddressBook;
+import com.hedera.mirror.importer.domain.AddressBookEntry;
+import com.hedera.mirror.importer.domain.AddressBookServiceEndpoint;
+import com.hedera.mirror.importer.domain.EntityId;
+import com.hedera.mirror.importer.domain.EntityTypeEnum;
+import com.hedera.mirror.importer.domain.FileData;
+import com.hedera.mirror.importer.domain.TransactionTypeEnum;
+import com.hedera.mirror.importer.parser.record.entity.EntityProperties;
+import com.hedera.mirror.importer.repository.AddressBookRepository;
+import com.hedera.mirror.importer.repository.AddressBookServiceEndpointRepository;
+import com.hedera.mirror.importer.repository.FileDataRepository;
+
+class MissingAddressBooksMigrationTest extends IntegrationTest {
+
+    private static final NodeAddressBook UPDATED = addressBook(10, 0);
+    private static final NodeAddressBook FINAL = addressBook(15, 0);
+
+    @Resource
+    private MissingAddressBooksMigration missingAddressBooksMigration;
+
+    @Resource
+    private AddressBookRepository addressBookRepository;
+
+    @Resource
+    private FileDataRepository fileDataRepository;
+
+    @Resource
+    private AddressBookServiceEndpointRepository addressBookServiceEndpointRepository;
+
+    @Resource
+    private EntityProperties entityProperties;
+
+    @Test
+    void verifyAddressBookMigrationWithNewFileDataAfterCurrentAddressBook() {
+        // store initial address books
+        addressBookRepository
+                .save(addressBook(ab -> ab.fileId(AddressBookServiceImpl.ADDRESS_BOOK_101_ENTITY_ID), 1, 4));
+        addressBookRepository
+                .save(addressBook(ab -> ab.fileId(AddressBookServiceImpl.ADDRESS_BOOK_102_ENTITY_ID), 2, 4));
+        addressBookRepository
+                .save(addressBook(ab -> ab.fileId(AddressBookServiceImpl.ADDRESS_BOOK_101_ENTITY_ID), 11, 8));
+        addressBookRepository
+                .save(addressBook(ab -> ab.fileId(AddressBookServiceImpl.ADDRESS_BOOK_102_ENTITY_ID), 12, 8));
+        assertEquals(4, addressBookRepository.count());
+
+        // un-parsed file_data
+        // file 101 update contents to be split over 1 update and 1 append operation
+        byte[] addressBook101Bytes = FINAL.toByteArray();
+        int index101 = addressBook101Bytes.length / 2;
+        byte[] addressBook101Bytes1 = Arrays.copyOfRange(addressBook101Bytes, 0, index101);
+        byte[] addressBook101Bytes2 = Arrays.copyOfRange(addressBook101Bytes, index101, addressBook101Bytes.length);
+        createAndStoreFileData(addressBook101Bytes1, 101, false, TransactionTypeEnum.FILEUPDATE);
+        createAndStoreFileData(addressBook101Bytes2, 102, false, TransactionTypeEnum.FILEAPPEND);
+
+        // file 102 update contents to be split over 1 update and 1 append operation
+        byte[] addressBook102Bytes = FINAL.toByteArray();
+        int index = addressBook102Bytes.length / 2;
+        byte[] addressBook102Bytes1 = Arrays.copyOfRange(addressBook102Bytes, 0, index);
+        byte[] addressBook102Bytes2 = Arrays.copyOfRange(addressBook102Bytes, index, addressBook102Bytes.length);
+        createAndStoreFileData(addressBook102Bytes1, 201, true, TransactionTypeEnum.FILEUPDATE);
+        createAndStoreFileData(addressBook102Bytes2, 202, true, TransactionTypeEnum.FILEAPPEND);
+        assertEquals(4, fileDataRepository.count());
+
+        // migration on startup
+        missingAddressBooksMigration.doMigrate();
+        assertEquals(6, addressBookRepository.count());
+        AddressBook newAddressBook = addressBookRepository
+                .findLatestAddressBook(205, AddressBookServiceImpl.ADDRESS_BOOK_102_ENTITY_ID.getId()).get();
+        assertThat(newAddressBook.getStartConsensusTimestamp()).isEqualTo(203L);
+        assertAddressBook(newAddressBook, FINAL);
+    }
+
+    @DisplayName("Verify skipMigration")
+    @ParameterizedTest(name = "with baseline {0} and target {1}")
+    @CsvSource({
+            "0, true",
+            "1, false"
+    })
+    void skipMigrationPreAddressBookService(int serviceEndpointCount, boolean result) {
+        for (int j = 1; j <= serviceEndpointCount; ++j) {
+            addressBookServiceEndpointRepository.save(new AddressBookServiceEndpoint(
+                    j,
+                    "127.0.0.1",
+                    443,
+                    EntityId.of(0, 0, 100, EntityTypeEnum.ACCOUNT)));
+        }
+        assertThat(missingAddressBooksMigration.skipMigration(getConfiguration())).isEqualTo(result);
+    }
+
+    private AddressBook addressBook(Consumer<AddressBook.AddressBookBuilder> addressBookCustomizer,
+                                    long consensusTimestamp, int nodeCount) {
+        long startConsensusTimestamp = consensusTimestamp + 1;
+        List<AddressBookEntry> addressBookEntryList = new ArrayList<>();
+        for (int i = 0; i < nodeCount; i++) {
+            long nodeId = 3 + i;
+            addressBookEntryList
+                    .add(addressBookEntry(a -> a.id(new AddressBookEntry.Id(startConsensusTimestamp, nodeId))
+                            .memo("0.0." + nodeId)
+                            .nodeAccountId(EntityId.of("0.0." + nodeId, EntityTypeEnum.ACCOUNT))));
+        }
+
+        AddressBook.AddressBookBuilder builder = AddressBook.builder()
+                .startConsensusTimestamp(startConsensusTimestamp)
+                .fileData("address book memo".getBytes())
+                .nodeCount(nodeCount)
+                .fileId(AddressBookServiceImpl.ADDRESS_BOOK_102_ENTITY_ID)
+                .entries(addressBookEntryList);
+
+        if (addressBookCustomizer != null) {
+            addressBookCustomizer.accept(builder);
+        }
+
+        return builder.build();
+    }
+
+    private AddressBookEntry addressBookEntry(Consumer<AddressBookEntry.AddressBookEntryBuilder> nodeAddressCustomizer) {
+        AddressBookEntry.AddressBookEntryBuilder builder = AddressBookEntry.builder()
+                .id(new AddressBookEntry.Id(Instant.now().getEpochSecond(), 5L))
+                .description("address book entry")
+                .publicKey("rsa+public/key")
+                .memo("0.0.3")
+                .nodeAccountId(EntityId.of("0.0.5", EntityTypeEnum.ACCOUNT))
+                .nodeCertHash("nodeCertHash".getBytes())
+                .stake(5L);
+
+        if (nodeAddressCustomizer != null) {
+            nodeAddressCustomizer.accept(builder);
+        }
+
+        return builder.build();
+    }
+
+    private static NodeAddressBook addressBook(int size, int endPointSize) {
+        NodeAddressBook.Builder builder = NodeAddressBook.newBuilder();
+        for (int i = 0; i < size; ++i) {
+            long nodeId = 3 + i;
+            NodeAddress.Builder nodeAddressBuilder = NodeAddress.newBuilder()
+                    .setIpAddress(ByteString.copyFromUtf8("127.0.0." + nodeId))
+                    .setPortno((int) nodeId)
+                    .setNodeId(nodeId)
+                    .setMemo(ByteString.copyFromUtf8("0.0." + nodeId))
+                    .setNodeAccountId(AccountID.newBuilder().setAccountNum(nodeId))
+                    .setNodeCertHash(ByteString.copyFromUtf8("nodeCertHash"))
+                    .setRSAPubKey("rsa+public/key");
+
+            // add service endpoints
+            if (endPointSize > 0) {
+                List<ServiceEndpoint> serviceEndpoints = new ArrayList<>();
+                for (int j = 1; j <= size; ++j) {
+                    serviceEndpoints.add(ServiceEndpoint.newBuilder()
+                            .setIpAddressV4(ByteString.copyFrom(new byte[] {127, 0, 0, (byte) j}))
+                            .setPort(443 + j)
+                            .build());
+                }
+            }
+
+            builder.addNodeAddress(nodeAddressBuilder.build());
+        }
+        return builder.build();
+    }
+
+    private FileData createAndStoreFileData(byte[] contents, long consensusTimeStamp, boolean is102,
+                                            TransactionTypeEnum transactionTypeEnum) {
+        EntityId entityId = is102 ? AddressBookServiceImpl.ADDRESS_BOOK_102_ENTITY_ID :
+                AddressBookServiceImpl.ADDRESS_BOOK_101_ENTITY_ID;
+        FileData fileData = new FileData(consensusTimeStamp, contents, entityId, transactionTypeEnum.getProtoId());
+        return fileDataRepository.save(fileData);
+    }
+
+    private void assertAddressBook(AddressBook actual, NodeAddressBook expected) {
+        ListAssert<AddressBookEntry> listAssert = assertThat(actual.getEntries())
+                .hasSize(expected.getNodeAddressCount());
+
+        for (NodeAddress nodeAddress : expected.getNodeAddressList()) {
+            listAssert.anySatisfy(abe -> {
+                assertThat(abe.getMemo()).isEqualTo(nodeAddress.getMemo().toStringUtf8());
+                assertThat(abe.getNodeAccountId()).isEqualTo(EntityId.of(nodeAddress.getNodeAccountId()));
+                assertThat(abe.getNodeCertHash()).isEqualTo(nodeAddress.getNodeCertHash().toByteArray());
+                assertThat(abe.getPublicKey()).isEqualTo(nodeAddress.getRSAPubKey());
+                assertThat(abe.getId().getNodeId()).isEqualTo(nodeAddress.getNodeId());
+            });
+        }
+    }
+
+    private ClassicConfiguration getConfiguration() {
+        ClassicConfiguration configuration = new ClassicConfiguration();
+        configuration.setTargetAsString("latest");
+        return configuration;
+    }
+}

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/TransactionSignatureTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/TransactionSignatureTest.java
@@ -70,6 +70,7 @@ import com.hedera.mirror.importer.parser.domain.RecordItem;
 import com.hedera.mirror.importer.parser.record.NonFeeTransferExtractionStrategy;
 import com.hedera.mirror.importer.parser.record.transactionhandler.TransactionHandler;
 import com.hedera.mirror.importer.parser.record.transactionhandler.TransactionHandlerFactory;
+import com.hedera.mirror.importer.repository.FileDataRepository;
 import com.hedera.mirror.importer.util.Utility;
 
 @ExtendWith(MockitoExtension.class)
@@ -93,6 +94,9 @@ class TransactionSignatureTest {
     @Mock
     private TransactionHandlerFactory transactionHandlerFactory;
 
+    @Mock
+    private FileDataRepository fileDataRepository;
+
     private SignatureMap.Builder defaultSignatureMap;
 
     private List<TransactionSignature> defaultTransactionSignatures;
@@ -106,7 +110,8 @@ class TransactionSignatureTest {
         CommonParserProperties commonParserProperties = new CommonParserProperties();
         EntityProperties entityProperties = new EntityProperties();
         entityRecordItemListener = new EntityRecordItemListener(commonParserProperties, entityProperties,
-                addressBookService, nonFeeTransferExtractionStrategy, entityListener, transactionHandlerFactory);
+                addressBookService, nonFeeTransferExtractionStrategy, entityListener, transactionHandlerFactory,
+                fileDataRepository);
         defaultSignatureMap = getDefaultSignatureMap();
         defaultTransactionSignatures = defaultSignatureMap.getSigPairList()
                 .stream()

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/FileDataRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/FileDataRepositoryTest.java
@@ -96,8 +96,30 @@ public class FileDataRepositoryTest extends AbstractRepositoryTest {
         fileDataRepository.saveAll(fileDataList);
 
         Assertions.assertThat(fileDataRepository
-                .findAddressBooksAfter(
-                        2, 5))
+                .findAddressBooksBetween(
+                        2, 5, 10))
+                .isNotNull()
+                .hasSize(2)
+                .extracting(FileData::getConsensusTimestamp)
+                .containsSequence(3L, 4L);
+    }
+
+    @Test
+    void findAddressBookFilesWithLimit() {
+        List<FileData> fileDataList = new ArrayList<>();
+        fileDataList.add(fileData(1, ADDRESS_BOOK_101.getId(), TransactionTypeEnum.FILECREATE.getProtoId()));
+        fileDataList.add(fileData(2, ADDRESS_BOOK_102.getId(), TransactionTypeEnum.FILECREATE.getProtoId()));
+        fileDataList.add(fileData(3, ADDRESS_BOOK_101.getId(), TransactionTypeEnum.FILEUPDATE.getProtoId()));
+        fileDataList.add(fileData(4, ADDRESS_BOOK_101.getId(), TransactionTypeEnum.FILEAPPEND.getProtoId()));
+        fileDataList.add(fileData(5, ADDRESS_BOOK_102.getId(), TransactionTypeEnum.FILEUPDATE.getProtoId()));
+        fileDataList.add(fileData(6, ADDRESS_BOOK_102.getId(), TransactionTypeEnum.FILEAPPEND.getProtoId()));
+        fileDataList.add(fileData(7, ADDRESS_BOOK_101.getId(), TransactionTypeEnum.FILEUPDATE.getProtoId()));
+        fileDataList.add(fileData(8, ADDRESS_BOOK_102.getId(), TransactionTypeEnum.FILEUPDATE.getProtoId()));
+        fileDataRepository.saveAll(fileDataList);
+
+        Assertions.assertThat(fileDataRepository
+                .findAddressBooksBetween(
+                        2, 10, 5))
                 .isNotNull()
                 .hasSize(5)
                 .extracting(FileData::getConsensusTimestamp)


### PR DESCRIPTION
**Description**:
Cherry pick Fix address book updates that occur within a single record file [PR 2317](https://github.com/hashgraph/hedera-mirror-node/pull/2352)

When new nodes are added to the address book the mirror node processes the transactions and updates the db with the new nodes. This will often come through as a FileCreate/FileUpdate followed by 1 or more FileAppend transactions.
The byte contents of each fileData object are combined to create the new addressBook.

There seems to be a regression where FileData bytes for addressbook were not being saved immediately and were being added to the cache for bulk inserts. For most transactions this is desired, however, for the addressBook case not saving it immediately means future transactions from the same record file do not have access to the need information.

- Update `EntityRecordItemListener` to save address book file data immediately 
- Update address book csvBackup and restore sqls
- Update `AddresBookService.migrate()` logic to check for missing fileData after current addressBook
- Add java migration to ensure missing file data missed by bug is processed prior to stream parsing
- Add a `validateAndCompleteAddressBookList()` method for `AddresBookService.update()` to use to fill in any missing files since last address book
- Add tests to capture issue

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
