### PR TITLE
Revert "Bump jib-maven-plugin from 3.1.2 to 3.1.3"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <jacoco.version>0.8.7</jacoco.version>
         <java.version>11</java.version>
         <javax.version>1</javax.version>
-        <jib.version>3.1.3</jib.version>
+        <jib.version>3.1.2</jib.version>
         <micrometer-jvm-extras.version>0.2.2</micrometer-jvm-extras.version>
         <msgpack.version>0.9.0</msgpack.version>
         <protobuf.version>3.17.3</protobuf.version>


### PR DESCRIPTION
Revert https://github.com/hashgraph/hedera-mirror-node/pull/2403 due to https://github.com/GoogleContainerTools/jib/issues/3409 which only shows up on push to gcr.io.