### PR TITLE
Fix rosetta token balance reconciliation for deleted account

### DIFF
--- a/.github/workflows/rosetta-api.yml
+++ b/.github/workflows/rosetta-api.yml
@@ -104,8 +104,6 @@ jobs:
           [[ $code -eq 0 ]] && { wait $pid || code=$?; }
           cat /tmp/construction-validation.log
           exit $code
-        env:
-          ROSETTA_CLI_VERSION: v0.7.1
 
       - name: Install Postman newman CLI
         run: npm install -g newman

--- a/.github/workflows/rosetta-api.yml
+++ b/.github/workflows/rosetta-api.yml
@@ -61,7 +61,10 @@ jobs:
         working-directory: ./hedera-mirror-rosetta/build
 
       - name: Importer Configuration
-        run: echo "${{ secrets.ROSETTA_IMPORTER_CONFIG }}" | base64 -d > /tmp/application.yml
+        run: echo "${{ secrets.ROSETTA_IMPORTER_CONFIG }}" | base64 -d > /tmp/application_importer.yml
+
+      - name: Rosetta Configuration
+        run: echo "${{ secrets.ROSETTA_ROSETTA_CONFIG }}" | base64 -d > /tmp/application_rosetta.yml
 
       - name: Construction Test Prefunded Accounts
         run: |
@@ -84,7 +87,8 @@ jobs:
         run: |
           CONTAINER_ID=$(docker run -d -e HEDERA_MIRROR_IMPORTER_STARTDATE=$STARTDATE \
             -e NETWORK=testnet \
-            -v /tmp/application.yml:/app/importer/application.yml \
+            -v /tmp/application_importer.yml:/app/importer/application.yml \
+            -v /tmp/application_rosetta.yml:/app/rosetta/application.yml \
             -p 5432:5432 -p 5700:5700 "${MODULE}")
           echo "CONTAINER_ID=$CONTAINER_ID" >> $GITHUB_ENV
 

--- a/.github/workflows/rosetta-api.yml
+++ b/.github/workflows/rosetta-api.yml
@@ -73,8 +73,10 @@ jobs:
 
       - name: Set Importer StartDate
         run: |
-          startdate=$(date --date='15 minutes ago' -Iseconds -u)
-          startdate=${startdate%+*}Z
+          # grep extracts the data up to minute, e.g., 2021-11-15T16:48:, so as to always round down to the whole minute
+          # and avoid importer saves the first account balance file but not the account balance entries
+          startdate=$(date --date='15 minutes ago' -Iseconds -u | grep -o -e '^[0-9T:-]\+:')
+          startdate="${startdate}00Z"
           echo "STARTDATE=$startdate" >> $GITHUB_ENV
           echo "Set importer startDate to $startdate"
 

--- a/hedera-mirror-rosetta/app/interfaces/account_repository.go
+++ b/hedera-mirror-rosetta/app/interfaces/account_repository.go
@@ -31,9 +31,11 @@ import (
 // AccountRepository Interface that all AccountRepository structs must implement
 type AccountRepository interface {
 
-	// RetrieveBalanceAtBlock returns the hbar balance and token balances of the account at a given block (
-	// provided by consensusEnd timestamp).
+	// RetrieveBalanceAtBlock returns the hbar balance and token balances of the account at a given block (provided by
+	// consensusEnd timestamp).
 	// balance = balanceAtLatestBalanceSnapshot + balanceChangeBetweenSnapshotAndBlock
+	// if the account is deleted at T1 and T1 <= consensusEnd, the balance is calculated as
+	// balance = balanceAtLatestBalanceSnapshotBeforeT1 + balanceChangeBetweenSnapshotAndT1
 	RetrieveBalanceAtBlock(ctx context.Context, accountId, consensusEnd int64) ([]types.Amount, *rTypes.Error)
 
 	// RetrieveEverOwnedTokensByBlockAfter returns the tokens the account has ever owned by the end of the block after

--- a/hedera-mirror-rosetta/app/persistence/domain/entity.go
+++ b/hedera-mirror-rosetta/app/persistence/domain/entity.go
@@ -1,0 +1,50 @@
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+package domain
+
+import "github.com/jackc/pgtype"
+
+const entityTableName = "entity"
+
+type Entity struct {
+	AutoRenewAccountId            *EntityId
+	AutoRenewPeriod               *int64
+	CreatedTimestamp              *int64
+	Deleted                       *bool
+	ExpirationTimestamp           *int64
+	Id                            EntityId
+	Key                           []byte
+	MaxAutomaticTokenAssociations *int32
+	Memo                          string
+	Num                           int64
+	PublicKey                     *string
+	ProxyAccountId                *EntityId
+	Realm                         int64
+	ReceiverSigRequired           *bool
+	Shard                         int64
+	SubmitKey                     []byte
+	TimestampRange                pgtype.Int8range
+	Type                          string
+}
+
+func (Entity) TableName() string {
+	return entityTableName
+}

--- a/hedera-mirror-rosetta/app/persistence/domain/entity_test.go
+++ b/hedera-mirror-rosetta/app/persistence/domain/entity_test.go
@@ -1,0 +1,31 @@
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+package domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEntityTableName(t *testing.T) {
+	assert.Equal(t, "entity", Entity{}.TableName())
+}

--- a/hedera-mirror-rosetta/test/db/db.go
+++ b/hedera-mirror-rosetta/test/db/db.go
@@ -209,7 +209,7 @@ func createPostgresDb(pool *dockertest.Pool, network *dockertest.Network) (*dock
 	options := &dockertest.RunOptions{
 		Name:       getDbHostname(network.Network),
 		Repository: "postgres",
-		Tag:        "9.6",
+		Tag:        "13",
 		Env:        env,
 		Networks:   []*dockertest.Network{network},
 	}
@@ -232,7 +232,7 @@ func runFlywayMigration(pool *dockertest.Pool, network *dockertest.Network, para
 	// run the container with tty and entrypoint "bin/sh" so it will stay alive in background
 	options := &dockertest.RunOptions{
 		Repository: "flyway/flyway",
-		Tag:        "7.9.1-alpine",
+		Tag:        "8.0.4-alpine",
 		Entrypoint: []string{"/bin/sh"},
 		Networks:   []*dockertest.Network{network},
 		Mounts:     []string{migrationPath + ":/flyway/sql"},


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

This PR adds support for deleted account's token balance reconciliation.

- Reconcile deleted account's token balance from latest account balance file before deletion
- Switch back to latest `rosetta-cli`
- Fix rare issue which causes `get-genesis-balance.sh` to fail
- Add support to override default rosetta configuration in github workflow CI

**Related issue(s)**:

Fixes #2793 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

The solution is described in the ticket #2793.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
