### PR TITLE
Update smart contract design w support for additional APIs

### DIFF
--- a/docs/design/smart-contracts.md
+++ b/docs/design/smart-contracts.md
@@ -56,8 +56,6 @@ alter table if exists contract
   add primary key (id);
 ```
 
-> _Note:_ Entity table should be updated by another PR to add `timestamp_range int8range`.
-
 #### Contract History
 
 Create a contract history table that is populated by application upsert logic. It should insert the old row to the
@@ -127,8 +125,8 @@ create table if not exists contract_log
 create index if not exists contract_log__id_timestamp
   on contract_log (contract_id, consensus_timestamp);
 
-create index if not exists contract_log__id_topics_bloom
-  on contract_log using bloom (contract_id, topic0, topic1, topic2, topic3);
+create index if not exists contract_log__topics_bloom
+  on contract_log using bloom (topic0, topic1, topic2, topic3);
 ```
 
 #### Contract Access List
@@ -148,7 +146,7 @@ create table if not exists contract_access
 
 #### Contract State Change
 
-Create a new table to store the stage changes of a contract execution
+Create a new table to store the state changes of a contract execution
 
 ```sql
 create table if not exists contract_state_change

--- a/docs/design/smart-contracts.md
+++ b/docs/design/smart-contracts.md
@@ -127,8 +127,8 @@ create table if not exists contract_log
 create index if not exists contract_log__id_timestamp
   on contract_log (contract_id, consensus_timestamp);
 
-create index if not exists contract_log__id_topics
-  on contract_log (contract_id, topic0, topic1, topic2, topic3);
+create index if not exists contract_log__id_topics_bloom
+  on contract_log using bloom (contract_id, topic0, topic1, topic2, topic3);
 ```
 
 #### Contract Access List

--- a/docs/design/smart-contracts.md
+++ b/docs/design/smart-contracts.md
@@ -303,7 +303,20 @@ Optional filters
 ```json
 {
   "amount": 10,
-  "access_list": [],
+  "access_list": [
+    {
+      "address": "0xde0b295669a9fd93d5f28d9ec85e40f4cb697bae",
+      "storage_keys": [
+        "0x0000000000000000000000000000000000000000000000000000000000000003"
+      ]
+    },
+    {
+      "address": "0xbb9bc244d798123fde783fcc1c72d3bb8c189413",
+      "storage_keys": [
+        "0x0000000000000000000000000000000000000000000000000000000000000007"
+      ]
+    }
+  ],
   "block_hash": "0x410ef7b5a5f",
   "block_number": 50,
   "bloom": "0x549358c4c2e573e02410ef7b5a5ffa5f36dd7398",
@@ -350,7 +363,20 @@ Optional filters
       ]
     }
   ],
-  "state_changes": [],
+  "state_changes": [
+    {
+      "slot": "0x0000000000000000000000000000000000000000000000000000000000000002",
+      "before": "0x000000000000000000000000000000000000000000c2a8c408d0e29d623347c5",
+      "after": "0x000000000000000000000000000000000000000000c2a8c80ee5fda74d69c302",
+      "timestamp": "12345.10001"
+    },
+    {
+      "slot": "0xe1b094dec1b7d360498fa8130bf1944104b7b5d8a48f9ca88c3fc0f96c2d7225",
+      "before": "0x0000000000000000000000000000000000000000000000000000000000000000",
+      "after": "0x000000000000000000000000000000000000000000000001eafa3aaed1d27246",
+      "timestamp": "12345.10001"
+    }
+  ],
   "timestamp": "12345.10001",
   "to": "0.0.1002"
 }
@@ -419,73 +445,6 @@ Optional filters
 - `topic1`
 - `topic2`
 - `topic3`
-
-### Get Contract Access List
-
-`GET /api/v1/contracts/{id}/results/access-list`
-
-```json
-{
-  "access_list": [
-    {
-      "address": "0xde0b295669a9fd93d5f28d9ec85e40f4cb697bae",
-      "storage_keys": [
-        "0x0000000000000000000000000000000000000000000000000000000000000003",
-        "0x0000000000000000000000000000000000000000000000000000000000000007"
-      ],
-      "timestamp": "12345.10001"
-    },
-    {
-      "address": "0xbb9bc244d798123fde783fcc1c72d3bb8c189413",
-      "storage_keys": [],
-      "timestamp": "12345.10001"
-    }
-  ],
-  "links": {
-    "next": null
-  }
-}
-```
-
-Optional filters
-
-- `limit` Maximum limit will be configurable and lower than current global max limit
-- `order`
-- `timestamp`
-- `address`
-
-### Get Contract State Changes
-
-`GET /api/v1/contracts/{id}/results/state-changes`
-
-```json
-{
-  "storage_changes": [
-    {
-      "slot": "0x0000000000000000000000000000000000000000000000000000000000000002",
-      "before": "0x000000000000000000000000000000000000000000c2a8c408d0e29d623347c5",
-      "after": "0x000000000000000000000000000000000000000000c2a8c80ee5fda74d69c302",
-      "timestamp": "12345.10001"
-    },
-    {
-      "slot": "0xe1b094dec1b7d360498fa8130bf1944104b7b5d8a48f9ca88c3fc0f96c2d7225",
-      "before": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "after": "0x000000000000000000000000000000000000000000000001eafa3aaed1d27246",
-      "timestamp": "12345.10001"
-    }
-  ],
-  "links": {
-    "next": null
-  }
-}
-```
-
-Optional filters
-
-- `limit` Maximum limit will be configurable and lower than current global max limit
-- `order`
-- `slot`
-- `timestamp`
 
 ## JSON-RPC
 

--- a/docs/design/smart-contracts.md
+++ b/docs/design/smart-contracts.md
@@ -127,8 +127,8 @@ create table if not exists contract_log
 create index if not exists contract_log__id_timestamp
   on contract_log (contract_id, consensus_timestamp);
 
-create index if not exists contract_log__id_topics_bloom
-  on contract_log using bloom (contract_id, topic0, topic1, topic2, topic3);
+create index if not exists contract_log__id_topics
+  on contract_log (contract_id, topic0, topic1, topic2, topic3);
 ```
 
 #### Contract Access List

