### PR TITLE
Update GCP Marketplace release with log4j2 fix (0.42)

### DIFF
--- a/charts/marketplace/gcp/schema.yaml
+++ b/charts/marketplace/gcp/schema.yaml
@@ -17,22 +17,12 @@ x-google-marketplace:
   publishedVersion: "$TAG"
   publishedVersionMetadata:
     releaseNote: >-
-      v0.37 brings many new features to the mirror node marketplace application since v0.27.
-      This upgrade includes breaking changes. Please refer to <a href"https://github.com/hashgraph/hedera-mirror-node/tree/main/charts/marketplace/gcp#v037">v0.37 Upgrade</a> for additional upgrade steps.
+      v0.37.1 fixes a critical vulnerability in the Log4j2 library. It is recommended you upgrade immediately.
 
-      The largest feature introduced since v0.13 is that of the Hedera Token Service (HTS) which allows for the creation and management of custom tokens on the Hedera network.
-      Token entity types are now ingested to the DB and can be queried through new REST APIs.
-      Support for the new v5 <a href="https://docs.hedera.com/guides/docs/record-and-event-stream-file-formats">Record and Event Stream File Formats</a> introduced in HAPI v0.11.0 was added.
-      Topic fragmentation support was added to the ingestion process as well as exposed through the appropriate REST and gRPC APIs.
-      State Proof alpha REST API was added to support Mirror node users who want to verify the cryptographic claims of submitted transactions for themselves.
-      <a href"https://swagger.io/specification">OpenAPI 3.0</a> specification support was added to the REST API along with a docs endpoint for up to date documentation and REST API curl support.
-      DB and process memory optimizations were made to improve the ingestion rate with at least 2x-3x improvements.
-      `startDate` and `endDate` properties were added to enable Mirror node users the ability to specify a time range for data processing.
-
-      Many more features went into the release, for detailed release notes refer to <a href="https://github.com/hashgraph/hedera-mirror-node/releases">hedera-mirror-node releases</a>.
+      For detailed release notes refer to <a href="https://github.com/hashgraph/hedera-mirror-node/releases">hedera-mirror-node releases</a>.
     # releaseTypes - Feature | BugFix | Security
     releaseTypes:
-      - Feature
+      - Security
     # If "recommended" is "true", users using older releases are encouraged
     # to update as soon as possible. This is useful if, for example, this release
     # fixes a critical issue.
@@ -81,7 +71,7 @@ properties:
   namespace:
     type: string
     x-google-marketplace:
-      type: NAMESPACE  
+      type: NAMESPACE
   db.owner.password:
     type: string
     description: The password used by the db owner to connect to the database for schema migrations

--- a/charts/marketplace/gcp/schema.yaml
+++ b/charts/marketplace/gcp/schema.yaml
@@ -17,7 +17,7 @@ x-google-marketplace:
   publishedVersion: "$TAG"
   publishedVersionMetadata:
     releaseNote: >-
-      v0.37.1 fixes a critical vulnerability in the Log4j2 library. It is recommended you upgrade immediately.
+      v0.42.1 fixes a critical vulnerability in the Log4j2 library. It is recommended you upgrade immediately.
 
       For detailed release notes refer to <a href="https://github.com/hashgraph/hedera-mirror-node/releases">hedera-mirror-node releases</a>.
     # releaseTypes - Feature | BugFix | Security

--- a/hedera-mirror-grpc/src/main/resources/log4j2.xml
+++ b/hedera-mirror-grpc/src/main/resources/log4j2.xml
@@ -4,7 +4,8 @@
         <Console name="console" target="SYSTEM_OUT">
             <PatternLayout>
                 <alwaysWriteExceptions>false</alwaysWriteExceptions>
-                <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}{GMT-6} %p %t %c{1.} %m %ex{separator(\\n)}%n</pattern>
+                <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}{GMT-6} %p %t %c{1.} %m{nolookups} %ex{separator(\\n)}%n
+                </pattern>
             </PatternLayout>
         </Console>
     </Appenders>

--- a/hedera-mirror-grpc/src/test/resources/log4j2-test.xml
+++ b/hedera-mirror-grpc/src/test/resources/log4j2-test.xml
@@ -4,7 +4,7 @@
         <Console name="console" target="SYSTEM_OUT">
             <PatternLayout>
                 <alwaysWriteExceptions>false</alwaysWriteExceptions>
