### PR TITLE
Increase wait time in rosetta-api github workflow

### DIFF
--- a/.github/workflows/rosetta-api.yml
+++ b/.github/workflows/rosetta-api.yml
@@ -149,6 +149,8 @@ jobs:
 
       - name: Wait for Mirror Node to start syncing
         run: ./scripts/wait-for-mirror-node.sh
+        env:
+          MAX_WAIT_SECONDS: 240
 
       - name: Get Genesis Account Balances
         run: ./scripts/validation/get-genesis-balance.sh testnet


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

This PR increases the wait time for rosetta server readiness (genesis balance file ingrestion) in rosetta-api
github workflow from the default of 120s to 240s. 

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
Testnet account balance files are getting bigger thus taking longer to process. 120s looks to be short and it's causing workflow failure frequently.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
