### PR TITLE
Fix startDate logic on empty DB

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/MirrorDateRangePropertiesProcessor.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/MirrorDateRangePropertiesProcessor.java
@@ -92,9 +92,7 @@ public class MirrorDateRangePropertiesProcessor {
         }
 
         if (startDate != null) {
-            if (lastFileInstant == null || lastFileInstant != null && startDate.isAfter(lastFileInstant)) {
-                filterStartDate = startDate;
-            }
+            filterStartDate = max(startDate, lastFileInstant);
         } else {
             if (mirrorProperties.getNetwork() != MirrorProperties.HederaNetwork.DEMO && lastFileInstant == null) {
                 filterStartDate = STARTUP_TIME;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/MirrorDateRangePropertiesProcessor.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/MirrorDateRangePropertiesProcessor.java
@@ -92,7 +92,7 @@ public class MirrorDateRangePropertiesProcessor {
         }
 
         if (startDate != null) {
-            if (lastFileInstant != null && startDate.isAfter(lastFileInstant)) {
+            if (lastFileInstant == null || lastFileInstant != null && startDate.isAfter(lastFileInstant)) {
                 filterStartDate = startDate;
             }
         } else {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/config/MirrorDateRangePropertiesProcessorTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/config/MirrorDateRangePropertiesProcessorTest.java
@@ -158,6 +158,20 @@ class MirrorDateRangePropertiesProcessorTest {
         assertThat(mirrorProperties.getVerifyHashAfter()).isEqualTo(Instant.EPOCH);
     }
 
+    @Test
+    void startDateSetAndDatabaseEmpty() {
+        mirrorProperties.setStartDate(STARTUP_TIME);
+        DateRangeFilter expectedFilter = new DateRangeFilter(mirrorProperties.getStartDate(), null);
+        Instant expectedDate = adjustStartDate(mirrorProperties.getStartDate());
+        for (var downloaderProperties : downloaderPropertiesList) {
+            StreamType streamType = downloaderProperties.getStreamType();
+            assertThat(mirrorDateRangePropertiesProcessor.getLastStreamFile(streamType))
+                    .isEqualTo(streamFile(streamType, expectedDate));
+            assertThat(mirrorDateRangePropertiesProcessor.getDateRangeFilter(streamType)).isEqualTo(expectedFilter);
+        }
+        assertThat(mirrorProperties.getVerifyHashAfter()).isEqualTo(adjustStartDate(STARTUP_TIME));
+    }
+
     @ParameterizedTest(name = "startDate {0}ns before application status, endDate")
     @ValueSource(longs = {0, 1})
     void startDateNotAfterDatabase(long nanos) {


### PR DESCRIPTION
Signed-off-by: Nana-EC <nana.essilfie-conduah@hedera.com>

**Description**:
The current MirrorDateRangePropertiesProcessor.newDateRangeFilter() currently doesn't honor the startDate set on an empty db

- Update newDateRangeFilter() logic to handle case when there's no lastFileInstant
- Add a test case to verify scenario

**Related issue(s)**:

Fixes #2355 

**Notes for reviewer**:


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
