### PR TITLE
Fix auto created account alias not cached

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/CacheConfiguration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/CacheConfiguration.java
@@ -55,7 +55,7 @@ public class CacheConfiguration {
     CacheManager cacheManagerAlias() {
         CaffeineCacheManager caffeineCacheManager = new CaffeineCacheManager();
         caffeineCacheManager.setCacheSpecification("maximumSize=100000,expireAfterWrite=30m");
-        return new TransactionAwareCacheManagerProxy(caffeineCacheManager);
+        return caffeineCacheManager;
     }
 
     @Bean(KEY_GENERATOR_ALIAS)

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/AbstractEntityRecordItemListenerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/AbstractEntityRecordItemListenerTest.java
@@ -29,9 +29,7 @@ import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.hederahashgraph.api.proto.java.AccountAmount;
 import com.hederahashgraph.api.proto.java.AccountID;
-import com.hederahashgraph.api.proto.java.ContractID;
 import com.hederahashgraph.api.proto.java.Duration;
-import com.hederahashgraph.api.proto.java.FileID;
 import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.SignatureMap;
@@ -168,24 +166,6 @@ public abstract class AbstractEntityRecordItemListenerTest extends IntegrationTe
                 .containsExactly(dbEntity.getShard(), dbEntity.getRealm(), dbEntity.getNum());
         assertThat(dbEntity.getType())
                 .isEqualTo(EntityType.ACCOUNT);
-    }
-
-    protected final void assertFile(FileID fileId, Entity dbEntity) {
-        assertThat(fileId)
-                .isNotEqualTo(FileID.getDefaultInstance())
-                .extracting(FileID::getShardNum, FileID::getRealmNum, FileID::getFileNum)
-                .containsExactly(dbEntity.getShard(), dbEntity.getRealm(), dbEntity.getNum());
-        assertThat(dbEntity.getType())
-                .isEqualTo(EntityType.FILE);
-    }
-
-    protected final void assertContract(ContractID contractId, Contract dbEntity) {
-        assertThat(contractId)
-                .isNotEqualTo(ContractID.getDefaultInstance())
-                .extracting(ContractID::getShardNum, ContractID::getRealmNum, ContractID::getContractNum)
-                .containsExactly(dbEntity.getShard(), dbEntity.getRealm(), dbEntity.getNum());
-        assertThat(dbEntity.getType())
-                .isEqualTo(EntityType.CONTRACT);
     }
 
     protected void parseRecordItemAndCommit(RecordItem recordItem) {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerCryptoTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerCryptoTest.java
@@ -65,18 +65,10 @@ import com.hedera.mirror.importer.util.Utility;
 class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItemListenerTest {
     private static final long INITIAL_BALANCE = 1000L;
     private static final AccountID accountId1 = AccountID.newBuilder().setAccountNum(1001).build();
-    private static final AccountID accountId2 = AccountID.newBuilder().setAccountNum(1002).build();
-    private static final String ALIAS_KEY_1 =
-            "0a2212200aa8e21064c61eab86e2a9c164565b4e7a9a4146106e0a6cd03a8c395a110fff";
-    private static final String ALIAS_KEY_2 =
-            "0a3312200aa8e21064c61eab86e2a9c164565b4e7a9a4146106e0a6cd03a8c395a110e92";
-    private static final long[] additionalTransfers = {5000, 6000};
-    private static final ByteString[] additionalAliasTransfers = {
-            ByteString.copyFromUtf8(ALIAS_KEY_1),
-            ByteString.copyFromUtf8(ALIAS_KEY_2)
-    };
+    private static final long[] additionalTransfers = {5000};
     private static final long[] additionalTransferAmounts = {1001, 1002};
-    private static final long[] additionalAliasTransferAmounts = {1003, 1004};
+    private static final ByteString ALIAS_KEY = ByteString.copyFromUtf8(
+            "0a2212200aa8e21064c61eab86e2a9c164565b4e7a9a4146106e0a6cd03a8c395a110fff");
 
     @BeforeEach
     void before() {
@@ -169,9 +161,8 @@ class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItemListene
         Transaction transaction = cryptoCreateTransaction();
         TransactionBody transactionBody = getTransactionBody(transaction);
         CryptoCreateTransactionBody cryptoCreateTransactionBody = transactionBody.getCryptoCreateAccount();
-        ByteString mirrorAlias = ByteString.copyFromUtf8(ALIAS_KEY_1);
         TransactionRecord record = buildTransactionRecord(
-                recordBuilder -> recordBuilder.setAlias(mirrorAlias).getReceiptBuilder().setAccountID(accountId1),
+                recordBuilder -> recordBuilder.setAlias(ALIAS_KEY).getReceiptBuilder().setAccountID(accountId1),
                 transactionBody,
                 ResponseCodeEnum.SUCCESS.getNumber());
 
@@ -189,10 +180,9 @@ class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItemListene
                 () -> assertEquals(5, cryptoTransferRepository.count()),
                 () -> assertCryptoTransaction(transactionBody, record),
                 () -> assertCryptoEntity(cryptoCreateTransactionBody, record.getConsensusTimestamp()),
-                () -> assertEquals(mirrorAlias, record.getAlias()),
                 () -> assertEquals(cryptoCreateTransactionBody.getInitialBalance(), dbTransaction.getInitialBalance()),
                 () -> assertThat(initialBalanceTransfer).isPresent(),
-                () -> assertThat(entityRepository.findByAlias(mirrorAlias.toByteArray())).get()
+                () -> assertThat(entityRepository.findByAlias(ALIAS_KEY.toByteArray())).get()
                         .isEqualTo(accountEntityId.getId())
         );
     }
@@ -481,7 +471,7 @@ class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItemListene
         assertAll(
                 () -> assertEquals(1, transactionRepository.count()),
                 () -> assertEntities(),
-                () -> assertEquals(5, cryptoTransferRepository.count()),
+                () -> assertEquals(4, cryptoTransferRepository.count()),
                 () -> assertTransactionAndRecord(transactionBody, record)
         );
     }
