### PR TITLE
Fix accounts query with balance only query param performance regression

### DIFF
--- a/hedera-mirror-rest/accounts.js
+++ b/hedera-mirror-rest/accounts.js
@@ -150,7 +150,7 @@ const getEntityBalanceQuery = (
   order,
   pubKeyQuery
 ) => {
-  const balanceJoinConditions = `ab.account_id = e.id and ${latestBalanceFilter}`;
+  const balanceJoinConditions = ['ab.account_id = e.id'];
   const balanceWhereConditions = [balanceQuery.query];
   let entityIdField = 'id'; // use 'id' from account / contract for inner and left outer joins
   let joinType = '';
@@ -162,13 +162,15 @@ const getEntityBalanceQuery = (
   // account_balance table
   if (balanceQuery.query && pubKeyQuery.query) {
     joinType = 'inner';
+    balanceJoinConditions.push(latestBalanceFilter);
     params = [entityAccountQuery.params, pubKeyQuery.params, balanceQuery.params];
   } else if (pubKeyQuery.query) {
     joinType = 'left outer';
+    balanceJoinConditions.push(latestBalanceFilter);
     params = [entityAccountQuery.params, pubKeyQuery.params];
   } else if (balanceQuery.query) {
     entityIdField = 'account_id';
-    balanceWhereConditions.push(balanceAccountQuery.query);
+    balanceWhereConditions.push(balanceAccountQuery.query, latestBalanceFilter);
     joinType = 'right outer';
     // no entity id filter needed for account / contract for right outer join
     params = [balanceQuery.params, balanceAccountQuery.params];
@@ -189,7 +191,7 @@ const getEntityBalanceQuery = (
       select ${entityIdField} id,${entityAndBalanceFields}
       from (${accountContractQuery}) e
       ${joinType} join account_balance ab
-        on ${balanceJoinConditions}
+        on ${balanceJoinConditions.join(' and ')}
       ${whereClause}
       order by ${entityIdField} ${order}
       ${limitQuery}

--- a/hedera-mirror-rest/api/v1/openapi.yml
+++ b/hedera-mirror-rest/api/v1/openapi.yml
@@ -57,7 +57,7 @@ paths:
       operationId: listAccountBalances
       parameters:
         - $ref: '#/components/parameters/accountIdQueryParam'
-        - $ref: '#/components/parameters/balanceQueryParam'
+        - $ref: '#/components/parameters/accountBalanceQueryParam'
         - $ref: '#/components/parameters/orderQueryParamDesc'
         - $ref: '#/components/parameters/accountPublicKeyQueryParam'
         - $ref: '#/components/parameters/timestampQueryParam'
@@ -567,7 +567,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/entityIdPathParam'
         - $ref: '#/components/parameters/accountIdQueryParam'
-        - $ref: '#/components/parameters/balanceQueryParam'
+        - $ref: '#/components/parameters/accountBalanceQueryParam'
         - $ref: '#/components/parameters/orderQueryParam'
         - $ref: '#/components/parameters/accountPublicKeyQueryParam'
         - $ref: '#/components/parameters/timestampQueryParam'


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
Rewrite the query to fix the performance regression.

**Related issue(s)**:

Relates to #3015

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
When there's only balance query params, e.g., `account.balance=gte:0`, the first CTE will be

```
...
entity e
right outer join account_balance ab
  on ab.account_id = e.id and ab.consensus_timestamp = (select max(consensus_timestamp) from account_balance)
where ab.balance > 0   
```

however, pg planner will always do a sequential scan on `account_balance` with filter `balance > 0`.

In order to utlize the `account_balance_pk` index, the query has to be rewritten as:

```
....
entity e
right outer join account_balance ab
  on ab.account_id = e.id
where ab.balance > 0 and ab.consensus_timestamp = (select max(consensus_timestamp) from account_balance)
``` 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
