### PR TITLE
Add NotifyingTopicListener Support for Citus w PG 14

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -188,6 +188,7 @@ value, it is recommended to only populate overridden properties in the custom `a
 | `hedera.mirror.grpc.db.name`                                | mirror_node      | The name of the database                                                                       |
 | `hedera.mirror.grpc.db.password`                            | mirror_grpc_pass | The database password the GRPC API uses to connect.                                            |
 | `hedera.mirror.grpc.db.port`                                | 5432             | The port used to connect to the database                                                       |
+| `hedera.mirror.grpc.db.sslMode`                             | DISABLE          | The ssl level of protection against Eavesdropping, Man-in-the-middle (MITM) and Impersonation on the db connection. Accepts either DISABLE, ALLOW, PREFER, REQUIRE, VERIFY_CA oe VERIFY_FULL. |
 | `hedera.mirror.grpc.db.username`                            | mirror_grpc      | The username the GRPC API uses to connect to the database                                      |
 | `hedera.mirror.grpc.endTimeInterval`                        | 30s              | How often we should check if a subscription has gone past the end time                         |
 | `hedera.mirror.grpc.entityCacheSize`                        | 50000            | The maximum size of the cache to store entities used for existence check                       |

--- a/hedera-mirror-grpc/pom.xml
+++ b/hedera-mirror-grpc/pom.xml
@@ -178,6 +178,10 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>com.ongres.scram</groupId>
+            <artifactId>client</artifactId>
+        </dependency>
         <!-- Test -->
         <dependency>
             <groupId>io.projectreactor</groupId>

--- a/hedera-mirror-grpc/pom.xml
+++ b/hedera-mirror-grpc/pom.xml
@@ -181,6 +181,7 @@
         <dependency>
             <groupId>com.ongres.scram</groupId>
             <artifactId>client</artifactId>
+            <version>2.1</version>
         </dependency>
         <!-- Test -->
         <dependency>

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/DbProperties.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/DbProperties.java
@@ -20,8 +20,10 @@ package com.hedera.mirror.grpc;
  * ‍
  */
 
+import io.vertx.pgclient.SslMode;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
@@ -41,6 +43,9 @@ public class DbProperties {
 
     @Min(0)
     private int port = 5432;
+
+    @NotNull
+    private SslMode sslMode = SslMode.DISABLE;
 
     @NotBlank
     private String username = "";

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/NotifyingTopicListener.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/NotifyingTopicListener.java
@@ -21,7 +21,7 @@ package com.hedera.mirror.grpc.listener;
  */
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import io.vertx.core.Vertx;
 import io.vertx.pgclient.PgConnectOptions;
 import io.vertx.pgclient.pubsub.PgChannel;
@@ -47,7 +47,7 @@ public class NotifyingTopicListener extends SharedTopicListener {
     public NotifyingTopicListener(DbProperties dbProperties, ListenerProperties listenerProperties) {
         super(listenerProperties);
 
-        objectMapper = new ObjectMapper().setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
+        objectMapper = new ObjectMapper().setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
         PgConnectOptions connectOptions = new PgConnectOptions()
                 .setDatabase(dbProperties.getName())
                 .setHost(dbProperties.getHost())
@@ -82,7 +82,7 @@ public class NotifyingTopicListener extends SharedTopicListener {
                 .doOnError(t -> log.error("Error listening for messages", t))
                 .retryWhen(Retry.backoff(Long.MAX_VALUE, interval).maxBackoff(interval.multipliedBy(4L)))
                 .share()
-                .doOnTerminate(this::unlisten);
+                .doOnTerminate(this::unListen);
     }
 
     @Override
@@ -97,7 +97,7 @@ public class NotifyingTopicListener extends SharedTopicListener {
         return sink.asFlux();
     }
 
-    private void unlisten() {
+    private void unListen() {
         channel.handler(null);
         log.info("Stopped listening for messages");
     }

--- a/hedera-mirror-grpc/src/main/resources/application.yml
+++ b/hedera-mirror-grpc/src/main/resources/application.yml
@@ -6,6 +6,7 @@ hedera:
         name: mirror_node
         password: mirror_grpc_pass
         port: 5432
+        sslMode: DISABLE
         username: mirror_grpc
       port: 5600
 grpc:
@@ -60,7 +61,7 @@ spring:
   datasource:
     name: ${hedera.mirror.grpc.db.name}
     password: ${hedera.mirror.grpc.db.password}
-    url: jdbc:postgresql://${hedera.mirror.grpc.db.host}:${hedera.mirror.grpc.db.port}/${hedera.mirror.grpc.db.name}
+    url: jdbc:postgresql://${hedera.mirror.grpc.db.host}:${hedera.mirror.grpc.db.port}/${hedera.mirror.grpc.db.name}?sslmode=${hedera.mirror.grpc.db.sslMode}
     username: ${hedera.mirror.grpc.db.username}
     hikari:
       connection-timeout: 3000

--- a/hedera-mirror-grpc/src/test/resources/config/application.yml
+++ b/hedera-mirror-grpc/src/test/resources/config/application.yml
@@ -16,7 +16,6 @@ hedera:
         port: ${embedded.postgresql.port}
         name: ${embedded.postgresql.schema}
         username: ${embedded.postgresql.user}
-        sslMode: DISABLE
         password: ${embedded.postgresql.password}
       endTimeInterval: 100ms
       listener:

--- a/hedera-mirror-grpc/src/test/resources/config/application.yml
+++ b/hedera-mirror-grpc/src/test/resources/config/application.yml
@@ -16,6 +16,7 @@ hedera:
         port: ${embedded.postgresql.port}
         name: ${embedded.postgresql.schema}
         username: ${embedded.postgresql.user}
+        sslMode: DISABLE
         password: ${embedded.postgresql.password}
       endTimeInterval: 100ms
       listener:
@@ -28,7 +29,7 @@ spring:
   datasource:
     name: ${hedera.mirror.grpc.db.name}
     password: ${hedera.mirror.grpc.db.password}
-    url: jdbc:postgresql://${hedera.mirror.grpc.db.host}:${hedera.mirror.grpc.db.port}/${hedera.mirror.grpc.db.name}
+    url: jdbc:postgresql://${hedera.mirror.grpc.db.host}:${hedera.mirror.grpc.db.port}/${hedera.mirror.grpc.db.name}?sslmode=${hedera.mirror.grpc.db.sslMode}
     username: ${hedera.mirror.grpc.db.username}
   flyway:
     baselineOnMigrate: true

--- a/hedera-mirror-grpc/src/test/resources/config/bootstrap-v2.yml
+++ b/hedera-mirror-grpc/src/test/resources/config/bootstrap-v2.yml
@@ -1,6 +1,6 @@
 embedded:
   postgresql:
-    docker-image: citusdata/citus:10.2.1-alpine
+    docker-image: citusdata/citus:10.2.2-alpine
 spring:
   flyway:
     baselineVersion: 1.999.999

--- a/hedera-mirror-importer/src/test/resources/config/bootstrap-v2.yml
+++ b/hedera-mirror-importer/src/test/resources/config/bootstrap-v2.yml
@@ -1,3 +1,3 @@
 embedded:
   postgresql:
-    docker-image: citusdata/citus:10.2.1-alpine
+    docker-image: citusdata/citus:10.2.2-alpine

--- a/hedera-mirror-rest/__tests__/integrationDbOps.js
+++ b/hedera-mirror-rest/__tests__/integrationDbOps.js
@@ -56,7 +56,7 @@ const v1SchemaConfigs = {
 const v2SchemaConfigs = {
   docker: {
     imageName: 'citusdata/citus',
-    tagName: '10.2.1-alpine',
+    tagName: '10.2.2-alpine',
   },
   flyway: {
     baselineVersion: '1.999.999',


### PR DESCRIPTION
**Description**:
When updating to citus for the v2 database the `NotifyingTopicListener` flow seemed to not be supported when using PG 14 as the underlying db.
It continuously hit an exception unable to find the `ScramException.class` in the classPath.
```
Unhandled exception java.lang.RuntimeException: java.lang.NoClassDefFoundError: com/ongres/scram/common/exception/ScramException
```

Vertx provides integration with the [SASL SCRAM-SHA-256 authentication mechanism](https://vertx.io/docs/4.1.5/vertx-pg-client/java/#_sasl_scram_sha_256_authentication_mechanism) that we were not utilizing.

- Add `com.ongres.scram: client` dependency to grpc `pom.xml` to ensure `ScramException.class` can be found in the classPath
- Update `DbProperties` with `sslMode` config, default to `SslMode.DISABLE`
- Update `NotifyingTopicListener` with support to set SslMode configuration.
- Update `vertx` dependency to `4.2.0` from `4.1.5`
- Replace deprecated reactor `EmitterProcessor` with `Sinks.many().multicast()`
- Update citus images from `10.2.2-alpine` to `10.2.2-alpine`
- Replace deprecated jackson `PropertyNamingStrategy` with `PropertyNamingStrategies` in `NotifyingTopicListener` 

**Related issue(s)**:

Fixes #2769 

**Notes for reviewer**:
`SslMode` support remains off. Future tickets around production deployment will need to explore additional logic for other modes

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
