### PR TITLE
Update Contract gas and Transaction memo set logic

### DIFF
--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AbstractNetworkClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AbstractNetworkClient.java
@@ -42,7 +42,7 @@ import com.hedera.mirror.test.e2e.acceptance.response.NetworkTransactionResponse
 
 @Data
 public abstract class AbstractNetworkClient {
-    private static final int ENTITY_MEMO_BYTES_MAX_LENGTH = 100;
+    private static final int MEMO_BYTES_MAX_LENGTH = 100;
     protected final Client client;
     protected final Logger log = LogManager.getLogger(getClass());
     protected final SDKClient sdkClient;
@@ -140,14 +140,10 @@ public abstract class AbstractNetworkClient {
                 .toTinybars();
     }
 
-    protected String getEntityMemo(String message) {
-        // Entity memos are capped at 100 bytes
-        int endIndex = ENTITY_MEMO_BYTES_MAX_LENGTH <= message.length() ?
-                ENTITY_MEMO_BYTES_MAX_LENGTH : message.length();
-        return String.format("Mirror Node acceptance test: %s %s", Instant.now(), message).substring(0, endIndex);
-    }
-
-    protected String getTransactionMemo(String message) {
-        return String.format("Mirror Node acceptance test: %s %s", Instant.now(), message);
+    protected String getMemo(String message) {
+        String memo = String.format("Mirror Node acceptance test: %s %s", Instant.now(), message);
+        // Memos are capped at 100 bytes
+        int endIndex = MEMO_BYTES_MAX_LENGTH <= memo.length() ? MEMO_BYTES_MAX_LENGTH : memo.length();
+        return memo.substring(0, endIndex);
     }
 }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AbstractNetworkClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AbstractNetworkClient.java
@@ -23,6 +23,7 @@ package com.hedera.mirror.test.e2e.acceptance.client;
 import java.time.Instant;
 import lombok.Data;
 import lombok.SneakyThrows;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.retry.support.RetryTemplate;
@@ -143,7 +144,6 @@ public abstract class AbstractNetworkClient {
     protected String getMemo(String message) {
         String memo = String.format("Mirror Node acceptance test: %s %s", Instant.now(), message);
         // Memos are capped at 100 bytes
-        int endIndex = MEMO_BYTES_MAX_LENGTH <= memo.length() ? MEMO_BYTES_MAX_LENGTH : memo.length();
-        return memo.substring(0, endIndex);
+        return StringUtils.truncate(memo, MEMO_BYTES_MAX_LENGTH);
     }
 }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AbstractNetworkClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AbstractNetworkClient.java
@@ -42,6 +42,7 @@ import com.hedera.mirror.test.e2e.acceptance.response.NetworkTransactionResponse
 
 @Data
 public abstract class AbstractNetworkClient {
+    private static final int ENTITY_MEMO_BYTES_MAX_LENGTH = 100;
     protected final Client client;
     protected final Logger log = LogManager.getLogger(getClass());
     protected final SDKClient sdkClient;
@@ -139,8 +140,14 @@ public abstract class AbstractNetworkClient {
                 .toTinybars();
     }
 
-    protected String getMemo(String message) {
-        // Try to keep short due to 100 byte entity memo limit
-        return String.format("Mirror Node acceptance test: %s %s", message, Instant.now());
+    protected String getEntityMemo(String message) {
+        // Entity memos are capped at 100 bytes
+        int endIndex = ENTITY_MEMO_BYTES_MAX_LENGTH <= message.length() ?
+                ENTITY_MEMO_BYTES_MAX_LENGTH : message.length();
+        return String.format("Mirror Node acceptance test: %s %s", Instant.now(), message).substring(0, endIndex);
+    }
+
+    protected String getTransactionMemo(String message) {
+        return String.format("Mirror Node acceptance test: %s %s", Instant.now(), message);
     }
 }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AccountClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AccountClient.java
@@ -128,15 +128,15 @@ public class AccountClient extends AbstractNetworkClient {
 
     public AccountCreateTransaction getAccountCreateTransaction(Hbar initialBalance, KeyList publicKeys,
                                                                 boolean receiverSigRequired, String customMemo) {
-        String memo = String.format("%s %s ", "Create Crypto Account", customMemo);
+        String memo = getMemo(String.format("%s %s ", "Create Crypto Account", customMemo));
         return new AccountCreateTransaction()
                 .setInitialBalance(initialBalance)
                 // The only _required_ property here is `key`
                 .setKey(publicKeys)
-                .setAccountMemo(getMemo(memo))
+                .setAccountMemo(memo)
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
                 .setReceiverSignatureRequired(receiverSigRequired)
-                .setTransactionMemo(getMemo(memo));
+                .setTransactionMemo(memo);
     }
 
     public ExpandedAccountId createNewAccount(long initialBalance) {

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AccountClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AccountClient.java
@@ -106,7 +106,7 @@ public class AccountClient extends AbstractNetworkClient {
                 .addHbarTransfer(sender, hbarAmount.negated())
                 .addHbarTransfer(recipient, hbarAmount)
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
-                .setTransactionMemo(getMemo("Crypto transfer"));
+                .setTransactionMemo(getTransactionMemo("Crypto transfer"));
     }
 
     public NetworkTransactionResponse sendCryptoTransfer(AccountId recipient, Hbar hbarAmount) {
@@ -128,15 +128,15 @@ public class AccountClient extends AbstractNetworkClient {
 
     public AccountCreateTransaction getAccountCreateTransaction(Hbar initialBalance, KeyList publicKeys,
                                                                 boolean receiverSigRequired, String customMemo) {
-        String memo = getMemo("Create Crypto Account " + customMemo);
+        String memo = String.format("%s %s ", "Create Crypto Account", customMemo);
         return new AccountCreateTransaction()
                 .setInitialBalance(initialBalance)
                 // The only _required_ property here is `key`
                 .setKey(publicKeys)
-                .setAccountMemo(memo)
+                .setAccountMemo(getEntityMemo(memo))
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
                 .setReceiverSignatureRequired(receiverSigRequired)
-                .setTransactionMemo(memo);
+                .setTransactionMemo(getTransactionMemo(memo));
     }
 
     public ExpandedAccountId createNewAccount(long initialBalance) {

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AccountClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AccountClient.java
@@ -106,7 +106,7 @@ public class AccountClient extends AbstractNetworkClient {
                 .addHbarTransfer(sender, hbarAmount.negated())
                 .addHbarTransfer(recipient, hbarAmount)
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
-                .setTransactionMemo(getTransactionMemo("Crypto transfer"));
+                .setTransactionMemo(getMemo("Crypto transfer"));
     }
 
     public NetworkTransactionResponse sendCryptoTransfer(AccountId recipient, Hbar hbarAmount) {
@@ -133,10 +133,10 @@ public class AccountClient extends AbstractNetworkClient {
                 .setInitialBalance(initialBalance)
                 // The only _required_ property here is `key`
                 .setKey(publicKeys)
-                .setAccountMemo(getEntityMemo(memo))
+                .setAccountMemo(getMemo(memo))
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
                 .setReceiverSignatureRequired(receiverSigRequired)
-                .setTransactionMemo(getTransactionMemo(memo));
+                .setTransactionMemo(getMemo(memo));
     }
 
     public ExpandedAccountId createNewAccount(long initialBalance) {

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/ContractClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/ContractClient.java
@@ -48,14 +48,14 @@ public class ContractClient extends AbstractNetworkClient {
 
     public NetworkTransactionResponse createContract(FileId fileId, long gas, Hbar payableAmount,
                                                      ContractFunctionParameters contractFunctionParameters) {
-        String memo = "Create contract";
-        log.debug(memo);
+        log.debug("Create new contract");
+        String memo = getMemo("Create contract");
         ContractCreateTransaction contractCreateTransaction = new ContractCreateTransaction()
                 .setAdminKey(sdkClient.getExpandedOperatorAccountId().getPublicKey())
                 .setBytecodeFileId(fileId)
-                .setContractMemo(getMemo(memo))
+                .setContractMemo(memo)
                 .setGas(gas)
-                .setTransactionMemo(getMemo(memo));
+                .setTransactionMemo(memo);
 
         if (contractFunctionParameters != null) {
             contractCreateTransaction.setConstructorParameters(contractFunctionParameters);
@@ -77,12 +77,12 @@ public class ContractClient extends AbstractNetworkClient {
     }
 
     public NetworkTransactionResponse updateContract(ContractId contractId) {
-        String memo = "Update contract";
-        log.debug("{} {}", memo, contractId);
+        log.debug("Update contract {}", contractId);
+        String memo = getMemo("Update contract");
         ContractUpdateTransaction contractUpdateTransaction = new ContractUpdateTransaction()
                 .setContractId(contractId)
-                .setContractMemo(getMemo(memo))
-                .setTransactionMemo(getMemo(memo));
+                .setContractMemo(memo)
+                .setTransactionMemo(memo);
 
         NetworkTransactionResponse networkTransactionResponse =
                 executeTransactionAndRetrieveReceipt(contractUpdateTransaction);
@@ -93,11 +93,11 @@ public class ContractClient extends AbstractNetworkClient {
 
     public NetworkTransactionResponse deleteContract(ContractId contractId, AccountId transferAccountId,
                                                      ContractId transferContractId) {
-        String memo = "Delete contract";
-        log.debug("{} {}", memo, contractId);
+        log.debug("Delete contract {}", contractId);
+        String memo = getMemo("Delete contract");
         ContractDeleteTransaction contractDeleteTransaction = new ContractDeleteTransaction()
                 .setContractId(contractId)
-                .setTransactionMemo(getMemo(memo));
+                .setTransactionMemo(memo);
 
         // either AccountId or ContractId, not both
         if (transferAccountId != null) {
@@ -119,11 +119,10 @@ public class ContractClient extends AbstractNetworkClient {
                                                       ContractFunctionParameters parameters, Hbar payableAmount) {
         log.debug("Call contract {}'s function {}", contractId, functionName);
 
-        String memo = "Execute contract";
         ContractExecuteTransaction contractExecuteTransaction = new ContractExecuteTransaction()
                 .setContractId(contractId)
                 .setGas(gas)
-                .setTransactionMemo(getMemo(memo))
+                .setTransactionMemo(getMemo("Execute contract"))
                 .setMaxTransactionFee(Hbar.from(100));
 
         if (parameters == null) {

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/ContractClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/ContractClient.java
@@ -53,9 +53,9 @@ public class ContractClient extends AbstractNetworkClient {
         ContractCreateTransaction contractCreateTransaction = new ContractCreateTransaction()
                 .setAdminKey(sdkClient.getExpandedOperatorAccountId().getPublicKey())
                 .setBytecodeFileId(fileId)
-                .setContractMemo(getEntityMemo(memo))
+                .setContractMemo(getMemo(memo))
                 .setGas(gas)
-                .setTransactionMemo(getTransactionMemo(memo));
+                .setTransactionMemo(getMemo(memo));
 
         if (contractFunctionParameters != null) {
             contractCreateTransaction.setConstructorParameters(contractFunctionParameters);
@@ -81,8 +81,8 @@ public class ContractClient extends AbstractNetworkClient {
         log.debug("{} {}", memo, contractId);
         ContractUpdateTransaction contractUpdateTransaction = new ContractUpdateTransaction()
                 .setContractId(contractId)
-                .setContractMemo(getEntityMemo(memo))
-                .setTransactionMemo(getTransactionMemo(memo));
+                .setContractMemo(getMemo(memo))
+                .setTransactionMemo(getMemo(memo));
 
         NetworkTransactionResponse networkTransactionResponse =
                 executeTransactionAndRetrieveReceipt(contractUpdateTransaction);
@@ -97,7 +97,7 @@ public class ContractClient extends AbstractNetworkClient {
         log.debug("{} {}", memo, contractId);
         ContractDeleteTransaction contractDeleteTransaction = new ContractDeleteTransaction()
                 .setContractId(contractId)
-                .setTransactionMemo(getTransactionMemo(memo));
+                .setTransactionMemo(getMemo(memo));
 
         // either AccountId or ContractId, not both
         if (transferAccountId != null) {
@@ -123,7 +123,7 @@ public class ContractClient extends AbstractNetworkClient {
         ContractExecuteTransaction contractExecuteTransaction = new ContractExecuteTransaction()
                 .setContractId(contractId)
                 .setGas(gas)
-                .setTransactionMemo(getTransactionMemo(memo))
+                .setTransactionMemo(getMemo(memo))
                 .setMaxTransactionFee(Hbar.from(100));
 
         if (parameters == null) {

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/FileClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/FileClient.java
@@ -50,8 +50,8 @@ public class FileClient extends AbstractNetworkClient {
         FileCreateTransaction fileCreateTransaction = new FileCreateTransaction()
                 .setKeys(sdkClient.getExpandedOperatorAccountId().getPublicKey())
                 .setContents(content)
-                .setFileMemo(getEntityMemo(memo))
-                .setTransactionMemo(getTransactionMemo(memo));
+                .setFileMemo(getMemo(memo))
+                .setTransactionMemo(getMemo(memo));
 
         NetworkTransactionResponse networkTransactionResponse = executeTransactionAndRetrieveReceipt(
                 fileCreateTransaction,
@@ -67,8 +67,8 @@ public class FileClient extends AbstractNetworkClient {
         log.debug(memo);
         FileUpdateTransaction fileUpdateTransaction = new FileUpdateTransaction()
                 .setFileId(fileId)
-                .setFileMemo(getEntityMemo(memo))
-                .setTransactionMemo(getTransactionMemo(memo));
+                .setFileMemo(getMemo(memo))
+                .setTransactionMemo(getMemo(memo));
 
         if (byteCode != null) {
             fileUpdateTransaction.setContents(byteCode);
@@ -87,7 +87,7 @@ public class FileClient extends AbstractNetworkClient {
         FileAppendTransaction fileAppendTransaction = new FileAppendTransaction()
                 .setFileId(fileId)
                 .setContents(byteCode)
-                .setTransactionMemo(getTransactionMemo("Append file"));
+                .setTransactionMemo(getMemo("Append file"));
 
         NetworkTransactionResponse networkTransactionResponse =
                 executeTransactionAndRetrieveReceipt(fileAppendTransaction);
@@ -101,7 +101,7 @@ public class FileClient extends AbstractNetworkClient {
         log.debug(memo);
         FileDeleteTransaction fileUpdateTransaction = new FileDeleteTransaction()
                 .setFileId(fileId)
-                .setTransactionMemo(getTransactionMemo(memo));
+                .setTransactionMemo(getMemo(memo));
 
         NetworkTransactionResponse networkTransactionResponse =
                 executeTransactionAndRetrieveReceipt(fileUpdateTransaction);

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/FileClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/FileClient.java
@@ -45,13 +45,13 @@ public class FileClient extends AbstractNetworkClient {
     }
 
     public NetworkTransactionResponse createFile(byte[] content) {
-        String memo = "Create file";
-        log.debug(memo);
+        log.debug("Create new file");
+        String memo = getMemo("Create file");
         FileCreateTransaction fileCreateTransaction = new FileCreateTransaction()
                 .setKeys(sdkClient.getExpandedOperatorAccountId().getPublicKey())
                 .setContents(content)
-                .setFileMemo(getMemo(memo))
-                .setTransactionMemo(getMemo(memo));
+                .setFileMemo(memo)
+                .setTransactionMemo(memo);
 
         NetworkTransactionResponse networkTransactionResponse = executeTransactionAndRetrieveReceipt(
                 fileCreateTransaction,
@@ -63,12 +63,12 @@ public class FileClient extends AbstractNetworkClient {
     }
 
     public NetworkTransactionResponse updateFile(FileId fileId, byte[] byteCode) {
-        String memo = "Update file";
-        log.debug(memo);
+        log.debug("Update file");
+        String memo = getMemo("Update file");
         FileUpdateTransaction fileUpdateTransaction = new FileUpdateTransaction()
                 .setFileId(fileId)
-                .setFileMemo(getMemo(memo))
-                .setTransactionMemo(getMemo(memo));
+                .setFileMemo(memo)
+                .setTransactionMemo(memo);
 
         if (byteCode != null) {
             fileUpdateTransaction.setContents(byteCode);

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/FileClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/FileClient.java
@@ -45,13 +45,13 @@ public class FileClient extends AbstractNetworkClient {
     }
 
     public NetworkTransactionResponse createFile(byte[] content) {
-        log.debug("Create new file");
-        String memo = getMemo("Create file");
+        String memo = "Create file";
+        log.debug(memo);
         FileCreateTransaction fileCreateTransaction = new FileCreateTransaction()
                 .setKeys(sdkClient.getExpandedOperatorAccountId().getPublicKey())
                 .setContents(content)
-                .setFileMemo(memo)
-                .setTransactionMemo(memo);
+                .setFileMemo(getEntityMemo(memo))
+                .setTransactionMemo(getTransactionMemo(memo));
 
         NetworkTransactionResponse networkTransactionResponse = executeTransactionAndRetrieveReceipt(
                 fileCreateTransaction,
@@ -63,12 +63,12 @@ public class FileClient extends AbstractNetworkClient {
     }
 
     public NetworkTransactionResponse updateFile(FileId fileId, byte[] byteCode) {
-        log.debug("Update file");
-        String memo = getMemo("Update file");
+        String memo = "Update file";
+        log.debug(memo);
         FileUpdateTransaction fileUpdateTransaction = new FileUpdateTransaction()
                 .setFileId(fileId)
-                .setFileMemo(memo)
-                .setTransactionMemo(memo);
+                .setFileMemo(getEntityMemo(memo))
+                .setTransactionMemo(getTransactionMemo(memo));
 
         if (byteCode != null) {
             fileUpdateTransaction.setContents(byteCode);
@@ -82,11 +82,12 @@ public class FileClient extends AbstractNetworkClient {
     }
 
     public NetworkTransactionResponse appendFile(FileId fileId, byte[] byteCode) {
-        log.debug("Append file");
+        String memo = "Append file";
+        log.debug(memo);
         FileAppendTransaction fileAppendTransaction = new FileAppendTransaction()
                 .setFileId(fileId)
                 .setContents(byteCode)
-                .setTransactionMemo(getMemo("Append file"));
+                .setTransactionMemo(getTransactionMemo("Append file"));
 
         NetworkTransactionResponse networkTransactionResponse =
                 executeTransactionAndRetrieveReceipt(fileAppendTransaction);
@@ -96,11 +97,11 @@ public class FileClient extends AbstractNetworkClient {
     }
 
     public NetworkTransactionResponse deleteFile(FileId fileId) {
-        log.debug("Delete file");
-        String memo = getMemo("Delete file");
+        String memo = "Delete file";
+        log.debug(memo);
         FileDeleteTransaction fileUpdateTransaction = new FileDeleteTransaction()
                 .setFileId(fileId)
-                .setTransactionMemo(memo);
+                .setTransactionMemo(getTransactionMemo(memo));
 
         NetworkTransactionResponse networkTransactionResponse =
                 executeTransactionAndRetrieveReceipt(fileUpdateTransaction);

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/FileClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/FileClient.java
@@ -87,7 +87,7 @@ public class FileClient extends AbstractNetworkClient {
         FileAppendTransaction fileAppendTransaction = new FileAppendTransaction()
                 .setFileId(fileId)
                 .setContents(byteCode)
-                .setTransactionMemo(getMemo("Append file"));
+                .setTransactionMemo(getMemo(memo));
 
         NetworkTransactionResponse networkTransactionResponse =
                 executeTransactionAndRetrieveReceipt(fileAppendTransaction);

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/ScheduleClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/ScheduleClient.java
@@ -57,14 +57,14 @@ public class ScheduleClient extends AbstractNetworkClient {
                 .setScheduled(true);
         transaction.setTransactionId(transactionId);
 
-        String memo = getMemo("Create schedule");
+        String memo = "Create schedule";
         ScheduleCreateTransaction scheduleCreateTransaction = transaction.schedule()
                 .setAdminKey(payerAccountId.getPublicKey())
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
                 .setPayerAccountId(payerAccountId.getAccountId())
-                .setScheduleMemo(memo)
+                .setScheduleMemo(getEntityMemo(memo))
                 .setTransactionId(transactionId.setScheduled(false))
-                .setTransactionMemo(memo);
+                .setTransactionMemo(getTransactionMemo(memo));
 
         if (signatureKeyList != null) {
             scheduleCreateTransaction.setNodeAccountIds(List.of(sdkClient.getRandomNodeAccountId()));
@@ -93,7 +93,7 @@ public class ScheduleClient extends AbstractNetworkClient {
         ScheduleSignTransaction scheduleSignTransaction = new ScheduleSignTransaction()
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
                 .setScheduleId(scheduleId)
-                .setTransactionMemo(getMemo("Sign schedule"));
+                .setTransactionMemo(getTransactionMemo("Sign schedule"));
 
         NetworkTransactionResponse networkTransactionResponse = executeTransactionAndRetrieveReceipt(
                 scheduleSignTransaction,
@@ -110,7 +110,7 @@ public class ScheduleClient extends AbstractNetworkClient {
         ScheduleDeleteTransaction scheduleDeleteTransaction = new ScheduleDeleteTransaction()
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
                 .setScheduleId(scheduleId)
-                .setTransactionMemo(getMemo("Delete schedule"));
+                .setTransactionMemo(getTransactionMemo("Delete schedule"));
 
         NetworkTransactionResponse networkTransactionResponse =
                 executeTransactionAndRetrieveReceipt(scheduleDeleteTransaction);

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/ScheduleClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/ScheduleClient.java
@@ -57,14 +57,14 @@ public class ScheduleClient extends AbstractNetworkClient {
                 .setScheduled(true);
         transaction.setTransactionId(transactionId);
 
-        String memo = "Create schedule";
+        String memo = getMemo("Create schedule");
         ScheduleCreateTransaction scheduleCreateTransaction = transaction.schedule()
                 .setAdminKey(payerAccountId.getPublicKey())
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
                 .setPayerAccountId(payerAccountId.getAccountId())
-                .setScheduleMemo(getMemo(memo))
+                .setScheduleMemo(memo)
                 .setTransactionId(transactionId.setScheduled(false))
-                .setTransactionMemo(getMemo(memo));
+                .setTransactionMemo(memo);
 
         if (signatureKeyList != null) {
             scheduleCreateTransaction.setNodeAccountIds(List.of(sdkClient.getRandomNodeAccountId()));

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/ScheduleClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/ScheduleClient.java
@@ -62,9 +62,9 @@ public class ScheduleClient extends AbstractNetworkClient {
                 .setAdminKey(payerAccountId.getPublicKey())
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
                 .setPayerAccountId(payerAccountId.getAccountId())
-                .setScheduleMemo(getEntityMemo(memo))
+                .setScheduleMemo(getMemo(memo))
                 .setTransactionId(transactionId.setScheduled(false))
-                .setTransactionMemo(getTransactionMemo(memo));
+                .setTransactionMemo(getMemo(memo));
 
         if (signatureKeyList != null) {
             scheduleCreateTransaction.setNodeAccountIds(List.of(sdkClient.getRandomNodeAccountId()));
@@ -93,7 +93,7 @@ public class ScheduleClient extends AbstractNetworkClient {
         ScheduleSignTransaction scheduleSignTransaction = new ScheduleSignTransaction()
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
                 .setScheduleId(scheduleId)
-                .setTransactionMemo(getTransactionMemo("Sign schedule"));
+                .setTransactionMemo(getMemo("Sign schedule"));
 
         NetworkTransactionResponse networkTransactionResponse = executeTransactionAndRetrieveReceipt(
                 scheduleSignTransaction,
@@ -110,7 +110,7 @@ public class ScheduleClient extends AbstractNetworkClient {
         ScheduleDeleteTransaction scheduleDeleteTransaction = new ScheduleDeleteTransaction()
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
                 .setScheduleId(scheduleId)
-                .setTransactionMemo(getTransactionMemo("Delete schedule"));
+                .setTransactionMemo(getMemo("Delete schedule"));
 
         NetworkTransactionResponse networkTransactionResponse =
                 executeTransactionAndRetrieveReceipt(scheduleDeleteTransaction);

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TokenClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TokenClient.java
@@ -21,7 +21,6 @@ package com.hedera.mirror.test.e2e.acceptance.client;
  */
 
 import java.time.Duration;
-import java.time.Instant;
 import java.util.List;
 import javax.inject.Named;
 import lombok.SneakyThrows;
@@ -88,19 +87,19 @@ public class TokenClient extends AbstractNetworkClient {
                                                              ExpandedAccountId treasuryAccount, TokenType tokenType,
                                                              TokenSupplyType tokenSupplyType, long maxSupply,
                                                              List<CustomFee> customFees) {
-        String memo = getMemo("Create token");
+        String memo = "Create token";
         PublicKey adminKey = expandedAccountId.getPublicKey();
         TokenCreateTransaction transaction = new TokenCreateTransaction()
                 .setAutoRenewAccountId(expandedAccountId.getAccountId())
                 .setAutoRenewPeriod(Duration.ofSeconds(6_999_999L))
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
-                .setTokenMemo(memo)
+                .setTokenMemo(getEntityMemo(memo))
                 .setTokenName(symbol + "_name")
                 .setSupplyType(tokenSupplyType)
                 .setTokenSymbol(symbol)
                 .setTokenType(tokenType)
                 .setTreasuryAccountId(treasuryAccount.getAccountId())
-                .setTransactionMemo(memo);
+                .setTransactionMemo(getTransactionMemo(memo));
 
         if (tokenSupplyType == TokenSupplyType.FINITE) {
             transaction.setMaxSupply(maxSupply);
@@ -178,7 +177,7 @@ public class TokenClient extends AbstractNetworkClient {
                 .setAccountId(accountId.getAccountId())
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
                 .setTokenIds((List.of(token)))
-                .setTransactionMemo(getMemo("Associate w token"));
+                .setTransactionMemo(getTransactionMemo("Associate w token"));
 
         NetworkTransactionResponse networkTransactionResponse =
                 executeTransactionAndRetrieveReceipt(tokenAssociateTransaction,
@@ -203,7 +202,7 @@ public class TokenClient extends AbstractNetworkClient {
         TokenMintTransaction tokenMintTransaction = new TokenMintTransaction()
                 .setTokenId(tokenId)
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
-                .setTransactionMemo(getMemo("Mint token"));
+                .setTransactionMemo(getTransactionMemo("Mint token"));
 
         if (metadata != null) {
             tokenMintTransaction.addMetadata(metadata);
@@ -224,7 +223,7 @@ public class TokenClient extends AbstractNetworkClient {
                 .setAccountId(accountId)
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
                 .setTokenId(tokenId)
-                .setTransactionMemo(getMemo("Freeze token account"));
+                .setTransactionMemo(getTransactionMemo("Freeze token account"));
 
         NetworkTransactionResponse response = executeTransactionAndRetrieveReceipt(tokenFreezeAccountTransaction);
 
@@ -238,7 +237,7 @@ public class TokenClient extends AbstractNetworkClient {
                 .setAccountId(accountId)
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
                 .setTokenId(tokenId)
-                .setTransactionMemo(getMemo("Unfreeze token account"));
+                .setTransactionMemo(getTransactionMemo("Unfreeze token account"));
 
         NetworkTransactionResponse response = executeTransactionAndRetrieveReceipt(tokenUnfreezeTransaction);
 
@@ -253,7 +252,7 @@ public class TokenClient extends AbstractNetworkClient {
                 .setAccountId(accountId)
                 .setTokenId(tokenId)
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
-                .setTransactionMemo(getMemo("Grant kyc for token"));
+                .setTransactionMemo(getTransactionMemo("Grant kyc for token"));
 
         NetworkTransactionResponse networkTransactionResponse = executeTransactionAndRetrieveReceipt(
                 tokenGrantKycTransaction);
@@ -269,7 +268,7 @@ public class TokenClient extends AbstractNetworkClient {
                 .setAccountId(accountId)
                 .setTokenId(tokenId)
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
-                .setTransactionMemo(getMemo("Revoke kyc for token"));
+                .setTransactionMemo(getTransactionMemo("Revoke kyc for token"));
 
         NetworkTransactionResponse networkTransactionResponse = executeTransactionAndRetrieveReceipt(
                 tokenRevokeKycTransaction);
@@ -284,7 +283,7 @@ public class TokenClient extends AbstractNetworkClient {
         TokenPauseTransaction tokenPauseTransaction = new TokenPauseTransaction()
                 .setTokenId(tokenId)
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
-                .setTransactionMemo(getMemo("Pause token"));
+                .setTransactionMemo(getTransactionMemo("Pause token"));
 
         NetworkTransactionResponse networkTransactionResponse = executeTransactionAndRetrieveReceipt(
                 tokenPauseTransaction);
@@ -299,7 +298,7 @@ public class TokenClient extends AbstractNetworkClient {
         TokenUnpauseTransaction tokenUnpauseTransaction = new TokenUnpauseTransaction()
                 .setTokenId(tokenId)
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
-                .setTransactionMemo(getMemo("Unpause token"));
+                .setTransactionMemo(getTransactionMemo("Unpause token"));
 
         NetworkTransactionResponse networkTransactionResponse = executeTransactionAndRetrieveReceipt(
                 tokenUnpauseTransaction);
@@ -326,10 +325,9 @@ public class TokenClient extends AbstractNetworkClient {
     }
 
     private TransferTransaction getTransferTransaction() {
-        Instant refInstant = Instant.now();
         return new TransferTransaction()
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
-                .setTransactionMemo(getMemo("Transfer token"));
+                .setTransactionMemo(getTransactionMemo("Transfer token"));
     }
 
     public NetworkTransactionResponse transferFungibleToken(TokenId tokenId, ExpandedAccountId sender,
@@ -351,17 +349,17 @@ public class TokenClient extends AbstractNetworkClient {
     public NetworkTransactionResponse updateToken(TokenId tokenId, ExpandedAccountId expandedAccountId) {
         PublicKey publicKey = expandedAccountId.getPublicKey();
         String newSymbol = RandomStringUtils.randomAlphabetic(4).toUpperCase();
-        String memo = getMemo("Update token");
+        String memo = "Update token";
         TokenUpdateTransaction tokenUpdateTransaction = new TokenUpdateTransaction()
                 .setAdminKey(publicKey)
                 .setAutoRenewAccountId(expandedAccountId.getAccountId())
                 .setAutoRenewPeriod(Duration.ofSeconds(8_000_001L))
                 .setTokenName(newSymbol + "_name")
                 .setSupplyKey(publicKey)
-                .setTokenMemo(memo)
+                .setTokenMemo(getEntityMemo(memo))
                 .setTokenSymbol(newSymbol)
                 .setTokenId(tokenId)
-                .setTransactionMemo(memo)
+                .setTransactionMemo(getTransactionMemo(memo))
                 .setTreasuryAccountId(client.getOperatorAccountId())
                 .setWipeKey(publicKey)
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee());
@@ -376,12 +374,12 @@ public class TokenClient extends AbstractNetworkClient {
 
     public NetworkTransactionResponse updateTokenTreasury(TokenId tokenId, ExpandedAccountId newTreasuryId) {
         AccountId treasuryAccountId = newTreasuryId.getAccountId();
-        String memo = getMemo("Update token");
+        String memo = "Update token";
         TokenUpdateTransaction tokenUpdateTransaction = new TokenUpdateTransaction()
                 .setTokenId(tokenId)
-                .setTokenMemo(memo)
+                .setTokenMemo(getEntityMemo(memo))
                 .setTreasuryAccountId(treasuryAccountId)
-                .setTransactionMemo(memo);
+                .setTransactionMemo(getTransactionMemo(memo));
 
         KeyList keyList = KeyList.of(newTreasuryId.getPrivateKey());
         NetworkTransactionResponse networkTransactionResponse =
@@ -396,14 +394,14 @@ public class TokenClient extends AbstractNetworkClient {
         return new TokenBurnTransaction()
                 .setTokenId(tokenId)
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
-                .setTransactionMemo(getMemo("Burn token"));
+                .setTransactionMemo(getTransactionMemo("Burn token"));
     }
 
     public NetworkTransactionResponse burnFungible(TokenId tokenId, long amount) {
         log.debug("Burn {} tokens from {}", amount, tokenId);
         TokenBurnTransaction tokenBurnTransaction = getTokenBurnTransaction(tokenId)
                 .setAmount(amount)
-                .setTransactionMemo(getMemo("Token burn"));
+                .setTransactionMemo(getTransactionMemo("Token burn"));
         NetworkTransactionResponse networkTransactionResponse =
                 executeTransactionAndRetrieveReceipt(tokenBurnTransaction);
 
@@ -417,7 +415,7 @@ public class TokenClient extends AbstractNetworkClient {
         log.debug("Burn serial number {} from token {}", serialNumber, tokenId);
         TokenBurnTransaction tokenBurnTransaction = getTokenBurnTransaction(tokenId)
                 .addSerial(serialNumber)
-                .setTransactionMemo(getMemo("Token burn"));
+                .setTransactionMemo(getTransactionMemo("Token burn"));
 
         NetworkTransactionResponse networkTransactionResponse =
                 executeTransactionAndRetrieveReceipt(tokenBurnTransaction);
@@ -432,7 +430,7 @@ public class TokenClient extends AbstractNetworkClient {
                 .setAccountId(expandedAccountId.getAccountId())
                 .setTokenId(tokenId)
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
-                .setTransactionMemo(getMemo("Wipe token"));
+                .setTransactionMemo(getTransactionMemo("Wipe token"));
     }
 
     public NetworkTransactionResponse wipeFungible(TokenId tokenId, long amount, ExpandedAccountId expandedAccountId) {
@@ -472,7 +470,7 @@ public class TokenClient extends AbstractNetworkClient {
         TokenDissociateTransaction tokenDissociateTransaction = new TokenDissociateTransaction()
                 .setAccountId(accountId.getAccountId())
                 .setTokenIds(List.of(token))
-                .setTransactionMemo(getMemo("Dissociate token"));
+                .setTransactionMemo(getTransactionMemo("Dissociate token"));
 
         NetworkTransactionResponse networkTransactionResponse =
                 executeTransactionAndRetrieveReceipt(tokenDissociateTransaction,
@@ -489,7 +487,7 @@ public class TokenClient extends AbstractNetworkClient {
         TokenDeleteTransaction tokenDissociateTransaction = new TokenDeleteTransaction()
                 .setTokenId(token)
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
-                .setTransactionMemo(getMemo("Delete token"));
+                .setTransactionMemo(getTransactionMemo("Delete token"));
 
         NetworkTransactionResponse networkTransactionResponse =
                 executeTransactionAndRetrieveReceipt(tokenDissociateTransaction,
@@ -506,7 +504,7 @@ public class TokenClient extends AbstractNetworkClient {
                 .setCustomFees(customFees)
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
                 .setTokenId(tokenId)
-                .setTransactionMemo(getMemo("Update token fee schedule"));
+                .setTransactionMemo(getTransactionMemo("Update token fee schedule"));
 
         NetworkTransactionResponse response = executeTransactionAndRetrieveReceipt(transaction,
                 KeyList.of(expandedAccountId.getPrivateKey()));

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TokenClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TokenClient.java
@@ -87,19 +87,19 @@ public class TokenClient extends AbstractNetworkClient {
                                                              ExpandedAccountId treasuryAccount, TokenType tokenType,
                                                              TokenSupplyType tokenSupplyType, long maxSupply,
                                                              List<CustomFee> customFees) {
-        String memo = "Create token";
+        String memo = getMemo("Create token");
         PublicKey adminKey = expandedAccountId.getPublicKey();
         TokenCreateTransaction transaction = new TokenCreateTransaction()
                 .setAutoRenewAccountId(expandedAccountId.getAccountId())
                 .setAutoRenewPeriod(Duration.ofSeconds(6_999_999L))
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
-                .setTokenMemo(getMemo(memo))
+                .setTokenMemo(memo)
                 .setTokenName(symbol + "_name")
                 .setSupplyType(tokenSupplyType)
                 .setTokenSymbol(symbol)
                 .setTokenType(tokenType)
                 .setTreasuryAccountId(treasuryAccount.getAccountId())
-                .setTransactionMemo(getMemo(memo));
+                .setTransactionMemo(memo);
 
         if (tokenSupplyType == TokenSupplyType.FINITE) {
             transaction.setMaxSupply(maxSupply);
@@ -349,17 +349,17 @@ public class TokenClient extends AbstractNetworkClient {
     public NetworkTransactionResponse updateToken(TokenId tokenId, ExpandedAccountId expandedAccountId) {
         PublicKey publicKey = expandedAccountId.getPublicKey();
         String newSymbol = RandomStringUtils.randomAlphabetic(4).toUpperCase();
-        String memo = "Update token";
+        String memo = getMemo("Update token");
         TokenUpdateTransaction tokenUpdateTransaction = new TokenUpdateTransaction()
                 .setAdminKey(publicKey)
                 .setAutoRenewAccountId(expandedAccountId.getAccountId())
                 .setAutoRenewPeriod(Duration.ofSeconds(8_000_001L))
                 .setTokenName(newSymbol + "_name")
                 .setSupplyKey(publicKey)
-                .setTokenMemo(getMemo(memo))
+                .setTokenMemo(memo)
                 .setTokenSymbol(newSymbol)
                 .setTokenId(tokenId)
-                .setTransactionMemo(getMemo(memo))
+                .setTransactionMemo(memo)
                 .setTreasuryAccountId(client.getOperatorAccountId())
                 .setWipeKey(publicKey)
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee());
@@ -374,12 +374,12 @@ public class TokenClient extends AbstractNetworkClient {
 
     public NetworkTransactionResponse updateTokenTreasury(TokenId tokenId, ExpandedAccountId newTreasuryId) {
         AccountId treasuryAccountId = newTreasuryId.getAccountId();
-        String memo = "Update token";
+        String memo = getMemo("Update token");
         TokenUpdateTransaction tokenUpdateTransaction = new TokenUpdateTransaction()
                 .setTokenId(tokenId)
-                .setTokenMemo(getMemo(memo))
+                .setTokenMemo(memo)
                 .setTreasuryAccountId(treasuryAccountId)
-                .setTransactionMemo(getMemo(memo));
+                .setTransactionMemo(memo);
 
         KeyList keyList = KeyList.of(newTreasuryId.getPrivateKey());
         NetworkTransactionResponse networkTransactionResponse =

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TokenClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TokenClient.java
@@ -93,13 +93,13 @@ public class TokenClient extends AbstractNetworkClient {
                 .setAutoRenewAccountId(expandedAccountId.getAccountId())
                 .setAutoRenewPeriod(Duration.ofSeconds(6_999_999L))
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
-                .setTokenMemo(getEntityMemo(memo))
+                .setTokenMemo(getMemo(memo))
                 .setTokenName(symbol + "_name")
                 .setSupplyType(tokenSupplyType)
                 .setTokenSymbol(symbol)
                 .setTokenType(tokenType)
                 .setTreasuryAccountId(treasuryAccount.getAccountId())
-                .setTransactionMemo(getTransactionMemo(memo));
+                .setTransactionMemo(getMemo(memo));
 
         if (tokenSupplyType == TokenSupplyType.FINITE) {
             transaction.setMaxSupply(maxSupply);
@@ -177,7 +177,7 @@ public class TokenClient extends AbstractNetworkClient {
                 .setAccountId(accountId.getAccountId())
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
                 .setTokenIds((List.of(token)))
-                .setTransactionMemo(getTransactionMemo("Associate w token"));
+                .setTransactionMemo(getMemo("Associate w token"));
 
         NetworkTransactionResponse networkTransactionResponse =
                 executeTransactionAndRetrieveReceipt(tokenAssociateTransaction,
@@ -202,7 +202,7 @@ public class TokenClient extends AbstractNetworkClient {
         TokenMintTransaction tokenMintTransaction = new TokenMintTransaction()
                 .setTokenId(tokenId)
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
-                .setTransactionMemo(getTransactionMemo("Mint token"));
+                .setTransactionMemo(getMemo("Mint token"));
 
         if (metadata != null) {
             tokenMintTransaction.addMetadata(metadata);
@@ -223,7 +223,7 @@ public class TokenClient extends AbstractNetworkClient {
                 .setAccountId(accountId)
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
                 .setTokenId(tokenId)
-                .setTransactionMemo(getTransactionMemo("Freeze token account"));
+                .setTransactionMemo(getMemo("Freeze token account"));
 
         NetworkTransactionResponse response = executeTransactionAndRetrieveReceipt(tokenFreezeAccountTransaction);
 
@@ -237,7 +237,7 @@ public class TokenClient extends AbstractNetworkClient {
                 .setAccountId(accountId)
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
                 .setTokenId(tokenId)
-                .setTransactionMemo(getTransactionMemo("Unfreeze token account"));
+                .setTransactionMemo(getMemo("Unfreeze token account"));
 
         NetworkTransactionResponse response = executeTransactionAndRetrieveReceipt(tokenUnfreezeTransaction);
 
@@ -252,7 +252,7 @@ public class TokenClient extends AbstractNetworkClient {
                 .setAccountId(accountId)
                 .setTokenId(tokenId)
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
-                .setTransactionMemo(getTransactionMemo("Grant kyc for token"));
+                .setTransactionMemo(getMemo("Grant kyc for token"));
 
         NetworkTransactionResponse networkTransactionResponse = executeTransactionAndRetrieveReceipt(
                 tokenGrantKycTransaction);
@@ -268,7 +268,7 @@ public class TokenClient extends AbstractNetworkClient {
                 .setAccountId(accountId)
                 .setTokenId(tokenId)
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
-                .setTransactionMemo(getTransactionMemo("Revoke kyc for token"));
+                .setTransactionMemo(getMemo("Revoke kyc for token"));
 
         NetworkTransactionResponse networkTransactionResponse = executeTransactionAndRetrieveReceipt(
                 tokenRevokeKycTransaction);
@@ -283,7 +283,7 @@ public class TokenClient extends AbstractNetworkClient {
         TokenPauseTransaction tokenPauseTransaction = new TokenPauseTransaction()
                 .setTokenId(tokenId)
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
-                .setTransactionMemo(getTransactionMemo("Pause token"));
+                .setTransactionMemo(getMemo("Pause token"));
 
         NetworkTransactionResponse networkTransactionResponse = executeTransactionAndRetrieveReceipt(
                 tokenPauseTransaction);
@@ -298,7 +298,7 @@ public class TokenClient extends AbstractNetworkClient {
         TokenUnpauseTransaction tokenUnpauseTransaction = new TokenUnpauseTransaction()
                 .setTokenId(tokenId)
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
-                .setTransactionMemo(getTransactionMemo("Unpause token"));
+                .setTransactionMemo(getMemo("Unpause token"));
 
         NetworkTransactionResponse networkTransactionResponse = executeTransactionAndRetrieveReceipt(
                 tokenUnpauseTransaction);
@@ -327,7 +327,7 @@ public class TokenClient extends AbstractNetworkClient {
     private TransferTransaction getTransferTransaction() {
         return new TransferTransaction()
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
-                .setTransactionMemo(getTransactionMemo("Transfer token"));
+                .setTransactionMemo(getMemo("Transfer token"));
     }
 
     public NetworkTransactionResponse transferFungibleToken(TokenId tokenId, ExpandedAccountId sender,
@@ -356,10 +356,10 @@ public class TokenClient extends AbstractNetworkClient {
                 .setAutoRenewPeriod(Duration.ofSeconds(8_000_001L))
                 .setTokenName(newSymbol + "_name")
                 .setSupplyKey(publicKey)
-                .setTokenMemo(getEntityMemo(memo))
+                .setTokenMemo(getMemo(memo))
                 .setTokenSymbol(newSymbol)
                 .setTokenId(tokenId)
-                .setTransactionMemo(getTransactionMemo(memo))
+                .setTransactionMemo(getMemo(memo))
                 .setTreasuryAccountId(client.getOperatorAccountId())
                 .setWipeKey(publicKey)
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee());
@@ -377,9 +377,9 @@ public class TokenClient extends AbstractNetworkClient {
         String memo = "Update token";
         TokenUpdateTransaction tokenUpdateTransaction = new TokenUpdateTransaction()
                 .setTokenId(tokenId)
-                .setTokenMemo(getEntityMemo(memo))
+                .setTokenMemo(getMemo(memo))
                 .setTreasuryAccountId(treasuryAccountId)
-                .setTransactionMemo(getTransactionMemo(memo));
+                .setTransactionMemo(getMemo(memo));
 
         KeyList keyList = KeyList.of(newTreasuryId.getPrivateKey());
         NetworkTransactionResponse networkTransactionResponse =
@@ -394,14 +394,14 @@ public class TokenClient extends AbstractNetworkClient {
         return new TokenBurnTransaction()
                 .setTokenId(tokenId)
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
-                .setTransactionMemo(getTransactionMemo("Burn token"));
+                .setTransactionMemo(getMemo("Burn token"));
     }
 
     public NetworkTransactionResponse burnFungible(TokenId tokenId, long amount) {
         log.debug("Burn {} tokens from {}", amount, tokenId);
         TokenBurnTransaction tokenBurnTransaction = getTokenBurnTransaction(tokenId)
                 .setAmount(amount)
-                .setTransactionMemo(getTransactionMemo("Token burn"));
+                .setTransactionMemo(getMemo("Token burn"));
         NetworkTransactionResponse networkTransactionResponse =
                 executeTransactionAndRetrieveReceipt(tokenBurnTransaction);
 
@@ -415,7 +415,7 @@ public class TokenClient extends AbstractNetworkClient {
         log.debug("Burn serial number {} from token {}", serialNumber, tokenId);
         TokenBurnTransaction tokenBurnTransaction = getTokenBurnTransaction(tokenId)
                 .addSerial(serialNumber)
-                .setTransactionMemo(getTransactionMemo("Token burn"));
+                .setTransactionMemo(getMemo("Token burn"));
 
         NetworkTransactionResponse networkTransactionResponse =
                 executeTransactionAndRetrieveReceipt(tokenBurnTransaction);
@@ -430,7 +430,7 @@ public class TokenClient extends AbstractNetworkClient {
                 .setAccountId(expandedAccountId.getAccountId())
                 .setTokenId(tokenId)
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
-                .setTransactionMemo(getTransactionMemo("Wipe token"));
+                .setTransactionMemo(getMemo("Wipe token"));
     }
 
     public NetworkTransactionResponse wipeFungible(TokenId tokenId, long amount, ExpandedAccountId expandedAccountId) {
@@ -470,7 +470,7 @@ public class TokenClient extends AbstractNetworkClient {
         TokenDissociateTransaction tokenDissociateTransaction = new TokenDissociateTransaction()
                 .setAccountId(accountId.getAccountId())
                 .setTokenIds(List.of(token))
-                .setTransactionMemo(getTransactionMemo("Dissociate token"));
+                .setTransactionMemo(getMemo("Dissociate token"));
 
         NetworkTransactionResponse networkTransactionResponse =
                 executeTransactionAndRetrieveReceipt(tokenDissociateTransaction,
@@ -487,7 +487,7 @@ public class TokenClient extends AbstractNetworkClient {
         TokenDeleteTransaction tokenDissociateTransaction = new TokenDeleteTransaction()
                 .setTokenId(token)
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
-                .setTransactionMemo(getTransactionMemo("Delete token"));
+                .setTransactionMemo(getMemo("Delete token"));
 
         NetworkTransactionResponse networkTransactionResponse =
                 executeTransactionAndRetrieveReceipt(tokenDissociateTransaction,
@@ -504,7 +504,7 @@ public class TokenClient extends AbstractNetworkClient {
                 .setCustomFees(customFees)
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
                 .setTokenId(tokenId)
-                .setTransactionMemo(getTransactionMemo("Update token fee schedule"));
+                .setTransactionMemo(getMemo("Update token fee schedule"));
 
         NetworkTransactionResponse response = executeTransactionAndRetrieveReceipt(transaction,
                 KeyList.of(expandedAccountId.getPrivateKey()));

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TopicClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TopicClient.java
@@ -64,13 +64,13 @@ public class TopicClient extends AbstractNetworkClient {
     }
 
     public NetworkTransactionResponse createTopic(ExpandedAccountId adminAccount, PublicKey submitKey) {
-        String memo = "Create Topic";
+        String memo = getMemo("Create Topic");
         TopicCreateTransaction consensusTopicCreateTransaction = new TopicCreateTransaction()
                 .setAdminKey(adminAccount.getPublicKey())
                 .setAutoRenewAccountId(sdkClient.getExpandedOperatorAccountId().getAccountId())
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
-                .setTopicMemo(getMemo(memo))
-                .setTransactionMemo(getMemo(memo))
+                .setTopicMemo(memo)
+                .setTransactionMemo(memo)
                 .setAutoRenewPeriod(autoRenewPeriod); // INSUFFICIENT_TX_FEE, also unsupported
 
         if (submitKey != null) {
@@ -87,16 +87,16 @@ public class TopicClient extends AbstractNetworkClient {
     }
 
     public NetworkTransactionResponse updateTopic(TopicId topicId) {
-        String memo = "Update Topic";
+        String memo = getMemo("Update Topic");
         TopicUpdateTransaction consensusTopicUpdateTransaction = new TopicUpdateTransaction()
                 .setTopicId(topicId)
-                .setTopicMemo(getMemo(memo))
+                .setTopicMemo(memo)
                 .setAutoRenewPeriod(autoRenewPeriod)
                 .clearAdminKey()
                 .clearSubmitKey()
                 .clearAutoRenewAccountId()
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
-                .setTransactionMemo(getMemo(memo));
+                .setTransactionMemo(memo);
 
         NetworkTransactionResponse networkTransactionResponse =
                 executeTransactionAndRetrieveReceipt(consensusTopicUpdateTransaction);

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TopicClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TopicClient.java
@@ -69,8 +69,8 @@ public class TopicClient extends AbstractNetworkClient {
                 .setAdminKey(adminAccount.getPublicKey())
                 .setAutoRenewAccountId(sdkClient.getExpandedOperatorAccountId().getAccountId())
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
-                .setTopicMemo(getEntityMemo(memo))
-                .setTransactionMemo(getTransactionMemo(memo))
+                .setTopicMemo(getMemo(memo))
+                .setTransactionMemo(getMemo(memo))
                 .setAutoRenewPeriod(autoRenewPeriod); // INSUFFICIENT_TX_FEE, also unsupported
 
         if (submitKey != null) {
@@ -90,13 +90,13 @@ public class TopicClient extends AbstractNetworkClient {
         String memo = "Update Topic";
         TopicUpdateTransaction consensusTopicUpdateTransaction = new TopicUpdateTransaction()
                 .setTopicId(topicId)
-                .setTopicMemo(getEntityMemo(memo))
+                .setTopicMemo(getMemo(memo))
                 .setAutoRenewPeriod(autoRenewPeriod)
                 .clearAdminKey()
                 .clearSubmitKey()
                 .clearAutoRenewAccountId()
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
-                .setTransactionMemo(getTransactionMemo(memo));
+                .setTransactionMemo(getMemo(memo));
 
         NetworkTransactionResponse networkTransactionResponse =
                 executeTransactionAndRetrieveReceipt(consensusTopicUpdateTransaction);
@@ -109,7 +109,7 @@ public class TopicClient extends AbstractNetworkClient {
         TopicDeleteTransaction consensusTopicDeleteTransaction = new TopicDeleteTransaction()
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
                 .setTopicId(topicId)
-                .setTransactionMemo(getTransactionMemo("Delete Topic"));
+                .setTransactionMemo(getMemo("Delete Topic"));
 
         NetworkTransactionResponse networkTransactionResponse =
                 executeTransactionAndRetrieveReceipt(consensusTopicDeleteTransaction);
@@ -164,7 +164,7 @@ public class TopicClient extends AbstractNetworkClient {
         TopicMessageSubmitTransaction consensusMessageSubmitTransaction = new TopicMessageSubmitTransaction()
                 .setTopicId(topicId)
                 .setMessage(message)
-                .setTransactionMemo(getTransactionMemo("Publish topic message"));
+                .setTransactionMemo(getMemo("Publish topic message"));
 
         TransactionId transactionId = executeTransaction(consensusMessageSubmitTransaction, submitKeys);
 

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TopicClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TopicClient.java
@@ -64,13 +64,13 @@ public class TopicClient extends AbstractNetworkClient {
     }
 
     public NetworkTransactionResponse createTopic(ExpandedAccountId adminAccount, PublicKey submitKey) {
-        String memo = getMemo("Create Topic");
+        String memo = "Create Topic";
         TopicCreateTransaction consensusTopicCreateTransaction = new TopicCreateTransaction()
                 .setAdminKey(adminAccount.getPublicKey())
                 .setAutoRenewAccountId(sdkClient.getExpandedOperatorAccountId().getAccountId())
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
-                .setTopicMemo(memo)
-                .setTransactionMemo(memo)
+                .setTopicMemo(getEntityMemo(memo))
+                .setTransactionMemo(getTransactionMemo(memo))
                 .setAutoRenewPeriod(autoRenewPeriod); // INSUFFICIENT_TX_FEE, also unsupported
 
         if (submitKey != null) {
@@ -87,17 +87,16 @@ public class TopicClient extends AbstractNetworkClient {
     }
 
     public NetworkTransactionResponse updateTopic(TopicId topicId) {
-        String memo = getMemo("Update Topic");
+        String memo = "Update Topic";
         TopicUpdateTransaction consensusTopicUpdateTransaction = new TopicUpdateTransaction()
                 .setTopicId(topicId)
-                .setTopicMemo(memo)
+                .setTopicMemo(getEntityMemo(memo))
                 .setAutoRenewPeriod(autoRenewPeriod)
                 .clearAdminKey()
                 .clearSubmitKey()
-                .clearTopicMemo()
                 .clearAutoRenewAccountId()
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
-                .setTransactionMemo(memo);
+                .setTransactionMemo(getTransactionMemo(memo));
 
         NetworkTransactionResponse networkTransactionResponse =
                 executeTransactionAndRetrieveReceipt(consensusTopicUpdateTransaction);
@@ -110,7 +109,7 @@ public class TopicClient extends AbstractNetworkClient {
         TopicDeleteTransaction consensusTopicDeleteTransaction = new TopicDeleteTransaction()
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
                 .setTopicId(topicId)
-                .setTransactionMemo(getMemo("Delete Topic"));
+                .setTransactionMemo(getTransactionMemo("Delete Topic"));
 
         NetworkTransactionResponse networkTransactionResponse =
                 executeTransactionAndRetrieveReceipt(consensusTopicDeleteTransaction);
@@ -165,7 +164,7 @@ public class TopicClient extends AbstractNetworkClient {
         TopicMessageSubmitTransaction consensusMessageSubmitTransaction = new TopicMessageSubmitTransaction()
                 .setTopicId(topicId)
                 .setMessage(message)
-                .setTransactionMemo(getMemo("Publish topic message"));
+                .setTransactionMemo(getTransactionMemo("Publish topic message"));
 
         TransactionId transactionId = executeTransaction(consensusMessageSubmitTransaction, submitKeys);
 

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ContractFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ContractFeature.java
@@ -54,6 +54,7 @@ import com.hedera.mirror.test.e2e.acceptance.response.MirrorContractResponse;
 @Log4j2
 @Cucumber
 public class ContractFeature extends AbstractFeature {
+    private final static long maxFunctionGas = 1_000_000;
     private final ObjectMapper mapper = new ObjectMapper()
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
             .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
@@ -148,7 +149,7 @@ public class ContractFeature extends AbstractFeature {
         persistContractBytes(byteCode.replaceFirst("0x", ""));
         networkTransactionResponse = contractClient.createContract(
                 fileId,
-                80000,
+                maxFunctionGas,
                 initialBalance == 0 ? null : Hbar.fromTinybars(initialBalance),
                 null);
 
@@ -193,7 +194,7 @@ public class ContractFeature extends AbstractFeature {
     private void executeCreateChildTransaction(int transferAmount) {
         networkTransactionResponse = contractClient.executeContract(
                 contractId,
-                70000,
+                maxFunctionGas,
                 "createChild",
                 new ContractFunctionParameters()
                         .addUint256(BigInteger.valueOf(transferAmount)),

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ContractFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ContractFeature.java
@@ -148,7 +148,7 @@ public class ContractFeature extends AbstractFeature {
         persistContractBytes(byteCode.replaceFirst("0x", ""));
         networkTransactionResponse = contractClient.createContract(
                 fileId,
-                750000,
+                80000,
                 initialBalance == 0 ? null : Hbar.fromTinybars(initialBalance),
                 null);
 
@@ -193,7 +193,7 @@ public class ContractFeature extends AbstractFeature {
     private void executeCreateChildTransaction(int transferAmount) {
         networkTransactionResponse = contractClient.executeContract(
                 contractId,
-                67000,
+                70000,
                 "createChild",
                 new ContractFunctionParameters()
                         .addUint256(BigInteger.valueOf(transferAmount)),


### PR DESCRIPTION
Signed-off-by: Nana-EC <nana.essilfie-conduah@hedera.com>

**Description**:

Acceptance tests sometimes fail with insufficient gas error.

- Updated gas assignment for create and call transactions
- Update memo logic to cap at 100 bytes for entity and transaction memos

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