@@ -529,44 +519,35 @@ class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItemListene
         entityProperties.getPersist().setCryptoTransferAmounts(true);
         entityProperties.getPersist().setNonFeeTransfers(true);
 
-        // setup alias creates
+        // Crypto create alias account
         Transaction accountCreateTransaction = cryptoCreateTransaction();
         TransactionBody accountCreateTransactionBody = getTransactionBody(accountCreateTransaction);
-        TransactionRecord record1 = buildTransactionRecord(
-                recordBuilder -> recordBuilder.setAlias(ByteString.copyFromUtf8(ALIAS_KEY_1)).getReceiptBuilder()
-                        .setAccountID(accountId1),
-                accountCreateTransactionBody,
-                ResponseCodeEnum.SUCCESS.getNumber());
-        TransactionRecord record2 = buildTransactionRecord(
-                recordBuilder -> recordBuilder.setAlias(ByteString.copyFromUtf8(ALIAS_KEY_2)).getReceiptBuilder()
-                        .setAccountID(accountId2),
+        TransactionRecord recordCreate = buildTransactionRecord(
+                recordBuilder -> recordBuilder.setAlias(ALIAS_KEY).getReceiptBuilder().setAccountID(accountId1),
                 accountCreateTransactionBody,
                 ResponseCodeEnum.SUCCESS.getNumber());
 
-        parseRecordItemsAndCommit(List.of(
-                new RecordItem(accountCreateTransaction, record1), new RecordItem(accountCreateTransaction, record2)));
-
-        // make the transfers to alias accounts
-        Transaction transaction = cryptoTransferTransactionUsingAlias();
+        // Crypto transfer to alias account
+        Transaction transaction = buildTransaction(builder -> builder.getCryptoTransferBuilder().getTransfersBuilder()
+                .addAccountAmounts(accountAliasAmount(ALIAS_KEY, 1003)));
         TransactionBody transactionBody = getTransactionBody(transaction);
-        TransactionRecord record = transactionRecordSuccess(transactionBody);
+        TransactionRecord recordTransfer = transactionRecordSuccess(transactionBody);
 
-        parseRecordItemAndCommit(new RecordItem(transaction, record));
+        parseRecordItemsAndCommit(List.of(new RecordItem(accountCreateTransaction, recordCreate),
+                new RecordItem(transaction, recordTransfer)));
 
         assertAll(
-                () -> assertEquals(3, transactionRepository.count()),
-                () -> assertEntities(EntityId.of(accountId1), EntityId.of(accountId2)),
-                () -> assertEquals(13, cryptoTransferRepository
-                        .count()), // ((5 transfers * 3 transactions) - 2 skipped alisa transfers in record test logic
-                () -> assertEquals(additionalTransfers.length + additionalTransfers.length +
-                        additionalAliasTransfers.length, nonFeeTransferRepository
-                        .count()), // 2 non fee transfers * 3 transactions
-                () -> assertTransactionAndRecord(transactionBody, record),
+                () -> assertEquals(2, transactionRepository.count()),
+                () -> assertEntities(EntityId.of(accountId1)),
+                () -> assertEquals(8, cryptoTransferRepository.count()),
+                () -> assertEquals(additionalTransfers.length + additionalTransfers.length + 1,
+                        nonFeeTransferRepository.count()), // 2 non fee transfers * 2 transactions
+                () -> assertTransactionAndRecord(transactionBody, recordTransfer),
                 () -> assertThat(nonFeeTransferRepository.findAll())
                         .extracting(NonFeeTransfer::getId)
                         .extracting(NonFeeTransfer.Id::getEntityId)
                         .extracting(EntityId::getEntityNum)
-                        .contains(accountId1.getAccountNum(), accountId2.getAccountNum())
+                        .contains(accountId1.getAccountNum())
         );
     }
 
