### PR TITLE
Fix account balance file ingestion performance issue

### DIFF
--- a/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.51.0__drop_account_balance_index.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.51.0__drop_account_balance_index.sql
@@ -1,0 +1,5 @@
+-------------------
+-- Drop the index account_balance__account_timestamp
+-------------------
+
+drop index if exists account_balance__account_timestamp;

--- a/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.3__index_init.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.3__index_init.sql
@@ -12,8 +12,6 @@ create index if not exists assessed_custom_fee__consensus_timestamp
 -- account_balance
 alter table account_balance
     add constraint account_balance__pk primary key (consensus_timestamp, account_id);
-create index if not exists account_balance__account_timestamp
-    on account_balance (account_id desc, consensus_timestamp desc);
 
 -- account_balance_file
 alter table account_balance_file


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

This PR fixes the account balance file ingestion performance issue.

- Drop index `account_balance__account_timestamp`
- Rewrite public key only query in accounts.js to use the primary key

**Related issue(s)**:

Fixes #2967

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

The index causes huge performance issue for testnet at the size of around 1.3 million account balance entries in an account balance file.

Unlike the primary key (consensus_timestamp, account_id), updating the `account_balance__account_timestamp` index for a balance file would touch far more random pages than the pk.

This causes up to 3 minutes ingestion time for the first 200,000 entries and tens of seconds for the remaining batches. In our cloudsql primary and replica configuration, this also causes huge replication lag every 15 minutes when processing account balance file.

Removing the index reduces the per batch insert time to less than 1 second most of the time:

```
2021-12-13T11:19:54.522-0600 INFO scheduling-4 c.h.m.i.p.b.BatchInserter Copied 200000 rows to account_balance table in 817.5 ms
2021-12-13T11:20:19.341-0600 INFO scheduling-4 c.h.m.i.p.b.BatchInserter Copied 200000 rows to account_balance table in 710.1 ms
2021-12-13T11:20:21.334-0600 INFO scheduling-4 c.h.m.i.p.b.BatchInserter Copied 200000 rows to account_balance table in 851.0 ms
2021-12-13T11:20:23.219-0600 INFO scheduling-4 c.h.m.i.p.b.BatchInserter Copied 200000 rows to account_balance table in 828.8 ms
2021-12-13T11:20:25.064-0600 INFO scheduling-4 c.h.m.i.p.b.BatchInserter Copied 200000 rows to account_balance table in 762.7 ms
2021-12-13T11:20:26.701-0600 INFO scheduling-4 c.h.m.i.p.b.BatchInserter Copied 200000 rows to account_balance table in 642.6 ms
2021-12-13T11:20:27.087-0600 INFO scheduling-4 c.h.m.i.p.b.BatchInserter Copied 78388 rows to account_balance table in 324.5 ms
```

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
