### PR TITLE
Downgrade k3d to 5.1.0 to workaround image import timeout

### DIFF
--- a/.github/workflows/charts.yml
+++ b/.github/workflows/charts.yml
@@ -37,7 +37,7 @@ jobs:
         timeout-minutes: 3
         run: |
           set -ex
-          curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash
+          curl -s https://raw.githubusercontent.com/rancher/k3d/v5.1.0/install.sh | bash
           k3d cluster create mirror --agents 1 --timeout 5m --image rancher/k3s:v1.21.7-k3s1
           k3d image import -c mirror "gcr.io/mirrornode/hedera-mirror-grpc:${IMAGE_TAG}"
           k3d image import -c mirror "gcr.io/mirrornode/hedera-mirror-importer:${IMAGE_TAG}"


### PR DESCRIPTION
**Description**:
Downgrade k3d to 5.1.0 to workaround image import timeout

**Related issue(s)**:


**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
