### PR TITLE
Change dashboards to be Grafana Cloud compatible

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -24,7 +24,7 @@ To install the wrapper chart:
 
 ```shell script
 $ helm repo add hedera https://hashgraph.github.io/hedera-mirror-node/charts
-$ helm upgrade --install "${RELEASE}" charts/hedera-mirror
+$ helm upgrade --install "${RELEASE}" hedera/hedera-mirror
 ```
 
 ## Configure

--- a/charts/hedera-mirror-common/Chart.yaml
+++ b/charts/hedera-mirror-common/Chart.yaml
@@ -3,25 +3,25 @@ appVersion: "main"
 dependencies:
   - name: loki
     condition: loki.enabled
-    version: 2.5.0
+    version: 2.6.0
     repository: https://grafana.github.io/helm-charts
   - condition: prometheus-adapter.enabled
     name: prometheus-adapter
     repository: https://prometheus-community.github.io/helm-charts
-    version: 2.14.2
+    version: 2.17.0
   - alias: prometheus
     condition: prometheus.enabled
     name: kube-prometheus-stack
     repository: https://prometheus-community.github.io/helm-charts
-    version: 16.9.0
+    version: 18.0.5
   - name: promtail
     condition: promtail.enabled
-    version: 3.6.0
+    version: 3.8.1
     repository: https://grafana.github.io/helm-charts
   - condition: traefik.enabled
     name: traefik
     repository: https://helm.traefik.io/traefik
-    version: 9.19.1
+    version: 10.3.2
 description: Hedera Mirror Node common components installed globally for use across namespaces
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067

--- a/charts/hedera-mirror-common/dashboards/alertmanager.json
+++ b/charts/hedera-mirror-common/dashboards/alertmanager.json
@@ -17,32 +17,26 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 34,
-  "iteration": 1624124412293,
+  "id": 33,
+  "iteration": 1630451681233,
   "links": [],
   "panels": [
     {
-      "datasource": null,
+      "datasource": "${prometheus}",
       "description": "The percent of alerts firing by name",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "palette-classic"
           },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": []
         },
         "overrides": []
       },
@@ -76,13 +70,16 @@
           "fields": "",
           "values": false
         },
-        "text": {}
+        "text": {},
+        "tooltip": {
+          "mode": "single"
+        }
       },
       "pluginVersion": "7.5.5",
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(ALERTS{namespace=~\"$namespace\",alertname!=\"Watchdog\",container=~\"$container\"}) by (alertname)",
+          "expr": "sum(ALERTS{cluster=~\"$cluster\",namespace=~\"$namespace\",alertname!=\"Watchdog\",container=~\"$container\"}) by (alertname)",
           "interval": "",
           "legendFormat": "{{alertname}}",
           "refId": "A"
@@ -93,27 +90,21 @@
       "type": "piechart"
     },
     {
-      "datasource": null,
+      "datasource": "${prometheus}",
       "description": "The percent of alerts by severity",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "palette-classic"
           },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": []
         },
         "overrides": []
       },
@@ -147,13 +138,16 @@
           "fields": "",
           "values": false
         },
-        "text": {}
+        "text": {},
+        "tooltip": {
+          "mode": "single"
+        }
       },
       "pluginVersion": "7.5.5",
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(ALERTS{namespace=~\"$namespace\",alertname!=\"Watchdog\",container=~\"$container\"}) by (severity)",
+          "expr": "sum(ALERTS{cluster=~\"$cluster\",namespace=~\"$namespace\",alertname!=\"Watchdog\",container=~\"$container\"}) by (severity)",
           "interval": "",
           "legendFormat": "{{severity}}",
           "refId": "A"
@@ -164,28 +158,22 @@
       "type": "piechart"
     },
     {
-      "datasource": null,
+      "datasource": "${prometheus}",
       "description": "The percent of alerts by state",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "palette-classic"
           },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
           "mappings": [],
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
+          "noValue": "0"
         },
         "overrides": []
       },
@@ -219,13 +207,16 @@
           "fields": "",
           "values": false
         },
