### PR TITLE
Bump swagger-ui-express from 4.2.0 to 4.3.0 (0.46)

### DIFF
--- a/hedera-mirror-rest/package-lock.json
+++ b/hedera-mirror-rest/package-lock.json
@@ -63,7 +63,7 @@
         "qs": "^6.10.1",
         "quick-lru": "^5.1.1",
         "swagger-stats": "^0.99.2",
-        "swagger-ui-express": "^4.2.0"
+        "swagger-ui-express": "^4.3.0"
       },
       "devDependencies": {
         "app-root-path": "^3.0.0",
@@ -10594,18 +10594,18 @@
       }
     },
     "node_modules/swagger-ui-dist": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.1.2.tgz",
-      "integrity": "sha512-Pj960coj9L0nAQPE1vgBzHulKGPNw1ifn/1GTIv/mlV9V3PoRM0uTcE0uhTiizx6aHg+vnFFmbA2J1gjFekOaQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.1.3.tgz",
+      "integrity": "sha512-WvfPSfAAMlE/sKS6YkW47nX/hA7StmhYnAHc6wWCXNL0oclwLj6UXv0hQCkLnDgvebi0MEV40SJJpVjKUgH1IQ==",
       "inBundle": true
     },
     "node_modules/swagger-ui-express": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.2.0.tgz",
-      "integrity": "sha512-znrHTwh9UpvsjqgWopA4noIet7mi7UGuIYZ465YfUDKQ5Dpas0jxnkfUKCo+0aB17YCBv26AhIjiQYDV4uvJFA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.3.0.tgz",
+      "integrity": "sha512-jN46SEEe9EoXa3ZgZoKgnSF6z0w3tnM1yqhO4Y+Q4iZVc8JOQB960EZpIAz6rNROrDApVDwcMHR0mhlnc/5Omw==",
       "inBundle": true,
       "dependencies": {
-        "swagger-ui-dist": ">3.52.5"
+        "swagger-ui-dist": ">=4.1.3"
       },
       "engines": {
         "node": ">= v0.10.32"
@@ -19677,16 +19677,16 @@
       }
     },
     "swagger-ui-dist": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.1.2.tgz",
-      "integrity": "sha512-Pj960coj9L0nAQPE1vgBzHulKGPNw1ifn/1GTIv/mlV9V3PoRM0uTcE0uhTiizx6aHg+vnFFmbA2J1gjFekOaQ=="
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.1.3.tgz",
+      "integrity": "sha512-WvfPSfAAMlE/sKS6YkW47nX/hA7StmhYnAHc6wWCXNL0oclwLj6UXv0hQCkLnDgvebi0MEV40SJJpVjKUgH1IQ=="
     },
     "swagger-ui-express": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.2.0.tgz",
-      "integrity": "sha512-znrHTwh9UpvsjqgWopA4noIet7mi7UGuIYZ465YfUDKQ5Dpas0jxnkfUKCo+0aB17YCBv26AhIjiQYDV4uvJFA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.3.0.tgz",
+      "integrity": "sha512-jN46SEEe9EoXa3ZgZoKgnSF6z0w3tnM1yqhO4Y+Q4iZVc8JOQB960EZpIAz6rNROrDApVDwcMHR0mhlnc/5Omw==",
       "requires": {
-        "swagger-ui-dist": ">3.52.5"
+        "swagger-ui-dist": ">=4.1.3"
       }
     },
     "symbol-tree": {

--- a/hedera-mirror-rest/package.json
+++ b/hedera-mirror-rest/package.json
@@ -42,7 +42,7 @@
     "qs": "^6.10.1",
     "quick-lru": "^5.1.1",
     "swagger-stats": "^0.99.2",
-    "swagger-ui-express": "^4.2.0"
+    "swagger-ui-express": "^4.3.0"
   },
   "bundledDependencies": [
     "asn1js",


### PR DESCRIPTION
**Description**:
Bump swagger-ui-express from 4.2.0 to 4.3.0

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
