### PR TITLE
Fix importer pubsub integration test always run with v1 db schema

### DIFF
--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/PubSubIntegrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/PubSubIntegrationTest.java
@@ -29,14 +29,13 @@ import java.util.stream.Collectors;
 import javax.annotation.Resource;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 
 import com.hedera.mirror.importer.parser.record.pubsub.PubSubProperties;
 
-@ActiveProfiles("pubsub")
 @SpringBootTest(properties = {
         "spring.cloud.gcp.core.enabled=true",
         "spring.cloud.gcp.pubsub.enabled=true",
+        "spring.profiles.include=pubsub",
         "hedera.mirror.importer.parser.record.entity.enabled=false",
         "hedera.mirror.importer.parser.record.pubsub.enabled=true"})
 public abstract class PubSubIntegrationTest extends IntegrationTest {


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
- Use `spring.profiles.include` to add `pubsub` to the active profiles

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
Annotation `ActiveProfiles` overrides the value from environment variable spring.profiles.active so the pubusb integration tests were always run with v1 schema.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
