### PR TITLE
Fix version replace for rest packages (v0.40)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -524,7 +524,7 @@
                                     <replacements>
                                         <replacement>
                                             <token>
-                                                <![CDATA[(?<="hedera-mirror-(rest|monitor)",\s{3}"version": ")[^"]+]]></token>
+                                                <![CDATA[(?<="@hashgraph/mirror-(rest|monitor)",\s{3}"version": ")[^"]+]]></token>
                                             <value>${release.version}</value>
                                         </replacement>
                                         <replacement>


### PR DESCRIPTION
Signed-off-by: Nana-EC <nana.essilfie-conduah@hedera.com>

**Description**:
When the rest packages were changed from `hedera-mirror` to `@hashgraph` the replacement logic was broken.

- Update replace regex to use `@hashgraph`

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
Ran locally to verify replacement
**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
