### PR TITLE
Expose account memo and receiverSigRequired files in API response

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/Entity.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/Entity.java
@@ -68,6 +68,8 @@ public class Entity {
 
     private Long realm;
 
+    private Boolean receiverSigRequired;
+
     private Long shard;
 
     private byte[] submitKey;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoCreateTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoCreateTransactionHandler.java
@@ -57,6 +57,7 @@ public class CryptoCreateTransactionHandler extends AbstractEntityCrudTransactio
         }
 
         entity.setMemo(txMessage.getMemo());
+        entity.setReceiverSigRequired(txMessage.getReceiverSigRequired());
     }
 
     @Override

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoUpdateTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoUpdateTransactionHandler.java
@@ -41,6 +41,7 @@ public class CryptoUpdateTransactionHandler extends AbstractEntityCrudTransactio
     }
 
     @Override
+    @SuppressWarnings("java:S1874")
     protected void doUpdateEntity(Entity entity, RecordItem recordItem) {
         CryptoUpdateTransactionBody txMessage = recordItem.getTransactionBody().getCryptoUpdateAccount();
         if (txMessage.hasExpirationTime()) {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoUpdateTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoUpdateTransactionHandler.java
@@ -61,6 +61,9 @@ public class CryptoUpdateTransactionHandler extends AbstractEntityCrudTransactio
 
         if (txMessage.hasReceiverSigRequiredWrapper()) {
             entity.setReceiverSigRequired(txMessage.getReceiverSigRequiredWrapper().getValue());
+        } else if (txMessage.getReceiverSigRequired()) {
+            // support old transactions
+            entity.setReceiverSigRequired(txMessage.getReceiverSigRequired());
         }
     }
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoUpdateTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoUpdateTransactionHandler.java
@@ -58,6 +58,10 @@ public class CryptoUpdateTransactionHandler extends AbstractEntityCrudTransactio
         if (txMessage.hasMemo()) {
             entity.setMemo(txMessage.getMemo().getValue());
         }
+
+        if (txMessage.hasReceiverSigRequiredWrapper()) {
+            entity.setReceiverSigRequired(txMessage.getReceiverSigRequiredWrapper().getValue());
+        }
     }
 
     @Override

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/EntityUpsertQueryGenerator.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/EntityUpsertQueryGenerator.java
@@ -36,7 +36,8 @@ public class EntityUpsertQueryGenerator extends AbstractUpsertQueryGenerator<Ent
     private final List<String> v2ConflictIdColumns = List.of(Entity_.ID);
     private final Set<String> nullableColumns = Set.of(Entity_.AUTO_RENEW_ACCOUNT_ID,
             Entity_.AUTO_RENEW_PERIOD, Entity_.CREATED_TIMESTAMP, Entity_.DELETED, Entity_.EXPIRATION_TIMESTAMP,
-            Entity_.KEY, Entity_.MODIFIED_TIMESTAMP, Entity_.PUBLIC_KEY, Entity_.PROXY_ACCOUNT_ID, Entity_.SUBMIT_KEY);
+            Entity_.KEY, Entity_.MODIFIED_TIMESTAMP, Entity_.PUBLIC_KEY, Entity_.PROXY_ACCOUNT_ID, Entity_.SUBMIT_KEY,
+            Entity_.RECEIVER_SIG_REQUIRED);
     private final Set<String> nonUpdatableColumns = Set.of(Entity_.CREATED_TIMESTAMP, Entity_.ID,
             Entity_.NUM, Entity_.REALM, Entity_.SHARD, Entity_.TYPE);
 

--- a/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.44.0__add_entity_receiver_sig_required.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.44.0__add_entity_receiver_sig_required.sql
@@ -1,0 +1,6 @@
+-------------------
+-- Add missing receiver_sig_required
+-------------------
+
+alter table if exists entity
+    add column if not exists receiver_sig_required boolean null;

--- a/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.0__time_scale_init.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.0__time_scale_init.sql
@@ -10,9 +10,9 @@ CREATE TYPE token_type AS ENUM ('FUNGIBLE_COMMON', 'NON_FUNGIBLE_UNIQUE');
 -- assessed_custom_fee
 create table if not exists assessed_custom_fee
 (
-    amount                      bigint not null,
-    collector_account_id        bigint not null,
-    consensus_timestamp         bigint not null,
+    amount                      bigint   not null,
+    collector_account_id        bigint   not null,
+    consensus_timestamp         bigint   not null,
     effective_payer_account_ids bigint[] not null,
     token_id                    bigint
 );
@@ -128,6 +128,7 @@ create table if not exists entity
     proxy_account_id      bigint,
     public_key            character varying,
     realm                 bigint          not null,
+    receiver_sig_required boolean         null,
     shard                 bigint          not null,
     submit_key            bytea,
     type                  integer         not null

--- a/hedera-mirror-importer/src/main/resources/db/scripts/timescaledb/csvRestoreTables.sql
+++ b/hedera-mirror-importer/src/main/resources/db/scripts/timescaledb/csvRestoreTables.sql
@@ -20,7 +20,7 @@
 
 \copy custom_fee (amount, amount_denominator, collector_account_id, created_timestamp, denominating_token_id, maximum_amount, minimum_amount, token_id) from custom_fee.csv csv;
 
-\copy entity (auto_renew_account_id, auto_renew_period, created_timestamp, deleted, expiration_timestamp, id, key, memo, modified_timestamp, num, public_key, proxy_account_id, realm, shard, submit_key, type) from entity.csv csv;
+\copy entity (auto_renew_account_id, auto_renew_period, created_timestamp, deleted, expiration_timestamp, id, key, memo, modified_timestamp, num, public_key, proxy_account_id, realm, receiver_sig_required, shard, submit_key, type) from entity.csv csv;
 
 \copy event_file (bytes, consesnsus_start, consensus_end, count, digest_algorithm, file_hash, hash, load_start, load_end, name, node_account_id, previous_hash, version) from event_file.csv csv;
 

