### PR TITLE
Improve monitor startup performance (0.38.1)

### DIFF
--- a/charts/hedera-mirror-monitor/values.yaml
+++ b/charts/hedera-mirror-monitor/values.yaml
@@ -113,10 +113,11 @@ ingress:
 labels: {}
 
 livenessProbe:
+  failureThreshold: 5
   httpGet:
     path: /actuator/health/liveness
     port: http
-  initialDelaySeconds: 150
+  initialDelaySeconds: 60
   periodSeconds: 10
   timeoutSeconds: 2
 
@@ -264,10 +265,11 @@ rbac:
   enabled: true
 
 readinessProbe:
+  failureThreshold: 5
   httpGet:
     path: /actuator/health/readiness
     port: http
-  initialDelaySeconds: 100
+  initialDelaySeconds: 60
   timeoutSeconds: 2
 
 replicas: 1

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/config/MonitorConfiguration.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/config/MonitorConfiguration.java
@@ -84,7 +84,6 @@ class MonitorConfiguration {
                 .retry()
                 .name("generate")
                 .metrics()
-                .subscribeOn(Schedulers.single())
                 .parallel(publishProperties.getClients())
                 .runOn(Schedulers.newParallel("publisher", publishProperties.getClients()))
                 .map(transactionPublisher::publish)
@@ -98,6 +97,7 @@ class MonitorConfiguration {
                 .onErrorContinue((t, r) -> log.error("Unexpected error during publish flow: ", t))
                 .doFinally(s -> log.warn("Stopped after {} signal", s))
                 .doOnSubscribe(s -> log.info("Starting publisher flow"))
+                .subscribeOn(Schedulers.single())
                 .subscribe(publishMetrics::onSuccess);
     }
 
@@ -117,6 +117,7 @@ class MonitorConfiguration {
                 .onErrorContinue((t, r) -> log.error("Unexpected error during subscribe: ", t))
                 .doFinally(s -> log.warn("Stopped after {} signal", s))
                 .doOnSubscribe(s -> log.info("Starting subscribe flow"))
+                .subscribeOn(Schedulers.parallel())
                 .subscribe(subscribeMetrics::onNext);
     }
 }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/TransactionPublisher.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/TransactionPublisher.java
@@ -56,8 +56,8 @@ public class TransactionPublisher implements AutoCloseable {
 
     private final MonitorProperties monitorProperties;
     private final PublishProperties publishProperties;
-    private final Flux<Client> clients = Flux.defer(this::getClients).cache();
     private final List<AccountId> nodeAccountIds = new CopyOnWriteArrayList<>();
+    private final Flux<Client> clients = Flux.defer(this::getClients).cache();
     private final SecureRandom secureRandom = new SecureRandom();
 
     @Override
@@ -186,8 +186,8 @@ public class TransactionPublisher implements AutoCloseable {
             new TransferTransaction()
                     .addHbarTransfer(nodeAccountId, hbar)
                     .addHbarTransfer(client.getOperatorAccountId(), hbar.negated())
-                    .execute(client, Duration.ofSeconds(10L))
-                    .getReceipt(client, Duration.ofSeconds(10L));
+                    .execute(client, Duration.ofSeconds(30L))
+                    .getReceipt(client, Duration.ofSeconds(30L));
             log.info("Validated node: {}", node);
             valid = true;
         } catch (TimeoutException e) {


### PR DESCRIPTION
**Description**:
* Improve monitor startup performance by moving publish and subscribe flow initialization off main thread
* Increase node validation timeout to 30s
* Adjust monitor probe delay to reflect startup improvement

**Related issue(s)**:

**Notes for reviewer**:
Cherry pick of #2395 to 0.38.1

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
