### PR TITLE
Fix test image build

### DIFF
--- a/hedera-mirror-test/src/main/resources/Dockerfile
+++ b/hedera-mirror-test/src/main/resources/Dockerfile
@@ -14,6 +14,7 @@ COPY hedera-mirror-protobuf/pom.xml hedera-mirror-protobuf/pom.xml
 COPY hedera-mirror-rest/pom.xml hedera-mirror-rest/pom.xml
 COPY hedera-mirror-rosetta/pom.xml hedera-mirror-rosetta/pom.xml
 COPY hedera-mirror-test/ hedera-mirror-test/
+COPY hedera-mirror-web3/ hedera-mirror-web3/
 
 # Ensure all maven dependecies are placed ahead of test run
 RUN ./mvnw clean integration-test -pl hedera-mirror-test --also-make -P=acceptance-tests -Dcucumber.filter.tags=none \


### PR DESCRIPTION
**Description**:
Add the missing `hedera-mirror-web3` module to the `hedera-mirror-test` Dockerfile to fix test image failing to build

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
