### PR TITLE
Port fix incorrect fixed fee denominating token id to release/0.37

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListener.java
@@ -871,7 +871,7 @@ public class EntityRecordItemListener implements RecordItemListener {
             var feeCase = protoCustomFee.getFeeCase();
             switch (feeCase) {
                 case FIXED_FEE:
-                    parseFixedFee(customFee, protoCustomFee.getFixedFee());
+                    parseFixedFee(customFee, protoCustomFee.getFixedFee(), tokenId);
                     break;
                 case FRACTIONAL_FEE:
                     parseFractionalFee(customFee, protoCustomFee.getFractionalFee());
@@ -893,9 +893,13 @@ public class EntityRecordItemListener implements RecordItemListener {
         }
     }
 
-    private void parseFixedFee(CustomFee customFee, FixedFee fixedFee) {
+    private void parseFixedFee(CustomFee customFee, FixedFee fixedFee, EntityId tokenId) {
         customFee.setAmount(fixedFee.getAmount());
-        customFee.setDenominatingTokenId(EntityId.of(fixedFee.getDenominatingTokenId()));
+
+        if (fixedFee.hasDenominatingTokenId()) {
+            EntityId denominatingTokenId = EntityId.of(fixedFee.getDenominatingTokenId());
+            customFee.setDenominatingTokenId(denominatingTokenId == EntityId.EMPTY ? tokenId : denominatingTokenId);
+        }
     }
 
     private void parseFractionalFee(CustomFee customFee, FractionalFee fractionalFee) {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerTokenTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerTokenTest.java
@@ -1203,14 +1203,20 @@ public class EntityRecordItemListenerTokenTest extends AbstractEntityRecordItemL
         fixedFee2.setDenominatingTokenId(FEE_DOMAIN_TOKEN_ID);
         fixedFee2.setId(id);
 
+        CustomFee fixedFee3 = new CustomFee();
+        fixedFee3.setAmount(13L);
+        fixedFee3.setCollectorAccountId(FEE_COLLECTOR_ACCOUNT_ID_2);
+        fixedFee3.setDenominatingTokenId(tokenId);
+        fixedFee3.setId(id);
+
         CustomFee fractionalFee = new CustomFee();
-        fractionalFee.setAmount(13L);
+        fractionalFee.setAmount(14L);
         fractionalFee.setAmountDenominator(31L);
         fractionalFee.setCollectorAccountId(FEE_COLLECTOR_ACCOUNT_ID_2);
         fractionalFee.setMaximumAmount(100L);
         fractionalFee.setId(id);
 
-        return List.of(fixedFee1, fixedFee2, fractionalFee);
+        return List.of(fixedFee1, fixedFee2, fixedFee3, fractionalFee);
     }
 
     private static Stream<Arguments> provideCustomFees() {
@@ -1265,8 +1271,13 @@ public class EntityRecordItemListenerTokenTest extends AbstractEntityRecordItemL
         if (customFee.getAmountDenominator() == null) {
             // fixed fee
             var fixedFee = FixedFee.newBuilder().setAmount(customFee.getAmount());
-            if (customFee.getDenominatingTokenId() != null) {
-                fixedFee.setDenominatingTokenId(convertTokenId(customFee.getDenominatingTokenId()));
+            EntityId denominatingTokenId = customFee.getDenominatingTokenId();
+            if (denominatingTokenId != null) {
+                if (denominatingTokenId.equals(customFee.getId().getTokenId())) {
+                    fixedFee.setDenominatingTokenId(TokenID.getDefaultInstance());
+                } else {
+                    fixedFee.setDenominatingTokenId(convertTokenId(denominatingTokenId));
+                }
             }
 
             protoCustomFee.setFixedFee(fixedFee).build();


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR ports the fix from `main` to `release/0.37`.

- Set the denominating token id of a fixed fee to the attached token id when it's the sentinel token 0.0.0

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
