### PR TITLE
Disable swagger metrics UI

### DIFF
--- a/hedera-mirror-rest/config/application.yml
+++ b/hedera-mirror-rest/config/application.yml
@@ -26,7 +26,10 @@ hedera:
         enabled: true
         config:
           authentication: true
+          durationBuckets: [ 100, 250, 500, 1000, 2500, 5000 ]
           password: password
+          requestSizeBuckets: [ 64, 256, 1024 ]
+          responseSizeBuckets: [ 512, 1024, 10240, 25600, 51200 ]
           swaggerOnly: true,
           username: metrics
           uriPath: '/swagger'

--- a/hedera-mirror-rest/middleware/openapiHandler.js
+++ b/hedera-mirror-rest/middleware/openapiHandler.js
@@ -80,9 +80,13 @@ const getV1OpenApiObject = () => {
  */
 const serveSwaggerDocs = (app) => {
   const options = {
-    explorer: true,
+    explorer: false,
     customCss:
       '.topbar-wrapper img { content:url(https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067); }',
+    swaggerOptions: {
+      operationsSorter: 'alpha',
+      tagsSorter: 'alpha',
+    },
   };
   app.use(`/api/v1/${config.openapi.swaggerUIPath}`, swaggerUi.serve, swaggerUi.setup(getV1OpenApiObject(), options));
 };


### PR DESCRIPTION
**Description**:
- Change OpenAPI docs to sort operations and tags
- Disable access to the swagger-metrics UI
- Reduce number of REST metric buckets

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
