### PR TITLE
Support CryptoCreateTransaction in Rosetta

### DIFF
--- a/.github/workflows/rosetta-api.yml
+++ b/.github/workflows/rosetta-api.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Set Importer StartDate
         run: |
-          # grep extracts the data up to minute, e.g., 2021-11-15T16:48:, so as to always round down to the whole minute
+          # grep extracts the date up to minute, e.g., 2021-11-15T16:48:, so as to always round down to the whole minute
           # and avoid importer saves the first account balance file but not the account balance entries
           startdate=$(date --date='15 minutes ago' -Iseconds -u | grep -o -e '^[0-9T:-]\+:')
           startdate="${startdate}00Z"

--- a/hedera-mirror-rosetta/app/domain/types/amount.go
+++ b/hedera-mirror-rosetta/app/domain/types/amount.go
@@ -22,6 +22,7 @@ package types
 
 import (
 	"encoding/base64"
+	"reflect"
 	"strconv"
 
 	"github.com/coinbase/rosetta-sdk-go/types"
@@ -136,6 +137,10 @@ func NewAmount(amount *types.Amount) (Amount, *types.Error) {
 	}
 
 	if currency.Symbol == CurrencyHbar.Symbol {
+		if !reflect.DeepEqual(currency, CurrencyHbar) {
+			return nil, errors.ErrInvalidCurrency
+		}
+
 		return &HbarAmount{Value: value}, nil
 	}
 

--- a/hedera-mirror-rosetta/app/domain/types/amount_test.go
+++ b/hedera-mirror-rosetta/app/domain/types/amount_test.go
@@ -236,10 +236,29 @@ func TestNewAmountFailure(t *testing.T) {
 			},
 		},
 		{
-			name: "InvalidCurrencyDecimals",
+			name: "NegativeCurrencyDecimals",
 			input: &types.Amount{
 				Value:    "1",
 				Currency: &types.Currency{Decimals: -1, Symbol: CurrencyHbar.Symbol},
+			},
+		},
+		{
+			name: "InvalidCurrencyDecimalsForHbar",
+			input: &types.Amount{
+				Value:    "1",
+				Currency: &types.Currency{Decimals: 2, Symbol: CurrencyHbar.Symbol},
+			},
+		},
+		{
+			name: "InvalidCurrencyMetadataForHbar",
+			input: &types.Amount{
+				Value: "1",
+				Currency: &types.Currency{
+					Symbol: CurrencyHbar.Symbol,
+					Metadata: map[string]interface{}{
+						"issuer": "group",
+					},
+				},
 			},
 		},
 		{

--- a/hedera-mirror-rosetta/app/domain/types/constants.go
+++ b/hedera-mirror-rosetta/app/domain/types/constants.go
@@ -23,20 +23,20 @@ package types
 import "github.com/coinbase/rosetta-sdk-go/types"
 
 const (
-	OperationTypeCryptoCreate    = "CRYPTOCREATE"
-	OperationTypeCryptoTransfer  = "CRYPTOTRANSFER"
-	OperationTypeTokenAssociate  = "TOKENASSOCIATE"
-	OperationTypeTokenBurn       = "TOKENBURN"
-	OperationTypeTokenCreate     = "TOKENCREATION"
-	OperationTypeTokenDelete     = "TOKENDELETION"
-	OperationTypeTokenDissociate = "TOKENDISSOCIATE" // #nosec
-	OperationTypeTokenFreeze     = "TOKENFREEZE"
-	OperationTypeTokenGrantKyc   = "TOKENGRANTKYC"
-	OperationTypeTokenMint       = "TOKENMINT"
-	OperationTypeTokenRevokeKyc  = "TOKENREVOKEKYC"
-	OperationTypeTokenUnfreeze   = "TOKENUNFREEZE"
-	OperationTypeTokenUpdate     = "TOKENUPDATE"
-	OperationTypeTokenWipe       = "TOKENWIPE"
+	OperationTypeCryptoCreateAccount = "CRYPTOCREATEACCOUNT"
+	OperationTypeCryptoTransfer      = "CRYPTOTRANSFER"
+	OperationTypeTokenAssociate      = "TOKENASSOCIATE"
+	OperationTypeTokenBurn           = "TOKENBURN"
+	OperationTypeTokenCreate         = "TOKENCREATION"
+	OperationTypeTokenDelete         = "TOKENDELETION"
+	OperationTypeTokenDissociate     = "TOKENDISSOCIATE" // #nosec
+	OperationTypeTokenFreeze         = "TOKENFREEZE"
+	OperationTypeTokenGrantKyc       = "TOKENGRANTKYC"
+	OperationTypeTokenMint           = "TOKENMINT"
+	OperationTypeTokenRevokeKyc      = "TOKENREVOKEKYC"
+	OperationTypeTokenUnfreeze       = "TOKENUNFREEZE"
+	OperationTypeTokenUpdate         = "TOKENUPDATE"
+	OperationTypeTokenWipe           = "TOKENWIPE"
 )
 
 const (
@@ -291,10 +291,10 @@ var TransactionTypes = map[int32]string{
 	8:  "CONTRACTCREATEINSTANCE",
 	9:  "CONTRACTUPDATEINSTANCE",
 	10: "CRYPTOADDLIVEHASH",
-	11: "CRYPTOCREATEACCOUNT",
+	11: OperationTypeCryptoCreateAccount,
 	12: "CRYPTODELETE",
 	13: "CRYPTODELETELIVEHASH",
-	14: "CRYPTOTRANSFER",
+	14: OperationTypeCryptoTransfer,
 	15: "CRYPTOUPDATEACCOUNT",
 	16: "FILEAPPEND",
 	17: "FILECREATE",
@@ -309,18 +309,18 @@ var TransactionTypes = map[int32]string{
 	26: "CONSENSUSDELETETOPIC",
 	27: "CONSENSUSSUBMITMESSAGE",
 	28: "UNCHECKEDSUBMIT",
-	29: "TOKENCREATION",
-	31: "TOKENFREEZE",
-	32: "TOKENUNFREEZE",
-	33: "TOKENGRANTKYC",
-	34: "TOKENREVOKEKYC",
-	35: "TOKENDELETION",
-	36: "TOKENUPDATE",
-	37: "TOKENMINT",
-	38: "TOKENBURN",
-	39: "TOKENWIPE",
-	40: "TOKENASSOCIATE",
-	41: "TOKENDISSOCIATE",
+	29: OperationTypeTokenCreate,
+	31: OperationTypeTokenFreeze,
+	32: OperationTypeTokenUnfreeze,
+	33: OperationTypeTokenGrantKyc,
+	34: OperationTypeTokenRevokeKyc,
+	35: OperationTypeTokenDelete,
+	36: OperationTypeTokenUpdate,
+	37: OperationTypeTokenMint,
+	38: OperationTypeTokenBurn,
+	39: OperationTypeTokenWipe,
+	40: OperationTypeTokenAssociate,
+	41: OperationTypeTokenDissociate,
 	42: "SCHEDULECREATE",
 	43: "SCHEDULEDELETE",
 	44: "SCHEDULESIGN",
@@ -339,7 +339,7 @@ var (
 	}
 
 	SupportedOperationTypes = []string{
-		OperationTypeCryptoCreate,
+		OperationTypeCryptoCreateAccount,
 		OperationTypeCryptoTransfer,
 		OperationTypeTokenAssociate,
 		OperationTypeTokenBurn,

--- a/hedera-mirror-rosetta/app/domain/types/constants.go
+++ b/hedera-mirror-rosetta/app/domain/types/constants.go
@@ -23,6 +23,7 @@ package types
 import "github.com/coinbase/rosetta-sdk-go/types"
 
 const (
+	OperationTypeCryptoCreate    = "CRYPTOCREATE"
 	OperationTypeCryptoTransfer  = "CRYPTOTRANSFER"
 	OperationTypeTokenAssociate  = "TOKENASSOCIATE"
 	OperationTypeTokenBurn       = "TOKENBURN"
@@ -338,6 +339,7 @@ var (
 	}
 
 	SupportedOperationTypes = []string{
+		OperationTypeCryptoCreate,
 		OperationTypeCryptoTransfer,
 		OperationTypeTokenAssociate,
 		OperationTypeTokenBurn,

--- a/hedera-mirror-rosetta/app/domain/types/transaction.go
+++ b/hedera-mirror-rosetta/app/domain/types/transaction.go
@@ -20,10 +20,14 @@
 
 package types
 
-import "github.com/coinbase/rosetta-sdk-go/types"
+import (
+	"github.com/coinbase/rosetta-sdk-go/types"
+	"github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/app/persistence/domain"
+)
 
 // Transaction is domain level struct used to represent Transaction conceptual mapping in Hedera
 type Transaction struct {
+	EntityId   *domain.EntityId
 	Hash       string
 	Operations []*Operation
 }
@@ -34,9 +38,14 @@ func (t *Transaction) ToRosetta() *types.Transaction {
 	for i, o := range t.Operations {
 		operations[i] = o.ToRosetta()
 	}
+	var metadata map[string]interface{}
+	if t.EntityId != nil {
+		metadata = map[string]interface{}{"entity_id": t.EntityId.String()}
+	}
 
 	return &types.Transaction{
 		TransactionIdentifier: &types.TransactionIdentifier{Hash: t.Hash},
 		Operations:            operations,
+		Metadata:              metadata,
 	}
 }

--- a/hedera-mirror-rosetta/app/interfaces/transaction.go
+++ b/hedera-mirror-rosetta/app/interfaces/transaction.go
@@ -28,6 +28,9 @@ type Transaction interface {
 	// Execute submits the Transaction to the network using client
 	Execute(client *hedera.Client) (hedera.TransactionResponse, error)
 
+	// IsFrozen returns if the transaction is frozen
+	IsFrozen() bool
+
 	// GetNodeAccountIDs returns the node accounts ids set for the Transaction
 	GetNodeAccountIDs() []hedera.AccountID
 

--- a/hedera-mirror-rosetta/app/interfaces/transaction_repository.go
+++ b/hedera-mirror-rosetta/app/interfaces/transaction_repository.go
@@ -40,5 +40,5 @@ type TransactionRepository interface {
 	)
 
 	// TypesAsArray returns all Transaction type names as an array
-	TypesAsArray(ctx context.Context) ([]string, *rTypes.Error)
+	TypesAsArray() []string
 }

--- a/hedera-mirror-rosetta/app/persistence/domain/entityid_test.go
+++ b/hedera-mirror-rosetta/app/persistence/domain/entityid_test.go
@@ -49,6 +49,42 @@ func TestEntityIdIsNotZero(t *testing.T) {
 	assert.False(t, entityId.IsZero())
 }
 
+func TestEntityIdScan(t *testing.T) {
+	var tests = []struct {
+		name     string
+		value    interface{}
+		expected *EntityId
+	}{
+		{
+			name:     "Success",
+			value:    int64(100),
+			expected: &EntityId{EntityNum: 100, EncodedId: 100},
+		},
+		{
+			name:     "InvalidType",
+			value:    "100",
+			expected: nil,
+		},
+		{
+			name:     "InvalidEncodedId",
+			value:    int64(-1),
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := &EntityId{}
+			err := actual.Scan(tt.value)
+			if tt.expected != nil {
+				assert.Equal(t, tt.expected, actual)
+			} else {
+				assert.Error(t, err)
+			}
+		})
+	}
+}
+
 func TestEntityIdString(t *testing.T) {
 	entityId := EntityId{EntityNum: 7, EncodedId: 7}
 
@@ -151,6 +187,20 @@ func TestEntityIdUnmarshalJSONThrows(t *testing.T) {
 			assert.Error(t, err)
 		})
 	}
+}
+
+func TestEntityIdValueZero(t *testing.T) {
+	entityId := EntityId{}
+	actual, err := entityId.Value()
+	assert.NoError(t, err)
+	assert.Equal(t, nil, actual)
+}
+
+func TestEntityIdValueNonZero(t *testing.T) {
+	entityId := MustDecodeEntityId(600)
+	actual, err := entityId.Value()
+	assert.NoError(t, err)
+	assert.Equal(t, int64(600), actual)
 }
 
 func TestEntityIdEncoding(t *testing.T) {

--- a/hedera-mirror-rosetta/app/persistence/transaction_test.go
+++ b/hedera-mirror-rosetta/app/persistence/transaction_test.go
@@ -111,11 +111,6 @@ func TestTokenTransferGetAmount(t *testing.T) {
 	assert.Equal(t, getFungibleTokenAmount(10, 3, tokenId1), tokenTransfer.getAmount())
 }
 
-// func TestTokenGetAmount(t *testing.T) {
-// 	token := token{Decimals: 5, TokenId: tokenId2}
-// 	assert.Equal(t, &types.TokenAmount{Decimals: 5, TokenId: tokenId2}, token.getAmount())
-// }
-
 func TestShouldFailConstructAccount(t *testing.T) {
 	data := int64(-1)
 	expected := errors.ErrInternalServerError
@@ -183,6 +178,7 @@ func assertTransactions(t *testing.T, expected, actual []*types.Transaction) {
 	for txHash, actualTx := range actualTransactionMap {
 		assert.Contains(t, expectedTransactionMap, txHash)
 		expectedTx := expectedTransactionMap[txHash]
+		assert.Equal(t, expectedTx.EntityId, actualTx.EntityId)
 		assert.ElementsMatch(t, expectedTx.Operations, actualTx.Operations)
 	}
 }
@@ -457,7 +453,8 @@ func (suite *transactionRepositorySuite) setupDb(createTokenEntity bool) []*type
 	}
 	operationType = types.OperationTypeTokenCreate
 	expectedTransaction3 := &types.Transaction{
-		Hash: "0xaaccdd",
+		EntityId: &tokenId2,
+		Hash:     "0xaaccdd",
 		Operations: []*types.Operation{
 			{Account: firstAccount, Amount: &types.HbarAmount{Value: -15}, Type: operationType, Status: resultSuccess},
 			{Account: nodeAccount, Amount: &types.HbarAmount{Value: 5}, Type: operationType, Status: resultSuccess},
@@ -498,7 +495,8 @@ func (suite *transactionRepositorySuite) setupDb(createTokenEntity bool) []*type
 		"initial_supply": int64(0),
 	}
 	expectedTransaction4 := &types.Transaction{
-		Hash: "0xaa1122",
+		EntityId: &tokenId3,
+		Hash:     "0xaa1122",
 		Operations: []*types.Operation{
 			{Account: firstAccount, Amount: &types.HbarAmount{Value: -15}, Type: operationType, Status: resultSuccess},
 			{Account: nodeAccount, Amount: &types.HbarAmount{Value: 5}, Type: operationType, Status: resultSuccess},
@@ -525,7 +523,8 @@ func (suite *transactionRepositorySuite) setupDb(createTokenEntity bool) []*type
 		nftTransfers)
 	operationType = types.OperationTypeTokenMint
 	expectedTransaction5 := &types.Transaction{
-		Hash: "0xaa1133",
+		EntityId: &tokenId3,
+		Hash:     "0xaa1133",
 		Operations: []*types.Operation{
 			{Account: firstAccount, Amount: &types.HbarAmount{Value: -15}, Type: operationType, Status: resultSuccess},
 			{Account: nodeAccount, Amount: &types.HbarAmount{Value: 5}, Type: operationType, Status: resultSuccess},
@@ -547,7 +546,7 @@ func (suite *transactionRepositorySuite) setupDb(createTokenEntity bool) []*type
 	nftTransfers = []domain.NftTransfer{
 		{consensusTimestamp, firstAccount.EntityId, &secondAccount.EntityId, &firstAccount.EntityId, 1, tokenId3},
 	}
-	addTransaction(dbClient, consensusTimestamp, &firstAccount.EntityId, &nodeAccount.EntityId, firstAccount.EntityId,
+	addTransaction(dbClient, consensusTimestamp, nil, &nodeAccount.EntityId, firstAccount.EntityId,
 		22, []byte{0xaa, 0x11, 0x66}, domain.TransactionTypeCryptoTransfer, validStartNs, cryptoTransfers, nil,
 		nil, nftTransfers)
 	operationType = types.OperationTypeCryptoTransfer

--- a/hedera-mirror-rosetta/app/persistence/transaction_test.go
+++ b/hedera-mirror-rosetta/app/persistence/transaction_test.go
@@ -203,8 +203,7 @@ func (suite *transactionRepositorySuite) TestNewTransactionRepository() {
 
 func (suite *transactionRepositorySuite) TestTypesAsArray() {
 	t := NewTransactionRepository(dbClient)
-	actual, err := t.TypesAsArray(defaultContext)
-	assert.Nil(suite.T(), err)
+	actual := t.TypesAsArray()
 	assert.NotEmpty(suite.T(), actual)
 }
 

--- a/hedera-mirror-rosetta/app/services/base_service.go
+++ b/hedera-mirror-rosetta/app/services/base_service.go
@@ -89,6 +89,6 @@ func (c *BaseService) FindBetween(ctx context.Context, start int64, end int64) (
 	return c.transactionRepo.FindBetween(ctx, start, end)
 }
 
-func (c *BaseService) TypesAsArray(ctx context.Context) ([]string, *rTypes.Error) {
-	return c.transactionRepo.TypesAsArray(ctx)
+func (c *BaseService) TypesAsArray() []string {
+	return c.transactionRepo.TypesAsArray()
 }

--- a/hedera-mirror-rosetta/app/services/base_service_test.go
+++ b/hedera-mirror-rosetta/app/services/base_service_test.go
@@ -319,23 +319,9 @@ func (suite *baseServiceSuite) TestTypesAsArray() {
 	suite.mockTransactionRepo.On("TypesAsArray").Return(exampleTypesArray, mocks.NilError)
 
 	// when:
-	res, e := suite.baseService.TypesAsArray(defaultContext)
+	res := suite.baseService.TypesAsArray()
 
 	// then:
-	assert.Nil(suite.T(), e)
 	assert.Equal(suite.T(), exampleTypesArray, res)
-	suite.mockBlockRepo.AssertExpectations(suite.T())
-}
-
-func (suite *baseServiceSuite) TestTypesAsArrayThrows() {
-	// given:
-	suite.mockTransactionRepo.On("TypesAsArray").Return(nilArray, &rTypes.Error{})
-
-	// when:
-	res, e := suite.baseService.TypesAsArray(defaultContext)
-
-	// then:
-	assert.Nil(suite.T(), res)
-	assert.NotNil(suite.T(), e)
 	suite.mockBlockRepo.AssertExpectations(suite.T())
 }

--- a/hedera-mirror-rosetta/app/services/construction/composite_transaction_constructor.go
+++ b/hedera-mirror-rosetta/app/services/construction/composite_transaction_constructor.go
@@ -88,7 +88,10 @@ func (c *compositeTransactionConstructor) addConstructor(constructor transaction
 	c.constructorsByTransactionType[constructor.GetSdkTransactionType()] = constructor
 }
 
-func (c *compositeTransactionConstructor) validate(operations []*rTypes.Operation) (transactionConstructorWithType, *rTypes.Error) {
+func (c *compositeTransactionConstructor) validate(operations []*rTypes.Operation) (
+	transactionConstructorWithType,
+	*rTypes.Error,
+) {
 	if len(operations) == 0 {
 		return nil, errors.ErrEmptyOperations
 	}

--- a/hedera-mirror-rosetta/app/services/construction/composite_transaction_constructor.go
+++ b/hedera-mirror-rosetta/app/services/construction/composite_transaction_constructor.go
@@ -115,6 +115,7 @@ func NewTransactionConstructor(tokenRepo interfaces.TokenRepository) Transaction
 		constructorsByTransactionType: make(map[string]transactionConstructorWithType),
 	}
 
+	c.addConstructor(newCryptoCreateTransactionConstructor())
 	c.addConstructor(newCryptoTransferTransactionConstructor(tokenRepo))
 	c.addConstructor(newTokenCreateTransactionConstructor())
 

--- a/hedera-mirror-rosetta/app/services/construction/crypto_create_transaction_constructor.go
+++ b/hedera-mirror-rosetta/app/services/construction/crypto_create_transaction_constructor.go
@@ -1,0 +1,207 @@
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+package construction
+
+import (
+	"context"
+	"reflect"
+	"time"
+
+	rTypes "github.com/coinbase/rosetta-sdk-go/types"
+	"github.com/go-playground/validator/v10"
+	"github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/app/domain/types"
+	"github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/app/errors"
+	"github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/app/interfaces"
+	"github.com/hashgraph/hedera-sdk-go/v2"
+	log "github.com/sirupsen/logrus"
+)
+
+type cryptoCreate struct {
+	AutoRenewPeriod               int64             `json:"auto_renew_period"`
+	InitialBalance                int64             `json:"-"`
+	Key                           *publicKey        `json:"key" validate:"required"`
+	MaxAutomaticTokenAssociations uint32            `json:"max_automatic_token_associations"`
+	Memo                          string            `json:"memo"`
+	ProxyAccountId                *hedera.AccountID `json:"proxy_account_id"`
+	// Add support for ReceiverSigRequired if needed and when the format to present an unknown account as a rosetta
+	// AccountIdentifier id decided
+}
+
+type cryptoCreateTransactionConstructor struct {
+	transactionType string
+	validate        *validator.Validate
+}
+
+func (c *cryptoCreateTransactionConstructor) Construct(
+	ctx context.Context,
+	nodeAccountId hedera.AccountID,
+	operations []*rTypes.Operation,
+	validStartNanos int64,
+) (interfaces.Transaction, []hedera.AccountID, *rTypes.Error) {
+	cryptoCreate, signer, rErr := c.preprocess(operations)
+	if rErr != nil {
+		return nil, nil, rErr
+	}
+
+	transaction := hedera.NewAccountCreateTransaction().
+		SetInitialBalance(hedera.HbarFromTinybar(cryptoCreate.InitialBalance)).
+		SetNodeAccountIDs([]hedera.AccountID{nodeAccountId}).
+		SetKey(cryptoCreate.Key.PublicKey).
+		SetTransactionID(getTransactionId(*signer, validStartNanos))
+
+	if cryptoCreate.AutoRenewPeriod > 0 {
+		transaction.SetAutoRenewPeriod(time.Second * time.Duration(cryptoCreate.AutoRenewPeriod))
+	}
+
+	if cryptoCreate.MaxAutomaticTokenAssociations != 0 {
+		transaction.SetMaxAutomaticTokenAssociations(cryptoCreate.MaxAutomaticTokenAssociations)
+	}
+
+	if cryptoCreate.Memo != "" {
+		transaction.SetAccountMemo(cryptoCreate.Memo)
+	}
+
+	if cryptoCreate.ProxyAccountId != nil {
+		transaction.SetProxyAccountID(*cryptoCreate.ProxyAccountId)
+	}
+
+	return transaction, []hedera.AccountID{*signer}, nil
+}
+
+func (c *cryptoCreateTransactionConstructor) GetOperationType() string {
+	return types.OperationTypeCryptoCreate
+}
+
+func (c *cryptoCreateTransactionConstructor) GetSdkTransactionType() string {
+	return c.transactionType
+}
+
+func (c *cryptoCreateTransactionConstructor) Parse(ctx context.Context, transaction interfaces.Transaction) (
+	[]*rTypes.Operation,
+	[]hedera.AccountID,
+	*rTypes.Error,
+) {
+	cryptoCreateTransaction, ok := transaction.(*hedera.AccountCreateTransaction)
+	if !ok {
+		return nil, nil, errors.ErrTransactionInvalidType
+	}
+
+	if cryptoCreateTransaction.GetTransactionID().AccountID == nil {
+		log.Error("Transaction ID is not set")
+		return nil, nil, errors.ErrInvalidTransaction
+	}
+
+	amount := types.HbarAmount{Value: cryptoCreateTransaction.GetInitialBalance().AsTinybar()}
+	payer := *cryptoCreateTransaction.GetTransactionID().AccountID
+	operation := &rTypes.Operation{
+		OperationIdentifier: &rTypes.OperationIdentifier{Index: 0},
+		Account:             &rTypes.AccountIdentifier{Address: payer.String()},
+		Amount:              amount.ToRosetta(),
+		Type:                c.GetOperationType(),
+	}
+
+	metadata := make(map[string]interface{})
+	operation.Metadata = metadata
+	metadata["memo"] = cryptoCreateTransaction.GetAccountMemo()
+
+	if cryptoCreateTransaction.GetAutoRenewPeriod() != 0 {
+		metadata["auto_renew_period"] = int64(cryptoCreateTransaction.GetAutoRenewPeriod().Seconds())
+	}
+
+	if key, err := cryptoCreateTransaction.GetKey(); err != nil {
+		log.Errorf("Failed to get key from crypto create transaction: %v", err)
+		return nil, nil, errors.ErrInvalidTransaction
+	} else if key == nil {
+		log.Errorf("Key not set for the crypto create transaction")
+		return nil, nil, errors.ErrInvalidTransaction
+	} else {
+		metadata["key"] = key.String()
+	}
+
+	if cryptoCreateTransaction.GetMaxAutomaticTokenAssociations() != 0 {
+		metadata["max_automatic_token_associations"] = cryptoCreateTransaction.GetMaxAutomaticTokenAssociations()
+	}
+
+	if !isZeroAccountId(cryptoCreateTransaction.GetProxyAccountID()) {
+		metadata["proxy_account_id"] = cryptoCreateTransaction.GetProxyAccountID().String()
+	}
+
+	return []*rTypes.Operation{operation}, []hedera.AccountID{payer}, nil
+}
+
+func (c *cryptoCreateTransactionConstructor) Preprocess(ctx context.Context, operations []*rTypes.Operation) (
+	[]hedera.AccountID,
+	*rTypes.Error,
+) {
+	_, signer, err := c.preprocess(operations)
+	if err != nil {
+		return nil, err
+	}
+
+	return []hedera.AccountID{*signer}, nil
+}
+
+func (c *cryptoCreateTransactionConstructor) preprocess(operations []*rTypes.Operation) (
+	*cryptoCreate,
+	*hedera.AccountID,
+	*rTypes.Error,
+) {
+	if rErr := validateOperations(operations, 1, c.GetOperationType(), false); rErr != nil {
+		return nil, nil, rErr
+	}
+
+	operation := operations[0]
+	account, err := hedera.AccountIDFromString(operation.Account.Address)
+	if err != nil {
+		log.Errorf("Invalid account %s: %s", operation.Account.Address, err)
+		return nil, nil, errors.ErrInvalidAccount
+	}
+
+	amount, rErr := types.NewAmount(operation.Amount)
+	if rErr != nil {
+		log.Errorf("Invalid amount %v: %v", operation.Amount, rErr)
+		return nil, nil, rErr
+	} else if _, ok := amount.(*types.HbarAmount); !ok {
+		log.Errorf("Operation amount currency is not HBAR: %v", operation.Amount)
+		return nil, nil, errors.ErrInvalidCurrency
+	} else if amount.GetValue() < 0 {
+		log.Errorf("Initial balance %d is < 0", amount.GetValue())
+		return nil, nil, errors.ErrInvalidOperationsAmount
+	}
+
+	cryptoCreate := &cryptoCreate{}
+	if rErr := parseOperationMetadata(c.validate, cryptoCreate, operation.Metadata); rErr != nil {
+		log.Errorf("Failed to parse and validate operation metadata %v: %v", operation.Metadata, rErr)
+		return nil, nil, rErr
+	}
+
+	cryptoCreate.InitialBalance = amount.GetValue()
+
+	return cryptoCreate, &account, nil
+}
+
+func newCryptoCreateTransactionConstructor() transactionConstructorWithType {
+	transactionType := reflect.TypeOf(hedera.AccountCreateTransaction{}).Name()
+	return &cryptoCreateTransactionConstructor{
+		transactionType: transactionType,
+		validate:        validator.New(),
+	}
+}

--- a/hedera-mirror-rosetta/app/services/construction/crypto_create_transaction_constructor.go
+++ b/hedera-mirror-rosetta/app/services/construction/crypto_create_transaction_constructor.go
@@ -83,11 +83,16 @@ func (c *cryptoCreateTransactionConstructor) Construct(
 		transaction.SetProxyAccountID(*cryptoCreate.ProxyAccountId)
 	}
 
+	if _, err := transaction.Freeze(); err != nil {
+		log.Errorf("Failed to freeze transaction: %s", err)
+		return nil, nil, errors.ErrTransactionFreezeFailed
+	}
+
 	return transaction, []hedera.AccountID{*signer}, nil
 }
 
 func (c *cryptoCreateTransactionConstructor) GetOperationType() string {
-	return types.OperationTypeCryptoCreate
+	return types.OperationTypeCryptoCreateAccount
 }
 
 func (c *cryptoCreateTransactionConstructor) GetSdkTransactionType() string {

--- a/hedera-mirror-rosetta/app/services/construction/crypto_create_transaction_constructor_test.go
+++ b/hedera-mirror-rosetta/app/services/construction/crypto_create_transaction_constructor_test.go
@@ -192,14 +192,22 @@ func (suite *cryptoCreateTransactionConstructorSuite) TestPreprocess() {
 	}{
 		{name: "Success"},
 		{
-			name:             "MissingMetadataKey",
-			updateOperations: deleteOperationMetadata("key"),
-			expectError:      true,
-		},
-		{
 			name:             "InvalidAccountAddress",
 			updateOperations: updateOperationAccount("x.y.z"),
 			expectError:      true,
+		},
+		{
+			name:             "InvalidCurrencySymbol",
+			updateOperations: updateCurrency(&rTypes.Currency{Symbol: "dummy"}),
+			expectError:      true,
+		},
+		{
+			name: "InvalidCurrencyType",
+			updateOperations: updateCurrency(&rTypes.Currency{
+				Symbol:   "0.0.8231",
+				Metadata: map[string]interface{}{"type": "FUNGIBLE_COMMON"},
+			}),
+			expectError: true,
 		},
 		{
 			name:             "InvalidMetadataKey",
@@ -232,8 +240,18 @@ func (suite *cryptoCreateTransactionConstructorSuite) TestPreprocess() {
 			expectError:      true,
 		},
 		{
+			name:             "MissingMetadataKey",
+			updateOperations: deleteOperationMetadata("key"),
+			expectError:      true,
+		},
+		{
 			name:             "MultipleOperations",
 			updateOperations: addOperation,
+			expectError:      true,
+		},
+		{
+			name:             "NegativeInitialBalance",
+			updateOperations: negateAmountValue,
 			expectError:      true,
 		},
 		{

--- a/hedera-mirror-rosetta/app/services/construction/crypto_create_transaction_constructor_test.go
+++ b/hedera-mirror-rosetta/app/services/construction/crypto_create_transaction_constructor_test.go
@@ -58,7 +58,7 @@ func (suite *cryptoCreateTransactionConstructorSuite) TestNewTransactionConstruc
 
 func (suite *cryptoCreateTransactionConstructorSuite) TestGetOperationType() {
 	h := newCryptoCreateTransactionConstructor()
-	assert.Equal(suite.T(), types.OperationTypeCryptoCreate, h.GetOperationType())
+	assert.Equal(suite.T(), types.OperationTypeCryptoCreateAccount, h.GetOperationType())
 }
 
 func (suite *cryptoCreateTransactionConstructorSuite) TestGetSdkTransactionType() {
@@ -293,6 +293,7 @@ func assertCryptoCreateTransaction(
 	actual interfaces.Transaction,
 ) {
 	assert.IsType(t, &hedera.AccountCreateTransaction{}, actual)
+	assert.True(t, actual.IsFrozen())
 
 	tx, _ := actual.(*hedera.AccountCreateTransaction)
 	payer := tx.GetTransactionID().AccountID.String()
@@ -314,7 +315,7 @@ func getCryptoCreateOperations() []*rTypes.Operation {
 	amount := &types.HbarAmount{Value: initialBalance}
 	operation := &rTypes.Operation{
 		OperationIdentifier: &rTypes.OperationIdentifier{Index: 0},
-		Type:                types.OperationTypeCryptoCreate,
+		Type:                types.OperationTypeCryptoCreateAccount,
 		Account:             payerAccountIdentifier,
 		Amount:              amount.ToRosetta(),
 		Metadata: map[string]interface{}{

--- a/hedera-mirror-rosetta/app/services/construction/crypto_create_transaction_constructor_test.go
+++ b/hedera-mirror-rosetta/app/services/construction/crypto_create_transaction_constructor_test.go
@@ -1,0 +1,312 @@
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+package construction
+
+import (
+	"testing"
+	"time"
+
+	rTypes "github.com/coinbase/rosetta-sdk-go/types"
+	"github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/app/domain/types"
+	"github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/app/interfaces"
+	"github.com/hashgraph/hedera-sdk-go/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	initialBalance                       = 10
+	maxAutomaticTokenAssociations uint32 = 10
+	newAccountKeyStr                     = "302a300506032b65700321006663a95da28adcb0fc129d1b4eda4be7dd90b54a337cd2dd953e1d2dc03ca6d1"
+)
+
+var (
+	newAccountKey, _ = hedera.PublicKeyFromString(newAccountKeyStr)
+	proxyAccountId   = hedera.AccountID{Account: 6000}
+)
+
+func TestCryptoCreateTransactionConstructorSuite(t *testing.T) {
+	suite.Run(t, new(cryptoCreateTransactionConstructorSuite))
+}
+
+type cryptoCreateTransactionConstructorSuite struct {
+	suite.Suite
+}
+
+func (suite *cryptoCreateTransactionConstructorSuite) TestNewTransactionConstructor() {
+	h := newCryptoCreateTransactionConstructor()
+	assert.NotNil(suite.T(), h)
+}
+
+func (suite *cryptoCreateTransactionConstructorSuite) TestGetOperationType() {
+	h := newCryptoCreateTransactionConstructor()
+	assert.Equal(suite.T(), types.OperationTypeCryptoCreate, h.GetOperationType())
+}
+
+func (suite *cryptoCreateTransactionConstructorSuite) TestGetSdkTransactionType() {
+	h := newCryptoCreateTransactionConstructor()
+	assert.Equal(suite.T(), "AccountCreateTransaction", h.GetSdkTransactionType())
+}
+
+func (suite *cryptoCreateTransactionConstructorSuite) TestConstruct() {
+	var tests = []struct {
+		name             string
+		updateOperations updateOperationsFunc
+		validStartNanos  int64
+		expectError      bool
+	}{
+		{name: "Success"},
+		{name: "SuccessValidStartNanos", validStartNanos: 100},
+		{name: "EmptyOperations", updateOperations: getEmptyOperations, expectError: true},
+	}
+
+	for _, tt := range tests {
+		suite.T().Run(tt.name, func(t *testing.T) {
+			// given
+			operations := getCryptoCreateOperations()
+			h := newCryptoCreateTransactionConstructor()
+
+			if tt.updateOperations != nil {
+				operations = tt.updateOperations(operations)
+			}
+
+			// when
+			tx, signers, err := h.Construct(defaultContext, nodeAccountId, operations, tt.validStartNanos)
+
+			// then
+			if tt.expectError {
+				assert.NotNil(t, err)
+				assert.Nil(t, signers)
+				assert.Nil(t, tx)
+			} else {
+				assert.Nil(t, err)
+				assert.ElementsMatch(t, []hedera.AccountID{payerId}, signers)
+				assertCryptoCreateTransaction(t, operations[0], nodeAccountId, tx)
+
+				if tt.validStartNanos != 0 {
+					assert.Equal(t, tt.validStartNanos, tx.GetTransactionID().ValidStart.UnixNano())
+				}
+			}
+		})
+	}
+}
+
+func (suite *cryptoCreateTransactionConstructorSuite) TestParse() {
+	defaultGetTransaction := func() interfaces.Transaction {
+		return hedera.NewAccountCreateTransaction().
+			SetAccountMemo(memo).
+			SetAutoRenewPeriod(time.Second * time.Duration(autoRenewPeriod)).
+			SetInitialBalance(hedera.HbarFromTinybar(initialBalance)).
+			SetKey(newAccountKey).
+			SetMaxAutomaticTokenAssociations(maxAutomaticTokenAssociations).
+			SetProxyAccountID(proxyAccountId).
+			SetTransactionID(hedera.TransactionIDGenerate(payerId))
+	}
+
+	var tests = []struct {
+		name           string
+		getTransaction func() interfaces.Transaction
+		expectError    bool
+	}{
+		{
+			name:           "Success",
+			getTransaction: defaultGetTransaction,
+		},
+		{
+			name: "InvalidTransaction",
+			getTransaction: func() interfaces.Transaction {
+				return hedera.NewTransferTransaction()
+			},
+			expectError: true,
+		},
+		{
+			name: "KeyNotSet",
+			getTransaction: func() interfaces.Transaction {
+				tx := defaultGetTransaction()
+				accountCreateTx, _ := tx.(*hedera.AccountCreateTransaction)
+				accountCreateTx.SetKey(nil)
+				return tx
+			},
+			expectError: true,
+		},
+		{
+			name: "TransactionIDNotSet",
+			getTransaction: func() interfaces.Transaction {
+				tx := defaultGetTransaction()
+				accountCreateTx, _ := tx.(*hedera.AccountCreateTransaction)
+				accountCreateTx.SetTransactionID(hedera.TransactionID{})
+				return tx
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		suite.T().Run(tt.name, func(t *testing.T) {
+			// given
+			expectedOperations := getCryptoCreateOperations()
+
+			h := newCryptoCreateTransactionConstructor()
+			tx := tt.getTransaction()
+
+			// when
+			operations, signers, err := h.Parse(defaultContext, tx)
+
+			// then
+			if tt.expectError {
+				assert.NotNil(t, err)
+				assert.Nil(t, operations)
+				assert.Nil(t, signers)
+			} else {
+				assert.Nil(t, err)
+				assert.ElementsMatch(t, []hedera.AccountID{payerId}, signers)
+				assert.ElementsMatch(t, expectedOperations, operations)
+			}
+		})
+	}
+}
+
+func (suite *cryptoCreateTransactionConstructorSuite) TestPreprocess() {
+	var tests = []struct {
+		name             string
+		updateOperations updateOperationsFunc
+		expectError      bool
+	}{
+		{name: "Success"},
+		{
+			name:             "MissingMetadataKey",
+			updateOperations: deleteOperationMetadata("key"),
+			expectError:      true,
+		},
+		{
+			name:             "InvalidAccountAddress",
+			updateOperations: updateOperationAccount("x.y.z"),
+			expectError:      true,
+		},
+		{
+			name:             "InvalidMetadataKey",
+			updateOperations: updateOperationMetadata("key", "key"),
+			expectError:      true,
+		},
+		{
+			name:             "InvalidMetadataAutoRenewPeriod",
+			updateOperations: updateOperationMetadata("auto_renew_period", "x"),
+			expectError:      true,
+		},
+		{
+			name:             "InvalidMetadataMaxAutomaticTokenAssociations",
+			updateOperations: updateOperationMetadata("max_automatic_token_associations", "xyz"),
+			expectError:      true,
+		},
+		{
+			name:             "InvalidMetadataMemo",
+			updateOperations: updateOperationMetadata("memo", 156),
+			expectError:      true,
+		},
+		{
+			name:             "InvalidMetadataProxyAccountId",
+			updateOperations: updateOperationMetadata("proxy_account_id", "x.y.z"),
+			expectError:      true,
+		},
+		{
+			name:             "MissingMetadata",
+			updateOperations: getEmptyOperationMetadata,
+			expectError:      true,
+		},
+		{
+			name:             "MultipleOperations",
+			updateOperations: addOperation,
+			expectError:      true,
+		},
+		{
+			name:             "InvalidOperationType",
+			updateOperations: updateOperationType(types.OperationTypeCryptoTransfer),
+			expectError:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		suite.T().Run(tt.name, func(t *testing.T) {
+			// given
+			operations := getCryptoCreateOperations()
+			h := newCryptoCreateTransactionConstructor()
+
+			if tt.updateOperations != nil {
+				operations = tt.updateOperations(operations)
+			}
+
+			// when
+			signers, err := h.Preprocess(defaultContext, operations)
+
+			// then
+			if tt.expectError {
+				assert.NotNil(t, err)
+				assert.Nil(t, signers)
+			} else {
+				assert.Nil(t, err)
+				assert.ElementsMatch(t, []hedera.AccountID{payerId}, signers)
+			}
+		})
+	}
+}
+
+func assertCryptoCreateTransaction(
+	t *testing.T,
+	operation *rTypes.Operation,
+	nodeAccountId hedera.AccountID,
+	actual interfaces.Transaction,
+) {
+	assert.IsType(t, &hedera.AccountCreateTransaction{}, actual)
+
+	tx, _ := actual.(*hedera.AccountCreateTransaction)
+	payer := tx.GetTransactionID().AccountID.String()
+
+	assert.Equal(t, operation.Account.Address, payer)
+	assert.ElementsMatch(t, []hedera.AccountID{nodeAccountId}, actual.GetNodeAccountIDs())
+
+	key, err := tx.GetKey()
+	assert.NoError(t, err)
+	assert.Equal(t, operation.Metadata["key"], key.String())
+
+	assert.Equal(t, operation.Metadata["auto_renew_period"], int64(tx.GetAutoRenewPeriod().Seconds()))
+	assert.Equal(t, operation.Metadata["max_automatic_token_associations"], tx.GetMaxAutomaticTokenAssociations())
+	assert.Equal(t, operation.Metadata["memo"], tx.GetAccountMemo())
+	assert.Equal(t, operation.Metadata["proxy_account_id"], tx.GetProxyAccountID().String())
+}
+
+func getCryptoCreateOperations() []*rTypes.Operation {
+	amount := &types.HbarAmount{Value: initialBalance}
+	operation := &rTypes.Operation{
+		OperationIdentifier: &rTypes.OperationIdentifier{Index: 0},
+		Type:                types.OperationTypeCryptoCreate,
+		Account:             payerAccountIdentifier,
+		Amount:              amount.ToRosetta(),
+		Metadata: map[string]interface{}{
+			"auto_renew_period":                autoRenewPeriod,
+			"key":                              newAccountKeyStr,
+			"max_automatic_token_associations": maxAutomaticTokenAssociations,
+			"memo":                             memo,
+			"proxy_account_id":                 proxyAccountId.String(),
+		},
+	}
+
+	return []*rTypes.Operation{operation}
+}

--- a/hedera-mirror-rosetta/app/services/construction/crypto_transfer_transaction_constructor.go
+++ b/hedera-mirror-rosetta/app/services/construction/crypto_transfer_transaction_constructor.go
@@ -155,7 +155,6 @@ func (c *cryptoTransferTransactionConstructor) Parse(ctx context.Context, transa
 	senderMap := senderMap{}
 
 	for accountId, hbarAmount := range hbarTransferMap {
-
 		operations = c.addOperation(accountId, &types.HbarAmount{Value: hbarAmount.AsTinybar()}, operations, senderMap)
 	}
 

--- a/hedera-mirror-rosetta/app/services/construction/crypto_transfer_transaction_constructor_test.go
+++ b/hedera-mirror-rosetta/app/services/construction/crypto_transfer_transaction_constructor_test.go
@@ -443,6 +443,7 @@ func assertCryptoTransferTransaction(
 	actual interfaces.Transaction,
 ) {
 	assert.IsType(t, &hedera.TransferTransaction{}, actual)
+	assert.True(t, actual.IsFrozen())
 
 	expectedTransfers := make([]string, 0, len(operations))
 	for _, operation := range operations {
@@ -453,6 +454,7 @@ func assertCryptoTransferTransaction(
 	}
 
 	tx, _ := actual.(*hedera.TransferTransaction)
+
 	actualHbarTransfers := tx.GetHbarTransfers()
 	actualTokenTransfers := tx.GetTokenTransfers()
 	actualNftTransfers := tx.GetNftTransfers()

--- a/hedera-mirror-rosetta/app/services/construction/token_associate_dissociate_transaction_constructor_test.go
+++ b/hedera-mirror-rosetta/app/services/construction/token_associate_dissociate_transaction_constructor_test.go
@@ -501,6 +501,7 @@ func assertTokenAssociateDissociateTransaction(
 	nodeAccountId hedera.AccountID,
 	actual interfaces.Transaction,
 ) {
+	assert.True(t, actual.IsFrozen())
 	if operations[0].Type == types.OperationTypeTokenAssociate {
 		assert.IsType(t, &hedera.TokenAssociateTransaction{}, actual)
 	} else {

--- a/hedera-mirror-rosetta/app/services/construction/token_burn_mint_transaction_constructor_test.go
+++ b/hedera-mirror-rosetta/app/services/construction/token_burn_mint_transaction_constructor_test.go
@@ -478,6 +478,7 @@ func assertTokenBurnMintTransaction(
 	nodeAccountId hedera.AccountID,
 	actual interfaces.Transaction,
 ) {
+	assert.True(t, actual.IsFrozen())
 	if operations[0].Type == types.OperationTypeTokenBurn {
 		assert.IsType(t, &hedera.TokenBurnTransaction{}, actual)
 	} else {

--- a/hedera-mirror-rosetta/app/services/construction/token_create_transaction_constructor_test.go
+++ b/hedera-mirror-rosetta/app/services/construction/token_create_transaction_constructor_test.go
@@ -358,6 +358,7 @@ func assertTokenCreateTransaction(
 	nodeAccountId hedera.AccountID,
 	actual interfaces.Transaction,
 ) {
+	assert.True(t, actual.IsFrozen())
 	assert.IsType(t, &hedera.TokenCreateTransaction{}, actual)
 
 	tx, _ := actual.(*hedera.TokenCreateTransaction)

--- a/hedera-mirror-rosetta/app/services/construction/token_create_transaction_constructor_test.go
+++ b/hedera-mirror-rosetta/app/services/construction/token_create_transaction_constructor_test.go
@@ -71,11 +71,9 @@ func (suite *tokenCreateTransactionConstructorSuite) TestConstruct() {
 		{name: "SuccessNFT", tokenType: domain.TokenTypeNonFungibleUnique},
 		{name: "SuccessValidStartNanos", validStartNanos: 100},
 		{
-			name: "EmptyOperations",
-			updateOperations: func([]*rTypes.Operation) []*rTypes.Operation {
-				return make([]*rTypes.Operation, 0)
-			},
-			expectError: true,
+			name:             "EmptyOperations",
+			updateOperations: getEmptyOperations,
+			expectError:      true,
 		},
 	}
 

--- a/hedera-mirror-rosetta/app/services/construction/token_delete_transaction_constructor_test.go
+++ b/hedera-mirror-rosetta/app/services/construction/token_delete_transaction_constructor_test.go
@@ -272,6 +272,7 @@ func assertTokenDeleteTransaction(
 	nodeAccountId hedera.AccountID,
 	actual interfaces.Transaction,
 ) {
+	assert.True(t, actual.IsFrozen())
 	assert.IsType(t, &hedera.TokenDeleteTransaction{}, actual)
 
 	tx, _ := actual.(*hedera.TokenDeleteTransaction)

--- a/hedera-mirror-rosetta/app/services/construction/token_freeze_unfreeze_transaction_constructor_test.go
+++ b/hedera-mirror-rosetta/app/services/construction/token_freeze_unfreeze_transaction_constructor_test.go
@@ -356,6 +356,7 @@ func assertTokenFreezeUnfreezeTransaction(
 	nodeAccountId hedera.AccountID,
 	actual interfaces.Transaction,
 ) {
+	assert.True(t, actual.IsFrozen())
 	if operation.Type == types.OperationTypeTokenFreeze {
 		assert.IsType(t, &hedera.TokenFreezeTransaction{}, actual)
 	} else {

--- a/hedera-mirror-rosetta/app/services/construction/token_grant_revoke_kyc_transaction_constructor_test.go
+++ b/hedera-mirror-rosetta/app/services/construction/token_grant_revoke_kyc_transaction_constructor_test.go
@@ -422,6 +422,7 @@ func assertTokenGrantRevokeKycTransaction(
 	nodeAccountId hedera.AccountID,
 	actual interfaces.Transaction,
 ) {
+	assert.True(t, actual.IsFrozen())
 	if operations[0].Type == types.OperationTypeTokenGrantKyc {
 		assert.IsType(t, &hedera.TokenGrantKycTransaction{}, actual)
 	} else {

--- a/hedera-mirror-rosetta/app/services/construction/token_update_transaction_constructor_test.go
+++ b/hedera-mirror-rosetta/app/services/construction/token_update_transaction_constructor_test.go
@@ -34,26 +34,26 @@ import (
 )
 
 const (
-	adminKeyStr  = "302a300506032b6570032100d619a3a22d6bd2a9e4b08f3d999df757e5a9ef0364c13b4b3356bc065b34fa01"
-	freezeKeyStr = "302a300506032b65700321006663a95da28adcb0fc129d1b4eda4be7dd90b54a337cd2dd953e1d2dc03ca6d1"
-	kycKeyStr    = "302a300506032b6570032100cf84dd35980ba09a3a4c5a19a3d63fe4937ab3fde3e2c5c6ba41e42c0c60ee9f"
-	memo         = "new memo"
-	name         = "new name"
-	supplyKeyStr = "302a300506032b65700321000d469b64f14cc584c6fc48f03c339defcba719c2b71abe05c4aea19d16127ba1"
-	symbol       = "new symbol"
-	wipeKeyStr   = "302a300506032b6570032100647b6d2a4efa666858c6d0d85e660698410d1bbe67763bc50ece0b5dcff0b6db"
+	autoRenewPeriod int64 = 3600
+	adminKeyStr           = "302a300506032b6570032100d619a3a22d6bd2a9e4b08f3d999df757e5a9ef0364c13b4b3356bc065b34fa01"
+	freezeKeyStr          = "302a300506032b65700321006663a95da28adcb0fc129d1b4eda4be7dd90b54a337cd2dd953e1d2dc03ca6d1"
+	kycKeyStr             = "302a300506032b6570032100cf84dd35980ba09a3a4c5a19a3d63fe4937ab3fde3e2c5c6ba41e42c0c60ee9f"
+	memo                  = "new memo"
+	name                  = "new name"
+	supplyKeyStr          = "302a300506032b65700321000d469b64f14cc584c6fc48f03c339defcba719c2b71abe05c4aea19d16127ba1"
+	symbol                = "new symbol"
+	wipeKeyStr            = "302a300506032b6570032100647b6d2a4efa666858c6d0d85e660698410d1bbe67763bc50ece0b5dcff0b6db"
 )
 
 var (
-	adminKey, _            = hedera.PublicKeyFromString(adminKeyStr)
-	autoRenewAccount       = hedera.AccountID{Account: 1981}
-	autoRenewPeriod  int64 = 3600
-	expiry                 = time.Unix(167000, 0)
-	freezeKey, _           = hedera.PublicKeyFromString(freezeKeyStr)
-	kycKey, _              = hedera.PublicKeyFromString(kycKeyStr)
-	supplyKey, _           = hedera.PublicKeyFromString(supplyKeyStr)
-	treasury               = hedera.AccountID{Account: 1701}
-	wipeKey, _             = hedera.PublicKeyFromString(wipeKeyStr)
+	adminKey, _      = hedera.PublicKeyFromString(adminKeyStr)
+	autoRenewAccount = hedera.AccountID{Account: 1981}
+	expiry           = time.Unix(167000, 0)
+	freezeKey, _     = hedera.PublicKeyFromString(freezeKeyStr)
+	kycKey, _        = hedera.PublicKeyFromString(kycKeyStr)
+	supplyKey, _     = hedera.PublicKeyFromString(supplyKeyStr)
+	treasury         = hedera.AccountID{Account: 1701}
+	wipeKey, _       = hedera.PublicKeyFromString(wipeKeyStr)
 )
 
 func TestTokenUpdateTransactionConstructorSuite(t *testing.T) {

--- a/hedera-mirror-rosetta/app/services/construction/token_update_transaction_constructor_test.go
+++ b/hedera-mirror-rosetta/app/services/construction/token_update_transaction_constructor_test.go
@@ -380,6 +380,7 @@ func assertTokenUpdateTransaction(
 	nodeAccountId hedera.AccountID,
 	actual interfaces.Transaction,
 ) {
+	assert.True(t, actual.IsFrozen())
 	assert.IsType(t, &hedera.TokenUpdateTransaction{}, actual)
 
 	tx, _ := actual.(*hedera.TokenUpdateTransaction)

--- a/hedera-mirror-rosetta/app/services/construction/token_wipe_transaction_constructor_test.go
+++ b/hedera-mirror-rosetta/app/services/construction/token_wipe_transaction_constructor_test.go
@@ -307,6 +307,7 @@ func assertTokenWipeTransaction(
 	nodeAccountId hedera.AccountID,
 	actual interfaces.Transaction,
 ) {
+	assert.True(t, actual.IsFrozen())
 	assert.IsType(t, &hedera.TokenWipeTransaction{}, actual)
 
 	tx, _ := actual.(*hedera.TokenWipeTransaction)

--- a/hedera-mirror-rosetta/app/services/construction_service.go
+++ b/hedera-mirror-rosetta/app/services/construction_service.go
@@ -220,10 +220,7 @@ func (c *constructionAPIService) ConstructionPreprocess(
 		requiredPublicKeys = append(requiredPublicKeys, &rTypes.AccountIdentifier{Address: signer.String()})
 	}
 
-	return &rTypes.ConstructionPreprocessResponse{
-		Options:            make(map[string]interface{}),
-		RequiredPublicKeys: requiredPublicKeys,
-	}, nil
+	return &rTypes.ConstructionPreprocessResponse{RequiredPublicKeys: requiredPublicKeys}, nil
 }
 
 // ConstructionSubmit implements the /construction/submit endpoint.
@@ -251,7 +248,6 @@ func (c *constructionAPIService) ConstructionSubmit(
 		TransactionIdentifier: &rTypes.TransactionIdentifier{
 			Hash: tools.SafeAddHexPrefix(hex.EncodeToString(hash[:])),
 		},
-		Metadata: nil,
 	}, nil
 }
 
@@ -319,7 +315,9 @@ func NewConstructionAPIService(
 
 func addSignature(transaction interfaces.Transaction, pubKey hedera.PublicKey, signature []byte) *rTypes.Error {
 	switch tx := transaction.(type) {
-	// these transaction types are what the construction service supports
+	// these transaction types are what the construction service supports]
+	case *hedera.AccountCreateTransaction:
+		tx.AddSignature(pubKey, signature)
 	case *hedera.TokenAssociateTransaction:
 		tx.AddSignature(pubKey, signature)
 	case *hedera.TokenBurnTransaction:
@@ -375,6 +373,8 @@ func unmarshallTransactionFromHexString(transactionString string) (interfaces.Tr
 
 	switch tx := transaction.(type) {
 	// these transaction types are what the construction service supports
+	case hedera.AccountCreateTransaction:
+		return &tx, nil
 	case hedera.TokenAssociateTransaction:
 		return &tx, nil
 	case hedera.TokenBurnTransaction:

--- a/hedera-mirror-rosetta/app/services/construction_service.go
+++ b/hedera-mirror-rosetta/app/services/construction_service.go
@@ -315,7 +315,7 @@ func NewConstructionAPIService(
 
 func addSignature(transaction interfaces.Transaction, pubKey hedera.PublicKey, signature []byte) *rTypes.Error {
 	switch tx := transaction.(type) {
-	// these transaction types are what the construction service supports]
+	// these transaction types are what the construction service supports
 	case *hedera.AccountCreateTransaction:
 		tx.AddSignature(pubKey, signature)
 	case *hedera.TokenAssociateTransaction:

--- a/hedera-mirror-rosetta/app/services/construction_service_test.go
+++ b/hedera-mirror-rosetta/app/services/construction_service_test.go
@@ -629,7 +629,6 @@ func TestConstructionSubmitThrowsWhenUnmarshalBinaryFails(t *testing.T) {
 func TestConstructionPreprocess(t *testing.T) {
 	// given:
 	expected := &types.ConstructionPreprocessResponse{
-		Options:            make(map[string]interface{}),
 		RequiredPublicKeys: []*types.AccountIdentifier{{Address: defaultCryptoAccountId1}},
 	}
 	mockConstructor := &mocks.MockTransactionConstructor{}
@@ -668,6 +667,10 @@ func freezeTransaction(transaction interfaces.Transaction) {
 
 	var err error
 	switch tx := transaction.(type) {
+	case *hedera.AccountCreateTransaction:
+		_, err = tx.SetNodeAccountIDs(nodeAccountIds).
+			SetTransactionID(transactionId).
+			Freeze()
 	case *hedera.TokenAssociateTransaction:
 		_, err = tx.SetNodeAccountIDs(nodeAccountIds).
 			SetTransactionID(transactionId).
@@ -743,6 +746,7 @@ func TestAddSignature(t *testing.T) {
 		transaction interfaces.Transaction
 		expectError bool
 	}{
+		{transaction: hedera.NewAccountCreateTransaction()},
 		{transaction: hedera.NewTokenAssociateTransaction()},
 		{transaction: hedera.NewTokenBurnTransaction()},
 		{transaction: hedera.NewTokenCreateTransaction()},
@@ -824,6 +828,7 @@ func TestGetFrozenTransactionBodyBytes(t *testing.T) {
 func TestUnmarshallTransactionFromHexString(t *testing.T) {
 	for _, signed := range []bool{false, true} {
 		transactions := []interfaces.Transaction{
+			hedera.NewAccountCreateTransaction(),
 			hedera.NewTokenAssociateTransaction(),
 			hedera.NewTokenBurnTransaction(),
 			hedera.NewTokenCreateTransaction(),
@@ -927,69 +932,75 @@ func convertSignatureMap(signatureMap map[*hedera.PublicKey][]byte) map[string][
 
 func createTransactionHexString(transaction interfaces.Transaction, signed bool) string {
 	nodeAccountIds := []hedera.AccountID{nodeAccountId}
+	transactionId := hedera.TransactionIDGenerate(payerId)
 	switch tx := transaction.(type) {
+	case *hedera.AccountCreateTransaction:
+		tx.SetNodeAccountIDs(nodeAccountIds).SetTransactionID(transactionId).Freeze()
+		if signed {
+			tx.Sign(privateKey)
+		}
 	case *hedera.TokenAssociateTransaction:
-		tx.SetNodeAccountIDs(nodeAccountIds).SetTransactionID(hedera.TransactionIDGenerate(payerId)).Freeze()
+		tx.SetNodeAccountIDs(nodeAccountIds).SetTransactionID(transactionId).Freeze()
 		if signed {
 			tx.Sign(privateKey)
 		}
 	case *hedera.TokenBurnTransaction:
-		tx.SetNodeAccountIDs(nodeAccountIds).SetTransactionID(hedera.TransactionIDGenerate(payerId)).Freeze()
+		tx.SetNodeAccountIDs(nodeAccountIds).SetTransactionID(transactionId).Freeze()
 		if signed {
 			tx.Sign(privateKey)
 		}
 	case *hedera.TokenCreateTransaction:
-		tx.SetNodeAccountIDs(nodeAccountIds).SetTransactionID(hedera.TransactionIDGenerate(payerId)).Freeze()
+		tx.SetNodeAccountIDs(nodeAccountIds).SetTransactionID(transactionId).Freeze()
 		if signed {
 			tx.Sign(privateKey)
 		}
 	case *hedera.TokenDeleteTransaction:
-		tx.SetNodeAccountIDs(nodeAccountIds).SetTransactionID(hedera.TransactionIDGenerate(payerId)).Freeze()
+		tx.SetNodeAccountIDs(nodeAccountIds).SetTransactionID(transactionId).Freeze()
 		if signed {
 			tx.Sign(privateKey)
 		}
 	case *hedera.TokenDissociateTransaction:
-		tx.SetNodeAccountIDs(nodeAccountIds).SetTransactionID(hedera.TransactionIDGenerate(payerId)).Freeze()
+		tx.SetNodeAccountIDs(nodeAccountIds).SetTransactionID(transactionId).Freeze()
 		if signed {
 			tx.Sign(privateKey)
 		}
 	case *hedera.TokenFreezeTransaction:
-		tx.SetNodeAccountIDs(nodeAccountIds).SetTransactionID(hedera.TransactionIDGenerate(payerId)).Freeze()
+		tx.SetNodeAccountIDs(nodeAccountIds).SetTransactionID(transactionId).Freeze()
 		if signed {
 			tx.Sign(privateKey)
 		}
 	case *hedera.TokenGrantKycTransaction:
-		tx.SetNodeAccountIDs(nodeAccountIds).SetTransactionID(hedera.TransactionIDGenerate(payerId)).Freeze()
+		tx.SetNodeAccountIDs(nodeAccountIds).SetTransactionID(transactionId).Freeze()
 		if signed {
 			tx.Sign(privateKey)
 		}
 	case *hedera.TokenMintTransaction:
-		tx.SetNodeAccountIDs(nodeAccountIds).SetTransactionID(hedera.TransactionIDGenerate(payerId)).Freeze()
+		tx.SetNodeAccountIDs(nodeAccountIds).SetTransactionID(transactionId).Freeze()
 		if signed {
 			tx.Sign(privateKey)
 		}
 	case *hedera.TokenRevokeKycTransaction:
-		tx.SetNodeAccountIDs(nodeAccountIds).SetTransactionID(hedera.TransactionIDGenerate(payerId)).Freeze()
+		tx.SetNodeAccountIDs(nodeAccountIds).SetTransactionID(transactionId).Freeze()
 		if signed {
 			tx.Sign(privateKey)
 		}
 	case *hedera.TokenUnfreezeTransaction:
-		tx.SetNodeAccountIDs(nodeAccountIds).SetTransactionID(hedera.TransactionIDGenerate(payerId)).Freeze()
+		tx.SetNodeAccountIDs(nodeAccountIds).SetTransactionID(transactionId).Freeze()
 		if signed {
 			tx.Sign(privateKey)
 		}
 	case *hedera.TokenUpdateTransaction:
-		tx.SetNodeAccountIDs(nodeAccountIds).SetTransactionID(hedera.TransactionIDGenerate(payerId)).Freeze()
+		tx.SetNodeAccountIDs(nodeAccountIds).SetTransactionID(transactionId).Freeze()
 		if signed {
 			tx.Sign(privateKey)
 		}
 	case *hedera.TokenWipeTransaction:
-		tx.SetNodeAccountIDs(nodeAccountIds).SetTransactionID(hedera.TransactionIDGenerate(payerId)).Freeze()
+		tx.SetNodeAccountIDs(nodeAccountIds).SetTransactionID(transactionId).Freeze()
 		if signed {
 			tx.Sign(privateKey)
 		}
 	case *hedera.TransferTransaction:
-		tx.SetNodeAccountIDs(nodeAccountIds).SetTransactionID(hedera.TransactionIDGenerate(payerId)).Freeze()
+		tx.SetNodeAccountIDs(nodeAccountIds).SetTransactionID(transactionId).Freeze()
 		if signed {
 			tx.Sign(privateKey)
 		}

--- a/hedera-mirror-rosetta/app/services/network_service.go
+++ b/hedera-mirror-rosetta/app/services/network_service.go
@@ -53,10 +53,6 @@ func (n *networkAPIService) NetworkOptions(
 	ctx context.Context,
 	request *rTypes.NetworkRequest,
 ) (*rTypes.NetworkOptionsResponse, *rTypes.Error) {
-	operationTypes, err := n.TypesAsArray(ctx)
-	if err != nil {
-		return nil, err
-	}
 	operationStatuses := make([]*rTypes.OperationStatus, 0, len(types.TransactionResults))
 	for value, name := range types.TransactionResults {
 		operationStatuses = append(operationStatuses, &rTypes.OperationStatus{
@@ -69,7 +65,7 @@ func (n *networkAPIService) NetworkOptions(
 		Version: n.version,
 		Allow: &rTypes.Allow{
 			OperationStatuses:       operationStatuses,
-			OperationTypes:          operationTypes,
+			OperationTypes:          n.TypesAsArray(),
 			Errors:                  errors.Errors,
 			HistoricalBalanceLookup: true,
 		},

--- a/hedera-mirror-rosetta/app/services/network_service_test.go
+++ b/hedera-mirror-rosetta/app/services/network_service_test.go
@@ -201,18 +201,6 @@ func (suite *networkServiceSuite) TestNetworkOptions() {
 	assert.Nil(suite.T(), e)
 }
 
-func (suite *networkServiceSuite) TestNetworkOptionsThrowsWhenTypesAsArrayFails() {
-	var NilTypesAsArray []string = nil
-	suite.mockTransactionRepo.On("TypesAsArray").Return(NilTypesAsArray, &rTypes.Error{})
-
-	// when:
-	res, e := suite.networkService.NetworkOptions(nil, nil)
-
-	assert.Nil(suite.T(), res)
-	assert.NotNil(suite.T(), e)
-	suite.mockTransactionRepo.AssertNotCalled(suite.T(), "Results")
-}
-
 func (suite *networkServiceSuite) TestNetworkStatus() {
 	// given:
 	exampleEntries := &types.AddressBookEntries{Entries: []types.AddressBookEntry{}}

--- a/hedera-mirror-rosetta/go.mod
+++ b/hedera-mirror-rosetta/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/go-playground/validator/v10 v10.9.0
 	github.com/hashgraph/hedera-sdk-go/v2 v2.4.0
 	github.com/hellofresh/health-go/v4 v4.5.0
+	github.com/jackc/pgtype v1.8.1
 	github.com/lib/pq v1.10.4
 	github.com/onrik/gorm-logrus v0.3.0
 	github.com/ory/dockertest/v3 v3.8.0
@@ -56,7 +57,6 @@ require (
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgproto3/v2 v2.1.1 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20200714003250-2b9c44734f2b // indirect
-	github.com/jackc/pgtype v1.8.1 // indirect
 	github.com/jackc/pgx/v4 v4.13.0 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.2 // indirect

--- a/hedera-mirror-rosetta/main.go
+++ b/hedera-mirror-rosetta/main.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"runtime"
 	"strings"
 
 	"github.com/coinbase/rosetta-sdk-go/asserter"
@@ -56,12 +57,18 @@ func configLogger(level string) {
 		logLevel = log.InfoLevel
 	}
 
-	log.SetLevel(logLevel)
-	log.SetOutput(os.Stdout)
 	log.SetFormatter(&log.TextFormatter{ // Use logfmt for easy parsing by Loki
+		CallerPrettyfier: func(frame *runtime.Frame) (function string, file string) {
+			parts := strings.Split(frame.File, moduleName)
+			relativeFilename := parts[len(parts)-1]
+			return "", fmt.Sprintf("%s:%d", relativeFilename, frame.Line)
+		},
 		DisableColors: true,
 		FullTimestamp: true,
 	})
+	log.SetLevel(logLevel)
+	log.SetOutput(os.Stdout)
+	log.SetReportCaller(true)
 }
 
 // newBlockchainOnlineRouter creates a Mux http.Handler from a collection

--- a/hedera-mirror-rosetta/main.go
+++ b/hedera-mirror-rosetta/main.go
@@ -60,8 +60,9 @@ func configLogger(level string) {
 	log.SetFormatter(&log.TextFormatter{ // Use logfmt for easy parsing by Loki
 		CallerPrettyfier: func(frame *runtime.Frame) (function string, file string) {
 			parts := strings.Split(frame.File, moduleName)
-			relativeFilename := parts[len(parts)-1]
-			return "", fmt.Sprintf("%s:%d", relativeFilename, frame.Line)
+			relativeFilepath := parts[len(parts)-1]
+			// remove function name, show file path relative to project root
+			return "", fmt.Sprintf("%s:%d", relativeFilepath, frame.Line)
 		},
 		DisableColors: true,
 		FullTimestamp: true,

--- a/hedera-mirror-rosetta/main.go
+++ b/hedera-mirror-rosetta/main.go
@@ -69,7 +69,7 @@ func configLogger(level string) {
 	})
 	log.SetLevel(logLevel)
 	log.SetOutput(os.Stdout)
-	log.SetReportCaller(true)
+	log.SetReportCaller(logLevel >= log.DebugLevel)
 }
 
 // newBlockchainOnlineRouter creates a Mux http.Handler from a collection

--- a/hedera-mirror-rosetta/pom.xml
+++ b/hedera-mirror-rosetta/pom.xml
@@ -54,7 +54,7 @@
                         <id>default-test</id>
                         <configuration>
                             <buildFlags>
-                                <flag>-coverpkg=./...</flag>
+                                <flag>-coverpkg=./app/...</flag>
                                 <flag>-coverprofile=coverage.txt</flag>
                                 <flag>-covermode=atomic</flag>
                                 <flag>-race</flag>

--- a/hedera-mirror-rosetta/scripts/wait-for-mirror-node.sh
+++ b/hedera-mirror-rosetta/scripts/wait-for-mirror-node.sh
@@ -32,8 +32,9 @@ if [[ -z "${network_identifier}" ]]; then
 fi
 
 SECONDS=0
+max_wait_seconds=${MAX_WAIT_SECONDS:-120}
 
-while [[ "${SECONDS}" -lt 90 ]];
+while [[ "${SECONDS}" -lt "${max_wait_seconds}" ]];
 do
     body="{ \"network_identifier\": ${network_identifier}, \"metadata\": {} }"
     response=$(curl -sL -w "%{http_code}" -d "${body}" -i "http://localhost:5700/network/status")

--- a/hedera-mirror-rosetta/test/mocks/transaction_repository.go
+++ b/hedera-mirror-rosetta/test/mocks/transaction_repository.go
@@ -52,16 +52,7 @@ func (m *MockTransactionRepository) FindBetween(ctx context.Context, start, end 
 	return args.Get(0).([]*types.Transaction), args.Get(1).(*rTypes.Error)
 }
 
-func (m *MockTransactionRepository) Types(ctx context.Context) (map[int]string, *rTypes.Error) {
-	panic("implement me")
-}
-
-func (m *MockTransactionRepository) TypesAsArray(ctx context.Context) ([]string, *rTypes.Error) {
+func (m *MockTransactionRepository) TypesAsArray() []string {
 	args := m.Called()
-	return args.Get(0).([]string), args.Get(1).(*rTypes.Error)
-}
-
-func (m *MockTransactionRepository) Results(ctx context.Context) (map[int]string, *rTypes.Error) {
-	args := m.Called()
-	return args.Get(0).(map[int]string), args.Get(1).(*rTypes.Error)
+	return args.Get(0).([]string)
 }


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR adds support of CryptoCreateTransaction to rosetta Construction API

- Add new cryptocreate transaction constructor handler
- Limit go test coverage report generation to packages in /app

**Related issue(s)**:

Fixes #2860 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

Passed end to end test for cryptocreate transaction with the new bdd test client.

Note in `/construction/submit`, the implementation does not try to get transaction receipt so as to return any new entity / confirmation to the client. This means for CryptoCreate, a client has to query rosetta DATA api to find the executed transaction and the new account ID in it. Getting transaction receipt will block the rosetta `/construction/submit` and it's against the rosetta spec:

```
/construction/submit
Submit a Signed Transaction

Submit a pre-signed transaction to the node. This call should not block on the transaction being included in a block. Rather, it should return immediately with an indication of whether or not the transaction was included in the mempool. The transaction submission response should only return a 200 status if the submitted transaction could be included in the mempool. Otherwise, it should return an error.
```


**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