@@ -683,16 +664,6 @@ class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItemListene
             for (int i = 0; i < additionalTransfers.length; i++) {
                 builder.getCryptoTransferBuilder().getTransfersBuilder()
                         .addAccountAmounts(accountAmount(additionalTransfers[i], additionalTransferAmounts[i]));
-            }
-        });
-    }
-
-    private Transaction cryptoTransferTransactionUsingAlias() {
-        return buildTransaction(builder -> {
-            for (int i = 0; i < additionalTransfers.length; i++) {
-                builder.getCryptoTransferBuilder().getTransfersBuilder()
-                        .addAccountAmounts(accountAliasAmount(additionalAliasTransfers[i],
-                                additionalAliasTransferAmounts[i]));
             }
         });
     }

--- a/pom.xml
+++ b/pom.xml
@@ -73,9 +73,11 @@
         <java.version>11</java.version>
         <javax.version>1</javax.version>
         <jib.version>3.1.4</jib.version>
-        <log4j2.version>2.17.0</log4j2.version>
+        <logback.version>1.2.9</logback.version> <!-- Temporarily added to address a vulnerability -->
+        <log4j2.version>2.17.0</log4j2.version> <!-- Temporarily added to address a vulnerability -->
         <micrometer-jvm-extras.version>0.2.2</micrometer-jvm-extras.version>
         <msgpack.version>0.9.0</msgpack.version>
+        <netty.version>4.1.72.Final</netty.version> <!-- Temporarily added to address a vulnerability -->
         <protobuf.version>3.19.1</protobuf.version>
         <release.version>0.48.0-SNAPSHOT</release.version> <!-- Used to replace release versions in all files -->
         <release.chartVersion>0.35.0-SNAPSHOT</release.chartVersion>

--- a/suppressions.xml
+++ b/suppressions.xml
@@ -39,8 +39,8 @@
         <cve>CVE-2020-8570</cve>
     </suppress>
     <suppress>
-        <notes>Scan shows it's using 4.1.52 but dependency:tree shows only unaffected 4.1.59 in use</notes>
-        <packageUrl regex="true">^pkg:maven/io\.netty/netty\-.*@4\.1\.52\.Final$</packageUrl>
+        <notes>Conflates netty-tcnative-classes version with netty</notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty\-tcnative\-classes.*$</packageUrl>
         <cpe>cpe:/a:netty:netty</cpe>
     </suppress>
     <suppress>


### PR DESCRIPTION
**Description**:
* Bump logback from 1.2.7 to 1.2.9
* Bump netty from 4.1.70.Final to 4.1.72.Final
* Fix auto created account alias not cached until after record file commit

**Related issue(s)**:

Fixes #3056

**Notes for reviewer**:
- Crypto transfer could not find the alias in either db or cache since neither would be populated until after commit.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
