### PR TITLE
Bump json-schema from 0.2.3 to 0.4.0

### DIFF
--- a/hedera-mirror-rest/package-lock.json
+++ b/hedera-mirror-rest/package-lock.json
@@ -22,6 +22,7 @@
         "@godaddy/terminus",
         "@hashgraph/proto",
         "js-yaml",
+        "json-schema",
         "lodash",
         "log4js",
         "long",
@@ -52,6 +53,7 @@
         "extend": "^3.0.2",
         "ip-anonymize": "^0.1.0",
         "js-yaml": "^4.1.0",
+        "json-schema": "^0.4.0",
         "lodash": "^4.17.21",
         "log4js": "^6.3.0",
         "long": "^5.2.0",
@@ -7361,9 +7363,9 @@
       "dev": true
     },
     "node_modules/json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "inBundle": true
     },
     "node_modules/json-schema-ref-parser": {
@@ -7431,6 +7433,12 @@
         "json-schema": "0.2.3",
         "verror": "1.10.0"
       }
+    },
+    "node_modules/jsprim/node_modules/json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "inBundle": true
     },
     "node_modules/just-extend": {
       "version": "4.2.1",
@@ -17393,9 +17401,9 @@
       "dev": true
     },
     "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
     },
     "json-schema-ref-parser": {
       "version": "9.0.9",
@@ -17447,6 +17455,13 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
+      },
+      "dependencies": {
+        "json-schema": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+        }
       }
     },
     "just-extend": {

--- a/hedera-mirror-rest/package.json
+++ b/hedera-mirror-rest/package.json
@@ -15,6 +15,9 @@
     "test": "jest --testPathPattern='__tests__/.*\\.test\\.js'"
   },
   "author": "Hedera Mirror Node Team",
+  "comments": {
+    "dependencies": "json-schema is a transitive dependency but we explicitly mark it as a dependency to bring in a non-vulnerable version"
+  },
   "license": "Apache-2.0",
   "dependencies": {
     "@awaitjs/express": "^0.9.0",
@@ -31,6 +34,7 @@
     "extend": "^3.0.2",
     "ip-anonymize": "^0.1.0",
     "js-yaml": "^4.1.0",
+    "json-schema": "^0.4.0",
     "lodash": "^4.17.21",
     "log4js": "^6.3.0",
     "long": "^5.2.0",
@@ -59,6 +63,7 @@
     "@godaddy/terminus",
     "@hashgraph/proto",
     "js-yaml",
+    "json-schema",
     "lodash",
     "log4js",
     "long",


### PR DESCRIPTION
**Description**:
Bump json-schema from 0.2.3 to 0.4.0

**Related issue(s)**:

**Notes for reviewer**:
```
$ npm ls json-schema
@hashgraph/mirror-rest@0.47.0-SNAPSHOT
└─┬ swagger-stats@0.99.2
  └─┬ request@2.88.2
    └─┬ http-signature@1.2.0
      └─┬ jsprim@1.4.1
        └── json-schema@0.2.3
```

`json-schema` is a transitive dependency brought in by `swagger-stats`. Unfortunately, `request` transitive dependency is deprecated and won't have any future updates. So the only way to bring in an updated version is to explicitly depend upon `json-schema`.

Since you can't add comments to JSON, I add an improvised `comments` section about `json-schema` being a transitive dependency as a note to our future selves.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
