### PR TITLE
Update Contract gas and Transaction memo set logic (0.45)

### DIFF
--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AbstractNetworkClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AbstractNetworkClient.java
@@ -23,6 +23,7 @@ package com.hedera.mirror.test.e2e.acceptance.client;
 import java.time.Instant;
 import lombok.Data;
 import lombok.SneakyThrows;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.retry.support.RetryTemplate;
@@ -42,6 +43,7 @@ import com.hedera.mirror.test.e2e.acceptance.response.NetworkTransactionResponse
 
 @Data
 public abstract class AbstractNetworkClient {
+    private static final int MEMO_BYTES_MAX_LENGTH = 100;
     protected final Client client;
     protected final Logger log = LogManager.getLogger(getClass());
     protected final SDKClient sdkClient;
@@ -140,7 +142,8 @@ public abstract class AbstractNetworkClient {
     }
 
     protected String getMemo(String message) {
-        // Try to keep short due to 100 byte entity memo limit
-        return String.format("Mirror Node acceptance test: %s %s", message, Instant.now());
+        String memo = String.format("Mirror Node acceptance test: %s %s", Instant.now(), message);
+        // Memos are capped at 100 bytes
+        return StringUtils.truncate(memo, MEMO_BYTES_MAX_LENGTH);
     }
 }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AccountClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AccountClient.java
@@ -128,7 +128,7 @@ public class AccountClient extends AbstractNetworkClient {
 
     public AccountCreateTransaction getAccountCreateTransaction(Hbar initialBalance, KeyList publicKeys,
                                                                 boolean receiverSigRequired, String customMemo) {
-        String memo = getMemo("Create Crypto Account " + customMemo);
+        String memo = getMemo(String.format("%s %s ", "Create Crypto Account", customMemo));
         return new AccountCreateTransaction()
                 .setInitialBalance(initialBalance)
                 // The only _required_ property here is `key`

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/ContractClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/ContractClient.java
@@ -70,6 +70,9 @@ public class ContractClient extends AbstractNetworkClient {
         ContractId contractId = networkTransactionResponse.getReceipt().contractId;
         log.debug("Created new contract {}", contractId);
 
+        TransactionRecord transactionRecord = getTransactionRecord(networkTransactionResponse.getTransactionId());
+        logContractFunctionResult("constructor", transactionRecord.contractFunctionResult);
+
         return networkTransactionResponse;
     }
 
@@ -116,11 +119,10 @@ public class ContractClient extends AbstractNetworkClient {
                                                       ContractFunctionParameters parameters, Hbar payableAmount) {
         log.debug("Call contract {}'s function {}", contractId, functionName);
 
-        String memo = getMemo("Execute contract");
         ContractExecuteTransaction contractExecuteTransaction = new ContractExecuteTransaction()
                 .setContractId(contractId)
                 .setGas(gas)
-                .setTransactionMemo(memo)
+                .setTransactionMemo(getMemo("Execute contract"))
                 .setMaxTransactionFee(Hbar.from(100));
 
         if (parameters == null) {
@@ -143,6 +145,10 @@ public class ContractClient extends AbstractNetworkClient {
     }
 
     private void logContractFunctionResult(String functionName, ContractFunctionResult contractFunctionResult) {
+        if (contractFunctionResult == null) {
+            return;
+        }
+
         log.trace("ContractFunctionResult for function {}, contractId: {}, gasUsed: {}, logCount: {}",
                 functionName,
                 contractFunctionResult.contractId,

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/FileClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/FileClient.java
@@ -82,11 +82,12 @@ public class FileClient extends AbstractNetworkClient {
     }
 
     public NetworkTransactionResponse appendFile(FileId fileId, byte[] byteCode) {
-        log.debug("Append file");
+        String memo = "Append file";
+        log.debug(memo);
         FileAppendTransaction fileAppendTransaction = new FileAppendTransaction()
                 .setFileId(fileId)
                 .setContents(byteCode)
-                .setTransactionMemo(getMemo("Append file"));
+                .setTransactionMemo(getMemo(memo));
 
         NetworkTransactionResponse networkTransactionResponse =
                 executeTransactionAndRetrieveReceipt(fileAppendTransaction);
@@ -96,11 +97,11 @@ public class FileClient extends AbstractNetworkClient {
     }
 
     public NetworkTransactionResponse deleteFile(FileId fileId) {
-        log.debug("Delete file");
-        String memo = getMemo("Delete file");
+        String memo = "Delete file";
+        log.debug(memo);
         FileDeleteTransaction fileUpdateTransaction = new FileDeleteTransaction()
                 .setFileId(fileId)
-                .setTransactionMemo(memo);
+                .setTransactionMemo(getMemo(memo));
 
         NetworkTransactionResponse networkTransactionResponse =
                 executeTransactionAndRetrieveReceipt(fileUpdateTransaction);

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TokenClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TokenClient.java
@@ -21,7 +21,6 @@ package com.hedera.mirror.test.e2e.acceptance.client;
  */
 
 import java.time.Duration;
-import java.time.Instant;
 import java.util.List;
 import javax.inject.Named;
 import lombok.SneakyThrows;
@@ -326,7 +325,6 @@ public class TokenClient extends AbstractNetworkClient {
     }
 
     private TransferTransaction getTransferTransaction() {
-        Instant refInstant = Instant.now();
         return new TransferTransaction()
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
                 .setTransactionMemo(getMemo("Transfer token"));

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TopicClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TopicClient.java
@@ -94,7 +94,6 @@ public class TopicClient extends AbstractNetworkClient {
                 .setAutoRenewPeriod(autoRenewPeriod)
                 .clearAdminKey()
                 .clearSubmitKey()
-                .clearTopicMemo()
                 .clearAutoRenewAccountId()
                 .setMaxTransactionFee(sdkClient.getMaxTransactionFee())
                 .setTransactionMemo(memo);

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ContractFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ContractFeature.java
@@ -54,6 +54,7 @@ import com.hedera.mirror.test.e2e.acceptance.response.MirrorContractResponse;
 @Log4j2
 @Cucumber
 public class ContractFeature extends AbstractFeature {
+    private final static long maxFunctionGas = 1_000_000;
     private final ObjectMapper mapper = new ObjectMapper()
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
             .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
@@ -148,7 +149,7 @@ public class ContractFeature extends AbstractFeature {
         persistContractBytes(byteCode.replaceFirst("0x", ""));
         networkTransactionResponse = contractClient.createContract(
                 fileId,
-                750000,
+                maxFunctionGas,
                 initialBalance == 0 ? null : Hbar.fromTinybars(initialBalance),
                 null);
 
@@ -193,7 +194,7 @@ public class ContractFeature extends AbstractFeature {
     private void executeCreateChildTransaction(int transferAmount) {
         networkTransactionResponse = contractClient.executeContract(
                 contractId,
-                67000,
+                maxFunctionGas,
                 "createChild",
                 new ContractFunctionParameters()
                         .addUint256(BigInteger.valueOf(transferAmount)),


### PR DESCRIPTION
**Description**:

Cherry pick of Acceptance tests sometimes fail with insufficient gas error.

- Updated gas assignment for create and call transactions
- Update memo logic to cap at 100 bytes for entity and transaction memos

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
