### PR TITLE
Switch to actions/setup-java's built-in cache

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -81,12 +81,12 @@ jobs:
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
-      - name: Cache Maven Packages
-        uses: actions/cache@v2
+      - name: Install JDK
+        uses: actions/setup-java@v2
         with:
-          key: ${{ runner.os }}-m2-${{ hashFiles('pom.xml') }}
-          path: ~/.m2
-          restore-keys: ${{ runner.os }}-m2
+          cache: 'maven'
+          distribution: 'adopt'
+          java-version: 11
 
       - name: Create and Switch to Release Branch
         run: |
@@ -172,12 +172,12 @@ jobs:
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
-      - name: Cache Maven Packages
-        uses: actions/cache@v2
+      - name: Install JDK
+        uses: actions/setup-java@v2
         with:
-          key: ${{ runner.os }}-m2-${{ hashFiles('pom.xml') }}
-          path: ~/.m2
-          restore-keys: ${{ runner.os }}-m2
+          cache: 'maven'
+          distribution: 'adopt'
+          java-version: 11
 
       - name: Reset main to release branch
         run: |

--- a/.github/workflows/grpc-api.yml
+++ b/.github/workflows/grpc-api.yml
@@ -29,15 +29,9 @@ jobs:
       - name: Install JDK
         uses: actions/setup-java@v2
         with:
+          cache: 'maven'
           distribution: 'adopt'
           java-version: 11
-
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          key: ${{ runner.os }}-m2-${{ hashFiles('./pom.xml') }}
-          path: ~/.m2
-          restore-keys: ${{ runner.os }}-m2
 
       - name: Maven verify
         run: ./mvnw ${MAVEN_CLI_OPTS} verify -pl "${MODULE}" --also-make -Dspring.profiles.active=${{ matrix.schema }}

--- a/.github/workflows/importer.yml
+++ b/.github/workflows/importer.yml
@@ -29,15 +29,9 @@ jobs:
       - name: Install JDK
         uses: actions/setup-java@v2
         with:
+          cache: 'maven'
           distribution: 'adopt'
           java-version: 11
-
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          key: ${{ runner.os }}-m2-${{ hashFiles('./pom.xml') }}
-          path: ~/.m2
-          restore-keys: ${{ runner.os }}-m2
 
       - name: Maven verify
         run: ./mvnw ${MAVEN_CLI_OPTS} verify -pl "${MODULE}" --also-make -Dspring.profiles.active=${{ matrix.schema }}

--- a/.github/workflows/monitor.yml
+++ b/.github/workflows/monitor.yml
@@ -26,15 +26,9 @@ jobs:
       - name: Install JDK
         uses: actions/setup-java@v2
         with:
+          cache: 'maven'
           distribution: 'adopt'
           java-version: 11
-
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          key: ${{ runner.os }}-m2-${{ hashFiles('./pom.xml') }}
-          path: ~/.m2
-          restore-keys: ${{ runner.os }}-m2
 
       - name: Maven verify
         run: ./mvnw ${MAVEN_CLI_OPTS} verify -pl "${MODULE}" --also-make -Dtest='!com.hedera.mirror.importer.**' -DfailIfNoTests=false

--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -12,12 +12,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Cache Maven packages
-        uses: actions/cache@v2
+      - name: Install JDK
+        uses: actions/setup-java@v2
         with:
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          path: ~/.m2
-          restore-keys: ${{ runner.os }}-m2
+          cache: 'maven'
+          distribution: 'adopt'
+          java-version: 11
 
       - name: Login to Google Container Registry
         uses: google-github-actions/setup-gcloud@master

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -13,12 +13,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Cache Maven packages
-        uses: actions/cache@v2
+      - name: Install JDK
+        uses: actions/setup-java@v2
         with:
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          path: ~/.m2
-          restore-keys: ${{ runner.os }}-m2
+          cache: 'maven'
+          distribution: 'adopt'
+          java-version: 11
 
       - name: Login to Google Container Registry
         uses: google-github-actions/setup-gcloud@master

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -18,12 +18,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Cache Maven dependencies
-        uses: actions/cache@v2
+      - name: Install JDK
+        uses: actions/setup-java@v2
         with:
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          path: ~/.m2
-          restore-keys: ${{ runner.os }}-m2
+          cache: 'maven'
+          distribution: 'adopt'
+          java-version: 11
 
       - name: Vulnerability check
         run: ./mvnw ${MAVEN_CLI_OPTS} dependency-check:aggregate
@@ -38,12 +38,12 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 
-      - name: Cache Maven dependencies
-        uses: actions/cache@v2
+      - name: Install JDK
+        uses: actions/setup-java@v2
         with:
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          path: ~/.m2
-          restore-keys: ${{ runner.os }}-m2
+          cache: 'maven'
+          distribution: 'adopt'
+          java-version: 11
 
       - name: Cache SonarCloud dependencies
         uses: actions/cache@v2

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,17 +12,13 @@ jobs:
     runs-on: windows-2019
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v2
-        with:
-          distribution: 'adopt'
-          java-version: '11'
 
-      - name: Cache Maven packages
-        uses: actions/cache@v2
+      - name: Install JDK
+        uses: actions/setup-java@v2
         with:
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          path: ~/.m2
-          restore-keys: ${{ runner.os }}-m2
+          cache: 'maven'
+          distribution: 'adopt'
+          java-version: 11
 
       - name: Maven package
         run: ./mvnw.cmd package --batch-mode --no-transfer-progress -DskipTests


### PR DESCRIPTION
**Description**:
- Switch from `actions/cache` to the [new](https://github.blog/changelog/2021-08-30-github-actions-setup-java-now-supports-dependency-caching/) built-in cache in `actions/setup-java`
- Fix some workflows using `mvnw` without explicitly installing Java. Presumably the VM has a built in java that is probably not our required AdoptOpenJDK 11.

**Related issue(s)**:

**Notes for reviewer**:
Besides simpler config syntax, it also provides build [performance improvements](https://github.com/actions/setup-java/pull/193) by installing java and dependencies in parallel.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