-        "text": {}
+        "text": {},
+        "tooltip": {
+          "mode": "single"
+        }
       },
       "pluginVersion": "7.5.5",
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(ALERTS{namespace=~\"$namespace\",alertname!=\"Watchdog\",container=~\"$container\"}) by (alertstate)",
+          "expr": "sum(ALERTS{cluster=~\"$cluster\",namespace=~\"$namespace\",alertname!=\"Watchdog\",container=~\"$container\"}) by (alertstate)",
           "interval": "",
           "legendFormat": "{{alertstate}}",
           "refId": "A"
@@ -236,7 +227,7 @@
       "type": "piechart"
     },
     {
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "description": "The number of AlertManager pods",
       "fieldConfig": {
         "defaults": {
@@ -280,11 +271,11 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.5.5",
+      "pluginVersion": "8.0.1",
       "targets": [
         {
           "exemplar": true,
-          "expr": "count(alertmanager_build_info{instance=~\"$instance\",namespace=~\"$namespace\"})",
+          "expr": "count(alertmanager_build_info{cluster=~\"$cluster\",namespace=~\"$namespace\",instance=~\"$instance\"})",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -296,7 +287,7 @@
       "type": "stat"
     },
     {
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "description": "Current number of active alerts.",
       "fieldConfig": {
         "defaults": {
@@ -340,11 +331,11 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.5.5",
+      "pluginVersion": "8.0.1",
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(ALERTS{alertstate=\"firing\",namespace=~\"$namespace\",instance=~\"$instance\",alertname!=\"Watchdog\",container=~\"$container\"})",
+          "expr": "sum(ALERTS{alertstate=\"firing\",cluster=~\"$cluster\",namespace=~\"$namespace\",instance=~\"$instance\",alertname!=\"Watchdog\",container=~\"$container\"})",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -356,7 +347,7 @@
       "type": "stat"
     },
     {
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "description": "Current number of suppressed alerts.",
       "fieldConfig": {
         "defaults": {
@@ -400,11 +391,11 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.5.5",
+      "pluginVersion": "8.0.1",
       "targets": [
         {
           "exemplar": true,
-          "expr": "avg(alertmanager_alerts{state=\"suppressed\",namespace=~\"$namespace\",instance=~\"$instance\",container=~\"$container\"})",
+          "expr": "avg(alertmanager_alerts{state=\"suppressed\",cluster=~\"$cluster\",namespace=~\"$namespace\",instance=~\"$instance\",container=~\"$container\"})",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -416,7 +407,7 @@
       "type": "stat"
     },
     {
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "description": "Current number of silenced alerts.",
       "fieldConfig": {
         "defaults": {
@@ -460,11 +451,11 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.5.5",
+      "pluginVersion": "8.0.1",
       "targets": [
         {
           "exemplar": true,
-          "expr": "avg(alertmanager_silences{state=\"active\",namespace=~\"$namespace\",instance=~\"$instance\",container=~\"$container\"})",
+          "expr": "avg(alertmanager_silences{state=\"active\",cluster=~\"$cluster\",namespace=~\"$namespace\",instance=~\"$instance\",container=~\"$container\"})",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -611,7 +602,7 @@
           }
         ]
       },
-      "pluginVersion": "7.5.5",
+      "pluginVersion": "8.0.1",
       "repeatDirection": "v",
       "targets": [
         {
@@ -653,8 +644,8 @@
       "type": "table"
     },
     {
-      "datasource": null,
-      "description": "Alerts that are currently active by container",
+      "datasource": "${prometheus}",
+      "description": "Alerts that are currently active by alert name",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -670,19 +661,27 @@
             "hideFrom": {
               "graph": false,
               "legend": false,
-              "tooltip": false
+              "tooltip": false,
+              "viz": false
             },
             "lineInterpolation": "linear",
             "lineStyle": {
               "fill": "solid"
             },
-            "lineWidth": 3,
+            "lineWidth": 2,
             "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
             },
-            "showPoints": "auto",
-            "spanNulls": false
+            "showPoints": "always",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
           "thresholds": {
@@ -707,14 +706,14 @@
       "options": {
         "legend": {
           "calcs": [
-            "lastNotNull",
+            "min",
             "max",
-            "sum"
+            "mean"
           ],
           "displayMode": "table",
           "placement": "right"
         },
-        "tooltipOptions": {
+        "tooltip": {
           "mode": "multi"
         }
       },
@@ -723,7 +722,116 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(ALERTS{namespace=~\"$namespace\",instance=~\"$instance\"}) by (container)",
+          "expr": "sum(ALERTS{cluster=~\"$cluster\",namespace=~\"$namespace\",alertname!=\"Watchdog\",container=~\"$container\"}) by (alertname)",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{alertname}}",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Active alerts by name",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": false,
+              "Value": true,
+              "severity": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "Time": "",
+              "message": "",
+              "severity": ""
+            }
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${prometheus}",
+      "description": "Alerts that are currently active by container",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 3,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 32
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "sum"
+          ],
+          "displayMode": "table",
+          "placement": "right"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "pluginVersion": "7.5.5",
+      "repeatDirection": "v",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(ALERTS{cluster=~\"$cluster\",namespace=~\"$namespace\",instance=~\"$instance\"}) by (container)",
           "interval": "",
           "legendFormat": "{{container}}",
           "refId": "A"
@@ -757,19 +865,15 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "description": "",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 32
+        "y": 40
       },
       "hiddenSeries": false,
       "id": 11,
@@ -789,7 +893,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.5",
+      "pluginVersion": "8.0.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -799,7 +903,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(alertmanager_notifications_total{instance=~\"$instance\"}[5m])) by (integration) > 0",
+          "expr": "sum(rate(alertmanager_notifications_total{cluster=~\"$cluster\",instance=~\"$instance\"}[5m])) by (integration) > 0",
           "interval": "",
           "legendFormat": "{{integration}}",
           "refId": "A"
@@ -847,7 +951,7 @@
       }
     }
   ],
-  "schemaVersion": 27,
+  "schemaVersion": 30,
   "style": "dark",
   "tags": [
     "alertmanager",
@@ -857,10 +961,30 @@
   "templating": {
     "list": [
       {
-        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "description": "Name of the Prometheus datasource to use",
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Prometheus",
+        "multi": false,
+        "name": "prometheus",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allValue": null,
         "current": {
           "selected": true,
-          "tags": [],
           "text": [
             "All"
           ],
@@ -868,8 +992,39 @@
             "$__all"
           ]
         },
-        "datasource": null,
-        "definition": "label_values(ALERTS, namespace)",
+        "datasource": "${prometheus}",
+        "definition": "label_values(ALERTS, cluster)",
+        "description": "Kubernetes cluster",
+        "error": null,
+        "hide": 0,
+        "includeAll": true,
+        "label": "Cluster",
+        "multi": true,
+        "name": "cluster",
+        "options": [],
+        "query": {
+          "query": "label_values(ALERTS, cluster)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 5,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": "${prometheus}",
+        "definition": "label_values(ALERTS{cluster=~\"$cluster\"}, namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -879,7 +1034,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(ALERTS, namespace)",
+          "query": "label_values(ALERTS{cluster=~\"$cluster\"}, namespace)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
@@ -887,7 +1042,6 @@
         "skipUrlSync": false,
         "sort": 5,
         "tagValuesQuery": "",
-        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
@@ -903,7 +1057,7 @@
             "$__all"
           ]
         },
-        "datasource": "Prometheus",
+        "datasource": "${prometheus}",
         "definition": "query_result(alertmanager_build_info)",
         "description": null,
         "error": null,
@@ -922,7 +1076,6 @@
         "skipUrlSync": false,
         "sort": 1,
         "tagValuesQuery": "",
-        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
@@ -938,8 +1091,8 @@
             "$__all"
           ]
         },
-        "datasource": null,
-        "definition": "label_values(ALERTS{namespace=~\"$namespace\"}, container)",
+        "datasource": "${prometheus}",
+        "definition": "label_values(ALERTS{cluster=~\"$cluster\",namespace=~\"$namespace\"}, container)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -949,7 +1102,7 @@
         "name": "container",
         "options": [],
         "query": {
-          "query": "label_values(ALERTS{namespace=~\"$namespace\"}, container)",
+          "query": "label_values(ALERTS{cluster=~\"$cluster\",namespace=~\"$namespace\"}, container)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -957,7 +1110,6 @@
         "skipUrlSync": false,
         "sort": 5,
         "tagValuesQuery": "",
-        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
@@ -965,12 +1117,12 @@
     ]
   },
   "time": {
-    "from": "now-1h",
+    "from": "now-3h",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "AlertManager",
-  "uid": "eea-9_sik",
+  "uid": "6wlGgbV7k",
   "version": 1
 }

--- a/charts/hedera-mirror-common/dashboards/hedera-mirror-grpc.json
+++ b/charts/hedera-mirror-common/dashboards/hedera-mirror-grpc.json
@@ -39,7 +39,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "description": "The number of pods that are up and ready for processing",
       "fieldConfig": {
         "defaults": {
@@ -99,7 +99,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(kube_pod_status_ready{namespace=~\"$namespace\",pod=~\"$pod\",pod=~\".*-grpc-.*\",condition=\"true\"})",
+          "expr": "sum(kube_pod_status_ready{cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\",pod=~\".*-grpc-.*\",condition=\"true\"})",
           "interval": "1m",
           "legendFormat": "",
           "refId": "A"
@@ -112,7 +112,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "description": "The average number of active subscribers",
       "fieldConfig": {
         "defaults": {
@@ -171,7 +171,7 @@
       "pluginVersion": "8.0.1",
       "targets": [
         {
-          "expr": "sum(hedera_mirror_subscribers{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "sum(hedera_mirror_subscribers{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "interval": "1m",
           "legendFormat": "",
           "refId": "A"
@@ -184,7 +184,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "description": "The current number of messages per second received by subscribers",
       "fieldConfig": {
         "defaults": {
@@ -247,7 +247,7 @@
       "pluginVersion": "8.0.1",
       "targets": [
         {
-          "expr": "sum(rate(hedera_mirror_publish_latency_seconds_count{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval]))",
+          "expr": "sum(rate(hedera_mirror_publish_latency_seconds_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval]))",
           "interval": "1m",
           "legendFormat": "",
           "refId": "A"
@@ -260,7 +260,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "description": "The max number of overall messages per second received by subscribers",
       "fieldConfig": {
         "defaults": {
@@ -327,7 +327,7 @@
       "pluginVersion": "8.0.1",
       "targets": [
         {
-          "expr": "sum(rate(hedera_mirror_publish_latency_seconds_count{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval]))",
+          "expr": "sum(rate(hedera_mirror_publish_latency_seconds_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval]))",
           "interval": "1m",
           "legendFormat": "",
           "refId": "A"
@@ -340,7 +340,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "description": "The average amount of time a client is subscribed",
       "fieldConfig": {
         "defaults": {
@@ -399,7 +399,7 @@
       "pluginVersion": "8.0.1",
       "targets": [
         {
-          "expr": "avg(rate(grpc_server_processing_duration_seconds_sum{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) / avg(rate(grpc_server_processing_duration_seconds_count{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval]))",
+          "expr": "avg(rate(grpc_server_processing_duration_seconds_sum{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) / avg(rate(grpc_server_processing_duration_seconds_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval]))",
           "interval": "1m",
           "legendFormat": "",
           "refId": "A"
@@ -418,7 +418,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "decimals": 1,
       "description": "The average number of active subscribers",
       "fieldConfig": {
@@ -468,7 +468,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(hedera_mirror_subscribers{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}) by (type)",
+          "expr": "sum(hedera_mirror_subscribers{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) by (type)",
           "interval": "1m",
           "legendFormat": "{{ type }}",
           "refId": "A"
@@ -524,7 +524,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "decimals": 1,
       "description": "The rate of incoming requests",
       "fieldConfig": {
@@ -574,7 +574,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(grpc_server_requests_received_messages_total{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (method)",
+          "expr": "sum(rate(grpc_server_requests_received_messages_total{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (method)",
           "interval": "1m",
           "legendFormat": "{{ method }}",
           "refId": "A"
@@ -630,7 +630,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "decimals": 1,
       "description": "The time it takes for a request to be considered complete",
       "fieldConfig": {
@@ -680,7 +680,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(grpc_server_processing_duration_seconds_sum{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (method) / sum(rate(grpc_server_processing_duration_seconds_count{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (method)",
+          "expr": "sum(rate(grpc_server_processing_duration_seconds_sum{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (method) / sum(rate(grpc_server_processing_duration_seconds_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (method)",
           "interval": "1m",
           "legendFormat": "{{method}}",
           "refId": "A"
@@ -735,7 +735,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "decimals": 1,
       "description": "The number of messages per second sent to subscribers",
       "fieldConfig": {
@@ -785,7 +785,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(grpc_server_responses_sent_messages_total{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (method)",
+          "expr": "sum(rate(grpc_server_responses_sent_messages_total{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (method)",
           "interval": "1m",
           "legendFormat": "{{ method }}",
           "refId": "A"
@@ -841,7 +841,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "decimals": 1,
       "description": "The number of errors encountered per second",
       "fieldConfig": {
@@ -891,7 +891,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(grpc_server_processing_duration_seconds_count{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\",statusCode!=\"OK\"}[$__rate_interval])) by (statusCode)",
+          "expr": "sum(rate(grpc_server_processing_duration_seconds_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\",statusCode!=\"OK\"}[$__rate_interval])) by (statusCode)",
           "interval": "1m",
           "legendFormat": "{{ statusCode }}",
           "refId": "A"
@@ -945,7 +945,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "description": "The difference between the time consensus was achieved and the mirror node published the entity",
       "fieldConfig": {
         "defaults": {
@@ -993,7 +993,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(hedera_mirror_publish_latency_seconds_sum{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (type) / sum(rate(hedera_mirror_publish_latency_seconds_count{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (type)",
+          "expr": "sum(rate(hedera_mirror_publish_latency_seconds_sum{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (type) / sum(rate(hedera_mirror_publish_latency_seconds_count{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (type)",
           "interval": "1m",
           "legendFormat": "{{ type }}",
           "refId": "A"
@@ -1042,7 +1042,7 @@
       }
     },
     {
-      "collapsed": false,
+      "collapsed": true,
       "datasource": null,
       "fieldConfig": {
         "defaults": {},
@@ -1064,7 +1064,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "decimals": 0,
       "description": "",
       "fill": 1,
@@ -1108,7 +1108,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(reactor_subscribed_subscribers_total{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (flow)",
+          "expr": "sum(rate(reactor_subscribed_subscribers_total{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (flow)",
           "interval": "1m",
           "legendFormat": "{{ flow }}",
           "refId": "A"
@@ -1161,7 +1161,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "description": "The number of requests per second for more data",
       "fill": 1,
       "fillGradient": 0,
@@ -1203,7 +1203,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(reactor_requested_requested_amount_count{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (flow)",
+          "expr": "sum(rate(reactor_requested_requested_amount_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (flow)",
           "interval": "1m",
           "legendFormat": "{{ flow }}",
           "refId": "A"
@@ -1255,7 +1255,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "decimals": 0,
       "description": "Times the duration elapsed between a subscription and the termination or cancellation of the sequence",
       "fill": 1,
@@ -1298,7 +1298,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(reactor_flow_duration_seconds_sum{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (flow) / sum(rate(reactor_flow_duration_seconds_count{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (flow)",
+          "expr": "sum(rate(reactor_flow_duration_seconds_sum{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (flow) / sum(rate(reactor_flow_duration_seconds_count{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (flow)",
           "interval": "1m",
           "legendFormat": "{{ flow }}",
           "refId": "A"
@@ -1351,7 +1351,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "decimals": 0,
       "description": "",
       "fill": 1,
@@ -1395,7 +1395,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(executor_pool_size_threads{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\"}) by (reactor_scheduler_id)",
+          "expr": "sum(executor_pool_size_threads{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}) by (reactor_scheduler_id)",
           "interval": "1m",
           "legendFormat": "{{ reactor_scheduler_id }}",
           "refId": "A"
@@ -1448,7 +1448,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "decimals": 0,
       "description": "",
       "fill": 1,
@@ -1492,7 +1492,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "\nsum(executor_queued_tasks{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\"} >= 0) by (reactor_scheduler_id)",
+          "expr": "\nsum(executor_queued_tasks{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"} >= 0) by (reactor_scheduler_id)",
           "interval": "1m",
           "legendFormat": "{{ reactor_scheduler_id }}",
           "refId": "A"
@@ -1545,7 +1545,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "decimals": 0,
       "description": "",
       "fill": 1,
@@ -1589,7 +1589,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(executor_seconds_max{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\"}) by (reactor_scheduler_id)",
+          "expr": "max(executor_seconds_max{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}) by (reactor_scheduler_id)",
           "interval": "1m",
           "legendFormat": "{{ reactor_scheduler_id }}",
           "refId": "A"
@@ -1642,7 +1642,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "decimals": 0,
       "description": "Measures delays between onNext signals (or between onSubscribe and first onNext)",
       "fill": 1,
@@ -1686,7 +1686,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(reactor_onNext_delay_seconds_sum{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (flow) / sum(rate(reactor_onNext_delay_seconds_count{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (flow)",
+          "expr": "sum(rate(reactor_onNext_delay_seconds_sum{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (flow) / sum(rate(reactor_onNext_delay_seconds_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (flow)",
           "interval": "1m",
           "legendFormat": "{{ flow }}",
           "refId": "A"
@@ -1757,7 +1757,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -1801,20 +1801,20 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(jvm_memory_committed_bytes{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "avg(jvm_memory_committed_bytes{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "interval": "1m",
           "legendFormat": "committed",
           "refId": "A"
         },
         {
-          "expr": "sum(jvm_memory_used_bytes{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "sum(jvm_memory_used_bytes{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "hide": false,
           "interval": "1m",
           "legendFormat": "used",
           "refId": "B"
         },
         {
-          "expr": "sum(jvm_memory_max_bytes{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "sum(jvm_memory_max_bytes{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "hide": false,
           "interval": "1m",
           "legendFormat": "max",
@@ -1867,7 +1867,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -1911,14 +1911,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(system_cpu_count{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "sum(system_cpu_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "hide": false,
           "interval": "1m",
           "legendFormat": "max",
           "refId": "A"
         },
         {
-          "expr": "sum(process_cpu_usage{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "sum(process_cpu_usage{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "hide": false,
           "interval": "1m",
           "legendFormat": "usage",
@@ -1976,7 +1976,7 @@
       "bars": true,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "decimals": 0,
       "fieldConfig": {
         "defaults": {
@@ -2020,7 +2020,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(jvm_threads_states_threads{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}) by (state)",
+          "expr": "sum(jvm_threads_states_threads{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) by (state)",
           "interval": "1m",
           "legendFormat": "{{ state }}",
           "refId": "A"
@@ -2077,7 +2077,7 @@
       "bars": true,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "decimals": 0,
       "fieldConfig": {
         "defaults": {
@@ -2121,13 +2121,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(process_files_open_files{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "sum(process_files_open_files{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "interval": "1m",
           "legendFormat": "open",
           "refId": "B"
         },
         {
-          "expr": "sum(process_files_max_files{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "sum(process_files_max_files{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "interval": "1m",
           "legendFormat": "max",
           "refId": "A"
@@ -2181,7 +2181,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "fieldConfig": {
         "defaults": {
           "links": []
@@ -2229,26 +2229,26 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(hikaricp_connections_active{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "sum(hikaricp_connections_active{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "interval": "1m",
           "legendFormat": "active",
           "refId": "A"
         },
         {
-          "expr": "sum(hikaricp_connections_idle{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "sum(hikaricp_connections_idle{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "interval": "1m",
           "legendFormat": "idle",
           "refId": "B"
         },
         {
-          "expr": "sum(hikaricp_connections_max{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "sum(hikaricp_connections_max{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "hide": false,
           "interval": "1m",
           "legendFormat": "max",
           "refId": "C"
         },
         {
-          "expr": "sum(hikaricp_connections_pending{application=\"$application\",namespace=~\"$namespace\",pod=\"$pod\"})",
+          "expr": "sum(hikaricp_connections_pending{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\"})",
           "hide": false,
           "interval": "1m",
           "legendFormat": "pending",
@@ -2303,7 +2303,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "fieldConfig": {
         "defaults": {
           "links": []
@@ -2351,26 +2351,26 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(jdbc_connections_active{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "sum(jdbc_connections_active{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "interval": "1m",
           "legendFormat": "active",
           "refId": "A"
         },
         {
-          "expr": "sum(jdbc_connections_idle{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "sum(jdbc_connections_idle{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "interval": "1m",
           "legendFormat": "idle",
           "refId": "B"
         },
         {
-          "expr": "sum(jdbc_connections_max{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "sum(jdbc_connections_max{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "hide": false,
           "interval": "1m",
           "legendFormat": "max",
           "refId": "C"
         },
         {
-          "expr": "sum(jdbc_connections_min{application=\"$application\",namespace=~\"$namespace\",pod=\"$pod\"})",
+          "expr": "sum(jdbc_connections_min{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\"})",
           "hide": false,
           "interval": "1m",
           "legendFormat": "min",
@@ -2423,7 +2423,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "decimals": 1,
       "description": "",
       "fieldConfig": {
@@ -2473,7 +2473,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(http_server_requests_seconds_count{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (method, uri)",
+          "expr": "sum(rate(http_server_requests_seconds_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (method, uri)",
           "interval": "1m",
           "legendFormat": "{{ method}} {{uri}}",
           "refId": "A"
@@ -2550,7 +2550,7 @@
       "bars": true,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "fieldConfig": {
         "defaults": {
           "links": []
@@ -2595,7 +2595,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(log4j2_events_total{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (level)",
+          "expr": "sum(rate(log4j2_events_total{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (level)",
           "interval": "1m",
           "legendFormat": "{{ level }}",
           "refId": "A"
@@ -2643,7 +2643,7 @@
       }
     },
     {
-      "datasource": "Loki",
+      "datasource": "${loki}",
       "description": "",
       "gridPos": {
         "h": 10,
@@ -2662,7 +2662,7 @@
       },
       "targets": [
         {
-          "expr": "{component=\"grpc\",namespace=~\"$namespace\",pod=~\"$pod\"}",
+          "expr": "{component=\"grpc\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}",
           "legendFormat": "",
           "refId": "A"
         }
@@ -2696,14 +2696,91 @@
         "type": "constant"
       },
       {
+        "current": {
+          "selected": true,
+          "text": "Loki",
+          "value": "Loki"
+        },
+        "description": "Name of the Loki datasource to use",
+        "error": null,
+        "hide": 2,
+        "includeAll": false,
+        "label": "Loki",
+        "multi": false,
+        "name": "loki",
+        "options": [],
+        "query": "loki",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "description": "Name of the Prometheus datasource to use",
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Prometheus",
+        "multi": false,
+        "name": "prometheus",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
         "allValue": null,
         "current": {
           "selected": true,
-          "text": "performance",
-          "value": "performance"
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
         },
-        "datasource": "Prometheus",
-        "definition": "label_values(system_cpu_count{application=\"$application\"},namespace)",
+        "datasource": "${prometheus}",
+        "definition": "label_values(system_cpu_count{application=\"$application\"}, cluster)",
+        "description": "Kubernetes cluster",
+        "error": null,
+        "hide": 0,
+        "includeAll": true,
+        "label": "Cluster",
+        "multi": true,
+        "name": "cluster",
+        "options": [],
+        "query": {
+          "query": "label_values(system_cpu_count{application=\"$application\"}, cluster)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 5,
+        "type": "query"
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": "${prometheus}",
+        "definition": "label_values(system_cpu_count{application=\"$application\",cluster=~\"$cluster\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2713,7 +2790,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(system_cpu_count{application=\"$application\"},namespace)",
+          "query": "label_values(system_cpu_count{application=\"$application\",cluster=~\"$cluster\"},namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "refresh": 2,
@@ -2732,8 +2809,8 @@
           "text": "All",
           "value": "$__all"
         },
-        "datasource": "Prometheus",
-        "definition": "label_values(system_cpu_count{application=\"$application\",namespace=~\"$namespace\"},pod)",
+        "datasource": "${prometheus}",
+        "definition": "label_values(system_cpu_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\"},pod)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2743,7 +2820,7 @@
         "name": "pod",
         "options": [],
         "query": {
-          "query": "label_values(system_cpu_count{application=\"$application\",namespace=~\"$namespace\"},pod)",
+          "query": "label_values(system_cpu_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\"},pod)",
           "refId": "Prometheus-pod-Variable-Query"
         },
         "refresh": 2,

--- a/charts/hedera-mirror-common/dashboards/hedera-mirror-importer.json
+++ b/charts/hedera-mirror-common/dashboards/hedera-mirror-importer.json
@@ -21,7 +21,7 @@
   "panels": [
     {
       "cacheTimeout": null,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "description": "The number of pods that are up and ready for processing",
       "fieldConfig": {
         "defaults": {
@@ -81,7 +81,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(kube_pod_status_ready{namespace=~\"$namespace\",pod=~\"$pod\",pod=~\".*-importer-.*\",condition=\"true\"})",
+          "expr": "sum(kube_pod_status_ready{cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\",pod=~\".*-importer-.*\",condition=\"true\"})",
           "interval": "1m",
           "legendFormat": "",
           "refId": "A"
@@ -94,7 +94,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "description": "The average number of overall transactions per second",
       "fieldConfig": {
         "defaults": {
@@ -161,7 +161,7 @@
       "pluginVersion": "8.0.1",
       "targets": [
         {
-          "expr": "sum(rate(hedera_mirror_transaction_latency_seconds_count{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval]))",
+          "expr": "sum(rate(hedera_mirror_transaction_latency_seconds_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval]))",
           "interval": "1m",
           "legendFormat": "",
           "refId": "A"
@@ -174,7 +174,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "description": "The average number of consensus submit message transactions per second",
       "fieldConfig": {
         "defaults": {
@@ -241,7 +241,7 @@
       "pluginVersion": "8.0.1",
       "targets": [
         {
-          "expr": "sum(rate(hedera_mirror_transaction_latency_seconds_count{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\",type=\"CONSENSUSSUBMITMESSAGE\"}[$__rate_interval]))",
+          "expr": "sum(rate(hedera_mirror_transaction_latency_seconds_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\",type=\"CONSENSUSSUBMITMESSAGE\"}[$__rate_interval]))",
           "interval": "1m",
           "legendFormat": "",
           "refId": "A"
@@ -254,7 +254,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "description": "The average transaction size",
       "fieldConfig": {
         "defaults": {
@@ -318,7 +318,7 @@
       "pluginVersion": "8.0.1",
       "targets": [
         {
-          "expr": "sum(hedera_mirror_transaction_size_bytes_sum{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}) / sum(hedera_mirror_transaction_size_bytes_count{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "sum(hedera_mirror_transaction_size_bytes_sum{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) / sum(hedera_mirror_transaction_size_bytes_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "interval": "1m",
           "legendFormat": "",
           "refId": "A"
@@ -331,7 +331,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "description": "How old the last processed record file is",
       "fieldConfig": {
         "defaults": {
@@ -395,7 +395,7 @@
       "pluginVersion": "8.0.1",
       "targets": [
         {
-          "expr": "sum(rate(hedera_mirror_parse_latency_seconds_sum{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\",type=~\"RECORD\"}[$__rate_interval])) / sum(rate(hedera_mirror_parse_latency_seconds_count{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\",type=~\"RECORD\"}[$__rate_interval]))",
+          "expr": "sum(rate(hedera_mirror_parse_latency_seconds_sum{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\",type=~\"RECORD\"}[$__rate_interval])) / sum(rate(hedera_mirror_parse_latency_seconds_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\",type=~\"RECORD\"}[$__rate_interval]))",
           "interval": "1m",
           "legendFormat": "",
           "refId": "A"
@@ -408,7 +408,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "description": "How old the last processed balance file is",
       "fieldConfig": {
         "defaults": {
@@ -470,7 +470,7 @@
       "pluginVersion": "8.0.1",
       "targets": [
         {
-          "expr": "sum(rate(hedera_mirror_parse_latency_seconds_sum{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\",type=\"BALANCE\"}[$__rate_interval])) / sum(rate(hedera_mirror_parse_latency_seconds_count{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\",type=\"BALANCE\"}[$__rate_interval]))",
+          "expr": "sum(rate(hedera_mirror_parse_latency_seconds_sum{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\",type=\"BALANCE\"}[$__rate_interval])) / sum(rate(hedera_mirror_parse_latency_seconds_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\",type=\"BALANCE\"}[$__rate_interval]))",
           "interval": "1m",
           "legendFormat": "",
           "refId": "A"
@@ -502,7 +502,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "decimals": 1,
       "description": "The transactions per second broken down by type",
       "fieldConfig": {
@@ -552,7 +552,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(hedera_mirror_transaction_latency_seconds_count{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (type)",
+          "expr": "sum(rate(hedera_mirror_transaction_latency_seconds_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (type)",
           "interval": "1m",
           "legendFormat": "{{ type }}",
           "refId": "A"
@@ -606,7 +606,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "fieldConfig": {
         "defaults": {
           "links": []
@@ -653,7 +653,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(hedera_mirror_transaction_size_bytes_sum{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (type) / sum(rate(hedera_mirror_transaction_size_bytes_count{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (type)",
+          "expr": "sum(rate(hedera_mirror_transaction_size_bytes_sum{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (type) / sum(rate(hedera_mirror_transaction_size_bytes_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (type)",
           "interval": "1m",
           "legendFormat": "{{ type }}",
           "refId": "A"
@@ -709,7 +709,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "decimals": 1,
       "description": "The amount of time it took to publish the domain entity",
       "fieldConfig": {
@@ -759,7 +759,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(hedera_mirror_importer_publish_duration_seconds_sum{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (type) / sum(rate(hedera_mirror_importer_publish_duration_seconds_count{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (type)",
+          "expr": "sum(rate(hedera_mirror_importer_publish_duration_seconds_sum{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (type) / sum(rate(hedera_mirror_importer_publish_duration_seconds_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (type)",
           "interval": "1m",
           "legendFormat": "{{ type }}",
           "refId": "A"
@@ -826,7 +826,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -870,20 +870,20 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(jvm_memory_committed_bytes{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "sum(jvm_memory_committed_bytes{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "interval": "1m",
           "legendFormat": "committed",
           "refId": "A"
         },
         {
-          "expr": "sum(jvm_memory_used_bytes{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "sum(jvm_memory_used_bytes{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "hide": false,
           "interval": "1m",
           "legendFormat": "used",
           "refId": "B"
         },
         {
-          "expr": "sum(jvm_memory_max_bytes{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "sum(jvm_memory_max_bytes{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "hide": false,
           "interval": "1m",
           "legendFormat": "max",
@@ -936,7 +936,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -980,14 +980,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(system_cpu_count{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "sum(system_cpu_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "hide": false,
           "interval": "1m",
           "legendFormat": "max",
           "refId": "A"
         },
         {
-          "expr": "sum(process_cpu_usage{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "sum(process_cpu_usage{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "hide": false,
           "interval": "1m",
           "legendFormat": "usage",
@@ -1045,7 +1045,7 @@
       "bars": true,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "decimals": 0,
       "fieldConfig": {
         "defaults": {
@@ -1089,7 +1089,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(jvm_threads_states_threads{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}) by (state)",
+          "expr": "sum(jvm_threads_states_threads{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) by (state)",
           "interval": "1m",
           "legendFormat": "{{ state }}",
           "refId": "A"
@@ -1141,7 +1141,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "decimals": 1,
       "description": "",
       "fieldConfig": {
@@ -1191,7 +1191,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(http_server_requests_seconds_count{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (method, uri)",
+          "expr": "sum(rate(http_server_requests_seconds_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (method, uri)",
           "interval": "1m",
           "legendFormat": "{{ method}} {{uri}}",
           "refId": "A"
@@ -1245,7 +1245,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "decimals": 1,
       "fieldConfig": {
         "defaults": {
@@ -1294,14 +1294,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(process_files_max_files{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "sum(process_files_max_files{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "hide": false,
           "interval": "1m",
           "legendFormat": "max",
           "refId": "A"
         },
         {
-          "expr": "sum(process_files_open_files{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "sum(process_files_open_files{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "hide": false,
           "interval": "1m",
           "legendFormat": "open",
@@ -1368,7 +1368,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "decimals": 0,
       "fieldConfig": {
         "defaults": {
@@ -1416,7 +1416,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(db_table_size_rows{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}) by (table)",
+          "expr": "avg(db_table_size_rows{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) by (table)",
           "interval": "1m",
           "legendFormat": "{{ table }}",
           "refId": "A"
@@ -1470,7 +1470,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "decimals": 1,
       "fieldConfig": {
         "defaults": {
@@ -1519,28 +1519,28 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(postgres_rows_fetched_total{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval]))",
+          "expr": "sum(rate(postgres_rows_fetched_total{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval]))",
           "hide": false,
           "interval": "1m",
           "legendFormat": "fetched",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(postgres_rows_inserted_total{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval]))",
+          "expr": "sum(rate(postgres_rows_inserted_total{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval]))",
           "hide": false,
           "interval": "1m",
           "legendFormat": "inserted",
           "refId": "B"
         },
         {
-          "expr": "sum(rate(postgres_rows_deleted_total{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval]))",
+          "expr": "sum(rate(postgres_rows_deleted_total{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval]))",
           "hide": false,
           "interval": "1m",
           "legendFormat": "deleted",
           "refId": "C"
         },
         {
-          "expr": "sum(rate(postgres_rows_updated_total{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval]))",
+          "expr": "sum(rate(postgres_rows_updated_total{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval]))",
           "hide": false,
           "interval": "1m",
           "legendFormat": "updated",
@@ -1595,7 +1595,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "fieldConfig": {
         "defaults": {
           "links": []
@@ -1643,26 +1643,26 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(hikaricp_connections_active{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "sum(hikaricp_connections_active{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "interval": "1m",
           "legendFormat": "active",
           "refId": "A"
         },
         {
-          "expr": "sum(hikaricp_connections_idle{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "sum(hikaricp_connections_idle{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "interval": "1m",
           "legendFormat": "idle",
           "refId": "B"
         },
         {
-          "expr": "sum(hikaricp_connections_max{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "sum(hikaricp_connections_max{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "hide": false,
           "interval": "1m",
           "legendFormat": "max",
           "refId": "C"
         },
         {
-          "expr": "sum(hikaricp_connections_pending{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "sum(hikaricp_connections_pending{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "hide": false,
           "interval": "1m",
           "legendFormat": "pending",
@@ -1717,7 +1717,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "fieldConfig": {
         "defaults": {
           "links": []
@@ -1763,26 +1763,26 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(jdbc_connections_active{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "sum(jdbc_connections_active{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "interval": "1m",
           "legendFormat": "active",
           "refId": "A"
         },
         {
-          "expr": "sum(jdbc_connections_idle{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "sum(jdbc_connections_idle{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "interval": "1m",
           "legendFormat": "idle",
           "refId": "B"
         },
         {
-          "expr": "sum(jdbc_connections_max{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "sum(jdbc_connections_max{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "hide": false,
           "interval": "1m",
           "legendFormat": "max",
           "refId": "C"
         },
         {
-          "expr": "sum(jdbc_connections_min{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "sum(jdbc_connections_min{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "hide": false,
           "interval": "1m",
           "legendFormat": "min",
@@ -1856,7 +1856,7 @@
       "bars": true,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "fieldConfig": {
         "defaults": {
           "links": []
@@ -1901,7 +1901,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(log4j2_events_total{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (level)",
+          "expr": "sum(rate(log4j2_events_total{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (level)",
           "interval": "1m",
           "legendFormat": "{{ level }}",
           "refId": "A"
@@ -1949,7 +1949,7 @@
       }
     },
     {
-      "datasource": "Loki",
+      "datasource": "${loki}",
       "description": "",
       "gridPos": {
         "h": 10,
@@ -1968,7 +1968,7 @@
       },
       "targets": [
         {
-          "expr": "{component=\"importer\",namespace=~\"$namespace\",pod=~\"$pod\"}",
+          "expr": "{component=\"importer\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}",
           "refId": "A"
         }
       ],
@@ -1979,7 +1979,7 @@
     },
     {
       "collapsed": true,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1993,7 +1993,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${prometheus}",
           "decimals": 2,
           "description": "The rate at which it the importer polls cloud storage for stream files",
           "fieldConfig": {
@@ -2047,7 +2047,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(hedera_mirror_download_request_seconds_count{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\", type=~\"$stream\", action=\"list\"}[$__rate_interval])) by (status)",
+              "expr": "sum(rate(hedera_mirror_download_request_seconds_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\", type=~\"$stream\", action=\"list\"}[$__rate_interval])) by (status)",
               "instant": false,
               "interval": "1m",
               "legendFormat": "{{status}}",
@@ -2102,7 +2102,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${prometheus}",
           "decimals": 1,
           "description": "How long it took to search for new stream files from cloud storage",
           "fieldConfig": {
@@ -2151,7 +2151,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(hedera_mirror_download_request_seconds_sum{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\", type=~\"$stream\", status=~\"^2.*\"}[$__rate_interval])) by (action) / sum(rate(hedera_mirror_download_request_seconds_count{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\", type=~\"$stream\", status=~\"^2.*\"}[$__rate_interval])) by (action)",
+              "expr": "sum(rate(hedera_mirror_download_request_seconds_sum{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\", type=~\"$stream\", status=~\"^2.*\"}[$__rate_interval])) by (action) / sum(rate(hedera_mirror_download_request_seconds_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\", type=~\"$stream\", status=~\"^2.*\"}[$__rate_interval])) by (action)",
               "interval": "4m",
               "legendFormat": "{{action}}",
               "refId": "A"
@@ -2204,7 +2204,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${prometheus}",
           "decimals": 2,
           "description": "The rate at which it the importer downloads stream file signatures from cloud storage",
           "fieldConfig": {
@@ -2253,7 +2253,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(hedera_mirror_download_request_seconds_count{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\", type=~\"$stream\", action=\"signature\", status=~\"^2.*\"}[$__rate_interval])) by (shard, realm, nodeAccount)",
+              "expr": "sum(rate(hedera_mirror_download_request_seconds_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\", type=~\"$stream\", action=\"signature\", status=~\"^2.*\"}[$__rate_interval])) by (shard, realm, nodeAccount)",
               "interval": "4m",
               "legendFormat": "{{shard}}.{{realm}}.{{nodeAccount}}",
               "refId": "A"
@@ -2306,7 +2306,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${prometheus}",
           "decimals": 1,
           "description": "How long it took to download the signature file from cloud storage",
           "fieldConfig": {
@@ -2355,7 +2355,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(hedera_mirror_download_request_seconds_sum{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\", type=~\"$stream\", action=\"signature\", status=~\"^2.*\"}[$__rate_interval])) by (shard, realm, nodeAccount) / sum(rate(hedera_mirror_download_request_seconds_count{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\", type=~\"$stream\", action=\"signature\", status=~\"^2.*\"}[$__rate_interval])) by (shard, realm, nodeAccount)",
+              "expr": "sum(rate(hedera_mirror_download_request_seconds_sum{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\", type=~\"$stream\", action=\"signature\", status=~\"^2.*\"}[$__rate_interval])) by (shard, realm, nodeAccount) / sum(rate(hedera_mirror_download_request_seconds_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\", type=~\"$stream\", action=\"signature\", status=~\"^2.*\"}[$__rate_interval])) by (shard, realm, nodeAccount)",
               "interval": "4m",
               "legendFormat": "{{shard}}.{{realm}}.{{nodeAccount}}",
               "refId": "A"
@@ -2408,7 +2408,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${prometheus}",
           "decimals": 2,
           "description": "The rate at which it the importer downloads stream files from cloud storage",
           "fieldConfig": {
@@ -2458,7 +2458,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(hedera_mirror_download_request_seconds_count{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\", type=~\"$stream\", action=\"signed\", status=~\"^2.*\"}[$__rate_interval])) by (shard, realm, nodeAccount)",
+              "expr": "sum(rate(hedera_mirror_download_request_seconds_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\", type=~\"$stream\", action=\"signed\", status=~\"^2.*\"}[$__rate_interval])) by (shard, realm, nodeAccount)",
               "interval": "4m",
               "legendFormat": "{{shard}}.{{realm}}.{{nodeAccount}}",
               "refId": "A"
@@ -2511,7 +2511,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${prometheus}",
           "decimals": 1,
           "description": "How long it took to download stream files from cloud storage",
           "fieldConfig": {
@@ -2560,7 +2560,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(hedera_mirror_download_request_seconds_sum{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\", type=~\"$stream\", action=\"signed\", status=~\"^2.*\"}[$__rate_interval])) by (shard, realm, nodeAccount) / sum(rate(hedera_mirror_download_request_seconds_count{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\", type=~\"$stream\", action=\"signed\", status=~\"^2.*\"}[$__rate_interval])) by (shard, realm, nodeAccount)",
+              "expr": "sum(rate(hedera_mirror_download_request_seconds_sum{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\", type=~\"$stream\", action=\"signed\", status=~\"^2.*\"}[$__rate_interval])) by (shard, realm, nodeAccount) / sum(rate(hedera_mirror_download_request_seconds_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\", type=~\"$stream\", action=\"signed\", status=~\"^2.*\"}[$__rate_interval])) by (shard, realm, nodeAccount)",
               "interval": "4m",
               "legendFormat": "{{shard}}.{{realm}}.{{nodeAccount}}",
               "refId": "A"
@@ -2613,7 +2613,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${prometheus}",
           "decimals": 1,
           "description": "The average stream file size",
           "fieldConfig": {
@@ -2662,7 +2662,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(hedera_mirror_download_response_bytes_sum{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\", type=~\"$stream\", action=\"signed\", status=~\"^2.*\"}[$__rate_interval])) by (shard, realm, nodeAccount) / sum(rate(hedera_mirror_download_response_bytes_count{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\", type=~\"$stream\", action=\"signed\", status=~\"^2.*\"}[$__rate_interval])) by (shard, realm, nodeAccount)",
+              "expr": "sum(rate(hedera_mirror_download_response_bytes_sum{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\", type=~\"$stream\", action=\"signed\", status=~\"^2.*\"}[$__rate_interval])) by (shard, realm, nodeAccount) / sum(rate(hedera_mirror_download_response_bytes_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\", type=~\"$stream\", action=\"signed\", status=~\"^2.*\"}[$__rate_interval])) by (shard, realm, nodeAccount)",
               "interval": "4m",
               "legendFormat": "{{shard}}.{{realm}}.{{nodeAccount}}",
               "refId": "A"
@@ -2715,7 +2715,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${prometheus}",
           "decimals": 1,
           "description": "The average stream signature file size",
           "fieldConfig": {
@@ -2764,7 +2764,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(hedera_mirror_download_response_bytes_sum{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\", type=~\"$stream\", action=\"signature\", status=~\"^2.*\"}[$__rate_interval])) by (shard, realm, nodeAccount) / sum(rate(hedera_mirror_download_response_bytes_count{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\", type=~\"$stream\", action=\"signature\", status=~\"^2.*\"}[$__rate_interval])) by (shard, realm, nodeAccount)",
+              "expr": "sum(rate(hedera_mirror_download_response_bytes_sum{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\", type=~\"$stream\", action=\"signature\", status=~\"^2.*\"}[$__rate_interval])) by (shard, realm, nodeAccount) / sum(rate(hedera_mirror_download_response_bytes_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\", type=~\"$stream\", action=\"signature\", status=~\"^2.*\"}[$__rate_interval])) by (shard, realm, nodeAccount)",
               "interval": "4m",
               "legendFormat": "{{shard}}.{{realm}}.{{nodeAccount}}",
               "refId": "A"
@@ -2817,7 +2817,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${prometheus}",
           "decimals": 1,
           "description": "The average file size of the stream list response from cloud storage",
           "fieldConfig": {
@@ -2866,7 +2866,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(hedera_mirror_download_response_bytes_sum{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\", type=~\"$stream\", action=\"list\", status=~\"^2.*\"}[$__rate_interval])) by (shard, realm, nodeAccount) / sum(rate(hedera_mirror_download_response_bytes_count{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\", type=~\"$stream\", action=\"list\", status=~\"^2.*\"}[$__rate_interval])) by (shard, realm, nodeAccount)",
+              "expr": "sum(rate(hedera_mirror_download_response_bytes_sum{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\", type=~\"$stream\", action=\"list\", status=~\"^2.*\"}[$__rate_interval])) by (shard, realm, nodeAccount) / sum(rate(hedera_mirror_download_response_bytes_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\", type=~\"$stream\", action=\"list\", status=~\"^2.*\"}[$__rate_interval])) by (shard, realm, nodeAccount)",
               "interval": "4m",
               "legendFormat": "{{shard}}.{{realm}}.{{nodeAccount}}",
               "refId": "A"
@@ -2919,7 +2919,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${prometheus}",
           "decimals": 2,
           "description": "The rate at which different node's signatures reach consensus",
           "fieldConfig": {
@@ -2969,7 +2969,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(hedera_mirror_download_signature_verification_total{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\", type=~\"$stream\", status=\"CONSENSUS_REACHED\"}[$__rate_interval])) by (shard, realm, nodeAccount)",
+              "expr": "sum(rate(hedera_mirror_download_signature_verification_total{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\", type=~\"$stream\", status=\"CONSENSUS_REACHED\"}[$__rate_interval])) by (shard, realm, nodeAccount)",
               "interval": "4m",
               "legendFormat": "{{shard}}.{{realm}}.{{nodeAccount}}",
               "refId": "A"
@@ -3022,7 +3022,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${prometheus}",
           "decimals": 2,
           "description": "The rate at which the stream file reaches consensus, hash chain verified (if applicable) and hash matches signature",
           "fieldConfig": {
@@ -3071,7 +3071,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(hedera_mirror_download_stream_verification_seconds_count{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\", type=~\"$stream\"}[$__rate_interval])) by (success)",
+              "expr": "sum(rate(hedera_mirror_download_stream_verification_seconds_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\", type=~\"$stream\"}[$__rate_interval])) by (success)",
               "interval": "4m",
               "legendFormat": "success={{success}}",
               "refId": "A"
@@ -3124,7 +3124,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${prometheus}",
           "decimals": 1,
           "description": "The duration in seconds it took to reach consensus,  verify hash chain (if applicable) and hash matches the signature.",
           "fieldConfig": {
@@ -3173,7 +3173,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(hedera_mirror_download_stream_verification_seconds_sum{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\", type=\"$stream\"}[$__rate_interval])) by (success) / sum(rate(hedera_mirror_download_stream_verification_seconds_count{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\", type=\"$stream\"}[$__rate_interval])) by (success)",
+              "expr": "sum(rate(hedera_mirror_download_stream_verification_seconds_sum{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\", type=\"$stream\"}[$__rate_interval])) by (success) / sum(rate(hedera_mirror_download_stream_verification_seconds_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\", type=\"$stream\"}[$__rate_interval])) by (success)",
               "interval": "4m",
               "legendFormat": "success={{success}}",
               "refId": "A"
@@ -3226,7 +3226,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${prometheus}",
           "decimals": 1,
           "description": "HTTP errors interacting with cloud storage",
           "fieldConfig": {
@@ -3278,7 +3278,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(hedera_mirror_download_request_seconds_count{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\", type=~\"$stream\", status!~\"^2.*\"}[$__rate_interval])) by (status, action)",
+              "expr": "sum(rate(hedera_mirror_download_request_seconds_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\", type=~\"$stream\", status!~\"^2.*\"}[$__rate_interval])) by (status, action)",
               "interval": "4m",
               "legendFormat": "{{action}}",
               "refId": "A"
@@ -3331,7 +3331,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${prometheus}",
           "decimals": 2,
           "description": "The difference between the consensus time of the last and first transaction in the stream file",
           "fieldConfig": {
@@ -3381,7 +3381,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(hedera_mirror_stream_close_latency_seconds_sum{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\",type=~\"$stream\"}[$__rate_interval]) / rate(hedera_mirror_stream_close_latency_seconds_count{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\",type=~\"$stream\"}[$__rate_interval])",
+              "expr": "sum(rate(hedera_mirror_stream_close_latency_seconds_sum{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\",type=~\"$stream\"}[$__rate_interval])) / sum(rate(hedera_mirror_stream_close_latency_seconds_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\",type=~\"$stream\"}[$__rate_interval]))",
               "interval": "1m",
               "legendFormat": "  ",
               "refId": "A"
@@ -3437,7 +3437,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${prometheus}",
           "decimals": 1,
           "description": "The duration in seconds it took to parse the file and store it in the database",
           "fieldConfig": {
@@ -3487,7 +3487,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(hedera_mirror_parse_duration_seconds_sum{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\",type=~\"$stream\"}[$__rate_interval])) by (success) / sum(rate(hedera_mirror_parse_duration_seconds_count{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\",type=\"$stream\"}[$__rate_interval])) by (success)",
+              "expr": "sum(rate(hedera_mirror_parse_duration_seconds_sum{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\",type=~\"$stream\"}[$__rate_interval])) by (success) / sum(rate(hedera_mirror_parse_duration_seconds_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\",type=\"$stream\"}[$__rate_interval])) by (success)",
               "interval": "1m",
               "legendFormat": "success: {{success}}",
               "refId": "A"
@@ -3540,7 +3540,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${prometheus}",
           "decimals": 2,
           "description": "The difference in time between the consensus time of the last transaction in the file and the time at which the file was created in the cloud storage provider",
           "fieldConfig": {
@@ -3590,7 +3590,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(hedera_mirror_importer_cloud_latency_seconds_sum{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\",type=~\"$stream\"}[$__rate_interval])) / sum(rate(hedera_mirror_importer_cloud_latency_seconds_count{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\",type=~\"$stream\"}[$__rate_interval]))",
+              "expr": "sum(rate(hedera_mirror_importer_cloud_latency_seconds_sum{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\",type=~\"$stream\"}[$__rate_interval])) / sum(rate(hedera_mirror_importer_cloud_latency_seconds_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\",type=~\"$stream\"}[$__rate_interval]))",
               "interval": "1m",
               "legendFormat": "  ",
               "refId": "A"
@@ -3643,7 +3643,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${prometheus}",
           "decimals": 2,
           "description": "The difference in time between the consensus time of the last transaction in the file and the time at which the file was downloaded and verified",
           "fieldConfig": {
@@ -3693,7 +3693,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(hedera_mirror_download_latency_seconds_sum{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\",type=~\"$stream\"}[$__rate_interval])) / sum(rate(hedera_mirror_download_latency_seconds_count{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\",type=~\"$stream\"}[$__rate_interval]))",
+              "expr": "sum(rate(hedera_mirror_download_latency_seconds_sum{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\",type=~\"$stream\"}[$__rate_interval])) / sum(rate(hedera_mirror_download_latency_seconds_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\",type=~\"$stream\"}[$__rate_interval]))",
               "interval": "1m",
               "legendFormat": "  ",
               "refId": "A"
@@ -3746,7 +3746,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${prometheus}",
           "decimals": 2,
           "description": "The difference in the consensus time of the last transaction in the file and the time at which the file was processed successfully",
           "fieldConfig": {
@@ -3796,7 +3796,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(hedera_mirror_parse_latency_seconds_sum{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\",type=~\"$stream\"}[$__rate_interval])) / sum(rate(hedera_mirror_parse_latency_seconds_count{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\",type=~\"$stream\"}[$__rate_interval]))",
+              "expr": "sum(rate(hedera_mirror_parse_latency_seconds_sum{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\",type=~\"$stream\"}[$__rate_interval])) / sum(rate(hedera_mirror_parse_latency_seconds_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\",type=~\"$stream\"}[$__rate_interval]))",
               "interval": "1m",
               "legendFormat": "  ",
               "refId": "A"
@@ -3867,14 +3867,87 @@
         "type": "constant"
       },
       {
+        "current": {
+          "selected": true,
+          "text": "Loki",
+          "value": "Loki"
+        },
+        "description": "Name of the Loki datasource to use",
+        "error": null,
+        "hide": 2,
+        "includeAll": false,
+        "label": "Loki",
+        "multi": false,
+        "name": "loki",
+        "options": [],
+        "query": "loki",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "description": "Name of the Prometheus datasource to use",
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Prometheus",
+        "multi": false,
+        "name": "prometheus",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": "${prometheus}",
+        "definition": "label_values(system_cpu_count{application=\"$application\"}, cluster)",
+        "description": "Kubernetes cluster",
+        "error": null,
+        "hide": 0,
+        "includeAll": true,
+        "label": "Cluster",
+        "multi": true,
+        "name": "cluster",
+        "options": [],
+        "query": {
+          "query": "label_values(system_cpu_count{application=\"$application\"}, cluster)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 5,
+        "type": "query"
+      },
+      {
         "allValue": null,
         "current": {
           "selected": true,
           "text": "All",
           "value": "$__all"
         },
-        "datasource": "Prometheus",
-        "definition": "label_values(system_cpu_count{application=\"$application\"}, namespace)",
+        "datasource": "${prometheus}",
+        "definition": "label_values(system_cpu_count{application=\"$application\",cluster=~\"$cluster\"}, namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -3884,13 +3957,13 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(system_cpu_count{application=\"$application\"}, namespace)",
+          "query": "label_values(system_cpu_count{application=\"$application\",cluster=~\"$cluster\"}, namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
-        "sort": 1,
+        "sort": 5,
         "tagValuesQuery": "",
         "tagsQuery": "",
         "type": "query",
@@ -3903,8 +3976,8 @@
           "text": "All",
           "value": "$__all"
         },
-        "datasource": "Prometheus",
-        "definition": "label_values(system_cpu_count{application=\"$application\",namespace=~\"$namespace\"}, pod)",
+        "datasource": "${prometheus}",
+        "definition": "label_values(system_cpu_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\"}, pod)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -3914,13 +3987,13 @@
         "name": "pod",
         "options": [],
         "query": {
-          "query": "label_values(system_cpu_count{application=\"$application\",namespace=~\"$namespace\"}, pod)",
+          "query": "label_values(system_cpu_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\"}, pod)",
           "refId": "Prometheus-pod-Variable-Query"
         },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
-        "sort": 1,
+        "sort": 5,
         "tagValuesQuery": "",
         "tagsQuery": "",
         "type": "query",
@@ -3933,8 +4006,8 @@
           "text": "All",
           "value": "$__all"
         },
-        "datasource": "Prometheus",
-        "definition": "label_values(hedera_mirror_download_request_seconds_count{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}, type)",
+        "datasource": "${prometheus}",
+        "definition": "label_values(hedera_mirror_download_request_seconds_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}, type)",
         "description": null,
         "error": null,
         "hide": 2,
@@ -3944,7 +4017,7 @@
         "name": "stream",
         "options": [],
         "query": {
-          "query": "label_values(hedera_mirror_download_request_seconds_count{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}, type)",
+          "query": "label_values(hedera_mirror_download_request_seconds_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}, type)",
           "refId": "Prometheus-stream-Variable-Query"
         },
         "refresh": 2,

--- a/charts/hedera-mirror-common/dashboards/hedera-mirror-monitor.json
+++ b/charts/hedera-mirror-common/dashboards/hedera-mirror-monitor.json
@@ -21,7 +21,7 @@
   "panels": [
     {
       "cacheTimeout": null,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "description": "The number of pods that are up and ready for processing",
       "fieldConfig": {
         "defaults": {
@@ -81,7 +81,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(kube_pod_status_ready{namespace=~\"$namespace\",pod=~\"$pod\",pod=~\".*-monitor-.*\",condition=\"true\"})",
+          "expr": "sum(kube_pod_status_ready{cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\",pod=~\".*-monitor-.*\",condition=\"true\"})",
           "interval": "1m",
           "legendFormat": "",
           "refId": "A"
@@ -94,7 +94,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "description": "The average publish TPS",
       "fieldConfig": {
         "defaults": {
@@ -157,7 +157,7 @@
       "pluginVersion": "8.0.1",
       "targets": [
         {
-          "expr": "sum(rate(hedera_mirror_monitor_publish_submit_seconds_count{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval]))",
+          "expr": "sum(rate(hedera_mirror_monitor_publish_submit_seconds_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval]))",
           "interval": "1m",
           "legendFormat": "",
           "refId": "A"
@@ -170,7 +170,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "description": "The average gRPC subscribe TPS",
       "fieldConfig": {
         "defaults": {
@@ -233,7 +233,7 @@
       "pluginVersion": "8.0.1",
       "targets": [
         {
-          "expr": "sum(rate(hedera_mirror_monitor_subscribe_e2e_seconds_count{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval]))",
+          "expr": "sum(rate(hedera_mirror_monitor_subscribe_e2e_seconds_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval]))",
           "interval": "1m",
           "legendFormat": "",
           "refId": "A"
@@ -246,7 +246,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "description": "The average amount of time all scenarios have been actively publishing transactions",
       "fieldConfig": {
         "defaults": {
@@ -306,7 +306,7 @@
       "pluginVersion": "8.0.1",
       "targets": [
         {
-          "expr": "avg(hedera_mirror_monitor_publish_duration_seconds{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "avg(hedera_mirror_monitor_publish_duration_seconds{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "interval": "1m",
           "legendFormat": "",
           "refId": "A"
@@ -319,7 +319,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "description": "The average amount of time all clients have been subscribed",
       "fieldConfig": {
         "defaults": {
@@ -379,7 +379,7 @@
       "pluginVersion": "8.0.1",
       "targets": [
         {
-          "expr": "avg(hedera_mirror_monitor_subscribe_duration_seconds{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "avg(hedera_mirror_monitor_subscribe_duration_seconds{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "interval": "1m",
           "legendFormat": "",
           "refId": "A"
@@ -392,7 +392,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "description": "The average time from submit to handle transaction",
       "fieldConfig": {
         "defaults": {
@@ -459,7 +459,7 @@
       "pluginVersion": "8.0.1",
       "targets": [
         {
-          "expr": "sum(rate(hedera_mirror_monitor_publish_handle_seconds_sum{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) / sum(rate(hedera_mirror_monitor_publish_handle_seconds_count{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval]))",
+          "expr": "sum(rate(hedera_mirror_monitor_publish_handle_seconds_sum{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) / sum(rate(hedera_mirror_monitor_publish_handle_seconds_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval]))",
           "interval": "1m",
           "legendFormat": "",
           "refId": "A"
@@ -472,7 +472,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "description": "The average end to end latency of the entire system",
       "fieldConfig": {
         "defaults": {
@@ -539,7 +539,7 @@
       "pluginVersion": "8.0.1",
       "targets": [
         {
-          "expr": "sum(rate(hedera_mirror_monitor_subscribe_e2e_seconds_sum{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\",protocol=\"GRPC\"}[$__rate_interval])) / sum(rate(hedera_mirror_monitor_subscribe_e2e_seconds_count{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\",protocol=\"GRPC\"}[$__rate_interval]))",
+          "expr": "sum(rate(hedera_mirror_monitor_subscribe_e2e_seconds_sum{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\",protocol=\"GRPC\"}[$__rate_interval])) / sum(rate(hedera_mirror_monitor_subscribe_e2e_seconds_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\",protocol=\"GRPC\"}[$__rate_interval]))",
           "interval": "1m",
           "legendFormat": "",
           "refId": "A"
@@ -576,7 +576,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "decimals": 1,
       "description": "The number of transactions per second published broken down by type",
       "fieldConfig": {
@@ -626,7 +626,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(hedera_mirror_monitor_publish_submit_seconds_count{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (type)",
+          "expr": "sum(rate(hedera_mirror_monitor_publish_submit_seconds_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (type)",
           "interval": "1m",
           "legendFormat": "{{ type }}",
           "refId": "A"
@@ -682,7 +682,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "decimals": 1,
       "description": "How long the publish scenario has been active",
       "fieldConfig": {
@@ -733,7 +733,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(hedera_mirror_monitor_publish_duration_seconds{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}) by (scenario)",
+          "expr": "sum(hedera_mirror_monitor_publish_duration_seconds{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) by (scenario)",
           "interval": "1m",
           "legendFormat": "{{ scenario }}",
           "refId": "A"
@@ -788,7 +788,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "decimals": 1,
       "description": "The number of errors per second when submitting transactions",
       "fieldConfig": {
@@ -838,7 +838,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(hedera_mirror_monitor_publish_submit_seconds_count{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\",status!=\"SUCCESS\"}[$__rate_interval])) by (status)",
+          "expr": "sum(rate(hedera_mirror_monitor_publish_submit_seconds_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\",status!=\"SUCCESS\"}[$__rate_interval])) by (status)",
           "interval": "1m",
           "legendFormat": "{{ status }}",
           "refId": "A"
@@ -892,7 +892,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "description": "How long it took to submit the transaction to the main node",
       "fieldConfig": {
         "defaults": {
@@ -940,7 +940,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(hedera_mirror_monitor_publish_submit_seconds_sum{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (scenario) / sum(rate(hedera_mirror_monitor_publish_submit_seconds_count{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (scenario)",
+          "expr": "sum(rate(hedera_mirror_monitor_publish_submit_seconds_sum{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (scenario) / sum(rate(hedera_mirror_monitor_publish_submit_seconds_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (scenario)",
           "interval": "1m",
           "legendFormat": "{{scenario}}",
           "refId": "A"
@@ -993,7 +993,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "description": "The time it takes from submit to being handled by the main nodes",
       "fieldConfig": {
         "defaults": {
@@ -1041,7 +1041,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(hedera_mirror_monitor_publish_handle_seconds_sum{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (scenario) / sum(rate(hedera_mirror_monitor_publish_handle_seconds_count{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (scenario)",
+          "expr": "sum(rate(hedera_mirror_monitor_publish_handle_seconds_sum{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (scenario) / sum(rate(hedera_mirror_monitor_publish_handle_seconds_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (scenario)",
           "interval": "1m",
           "legendFormat": "{{scenario}}",
           "refId": "A"
@@ -1115,7 +1115,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "decimals": 1,
       "description": "The number of transactions per second received broken down by scenario",
       "fieldConfig": {
@@ -1165,7 +1165,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(hedera_mirror_monitor_subscribe_e2e_seconds_count{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (scenario)",
+          "expr": "sum(rate(hedera_mirror_monitor_subscribe_e2e_seconds_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (scenario)",
           "interval": "1m",
           "legendFormat": "{{ scenario }}",
           "refId": "A"
@@ -1221,7 +1221,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "decimals": 1,
       "description": "How long it took to submit the transaction to the main node and receive it back from the mirror node",
       "fieldConfig": {
@@ -1271,7 +1271,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(hedera_mirror_monitor_subscribe_e2e_seconds_sum{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (scenario) / sum(rate(hedera_mirror_monitor_subscribe_e2e_seconds_count{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (scenario)",
+          "expr": "sum(rate(hedera_mirror_monitor_subscribe_e2e_seconds_sum{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (scenario) / sum(rate(hedera_mirror_monitor_subscribe_e2e_seconds_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (scenario)",
           "interval": "1m",
           "legendFormat": "{{ scenario }}",
           "refId": "A"
@@ -1327,7 +1327,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "decimals": 1,
       "description": "How long the subscribe scenario has been active",
       "fieldConfig": {
@@ -1378,7 +1378,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(hedera_mirror_monitor_subscribe_duration_seconds{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}) by (scenario)",
+          "expr": "sum(hedera_mirror_monitor_subscribe_duration_seconds{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) by (scenario)",
           "interval": "1m",
           "legendFormat": "{{ scenario }}",
           "refId": "A"
@@ -1428,7 +1428,7 @@
     },
     {
       "collapsed": true,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "fieldConfig": {
         "defaults": {},
         "overrides": []
@@ -1446,7 +1446,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${prometheus}",
           "decimals": 1,
           "description": "",
           "fieldConfig": {
@@ -1496,7 +1496,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(reactor_subscribed_subscribers_total{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (flow)",
+              "expr": "sum(rate(reactor_subscribed_subscribers_total{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (flow)",
               "interval": "1m",
               "legendFormat": "{{ flow }}",
               "refId": "A"
@@ -1549,7 +1549,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${prometheus}",
           "description": "The number of requests per second for more data",
           "fill": 1,
           "fillGradient": 0,
@@ -1591,7 +1591,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(reactor_requested_requested_amount_count{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (flow)",
+              "expr": "sum(rate(reactor_requested_requested_amount_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (flow)",
               "interval": "1m",
               "legendFormat": "{{ flow }}",
               "refId": "A"
@@ -1643,7 +1643,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${prometheus}",
           "decimals": 0,
           "description": "Times the duration elapsed between a subscription and the termination or cancellation of the sequence",
           "fill": 1,
@@ -1686,7 +1686,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(reactor_flow_duration_seconds_sum{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (flow) / sum(rate(reactor_flow_duration_seconds_count{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (flow)",
+              "expr": "sum(rate(reactor_flow_duration_seconds_sum{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (flow) / sum(rate(reactor_flow_duration_seconds_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (flow)",
               "interval": "1m",
               "legendFormat": "{{ flow }}",
               "refId": "A"
@@ -1739,7 +1739,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${prometheus}",
           "decimals": 0,
           "description": "",
           "fill": 1,
@@ -1783,7 +1783,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(executor_pool_size_threads{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\"}) by (reactor_scheduler_id)",
+              "expr": "sum(executor_pool_size_threads{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}) by (reactor_scheduler_id)",
               "interval": "1m",
               "legendFormat": "{{ reactor_scheduler_id }}",
               "refId": "A"
@@ -1836,7 +1836,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${prometheus}",
           "decimals": 0,
           "description": "",
           "fill": 1,
@@ -1880,7 +1880,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "\nsum(executor_queued_tasks{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\"} >= 0) by (reactor_scheduler_id)",
+              "expr": "\nsum(executor_queued_tasks{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"} >= 0) by (reactor_scheduler_id)",
               "interval": "1m",
               "legendFormat": "{{ reactor_scheduler_id }}",
               "refId": "A"
@@ -1933,7 +1933,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${prometheus}",
           "decimals": 0,
           "description": "",
           "fill": 1,
@@ -1977,7 +1977,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "max(executor_seconds_max{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\"}) by (reactor_scheduler_id)",
+              "expr": "max(executor_seconds_max{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}) by (reactor_scheduler_id)",
               "interval": "1m",
               "legendFormat": "{{ reactor_scheduler_id }}",
               "refId": "A"
@@ -2030,7 +2030,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
+          "datasource": "${prometheus}",
           "decimals": 0,
           "description": "Measures delays between onNext signals (or between onSubscribe and first onNext)",
           "fill": 1,
@@ -2074,7 +2074,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(reactor_onNext_delay_seconds_sum{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (flow) / sum(rate(reactor_onNext_delay_seconds_count{application=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (flow)",
+              "expr": "sum(rate(reactor_onNext_delay_seconds_sum{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (flow) / sum(rate(reactor_onNext_delay_seconds_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (flow)",
               "interval": "1m",
               "legendFormat": "{{ flow }}",
               "refId": "A"
@@ -2149,7 +2149,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -2193,20 +2193,20 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(jvm_memory_committed_bytes{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "avg(jvm_memory_committed_bytes{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "interval": "1m",
           "legendFormat": "committed",
           "refId": "A"
         },
         {
-          "expr": "sum(jvm_memory_used_bytes{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "sum(jvm_memory_used_bytes{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "hide": false,
           "interval": "1m",
           "legendFormat": "used",
           "refId": "B"
         },
         {
-          "expr": "sum(jvm_memory_max_bytes{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "sum(jvm_memory_max_bytes{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "hide": false,
           "interval": "1m",
           "legendFormat": "max",
@@ -2259,7 +2259,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -2303,14 +2303,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(system_cpu_count{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "sum(system_cpu_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "hide": false,
           "interval": "1m",
           "legendFormat": "max",
           "refId": "A"
         },
         {
-          "expr": "sum(process_cpu_usage{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "sum(process_cpu_usage{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "hide": false,
           "interval": "1m",
           "legendFormat": "usage",
@@ -2368,7 +2368,7 @@
       "bars": true,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "decimals": 0,
       "fieldConfig": {
         "defaults": {
@@ -2412,7 +2412,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(jvm_threads_states_threads{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}) by (state)",
+          "expr": "sum(jvm_threads_states_threads{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) by (state)",
           "interval": "1m",
           "legendFormat": "{{ state }}",
           "refId": "A"
@@ -2469,7 +2469,7 @@
       "bars": true,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "decimals": 0,
       "fieldConfig": {
         "defaults": {
@@ -2513,13 +2513,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(process_files_open_files{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "sum(process_files_open_files{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "interval": "1m",
           "legendFormat": "open",
           "refId": "B"
         },
         {
-          "expr": "sum(process_files_max_files{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "sum(process_files_max_files{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "interval": "1m",
           "legendFormat": "max",
           "refId": "A"
@@ -2571,7 +2571,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "decimals": 1,
       "description": "",
       "fieldConfig": {
@@ -2621,7 +2621,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(http_server_requests_seconds_count{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (method, uri)",
+          "expr": "sum(rate(http_server_requests_seconds_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (method, uri)",
           "interval": "1m",
           "legendFormat": "{{ method}} {{uri}}",
           "refId": "A"
@@ -2698,7 +2698,7 @@
       "bars": true,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${prometheus}",
       "fieldConfig": {
         "defaults": {
           "links": []
@@ -2743,7 +2743,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(log4j2_events_total{application=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (level)",
+          "expr": "sum(rate(log4j2_events_total{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (level)",
           "interval": "1m",
           "legendFormat": "{{ level }}",
           "refId": "A"
@@ -2791,7 +2791,7 @@
       }
     },
     {
-      "datasource": "Loki",
+      "datasource": "${loki}",
       "description": "",
       "gridPos": {
         "h": 10,
@@ -2810,7 +2810,7 @@
       },
       "targets": [
         {
-          "expr": "{component=\"monitor\",namespace=~\"$namespace\",pod=~\"$pod\"}",
+          "expr": "{component=\"monitor\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}",
           "legendFormat": "",
           "refId": "A"
         }
@@ -2843,14 +2843,87 @@
         "type": "constant"
       },
       {
+        "current": {
+          "selected": true,
+          "text": "Loki",
+          "value": "Loki"
+        },
+        "description": "Name of the Loki datasource to use",
+        "error": null,
+        "hide": 2,
+        "includeAll": false,
+        "label": "Loki",
+        "multi": false,
+        "name": "loki",
+        "options": [],
+        "query": "loki",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "description": "Name of the Prometheus datasource to use",
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Prometheus",
+        "multi": false,
+        "name": "prometheus",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": "${prometheus}",
+        "definition": "label_values(system_cpu_count{application=\"$application\"}, cluster)",
+        "description": "Kubernetes cluster",
+        "error": null,
+        "hide": 0,
+        "includeAll": true,
+        "label": "Cluster",
+        "multi": true,
+        "name": "cluster",
+        "options": [],
+        "query": {
+          "query": "label_values(system_cpu_count{application=\"$application\"}, cluster)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 5,
+        "type": "query"
+      },
+      {
         "allValue": null,
         "current": {
           "selected": false,
           "text": "All",
           "value": "$__all"
         },
-        "datasource": "Prometheus",
-        "definition": "label_values(system_cpu_count{application=\"$application\"},namespace)",
+        "datasource": "${prometheus}",
+        "definition": "label_values(system_cpu_count{application=\"$application\",cluster=~\"$cluster\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2860,13 +2933,13 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(system_cpu_count{application=\"$application\"},namespace)",
+          "query": "label_values(system_cpu_count{application=\"$application\",cluster=~\"$cluster\"},namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
-        "sort": 1,
+        "sort": 5,
         "tagValuesQuery": "",
         "tagsQuery": "",
         "type": "query",
@@ -2879,8 +2952,8 @@
           "text": "All",
           "value": "$__all"
         },
-        "datasource": "Prometheus",
-        "definition": "label_values(system_cpu_count{application=\"$application\",namespace=~\"$namespace\"},pod)",
+        "datasource": "${prometheus}",
+        "definition": "label_values(system_cpu_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\"},pod)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2890,13 +2963,13 @@
         "name": "pod",
         "options": [],
         "query": {
-          "query": "label_values(system_cpu_count{application=\"$application\",namespace=~\"$namespace\"},pod)",
+          "query": "label_values(system_cpu_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\"},pod)",
           "refId": "Prometheus-pod-Variable-Query"
         },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
-        "sort": 1,
+        "sort": 5,
         "tagValuesQuery": "",
         "tagsQuery": "",
         "type": "query",

--- a/charts/hedera-mirror-common/dashboards/hedera-mirror-rest.json
+++ b/charts/hedera-mirror-common/dashboards/hedera-mirror-rest.json
@@ -38,11 +38,22 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "description": "The number of pods that are up and ready for processing",
       "fieldConfig": {
         "defaults": {
-          "mappings": [],
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "color": "red",
+                  "text": "0"
+                }
+              },
+              "type": "special"
+            }
+          ],
           "max": 100,
           "min": 0,
           "thresholds": {
@@ -91,7 +102,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(kube_pod_status_ready{namespace=~\"$namespace\",pod=~\"$pod\",pod=~\".*-rest-.*\",condition=\"true\"})",
+          "expr": "sum(kube_pod_status_ready{cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\",pod=~\".*-rest-.*\",condition=\"true\"})",
           "format": "time_series",
           "interval": "1m",
           "intervalFactor": 2,
@@ -105,7 +116,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "description": "The rate of incoming requests",
       "fieldConfig": {
         "defaults": {
@@ -165,7 +176,7 @@
       "pluginVersion": "8.0.1",
       "targets": [
         {
-          "expr": "sum(rate(api_all_request_total{container=\"$application\",namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))  ",
+          "expr": "sum(rate(api_all_request_total{container=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))  ",
           "format": "time_series",
           "interval": "1m",
           "intervalFactor": 2,
@@ -179,7 +190,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "description": "The total number of all API requests currently in processing (no response yet)",
       "fieldConfig": {
         "defaults": {
@@ -239,7 +250,7 @@
       "pluginVersion": "8.0.1",
       "targets": [
         {
-          "expr": "sum(api_all_request_in_processing_total{container=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "sum(api_all_request_in_processing_total{container=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "format": "time_series",
           "interval": "1m",
           "intervalFactor": 2,
@@ -253,7 +264,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "description": "The average response size",
       "fieldConfig": {
         "defaults": {
@@ -311,7 +322,7 @@
       "pluginVersion": "8.0.1",
       "targets": [
         {
-          "expr": "sum(rate(api_response_size_bytes_sum{container=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\",code=~\"^2..\"}[$__rate_interval])) / \nsum(rate(api_response_size_bytes_count{container=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\",code=~\"^2..\"}[$__rate_interval]))",
+          "expr": "sum(rate(api_response_size_bytes_sum{container=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\",code=~\"^2..\"}[$__rate_interval])) / \nsum(rate(api_response_size_bytes_count{container=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\",code=~\"^2..\"}[$__rate_interval]))",
           "format": "time_series",
           "interval": "1m",
           "intervalFactor": 2,
@@ -325,7 +336,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "description": "The total number of all API requests with server error response",
       "fieldConfig": {
         "defaults": {
@@ -392,7 +403,7 @@
       "pluginVersion": "8.0.1",
       "targets": [
         {
-          "expr": "sum(rate(api_all_errors_total{container=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) / \nsum(rate(api_all_request_total{container=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval]))",
+          "expr": "sum(rate(api_all_errors_total{container=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) / \nsum(rate(api_all_request_total{container=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval]))",
           "format": "time_series",
           "interval": "1m",
           "intervalFactor": 2,
@@ -406,7 +417,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "fieldConfig": {
         "defaults": {
           "mappings": [
@@ -466,7 +477,7 @@
       "pluginVersion": "8.0.1",
       "targets": [
         {
-          "expr": "(sum(rate(api_request_duration_milliseconds_bucket{container=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\",le=\"100\",code=~\"^2..$\"}[$__rate_interval])) +\nsum(rate(api_request_duration_milliseconds_bucket{container=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\",le=\"250\",code=~\"^2..$\"}[$__rate_interval])))\n/ 2 / sum(rate(api_request_duration_milliseconds_count{container=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval]))",
+          "expr": "(sum(rate(api_request_duration_milliseconds_bucket{container=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\",le=\"100\",code=~\"^2..$\"}[$__rate_interval])) +\nsum(rate(api_request_duration_milliseconds_bucket{container=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\",le=\"250\",code=~\"^2..$\"}[$__rate_interval])))\n/ 2 / sum(rate(api_request_duration_milliseconds_count{container=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval]))",
           "format": "time_series",
           "interval": "1m",
           "intervalFactor": 2,
@@ -503,7 +514,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "description": "The rate of all API requests received",
       "fill": 1,
       "fillGradient": 0,
@@ -546,7 +557,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk(10, sum(rate(api_request_total{container=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (path))",
+          "expr": "topk(10, sum(rate(api_request_total{container=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (path))",
           "format": "time_series",
           "interval": "1m",
           "intervalFactor": 10,
@@ -601,7 +612,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "description": "The total number of all API requests with error response",
       "fill": 1,
       "fillGradient": 0,
@@ -646,7 +657,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(api_request_total{container=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\",code=~\"^2..$\"}[$__rate_interval]))",
+          "expr": "sum(rate(api_request_total{container=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\",code=~\"^2..$\"}[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
           "interval": "1m",
@@ -656,7 +667,7 @@
           "step": 2
         },
         {
-          "expr": "sum(rate(api_request_total{container=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\",code=~\"^3..$\"}[$__rate_interval]))",
+          "expr": "sum(rate(api_request_total{container=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\",code=~\"^3..$\"}[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
           "interval": "1m",
@@ -666,7 +677,7 @@
           "step": 2
         },
         {
-          "expr": "sum(rate(api_request_total{container=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\",code=~\"^4..$\"}[$__rate_interval]))",
+          "expr": "sum(rate(api_request_total{container=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\",code=~\"^4..$\"}[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
           "interval": "1m",
@@ -676,7 +687,7 @@
           "step": 2
         },
         {
-          "expr": "sum(rate(api_request_total{container=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\",code=~\"^5..$\"}[$__rate_interval]))",
+          "expr": "sum(rate(api_request_total{container=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\",code=~\"^5..$\"}[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
           "interval": "1m",
@@ -732,7 +743,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "description": "How long a request took to process and return a response",
       "fill": 1,
       "fillGradient": 0,
@@ -752,6 +763,8 @@
         "min": true,
         "rightSide": true,
         "show": true,
+        "sort": "avg",
+        "sortDesc": true,
         "total": false,
         "values": true
       },
@@ -773,7 +786,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk(10, sum(rate(api_request_duration_milliseconds_sum{container=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) /  sum(rate(api_request_duration_milliseconds_count{container=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) > 0)",
+          "expr": "topk(10, sum(rate(api_request_duration_milliseconds_sum{container=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) /  sum(rate(api_request_duration_milliseconds_count{container=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) > 0)",
           "format": "time_series",
           "interval": "1m",
           "intervalFactor": 2,
@@ -782,7 +795,7 @@
           "step": 2
         },
         {
-          "expr": "sum(rate(api_request_duration_milliseconds_sum{container=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (path) /  sum(rate(api_request_duration_milliseconds_count{container=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (path) > 0",
+          "expr": "sum(rate(api_request_duration_milliseconds_sum{container=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (path) /  sum(rate(api_request_duration_milliseconds_count{container=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (path) > 0",
           "format": "time_series",
           "interval": "1m",
           "intervalFactor": 2,
@@ -833,7 +846,7 @@
       }
     },
     {
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "description": "API request duration distributed into buckets",
       "fieldConfig": {
         "defaults": {
@@ -879,7 +892,7 @@
       "pluginVersion": "8.0.1",
       "targets": [
         {
-          "expr": "sum(increase(api_request_duration_milliseconds_bucket{container=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\",code=~\"^2..$\"}[$__rate_interval])) by (le)",
+          "expr": "sum(increase(api_request_duration_milliseconds_bucket{container=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\",code=~\"^2..$\"}[$__rate_interval])) by (le)",
           "format": "heatmap",
           "hide": false,
           "instant": false,
@@ -900,7 +913,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "description": "API request size in bytes",
       "fill": 1,
       "fillGradient": 0,
@@ -945,7 +958,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": " sum(api_request_size_bytes_sum{container=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}) / \n sum(api_request_size_bytes_count{container=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": " sum(api_request_size_bytes_sum{container=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) / \n sum(api_request_size_bytes_count{container=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "format": "time_series",
           "hide": false,
           "interval": "1m",
@@ -1001,7 +1014,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "description": "The total number of all API requests with error response",
       "fill": 1,
       "fillGradient": 0,
@@ -1046,7 +1059,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(api_request_total{container=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\",code!~\"^2..$\"}[$__rate_interval])) by (code)",
+          "expr": "sum(rate(api_request_total{container=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\",code!~\"^2..$\"}[$__rate_interval])) by (code)",
           "format": "time_series",
           "hide": false,
           "interval": "1m",
@@ -1102,7 +1115,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "description": "API response size in bytes by path",
       "fill": 1,
       "fillGradient": 0,
@@ -1147,7 +1160,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(api_response_size_bytes_sum{container=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\",code=~\"^2..\"}[$__rate_interval])) by (path) / \nsum(rate(api_response_size_bytes_count{container=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\",code=~\"^2..\"}[$__rate_interval])) by (path)",
+          "expr": "sum(rate(api_response_size_bytes_sum{container=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\",code=~\"^2..\"}[$__rate_interval])) by (path) / \nsum(rate(api_response_size_bytes_count{container=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\",code=~\"^2..\"}[$__rate_interval])) by (path)",
           "format": "time_series",
           "hide": false,
           "interval": "1m",
@@ -1199,7 +1212,7 @@
       }
     },
     {
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "description": "API response size distributed into buckets",
       "fieldConfig": {
         "defaults": {
@@ -1245,7 +1258,7 @@
       "repeat": null,
       "targets": [
         {
-          "expr": "sum(increase(api_response_size_bytes_bucket{container=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (le)",
+          "expr": "sum(increase(api_response_size_bytes_bucket{container=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (le)",
           "format": "heatmap",
           "hide": false,
           "instant": false,
@@ -1284,7 +1297,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "description": "The average Node.js process memory",
       "fill": 1,
       "fillGradient": 0,
@@ -1329,7 +1342,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(nodejs_process_memory_external_bytes{container=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "avg(nodejs_process_memory_external_bytes{container=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "format": "time_series",
           "hide": false,
           "interval": "1m",
@@ -1339,7 +1352,7 @@
           "step": 2
         },
         {
-          "expr": "avg(nodejs_process_memory_rss_bytes{container=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "avg(nodejs_process_memory_rss_bytes{container=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "format": "time_series",
           "hide": false,
           "interval": "1m",
@@ -1349,7 +1362,7 @@
           "step": 2
         },
         {
-          "expr": "avg(nodejs_process_memory_heap_used_bytes{container=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "avg(nodejs_process_memory_heap_used_bytes{container=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "format": "time_series",
           "hide": false,
           "interval": "1m",
@@ -1359,7 +1372,7 @@
           "step": 2
         },
         {
-          "expr": "avg(nodejs_process_memory_heap_total_bytes{container=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "avg(nodejs_process_memory_heap_total_bytes{container=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "format": "time_series",
           "hide": false,
           "interval": "1m",
@@ -1415,7 +1428,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "description": "The average Node.js process CPU utilization",
       "fill": 1,
       "fillGradient": 0,
@@ -1460,7 +1473,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(nodejs_process_cpu_usage_percentage{container=\"$application\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "avg(nodejs_process_cpu_usage_percentage{container=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "format": "time_series",
           "hide": false,
           "interval": "1m",
@@ -1534,7 +1547,7 @@
       "bars": true,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Loki",
+      "datasource": "${loki}",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -1578,7 +1591,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate({component=\"rest\",namespace=~\"$namespace\",pod=~\"$pod\"} | regexp `(?P<timestamp>\\S+) (?P<level>\\S+) (?P<requestId>\\S+) (?P<message>.+)`[5m])) by (level)",
+          "expr": "sum(rate({component=\"rest\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"} | regexp `(?P<timestamp>\\S+) (?P<level>\\S+) (?P<requestId>\\S+) (?P<message>.+)`[5m])) by (level)",
           "instant": false,
           "legendFormat": "{{level}}",
           "range": true,
@@ -1629,7 +1642,7 @@
       }
     },
     {
-      "datasource": "Loki",
+      "datasource": "${loki}",
       "description": "",
       "gridPos": {
         "h": 8,
@@ -1649,7 +1662,7 @@
       "pluginVersion": "7.2.1",
       "targets": [
         {
-          "expr": "{component=\"rest\",namespace=~\"$namespace\",pod=~\"$pod\"}",
+          "expr": "{component=\"rest\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}",
           "legendFormat": "",
           "refId": "A"
         }
@@ -1683,14 +1696,87 @@
         "type": "constant"
       },
       {
+        "current": {
+          "selected": true,
+          "text": "Loki",
+          "value": "Loki"
+        },
+        "description": "Name of the Loki datasource to use",
+        "error": null,
+        "hide": 2,
+        "includeAll": false,
+        "label": "Loki",
+        "multi": false,
+        "name": "loki",
+        "options": [],
+        "query": "loki",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "description": "Name of the Prometheus datasource to use",
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Prometheus",
+        "multi": false,
+        "name": "prometheus",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": "${prometheus}",
+        "definition": "label_values(nodejs_process_cpu_usage_percentage{container=\"$application\"}, cluster)",
+        "description": "Kubernetes cluster",
+        "error": null,
+        "hide": 0,
+        "includeAll": true,
+        "label": "Cluster",
+        "multi": true,
+        "name": "cluster",
+        "options": [],
+        "query": {
+          "query": "label_values(nodejs_process_cpu_usage_percentage{container=\"$application\"}, cluster)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 5,
+        "type": "query"
+      },
+      {
         "allValue": null,
         "current": {
           "selected": true,
           "text": "All",
           "value": "$__all"
         },
-        "datasource": "Prometheus",
-        "definition": "label_values(nodejs_process_cpu_usage_percentage{container=\"$application\"}, namespace)",
+        "datasource": "${prometheus}",
+        "definition": "label_values(nodejs_process_cpu_usage_percentage{container=\"$application\",cluster=~\"$cluster\"}, namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1700,13 +1786,13 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(nodejs_process_cpu_usage_percentage{container=\"$application\"}, namespace)",
+          "query": "label_values(nodejs_process_cpu_usage_percentage{container=\"$application\",cluster=~\"$cluster\"}, namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
-        "sort": 1,
+        "sort": 5,
         "tagValuesQuery": "",
         "tagsQuery": "",
         "type": "query",
@@ -1719,8 +1805,8 @@
           "text": "All",
           "value": "$__all"
         },
-        "datasource": "Prometheus",
-        "definition": "label_values(nodejs_process_cpu_usage_percentage{container=\"$application\",namespace=~\"$namespace\"}, pod)",
+        "datasource": "${prometheus}",
+        "definition": "label_values(nodejs_process_cpu_usage_percentage{container=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\"}, pod)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1730,13 +1816,13 @@
         "name": "pod",
         "options": [],
         "query": {
-          "query": "label_values(nodejs_process_cpu_usage_percentage{container=\"$application\",namespace=~\"$namespace\"}, pod)",
+          "query": "label_values(nodejs_process_cpu_usage_percentage{container=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\"}, pod)",
           "refId": "Prometheus-pod-Variable-Query"
         },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
-        "sort": 1,
+        "sort": 5,
         "tagValuesQuery": "",
         "tagsQuery": "",
         "type": "query",
@@ -1745,7 +1831,7 @@
     ]
   },
   "time": {
-    "from": "now-15m",
+    "from": "now-3h",
     "to": "now"
   },
   "timepicker": {

--- a/charts/hedera-mirror-common/dashboards/jvm-micrometer-rev9.json
+++ b/charts/hedera-mirror-common/dashboards/jvm-micrometer-rev9.json
@@ -13,9 +13,9 @@
         "type": "dashboard"
       },
       {
-        "datasource": "Prometheus",
+        "datasource": "${prometheus}",
         "enable": true,
-        "expr": "resets(process_uptime_seconds{application=\"$application\", pod=\"$pod\"}[1m]) > 0",
+        "expr": "resets(process_uptime_seconds{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\"}[1m]) > 0",
         "iconColor": "rgba(255, 96, 96, 1)",
         "name": "Restart Detection",
         "showIn": 0,
@@ -58,7 +58,7 @@
         "rgba(237, 129, 40, 0.89)",
         "rgba(50, 172, 45, 0.97)"
       ],
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "decimals": 1,
       "editable": true,
       "error": false,
@@ -120,7 +120,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(process_uptime_seconds{application=\"$application\", pod=\"$pod\"})",
+          "expr": "sum(process_uptime_seconds{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -145,7 +145,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -198,12 +198,15 @@
           "fields": "",
           "values": false
         },
+        "text": {
+          "valueSize": 28
+        },
         "textMode": "value"
       },
       "pluginVersion": "7.2.1",
       "targets": [
         {
-          "expr": "sum(process_start_time_seconds{application=\"$application\", pod=\"$pod\"} * 1000)",
+          "expr": "sum(process_start_time_seconds{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\"} * 1000)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -225,7 +228,7 @@
         "rgba(237, 129, 40, 0.89)",
         "rgba(245, 54, 54, 0.9)"
       ],
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "decimals": 2,
       "editable": true,
       "error": false,
@@ -286,7 +289,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(jvm_memory_used_bytes{application=\"$application\", pod=\"$pod\", area=\"heap\"})*100/sum(jvm_memory_max_bytes{application=\"$application\",pod=\"$pod\", area=\"heap\"})",
+          "expr": "sum(jvm_memory_used_bytes{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\", area=\"heap\"})*100/sum(jvm_memory_max_bytes{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\", area=\"heap\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -317,7 +320,7 @@
         "rgba(237, 129, 40, 0.89)",
         "rgba(245, 54, 54, 0.9)"
       ],
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "decimals": 2,
       "editable": true,
       "error": false,
@@ -383,7 +386,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(jvm_memory_used_bytes{application=\"$application\", pod=\"$pod\", area=\"nonheap\"})*100/sum(jvm_memory_max_bytes{application=\"$application\",pod=\"$pod\", area=\"nonheap\"})",
+          "expr": "sum(jvm_memory_used_bytes{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\", area=\"nonheap\"})*100/sum(jvm_memory_max_bytes{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\", area=\"nonheap\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",
@@ -429,7 +432,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -474,7 +477,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(http_server_requests_seconds_count{application=\"$application\", pod=\"$pod\"}[1m]))",
+          "expr": "sum(rate(http_server_requests_seconds_count{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\"}[1m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "HTTP",
@@ -531,7 +534,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -576,7 +579,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(http_server_requests_seconds_count{application=\"$application\", pod=\"$pod\", status=~\"5..\"}[1m]))",
+          "expr": "sum(rate(http_server_requests_seconds_count{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\", status=~\"5..\"}[1m]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -631,7 +634,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -676,7 +679,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(http_server_requests_seconds_sum{application=\"$application\", pod=\"$pod\", status!~\"5..\"}[1m]))/sum(rate(http_server_requests_seconds_count{application=\"$application\", pod=\"$pod\", status!~\"5..\"}[1m]))",
+          "expr": "sum(rate(http_server_requests_seconds_sum{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\", status!~\"5..\"}[1m]))/sum(rate(http_server_requests_seconds_count{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\", status!~\"5..\"}[1m]))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -684,7 +687,7 @@
           "refId": "A"
         },
         {
-          "expr": "max(http_server_requests_seconds_max{application=\"$application\", pod=\"$pod\", status!~\"5..\"})",
+          "expr": "max(http_server_requests_seconds_max{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\", status!~\"5..\"})",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -738,7 +741,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -785,7 +788,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "tomcat_threads_busy_threads{application=\"$application\", pod=\"$pod\"}",
+          "expr": "tomcat_threads_busy_threads{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\"}",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -793,7 +796,7 @@
           "refId": "A"
         },
         {
-          "expr": "tomcat_threads_current_threads{application=\"$application\", pod=\"$pod\"}",
+          "expr": "tomcat_threads_current_threads{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\"}",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -801,7 +804,7 @@
           "refId": "B"
         },
         {
-          "expr": "tomcat_threads_config_max_threads{application=\"$application\", pod=\"$pod\"}",
+          "expr": "tomcat_threads_config_max_threads{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\"}",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -809,7 +812,7 @@
           "refId": "C"
         },
         {
-          "expr": "jetty_threads_busy{application=\"$application\", pod=\"$pod\"}",
+          "expr": "jetty_threads_busy{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\"}",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -817,7 +820,7 @@
           "refId": "D"
         },
         {
-          "expr": "jetty_threads_current{application=\"$application\", pod=\"$pod\"}",
+          "expr": "jetty_threads_current{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\"}",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -825,7 +828,7 @@
           "refId": "E"
         },
         {
-          "expr": "jetty_threads_config_max{application=\"$application\", pod=\"$pod\"}",
+          "expr": "jetty_threads_config_max{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\"}",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -837,7 +840,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Utilisation",
+      "title": "Web Container Threads",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -894,7 +897,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "editable": true,
       "error": false,
       "fieldConfig": {
@@ -949,7 +952,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(jvm_memory_used_bytes{application=\"$application\", pod=\"$pod\", area=\"heap\"})",
+          "expr": "sum(jvm_memory_used_bytes{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\", area=\"heap\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "used",
@@ -958,7 +961,7 @@
           "step": 2400
         },
         {
-          "expr": "sum(jvm_memory_committed_bytes{application=\"$application\", pod=\"$pod\", area=\"heap\"})",
+          "expr": "sum(jvm_memory_committed_bytes{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\", area=\"heap\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "committed",
@@ -966,7 +969,7 @@
           "step": 2400
         },
         {
-          "expr": "sum(jvm_memory_max_bytes{application=\"$application\", pod=\"$pod\", area=\"heap\"})",
+          "expr": "sum(jvm_memory_max_bytes{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\", area=\"heap\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "max",
@@ -1027,7 +1030,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "editable": true,
       "error": false,
       "fieldConfig": {
@@ -1082,7 +1085,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(jvm_memory_used_bytes{application=\"$application\", pod=\"$pod\", area=\"nonheap\"})",
+          "expr": "sum(jvm_memory_used_bytes{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\", area=\"nonheap\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -1092,7 +1095,7 @@
           "step": 2400
         },
         {
-          "expr": "sum(jvm_memory_committed_bytes{application=\"$application\", pod=\"$pod\", area=\"nonheap\"})",
+          "expr": "sum(jvm_memory_committed_bytes{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\", area=\"nonheap\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "committed",
@@ -1100,7 +1103,7 @@
           "step": 2400
         },
         {
-          "expr": "sum(jvm_memory_max_bytes{application=\"$application\", pod=\"$pod\", area=\"nonheap\"})",
+          "expr": "sum(jvm_memory_max_bytes{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\", area=\"nonheap\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "max",
@@ -1161,7 +1164,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "editable": true,
       "error": false,
       "fieldConfig": {
@@ -1217,7 +1220,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(jvm_memory_used_bytes{application=\"$application\", pod=\"$pod\"})",
+          "expr": "sum(jvm_memory_used_bytes{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "used",
@@ -1226,7 +1229,7 @@
           "step": 2400
         },
         {
-          "expr": "sum(jvm_memory_committed_bytes{application=\"$application\", pod=\"$pod\"})",
+          "expr": "sum(jvm_memory_committed_bytes{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "committed",
@@ -1234,7 +1237,7 @@
           "step": 2400
         },
         {
-          "expr": "sum(jvm_memory_max_bytes{application=\"$application\", pod=\"$pod\"})",
+          "expr": "sum(jvm_memory_max_bytes{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "max",
@@ -1295,7 +1298,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "editable": true,
       "error": false,
       "fieldConfig": {
@@ -1351,7 +1354,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(process_memory_vss_bytes{application=\"$application\", pod=\"$pod\"})",
+          "expr": "sum(process_memory_vss_bytes{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\"})",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -1362,7 +1365,7 @@
           "step": 2400
         },
         {
-          "expr": "sum(process_memory_rss_bytes{application=\"$application\", pod=\"$pod\"})",
+          "expr": "sum(process_memory_rss_bytes{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -1370,7 +1373,7 @@
           "refId": "B"
         },
         {
-          "expr": "sum(process_memory_swap_bytes{application=\"$application\", pod=\"$pod\"})",
+          "expr": "sum(process_memory_swap_bytes{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -1378,7 +1381,7 @@
           "refId": "C"
         },
         {
-          "expr": "sum(process_memory_rss_bytes{application=\"$application\", pod=\"$pod\"} + process_memory_swap_bytes{application=\"$application\", pod=\"$pod\"})",
+          "expr": "sum(process_memory_rss_bytes{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\"} + process_memory_swap_bytes{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -1454,7 +1457,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "editable": true,
       "error": false,
       "fieldConfig": {
@@ -1509,7 +1512,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(system_cpu_usage{application=\"$application\", pod=\"$pod\"})",
+          "expr": "sum(system_cpu_usage{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\"})",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -1520,7 +1523,7 @@
           "step": 2400
         },
         {
-          "expr": "sum(process_cpu_usage{application=\"$application\", pod=\"$pod\"})",
+          "expr": "sum(process_cpu_usage{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\"})",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -1529,7 +1532,7 @@
           "refId": "B"
         },
         {
-          "expr": "sum(avg_over_time(process_cpu_usage{application=\"$application\", pod=\"$pod\"}[1h]))",
+          "expr": "sum(avg_over_time(process_cpu_usage{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\"}[1h]))",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -1592,7 +1595,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "editable": true,
       "error": false,
       "fieldConfig": {
@@ -1647,7 +1650,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(system_load_average_1m{application=\"$application\", pod=\"$pod\"})",
+          "expr": "sum(system_load_average_1m{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -1657,7 +1660,7 @@
           "step": 2400
         },
         {
-          "expr": "avg(system_cpu_count{application=\"$application\", pod=\"$pod\"})",
+          "expr": "avg(system_cpu_count{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -1719,7 +1722,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "editable": true,
       "error": false,
       "fieldConfig": {
@@ -1774,7 +1777,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(jvm_threads_live_threads{application=\"$application\", pod=\"$pod\"})",
+          "expr": "sum(jvm_threads_live_threads{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -1784,7 +1787,7 @@
           "step": 2400
         },
         {
-          "expr": "sum(jvm_threads_daemon_threads{application=\"$application\", pod=\"$pod\"})",
+          "expr": "sum(jvm_threads_daemon_threads{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -1794,7 +1797,7 @@
           "step": 2400
         },
         {
-          "expr": "sum(jvm_threads_peak_threads{application=\"$application\", pod=\"$pod\"})",
+          "expr": "sum(jvm_threads_peak_threads{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -1803,7 +1806,7 @@
           "step": 2400
         },
         {
-          "expr": "sum(process_threads{application=\"$application\", pod=\"$pod\"})",
+          "expr": "sum(process_threads{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -1873,7 +1876,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -1920,7 +1923,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(jvm_threads_states_threads{application=\"$application\", pod=\"$pod\"}) by (state)",
+          "expr": "sum(jvm_threads_states_threads{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\"}) by (state)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -1980,7 +1983,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "editable": true,
       "error": false,
       "fieldConfig": {
@@ -2049,7 +2052,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(log4j2_events_total{application=\"$application\", pod=\"$pod\"}[5m])) by (level)",
+          "expr": "sum(rate(log4j2_events_total{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\"}[5m])) by (level)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -2113,7 +2116,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "editable": true,
       "error": false,
       "fieldConfig": {
@@ -2168,7 +2171,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(process_files_open_files{application=\"$application\", pod=\"$pod\"})",
+          "expr": "sum(process_files_open_files{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\"})",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -2179,7 +2182,7 @@
           "step": 2400
         },
         {
-          "expr": "sum(process_files_max_files{application=\"$application\", pod=\"$pod\"})",
+          "expr": "sum(process_files_max_files{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\"})",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -2259,7 +2262,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "editable": true,
       "error": false,
       "fieldConfig": {
@@ -2324,7 +2327,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(jvm_memory_used_bytes{application=\"$application\", pod=\"$pod\", id=~\"$jvm_memory_pool_heap\"})",
+          "expr": "sum(jvm_memory_used_bytes{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\", id=~\"$jvm_memory_pool_heap\"})",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -2335,7 +2338,7 @@
           "step": 1800
         },
         {
-          "expr": "sum(jvm_memory_committed_bytes{application=\"$application\", pod=\"$pod\", id=~\"$jvm_memory_pool_heap\"})",
+          "expr": "sum(jvm_memory_committed_bytes{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\", id=~\"$jvm_memory_pool_heap\"})",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -2346,7 +2349,7 @@
           "step": 1800
         },
         {
-          "expr": "sum(jvm_memory_max_bytes{application=\"$application\", pod=\"$pod\", id=~\"$jvm_memory_pool_heap\"})",
+          "expr": "sum(jvm_memory_max_bytes{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\", id=~\"$jvm_memory_pool_heap\"})",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -2410,7 +2413,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "editable": true,
       "error": false,
       "fieldConfig": {
@@ -2476,7 +2479,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(jvm_memory_used_bytes{application=\"$application\", pod=\"$pod\", id=~\"$jvm_memory_pool_heap\"})",
+          "expr": "sum(jvm_memory_used_bytes{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\", id=~\"$jvm_memory_pool_heap\"})",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -2487,7 +2490,7 @@
           "step": 1800
         },
         {
-          "expr": "sum(jvm_memory_committed_bytes{application=\"$application\", pod=\"$pod\", id=~\"$jvm_memory_pool_heap\"})",
+          "expr": "sum(jvm_memory_committed_bytes{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\", id=~\"$jvm_memory_pool_heap\"})",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -2498,7 +2501,7 @@
           "step": 1800
         },
         {
-          "expr": "sum(jvm_memory_max_bytes{application=\"$application\", pod=\"$pod\", id=~\"$jvm_memory_pool_heap\"})",
+          "expr": "sum(jvm_memory_max_bytes{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\", id=~\"$jvm_memory_pool_heap\"})",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -2562,7 +2565,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "editable": true,
       "error": false,
       "fieldConfig": {
@@ -2628,7 +2631,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(jvm_memory_used_bytes{application=\"$application\", pod=\"$pod\", id=~\"$jvm_memory_pool_heap\"})",
+          "expr": "sum(jvm_memory_used_bytes{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\", id=~\"$jvm_memory_pool_heap\"})",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -2639,7 +2642,7 @@
           "step": 1800
         },
         {
-          "expr": "sum(jvm_memory_committed_bytes{application=\"$application\", pod=\"$pod\", id=~\"$jvm_memory_pool_heap\"})",
+          "expr": "sum(jvm_memory_committed_bytes{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\", id=~\"$jvm_memory_pool_heap\"})",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -2650,7 +2653,7 @@
           "step": 1800
         },
         {
-          "expr": "sum(jvm_memory_max_bytes{application=\"$application\", pod=\"$pod\", id=~\"$jvm_memory_pool_heap\"})",
+          "expr": "sum(jvm_memory_max_bytes{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\", id=~\"$jvm_memory_pool_heap\"})",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -2729,7 +2732,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "editable": true,
       "error": false,
       "fieldConfig": {
@@ -2794,7 +2797,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(jvm_memory_used_bytes{application=\"$application\", pod=\"$pod\", id=~\"$jvm_memory_pool_nonheap\"})",
+          "expr": "sum(jvm_memory_used_bytes{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\", id=~\"$jvm_memory_pool_nonheap\"})",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -2805,7 +2808,7 @@
           "step": 1800
         },
         {
-          "expr": "sum(jvm_memory_committed_bytes{application=\"$application\", pod=\"$pod\", id=~\"$jvm_memory_pool_nonheap\"})",
+          "expr": "sum(jvm_memory_committed_bytes{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\", id=~\"$jvm_memory_pool_nonheap\"})",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -2816,7 +2819,7 @@
           "step": 1800
         },
         {
-          "expr": "sum(jvm_memory_max_bytes{application=\"$application\", pod=\"$pod\", id=~\"$jvm_memory_pool_nonheap\"})",
+          "expr": "sum(jvm_memory_max_bytes{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\", id=~\"$jvm_memory_pool_nonheap\"})",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -2880,7 +2883,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "editable": true,
       "error": false,
       "fieldConfig": {
@@ -2946,7 +2949,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "jvm_memory_used_bytes{application=\"$application\", pod=\"$pod\", id=~\"$jvm_memory_pool_nonheap\"}",
+          "expr": "jvm_memory_used_bytes{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\", id=~\"$jvm_memory_pool_nonheap\"}",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -2957,7 +2960,7 @@
           "step": 1800
         },
         {
-          "expr": "jvm_memory_committed_bytes{application=\"$application\", pod=\"$pod\", id=~\"$jvm_memory_pool_nonheap\"}",
+          "expr": "jvm_memory_committed_bytes{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\", id=~\"$jvm_memory_pool_nonheap\"}",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -2968,7 +2971,7 @@
           "step": 1800
         },
         {
-          "expr": "jvm_memory_max_bytes{application=\"$application\", pod=\"$pod\", id=~\"$jvm_memory_pool_nonheap\"}",
+          "expr": "jvm_memory_max_bytes{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\", id=~\"$jvm_memory_pool_nonheap\"}",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -3032,7 +3035,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "editable": true,
       "error": false,
       "fieldConfig": {
@@ -3098,7 +3101,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "jvm_memory_used_bytes{application=\"$application\", pod=\"$pod\", id=~\"$jvm_memory_pool_nonheap\"}",
+          "expr": "jvm_memory_used_bytes{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\", id=~\"$jvm_memory_pool_nonheap\"}",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -3109,7 +3112,7 @@
           "step": 1800
         },
         {
-          "expr": "jvm_memory_committed_bytes{application=\"$application\", pod=\"$pod\", id=~\"$jvm_memory_pool_nonheap\"}",
+          "expr": "jvm_memory_committed_bytes{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\", id=~\"$jvm_memory_pool_nonheap\"}",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -3120,7 +3123,7 @@
           "step": 1800
         },
         {
-          "expr": "jvm_memory_max_bytes{application=\"$application\", pod=\"$pod\", id=~\"$jvm_memory_pool_nonheap\"}",
+          "expr": "jvm_memory_max_bytes{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\", id=~\"$jvm_memory_pool_nonheap\"}",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -3184,7 +3187,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "editable": true,
       "error": false,
       "fieldConfig": {
@@ -3250,7 +3253,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "jvm_memory_used_bytes{application=\"$application\", pod=\"$pod\", id=~\"$jvm_memory_pool_nonheap\"}",
+          "expr": "jvm_memory_used_bytes{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\", id=~\"$jvm_memory_pool_nonheap\"}",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -3261,7 +3264,7 @@
           "step": 1800
         },
         {
-          "expr": "jvm_memory_committed_bytes{application=\"$application\", pod=\"$pod\", id=~\"$jvm_memory_pool_nonheap\"}",
+          "expr": "jvm_memory_committed_bytes{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\", id=~\"$jvm_memory_pool_nonheap\"}",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -3272,7 +3275,7 @@
           "step": 1800
         },
         {
-          "expr": "jvm_memory_max_bytes{application=\"$application\", pod=\"$pod\", id=~\"$jvm_memory_pool_nonheap\"}",
+          "expr": "jvm_memory_max_bytes{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\", id=~\"$jvm_memory_pool_nonheap\"}",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -3336,7 +3339,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "editable": true,
       "error": false,
       "fieldConfig": {
@@ -3402,7 +3405,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "jvm_memory_used_bytes{application=\"$application\", pod=\"$pod\", id=~\"$jvm_memory_pool_nonheap\"}",
+          "expr": "jvm_memory_used_bytes{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\", id=~\"$jvm_memory_pool_nonheap\"}",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -3413,7 +3416,7 @@
           "step": 1800
         },
         {
-          "expr": "jvm_memory_committed_bytes{application=\"$application\", pod=\"$pod\", id=~\"$jvm_memory_pool_nonheap\"}",
+          "expr": "jvm_memory_committed_bytes{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\", id=~\"$jvm_memory_pool_nonheap\"}",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -3424,7 +3427,7 @@
           "step": 1800
         },
         {
-          "expr": "jvm_memory_max_bytes{application=\"$application\", pod=\"$pod\", id=~\"$jvm_memory_pool_nonheap\"}",
+          "expr": "jvm_memory_max_bytes{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\", id=~\"$jvm_memory_pool_nonheap\"}",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -3503,7 +3506,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "fieldConfig": {
         "defaults": {
           "custom": {}
@@ -3547,7 +3550,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(jvm_gc_pause_seconds_count{application=\"$application\", pod=\"$pod\"}[1m])) by (action, cause)",
+          "expr": "sum(rate(jvm_gc_pause_seconds_count{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\"}[1m])) by (action, cause)",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -3602,7 +3605,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "fieldConfig": {
         "defaults": {
           "custom": {}
@@ -3646,7 +3649,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(jvm_gc_pause_seconds_sum{application=\"$application\", pod=\"$pod\"}[1m])/rate(jvm_gc_pause_seconds_count{application=\"$application\", pod=\"$pod\"}[1m])) by (action, cause)",
+          "expr": "sum(rate(jvm_gc_pause_seconds_sum{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\"}[1m])/rate(jvm_gc_pause_seconds_count{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\"}[1m])) by (action, cause)",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -3656,7 +3659,7 @@
           "refId": "A"
         },
         {
-          "expr": "sum(jvm_gc_pause_seconds_max{application=\"$application\", pod=\"$pod\"}) by (action, cause)",
+          "expr": "sum(jvm_gc_pause_seconds_max{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\"}) by (action, cause)",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -3712,7 +3715,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "fieldConfig": {
         "defaults": {
           "custom": {}
@@ -3756,7 +3759,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(jvm_gc_memory_allocated_bytes_total{application=\"$application\", pod=\"$pod\"}[1m]))",
+          "expr": "sum(rate(jvm_gc_memory_allocated_bytes_total{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\"}[1m]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -3764,7 +3767,7 @@
           "refId": "A"
         },
         {
-          "expr": "sum(rate(jvm_gc_memory_promoted_bytes_total{application=\"$application\", pod=\"$pod\"}[1m]))",
+          "expr": "sum(rate(jvm_gc_memory_promoted_bytes_total{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\"}[1m]))",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -3834,7 +3837,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "editable": true,
       "error": false,
       "fieldConfig": {
@@ -3888,7 +3891,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(jvm_classes_loaded_classes{application=\"$application\", pod=\"$pod\"})",
+          "expr": "sum(jvm_classes_loaded_classes{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -3951,7 +3954,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "editable": true,
       "error": false,
       "fieldConfig": {
@@ -4005,7 +4008,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(delta(jvm_classes_loaded_classes{application=\"$application\",pod=\"$pod\"}[1m]))",
+          "expr": "sum(delta(jvm_classes_loaded_classes{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\"}[1m]))",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -4085,7 +4088,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "editable": true,
       "error": false,
       "fieldConfig": {
@@ -4139,7 +4142,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(jvm_buffer_memory_used_bytes{application=\"$application\", pod=\"$pod\", id=\"direct\"})",
+          "expr": "sum(jvm_buffer_memory_used_bytes{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\", id=\"direct\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -4149,7 +4152,7 @@
           "step": 2400
         },
         {
-          "expr": "sum(jvm_buffer_total_capacity_bytes{application=\"$application\", pod=\"$pod\", id=\"direct\"})",
+          "expr": "sum(jvm_buffer_total_capacity_bytes{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\", id=\"direct\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -4212,7 +4215,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "editable": true,
       "error": false,
       "fieldConfig": {
@@ -4266,7 +4269,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(jvm_buffer_count_buffers{application=\"$application\", pod=\"$pod\", id=\"direct\"})",
+          "expr": "sum(jvm_buffer_count_buffers{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\", id=\"direct\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -4330,7 +4333,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "editable": true,
       "error": false,
       "fieldConfig": {
@@ -4384,7 +4387,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(jvm_buffer_memory_used_bytes{application=\"$application\", pod=\"$pod\", id=\"mapped\"})",
+          "expr": "sum(jvm_buffer_memory_used_bytes{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\", id=\"mapped\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -4394,7 +4397,7 @@
           "step": 2400
         },
         {
-          "expr": "sum(jvm_buffer_total_capacity_bytes{application=\"$application\", pod=\"$pod\", id=\"mapped\"})",
+          "expr": "sum(jvm_buffer_total_capacity_bytes{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\", id=\"mapped\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -4457,7 +4460,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${prometheus}",
       "editable": true,
       "error": false,
       "fieldConfig": {
@@ -4511,7 +4514,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(jvm_buffer_count_buffers{application=\"$application\", pod=\"$pod\", id=\"mapped\"})",
+          "expr": "sum(jvm_buffer_count_buffers{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\", id=\"mapped\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -4578,13 +4581,34 @@
   "templating": {
     "list": [
       {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "description": "Name of the Prometheus datasource to use",
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Prometheus",
+        "multi": false,
+        "name": "prometheus",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
         "allValue": null,
         "current": {
           "selected": false,
           "text": "hedera-mirror-importer",
           "value": "hedera-mirror-importer"
         },
-        "datasource": "Prometheus",
+        "datasource": "${prometheus}",
         "definition": "",
         "hide": 0,
         "includeAll": false,
@@ -4592,11 +4616,11 @@
         "multi": false,
         "name": "application",
         "options": [],
-        "query": "label_values(application)",
+        "query": "label_values(jvm_memory_used_bytes, application)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
-        "sort": 0,
+        "sort": 5,
         "tagValuesQuery": "",
         "tags": [],
         "tagsQuery": "",
@@ -4604,14 +4628,70 @@
         "useTags": false
       },
       {
-        "allFormat": "glob",
+        "allValue": null,
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": "${prometheus}",
+        "definition": "label_values(jvm_memory_used_bytes{application=\"$application\"}, cluster)",
+        "description": "Kubernetes cluster",
+        "error": null,
+        "hide": 0,
+        "includeAll": true,
+        "label": "Cluster",
+        "multi": true,
+        "name": "cluster",
+        "options": [],
+        "query": {
+          "query": "label_values(jvm_memory_used_bytes{application=\"$application\"}, cluster)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 5,
+        "type": "query"
+      },
+      {
         "allValue": null,
         "current": {
           "selected": false,
-          "text": "dev-mirror-importer-0",
-          "value": "dev-mirror-importer-0"
+          "text": "All",
+          "value": "$__all"
         },
-        "datasource": "Prometheus",
+        "datasource": "${prometheus}",
+        "definition": "label_values(jvm_memory_used_bytes{application=\"$application\",cluster=~\"$cluster\"},namespace)",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": true,
+        "label": "Namespace",
+        "multi": false,
+        "name": "namespace",
+        "options": [],
+        "query": {
+          "query": "label_values(jvm_memory_used_bytes{application=\"$application\",cluster=~\"$cluster\"},namespace)",
+          "refId": "Prometheus-namespace-Variable-Query"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 5,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allFormat": "glob",
+        "allValue": null,
+        "datasource": "${prometheus}",
         "definition": "",
         "hide": 0,
         "includeAll": false,
@@ -4620,11 +4700,11 @@
         "multiFormat": "glob",
         "name": "pod",
         "options": [],
-        "query": "label_values(jvm_memory_used_bytes{application=\"$application\"}, pod)",
+        "query": "label_values(jvm_memory_used_bytes{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\"}, pod)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
-        "sort": 0,
+        "sort": 5,
         "tagValuesQuery": "",
         "tags": [],
         "tagsQuery": "",
@@ -4639,16 +4719,16 @@
           "text": "All",
           "value": "$__all"
         },
-        "datasource": "Prometheus",
+        "datasource": "${prometheus}",
         "definition": "",
-        "hide": 0,
+        "hide": 2,
         "includeAll": true,
         "label": "JVM Memory Pools Heap",
         "multi": false,
         "multiFormat": "glob",
         "name": "jvm_memory_pool_heap",
         "options": [],
-        "query": "label_values(jvm_memory_used_bytes{application=\"$application\", pod=\"$pod\", area=\"heap\"},id)",
+        "query": "label_values(jvm_memory_used_bytes{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\", area=\"heap\"},id)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -4667,16 +4747,16 @@
           "text": "All",
           "value": "$__all"
         },
-        "datasource": "Prometheus",
+        "datasource": "${prometheus}",
         "definition": "",
-        "hide": 0,
+        "hide": 2,
         "includeAll": true,
         "label": "JVM Memory Pools Non-Heap",
         "multi": false,
         "multiFormat": "glob",
         "name": "jvm_memory_pool_nonheap",
         "options": [],
-        "query": "label_values(jvm_memory_used_bytes{application=\"$application\", pod=\"$pod\", area=\"nonheap\"},id)",
+        "query": "label_values(jvm_memory_used_bytes{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\", area=\"nonheap\"},id)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -4690,7 +4770,7 @@
     ]
   },
   "time": {
-    "from": "now-24h",
+    "from": "now-3h",
     "to": "now"
   },
   "timepicker": {

--- a/charts/hedera-mirror-common/dashboards/traefik.json
+++ b/charts/hedera-mirror-common/dashboards/traefik.json
@@ -43,7 +43,7 @@
           "rgba(237, 129, 40, 0.89)",
           "#299c46"
         ],
-        "datasource": "Prometheus",
+        "datasource": "${prometheus}",
         "format": "none",
         "gauge": {
           "maxValue": 100,
@@ -96,7 +96,7 @@
         "tableColumn": "",
         "targets": [
           {
-            "expr": "count(kube_pod_status_ready{namespace=\"$namespace\",condition=\"true\",pod=~\".*traefik.*\"})",
+            "expr": "count(kube_pod_status_ready{cluster=~\"$cluster\",namespace=\"$namespace\",condition=\"true\",pod=~\"$pod\"})",
             "format": "time_series",
             "intervalFactor": 1,
             "refId": "A"
@@ -109,7 +109,7 @@
         "valueMaps": [
           {
             "op": "=",
-            "text": "N/A",
+            "text": "0",
             "value": "null"
           }
         ],
@@ -120,7 +120,7 @@
         "bars": false,
         "dashLength": 10,
         "dashes": false,
-        "datasource": "Prometheus",
+        "datasource": "${prometheus}",
         "fill": 2,
         "fillGradient": 0,
         "gridPos": {
@@ -157,7 +157,7 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "histogram_quantile(0.$percentiles, sum(rate(traefik_entrypoint_request_duration_seconds_bucket{namespace=\"$namespace\", code=~\"2..\"}[5m])) by (le))",
+            "expr": "histogram_quantile(0.$percentiles, sum(rate(traefik_entrypoint_request_duration_seconds_bucket{cluster=~\"$cluster\",namespace=\"$namespace\",pod=~\"$pod\",code=~\"2..\"}[5m])) by (le))",
             "format": "time_series",
             "hide": false,
             "intervalFactor": 1,
@@ -211,7 +211,7 @@
         "bars": false,
         "dashLength": 10,
         "dashes": false,
-        "datasource": "Prometheus",
+        "datasource": "${prometheus}",
         "fill": 1,
         "fillGradient": 0,
         "gridPos": {
@@ -250,7 +250,7 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "histogram_quantile(0.$percentiles, sum(rate(traefik_entrypoint_request_duration_seconds_bucket{namespace=\"$namespace\",code=~\"2..\"}[5m])) by (instance, le))",
+            "expr": "histogram_quantile(0.$percentiles, sum(rate(traefik_entrypoint_request_duration_seconds_bucket{cluster=~\"$cluster\",namespace=\"$namespace\",pod=~\"$pod\",code=~\"2..\"}[5m])) by (instance, le))",
             "format": "time_series",
             "intervalFactor": 1,
             "legendFormat": "{{ instance }}",
@@ -317,7 +317,7 @@
         "bars": false,
         "dashLength": 10,
         "dashes": false,
-        "datasource": "Prometheus",
+        "datasource": "${prometheus}",
         "decimals": 1,
         "fill": 7,
         "fillGradient": 0,
@@ -360,7 +360,7 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "sum(traefik_entrypoint_open_connections{namespace=\"$namespace\"}) by (entrypoint)",
+            "expr": "sum(traefik_entrypoint_open_connections{cluster=~\"$cluster\",namespace=\"$namespace\",pod=~\"$pod\"}) by (entrypoint)",
             "format": "time_series",
             "intervalFactor": 1,
             "legendFormat": "{{ entrypoint }}",
@@ -415,7 +415,7 @@
         "bars": false,
         "dashLength": 10,
         "dashes": false,
-        "datasource": "Prometheus",
+        "datasource": "${prometheus}",
         "fill": 1,
         "fillGradient": 0,
         "gridPos": {
@@ -454,7 +454,7 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "(sum(rate(traefik_entrypoint_request_duration_seconds_bucket{namespace=\"$namespace\",le=\"0.1\",code=\"200\"}[5m])) by (job) + sum(rate(traefik_entrypoint_request_duration_seconds_bucket{namespace=\"$namespace\",le=\"0.3\",code=\"200\"}[5m])) by (job)) / 2 / sum(rate(traefik_entrypoint_request_duration_seconds_count{namespace=\"$namespace\",code=\"200\"}[5m])) by (job)",
+            "expr": "(sum(rate(traefik_entrypoint_request_duration_seconds_bucket{cluster=~\"$cluster\",namespace=\"$namespace\",pod=~\"$pod\",le=\"0.1\",code=\"200\"}[5m])) by (job) + sum(rate(traefik_entrypoint_request_duration_seconds_bucket{cluster=~\"$cluster\",namespace=\"$namespace\",pod=~\"$pod\",le=\"0.3\",code=\"200\"}[5m])) by (job)) / 2 / sum(rate(traefik_entrypoint_request_duration_seconds_count{cluster=~\"$cluster\",namespace=\"$namespace\",pod=~\"$pod\",code=\"200\"}[5m])) by (job)",
             "format": "time_series",
             "intervalFactor": 1,
             "legendFormat": "Code 200",
@@ -507,7 +507,7 @@
         "bars": false,
         "dashLength": 10,
         "dashes": false,
-        "datasource": "Prometheus",
+        "datasource": "${prometheus}",
         "decimals": 1,
         "fill": 1,
         "fillGradient": 0,
@@ -550,7 +550,7 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "sum(rate(traefik_entrypoint_requests_total{namespace=\"$namespace\"}[1m])) by (entrypoint)",
+            "expr": "sum(rate(traefik_entrypoint_requests_total{cluster=~\"$cluster\",namespace=\"$namespace\",pod=~\"$pod\"}[1m])) by (entrypoint)",
             "format": "time_series",
             "intervalFactor": 2,
             "legendFormat": "{{ entrypoint }}",
@@ -617,7 +617,7 @@
         "bars": false,
         "dashLength": 10,
         "dashes": false,
-        "datasource": "Prometheus",
+        "datasource": "${prometheus}",
         "fill": 7,
         "fillGradient": 0,
         "gridPos": {
@@ -658,7 +658,7 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "sum(traefik_service_open_connections{namespace=\"$namespace\"}) by (method)",
+            "expr": "sum(traefik_service_open_connections{cluster=~\"$cluster\",namespace=\"$namespace\",pod=~\"$pod\"}) by (method)",
             "format": "time_series",
             "intervalFactor": 1,
             "legendFormat": "{{ method }}",
@@ -711,7 +711,7 @@
         "bars": false,
         "dashLength": 10,
         "dashes": false,
-        "datasource": "Prometheus",
+        "datasource": "${prometheus}",
         "fill": 1,
         "fillGradient": 0,
         "gridPos": {
@@ -750,7 +750,7 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "(sum(rate(traefik_service_request_duration_seconds_bucket{namespace=\"$namespace\",le=\"0.1\",code=\"200\"}[5m])) by (job) + sum(rate(traefik_service_request_duration_seconds_bucket{namespace=\"$namespace\",le=\"0.3\",code=\"200\"}[5m])) by (job)) / 2 / sum(rate(traefik_service_request_duration_seconds_count{namespace=\"$namespace\",code=\"200\"}[5m])) by (job)",
+            "expr": "(sum(rate(traefik_service_request_duration_seconds_bucket{cluster=~\"$cluster\",namespace=\"$namespace\",pod=~\"$pod\",le=\"0.1\",code=\"200\"}[5m])) by (job) + sum(rate(traefik_service_request_duration_seconds_bucket{cluster=~\"$cluster\",namespace=\"$namespace\",pod=~\"$pod\",le=\"0.3\",code=\"200\"}[5m])) by (job)) / 2 / sum(rate(traefik_service_request_duration_seconds_count{cluster=~\"$cluster\",namespace=\"$namespace\",pod=~\"$pod\",code=\"200\"}[5m])) by (job)",
             "format": "time_series",
             "intervalFactor": 1,
             "legendFormat": "Code 200",
@@ -803,7 +803,7 @@
         "bars": false,
         "dashLength": 10,
         "dashes": false,
-        "datasource": "Prometheus",
+        "datasource": "${prometheus}",
         "fill": 1,
         "fillGradient": 0,
         "gridPos": {
@@ -844,7 +844,7 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "sum(rate(traefik_service_requests_total{namespace=\"$namespace\"}[1m])) by (service)",
+            "expr": "sum(rate(traefik_service_requests_total{cluster=~\"$cluster\",namespace=\"$namespace\",pod=~\"$pod\"}[1m])) by (service)",
             "format": "time_series",
             "intervalFactor": 2,
             "legendFormat": "{{ service }}",
@@ -911,7 +911,7 @@
         "bars": true,
         "dashLength": 10,
         "dashes": false,
-        "datasource": "Prometheus",
+        "datasource": "${prometheus}",
         "decimals": 1,
         "fill": 1,
         "fillGradient": 0,
@@ -953,7 +953,7 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "sum(rate(traefik_service_requests_total{namespace=\"$namespace\"}[5m])) by (method, code)",
+            "expr": "sum(rate(traefik_service_requests_total{cluster=~\"$cluster\",namespace=\"$namespace\",pod=~\"$pod\"}[5m])) by (method, code)",
             "format": "time_series",
             "intervalFactor": 2,
             "legendFormat": "{{method}} : {{code}}",
@@ -1008,7 +1008,7 @@
         "bars": true,
         "dashLength": 10,
         "dashes": false,
-        "datasource": "Prometheus",
+        "datasource": "${prometheus}",
         "decimals": 1,
         "fill": 1,
         "fillGradient": 0,
@@ -1050,7 +1050,7 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "sum(rate(traefik_service_requests_total{namespace=\"$namespace\"}[5m])) by (service, code)",
+            "expr": "sum(rate(traefik_service_requests_total{cluster=~\"$cluster\",namespace=\"$namespace\",pod=~\"$pod\"}[5m])) by (service, code)",
             "format": "time_series",
             "intervalFactor": 2,
             "legendFormat": "{{service}} ({{code}})",
@@ -1117,7 +1117,7 @@
         "bars": false,
         "dashLength": 10,
         "dashes": false,
-        "datasource": "Prometheus",
+        "datasource": "${prometheus}",
         "fill": 1,
         "fillGradient": 0,
         "gridPos": {
@@ -1156,21 +1156,21 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "sum(container_memory_usage_bytes{namespace=\"$namespace\", container=~\".*traefik\"})",
+            "expr": "sum(container_memory_usage_bytes{cluster=~\"$cluster\",namespace=\"$namespace\",pod=~\"$pod\"})",
             "format": "time_series",
             "intervalFactor": 1,
             "legendFormat": "Memory used",
             "refId": "A"
           },
           {
-            "expr": "sum(kube_pod_container_resource_requests_memory_bytes{namespace=\"$namespace\", container=~\".*traefik\"})",
+            "expr": "sum(kube_pod_container_resource_requests{cluster=~\"$cluster\",namespace=\"$namespace\",pod=~\"$pod\",unit=\"byte\"})",
             "format": "time_series",
             "intervalFactor": 1,
             "legendFormat": "Requested memory",
             "refId": "B"
           },
           {
-            "expr": "sum(kube_pod_container_resource_limits_memory_bytes{namespace=\"$namespace\", container=~\".*traefik\"})",
+            "expr": "sum(kube_pod_container_resource_limits{cluster=~\"$cluster\",namespace=\"$namespace\",pod=~\"$pod\",unit=\"byte\"})",
             "format": "time_series",
             "intervalFactor": 1,
             "legendFormat": "Limit memory usage",
@@ -1223,7 +1223,7 @@
         "bars": false,
         "dashLength": 10,
         "dashes": false,
-        "datasource": "Prometheus",
+        "datasource": "${prometheus}",
         "fill": 1,
         "fillGradient": 0,
         "gridPos": {
@@ -1261,21 +1261,21 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", container=~\".*traefik\"}[2m]))",
+            "expr": "sum(rate(container_cpu_usage_seconds_total{cluster=~\"$cluster\",namespace=\"$namespace\",pod=~\"$pod\"}[2m]))",
             "format": "time_series",
             "intervalFactor": 1,
             "legendFormat": "Cpu used",
             "refId": "A"
           },
           {
-            "expr": "sum(kube_pod_container_resource_requests_cpu_cores{namespace=\"$namespace\", container=~\".*traefik\"})",
+            "expr": "sum(kube_pod_container_resource_requests{cluster=~\"$cluster\",namespace=\"$namespace\",pod=~\"$pod\",unit=\"core\"})",
             "format": "time_series",
             "intervalFactor": 1,
             "legendFormat": "Requested cpu",
             "refId": "B"
           },
           {
-            "expr": "sum(kube_pod_container_resource_limits_cpu_cores{namespace=\"$namespace\", container=~\".*traefik\"})",
+            "expr": "sum(kube_pod_container_resource_limits{cluster=~\"$cluster\",namespace=\"$namespace\",pod=~\"$pod\",unit=\"core\"})",
             "format": "time_series",
             "intervalFactor": 1,
             "legendFormat": "Limit cpu usage",
@@ -1322,6 +1322,131 @@
           "align": false,
           "alignLevel": null
         }
+      },
+      {
+        "collapsed": false,
+        "datasource": null,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 80
+        },
+        "id": 38,
+        "panels": [],
+        "title": "Logs",
+        "type": "row"
+      },
+      {
+        "datasource": "${loki}",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 9,
+          "w": 24,
+          "x": 0,
+          "y": 81
+        },
+        "id": 40,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "single"
+          }
+        },
+        "targets": [
+          {
+            "expr": "sum(rate({cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[5m]))",
+            "instant": false,
+            "legendFormat": " all",
+            "queryType": "randomWalk",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Rate",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "${loki}",
+        "gridPos": {
+          "h": 8,
+          "w": 24,
+          "x": 0,
+          "y": 90
+        },
+        "id": 42,
+        "options": {
+          "dedupStrategy": "none",
+          "enableLogDetails": true,
+          "prettifyLogMessage": false,
+          "showCommonLabels": false,
+          "showLabels": false,
+          "showTime": false,
+          "sortOrder": "Descending",
+          "wrapLogMessage": false
+        },
+        "targets": [
+          {
+            "expr": "{cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}",
+            "legendFormat": "",
+            "refId": "A"
+          }
+        ],
+        "title": "Messages",
+        "type": "logs"
       }
     ],
     "schemaVersion": 22,
@@ -1331,27 +1456,136 @@
     ],
     "templating": {
       "list": [
+
         {
-          "allValue": null,
           "current": {
-            "text": "default",
-            "value": "default"
+            "selected": true,
+            "text": "Loki",
+            "value": "Loki"
           },
-          "datasource": "Prometheus",
-          "definition": "",
-          "hide": 0,
+          "description": "Name of the Loki datasource to use",
+          "error": null,
+          "hide": 2,
           "includeAll": false,
-          "label": null,
+          "label": "Loki",
           "multi": false,
-          "name": "namespace",
+          "name": "loki",
           "options": [],
-          "query": "label_values(traefik_config_reloads_total, namespace)",
+          "query": "loki",
+          "queryValue": "",
           "refresh": 1,
           "regex": "",
           "skipUrlSync": false,
-          "sort": 0,
+          "type": "datasource"
+        },
+        {
+          "current": {
+            "selected": false,
+            "text": "Prometheus",
+            "value": "Prometheus"
+          },
+          "description": "Name of the Prometheus datasource to use",
+          "error": null,
+          "hide": 0,
+          "includeAll": false,
+          "label": "Prometheus",
+          "multi": false,
+          "name": "prometheus",
+          "options": [],
+          "query": "prometheus",
+          "queryValue": "",
+          "refresh": 1,
+          "regex": "",
+          "skipUrlSync": false,
+          "type": "datasource"
+        },
+        {
+          "allValue": null,
+          "current": {
+            "selected": true,
+            "text": [
+              "All"
+            ],
+            "value": [
+              "$__all"
+            ]
+          },
+          "datasource": "${prometheus}",
+          "definition": "label_values(traefik_config_reloads_total, cluster)",
+          "description": "Kubernetes cluster",
+          "error": null,
+          "hide": 0,
+          "includeAll": true,
+          "label": "Cluster",
+          "multi": true,
+          "name": "cluster",
+          "options": [],
+          "query": {
+            "query": "label_values(traefik_config_reloads_total, cluster)",
+            "refId": "StandardVariableQuery"
+          },
+          "refresh": 1,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 5,
+          "type": "query"
+        },
+        {
+          "allValue": null,
+          "current": {
+            "selected": true,
+            "text": [
+              "All"
+            ],
+            "value": [
+              "$__all"
+            ]
+          },
+          "datasource": "${prometheus}",
+          "definition": "",
+          "hide": 0,
+          "includeAll": true,
+          "label": "Namespace",
+          "multi": true,
+          "name": "namespace",
+          "options": [],
+          "query": "label_values(traefik_config_reloads_total{cluster=~\"$cluster\"}, namespace)",
+          "refresh": 1,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 5,
           "tagValuesQuery": "",
           "tags": [],
+          "tagsQuery": "",
+          "type": "query",
+          "useTags": false
+        },
+        {
+          "allValue": null,
+          "current": {
+            "selected": true,
+            "text": "All",
+            "value": "$__all"
+          },
+          "datasource": "${prometheus}",
+          "definition": "label_values(traefik_config_reloads_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}, pod)",
+          "description": null,
+          "error": null,
+          "hide": 0,
+          "includeAll": true,
+          "label": "Pod",
+          "multi": false,
+          "name": "pod",
+          "options": [],
+          "query": {
+            "query": "label_values(traefik_config_reloads_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}, pod)",
+            "refId": "Prometheus-pod-Variable-Query"
+          },
+          "refresh": 2,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 5,
+          "tagValuesQuery": "",
           "tagsQuery": "",
           "type": "query",
           "useTags": false
@@ -1387,7 +1621,7 @@
       ]
     },
     "time": {
-      "from": "now-30m",
+      "from": "now-3h",
       "to": "now"
     },
     "timepicker": {

--- a/charts/hedera-mirror-common/templates/NOTES.txt
+++ b/charts/hedera-mirror-common/templates/NOTES.txt
@@ -3,9 +3,4 @@ Hedera Mirror Node {{ .Chart.AppVersion }} successfully installed.
 {{ if .Values.traefik.enabled -}}
 To get the load balancer IP:
   export SERVICE_IP=$(kubectl get svc -n {{ include "hedera-mirror-common.namespace" . }} {{ printf "%s-traefik" .Release.Name }} -o jsonpath="{.status.loadBalancer.ingress[0].ip}")
-
-{{ if and .Values.prometheus.enabled .Values.prometheus.grafana.enabled -}}
-To view the Grafana dashboard:
-  open "http://${SERVICE_IP}:{{ .Values.traefik.ports.web.exposedPort }}/grafana"
-{{- end -}}
 {{- end -}}

--- a/charts/hedera-mirror-common/values.yaml
+++ b/charts/hedera-mirror-common/values.yaml
@@ -258,7 +258,7 @@ prometheus:
     additionalPodMonitors:
       - name: traefik
         podMetricsEndpoints:
-          - port: traefik
+          - port: metrics
             path: /metrics
             interval: 15s
         selector:
@@ -317,7 +317,6 @@ traefik:
   additionalArguments:
     - "--accesslog=true"
     - "--entrypoints.websecure.http.tls=true"
-    - "--metrics.prometheus=true"
   affinity:
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:

--- a/charts/hedera-mirror-grpc/templates/poddisruptionbudget.yaml
+++ b/charts/hedera-mirror-grpc/templates/poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podDisruptionBudget.enabled -}}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels: {{ include "hedera-mirror-grpc.labels" . | nindent 4 }}

--- a/charts/hedera-mirror-grpc/values.yaml
+++ b/charts/hedera-mirror-grpc/values.yaml
@@ -211,7 +211,7 @@ prometheusRules:
       description: "No gRPC API instances are currently running in {{ $labels.namespace }}"
       summary: No gRPC API instances running
     enabled: true
-    expr: sum(kube_pod_container_status_ready{container="grpc"}) by (namespace) < 1
+    expr: sum(kube_pod_status_ready{pod=~".*-grpc-.*",condition="true"}) by (namespace) < 1
     for: 2m
     labels:
       severity: critical

--- a/charts/hedera-mirror-importer/templates/poddisruptionbudget.yaml
+++ b/charts/hedera-mirror-importer/templates/poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podDisruptionBudget.enabled -}}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels: {{ include "hedera-mirror-importer.labels" . | nindent 4 }}

--- a/charts/hedera-mirror-importer/values.yaml
+++ b/charts/hedera-mirror-importer/values.yaml
@@ -325,7 +325,7 @@ prometheusRules:
       description: "No importer instances are currently ready in {{ $labels.namespace }}"
       summary: No importer instances are ready
     enabled: true
-    expr: sum(kube_pod_container_status_ready{container="importer"}) by (namespace) < 1
+    expr: sum(kube_pod_status_ready{pod=~".*-importer-.*",condition="true"}) by (namespace) < 1
     for: 2m
     labels:
       severity: critical

--- a/charts/hedera-mirror-monitor/values.yaml
+++ b/charts/hedera-mirror-monitor/values.yaml
@@ -25,19 +25,6 @@ alertmanager:
             - namespace
             - pod
 
-    InhibitLogAlertWhenHighPublishErrors:
-      enabled: true
-      matches:
-        - sourceMatch:
-            - name: alertname
-              value: MonitorPublishErrors
-          targetMatch:
-            - name: alertname
-              value: MonitorLog4j2Errors
-          equal:
-            - namespace
-            - pod
-
     InhibitAllWhenPodIssues:
       enabled: true
       matches:
@@ -174,7 +161,7 @@ prometheusRules:
       description: "No monitor instances are currently running in {{ $labels.namespace }}"
       summary: No monitor instances running
     enabled: true
-    expr: sum(kube_pod_container_status_ready{container="monitor"}) by (namespace) < 1
+    expr: sum(kube_pod_status_ready{pod=~".*-monitor-.*",condition="true"}) by (namespace) < 1
     for: 2m
     labels:
       severity: critical

--- a/charts/hedera-mirror-rest/templates/poddisruptionbudget.yaml
+++ b/charts/hedera-mirror-rest/templates/poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podDisruptionBudget.enabled -}}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels: {{ include "hedera-mirror-rest.labels" . | nindent 4 }}

--- a/charts/hedera-mirror-rest/values.yaml
+++ b/charts/hedera-mirror-rest/values.yaml
@@ -142,7 +142,7 @@ prometheusRules:
       description: "No REST API instances are currently running in {{ $labels.namespace }}"
       summary: No REST API instances running
     enabled: true
-    expr: sum(kube_pod_container_status_ready{container="rest"}) by (namespace) < 1
+    expr: sum(kube_pod_status_ready{pod=~".*-rest-.*",condition="true"}) by (namespace) < 1
     for: 2m
     labels:
       severity: critical

--- a/charts/hedera-mirror/Chart.yaml
+++ b/charts/hedera-mirror/Chart.yaml
@@ -22,11 +22,11 @@ dependencies:
     condition: postgresql.enabled
     name: postgresql-ha
     repository: https://charts.bitnami.com/bitnami
-    version: 7.7.0
+    version: 7.9.2
   - condition: redis.enabled
     name: redis
     repository: https://charts.bitnami.com/bitnami
-    version: 14.4.0
+    version: 15.3.1
   - alias: rest
     condition: rest.enabled
     name: hedera-mirror-rest

--- a/charts/hedera-mirror/templates/application.yaml
+++ b/charts/hedera-mirror/templates/application.yaml
@@ -20,7 +20,7 @@ spec:
       kind: Deployment
     - group: v1
       kind: Pod
-    - group: policy/v1beta1
+    - group: policy/v1
       kind: PodDisruptionBudget
     - group: v1
       kind: Secret

--- a/charts/hedera-mirror/values.yaml
+++ b/charts/hedera-mirror/values.yaml
@@ -181,7 +181,7 @@ postgresql:
     debug: true
   postgresqlImage:
     debug: true
-    tag: 13.3.0-debian-10-r11
+    tag: 13.4.0-debian-10-r22
   postgresql:
     existingSecret: mirror-passwords
     extraEnvVarsSecret: mirror-passwords
@@ -302,7 +302,7 @@ timescaledb:
   enabled: false
   image:
     pullPolicy: IfNotPresent
-    tag: pg13.3-ts2.3.1-p1
+    tag: pg13.4-ts2.4.1-latest
   loadBalancer:
     enabled: false
   patroni:
@@ -337,7 +337,7 @@ timescaledb:
     image:
       pullPolicy: IfNotPresent
       repository: quay.io/prometheuscommunity/postgres-exporter
-      tag: v0.9.0
+      tag: v0.10.0
   replicaCount: 1
   resources:
     limits:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 version: "3.7"
 services:
   db:
-    image: postgres:13.3-alpine # Or timescale/timescaledb-ha:pg13.3-ts2.3.1-p1
+    image: postgres:13.3-alpine # Or timescale/timescaledb-ha:pg13-latest
     restart: unless-stopped
     stop_grace_period: 2m
     stop_signal: SIGTERM

--- a/hedera-mirror-grpc/src/test/resources/config/bootstrap-v2.yml
+++ b/hedera-mirror-grpc/src/test/resources/config/bootstrap-v2.yml
@@ -1,6 +1,6 @@
 embedded:
   postgresql:
-    docker-image: timescale/timescaledb-ha:pg13.3-ts2.3.1-p1
+    docker-image: timescale/timescaledb-ha:pg13.4-ts2.4.1-latest
 spring:
   flyway:
     baselineVersion: 1.999.999

--- a/hedera-mirror-importer/src/test/resources/config/bootstrap-v2.yml
+++ b/hedera-mirror-importer/src/test/resources/config/bootstrap-v2.yml
@@ -1,3 +1,3 @@
 embedded:
   postgresql:
-    docker-image: timescale/timescaledb-ha:pg13.3-ts2.3.1-p1
+    docker-image: timescale/timescaledb-ha:pg13.4-ts2.4.1-latest

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishException.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishException.java
@@ -20,7 +20,12 @@ package com.hedera.mirror.monitor.publish;
  * ‍
  */
 
+import com.google.common.base.Throwables;
+import io.grpc.StatusRuntimeException;
 import lombok.Getter;
+
+import com.hedera.hashgraph.sdk.PrecheckStatusException;
+import com.hedera.hashgraph.sdk.ReceiptStatusException;
 
 @Getter
 public class PublishException extends RuntimeException {
@@ -31,5 +36,22 @@ public class PublishException extends RuntimeException {
     public PublishException(PublishRequest publishRequest, Throwable throwable) {
         super(throwable);
         this.publishRequest = publishRequest;
+    }
+
+    public String getStatus() {
+        Throwable throwable = Throwables.getRootCause(this);
+
+        if (throwable instanceof PrecheckStatusException) {
+            PrecheckStatusException pse = (PrecheckStatusException) throwable;
+            return pse.status.toString();
+        } else if (throwable instanceof ReceiptStatusException) {
+            ReceiptStatusException rse = (ReceiptStatusException) throwable;
+            return rse.receipt.status.toString();
+        } else if (throwable instanceof StatusRuntimeException) {
+            StatusRuntimeException sre = (StatusRuntimeException) throwable;
+            return sre.getStatus().getCode().toString();
+        } else {
+            return throwable.getClass().getSimpleName();
+        }
     }
 }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishScenario.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishScenario.java
@@ -43,4 +43,14 @@ public class PublishScenario extends AbstractScenario<PublishScenarioProperties,
     public ScenarioProtocol getProtocol() {
         return ScenarioProtocol.GRPC;
     }
+
+    @Override
+    public void onError(Throwable throwable) {
+        if (throwable instanceof PublishException) {
+            PublishException publishException = (PublishException) throwable;
+            errors.add(publishException.getStatus());
+        } else {
+            super.onError(throwable);
+        }
+    }
 }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/TransactionPublisher.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/TransactionPublisher.java
@@ -94,9 +94,9 @@ public class TransactionPublisher implements AutoCloseable {
                             }
                         })
                         .timeout(properties.getTimeout())
+                        .onErrorMap(t -> new PublishException(request, t))
                         .doOnNext(scenario::onNext)
-                        .doOnError(scenario::onError)
-                        .onErrorMap(t -> new PublishException(request, t)));
+                        .doOnError(scenario::onError));
     }
 
     private Mono<TransactionResponse> getTransactionResponse(PublishRequest request, Client client) {

--- a/hedera-mirror-rest/__tests__/integrationDbOps.js
+++ b/hedera-mirror-rest/__tests__/integrationDbOps.js
@@ -54,7 +54,7 @@ const v1SchemaConfigs = {
 const v2SchemaConfigs = {
   docker: {
     imageName: 'timescale/timescaledb-ha',
-    tagName: 'pg13.3-ts2.3.1-p1',
+    tagName: 'pg13.4-ts2.4.1-latest',
   },
   flyway: {
     baselineVersion: '1.999.999',


### PR DESCRIPTION
**Description**:
- Add cluster drop down to relevant dashboards with a default of all
- Add a datasource drop down to relevant dashboards
- Add an alerts graph by name over time to AlertManager graph
- Add log graph and messages to Traefik dashboard
- Bump chart dependencies and image tags
- Change deprecated `policy/v1beta1` to `policy/v1`
- Fix chart install directions in README
- Fix monitor status logs not showing the same errors as metrics
- Fix various issues with the dashboards
- Remove `InhibitLogAlertWhenHighPublishErrors` alert

**Related issue(s)**:

Fixes #2427 

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