--- a/docs/design/smart-contracts.md
+++ b/docs/design/smart-contracts.md
@@ -373,7 +373,8 @@ Optional filters
 ```
 
 - `access_list` should be retrieved by a join between the `contract_result` and `contract_access_list` tables.
-- `block_hash` should be retrieved by a join with the `record_file` table to find the file containing the transaction.
+- `block_hash` should be retrieved by a join with the `record_file` table to find the `file_hash` of the file containing
+  the transaction.
 - `hash` should be retrieved by a join with the `transaction` table
 - `hedera_child_transactions` (when added) will be retrieved by a join between the `contract_result` and transfer tables
   (`assessed_custom_fee`, `crypto_transfer`, `token_transfer`, `nft_transfer`) tables based on child timestamps.
@@ -504,21 +505,29 @@ public class JSONRpcRequest {
 
 Responses are typically of the standard [JSON-RPC format](https://www.jsonrpc.org/specification#response_object)
 
-e.g.
+- Successful request response
+  ```json
+  {
+    "id": 1,
+    "jsonrpc": "2.0",
+    "result": "SUCCESS"
+  }
+  ```
 
-```json
-{
-  "error": {
-    "code": -32600,
-    "meaning": "The JSON sent is not a valid Request object.",
-    "message": "Invalid Request"
-  },
-  "id": 1,
-  "jsonrpc": "2.0"
-}
-```
+- Failed request response
+  ```json
+  {
+    "error": {
+      "code": -32600,
+      "meaning": "The JSON sent is not a valid Request object.",
+      "message": "Invalid Request"
+    },
+    "id": 1,
+    "jsonrpc": "2.0"
+  }
+  ```
 
-> _Note:_ `result` data type is dynamic. Also `error` is not present on a successful response.
+> _Note:_ `result` data type is dynamic. Either `result` or `error` must be present in a response, not both.
 
 An appropriate set of POJO schema would be
 

--- a/docs/design/smart-contracts.md
+++ b/docs/design/smart-contracts.md
@@ -34,22 +34,22 @@ contract-specific fields will need to be marked as nullable since we didn't stor
 ```sql
 create table if not exists contract
 (
-  auto_renew_period    bigint                     null,
-  created_timestamp    bigint                     null,
-  deleted              boolean                    null,
-  expiration_timestamp bigint                     null,
-  file_id              bigint                     null,
-  id                   bigint                     not null,
-  key                  bytea                      null,
-  memo                 text    default ''         not null,
-  num                  bigint                     not null,
-  obtainer_id          bigint                     null,
-  proxy_account_id     bigint                     null,
-  public_key           character varying          null,
-  realm                bigint                     not null,
-  shard                bigint                     not null,
-  timestamp_range      int8range                  not null,
-  type                 integer default 'CONTRACT' not null
+  auto_renew_period    bigint                         null,
+  created_timestamp    bigint                         null,
+  deleted              boolean                        null,
+  expiration_timestamp bigint                         null,
+  file_id              bigint                         null,
+  id                   bigint                         not null,
+  key                  bytea                          null,
+  memo                 text        default ''         not null,
+  num                  bigint                         not null,
+  obtainer_id          bigint                         null,
+  proxy_account_id     bigint                         null,
+  public_key           character varying              null,
+  realm                bigint                         not null,
+  shard                bigint                         not null,
+  timestamp_range      int8range                      not null,
+  type                 entity_type default 'CONTRACT' not null
 );
 
 alter table if exists contract
@@ -483,10 +483,10 @@ methods for ease of interaction by DApps.
 The HyperLedger Besu EVM supports the methods capture
 at [ETH methods](https://besu.hyperledger.org/en/stable/Reference/API-Methods/#eth-methods)
 
-The Mirror Node should implement a subset of the standard calls using to
+The Mirror Node should implement a subset of the standard calls used to
 
 - support existing ethereum developers who may call the JSON-RPC endpoints directly
-- to encompass Hedera EVM translation logic that can be wrapped by potential web3 modules.
+- encompass Hedera EVM translation logic that can be wrapped by potential web3 modules.
 
 ### Setup
 
@@ -509,7 +509,7 @@ Establish an
 
 - `EthRpcService` interface that describes the supported rpc methods
 - `EthRpcServiceImpl` class that contains the logic to service the rpc methods called. Methods query the appropriate
-  `account_balance`, `contract`, `record_file` and `transaction` tables returning data in expected schema formats.
+  `account_balance`, `contract`, `record_file`, and `transaction` tables returning data in expected schema formats.
 
 #### Request POJOs
 

--- a/docs/design/smart-contracts.md
+++ b/docs/design/smart-contracts.md
@@ -339,10 +339,6 @@ Optional filters
   "gas_limit": 2500,
   "gas_used": 1000,
   "hash": "0x5b2e3c1a49352f1ca9fb5dfe74b7ffbbb6d70e23a12693444e26058d8a8e6296",
-  "hedera_child_transactions": [
-    "api/v1/transactions/0.0.11943-1637100159-861284000",
-    "api/v1/transactions/0.0.10459-1637099842-891982153"
-  ],
   "logs": [
     {
       "contract_id": "0.0.1234",
@@ -378,7 +374,13 @@ Optional filters
     }
   ],
   "timestamp": "12345.10001",
-  "to": "0.0.1002"
+  "to": "0.0.1002",
+  "links": {
+    "hedera_child_transactions": [
+      "api/v1/transactions/0.0.11943-1637100159-861284000",
+      "api/v1/transactions/0.0.10459-1637099842-891982153"
+    ]
+  }
 }
 ```
 
@@ -535,18 +537,17 @@ An appropriate set of POJO schema would be
 
 - `JSONRpcResponse`
   ```java
