### PR TITLE
Remove the 'Mirror' milestone prefix

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -43,7 +43,7 @@ jobs:
         if: ${{ steps.version_parser.outputs.pre-release == '' }}
         uses: julb/action-manage-milestone@v1
         with:
-          title: Mirror ${{ steps.version_parser.outputs.version }}
+          title: ${{ steps.version_parser.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -138,7 +138,7 @@ jobs:
         if: ${{ steps.milestone.outputs.number != '' }}
         uses: julb/action-manage-milestone@v1
         with:
-          title: Mirror ${{ steps.version_parser.outputs.version }}
+          title: ${{ steps.version_parser.outputs.version }}
           state: closed
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Description**:
Remove the `Mirror ` prefix from release automation so we can name milestones without any prefix. The prefix was only necessary for ZenHub since it showed milestones across repos and we're moving away from ZenHub.

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
