### PR TITLE
Fix cleanup script for Citus 

### DIFF
--- a/hedera-mirror-grpc/src/test/resources/cleanup.sql
+++ b/hedera-mirror-grpc/src/test/resources/cleanup.sql
@@ -3,11 +3,11 @@ do
 declare
     t record;
 begin
-    for t in select table_name
-             from information_schema.tables
-             where table_schema = ''public'' and table_name !~ ''.*(flyway|transaction_type|transaction_result|citus_).*'' and table_type <> ''VIEW''
-        loop
-            execute format(''truncate %s restart identity cascade'', t.table_name);
-        end loop;
+for t in select table_name
+from information_schema.tables
+where table_schema = ''public'' and table_name !~ ''.*(flyway|transaction_type|transaction_result|citus_|_\d+).*'' and table_type <> ''VIEW''
+    loop
+    execute format(''truncate %s restart identity cascade'', t.table_name);
+    end loop;
 end;
 ';

--- a/hedera-mirror-grpc/src/test/resources/cleanup.sql
+++ b/hedera-mirror-grpc/src/test/resources/cleanup.sql
@@ -3,11 +3,11 @@ do
 declare
     t record;
 begin
-for t in select table_name
-from information_schema.tables
-where table_schema = ''public'' and table_name !~ ''.*(flyway|transaction_type|transaction_result|citus_|_\d+).*'' and table_type <> ''VIEW''
-    loop
-    execute format(''truncate %s restart identity cascade'', t.table_name);
-    end loop;
+    for t in select table_name
+             from information_schema.tables
+             where table_schema = ''public'' and table_name !~ ''.*(flyway|transaction_type|transaction_result|citus_|_\d+).*'' and table_type <> ''VIEW''
+        loop
+            execute format(''truncate %s restart identity cascade'', t.table_name);
+        end loop;
 end;
 ';

--- a/hedera-mirror-importer/src/main/resources/db/scripts/cleanup.sql
+++ b/hedera-mirror-importer/src/main/resources/db/scripts/cleanup.sql
@@ -1,13 +1,13 @@
 do
 '
-declare
-    t record;
-begin
-    for t in select table_name
-             from information_schema.tables
-             where table_schema = ''public'' and table_name !~ ''.*(flyway|transaction_type|transaction_result|citus_|_\d+).*'' and table_type <> ''VIEW''
-        loop
-            execute format(''truncate %s restart identity cascade'', t.table_name);
-        end loop;
-end;
+    declare
+        t record;
+    begin
+        for t in select table_name
+                 from information_schema.tables
+                 where table_schema = ''public'' and table_name !~ ''.*(flyway|transaction_type|transaction_result|citus_|_\d+).*'' and table_type <> ''VIEW''
+            loop
+                execute format(''truncate %s restart identity cascade'', t.table_name);
+            end loop;
+    end;
 ';

--- a/hedera-mirror-importer/src/main/resources/db/scripts/cleanup.sql
+++ b/hedera-mirror-importer/src/main/resources/db/scripts/cleanup.sql
@@ -1,13 +1,13 @@
 do
 '
-    declare
-        t record;
-    begin
-        for t in select table_name
-                 from information_schema.tables
-                 where table_schema = ''public'' and table_name !~ ''.*(flyway|transaction_type|transaction_result|citus_).*'' and table_type <> ''VIEW''
-            loop
-                execute format(''truncate %s restart identity cascade'', t.table_name);
-            end loop;
-    end;
+declare
+    t record;
+begin
+for t in select table_name
+from information_schema.tables
+where table_schema = ''public'' and table_name !~ ''.*(flyway|transaction_type|transaction_result|citus_\|_\d+).*'' and table_type <> ''VIEW''
+    loop
+    execute format(''truncate table %s restart identity cascade'', t.table_name);
+    end loop;
+end;
 ';

--- a/hedera-mirror-importer/src/main/resources/db/scripts/cleanup.sql
+++ b/hedera-mirror-importer/src/main/resources/db/scripts/cleanup.sql
@@ -5,7 +5,7 @@ declare
 begin
 for t in select table_name
 from information_schema.tables
-where table_schema = ''public'' and table_name !~ ''.*(flyway|transaction_type|transaction_result|citus_\|_\d+).*'' and table_type <> ''VIEW''
+where table_schema = ''public'' and table_name !~ ''.*(flyway|transaction_type|transaction_result|citus_|_\d+).*'' and table_type <> ''VIEW''
     loop
     execute format(''truncate table %s restart identity cascade'', t.table_name);
     end loop;

--- a/hedera-mirror-importer/src/main/resources/db/scripts/cleanup.sql
+++ b/hedera-mirror-importer/src/main/resources/db/scripts/cleanup.sql
@@ -3,11 +3,11 @@ do
 declare
     t record;
 begin
-for t in select table_name
-from information_schema.tables
-where table_schema = ''public'' and table_name !~ ''.*(flyway|transaction_type|transaction_result|citus_|_\d+).*'' and table_type <> ''VIEW''
-    loop
-    execute format(''truncate table %s restart identity cascade'', t.table_name);
-    end loop;
+    for t in select table_name
+             from information_schema.tables
+             where table_schema = ''public'' and table_name !~ ''.*(flyway|transaction_type|transaction_result|citus_|_\d+).*'' and table_type <> ''VIEW''
+        loop
+            execute format(''truncate %s restart identity cascade'', t.table_name);
+        end loop;
 end;
 ';


### PR DESCRIPTION
**Description**:
Creating distributed tables results in several table names to represent the different shards of the table, e.g. `contract_102062`.  The test cleanup scripts fail with the following error: `cannot modify "entity_102008" because it is a shard of a distributed table`.  This PR adds a regex to the cleanup script to ignore any tables that end in an underscore and one or more numbers.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
Created a separate PR for this because I think it will affect multiple tickets.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
