### PR TITLE
Fix obtainer ID not being set on contract deletion (0.43)

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractDeleteTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractDeleteTransactionHandler.java
@@ -42,6 +42,16 @@ class ContractDeleteTransactionHandler extends AbstractEntityCrudTransactionHand
 
     @Override
     protected void doUpdateEntity(Contract contract, RecordItem recordItem) {
+        var transactionBody = recordItem.getTransactionBody().getContractDeleteInstance();
+        EntityId obtainerId = null;
+
+        if (transactionBody.hasTransferAccountID()) {
+            obtainerId = EntityId.of(transactionBody.getTransferAccountID());
+        } else if (transactionBody.hasTransferContractID()) {
+            obtainerId = EntityId.of(transactionBody.getTransferContractID());
+        }
+
+        contract.setObtainerId(obtainerId);
         entityListener.onContract(contract);
     }
 }


### PR DESCRIPTION
**Description**:
* Cherry-pick of #2805 to `release/0.43`
* Fix contract obtainer ID not being set

**Related issue(s)**:

Fixes #2804 

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
