### PR TITLE
Bump log4j2 from 2.15.0 to 2.16.0

### DIFF
--- a/hedera-mirror-grpc/src/main/resources/log4j2.xml
+++ b/hedera-mirror-grpc/src/main/resources/log4j2.xml
@@ -4,7 +4,7 @@
         <Console name="console" target="SYSTEM_OUT">
             <PatternLayout>
                 <alwaysWriteExceptions>false</alwaysWriteExceptions>
-                <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}{GMT-6} %p %t %c{1.} %m{nolookups} %ex{separator(\\n)}%n
+                <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}{GMT-6} %p %t %c{1.} %m %ex{separator(\\n)}%n
                 </pattern>
             </PatternLayout>
         </Console>

--- a/hedera-mirror-grpc/src/test/resources/log4j2-test.xml
+++ b/hedera-mirror-grpc/src/test/resources/log4j2-test.xml
@@ -4,7 +4,7 @@
         <Console name="console" target="SYSTEM_OUT">
             <PatternLayout>
                 <alwaysWriteExceptions>false</alwaysWriteExceptions>
-                <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}{GMT-6} %p %t %c{1.} %m{nolookups} %ex{short}%n</pattern>
+                <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}{GMT-6} %p %t %c{1.} %m %ex{short}%n</pattern>
             </PatternLayout>
         </Console>
     </Appenders>

--- a/hedera-mirror-importer/src/main/resources/log4j2.xml
+++ b/hedera-mirror-importer/src/main/resources/log4j2.xml
@@ -4,8 +4,7 @@
         <Console name="console" target="SYSTEM_OUT">
             <PatternLayout>
                 <alwaysWriteExceptions>false</alwaysWriteExceptions>
-                <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}{GMT-6} %p %t %c{1.} %m{nolookups} %ex{separator(\\n)}%n
-                </pattern>
+                <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}{GMT-6} %p %t %c{1.} %m %ex{separator(\\n)}%n</pattern>
             </PatternLayout>
         </Console>
     </Appenders>

--- a/hedera-mirror-importer/src/test/resources/log4j2-test.xml
+++ b/hedera-mirror-importer/src/test/resources/log4j2-test.xml
@@ -4,7 +4,7 @@
         <Console name="console" target="SYSTEM_OUT">
             <PatternLayout>
                 <alwaysWriteExceptions>false</alwaysWriteExceptions>
-                <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}{GMT-6} %p %t %c{1.} %m{nolookups} %ex{short}%n</pattern>
+                <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}{GMT-6} %p %t %c{1.} %m %ex{short}%n</pattern>
             </PatternLayout>
         </Console>
     </Appenders>

--- a/hedera-mirror-monitor/src/main/resources/log4j2.xml
+++ b/hedera-mirror-monitor/src/main/resources/log4j2.xml
@@ -4,7 +4,7 @@
         <Console name="console" target="SYSTEM_OUT">
             <PatternLayout>
                 <alwaysWriteExceptions>false</alwaysWriteExceptions>
-                <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}{GMT-6} %p %t %c{1.} %m{nolookups} %ex{separator(\\n)}%n
+                <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}{GMT-6} %p %t %c{1.} %m %ex{separator(\\n)}%n
                 </pattern>
             </PatternLayout>
         </Console>

--- a/hedera-mirror-monitor/src/test/resources/log4j2-test.xml
+++ b/hedera-mirror-monitor/src/test/resources/log4j2-test.xml
@@ -4,7 +4,7 @@
         <Console name="console" target="SYSTEM_OUT">
             <PatternLayout>
                 <alwaysWriteExceptions>false</alwaysWriteExceptions>
-                <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}{GMT-6} %p %t %c{1.} %m{nolookups} %ex{short}%n</pattern>
+                <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}{GMT-6} %p %t %c{1.} %m %ex{short}%n</pattern>
             </PatternLayout>
         </Console>
     </Appenders>

--- a/hedera-mirror-test/src/test/resources/log4j2.xml
+++ b/hedera-mirror-test/src/test/resources/log4j2.xml
@@ -4,7 +4,7 @@
         <Console name="console" target="SYSTEM_OUT">
             <PatternLayout>
                 <alwaysWriteExceptions>false</alwaysWriteExceptions>
-                <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}{GMT-6} %p %t %c{1.} %m{nolookups} %ex{short}%n</pattern>
+                <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}{GMT-6} %p %t %c{1.} %m %ex{short}%n</pattern>
             </PatternLayout>
         </Console>
     </Appenders>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <java.version>11</java.version>
         <javax.version>1</javax.version>
         <jib.version>3.1.4</jib.version>
-        <log4j2.version>2.15.0</log4j2.version>
+        <log4j2.version>2.16.0</log4j2.version>
         <micrometer-jvm-extras.version>0.2.2</micrometer-jvm-extras.version>
         <msgpack.version>0.9.0</msgpack.version>
         <protobuf.version>3.19.1</protobuf.version>


### PR DESCRIPTION
**Description**:
* Bump log4j2 from 2.15.0 to 2.16.0
* Remove `{nolookups}` option from `log4j2.xml` to avoid warnings that it's not implemented

**Related issue(s)**:


**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
