### PR TITLE
Add a cluster health endpoint to monitor

### DIFF
--- a/charts/hedera-mirror-monitor/values.yaml
+++ b/charts/hedera-mirror-monitor/values.yaml
@@ -183,7 +183,7 @@ prometheusRules:
       description: "Averaging {{ $value | humanizePercentage }} error rate publishing '{{ $labels.scenario }}' scenario from {{ $labels.namespace }}/{{ $labels.pod }}"
       summary: "Publish error rate exceeds 15%"
     enabled: true
-    expr: expr: sum(rate(hedera_mirror_monitor_publish_submit_seconds_count{application="hedera-mirror-monitor",status!="SUCCESS"}[2m])) by (namespace, pod, scenario) / sum(rate(hedera_mirror_monitor_publish_submit_seconds_count{application="hedera-mirror-monitor"}[2m])) by (namespace, pod, scenario) > 0.33
+    expr: sum(rate(hedera_mirror_monitor_publish_submit_seconds_count{application="hedera-mirror-monitor",status!="SUCCESS"}[2m])) by (namespace, pod, scenario) / sum(rate(hedera_mirror_monitor_publish_submit_seconds_count{application="hedera-mirror-monitor"}[2m])) by (namespace, pod, scenario) > 0.33
     for: 3m
     labels:
       severity: critical

--- a/charts/hedera-mirror-monitor/values.yaml
+++ b/charts/hedera-mirror-monitor/values.yaml
@@ -181,7 +181,7 @@ prometheusRules:
   MonitorPublishErrors:
     annotations:
       description: "Averaging {{ $value | humanizePercentage }} error rate publishing '{{ $labels.scenario }}' scenario from {{ $labels.namespace }}/{{ $labels.pod }}"
-      summary: "Publish error rate exceeds 15%"
+      summary: "Publish error rate exceeds 33%"
     enabled: true
     expr: sum(rate(hedera_mirror_monitor_publish_submit_seconds_count{application="hedera-mirror-monitor",status!="SUCCESS"}[2m])) by (namespace, pod, scenario) / sum(rate(hedera_mirror_monitor_publish_submit_seconds_count{application="hedera-mirror-monitor"}[2m])) by (namespace, pod, scenario) > 0.33
     for: 3m
@@ -207,7 +207,7 @@ prometheusRules:
       description: "Averaging {{ $value | humanizePercentage }} PLATFORM_NOT_ACTIVE or UNAVAILABLE errors while attempting to publish in {{ $labels.namespace }}"
       summary: "Platform is not active"
     enabled: true
-    expr: sum(rate(hedera_mirror_monitor_publish_submit_seconds_count{application="hedera-mirror-monitor",status=~"(PLATFORM_NOT_ACTIVE|UNAVAILABLE)"}[2m])) by (namespace) / sum(rate(hedera_mirror_monitor_publish_submit_seconds_count{application="hedera-mirror-monitor"}[2m])) by (namespace) > 0
+    expr: sum(rate(hedera_mirror_monitor_publish_submit_seconds_count{application="hedera-mirror-monitor",status=~"(PLATFORM_NOT_ACTIVE|UNAVAILABLE)"}[2m])) by (namespace) / sum(rate(hedera_mirror_monitor_publish_submit_seconds_count{application="hedera-mirror-monitor"}[2m])) by (namespace) > 0.33
     for: 1m
     labels:
       application: hedera-mirror-monitor

--- a/charts/hedera-mirror-monitor/values.yaml
+++ b/charts/hedera-mirror-monitor/values.yaml
@@ -183,8 +183,8 @@ prometheusRules:
       description: "Averaging {{ $value | humanizePercentage }} error rate publishing '{{ $labels.scenario }}' scenario from {{ $labels.namespace }}/{{ $labels.pod }}"
       summary: "Publish error rate exceeds 15%"
     enabled: true
-    expr: sum(rate(hedera_mirror_monitor_publish_submit_seconds_sum{application="hedera-mirror-monitor",status!="SUCCESS"}[2m])) by (namespace, pod, scenario) / sum(rate(hedera_mirror_monitor_publish_submit_seconds_count{application="hedera-mirror-monitor"}[2m])) by (namespace, pod, scenario) > 0.15
-    for: 2m
+    expr: expr: sum(rate(hedera_mirror_monitor_publish_submit_seconds_count{application="hedera-mirror-monitor",status!="SUCCESS"}[2m])) by (namespace, pod, scenario) / sum(rate(hedera_mirror_monitor_publish_submit_seconds_count{application="hedera-mirror-monitor"}[2m])) by (namespace, pod, scenario) > 0.33
+    for: 3m
     labels:
       severity: critical
       application: hedera-mirror-monitor

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -249,10 +249,10 @@ Name                                                            | Default    | D
 `hedera.mirror.monitor.publish.scenarios.<name>.enabled`        | true       | Whether this publish scenario is enabled
 `hedera.mirror.monitor.publish.scenarios.<name>.limit`          | 0          | How many transactions to publish before halting. 0 for unlimited
 `hedera.mirror.monitor.publish.scenarios.<name>.logResponse`    | false      | Whether to log the response from HAPI
-`hedera.mirror.monitor.publish.scenarios.<name>.maxAttempts`    | 1          | The maximum number of times a scenario transaction will be attempted
 `hedera.mirror.monitor.publish.scenarios.<name>.properties`     | {}         | Key/value pairs used to configure the [`TransactionSupplier`](/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier) associated with this scenario type
 `hedera.mirror.monitor.publish.scenarios.<name>.receiptPercent` | 0.0        | The percentage of receipts to retrieve from HAPI. Accepts values between 0-1
 `hedera.mirror.monitor.publish.scenarios.<name>.recordPercent`  | 0.0        | The percentage of records to retrieve from HAPI. Accepts values between 0-1
+`hedera.mirror.monitor.publish.scenarios.<name>.retry.maxAttempts` | 1          | The maximum number of times a scenario transaction will be attempted
 `hedera.mirror.monitor.publish.scenarios.<name>.timeout`        | 12s        | How long to wait for the transaction result
 `hedera.mirror.monitor.publish.scenarios.<name>.tps`            | 1.0        | The rate at which transactions will publish
 `hedera.mirror.monitor.publish.scenarios.<name>.type`           |            | The type of transaction to publish. See the [`TransactionType`](/hedera-mirror-datagenerator/src/main/java/com/hedera/datagenerator/sdk/supplier/TransactionType.java) enum for a list of possible values

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/ClusterHealthIndicator.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/ClusterHealthIndicator.java
@@ -1,0 +1,75 @@
+package com.hedera.mirror.monitor;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import javax.inject.Named;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.ReactiveHealthIndicator;
+import org.springframework.boot.actuate.health.Status;
+import reactor.core.publisher.Mono;
+
+import com.hedera.mirror.monitor.publish.generator.TransactionGenerator;
+import com.hedera.mirror.monitor.subscribe.MirrorSubscriber;
+import com.hedera.mirror.monitor.subscribe.Scenario;
+
+@Named
+@RequiredArgsConstructor
+public class ClusterHealthIndicator implements ReactiveHealthIndicator {
+
+    private static final Mono<Health> DOWN = health(Status.DOWN, "Subscribing is inactive");
+    private static final Mono<Health> UNKNOWN = health(Status.UNKNOWN, "Publishing is inactive");
+    private static final Mono<Health> UP = health(Status.UP, "");
+
+    private final MirrorSubscriber mirrorSubscriber;
+    private final TransactionGenerator transactionGenerator;
+
+    private static Mono<Health> health(Status status, String reason) {
+        Health.Builder health = Health.status(status);
+        if (StringUtils.isNotBlank(reason)) {
+            health.withDetail("reason", reason);
+        }
+        return Mono.just(health.build());
+    }
+
+    @Override
+    public Mono<Health> health() {
+        return publishing().switchIfEmpty(subscribing());
+    }
+
+    private Mono<Health> publishing() {
+        return transactionGenerator.scenarios()
+                .map(Scenario::getRate)
+                .reduce(0.0, (c, n) -> c + n)
+                .filter(sum -> sum <= 0)
+                .flatMap(n -> UNKNOWN);
+    }
+
+    private Mono<Health> subscribing() {
+        return mirrorSubscriber.getSubscriptions()
+                .map(Scenario::getRate)
+                .reduce(0.0, (cur, next) -> cur + next)
+                .filter(sum -> sum > 0)
+                .flatMap(n -> UP)
+                .switchIfEmpty(DOWN);
+    }
+}

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/ClusterHealthIndicator.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/ClusterHealthIndicator.java
@@ -56,6 +56,7 @@ public class ClusterHealthIndicator implements ReactiveHealthIndicator {
         return publishing().switchIfEmpty(subscribing());
     }
 
