### PR TITLE
Add cluster health to ingress

### DIFF
--- a/charts/hedera-mirror-common/values.yaml
+++ b/charts/hedera-mirror-common/values.yaml
@@ -228,6 +228,17 @@ prometheus:
     enabled: false
   kubeEtcd:
     enabled: false
+  kubelet:
+    # Disable these high cardinality metrics
+    serviceMonitor:
+      cAdvisorMetricRelabelings:
+        - action: drop
+          regex: container_(memory_failures_total|tasks_state)
+          sourceLabels: [__name__]
+      metricRelabelings:
+        - action: drop
+          regex: .*_bucket
+          sourceLabels: [__name__]
   kubeProxy:
     enabled: false
   kubeScheduler:

--- a/charts/hedera-mirror-monitor/values.yaml
+++ b/charts/hedera-mirror-monitor/values.yaml
@@ -104,6 +104,8 @@ ingress:
   hosts:
     - host: ""
       paths: ["/monitor/api"]
+    - host: ""
+      paths: ["/actuator/health/cluster"]
   middleware:
     enabled: false
   tls:


### PR DESCRIPTION
**Description**:
- Add cluster health endpoint to ingress so load balancer can reach it
- Disable some high cardinality kubelet time series

**Related issue(s)**:

**Notes for reviewer**:
We've had those time series disabled manually in all environments for awhile. Just moving the config from deploy to main branch.

Once ops migrates off of old API I'll remove it from ingress.

Will backport to 0.38.1

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
