### PR TITLE
Handle inner ReadTimeoutException during acceptance tests

### DIFF
--- a/hedera-mirror-test/README.md
+++ b/hedera-mirror-test/README.md
@@ -77,6 +77,11 @@ under `hedera.mirror.test.acceptance` include:
   nodes. Populating `hedera.mirror.test.acceptance.nodes` will take priority over this.
 - `sdkProperties`
   - `maxAttempts` - The maximum number of times the sdk should try to submit a transaction to the network.
+- `webclient`
+  - `connectionTimeout` - The timeout duration to wait to establish a connection with the server
+  - `readTimeout` - The timeout duration to wait for data to be read.
+  - `wiretap` - Whether a wire logger configuration should be applied to connection calls.
+  - `writeTimeout` - The timeout duration to wait for data to be written.
 
 (Recommended) Options can be set by creating your own configuration file with the above properties. This allows for
 multiple files per env. The following command will help to point out which file to use:

--- a/hedera-mirror-test/README.md
+++ b/hedera-mirror-test/README.md
@@ -123,11 +123,11 @@ tag are run. To run a different set of files different tags can be specified
 
 Test Suite Tags
 
-- `@critical` - Test cases to ensure the network is up and running and satisfies base scenarios. Total cost to run 31.6
+- `@critical` - Test cases to ensure the network is up and running and satisfies base scenarios. Total cost to run 6.5
   ℏ.
 - `@release` - Test cases to verify a new deployed version satisfies core scenarios and is release worthy. Total cost to
   run 19.2 ℏ.
-- `@acceptance` - Test cases to verify most feature scenarios meet customer acceptance criteria. Total cost to run 6.5
+- `@acceptance` - Test cases to verify most feature scenarios meet customer acceptance criteria. Total cost to run 31.6
   ℏ.
 - `@fullsuite` - All cases - this will require some configuration of feature files and may include some disabled tests
   that will fail on execution. Total cost to run 33.9 ℏ.

--- a/hedera-mirror-test/README.md
+++ b/hedera-mirror-test/README.md
@@ -73,6 +73,7 @@ under `hedera.mirror.test.acceptance` include:
   - `maxAttempts` - The maximum number of attempts when calling a REST API endpoint and receiving a 404.
   - `maxBackoff` - The maximum backoff duration the mirror grpc subscriber will wait between attempts.
   - `minBackoff` - The minimum backoff duration the mirror grpc subscriber will wait between attempts.
+  - `retryableExceptions` - List of retryable exception class types
 - `retrieveAddressBook` - Whether to download the address book from the network and use those nodes over the default
   nodes. Populating `hedera.mirror.test.acceptance.nodes` will take priority over this.
 - `sdkProperties`

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AccountClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AccountClient.java
@@ -114,7 +114,7 @@ public class AccountClient extends AbstractNetworkClient {
                 .setTransactionMemo("transfer test");
     }
 
