### PR TITLE
Fix slow schedules REST API query

### DIFF
--- a/hedera-mirror-rest/__tests__/schedules.test.js
+++ b/hedera-mirror-rest/__tests__/schedules.test.js
@@ -94,16 +94,21 @@ describe('schedule formatScheduleRow tests', () => {
       },
     },
     {
-      description: 'input with null signature entry',
+      description: 'input with null signatures',
       input: {
         ...defaultInput,
-        signatures: [
-          {
-            consensus_timestamp: null,
-            public_key_prefix: null,
-            signature: null,
-          },
-        ],
+        signatures: null,
+      },
+      expected: {
+        ...defaultExpected,
+        signatures: [],
+      },
+    },
+    {
+      description: 'input with undefined signatures',
+      input: {
+        ...defaultInput,
+        signatures: null,
       },
       expected: {
         ...defaultExpected,


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR optimizes the db query in the schedules REST API

- use a subquery to aggregate and build the transaction signatures of a schedule so no more slow group by 

**Related issue(s)**:

Fixes #2446 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
explain analyze shows it's the group by (inherently also sort by the columns) which slows down the query. This is the perf numbers with the optimization in testnet:

```
mirror_node=> explain analyze select
mirror_node->   e.key,
mirror_node->   s.consensus_timestamp,
mirror_node->   s.creator_account_id,
mirror_node->   s.executed_timestamp,
mirror_node->   e.memo,
mirror_node->   s.payer_account_id,
mirror_node->   s.schedule_id,
mirror_node->   s.transaction_body,
mirror_node->   (
mirror_node(>       select json_agg(
mirror_node(>         json_build_object(
mirror_node(>           'consensus_timestamp', ts.consensus_timestamp::text,
mirror_node(>           'public_key_prefix', encode(ts.public_key_prefix, 'base64'),
mirror_node(>           'signature', encode(ts.signature, 'base64')
mirror_node(>         ) order by ts.consensus_timestamp
mirror_node(>       )
mirror_node(>       from transaction_signature ts
mirror_node(>       where ts.entity_id = s.schedule_id
mirror_node(>     ) as signatures
mirror_node-> from schedule s
mirror_node-> join entity e on e.id = s.schedule_id
mirror_node-> order by s.schedule_id asc
mirror_node-> limit 500;
                                                                                    QUERY PLAN
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.86..1660.73 rows=500 width=802) (actual time=0.148..10.401 rows=500 loops=1)
   ->  Nested Loop  (cost=0.86..3889777.54 rows=1171706 width=802) (actual time=0.148..10.332 rows=500 loops=1)
         ->  Index Scan using schedule_pkey on schedule s  (cost=0.43..130305.16 rows=1171706 width=728) (actual time=0.027..0.149 rows=500 loops=1)
         ->  Index Scan using entity_pkey on entity e  (cost=0.43..0.53 rows=1 width=50) (actual time=0.002..0.002 rows=1 loops=500)
               Index Cond: (id = s.schedule_id)
         SubPlan 1
           ->  Aggregate  (cost=2.66..2.67 rows=1 width=32) (actual time=0.017..0.017 rows=1 loops=500)
                 ->  Index Scan using transaction_signature__entity_id on transaction_signature ts  (cost=0.43..2.65 rows=1 width=74) (actual time=0.001..0.002 rows=4 loops=500)
                       Index Cond: (entity_id = s.schedule_id)
 Planning time: 0.263 ms
 Execution time: 10.505 ms
(11 rows)
```

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
