### PR TITLE
Fix Java OpenAPI generation for REST API

### DIFF
--- a/hedera-mirror-rest/api/v1/openapi.yml
+++ b/hedera-mirror-rest/api/v1/openapi.yml
@@ -17,12 +17,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  accounts:
-                    $ref: '#/components/schemas/Accounts'
-                  links:
-                    $ref: '#/components/schemas/Links'
+                $ref: '#/components/schemas/AccountsResponse'
         400:
           $ref: '#/components/responses/InvalidParameterError'
       tags:
@@ -72,16 +67,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  timestamp:
-                    $ref: '#/components/schemas/Timestamp'
-                  balances:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/AccountBalance'
-                  links:
-                    $ref: '#/components/schemas/Links'
+                $ref: '#/components/schemas/BalancesResponse'
         400:
           $ref: '#/components/responses/InvalidParameterError'
       tags:
@@ -102,12 +88,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  schedules:
-                    $ref: '#/components/schemas/Schedules'
-                  links:
-                    $ref: '#/components/schemas/Links'
+                $ref: '#/components/schemas/SchedulesResponse'
         400:
           $ref: '#/components/responses/InvalidParameterError'
       tags:
@@ -158,12 +139,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  transactions:
-                    $ref: '#/components/schemas/Transactions'
-                  links:
-                    $ref: '#/components/schemas/Links'
+                $ref: '#/components/schemas/TransactionsResponse'
         400:
           $ref: '#/components/responses/InvalidParameterError'
       tags:
@@ -188,10 +164,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  transactions:
-                    $ref: '#/components/schemas/Transactions'
+                $ref: '#/components/schemas/TransactionByIdResponse'
         400:
           $ref: '#/components/responses/InvalidParameterError'
         404:
@@ -219,10 +192,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  transactions:
-                    $ref: '#/components/schemas/StateProofFiles'
+                $ref: '#/components/schemas/StateProofResponse'
         400:
           $ref: '#/components/responses/InvalidParameterError'
         404:
@@ -257,12 +227,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  messages:
-                    $ref: '#/components/schemas/TopicMessages'
-                  links:
-                    $ref: '#/components/schemas/Links'
+                $ref: '#/components/schemas/TopicMessagesResponse'
         400:
           $ref: '#/components/responses/InvalidParameterError'
         404:
@@ -289,12 +254,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  messages:
-                    $ref: '#/components/schemas/TopicMessages'
-                  links:
-                    $ref: '#/components/schemas/Links'
+                $ref: '#/components/schemas/TopicMessagesResponse'
         400:
           $ref: '#/components/responses/InvalidParameterError'
         404:
@@ -346,12 +306,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  tokens:
-                    $ref: '#/components/schemas/Tokens'
-                  links:
-                    $ref: '#/components/schemas/Links'
+                $ref: '#/components/schemas/TokensResponse'
         400:
           $ref: '#/components/responses/InvalidParameterError'
       tags:
@@ -493,14 +448,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  timestamp:
-                    $ref: '#/components/schemas/Timestamp'
-                  balances:
-                    $ref: '#/components/schemas/TokenDistribution'
-                  links:
-                    $ref: '#/components/schemas/Links'
+                $ref: '#/components/schemas/TokenBalancesResponse'
         400:
           $ref: '#/components/responses/InvalidParameterError'
       tags:
@@ -602,7 +550,7 @@ tags:
     externalDocs:
       url: https://docs.hedera.com/guides/docs/mirror-node-api/cryptocurrency-api#transactions
   - name: topics
-    description: The topics object represents the information associated with a topic enitty and returns topic messages information.
+    description: The topics object represents the information associated with a topic entity and returns topic messages information.
     externalDocs:
       url: https://docs.hedera.com/guides/docs/mirror-node-api/cryptocurrency-api#topic-messages
   - name: tokens
@@ -637,6 +585,73 @@ servers:
         enum: [ mainnet, previewnet, testnet ]
 components:
   schemas:
