### PR TITLE
Performance optimizations to reach 15K

### DIFF
--- a/charts/hedera-mirror-common/dashboards/alertmanager.json
+++ b/charts/hedera-mirror-common/dashboards/alertmanager.json
@@ -963,8 +963,8 @@
       {
         "current": {
           "selected": false,
-          "text": "Prometheus",
-          "value": "Prometheus"
+          "text": "",
+          "value": ""
         },
         "description": "Name of the Prometheus datasource to use",
         "error": null,
@@ -1006,7 +1006,7 @@
           "query": "label_values(ALERTS, cluster)",
           "refId": "StandardVariableQuery"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 5,
@@ -1037,7 +1037,7 @@
           "query": "label_values(ALERTS{cluster=~\"$cluster\"}, namespace)",
           "refId": "StandardVariableQuery"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 5,

--- a/charts/hedera-mirror-common/dashboards/hedera-mirror-grpc.json
+++ b/charts/hedera-mirror-common/dashboards/hedera-mirror-grpc.json
@@ -2698,8 +2698,8 @@
       {
         "current": {
           "selected": true,
-          "text": "Loki",
-          "value": "Loki"
+          "text": "",
+          "value": ""
         },
         "description": "Name of the Loki datasource to use",
         "error": null,
@@ -2719,8 +2719,8 @@
       {
         "current": {
           "selected": false,
-          "text": "Prometheus",
-          "value": "Prometheus"
+          "text": "",
+          "value": ""
         },
         "description": "Name of the Prometheus datasource to use",
         "error": null,
@@ -2762,7 +2762,7 @@
           "query": "label_values(system_cpu_count{application=\"$application\"}, cluster)",
           "refId": "StandardVariableQuery"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 5,

--- a/charts/hedera-mirror-common/dashboards/hedera-mirror-importer.json
+++ b/charts/hedera-mirror-common/dashboards/hedera-mirror-importer.json
@@ -8,6 +8,12 @@
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
         "type": "dashboard"
       }
     ]
@@ -15,8 +21,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 36,
-  "iteration": 1623864346421,
+  "id": 41,
+  "iteration": 1632265443525,
   "links": [],
   "panels": [
     {
@@ -77,7 +83,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.0.1",
+      "pluginVersion": "8.1.4",
       "targets": [
         {
           "exemplar": true,
@@ -150,7 +156,7 @@
         "orientation": "horizontal",
         "reduceOptions": {
           "calcs": [
-            "mean"
+            "lastNotNull"
           ],
           "fields": "",
           "values": false
@@ -158,7 +164,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.0.1",
+      "pluginVersion": "8.1.4",
       "targets": [
         {
           "expr": "sum(rate(hedera_mirror_transaction_latency_seconds_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval]))",
@@ -170,86 +176,6 @@
       "timeFrom": null,
       "timeShift": null,
       "title": "TPS",
-      "type": "stat"
-    },
-    {
-      "cacheTimeout": null,
-      "datasource": "${prometheus}",
-      "description": "The average number of consensus submit message transactions per second",
-      "fieldConfig": {
-        "defaults": {
-          "mappings": [
-            {
-              "options": {
-                "match": "null",
-                "result": {
-                  "color": "red",
-                  "text": "0"
-                }
-              },
-              "type": "special"
-            }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 0
-              },
-              {
-                "color": "#EAB839",
-                "value": 2
-              },
-              {
-                "color": "green",
-                "value": 4
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 3,
-        "x": 6,
-        "y": 0
-      },
-      "id": 30,
-      "links": [],
-      "options": {
-        "colorMode": "background",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "mean"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "auto"
-      },
-      "pluginVersion": "8.0.1",
-      "targets": [
-        {
-          "expr": "sum(rate(hedera_mirror_transaction_latency_seconds_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\",type=\"CONSENSUSSUBMITMESSAGE\"}[$__rate_interval]))",
-          "interval": "1m",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "HCS TPS",
       "type": "stat"
     },
     {
@@ -295,7 +221,7 @@
       "gridPos": {
         "h": 4,
         "w": 3,
-        "x": 9,
+        "x": 6,
         "y": 0
       },
       "id": 18,
@@ -307,7 +233,7 @@
         "orientation": "auto",
         "reduceOptions": {
           "calcs": [
-            "mean"
+            "lastNotNull"
           ],
           "fields": "",
           "values": false
@@ -315,7 +241,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.0.1",
+      "pluginVersion": "8.1.4",
       "targets": [
         {
           "expr": "sum(hedera_mirror_transaction_size_bytes_sum{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) / sum(hedera_mirror_transaction_size_bytes_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
@@ -332,7 +258,7 @@
     {
       "cacheTimeout": null,
       "datasource": "${prometheus}",
-      "description": "How old the last processed record file is",
+      "description": "The amount of time it took to successfully parse the record file",
       "fieldConfig": {
         "defaults": {
           "displayName": "",
@@ -357,11 +283,89 @@
               },
               {
                 "color": "orange",
-                "value": 15
+                "value": 1.5
               },
               {
                 "color": "red",
-                "value": 20
+                "value": 2
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 9,
+        "y": 0
+      },
+      "id": 30,
+      "links": [],
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.1.4",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(rate(hedera_mirror_parse_duration_seconds_sum{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\",type=~\"RECORD\",success=\"true\"}[$__rate_interval])) / sum(rate(hedera_mirror_parse_duration_seconds_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\",type=\"RECORD\",success=\"true\"}[$__rate_interval]))",
+          "interval": "1m",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Record Parse Duration",
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "${prometheus}",
+      "description": "The difference in the consensus time of the last transaction in the file and the time at which the file was processed successfully",
+      "fieldConfig": {
+        "defaults": {
+          "displayName": "",
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "color": "green",
+                  "text": "0"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 15
               }
             ]
           },
@@ -392,7 +396,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.0.1",
+      "pluginVersion": "8.1.4",
       "targets": [
         {
           "expr": "sum(rate(hedera_mirror_parse_latency_seconds_sum{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\",type=~\"RECORD\"}[$__rate_interval])) / sum(rate(hedera_mirror_parse_latency_seconds_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\",type=~\"RECORD\"}[$__rate_interval]))",
@@ -403,13 +407,13 @@
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Record File Age",
+      "title": "Record Parse Latency",
       "type": "stat"
     },
     {
       "cacheTimeout": null,
       "datasource": "${prometheus}",
-      "description": "How old the last processed balance file is",
+      "description": "Amount of time it took to successfully parse the balance file",
       "fieldConfig": {
         "defaults": {
           "mappings": [
@@ -432,11 +436,11 @@
               },
               {
                 "color": "orange",
-                "value": 900
+                "value": 15
               },
               {
                 "color": "red",
-                "value": 1800
+                "value": 60
               }
             ]
           },
@@ -467,10 +471,11 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.0.1",
+      "pluginVersion": "8.1.4",
       "targets": [
         {
-          "expr": "sum(rate(hedera_mirror_parse_latency_seconds_sum{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\",type=\"BALANCE\"}[$__rate_interval])) / sum(rate(hedera_mirror_parse_latency_seconds_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\",type=\"BALANCE\"}[$__rate_interval]))",
+          "exemplar": true,
+          "expr": "sum(rate(hedera_mirror_parse_duration_seconds_sum{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\",type=~\"BALANCE\",success=\"true\"}[$__rate_interval])) / sum(rate(hedera_mirror_parse_duration_seconds_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\",type=\"BALANCE\",success=\"true\"}[$__rate_interval]))",
           "interval": "1m",
           "legendFormat": "",
           "refId": "A"
@@ -478,7 +483,7 @@
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Balance File Age",
+      "title": "Balance Parse Duration",
       "type": "stat"
     },
     {
@@ -542,7 +547,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.0.1",
+      "pluginVersion": "8.1.4",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -552,10 +557,16 @@
       "steppedLine": false,
       "targets": [
         {
+          "expr": "sum(rate(hedera_mirror_transaction_latency_seconds_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval]))",
+          "interval": "1m",
+          "legendFormat": "Total",
+          "refId": "A"
+        },
+        {
           "expr": "sum(rate(hedera_mirror_transaction_latency_seconds_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (type)",
           "interval": "1m",
           "legendFormat": "{{ type }}",
-          "refId": "A"
+          "refId": "B"
         }
       ],
       "thresholds": [],
@@ -643,7 +654,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.0.1",
+      "pluginVersion": "8.1.4",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -653,10 +664,16 @@
       "steppedLine": false,
       "targets": [
         {
+          "expr": "sum(rate(hedera_mirror_transaction_size_bytes_sum{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) / sum(rate(hedera_mirror_transaction_size_bytes_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval]))",
+          "interval": "1m",
+          "legendFormat": "Total",
+          "refId": "A"
+        },
+        {
           "expr": "sum(rate(hedera_mirror_transaction_size_bytes_sum{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (type) / sum(rate(hedera_mirror_transaction_size_bytes_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (type)",
           "interval": "1m",
           "legendFormat": "{{ type }}",
-          "refId": "A"
+          "refId": "B"
         }
       ],
       "thresholds": [],
@@ -749,7 +766,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.0.1",
+      "pluginVersion": "8.1.4",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -860,7 +877,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.0.1",
+      "pluginVersion": "8.1.4",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -970,7 +987,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.0.1",
+      "pluginVersion": "8.1.4",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1079,7 +1096,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.0.1",
+      "pluginVersion": "8.1.4",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1181,7 +1198,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.0.1",
+      "pluginVersion": "8.1.4",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1284,7 +1301,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.0.1",
+      "pluginVersion": "8.1.4",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1406,7 +1423,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.0.1",
+      "pluginVersion": "8.1.4",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1509,7 +1526,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.0.1",
+      "pluginVersion": "8.1.4",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1633,7 +1650,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.0.1",
+      "pluginVersion": "8.1.4",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1753,7 +1770,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.0.1",
+      "pluginVersion": "8.1.4",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1891,7 +1908,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.0.1",
+      "pluginVersion": "8.1.4",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1961,6 +1978,8 @@
       "options": {
         "dedupStrategy": "none",
         "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
         "showLabels": false,
         "showTime": false,
         "sortOrder": "Descending",
@@ -3868,9 +3887,9 @@
       },
       {
         "current": {
-          "selected": true,
-          "text": "Loki",
-          "value": "Loki"
+          "selected": false,
+          "text": "",
+          "value": ""
         },
         "description": "Name of the Loki datasource to use",
         "error": null,
@@ -3889,9 +3908,9 @@
       },
       {
         "current": {
-          "selected": false,
-          "text": "Prometheus",
-          "value": "Prometheus"
+          "selected": true,
+          "text": "",
+          "value": ""
         },
         "description": "Name of the Prometheus datasource to use",
         "error": null,
@@ -3933,7 +3952,7 @@
           "query": "label_values(system_cpu_count{application=\"$application\"}, cluster)",
           "refId": "StandardVariableQuery"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 5,
@@ -3960,7 +3979,7 @@
           "query": "label_values(system_cpu_count{application=\"$application\",cluster=~\"$cluster\"}, namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 5,
@@ -3972,7 +3991,7 @@
       {
         "allValue": null,
         "current": {
-          "selected": false,
+          "selected": true,
           "text": "All",
           "value": "$__all"
         },
@@ -3990,7 +4009,7 @@
           "query": "label_values(system_cpu_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\"}, pod)",
           "refId": "Prometheus-pod-Variable-Query"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 5,

--- a/charts/hedera-mirror-common/dashboards/hedera-mirror-monitor.json
+++ b/charts/hedera-mirror-common/dashboards/hedera-mirror-monitor.json
@@ -2845,8 +2845,8 @@
       {
         "current": {
           "selected": true,
-          "text": "Loki",
-          "value": "Loki"
+          "text": "",
+          "value": ""
         },
         "description": "Name of the Loki datasource to use",
         "error": null,
@@ -2866,8 +2866,8 @@
       {
         "current": {
           "selected": false,
-          "text": "Prometheus",
-          "value": "Prometheus"
+          "text": "",
+          "value": ""
         },
         "description": "Name of the Prometheus datasource to use",
         "error": null,
@@ -2909,7 +2909,7 @@
           "query": "label_values(system_cpu_count{application=\"$application\"}, cluster)",
           "refId": "StandardVariableQuery"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 5,

--- a/charts/hedera-mirror-common/dashboards/hedera-mirror-rest.json
+++ b/charts/hedera-mirror-common/dashboards/hedera-mirror-rest.json
@@ -1698,8 +1698,8 @@
       {
         "current": {
           "selected": true,
-          "text": "Loki",
-          "value": "Loki"
+          "text": "",
+          "value": ""
         },
         "description": "Name of the Loki datasource to use",
         "error": null,
@@ -1719,8 +1719,8 @@
       {
         "current": {
           "selected": false,
-          "text": "Prometheus",
-          "value": "Prometheus"
+          "text": "",
+          "value": ""
         },
         "description": "Name of the Prometheus datasource to use",
         "error": null,
@@ -1762,7 +1762,7 @@
           "query": "label_values(nodejs_process_cpu_usage_percentage{container=\"$application\"}, cluster)",
           "refId": "StandardVariableQuery"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 5,

--- a/charts/hedera-mirror-common/dashboards/hedera-mirror-rosetta.json
+++ b/charts/hedera-mirror-common/dashboards/hedera-mirror-rosetta.json
@@ -1788,8 +1788,8 @@
       {
         "current": {
           "selected": true,
-          "text": "Loki",
-          "value": "Loki"
+          "text": "",
+          "value": ""
         },
         "description": "Name of the Loki datasource to use",
         "error": null,
@@ -1809,8 +1809,8 @@
       {
         "current": {
           "selected": false,
-          "text": "Prometheus",
-          "value": "Prometheus"
+          "text": "",
+          "value": ""
         },
         "description": "Name of the Prometheus datasource to use",
         "error": null,
@@ -1852,7 +1852,7 @@
           "query": "label_values(go_info{container=\"$application\"}, cluster)",
           "refId": "StandardVariableQuery"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 5,

--- a/charts/hedera-mirror-common/dashboards/jvm-micrometer-rev9.json
+++ b/charts/hedera-mirror-common/dashboards/jvm-micrometer-rev9.json
@@ -4583,8 +4583,8 @@
       {
         "current": {
           "selected": false,
-          "text": "Prometheus",
-          "value": "Prometheus"
+          "text": "",
+          "value": ""
         },
         "description": "Name of the Prometheus datasource to use",
         "error": null,
@@ -4652,7 +4652,7 @@
           "query": "label_values(jvm_memory_used_bytes{application=\"$application\"}, cluster)",
           "refId": "StandardVariableQuery"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 5,
@@ -4729,7 +4729,7 @@
         "name": "jvm_memory_pool_heap",
         "options": [],
         "query": "label_values(jvm_memory_used_bytes{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\", area=\"heap\"},id)",
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 1,
@@ -4757,7 +4757,7 @@
         "name": "jvm_memory_pool_nonheap",
         "options": [],
         "query": "label_values(jvm_memory_used_bytes{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\", area=\"nonheap\"},id)",
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 2,

--- a/charts/hedera-mirror-common/dashboards/kubernetes-cluster-monitoring-via-prometheus_rev2.json
+++ b/charts/hedera-mirror-common/dashboards/kubernetes-cluster-monitoring-via-prometheus_rev2.json
@@ -1864,7 +1864,7 @@
           "query": "label_values(container_memory_working_set_bytes, namespace)",
           "refId": "StandardVariableQuery"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 1,
@@ -1891,7 +1891,7 @@
           "query": "label_values(kube_pod_info, node)",
           "refId": "Prometheus-Node-Variable-Query"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,

--- a/charts/hedera-mirror-common/dashboards/traefik.json
+++ b/charts/hedera-mirror-common/dashboards/traefik.json
@@ -1460,8 +1460,8 @@
         {
           "current": {
             "selected": true,
-            "text": "Loki",
-            "value": "Loki"
+            "text": "",
+            "value": ""
           },
           "description": "Name of the Loki datasource to use",
           "error": null,
@@ -1481,8 +1481,8 @@
         {
           "current": {
             "selected": false,
-            "text": "Prometheus",
-            "value": "Prometheus"
+            "text": "",
+            "value": ""
           },
           "description": "Name of the Prometheus datasource to use",
           "error": null,
@@ -1524,7 +1524,7 @@
             "query": "label_values(traefik_config_reloads_total, cluster)",
             "refId": "StandardVariableQuery"
           },
-          "refresh": 1,
+          "refresh": 2,
           "regex": "",
           "skipUrlSync": false,
           "sort": 5,
@@ -1550,7 +1550,7 @@
           "name": "namespace",
           "options": [],
           "query": "label_values(traefik_config_reloads_total{cluster=~\"$cluster\"}, namespace)",
-          "refresh": 1,
+          "refresh": 2,
           "regex": "",
           "skipUrlSync": false,
           "sort": 5,

--- a/charts/hedera-mirror-importer/values.yaml
+++ b/charts/hedera-mirror-importer/values.yaml
@@ -422,8 +422,8 @@ replicas: 1
 
 resources:
   limits:
-    cpu: 1.8
-    memory: 3072Mi
+    cpu: 2.5
+    memory: 4Gi
   requests:
     cpu: 200m
     memory: 512Mi

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/converter/ByteArrayToHexSerializer.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/converter/ByteArrayToHexSerializer.java
@@ -29,12 +29,14 @@ import org.apache.commons.codec.binary.Hex;
 
 @Named
 public class ByteArrayToHexSerializer extends JsonSerializer<byte[]> {
+
     public static final ByteArrayToHexSerializer INSTANCE = new ByteArrayToHexSerializer();
+    static final String PREFIX = "\\x";
 
     @Override
-    public void serialize(byte[] value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+    public void serialize(byte[] value, JsonGenerator jsonGenerator, SerializerProvider serializers) throws IOException {
         if (value != null) {
-            gen.writeString("\\x" + Hex.encodeHexString(value));
+            jsonGenerator.writeString(PREFIX + Hex.encodeHexString(value));
         }
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordFileParser.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordFileParser.java
@@ -119,13 +119,12 @@ public class RecordFileParser extends AbstractStreamFileParser<RecordFile> {
         try {
             Flux<RecordItem> recordItems = recordFile.getItems();
 
-            if (log.getLevel().isInRange(Level.TRACE, Level.DEBUG)) {
+            if (log.getLevel().isInRange(Level.DEBUG, Level.TRACE)) {
                 recordItems = recordItems.doOnNext(this::logItem);
             }
 
             recordStreamFileListener.onStart();
             long count = recordItems.filter(r -> dateRangeFilter.filter(r.getConsensusTimestamp()))
-                    .filter(r -> dateRangeFilter.filter(r.getConsensusTimestamp()))
                     .doOnNext(recordItemListener::onItem)
                     .doOnNext(this::recordMetrics)
                     .count()
@@ -146,7 +145,7 @@ public class RecordFileParser extends AbstractStreamFileParser<RecordFile> {
                     Utility.printProtoMessage(recordItem.getTransaction()),
                     Utility.printProtoMessage(recordItem.getRecord()));
         } else if (log.isDebugEnabled()) {
-            log.debug("Storing transaction with consensus timestamp {}", recordItem.getConsensusTimestamp());
+            log.debug("Parsing transaction with consensus timestamp {}", recordItem.getConsensusTimestamp());
         }
     }
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordFileParser.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordFileParser.java
@@ -30,9 +30,11 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Map;
 import javax.inject.Named;
+import org.apache.logging.log4j.Level;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.transaction.annotation.Transactional;
+import reactor.core.publisher.Flux;
 
 import com.hedera.mirror.importer.config.MirrorDateRangePropertiesProcessor;
 import com.hedera.mirror.importer.domain.RecordFile;
@@ -115,9 +117,14 @@ public class RecordFileParser extends AbstractStreamFileParser<RecordFile> {
                 .getDateRangeFilter(parserProperties.getStreamType());
 
         try {
+            Flux<RecordItem> recordItems = recordFile.getItems();
+
+            if (log.getLevel().isInRange(Level.TRACE, Level.DEBUG)) {
+                recordItems = recordItems.doOnNext(this::logItem);
+            }
+
             recordStreamFileListener.onStart();
-            long count = recordFile.getItems()
-                    .doOnNext(this::logItem)
+            long count = recordItems.filter(r -> dateRangeFilter.filter(r.getConsensusTimestamp()))
                     .filter(r -> dateRangeFilter.filter(r.getConsensusTimestamp()))
                     .doOnNext(recordItemListener::onItem)
                     .doOnNext(this::recordMetrics)

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/CompositeEntityListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/CompositeEntityListener.java
@@ -55,10 +55,11 @@ public class CompositeEntityListener implements EntityListener {
     private final List<EntityListener> entityListeners;
 
     private <T> void onEach(BiConsumer<EntityListener, T> consumer, T t) {
-        entityListeners.stream()
-                .filter(EntityListener::isEnabled)
-                .peek(e -> log.trace("On: {}", t))
-                .forEach(e -> consumer.accept(e, t));
+        for (EntityListener entityListener : entityListeners) {
+            if (entityListener.isEnabled()) {
+                consumer.accept(entityListener, t);
+            }
+        }
     }
 
     @Override

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/converter/ByteArrayToHexSerializerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/converter/ByteArrayToHexSerializerTest.java
@@ -20,6 +20,7 @@ package com.hedera.mirror.importer.converter;
  * ‍
  */
 
+import static com.hedera.mirror.importer.converter.ByteArrayToHexSerializer.PREFIX;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
@@ -31,33 +32,27 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class ByteArrayToHexSerializerTest {
+
+    private final ByteArrayToHexSerializer byteArrayToHexSerializer = ByteArrayToHexSerializer.INSTANCE;
+
     @Mock
-    JsonGenerator jsonGenerator;
+    private JsonGenerator jsonGenerator;
 
     @Test
     void testNullBytes() throws Exception {
-        // when
-        new ByteArrayToHexSerializer().serialize(null, jsonGenerator, null);
-
-        // then
+        byteArrayToHexSerializer.serialize(null, jsonGenerator, null);
         verifyNoInteractions(jsonGenerator);
     }
 
     @Test
     void testEmptyBytes() throws Exception {
-        // when
-        new ByteArrayToHexSerializer().serialize(new byte[0], jsonGenerator, null);
-
-        // then
-        verify(jsonGenerator).writeString("\\x");
+        byteArrayToHexSerializer.serialize(new byte[0], jsonGenerator, null);
+        verify(jsonGenerator).writeString(PREFIX);
     }
 
     @Test
     void testBytes() throws Exception {
-        // when
-        new ByteArrayToHexSerializer().serialize(new byte[] {0b0, 0b1, 0b10, 0b01111111}, jsonGenerator, null);
-
-        // then
-        verify(jsonGenerator).writeString("\\x0001027f");
+        byteArrayToHexSerializer.serialize(new byte[] {0b0, 0b1, 0b10, 0b01111111}, jsonGenerator, null);
+        verify(jsonGenerator).writeString(PREFIX + "0001027f");
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/util/UtilityTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/util/UtilityTest.java
@@ -24,14 +24,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.google.protobuf.ByteString;
+import com.google.protobuf.Internal;
+import com.google.protobuf.UnsafeByteOperations;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.KeyList;
 import com.hederahashgraph.api.proto.java.ThresholdKey;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TransactionID;
+import java.nio.ByteBuffer;
 import java.time.Instant;
 import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.lang3.RandomUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -227,6 +231,26 @@ class UtilityTest {
         assertThat(Utility.sanitize("")).isEmpty();
         assertThat(Utility.sanitize("abc")).isEqualTo("abc");
         assertThat(Utility.sanitize("abc" + (char) 0 + "123" + (char) 0)).isEqualTo("abc�123�");
+    }
+
+    @Test
+    void toBytes() {
+        byte[] smallArray = RandomUtils.nextBytes(Utility.UnsafeByteOutput.SIZE);
+        byte[] largeArray = RandomUtils.nextBytes(256);
+
+        assertThat(Utility.toBytes(null)).isNull();
+        assertThat(Utility.toBytes(ByteString.EMPTY)).isEqualTo(new byte[0]).isSameAs(Internal.EMPTY_BYTE_ARRAY);
+        assertThat(Utility.toBytes(UnsafeByteOperations.unsafeWrap(smallArray)))
+                .isEqualTo(smallArray)
+                .isNotSameAs(smallArray);
+
+        assertThat(Utility.toBytes(UnsafeByteOperations.unsafeWrap(largeArray)))
+                .isEqualTo(largeArray)
+                .isSameAs(largeArray);
+
+        assertThat(Utility.toBytes(UnsafeByteOperations.unsafeWrap(ByteBuffer.wrap(largeArray))))
+                .isEqualTo(largeArray)
+                .isNotSameAs(largeArray);
     }
 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -235,7 +235,7 @@
                         <container>
                             <creationTime>USE_CURRENT_TIMESTAMP</creationTime>
                             <jvmFlags>
-                                <jvmFlag>-XX:MaxRAMPercentage=70</jvmFlag>
+                                <jvmFlag>-XX:MaxRAMPercentage=80</jvmFlag>
                             </jvmFlags>
                         </container>
                         <extraDirectories>


### PR DESCRIPTION
**Description**:
- Avoid unnecessary copies of `ByteString` objects
- Change from Stream API to regular for loop in hot code path
- Change to use a cache for costly `String.format()` to construct Redis message channel name
- Fix some dashboard templating errors due to unavailable default datasource
- Increase importer pod CPU and memory
- Increase `XX:MaxRAMPercentage` to 80%
- Redo the Importer dashboard single stats at the top to be more relevant:

![Screen Shot 2021-09-22 at 09 30 46](https://user-images.githubusercontent.com/17552371/134363302-9e6add80-869a-4d54-aa23-82364c5414a9.png)

**Related issue(s)**:

Fixes #2506 

**Notes for reviewer**:
Tests in performance environment at 15K showed the Kubernetes importer could keep up with similar latency as VM importer.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
