### PR TITLE
Default maven to --also-make

### DIFF
--- a/.github/workflows/charts.yml
+++ b/.github/workflows/charts.yml
@@ -31,7 +31,7 @@ jobs:
           fetch-depth: 0
 
       - name: Build images
-        run: ./mvnw install -pl hedera-mirror-grpc,hedera-mirror-importer,hedera-mirror-rest,hedera-mirror-rosetta --also-make -Dskip.npm -DskipTests -Ddocker.tag.version=${IMAGE_TAG}
+        run: ./mvnw install -pl hedera-mirror-grpc,hedera-mirror-importer,hedera-mirror-rest,hedera-mirror-rosetta -Dskip.npm -DskipTests -Ddocker.tag.version=${IMAGE_TAG}
 
       - name: Create k3d cluster
         timeout-minutes: 3

--- a/.github/workflows/grpc-api.yml
+++ b/.github/workflows/grpc-api.yml
@@ -33,7 +33,7 @@ jobs:
           java-version: 11
 
       - name: Maven verify
-        run: ./mvnw verify -pl "${MODULE}" --also-make -Dspring.profiles.active=${{ matrix.schema }}
+        run: ./mvnw verify -pl "${MODULE}" -Dspring.profiles.active=${{ matrix.schema }}
         working-directory: .
 
       - name: Upload coverage report

--- a/.github/workflows/importer.yml
+++ b/.github/workflows/importer.yml
@@ -33,7 +33,7 @@ jobs:
           java-version: 11
 
       - name: Maven verify
-        run: ./mvnw verify -pl "${MODULE}" --also-make -Dspring.profiles.active=${{ matrix.schema }}
+        run: ./mvnw verify -pl "${MODULE}" -Dspring.profiles.active=${{ matrix.schema }}
         working-directory: .
 
       - name: Upload coverage report

--- a/.github/workflows/monitor.yml
+++ b/.github/workflows/monitor.yml
@@ -30,7 +30,7 @@ jobs:
           java-version: 11
 
       - name: Maven verify
-        run: ./mvnw verify -pl "${MODULE}" --also-make -Dtest='!com.hedera.mirror.importer.**' -DfailIfNoTests=false
+        run: ./mvnw verify -pl "${MODULE}" -Dtest='!com.hedera.mirror.importer.**' -DfailIfNoTests=false
         working-directory: .
 
       - name: Upload coverage report

--- a/.github/workflows/rest-api.yml
+++ b/.github/workflows/rest-api.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Test
         env:
           MIRROR_NODE_SCHEMA: ${{ matrix.schema}}
-        run: ./mvnw verify -pl "${MODULE}" --also-make
+        run: ./mvnw verify -pl "${MODULE}"
         working-directory: .
 
       - name: Rename artifact

--- a/.github/workflows/rosetta-api.yml
+++ b/.github/workflows/rosetta-api.yml
@@ -30,7 +30,7 @@ jobs:
           restore-keys: ${{ runner.os }}-go-
 
       - name: Maven verify
-        run: ./mvnw verify -pl "${MODULE}" --also-make
+        run: ./mvnw verify -pl "${MODULE}"
         working-directory: .
         env:
           GOPATH: ~/go
@@ -84,7 +84,7 @@ jobs:
     needs: image
     strategy:
       matrix:
-        online-only: ['true', 'false']
+        online-only: [ 'true', 'false' ]
     timeout-minutes: 15
     env:
       OFFLINE_URL: http://localhost:5700

--- a/.github/workflows/web3.yml
+++ b/.github/workflows/web3.yml
@@ -33,7 +33,7 @@ jobs:
           java-version: 11
 
       - name: Maven verify
-        run: ./mvnw verify -pl "${MODULE}" --also-make -Dspring.profiles.active=${{ matrix.schema }}
+        run: ./mvnw verify -pl "${MODULE}" -Dspring.profiles.active=${{ matrix.schema }}
         working-directory: .
 
       - name: Upload coverage report

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,1 +1,1 @@
---threads 1C --batch-mode --no-transfer-progress -Dmaven.artifact.threads=10 -Dmaven.wagon.provider.http=httpclient -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.count=5 -Dmaven.wagon.rto=10000
+--also-make --batch-mode --no-transfer-progress --show-version --threads 1C -Dmaven.artifact.threads=10 -Dmaven.wagon.provider.http=httpclient -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.count=5 -Dmaven.wagon.rto=10000

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.2/apache-maven-3.8.2-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.4/apache-maven-3.8.4-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar

--- a/hedera-mirror-rosetta/build/Dockerfile
+++ b/hedera-mirror-rosetta/build/Dockerfile
@@ -9,8 +9,7 @@ ARG GIT_REF=main
 RUN apt-get update && apt-get install -y gcc git openjdk-11-jdk-headless
 RUN git clone -b ${GIT_REF} --depth 1 https://github.com/hashgraph/hedera-mirror-node
 WORKDIR /hedera-mirror-node
-RUN ./mvnw --batch-mode --no-transfer-progress --show-version clean package -Dmaven.test.skip \
-    -pl hedera-mirror-importer,hedera-mirror-rosetta --also-make
+RUN ./mvnw clean package -DskipTests -pl hedera-mirror-importer,hedera-mirror-rosetta
 WORKDIR /app
 RUN mkdir importer rosetta scripts \
     && cp /hedera-mirror-node/hedera-mirror-rosetta/build/* . \

--- a/hedera-mirror-test/src/main/resources/Dockerfile
+++ b/hedera-mirror-test/src/main/resources/Dockerfile
@@ -17,7 +17,7 @@ COPY hedera-mirror-test/ hedera-mirror-test/
 COPY hedera-mirror-web3/ hedera-mirror-web3/
 
 # Ensure all maven dependecies are placed ahead of test run
-RUN ./mvnw clean integration-test -pl hedera-mirror-test --also-make -P=acceptance-tests -Dcucumber.filter.tags=none \
+RUN ./mvnw clean integration-test -pl hedera-mirror-test -P=acceptance-tests -Dcucumber.filter.tags=none \
   --no-transfer-progress --batch-mode
 
 ENTRYPOINT ./mvnw integration-test -pl hedera-mirror-test -P=acceptance-tests -Dcucumber.filter.tags=${cucumberFlags} -e


### PR DESCRIPTION
**Description**:
* Change maven wrapper to use `--also-make` by default to simplify build commands
* Bump maven version to 3.8.4

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
