### PR TITLE
Fix obtainer ID not being set on contract deletion (0.44)

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractDeleteTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractDeleteTransactionHandler.java
@@ -42,6 +42,16 @@ class ContractDeleteTransactionHandler extends AbstractEntityCrudTransactionHand
 
     @Override
     protected void doUpdateEntity(Contract contract, RecordItem recordItem) {
+        var transactionBody = recordItem.getTransactionBody().getContractDeleteInstance();
+        EntityId obtainerId = null;
+
+        if (transactionBody.hasTransferAccountID()) {
+            obtainerId = EntityId.of(transactionBody.getTransferAccountID());
+        } else if (transactionBody.hasTransferContractID()) {
+            obtainerId = EntityId.of(transactionBody.getTransferContractID());
+        }
+
+        contract.setObtainerId(obtainerId);
         entityListener.onContract(contract);
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerContractTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerContractTest.java
@@ -245,7 +245,7 @@ class EntityRecordItemListenerContractTest extends AbstractEntityRecordItemListe
     void contractDeleteToExisting() {
         EntityId contractId = EntityId.of(CONTRACT_ID);
         Contract contract = domainBuilder.contract()
-                .customize(c -> c.id(contractId.getId()).num(contractId.getEntityNum()))
+                .customize(c -> c.obtainerId(null).id(contractId.getId()).num(contractId.getEntityNum()))
                 .persist();
 
         Transaction transaction = contractDeleteTransaction();
@@ -267,8 +267,9 @@ class EntityRecordItemListenerContractTest extends AbstractEntityRecordItemListe
                         .isNotNull()
                         .returns(true, Contract::getDeleted)
                         .returns(recordItem.getConsensusTimestamp(), Contract::getModifiedTimestamp)
+                        .returns(EntityId.of(PAYER), Contract::getObtainerId)
                         .usingRecursiveComparison()
-                        .ignoringFields("deleted", "timestampRange")
+                        .ignoringFields("deleted", "obtainerId", "timestampRange")
                         .isEqualTo(contract)
         );
     }
@@ -296,6 +297,7 @@ class EntityRecordItemListenerContractTest extends AbstractEntityRecordItemListe
                         .returns(null, Contract::getAutoRenewPeriod)
                         .returns(null, Contract::getExpirationTimestamp)
                         .returns(null, Contract::getKey)
+                        .returns(EntityId.of(PAYER), Contract::getObtainerId)
                         .returns(null, Contract::getProxyAccountId)
 
         );
@@ -666,6 +668,7 @@ class EntityRecordItemListenerContractTest extends AbstractEntityRecordItemListe
         return buildTransaction(builder -> {
             ContractDeleteTransactionBody.Builder contractDelete = builder.getContractDeleteInstanceBuilder();
             contractDelete.setContractID(CONTRACT_ID);
+            contractDelete.setTransferAccountID(PAYER);
         });
     }
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractDeleteTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractDeleteTransactionHandlerTest.java
@@ -20,13 +20,20 @@ package com.hedera.mirror.importer.parser.record.transactionhandler;
  * ‍
  */
 
+import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ContractDeleteTransactionBody;
 import com.hederahashgraph.api.proto.java.ContractID;
 import com.hederahashgraph.api.proto.java.TransactionBody;
+import java.util.ArrayList;
+import java.util.List;
 
+import com.hedera.mirror.importer.domain.Contract;
+import com.hedera.mirror.importer.domain.EntityId;
 import com.hedera.mirror.importer.domain.EntityType;
 
 class ContractDeleteTransactionHandlerTest extends AbstractDeleteOrUndeleteTransactionHandlerTest {
+
+    private static final long OBTAINER_ID = 99L;
 
     @Override
     protected TransactionHandler getTransactionHandler() {
@@ -37,11 +44,44 @@ class ContractDeleteTransactionHandlerTest extends AbstractDeleteOrUndeleteTrans
     protected TransactionBody.Builder getDefaultTransactionBody() {
         return TransactionBody.newBuilder()
                 .setContractDeleteInstance(ContractDeleteTransactionBody.newBuilder()
-                        .setContractID(ContractID.newBuilder().setContractNum(DEFAULT_ENTITY_NUM).build()));
+                        .setContractID(ContractID.newBuilder().setContractNum(DEFAULT_ENTITY_NUM).build())
+                        .setTransferAccountID(AccountID.newBuilder().setAccountNum(OBTAINER_ID).build()));
     }
 
     @Override
     protected EntityType getExpectedEntityIdType() {
         return EntityType.CONTRACT;
+    }
+
+    @Override
+    protected List<UpdateEntityTestSpec> getUpdateEntityTestSpecs() {
+        List<UpdateEntityTestSpec> specs = new ArrayList<>();
+        Contract expected = (Contract) getExpectedEntityWithTimestamp();
+        expected.setDeleted(true);
+        expected.setObtainerId(EntityId.of(OBTAINER_ID, EntityType.ACCOUNT));
+
+        specs.add(
+                UpdateEntityTestSpec.builder()
+                        .description("Delete with account obtainer")
+                        .expected(expected)
+                        .recordItem(getRecordItem(getDefaultTransactionBody().build(),
+                                getDefaultTransactionRecord().build()))
+                        .build()
+        );
+
+        TransactionBody.Builder transactionBody = TransactionBody.newBuilder()
+                .setContractDeleteInstance(ContractDeleteTransactionBody.newBuilder()
+                        .setContractID(ContractID.newBuilder().setContractNum(DEFAULT_ENTITY_NUM).build())
+                        .setTransferContractID(ContractID.newBuilder().setContractNum(OBTAINER_ID).build()));
+
+        specs.add(
+                UpdateEntityTestSpec.builder()
+                        .description("Delete with contract obtainer")
+                        .expected(expected)
+                        .recordItem(getRecordItem(transactionBody.build(),
+                                getDefaultTransactionRecord().build()))
+                        .build()
+        );
+        return specs;
     }
 }


### PR DESCRIPTION
**Description**:
* Cherry-pick of #2805 to `release/0.44`
* Fix obtainer ID not being set on contract deletion

**Related issue(s)**:

Fixes #2804 

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
