### PR TITLE
Add missing default transfers to REST spec tests

### DIFF
--- a/hedera-mirror-rest/__tests__/specs/accounts-10-account-transactions.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/accounts-10-account-transactions.spec.json
@@ -61,7 +61,6 @@
     ],
     "transactions": [
       {
-        "charged_tx_fee": 0,
         "payerAccountId": "0.0.8",
         "nodeAccountId": "0.0.3",
         "consensus_timestamp": "1234567890000000006",
@@ -95,7 +94,7 @@
     "transactions": [
       {
         "bytes": "Ynl0ZXM=",
-        "charged_tx_fee": 0,
+        "charged_tx_fee": 7,
         "consensus_timestamp": "1234567890.000000006",
         "entity_id": "0.0.9",
         "max_fee": "33",

--- a/hedera-mirror-rest/__tests__/specs/accounts-10-account-transactions.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/accounts-10-account-transactions.spec.json
@@ -106,7 +106,20 @@
         "scheduled": false,
         "transaction_hash": "aGFzaA==",
         "transaction_id": "0.0.8-1234567890-000000005",
-        "transfers": [],
+        "transfers": [
+          {
+            "account": "0.0.3",
+            "amount": 2
+          },
+          {
+            "account": "0.0.8",
+            "amount": -3
+          },
+          {
+            "account": "0.0.98",
+            "amount": 1
+          }
+        ],
         "valid_duration_seconds": "11",
         "valid_start_timestamp": "1234567890.000000005"
       },

--- a/hedera-mirror-rest/__tests__/specs/accounts-18-account-transactions-no-balances.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/accounts-18-account-transactions-no-balances.spec.json
@@ -66,7 +66,6 @@
     ],
     "transactions": [
       {
-        "charged_tx_fee": 0,
         "payerAccountId": "0.0.8",
         "nodeAccountId": "0.0.3",
         "consensus_timestamp": "1234567890000000031",
@@ -114,7 +113,7 @@
     "transactions": [
       {
         "bytes": "Ynl0ZXM=",
-        "charged_tx_fee": 0,
+        "charged_tx_fee": 7,
         "consensus_timestamp": "1234567890.000000031",
         "entity_id": "0.0.9",
         "max_fee": "33",

--- a/hedera-mirror-rest/__tests__/specs/accounts-18-account-transactions-no-balances.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/accounts-18-account-transactions-no-balances.spec.json
@@ -125,7 +125,20 @@
         "scheduled": false,
         "transaction_hash": "aGFzaA==",
         "transaction_id": "0.0.8-1234567890-000000030",
-        "transfers": [],
+        "transfers": [
+          {
+            "account": "0.0.3",
+            "amount": 2
+          },
+          {
+            "account": "0.0.8",
+            "amount": -3
+          },
+          {
+            "account": "0.0.98",
+            "amount": 1
+          }
+        ],
         "valid_duration_seconds": "11",
         "valid_start_timestamp": "1234567890.000000030"
       },

--- a/hedera-mirror-rest/__tests__/specs/tokens-nft-history-01-no-args.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/tokens-nft-history-01-no-args.spec.json
@@ -42,7 +42,6 @@
       {
         "name": "TOKENMINT",
         "type": "37",
-        "charged_tx_fee": 7,
         "valid_start_timestamp": "1234567890000000005",
         "consensus_timestamp": "1234567890000000005",
         "payerAccountId": "0.0.8",
@@ -62,7 +61,6 @@
       {
         "name": "CRYPTOTRANSFER",
         "type": "14",
-        "charged_tx_fee": 7,
         "valid_start_timestamp": "1234567890000000006",
         "consensus_timestamp": "1234567890000000006",
         "payerAccountId": "0.0.8",
@@ -81,7 +79,6 @@
       {
         "name": "CRYPTOTRANSFER",
         "type": "14",
-        "charged_tx_fee": 7,
         "valid_start_timestamp": "1234567890000000007",
         "consensus_timestamp": "1234567890000000007",
         "payerAccountId": "0.0.8",
@@ -100,7 +97,6 @@
       {
         "name": "CRYPTOTRANSFER",
         "type": "14",
-        "charged_tx_fee": 7,
         "valid_start_timestamp": "1234567890000000008",
         "consensus_timestamp": "1234567890000000008",
         "payerAccountId": "0.0.8",
@@ -119,7 +115,6 @@
       {
         "name": "TOKENWIPE",
         "type": "39",
-        "charged_tx_fee": 7,
         "valid_start_timestamp": "1234567890000000009",
         "consensus_timestamp": "1234567890000000009",
         "payerAccountId": "0.0.8",
@@ -139,7 +134,6 @@
       {
         "name": "TOKENDELETION",
         "type": "35",
-        "charged_tx_fee": 7,
         "valid_start_timestamp": "1234567890000000010",
         "consensus_timestamp": "1234567890000000010",
         "payerAccountId": "0.0.98",

--- a/hedera-mirror-rest/__tests__/specs/tokens-nft-history-02-not-found.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/tokens-nft-history-02-not-found.spec.json
@@ -61,7 +61,6 @@
       {
         "name": "CRYPTOTRANSFER",
         "type": "14",
-        "charged_tx_fee": 7,
         "valid_start_timestamp": "1234567890000000000",
         "consensus_timestamp": "1234567890000000005",
         "payerAccountId": "0.0.8",

--- a/hedera-mirror-rest/__tests__/specs/tokens-nft-history-03-timestamp.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/tokens-nft-history-03-timestamp.spec.json
@@ -42,7 +42,6 @@
       {
         "name": "TOKENMINT",
         "type": "37",
-        "charged_tx_fee": 7,
         "valid_start_timestamp": "1234567890000000005",
         "consensus_timestamp": "1234567890000000005",
         "payerAccountId": "0.0.8",
@@ -62,7 +61,6 @@
       {
         "name": "CRYPTOTRANSFER",
         "type": "14",
-        "charged_tx_fee": 7,
         "valid_start_timestamp": "1234567890000000006",
         "consensus_timestamp": "1234567890000000006",
         "payerAccountId": "0.0.8",
@@ -81,7 +79,6 @@
       {
         "name": "CRYPTOTRANSFER",
         "type": "14",
-        "charged_tx_fee": 7,
         "valid_start_timestamp": "1234567890000000007",
         "consensus_timestamp": "1234567890000000007",
         "payerAccountId": "0.0.8",
@@ -100,7 +97,6 @@
       {
         "name": "CRYPTOTRANSFER",
         "type": "14",
-        "charged_tx_fee": 7,
         "valid_start_timestamp": "1234567890000000008",
         "consensus_timestamp": "1234567890000000008",
         "payerAccountId": "0.0.8",
@@ -119,7 +115,6 @@
       {
         "name": "TOKENDELETE",
         "type": "35",
-        "charged_tx_fee": 7,
         "valid_start_timestamp": "1234567890000000009",
         "consensus_timestamp": "1234567890000000009",
         "payerAccountId": "0.0.8",

--- a/hedera-mirror-rest/__tests__/specs/tokens-nft-history-04-timestamp-out-of-range.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/tokens-nft-history-04-timestamp-out-of-range.spec.json
@@ -42,7 +42,6 @@
       {
         "name": "TOKENMINT",
         "type": "37",
-        "charged_tx_fee": 7,
         "valid_start_timestamp": "1234567890000000005",
         "consensus_timestamp": "1234567890000000005",
         "payerAccountId": "0.0.8",
@@ -62,7 +61,6 @@
       {
         "name": "CRYPTOTRANSFER",
         "type": "14",
-        "charged_tx_fee": 7,
         "valid_start_timestamp": "1234567890000000006",
         "consensus_timestamp": "1234567890000000006",
         "payerAccountId": "0.0.8",
@@ -81,7 +79,6 @@
       {
         "name": "CRYPTOTRANSFER",
         "type": "14",
-        "charged_tx_fee": 7,
         "valid_start_timestamp": "1234567890000000007",
         "consensus_timestamp": "1234567890000000007",
         "payerAccountId": "0.0.8",
@@ -100,7 +97,6 @@
       {
         "name": "CRYPTOTRANSFER",
         "type": "14",
-        "charged_tx_fee": 7,
         "valid_start_timestamp": "1234567890000000008",
         "consensus_timestamp": "1234567890000000008",
         "payerAccountId": "0.0.8",
@@ -119,7 +115,6 @@
       {
         "name": "TOKENDELETE",
         "type": "35",
-        "charged_tx_fee": 7,
         "valid_start_timestamp": "1234567890000000009",
         "consensus_timestamp": "1234567890000000009",
         "payerAccountId": "0.0.8",

--- a/hedera-mirror-rest/__tests__/specs/tokens-nft-history-05-all-args.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/tokens-nft-history-05-all-args.spec.json
@@ -42,7 +42,6 @@
       {
         "name": "TOKENMINT",
         "type": "37",
-        "charged_tx_fee": 7,
         "valid_start_timestamp": "1234567890000000005",
         "consensus_timestamp": "1234567890000000005",
         "payerAccountId": "0.0.8",
@@ -62,7 +61,6 @@
       {
         "name": "CRYPTOTRANSFER",
         "type": "14",
-        "charged_tx_fee": 7,
         "valid_start_timestamp": "1234567890000000006",
         "consensus_timestamp": "1234567890000000006",
         "payerAccountId": "0.0.8",
@@ -81,7 +79,6 @@
       {
         "name": "CRYPTOTRANSFER",
         "type": "14",
-        "charged_tx_fee": 7,
         "valid_start_timestamp": "1234567890000000007",
         "consensus_timestamp": "1234567890000000007",
         "payerAccountId": "0.0.8",
@@ -100,7 +97,6 @@
       {
         "name": "CRYPTOTRANSFER",
         "type": "14",
-        "charged_tx_fee": 7,
         "valid_start_timestamp": "1234567890000000008",
         "consensus_timestamp": "1234567890000000008",
         "payerAccountId": "0.0.8",
@@ -119,7 +115,6 @@
       {
         "name": "TOKENDELETE",
         "type": "35",
-        "charged_tx_fee": 7,
         "valid_start_timestamp": "1234567890000000009",
         "consensus_timestamp": "1234567890000000009",
         "payerAccountId": "0.0.8",

--- a/hedera-mirror-rest/__tests__/specs/tokens-nft-history-09-partial-data-missing-create.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/tokens-nft-history-09-partial-data-missing-create.spec.json
@@ -36,7 +36,6 @@
       {
         "name": "TOKENMINT",
         "type": "37",
-        "charged_tx_fee": 7,
         "valid_start_timestamp": "1234567890000000005",
         "consensus_timestamp": "1234567890000000005",
         "payerAccountId": "0.0.8",
@@ -56,7 +55,6 @@
       {
         "name": "CRYPTOTRANSFER",
         "type": "14",
-        "charged_tx_fee": 7,
         "valid_start_timestamp": "1234567890000000006",
         "consensus_timestamp": "1234567890000000006",
         "payerAccountId": "0.0.8",
@@ -75,7 +73,6 @@
       {
         "name": "CRYPTOTRANSFER",
         "type": "14",
-        "charged_tx_fee": 7,
         "valid_start_timestamp": "1234567890000000007",
         "consensus_timestamp": "1234567890000000007",
         "payerAccountId": "0.0.8",
@@ -94,7 +91,6 @@
       {
         "name": "CRYPTOTRANSFER",
         "type": "14",
-        "charged_tx_fee": 7,
         "valid_start_timestamp": "1234567890000000008",
         "consensus_timestamp": "1234567890000000008",
         "payerAccountId": "0.0.8",
@@ -113,7 +109,6 @@
       {
         "name": "TOKENWIPE",
         "type": "39",
-        "charged_tx_fee": 7,
         "valid_start_timestamp": "1234567890000000009",
         "consensus_timestamp": "1234567890000000009",
         "payerAccountId": "0.0.8",
@@ -133,7 +128,6 @@
       {
         "name": "TOKENDELETION",
         "type": "35",
-        "charged_tx_fee": 7,
         "valid_start_timestamp": "1234567890000000010",
         "consensus_timestamp": "1234567890000000010",
         "payerAccountId": "0.0.98",

--- a/hedera-mirror-rest/__tests__/specs/tokens-nft-history-10-partial-data-missing-nft.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/tokens-nft-history-10-partial-data-missing-nft.spec.json
@@ -29,7 +29,6 @@
       {
         "name": "CRYPTOTRANSFER",
         "type": "14",
-        "charged_tx_fee": 7,
         "valid_start_timestamp": "1234567890000000006",
         "consensus_timestamp": "1234567890000000006",
         "payerAccountId": "0.0.8",
@@ -48,7 +47,6 @@
       {
         "name": "CRYPTOTRANSFER",
         "type": "14",
-        "charged_tx_fee": 7,
         "valid_start_timestamp": "1234567890000000007",
         "consensus_timestamp": "1234567890000000007",
         "payerAccountId": "0.0.8",
@@ -67,7 +65,6 @@
       {
         "name": "CRYPTOTRANSFER",
         "type": "14",
-        "charged_tx_fee": 7,
         "valid_start_timestamp": "1234567890000000008",
         "consensus_timestamp": "1234567890000000008",
         "payerAccountId": "0.0.8",
@@ -86,7 +83,6 @@
       {
         "name": "TOKENWIPE",
         "type": "39",
-        "charged_tx_fee": 7,
         "valid_start_timestamp": "1234567890000000009",
         "consensus_timestamp": "1234567890000000009",
         "payerAccountId": "0.0.8",
@@ -106,7 +102,6 @@
       {
         "name": "TOKENDELETION",
         "type": "35",
-        "charged_tx_fee": 7,
         "valid_start_timestamp": "1234567890000000010",
         "consensus_timestamp": "1234567890000000010",
         "payerAccountId": "0.0.98",

--- a/hedera-mirror-rest/__tests__/specs/transactions-01-no-args.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-01-no-args.spec.json
@@ -21,7 +21,6 @@
     "balances": [],
     "transactions": [
       {
-        "charged_tx_fee": 0,
         "payerAccountId": "0.0.8",
         "nodeAccountId": null,
         "consensus_timestamp": "1234567800000000009",
@@ -251,7 +250,7 @@
         ]
       },
       {
-        "charged_tx_fee": 0,
+        "charged_tx_fee": 7,
         "consensus_timestamp": "1234567800.000000009",
         "entity_id": "0.0.10",
         "max_fee": "33",

--- a/hedera-mirror-rest/__tests__/specs/transactions-01-no-args.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-01-no-args.spec.json
@@ -263,7 +263,20 @@
         "bytes": "Ynl0ZXM=",
         "transaction_hash": "aGFzaA==",
         "transaction_id": "0.0.8-1234567800-000000008",
-        "transfers": [],
+        "transfers": [
+          {
+            "account": "0.0.3",
+            "amount": 2
+          },
+          {
+            "account": "0.0.8",
+            "amount": -3
+          },
+          {
+            "account": "0.0.98",
+            "amount": 1
+          }
+        ],
         "valid_duration_seconds": "11",
         "valid_start_timestamp": "1234567800.000000008"
       }

--- a/hedera-mirror-rest/__tests__/specs/transactions-02-specific-id.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-02-specific-id.spec.json
@@ -27,7 +27,6 @@
     "balances": [],
     "transactions": [
       {
-        "charged_tx_fee": 7,
         "payerAccountId": "0.0.10",
         "nodeAccountId": "0.0.3",
         "consensus_timestamp": "1234567890000000002",

--- a/hedera-mirror-rest/__tests__/specs/transactions-08-debit-type.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-08-debit-type.spec.json
@@ -19,17 +19,7 @@
       }
     ],
     "balances": [],
-    "transactions": [
-      {
-        "charged_tx_fee": 0,
-        "payerAccountId": "0.0.10",
-        "nodeAccountId": "0.0.3",
-        "consensus_timestamp": "1565779444711927001",
-        "name": "CRYPTOUPDATEACCOUNT",
-        "type": "15",
-        "entity_id": "0.0.8"
-      }
-    ],
+    "transactions": [],
     "cryptotransfers": [
       {
         "consensus_timestamp": "1565779111711927001",

--- a/hedera-mirror-rest/__tests__/specs/transactions-09-account-id.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-09-account-id.spec.json
@@ -78,7 +78,20 @@
         "scheduled": false,
         "transaction_hash": "aGFzaA==",
         "transaction_id": "0.0.8-1565779444-711927000",
-        "transfers": [],
+        "transfers": [
+          {
+            "account": "0.0.3",
+            "amount": 2
+          },
+          {
+            "account": "0.0.8",
+            "amount": -3
+          },
+          {
+            "account": "0.0.98",
+            "amount": 1
+          }
+        ],
         "valid_duration_seconds": "11",
         "valid_start_timestamp": "1565779444.711927000"
       },

--- a/hedera-mirror-rest/__tests__/specs/transactions-09-account-id.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-09-account-id.spec.json
@@ -21,7 +21,7 @@
     "balances": [],
     "transactions": [
       {
-        "charged_tx_fee": 0,
+        "charged_tx_fee": 7,
         "payerAccountId": "0.0.8",
         "nodeAccountId": "0.0.3",
         "consensus_timestamp": "1565779444711927001",
@@ -67,7 +67,7 @@
     "transactions": [
       {
         "bytes": "Ynl0ZXM=",
-        "charged_tx_fee": 0,
+        "charged_tx_fee": 7,
         "consensus_timestamp": "1565779444.711927001",
         "entity_id": "0.0.8",
         "max_fee": "33",

--- a/hedera-mirror-rest/__tests__/specs/transactions-15-limit.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-15-limit.spec.json
@@ -135,7 +135,20 @@
         "scheduled": false,
         "transaction_hash": "aGFzaA==",
         "transaction_id": "0.0.8-1565779600-711927000",
-        "transfers": [],
+        "transfers": [
+          {
+            "account": "0.0.3",
+            "amount": 2
+          },
+          {
+            "account": "0.0.8",
+            "amount": -3
+          },
+          {
+            "account": "0.0.98",
+            "amount": 1
+          }
+        ],
         "valid_duration_seconds": "11",
         "valid_start_timestamp": "1565779600.711927000"
       }

--- a/hedera-mirror-rest/__tests__/specs/transactions-15-limit.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-15-limit.spec.json
@@ -21,7 +21,6 @@
     "balances": [],
     "transactions": [
       {
-        "charged_tx_fee": 0,
         "payerAccountId": "0.0.8",
         "nodeAccountId": "0.0.3",
         "consensus_timestamp": "1565779600711927001",
@@ -124,7 +123,7 @@
       },
       {
         "bytes": "Ynl0ZXM=",
-        "charged_tx_fee": 0,
+        "charged_tx_fee": 7,
         "consensus_timestamp": "1565779600.711927001",
         "entity_id": "0.0.8",
         "max_fee": "33",

--- a/hedera-mirror-rest/__tests__/specs/transactions-18-specific-id-no-transfers.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-18-specific-id-no-transfers.spec.json
@@ -48,7 +48,20 @@
         "transaction_id": "0.0.10-1234567890-999999998",
         "valid_duration_seconds": "11",
         "max_fee": "33",
-        "transfers": []
+        "transfers": [
+          {
+            "account": "0.0.3",
+            "amount": 2
+          },
+          {
+            "account": "0.0.10",
+            "amount": -3
+          },
+          {
+            "account": "0.0.98",
+            "amount": 1
+          }
+        ]
       }
     ]
   }

--- a/hedera-mirror-rest/__tests__/specs/transactions-18-specific-id-no-transfers.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-18-specific-id-no-transfers.spec.json
@@ -48,20 +48,7 @@
         "transaction_id": "0.0.10-1234567890-999999998",
         "valid_duration_seconds": "11",
         "max_fee": "33",
-        "transfers": [
-          {
-            "account": "0.0.3",
-            "amount": 2
-          },
-          {
-            "account": "0.0.10",
-            "amount": -3
-          },
-          {
-            "account": "0.0.98",
-            "amount": 1
-          }
-        ]
+        "transfers": []
       }
     ]
   }

--- a/hedera-mirror-rest/__tests__/specs/transactions-19-timestamp-no-transfers.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-19-timestamp-no-transfers.spec.json
@@ -68,7 +68,20 @@
         "transaction_id": "0.0.10-1565779209-711927000",
         "valid_duration_seconds": "11",
         "max_fee": "33",
-        "transfers": []
+        "transfers": [
+          {
+            "account": "0.0.3",
+            "amount": 2
+          },
+          {
+            "account": "0.0.10",
+            "amount": -3
+          },
+          {
+            "account": "0.0.98",
+            "amount": 1
+          }
+        ]
       }
     ],
     "links": {

--- a/hedera-mirror-rest/__tests__/specs/transactions-19-timestamp-no-transfers.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-19-timestamp-no-transfers.spec.json
@@ -68,20 +68,7 @@
         "transaction_id": "0.0.10-1565779209-711927000",
         "valid_duration_seconds": "11",
         "max_fee": "33",
-        "transfers": [
-          {
-            "account": "0.0.3",
-            "amount": 2
-          },
-          {
-            "account": "0.0.10",
-            "amount": -3
-          },
-          {
-            "account": "0.0.98",
-            "amount": 1
-          }
-        ]
+        "transfers": []
       }
     ],
     "links": {

--- a/hedera-mirror-rest/__tests__/specs/transactions-27-multiple-account-ids.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-27-multiple-account-ids.spec.json
@@ -24,7 +24,7 @@
     "balances": [],
     "transactions": [
       {
-        "charged_tx_fee": 0,
+        "charged_tx_fee": 7,
         "payerAccountId": "0.0.8",
         "nodeAccountId": "0.0.3",
         "consensus_timestamp": "1565779444711927001",
@@ -74,7 +74,7 @@
     "transactions": [
       {
         "bytes": "Ynl0ZXM=",
-        "charged_tx_fee": 0,
+        "charged_tx_fee": 7,
         "consensus_timestamp": "1565779444.711927001",
         "entity_id": "0.0.11",
         "max_fee": "33",

--- a/hedera-mirror-rest/__tests__/specs/transactions-27-multiple-account-ids.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-27-multiple-account-ids.spec.json
@@ -85,7 +85,20 @@
         "scheduled": false,
         "transaction_hash": "aGFzaA==",
         "transaction_id": "0.0.8-1565779444-711927000",
-        "transfers": [],
+        "transfers": [
+          {
+            "account": "0.0.3",
+            "amount": 2
+          },
+          {
+            "account": "0.0.8",
+            "amount": -3
+          },
+          {
+            "account": "0.0.98",
+            "amount": 1
+          }
+        ],
         "valid_duration_seconds": "11",
         "valid_start_timestamp": "1565779444.711927000"
       },

--- a/hedera-mirror-rest/__tests__/specs/transactions-28-account-id-only-token-transfers.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-28-account-id-only-token-transfers.spec.json
@@ -73,7 +73,20 @@
         "transaction_id": "0.0.8-1234567890-000000000",
         "valid_duration_seconds": "11",
         "max_fee": "33",
-        "transfers": [],
+        "transfers": [
+          {
+            "account": "0.0.3",
+            "amount": 2
+          },
+          {
+            "account": "0.0.8",
+            "amount": -3
+          },
+          {
+            "account": "0.0.98",
+            "amount": 1
+          }
+        ],
         "token_transfers": [
           {
             "account": "0.0.8",

--- a/hedera-mirror-rest/__tests__/specs/transactions-29-tokenwipe.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-29-tokenwipe.spec.json
@@ -58,7 +58,20 @@
         "transaction_id": "0.0.8-1234567890-000000000",
         "valid_duration_seconds": "11",
         "max_fee": "33",
-        "transfers": [],
+        "transfers": [
+          {
+            "account": "0.0.3",
+            "amount": 2
+          },
+          {
+            "account": "0.0.8",
+            "amount": -3
+          },
+          {
+            "account": "0.0.98",
+            "amount": 1
+          }
+        ],
         "token_transfers": [
           {
             "account": "0.0.9",

--- a/hedera-mirror-rest/__tests__/specs/transactions-30-specific-id-tokenwipe.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-30-specific-id-tokenwipe.spec.json
@@ -52,7 +52,20 @@
         "transaction_id": "0.0.8-1234567890-000000000",
         "valid_duration_seconds": "11",
         "max_fee": "33",
-        "transfers": [],
+        "transfers": [
+          {
+            "account": "0.0.3",
+            "amount": 2
+          },
+          {
+            "account": "0.0.8",
+            "amount": -3
+          },
+          {
+            "account": "0.0.98",
+            "amount": 1
+          }
+        ],
         "token_transfers": [
           {
             "account": "0.0.9",

--- a/hedera-mirror-rest/__tests__/specs/transactions-31-credit-type-only-token-transfers.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-31-credit-type-only-token-transfers.spec.json
@@ -97,7 +97,20 @@
         "transaction_id": "0.0.8-1234567890-000000000",
         "valid_duration_seconds": "11",
         "max_fee": "33",
-        "transfers": [],
+        "transfers": [
+          {
+            "account": "0.0.3",
+            "amount": 2
+          },
+          {
+            "account": "0.0.8",
+            "amount": -3
+          },
+          {
+            "account": "0.0.98",
+            "amount": 1
+          }
+        ],
         "token_transfers": [
           {
             "account": "0.0.8",

--- a/hedera-mirror-rest/__tests__/specs/transactions-32-debit-type-only-token-transfers.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-32-debit-type-only-token-transfers.spec.json
@@ -97,7 +97,20 @@
         "transaction_id": "0.0.8-1234567890-000000000",
         "valid_duration_seconds": "11",
         "max_fee": "33",
-        "transfers": [],
+        "transfers": [
+          {
+            "account": "0.0.3",
+            "amount": 2
+          },
+          {
+            "account": "0.0.8",
+            "amount": -3
+          },
+          {
+            "account": "0.0.98",
+            "amount": 1
+          }
+        ],
         "token_transfers": [
           {
             "account": "0.0.9",

--- a/hedera-mirror-rest/__tests__/specs/transactions-33-credit-type-crypto-and-token-transfers.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-33-credit-type-crypto-and-token-transfers.spec.json
@@ -211,7 +211,20 @@
         "transaction_id": "0.0.8-1234567890-000000000",
         "valid_duration_seconds": "11",
         "max_fee": "33",
-        "transfers": [],
+        "transfers": [
+          {
+            "account": "0.0.3",
+            "amount": 2
+          },
+          {
+            "account": "0.0.8",
+            "amount": -3
+          },
+          {
+            "account": "0.0.98",
+            "amount": 1
+          }
+        ],
         "token_transfers": [
           {
             "account": "0.0.8",

--- a/hedera-mirror-rest/__tests__/specs/transactions-34-debit-type-crypto-and-token-transfers.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-34-debit-type-crypto-and-token-transfers.spec.json
@@ -211,7 +211,20 @@
         "transaction_id": "0.0.8-1234567890-000000000",
         "valid_duration_seconds": "11",
         "max_fee": "33",
-        "transfers": [],
+        "transfers": [
+          {
+            "account": "0.0.3",
+            "amount": 2
+          },
+          {
+            "account": "0.0.8",
+            "amount": -3
+          },
+          {
+            "account": "0.0.98",
+            "amount": 1
+          }
+        ],
         "token_transfers": [
           {
             "account": "0.0.9",

--- a/hedera-mirror-rest/__tests__/specs/transactions-36-nft-transfers.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-36-nft-transfers.spec.json
@@ -72,7 +72,20 @@
         "transaction_id": "0.0.8-1234567890-000000000",
         "valid_duration_seconds": "11",
         "max_fee": "33",
-        "transfers": []
+        "transfers": [
+          {
+            "account": "0.0.3",
+            "amount": 2
+          },
+          {
+            "account": "0.0.8",
+            "amount": -3
+          },
+          {
+            "account": "0.0.98",
+            "amount": 1
+          }
+        ]
       }
     ],
     "links": {

--- a/hedera-mirror-rest/__tests__/specs/transactions-37-specific-id-nft-transfers.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-37-specific-id-nft-transfers.spec.json
@@ -72,7 +72,20 @@
         "transaction_id": "0.0.8-1234567890-000000000",
         "valid_duration_seconds": "11",
         "max_fee": "33",
-        "transfers": [],
+        "transfers": [
+          {
+            "account": "0.0.3",
+            "amount": 2
+          },
+          {
+            "account": "0.0.8",
+            "amount": -3
+          },
+          {
+            "account": "0.0.98",
+            "amount": 1
+          }
+        ],
         "nft_transfers": [
           {
             "receiver_account_id": "0.0.8",

--- a/hedera-mirror-rest/__tests__/specs/transactions-38-nft-transfers-multiple-tokens.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions-38-nft-transfers-multiple-tokens.spec.json
@@ -84,7 +84,20 @@
         "transaction_id": "0.0.8-1234567890-000000000",
         "valid_duration_seconds": "11",
         "max_fee": "33",
-        "transfers": [],
+        "transfers": [
+          {
+            "account": "0.0.3",
+            "amount": 2
+          },
+          {
+            "account": "0.0.8",
+            "amount": -3
+          },
+          {
+            "account": "0.0.98",
+            "amount": 1
+          }
+        ],
         "nft_transfers": [
           {
             "receiver_account_id": "0.0.9",


### PR DESCRIPTION
Signed-off-by: Nana-EC <nana.essilfie-conduah@hedera.com>

**Description**:
REST spec tests in many cases were missing default transfers to node and treasury that exist for every transaction.
This could result in incorrect results being returned that relied on the presence of crypto transfers for every transaction.

- Add default transfers to db if a spec specifies a transaction with no transfers
- Update specs to reflect default transfers

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
