### PR TITLE
Fix rest service startup crash

### DIFF
--- a/hedera-mirror-rest/health.js
+++ b/hedera-mirror-rest/health.js
@@ -22,7 +22,6 @@
 
 const {DbError} = require('./errors/dbError');
 const {NotFoundError} = require('./errors/notFoundError');
-const config = require('./config.js');
 
 const readinessQuery = `select true
                         from t_entity_types
@@ -30,7 +29,8 @@ const readinessQuery = `select true
 
 /**
  * Function to determine readiness of application.
- * @return {} None.
+ *
+ * @returns {Promise<void>}
  */
 const readinessCheck = async () => {
   return pool
@@ -47,15 +47,16 @@ const readinessCheck = async () => {
 
 /**
  * Function to determine liveness of application.
- * @return {} None.
+ *
+ * @returns {Promise<void>}
  */
 const livenessCheck = async () => {};
 
 /**
  * Allows for a graceful shutdown.
- * @return {} None.
+ *
+ * @returns {Promise<*>}
  */
-
 const beforeShutdown = async () => {
   logger.info(`Closing connection pool`);
   return pool.end();

--- a/hedera-mirror-rest/server.js
+++ b/hedera-mirror-rest/server.js
@@ -42,7 +42,6 @@ const tokens = require('./tokens');
 const topicmessage = require('./topicmessage');
 const transactions = require('./transactions');
 const {getPoolClass, isTestEnv} = require('./utils');
-const {DbError} = require('./errors/dbError');
 const {handleError} = require('./middleware/httpErrorHandler');
 const {metricsHandler, recordIpAndEndpoint} = require('./middleware/metricsHandler');
 const {serveSwaggerDocs} = require('./middleware/openapiHandler');
@@ -119,6 +118,14 @@ app.use(cors());
 // logging middleware
 app.use(httpContext.middleware);
 app.useAsync(requestLogger);
+app.useAsync(async (req, res, next) => {
+  try {
+    await TransactionResultService.loadTransactionResults();
+    await TransactionTypeService.loadTransactionTypes();
+  } catch (err) {
+    logger.warn('Failed to load transaction results / types', err);
+  }
+});
 
 // metrics middleware
 if (config.metrics.enabled) {
@@ -172,33 +179,19 @@ app.useAsync(responseHandler);
 // response error handling middleware
 app.useAsync(handleError);
 
-const verifyDbConnection = async () => {
-  // initial db calls, serves as connection validation
-  await TransactionTypeService.loadTransactionTypes();
-  await TransactionResultService.loadTransactionResults();
-};
-
 if (!isTestEnv()) {
-  verifyDbConnection()
-    .catch((err) => {
-      logger.error(err);
-      process.exit(1);
-    })
-    .then(() => {
-      logger.info(`DB connection validated`);
-      const server = app.listen(port, () => {
-        logger.info(`Server running on port: ${port}`);
-      });
+  const server = app.listen(port, () => {
+    logger.info(`Server running on port: ${port}`);
+  });
 
-      // Health check endpoints
-      createTerminus(server, {
-        healthChecks: {
-          '/health/readiness': health.readinessCheck,
-          '/health/liveness': health.livenessCheck,
-        },
-        beforeShutdown: health.beforeShutdown,
-      });
-    });
+  // Health check endpoints
+  createTerminus(server, {
+    healthChecks: {
+      '/health/readiness': health.readinessCheck,
+      '/health/liveness': health.livenessCheck,
+    },
+    beforeShutdown: health.beforeShutdown,
+  });
 }
 
 module.exports = app;

--- a/hedera-mirror-rest/service/transactionResultService.js
+++ b/hedera-mirror-rest/service/transactionResultService.js
@@ -65,6 +65,10 @@ class TransactionResultService {
   }
 
   async loadTransactionResults() {
+    if (this.transactionResultToProtoMap.size > 0) {
+      return;
+    }
+
     const transactionTypes = await this.getTransactionResults();
     this.populateTransactionResultMaps(transactionTypes);
   }
@@ -79,18 +83,6 @@ class TransactionResultService {
       throw new InvalidArgumentError(`Transaction type ${transactionResultName.toUpperCase()} not found in db`);
     }
     return type.protoId;
-  }
-
-  getResult(transactionResultId) {
-    if (!_.isNumber(transactionResultId)) {
-      throw new InvalidArgumentError(`Invalid argument ${transactionResultId} is not a number`);
-    }
-
-    const type = this.transactionResultProtoToResultMap.get(transactionResultId);
-    if (type === undefined) {
-      throw new InvalidArgumentError(`Transaction type ${transactionResultId} not found in db`);
-    }
-    return type.result;
   }
 }
 

--- a/hedera-mirror-rest/service/transactionTypeService.js
+++ b/hedera-mirror-rest/service/transactionTypeService.js
@@ -59,6 +59,10 @@ class TransactionTypeService {
   }
 
   async loadTransactionTypes() {
+    if (this.transactionTypeToProtoMap.size > 0) {
+      return;
+    }
+
     const transactionTypes = await this.getTransactionTypes();
     this.populateTransactionTypeMaps(transactionTypes);
   }


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR fixes the rest service startup crash when waiting for db to get ready. The issue causes pods failure & restart in k8s environment.

- replace the one-time `verifyDbConnection` with on-demand transaction result & type loading
 
**Related issue(s)**:

Fixes #2344 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
We have liveness probe for k8s environment. The probe does a simple db check. We should just rely on it instead of having a one shot db connection verification at startup.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
