### PR TITLE
Disabling hedera.mirror.rest.response.compression

### DIFF
--- a/hedera-mirror-rest/config/application.yml
+++ b/hedera-mirror-rest/config/application.yml
@@ -96,7 +96,7 @@ hedera:
         swaggerUIPath: 'docs'
       port: 5551
       response:
-        compression: true
+        compression: false
         includeHostInLink: false
         limit:
           default: 25


### PR DESCRIPTION
**Description**:
Disable compression on the REST API by updating the following config key and setting it to false: hedera.mirror.rest.response.compression

This PR modifies ... in order to support ...
* Disable compression on REST API
* hedera.mirror.rest.response.compression  to "False"
 
-->

**Related issue(s)**: Updates to REST service for mirrornodes #1920

Fixes #

**Notes for reviewer**:
Switching over to HAproxy http compression

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
