### PR TITLE
Fix cleanup.sql causing stream reset to timeout

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -158,7 +158,7 @@ sudo vi /usr/etc/hedera-mirror-importer/application.yml
 3 ) Wipe Database
 
 ```console
-scp hedera-mirror-importer/src/main/resources/db/scripts/cleanup.sql user@server:~
+scp hedera-mirror-importer/src/main/resources/db/scripts/drop.sql user@server:~
 ssh user@server
 psql -h dbhost -d mirror_node -U mirror_node -f drop.sql
 ```

--- a/hedera-mirror-importer/src/test/resources/db/scripts/cleanup.sql
+++ b/hedera-mirror-importer/src/test/resources/db/scripts/cleanup.sql
@@ -7,7 +7,7 @@ do
                  from information_schema.tables
                  where table_schema = ''public'' and table_name !~ ''.*(flyway|transaction_type|citus_|_\d+).*'' and table_type <> ''VIEW''
             loop
-                execute format(''truncate %s restart identity cascade'', t.table_name);
+                execute format(''delete from %s'', t.table_name);
             end loop;
     end;
 ';

--- a/hedera-mirror-rest/__tests__/integrationDbOps.js
+++ b/hedera-mirror-rest/__tests__/integrationDbOps.js
@@ -198,7 +198,7 @@ const cleanupSql = fs.readFileSync(
     '..',
     'hedera-mirror-importer',
     'src',
-    'main',
+    'test',
     'resources',
     'db',
     'scripts',

--- a/hedera-mirror-rosetta/test/db/db.go
+++ b/hedera-mirror-rosetta/test/db/db.go
@@ -44,7 +44,7 @@ import (
 )
 
 const (
-	dbCleanupScript = "hedera-mirror-importer/src/main/resources/db/scripts/cleanup.sql"
+	dbCleanupScript = "hedera-mirror-importer/src/test/resources/db/scripts/cleanup.sql"
 	dbMigrationPath = "hedera-mirror-importer/src/main/resources/db/migration/v1"
 	dbName          = "mirror_node"
 	dbUsername      = "mirror_rosetta_integration"


### PR DESCRIPTION
**Description**:
- Fix `cleanup.sql` slow performance causing stream reset to timeout

**Related issue(s)**:

Fixes #2920

**Notes for reviewer**:
Hopefully CitusDB addresses the slow truncate performance by the time we need to re-consolidate the two `cleanup.sql`

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