-                <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}{GMT-6} %p %t %c{1.} %m %ex{short}%n</pattern>
+                <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}{GMT-6} %p %t %c{1.} %m{nolookups} %ex{short}%n</pattern>
             </PatternLayout>
         </Console>
     </Appenders>

--- a/hedera-mirror-importer/src/main/resources/log4j2.xml
+++ b/hedera-mirror-importer/src/main/resources/log4j2.xml
@@ -4,7 +4,8 @@
         <Console name="console" target="SYSTEM_OUT">
             <PatternLayout>
                 <alwaysWriteExceptions>false</alwaysWriteExceptions>
-                <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}{GMT-6} %p %t %c{1.} %m %ex{separator(\\n)}%n</pattern>
+                <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}{GMT-6} %p %t %c{1.} %m{nolookups} %ex{separator(\\n)}%n
+                </pattern>
             </PatternLayout>
         </Console>
     </Appenders>

--- a/hedera-mirror-importer/src/test/resources/log4j2-test.xml
+++ b/hedera-mirror-importer/src/test/resources/log4j2-test.xml
@@ -4,7 +4,7 @@
         <Console name="console" target="SYSTEM_OUT">
             <PatternLayout>
                 <alwaysWriteExceptions>false</alwaysWriteExceptions>
-                <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}{GMT-6} %p %t %c{1.} %m %ex{short}%n</pattern>
+                <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}{GMT-6} %p %t %c{1.} %m{nolookups} %ex{short}%n</pattern>
             </PatternLayout>
         </Console>
     </Appenders>

--- a/hedera-mirror-monitor/src/main/resources/log4j2.xml
+++ b/hedera-mirror-monitor/src/main/resources/log4j2.xml
@@ -4,7 +4,8 @@
         <Console name="console" target="SYSTEM_OUT">
             <PatternLayout>
                 <alwaysWriteExceptions>false</alwaysWriteExceptions>
-                <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}{GMT-6} %p %t %c{1.} %m %ex{separator(\\n)}%n</pattern>
+                <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}{GMT-6} %p %t %c{1.} %m{nolookups} %ex{separator(\\n)}%n
+                </pattern>
             </PatternLayout>
         </Console>
     </Appenders>

--- a/hedera-mirror-monitor/src/test/resources/log4j2-test.xml
+++ b/hedera-mirror-monitor/src/test/resources/log4j2-test.xml
@@ -4,7 +4,7 @@
         <Console name="console" target="SYSTEM_OUT">
             <PatternLayout>
                 <alwaysWriteExceptions>false</alwaysWriteExceptions>
-                <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}{GMT-6} %p %t %c{1.} %m %ex{short}%n</pattern>
+                <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}{GMT-6} %p %t %c{1.} %m{nolookups} %ex{short}%n</pattern>
             </PatternLayout>
         </Console>
     </Appenders>

--- a/hedera-mirror-test/src/test/resources/log4j2.xml
+++ b/hedera-mirror-test/src/test/resources/log4j2.xml
@@ -4,7 +4,7 @@
         <Console name="console" target="SYSTEM_OUT">
             <PatternLayout>
                 <alwaysWriteExceptions>false</alwaysWriteExceptions>
-                <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}{GMT-6} %p %t %c{1.} %m %ex{short}%n</pattern>
+                <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}{GMT-6} %p %t %c{1.} %m{nolookups} %ex{short}%n</pattern>
             </PatternLayout>
         </Console>
     </Appenders>

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
         <java.version>11</java.version>
         <javax.version>1</javax.version>
         <jib.version>3.1.4</jib.version>
+        <log4j2.version>2.15.0</log4j2.version>
         <micrometer-jvm-extras.version>0.2.2</micrometer-jvm-extras.version>
         <msgpack.version>0.9.0</msgpack.version>
         <protobuf.version>3.18.0</protobuf.version>


### PR DESCRIPTION
**Description**:

* Bump log4j2 to 2.15.0
* Disable log4j2 message lookups
* Update release notes with appropriate features and description


**Related issue(s)**:

Fixes #2996 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