-  public abstract class JSONRpcResponse {
+  @Data
+  public class JSONRpcResponse<T> {
+    private final String jsonrpc = "2.0";
     private Long id;
-    private String jsonrpc;
-    private String result;
+    private T result;
   }
   ```
 
 - `ErrorJSONRpcResponse`
   ```java
   public class JSONRpcErrorResponse extends JSONRpcResponse {
-    private Long id;
-    private String jsonrpc;
     private ErrorJSONRpcResponse error;
 
     private class ErrorJSONRpcResponse {
@@ -557,15 +558,8 @@ An appropriate set of POJO schema would be
   }
   ```
 
-- `DynamicJSONRpcResponse`
-  ```java
-  public class DynamicJSONRpcResponse extends JSONRpcResponse {
-    private T result;
-  }
-  ```
-
-The result field will be populated with the JSON serialized value to be returned. The value can range from primitive
-data types (String, int, array) or defined Ethereum objects such as
+The result field will be populated with the value to be returned. Additional POJOs per complex response value should be
+added. The value can range from regular data types (String, int, array) or defined Ethereum objects such as
 
 - [Block](https://besu.hyperledger.org/en/stable/Reference/API-Objects/#block-object)
 - [Log](https://besu.hyperledger.org/en/stable/Reference/API-Objects/#log-object)
@@ -577,7 +571,7 @@ data types (String, int, array) or defined Ethereum objects such as
 The Mirror Node is essentially a full archive node (i.e. it can provide the state of the ledger at present but also at
 multiple snapshots of time). However, its current implementation is limited by the lack of connectivity to the actual
 Gossip based network of consensus nodes. As a result some network specific details are not available to it unless
-provided through the record stream and therefore some `eth_` related methods may not be applicable to it's current
+provided through the record stream and therefore some `eth_` related methods may not be applicable to its current
 iteration. Below is a table of compatibility. All methods are referenced from the Ethereum
 Wikis [JSON-RPC API](https://eth.wiki/json-rpc/API)
 
@@ -622,6 +616,9 @@ Wikis [JSON-RPC API](https://eth.wiki/json-rpc/API)
 | [eth_submitWork](https://eth.wiki/json-rpc/API#eth_submitwork)                                                  | Submits a Proof of Work (Ethash) solution.                                                            | N/A                           | Mirror node is not an EVM bearing client
 | [eth_syncing](https://eth.wiki/json-rpc/API#eth_syncing)                                                        | Returns an object with data about the synchronization status, or false if not synchronizing.          | N/A                           | Mirror node is not an EVM bearing client
 | [eth_uninstallFilter](https://eth.wiki/json-rpc/API#eth_uninstallfilter)                                        | Uninstalls a filter with the specified ID.                                                            | N/A                           | Mirror node REST APIs should be stateless and will not support persisting filters. Instead, desired filter should be applied to getLogs
+
+> _Note:_ Methods may become applicable over time should the Mirror Node become connected to a gossip based network or
+> should the REST APIs move from a stateless to stateful design for items such as search
 
 #### RPC Methods
 

--- a/docs/design/smart-contracts.md
+++ b/docs/design/smart-contracts.md
@@ -196,6 +196,7 @@ create table if not exists contract_state_change
         "_type": "ProtobufEncoded",
         "key": "7b2233222c2233222c2233227d"
       },
+      "address": "0x0000000000000000000000000000000000001001",
       "auto_renew_period": 7776000,
       "contract_id": "0.0.10001",
       "created_timestamp": "1633466568.31556926",
@@ -205,7 +206,6 @@ create table if not exists contract_state_change
       "memo": "First contract",
       "obtainer_id": null,
       "proxy_account_id": "0.0.100",
-      "solidity_address": "0x0000000000000000000000000000000000001001",
       "timestamp": {
         "from": "1633466568.31556926",
         "to": null
@@ -234,6 +234,7 @@ Optional filters
     "_type": "ProtobufEncoded",
     "key": "7b2233222c2233222c2233227d"
   },
+  "address": "0x0000000000000000000000000000000000001001",
   "auto_renew_period": 7776000,
   "bytecode": "0xc896c66db6d98784cc03807640f3dfd41ac3a48c",
   "contract_id": "0.0.10001",
@@ -244,7 +245,6 @@ Optional filters
   "memo": "First contract",
   "obtainer_id": "0.0.101",
   "proxy_account_id": "0.0.100",
-  "solidity_address": "0x0000000000000000000000000000000000001001",
   "timestamp": {
     "from": "1633466229.96874612",
     "to": "1633466568.31556926"
@@ -272,12 +272,12 @@ Optional filters
         "0.0.1003"
       ],
       "error_message": "",
-      "from": "0.0.1001",
+      "from": "0x0000000000000000000000000000000000001001",
       "function_parameters": "0xbb9f02dc6f0e3289f57a1f33b71c73aa8548ab8b",
       "gas_limit": 2500,
       "gas_used": 1000,
       "timestamp": "12345.10001",
-      "to": "0.0.1002"
+      "to": "0x0000000000000000000000000000000000001002"
     }
   ],
   "links": {
@@ -326,7 +326,7 @@ Optional filters
     "0.0.1003"
   ],
   "error_message": "",
-  "from": "0.0.1001",
+  "from": "0x0000000000000000000000000000000000001001",
   "function_parameters": "0xbb9f02dc6f0e3289f57a1f33b71c73aa8548ab8b",
   "gas_limit": 2500,
   "gas_used": 1000,
@@ -368,7 +368,7 @@ Optional filters
     }
   ],
   "timestamp": "12345.10001",
-  "to": "0.0.1002"
+  "to": "0x0000000000000000000000000000000000001002"
 }
 ```
 
@@ -398,7 +398,7 @@ Optional filters
 {
   "logs": [
     {
-      "solidity_address": "0x0000000000000000000000000000000000001234",
+      "address": "0x0000000000000000000000000000000000001234",
       "contract_id": "0.0.1234",
       "bloom": "0x1513001083c899b1996ec7fa33621e2c340203f0",
       "data": "0x8f705727c88764031b98fc32c314f8f9e463fb62",
@@ -409,7 +409,7 @@ Optional filters
       ]
     },
     {
-      "solidity_address": "0x0000000000000000000000000000000000001893",
+      "address": "0x0000000000000000000000000000000000001893",
       "contract_id": "0.0.1893",
       "bloom": "0x8f705727c88764031b98fc32c314f8f9e463fb62",
       "data": "0x1513001083c899b1996ec7fa33621e2c340203f0",
@@ -841,8 +841,8 @@ The Mirror Node should additional provide support for this.
     ```json
       "evm_internal_transactions": [
         {
-          "from": "0.0.1002",
-          "to": "0.0.1003",
+          "from": "0x0000000000000000000000000000000000001002",
+          "to": "0x0000000000000000000000000000000000001003",
           "type": "call_0",
           "value": "20"
         }

--- a/docs/design/smart-contracts.md
+++ b/docs/design/smart-contracts.md
@@ -399,7 +399,6 @@ Optional filters
   "logs": [
     {
       "address": "0x0000000000000000000000000000000000001234",
-      "contract_id": "0.0.1234",
       "bloom": "0x1513001083c899b1996ec7fa33621e2c340203f0",
       "data": "0x8f705727c88764031b98fc32c314f8f9e463fb62",
       "timestamp": "12345.10002",
@@ -410,7 +409,6 @@ Optional filters
     },
     {
       "address": "0x0000000000000000000000000000000000001893",
-      "contract_id": "0.0.1893",
       "bloom": "0x8f705727c88764031b98fc32c314f8f9e463fb62",
       "data": "0x1513001083c899b1996ec7fa33621e2c340203f0",
       "timestamp": "12345.10002",

--- a/docs/design/smart-contracts.md
+++ b/docs/design/smart-contracts.md
@@ -384,22 +384,22 @@ Optional filters
 }
 ```
 
-- `access_list` schema is described by [Get Contract Access List](#contract-access-list). This should be retrieved by a
-  join between the `contract_result` and `contract_access_list` tables.
-- `logs` schema is described by [Get Contract Logs](#contract-log). This should be retrieved by a join between
-  the `contract_result` and `contract_log` tables.
-- `internal_transactions` should be retrieved by a join between the `contract_result` and transfer tables
-  (`assessed_custom_fee`, `crypto_transfer`, `token_transfer`, `nft_transfer`) tables.
-- `state-changes` schema is described by [Get State Changes](#contract-state-change). This should be retrieved by a join
-  between the `contract_result` and `contract-state-change` tables.
+- `access_list` should be retrieved by a join between the `contract_result` and `contract_access_list` tables.
+- `logs` should be retrieved by a join between the `contract_result` and `contract_log` tables.
+- `hedera_child_transactions` should be retrieved by a join between the `contract_result` and transfer tables
+  (`assessed_custom_fee`, `crypto_transfer`, `token_transfer`, `nft_transfer`) tables based on child timestamps.
+- `state-changes` should be retrieved by a join between the `contract_result` and `contract-state-change` tables.
 
 > _Note:_ `/api/v1/contracts/results/{transactionId}` will have to extract the correlating contractId and timestamp to
 > retrieve the correct contract_result row
 
-> _Note 2:_ Internal transactions issued by HTS precompiled transactions will produce regular HTS transactions.
-> The HTS transaction will contain the transferList that describes the internal transfers to be extracted. The parent
+> _Note 2:_ Child transactions issued by HTS precompiled transactions will produce regular HTS transactions.
+> These differ from EVM internal transactions between contracts.
+> The HTS transactions will contain the transferList that describes the internal transfers to be extracted. The parent
 > transactions `transaction.child_transactions` will denote the range of consensusTimestamps for child transactions
 > i.e. `[parent_timestamp, parent_timestamp + transaction.child_transactions)`
+
+> _Note 3:_ `internal_transactions` will be retrieved from `ContractAction` related information
 
 ### Get Contract Logs
 
@@ -837,14 +837,6 @@ The Mirror Node should additional provide support for this.
 
 ## Open Questions
 
-1. What will externalization of the contract state in the transaction record look like? Still being designed.
-2. How should we allow searching by topics or logs?
-3. How will Hedera transactions triggered from a smart contract be externalized in the record stream? Still being
-   designed. Tentatively, each contract triggered transaction will show up as a separate transaction and record with an
-   incremented consensus timestamp and a parent timestamp populated.
-4. Should we show individual function parameters in a normalized form? We decided against it at this time as it might be
-   a performance concern or require parsing the solidity contract. Can revisit in the future by adding a new field with
-   the normalized structure.
-5. How will internal transactions show up in record stream and will they follow a hierarchy that highlights transfer
-   succession or will it be flattened?
-6. How should non HTS precompiled internal transactions be handled?
+1. What will externalization of the contract call type in the transaction record look like? Still being designed.
+2. How will EVM internal transactions (i.e. non HTS precompiled child transactions) show up in record stream and will
+   they follow a hierarchy that highlights transfer succession or will it be flattened?

--- a/docs/design/smart-contracts.md
+++ b/docs/design/smart-contracts.md
@@ -437,8 +437,8 @@ Optional filters
 
 ## JSON-RPC
 
-On the ethereum network, all client nodes implement
-the [Ethereum JSON-RPC Specification](https://playground.open-rpc.org/?schemaUrl=https://raw.githubusercontent.com/ethereum/eth1.0-apis/assembled-spec/openrpc.json&uiSchema%5BappBar%5D%5Bui:splitView%5D=false&uiSchema%5BappBar%5D%5Bui:input%5D=false&uiSchema%5BappBar%5D%5Bui:examplesDropdown%5D=false)
+On the Ethereum network, all client nodes implement
+the [Ethereum JSON-RPC Specification](https://playground.open-rpc.org/?schemaUrl=https://raw.githubusercontent.com/ethereum/eth1.0-apis/assembled-spec/openrpc.json)
 methods for ease of interaction by DApps.
 
 The HyperLedger Besu EVM supports the methods captured
@@ -446,8 +446,8 @@ at [ETH methods](https://besu.hyperledger.org/en/stable/Reference/API-Methods/#e
 
 The Mirror Node should implement a subset of the standard calls used to
 
-- support existing ethereum developers who may call the JSON-RPC endpoints directly
-- encompass Hedera EVM translation logic that can be wrapped by potential web3 modules.
+- support existing Ethereum developers who may call the JSON-RPC endpoints directly
+- encompass Hedera EVM translation logic that can be wrapped by potential Web3 modules.
 
 ### Setup
 
@@ -464,7 +464,7 @@ The Mirror Node should implement a subset of the standard calls used to
 Existing domain classes can be utilized from the `hedera-mirror-common` dependencies. Applicable CRUD repositories can
 be created using Spring based on `hedera-mirror-common` domains to extract information from the database.
 
-### JSON RPC Service
+### JSON-RPC Service
 
 Establish an
 
@@ -475,7 +475,7 @@ Establish an
 #### Request POJOs
 
 Depending on the web dependency used we may have to manually handle input conversion from String to JSON. If so utilize
-[Jackson](https://github.com/FasterXML/jackson) library to create a `JSONRpcRequest` object that each method can parse
+[Jackson](https://github.com/FasterXML/jackson) library to create a `JSONRpcRequest` object that each method can parse.
 
 Requests are typically of the JSON format
 
@@ -553,7 +553,7 @@ An appropriate set of POJO schema would be
   ```
 
 The result field will be populated with the value to be returned. Additional POJOs per complex response value should be
-added. The value can range from regular data types (String, int, array) or defined Ethereum objects such as
+added. The value can range from regular data types (String, int, array) to defined Ethereum objects such as
 
 - [Block](https://besu.hyperledger.org/en/stable/Reference/API-Objects/#block-object)
 - [Log](https://besu.hyperledger.org/en/stable/Reference/API-Objects/#log-object)
@@ -571,10 +571,10 @@ Wikis [JSON-RPC API](https://eth.wiki/json-rpc/API)
 
 | Method                                                                                                          | Description                                                                                           | Mirror Node Support Priority  | Justification                   |
 | --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | ----------------------------- | -------------------------------- |
-| [eth_accounts](https://eth.wiki/json-rpc/API#eth_accounts)                                                      | Returns a list of addresses owned by client.                                                          | N/A                           | Mirror node is not an ethereum client                          |
+| [eth_accounts](https://eth.wiki/json-rpc/API#eth_accounts)                                                      | Returns a list of addresses owned by client.                                                          | N/A                           | Mirror node is not an Ethereum client                          |
 | [eth_blockNumber](https://eth.wiki/json-rpc/API#eth_blocknumber)                                                | Returns the index corresponding to the block number of the current chain head.                        | P1*                           | Mirror node is able to return the current record file count. However, this may be inaccurate depending on network load.
-| [eth_call](https://eth.wiki/json-rpc/API#eth_call)                                                              | Invokes a contract function locally and does not change the state of the blockchain.                  | N/A                           | Mirror node is not an ethereum client                          |
-| [eth_coinbase](https://eth.wiki/json-rpc/API#eth_coinbase)                                                      | Returns the client coinbase address. The coinbase address is the account to pay mining rewards to.    | N/A                           | Mirror node is not an ethereum client                          |
+| [eth_call](https://eth.wiki/json-rpc/API#eth_call)                                                              | Invokes a contract function locally and does not change the state of the blockchain.                  | N/A                           | Mirror node is not an Ethereum client                          |
+| [eth_coinbase](https://eth.wiki/json-rpc/API#eth_coinbase)                                                      | Returns the client coinbase address. The coinbase address is the account to pay mining rewards to.    | N/A                           | Mirror node is not an Ethereum client                          |
 | [eth_estimateGas](https://eth.wiki/json-rpc/API#eth_estimategas)                                                | Returns an estimate of the gas required for a transaction to complete.                                | N/A                           | Mirror node is not an EVM bearing client                          |
 | [eth_gasPrice](https://eth.wiki/json-rpc/API#eth_gasprice)                                                      | Returns a percentile gas unit price for the most recent blocks, in Wei.                               | N/A                           | Mirror node is not an EVM bearing client                          |
 | [eth_getBalance](https://eth.wiki/json-rpc/API#eth_getbalance)                                                  | Returns the account balance of the specified address.                                                 | P1*                           | Mirror node can return an accounts balance. However, as of receipt it may be stale for up to 15 mins due to balance file parse rate.

--- a/docs/design/smart-contracts.md
+++ b/docs/design/smart-contracts.md
@@ -85,9 +85,9 @@ create table if not exists contract_result
   amount               bigint             null,
   bloom                bytea              null,
   call_result          bytea              null,
+  child_transactions   bigint             null,
   consensus_timestamp  bigint primary key not null,
   contract_id          bigint             null,
-  child_transactions   bigint             null,
   created_contract_ids bigint array       null,
   error_message        text               null,
   function_parameters  bytea              not null,
@@ -110,6 +110,7 @@ create table if not exists contract_log
   contract_id         bigint      not null,
   data                bytea       not null,
   index               int         not null,
+  record_index        int         not null,
   topic0              varchar(64) null,
   topic1              varchar(64) null,
   topic2              varchar(64) null,
@@ -566,44 +567,44 @@ Wikis [JSON-RPC API](https://eth.wiki/json-rpc/API)
 | Method                                                                                                          | Description                                                                                           | Mirror Node Support Priority  | Justification                   |
 | --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | ----------------------------- | -------------------------------- |
 | [eth_accounts](https://eth.wiki/json-rpc/API#eth_accounts)                                                      | Returns a list of addresses owned by client.                                                          | N/A                           | Mirror node is not an ethereum client                          |
-| [eth_blockNumber](https://eth.wiki/json-rpc/API#eth_blocknumber)                                                | Returns the index corresponding to the block number of the current chain head.                        | P1* | Mirror node is able to return the current record file count. However, this may be inaccurate depending on network load.
+| [eth_blockNumber](https://eth.wiki/json-rpc/API#eth_blocknumber)                                                | Returns the index corresponding to the block number of the current chain head.                        | P1*                           | Mirror node is able to return the current record file count. However, this may be inaccurate depending on network load.
 | [eth_call](https://eth.wiki/json-rpc/API#eth_call)                                                              | Invokes a contract function locally and does not change the state of the blockchain.                  | N/A                           | Mirror node is not an ethereum client                          |
 | [eth_coinbase](https://eth.wiki/json-rpc/API#eth_coinbase)                                                      | Returns the client coinbase address. The coinbase address is the account to pay mining rewards to.    | N/A                           | Mirror node is not an ethereum client                          |
-| [eth_estimateGas](https://eth.wiki/json-rpc/API#eth_estimategas)                                                | Returns an estimate of the gas required for a transaction to complete. | N/A                           | Mirror node is not an EVM bearing client                          |
-| [eth_gasPrice](https://eth.wiki/json-rpc/API#eth_gasprice)                                                      | Returns a percentile gas unit price for the most recent blocks, in Wei. | N/A                           | Mirror node is not an EVM bearing client                          |
-| [eth_getBalance](https://eth.wiki/json-rpc/API#eth_getbalance)                                                  | Returns the account balance of the specified address. | P1* | Mirror node can return an accounts balance. However, as of receipt it may be stale for up to 15 mins due to balance file parse rate.
-| [eth_getBlockByHash](https://eth.wiki/json-rpc/API#eth_getblockbyhash)                                          | Returns information about the block by hash. | P2 | Mirror node is able to return record file information. Block info will be secondary to transactions.
-| [eth_getBlockByNumber](https://eth.wiki/json-rpc/API#eth_getblockbynumber)                                      | Returns information about a block by block number.
-| [eth_getBlockTransactionCountByHash](https://eth.wiki/json-rpc/API#eth_getblocktransactioncountbyhash)          | Returns the number of transactions in the block matching the given block hash.
-| [eth_getBlockTransactionCountByNumber](https://eth.wiki/json-rpc/API#eth_getblocktransactioncountbynumber)      | Returns the number of transactions in a block matching the specified block number.
-| [eth_getCode](https://eth.wiki/json-rpc/API#eth_getcode)                                                        | Returns the code of the smart contract at the specified address.
-| [eth_getFilterChanges](https://eth.wiki/json-rpc/API#eth_getfilterchanges)                                      | Polls the specified filter and returns an array of changes that have occurred since the last poll.
-| [eth_getFilterLogs](https://eth.wiki/json-rpc/API#eth_getfilterlogs)                                            | Returns an array of logs for the specified filter.
-| [eth_getLogs](https://eth.wiki/json-rpc/API#eth_getlogs)                                                        | Returns an array of logs matching a specified filter object.
-| [eth_getStorageAt](https://eth.wiki/json-rpc/API#eth_getstorageat)                                              | Returns the value of a storage position at a specified address.
-| [eth_getTransactionByBlockHashAndIndex](https://eth.wiki/json-rpc/API#eth_gettransactionbyblockhashandindex)    | Returns transaction information for the specified block hash and transaction index position.
-| [eth_getTransactionByBlockNumberAndIndex](https://eth.wiki/json-rpc/API#eth_gettransactionbyblocknumberandindex)| Returns transaction information for the specified block number and transaction index position.
-| [eth_getTransactionByHash](https://eth.wiki/json-rpc/API#eth_gettransactionbyhash)                              | Returns transaction information for the specified transaction hash.
-| [eth_getTransactionCount](https://eth.wiki/json-rpc/API#eth_gettransactioncount)                                | Returns the number of transactions sent from a specified address.
-| [eth_getTransactionReceipt](https://eth.wiki/json-rpc/API#eth_gettransactionreceipt)                            | Returns the receipt of a transaction by transaction hash.
-| [eth_getUncleByBlockHashAndIndex](https://eth.wiki/json-rpc/API#eth_getunclebyblockhashandindex)                | Returns uncle specified by block hash and index.
-| [eth_getUncleByBlockNumberAndIndex](https://eth.wiki/json-rpc/API#eth_getunclebyblocknumberandindex)            | Returns uncle specified by block number and index.
-| [eth_getUncleCountByBlockHash](https://eth.wiki/json-rpc/API#eth_getunclecountbyblockhash)                      | Returns the number of uncles in a block from a block matching the given block hash.
-| [eth_getUncleCountByBlockNumber](https://eth.wiki/json-rpc/API#eth_getunclecountbyblocknumber)                  | Returns the number of uncles in a block matching the specified block number.
-| [eth_getWork](https://eth.wiki/json-rpc/API#eth_getwork)                                                        | Returns the hash of the current block, the seed hash, and the required target boundary condition.
-| [eth_hashrate](https://eth.wiki/json-rpc/API#eth_hashrate)                                                      | Returns the number of hashes per second with which the node is mining.
-| [eth_mining](https://eth.wiki/json-rpc/API#eth_mining)                                                          | Whether the client is actively mining new blocks.
-| [eth_newBlockFilter](https://eth.wiki/json-rpc/API#eth_newblockfilter)                                          | Creates a filter to retrieve new block hashes.
-| [eth_newFilter](https://eth.wiki/json-rpc/API#eth_newfilter)                                                    | Creates a log filter.
-| [eth_newPendingTransactionFilter](https://eth.wiki/json-rpc/API#eth_newpendingtransactionfilter)                | Creates a filter to retrieve new pending transactions hashes.
-| [eth_protocolVersion](https://eth.wiki/json-rpc/API#eth_protocolversion)                                        | Returns current Ethereum protocol version.
-| [eth_sendRawTransaction](https://eth.wiki/json-rpc/API#eth_sendrawtransaction)                                  | Sends a signed transaction.
-| [eth_sign](https://eth.wiki/json-rpc/API#eth_sign)                                                              | Returns an EIP-191 signature over the provided data
-| [eth_signTransaction](https://eth.wiki/json-rpc/API#eth_signtransaction)                                        | Returns and RLP encoded transaction signed by the specified account
-| [eth_submitHashrate](https://eth.wiki/json-rpc/API#eth_submithashrate)                                          | Submits the mining hashrate.
-| [eth_submitWork](https://eth.wiki/json-rpc/API#eth_submitwork)                                                  | Submits a Proof of Work (Ethash) solution.
-| [eth_syncing](https://eth.wiki/json-rpc/API#eth_syncing)                                                        | Returns an object with data about the synchronization status, or false if not synchronizing.
-| [eth_uninstallFilter](https://eth.wiki/json-rpc/API#eth_uninstallfilter)                                        | Uninstalls a filter with the specified ID.
+| [eth_estimateGas](https://eth.wiki/json-rpc/API#eth_estimategas)                                                | Returns an estimate of the gas required for a transaction to complete.                                | N/A                           | Mirror node is not an EVM bearing client                          |
+| [eth_gasPrice](https://eth.wiki/json-rpc/API#eth_gasprice)                                                      | Returns a percentile gas unit price for the most recent blocks, in Wei.                               | N/A                           | Mirror node is not an EVM bearing client                          |
+| [eth_getBalance](https://eth.wiki/json-rpc/API#eth_getbalance)                                                  | Returns the account balance of the specified address.                                                 | P1*                           | Mirror node can return an accounts balance. However, as of receipt it may be stale for up to 15 mins due to balance file parse rate.
+| [eth_getBlockByHash](https://eth.wiki/json-rpc/API#eth_getblockbyhash)                                          | Returns information about the block by hash.                                                          | P2                            | Mirror node is able to return record file information. Block info will be secondary to transactions.
+| [eth_getBlockByNumber](https://eth.wiki/json-rpc/API#eth_getblockbynumber)                                      | Returns information about a block by block number.                                                    | P2                            | Mirror node is able to return record file information. Block info will be secondary to transactions.
+| [eth_getBlockTransactionCountByHash](https://eth.wiki/json-rpc/API#eth_getblocktransactioncountbyhash)          | Returns the number of transactions in the block matching the given block hash.                        | P2                            | Mirror node is able to return record file information. Block info will be secondary to transactions.
+| [eth_getBlockTransactionCountByNumber](https://eth.wiki/json-rpc/API#eth_getblocktransactioncountbynumber)      | Returns the number of transactions in a block matching the specified block number.                    | P2                            | Mirror node is able to return record file information. Block info will be secondary to transactions.
+| [eth_getCode](https://eth.wiki/json-rpc/API#eth_getcode)                                                        | Returns the code of the smart contract at the specified address.                                      | P0                            | Mirror node is able to return contract bytes from file_data table.
+| [eth_getFilterChanges](https://eth.wiki/json-rpc/API#eth_getfilterchanges)                                      | Polls the specified filter and returns an array of changes that have occurred since the last poll.    | N/A                           | Mirror node REST APIs should be stateless and will not support persisting filters. Instead, desired filter should be applied to getLogs
+| [eth_getFilterLogs](https://eth.wiki/json-rpc/API#eth_getfilterlogs)                                            | Returns an array of logs for the specified filter.                                                    | N/A                           | Mirror node REST APIs should be stateless and will not support persisting filters. Instead, desired filter should be applied to getLogs
+| [eth_getLogs](https://eth.wiki/json-rpc/API#eth_getlogs)                                                        | Returns an array of logs matching a specified filter object.                                          | P1                            | Mirror node is able to return contract log rows based on filter parameters.
+| [eth_getStorageAt](https://eth.wiki/json-rpc/API#eth_getstorageat)                                              | Returns the value of a storage position at a specified address.                                       | P2                            | Mirror node is able to return the contract_state row based on the filter parameters.
+| [eth_getTransactionByBlockHashAndIndex](https://eth.wiki/json-rpc/API#eth_gettransactionbyblockhashandindex)    | Returns transaction information for the specified block hash and transaction index position.          | P2                            | Mirror node can return contract transaction details mapped by record hash and transaction count.
+| [eth_getTransactionByBlockNumberAndIndex](https://eth.wiki/json-rpc/API#eth_gettransactionbyblocknumberandindex)| Returns transaction information for the specified block number and transaction index position.        | P2                            | Mirror node can return contract transaction details mapped by record number and transaction count.
+| [eth_getTransactionByHash](https://eth.wiki/json-rpc/API#eth_gettransactionbyhash)                              | Returns transaction information for the specified transaction hash.                                   | P1                            | Mirror node can return contract transaction metadata details mapped by transaction hash.
+| [eth_getTransactionCount](https://eth.wiki/json-rpc/API#eth_gettransactioncount)                                | Returns the number of transactions sent from a specified address.                                     | P2                            | Mirror node can return contract transaction count from the specified contract address.
+| [eth_getTransactionReceipt](https://eth.wiki/json-rpc/API#eth_gettransactionreceipt)                            | Returns the receipt of a transaction by transaction hash.                                             | P0                            | Mirror node can return contract transaction details mapped by transaction hash.
+| [eth_getUncleByBlockHashAndIndex](https://eth.wiki/json-rpc/API#eth_getunclebyblockhashandindex)                | Returns uncle specified by block hash and index.                                                      | N/A                           | Hedera has no concept of uncles. Gossip protocol avoids this pitfall.
+| [eth_getUncleByBlockNumberAndIndex](https://eth.wiki/json-rpc/API#eth_getunclebyblocknumberandindex)            | Returns uncle specified by block number and index.                                                    | N/A                           | Hedera has no concept of uncles. Gossip protocol avoids this pitfall.
+| [eth_getUncleCountByBlockHash](https://eth.wiki/json-rpc/API#eth_getunclecountbyblockhash)                      | Returns the number of uncles in a block from a block matching the given block hash.                   | N/A                           | Hedera has no concept of uncles. Gossip protocol avoids this pitfall.
+| [eth_getUncleCountByBlockNumber](https://eth.wiki/json-rpc/API#eth_getunclecountbyblocknumber)                  | Returns the number of uncles in a block matching the specified block number.                          | N/A                           | Hedera has no concept of uncles. Gossip protocol avoids this pitfall.
+| [eth_getWork](https://eth.wiki/json-rpc/API#eth_getwork)                                                        | Returns the hash of the current block, the seed hash, and the required target boundary condition.     | N/A                           | Hedera uses the Gossip about Gossip protocol which is not proof of work based.
+| [eth_hashrate](https://eth.wiki/json-rpc/API#eth_hashrate)                                                      | Returns the number of hashes per second with which the node is mining.                                | N/A                           | Mirror node is not an EVM bearing client
+| [eth_mining](https://eth.wiki/json-rpc/API#eth_mining)                                                          | Whether the client is actively mining new blocks.                                                     | N/A                           | Mirror node is not an EVM bearing client
+| [eth_newBlockFilter](https://eth.wiki/json-rpc/API#eth_newblockfilter)                                          | Creates a filter to retrieve new block hashes.                                                        | N/A                           | Mirror node REST APIs should be stateless and will not support persisting filters. Instead, desired filter should be applied to getLogs
+| [eth_newFilter](https://eth.wiki/json-rpc/API#eth_newfilter)                                                    | Creates a log filter.                                                                                 | N/A                           | Mirror node REST APIs should be stateless and will not support persisting filters. Instead, desired filter should be applied to getLogs
+| [eth_newPendingTransactionFilter](https://eth.wiki/json-rpc/API#eth_newpendingtransactionfilter)                | Creates a filter to retrieve new pending transactions hashes.                                         | N/A                           | Mirror node REST APIs should be stateless and will not support persisting filters. Instead, desired filter should be applied to getLogs
+| [eth_protocolVersion](https://eth.wiki/json-rpc/API#eth_protocolversion)                                        | Returns current Ethereum protocol version.                                                            | N/A                           | Mirror node is not an EVM bearing client
+| [eth_sendRawTransaction](https://eth.wiki/json-rpc/API#eth_sendrawtransaction)                                  | Sends a signed transaction.                                                                           | N/A                           | Mirror node is not an EVM bearing client
+| [eth_sign](https://eth.wiki/json-rpc/API#eth_sign)                                                              | Returns an EIP-191 signature over the provided data                                                   | N/A                           | Mirror node is not an EVM bearing client
+| [eth_signTransaction](https://eth.wiki/json-rpc/API#eth_signtransaction)                                        | Returns and RLP encoded transaction signed by the specified account                                   | N/A                           | Mirror node is not an EVM bearing client
+| [eth_submitHashrate](https://eth.wiki/json-rpc/API#eth_submithashrate)                                          | Submits the mining hashrate.                                                                          | N/A                           | Mirror node is not an EVM bearing client
+| [eth_submitWork](https://eth.wiki/json-rpc/API#eth_submitwork)                                                  | Submits a Proof of Work (Ethash) solution.                                                            | N/A                           | Mirror node is not an EVM bearing client
+| [eth_syncing](https://eth.wiki/json-rpc/API#eth_syncing)                                                        | Returns an object with data about the synchronization status, or false if not synchronizing.          | N/A                           | Mirror node is not an EVM bearing client
+| [eth_uninstallFilter](https://eth.wiki/json-rpc/API#eth_uninstallfilter)                                        | Uninstalls a filter with the specified ID.                                                            | N/A                           | Mirror node REST APIs should be stateless and will not support persisting filters. Instead, desired filter should be applied to getLogs
 
 #### RPC Methods
 
@@ -638,98 +639,6 @@ Methods marked with P0 or P1 support serve as a starting subset of Ethereum JSON
     "jsonrpc": "2.0",
     "result": "0x0234c8a3397aab58"
     // 158972490234375000
-  }
-  ```
-
-- getBlockByHash
-
-  Request
-  ```shell
-  curl -X POST --data '{"jsonrpc":"2.0","method":"getBlockByHash","params":["0xdc0818cf78f21a8e70579cb46a43643f78291264dda342ae31049421c82d21ae", false],"id":1}'
-  ```
-  Response
-
-  ```json
-  {
-    "jsonrpc": "2.0",
-    "id": 1,
-    "result": {
-      "difficulty": "0x4ea3f27bc",
-      "extraData": "0x476574682f4c5649562f76312e302e302f6c696e75782f676f312e342e32",
-      "gasLimit": "0x1388",
-      "gasUsed": "0x0",
-      "hash": "0xdc0818cf78f21a8e70579cb46a43643f78291264dda342ae31049421c82d21ae",
-      "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-      "miner": "0xbb7b8287f3f0a933474a79eae42cbca977791171",
-      "mixHash": "0x4fffe9ae21f1c9e15207b1f472d5bbdd68c9595d461666602f2be20daf5e7843",
-      "nonce": "0x689056015818adbe",
-      "number": "0x1b4",
-      "parentHash": "0xe99e022112df268087ea7eafaf4790497fd21dbeeb6bd7a1721df161a6657a54",
-      "receiptsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
-      "sha3Uncles": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
-      "size": "0x220",
-      "stateRoot": "0xddc8b0234c2e0cad087c8b389aa7ef01f7d79b2570bccb77ce48648aa61c904d",
-      "timestamp": "0x55ba467c",
-      "totalDifficulty": "0x78ed983323d",
-      "transactions": [
-      ],
-      "transactionsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
-      "uncles": [
-      ]
-    }
-  }
-  ```
-
-- getBlockByNumber
-
-  Request
-  ```shell
-  curl -X POST --data '{"jsonrpc":"2.0","method":"getBlockByNumber","params":["0x1b4", true],"id":1}'
-  ```
-  Response
-  ```json
-  {
-    "jsonrpc": "2.0",
-    "id": 1,
-    "result": {
-      "difficulty": "0x4ea3f27bc",
-      "extraData": "0x476574682f4c5649562f76312e302e302f6c696e75782f676f312e342e32",
-      "gasLimit": "0x1388",
-      "gasUsed": "0x0",
-      "hash": "0xdc0818cf78f21a8e70579cb46a43643f78291264dda342ae31049421c82d21ae",
-      "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-      "miner": "0xbb7b8287f3f0a933474a79eae42cbca977791171",
-      "mixHash": "0x4fffe9ae21f1c9e15207b1f472d5bbdd68c9595d461666602f2be20daf5e7843",
-      "nonce": "0x689056015818adbe",
-      "number": "0x1b4",
-      "parentHash": "0xe99e022112df268087ea7eafaf4790497fd21dbeeb6bd7a1721df161a6657a54",
-      "receiptsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
-      "sha3Uncles": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
-      "size": "0x220",
-      "stateRoot": "0xddc8b0234c2e0cad087c8b389aa7ef01f7d79b2570bccb77ce48648aa61c904d",
-      "timestamp": "0x55ba467c",
-      "totalDifficulty": "0x78ed983323d",
-      "transactions": [
-      ],
-      "transactionsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
-      "uncles": [
-      ]
-    }
-  }
-  ```
-
-- getBlockTransactionCountByHash
-
-  Request
-  ```shell
-  curl -X POST --data '{"jsonrpc":"2.0","method":"getBlockTransactionCountByHash","params":["0xb903239f8543d04b5dc1ba6579132b143087c68db1b2168786408fcbce568238"],"id":1}'
-  ```
-  Response
-  ```json
-  {
-    "id":1,
-    "jsonrpc": "2.0",
-    "result": "0xb" // 11
   }
   ```
 


### PR DESCRIPTION
**Description**:
The current smart contract design was partial by design and lacks a recommendation for APIs that provide Dapp developers a minimal viable API experience for Ethereum smart contract development.

To address this , the updated design will
- Update the `/api/v1/contracts/{id}/results/{timestamp}` response schema
- Add `/api/v1/contracts/results/{transactionId}`
- Add `/api/v1/contracts/{id}/results/logs`
- Add a suggestion for a starting point for an Ethereum JSON-RPC API spec
   - Highlight new `hedera-mirror-common` module
   - Highlight new `hedera-mirror-web3` module
   - Present Ethereum RPC methods compatibility with Mirror Node
   - Highlight Ethereum RPC Service structure and suggested methods


**Related issue(s)**:

Fixes #2721 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
