### PR TITLE
Fill missing transaction data for mainnet

### DIFF
--- a/hedera-mirror-importer/src/main/resources/db/scripts/fill_missing_transaction_data.sql
+++ b/hedera-mirror-importer/src/main/resources/db/scripts/fill_missing_transaction_data.sql
@@ -1,0 +1,22 @@
+-- Fills missing max fee, transaction hash, and valid duration seconds for mainnet for the period from OA to 12/05/2019
+
+begin;
+
+create temporary table transaction_temp (
+    consensus_ns           bigint,
+    max_fee                bigint,
+    transaction_hash       bytea,
+    valid_duration_seconds bigint
+) on commit drop;
+
+\copy transaction_temp from 'transaction.csv' with csv;
+
+update transaction
+set
+    max_fee = transaction_temp.max_fee,
+    transaction_hash = transaction_temp.transaction_hash,
+    valid_duration_seconds = transaction_temp.valid_duration_seconds
+from transaction_temp
+where transaction.consensus_ns = transaction_temp.consensus_ns and transaction.transaction_hash is null;
+
+commit;


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

Adds an sql script to fill missing transaction data for mainnet.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

The intention of the PR is for review only, and the script will stay in the branch.

`max_fee` and `valid_duration_seconds` were added in migration v1.12, and `transaction_hash` was added in migration v1.13

- migration history for mainnet primary

 version  | description                                 | installed_on
---------|-------------------------------|-------------------------------
1.12         | transactions maxfee duration   | 2019-12-04 22:55:30.520074
1.13         | transaction hash                        | 2019-12-04 22:55:30.59231

- migration history for mainnet failover


 version  | description                                 | installed_on
---------|-------------------------------|-------------------------------
1.12         | transactions maxfee duration  | 2019-12-04 19:10:56.527034
1.13         | transaction hash                       | 2019-12-04 19:10:56.554467


The importer used to ingest the missing data was set to parser record_files f from epoch till `2019-12-05T01:00:00Z`.

The extracted transaction data with the `consensus_ns` column plus the  3 columns with missing data, and its sha512 sum  are uploaded to

gs://hedera-mirror-dev/mainnet-missing-data/transaction.csv
gs://hedera-mirror-dev/mainnet-missing-data/SHA512SUM

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
