### PR TITLE
Remove V1.46.4 migration

### DIFF
--- a/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.46.4__token_balance_index.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.46.4__token_balance_index.sql
@@ -1,3 +1,0 @@
--- Adds an index to speed up token balances query
-
-create index if not exists token_balance__timestamp_token on token_balance (consensus_timestamp desc, token_id);


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR removes the V1.46.4 migration.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

Unfortunately, the `create index` in the migration takes forever to finish in testnet, it's been > 16 hours now. testnet token_balance has roughly 44b rows, with pg9.6 only using a single worker for each index creation, this is likely to take > 40 hours.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
