### PR TITLE
Timeout chart workflow

### DIFF
--- a/.github/ct.yaml
+++ b/.github/ct.yaml
@@ -2,8 +2,6 @@ chart-repos:
   - bitnami=https://charts.bitnami.com/bitnami
   - loki=https://grafana.github.io/helm-charts
   - prometheus=https://prometheus-community.github.io/helm-charts
-  - timescaledb=https://raw.githubusercontent.com/timescale/timescaledb-kubernetes/master/charts/repo/
   - traefik=https://helm.traefik.io/traefik
 check-version-increment: false
 validate-maintainers: false
-

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -70,19 +70,19 @@ jobs:
 
       - name: Import GPG Key
         id: gpg_importer
-        uses: crazy-max/ghaction-import-gpg@v3.1.0
+        uses: crazy-max/ghaction-import-gpg@v4.1.0
         with:
-          git-commit-gpgsign: true
-          git-tag-gpgsign: true
-          git-user-signingkey: true
-          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          git_commit_gpgsign: true
+          git_tag_gpgsign: true
+          git_user_signingkey: true
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Install JDK
         uses: actions/setup-java@v2
         with:
           cache: 'maven'
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 11
 
       - name: Create and Switch to Release Branch
@@ -161,19 +161,19 @@ jobs:
 
       - name: Import GPG Key
         id: gpg_importer
-        uses: crazy-max/ghaction-import-gpg@v3.1.0
+        uses: crazy-max/ghaction-import-gpg@v4.1.0
         with:
-          git-commit-gpgsign: true
-          git-tag-gpgsign: true
-          git-user-signingkey: true
-          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          git_commit_gpgsign: true
+          git_tag_gpgsign: true
+          git_user_signingkey: true
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Install JDK
         uses: actions/setup-java@v2
         with:
           cache: 'maven'
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 11
 
       - name: Reset main to release branch

--- a/.github/workflows/charts.yml
+++ b/.github/workflows/charts.yml
@@ -34,10 +34,11 @@ jobs:
         run: ./mvnw install -pl hedera-mirror-grpc,hedera-mirror-importer,hedera-mirror-rest,hedera-mirror-rosetta --also-make -Dskip.npm -DskipTests -Ddocker.tag.version=${IMAGE_TAG}
 
       - name: Create k3d cluster
+        timeout-minutes: 3
         run: |
           set -ex
           curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash
-          k3d cluster create mirror --agents 1 --timeout 5m --image rancher/k3s:v1.20.10-k3s1
+          k3d cluster create mirror --agents 1 --timeout 5m --image rancher/k3s:v1.21.7-k3s1
           k3d image import -c mirror "gcr.io/mirrornode/hedera-mirror-grpc:${IMAGE_TAG}"
           k3d image import -c mirror "gcr.io/mirrornode/hedera-mirror-importer:${IMAGE_TAG}"
           k3d image import -c mirror "gcr.io/mirrornode/hedera-mirror-rest:${IMAGE_TAG}"

--- a/.github/workflows/grpc-api.yml
+++ b/.github/workflows/grpc-api.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           cache: 'maven'
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 11
 
       - name: Maven verify

--- a/.github/workflows/importer.yml
+++ b/.github/workflows/importer.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           cache: 'maven'
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 11
 
       - name: Maven verify

--- a/.github/workflows/monitor.yml
+++ b/.github/workflows/monitor.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           cache: 'maven'
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 11
 
       - name: Maven verify

--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           cache: 'maven'
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 11
 
       - name: Login to Google Container Registry

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           cache: 'maven'
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 11
 
       - name: Login to Google Container Registry

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           cache: 'maven'
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 11
 
       - name: Vulnerability check
@@ -39,7 +39,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           cache: 'maven'
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 11
 
       - name: Cache SonarCloud dependencies

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           cache: 'maven'
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 11
 
       - name: Maven package


### PR DESCRIPTION
**Description**:
- Bump Kubernetes from v1.20 to v1.21 in workflow
- Change workflows from the deprecated [AdoptOpenJDK](https://adoptopenjdk.net/) to [Eclipse Temurin](https://adoptium.net/)
- Fix charts workflow from taking an hour to timeout due to https://github.com/rancher/k3d/issues/878

**Related issue(s)**:

**Notes for reviewer**:
Permanent fix for charts workflow will come when https://github.com/rancher/k3d/issues/878 is released in v5.2.2

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