+    // Returns unknown if all publish scenarios aggregated rate has dropped to zero, otherwise returns an empty flux
     private Mono<Health> publishing() {
         return transactionGenerator.scenarios()
                 .map(Scenario::getRate)
@@ -64,6 +65,7 @@ public class ClusterHealthIndicator implements ReactiveHealthIndicator {
                 .flatMap(n -> UNKNOWN);
     }
 
+    // Returns up if any subscription is running and its rate is above zero, otherwise returns down
     private Mono<Health> subscribing() {
         return mirrorSubscriber.getSubscriptions()
                 .map(Scenario::getRate)

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/HederaNetwork.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/HederaNetwork.java
@@ -29,7 +29,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum HederaNetwork {
 
-    MAINNET(mainnet(), mirrorNode("mainnet")),
+    MAINNET(mainnet(), mirrorNode("mainnet-public")),
     PREVIEWNET(previewnet(), mirrorNode("previewnet")),
     TESTNET(testnet(), mirrorNode("testnet")),
     OTHER(Collections.emptySet(), null);
@@ -42,6 +42,10 @@ public enum HederaNetwork {
         MirrorNodeProperties mirrorNodeProperties = new MirrorNodeProperties();
         mirrorNodeProperties.getGrpc().setHost("hcs." + host);
         mirrorNodeProperties.getRest().setHost(host);
+        if ("mainnet-public".equals(environment)) {
+            mirrorNodeProperties.getGrpc().setHost(host);
+            mirrorNodeProperties.getGrpc().setPort(443);
+        }
         return mirrorNodeProperties;
     }
 
@@ -76,7 +80,8 @@ public enum HederaNetwork {
                 new NodeProperties("0.0.3", "0.previewnet.hedera.com"),
                 new NodeProperties("0.0.4", "1.previewnet.hedera.com"),
                 new NodeProperties("0.0.5", "2.previewnet.hedera.com"),
-                new NodeProperties("0.0.6", "3.previewnet.hedera.com")
+                new NodeProperties("0.0.6", "3.previewnet.hedera.com"),
+                new NodeProperties("0.0.7", "4.previewnet.hedera.com")
         );
     }
 

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/NodeProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/NodeProperties.java
@@ -46,6 +46,7 @@ public class NodeProperties {
     private int port = 50211;
 
     public String getEndpoint() {
+        // Allow for in-process testing of gRPC stubs
         if (host.startsWith("in-process:")) {
             return host;
         }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/NodeProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/NodeProperties.java
@@ -46,6 +46,9 @@ public class NodeProperties {
     private int port = 50211;
 
     public String getEndpoint() {
+        if (host.startsWith("in-process:")) {
+            return host;
+        }
         return host + ":" + port;
     }
 }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/ScenarioProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/ScenarioProperties.java
@@ -1,4 +1,4 @@
-package com.hedera.mirror.monitor.generator;
+package com.hedera.mirror.monitor;
 
 /*-
  * ‌
@@ -21,61 +21,42 @@ package com.hedera.mirror.monitor.generator;
  */
 
 import java.time.Duration;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import lombok.Data;
 import org.hibernate.validator.constraints.time.DurationMin;
 import org.springframework.validation.annotation.Validated;
 
-import com.hedera.datagenerator.sdk.supplier.TransactionType;
-
 @Data
-@Validated
-public class ScenarioProperties {
+public abstract class ScenarioProperties {
 
     @NotNull
     @DurationMin(seconds = 30)
-    private Duration duration = Duration.ofNanos(Long.MAX_VALUE);
+    protected Duration duration = Duration.ofNanos(Long.MAX_VALUE);
 
-    private boolean enabled = true;
+    protected boolean enabled = true;
 
     @Min(0)
-    private long limit = 0;
+    protected long limit = 0; // 0 for unlimited
 
-    private boolean logResponse = false;
-
-    @Min(1)
-    private int maxAttempts = 1;
-
-    private String name;
+    protected String name;
 
     @NotNull
-    private Map<String, String> properties = new LinkedHashMap<>();
+    protected RetryProperties retry = new RetryProperties();
 
-    @Min(0)
-    @Max(1)
-    private double receiptPercent = 0.0;
+    @Data
+    @Validated
+    public static class RetryProperties {
 
-    @Min(0)
-    @Max(1)
-    private double recordPercent = 0.0;
+        @Min(0)
+        private long maxAttempts = 16L;
 
-    @NotNull
-    @DurationMin(seconds = 1)
-    private Duration timeout = Duration.ofSeconds(13);
+        @NotNull
+        @DurationMin(millis = 500L)
+        private Duration maxBackoff = Duration.ofSeconds(8L);
 
-    @Min(0)
-    private double tps = 1.0;
-
-    @NotNull
-    private TransactionType type;
-
-    public long getLimit() {
-        return limit > 0 ? limit : Long.MAX_VALUE;
+        @NotNull
+        @DurationMin(millis = 100L)
+        private Duration minBackoff = Duration.ofMillis(250L);
     }
 }
-
-

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/ScenarioProtocol.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/ScenarioProtocol.java
@@ -1,4 +1,4 @@
-package com.hedera.mirror.monitor.subscribe;
+package com.hedera.mirror.monitor;
 
 /*-
  * ‌
@@ -20,7 +20,7 @@ package com.hedera.mirror.monitor.subscribe;
  * ‍
  */
 
-public enum SubscriberProtocol {
+public enum ScenarioProtocol {
     GRPC,
     REST
 }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/ScenarioStatus.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/ScenarioStatus.java
@@ -1,4 +1,4 @@
-package com.hedera.mirror.monitor.generator;
+package com.hedera.mirror.monitor;
 
 /*-
  * ‌
@@ -20,17 +20,8 @@ package com.hedera.mirror.monitor.generator;
  * ‍
  */
 
-import lombok.Getter;
-
-public class ScenarioException extends RuntimeException {
-
-    private static final long serialVersionUID = 1690349494197296387L;
-
-    @Getter
-    private final transient ScenarioProperties properties;
-
-    public ScenarioException(ScenarioProperties properties, String message) {
-        super(message);
-        this.properties = properties;
-    }
+public enum ScenarioStatus {
+    COMPLETED, // The scenario has completed normally due to reaching the configured duration or limit
+    IDLE,      // The scenario has not completed but is not currently receiving any responses
+    RUNNING,   // The scenario is still actively receiving responses
 }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/config/MonitorConfiguration.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/config/MonitorConfiguration.java
@@ -31,12 +31,12 @@ import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
 import reactor.core.scheduler.Schedulers;
 
-import com.hedera.mirror.monitor.generator.TransactionGenerator;
 import com.hedera.mirror.monitor.publish.PublishException;
 import com.hedera.mirror.monitor.publish.PublishMetrics;
 import com.hedera.mirror.monitor.publish.PublishProperties;
 import com.hedera.mirror.monitor.publish.PublishRequest;
 import com.hedera.mirror.monitor.publish.TransactionPublisher;
+import com.hedera.mirror.monitor.publish.generator.TransactionGenerator;
 import com.hedera.mirror.monitor.subscribe.MirrorSubscriber;
 import com.hedera.mirror.monitor.subscribe.SubscribeMetrics;
 

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/expression/ExpressionConverterImpl.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/expression/ExpressionConverterImpl.java
@@ -35,8 +35,7 @@ import lombok.Value;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.StringUtils;
 import reactor.core.publisher.Mono;
-import reactor.util.retry.RetryBackoffSpec;
-import reactor.util.retry.RetrySpec;
+import reactor.util.retry.Retry;
 
 import com.hedera.datagenerator.sdk.supplier.AdminKeyable;
 import com.hedera.datagenerator.sdk.supplier.TransactionSupplier;
@@ -127,7 +126,7 @@ public class ExpressionConverterImpl implements ExpressionConverter {
                     .transaction(transactionSupplier.get())
                     .build();
 
-            RetryBackoffSpec retrySpec = RetrySpec.backoff(Long.MAX_VALUE, Duration.ofMillis(500L))
+            Retry retrySpec = Retry.backoff(Long.MAX_VALUE, Duration.ofMillis(500L))
                     .maxBackoff(Duration.ofSeconds(8L))
                     .doBeforeRetry(r -> log.warn("Retry attempt #{} after failure: {}",
                             r.totalRetries() + 1, r.failure().getMessage()));

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/expression/ExpressionConverterImpl.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/expression/ExpressionConverterImpl.java
@@ -49,6 +49,8 @@ import com.hedera.mirror.monitor.MonitorProperties;
 import com.hedera.mirror.monitor.NodeProperties;
 import com.hedera.mirror.monitor.publish.PublishRequest;
 import com.hedera.mirror.monitor.publish.PublishResponse;
+import com.hedera.mirror.monitor.publish.PublishScenario;
+import com.hedera.mirror.monitor.publish.PublishScenarioProperties;
 import com.hedera.mirror.monitor.publish.TransactionPublisher;
 
 @Log4j2
@@ -112,14 +114,16 @@ public class ExpressionConverterImpl implements ExpressionConverter {
                         .setOperatorAccountId(monitorProperties.getOperator().getAccountId());
             }
 
+            PublishScenarioProperties publishScenarioProperties = new PublishScenarioProperties();
+            publishScenarioProperties.setName(expression.toString());
+            publishScenarioProperties.setTimeout(Duration.ofSeconds(30L));
+            publishScenarioProperties.setType(type.getTransactionType());
+            PublishScenario scenario = new PublishScenario(publishScenarioProperties);
             PublishRequest request = PublishRequest.builder()
-                    .logResponse(true)
                     .receipt(true)
-                    .scenarioName(expression.toString())
-                    .timeout(Duration.ofSeconds(30L))
+                    .scenario(scenario)
                     .timestamp(Instant.now())
                     .transaction(transactionSupplier.get())
-                    .type(type.getTransactionType())
                     .build();
 
             PublishResponse publishResponse = Mono.defer(() -> transactionPublisher.publish(request))

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishMetrics.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishMetrics.java
@@ -144,16 +144,19 @@ public class PublishMetrics {
     @Scheduled(fixedDelayString = "${hedera.mirror.monitor.publish.statusFrequency:10000}")
     public void status() {
         if (publishProperties.isEnabled()) {
-            durationGauges.keySet().stream().map(Tags::getScenario).distinct().forEach(this::status);
+            durationGauges.keySet()
+                    .stream()
+                    .map(Tags::getScenario)
+                    .distinct()
+                    .filter(PublishScenario::isRunning)
+                    .forEach(this::status);
         }
     }
 
     private void status(PublishScenario scenario) {
-        if (scenario.isRunning()) {
-            String elapsed = DurationToStringSerializer.convert(scenario.getElapsed());
-            log.info("{}: {} transactions in {} at {}/s. Errors: {}",
-                    scenario, scenario.getCount(), elapsed, scenario.getRate(), scenario.getErrors());
-        }
+        String elapsed = DurationToStringSerializer.convert(scenario.getElapsed());
+        log.info("{}: {} transactions in {} at {}/s. Errors: {}",
+                scenario, scenario.getCount(), elapsed, scenario.getRate(), scenario.getErrors());
     }
 
     @Value

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishProperties.java
@@ -32,8 +32,6 @@ import org.hibernate.validator.constraints.time.DurationMin;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
-import com.hedera.mirror.monitor.generator.ScenarioProperties;
-
 @Data
 @Validated
 @ConfigurationProperties("hedera.mirror.monitor.publish")
@@ -48,7 +46,7 @@ public class PublishProperties {
     private boolean enabled = true;
 
     @NotNull
-    private Map<String, ScenarioProperties> scenarios = new LinkedHashMap<>();
+    private Map<String, PublishScenarioProperties> scenarios = new LinkedHashMap<>();
 
     @DurationMin(seconds = 1L)
     @NotNull

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishScenario.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishScenario.java
@@ -20,18 +20,27 @@ package com.hedera.mirror.monitor.publish;
  * ‍
  */
 
-import java.time.Instant;
-import lombok.Builder;
-import lombok.Value;
+import java.util.Objects;
 
-import com.hedera.hashgraph.sdk.Transaction;
+import com.hedera.mirror.monitor.AbstractScenario;
+import com.hedera.mirror.monitor.ScenarioProtocol;
 
-@Builder
-@Value
-public class PublishRequest {
-    private final boolean receipt;
-    private final boolean record;
-    private final PublishScenario scenario;
-    private final Instant timestamp;
-    private final Transaction<?> transaction;
+public class PublishScenario extends AbstractScenario<PublishScenarioProperties, PublishResponse> {
+
+    private final String memo;
+
+    public PublishScenario(PublishScenarioProperties properties) {
+        super(1, properties);
+        String hostname = Objects.requireNonNullElse(System.getenv("HOSTNAME"), "unknown");
+        this.memo = String.format("Monitor %s on %s", properties.getName(), hostname);
+    }
+
+    public String getMemo() {
+        return memo;
+    }
+
+    @Override
+    public ScenarioProtocol getProtocol() {
+        return ScenarioProtocol.GRPC;
+    }
 }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishScenarioProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishScenarioProperties.java
@@ -1,0 +1,73 @@
+package com.hedera.mirror.monitor.publish;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import lombok.Data;
+import org.hibernate.validator.constraints.time.DurationMin;
+import org.springframework.validation.annotation.Validated;
+
+import com.hedera.datagenerator.sdk.supplier.TransactionType;
+import com.hedera.mirror.monitor.ScenarioProperties;
+
+@Data
+@Validated
+public class PublishScenarioProperties extends ScenarioProperties {
+
+    private boolean logResponse = false;
+
+    @NotNull
+    private Map<String, String> properties = new LinkedHashMap<>();
+
+    @Min(0)
+    @Max(1)
+    private double receiptPercent = 0.0;
+
+    @Min(0)
+    @Max(1)
+    private double recordPercent = 0.0;
+
+    @NotNull
+    @DurationMin(seconds = 1)
+    private Duration timeout = Duration.ofSeconds(13);
+
+    @Min(0)
+    private double tps = 1.0;
+
+    @NotNull
+    private TransactionType type;
+
+    public PublishScenarioProperties() {
+        getRetry().setMaxAttempts(1L);
+    }
+
+    @Override
+    public long getLimit() {
+        return limit > 0 ? limit : Long.MAX_VALUE;
+    }
+}
+
+

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/TransactionPublisher.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/TransactionPublisher.java
@@ -20,32 +20,29 @@ package com.hedera.mirror.monitor.publish;
  * ‍
  */
 
-import com.google.common.base.Suppliers;
 import java.security.SecureRandom;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import javax.inject.Named;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-import com.hedera.hashgraph.sdk.AccountBalanceQuery;
 import com.hedera.hashgraph.sdk.AccountId;
 import com.hedera.hashgraph.sdk.Client;
+import com.hedera.hashgraph.sdk.Hbar;
+import com.hedera.hashgraph.sdk.HbarUnit;
 import com.hedera.hashgraph.sdk.PrivateKey;
-import com.hedera.hashgraph.sdk.Transaction;
 import com.hedera.hashgraph.sdk.TransactionId;
+import com.hedera.hashgraph.sdk.TransactionRecordQuery;
 import com.hedera.hashgraph.sdk.TransactionResponse;
+import com.hedera.hashgraph.sdk.TransferTransaction;
 import com.hedera.mirror.monitor.MonitorProperties;
 import com.hedera.mirror.monitor.NodeProperties;
 
@@ -56,55 +53,44 @@ public class TransactionPublisher implements AutoCloseable {
 
     private final MonitorProperties monitorProperties;
     private final PublishProperties publishProperties;
-    private final Supplier<List<Client>> clients = Suppliers.memoize(this::getClients);
-    private final Supplier<List<AccountId>> nodeAccountIds = Suppliers.memoize(this::getNodeAccountIds);
-    private final AtomicInteger counter = new AtomicInteger(0);
+    private final Flux<Client> clients = Flux.defer(this::getClients).cache();
     private final SecureRandom secureRandom = new SecureRandom();
-    private final AtomicBoolean initialized = new AtomicBoolean(false);
 
     @Override
     public void close() {
-        if (initialized.get()) {
-            log.info("Closing {} clients", clients.get().size());
-
-            for (Client client : clients.get()) {
+        if (publishProperties.isEnabled()) {
+            log.warn("Closing {} clients", publishProperties.getClients());
+            clients.subscribe(client -> {
                 try {
                     client.close();
                 } catch (Exception e) {
                     // Ignore
                 }
-            }
+            });
         }
     }
 
     public Mono<PublishResponse> publish(PublishRequest request) {
         log.trace("Publishing: {}", request);
-        int clientIndex = counter.getAndUpdate(n -> (n + 1 < clients.get().size()) ? n + 1 : 0);
-        Client client = clients.get().get(clientIndex);
+        int clientIndex = secureRandom.nextInt(publishProperties.getClients());
+        PublishScenario scenario = request.getScenario();
+        PublishScenarioProperties properties = scenario.getProperties();
 
-        return getTransactionResponse(request, client)
-                .flatMap(transactionResponse -> processTransactionResponse(client, request, transactionResponse))
-                .map(PublishResponse.PublishResponseBuilder::build)
-                .doOnNext(response -> {
-                    if (log.isTraceEnabled() || request.isLogResponse()) {
-                        log.info("Received response : {}", response);
-                    }
-                })
-                .timeout(request.getTimeout())
-                .onErrorMap(t -> new PublishException(request, t));
-    }
-
-    private Mono<TransactionResponse> getTransactionResponse(PublishRequest request, Client client) {
-        Transaction<?> transaction = request.getTransaction();
-
-        // set transaction node where applicable
-        if (transaction.getNodeAccountIds() == null) {
-            int nodeIndex = secureRandom.nextInt(nodeAccountIds.get().size());
-            List<AccountId> nodeAccountId = List.of(nodeAccountIds.get().get(nodeIndex));
-            transaction.setNodeAccountIds(nodeAccountId);
-        }
-
-        return Mono.fromFuture(transaction.executeAsync(client));
+        return clients.elementAt(clientIndex)
+                .flatMap(client -> Mono.fromFuture(request.getTransaction()
+                                .setTransactionMemo(scenario.getMemo())
+                                .executeAsync(client))
+                        .flatMap(r -> processTransactionResponse(client, request, r))
+                        .map(PublishResponse.PublishResponseBuilder::build)
+                        .doOnNext(response -> {
+                            if (log.isTraceEnabled() || properties.isLogResponse()) {
+                                log.info("Received response : {}", response);
+                            }
+                        })
+                        .timeout(properties.getTimeout())
+                        .doOnNext(scenario::onNext)
+                        .doOnError(scenario::onError)
+                        .onErrorMap(t -> new PublishException(request, t)));
     }
 
     private Mono<PublishResponse.PublishResponseBuilder> processTransactionResponse(Client client,
@@ -117,55 +103,48 @@ public class TransactionPublisher implements AutoCloseable {
                 .transactionId(transactionId);
 
         if (request.isRecord()) {
-            return Mono.fromFuture(transactionId.getRecordAsync(client))
+            // TransactionId.getRecordAsync() is inefficient doing a get receipt, a cost query, then the get record
+            TransactionRecordQuery transactionRecordQuery = new TransactionRecordQuery()
+                    .setQueryPayment(Hbar.from(1, HbarUnit.HBAR))
+                    .setTransactionId(transactionId);
+            return Mono.fromFuture(transactionRecordQuery.executeAsync(client))
                     .map(r -> builder.record(r).receipt(r.receipt));
         } else if (request.isReceipt()) {
-            // TODO: Implement a faster retry for get receipt for more accurate metrics
-            return Mono.fromFuture(transactionId.getReceiptAsync(client))
-                    .map(builder::receipt);
+            return Mono.fromFuture(transactionId.getReceiptAsync(client)).map(builder::receipt);
         }
 
         return Mono.just(builder);
     }
 
-    private List<Client> getClients() {
-        Collection<NodeProperties> validNodes = validateNodes();
+    private Flux<Client> getClients() {
+        List<NodeProperties> validNodes = validateNodes();
 
         if (validNodes.isEmpty()) {
             throw new IllegalArgumentException("No valid nodes found");
         }
 
-        List<Client> validatedClients = new ArrayList<>();
-        Map<String, AccountId> network = toNetwork(validNodes);
-        for (int i = 0; i < publishProperties.getClients(); ++i) {
-            Client client = toClient(network);
-            validatedClients.add(client);
-        }
-
-        initialized.set(true);
-        return validatedClients;
+        return Flux.range(0, publishProperties.getClients())
+                .map(i -> i % validNodes.size())
+                .flatMap(i -> Flux.defer(() -> Mono.just(toClient(validNodes.get(i)))));
     }
 
-    private List<AccountId> getNodeAccountIds() {
-        return new ArrayList<>(clients.get().get(0).getNetwork().values());
-    }
-
-    private Collection<NodeProperties> validateNodes() {
+    private List<NodeProperties> validateNodes() {
         Set<NodeProperties> nodes = monitorProperties.getNodes();
 
         if (!monitorProperties.isValidateNodes()) {
-            return nodes;
+            return new ArrayList<>(nodes);
         }
 
         List<NodeProperties> validNodes = new ArrayList<>();
-        try (Client client = toClient(toNetwork(nodes))) {
-            for (NodeProperties node : nodes) {
+
+        for (NodeProperties node : nodes) {
+            try (Client client = toClient(node)) {
                 if (validateNode(client, node)) {
                     validNodes.add(node);
                 }
+            } catch (Exception e) {
+                log.warn("Error validating nodes: {}", e.getMessage());
             }
-        } catch (Exception e) {
-            log.warn("Error validating nodes: {}", e.getMessage());
         }
 
         log.info("{} of {} nodes are functional", validNodes.size(), nodes.size());
@@ -174,12 +153,15 @@ public class TransactionPublisher implements AutoCloseable {
 
     private boolean validateNode(Client client, NodeProperties node) {
         boolean valid = false;
+
         try {
             AccountId nodeAccountId = AccountId.fromString(node.getAccountId());
-            new AccountBalanceQuery()
-                    .setAccountId(nodeAccountId)
-                    .setNodeAccountIds(List.of(nodeAccountId))
-                    .execute(client, Duration.ofSeconds(10L));
+            Hbar hbar = Hbar.fromTinybars(1L);
+            new TransferTransaction()
+                    .addHbarTransfer(nodeAccountId, hbar)
+                    .addHbarTransfer(client.getOperatorAccountId(), hbar.negated())
+                    .execute(client, Duration.ofSeconds(10L))
+                    .getReceipt(client, Duration.ofSeconds(10L));
             log.info("Validated node: {}", node);
             valid = true;
         } catch (TimeoutException e) {
@@ -191,16 +173,13 @@ public class TransactionPublisher implements AutoCloseable {
         return valid;
     }
 
-    private Client toClient(Map<String, AccountId> network) {
+    private Client toClient(NodeProperties nodeProperties) {
+        AccountId nodeAccount = AccountId.fromString(nodeProperties.getAccountId());
         AccountId operatorId = AccountId.fromString(monitorProperties.getOperator().getAccountId());
         PrivateKey operatorPrivateKey = PrivateKey.fromString(monitorProperties.getOperator().getPrivateKey());
-        Client client = Client.forNetwork(network);
+
+        Client client = Client.forNetwork(Map.of(nodeProperties.getEndpoint(), nodeAccount));
         client.setOperator(operatorId, operatorPrivateKey);
         return client;
-    }
-
-    private Map<String, AccountId> toNetwork(Collection<NodeProperties> nodes) {
-        return nodes.stream()
-                .collect(Collectors.toMap(NodeProperties::getEndpoint, p -> AccountId.fromString(p.getAccountId())));
     }
 }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/TransactionPublisher.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/TransactionPublisher.java
@@ -71,6 +71,10 @@ public class TransactionPublisher implements AutoCloseable {
     }
 
     public Mono<PublishResponse> publish(PublishRequest request) {
+        if (!publishProperties.isEnabled()) {
+            return Mono.empty();
+        }
+
         log.trace("Publishing: {}", request);
         int clientIndex = secureRandom.nextInt(publishProperties.getClients());
         PublishScenario scenario = request.getScenario();

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/generator/ConfigurableTransactionGenerator.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/generator/ConfigurableTransactionGenerator.java
@@ -38,6 +38,7 @@ import javax.validation.Validator;
 import lombok.Getter;
 import lombok.extern.log4j.Log4j2;
 import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
+import org.springframework.util.Assert;
 import reactor.core.publisher.Flux;
 
 import com.hedera.datagenerator.sdk.supplier.TransactionSupplier;
@@ -73,6 +74,7 @@ public class ConfigurableTransactionGenerator implements TransactionGenerator {
         stopTime = System.nanoTime() + properties.getDuration().toNanos();
         scenario = new PublishScenario(properties);
         builder = PublishRequest.builder().scenario(scenario);
+        Assert.state(properties.getRetry().getMaxAttempts() > 0, "maxAttempts must be positive");
     }
 
     @Override

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/generator/ScenarioException.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/generator/ScenarioException.java
@@ -1,4 +1,4 @@
-package com.hedera.mirror.monitor.subscribe;
+package com.hedera.mirror.monitor.publish.generator;
 
 /*-
  * ‌
@@ -20,8 +20,19 @@ package com.hedera.mirror.monitor.subscribe;
  * ‍
  */
 
-public enum SubscriptionStatus {
-    COMPLETED, // The scenario has completed normally due to reaching the configured duration or limit
-    IDLE,      // The scenario has not completed but is not currently receiving any responses
-    RUNNING,   // The scenario is still actively receiving responses
+import lombok.Getter;
+
+import com.hedera.mirror.monitor.subscribe.Scenario;
+
+public class ScenarioException extends RuntimeException {
+
+    private static final long serialVersionUID = 1690349494197296387L;
+
+    @Getter
+    private final transient Scenario<?, ?> scenario;
+
+    public ScenarioException(Scenario<?, ?> scenario, String message) {
+        super(message);
+        this.scenario = scenario;
+    }
 }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/generator/TransactionGenerator.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/generator/TransactionGenerator.java
@@ -1,4 +1,4 @@
-package com.hedera.mirror.monitor.generator;
+package com.hedera.mirror.monitor.publish.generator;
 
 /*-
  * ‌
@@ -21,14 +21,16 @@ package com.hedera.mirror.monitor.generator;
  */
 
 import java.util.List;
+import reactor.core.publisher.Flux;
 
 import com.hedera.mirror.monitor.publish.PublishRequest;
+import com.hedera.mirror.monitor.publish.PublishScenario;
 
 public interface TransactionGenerator {
 
     /**
-     * Gets the next count publish requests. If count > 0, up to count publish requests will be generated;
-     * if count <= 0, the generator will determine the actual count.
+     * Gets the next count publish requests. If count > 0, up to count publish requests will be generated; if count <=
+     * 0, the generator will determine the actual count.
      *
      * @param count
      * @return
@@ -38,4 +40,6 @@ public interface TransactionGenerator {
     default List<PublishRequest> next() {
         return next(1);
     }
+
+    Flux<PublishScenario> scenarios();
 }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/AbstractSubscriberProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/AbstractSubscriberProperties.java
@@ -20,51 +20,20 @@ package com.hedera.mirror.monitor.subscribe;
  * ‍
  */
 
-import java.time.Duration;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
-import javax.validation.constraints.NotNull;
 import lombok.Data;
-import org.hibernate.validator.constraints.time.DurationMin;
 import org.springframework.validation.annotation.Validated;
+
+import com.hedera.mirror.monitor.ScenarioProperties;
 
 @Data
 @Validated
-public abstract class AbstractSubscriberProperties {
-
-    @NotNull
-    @DurationMin(seconds = 30)
-    protected Duration duration = Duration.ofNanos(Long.MAX_VALUE);
-
-    protected boolean enabled = true;
-
-    @Min(0)
-    protected long limit = 0; // 0 for unlimited
-
-    protected String name;
-
-    @NotNull
-    protected RetryProperties retry = new RetryProperties();
+public abstract class AbstractSubscriberProperties extends ScenarioProperties {
 
     @Min(1)
     @Max(1024)
     protected int subscribers = 1;
-
-    @Data
-    @Validated
-    public static class RetryProperties {
-
-        @Min(0)
-        private long maxAttempts = 16L;
-
-        @NotNull
-        @DurationMin(millis = 500L)
-        private Duration maxBackoff = Duration.ofSeconds(8L);
-
-        @NotNull
-        @DurationMin(millis = 100L)
-        private Duration minBackoff = Duration.ofMillis(250L);
-    }
 }
 
 

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/CompositeSubscriber.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/CompositeSubscriber.java
@@ -46,7 +46,7 @@ public class CompositeSubscriber implements MirrorSubscriber {
     }
 
     @Override
-    public Flux<Subscription> getSubscriptions() {
+    public Flux<Scenario> getSubscriptions() {
         return Flux.fromIterable(subscribers).flatMap(MirrorSubscriber::getSubscriptions);
     }
 }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/MirrorSubscriber.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/MirrorSubscriber.java
@@ -31,5 +31,5 @@ public interface MirrorSubscriber {
 
     Flux<SubscribeResponse> subscribe();
 
-    <T extends Scenario> Flux<T> getSubscriptions();
+    <T extends Scenario<?, ?>> Flux<T> getSubscriptions();
 }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/MirrorSubscriber.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/MirrorSubscriber.java
@@ -31,5 +31,5 @@ public interface MirrorSubscriber {
 
     Flux<SubscribeResponse> subscribe();
 
-    <T extends Subscription> Flux<T> getSubscriptions();
+    <T extends Scenario> Flux<T> getSubscriptions();
 }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/Scenario.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/Scenario.java
@@ -26,11 +26,14 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.time.Duration;
 import java.util.Map;
 
+import com.hedera.mirror.monitor.ScenarioProperties;
+import com.hedera.mirror.monitor.ScenarioProtocol;
+import com.hedera.mirror.monitor.ScenarioStatus;
 import com.hedera.mirror.monitor.converter.DurationToStringSerializer;
 import com.hedera.mirror.monitor.converter.StringToDurationDeserializer;
 
-@JsonSerialize(as = Subscription.class)
-public interface Subscription {
+@JsonSerialize(as = Scenario.class)
+public interface Scenario<P extends ScenarioProperties, T> {
 
     long getCount();
 
@@ -47,11 +50,19 @@ public interface Subscription {
     }
 
     @JsonIgnore
-    <T extends AbstractSubscriberProperties> T getProperties();
+    P getProperties();
 
-    SubscriberProtocol getProtocol();
+    ScenarioProtocol getProtocol();
 
     double getRate();
 
-    SubscriptionStatus getStatus();
+    ScenarioStatus getStatus();
+
+    boolean isRunning();
+
+    void onComplete();
+
+    void onError(Throwable t);
+
+    void onNext(T response);
 }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/SubscribeMetrics.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/SubscribeMetrics.java
@@ -46,14 +46,14 @@ public class SubscribeMetrics {
     static final String TAG_SCENARIO = "scenario";
     static final String TAG_SUBSCRIBER = "subscriber";
 
-    private final Map<Scenario, TimeGauge> durationMetrics = new ConcurrentHashMap<>();
-    private final Map<Scenario, Timer> latencyMetrics = new ConcurrentHashMap<>();
+    private final Map<Scenario<?, ?>, TimeGauge> durationMetrics = new ConcurrentHashMap<>();
+    private final Map<Scenario<?, ?>, Timer> latencyMetrics = new ConcurrentHashMap<>();
     private final MeterRegistry meterRegistry;
     private final SubscribeProperties subscribeProperties;
 
     public void onNext(SubscribeResponse response) {
         log.trace("Response: {}", response);
-        Scenario scenario = response.getScenario();
+        Scenario<?, ?> scenario = response.getScenario();
         Instant publishedTimestamp = response.getPublishedTimestamp();
         durationMetrics.computeIfAbsent(scenario, this::newDurationGauge);
 
@@ -63,7 +63,7 @@ public class SubscribeMetrics {
         }
     }
 
-    private TimeGauge newDurationGauge(Scenario scenario) {
+    private TimeGauge newDurationGauge(Scenario<?, ?> scenario) {
         return TimeGauge.builder(METRIC_DURATION, scenario, TimeUnit.NANOSECONDS, s -> s.getElapsed().toNanos())
                 .description("How long the subscriber has been running")
                 .tag(TAG_PROTOCOL, scenario.getProtocol().toString())
@@ -72,7 +72,7 @@ public class SubscribeMetrics {
                 .register(meterRegistry);
     }
 
-    private final Timer newLatencyTimer(Scenario scenario) {
+    private final Timer newLatencyTimer(Scenario<?, ?> scenario) {
         return Timer.builder(METRIC_E2E)
                 .description("The end to end transaction latency starting from publish and ending at receive")
                 .tag(TAG_PROTOCOL, scenario.getProtocol().toString())
@@ -88,7 +88,7 @@ public class SubscribeMetrics {
         }
     }
 
-    private void status(Scenario s) {
+    private void status(Scenario<?, ?> s) {
         if (s.isRunning()) {
             String elapsed = DurationToStringSerializer.convert(s.getElapsed());
             log.info("{} {}: {} transactions in {} at {}/s. Errors: {}",

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/SubscribeMetrics.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/SubscribeMetrics.java
@@ -46,38 +46,38 @@ public class SubscribeMetrics {
     static final String TAG_SCENARIO = "scenario";
     static final String TAG_SUBSCRIBER = "subscriber";
 
-    private final Map<Subscription, TimeGauge> durationMetrics = new ConcurrentHashMap<>();
-    private final Map<Subscription, Timer> latencyMetrics = new ConcurrentHashMap<>();
+    private final Map<Scenario, TimeGauge> durationMetrics = new ConcurrentHashMap<>();
+    private final Map<Scenario, Timer> latencyMetrics = new ConcurrentHashMap<>();
     private final MeterRegistry meterRegistry;
     private final SubscribeProperties subscribeProperties;
 
     public void onNext(SubscribeResponse response) {
         log.trace("Response: {}", response);
-        Subscription subscription = response.getSubscription();
+        Scenario scenario = response.getScenario();
         Instant publishedTimestamp = response.getPublishedTimestamp();
-        durationMetrics.computeIfAbsent(subscription, this::newDurationGauge);
+        durationMetrics.computeIfAbsent(scenario, this::newDurationGauge);
 
         if (publishedTimestamp != null) {
             Duration latency = Duration.between(publishedTimestamp, response.getReceivedTimestamp());
-            latencyMetrics.computeIfAbsent(subscription, this::newLatencyTimer).record(latency);
+            latencyMetrics.computeIfAbsent(scenario, this::newLatencyTimer).record(latency);
         }
     }
 
-    private TimeGauge newDurationGauge(Subscription subscription) {
-        return TimeGauge.builder(METRIC_DURATION, subscription, TimeUnit.NANOSECONDS, s -> s.getElapsed().toNanos())
+    private TimeGauge newDurationGauge(Scenario scenario) {
+        return TimeGauge.builder(METRIC_DURATION, scenario, TimeUnit.NANOSECONDS, s -> s.getElapsed().toNanos())
                 .description("How long the subscriber has been running")
-                .tag(TAG_PROTOCOL, subscription.getProtocol().toString())
-                .tag(TAG_SCENARIO, subscription.getName())
-                .tag(TAG_SUBSCRIBER, String.valueOf(subscription.getId()))
+                .tag(TAG_PROTOCOL, scenario.getProtocol().toString())
+                .tag(TAG_SCENARIO, scenario.getName())
+                .tag(TAG_SUBSCRIBER, String.valueOf(scenario.getId()))
                 .register(meterRegistry);
     }
 
-    private final Timer newLatencyTimer(Subscription subscription) {
+    private final Timer newLatencyTimer(Scenario scenario) {
         return Timer.builder(METRIC_E2E)
                 .description("The end to end transaction latency starting from publish and ending at receive")
-                .tag(TAG_PROTOCOL, subscription.getProtocol().toString())
-                .tag(TAG_SCENARIO, subscription.getName())
-                .tag(TAG_SUBSCRIBER, String.valueOf(subscription.getId()))
+                .tag(TAG_PROTOCOL, scenario.getProtocol().toString())
+                .tag(TAG_SCENARIO, scenario.getName())
+                .tag(TAG_SUBSCRIBER, String.valueOf(scenario.getId()))
                 .register(meterRegistry);
     }
 
@@ -88,8 +88,8 @@ public class SubscribeMetrics {
         }
     }
 
-    private void status(Subscription s) {
-        if (s.getStatus() == SubscriptionStatus.RUNNING) {
+    private void status(Scenario s) {
+        if (s.isRunning()) {
             String elapsed = DurationToStringSerializer.convert(s.getElapsed());
             log.info("{} {}: {} transactions in {} at {}/s. Errors: {}",
                     s.getProtocol(), s, s.getCount(), elapsed, s.getRate(), s.getErrors());

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/SubscribeMetrics.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/SubscribeMetrics.java
@@ -84,15 +84,16 @@ public class SubscribeMetrics {
     @Scheduled(fixedDelayString = "${hedera.mirror.monitor.subscribe.statusFrequency:10000}")
     public void status() {
         if (subscribeProperties.isEnabled()) {
-            durationMetrics.keySet().forEach(this::status);
+            durationMetrics.keySet()
+                    .stream()
+                    .filter(Scenario::isRunning)
+                    .forEach(this::status);
         }
     }
 
     private void status(Scenario<?, ?> s) {
-        if (s.isRunning()) {
-            String elapsed = DurationToStringSerializer.convert(s.getElapsed());
-            log.info("{} {}: {} transactions in {} at {}/s. Errors: {}",
-                    s.getProtocol(), s, s.getCount(), elapsed, s.getRate(), s.getErrors());
-        }
+        String elapsed = DurationToStringSerializer.convert(s.getElapsed());
+        log.info("{} {}: {} transactions in {} at {}/s. Errors: {}",
+                s.getProtocol(), s, s.getCount(), elapsed, s.getRate(), s.getErrors());
     }
 }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/SubscribeResponse.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/SubscribeResponse.java
@@ -30,5 +30,5 @@ public class SubscribeResponse {
     private final Instant consensusTimestamp;
     private final Instant publishedTimestamp;
     private final Instant receivedTimestamp;
-    private final Scenario scenario;
+    private final Scenario<?, ?> scenario;
 }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/SubscribeResponse.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/SubscribeResponse.java
@@ -30,5 +30,5 @@ public class SubscribeResponse {
     private final Instant consensusTimestamp;
     private final Instant publishedTimestamp;
     private final Instant receivedTimestamp;
-    private final Subscription subscription;
+    private final Scenario scenario;
 }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/controller/SubscriberController.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/controller/SubscriberController.java
@@ -36,10 +36,10 @@ import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import com.hedera.mirror.monitor.ScenarioProtocol;
+import com.hedera.mirror.monitor.ScenarioStatus;
 import com.hedera.mirror.monitor.subscribe.MirrorSubscriber;
-import com.hedera.mirror.monitor.subscribe.SubscriberProtocol;
-import com.hedera.mirror.monitor.subscribe.Subscription;
-import com.hedera.mirror.monitor.subscribe.SubscriptionStatus;
+import com.hedera.mirror.monitor.subscribe.Scenario;
 
 @Log4j2
 @RequestMapping("/api/v1/subscriber")
@@ -50,8 +50,8 @@ class SubscriberController {
     private final MirrorSubscriber mirrorSubscriber;
 
     @GetMapping
-    public Flux<Subscription> subscriptions(@RequestParam Optional<SubscriberProtocol> protocol,
-                                            @RequestParam Optional<List<SubscriptionStatus>> status) {
+    public Flux<Scenario> subscriptions(@RequestParam Optional<ScenarioProtocol> protocol,
+                                        @RequestParam Optional<List<ScenarioStatus>> status) {
         return mirrorSubscriber.getSubscriptions()
                 .filter(s -> !protocol.isPresent() || protocol.get() == s.getProtocol())
                 .filter(s -> !status.isPresent() || status.get().contains(s.getStatus()))
@@ -59,15 +59,15 @@ class SubscriberController {
     }
 
     @GetMapping("/{name}")
-    public Flux<Subscription> subscriptions(@PathVariable String name,
-                                            @RequestParam Optional<List<SubscriptionStatus>> status) {
+    public Flux<Scenario> subscriptions(@PathVariable String name,
+                                        @RequestParam Optional<List<ScenarioStatus>> status) {
         return subscriptions(Optional.empty(), status)
                 .filter(subscription -> subscription.getName().equals(name))
                 .switchIfEmpty(Mono.error(new NoSuchElementException()));
     }
 
     @GetMapping("/{name}/{id}")
-    public Mono<Subscription> subscription(@PathVariable String name, @PathVariable int id) {
+    public Mono<Scenario> subscription(@PathVariable String name, @PathVariable int id) {
         return subscriptions(name, Optional.empty())
                 .filter(s -> s.getId() == id)
                 .last();

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/controller/SubscriberController.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/controller/SubscriberController.java
@@ -50,8 +50,8 @@ class SubscriberController {
     private final MirrorSubscriber mirrorSubscriber;
 
     @GetMapping
-    public Flux<Scenario> subscriptions(@RequestParam Optional<ScenarioProtocol> protocol,
-                                        @RequestParam Optional<List<ScenarioStatus>> status) {
+    public Flux<Scenario<?, ?>> subscriptions(@RequestParam Optional<ScenarioProtocol> protocol,
+                                              @RequestParam Optional<List<ScenarioStatus>> status) {
         return mirrorSubscriber.getSubscriptions()
                 .filter(s -> !protocol.isPresent() || protocol.get() == s.getProtocol())
                 .filter(s -> !status.isPresent() || status.get().contains(s.getStatus()))
@@ -59,15 +59,15 @@ class SubscriberController {
     }
 
     @GetMapping("/{name}")
-    public Flux<Scenario> subscriptions(@PathVariable String name,
-                                        @RequestParam Optional<List<ScenarioStatus>> status) {
+    public Flux<Scenario<?, ?>> subscriptions(@PathVariable String name,
+                                              @RequestParam Optional<List<ScenarioStatus>> status) {
         return subscriptions(Optional.empty(), status)
                 .filter(subscription -> subscription.getName().equals(name))
                 .switchIfEmpty(Mono.error(new NoSuchElementException()));
     }
 
     @GetMapping("/{name}/{id}")
-    public Mono<Scenario> subscription(@PathVariable String name, @PathVariable int id) {
+    public Mono<Scenario<?, ?>> subscription(@PathVariable String name, @PathVariable int id) {
         return subscriptions(name, Optional.empty())
                 .filter(s -> s.getId() == id)
                 .last();

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/grpc/GrpcClientSDK.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/grpc/GrpcClientSDK.java
@@ -64,7 +64,7 @@ class GrpcClientSDK implements GrpcClient {
     @Override
     public Flux<SubscribeResponse> subscribe(GrpcSubscription subscription) {
         int clientIndex = secureRandom.nextInt(subscribeProperties.getClients());
-        log.info("Starting '{}' subscription to client {}", subscription, clientIndex);
+        log.info("Starting '{}' scenario to client {}", subscription, clientIndex);
         return clients.elementAt(clientIndex)
                 .flatMapMany(client -> subscribeToClient(client, subscription));
     }
@@ -100,7 +100,7 @@ class GrpcClientSDK implements GrpcClient {
                 .consensusTimestamp(topicMessage.consensusTimestamp)
                 .publishedTimestamp(publishedTimestamp)
                 .receivedTimestamp(receivedTimestamp)
-                .subscription(subscription)
+                .scenario(subscription)
                 .build();
     }
 

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/grpc/GrpcSubscription.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/grpc/GrpcSubscription.java
@@ -27,18 +27,18 @@ import java.time.Instant;
 import com.hedera.hashgraph.sdk.TopicId;
 import com.hedera.hashgraph.sdk.TopicMessage;
 import com.hedera.hashgraph.sdk.TopicMessageQuery;
-import com.hedera.mirror.monitor.subscribe.AbstractSubscription;
-import com.hedera.mirror.monitor.subscribe.SubscriberProtocol;
+import com.hedera.mirror.monitor.AbstractScenario;
+import com.hedera.mirror.monitor.ScenarioProtocol;
 
-class GrpcSubscription extends AbstractSubscription<GrpcSubscriberProperties, TopicMessage> {
+class GrpcSubscription extends AbstractScenario<GrpcSubscriberProperties, TopicMessage> {
 
     GrpcSubscription(int id, GrpcSubscriberProperties properties) {
         super(id, properties);
     }
 
     @Override
-    public SubscriberProtocol getProtocol() {
-        return SubscriberProtocol.GRPC;
+    public ScenarioProtocol getProtocol() {
+        return ScenarioProtocol.GRPC;
     }
 
     TopicMessageQuery getTopicMessageQuery() {
@@ -77,5 +77,11 @@ class GrpcSubscription extends AbstractSubscription<GrpcSubscriberProperties, To
             statusCode = ((StatusRuntimeException) t).getStatus().getCode();
         }
         errors.add(statusCode.name());
+    }
+
+    @Override
+    public String toString() {
+        String name = getName();
+        return getProperties().getSubscribers() <= 1 ? name : name + " #" + getId();
     }
 }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/rest/RestSubscriber.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/rest/RestSubscriber.java
@@ -43,7 +43,6 @@ import com.hedera.mirror.monitor.publish.PublishResponse;
 import com.hedera.mirror.monitor.subscribe.MirrorSubscriber;
 import com.hedera.mirror.monitor.subscribe.SubscribeProperties;
 import com.hedera.mirror.monitor.subscribe.SubscribeResponse;
-import com.hedera.mirror.monitor.subscribe.SubscriptionStatus;
 import com.hedera.mirror.monitor.subscribe.rest.response.MirrorTransaction;
 
 @Log4j2
@@ -75,14 +74,14 @@ class RestSubscriber implements MirrorSubscriber {
     }
 
     private boolean shouldSample(RestSubscription subscription, PublishResponse response) {
-        if (subscription.getStatus() == SubscriptionStatus.COMPLETED) {
+        if (!subscription.isRunning()) {
             return false;
         }
 
         RestSubscriberProperties properties = subscription.getProperties();
         Set<String> publishers = properties.getPublishers();
 
-        if (!publishers.isEmpty() && !publishers.contains(response.getRequest().getScenarioName())) {
+        if (!publishers.isEmpty() && !publishers.contains(response.getRequest().getScenario().getName())) {
             return false;
         }
 
@@ -151,7 +150,7 @@ class RestSubscriber implements MirrorSubscriber {
                 .consensusTimestamp(transaction.getConsensusTimestamp())
                 .publishedTimestamp(publishResponse.getRequest().getTimestamp())
                 .receivedTimestamp(receivedTimestamp)
-                .subscription(subscription)
+                .scenario(subscription)
                 .build();
     }
 

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/rest/RestSubscription.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/rest/RestSubscription.java
@@ -25,13 +25,13 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 import reactor.core.Exceptions;
 import reactor.core.publisher.Sinks;
 
+import com.hedera.mirror.monitor.AbstractScenario;
+import com.hedera.mirror.monitor.ScenarioProtocol;
 import com.hedera.mirror.monitor.publish.PublishResponse;
-import com.hedera.mirror.monitor.subscribe.AbstractSubscription;
-import com.hedera.mirror.monitor.subscribe.SubscriberProtocol;
 import com.hedera.mirror.monitor.subscribe.rest.response.MirrorTransaction;
 
 @Getter
-class RestSubscription extends AbstractSubscription<RestSubscriberProperties, MirrorTransaction> {
+class RestSubscription extends AbstractScenario<RestSubscriberProperties, MirrorTransaction> {
 
     private final Sinks.Many<PublishResponse> sink;
 
@@ -41,8 +41,8 @@ class RestSubscription extends AbstractSubscription<RestSubscriberProperties, Mi
     }
 
     @Override
-    public SubscriberProtocol getProtocol() {
-        return SubscriberProtocol.REST;
+    public ScenarioProtocol getProtocol() {
+        return ScenarioProtocol.REST;
     }
 
     @Override
@@ -60,5 +60,11 @@ class RestSubscription extends AbstractSubscription<RestSubscriberProperties, Mi
         }
 
         errors.add(error);
+    }
+
+    @Override
+    public String toString() {
+        String name = getName();
+        return getProperties().getSubscribers() <= 1 ? name : name + " #" + getId();
     }
 }

--- a/hedera-mirror-monitor/src/main/resources/application.yml
+++ b/hedera-mirror-monitor/src/main/resources/application.yml
@@ -44,6 +44,8 @@ management:
   endpoint:
     health:
       group:
+        cluster:
+          include: cluster
         liveness:
           include: ping
         readiness:

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/ClusterHealthIndicatorTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/ClusterHealthIndicatorTest.java
@@ -1,0 +1,103 @@
+package com.hedera.mirror.monitor;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import lombok.Getter;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Status;
+import reactor.core.publisher.Flux;
+
+import com.hedera.mirror.monitor.publish.PublishScenario;
+import com.hedera.mirror.monitor.publish.PublishScenarioProperties;
+import com.hedera.mirror.monitor.publish.generator.TransactionGenerator;
+import com.hedera.mirror.monitor.subscribe.MirrorSubscriber;
+import com.hedera.mirror.monitor.subscribe.Scenario;
+import com.hedera.mirror.monitor.subscribe.TestScenario;
+
+@ExtendWith(MockitoExtension.class)
+class ClusterHealthIndicatorTest {
+
+    @Mock
+    private MirrorSubscriber mirrorSubscriber;
+
+    @Mock
+    private TransactionGenerator transactionGenerator;
+
+    @InjectMocks
+    private ClusterHealthIndicator clusterHealthIndicator;
+
+    @Test
+    void healthy() {
+        when(transactionGenerator.scenarios()).thenReturn(Flux.just(publishScenario(1.0)));
+        when(mirrorSubscriber.getSubscriptions()).thenReturn(Flux.just(subscribeScenario(1.0)));
+        assertThat(clusterHealthIndicator.health().block()).isEqualTo(Health.up().build());
+    }
+
+    @Test
+    void publishingInactive() {
+        when(transactionGenerator.scenarios()).thenReturn(Flux.just(publishScenario(0.0)));
+        when(mirrorSubscriber.getSubscriptions()).thenReturn(Flux.just(subscribeScenario(1.0)));
+        assertThat(clusterHealthIndicator.health().block()).extracting(Health::getStatus).isEqualTo(Status.UNKNOWN);
+    }
+
+    @Test
+    void subscribingInactive() {
+        when(transactionGenerator.scenarios()).thenReturn(Flux.just(publishScenario(1.0)));
+        when(mirrorSubscriber.getSubscriptions()).thenReturn(Flux.just(subscribeScenario(0.0)));
+        assertThat(clusterHealthIndicator.health().block()).extracting(Health::getStatus).isEqualTo(Status.DOWN);
+    }
+
+    @Test
+    void bothInactive() {
+        when(transactionGenerator.scenarios()).thenReturn(Flux.just(publishScenario(0.0)));
+        when(mirrorSubscriber.getSubscriptions()).thenReturn(Flux.just(subscribeScenario(0.0)));
+        assertThat(clusterHealthIndicator.health().block()).extracting(Health::getStatus).isEqualTo(Status.UNKNOWN);
+    }
+
+    private PublishScenario publishScenario(double rate) {
+        return new TestPublishScenario(rate);
+    }
+
+    private Scenario<?, ?> subscribeScenario(double rate) {
+        TestScenario testScenario = new TestScenario();
+        testScenario.setRate(rate);
+        return testScenario;
+    }
+
+    @Getter
+    private class TestPublishScenario extends PublishScenario {
+
+        private final double rate;
+
+        private TestPublishScenario(double rate) {
+            super(new PublishScenarioProperties());
+            this.rate = rate;
+        }
+    }
+}

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/expression/ExpressionConverterImplTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/expression/ExpressionConverterImplTest.java
@@ -130,7 +130,7 @@ class ExpressionConverterImplTest {
         assertThat(expressionConverter.convert("${account.foo}")).isEqualTo("0.0.100");
 
         verify(transactionPublisher).publish(request.capture());
-        assertThat(request.getValue().getType()).isEqualTo(type);
+        assertThat(request.getValue().getScenario().getProperties().getType()).isEqualTo(type);
     }
 
     @Test
@@ -140,7 +140,7 @@ class ExpressionConverterImplTest {
         assertThat(expressionConverter.convert("${token.foo}")).isEqualTo("0.0.101");
 
         verify(transactionPublisher).publish(request.capture());
-        assertThat(request.getValue().getType()).isEqualTo(type);
+        assertThat(request.getValue().getScenario().getProperties().getType()).isEqualTo(type);
     }
 
     @Test
@@ -150,7 +150,7 @@ class ExpressionConverterImplTest {
         assertThat(expressionConverter.convert("${nft.foo}")).isEqualTo("0.0.101");
 
         verify(transactionPublisher).publish(request.capture());
-        assertThat(request.getValue().getType()).isEqualTo(type);
+        assertThat(request.getValue().getScenario().getProperties().getType()).isEqualTo(type);
     }
 
     @Test
@@ -160,7 +160,7 @@ class ExpressionConverterImplTest {
         assertThat(expressionConverter.convert("${topic.foo}")).isEqualTo("0.0.100");
 
         verify(transactionPublisher).publish(request.capture());
-        assertThat(request.getValue().getType()).isEqualTo(type);
+        assertThat(request.getValue().getScenario().getProperties().getType()).isEqualTo(type);
     }
 
     @Test
@@ -171,7 +171,7 @@ class ExpressionConverterImplTest {
         assertThat(expressionConverter.convert("${schedule.foo}")).isEqualTo("0.0.100");
 
         verify(transactionPublisher).publish(request.capture());
-        assertThat(request.getValue().getType()).isEqualTo(type);
+        assertThat(request.getValue().getScenario().getProperties().getType()).isEqualTo(type);
     }
 
     @Test
@@ -184,7 +184,7 @@ class ExpressionConverterImplTest {
         assertThat(expressionConverter.convert("${topic.foo}")).isEqualTo("0.0.100");
 
         verify(transactionPublisher).publish(request.capture());
-        assertThat(request.getValue().getType()).isEqualTo(type);
+        assertThat(request.getValue().getScenario().getProperties().getType()).isEqualTo(type);
     }
 
     @Test
@@ -199,7 +199,7 @@ class ExpressionConverterImplTest {
                 .containsEntry("topicId", "0.0.101");
 
         verify(transactionPublisher).publish(request.capture());
-        assertThat(request.getValue().getType()).isEqualTo(type);
+        assertThat(request.getValue().getScenario().getProperties().getType()).isEqualTo(type);
     }
 
     private Mono<PublishResponse> response(TransactionType type, long id) throws InvalidProtocolBufferException {

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/PublishPropertiesTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/PublishPropertiesTest.java
@@ -28,36 +28,34 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import com.hedera.mirror.monitor.generator.ScenarioProperties;
-
 class PublishPropertiesTest {
 
-    private ScenarioProperties scenarioProperties;
+    private PublishScenarioProperties publishScenarioProperties;
     private PublishProperties publishProperties;
 
     @BeforeEach
     void setup() {
-        scenarioProperties = new ScenarioProperties();
+        publishScenarioProperties = new PublishScenarioProperties();
         publishProperties = new PublishProperties();
-        publishProperties.getScenarios().put("test1", scenarioProperties);
+        publishProperties.getScenarios().put("test1", publishScenarioProperties);
     }
 
     @Test
     void validate() {
         publishProperties.validate();
-        assertThat(scenarioProperties.getName()).isEqualTo("test1");
+        assertThat(publishScenarioProperties.getName()).isEqualTo("test1");
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"", " "})
     void emptyName(String name) {
-        publishProperties.getScenarios().put(name, scenarioProperties);
+        publishProperties.getScenarios().put(name, publishScenarioProperties);
         assertThrows(IllegalArgumentException.class, publishProperties::validate);
     }
 
     @Test
     void nullName() {
-        publishProperties.getScenarios().put(null, scenarioProperties);
+        publishProperties.getScenarios().put(null, publishScenarioProperties);
         assertThrows(IllegalArgumentException.class, publishProperties::validate);
     }
 

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/TransactionPublisherTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/TransactionPublisherTest.java
@@ -296,6 +296,11 @@ class TransactionPublisherTest {
     void closeWhenDisabled() {
         publishProperties.setEnabled(false);
         transactionPublisher.close();
+        transactionPublisher.publish(request().build())
+                .as(StepVerifier::create)
+                .expectNextCount(0L)
+                .expectComplete()
+                .verify(Duration.ofSeconds(1L));
     }
 
     private PublishRequest.PublishRequestBuilder request() {

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/TransactionPublisherTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/TransactionPublisherTest.java
@@ -1,0 +1,384 @@
+package com.hedera.mirror.monitor.publish;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import static com.hedera.hashgraph.sdk.proto.ResponseCodeEnum.OK;
+import static com.hedera.hashgraph.sdk.proto.ResponseCodeEnum.SUCCESS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.grpc.Server;
+import io.grpc.Status;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.StreamObserver;
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.TimeoutException;
+import lombok.Data;
+import lombok.extern.log4j.Log4j2;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import com.hedera.datagenerator.sdk.supplier.TransactionType;
+import com.hedera.hashgraph.sdk.PrivateKey;
+import com.hedera.hashgraph.sdk.TransferTransaction;
+import com.hedera.hashgraph.sdk.proto.CryptoServiceGrpc;
+import com.hedera.hashgraph.sdk.proto.Query;
+import com.hedera.hashgraph.sdk.proto.Response;
+import com.hedera.hashgraph.sdk.proto.ResponseCodeEnum;
+import com.hedera.hashgraph.sdk.proto.ResponseHeader;
+import com.hedera.hashgraph.sdk.proto.Transaction;
+import com.hedera.hashgraph.sdk.proto.TransactionGetReceiptResponse;
+import com.hedera.hashgraph.sdk.proto.TransactionGetRecordResponse;
+import com.hedera.hashgraph.sdk.proto.TransactionReceipt;
+import com.hedera.hashgraph.sdk.proto.TransactionRecord;
+import com.hedera.hashgraph.sdk.proto.TransactionResponse;
+import com.hedera.mirror.monitor.MonitorProperties;
+import com.hedera.mirror.monitor.NodeProperties;
+import com.hedera.mirror.monitor.OperatorProperties;
+
+@Log4j2
+class TransactionPublisherTest {
+
+    private CryptoServiceStub cryptoServiceStub;
+    private MonitorProperties monitorProperties;
+    private PublishProperties publishProperties;
+    private PublishScenarioProperties publishScenarioProperties;
+    private Server server;
+    private TransactionPublisher transactionPublisher;
+
+    @BeforeEach
+    void setup() throws IOException {
+        OperatorProperties operatorProperties = new OperatorProperties();
+        operatorProperties.setAccountId("0.0.100");
+        operatorProperties.setPrivateKey(PrivateKey.generate().toString());
+        publishScenarioProperties = new PublishScenarioProperties();
+        publishScenarioProperties.setName("test");
+        publishScenarioProperties.setType(TransactionType.CRYPTO_TRANSFER);
+        monitorProperties = new MonitorProperties();
+        monitorProperties.setNodes(Set.of(new NodeProperties("0.0.3", "in-process:test")));
+        monitorProperties.setOperator(operatorProperties);
+        publishProperties = new PublishProperties();
+        transactionPublisher = new TransactionPublisher(monitorProperties, publishProperties);
+
+        cryptoServiceStub = new CryptoServiceStub();
+        server = InProcessServerBuilder.forName("test")
+                .addService(cryptoServiceStub)
+                .directExecutor()
+                .build()
+                .start();
+    }
+
+    @AfterEach
+    void teardown() throws InterruptedException {
+        cryptoServiceStub.verify();
+        transactionPublisher.close();
+        if (server != null) {
+            server.shutdown();
+            server.awaitTermination();
+        }
+    }
+
+    @Test
+    @Timeout(3)
+    void publish() {
+        PublishRequest request = request().build();
+        cryptoServiceStub.addQueries(Mono.just(receipt(SUCCESS)));
+        cryptoServiceStub.addTransactions(Mono.just(response(OK)), Mono.just(response(OK)));
+
+        transactionPublisher.publish(request)
+                .as(StepVerifier::create)
+                .expectNextMatches(r -> {
+                    assertThat(r)
+                            .isNotNull()
+                            .returns(request, PublishResponse::getRequest)
+                            .returns(request.getTransaction().getTransactionId(), PublishResponse::getTransactionId)
+                            .extracting(PublishResponse::getTimestamp)
+                            .isNotNull();
+                    return true;
+                })
+                .expectComplete()
+                .verify(Duration.ofSeconds(1L));
+    }
+
+    @Test
+    @Timeout(3)
+    void publishWithLogResponse() {
+        publishScenarioProperties.setLogResponse(true);
+        cryptoServiceStub.addQueries(Mono.just(receipt(SUCCESS)));
+        cryptoServiceStub.addTransactions(Mono.just(response(OK)), Mono.just(response(OK)));
+
+        transactionPublisher.publish(request().build())
+                .as(StepVerifier::create)
+                .expectNextCount(1L)
+                .expectComplete()
+                .verify(Duration.ofSeconds(1L));
+    }
+
+    @Test
+    @Timeout(3)
+    void publishWithReceipt() {
+        cryptoServiceStub.addQueries(Mono.just(receipt(SUCCESS)), Mono.just(receipt(SUCCESS)));
+        cryptoServiceStub.addTransactions(Mono.just(response(OK)), Mono.just(response(OK)));
+
+        transactionPublisher.publish(request().receipt(true).build())
+                .as(StepVerifier::create)
+                .expectNextMatches(r -> {
+                    assertThat(r).extracting(PublishResponse::getReceipt).isNotNull();
+                    assertThat(r).extracting(PublishResponse::getRecord).isNull();
+                    return true;
+                })
+                .expectComplete()
+                .verify(Duration.ofSeconds(1L));
+    }
+
+    @Test
+    @Timeout(3)
+    void publishWithRecord() {
+        cryptoServiceStub.addQueries(Mono.just(receipt(SUCCESS)), Mono.just(record(SUCCESS)));
+        cryptoServiceStub.addTransactions(Mono.just(response(OK)), Mono.just(response(OK)));
+
+        transactionPublisher.publish(request().record(true).build())
+                .as(StepVerifier::create)
+                .expectNextMatches(r -> {
+                    assertThat(r).extracting(PublishResponse::getReceipt).isNotNull();
+                    assertThat(r).extracting(PublishResponse::getRecord).isNotNull();
+                    return true;
+                })
+                .expectComplete()
+                .verify(Duration.ofSeconds(1L));
+    }
+
+    @Test
+    @Timeout(3)
+    void publishPreCheckError() {
+        ResponseCodeEnum errorResponseCode = ResponseCodeEnum.INSUFFICIENT_ACCOUNT_BALANCE;
+        cryptoServiceStub.addQueries(Mono.just(receipt(SUCCESS)));
+        cryptoServiceStub.addTransactions(Mono.just(response(OK)), Mono.just(response(errorResponseCode)));
+
+        transactionPublisher.publish(request().build())
+                .as(StepVerifier::create)
+                .expectErrorSatisfies(t -> assertThat(t)
+                        .isInstanceOf(PublishException.class)
+                        .hasMessageContaining(errorResponseCode.toString()))
+                .verify(Duration.ofSeconds(1L));
+    }
+
+    @Test
+    @Timeout(3)
+    void publishRetrySuccessful() {
+        cryptoServiceStub.addQueries(Mono.just(receipt(SUCCESS)));
+        cryptoServiceStub.addTransactions(Mono.just(response(OK)),
+                Mono.just(response(ResponseCodeEnum.PLATFORM_TRANSACTION_NOT_CREATED)),
+                Mono.just(response(ResponseCodeEnum.OK)));
+
+        transactionPublisher.publish(request().build())
+                .as(StepVerifier::create)
+                .expectNextCount(1L)
+                .expectComplete()
+                .verify(Duration.ofSeconds(1L));
+    }
+
+    @Test
+    @Timeout(3)
+    void publishRetryError() {
+        ResponseCodeEnum errorResponseCode = ResponseCodeEnum.PLATFORM_TRANSACTION_NOT_CREATED;
+        cryptoServiceStub.addQueries(Mono.just(receipt(SUCCESS)));
+        cryptoServiceStub.addTransactions(Mono.just(response(OK)),
+                Mono.just(response(errorResponseCode)),
+                Mono.just(response(errorResponseCode)));
+
+        transactionPublisher.publish(request().build())
+                .as(StepVerifier::create)
+                .expectErrorSatisfies(t -> assertThat(t)
+                        .isInstanceOf(PublishException.class)
+                        .hasMessageContaining("Failed to get gRPC response within maximum retry count")
+                        .getRootCause()
+                        .hasMessageContaining(errorResponseCode.toString()))
+                .verify(Duration.ofSeconds(1L));
+    }
+
+    @Test
+    @Timeout(3)
+    void publishTimeout() {
+        publishScenarioProperties.setTimeout(Duration.ofMillis(100L));
+        cryptoServiceStub.addQueries(Mono.just(receipt(SUCCESS)));
+        cryptoServiceStub.addTransactions(Mono.just(response(OK)),
+                Mono.delay(Duration.ofMillis(500L)).thenReturn(response(OK)));
+
+        transactionPublisher.publish(request().build())
+                .as(StepVerifier::create)
+                .expectErrorSatisfies(t -> assertThat(t)
+                        .isInstanceOf(PublishException.class)
+                        .hasMessageContaining("Did not observe any item or terminal signal within 100ms")
+                        .hasCauseInstanceOf(TimeoutException.class))
+                .verify(Duration.ofSeconds(1L));
+    }
+
+    @Test
+    @Timeout(3)
+    void noValidNodes() {
+        cryptoServiceStub.addTransactions(Mono.error(Status.INTERNAL.asRuntimeException()));
+        transactionPublisher.publish(request().build())
+                .as(StepVerifier::create)
+                .expectError(IllegalArgumentException.class)
+                .verify(Duration.ofSeconds(1L));
+    }
+
+    @Test
+    @Timeout(3)
+    void skipNodeValidation() {
+        monitorProperties.setValidateNodes(false);
+        cryptoServiceStub.addTransactions(Mono.just(response(OK)));
+
+        transactionPublisher.publish(request().build())
+                .as(StepVerifier::create)
+                .expectNextCount(1L)
+                .expectComplete()
+                .verify(Duration.ofSeconds(1L));
+    }
+
+    @Test
+    @Timeout(3)
+    void nodeValidationFailsReceipt() {
+        cryptoServiceStub.addQueries(Mono.just(receipt(ResponseCodeEnum.ACCOUNT_DELETED)));
+        cryptoServiceStub.addTransactions(Mono.just(response(OK)));
+
+        transactionPublisher.publish(request().build())
+                .as(StepVerifier::create)
+                .expectError(IllegalArgumentException.class)
+                .verify(Duration.ofSeconds(1L));
+    }
+
+    @Test
+    @Timeout(3)
+    void someValidNodes() {
+        monitorProperties.setNodes(Set.of(new NodeProperties("0.0.3", "in-process:test"),
+                new NodeProperties("0.0.4", "invalid:1"))); // Illegal DNS to avoid SDK retry
+        cryptoServiceStub.addQueries(Mono.just(receipt(SUCCESS)));
+        cryptoServiceStub.addTransactions(Mono.just(response(OK)), Mono.just(response(OK)));
+
+        transactionPublisher.publish(request().build())
+                .as(StepVerifier::create)
+                .expectNextCount(1L)
+                .expectComplete()
+                .verify(Duration.ofSeconds(1L));
+    }
+
+    @Test
+    @Timeout(3)
+    void closeWhenDisabled() {
+        publishProperties.setEnabled(false);
+        transactionPublisher.close();
+    }
+
+    private PublishRequest.PublishRequestBuilder request() {
+        return PublishRequest.builder()
+                .scenario(new PublishScenario(publishScenarioProperties))
+                .timestamp(Instant.now())
+                .transaction(new TransferTransaction().setMaxAttempts(2));
+    }
+
+    private TransactionResponse response(ResponseCodeEnum responseCode) {
+        return TransactionResponse.newBuilder()
+                .setNodeTransactionPrecheckCode(responseCode)
+                .build();
+    }
+
+    private Response receipt(ResponseCodeEnum responseCode) {
+        ResponseHeader responseHeader = ResponseHeader.newBuilder()
+                .setNodeTransactionPrecheckCode(OK)
+                .build();
+        return Response.newBuilder()
+                .setTransactionGetReceipt(TransactionGetReceiptResponse.newBuilder()
+                        .setHeader(responseHeader)
+                        .setReceipt(TransactionReceipt.newBuilder().setStatus(responseCode).build())
+                        .build())
+                .build();
+    }
+
+    private Response record(ResponseCodeEnum responseCode) {
+        ResponseHeader.Builder responseHeader = ResponseHeader.newBuilder()
+                .setNodeTransactionPrecheckCode(OK);
+        TransactionReceipt.Builder transactionReceipt = TransactionReceipt.newBuilder().setStatus(responseCode);
+        return Response.newBuilder()
+                .setTransactionGetRecord(TransactionGetRecordResponse.newBuilder()
+                        .setHeader(responseHeader)
+                        .setTransactionRecord(TransactionRecord.newBuilder().setReceipt(transactionReceipt)))
+                .build();
+    }
+
+    @Data
+    private class CryptoServiceStub extends CryptoServiceGrpc.CryptoServiceImplBase {
+
+        private Queue<Mono<TransactionResponse>> transactions = new LinkedList<>();
+        private Queue<Mono<Response>> queries = new LinkedList<>();
+
+        void addQueries(Mono<Response>... query) {
+            queries.addAll(Arrays.asList(query));
+        }
+
+        void addTransactions(Mono<TransactionResponse>... transaction) {
+            transactions.addAll(Arrays.asList(transaction));
+        }
+
+        @Override
+        public void cryptoTransfer(Transaction request, StreamObserver<TransactionResponse> responseObserver) {
+            log.debug("cryptoTransfer: {}", request);
+            send(responseObserver, transactions.poll());
+        }
+
+        @Override
+        public void getTransactionReceipts(Query request, StreamObserver<Response> responseObserver) {
+            log.debug("getTransactionReceipts: {}", request);
+            send(responseObserver, queries.poll());
+        }
+
+        @Override
+        public void getTxRecordByTxID(Query request, StreamObserver<Response> responseObserver) {
+            log.debug("getTxRecordByTxID: {}", request);
+            send(responseObserver, queries.poll());
+        }
+
+        private <T> void send(StreamObserver<T> responseObserver, Mono<T> response) {
+            assertThat(response).isNotNull();
+            response.delayElement(Duration.ofMillis(100L))
+                    .doOnError(responseObserver::onError)
+                    .doOnNext(responseObserver::onNext)
+                    .doOnNext(t -> log.trace("Next: {}", t))
+                    .doOnSuccess(r -> responseObserver.onCompleted())
+                    .subscribe();
+        }
+
+        void verify() {
+            assertThat(queries).isEmpty();
+            assertThat(transactions).isEmpty();
+        }
+    }
+}

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/generator/ConfigurableTransactionGeneratorTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/generator/ConfigurableTransactionGeneratorTest.java
@@ -94,9 +94,8 @@ class ConfigurableTransactionGeneratorTest {
     @Test
     void unknownField() {
         properties.setProperties(Map.of("foo", "bar", "topicId", TOPIC_ID));
-        assertThatThrownBy(() -> generator.get().next())
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("Unrecognized field");
+        List<PublishRequest> publishRequests = generator.get().next();
+        assertThat(publishRequests).hasSize(1); // No error
     }
 
     @Test

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/generator/ConfigurableTransactionGeneratorTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/generator/ConfigurableTransactionGeneratorTest.java
@@ -91,6 +91,14 @@ class ConfigurableTransactionGeneratorTest {
     }
 
     @Test
+    void invalidMaxAttempts() {
+        properties.getRetry().setMaxAttempts(0L);
+        assertThatThrownBy(generator::get)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("maxAttempts must be positive");
+    }
+
+    @Test
     void unknownField() {
         properties.setProperties(Map.of("foo", "bar", "topicId", TOPIC_ID));
         List<PublishRequest> publishRequests = generator.get().next();

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/generator/ConfigurableTransactionGeneratorTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/generator/ConfigurableTransactionGeneratorTest.java
@@ -1,4 +1,4 @@
-package com.hedera.mirror.monitor.generator;
+package com.hedera.mirror.monitor.publish.generator;
 
 /*-
  * ‌
@@ -42,18 +42,19 @@ import org.junit.jupiter.params.provider.ValueSource;
 import com.hedera.datagenerator.sdk.supplier.TransactionType;
 import com.hedera.hashgraph.sdk.TopicId;
 import com.hedera.mirror.monitor.publish.PublishRequest;
+import com.hedera.mirror.monitor.publish.PublishScenarioProperties;
 
 class ConfigurableTransactionGeneratorTest {
 
     private static final int SAMPLE_SIZE = 10_000;
     private static final String TOPIC_ID = "0.0.1000";
 
-    private ScenarioProperties properties;
+    private PublishScenarioProperties properties;
     private Supplier<ConfigurableTransactionGenerator> generator;
 
     @BeforeEach
     void init() {
-        properties = new ScenarioProperties();
+        properties = new PublishScenarioProperties();
         properties.setReceiptPercent(1);
         properties.setRecordPercent(1);
         properties.setName("test");
@@ -88,12 +89,6 @@ class ConfigurableTransactionGeneratorTest {
         assertThatThrownBy(() -> generator.get().next())
                 .isInstanceOf(ScenarioException.class)
                 .hasMessageContaining("Reached publish limit");
-    }
-
-    @Test
-    void logResponse() {
-        properties.setLogResponse(true);
-        assertRequests(generator.get().next());
     }
 
     @Test
@@ -202,10 +197,8 @@ class ConfigurableTransactionGeneratorTest {
         assertThat(publishRequests).hasSize(size).allSatisfy(publishRequest -> assertThat(publishRequest)
                 .isNotNull()
                 .hasNoNullFieldsOrProperties()
-                .hasFieldOrPropertyWithValue("logResponse", properties.isLogResponse())
                 .hasFieldOrPropertyWithValue("receipt", true)
                 .hasFieldOrPropertyWithValue("record", true)
-                .hasFieldOrPropertyWithValue("type", properties.getType())
                 .hasFieldOrPropertyWithValue("transaction.topicId", TopicId.fromString(TOPIC_ID))
         );
     }

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/CompositeSubscriberTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/CompositeSubscriberTest.java
@@ -73,8 +73,8 @@ class CompositeSubscriberTest {
 
     @Test
     void subscriptions() {
-        TestSubscription subscription1 = new TestSubscription();
-        TestSubscription subscription2 = new TestSubscription();
+        TestScenario subscription1 = new TestScenario();
+        TestScenario subscription2 = new TestScenario();
         when(mirrorSubscriber1.getSubscriptions()).thenReturn(Flux.just(subscription1));
         when(mirrorSubscriber2.getSubscriptions()).thenReturn(Flux.just(subscription2));
 

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/SubscribeMetricsTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/SubscribeMetricsTest.java
@@ -39,6 +39,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import com.hedera.mirror.monitor.ScenarioStatus;
 import com.hedera.mirror.monitor.subscribe.grpc.GrpcSubscriberProperties;
 
 class SubscribeMetricsTest {
@@ -77,7 +78,7 @@ class SubscribeMetricsTest {
 
     @Test
     void recordDuration() {
-        TestSubscription subscription = new TestSubscription();
+        TestScenario subscription = new TestScenario();
         SubscribeResponse response1 = response(subscription);
         SubscribeResponse response2 = response(subscription);
         subscribeMetrics.onNext(response1);
@@ -94,7 +95,7 @@ class SubscribeMetricsTest {
 
     @Test
     void recordE2E() {
-        TestSubscription subscription = new TestSubscription();
+        TestScenario subscription = new TestScenario();
         SubscribeResponse response1 = response(subscription);
         subscribeMetrics.onNext(response1);
 
@@ -125,8 +126,8 @@ class SubscribeMetricsTest {
 
     @Test
     void status() {
-        TestSubscription testSubscription1 = new TestSubscription();
-        TestSubscription testSubscription2 = new TestSubscription();
+        TestScenario testSubscription1 = new TestScenario();
+        TestScenario testSubscription2 = new TestScenario();
         testSubscription2.setName("Test2");
 
         subscribeMetrics.onNext(response(testSubscription1));
@@ -143,7 +144,7 @@ class SubscribeMetricsTest {
     void statusDisabled() {
         subscribeProperties.setEnabled(false);
 
-        subscribeMetrics.onNext(response(new TestSubscription()));
+        subscribeMetrics.onNext(response(new TestScenario()));
         subscribeMetrics.status();
 
         assertThat(logOutput).asString().isEmpty();
@@ -151,8 +152,8 @@ class SubscribeMetricsTest {
 
     @Test
     void statusNotRunning() {
-        TestSubscription testSubscription = new TestSubscription();
-        testSubscription.setStatus(SubscriptionStatus.COMPLETED);
+        TestScenario testSubscription = new TestScenario();
+        testSubscription.setStatus(ScenarioStatus.COMPLETED);
 
         subscribeMetrics.onNext(response(testSubscription));
         subscribeMetrics.status();
@@ -160,13 +161,13 @@ class SubscribeMetricsTest {
         assertThat(logOutput).asString().isEmpty();
     }
 
-    private SubscribeResponse response(Subscription subscription) {
+    private SubscribeResponse response(Scenario scenario) {
         Instant timestamp = Instant.now().minusSeconds(5L);
         return SubscribeResponse.builder()
                 .publishedTimestamp(timestamp)
-                .consensusTimestamp(timestamp.plusSeconds(1L * subscription.getCount()))
-                .receivedTimestamp(timestamp.plusSeconds(2L * subscription.getCount()))
-                .subscription(subscription)
+                .consensusTimestamp(timestamp.plusSeconds(1L * scenario.getCount()))
+                .receivedTimestamp(timestamp.plusSeconds(2L * scenario.getCount()))
+                .scenario(scenario)
                 .build();
     }
 }

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/TestScenario.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/TestScenario.java
@@ -25,8 +25,11 @@ import java.util.HashMap;
 import java.util.Map;
 import lombok.Data;
 
+import com.hedera.mirror.monitor.ScenarioProtocol;
+import com.hedera.mirror.monitor.ScenarioStatus;
+
 @Data
-public class TestSubscription implements Subscription {
+public class TestScenario implements Scenario {
 
     private long count = 1;
     private Duration elapsed = Duration.ofSeconds(1L);
@@ -34,12 +37,32 @@ public class TestSubscription implements Subscription {
     private int id = 1;
     private String name = "Test";
     private AbstractSubscriberProperties properties;
-    private SubscriberProtocol protocol = SubscriberProtocol.GRPC;
+    private ScenarioProtocol protocol = ScenarioProtocol.GRPC;
     private double rate = 1.0;
-    private SubscriptionStatus status = SubscriptionStatus.RUNNING;
+    private ScenarioStatus status = ScenarioStatus.RUNNING;
+
+    @Override
+    public boolean isRunning() {
+        return status == ScenarioStatus.RUNNING;
+    }
 
     @Override
     public String toString() {
         return name;
+    }
+
+    @Override
+    public void onComplete() {
+        // Ignore
+    }
+
+    @Override
+    public void onError(Throwable t) {
+        // Ignore
+    }
+
+    @Override
+    public void onNext(Object response) {
+        // Ignore
     }
 }

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/controller/SubscriberControllerTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/controller/SubscriberControllerTest.java
@@ -32,11 +32,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import reactor.core.publisher.Flux;
 
+import com.hedera.mirror.monitor.ScenarioProtocol;
+import com.hedera.mirror.monitor.ScenarioStatus;
 import com.hedera.mirror.monitor.config.LoggingFilter;
 import com.hedera.mirror.monitor.subscribe.MirrorSubscriber;
-import com.hedera.mirror.monitor.subscribe.SubscriberProtocol;
-import com.hedera.mirror.monitor.subscribe.SubscriptionStatus;
-import com.hedera.mirror.monitor.subscribe.TestSubscription;
+import com.hedera.mirror.monitor.subscribe.TestScenario;
 
 @Log4j2
 @ExtendWith(MockitoExtension.class)
@@ -47,22 +47,22 @@ class SubscriberControllerTest {
 
     private WebTestClient webTestClient;
 
-    private TestSubscription subscription1;
-    private TestSubscription subscription2;
+    private TestScenario subscription1;
+    private TestScenario subscription2;
 
     @BeforeEach
     void setup() {
-        subscription1 = new TestSubscription();
+        subscription1 = new TestScenario();
         subscription1.setName("grpc1");
         subscription1.setId(1);
-        subscription1.setProtocol(SubscriberProtocol.GRPC);
-        subscription1.setStatus(SubscriptionStatus.COMPLETED);
+        subscription1.setProtocol(ScenarioProtocol.GRPC);
+        subscription1.setStatus(ScenarioStatus.COMPLETED);
 
-        subscription2 = new TestSubscription();
+        subscription2 = new TestScenario();
         subscription2.setName("rest1");
         subscription2.setId(1);
-        subscription2.setProtocol(SubscriberProtocol.REST);
-        subscription2.setStatus(SubscriptionStatus.RUNNING);
+        subscription2.setProtocol(ScenarioProtocol.REST);
+        subscription2.setStatus(ScenarioStatus.RUNNING);
 
         SubscriberController subscriberController = new SubscriberController(mirrorSubscriber);
         webTestClient = WebTestClient.bindToController(subscriberController).webFilter(new LoggingFilter()).build();
@@ -76,7 +76,7 @@ class SubscriberControllerTest {
                 .exchange()
                 .expectStatus()
                 .is2xxSuccessful()
-                .expectBodyList(TestSubscription.class)
+                .expectBodyList(TestScenario.class)
                 .isEqualTo(Arrays.asList(subscription1, subscription2));
     }
 
@@ -87,7 +87,7 @@ class SubscriberControllerTest {
                 .exchange()
                 .expectStatus()
                 .is2xxSuccessful()
-                .expectBodyList(TestSubscription.class)
+                .expectBodyList(TestScenario.class)
                 .isEqualTo(Arrays.asList(subscription2));
     }
 
@@ -98,7 +98,7 @@ class SubscriberControllerTest {
                 .exchange()
                 .expectStatus()
                 .is2xxSuccessful()
-                .expectBodyList(TestSubscription.class)
+                .expectBodyList(TestScenario.class)
                 .isEqualTo(Arrays.asList(subscription1));
     }
 
@@ -109,7 +109,7 @@ class SubscriberControllerTest {
                 .exchange()
                 .expectStatus()
                 .is2xxSuccessful()
-                .expectBodyList(TestSubscription.class)
+                .expectBodyList(TestScenario.class)
                 .isEqualTo(Arrays.asList(subscription1, subscription2));
     }
 
@@ -120,7 +120,7 @@ class SubscriberControllerTest {
                 .exchange()
                 .expectStatus()
                 .is2xxSuccessful()
-                .expectBodyList(TestSubscription.class)
+                .expectBodyList(TestScenario.class)
                 .isEqualTo(Arrays.asList(subscription1, subscription2));
     }
 
@@ -143,7 +143,7 @@ class SubscriberControllerTest {
                 .exchange()
                 .expectStatus()
                 .is2xxSuccessful()
-                .expectBodyList(TestSubscription.class)
+                .expectBodyList(TestScenario.class)
                 .isEqualTo(Arrays.asList(subscription1, subscription2));
     }
 
@@ -156,7 +156,7 @@ class SubscriberControllerTest {
                 .exchange()
                 .expectStatus()
                 .is2xxSuccessful()
-                .expectBodyList(TestSubscription.class)
+                .expectBodyList(TestScenario.class)
                 .isEqualTo(Arrays.asList(subscription1));
     }
 
@@ -178,7 +178,7 @@ class SubscriberControllerTest {
                 .exchange()
                 .expectStatus()
                 .is2xxSuccessful()
-                .expectBodyList(TestSubscription.class)
+                .expectBodyList(TestScenario.class)
                 .isEqualTo(Arrays.asList(subscription2));
     }
 

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/grpc/GrpcSubscriberTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/grpc/GrpcSubscriberTest.java
@@ -37,12 +37,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
+import com.hedera.mirror.monitor.ScenarioProtocol;
 import com.hedera.mirror.monitor.expression.ExpressionConverter;
 import com.hedera.mirror.monitor.publish.PublishResponse;
+import com.hedera.mirror.monitor.subscribe.Scenario;
 import com.hedera.mirror.monitor.subscribe.SubscribeProperties;
 import com.hedera.mirror.monitor.subscribe.SubscribeResponse;
-import com.hedera.mirror.monitor.subscribe.SubscriberProtocol;
-import com.hedera.mirror.monitor.subscribe.Subscription;
 
 @ExtendWith(MockitoExtension.class)
 class GrpcSubscriberTest {
@@ -80,7 +80,7 @@ class GrpcSubscriberTest {
                 .verify(Duration.ofMillis(500L));
         assertThat(grpcSubscriber.getSubscriptions().blockFirst())
                 .isNotNull()
-                .returns(SubscriberProtocol.GRPC, Subscription::getProtocol);
+                .returns(ScenarioProtocol.GRPC, Scenario::getProtocol);
     }
 
     @Test
@@ -95,9 +95,9 @@ class GrpcSubscriberTest {
                 .hasSize(2)
                 .doesNotHaveDuplicates()
                 .allSatisfy(s -> assertThat(s).isNotNull()
-                        .returns(grpcSubscriberProperties, Subscription::getProperties)
-                        .returns(SubscriberProtocol.GRPC, Subscription::getProtocol))
-                .extracting(Subscription::getId)
+                        .returns(grpcSubscriberProperties, Scenario::getProperties)
+                        .returns(ScenarioProtocol.GRPC, Scenario::getProtocol))
+                .extracting(Scenario::getId)
                 .containsExactly(1, 2);
     }
 
@@ -117,8 +117,8 @@ class GrpcSubscriberTest {
                 .hasSize(2)
                 .doesNotHaveDuplicates()
                 .allSatisfy(s -> assertThat(s).isNotNull()
-                        .returns(SubscriberProtocol.GRPC, Subscription::getProtocol))
-                .extracting(Subscription::getName)
+                        .returns(ScenarioProtocol.GRPC, Scenario::getProtocol))
+                .extracting(Scenario::getName)
                 .doesNotHaveDuplicates();
     }
 


### PR DESCRIPTION
**Description**:
Adds a cluster health endpoint to monitor and fixes various bugs with the monitor encountered during testing.

- Add an `/actuator/health/cluster` endpoint that returns unknown when publishing inactive
- Add transaction memo with hostname & scenario to track publish source
- Add new previewnet node `0.0.7`
- Add support for in-process testing of `TransactionPublisher`
- Change mainnet network configuration to use mainnet-public
- Fix `MonitorPublishErrors` alert not calculating percentage properly and triggering repeatedly
- Fix node validation succeeding when network is frozen by switching from a query to a transaction
- Fix not printing status logs or sampling when scenario is idle
- Fix rate calculation sometimes returning 0.0 at low TPS
- Fix publish properties failing on unknown properties (this allows camelcase properties to be supplied via env variables)
- Fix transaction record lookup doing 3 separate queries
- Refactor publish flow to store scenario state in new `PublishScenario`
- Refactor publish & subscribe flows to use common scenario and scenario properties classes
- Refactor publish client setup to use Flux

**Related issue(s)**:
Fixes #2313 

**Notes for reviewer**:
Waiting on access to perfnet to test changes at 10K.
Will keep subscriber REST API for now to ease rollout. May delete it later.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
