### PR TITLE
Change network supply timestamp filter to less than equals

### DIFF
--- a/hedera-mirror-rest/__tests__/specs/network-supply-02-timestamp.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/network-supply-02-timestamp.spec.json
@@ -14,22 +14,22 @@
         "balance": 1
       },
       {
-        "timestamp": 1000000001,
+        "timestamp": 1000000005,
         "id": 1,
         "balance": 10
       },
       {
-        "timestamp": 1000000001,
+        "timestamp": 1000000005,
         "id": 2,
         "balance": 4000000000000000000
       },
       {
-        "timestamp": 1000000001,
+        "timestamp": 1000000005,
         "id": 42,
         "balance": 50
       },
       {
-        "timestamp": 1000000001,
+        "timestamp": 1000000005,
         "id": 100,
         "balance": 1
       }
@@ -40,9 +40,14 @@
   "urls": [
     "/api/v1/network/supply?timestamp=1",
     "/api/v1/network/supply?timestamp=1.000000000",
+    "/api/v1/network/supply?timestamp=eq:1",
+    "/api/v1/network/supply?timestamp=eq:1.000000000",
+    "/api/v1/network/supply?timestamp=1.000000001",
+    "/api/v1/network/supply?timestamp=eq:1.000000001",
+    "/api/v1/network/supply?timestamp=ne:1.000000005",
     "/api/v1/network/supply?timestamp=lte:1.000000000",
     "/api/v1/network/supply?timestamp=gte:1.000000000&timestamp=lte:1.000000000",
-    "/api/v1/network/supply?timestamp=gt:0&timestamp=lt:1.000000001"
+    "/api/v1/network/supply?timestamp=gt:0&timestamp=lt:1.000000005"
   ],
   "responseStatus": 200,
   "responseJson": {

--- a/hedera-mirror-rest/__tests__/specs/network-supply-04-not-found.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/network-supply-04-not-found.spec.json
@@ -38,7 +38,8 @@
     "cryptotransfers": []
   },
   "urls": [
-    "/api/v1/network/supply?timestamp=999",
+    "/api/v1/network/supply?timestamp=0.0001",
+    "/api/v1/network/supply?timestamp=eq:0.0001",
     "/api/v1/network/supply?timestamp=lt:0",
     "/api/v1/network/supply?timestamp=gt:999"
   ],

--- a/hedera-mirror-rest/network.js
+++ b/hedera-mirror-rest/network.js
@@ -57,7 +57,9 @@ const formatResponse = (result) => {
  */
 const getSupply = async (req, res) => {
   utils.validateReq(req);
-  const [tsQuery, tsParams] = utils.parseTimestampQueryParam(req.query, 'abf.consensus_timestamp');
+  const [tsQuery, tsParams] = utils.parseTimestampQueryParam(req.query, 'abf.consensus_timestamp', {
+    [utils.opsMap.eq]: utils.opsMap.lte,
+  });
 
   const sqlQuery = `
     select sum(balance) as unreleased_supply, max(consensus_timestamp) as consensus_timestamp


### PR DESCRIPTION
**Description**:
Change network supply to convert timestamp equality filter (both `timestamp=<num>` and `timestamp=eq:<num>`) to less than or equals. This was requested by product and matches the balance API which are both derived from the 15 minute balance file.

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
