### PR TITLE
Enable TCP keepalive on JDBC connections

### DIFF
--- a/hedera-mirror-grpc/src/main/resources/application.yml
+++ b/hedera-mirror-grpc/src/main/resources/application.yml
@@ -19,7 +19,7 @@ logging:
   level:
     root: warn
     com.hedera.mirror.grpc: info
-    org.springframework.cloud.kubernetes.fabric8.config.Fabric8ConfigUtils: error
+    org.springframework.cloud.kubernetes.fabric8.config: error
     # io.grpc: debug
     # org.hibernate.SQL: debug
     # org.hibernate.type.descriptor.sql.BasicBinder: trace
@@ -62,7 +62,7 @@ spring:
   datasource:
     name: ${hedera.mirror.grpc.db.name}
     password: ${hedera.mirror.grpc.db.password}
-    url: jdbc:postgresql://${hedera.mirror.grpc.db.host}:${hedera.mirror.grpc.db.port}/${hedera.mirror.grpc.db.name}?sslmode=${hedera.mirror.grpc.db.sslMode}
+    url: jdbc:postgresql://${hedera.mirror.grpc.db.host}:${hedera.mirror.grpc.db.port}/${hedera.mirror.grpc.db.name}
     username: ${hedera.mirror.grpc.db.username}
     hikari:
       connection-timeout: 3000
@@ -70,6 +70,8 @@ spring:
         idle_in_transaction_session_timeout: "30000"
         lock_timeout: "10000"
         statement_timeout: "60000"
+        sslmode: ${hedera.mirror.grpc.db.sslMode}
+        tcpKeepAlive: true
       maximum-pool-size: 50
       minimum-idle: 4
       validation-timeout: 3000

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/addressbook/AddressBookServiceImpl.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/addressbook/AddressBookServiceImpl.java
@@ -107,6 +107,8 @@ public class AddressBookServiceImpl implements AddressBookService {
             return;
         }
 
+        log.info("Received an address book update: {}", fileData);
+
         // ensure address_book table is populated with latest addressBook prior to additions
         validateAndCompleteAddressBookList(fileData);
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/AbstractUpsertQueryGenerator.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/AbstractUpsertQueryGenerator.java
@@ -48,21 +48,14 @@ import org.springframework.util.ReflectionUtils;
 
 @RequiredArgsConstructor
 public abstract class AbstractUpsertQueryGenerator<T> implements UpsertQueryGenerator {
-    protected static final String EMPTY_STRING = "''";
+
+    private static final String EMPTY_STRING = "''";
     private static final String EMPTY_CLAUSE = "";
-    private static final String V1_DIRECTORY = "/v1";
-    private static final String V2_DIRECTORY = "/v2";
     private static final Comparator<DomainField> DOMAIN_FIELD_COMPARATOR = Comparator.comparing(DomainField::getName);
+
     protected final Logger log = LogManager.getLogger(getClass());
-    private final Class<T> metaModelClass = (Class<T>) new TypeToken<T>(getClass()) {
-    }.getRawType();
-    @Getter(lazy = true)
-    private final String insertQuery = generateInsertQuery();
+    private final Class<T> metaModelClass = (Class<T>) new TypeToken<T>(getClass()) { }.getRawType();
     private volatile Set<Field> attributes = null;
-    @Getter(lazy = true)
-    private final String updateQuery = generateUpdateQuery();
-    @Value("${spring.flyway.locations:v1}")
-    private String version;
 
     protected boolean isInsertOnly() {
         return false;
@@ -124,7 +117,8 @@ public abstract class AbstractUpsertQueryGenerator<T> implements UpsertQueryGene
         return Collections.emptySet();
     }
 
-    private String generateInsertQuery() {
+    @Override
+    public String getInsertQuery() {
         StringBuilder insertQueryBuilder = new StringBuilder(StringUtils.joinWith(
                 " ",
                 getCteForInsert(),
@@ -149,7 +143,8 @@ public abstract class AbstractUpsertQueryGenerator<T> implements UpsertQueryGene
         return insertQueryBuilder.toString();
     }
 
-    private String generateUpdateQuery() {
+    @Override
+    public String getUpdateQuery() {
         if (isInsertOnly()) {
             return EMPTY_CLAUSE;
         }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/UpsertQueryGeneratorFactory.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/UpsertQueryGeneratorFactory.java
@@ -80,7 +80,6 @@ public class UpsertQueryGeneratorFactory {
     }
 
     UpsertEntity createEntity(Class<?> domainClass) {
-        Table table = AnnotationUtils.findAnnotation(domainClass, Table.class);
         Upsertable upsertable = AnnotationUtils.findAnnotation(domainClass, Upsertable.class);
 
         if (upsertable == null) {
@@ -88,6 +87,7 @@ public class UpsertQueryGeneratorFactory {
         }
 
         EntityType<?> entityType = entityManager.getMetamodel().entity(domainClass);
+        Table table = AnnotationUtils.findAnnotation(domainClass, Table.class);
         String tableName = table != null ? table.name() : toSnakeCase(entityType.getName());
         Set<String> idAttributes = getIdAttributes(entityType);
         Set<UpsertColumn> upsertColumns = new TreeSet<>();

--- a/hedera-mirror-importer/src/main/resources/application.yml
+++ b/hedera-mirror-importer/src/main/resources/application.yml
@@ -18,7 +18,7 @@ logging:
     root: warn
     com.hedera.mirror.importer: info
     org.flywaydb.core.internal.command.DbMigrate: info
-    org.springframework.cloud.kubernetes.fabric8.config.Fabric8ConfigUtils: error
+    org.springframework.cloud.kubernetes.fabric8.config: error
     #org.hibernate.type.descriptor.sql.BasicBinder: trace
 management:
   endpoints:
@@ -68,14 +68,15 @@ spring:
   datasource:
     name: ${hedera.mirror.importer.db.name}
     password: ${hedera.mirror.importer.db.password}
-    url: jdbc:postgresql://${hedera.mirror.importer.db.host}:${hedera.mirror.importer.db.port}/${hedera.mirror.importer.db.name}
+    url: jdbc:postgresql://${hedera.mirror.importer.db.host}:${hedera.mirror.importer.db.port}/${hedera.mirror.importer.db.name}?tcpKeepAlive=true
     username: ${hedera.mirror.importer.db.username}
     hikari:
+      # Note: Flyway does not use Hikari so these properties are ignored. Use URL properties for Flyway instead.
       data-source-properties:
         #loggerLevel: TRACE
         logUnclosedConnections: true
         reWriteBatchedInserts: true
-      maximumPoolSize: 14 # recommended connections = ((core_count * 2) + effective_spindle_count), though somewhat outdated as we use SSDs
+      maximumPoolSize: 14
   flyway:
     baselineOnMigrate: true
     connectRetries: 20

--- a/hedera-mirror-monitor/src/main/resources/application.yml
+++ b/hedera-mirror-monitor/src/main/resources/application.yml
@@ -24,7 +24,7 @@ logging:
     com.hedera.mirror.monitor: info
     com.hedera.hashgraph.sdk.Executable: error
     com.hedera.hashgraph.sdk.TransactionReceiptQuery: error
-    org.springframework.cloud.kubernetes.fabric8.config.Fabric8ConfigUtils: error
+    org.springframework.cloud.kubernetes.fabric8.config: error
 management:
   endpoints:
     web:


### PR DESCRIPTION
**Description**:
- Enable TCP keepalive on JDBC connections
- Suppress Spring Cloud Kubernetes warnings about restarting watch connection

**Related issue(s)**:

Fixes #2895 

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