+    # API call responses.
+    AccountsResponse:
+      type: object
+      properties:
+        accounts:
+          $ref: '#/components/schemas/Accounts'
+        links:
+          $ref: '#/components/schemas/Links'
+    BalancesResponse:
+      type: object
+      properties:
+        timestamp:
+          $ref: '#/components/schemas/Timestamp'
+        balances:
+          type: array
+          items:
+            $ref: '#/components/schemas/AccountBalance'
+        links:
+          $ref: '#/components/schemas/Links'
+    SchedulesResponse:
+      type: object
+      properties:
+        schedules:
+          $ref: '#/components/schemas/Schedules'
+        links:
+          $ref: '#/components/schemas/Links'
+    StateProofResponse:
+      type: object
+      properties:
+        transactions:
+          $ref: '#/components/schemas/StateProofFiles'
+    TokenBalancesResponse:
+      type: object
+      properties:
+        timestamp:
+          $ref: '#/components/schemas/Timestamp'
+        balances:
+          $ref: '#/components/schemas/TokenDistribution'
+        links:
+          $ref: '#/components/schemas/Links'
+    TokensResponse:
+      type: object
+      properties:
+        tokens:
+          $ref: '#/components/schemas/Tokens'
+        links:
+          $ref: '#/components/schemas/Links'
+    TopicMessagesResponse:
+      type: object
+      properties:
+        messages:
+          $ref: '#/components/schemas/TopicMessages'
+        links:
+          $ref: '#/components/schemas/Links'
+    TransactionByIdResponse:
+      type: object
+      properties:
+        transactions:
+          $ref: '#/components/schemas/Transactions'
+    TransactionsResponse:
+      type: object
+      properties:
+        transactions:
+          $ref: '#/components/schemas/Transactions'
+        links:
+          $ref: '#/components/schemas/Links'
+    # API objects.
     AccountInfo:
       type: object
       required:
@@ -984,9 +999,6 @@ components:
             0.0.6:
               type: string
               format: byte
-          additionalProperties:
-            type: string
-            format: byte
       example:
         record_file: YzNkOTg3Yzg3NDI5NGViOTViMmRmOWZkMzZiMDY1NjYyMzMxNTc2OWFmMmVmMzQ0YzM1ODY4NzgwMTAyYjVjMA==
         address_books:

--- a/hedera-mirror-rest/api/v1/openapi.yml
+++ b/hedera-mirror-rest/api/v1/openapi.yml
@@ -24,15 +24,7 @@ paths:
                   links:
                     $ref: '#/components/schemas/Links'
         400:
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/responses/InvalidParameterError'
-              example:
-                _status:
-                  messages:
-                    - message: "Invalid parameter: account.id"
+          $ref: '#/components/responses/InvalidParameterError'
       tags:
         - accounts
   /api/v1/accounts/{accountId}:
@@ -57,15 +49,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/AccountBalanceTransactions'
         400:
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/responses/InvalidParameterError'
-              example:
-                _status:
-                  messages:
-                    - message: "Invalid parameter: account.id"
+          $ref: '#/components/responses/InvalidParameterError'
         404:
           $ref: '#/components/responses/NotFoundError'
       tags:
@@ -99,15 +83,7 @@ paths:
                   links:
                     $ref: '#/components/schemas/Links'
         400:
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/responses/InvalidParameterError'
-              example:
-                _status:
-                  messages:
-                    - message: "Invalid parameter: account.id"
+          $ref: '#/components/responses/InvalidParameterError'
       tags:
         - balances
   /api/v1/schedules:
@@ -133,15 +109,7 @@ paths:
                   links:
                     $ref: '#/components/schemas/Links'
         400:
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/responses/InvalidParameterError'
-              example:
-                _status:
-                  messages:
-                    - message: "Invalid parameter: schedule.id"
+          $ref: '#/components/responses/InvalidParameterError'
       tags:
         - schedules
   /api/v1/schedules/{scheduleId}:
@@ -159,15 +127,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Schedule'
         400:
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/responses/InvalidParameterError'
-              example:
-                _status:
-                  messages:
-                    - message: "Invalid parameter: scheduleid"
+          $ref: '#/components/responses/InvalidParameterError'
         404:
           $ref: '#/components/responses/NotFoundError'
       tags:
@@ -205,15 +165,7 @@ paths:
                   links:
                     $ref: '#/components/schemas/Links'
         400:
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/responses/InvalidParameterError'
-              example:
-                _status:
-                  messages:
-                    - message: "Invalid parameter: timestamp"
+          $ref: '#/components/responses/InvalidParameterError'
       tags:
         - transactions
   /api/v1/transactions/{transactionId}:
