### PR TITLE
Revert PodDisruptionBudget change to policy/v1 (0.40) (#2515)

### DIFF
--- a/charts/hedera-mirror-grpc/templates/poddisruptionbudget.yaml
+++ b/charts/hedera-mirror-grpc/templates/poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podDisruptionBudget.enabled -}}
-apiVersion: policy/v1
+apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   labels: {{ include "hedera-mirror-grpc.labels" . | nindent 4 }}

--- a/charts/hedera-mirror-importer/templates/poddisruptionbudget.yaml
+++ b/charts/hedera-mirror-importer/templates/poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podDisruptionBudget.enabled -}}
-apiVersion: policy/v1
+apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   labels: {{ include "hedera-mirror-importer.labels" . | nindent 4 }}

--- a/charts/hedera-mirror-rest/templates/poddisruptionbudget.yaml
+++ b/charts/hedera-mirror-rest/templates/poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podDisruptionBudget.enabled -}}
-apiVersion: policy/v1
+apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   labels: {{ include "hedera-mirror-rest.labels" . | nindent 4 }}

--- a/charts/hedera-mirror/templates/application.yaml
+++ b/charts/hedera-mirror/templates/application.yaml
@@ -20,7 +20,7 @@ spec:
       kind: Deployment
     - group: v1
       kind: Pod
-    - group: policy/v1
+    - group: policy/v1beta1
       kind: PodDisruptionBudget
     - group: v1
       kind: Secret

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <grpc-spring-boot.version>2.11.0.RELEASE</grpc-spring-boot.version>
         <grpc.version>1.40.1</grpc.version>
         <guava.version>30.1.1-jre</guava.version>
-        <hedera-protobuf.version>0.18.0-alpha.3-SNAPSHOT</hedera-protobuf.version>
+        <hedera-protobuf.version>0.18.0-alpha.3</hedera-protobuf.version>
         <hedera-sdk.version>2.0.14</hedera-sdk.version>
         <jacoco.version>0.8.7</jacoco.version>
         <java.version>11</java.version>
@@ -130,19 +130,6 @@
             <version>${guava.version}</version>
         </dependency>
     </dependencies>
-
-    <repositories>
-        <repository>
-            <id>ossrh-snapshots</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
 
     <build>
         <pluginManagement>


### PR DESCRIPTION
**Description**:
Cherry pick https://github.com/hashgraph/hedera-mirror-node/pull/2515 to 0.40

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
