### PR TITLE
Fix notes bug in helm template

### DIFF
--- a/charts/hedera-mirror/templates/application.yaml
+++ b/charts/hedera-mirror/templates/application.yaml
@@ -55,7 +55,7 @@ spec:
       - name: Hedera Mirror Node team
         email: mirrornode@hedera.com
     notes: |
-      {{- if .Values.grpc.enabled -}}
+      {{ if .Values.grpc.enabled -}}
       To access the GRPC API:
 
         GRPC_IP=$(kubectl get service/{{ .Release.Name }}-grpc -n {{ include "hedera-mirror.namespace" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')


### PR DESCRIPTION
Signed-off-by: Ian Jungmann <ian.jungmann@hedera.com>

**Description**:
The helm chart has an issue trying to render notes (when notes need to be rendered), because of a formatting issue.
```Error: YAML parse error on hedera-mirror/templates/application.yaml: error converting YAML to JSON: yaml: line 63: did not find expected comment or line break```

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
This was discovered when working on a Marketplace upgrade.  After this fix the Helm template looks correct.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
