### PR TITLE
Fix rosetta-cli configuration typo

### DIFF
--- a/hedera-mirror-rosetta/scripts/validation/demo/validation.json
+++ b/hedera-mirror-rosetta/scripts/validation/demo/validation.json
@@ -13,7 +13,7 @@
   "tip_delay": 300,
   "data": {
     "reconciliation_disabled": false,
-    "inactive_discrepency_search_disabled": false,
+    "inactive_discrepancy_search_disabled": false,
     "balance_tracking_disabled": false,
     "bootstrap_balances": "./data_genesis_balances.json",
     "end_conditions": {

--- a/hedera-mirror-rosetta/scripts/validation/testnet/validation.json
+++ b/hedera-mirror-rosetta/scripts/validation/testnet/validation.json
@@ -25,7 +25,7 @@
   },
   "data": {
     "reconciliation_disabled": false,
-    "inactive_discrepency_search_disabled": false,
+    "inactive_discrepancy_search_disabled": false,
     "balance_tracking_disabled": false,
     "bootstrap_balances": "./data_genesis_balances.json",
     "end_conditions": {

--- a/hedera-mirror-rosetta/test/bdd-client/README.md
+++ b/hedera-mirror-rosetta/test/bdd-client/README.md
@@ -88,6 +88,6 @@ The following table lists the available properties along with their default valu
 | `hedera.mirror.rosetta.test.server.dataRetry.max`       | 20                    | The max retries of a data request                                          |
 | `hedera.mirror.rosetta.test.server.offlineUrl`          | http://localhost:5701 | The url of the offline rosetta server                                      |
 | `hedera.mirror.rosetta.test.server.onlineUrl`           | http://localhost:5700 | The url of the online rosetta server                                       |
-| `hedera.mirror.rosetta.test.server.httpTimeout`         | 15s                   | The timeout of an http request sent to the rosetta server                  |
+| `hedera.mirror.rosetta.test.server.httpTimeout`         | 25s                   | The timeout of an http request sent to the rosetta server                  |
 | `hedera.mirror.rosetta.test.server.submitRetry.backOff` | 200ms                 | The amount of time to wait between submit request retries                  |
 | `hedera.mirror.rosetta.test.server.submitRetry.max`     | 5                     | The max retries of a submit request                                        |

--- a/hedera-mirror-rosetta/test/bdd-client/config.go
+++ b/hedera-mirror-rosetta/test/bdd-client/config.go
@@ -52,7 +52,7 @@ hedera:
              max: 20
            offlineUrl: http://localhost:5701
            onlineUrl: http://localhost:5700
-           httpTimeout: 15s
+           httpTimeout: 25s
            submitRetry:
              backOff: 200ms
              max: 5


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR fixes the typo in rosetta-cli configuration and tune some bdd-test client params.

- Fix the typo in `inactive_discrepency_search_disabled` in rosetta-cli configuration
- Increase bdd test client httpTimeout to 25s

**Related issue(s)**:

Fixes #2966

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

coinbase just released `rosetta-cli` v0.7.3 which has a fix for the configuration param name typo, so our github workflow is broken.

Also set the bdd test client httpTimeout to 25s since I saw sometime if a node proxy is unhealthy, it takes ~17s to submit a transaction. This should make the bdd test in github workflow more robust against proxy issues.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