--- a/hedera-mirror-importer/src/main/resources/db/scripts/timescaledb/csvRestoreTables.sql
+++ b/hedera-mirror-importer/src/main/resources/db/scripts/timescaledb/csvRestoreTables.sql
@@ -20,7 +20,7 @@
 
 \copy custom_fee (amount, amount_denominator, collector_account_id, created_timestamp, denominating_token_id, maximum_amount, minimum_amount, token_id) from custom_fee.csv csv;
 
-\copy entity (auto_renew_account_id, auto_renew_period, created_timestamp, deleted, expiration_timestamp, id, key, memo, modified_timestamp, num, public_key, proxy_account_id, realm, receiver_sig_required, shard, submit_key, type) from entity.csv csv;
+\copy entity (auto_renew_account_id, auto_renew_period, created_timestamp, deleted, expiration_timestamp, id, key, memo, modified_timestamp, num, public_key, proxy_account_id, realm, shard, submit_key, type, receiver_sig_required) from entity.csv csv;
 
 \copy event_file (bytes, consesnsus_start, consensus_end, count, digest_algorithm, file_hash, hash, load_start, load_end, name, node_account_id, previous_hash, version) from event_file.csv csv;
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/CleanupEntityMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/CleanupEntityMigrationTest.java
@@ -141,9 +141,7 @@ class CleanupEntityMigrationTest extends IntegrationTest {
 
     private Optional<Entity> retrieveEntity(Long id) {
         return Optional.of(jdbcOperations.queryForObject(
-                "select auto_renew_account_id, auto_renew_period, created_timestamp, deleted, expiration_timestamp, " +
-                        "id, key, memo, modified_timestamp, num, public_key, proxy_account_id, realm, shard, " +
-                        "submit_key, type from entity where id = ?",
+                "select * from entity where id = ?",
                 new Object[] {id},
                 (rs, rowNum) -> {
                     Entity entity = new Entity();

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/CleanupEntityMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/CleanupEntityMigrationTest.java
@@ -128,7 +128,7 @@ class CleanupEntityMigrationTest extends IntegrationTest {
 
         assertEquals(createTimestamps.length, entityRepository.count());
         for (int i = 0; i < ids.length; i++) {
-            Optional<Entity> entity = entityRepository.findById(ids[i]);
+            Optional<Entity> entity = retrieveEntity(ids[i]);
             long consensusTimestamp = createTimestamps[i];
             assertAll(
                     () -> assertThat(entity).isPresent().get()
@@ -137,6 +137,35 @@ class CleanupEntityMigrationTest extends IntegrationTest {
                             .returns("", Entity::getMemo)
             );
         }
+    }
+
+    private Optional<Entity> retrieveEntity(Long id) {
+        return Optional.of(jdbcOperations.queryForObject(
+                "select auto_renew_account_id, auto_renew_period, created_timestamp, deleted, expiration_timestamp, " +
+                        "id, key, memo, modified_timestamp, num, public_key, proxy_account_id, realm, shard, " +
+                        "submit_key, type from entity where id = ?",
+                new Object[] {id},
+                (rs, rowNum) -> {
+                    Entity entity = new Entity();
+                    entity.setAutoRenewAccountId(EntityIdEndec
+                            .decode(rs.getLong("auto_renew_account_id"), EntityTypeEnum.ACCOUNT));
+                    entity.setAutoRenewPeriod(rs.getLong("auto_renew_period"));
+                    entity.setCreatedTimestamp(rs.getLong("created_timestamp"));
+                    entity.setDeleted(rs.getBoolean("deleted"));
+                    entity.setExpirationTimestamp(rs.getLong("expiration_timestamp"));
+                    entity.setId(rs.getLong("id"));
+                    entity.setKey(rs.getBytes("key"));
+                    entity.setMemo(rs.getString("memo"));
+                    entity.setModifiedTimestamp(rs.getLong("modified_timestamp"));
+                    entity.setNum(rs.getLong("num"));
+                    entity.setPublicKey(rs.getString("public_key"));
+                    entity.setRealm(rs.getLong("realm"));
+                    entity.setShard(rs.getLong("shard"));
+                    entity.setSubmitKey(rs.getBytes("submit_key"));
+                    entity.setType(rs.getInt("type"));
+
+                    return entity;
+                }));
     }
 
     @Test
@@ -185,7 +214,7 @@ class CleanupEntityMigrationTest extends IntegrationTest {
 
         assertEquals(createTimestamps.length, entityRepository.count());
         for (int i = 0; i < ids.length; i++) {
-            Optional<Entity> entity = entityRepository.findById(ids[i]);
+            Optional<Entity> entity = retrieveEntity(ids[i]);
             long consensusTimestamp = createTimestamps[i];
             assertAll(
                     () -> assertThat(entity).isPresent().get()
@@ -238,7 +267,7 @@ class CleanupEntityMigrationTest extends IntegrationTest {
 
         assertEquals(createTimestamps.length, entityRepository.count());
         for (int i = 0; i < ids.length; i++) {
-            Optional<Entity> entity = entityRepository.findById(ids[i]);
+            Optional<Entity> entity = retrieveEntity(ids[i]);
             long createdTimestamp = createTimestamps[i];
             long modifiedTimestamp = modifiedTimestamps[i];
             assertAll(
@@ -303,7 +332,7 @@ class CleanupEntityMigrationTest extends IntegrationTest {
 
         assertEquals(createTimestamps.length, entityRepository.count());
         for (int i = 0; i < ids.length; i++) {
-            Optional<Entity> entity = entityRepository.findById(ids[i]);
+            Optional<Entity> entity = retrieveEntity(ids[i]);
             long createdTimestamp = createTimestamps[i];
             long modifiedTimestamp = deletedTimestamps[i];
             assertAll(

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/EntityTimestampMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/EntityTimestampMigrationTest.java
@@ -82,7 +82,7 @@ class EntityTimestampMigrationTest extends IntegrationTest {
     @Test
     void verifyEntityTimestampMigration() throws Exception {
         // given
-        entityRepository.saveAll(List.of(
+        persistEntities(List.of(
                 entity(9000, EntityTypeEnum.ACCOUNT, 99L, 99L),
                 entity(9001, EntityTypeEnum.ACCOUNT, 100L, 101L),
                 entity(9002, EntityTypeEnum.CONTRACT),
@@ -120,7 +120,7 @@ class EntityTimestampMigrationTest extends IntegrationTest {
         migrate();
 
         // then
-        assertThat(entityRepository.findAll())
+        assertThat(retrieveAllEntity())
                 .usingElementComparatorOnFields("id", "createdTimestamp", "modifiedTimestamp")
                 .containsExactlyInAnyOrderElementsOf(expected);
     }
@@ -153,5 +153,60 @@ class EntityTimestampMigrationTest extends IntegrationTest {
 
     private void migrate() throws Exception {
         jdbcOperations.update(FileUtils.readFileToString(migrationSql, "UTF-8"));
+    }
+
+    private void persistEntities(List<Entity> entities) {
+        for (Entity entity : entities) {
+            jdbcOperations.update(
+                    "insert into entity (auto_renew_account_id, auto_renew_period, created_timestamp, deleted, " +
+                            "expiration_timestamp, id, key, memo, modified_timestamp, num, public_key, " +
+                            "proxy_account_id, realm, shard, submit_key, type) " +
+                            "values (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                    entity.getAutoRenewAccountId() == null ? null : entity.getAutoRenewAccountId().getId(),
+                    entity.getAutoRenewPeriod(),
+                    entity.getCreatedTimestamp(),
+                    entity.getDeleted(),
+                    entity.getExpirationTimestamp(),
+                    entity.getId(),
+                    entity.getKey(),
+                    entity.getMemo(),
+                    entity.getModifiedTimestamp(),
+                    entity.getNum(),
+                    entity.getPublicKey(),
+                    entity.getProxyAccountId() == null ? null : entity.getProxyAccountId().getId(),
+                    entity.getRealm(),
+                    entity.getShard(),
+                    entity.getSubmitKey(),
+                    entity.getType()
+            );
+        }
+    }
+
+    private List<Entity> retrieveAllEntity() {
+        return jdbcOperations.query(
+                "select auto_renew_account_id, auto_renew_period, created_timestamp, deleted, expiration_timestamp, " +
+                        "id, key, memo, modified_timestamp, num, public_key, proxy_account_id, realm, shard, " +
+                        "submit_key, type from entity",
+                (rs, rowNum) -> {
+                    Entity entity = new Entity();
+                    entity.setAutoRenewAccountId(EntityIdEndec
+                            .decode(rs.getLong("auto_renew_account_id"), EntityTypeEnum.ACCOUNT));
+                    entity.setAutoRenewPeriod(rs.getLong("auto_renew_period"));
+                    entity.setCreatedTimestamp(rs.getLong("created_timestamp"));
+                    entity.setDeleted(rs.getBoolean("deleted"));
+                    entity.setExpirationTimestamp(rs.getLong("expiration_timestamp"));
+                    entity.setId(rs.getLong("id"));
+                    entity.setKey(rs.getBytes("key"));
+                    entity.setMemo(rs.getString("memo"));
+                    entity.setModifiedTimestamp(rs.getLong("modified_timestamp"));
+                    entity.setNum(rs.getLong("num"));
+                    entity.setPublicKey(rs.getString("public_key"));
+                    entity.setRealm(rs.getLong("realm"));
+                    entity.setShard(rs.getLong("shard"));
+                    entity.setSubmitKey(rs.getBytes("submit_key"));
+                    entity.setType(rs.getInt("type"));
+
+                    return entity;
+                });
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileParserIntegrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileParserIntegrationTest.java
@@ -117,7 +117,9 @@ class RecordFileParserIntegrationTest extends IntegrationTest {
         verifyFinalDatabaseState(recordFileDescriptor1);
 
         // when
-        Assertions.assertThrows(ParserException.class, () -> recordFileParser.parse(recordFile));
+        Assertions.assertThrows(
+                ParserException.class,
+                () -> recordFileParser.parse(recordFileDescriptor2.getRecordFile()));
 
         // then
         verifyFinalDatabaseState(recordFileDescriptor1);

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileParserIntegrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileParserIntegrationTest.java
@@ -117,7 +117,7 @@ class RecordFileParserIntegrationTest extends IntegrationTest {
         verifyFinalDatabaseState(recordFileDescriptor1);
 
         // when
-        Assertions.assertThrows(ParserException.class, () -> recordFileParser.parse(recordFileDescriptor2.getRecordFile()));
+        Assertions.assertThrows(ParserException.class, () -> recordFileParser.parse(recordFile));
 
         // then
         verifyFinalDatabaseState(recordFileDescriptor1);

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileParserIntegrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileParserIntegrationTest.java
@@ -117,9 +117,7 @@ class RecordFileParserIntegrationTest extends IntegrationTest {
         verifyFinalDatabaseState(recordFileDescriptor1);
 
         // when
-        Assertions.assertThrows(
-                ParserException.class,
-                () -> recordFileParser.parse(recordFileDescriptor2.getRecordFile()));
+        Assertions.assertThrows(ParserException.class, () -> recordFileParser.parse(recordFileDescriptor2.getRecordFile()));
 
         // then
         verifyFinalDatabaseState(recordFileDescriptor1);

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/AbstractTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/AbstractTransactionHandlerTest.java
@@ -69,6 +69,8 @@ public abstract class AbstractTransactionHandlerTest {
 
     protected static final String DEFAULT_MEMO = "default entity memo";
 
+    protected static final boolean DEFAULT_RECEIVER_SIG_REQUIRED = false;
+
     protected static final Key DEFAULT_SUBMIT_KEY = getKey(
             "5a5ad514f0957fa170a676210c9bdbddf3bc9519702cf915fa6767a40463b96G");
 
@@ -350,8 +352,12 @@ public abstract class AbstractTransactionHandlerTest {
                 case "keys":
                     entity.setKey(DEFAULT_KEY_LIST.toByteArray());
                     break;
+                case "receiverSigRequired":
+                    entity.setReceiverSigRequired(DEFAULT_RECEIVER_SIG_REQUIRED);
+                    break;
                 case "submitKey":
                     entity.setSubmitKey(DEFAULT_SUBMIT_KEY.toByteArray());
+                    break;
                 default:
                     break;
             }
@@ -382,8 +388,12 @@ public abstract class AbstractTransactionHandlerTest {
                 case "keys":
                     builder.setField(field, DEFAULT_KEY_LIST);
                     break;
+                case "receiverSigRequired":
+                    builder.setField(field, DEFAULT_RECEIVER_SIG_REQUIRED);
+                    break;
                 case "submitKey":
                     builder.setField(field, DEFAULT_SUBMIT_KEY);
+                    break;
                 default:
                     break;
             }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/AbstractTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/AbstractTransactionHandlerTest.java
@@ -166,7 +166,7 @@ public abstract class AbstractTransactionHandlerTest {
                     receiverSigRequiredField.getType() == FieldDescriptor.Type.BOOL;
 
             if ((isMemoString && memoWrapperField == null) || (isReceiverSigRequiredBool && receiverSigRequiredWrapperField == null)) {
-                testSpecs = getUpdateEntityTestSpecsForCreateTransaction(memoField, receiverSigRequiredField);
+                testSpecs = getUpdateEntityTestSpecsForCreateTransaction(memoField);
             } else {
                 testSpecs = getUpdateEntityTestSpecsForUpdateTransaction(
                         memoField,
@@ -221,8 +221,7 @@ public abstract class AbstractTransactionHandlerTest {
         return entity;
     }
 
-    private List<UpdateEntityTestSpec> getUpdateEntityTestSpecsForCreateTransaction(FieldDescriptor memoField,
-                                                                                    FieldDescriptor receiverSigRequiredField) {
+    private List<UpdateEntityTestSpec> getUpdateEntityTestSpecsForCreateTransaction(FieldDescriptor memoField) {
         TransactionBody body = getTransactionBodyForUpdateEntityWithoutMemo();
         Message innerBody = getInnerBody(body);
         List<UpdateEntityTestSpec> testSpecs = new LinkedList<>();
@@ -334,7 +333,7 @@ public abstract class AbstractTransactionHandlerTest {
         input = new Entity();
         input.setMemo(DEFAULT_MEMO);
         expected = getExpectedUpdatedEntity();
-        Message updatedInnerBody = innerBody.toBuilder().setField(field, StringValue.of("")).build();
+        Message clearedMemoInnerBody = innerBody.toBuilder().setField(field, StringValue.of("")).build();
 
         if (receiverSigRequiredWrapperField != null) {
             input.setReceiverSigRequired(DEFAULT_RECEIVER_SIG_REQUIRED);
@@ -346,7 +345,7 @@ public abstract class AbstractTransactionHandlerTest {
                         .description("update entity with empty StringValue memo, expect memo cleared")
                         .expected(expected)
                         .input(input)
-                        .recordItem(getRecordItem(body, updatedInnerBody))
+                        .recordItem(getRecordItem(body, clearedMemoInnerBody))
                         .build()
         );
 
@@ -355,7 +354,8 @@ public abstract class AbstractTransactionHandlerTest {
         expected.setMemo(UPDATED_MEMO);
         input = new Entity();
         input.setMemo(DEFAULT_MEMO);
-        updatedInnerBody = innerBody.toBuilder().setField(field, StringValue.of(UPDATED_MEMO)).build();
+        Message memoStringValueUpdatedInnerBody = innerBody.toBuilder().setField(field, StringValue.of(UPDATED_MEMO))
+                .build();
 
         if (receiverSigRequiredWrapperField != null) {
             input.setReceiverSigRequired(DEFAULT_RECEIVER_SIG_REQUIRED);
@@ -367,7 +367,7 @@ public abstract class AbstractTransactionHandlerTest {
                         .description("update entity with non-empty StringValue memo, expect memo updated")
                         .expected(expected)
                         .input(input)
-                        .recordItem(getRecordItem(body, updatedInnerBody))
+                        .recordItem(getRecordItem(body, memoStringValueUpdatedInnerBody))
                         .build()
         );
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/EntityUpsertQueryGeneratorTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/EntityUpsertQueryGeneratorTest.java
@@ -38,15 +38,14 @@ class EntityUpsertQueryGeneratorTest extends AbstractUpsertQueryGeneratorTest {
     protected String getInsertQuery() {
         return "insert into entity (auto_renew_account_id, auto_renew_period, created_timestamp, deleted, " +
                 "expiration_timestamp, id, key, memo, modified_timestamp, num, proxy_account_id, public_key, realm, " +
-                "shard, submit_key, type) select entity_temp.auto_renew_account_id, entity_temp.auto_renew_period, " +
-                "entity_temp.created_timestamp, entity_temp.deleted, entity_temp.expiration_timestamp, entity_temp" +
-                ".id, entity_temp.key, case when entity_temp.memo = '<uuid>' then '' else coalesce(entity_temp.memo, " +
-                "'') " +
+                "receiver_sig_required, shard, submit_key, type) select entity_temp.auto_renew_account_id, " +
+                "entity_temp.auto_renew_period, entity_temp.created_timestamp, entity_temp.deleted, " +
+                "entity_temp.expiration_timestamp, entity_temp.id, entity_temp.key, " +
+                "case when entity_temp.memo = '<uuid>' then '' else coalesce(entity_temp.memo, '') " +
                 "end, entity_temp.modified_timestamp, entity_temp.num, entity_temp.proxy_account_id, case when " +
                 "entity_temp.public_key = '<uuid>' then '' else coalesce(entity_temp.public_key, null) end, " +
-                "entity_temp" +
-                ".realm, entity_temp.shard, entity_temp.submit_key, entity_temp.type from entity_temp " +
-                "on conflict (id) do nothing";
+                "entity_temp.realm, entity_temp.receiver_sig_required, entity_temp.shard, entity_temp.submit_key, " +
+                "entity_temp.type from entity_temp on conflict (id) do nothing";
     }
 
     @Override
@@ -63,6 +62,7 @@ class EntityUpsertQueryGeneratorTest extends AbstractUpsertQueryGeneratorTest {
                 "proxy_account_id = coalesce(entity_temp.proxy_account_id, entity.proxy_account_id), " +
                 "public_key = case when entity_temp.public_key = '<uuid>' then '' else " +
                 "coalesce(entity_temp.public_key, entity.public_key) end, " +
+                "receiver_sig_required = coalesce(entity_temp.receiver_sig_required, entity.receiver_sig_required), " +
                 "submit_key = coalesce(entity_temp.submit_key, entity.submit_key) " +
                 "from entity_temp where entity.id = entity_temp.id and entity_temp.created_timestamp is null";
     }

--- a/hedera-mirror-rest/__tests__/integrationDomainOps.js
+++ b/hedera-mirror-rest/__tests__/integrationDomainOps.js
@@ -186,7 +186,7 @@ const addEntity = async (defaults, entity) => {
     deleted: false,
     expiration_timestamp: null,
     key: null,
-    memo: '',
+    memo: 'entity memo',
     public_key: null,
     realm: 0,
     receiver_sig_required: false,

--- a/hedera-mirror-rest/__tests__/integrationDomainOps.js
+++ b/hedera-mirror-rest/__tests__/integrationDomainOps.js
@@ -189,6 +189,7 @@ const addEntity = async (defaults, entity) => {
     memo: '',
     public_key: null,
     realm: 0,
+    receiver_sig_required: false,
     shard: 0,
     type: 1,
     ...defaults,
@@ -197,8 +198,8 @@ const addEntity = async (defaults, entity) => {
 
   await sqlConnection.query(
     `INSERT INTO entity (id, type, shard, realm, num, expiration_timestamp, deleted, public_key,
-                         auto_renew_period, key, memo)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11);`,
+                         auto_renew_period, key, memo, receiver_sig_required)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12);`,
     [
       EntityId.of(BigInt(entity.shard), BigInt(entity.realm), BigInt(entity.num)).getEncodedId(),
       entity.type,
@@ -211,6 +212,7 @@ const addEntity = async (defaults, entity) => {
       entity.auto_renew_period,
       entity.key,
       entity.memo,
+      entity.receiver_sig_required,
     ]
   );
 };

--- a/hedera-mirror-rest/__tests__/specs/accounts-01-no-args.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/accounts-01-no-args.spec.json
@@ -28,11 +28,13 @@
       },
       {
         "num": 9,
-        "expiration_timestamp": "-9223372036854775808"
+        "expiration_timestamp": "-9223372036854775808",
+        "receiver_sig_required": null
       },
       {
         "num": 10,
-        "expiration_timestamp": "9223372036854775807"
+        "expiration_timestamp": "9223372036854775807",
+        "receiver_sig_required": true
       }
     ],
     "balances": [
@@ -281,7 +283,7 @@
         "key": null,
         "deleted": false,
         "memo": "entity memo",
-        "receiver_sig_required": false
+        "receiver_sig_required": null
       },
       {
         "balance": {
@@ -295,7 +297,7 @@
         "key": null,
         "deleted": false,
         "memo": "entity memo",
-        "receiver_sig_required": false
+        "receiver_sig_required": true
       }
     ],
     "links": {

--- a/hedera-mirror-rest/__tests__/specs/accounts-01-no-args.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/accounts-01-no-args.spec.json
@@ -146,10 +146,12 @@
           ]
         },
         "account": "0.0.1",
+        "deleted": false,
         "expiry_timestamp": null,
         "auto_renew_period": null,
         "key": null,
-        "deleted": false
+        "memo": "entity memo",
+        "receiver_sig_required": false
       },
       {
         "balance": {
@@ -170,7 +172,9 @@
         "expiry_timestamp": null,
         "auto_renew_period": null,
         "key": null,
-        "deleted": false
+        "deleted": false,
+        "memo": "entity memo",
+        "receiver_sig_required": false
       },
       {
         "balance": {
@@ -182,7 +186,9 @@
         "expiry_timestamp": null,
         "auto_renew_period": null,
         "key": null,
-        "deleted": false
+        "deleted": false,
+        "memo": "entity memo",
+        "receiver_sig_required": false
       },
       {
         "balance": {
@@ -194,7 +200,9 @@
         "expiry_timestamp": null,
         "auto_renew_period": null,
         "key": null,
-        "deleted": false
+        "deleted": false,
+        "memo": "entity memo",
+        "receiver_sig_required": false
       },
       {
         "balance": {
@@ -215,7 +223,9 @@
         "expiry_timestamp": null,
         "auto_renew_period": null,
         "key": null,
-        "deleted": false
+        "deleted": false,
+        "memo": "entity memo",
+        "receiver_sig_required": false
       },
       {
         "balance": {
@@ -227,7 +237,9 @@
         "expiry_timestamp": null,
         "auto_renew_period": null,
         "key": null,
-        "deleted": false
+        "deleted": false,
+        "memo": "entity memo",
+        "receiver_sig_required": false
       },
       {
         "balance": {
@@ -239,7 +251,9 @@
         "expiry_timestamp": null,
         "auto_renew_period": null,
         "key": null,
-        "deleted": false
+        "deleted": false,
+        "memo": "entity memo",
+        "receiver_sig_required": false
       },
       {
         "balance": {
@@ -251,7 +265,9 @@
         "expiry_timestamp": null,
         "auto_renew_period": null,
         "key": null,
-        "deleted": false
+        "deleted": false,
+        "memo": "entity memo",
+        "receiver_sig_required": false
       },
       {
         "balance": {
@@ -263,7 +279,9 @@
         "expiry_timestamp": "-9223372036.854775808",
         "auto_renew_period": null,
         "key": null,
-        "deleted": false
+        "deleted": false,
+        "memo": "entity memo",
+        "receiver_sig_required": false
       },
       {
         "balance": {
@@ -275,7 +293,9 @@
         "expiry_timestamp": "9223372036.854775807",
         "auto_renew_period": null,
         "key": null,
-        "deleted": false
+        "deleted": false,
+        "memo": "entity memo",
+        "receiver_sig_required": false
       }
     ],
     "links": {

--- a/hedera-mirror-rest/__tests__/specs/accounts-02-specific-id.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/accounts-02-specific-id.spec.json
@@ -70,7 +70,9 @@
         "expiry_timestamp": null,
         "auto_renew_period": null,
         "key": null,
-        "deleted": false
+        "deleted": false,
+        "memo": "entity memo",
+        "receiver_sig_required": false
       }
     ],
     "links": {

--- a/hedera-mirror-rest/__tests__/specs/accounts-03-accounts-range.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/accounts-03-accounts-range.spec.json
@@ -107,7 +107,9 @@
         "expiry_timestamp": null,
         "auto_renew_period": null,
         "key": null,
-        "deleted": false
+        "deleted": false,
+        "memo": "entity memo",
+        "receiver_sig_required": false
       },
       {
         "balance": {
@@ -119,7 +121,9 @@
         "expiry_timestamp": null,
         "auto_renew_period": null,
         "key": null,
-        "deleted": false
+        "deleted": false,
+        "memo": "entity memo",
+        "receiver_sig_required": false
       }
     ],
     "links": {

--- a/hedera-mirror-rest/__tests__/specs/accounts-04-balance-range.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/accounts-04-balance-range.spec.json
@@ -95,7 +95,9 @@
         "expiry_timestamp": null,
         "auto_renew_period": null,
         "key": null,
-        "deleted": false
+        "deleted": false,
+        "memo": "entity memo",
+        "receiver_sig_required": false
       },
       {
         "balance": {
@@ -107,7 +109,9 @@
         "expiry_timestamp": null,
         "auto_renew_period": null,
         "key": null,
-        "deleted": false
+        "deleted": false,
+        "memo": "entity memo",
+        "receiver_sig_required": false
       }
     ],
     "links": {

--- a/hedera-mirror-rest/__tests__/specs/accounts-05-publickey.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/accounts-05-publickey.spec.json
@@ -89,7 +89,9 @@
         "expiry_timestamp": null,
         "auto_renew_period": null,
         "key": null,
-        "deleted": false
+        "deleted": false,
+        "memo": "entity memo",
+        "receiver_sig_required": false
       }
     ],
     "links": {

--- a/hedera-mirror-rest/__tests__/specs/accounts-06-all-params.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/accounts-06-all-params.spec.json
@@ -133,7 +133,9 @@
         "key": {
           "_type": "ProtobufEncoded",
           "key": "7b2233222c2233222c2233227d"
-        }
+        },
+        "memo": "entity memo",
+        "receiver_sig_required": false
       }
     ],
     "links": {

--- a/hedera-mirror-rest/__tests__/specs/accounts-10-account-transactions.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/accounts-10-account-transactions.spec.json
@@ -202,6 +202,8 @@
     "auto_renew_period": null,
     "key": null,
     "deleted": false,
+    "memo": "entity memo",
+    "receiver_sig_required": false,
     "links": {
       "next": null
     }

--- a/hedera-mirror-rest/__tests__/specs/accounts-13-accounts-limit.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/accounts-13-accounts-limit.spec.json
@@ -95,7 +95,9 @@
         "expiry_timestamp": null,
         "auto_renew_period": null,
         "key": null,
-        "deleted": false
+        "deleted": false,
+        "memo": "entity memo",
+        "receiver_sig_required": false
       },
       {
         "balance": {
@@ -107,7 +109,9 @@
         "expiry_timestamp": null,
         "auto_renew_period": null,
         "key": null,
-        "deleted": false
+        "deleted": false,
+        "memo": "entity memo",
+        "receiver_sig_required": false
       }
     ],
     "links": {

--- a/hedera-mirror-rest/__tests__/specs/accounts-14-account-transactions-transactiontype.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/accounts-14-account-transactions-transactiontype.spec.json
@@ -216,6 +216,8 @@
     "auto_renew_period": null,
     "key": null,
     "deleted": false,
+    "memo": "entity memo",
+    "receiver_sig_required": false,
     "links": {
       "next": null
     }

--- a/hedera-mirror-rest/__tests__/specs/accounts-16-no-balances.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/accounts-16-no-balances.spec.json
@@ -143,7 +143,9 @@
         "expiry_timestamp": null,
         "auto_renew_period": null,
         "key": null,
-        "deleted": false
+        "deleted": false,
+        "memo": "entity memo",
+        "receiver_sig_required": false
       },
       {
         "balance": {
@@ -164,7 +166,9 @@
         "expiry_timestamp": null,
         "auto_renew_period": null,
         "key": null,
-        "deleted": false
+        "deleted": false,
+        "memo": "entity memo",
+        "receiver_sig_required": false
       },
       {
         "balance": {
@@ -176,7 +180,9 @@
         "expiry_timestamp": null,
         "auto_renew_period": null,
         "key": null,
-        "deleted": false
+        "deleted": false,
+        "memo": "entity memo",
+        "receiver_sig_required": false
       },
       {
         "balance": {
@@ -188,7 +194,9 @@
         "expiry_timestamp": null,
         "auto_renew_period": null,
         "key": null,
-        "deleted": false
+        "deleted": false,
+        "memo": "entity memo",
+        "receiver_sig_required": false
       },
       {
         "balance": {
@@ -209,7 +217,9 @@
         "expiry_timestamp": null,
         "auto_renew_period": null,
         "key": null,
-        "deleted": false
+        "deleted": false,
+        "memo": "entity memo",
+        "receiver_sig_required": false
       }
     ],
     "links": {

--- a/hedera-mirror-rest/__tests__/specs/accounts-17-specific-id-no-balance.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/accounts-17-specific-id-no-balance.spec.json
@@ -87,7 +87,9 @@
         "expiry_timestamp": null,
         "auto_renew_period": null,
         "key": null,
-        "deleted": false
+        "deleted": false,
+        "memo": "entity memo",
+        "receiver_sig_required": false
       }
     ],
     "links": {

--- a/hedera-mirror-rest/__tests__/specs/accounts-18-account-transactions-no-balances.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/accounts-18-account-transactions-no-balances.spec.json
@@ -212,6 +212,8 @@
     "auto_renew_period": null,
     "key": null,
     "deleted": false,
+    "memo": "entity memo",
+    "receiver_sig_required": false,
     "links": {
       "next": null
     }

--- a/hedera-mirror-rest/__tests__/specs/accounts-19-account-transactions-timestamp.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/accounts-19-account-transactions-timestamp.spec.json
@@ -233,6 +233,8 @@
     "auto_renew_period": null,
     "key": null,
     "deleted": false,
+    "memo": "entity memo",
+    "receiver_sig_required": false,
     "links": {
       "next": null
     }

--- a/hedera-mirror-rest/__tests__/specs/accounts-20-multiple-ids.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/accounts-20-multiple-ids.spec.json
@@ -74,7 +74,9 @@
         "expiry_timestamp": null,
         "auto_renew_period": null,
         "key": null,
-        "deleted": false
+        "deleted": false,
+        "memo": "entity memo",
+        "receiver_sig_required": false
       },
       {
         "balance": {
@@ -86,7 +88,9 @@
         "expiry_timestamp": null,
         "auto_renew_period": null,
         "key": null,
-        "deleted": false
+        "deleted": false,
+        "memo": "entity memo",
+        "receiver_sig_required": false
       }
     ],
     "links": {

--- a/hedera-mirror-rest/accounts.js
+++ b/hedera-mirror-rest/accounts.js
@@ -46,12 +46,6 @@ const processRow = (row) => {
   accRecord.memo = row.memo;
   accRecord.receiver_sig_required = row.receiver_sig_required;
 
-  logger.info(`*** getAccounts processRow row.memo: ${JSON.stringify(row.memo)}`);
-  logger.info(`*** getAccounts processRow accRecord.memo: ${JSON.stringify(accRecord.memo)}`);
-  logger.info(`*** getAccounts processRow row.receiver_sig_required: ${JSON.stringify(row.receiver_sig_required)}`);
-  logger.info(
-    `*** getAccounts processRow accRecord.receiver_sig_required: ${JSON.stringify(accRecord.receiver_sig_required)}`
-  );
   return accRecord;
 };
 

--- a/hedera-mirror-rest/accounts.js
+++ b/hedera-mirror-rest/accounts.js
@@ -46,6 +46,12 @@ const processRow = (row) => {
   accRecord.memo = row.memo;
   accRecord.receiver_sig_required = row.receiver_sig_required;
 
+  logger.info(`*** getAccounts processRow row.memo: ${JSON.stringify(row.memo)}`);
+  logger.info(`*** getAccounts processRow accRecord.memo: ${JSON.stringify(accRecord.memo)}`);
+  logger.info(`*** getAccounts processRow row.receiver_sig_required: ${JSON.stringify(row.receiver_sig_required)}`);
+  logger.info(
+    `*** getAccounts processRow accRecord.receiver_sig_required: ${JSON.stringify(accRecord.receiver_sig_required)}`
+  );
   return accRecord;
 };
 
@@ -94,6 +100,8 @@ const getAccountQuery = (
        e.auto_renew_period,
        e.key,
        e.deleted,
+       e.memo,
+       e.receiver_sig_required,
        (
          select json_agg(
            json_build_object(
@@ -112,7 +120,7 @@ const getAccountQuery = (
       ${limitQuery || ''}
     ) ab
     ${joinType} join (
-      select id, expiration_timestamp, auto_renew_period, key, deleted, type, public_key
+      select id, expiration_timestamp, auto_renew_period, key, deleted, type, public_key, memo, receiver_sig_required
       from entity e
       where ${entityWhereFilter}
       order by e.id ${order || ''}

--- a/hedera-mirror-rest/accounts.js
+++ b/hedera-mirror-rest/accounts.js
@@ -36,10 +36,11 @@ const processRow = (row) => {
   const accRecord = {};
   accRecord.account = EntityId.fromEncodedId(row.entity_id).toString();
   accRecord.auto_renew_period = row.auto_renew_period === null ? null : Number(row.auto_renew_period);
-  accRecord.balance = {};
-  accRecord.balance.balance = row.account_balance === null ? null : Number(row.account_balance);
-  accRecord.balance.timestamp = row.consensus_timestamp === null ? null : utils.nsToSecNs(row.consensus_timestamp);
-  accRecord.balance.tokens = utils.parseTokenBalances(row.token_balances);
+  accRecord.balance = {
+    balance: row.account_balance === null ? null : Number(row.account_balance),
+    timestamp: row.consensus_timestamp === null ? null : utils.nsToSecNs(row.consensus_timestamp),
+    tokens: utils.parseTokenBalances(row.token_balances),
+  };
   accRecord.deleted = row.deleted;
   accRecord.expiry_timestamp = row.expiration_timestamp === null ? null : utils.nsToSecNs(row.expiration_timestamp);
   accRecord.key = row.key === null ? null : utils.encodeKey(row.key);

--- a/hedera-mirror-rest/accounts.js
+++ b/hedera-mirror-rest/accounts.js
@@ -34,15 +34,17 @@ const {DbError} = require('./errors/dbError');
  */
 const processRow = (row) => {
   const accRecord = {};
-  accRecord.balance = {};
   accRecord.account = EntityId.fromEncodedId(row.entity_id).toString();
-  accRecord.balance.timestamp = row.consensus_timestamp === null ? null : utils.nsToSecNs(row.consensus_timestamp);
-  accRecord.balance.balance = row.account_balance === null ? null : Number(row.account_balance);
-  accRecord.balance.tokens = utils.parseTokenBalances(row.token_balances);
-  accRecord.expiry_timestamp = row.expiration_timestamp === null ? null : utils.nsToSecNs(row.expiration_timestamp);
   accRecord.auto_renew_period = row.auto_renew_period === null ? null : Number(row.auto_renew_period);
-  accRecord.key = row.key === null ? null : utils.encodeKey(row.key);
+  accRecord.balance = {};
+  accRecord.balance.balance = row.account_balance === null ? null : Number(row.account_balance);
+  accRecord.balance.timestamp = row.consensus_timestamp === null ? null : utils.nsToSecNs(row.consensus_timestamp);
+  accRecord.balance.tokens = utils.parseTokenBalances(row.token_balances);
   accRecord.deleted = row.deleted;
+  accRecord.expiry_timestamp = row.expiration_timestamp === null ? null : utils.nsToSecNs(row.expiration_timestamp);
+  accRecord.key = row.key === null ? null : utils.encodeKey(row.key);
+  accRecord.memo = row.memo;
+  accRecord.receiver_sig_required = row.receiver_sig_required;
 
   return accRecord;
 };

--- a/hedera-mirror-rest/api/v1/openapi.yml
+++ b/hedera-mirror-rest/api/v1/openapi.yml
@@ -679,6 +679,7 @@ components:
         memo:
           type: string
         receiver_sig_required:
+          nullable: true
           type: boolean
       example:
         account: 0.0.8

--- a/hedera-mirror-rest/api/v1/openapi.yml
+++ b/hedera-mirror-rest/api/v1/openapi.yml
@@ -661,31 +661,39 @@ components:
         - auto_renew_period
         - key
         - deleted
+        - memo
+        - receiver_sig_required
       properties:
-        balance:
-          $ref: '#/components/schemas/Balance'
         account:
           $ref: '#/components/schemas/EntityId'
-        expiry_timestamp:
-          nullable: true
         auto_renew_period:
+          nullable: true
+        balance:
+          $ref: '#/components/schemas/Balance'
+        deleted:
+          type: boolean
+        expiry_timestamp:
           nullable: true
         key:
           $ref: '#/components/schemas/Key'
-        deleted:
+        memo:
+          type: string
+        receiver_sig_required:
           type: boolean
       example:
+        account: 0.0.8
+        auto_renew_period: null
         balance:
           timestamp: "0.000002345"
           balance: 80
           tokens:
             - token_id: 0.0.200001
               balance: 8
-        account: 0.0.8
-        expiry_timestamp: null
-        auto_renew_period: null
-        key: null
         deleted: false
+        expiry_timestamp: null
+        key: null
+        memo: "entity memo"
+        receiver_sig_required: false
     Accounts:
       type: array
       items:
@@ -727,6 +735,10 @@ components:
         key:
           $ref: '#/components/schemas/Key'
         deleted:
+          type: boolean
+        memo:
+          type: string
+        receiver_sig_required:
           type: boolean
         links:
           $ref: '#/components/schemas/Links'
@@ -1328,8 +1340,8 @@ components:
           - amount: 100
             collector_account_id: 0.0.10
             effective_payer_account_ids:
-             - 0.0.8
-             - 0.0.72
+              - 0.0.8
+              - 0.0.72
             token_id: 0.0.90001
     Transactions:
       type: array


### PR DESCRIPTION
**Description**:
`receiverSigRequired` value is missing for crypto account API responses since we currently don't persist it in create and update transactions.

- Add `receiverSigRequired` to `Entity` domain
- Update`CryptoCreateTransactionHandler` and `CryptoUpdateTransactionHandler` to persist `receiverSigRequired`
- Add migration to add nullable `receiver_sig_required` column to `entity` table
- Update `integrationDOmainOPs.js` with default `receiver_sig_required` column value
- Update `accounts.js` to expose `memo` and `receiver_sig_required` in response
- Update `openapi.yaml`

**Related issue(s)**:

Fixes #2428 

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
