### PR TITLE
Shorten AccountCreateTransaction memo length (0.45)

### DIFF
--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AbstractNetworkClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AbstractNetworkClient.java
@@ -140,6 +140,7 @@ public abstract class AbstractNetworkClient {
     }
 
     protected String getMemo(String message) {
-        return String.format("Hedera Mirror Node acceptance test: %s %s", message, Instant.now());
+        // Try to keep short due to 100 byte entity memo limit
+        return String.format("Mirror Node acceptance test: %s %s", message, Instant.now());
     }
 }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AccountClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AccountClient.java
@@ -71,7 +71,7 @@ public class AccountClient extends AbstractNetworkClient {
                     try {
                         return createNewAccount(SMALL_INITIAL_BALANCE, accountNameEnum);
                     } catch (Exception e) {
-                        log.trace("Issue creating additional account: {}, ex: {}", accountNameEnum, e);
+                        log.debug("Issue creating additional account: {}, ex: {}", accountNameEnum, e);
                         return null;
                     }
                 });
@@ -128,7 +128,7 @@ public class AccountClient extends AbstractNetworkClient {
 
     public AccountCreateTransaction getAccountCreateTransaction(Hbar initialBalance, KeyList publicKeys,
                                                                 boolean receiverSigRequired, String customMemo) {
-        String memo = getMemo("Create Crypto Account" + customMemo);
+        String memo = getMemo("Create Crypto Account " + customMemo);
         return new AccountCreateTransaction()
                 .setInitialBalance(initialBalance)
                 // The only _required_ property here is `key`
@@ -148,7 +148,7 @@ public class AccountClient extends AbstractNetworkClient {
                 Hbar.fromTinybars(initialBalance),
                 accountNameEnum.receiverSigRequired,
                 null,
-                accountNameEnum.toString());
+                null);
     }
 
     public ExpandedAccountId createCryptoAccount(Hbar initialBalance, boolean receiverSigRequired, KeyList keyList,

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ScheduleFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ScheduleFeature.java
@@ -151,7 +151,7 @@ public class ScheduleFeature {
                         Hbar.fromTinybars(DEFAULT_TINY_HBAR),
                         false,
                         publicKeyList,
-                        "scheduled crypto transfer");
+                        "scheduled transfer");
 
         scheduledTransaction = accountClient
                 .getCryptoTransferTransaction(


### PR DESCRIPTION
Signed-off-by: Nana-EC <nana.essilfie-conduah@hedera.com>

**Description**:
Cherry pick to v0.45

Acceptance test were failing for tests that pulled the cached accounts with the error
```shell
com.hedera.hashgraph.sdk.PrecheckStatusException: Hedera transaction `0.0.1091@1637602397.474816030` failed pre-check with the status `MEMO_TOO_LONG`
```

The max byte length for Entity memo create scenarios was 100. The current config was resulting in a length of about 119 bytes

- Reduce the length of the memo string passed in

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