-    public TransactionReceipt sendCryptoTransfer(AccountId recipient, Hbar hbarAmount) {
+    public NetworkTransactionResponse sendCryptoTransfer(AccountId recipient, Hbar hbarAmount) {
         log.debug(
                 "Send CryptoTransfer of {} tℏ from {} to {}", hbarAmount.toTinybars(),
                 sdkClient.getExpandedOperatorAccountId().getAccountId(),
@@ -123,12 +123,12 @@ public class AccountClient extends AbstractNetworkClient {
         TransferTransaction cryptoTransferTransaction = getCryptoTransferTransaction(sdkClient
                 .getExpandedOperatorAccountId().getAccountId(), recipient, hbarAmount);
 
-        TransactionReceipt transactionReceipt = executeTransactionAndRetrieveReceipt(cryptoTransferTransaction)
-                .getReceipt();
+        NetworkTransactionResponse networkTransactionResponse =
+                executeTransactionAndRetrieveReceipt(cryptoTransferTransaction);
 
         log.debug("Sent CryptoTransfer");
 
-        return transactionReceipt;
+        return networkTransactionResponse;
     }
 
     public AccountCreateTransaction getAccountCreateTransaction(Hbar initialBalance, KeyList publicKeys,

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AccountClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AccountClient.java
@@ -101,7 +101,7 @@ public class AccountClient extends AbstractNetworkClient {
                 .execute(client)
                 .hbars;
 
-        log.debug("{} balance is {}", accountId, balance);
+        log.info("{} balance is {}", accountId, balance);
 
         return balance.toTinybars();
     }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/MirrorNodeClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/MirrorNodeClient.java
@@ -27,7 +27,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import javax.inject.Named;
 import lombok.extern.log4j.Log4j2;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -180,7 +179,6 @@ public class MirrorNodeClient extends AbstractNetworkClient {
                 t instanceof ReadTimeoutException ||
                 t.getCause() instanceof ReadTimeoutException ||
                 t instanceof TimeoutException ||
-                (t instanceof WebClientResponseException &&
-                        ((WebClientResponseException) t).getStatusCode() == HttpStatus.NOT_FOUND);
+                t instanceof WebClientResponseException;
     }
 }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/MirrorNodeClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/MirrorNodeClient.java
@@ -21,7 +21,7 @@ package com.hedera.mirror.test.e2e.acceptance.client;
  */
 
 import com.google.common.base.Stopwatch;
-import io.grpc.netty.shaded.io.netty.handler.timeout.ReadTimeoutException;
+import io.netty.handler.timeout.ReadTimeoutException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -178,6 +178,7 @@ public class MirrorNodeClient extends AbstractNetworkClient {
     protected boolean shouldRetryRestCall(Throwable t) {
         return t instanceof PrematureCloseException ||
                 t instanceof ReadTimeoutException ||
+                t.getCause() instanceof ReadTimeoutException ||
                 t instanceof TimeoutException ||
                 (t instanceof WebClientResponseException &&
                         ((WebClientResponseException) t).getStatusCode() == HttpStatus.NOT_FOUND);

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/MirrorNodeClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/MirrorNodeClient.java
@@ -21,17 +21,14 @@ package com.hedera.mirror.test.e2e.acceptance.client;
  */
 
 import com.google.common.base.Stopwatch;
-import io.netty.handler.timeout.ReadTimeoutException;
+import com.google.common.base.Throwables;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import javax.inject.Named;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.MediaType;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.web.reactive.function.client.WebClient;
-import org.springframework.web.reactive.function.client.WebClientResponseException;
-import reactor.netty.http.client.PrematureCloseException;
 import reactor.util.retry.Retry;
 import reactor.util.retry.RetryBackoffSpec;
 
@@ -175,10 +172,8 @@ public class MirrorNodeClient extends AbstractNetworkClient {
     }
 
     protected boolean shouldRetryRestCall(Throwable t) {
-        return t instanceof PrematureCloseException ||
-                t instanceof ReadTimeoutException ||
-                t.getCause() instanceof ReadTimeoutException ||
-                t instanceof TimeoutException ||
-                t instanceof WebClientResponseException;
+        return sdkClient.getAcceptanceTestProperties().getRestPollingProperties().getRetryableExceptions()
+                .stream()
+                .anyMatch(ex -> ex.isInstance(t) || ex.isInstance(Throwables.getRootCause(t)));
     }
 }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
@@ -75,6 +75,8 @@ public class AcceptanceTestProperties {
 
     private final SdkProperties sdkProperties;
 
+    private final WebClientProperties webClientProperties;
+
     public Set<NodeProperties> getNodes() {
         if (network == HederaNetwork.OTHER && nodes.isEmpty()) {
             throw new IllegalArgumentException("nodes must not be empty");

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/ClientConfiguration.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/ClientConfiguration.java
@@ -81,13 +81,13 @@ class ClientConfiguration {
         HttpClient httpClient = HttpClient.create()
                 .option(
                         ChannelOption.CONNECT_TIMEOUT_MILLIS,
-                        acceptanceTestProperties.getWebClientProperties().getConnectTimeoutMillis())
+                        (int) acceptanceTestProperties.getWebClientProperties().getConnectionTimeout().toMillis())
                 .doOnConnected(connection -> {
                     connection.addHandlerLast(new ReadTimeoutHandler(
-                            acceptanceTestProperties.getWebClientProperties().getConnectionReadTimeoutMillis(),
+                            acceptanceTestProperties.getWebClientProperties().getReadTimeout().toMillis(),
                             TimeUnit.MILLISECONDS));
                     connection.addHandlerLast(new WriteTimeoutHandler(
-                            acceptanceTestProperties.getWebClientProperties().getConnectionWriteTimeoutMillis(),
+                            acceptanceTestProperties.getWebClientProperties().getWriteTimeout().toMillis(),
                             TimeUnit.MILLISECONDS));
                 })
                 .wiretap(acceptanceTestProperties.getWebClientProperties().isWiretap()); // enable request logging

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/RestPollingProperties.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/RestPollingProperties.java
@@ -21,6 +21,7 @@ package com.hedera.mirror.test.e2e.acceptance.config;
  */
 
 import java.time.Duration;
+import java.util.Set;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
@@ -51,4 +52,6 @@ public class RestPollingProperties {
     @NotNull
     @DurationMin(millis = 100L)
     private Duration minBackoff = Duration.ofMillis(250L);
+
+    private Set<Class> retryableExceptions = Set.of(Exception.class);
 }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/RestPollingProperties.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/RestPollingProperties.java
@@ -53,5 +53,6 @@ public class RestPollingProperties {
     @DurationMin(millis = 100L)
     private Duration minBackoff = Duration.ofMillis(250L);
 
+    @NotNull
     private Set<Class> retryableExceptions = Set.of(Exception.class);
 }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/WebClientProperties.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/WebClientProperties.java
@@ -1,0 +1,48 @@
+package com.hedera.mirror.test.e2e.acceptance.config;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+@Component
+@ConfigurationProperties(prefix = "hedera.mirror.test.acceptance.webclient")
+@Data
+@Validated
+public class WebClientProperties {
+    @Min(5000)
+    @Max(60000)
+    private int connectionReadTimeoutMillis = 10000;
+
+    @Min(5000)
+    @Max(60000)
+    private int connectionWriteTimeoutMillis = 10000;
+
+    @Min(5000)
+    @Max(60000)
+    private int connectTimeoutMillis = 10000;
+
+    private boolean wiretap = false;
+}

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/WebClientProperties.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/WebClientProperties.java
@@ -20,9 +20,11 @@ package com.hedera.mirror.test.e2e.acceptance.config;
  * ‍
  */
 
-import javax.validation.constraints.Max;
-import javax.validation.constraints.Min;
+import java.time.Duration;
+import javax.validation.constraints.NotNull;
 import lombok.Data;
+import org.hibernate.validator.constraints.time.DurationMax;
+import org.hibernate.validator.constraints.time.DurationMin;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.annotation.Validated;
@@ -32,17 +34,20 @@ import org.springframework.validation.annotation.Validated;
 @Data
 @Validated
 public class WebClientProperties {
-    @Min(5000)
-    @Max(60000)
-    private int connectionReadTimeoutMillis = 10000;
+    @NotNull
+    @DurationMin(millis = 5000L)
+    @DurationMax(millis = 60000L)
+    private Duration connectionTimeout = Duration.ofSeconds(10L);
 
-    @Min(5000)
-    @Max(60000)
-    private int connectionWriteTimeoutMillis = 10000;
-
-    @Min(5000)
-    @Max(60000)
-    private int connectTimeoutMillis = 10000;
+    @NotNull
+    @DurationMin(millis = 5000L)
+    @DurationMax(millis = 10000L)
+    private Duration readTimeout = Duration.ofSeconds(10L);
 
     private boolean wiretap = false;
+
+    @NotNull
+    @DurationMin(millis = 5000L)
+    @DurationMax(millis = 10000L)
+    private Duration writeTimeout = Duration.ofSeconds(10L);
 }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/WebClientProperties.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/WebClientProperties.java
@@ -35,19 +35,19 @@ import org.springframework.validation.annotation.Validated;
 @Validated
 public class WebClientProperties {
     @NotNull
-    @DurationMin(millis = 5000L)
-    @DurationMax(millis = 60000L)
+    @DurationMin(seconds = 5L)
+    @DurationMax(seconds = 60L)
     private Duration connectionTimeout = Duration.ofSeconds(10L);
 
     @NotNull
-    @DurationMin(millis = 5000L)
-    @DurationMax(millis = 10000L)
+    @DurationMin(seconds = 5L)
+    @DurationMax(seconds = 60L)
     private Duration readTimeout = Duration.ofSeconds(10L);
 
     private boolean wiretap = false;
 
     @NotNull
-    @DurationMin(millis = 5000L)
-    @DurationMax(millis = 10000L)
+    @DurationMin(seconds = 5L)
+    @DurationMax(seconds = 60L)
     private Duration writeTimeout = Duration.ofSeconds(10L);
 }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AccountFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AccountFeature.java
@@ -60,9 +60,6 @@ public class AccountFeature {
     @When("I request balance info for this account")
     public void getAccountBalance() {
         balance = accountClient.getBalance();
-        log.info("{} account balance is {}",
-                accountClient.getSdkClient().getExpandedOperatorAccountId().getAccountId(),
-                balance);
     }
 
     @Then("the crypto balance should be greater than or equal to {long}")

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AccountFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AccountFeature.java
@@ -121,21 +121,17 @@ public class AccountFeature {
     }
 
     @Then("the mirror node REST API should return status {int} for the crypto transfer transaction")
-    public void verifyMirrorAPIResponses(int status) {
+    public void verifyMirrorAPICryptoTransferResponse(int status) {
         log.info("Verify transaction");
         String transactionId = networkTransactionResponse.getTransactionIdStringNoCheckSum();
-
         MirrorTransactionsResponse mirrorTransactionsResponse = mirrorClient.getTransactions(transactionId);
 
-        verifyCryptoTransfers(mirrorTransactionsResponse, status, transactionId);
-    }
-
-    private void verifyCryptoTransfers(MirrorTransactionsResponse mirrorTransactionsResponse, int status,
-                                       String transactionId) {
+        // verify valid set of transactions
         List<MirrorTransaction> transactions = mirrorTransactionsResponse.getTransactions();
         assertNotNull(transactions);
         assertThat(transactions).isNotEmpty();
 
+        // verify transaction details
         MirrorTransaction mirrorTransaction = transactions.get(0);
         if (status == HttpStatus.OK.value()) {
             assertThat(mirrorTransaction.getResult()).isEqualTo("SUCCESS");

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AccountFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AccountFeature.java
@@ -20,19 +20,27 @@ package com.hedera.mirror.test.e2e.acceptance.steps;
  * ‍
  */
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
+import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import io.cucumber.junit.platform.engine.Cucumber;
+import java.util.List;
 import lombok.Data;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 
 import com.hedera.hashgraph.sdk.AccountId;
 import com.hedera.hashgraph.sdk.Hbar;
-import com.hedera.hashgraph.sdk.TransactionReceipt;
 import com.hedera.mirror.test.e2e.acceptance.client.AccountClient;
+import com.hedera.mirror.test.e2e.acceptance.client.MirrorNodeClient;
+import com.hedera.mirror.test.e2e.acceptance.props.MirrorTransaction;
+import com.hedera.mirror.test.e2e.acceptance.props.MirrorTransfer;
+import com.hedera.mirror.test.e2e.acceptance.response.MirrorTransactionsResponse;
+import com.hedera.mirror.test.e2e.acceptance.response.NetworkTransactionResponse;
 
 @Log4j2
 @Cucumber
@@ -41,13 +49,20 @@ public class AccountFeature {
     private long balance;
     private AccountId accountId;
     private long startingBalance;
+    private NetworkTransactionResponse networkTransactionResponse;
 
     @Autowired
     private AccountClient accountClient;
 
+    @Autowired
+    private MirrorNodeClient mirrorClient;
+
     @When("I request balance info for this account")
     public void getAccountBalance() {
         balance = accountClient.getBalance();
+        log.info("{} account balance is {}",
+                accountClient.getSdkClient().getExpandedOperatorAccountId().getAccountId(),
+                balance);
     }
 
     @Then("the crypto balance should be greater than or equal to {long}")
@@ -61,31 +76,83 @@ public class AccountFeature {
         assertNotNull(accountId);
     }
 
+    @Given("I send {long} tℏ to {string}")
+    public void treasuryDisbursement(long amount, String accountName) {
+        accountId = accountClient
+                .getAccount(AccountClient.AccountNameEnum.valueOf(accountName)).getAccountId();
+
+        startingBalance = accountClient.getBalance(accountId);
+
+        networkTransactionResponse = accountClient
+                .sendCryptoTransfer(accountId, Hbar.fromTinybars(amount));
+        assertNotNull(networkTransactionResponse.getTransactionId());
+        assertNotNull(networkTransactionResponse.getReceipt());
+    }
+
     @When("I send {long} tℏ to newly created account")
     public void sendTinyHbars(long amount) {
         startingBalance = accountClient.getBalance(accountId);
-        TransactionReceipt receipt = accountClient.sendCryptoTransfer(accountId, Hbar.fromTinybars(amount));
-        assertNotNull(receipt);
+        networkTransactionResponse = accountClient.sendCryptoTransfer(accountId, Hbar.fromTinybars(amount));
+        assertNotNull(networkTransactionResponse.getTransactionId());
+        assertNotNull(networkTransactionResponse.getReceipt());
     }
 
     @When("I send {long} tℏ to account {int}")
     public void sendTinyHbars(long amount, int accountNum) {
         accountId = new AccountId(accountNum);
         startingBalance = accountClient.getBalance(accountId);
-        TransactionReceipt receipt = accountClient.sendCryptoTransfer(accountId, Hbar.fromTinybars(amount));
-        assertNotNull(receipt);
+        networkTransactionResponse = accountClient.sendCryptoTransfer(accountId, Hbar.fromTinybars(amount));
+        assertNotNull(networkTransactionResponse.getTransactionId());
+        assertNotNull(networkTransactionResponse.getReceipt());
     }
 
     @When("I send {int} ℏ to account {int}")
     public void sendHbars(int amount, int accountNum) {
         accountId = new AccountId(accountNum);
         startingBalance = accountClient.getBalance(accountId);
-        TransactionReceipt receipt = accountClient.sendCryptoTransfer(accountId, Hbar.from(amount));
-        assertNotNull(receipt);
+        networkTransactionResponse = accountClient.sendCryptoTransfer(accountId, Hbar.from(amount));
+        assertNotNull(networkTransactionResponse.getTransactionId());
+        assertNotNull(networkTransactionResponse.getReceipt());
     }
 
     @Then("the new balance should reflect cryptotransfer of {long}")
     public void accountReceivedFunds(long amount) {
-        assertTrue(accountClient.getBalance(accountId) >= startingBalance + amount);
+        assertThat(accountClient.getBalance(accountId)).isGreaterThanOrEqualTo(startingBalance + amount);
+    }
+
+    @Then("the mirror node REST API should return status {int} for the crypto transfer transaction")
+    public void verifyMirrorAPIResponses(int status) {
+        log.info("Verify transaction");
+        String transactionId = networkTransactionResponse.getTransactionIdStringNoCheckSum();
+
+        MirrorTransactionsResponse mirrorTransactionsResponse = mirrorClient.getTransactions(transactionId);
+
+        verifyCryptoTransfers(mirrorTransactionsResponse, status, transactionId);
+    }
+
+    private void verifyCryptoTransfers(MirrorTransactionsResponse mirrorTransactionsResponse, int status,
+                                       String transactionId) {
+        List<MirrorTransaction> transactions = mirrorTransactionsResponse.getTransactions();
+        assertNotNull(transactions);
+        assertThat(transactions).isNotEmpty();
+
+        MirrorTransaction mirrorTransaction = transactions.get(0);
+        if (status == HttpStatus.OK.value()) {
+            assertThat(mirrorTransaction.getResult()).isEqualTo("SUCCESS");
+        }
+        assertThat(mirrorTransaction.getTransactionId()).isEqualTo(transactionId);
+        assertThat(mirrorTransaction.getValidStartTimestamp())
+                .isEqualTo(networkTransactionResponse.getValidStartString());
+        assertThat(mirrorTransaction.getName()).isEqualTo("CRYPTOTRANSFER");
+
+        assertThat(mirrorTransaction.getTransfers().size()).isGreaterThanOrEqualTo(3); // network, node and transfer
+
+        //verify transfer credit and debits balance out
+        long transferSum = 0;
+        for (MirrorTransfer cryptoTransfer : mirrorTransaction.getTransfers()) {
+            transferSum += Long.valueOf(cryptoTransfer.getAmount());
+        }
+
+        assertThat(transferSum).isEqualTo(0);
     }
 }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AccountFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AccountFeature.java
@@ -153,6 +153,6 @@ public class AccountFeature {
             transferSum += Long.valueOf(cryptoTransfer.getAmount());
         }
 
-        assertThat(transferSum).isEqualTo(0);
+        assertThat(transferSum).isZero();
     }
 }

--- a/hedera-mirror-test/src/test/resources/features/account/account.feature
+++ b/hedera-mirror-test/src/test/resources/features/account/account.feature
@@ -6,8 +6,8 @@ Feature: Account Coverage Feature
         When I request balance info for this account
         Then the crypto balance should be greater than or equal to <threshold>
         Examples:
-            | threshold |
-            | 1000000   |
+            | threshold  |
+            | 1000000000 |
 
     @createcryptoaccount
     Scenario Outline: Create crypto account
@@ -16,3 +16,12 @@ Feature: Account Coverage Feature
         Examples:
             | amount    |
             | 100000000 |
+
+    @critical @release @acceptance @cryptotransfer
+    Scenario Outline: Validate simple CryptoTransfer
+        Given I send <amount> tℏ to <accountName>
+        Then the mirror node REST API should return status <httpStatusCode> for the crypto transfer transaction
+        And the new balance should reflect cryptotransfer of <amount>
+        Examples:
+            | amount | accountName | httpStatusCode |
+            | 1      | "ALICE"     | 200            |

--- a/hedera-mirror-test/src/test/resources/features/account/account.feature
+++ b/hedera-mirror-test/src/test/resources/features/account/account.feature
@@ -7,7 +7,7 @@ Feature: Account Coverage Feature
         Then the crypto balance should be greater than or equal to <threshold>
         Examples:
             | threshold  |
-            | 1000000000 |
+            | 4000000000 |
 
     @createcryptoaccount
     Scenario Outline: Create crypto account


### PR DESCRIPTION
Signed-off-by: Nana-EC <nana.essilfie-conduah@hedera.com>

**Description**:
Occasionally during runs of the acceptance tests the `@nft` tagged tests would fail with a `ReadTimeoutException`.
The retry logic failed to run since the `ReadTimeoutException` was a root cause and not the surface exception.

Retry logic will give the server and client time to manage the load from successive calls in acceptance tests that were likely causing the issue.

- Add logic to `shouldRetryRestCall()` to check if inner exception is `ReadTimeoutException`
- Add a simple crypto transfer test to `Account` flow
- Clean up `AccountClient` and `AccountFeature`
- Add `WebClientProperties` to capture configurable timeout properties for webClient.
- Update WebClient configuration removing deprecated items and swapping `TcpClient` for `HttpClient`
- Update `account.feature` threshold check value to be `10 Hbar`

**Related issue(s)**:

Fixes #2477 

**Notes for reviewer**:
Was able to partially reproduce the issue is a modified test and an lucky local run.
There's still some uncertainty as to the finite connection issue but I've confirmed the retry logic will now be employed which will facilitate great run success.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
