### PR TITLE
Downgrade Flyway from 8.0.4 to 7.15.0 for PostgreSQL 9.6 compatibility (0.47)

### DIFF
--- a/hedera-mirror-grpc/src/test/resources/config/bootstrap.yml
+++ b/hedera-mirror-grpc/src/test/resources/config/bootstrap.yml
@@ -1,7 +1,7 @@
 embedded:
   postgresql:
     enabled: true
-    docker-image: postgres:13.5-alpine
+    docker-image: postgres:9.6-alpine
   redis:
     docker-image: redis:6.2.3-alpine
 spring:

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/MirrorBaseJavaMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/MirrorBaseJavaMigration.java
@@ -33,8 +33,11 @@ public abstract class MirrorBaseJavaMigration implements JavaMigration {
 
     protected final Logger log = LogManager.getLogger(getClass());
 
-    @Override
     public boolean isBaselineMigration() {
+        return false;
+    }
+
+    public boolean isStateScript() {
         return false;
     }
 

--- a/hedera-mirror-importer/src/test/resources/config/bootstrap.yml
+++ b/hedera-mirror-importer/src/test/resources/config/bootstrap.yml
@@ -5,6 +5,6 @@ embedded:
       # so it is enabled only for those tests.
       enabled: false
   postgresql:
-    docker-image: postgres:13.5-alpine
+    docker-image: postgres:9.6-alpine
   redis:
     docker-image: redis:6.2.3-alpine

--- a/hedera-mirror-rest/__tests__/integrationDbOps.js
+++ b/hedera-mirror-rest/__tests__/integrationDbOps.js
@@ -45,7 +45,7 @@ const dbAdminPassword = process.env.POSTGRES_PASSWORD || crypto.randomBytes(16).
 const v1SchemaConfigs = {
   docker: {
     imageName: 'postgres',
-    tagName: '13.5-alpine',
+    tagName: '9.6-alpine',
   },
   flyway: {
     baselineVersion: '0',
@@ -152,7 +152,7 @@ const flywayMigrate = async (dbSessionConfig) => {
       "url": "jdbc:postgresql://${dbSessionConfig.host}:${dbSessionConfig.port}/${dbSessionConfig.name}",
       "user": "${dbAdminUser}"
     },
-    "version": "8.0.4",
+    "version": "7.15.0",
     "downloads": {
       "storageDirectory": "${flywayDataPath}"
     }

--- a/hedera-mirror-rosetta/test/db/db.go
+++ b/hedera-mirror-rosetta/test/db/db.go
@@ -209,7 +209,7 @@ func createPostgresDb(pool *dockertest.Pool, network *dockertest.Network) (*dock
 	options := &dockertest.RunOptions{
 		Name:       getDbHostname(network.Network),
 		Repository: "postgres",
-		Tag:        "13",
+		Tag:        "9.6-alpine",
 		Env:        env,
 		Networks:   []*dockertest.Network{network},
 	}
@@ -232,7 +232,7 @@ func runFlywayMigration(pool *dockertest.Pool, network *dockertest.Network, para
 	// run the container with tty and entrypoint "bin/sh" so it will stay alive in background
 	options := &dockertest.RunOptions{
 		Repository: "flyway/flyway",
-		Tag:        "8.0.4-alpine",
+		Tag:        "7.15.0-alpine",
 		Entrypoint: []string{"/bin/sh"},
 		Networks:   []*dockertest.Network{network},
 		Mounts:     []string{migrationPath + ":/flyway/sql"},

--- a/hedera-mirror-web3/src/test/resources/bootstrap.yml
+++ b/hedera-mirror-web3/src/test/resources/bootstrap.yml
@@ -1,7 +1,7 @@
 embedded:
   postgresql:
     enabled: true
-    docker-image: postgres:13.5-alpine
+    docker-image: postgres:9.6-alpine
 spring:
   flyway:
     baselineVersion: 0

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
         <docker.resources>${project.build.directory}/container</docker.resources>
         <docker.tag.version>${release.version}</docker.tag.version>
         <embedded.testcontainers.version>2.0.18</embedded.testcontainers.version>
+        <flyway.version>7.15.0</flyway.version>
         <git-commit-id-plugin.version>4.0.4</git-commit-id-plugin.version>
         <grpc-spring-boot.version>2.11.0.RELEASE</grpc-spring-boot.version>
         <grpc.version>1.43.0</grpc.version>


### PR DESCRIPTION
**Description**:
Cherry pick of https://github.com/hashgraph/hedera-mirror-node/pull/3054 to 0.47

**Related issue(s)**:


**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
