### PR TITLE
Add simple retry logic on network gets in entity-updater migration script

### DIFF
--- a/hedera-mirror-rest/entity-info-updater/config/application.yml
+++ b/hedera-mirror-rest/entity-info-updater/config/application.yml
@@ -20,4 +20,6 @@ hedera:
         nodeId:
         operatorId:
         operatorKey:
+        retryCount: 10
+        retryMsDelay: 1000
         useCache: false

--- a/hedera-mirror-rest/entity-info-updater/dbEntityService.js
+++ b/hedera-mirror-rest/entity-info-updater/dbEntityService.js
@@ -186,7 +186,7 @@ const restoreDbEntityCache = () => {
 restoreDbEntityCache();
 if (config.db.useCache && !_.isEmpty(dbEntityCache)) {
   logger.info(
-    "SDK network calls will pull from local cache as 'hedera.mirror.entityUpdate.db.useCache' is set to true and valid cache exists"
+    "Db calls will pull from local cache as 'hedera.mirror.entityUpdate.db.useCache' is set to true and valid cache exists"
   );
 }
 

--- a/hedera-mirror-rest/entity-info-updater/networkEntityService.js
+++ b/hedera-mirror-rest/entity-info-updater/networkEntityService.js
@@ -44,9 +44,8 @@ let networkEntityCache = {};
  */
 const getInfoWithRetry = async (networkCall, message) => {
   let retries = config.sdkClient.retryCount;
-  let success = false;
   let latestError = Error('Network item retrieval error');
-  while (retries-- > 0 && !success) {
+  while (retries-- > 0) {
     try {
       return await networkCall();
     } catch (e) {

--- a/hedera-mirror-rest/entity-info-updater/networkEntityService.js
+++ b/hedera-mirror-rest/entity-info-updater/networkEntityService.js
@@ -37,6 +37,37 @@ let clientConfigured = false;
 let networkEntityCache = {};
 
 /**
+ * Retrieve entity information with retry logic
+ * @param {method} networkCall Entity specific query
+ * @param {String} message Entity identifyng message used for logging
+ * @returns
+ */
+const getInfoWithRetry = async (networkCall, message) => {
+  let retries = config.sdkClient.retryCount;
+  let success = false;
+  let latestError = Error('Network item retrieval error');
+  while (retries-- > 0 && !success) {
+    try {
+      return await networkCall();
+    } catch (e) {
+      if (e.toString().indexOf('INVALID_ACCOUNT_ID') < 0 && e.toString().indexOf('ACCOUNT_DELETED') < 0) {
+        logger.trace(`Error getting ${message} from network, error: ${e}.`);
+        throw e;
+      }
+
+      latestError = e;
+      logger.debug(
+        `Error retreiving ${message} from network, error: ${e}. Retries left ${retries}. Waiting ${config.sdkClient.retryMsDelay} ms before retrying.`
+      );
+      await new Promise((resolve) => setTimeout(resolve, config.sdkClient.retryMsDelay));
+    }
+  }
+
+  logger.debug(`Unable to retrieve ${message}, error: ${e}.`);
+  throw latestError;
+};
+
+/**
  * Get account info from network
  * @param accountId
  * @returns {Promise<AccountInfo>}
@@ -44,21 +75,13 @@ let networkEntityCache = {};
 const getAccountInfo = async (accountId) => {
   logger.trace(`Retrieve account info for ${accountId}`);
   let accountInfo;
-  try {
-    if (config.sdkClient.useCache && networkEntityCache[`${accountId}`] !== undefined) {
-      accountInfo = AccountInfo.fromBytes(Buffer.from(networkEntityCache[accountId.toString()]));
-      logger.trace(`Retrieved ${accountId} from cache`);
-    } else {
-      accountInfo = await new AccountInfoQuery().setAccountId(accountId).execute(client);
-    }
-  } catch (e) {
-    if (e.toString().indexOf('INVALID_ACCOUNT_ID') < 0 && e.toString().indexOf('ACCOUNT_DELETED') < 0) {
-      logger.trace(`Error getting accountInfo ${accountId} from network, error: ${e}.`);
-      throw e;
-    }
-
-    logger.trace(`${accountId} is not present on the network, error: ${e}`);
-    return null;
+  if (config.sdkClient.useCache && networkEntityCache[`${accountId}`] !== undefined) {
+    accountInfo = AccountInfo.fromBytes(Buffer.from(networkEntityCache[accountId.toString()]));
+    logger.trace(`Retrieved ${accountId} from cache`);
+  } else {
+    accountInfo = await getInfoWithRetry(() => {
+      return new AccountInfoQuery().setAccountId(accountId).execute(client);
+    }, `accountInfo: ${accountId}`);
   }
 
   logger.trace(`Retrieved account info from network: ${JSON.stringify(accountInfo)}`);

--- a/hedera-mirror-rest/entity-info-updater/package-lock.json
+++ b/hedera-mirror-rest/entity-info-updater/package-lock.json
@@ -393,90 +393,53 @@
       }
     },
     "@grpc/grpc-js": {
-      "version": "1.2.12",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.2.12.tgz",
-      "integrity": "sha512-+gPCklP1eqIgrNPyzddYQdt9+GvZqPlLpIjIo+TveE+gbtp74VV1A2ju8ExeO8ma8f7MbpaGZx/KJPYVWL9eDw==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.3.7.tgz",
+      "integrity": "sha512-CKQVuwuSPh40tgOkR7c0ZisxYRiN05PcKPW72mQL5y++qd7CwBRoaJZvU5xfXnCJDFBmS3qZGQ71Frx6Ofo2XA==",
       "requires": {
-        "@types/node": ">=12.12.47",
-        "google-auth-library": "^6.1.1",
-        "semver": "^6.2.0"
+        "@types/node": ">=12.12.47"
       }
     },
     "@hashgraph/cryptography": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/@hashgraph/cryptography/-/cryptography-1.0.14.tgz",
-      "integrity": "sha512-qtlBzCCzePm9KOuy1GJ9FtEU8L7dNPrL4iAaFOlCn1UmDa0u4tPwYHDKcsuDhZetS47QJl0y+Vzgpo+b968WMg==",
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/@hashgraph/cryptography/-/cryptography-1.0.20.tgz",
+      "integrity": "sha512-rdKKnENJfs0gsqAtY+7nzpG9TQshtnf+F3/PdH8z+qdy4mo4RSULBMc55FkWWNZLnoA4/34wEW8kohjFEzsLRA==",
       "requires": {
-        "@stablelib/utf8": "^1.0.0",
-        "@types/crypto-js": "^4.0.1",
+        "@types/crypto-js": "^4.0.2",
+        "@types/utf8": "^3.0.0",
         "bignumber.js": "^9.0.1",
         "crypto-js": "^4.0.0",
-        "expo-crypto": "^9.1.0",
-        "expo-random": "^11.1.2",
-        "js-base64": "^3.6.0",
+        "expo-crypto": "^9.2.0",
+        "expo-random": "^11.2.0",
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "js-base64": "^3.6.1",
         "tweetnacl": "^1.0.3"
       }
     },
     "@hashgraph/proto": {
-      "version": "1.0.24",
-      "resolved": "https://registry.npmjs.org/@hashgraph/proto/-/proto-1.0.24.tgz",
-      "integrity": "sha512-ARc+wom2K/b4X0XYuQJiy4PUcJy5IbSFXVS7UD1g2T0xTRrYmhKbyDpZ/CdSGB8iep1YNCCkKIBhIyMN+s5egw==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@hashgraph/proto/-/proto-1.1.8.tgz",
+      "integrity": "sha512-SCKw45a7rX99o6szdB2orJzVSRfTMHNNiTb7FPxOGXyEnXilIjng7S33aMxS9Q34xQLU/fDBrkWiSpn1boZybg==",
       "requires": {
-        "@hashgraph/protobufjs": "^6.10.1-hashgraph.2"
-      }
-    },
-    "@hashgraph/protobufjs": {
-      "version": "6.10.1-hashgraph.2",
-      "resolved": "https://registry.npmjs.org/@hashgraph/protobufjs/-/protobufjs-6.10.1-hashgraph.2.tgz",
-      "integrity": "sha512-WqxBUgAn2to2R8s95pUhrCH2tezkEVguDqJWPj+riH/J0BhqA5pd6VJ07jXj8woC9jKsOWoSxY5Rxezbr2swsw==",
-      "requires": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.1",
-        "@types/node": "^13.7.0",
-        "long": "^4.0.0"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "13.13.47",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.47.tgz",
-          "integrity": "sha512-R6851wTjN1YJza8ZIeX6puNBSi/ZULHVh4WVleA7q256l+cP2EtXnKbO455fTs2ytQk3dL9qkU+Wh8l/uROdKg=="
-        }
+        "protobufjs": "^6.11.2"
       }
     },
     "@hashgraph/sdk": {
-      "version": "2.0.17-beta.7",
-      "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.0.17-beta.7.tgz",
-      "integrity": "sha512-ERfWLOzXJ/0AcE7q1hBl62LJg2/ioQCcgDMjjpAd50Qw0kb3dPyMjK1KffwuVNY+SpGYAx8v2uJ5k9kCZq3L8w==",
+      "version": "2.0.28",
+      "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.0.28.tgz",
+      "integrity": "sha512-VehiPcui8YfShVi/6bJLM8OJv+LUGGTWDgr19qR1GCfrz+hJ8XnK29fxD+IrayL6ptk9ZSSQqitZkxICRLhHBw==",
       "requires": {
-        "@grpc/grpc-js": "^1.2.2",
-        "@hashgraph/cryptography": "^1.0.14",
-        "@hashgraph/proto": "^1.0.24",
-        "@types/crypto-js": "^4.0.1",
-        "@types/utf8": "^2.1.6",
+        "@grpc/grpc-js": "^1.3.4",
+        "@hashgraph/cryptography": "^1.0.20",
+        "@hashgraph/proto": "1.1.8",
+        "@types/crypto-js": "^4.0.2",
+        "@types/utf8": "^3.0.0",
         "bignumber.js": "^9.0.1",
         "crypto-js": "^4.0.0",
-        "js-base64": "^3.6.0",
+        "js-base64": "^3.6.1",
         "long": "^4.0.0",
+        "protobufjs": "^6.11.2",
         "utf8": "^3.0.0"
-      },
-      "dependencies": {
-        "@hashgraph/proto": {
-          "version": "1.0.24",
-          "resolved": "https://registry.npmjs.org/@hashgraph/proto/-/proto-1.0.24.tgz",
-          "integrity": "sha512-ARc+wom2K/b4X0XYuQJiy4PUcJy5IbSFXVS7UD1g2T0xTRrYmhKbyDpZ/CdSGB8iep1YNCCkKIBhIyMN+s5egw==",
-          "requires": {
-            "@hashgraph/protobufjs": "^6.10.1-hashgraph.2"
-          }
-        }
       }
     },
     "@istanbuljs/load-nyc-config": {
@@ -758,11 +721,6 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
-    "@stablelib/utf8": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@stablelib/utf8/-/utf8-1.0.0.tgz",
-      "integrity": "sha512-Y8QWrK4T0yW0HMFfSI3ZaMHKV37q27hX5ilsmKV358x01mzYfj5fwIf2LjzTlF+UIemHEXSlSN9XJnv1ML4znQ=="
-    },
     "@types/babel__core": {
       "version": "7.1.12",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.12.tgz",
@@ -801,9 +759,9 @@
       }
     },
     "@types/crypto-js": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/crypto-js/-/crypto-js-4.0.1.tgz",
-      "integrity": "sha512-6+OPzqhKX/cx5xh+yO8Cqg3u3alrkhoxhE5ZOdSEv0DOzJ13lwJ6laqGU0Kv6+XDMFmlnGId04LtY22PsFLQUw=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/crypto-js/-/crypto-js-4.0.2.tgz",
+      "integrity": "sha512-sCVniU+h3GcGqxOmng11BRvf9TfN9yIs8KKjB8C8d75W69cpTfZG80gau9yTx5SxF3gvHGbJhdESzzvnjtf3Og=="
     },
     "@types/graceful-fs": {
       "version": "4.1.5",
@@ -860,9 +818,9 @@
       "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw=="
     },
     "@types/utf8": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@types/utf8/-/utf8-2.1.6.tgz",
-      "integrity": "sha512-pRs2gYF5yoKYrgSaira0DJqVg2tFuF+Qjp838xS7K+mJyY2jJzjsrl6y17GbIa4uMRogMbxs+ghNCvKg6XyNrA=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/utf8/-/utf8-3.0.0.tgz",
+      "integrity": "sha512-QrhvCktdm5wD48axAnjqSzPH9lOj0MiCYfMX6MSqGs2Jv+txwvdxviXiCEj8zSCWIEDU9SIJ7g9pU5KtxRgYSg=="
     },
     "@types/yargs": {
       "version": "15.0.13",
@@ -881,14 +839,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
       "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q=="
-    },
-    "abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "requires": {
-        "event-target-shim": "^5.0.0"
-      }
     },
     "acorn": {
       "version": "8.1.0",
@@ -915,14 +865,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
       "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA=="
-    },
-    "agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "requires": {
-        "debug": "4"
-      }
     },
     "ajv": {
       "version": "6.12.6",
@@ -999,11 +941,6 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
-    },
-    "arrify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
     },
     "asn1": {
       "version": "0.2.4",
@@ -1231,11 +1168,6 @@
         "node-int64": "^0.4.0"
       }
     },
-    "buffer-equal-constant-time": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
-    },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -1450,9 +1382,9 @@
       }
     },
     "crypto-js": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.0.0.tgz",
-      "integrity": "sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
+      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
     },
     "cssom": {
       "version": "0.4.4",
@@ -1606,14 +1538,6 @@
         "safer-buffer": "^2.1.0"
       }
     },
-    "ecdsa-sig-formatter": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
     "electron-to-chromium": {
       "version": "1.3.686",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.686.tgz",
@@ -1686,11 +1610,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
-    },
-    "event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
     },
     "exec-sh": {
       "version": "0.3.4",
@@ -1782,14 +1701,14 @@
       }
     },
     "expo-crypto": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/expo-crypto/-/expo-crypto-9.1.0.tgz",
-      "integrity": "sha512-5N3W/B4L7sx8IT/DhUjkSlbAfY0eQXo9ApiQ/67n2VjUNW/NKna4b1kCvAIjetPuqugAR2CFLltcYIc8PinRmA=="
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/expo-crypto/-/expo-crypto-9.2.0.tgz",
+      "integrity": "sha512-jc9E7jHlOT8fYs64DIsSOdnLtxtIK1pV78O/nBamPwKdGrvFSNqMSFndxyVSuEimBNoPPNRwN+4Pb4W1RRltJA=="
     },
     "expo-random": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/expo-random/-/expo-random-11.1.2.tgz",
-      "integrity": "sha512-JaNqoYwFWJnyRSsMPpFjjSsm09wrEv+Uoif6IExfR8v6K3m/tIySoVjzS47tD6YVdxLtL/I8RmqmB6Nwh1p6AQ==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/expo-random/-/expo-random-11.2.0.tgz",
+      "integrity": "sha512-kgBJBB02iCX/kpoTHN57V7b4hWOCj4eACIQDl7bN94lycUcZu62T00P/rVZIcE/29x0GAi+Pw5ZWj0NlqBsMQQ==",
       "requires": {
         "base64-js": "^1.3.0"
       }
@@ -1897,10 +1816,10 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
-    "fast-text-encoding": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.3.tgz",
-      "integrity": "sha512-dtm4QZH9nZtcDt8qJiOH9fcQd1NAgi+K1O2DbE6GG1PPCK/BWfOH3idCTRQ4ImXRUOyopDEgDEnVEE7Y/2Wrig=="
+    "fastestsmallesttextencoderdecoder": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
+      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw=="
     },
     "fb-watchman": {
       "version": "2.0.1",
@@ -1996,27 +1915,6 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
-    "gaxios": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.2.0.tgz",
-      "integrity": "sha512-Ms7fNifGv0XVU+6eIyL9LB7RVESeML9+cMvkwGS70xyD6w2Z80wl6RiqiJ9k1KFlJCUTQqFFc8tXmPQfSKUe8g==",
-      "requires": {
-        "abort-controller": "^3.0.0",
-        "extend": "^3.0.2",
-        "https-proxy-agent": "^5.0.0",
-        "is-stream": "^2.0.0",
-        "node-fetch": "^2.3.0"
-      }
-    },
-    "gcp-metadata": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.2.1.tgz",
-      "integrity": "sha512-tSk+REe5iq/N+K+SK1XjZJUrFPuDqGZVzCy2vocIHIGmPlTGsa8owXMJwGkrXr73NO0AzhPW4MF2DEHz7P2AVw==",
-      "requires": {
-        "gaxios": "^4.0.0",
-        "json-bigint": "^1.0.0"
-      }
-    },
     "gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -2071,30 +1969,6 @@
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
     },
-    "google-auth-library": {
-      "version": "6.1.6",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.1.6.tgz",
-      "integrity": "sha512-Q+ZjUEvLQj/lrVHF/IQwRo6p3s8Nc44Zk/DALsN+ac3T4HY/g/3rrufkgtl+nZ1TW7DNAw5cTChdVp4apUXVgQ==",
-      "requires": {
-        "arrify": "^2.0.0",
-        "base64-js": "^1.3.0",
-        "ecdsa-sig-formatter": "^1.0.11",
-        "fast-text-encoding": "^1.0.0",
-        "gaxios": "^4.0.0",
-        "gcp-metadata": "^4.2.0",
-        "gtoken": "^5.0.4",
-        "jws": "^4.0.0",
-        "lru-cache": "^6.0.0"
-      }
-    },
-    "google-p12-pem": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.0.3.tgz",
-      "integrity": "sha512-wS0ek4ZtFx/ACKYF3JhyGe5kzH7pgiQ7J5otlumqR9psmWMYc+U9cErKlCYVYHoUaidXHdZ2xbo34kB+S+24hA==",
-      "requires": {
-        "node-forge": "^0.10.0"
-      }
-    },
     "graceful-fs": {
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
@@ -2105,16 +1979,6 @@
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "optional": true
-    },
-    "gtoken": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.2.1.tgz",
-      "integrity": "sha512-OY0BfPKe3QnMsY9MzTHTSKn+Vl2l1CcLe6BwDEQj00mbbkl5nyQ/7EUREstg4fQNZ8iYE7br4JJ7TdKeDOPWmw==",
-      "requires": {
-        "gaxios": "^4.0.0",
-        "google-p12-pem": "^3.0.3",
-        "jws": "^4.0.0"
-      }
     },
     "har-schema": {
       "version": "2.0.0",
@@ -2216,15 +2080,6 @@
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
-      }
-    },
-    "https-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
-      "requires": {
-        "agent-base": "6",
-        "debug": "4"
       }
     },
     "human-signals": {
@@ -2967,9 +2822,9 @@
       }
     },
     "js-base64": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.6.0.tgz",
-      "integrity": "sha512-wVdUBYQeY2gY73RIlPrysvpYx+2vheGo8Y1SNQv/BzHToWpAZzJU7Z6uheKMAe+GLSBig5/Ps2nxg/8tRB73xg=="
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.6.1.tgz",
+      "integrity": "sha512-Frdq2+tRRGLQUIQOgsIGSCd1VePCS2fsddTG5dTCqR0JHgltXWfsxnY0gIXPoMeRmdom6Oyq+UMOFg5suduOjQ=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -3034,14 +2889,6 @@
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
     },
-    "json-bigint": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
-      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
-      "requires": {
-        "bignumber.js": "^9.0.0"
-      }
-    },
     "json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -3087,25 +2934,6 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
-      }
-    },
-    "jwa": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
-      "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
-      "requires": {
-        "buffer-equal-constant-time": "1.0.1",
-        "ecdsa-sig-formatter": "1.0.11",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "jws": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
-      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
-      "requires": {
-        "jwa": "^2.0.0",
-        "safe-buffer": "^5.0.1"
       }
     },
     "kind-of": {
@@ -3320,16 +3148,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
-    },
-    "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
-    },
-    "node-forge": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
     },
     "node-int64": {
       "version": "0.4.0",
@@ -3716,6 +3534,26 @@
       "requires": {
         "kleur": "^3.0.3",
         "sisteransi": "^1.0.5"
+      }
+    },
+    "protobufjs": {
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
+      "integrity": "sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==",
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": ">=13.7.0",
+        "long": "^4.0.0"
       }
     },
     "psl": {

--- a/hedera-mirror-rest/entity-info-updater/package.json
+++ b/hedera-mirror-rest/entity-info-updater/package.json
@@ -26,8 +26,8 @@
     "entity-info-updater": "./index.js"
   },
   "dependencies": {
-    "@hashgraph/proto": "^1.0.24",
-    "@hashgraph/sdk": "^2.0.17-beta.7",
+    "@hashgraph/proto": "^1.1.8",
+    "@hashgraph/sdk": "^2.0.28",
     "fs": "0.0.2",
     "jest": "^26.6.3",
     "js-yaml": "^4.0.0",

--- a/hedera-mirror-rest/entity-info-updater/tests/entityInfoUpdater.test.js
+++ b/hedera-mirror-rest/entity-info-updater/tests/entityInfoUpdater.test.js
@@ -49,6 +49,8 @@ const custom = {
           nodeId: '0.0.3',
           operatorId: '0.0.2',
           operatorKey: 'fakeKey',
+          retryCount: 10,
+          retryMsDelay: 1000,
           useCache: true,
         },
       },


### PR DESCRIPTION
Signed-off-by: Nana-EC <nana.essilfie-conduah@hedera.com>

**Description**:
When running the migration script calls to network to get AccountIds occasionally hit the `13 INTERNAL: Received RST_STREAM with code 0` error.
The js-sdk doesn't seem to handle the retries correctly.

- Add retry logic on get call
- Make retry count and wait time customizable 
- Bump js-sdk to newest
- Bump proto to newest

**Related issue(s)**:

Fixes #
This serves as a temporary workaround for [js sdk bug 494](https://github.com/hashgraph/hedera-sdk-js/issues/494), once it's addressed this can be removed

**Notes for reviewer**:
Locally tested against mainnet by used DB cache and valid mainnet account

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
