### PR TITLE
Increase default acceptance test max transaction fee to 20ℏ

### DIFF
--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
@@ -50,7 +50,7 @@ public class AcceptanceTestProperties {
     private int maxRetries = 2;
 
     @NotNull
-    private Long maxTinyBarTransactionFee = 1_000_000_000L;
+    private Long maxTinyBarTransactionFee = 2_000_000_000L;
 
     @NotNull
     private Duration messageTimeout = Duration.ofSeconds(60);


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR increase the acceptance test max transaction fee to 20ℏ.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
`TokenCreate` with custom fees costs at least $2.00, this causes acceptance test failure with the default max of 10ℏ (exchange rate at ~$0.14).

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