@@ -241,15 +193,7 @@ paths:
                   transactions:
                     $ref: '#/components/schemas/Transactions'
         400:
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/responses/InvalidParameterError'
-              example:
-                _status:
-                  messages:
-                    - message: Invalid Transaction id. Please use \shard.realm.num-sss-nnn\ format where sss are seconds and nnn are nanoseconds
+          $ref: '#/components/responses/InvalidParameterError'
         404:
           $ref: '#/components/responses/NotFoundError'
       tags:
@@ -280,27 +224,11 @@ paths:
                   transactions:
                     $ref: '#/components/schemas/StateProofFiles'
         400:
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/responses/InvalidParameterError'
-              example:
-                _status:
-                  messages:
-                    - message: Invalid Transaction id. Please use \shard.realm.num-sss-nnn\ format where sss are seconds and nnn are nanoseconds
+          $ref: '#/components/responses/InvalidParameterError'
         404:
           $ref: '#/components/responses/TransactionNotFound'
         502:
-          description: Bad Gateway
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/responses/ServiceUnavailableError'
-              example:
-                _status:
-                  messages:
-                    - message: Require at least 1/3 signature files to prove consensus, got 1 out of 4 for file 2019-10-11T13_33_25.526889Z.rcd_sig
+          $ref: '#/components/responses/ServiceUnavailableError'
       tags:
         - transactions
   /api/v1/topics/{topicId}/messages:
@@ -336,15 +264,7 @@ paths:
                   links:
                     $ref: '#/components/schemas/Links'
         400:
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/responses/InvalidParameterError'
-              example:
-                _status:
-                  messages:
-                    - message: "Invalid parameter: topic_num"
+          $ref: '#/components/responses/InvalidParameterError'
         404:
           $ref: '#/components/responses/TopicNotFound'
       tags:
@@ -376,15 +296,7 @@ paths:
                   links:
                     $ref: '#/components/schemas/Links'
         400:
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/responses/InvalidParameterError'
-              example:
-                _status:
-                  messages:
-                    - message: "Invalid parameter: topic_num"
+          $ref: '#/components/responses/InvalidParameterError'
         404:
           $ref: '#/components/responses/NotFoundError'
       tags:
@@ -411,15 +323,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/TopicMessage'
         400:
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/responses/InvalidParameterError'
-              example:
-                _status:
-                  messages:
-                    - message: "Invalid parameter: consensus_timestamp"
+          $ref: '#/components/responses/InvalidParameterError'
         404:
           $ref: '#/components/responses/NotFoundError'
       tags:
@@ -449,15 +353,7 @@ paths:
                   links:
                     $ref: '#/components/schemas/Links'
         400:
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/responses/InvalidParameterError'
-              example:
-                _status:
-                  messages:
-                    - message: "Invalid parameter: account.id"
+          $ref: '#/components/responses/InvalidParameterError'
       tags:
         - tokens
   /api/v1/tokens/{tokenId}:
@@ -572,15 +468,7 @@ paths:
                             amount: 100
                             denominating_token_id: 0.10.7
         400:
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/responses/InvalidParameterError'
-              example:
-                _status:
-                  messages:
-                    - message: "Invalid parameter: tokenid"
+          $ref: '#/components/responses/InvalidParameterError'
         404:
           $ref: '#/components/responses/NotFoundError'
       tags:
@@ -614,15 +502,7 @@ paths:
                   links:
                     $ref: '#/components/schemas/Links'
         400:
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/responses/InvalidParameterError'
-              example:
-                _status:
-                  messages:
-                    - message: "Invalid parameter: account.id"
+          $ref: '#/components/responses/InvalidParameterError'
       tags:
         - tokens
   /api/v1/tokens/{tokenId}/nfts:
@@ -649,18 +529,7 @@ paths:
               schema:
                 type: object
         400:
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/responses/InvalidParameterError'
-              example:
-                _status:
-                  messages:
-                    - message: "Invalid parameter: account.id"
-                    - message: "Invalid parameter: serialnumber"
-                    - message: "Invalid parameter: limit"
-                    - message: "Invalid parameter: order"
+          $ref: '#/components/responses/InvalidParameterError'
         404:
           $ref: '#/components/responses/NotFoundError'
       tags:
@@ -712,16 +581,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/NftTransactionHistory'
         400:
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/responses/InvalidParameterError'
-              example:
-                _status:
-                  messages:
-                    - message: "Invalid parameter: limit"
-                    - message: "Invalid parameter: order"
+          $ref: '#/components/responses/InvalidParameterError'
         404:
           $ref: '#/components/responses/NotFoundError'
       tags:
@@ -1500,12 +1360,21 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/Error'
+          example:
+            _status:
+              messages:
+                - message: "Invalid parameter: account.id"
+                - message: Invalid Transaction id. Please use \shard.realm.num-sss-nnn\ format where sss are seconds and nnn are nanoseconds
     ServiceUnavailableError:
       description: Service Unavailable
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/Error'
+          example:
+            _status:
+              messages:
+                - message: Require at least 1/3 signature files to prove consensus, got 1 out of 4 for file 2019-10-11T13_33_25.526889Z.rcd_sig
   parameters:
     accountIdQueryParam:
       name: account.id

--- a/hedera-mirror-rest/pom.xml
+++ b/hedera-mirror-rest/pom.xml
@@ -18,6 +18,8 @@
         <sonar.exclusions>pom.xml</sonar.exclusions>
         <sonar.sources>${project.basedir}</sonar.sources>
         <sonar.javascript.lcov.reportPaths>${project.basedir}/coverage/lcov.info</sonar.javascript.lcov.reportPaths>
+        <frontend-maven-plugin.version>1.12.0</frontend-maven-plugin.version>
+        <openapi-generator.version>5.2.1</openapi-generator.version>
     </properties>
 
     <build>
@@ -25,7 +27,7 @@
             <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
-                <version>1.12.0</version>
+                <version>${frontend-maven-plugin.version}</version>
                 <configuration>
                     <installDirectory>${project.basedir}</installDirectory>
                 </configuration>
@@ -112,6 +114,24 @@
             <plugin>
                 <groupId>io.fabric8</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
+            </plugin>
+            <!-- Attempt to create the REST API client in Java to validate our OpenAPI spec. -->
+            <plugin>
+                <groupId>org.openapitools</groupId>
+                <artifactId>openapi-generator-maven-plugin</artifactId>
+                <version>${openapi-generator.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <inputSpec>${project.basedir}/api/v1/openapi.yml</inputSpec>
+                            <generatorName>java</generatorName>
+                            <library>jersey2</library>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR modifies the OpenAPI YAML spec file in order to support Java REST client generation when using [OpenAPITools/openapi-generator](https://github.com/OpenAPITools/openapi-generator).

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
- The previous way of recording `400` errors was actually wrong: you were actually nesting a schema reference within an existing definition, so you ended up with the following.
```yaml
400:
          description: Bad Request
          content:
            application/json:
              schema:
                $ref: '#/components/responses/InvalidParameterError'
              example:
                _status:
                  messages:
                    - message: "Invalid parameter: account.id"
```
became
```yaml
400:
          description: Bad Request
          content:
            application/json:
              schema:
                description: Invalid parameter
                content:
                  application/json:
                    schema:
                      $ref: '#/components/schemas/Error'
                    example:
                      _status:
                        messages:
                          - message: "Invalid parameter: account.id"
                          - message: Invalid Transaction id. Please use \shard.realm.num-sss-nnn\ format where sss are seconds and nnn are nanoseconds
              example:
                _status:
                  messages:
                    - message: "Invalid parameter: account.id"
```
, which, of course, breaks the build when you do try to generate the client files. Doing this change resulted in much more consistent response code blocks (400s and 404s now share the same structure of pointing to a reference).
- Many of the responses outlined in the spec became `InlineResponseXXX` objects when generated, which is not good for naming. Screenshot included below. I moved these to their own reference names—this also keeps consistency with the overall structure of writing this spec file.
<img width="613" alt="InlineResponse200 (AccountInfo)" src="https://user-images.githubusercontent.com/12435342/130660111-d4ab7aed-7f58-413f-b43c-3e5368630a4e.png">
<img width="314" alt="InlineResponses" src="https://user-images.githubusercontent.com/12435342/130660116-6a5889ec-6cd2-4804-9777-88aa2fc731dd.png">

- We had to delete `additional_properties` from the spec for state proofs to get generation to work. According to the current alpha API for state proofs, there is no such property in the response, which might explain why it breaks generation.
<img width="1002" alt="Screen Shot 2021-08-24 at 1 19 24 PM" src="https://user-images.githubusercontent.com/12435342/130661187-d617a0bc-56d4-4ebc-b710-ae8074f7821c.png">


**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
