### PR TITLE
Fix auto created account alias not cached (0.46)

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/CacheConfiguration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/CacheConfiguration.java
@@ -55,7 +55,7 @@ public class CacheConfiguration {
     CacheManager cacheManagerAlias() {
         CaffeineCacheManager caffeineCacheManager = new CaffeineCacheManager();
         caffeineCacheManager.setCacheSpecification("maximumSize=100000,expireAfterWrite=30m");
-        return new TransactionAwareCacheManagerProxy(caffeineCacheManager);
+        return caffeineCacheManager;
     }
 
     @Bean(KEY_GENERATOR_ALIAS)

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/AbstractEntityRecordItemListenerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/AbstractEntityRecordItemListenerTest.java
@@ -29,9 +29,7 @@ import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.hederahashgraph.api.proto.java.AccountAmount;
 import com.hederahashgraph.api.proto.java.AccountID;
-import com.hederahashgraph.api.proto.java.ContractID;
 import com.hederahashgraph.api.proto.java.Duration;
-import com.hederahashgraph.api.proto.java.FileID;
 import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.SignatureMap;
@@ -168,24 +166,6 @@ public abstract class AbstractEntityRecordItemListenerTest extends IntegrationTe
                 .containsExactly(dbEntity.getShard(), dbEntity.getRealm(), dbEntity.getNum());
         assertThat(dbEntity.getType())
                 .isEqualTo(EntityType.ACCOUNT);
-    }
-
-    protected final void assertFile(FileID fileId, Entity dbEntity) {
-        assertThat(fileId)
-                .isNotEqualTo(FileID.getDefaultInstance())
-                .extracting(FileID::getShardNum, FileID::getRealmNum, FileID::getFileNum)
-                .containsExactly(dbEntity.getShard(), dbEntity.getRealm(), dbEntity.getNum());
-        assertThat(dbEntity.getType())
-                .isEqualTo(EntityType.FILE);
-    }
-
-    protected final void assertContract(ContractID contractId, Contract dbEntity) {
-        assertThat(contractId)
-                .isNotEqualTo(ContractID.getDefaultInstance())
-                .extracting(ContractID::getShardNum, ContractID::getRealmNum, ContractID::getContractNum)
-                .containsExactly(dbEntity.getShard(), dbEntity.getRealm(), dbEntity.getNum());
-        assertThat(dbEntity.getType())
-                .isEqualTo(EntityType.CONTRACT);
     }
 
     protected void parseRecordItemAndCommit(RecordItem recordItem) {

--- a/pom.xml
+++ b/pom.xml
@@ -72,9 +72,11 @@
         <java.version>11</java.version>
         <javax.version>1</javax.version>
         <jib.version>3.1.4</jib.version>
-        <log4j2.version>2.15.0</log4j2.version>
+        <logback.version>1.2.9</logback.version> <!-- Temporarily added to address a vulnerability -->
+        <log4j2.version>2.17.0</log4j2.version> <!-- Temporarily added to address a vulnerability -->
         <micrometer-jvm-extras.version>0.2.2</micrometer-jvm-extras.version>
         <msgpack.version>0.9.0</msgpack.version>
+        <netty.version>4.1.72.Final</netty.version> <!-- Temporarily added to address a vulnerability -->
         <protobuf.version>3.19.1</protobuf.version>
         <release.version>0.46.1</release.version> <!-- Used to replace release versions in all files -->
         <release.chartVersion>0.33.1</release.chartVersion>

--- a/suppressions.xml
+++ b/suppressions.xml
@@ -39,8 +39,8 @@
         <cve>CVE-2020-8570</cve>
     </suppress>
     <suppress>
-        <notes>Scan shows it's using 4.1.52 but dependency:tree shows only unaffected 4.1.59 in use</notes>
-        <packageUrl regex="true">^pkg:maven/io\.netty/netty\-.*@4\.1\.52\.Final$</packageUrl>
+        <notes>Conflates netty-tcnative-classes version with netty</notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty\-tcnative\-classes.*$</packageUrl>
         <cpe>cpe:/a:netty:netty</cpe>
     </suppress>
 </suppressions>


### PR DESCRIPTION
**Description**:
Cherry pick of https://github.com/hashgraph/hedera-mirror-node/pull/3057 to release/0.46

* Bump logback from 1.2.7 to 1.2.9
* Bump netty from 4.1.70.Final to 4.1.72.Final
* Fix auto created account alias not cached until after record file commit

**Related issue(s)**:

Fixes #3056

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
