### PR TITLE
Fix helm test waiting for balance file on reset network

### DIFF
--- a/charts/hedera-mirror-rest/templates/tests/configmap.yaml
+++ b/charts/hedera-mirror-rest/templates/tests/configmap.yaml
@@ -34,10 +34,6 @@ data:
       has_data "accounts"
     }
 
-    @test "Has balances" {
-      has_data "balances"
-    }
-
     @test "Has transactions" {
       has_data "transactions"
     }
@@ -53,3 +49,4 @@ data:
     }
     {{- end }}
 {{- end -}}
+


### PR DESCRIPTION
**Description**:
- Fix helm test waiting for balance file on reset networks by dropping balance check

**Related issue(s)**:

**Notes for reviewer**:
This can cause the deploy to repeatedly fail until a balance file shows up. We don't validate recent balance data regardless to ensure balance flow working so removing it doesn't lose much.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
