### PR TITLE
Support token transfer in token dissociate transactions

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/NftTransferId.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/NftTransferId.java
@@ -37,6 +37,8 @@ import com.hedera.mirror.importer.converter.TokenIdConverter;
 @NoArgsConstructor
 public class NftTransferId implements Serializable {
 
+    public static final long WILDCARD_SERIAL_NUMBER = -1;
+
     private static final long serialVersionUID = -5289483288889859240L;
 
     private long consensusTimestamp;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/Token.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/Token.java
@@ -73,8 +73,6 @@ public class Token {
 
     private Long initialSupply;
 
-    private Long totalSupply; // Increment with initialSupply and mint amounts, decrement with burn amount
-
     private byte[] kycKey;
 
     @Column(name = "kyc_key_ed25519_hex")
@@ -98,6 +96,8 @@ public class Token {
     private TokenSupplyTypeEnum supplyType;
 
     private String symbol;
+
+    private Long totalSupply; // Increment with initialSupply and mint amounts, decrement with burn amount
 
     @Convert(converter = AccountIdConverter.class)
     private EntityId treasuryAccountId;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/TokenTransfer.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/TokenTransfer.java
@@ -28,6 +28,7 @@ import javax.persistence.Convert;
 import javax.persistence.Embeddable;
 import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;
+import javax.persistence.Transient;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -43,8 +44,14 @@ import com.hedera.mirror.importer.converter.TokenIdConverter;
 public class TokenTransfer implements Persistable<TokenTransfer.Id> {
 
     public TokenTransfer(long consensusTimestamp, long amount, EntityId tokenId, EntityId accountId) {
+        this(consensusTimestamp, amount, tokenId, accountId, false);
+    }
+
+    public TokenTransfer(long consensusTimestamp, long amount, EntityId tokenId, EntityId accountId,
+            boolean tokenDissociate) {
         id = new TokenTransfer.Id(consensusTimestamp, tokenId, accountId);
         this.amount = amount;
+        this.tokenDissociate = tokenDissociate;
     }
 
     @EmbeddedId
@@ -52,6 +59,10 @@ public class TokenTransfer implements Persistable<TokenTransfer.Id> {
     private Id id;
 
     private long amount;
+
+    @JsonIgnore
+    @Transient
+    private boolean tokenDissociate;
 
     @JsonIgnore
     @Override

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/AbstractEntityListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/AbstractEntityListener.java
@@ -119,8 +119,13 @@ public class AbstractEntityListener implements EntityListener {
         if (newToken.getTotalSupply() != null) {
             Long newTotalSupply = newToken.getTotalSupply();
             if (cachedToken.getTotalSupply() != null && newTotalSupply < 0) {
+                // if the cached token has total supply set, and the new total supply is negative because it's an update
+                // from the token transfer of a token dissociate of a deleted token, aggregate the change
                 cachedToken.setTotalSupply(cachedToken.getTotalSupply() + newTotalSupply);
             } else {
+                // if the cached token doesn't have total supply or the new total supply is non-negative, set it to the
+                // new token's total supply. Later step should apply the change on the current total supply in db if
+                // the value is negative.
                 cachedToken.setTotalSupply(newToken.getTotalSupply());
             }
         }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/AbstractEntityListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/AbstractEntityListener.java
@@ -117,7 +117,12 @@ public class AbstractEntityListener implements EntityListener {
         }
 
         if (newToken.getTotalSupply() != null) {
-            cachedToken.setTotalSupply(newToken.getTotalSupply());
+            Long newTotalSupply = newToken.getTotalSupply();
+            if (cachedToken.getTotalSupply() != null && newTotalSupply < 0) {
+                cachedToken.setTotalSupply(cachedToken.getTotalSupply() + newTotalSupply);
+            } else {
+                cachedToken.setTotalSupply(newToken.getTotalSupply());
+            }
         }
 
         if (newToken.getTreasuryAccountId() != null) {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListener.java
@@ -677,6 +677,9 @@ public class EntityRecordItemListener implements RecordItemListener {
                             isTokenDissociate));
 
                     if (isTokenDissociate) {
+                        // token transfers in token dissociate are for deleted tokens and the amount is negative to
+                        // bring the account's balance of the token to 0. Set the totalSupply of the token object to the
+                        // negative amount, later in the pipeline the token total supply will be reduced accordingly
                         Token token = Token.of(tokenId);
                         token.setModifiedTimestamp(consensusTimestamp);
                         token.setTotalSupply(accountAmount.getAmount());

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListener.java
@@ -678,6 +678,7 @@ public class EntityRecordItemListener implements RecordItemListener {
 
                     if (isTokenDissociate) {
                         Token token = Token.of(tokenId);
+                        token.setModifiedTimestamp(consensusTimestamp);
                         token.setTotalSupply(accountAmount.getAmount());
                         entityListener.onToken(token);
                     }
@@ -685,7 +686,7 @@ public class EntityRecordItemListener implements RecordItemListener {
 
                 tokenTransferList.getNftTransfersList().forEach(nftTransfer -> {
                     long serialNumber = nftTransfer.getSerialNumber();
-                    if (serialNumber == TokenUpdateTransactionHandler.WILDCARD_SERIAL_NUMBER) {
+                    if (serialNumber == NftTransferId.WILDCARD_SERIAL_NUMBER) {
                         // do not persist nft transfers with the wildcard serial number (-1) which signify an nft token
                         // treasury change
                         return;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/repository/RepositoryEntityListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/repository/RepositoryEntityListener.java
@@ -181,6 +181,13 @@ public class RepositoryEntityListener extends AbstractEntityListener {
 
     @Override
     public void onTokenTransfer(TokenTransfer tokenTransfer) throws ImporterException {
+        if (tokenTransfer.isTokenDissociate()) {
+            TokenTransfer.Id id = tokenTransfer.getId();
+            tokenTransferRepository.insertTransferForTokenDissociate(id.getAccountId().getId(),
+                    tokenTransfer.getAmount(), id.getConsensusTimestamp(), id.getTokenId().getId());
+            return;
+        }
+
         tokenTransferRepository.save(tokenTransfer);
     }
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenUpdateTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenUpdateTransactionHandler.java
@@ -34,7 +34,7 @@ import com.hedera.mirror.importer.util.Utility;
 @Named
 public class TokenUpdateTransactionHandler extends AbstractEntityCrudTransactionHandler {
 
-    static final long WILDCARD_SERIAL_NUMBER = -1;
+    public static final long WILDCARD_SERIAL_NUMBER = -1;
     private final NftRepository nftRepository;
 
     public TokenUpdateTransactionHandler(NftRepository nftRepository) {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenUpdateTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenUpdateTransactionHandler.java
@@ -27,6 +27,7 @@ import javax.inject.Named;
 
 import com.hedera.mirror.importer.domain.Entity;
 import com.hedera.mirror.importer.domain.EntityId;
+import com.hedera.mirror.importer.domain.NftTransferId;
 import com.hedera.mirror.importer.parser.domain.RecordItem;
 import com.hedera.mirror.importer.repository.NftRepository;
 import com.hedera.mirror.importer.util.Utility;
@@ -34,7 +35,6 @@ import com.hedera.mirror.importer.util.Utility;
 @Named
 public class TokenUpdateTransactionHandler extends AbstractEntityCrudTransactionHandler {
 
-    public static final long WILDCARD_SERIAL_NUMBER = -1;
     private final NftRepository nftRepository;
 
     public TokenUpdateTransactionHandler(NftRepository nftRepository) {
@@ -77,7 +77,7 @@ public class TokenUpdateTransactionHandler extends AbstractEntityCrudTransaction
     private void updateTreasury(RecordItem recordItem) {
         for (TokenTransferList tokenTransferList : recordItem.getRecord().getTokenTransferListsList()) {
             for (NftTransfer nftTransfer : tokenTransferList.getNftTransfersList()) {
-                if (nftTransfer.getSerialNumber() == WILDCARD_SERIAL_NUMBER) {
+                if (nftTransfer.getSerialNumber() == NftTransferId.WILDCARD_SERIAL_NUMBER) {
                     EntityId newTreasury = EntityId.of(nftTransfer.getReceiverAccountID());
                     EntityId previousTreasury = EntityId.of(nftTransfer.getSenderAccountID());
                     EntityId tokenId = EntityId.of(tokenTransferList.getToken());

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/TokenRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/TokenRepository.java
@@ -25,13 +25,9 @@ import static com.hedera.mirror.importer.config.CacheConfiguration.EXPIRE_AFTER_
 import java.util.Optional;
 import javax.transaction.Transactional;
 import org.springframework.cache.annotation.CacheConfig;
-import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
-import org.springframework.data.repository.query.Param;
 
 import com.hedera.mirror.importer.domain.Token;
 import com.hedera.mirror.importer.domain.TokenId;
@@ -46,10 +42,4 @@ public interface TokenRepository extends CrudRepository<Token, TokenId> {
     @CachePut(key = "{#p0.tokenId.tokenId.id}")
     @Override
     <S extends Token> S save(S entity);
-
-    @Modifying
-    @CacheEvict(key = "{#p0.tokenId.id}")
-    @Query("update Token set totalSupply = :supply, modifiedTimestamp = :timestamp where tokenId = :token")
-    void updateTokenSupply(@Param("token") TokenId tokenId, @Param("supply") long newTotalSupply,
-                           @Param("timestamp") long modifiedTimestamp);
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/TokenTransferRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/TokenTransferRepository.java
@@ -20,13 +20,12 @@ package com.hedera.mirror.importer.repository;
  * ‍
  */
 
+import javax.transaction.Transactional;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 
 import com.hedera.mirror.importer.domain.TokenTransfer;
-
-import javax.transaction.Transactional;
 
 @Transactional
 public interface TokenTransferRepository extends CrudRepository<TokenTransfer, TokenTransfer.Id> {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/TokenTransferRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/TokenTransferRepository.java
@@ -20,9 +20,30 @@ package com.hedera.mirror.importer.repository;
  * ‍
  */
 
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 
 import com.hedera.mirror.importer.domain.TokenTransfer;
 
+import javax.transaction.Transactional;
+
+@Transactional
 public interface TokenTransferRepository extends CrudRepository<TokenTransfer, TokenTransfer.Id> {
+
+    @Modifying
+    @Query(value = "with dissociated_nft as (" +
+            "  update nft set deleted = true, modified_timestamp = ?3" +
+            "  where token_id = ?4 and account_id = ?1 and deleted is false" +
+            "  returning serial_number), " +
+            "transferred_nft as (" +
+            "  insert into nft_transfer" +
+            "    (token_id, sender_account_id, consensus_timestamp, serial_number)" +
+            "  select ?4, ?1, ?3, dissociated_nft.serial_number " +
+            "  from dissociated_nft" +
+            "  returning serial_number) " +
+            "insert into token_transfer (account_id, amount, consensus_timestamp, token_id) " +
+            "select ?1, ?2, ?3, ?4 " +
+            "where not exists (select * from transferred_nft)", nativeQuery = true)
+    void insertTransferForTokenDissociate(long accountId, long amount, long consensusTimestamp, long tokenId);
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/AbstractUpsertQueryGenerator.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/AbstractUpsertQueryGenerator.java
@@ -335,11 +335,10 @@ public abstract class AbstractUpsertQueryGenerator<T> implements UpsertQueryGene
         StringBuilder updateQueryBuilder = new StringBuilder();
 
         List<String> updateQueries = new ArrayList<>();
-        // sort fields alphabetically
         List<DomainField> updatableAttributes = getAttributes().stream()
                 .filter(x -> !getNonUpdatableColumns().contains(x.getName())) // filter out non-updatable fields
                 .map(a -> new DomainField(extractJavaType(a), a.getName()))
-                .sorted(DOMAIN_FIELD_COMPARATOR)
+                .sorted(DOMAIN_FIELD_COMPARATOR) // sort fields alphabetically
                 .collect(Collectors.toList());
         updatableAttributes.forEach(d -> {
             String attributeUpdateQuery;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/AbstractUpsertQueryGenerator.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/AbstractUpsertQueryGenerator.java
@@ -153,16 +153,13 @@ public abstract class AbstractUpsertQueryGenerator<T> implements UpsertQueryGene
             return EMPTY_CLAUSE;
         }
 
-        StringBuilder updateQueryBuilder = new StringBuilder("update " + getFinalTableName() + " set ");
-
-        updateQueryBuilder.append(getUpdateClause());
-
-        updateQueryBuilder.append(" from " + getTemporaryTableName());
-
-        // insertable query
-        updateQueryBuilder.append(getUpdateWhereClause());
-
-        return updateQueryBuilder.toString();
+        return StringUtils.joinWith(
+                " ",
+                "update", getFinalTableName(), "set",
+                getUpdateClause(),
+                "from", getTemporaryTableName(),
+                getUpdateWhereClause()
+        );
     }
 
     private boolean isNullableColumn(String columnName) {
@@ -338,13 +335,14 @@ public abstract class AbstractUpsertQueryGenerator<T> implements UpsertQueryGene
         StringBuilder updateQueryBuilder = new StringBuilder();
 
         List<String> updateQueries = new ArrayList<>();
+        // sort fields alphabetically
         List<DomainField> updatableAttributes = getAttributes().stream()
                 .filter(x -> !getNonUpdatableColumns().contains(x.getName())) // filter out non-updatable fields
                 .map(a -> new DomainField(extractJavaType(a), a.getName()))
+                .sorted(DOMAIN_FIELD_COMPARATOR)
                 .collect(Collectors.toList());
-        Collections.sort(updatableAttributes, DOMAIN_FIELD_COMPARATOR); // sort fields alphabetically
         updatableAttributes.forEach(d -> {
-            String attributeUpdateQuery = "";
+            String attributeUpdateQuery;
             // get column custom update implementations
             String columnSelectQuery = getAttributeUpdateQuery(d.getName());
             if (!StringUtils.isEmpty(columnSelectQuery)) {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/NftUpsertQueryGenerator.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/NftUpsertQueryGenerator.java
@@ -96,6 +96,6 @@ public class NftUpsertQueryGenerator extends AbstractUpsertQueryGenerator<Nft_> 
                     getFullFinalTableColumnName(Nft_.DELETED));
         }
 
-        return null;
+        return super.getAttributeUpdateQuery(attributeName);
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/TokenDissociateTransferUpsertQueryGenerator.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/TokenDissociateTransferUpsertQueryGenerator.java
@@ -1,0 +1,69 @@
+package com.hedera.mirror.importer.repository.upsert;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+public class TokenDissociateTransferUpsertQueryGenerator implements UpsertQueryGenerator {
+
+    private static final String FINAL_TABLE_NAME = "token_transfer";
+
+    private static final String TEMP_TABLE_NAME = "token_dissociate_transfer";
+
+    private static final String INSERT_SQL = "with dissociated_nft as (" +
+            "  update nft set deleted = true, modified_timestamp = tdt.consensus_timestamp" +
+            "  from " + TEMP_TABLE_NAME + " tdt" +
+            "  where nft.token_id = tdt.token_id and nft.account_id = tdt.account_id and nft.deleted is false" +
+            "  returning nft.token_id, nft.serial_number, nft.account_id, nft.modified_timestamp" +
+            "), updated_nft as (" +
+            "  insert into nft_transfer (consensus_timestamp, sender_account_id, serial_number, token_id)" +
+            "  select modified_timestamp, account_id, serial_number, token_id" +
+            "  from dissociated_nft" +
+            "  returning token_id" +
+            ") " +
+            "insert into " + FINAL_TABLE_NAME + " " +
+            "select * from " + TEMP_TABLE_NAME + " tdt " +
+            "where tdt.token_id not in (select distinct token_id from updated_nft)";
+
+    @Override
+    public String getCreateTempTableQuery() {
+        return String.format("create temporary table if not exists %s on commit drop as table %s limit 0",
+                TEMP_TABLE_NAME, FINAL_TABLE_NAME);
+    }
+
+    @Override
+    public String getFinalTableName() {
+        return FINAL_TABLE_NAME;
+    }
+
+    @Override
+    public String getInsertQuery() {
+        return INSERT_SQL;
+    }
+
+    @Override
+    public String getTemporaryTableName() {
+        return TEMP_TABLE_NAME;
+    }
+
+    @Override
+    public String getUpdateQuery() {
+        return "";
+    }
+}

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/TokenUpsertQueryGenerator.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/TokenUpsertQueryGenerator.java
@@ -57,6 +57,21 @@ public class TokenUpsertQueryGenerator extends AbstractUpsertQueryGenerator<Toke
             Token_.wipeKeyEd25519Hex);
 
     @Override
+    protected String getAttributeUpdateQuery(String attributeName) {
+        if (attributeName.equalsIgnoreCase(Token_.TOTAL_SUPPLY)) {
+            return String.format("%s = case when %s >= 0 then %s else %s + coalesce(%s, 0) end",
+                    getFormattedColumnName(Token_.TOTAL_SUPPLY),
+                    getFullTempTableColumnName(Token_.TOTAL_SUPPLY),
+                    getFullTempTableColumnName(Token_.TOTAL_SUPPLY),
+                    getFullFinalTableColumnName(Token_.TOTAL_SUPPLY),
+                    getFullTempTableColumnName(Token_.TOTAL_SUPPLY)
+            );
+        }
+
+        return super.getAttributeUpdateQuery(attributeName);
+    }
+
+    @Override
     public String getFinalTableName() {
         return TABLE;
     }

--- a/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.45.0__support_deleted_token_dissociate.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.45.0__support_deleted_token_dissociate.sql
@@ -1,0 +1,89 @@
+-------------------
+-- Fix token total supply, nft transfer, and nft ownership for token dissociate of deleted tokens
+-------------------
+
+create index if not exists nft__account_token on nft (account_id, token_id);
+
+-- create temp table and populate it with token transfers of token dissociate transactions
+create temporary table if not exists token_dissociate_transfer on commit drop as table token_transfer limit 0;
+
+insert into token_dissociate_transfer
+select tt.*
+from transaction t
+join token_transfer tt on tt.consensus_timestamp = t.consensus_ns
+where t.type = 41
+order by t.consensus_ns;
+
+-- update token total supply
+update token t
+set total_supply = t.total_supply + amount, modified_timestamp = consensus_timestamp
+from token_dissociate_transfer
+where token_dissociate_transfer.token_id = t.token_id;
+
+-- mark still alive nfts involved in the transfer as deleted, update the timestamp, and return the nft info
+with dissociated_nft as (
+    update nft set deleted = true, modified_timestamp = tdt.consensus_timestamp
+    from token_dissociate_transfer tdt
+    where nft.token_id = tdt.token_id and nft.account_id = tdt.account_id and nft.deleted is false
+    returning nft.token_id, nft.serial_number, nft.account_id, nft.modified_timestamp
+),
+-- for each dissociated nft, insert a nft transfer, and return the nft token id
+updated_nft as (
+    insert into nft_transfer (consensus_timestamp, sender_account_id, serial_number, token_id)
+    select modified_timestamp, account_id, serial_number, token_id
+    from dissociated_nft
+    returning token_id
+),
+-- find the nft token transfers presented as token transfers
+dissociate_nft_transfer as (
+    select tdt.*
+    from token_dissociate_transfer tdt
+    join updated_nft un on un.token_id = tdt.token_id
+)
+-- delete the nft transfers from token_transfer table
+delete from token_transfer tt using dissociate_nft_transfer dnt
+where tt.consensus_timestamp = dnt.consensus_timestamp and
+      tt.account_id = dnt.account_id and
+      tt.amount = dnt.amount and
+      tt.token_id = dnt.token_id;
+
+-- drop the temp table
+drop table if exists token_dissociate_transfer;
+
+-- fix nft class total supply, nft, and add nft transfers for those without a token transfer from the token dissociate
+-- find deleted nft classes
+with deleted_nft_class as (
+    select token_id, e.modified_timestamp
+    from token t
+    join entity e on e.id = t.token_id and e.deleted = true
+    where t.type = 'NON_FUNGIBLE_UNIQUE'
+),
+-- the only change can be done to a token relationship of a deleted token is dissociate
+dissociated_nft_relationship as (
+    select ta.account_id, ta.modified_timestamp, ta.token_id
+    from token_account ta
+    join deleted_nft_class dnc on dnc.token_id = ta.token_id and ta.modified_timestamp > dnc.modified_timestamp
+),
+-- mark nfts as deleted, update its modified_timestamp, and return the nft info
+dissociated_nft as (
+    update nft set deleted = true, modified_timestamp = dnr.modified_timestamp
+    from dissociated_nft_relationship dnr
+    where nft.account_id = dnr.account_id and nft.token_id = dnr.token_id and nft.deleted is false
+    returning nft.account_id, nft.token_id, nft.serial_number, nft.modified_timestamp
+),
+-- insert nft transfers
+dissociated_nft_transfer as (
+    insert into nft_transfer (consensus_timestamp, sender_account_id, serial_number, token_id)
+    select modified_timestamp, account_id, serial_number, token_id
+    from dissociated_nft
+    returning consensus_timestamp, token_id
+)
+update token t
+set
+    total_supply = total_supply - 1,
+    modified_timestamp = GREATEST(modified_timestamp, dnt.consensus_timestamp)
+from dissociated_nft_transfer dnt
+where dnt.token_id = t.token_id;
+
+-- remove any nft transfer with the wildcard serial number (-1) which signifies an nft treasury update
+delete from nft_transfer where serial_number = -1;

--- a/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.2__time_scale_index_init.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.2__time_scale_index_init.sql
@@ -78,6 +78,7 @@ alter table live_hash
 -- nft
 alter table nft
     add primary key (token_id, serial_number, created_timestamp);
+create index if not exists nft__account_token on nft (account_id, token_id);
 
 -- nft_transfer
 create unique index if not exists nft_transfer__timestamp_token_id_serial_num

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/SupportDeletedTokenDissociateMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/SupportDeletedTokenDissociateMigrationTest.java
@@ -1,0 +1,310 @@
+package com.hedera.mirror.importer.migration;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import static com.hedera.mirror.importer.domain.EntityTypeEnum.ACCOUNT;
+import static com.hedera.mirror.importer.domain.EntityTypeEnum.TOKEN;
+import static com.hedera.mirror.importer.domain.TokenTypeEnum.FUNGIBLE_COMMON;
+import static com.hedera.mirror.importer.domain.TokenTypeEnum.NON_FUNGIBLE_UNIQUE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.util.List;
+import javax.annotation.Resource;
+import lombok.SneakyThrows;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.jdbc.core.JdbcOperations;
+import org.springframework.test.context.TestPropertySource;
+
+import com.hedera.mirror.importer.EnabledIfV1;
+import com.hedera.mirror.importer.IntegrationTest;
+import com.hedera.mirror.importer.domain.Entity;
+import com.hedera.mirror.importer.domain.EntityId;
+import com.hedera.mirror.importer.domain.Nft;
+import com.hedera.mirror.importer.domain.NftTransfer;
+import com.hedera.mirror.importer.domain.NftTransferId;
+import com.hedera.mirror.importer.domain.Token;
+import com.hedera.mirror.importer.domain.TokenAccount;
+import com.hedera.mirror.importer.domain.TokenFreezeStatusEnum;
+import com.hedera.mirror.importer.domain.TokenKycStatusEnum;
+import com.hedera.mirror.importer.domain.TokenSupplyTypeEnum;
+import com.hedera.mirror.importer.domain.TokenTransfer;
+import com.hedera.mirror.importer.domain.TokenTypeEnum;
+import com.hedera.mirror.importer.domain.Transaction;
+import com.hedera.mirror.importer.repository.EntityRepository;
+import com.hedera.mirror.importer.repository.NftRepository;
+import com.hedera.mirror.importer.repository.NftTransferRepository;
+import com.hedera.mirror.importer.repository.TokenAccountRepository;
+import com.hedera.mirror.importer.repository.TokenRepository;
+import com.hedera.mirror.importer.repository.TokenTransferRepository;
+import com.hedera.mirror.importer.repository.TransactionRepository;
+
+@EnabledIfV1
+@Tag("migration")
+@TestPropertySource(properties = "spring.flyway.target=1.44.1")
+class SupportDeletedTokenDissociateMigrationTest extends IntegrationTest {
+
+    private static final int TRANSACTION_TYPE_TOKEN_DISSOCIATE = 41;
+    private static final EntityId TREASURY = EntityId.of("0.0.200", ACCOUNT);
+    private static final EntityId NEW_TREASURY = EntityId.of("0.0.201", ACCOUNT);
+
+    @Resource
+    private EntityRepository entityRepository;
+
+    @Resource
+    private JdbcOperations jdbcOperations;
+
+    @Value("classpath:db/migration/v1/V1.45.0__support_deleted_token_dissociate.sql")
+    private File migrationSql;
+
+    @Resource
+    private NftRepository nftRepository;
+
+    @Resource
+    private NftTransferRepository nftTransferRepository;
+
+    @Resource
+    private TokenAccountRepository tokenAccountRepository;
+
+    @Resource
+    private TokenRepository tokenRepository;
+
+    @Resource
+    private TokenTransferRepository tokenTransferRepository;
+
+    @Resource
+    private TransactionRepository transactionRepository;
+
+    @Test
+    void verify() {
+        // given
+        // entities
+        // - 2 ft classes
+        //   - deleted, account1's token dissociate includes token transfer
+        //   - still alive
+        // - 3 nft classes
+        //   - deleted, account1's token dissociate doesn't include token transfer, account2's includes
+        //   - deleted, account1's token dissociate doesn't include token transfer, account2's dissociate happened
+        //     before token deletion
+        //   - still alive
+        EntityId account1 = EntityId.of("0.0.210", ACCOUNT);
+        EntityId account2 = EntityId.of("0.0.211", ACCOUNT);
+        EntityId ftId1 = EntityId.of("0.0.500", TOKEN);
+        EntityId ftId2 = EntityId.of("0.0.501", TOKEN);
+        EntityId nftId1 = EntityId.of("0.0.502", TOKEN);
+        EntityId nftId2 = EntityId.of("0.0.503", TOKEN);
+        EntityId nftId3 = EntityId.of("0.0.504", TOKEN);
+
+        Token ftClass1 = token( 10L, ftId1, FUNGIBLE_COMMON);
+        Token ftClass2 = token(15L, ftId2, FUNGIBLE_COMMON);
+        Token nftClass1 = token(20L, nftId1, NON_FUNGIBLE_UNIQUE);
+        Token nftClass2 = token(25L, nftId2, NON_FUNGIBLE_UNIQUE);
+        Token nftClass3 = token(30L, nftId3, NON_FUNGIBLE_UNIQUE);
+
+        Entity ft1Entity = entity(ftClass1, true, 50L);
+        Entity ft2Entity = entity(ftClass2);
+        Entity nft1Entity = entity(nftClass1, true, 55L);
+        Entity nft2Entity = entity(nftClass2, true, 60L);
+        Entity nft3Entity = entity(nftClass3);
+
+        entityRepository.saveAll(List.of(ft1Entity, ft2Entity, nft1Entity, nft2Entity, nft3Entity));
+        tokenRepository.saveAll(List.of(ftClass1, ftClass2, nftClass1, nftClass2, nftClass3));
+
+        long account1Ft1DissociateTimestamp = 70;
+        long account1Nft1DissociateTimestamp = 75;
+        long account2Nft1DissociateTimestamp = 80;
+        long account1Nft2DissociateTimestamp = 85;
+        long account2Nft2DissociateTimestamp = 55; // happened before token deletion
+        List<TokenAccount> tokenAccounts = List.of(
+                tokenAccount(account1, true, 12L, 12L, ftId1),
+                tokenAccount(account1, false, 12L, account1Ft1DissociateTimestamp, ftId1),
+                tokenAccount(account2, true, 15L, 15L, ftId1),
+                tokenAccount(account1, true, 20L, 20L, ftId2),
+                tokenAccount(account1, true, 23L, 23L, nftId1),
+                tokenAccount(account1, false, 23L, account1Nft1DissociateTimestamp, nftId1),
+                tokenAccount(account2, true, 25L, 25L, nftId1),
+                tokenAccount(account2, false, 25L, account2Nft1DissociateTimestamp, nftId1),
+                tokenAccount(account1, true, 27L, 27L, nftId2),
+                tokenAccount(account1, false, 27L, account1Nft2DissociateTimestamp, nftId2),
+                tokenAccount(account2, true, 29L, 29L, nftId2),
+                tokenAccount(account2, false, 29L, account2Nft2DissociateTimestamp, nftId2)
+        );
+        tokenAccountRepository.saveAll(tokenAccounts);
+
+        // token dissociate transactions
+        List<Transaction> transactions = List.of(
+                tokenDissociateTransaction(account1Ft1DissociateTimestamp, account1),
+                tokenDissociateTransaction(account1Nft1DissociateTimestamp, account1),
+                tokenDissociateTransaction(account2Nft1DissociateTimestamp, account2),
+                tokenDissociateTransaction(account1Nft2DissociateTimestamp, account1),
+                tokenDissociateTransaction(account2Nft2DissociateTimestamp, account2)
+        );
+        transactionRepository.saveAll(transactions);
+
+        // transfers
+        tokenTransferRepository.saveAll(List.of(
+                new TokenTransfer(account1Ft1DissociateTimestamp, -10, ftId1, account1),
+                new TokenTransfer(account2Nft1DissociateTimestamp, -1, nftId1, account2)
+        ));
+
+        // nfts
+        // - 2 for <account1, nftId1>, 1 already deleted before dissociate, the other without dissociate transfer
+        // - 2 for <account1, nftId2>, 1 already deleted before dissociate, the other without dissociate transfer
+        // - 2 for <account2, nftId1>, 1 already deleted before dissociate, the other with dissociate transfer
+        // - 1 for <account2, nftId2>, already deleted, account2 dissociated nftId2 before nft class deletion
+        // - 1 for <account1, nftId3>
+        // - 1 for <account2, nftId3>
+        nftRepository.saveAll(List.of(
+                nft(account1, 25L, true, 27L, 1L, nftId1),
+                nft(account1, 25L, false, 25L, 2L, nftId1),
+                nft(account1, 30L, true, 35L, 1L, nftId2),
+                nft(account1, 30L, false, 30L, 2L, nftId2),
+                nft(account1, 40L, false, 40L, 1L, nftId3),
+                nft(account2, 28L, true, 32L, 3L, nftId1),
+                nft(account2, 28L, false, 28L, 4L, nftId1),
+                nft(account2, 33L, true, 37L, 3L, nftId2),
+                nft(account2, 45L, false, 45L, 2L, nftId3)
+        ));
+
+        // nft transfers from nft class treasury update
+        nftTransferRepository.save(nftTransfer(40L, NEW_TREASURY, TREASURY, -1, nftId3));
+
+        // expected token changes
+        ftClass1.setTotalSupply(ftClass1.getTotalSupply() - 10);
+        ftClass1.setModifiedTimestamp(account1Ft1DissociateTimestamp);
+        // 1 nft wiped from explicit token transfer of the token dissociate, 1 wiped from a previous token dissociate
+        // without explicit token transfer
+        nftClass1.setTotalSupply(nftClass1.getTotalSupply() - 2);
+        nftClass1.setModifiedTimestamp(account2Nft1DissociateTimestamp);
+        nftClass2.setTotalSupply(nftClass2.getTotalSupply() - 1);
+        nftClass2.setModifiedTimestamp(account1Nft2DissociateTimestamp);
+
+        // when
+        migrate();
+
+        // then
+        assertThat(nftRepository.findAll()).containsExactlyInAnyOrder(
+                nft(account1, 25L, true, 27L, 1L, nftId1),
+                nft(account1, 25L, true, account1Nft1DissociateTimestamp, 2L, nftId1),
+                nft(account1, 30L, true, 35L, 1L, nftId2),
+                nft(account1, 30L, true, account1Nft2DissociateTimestamp, 2L, nftId2),
+                nft(account1, 40L, false, 40L, 1L, nftId3),
+                nft(account2, 28L, true, 32L, 3L, nftId1),
+                nft(account2, 28L, true, account2Nft1DissociateTimestamp, 4L, nftId1),
+                nft(account2, 33L, true, 37L, 3L, nftId2),
+                nft(account2, 45L, false, 45L, 2L, nftId3)
+        );
+        // expect new nft transfers from token dissociate of deleted nft class
+        // expect nft transfers for nft treasury update removed
+        assertThat(nftTransferRepository.findAll()).containsExactlyInAnyOrder(
+                nftTransfer(account1Nft1DissociateTimestamp, null, account1, 2L, nftId1),
+                nftTransfer(account1Nft2DissociateTimestamp, null, account1, 2L, nftId2),
+                nftTransfer(account2Nft1DissociateTimestamp, null, account2, 4L, nftId1)
+        );
+        assertThat(tokenAccountRepository.findAll()).containsExactlyInAnyOrderElementsOf(tokenAccounts);
+        assertThat(tokenRepository.findAll()).containsExactlyInAnyOrder(ftClass1, ftClass2, nftClass1, nftClass2,
+                nftClass3);
+        // the token transfer for nft should have been removed
+        assertThat(tokenTransferRepository.findAll()).containsExactlyInAnyOrder(
+                new TokenTransfer(account1Ft1DissociateTimestamp, -10, ftId1, account1)
+        );
+        assertThat(transactionRepository.findAll()).containsExactlyInAnyOrderElementsOf(transactions);
+    }
+
+    @SneakyThrows
+    private void migrate() {
+        jdbcOperations.execute(FileUtils.readFileToString(migrationSql, "UTF-8"));
+    }
+
+    private Entity entity(Token token) {
+        return entity(token, false, token.getCreatedTimestamp());
+    }
+
+    private Entity entity(Token token, boolean deleted, long modifiedTimestamp) {
+        Entity entity = token.getTokenId().getTokenId().toEntity();
+        entity.setCreatedTimestamp(token.getCreatedTimestamp());
+        entity.setDeleted(deleted);
+        entity.setMemo("");
+        entity.setModifiedTimestamp(modifiedTimestamp);
+        return entity;
+    }
+
+    private Nft nft(EntityId accountId, long createdTimestamp, boolean deleted, long modifiedTimestamp,
+            long serialNumber, EntityId tokenId) {
+        Nft nft = new Nft(serialNumber, tokenId);
+        nft.setAccountId(accountId);
+        nft.setCreatedTimestamp(createdTimestamp);
+        nft.setDeleted(deleted);
+        nft.setMetadata(new byte[]{1});
+        nft.setModifiedTimestamp(modifiedTimestamp);
+        return nft;
+    }
+
+    private NftTransfer nftTransfer(long consensusTimestamp, EntityId receiver, EntityId sender, long serialNumber,
+            EntityId tokenId) {
+        NftTransfer nftTransfer = new NftTransfer();
+        nftTransfer.setId(new NftTransferId(consensusTimestamp, serialNumber, tokenId));
+        nftTransfer.setReceiverAccountId(receiver);
+        nftTransfer.setSenderAccountId(sender);
+        return nftTransfer;
+    }
+
+    private Token token(long createdTimestamp, EntityId tokenId, TokenTypeEnum tokenType) {
+        Token token = Token.of(tokenId);
+        token.setCreatedTimestamp(createdTimestamp);
+        token.setDecimals(0);
+        token.setFreezeDefault(false);
+        token.setInitialSupply(0L);
+        token.setModifiedTimestamp(createdTimestamp);
+        token.setName("foo");
+        token.setTotalSupply(1_000_000L);
+        token.setSupplyType(TokenSupplyTypeEnum.INFINITE);
+        token.setSymbol("bar");
+        token.setTreasuryAccountId(TREASURY);
+        token.setType(tokenType);
+        return token;
+    }
+
+    private TokenAccount tokenAccount(EntityId accountId, boolean associated, long createdTimestamp,
+            long modifiedTimestamp, EntityId tokenId) {
+        TokenAccount tokenAccount = new TokenAccount(tokenId, accountId, modifiedTimestamp);
+        tokenAccount.setAssociated(associated);
+        tokenAccount.setAutomaticAssociation(false);
+        tokenAccount.setCreatedTimestamp(createdTimestamp);
+        tokenAccount.setFreezeStatus(TokenFreezeStatusEnum.NOT_APPLICABLE);
+        tokenAccount.setKycStatus(TokenKycStatusEnum.NOT_APPLICABLE);
+        return tokenAccount;
+    }
+
+    private Transaction tokenDissociateTransaction(long consensusNs, EntityId payer) {
+        Transaction transaction = new Transaction();
+        transaction.setConsensusNs(consensusNs);
+        transaction.setEntityId(payer);
+        transaction.setPayerAccountId(payer);
+        transaction.setResult(22);
+        transaction.setType(TRANSACTION_TYPE_TOKEN_DISSOCIATE);
+        transaction.setValidStartNs(consensusNs - 5);
+        return transaction;
+    }
+}

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/SupportDeletedTokenDissociateMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/SupportDeletedTokenDissociateMigrationTest.java
@@ -188,7 +188,9 @@ class SupportDeletedTokenDissociateMigrationTest extends IntegrationTest {
         ));
 
         // nft transfers from nft class treasury update
-        nftTransferRepository.save(nftTransfer(40L, NEW_TREASURY, TREASURY, -1, nftId3));
+        nftTransferRepository.save(
+                nftTransfer(40L, NEW_TREASURY, TREASURY, NftTransferId.WILDCARD_SERIAL_NUMBER,nftId3)
+        );
 
         // expected token changes
         ftClass1.setTotalSupply(ftClass1.getTotalSupply() - 10);

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/repository/RepositoryEntityListenerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/repository/RepositoryEntityListenerTest.java
@@ -457,6 +457,15 @@ class RepositoryEntityListenerTest extends IntegrationTest {
     }
 
     @Test
+    void onTokenTransferFromDissociate() throws ImporterException {
+        TokenTransfer tokenTransfer = new TokenTransfer(10L, -2, TOKEN_ID, ENTITY_ID, true);
+        repositoryEntityListener.onTokenTransfer(tokenTransfer);
+        assertThat(tokenTransferRepository.findAll())
+                .usingElementComparatorIgnoringFields("tokenDissociate")
+                .containsOnly(tokenTransfer);
+    }
+
+    @Test
     void onTopicMessage() {
         TopicMessage topicMessage = new TopicMessage();
         topicMessage.setConsensusTimestamp(1L);

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListenerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListenerTest.java
@@ -35,13 +35,12 @@ import java.util.Optional;
 import java.util.UUID;
 import javax.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-import org.apache.commons.codec.DecoderException;
+import lombok.SneakyThrows;
 import org.apache.commons.codec.binary.Hex;
 import org.bouncycastle.util.Strings;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.transaction.support.TransactionTemplate;
 
@@ -141,7 +140,7 @@ class SqlEntityListenerTest extends IntegrationTest {
     }
 
     @Test
-    void onCryptoTransferList() throws Exception {
+    void onCryptoTransferList() {
         // given
         CryptoTransfer cryptoTransfer1 = new CryptoTransfer(1L, 1L, EntityId.of(0L, 0L, 1L, ACCOUNT));
         CryptoTransfer cryptoTransfer2 = new CryptoTransfer(2L, -2L, EntityId.of(0L, 0L, 2L, ACCOUNT));
@@ -159,7 +158,7 @@ class SqlEntityListenerTest extends IntegrationTest {
     }
 
     @Test
-    void onNonFeeTransfer() throws Exception {
+    void onNonFeeTransfer() {
         // given
         NonFeeTransfer nonFeeTransfer1 = new NonFeeTransfer(1L, new NonFeeTransfer.Id(1L, EntityId
                 .of(0L, 0L, 1L, ACCOUNT)));
@@ -179,7 +178,7 @@ class SqlEntityListenerTest extends IntegrationTest {
     }
 
     @Test
-    void onTopicMessage() throws Exception {
+    void onTopicMessage() {
         // given
         TopicMessage topicMessage = getTopicMessage();
 
@@ -194,7 +193,7 @@ class SqlEntityListenerTest extends IntegrationTest {
     }
 
     @Test
-    void onFileData() throws Exception {
+    void onFileData() {
         // given
         FileData expectedFileData = new FileData(11L, Strings.toByteArray("file data"), EntityId
                 .of(0, 0, 111, EntityTypeEnum.FILE), TransactionTypeEnum.CONSENSUSSUBMITMESSAGE.getProtoId());
@@ -210,7 +209,7 @@ class SqlEntityListenerTest extends IntegrationTest {
     }
 
     @Test
-    void onContractResult() throws Exception {
+    void onContractResult() {
         // given
         ContractResult expectedContractResult = new ContractResult(15L, "function parameters".getBytes(),
                 10000L, "call result".getBytes(), 10000L);
@@ -226,7 +225,7 @@ class SqlEntityListenerTest extends IntegrationTest {
     }
 
     @Test
-    void onLiveHash() throws Exception {
+    void onLiveHash() {
         // given
         LiveHash expectedLiveHash = new LiveHash(20L, "live hash".getBytes());
 
@@ -241,7 +240,7 @@ class SqlEntityListenerTest extends IntegrationTest {
     }
 
     @Test
-    void onTransaction() throws Exception {
+    void onTransaction() {
         // given
         var expectedTransaction = makeTransaction();
 
@@ -257,7 +256,7 @@ class SqlEntityListenerTest extends IntegrationTest {
 
     @Test
     @Transactional
-    void onEntityId() throws Exception {
+    void onEntityId() {
         // given
         EntityId entityId = EntityId.of(0L, 0L, 10L, ACCOUNT);
 
@@ -272,7 +271,7 @@ class SqlEntityListenerTest extends IntegrationTest {
     }
 
     @Test
-    void onEntityIdDuplicates() throws Exception {
+    void onEntityIdDuplicates() {
         // given
         EntityId entityId = EntityId.of(0L, 0L, 10L, ACCOUNT);
 
@@ -293,7 +292,7 @@ class SqlEntityListenerTest extends IntegrationTest {
     }
 
     @Test
-    void onEntityMerge() throws Exception {
+    void onEntityMerge() {
         // given
         Entity entity = getEntity(1, 1L, 1L, "memo", keyFromString(KEY),
                 null, null, false, null, null);
@@ -327,7 +326,7 @@ class SqlEntityListenerTest extends IntegrationTest {
     }
 
     @Test
-    void onEntityEntityIdMerge() throws Exception {
+    void onEntityEntityIdMerge() {
         // given
         Entity entity = getEntity(1, 1L, 1L, "memo-updated", keyFromString(KEY),
                 EntityId.of(0L, 0L, 10L, ACCOUNT), 360L, false, 720L, keyFromString(KEY2));
@@ -354,7 +353,7 @@ class SqlEntityListenerTest extends IntegrationTest {
     }
 
     @Test
-    void onNft() throws Exception {
+    void onNft() {
         // create token first
         EntityId tokenId1 = EntityId.of("0.0.1", TOKEN);
         EntityId tokenId2 = EntityId.of("0.0.3", TOKEN);
@@ -391,7 +390,7 @@ class SqlEntityListenerTest extends IntegrationTest {
     }
 
     @Test
-    void onNftMintOutOfOrder() throws Exception {
+    void onNftMintOutOfOrder() {
         // create token first
         EntityId tokenId1 = EntityId.of("0.0.1", TOKEN);
         EntityId tokenId2 = EntityId.of("0.0.3", TOKEN);
@@ -428,7 +427,7 @@ class SqlEntityListenerTest extends IntegrationTest {
     }
 
     @Test
-    void onNftDomainTransfer() throws Exception {
+    void onNftDomainTransfer() {
         // create token first
         EntityId tokenId1 = EntityId.of("0.0.1", TOKEN);
         EntityId tokenId2 = EntityId.of("0.0.3", TOKEN);
@@ -470,7 +469,7 @@ class SqlEntityListenerTest extends IntegrationTest {
     }
 
     @Test
-    void onNftTransferOwnershipAndDelete() throws Exception {
+    void onNftTransferOwnershipAndDelete() {
         // create token first
         EntityId tokenId1 = EntityId.of("0.0.1", TOKEN);
         EntityId accountId1 = EntityId.of("0.0.2", ACCOUNT);
@@ -517,7 +516,7 @@ class SqlEntityListenerTest extends IntegrationTest {
     }
 
     @Test
-    void onNftTransferOwnershipAndDeleteOutOfOrder() throws Exception {
+    void onNftTransferOwnershipAndDeleteOutOfOrder() {
         // create token first
         EntityId tokenId1 = EntityId.of("0.0.1", TOKEN);
         EntityId accountId1 = EntityId.of("0.0.2", ACCOUNT);
@@ -563,7 +562,7 @@ class SqlEntityListenerTest extends IntegrationTest {
     }
 
     @Test
-    void onNftTransfer() throws Exception {
+    void onNftTransfer() {
         NftTransfer nftTransfer1 = getNftTransfer(1L, "0.0.1", 1L, "0.0.2", "0.0.3");
         NftTransfer nftTransfer2 = getNftTransfer(2L, "0.0.1", 2L, "0.0.2", "0.0.3");
         NftTransfer nftTransfer3 = getNftTransfer(3L, "0.0.2", 1L, "0.0.2", "0.0.3");
@@ -585,7 +584,7 @@ class SqlEntityListenerTest extends IntegrationTest {
     }
 
     @Test
-    void onToken() throws Exception {
+    void onToken() {
         Token token1 = getToken(EntityId.of("0.0.3", TOKEN), EntityId.of("0.0.5", ACCOUNT), 1L, 1L);
         Token token2 = getToken(EntityId.of("0.0.7", TOKEN), EntityId.of("0.0.11", ACCOUNT), 2L, 2L);
 
@@ -602,7 +601,7 @@ class SqlEntityListenerTest extends IntegrationTest {
     }
 
     @Test
-    void onTokenMerge() throws Exception {
+    void onTokenMerge() {
         EntityId tokenId = EntityId.of("0.0.3", TOKEN);
         EntityId accountId = EntityId.of("0.0.500", ACCOUNT);
 
@@ -625,7 +624,62 @@ class SqlEntityListenerTest extends IntegrationTest {
     }
 
     @Test
-    void onTokenAccount() throws Exception {
+    void onTokenConsecutiveNegativeTotalSupply() {
+        // given
+        EntityId tokenId = EntityId.of("0.0.3", TOKEN);
+        EntityId accountId = EntityId.of("0.0.500", ACCOUNT);
+
+        // save token
+        Token token = getToken(tokenId, accountId, 1L, 1L);
+        sqlEntityListener.onToken(token);
+        completeFileAndCommit();
+
+        // when
+        // two dissociate of the deleted token, both with negative amount
+        Token update = getTokenUpdate(tokenId, 5);
+        update.setTotalSupply(-10L);
+        sqlEntityListener.onToken(update);
+
+        update = getTokenUpdate(tokenId, 6);
+        update.setTotalSupply(-15L);
+        sqlEntityListener.onToken(update);
+
+        completeFileAndCommit(recordFile2);
+
+        // then
+        assertThat(recordFileRepository.findAll()).containsExactlyInAnyOrder(recordFile1, recordFile2);
+        token.setTotalSupply(token.getTotalSupply() - 25);
+        token.setModifiedTimestamp(6);
+        assertExistsAndEquals(tokenRepository, token, new TokenId(tokenId));
+    }
+
+    @Test
+    void onTokenMergeNegativeTotalSupply() {
+        // given
+        EntityId tokenId = EntityId.of("0.0.3", TOKEN);
+        EntityId accountId = EntityId.of("0.0.500", ACCOUNT);
+
+        // when
+        // create token
+        Token token = getToken(tokenId, accountId, 1L, 1L);
+        sqlEntityListener.onToken(token);
+
+        // token dissociate of the deleted token
+        Token update = getTokenUpdate(tokenId, 5);
+        update.setTotalSupply(-10L);
+        sqlEntityListener.onToken(update);
+
+        completeFileAndCommit();
+
+        // then
+        Token expected = getToken(tokenId, accountId, 1L, 5L);
+        expected.setTotalSupply(expected.getTotalSupply() - 10);
+        assertThat(recordFileRepository.findAll()).containsOnly(recordFile1);
+        assertExistsAndEquals(tokenRepository, expected, new TokenId(tokenId));
+    }
+
+    @Test
+    void onTokenAccount() {
         EntityId tokenId1 = EntityId.of("0.0.3", TOKEN);
         EntityId tokenId2 = EntityId.of("0.0.5", TOKEN);
 
@@ -656,7 +710,7 @@ class SqlEntityListenerTest extends IntegrationTest {
     }
 
     @Test
-    void onTokenAccountDissociate() throws Exception {
+    void onTokenAccountDissociate() {
         EntityId tokenId1 = EntityId.of("0.0.3", TOKEN);
 
         // save token entities first
@@ -667,24 +721,24 @@ class SqlEntityListenerTest extends IntegrationTest {
         EntityId accountId1 = EntityId.of("0.0.7", ACCOUNT);
         TokenAccount associate = getTokenAccount(tokenId1, accountId1, 5L, 5L, true, false,
                 TokenFreezeStatusEnum.NOT_APPLICABLE, TokenKycStatusEnum.NOT_APPLICABLE);
-        TokenAccount dissociate = getTokenAccount(tokenId1, accountId1, null, 10L, false, null,
-                null, null);
+        TokenAccount dissociate = getTokenAccount(tokenId1, accountId1, null, 10L, false, null, null, null);
 
         // when
         sqlEntityListener.onTokenAccount(associate);
         sqlEntityListener.onTokenAccount(dissociate);
-        completeFileAndCommit();
+        completeFileAndCommit(recordFile2);
 
         // then
-        assertThat(recordFileRepository.findAll()).containsExactly(recordFile1);
+        assertThat(recordFileRepository.findAll()).containsExactlyInAnyOrder(recordFile1, recordFile2);
         assertThat(tokenAccountRepository.findAll()).containsExactlyInAnyOrder(
                 associate,
-                getTokenAccount(tokenId1, accountId1, 5L, 10L, false, false, TokenFreezeStatusEnum.NOT_APPLICABLE, TokenKycStatusEnum.NOT_APPLICABLE)
+                getTokenAccount(tokenId1, accountId1, 5L, 10L, false, false, TokenFreezeStatusEnum.NOT_APPLICABLE,
+                        TokenKycStatusEnum.NOT_APPLICABLE)
         );
     }
 
     @Test
-    void onTokenAccountMerge() throws Exception {
+    void onTokenAccountMerge() {
         EntityId tokenId1 = EntityId.of("0.0.3", TOKEN);
 
         // save token entities first
@@ -693,12 +747,11 @@ class SqlEntityListenerTest extends IntegrationTest {
 
         // when
         EntityId accountId1 = EntityId.of("0.0.7", ACCOUNT);
-        TokenAccount tokenAccountAssociate = getTokenAccount(tokenId1, accountId1, 5L, 5L, true, false,
-                null, null);
+        TokenAccount tokenAccountAssociate = getTokenAccount(tokenId1, accountId1, 5L, 5L, true, false, null, null);
         sqlEntityListener.onTokenAccount(tokenAccountAssociate);
 
-        TokenAccount tokenAccountKyc = getTokenAccount(tokenId1, accountId1, null, 15L, null, null,
-                null, TokenKycStatusEnum.GRANTED);
+        TokenAccount tokenAccountKyc = getTokenAccount(tokenId1, accountId1, null, 15L, null, null, null,
+                TokenKycStatusEnum.GRANTED);
         sqlEntityListener.onTokenAccount(tokenAccountKyc);
 
         completeFileAndCommit();
@@ -712,7 +765,7 @@ class SqlEntityListenerTest extends IntegrationTest {
     }
 
     @Test
-    void onTokenAccountReassociate() throws Exception {
+    void onTokenAccountReassociate() {
         List<TokenAccount> expected = new ArrayList<>();
         EntityId tokenId1 = EntityId.of("0.0.3", TOKEN);
 
@@ -722,7 +775,8 @@ class SqlEntityListenerTest extends IntegrationTest {
 
         // token account was associated before this record file
         EntityId accountId1 = EntityId.of("0.0.7", ACCOUNT);
-        TokenAccount associate = getTokenAccount(tokenId1, accountId1, 5L, 5L, true, false, TokenFreezeStatusEnum.FROZEN, TokenKycStatusEnum.REVOKED);
+        TokenAccount associate = getTokenAccount(tokenId1, accountId1, 5L, 5L, true, false,
+                TokenFreezeStatusEnum.FROZEN, TokenKycStatusEnum.REVOKED);
         tokenAccountRepository.save(associate);
         expected.add(associate);
 
@@ -733,22 +787,20 @@ class SqlEntityListenerTest extends IntegrationTest {
         expected.add(getTokenAccount(tokenId1, accountId1, 5L, 10L, true, false, TokenFreezeStatusEnum.FROZEN,
                 TokenKycStatusEnum.REVOKED));
 
-        TokenAccount kycGrant = getTokenAccount(tokenId1, accountId1, null, 15L, null, null,
-                null, TokenKycStatusEnum.GRANTED);
+        TokenAccount kycGrant = getTokenAccount(tokenId1, accountId1, null, 15L, null, null, null,
+                TokenKycStatusEnum.GRANTED);
         sqlEntityListener.onTokenAccount(kycGrant);
         expected.add(getTokenAccount(tokenId1, accountId1, 5L, 15L, true, false, TokenFreezeStatusEnum.FROZEN,
                 TokenKycStatusEnum.GRANTED));
 
-        TokenAccount dissociate = getTokenAccount(tokenId1, accountId1, null, 16L, false, null,
-                null, null);
+        TokenAccount dissociate = getTokenAccount(tokenId1, accountId1, null, 16L, false, null, null, null);
         sqlEntityListener.onTokenAccount(dissociate);
         expected.add(getTokenAccount(tokenId1, accountId1, 5L, 16L, false, false, TokenFreezeStatusEnum.FROZEN,
                 TokenKycStatusEnum.GRANTED));
 
         // associate after dissociate, the token has freeze key with freezeDefault = false, the token also has kyc key,
         // so the new relationship should have UNFROZEN, REVOKED
-        TokenAccount reassociate = getTokenAccount(tokenId1, accountId1, 20L, 20L, true, false,
-                null, null);
+        TokenAccount reassociate = getTokenAccount(tokenId1, accountId1, 20L, 20L, true, false, null, null);
         sqlEntityListener.onTokenAccount(reassociate);
         expected.add(getTokenAccount(tokenId1, accountId1, 20L, 20L, true, false, TokenFreezeStatusEnum.UNFROZEN,
                 TokenKycStatusEnum.REVOKED));
@@ -783,7 +835,7 @@ class SqlEntityListenerTest extends IntegrationTest {
     }
 
     @Test
-    void onTokenAccountMissingLastAssociation() throws Exception {
+    void onTokenAccountMissingLastAssociation() {
         EntityId tokenId1 = EntityId.of("0.0.3", TOKEN);
         EntityId accountId1 = EntityId.of("0.0.7", ACCOUNT);
 
@@ -808,7 +860,7 @@ class SqlEntityListenerTest extends IntegrationTest {
     }
 
     @Test
-    void onTokenAccountSpanningRecordFiles() throws Exception {
+    void onTokenAccountSpanningRecordFiles() {
         List<TokenAccount> expected = new ArrayList<>();
         EntityId tokenId1 = EntityId.of("0.0.3", TOKEN);
         EntityId accountId1 = EntityId.of("0.0.7", ACCOUNT);
@@ -862,7 +914,7 @@ class SqlEntityListenerTest extends IntegrationTest {
     }
 
     @Test
-    void onTokenTransfer() throws Exception {
+    void onTokenTransfer() {
         EntityId tokenId1 = EntityId.of("0.0.3", TOKEN);
         EntityId tokenId2 = EntityId.of("0.0.7", TOKEN);
         EntityId accountId1 = EntityId.of("0.0.5", ACCOUNT);
@@ -887,7 +939,7 @@ class SqlEntityListenerTest extends IntegrationTest {
     }
 
     @Test
-    void onSchedule() throws Exception {
+    void onSchedule() {
         EntityId entityId1 = EntityId.of("0.0.100", EntityTypeEnum.SCHEDULE);
         EntityId entityId2 = EntityId.of("0.0.200", EntityTypeEnum.SCHEDULE);
 
@@ -907,7 +959,7 @@ class SqlEntityListenerTest extends IntegrationTest {
     }
 
     @Test
-    void onScheduleSignature() throws Exception {
+    void onScheduleSignature() {
         EntityId entityId1 = EntityId.of("0.0.100", EntityTypeEnum.SCHEDULE);
         EntityId entityId2 = EntityId.of("0.0.200", EntityTypeEnum.SCHEDULE);
         EntityId entityId3 = EntityId.of("0.0.300", EntityTypeEnum.SCHEDULE);
@@ -940,7 +992,7 @@ class SqlEntityListenerTest extends IntegrationTest {
     }
 
     @Test
-    void onScheduleMerge() throws Exception {
+    void onScheduleMerge() {
         String scheduleId = "0.0.100";
         EntityId entityId = EntityId.of(scheduleId, EntityTypeEnum.SCHEDULE);
 
@@ -963,7 +1015,7 @@ class SqlEntityListenerTest extends IntegrationTest {
         assertExistsAndEquals(scheduleRepository, scheduleMerged, entityId.getId());
     }
 
-    private <T, ID> void assertExistsAndEquals(CrudRepository<T, ID> repository, T expected, ID id) throws Exception {
+    private <T, ID> void assertExistsAndEquals(CrudRepository<T, ID> repository, T expected, ID id) {
         Optional<T> actual = repository.findById(id);
         assertTrue(actual.isPresent());
         assertEquals(expected, actual.get());
@@ -1066,7 +1118,8 @@ class SqlEntityListenerTest extends IntegrationTest {
         return topicMessage;
     }
 
-    private Token getToken(EntityId tokenId, EntityId accountId, Long createdTimestamp, long modifiedTimestamp) throws DecoderException {
+    @SneakyThrows
+    private Token getToken(EntityId tokenId, EntityId accountId, Long createdTimestamp, long modifiedTimestamp) {
         var instr = "0011223344556677889900aabbccddeeff0011223344556677889900aabbccddeeff";
         var hexKey = Key.newBuilder().setEd25519(ByteString.copyFrom(Hex.decodeHex(instr))).build();
         return getToken(tokenId, accountId, createdTimestamp, modifiedTimestamp, 1000, false, hexKey,
@@ -1094,6 +1147,12 @@ class SqlEntityListenerTest extends IntegrationTest {
         token.setTreasuryAccountId(accountId);
         token.setWipeKey(wipeKey != null ? wipeKey.toByteArray() : null);
 
+        return token;
+    }
+
+    private Token getTokenUpdate(EntityId tokenId, long modifiedTimestamp) {
+        Token token = Token.of(tokenId);
+        token.setModifiedTimestamp(modifiedTimestamp);
         return token;
     }
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenUpdateTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenUpdateTransactionHandlerTest.java
@@ -37,6 +37,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.hedera.mirror.importer.domain.Entity;
 import com.hedera.mirror.importer.domain.EntityTypeEnum;
+import com.hedera.mirror.importer.domain.NftTransferId;
 import com.hedera.mirror.importer.parser.domain.RecordItem;
 import com.hedera.mirror.importer.repository.NftRepository;
 import com.hedera.mirror.importer.util.Utility;
@@ -88,7 +89,7 @@ class TokenUpdateTransactionHandlerTest extends AbstractTransactionHandlerTest {
                 .addNftTransfers(NftTransfer.newBuilder()
                         .setReceiverAccountID(newAccountId)
                         .setSenderAccountID(previousAccountId)
-                        .setSerialNumber(TokenUpdateTransactionHandler.WILDCARD_SERIAL_NUMBER)
+                        .setSerialNumber(NftTransferId.WILDCARD_SERIAL_NUMBER)
                         .build())
                 .build();
         TransactionRecord record = getDefaultTransactionRecord().addTokenTransferLists(tokenTransferList).build();

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/TokenRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/TokenRepositoryTest.java
@@ -21,23 +21,23 @@ package com.hedera.mirror.importer.repository;
  */
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.from;
 
 import com.google.protobuf.ByteString;
 import com.hederahashgraph.api.proto.java.Key;
 import javax.annotation.Resource;
-import org.apache.commons.codec.DecoderException;
+import lombok.SneakyThrows;
 import org.apache.commons.codec.binary.Hex;
 import org.junit.jupiter.api.Test;
 
 import com.hedera.mirror.importer.domain.EntityId;
 import com.hedera.mirror.importer.domain.EntityTypeEnum;
 import com.hedera.mirror.importer.domain.Token;
+import com.hedera.mirror.importer.domain.TokenId;
 import com.hedera.mirror.importer.domain.TokenSupplyTypeEnum;
 import com.hedera.mirror.importer.domain.TokenTypeEnum;
-import com.hedera.mirror.importer.domain.TokenId;
 
 class TokenRepositoryTest extends AbstractRepositoryTest {
+
     @Resource
     protected TokenRepository tokenRepository;
 
@@ -47,14 +47,13 @@ class TokenRepositoryTest extends AbstractRepositoryTest {
     private static final long INITIAL_SUPPLY = 1_000_000L;
 
     @Test
-    void save() throws DecoderException {
+    void save() {
         Token token = tokenRepository.save(token(1));
-        assertThat(tokenRepository.findById(token.getTokenId())
-                .get()).isEqualTo(token);
+        assertThat(tokenRepository.findById(token.getTokenId())).get().isEqualTo(token);
     }
 
     @Test
-    void nullCharacter() throws DecoderException {
+    void nullCharacter() {
         Token token = token(1);
         token.setName("abc" + (char) 0);
         token.setSymbol("abc" + (char) 0);
@@ -62,31 +61,8 @@ class TokenRepositoryTest extends AbstractRepositoryTest {
         assertThat(tokenRepository.findById(token.getTokenId())).get().isEqualTo(token);
     }
 
-    @Test
-    void updateSupply() throws DecoderException {
-        Token token = tokenRepository.save(token(1));
-        long newTotalSupply = INITIAL_SUPPLY - 1000;
-        long modifiedTimestamp = 5L;
-        tokenRepository.updateTokenSupply(token.getTokenId(), newTotalSupply, modifiedTimestamp);
-        assertThat(tokenRepository.findById(token.getTokenId()).get())
-                .returns(modifiedTimestamp, from(Token::getModifiedTimestamp))
-                .returns(newTotalSupply, from(Token::getTotalSupply));
-    }
-
-    @Test
-    void updateSupplyOnMissingToken() throws DecoderException {
-        long createdTimestamp = 1L;
-        Token token = tokenRepository.save(token(createdTimestamp));
-        long newTotalSupply = INITIAL_SUPPLY - 1000;
-        long modifiedTimestamp = 5L;
-        TokenId missingTokenId = new TokenId(EntityId.of("0.0.555", EntityTypeEnum.TOKEN));
-        tokenRepository.updateTokenSupply(missingTokenId, newTotalSupply, modifiedTimestamp);
-        assertThat(tokenRepository.findById(token.getTokenId()).get())
-                .returns(createdTimestamp, from(Token::getModifiedTimestamp))
-                .returns(INITIAL_SUPPLY, from(Token::getTotalSupply));
-    }
-
-    private Token token(long consensusTimestamp) throws DecoderException {
+    @SneakyThrows
+    private Token token(long consensusTimestamp) {
         var hexKey = Key.newBuilder().setEd25519(ByteString.copyFrom(Hex.decodeHex(key))).build().toByteArray();
         Token token = new Token();
         token.setCreatedTimestamp(consensusTimestamp);

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/TokenTransferRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/TokenTransferRepositoryTest.java
@@ -24,15 +24,33 @@ import static com.hedera.mirror.importer.domain.EntityTypeEnum.ACCOUNT;
 import static com.hedera.mirror.importer.domain.EntityTypeEnum.TOKEN;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
 import javax.annotation.Resource;
 import org.junit.jupiter.api.Test;
 
 import com.hedera.mirror.importer.domain.EntityId;
+import com.hedera.mirror.importer.domain.EntityTypeEnum;
+import com.hedera.mirror.importer.domain.Nft;
+import com.hedera.mirror.importer.domain.NftTransfer;
+import com.hedera.mirror.importer.domain.NftTransferId;
+import com.hedera.mirror.importer.domain.Token;
+import com.hedera.mirror.importer.domain.TokenSupplyTypeEnum;
 import com.hedera.mirror.importer.domain.TokenTransfer;
+import com.hedera.mirror.importer.domain.TokenTypeEnum;
 
 class TokenTransferRepositoryTest extends AbstractRepositoryTest {
+
     @Resource
-    protected TokenTransferRepository tokenTransferRepository;
+    private NftRepository nftRepository;
+
+    @Resource
+    private NftTransferRepository nftTransferRepository;
+
+    @Resource
+    private TokenRepository tokenRepository;
+
+    @Resource
+    private TokenTransferRepository tokenTransferRepository;
 
     @Test
     void findById() {
@@ -46,5 +64,93 @@ class TokenTransferRepositoryTest extends AbstractRepositoryTest {
         assertThat(tokenTransferRepository.findById(tokenTransfer.getId()))
                 .get()
                 .isEqualTo(tokenTransfer);
+    }
+
+    @Test
+    void insertNftTransferForTokenDissociate() {
+        // given
+        // it's nft and the account has 2 nft instances at the time of token dissociate
+        Token token = deletedNftClass(10L, 18L);
+        EntityId tokenId = token.getTokenId().getTokenId();
+        EntityId accountId = EntityId.of("0.0.210", EntityTypeEnum.ACCOUNT);
+        Nft nft1 = nft(tokenId, accountId, 1, 15L);
+        Nft nft2 = nft(tokenId, accountId, 2, 16L);
+
+        tokenRepository.save(token);
+        nftRepository.saveAll(List.of(nft1, nft2));
+
+        // when
+        // there is a tokenTransferList in the transaction record of a token dissociate transaction
+        tokenTransferRepository.insertTransferForTokenDissociate(accountId.getId(), -2, 20L, tokenId.getId());
+
+        // then
+        assertThat(nftRepository.findAll()).containsExactlyInAnyOrder(
+                nft(tokenId, accountId, 1, 15L, 20L, true),
+                nft(tokenId, accountId, 2, 16L, 20L, true)
+        );
+        assertThat(nftTransferRepository.findAll()).containsExactlyInAnyOrder(
+                nftTransfer(tokenId, accountId, 1L, 20L),
+                nftTransfer(tokenId, accountId, 2L, 20L)
+        );
+        assertThat(tokenTransferRepository.findAll()).isEmpty();
+    }
+
+    @Test
+    void insertTokenTransferForTokenDissociate() {
+        // given
+        // it's a fungible token transfer from a token dissociate transaction
+        EntityId accountId = EntityId.of("0.0.200", EntityTypeEnum.ACCOUNT);
+        long amount = -2;
+        long consensusTimestamp = 20;
+        EntityId tokenId = EntityId.of("0.0.100", EntityTypeEnum.TOKEN);
+        TokenTransfer expected = new TokenTransfer(consensusTimestamp, amount, tokenId, accountId);
+
+        // when
+        tokenTransferRepository.insertTransferForTokenDissociate(accountId.getId(), amount, consensusTimestamp,
+                tokenId.getId());
+
+        // then
+        assertThat(nftRepository.findAll()).isEmpty();
+        assertThat(nftTransferRepository.findAll()).isEmpty();
+        assertThat(tokenTransferRepository.findAll()).containsOnly(expected);
+    }
+
+    private Token deletedNftClass(long createdTimestamp, long deletedTimestamp) {
+        Token token = Token.of(EntityId.of("0.0.100", EntityTypeEnum.TOKEN));
+        token.setCreatedTimestamp(createdTimestamp);
+        token.setDecimals(0);
+        token.setFreezeDefault(false);
+        token.setInitialSupply(0L);
+        token.setModifiedTimestamp(deletedTimestamp);
+        token.setName("foo");
+        token.setSupplyType(TokenSupplyTypeEnum.FINITE);
+        token.setSymbol("bar");
+        token.setTotalSupply(200L);
+        token.setTreasuryAccountId(EntityId.of("0.0.200", EntityTypeEnum.ACCOUNT));
+        token.setType(TokenTypeEnum.NON_FUNGIBLE_UNIQUE);
+        return token;
+    }
+
+    private Nft nft(EntityId tokenId, EntityId accountId, long serialNumber, long consensusTimestamp) {
+        return nft(tokenId, accountId, serialNumber, consensusTimestamp, consensusTimestamp, false);
+    }
+
+    private Nft nft(EntityId tokenId, EntityId accountId, long serialNumber, long consensusTimestamp,
+            long modifiedTimestamp, boolean deleted) {
+        Nft nft = new Nft(serialNumber, tokenId);
+        nft.setAccountId(accountId);
+        nft.setCreatedTimestamp(consensusTimestamp);
+        nft.setMetadata(new byte[] {1});
+        nft.setDeleted(deleted);
+        nft.setModifiedTimestamp(modifiedTimestamp);
+        return nft;
+    }
+
+    private NftTransfer nftTransfer(EntityId tokenId, EntityId senderAccountId, long serialNumber,
+            long consensusTimestamp) {
+        NftTransfer nftTransfer = new NftTransfer();
+        nftTransfer.setId(new NftTransferId(consensusTimestamp, serialNumber, tokenId));
+        nftTransfer.setSenderAccountId(senderAccountId);
+        return nftTransfer;
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/TokenUpsertQueryGeneratorTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/TokenUpsertQueryGeneratorTest.java
@@ -64,29 +64,44 @@ class TokenUpsertQueryGeneratorTest extends AbstractUpsertQueryGeneratorTest {
     @Override
     protected String getUpdateQuery() {
         return "update token set " +
-                "fee_schedule_key = coalesce(token_temp.fee_schedule_key, token.fee_schedule_key), " +
-                "fee_schedule_key_ed25519_hex = case when token_temp.fee_schedule_key_ed25519_hex = '<uuid>' then '' " +
-                "else " +
-                "coalesce(token_temp.fee_schedule_key_ed25519_hex, token.fee_schedule_key_ed25519_hex) end, " +
-                "freeze_key = coalesce(token_temp.freeze_key, token.freeze_key), " +
-                "freeze_key_ed25519_hex = case when token_temp.freeze_key_ed25519_hex = '<uuid>' then '' else " +
-                "coalesce(token_temp.freeze_key_ed25519_hex, token.freeze_key_ed25519_hex) end, " +
-                "kyc_key = coalesce(token_temp.kyc_key, token.kyc_key), " +
-                "kyc_key_ed25519_hex = case when token_temp.kyc_key_ed25519_hex = '<uuid>' then " +
-                "'' else coalesce(token_temp.kyc_key_ed25519_hex, token.kyc_key_ed25519_hex) end, " +
-                "modified_timestamp = coalesce(token_temp.modified_timestamp, token.modified_timestamp), " +
-                "name = case when token_temp.name = '<uuid>' then '' else coalesce(token_temp.name, token.name) end, " +
-                "supply_key = coalesce(token_temp.supply_key, token.supply_key), " +
-                "supply_key_ed25519_hex = case when token_temp.supply_key_ed25519_hex = '<uuid>' then '' else " +
-                "coalesce(token_temp.supply_key_ed25519_hex, token.supply_key_ed25519_hex) end, " +
-                "symbol = case when token_temp.symbol = '<uuid>' then '' else coalesce(token_temp.symbol, token" +
-                ".symbol) end, " +
-                "total_supply = coalesce(token_temp.total_supply, token.total_supply), " +
-                "treasury_account_id = coalesce(token_temp.treasury_account_id, token.treasury_account_id), " +
-                "wipe_key = coalesce(token_temp.wipe_key, token.wipe_key), " +
-                "wipe_key_ed25519_hex = case when token_temp.wipe_key_ed25519_hex = '<uuid>' " +
-                "then '' else coalesce(token_temp.wipe_key_ed25519_hex, token.wipe_key_ed25519_hex) end " +
-                "from token_temp where token.token_id = token_temp.token_id and token_temp.created_timestamp is null";
+                "  fee_schedule_key = coalesce(token_temp.fee_schedule_key, token.fee_schedule_key), " +
+                "  fee_schedule_key_ed25519_hex =" +
+                "    case when token_temp.fee_schedule_key_ed25519_hex = '<uuid>' then ''" +
+                "         else coalesce(token_temp.fee_schedule_key_ed25519_hex, token.fee_schedule_key_ed25519_hex)" +
+                "    end," +
+                "  freeze_key = coalesce(token_temp.freeze_key, token.freeze_key)," +
+                "  freeze_key_ed25519_hex =" +
+                "    case when token_temp.freeze_key_ed25519_hex = '<uuid>' then ''" +
+                "         else coalesce(token_temp.freeze_key_ed25519_hex, token.freeze_key_ed25519_hex)" +
+                "    end," +
+                "  kyc_key = coalesce(token_temp.kyc_key, token.kyc_key)," +
+                "  kyc_key_ed25519_hex =" +
+                "    case when token_temp.kyc_key_ed25519_hex = '<uuid>' then ''" +
+                "         else coalesce(token_temp.kyc_key_ed25519_hex, token.kyc_key_ed25519_hex)" +
+                "    end," +
+                "  modified_timestamp = coalesce(token_temp.modified_timestamp, token.modified_timestamp)," +
+                "  name = case when token_temp.name = '<uuid>' then '' else coalesce(token_temp.name, token.name) end," +
+                "  supply_key = coalesce(token_temp.supply_key, token.supply_key), " +
+                "  supply_key_ed25519_hex =" +
+                "    case when token_temp.supply_key_ed25519_hex = '<uuid>' then ''" +
+                "         else coalesce(token_temp.supply_key_ed25519_hex, token.supply_key_ed25519_hex)" +
+                "    end," +
+                "  symbol =" +
+                "    case when token_temp.symbol = '<uuid>' then ''" +
+                "         else coalesce(token_temp.symbol, token.symbol)" +
+                "    end," +
+                "  total_supply = " +
+                "     case when token_temp.total_supply >= 0 then token_temp.total_supply" +
+                "          else token.total_supply + coalesce(token_temp.total_supply, 0)" +
+                "     end," +
+                "  treasury_account_id = coalesce(token_temp.treasury_account_id, token.treasury_account_id), " +
+                "  wipe_key = coalesce(token_temp.wipe_key, token.wipe_key), " +
+                "  wipe_key_ed25519_hex =" +
+                "    case when token_temp.wipe_key_ed25519_hex = '<uuid>' then ''" +
+                "         else coalesce(token_temp.wipe_key_ed25519_hex, token.wipe_key_ed25519_hex)" +
+                "    end " +
+                "from token_temp " +
+                "where token.token_id = token_temp.token_id and token_temp.created_timestamp is null";
     }
 
     @Test


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR adds support for token transfer in token dissociate transactions. 

- update token's total supply
- create nft transfers from the token transfer for a token dissociate of a deleted nft class
- do not persist token transfers for deleted nft class in token dissociate
- do not persist nft transfer from nft treasury update
- add migration to update token, nft, nft transfer, and token transfer for existing data
 
**Related issue(s)**:

Fixes #2548 
Fixes #2578 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

Note only when a token is deleted and at the time of token dissociate the account still have a positive balance of the token, there will be a token transfer of a negative amount to bring the balance to 0.

For a token dissociate with a deleted nft class, the amount change is presented as a `TokenTransferList.transfers` of type `AccountAmount` in the transaction record.

The migration should be able to re-create all the necessary nft transfers, update the `nft`s for existing data.

Deleted fungible token supply update for token dissociate without a token transfer is left out since it requires scanning `token_transfer` to get the accurate account's token balance before token dissociate. 

The support in importer to update the token total supply and create nft transfers are done in separate paths for both `RepositoryEntityListener` and `SqlEntityLister`:

- `RepositoryEntityListener`
  - token total supply is updated by updating the total supply when merging with the cache and then `TokenRepository.save`
  - creating necessary nft transfers and updating `nft`s / persisting token transfer for fungible token is done by `TokenTransferRepository.insertTransferForTokenDissociate`
- `SqlEntityListener`
  - token total supply is taken care of by overloading `TotalSupply` to reflect the supply reduction with no previous cached copy and the updated token upsert sql statement  
  - token transfers in a token dissociate are handled by the new `TokenDissociateTransferUpsertQueryGenerator`

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
