### PR TITLE
Optimize NFT transfer history rest endpoint

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -1,0 +1,13 @@
+# Database
+
+# Indexes
+
+The table below documents the database indexes with the usage in APIs / services.
+
+| Table        | Indexed Columns                              | Component   | Service                    | Description                                                                       |
+|--------------|----------------------------------------------|-------------|----------------------------|-----------------------------------------------------------------------------------|
+| nft_transfer | consensus_timestamp                          | REST API    | `/api/v1/transactions/:id` | Used to join `nft_transfer` and the `tlist` CTE on `consensus_timestamp` equality |
+| nft_transfer | token_id, serial_number, consensus_timestamp | REST API    | `/api/v1/tokens/:id/nfts/:serialNumber/transactions` | Used to query the transfer consensus timestamps of a NFT (token_id, serial_number) with optional timestamp filter |
+| nft_transfer | consensus_timestamp                          | Rosetta API | `/account/balance`         | Used to calculate an account's nft token balance including serial numbers at a block |
+| nft_transfer | consensus_timestamp                          | Rosetta API | `/block`                   | Used to join `nft_transfer` and `transaction` on `consensus_timestamp` equality   |
+| nft_transfer | consensus_timestamp                          | Rosetta API | `/block/transaction`       | Used to join `nft_transfer` and `transaction` on `consensus_timestamp` equality   |

--- a/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.52.0__nft_transfer_index.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.52.0__nft_transfer_index.sql
@@ -2,5 +2,10 @@
 -- Add index to speed up nft transfer query for the combination of token id, serial number, and optional timestamp
 -------------------
 
-create index if not exists nft_transfer__token_id_serial_num_timestamp
+-- drop the big index and replace it with the index on consensus_timestamp
+drop index if exists nft_transfer__timestamp_token_id_serial_num;
+create index if not exists nft_transfer__timestamp on nft_transfer(consensus_timestamp desc);
+
+-- add the index to speed up nft transfer query
+create unique index if not exists nft_transfer__token_id_serial_num_timestamp
   on nft_transfer(token_id desc, serial_number desc, consensus_timestamp desc);

--- a/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.52.0__nft_transfer_index.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.52.0__nft_transfer_index.sql
@@ -1,0 +1,6 @@
+-------------------
+-- Add index to speed up nft transfer query for the combination of token id, serial number, and optional timestamp
+-------------------
+
+create index if not exists nft_transfer__token_id_serial_num_timestamp
+  on nft_transfer(token_id desc, serial_number desc, consensus_timestamp desc);

--- a/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.3__index_init.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.3__index_init.sql
@@ -115,9 +115,8 @@ alter table nft
 create index if not exists nft__account_token on nft (account_id, token_id);
 
 -- nft_transfer
-create unique index if not exists nft_transfer__timestamp_token_id_serial_num
-    on nft_transfer (consensus_timestamp desc, token_id desc, serial_number desc);
-create index if not exists nft_transfer__token_id_serial_num_timestamp
+create index if not exists nft_transfer__timestamp on nft_transfer (consensus_timestamp desc);
+create unique index if not exists nft_transfer__token_id_serial_num_timestamp
     on nft_transfer(token_id desc, serial_number desc, consensus_timestamp desc);
 
 -- non_fee_transfer

--- a/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.3__index_init.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.3__index_init.sql
@@ -117,6 +117,8 @@ create index if not exists nft__account_token on nft (account_id, token_id);
 -- nft_transfer
 create unique index if not exists nft_transfer__timestamp_token_id_serial_num
     on nft_transfer (consensus_timestamp desc, token_id desc, serial_number desc);
+create index if not exists nft_transfer__token_id_serial_num_timestamp
+    on nft_transfer(token_id desc, serial_number desc, consensus_timestamp desc);
 
 -- non_fee_transfer
 create index if not exists non_fee_transfer__consensus_timestamp

--- a/hedera-mirror-rest/__tests__/specs/tokens-nft-history-01-no-args.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/tokens-nft-history-01-no-args.spec.json
@@ -16,6 +16,8 @@
       },
       {
         "num": 1500,
+        "deleted": true,
+        "timestamp_range": "[1234567890000000010,)",
         "type": "TOKEN"
       },
       {

--- a/hedera-mirror-rest/__tests__/specs/tokens-nft-history-03-timestamp.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/tokens-nft-history-03-timestamp.spec.json
@@ -16,6 +16,8 @@
       },
       {
         "num": 1500,
+        "deleted": true,
+        "timestamp_range": "[1234567890000000009,)",
         "type": "TOKEN"
       },
       {
@@ -113,7 +115,7 @@
         ]
       },
       {
-        "name": "TOKENDELETE",
+        "name": "TOKENDELETION",
         "type": "35",
         "valid_start_timestamp": "1234567890000000009",
         "consensus_timestamp": "1234567890000000009",

--- a/hedera-mirror-rest/__tests__/specs/tokens-nft-history-04-timestamp-out-of-range.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/tokens-nft-history-04-timestamp-out-of-range.spec.json
@@ -16,6 +16,8 @@
       },
       {
         "num": 1500,
+        "deleted": true,
+        "timestamp_range": "[1234567890000000009,)",
         "type": "TOKEN"
       },
       {
@@ -113,7 +115,7 @@
         ]
       },
       {
-        "name": "TOKENDELETE",
+        "name": "TOKENDELETION",
         "type": "35",
         "valid_start_timestamp": "1234567890000000009",
         "consensus_timestamp": "1234567890000000009",

--- a/hedera-mirror-rest/__tests__/specs/tokens-nft-history-09-partial-data-missing-create.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/tokens-nft-history-09-partial-data-missing-create.spec.json
@@ -16,6 +16,8 @@
       },
       {
         "num": 1500,
+        "deleted": true,
+        "timestamp_range": "[1234567890000000010,)",
         "type": "TOKEN"
       },
       {

--- a/hedera-mirror-rest/__tests__/specs/tokens-nft-history-10-partial-data-missing-nft.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/tokens-nft-history-10-partial-data-missing-nft.spec.json
@@ -16,6 +16,8 @@
       },
       {
         "num": 1500,
+        "deleted": true,
+        "timestamp_range": "[1234567890000000010,)",
         "type": "TOKEN"
       },
       {

--- a/hedera-mirror-rest/__tests__/specs/tokens-nft-history-11-timestamp-range.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/tokens-nft-history-11-timestamp-range.spec.json
@@ -1,5 +1,5 @@
 {
-  "description": "NFT token history",
+  "description": "NFT token history with timestamp range filter which excludes token mint and token delete",
   "setup": {
     "entities": [
       {
@@ -17,7 +17,7 @@
       {
         "num": 1500,
         "deleted": true,
-        "timestamp_range": "[1234567890000000009,)",
+        "timestamp_range": "[1234567890000000010,)",
         "type": "TOKEN"
       },
       {
@@ -67,6 +67,7 @@
         "consensus_timestamp": "1234567890000000006",
         "payerAccountId": "0.0.8",
         "nodeAccountId": "0.0.3",
+        "nonce": 1,
         "treasuryAccountId": "0.0.98",
         "transfers": [],
         "nft_transfer_list": [
@@ -115,11 +116,30 @@
         ]
       },
       {
-        "name": "TOKENDELETION",
-        "type": "35",
+        "name": "TOKENWIPE",
+        "type": "39",
         "valid_start_timestamp": "1234567890000000009",
         "consensus_timestamp": "1234567890000000009",
         "payerAccountId": "0.0.8",
+        "nodeAccountId": "0.0.3",
+        "treasuryAccountId": "0.0.98",
+        "transfers": [],
+        "nft_transfer_list": [
+          {
+            "receiver_account_id": null,
+            "sender_account_id": "0.0.4001",
+            "serial_number": 2,
+            "token_id": "0.0.1500"
+          }
+        ],
+        "entity_id": "0.0.1500"
+      },
+      {
+        "name": "TOKENDELETION",
+        "type": "35",
+        "valid_start_timestamp": "1234567890000000010",
+        "consensus_timestamp": "1234567890000000010",
+        "payerAccountId": "0.0.98",
         "nodeAccountId": "0.0.3",
         "treasuryAccountId": "0.0.98",
         "transfers": [],
@@ -154,21 +174,41 @@
       }
     ]
   },
-  "url": "/api/v1/tokens/1500/nfts/2/transactions?timestamp=gte:1234567890.000000005&order=asc&limit=2",
+  "urls": [
+    "/api/v1/tokens/1500/nfts/2/transactions?timestamp=gt:1234567890.000000005&timestamp=lt:1234567890.000000010",
+    "/api/v1/tokens/0.1500/nfts/2/transactions?timestamp=gt:1234567890.000000005&timestamp=lt:1234567890.000000010",
+    "/api/v1/tokens/0.0.1500/nfts/2/transactions?timestamp=gt:1234567890.000000005&timestamp=lt:1234567890.000000010"
+  ],
   "responseStatus": 200,
   "responseJson": {
     "transactions": [
       {
-        "consensus_timestamp": "1234567890.000000005",
+        "consensus_timestamp": "1234567890.000000009",
         "nonce": 0,
-        "transaction_id": "0.0.8-1234567890-000000005",
-        "receiver_account_id": "0.0.1001",
-        "sender_account_id": null,
-        "type": "TOKENMINT"
+        "transaction_id": "0.0.8-1234567890-000000009",
+        "receiver_account_id": null,
+        "sender_account_id": "0.0.4001",
+        "type": "TOKENWIPE"
+      },
+      {
+        "consensus_timestamp": "1234567890.000000008",
+        "nonce": 0,
+        "transaction_id": "0.0.8-1234567890-000000008",
+        "receiver_account_id": "0.0.4001",
+        "sender_account_id": "0.0.3001",
+        "type": "CRYPTOTRANSFER"
+      },
+      {
+        "consensus_timestamp": "1234567890.000000007",
+        "nonce": 0,
+        "transaction_id": "0.0.8-1234567890-000000007",
+        "receiver_account_id": "0.0.3001",
+        "sender_account_id": "0.0.2001",
+        "type": "CRYPTOTRANSFER"
       },
       {
         "consensus_timestamp": "1234567890.000000006",
-        "nonce": 0,
+        "nonce": 1,
         "transaction_id": "0.0.8-1234567890-000000006",
         "receiver_account_id": "0.0.2001",
         "sender_account_id": "0.0.1001",
@@ -176,7 +216,7 @@
       }
     ],
     "links": {
-      "next": "/api/v1/tokens/1500/nfts/2/transactions?order=asc&limit=2&timestamp=gt:1234567890.000000006"
+      "next": null
     }
   }
 }

--- a/hedera-mirror-rest/__tests__/specs/tokens-nft-history-12-token-not-deleted.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/tokens-nft-history-12-token-not-deleted.spec.json
@@ -1,0 +1,216 @@
+{
+  "description": "NFT token history when the token class isn't deleted",
+  "setup": {
+    "entities": [
+      {
+        "num": 1001
+      },
+      {
+        "num": 2001
+      },
+      {
+        "num": 3001
+      },
+      {
+        "num": 4001
+      },
+      {
+        "num": 1500,
+        "type": "TOKEN"
+      },
+      {
+        "num": 2500,
+        "type": "TOKEN"
+      }
+    ],
+    "tokens": [
+      {
+        "token_id": "0.0.1500",
+        "symbol": "FIRSTMOVERLPDJH",
+        "created_timestamp": "1234567890000000002",
+        "type": "NON_FUNGIBLE_UNIQUE"
+      },
+      {
+        "token_id": "0.0.2500",
+        "symbol": "ORIGINALRDKSE",
+        "created_timestamp": "1234567890000000003",
+        "type": "NON_FUNGIBLE_UNIQUE"
+      }
+    ],
+    "balances": [],
+    "transactions": [
+      {
+        "name": "TOKENMINT",
+        "type": "37",
+        "valid_start_timestamp": "1234567890000000005",
+        "consensus_timestamp": "1234567890000000005",
+        "payerAccountId": "0.0.8",
+        "nodeAccountId": "0.0.3",
+        "treasuryAccountId": "0.0.98",
+        "transfers": [],
+        "nft_transfer_list": [
+          {
+            "receiver_account_id": "0.0.1001",
+            "sender_account_id": null,
+            "serial_number": 2,
+            "token_id": "0.0.1500"
+          }
+        ],
+        "entity_id": "0.0.1500"
+      },
+      {
+        "name": "CRYPTOTRANSFER",
+        "type": "14",
+        "valid_start_timestamp": "1234567890000000006",
+        "consensus_timestamp": "1234567890000000006",
+        "payerAccountId": "0.0.8",
+        "nodeAccountId": "0.0.3",
+        "nonce": 1,
+        "treasuryAccountId": "0.0.98",
+        "transfers": [],
+        "nft_transfer_list": [
+          {
+            "receiver_account_id": "0.0.2001",
+            "sender_account_id": "0.0.1001",
+            "serial_number": 2,
+            "token_id": "0.0.1500"
+          }
+        ]
+      },
+      {
+        "name": "CRYPTOTRANSFER",
+        "type": "14",
+        "valid_start_timestamp": "1234567890000000007",
+        "consensus_timestamp": "1234567890000000007",
+        "payerAccountId": "0.0.8",
+        "nodeAccountId": "0.0.3",
+        "treasuryAccountId": "0.0.98",
+        "transfers": [],
+        "nft_transfer_list": [
+          {
+            "receiver_account_id": "0.0.3001",
+            "sender_account_id": "0.0.2001",
+            "serial_number": 2,
+            "token_id": "0.0.1500"
+          }
+        ]
+      },
+      {
+        "name": "CRYPTOTRANSFER",
+        "type": "14",
+        "valid_start_timestamp": "1234567890000000008",
+        "consensus_timestamp": "1234567890000000008",
+        "payerAccountId": "0.0.8",
+        "nodeAccountId": "0.0.3",
+        "treasuryAccountId": "0.0.98",
+        "transfers": [],
+        "nft_transfer_list": [
+          {
+            "receiver_account_id": "0.0.4001",
+            "sender_account_id": "0.0.3001",
+            "serial_number": 2,
+            "token_id": "0.0.1500"
+          }
+        ]
+      },
+      {
+        "name": "TOKENWIPE",
+        "type": "39",
+        "valid_start_timestamp": "1234567890000000009",
+        "consensus_timestamp": "1234567890000000009",
+        "payerAccountId": "0.0.8",
+        "nodeAccountId": "0.0.3",
+        "treasuryAccountId": "0.0.98",
+        "transfers": [],
+        "nft_transfer_list": [
+          {
+            "receiver_account_id": null,
+            "sender_account_id": "0.0.4001",
+            "serial_number": 2,
+            "token_id": "0.0.1500"
+          }
+        ],
+        "entity_id": "0.0.1500"
+      }
+    ],
+    "cryptotransfers": [],
+    "nfts": [
+      {
+        "account_id": "0.0.4001",
+        "created_timestamp": "1234567890000000004",
+        "metadata": "m1",
+        "serial_number": 1,
+        "token_id": "0.0.1500"
+      },
+      {
+        "account_id": "0.0.4001",
+        "created_timestamp": "1234567890000000005",
+        "deleted": true,
+        "metadata": "m1",
+        "modified_timestamp": "1234567890000000009",
+        "serial_number": 2,
+        "token_id": "0.0.1500"
+      },
+      {
+        "account_id": "0.0.1001",
+        "created_timestamp": "1234567890000000006",
+        "metadata": "s1",
+        "serial_number": 1,
+        "token_id": "0.0.2500"
+      }
+    ]
+  },
+  "urls": [
+    "/api/v1/tokens/1500/nfts/2/transactions",
+    "/api/v1/tokens/0.1500/nfts/2/transactions",
+    "/api/v1/tokens/0.0.1500/nfts/2/transactions"
+  ],
+  "responseStatus": 200,
+  "responseJson": {
+    "transactions": [
+      {
+        "consensus_timestamp": "1234567890.000000009",
+        "nonce": 0,
+        "transaction_id": "0.0.8-1234567890-000000009",
+        "receiver_account_id": null,
+        "sender_account_id": "0.0.4001",
+        "type": "TOKENWIPE"
+      },
+      {
+        "consensus_timestamp": "1234567890.000000008",
+        "nonce": 0,
+        "transaction_id": "0.0.8-1234567890-000000008",
+        "receiver_account_id": "0.0.4001",
+        "sender_account_id": "0.0.3001",
+        "type": "CRYPTOTRANSFER"
+      },
+      {
+        "consensus_timestamp": "1234567890.000000007",
+        "nonce": 0,
+        "transaction_id": "0.0.8-1234567890-000000007",
+        "receiver_account_id": "0.0.3001",
+        "sender_account_id": "0.0.2001",
+        "type": "CRYPTOTRANSFER"
+      },
+      {
+        "consensus_timestamp": "1234567890.000000006",
+        "nonce": 1,
+        "transaction_id": "0.0.8-1234567890-000000006",
+        "receiver_account_id": "0.0.2001",
+        "sender_account_id": "0.0.1001",
+        "type": "CRYPTOTRANSFER"
+      },
+      {
+        "consensus_timestamp": "1234567890.000000005",
+        "nonce": 0,
+        "transaction_id": "0.0.8-1234567890-000000005",
+        "receiver_account_id": "0.0.1001",
+        "sender_account_id": null,
+        "type": "TOKENMINT"
+      }
+    ],
+    "links": {
+      "next": null
+    }
+  }
+}

--- a/hedera-mirror-rest/__tests__/tokens.test.js
+++ b/hedera-mirror-rest/__tests__/tokens.test.js
@@ -1298,48 +1298,24 @@ describe('token extractSqlFromNftTransferHistoryRequest tests', () => {
     limit $${paramIndex}`;
   };
 
-  const verifyExtractSqlFromNftTransferHistoryRequest = (
-    tokenId,
-    serialNumber,
-    transferQuery,
-    deletedQuery,
-    expectedQuery,
-    expectedParams,
-    filters
-  ) => {
-    const {query, params} = tokens.extractSqlFromNftTransferHistoryRequest(
-      tokenId,
-      serialNumber,
-      transferQuery,
-      deletedQuery,
-      filters
-    );
-
-    assertSqlQueryEqual(query, expectedQuery);
-    expect(params).toStrictEqual(expectedParams);
-  };
+  const tokenId = '1009'; // encoded
+  const serialNumber = '960';
 
   test('Verify simple query', () => {
-    const tokenId = '1009'; // encoded
-    const serialNumber = '960';
-    const filters = [];
-
     const expectedQuery = getExpectedQuery();
     const expectedParams = [tokenId, serialNumber, defaultLimit];
 
-    const actual = tokens.extractSqlFromNftTransferHistoryRequest(tokenId, serialNumber, filters);
+    const actual = tokens.extractSqlFromNftTransferHistoryRequest(tokenId, serialNumber, []);
     assertSqlQueryEqual(actual.query, expectedQuery);
     expect(actual.params).toStrictEqual(expectedParams);
   });
 
   test('Verify limit and order query', () => {
-    const tokenId = '1009'; // encoded
-    const serialNumber = '960';
     const limit = '3';
     const order = orderFilterValues.ASC;
     const filters = [
-      {key: filterKeys.LIMIT, operator: ' = ', value: limit},
-      {key: filterKeys.ORDER, operator: ' = ', value: order},
+      {key: filterKeys.LIMIT, operator: utils.opsMap.eq, value: limit},
+      {key: filterKeys.ORDER, operator: utils.opsMap.eq, value: order},
     ];
 
     const expectedQuery = getExpectedQuery(order);
@@ -1351,10 +1327,8 @@ describe('token extractSqlFromNftTransferHistoryRequest tests', () => {
   });
 
   test('Verify timestamp query', () => {
-    const tokenId = '1009'; // encoded
-    const serialNumber = '960';
     const timestamp = 5;
-    const filters = [{key: filterKeys.TIMESTAMP, operator: ' > ', value: timestamp}];
+    const filters = [{key: filterKeys.TIMESTAMP, operator: utils.opsMap.gt, value: timestamp}];
 
     const expectedQuery = getExpectedQuery(orderFilterValues.DESC, filters);
     const expectedParams = [tokenId, serialNumber, timestamp, defaultLimit];

--- a/hedera-mirror-rest/__tests__/tokens.test.js
+++ b/hedera-mirror-rest/__tests__/tokens.test.js
@@ -1247,7 +1247,7 @@ describe('token extractSqlFromNftTransferHistoryRequest tests', () => {
       .join(' and ');
     const deleteTimestampCondition = transferTimestampCondition.replace(
       'nft_tr.consensus_timestamp',
-      't.consensus_timestamp'
+      'consensus_timestamp'
     );
     const limitQuery = `limit $${paramIndex}`;
     return `with serial_transfers as (
@@ -1275,16 +1275,17 @@ describe('token extractSqlFromNftTransferHistoryRequest tests', () => {
       on nft_tr.consensus_timestamp = t.consensus_timestamp
     ), token_deletion as (
       select
-        t.consensus_timestamp,
-        t.nonce,
-        t.payer_account_id,
-        t.type,
-        t.valid_start_ns
-      from entity e
-      join transaction t
-        on t.consensus_timestamp = lower(e.timestamp_range)
-      where e.id = $1 and e.deleted is true
-        ${(deleteTimestampCondition && ' and ' + deleteTimestampCondition) || ''}
+        consensus_timestamp,
+        nonce,
+        payer_account_id,
+        type,
+        valid_start_ns
+      from transaction
+      where consensus_timestamp = (
+          select lower(timestamp_range)
+          from entity
+          where id = $1 and deleted is true
+        ) ${(deleteTimestampCondition && ' and ' + deleteTimestampCondition) || ''}
     )
     select * from token_transactions
     union

--- a/hedera-mirror-rest/__tests__/tokens.test.js
+++ b/hedera-mirror-rest/__tests__/tokens.test.js
@@ -1240,6 +1240,64 @@ describe('token validateTokenIdParam tests', () => {
 });
 
 describe('token extractSqlFromNftTransferHistoryRequest tests', () => {
+  const getExpectedQuery = (order = orderFilterValues.DESC, timestampFilters = []) => {
+    let paramIndex = 3;
+    const transferTimestampCondition = timestampFilters
+      .map((f) => `nft_tr.consensus_timestamp ${f.operator} $${paramIndex++}`)
+      .join(' and ');
+    const deleteTimestampCondition = transferTimestampCondition.replace(
+      'nft_tr.consensus_timestamp',
+      't.consensus_timestamp'
+    );
+    return `with serial_transfers as (
+      select
+        consensus_timestamp,
+        receiver_account_id,
+        sender_account_id,
+        token_id
+      from nft_transfer nft_tr
+      where nft_tr.token_id = $1 and nft_tr.serial_number = $2
+        ${(transferTimestampCondition && ' and ' + transferTimestampCondition) || ''}
+    ), token_transactions as (
+      select
+        nft_tr.consensus_timestamp,
+        nft_tr.receiver_account_id,
+        nft_tr.sender_account_id,
+        t.nonce,
+        t.payer_account_id,
+        t.type,
+        t.valid_start_ns
+      from serial_transfers nft_tr
+      join transaction t
+      on nft_tr.consensus_timestamp = t.consensus_timestamp
+    ), token_deletion as (
+      select
+        t.consensus_timestamp,
+        t.nonce,
+        t.payer_account_id,
+        t.type,
+        t.valid_start_ns
+      from entity e
+      join transaction t
+        on t.consensus_timestamp = lower(e.timestamp_range)
+      where e.id = $1 and e.deleted is true
+        ${(deleteTimestampCondition && ' and ' + deleteTimestampCondition) || ''}
+    )
+    select * from token_transactions
+    union
+    select
+      consensus_timestamp,
+      null as receiver_account_id,
+      null as sender_account_id,
+      nonce,
+      payer_account_id,
+      type,
+      valid_start_ns
+    from token_deletion
+    order by consensus_timestamp ${order}
+    limit $${paramIndex}`;
+  };
+
   const verifyExtractSqlFromNftTransferHistoryRequest = (
     tokenId,
     serialNumber,
@@ -1264,203 +1322,46 @@ describe('token extractSqlFromNftTransferHistoryRequest tests', () => {
   test('Verify simple query', () => {
     const tokenId = '1009'; // encoded
     const serialNumber = '960';
-    const transferQuery = [tokens.nftTransferHistorySelectQuery].join('\n');
-    const deletedQuery = [tokens.nftDeleteHistorySelectQuery].join('\n');
     const filters = [];
 
-    const expectedQuery = `with serial_transfers as (
-        select nft_tr.consensus_timestamp,
-          nft_tr.receiver_account_id,
-          nft_tr.sender_account_id,
-          nft_tr.token_id
-        from nft_transfer nft_tr
-        where nft_tr.token_id = $1 and nft_tr.serial_number = $2
-      ),
-      token_transactions as (
-        select nft_tr.consensus_timestamp,
-          t.payer_account_id,
-          t.valid_start_ns,
-          nft_tr.receiver_account_id,
-          nft_tr.sender_account_id,
-          t.type,
-          t.nonce
-        from serial_transfers nft_tr
-        join transaction t on nft_tr.consensus_timestamp = t.consensus_timestamp and nft_tr.token_id = t.entity_id
-      ),
-      token_transfers as (
-        select nft_tr.consensus_timestamp,
-          t.payer_account_id,
-          t.valid_start_ns,
-          nft_tr.receiver_account_id,
-          nft_tr.sender_account_id,
-          t.type,
-          t.nonce
-        from serial_transfers nft_tr
-        join transaction t on nft_tr.consensus_timestamp = t.consensus_timestamp and t.entity_id is null
-      )
-      select *
-      from token_transactions
-      union
-      select *
-      from token_transfers
-      union
-      select t.consensus_timestamp as consensus_timestamp,
-        t.payer_account_id,
-        t.valid_start_ns,
-        null as receiver_account_id,
-        null as sender_account_id,
-        t.type,
-        t.nonce
-      from transaction t
-      where t.entity_id = $1 and t.type = 35 and t.result = 22
-      order by consensus_timestamp desc
-      limit $3`;
+    const expectedQuery = getExpectedQuery();
     const expectedParams = [tokenId, serialNumber, defaultLimit];
-    verifyExtractSqlFromNftTransferHistoryRequest(
-      tokenId,
-      serialNumber,
-      transferQuery,
-      deletedQuery,
-      expectedQuery,
-      expectedParams,
-      filters
-    );
+
+    const actual = tokens.extractSqlFromNftTransferHistoryRequest(tokenId, serialNumber, filters);
+    assertSqlQueryEqual(actual.query, expectedQuery);
+    expect(actual.params).toStrictEqual(expectedParams);
   });
 
   test('Verify limit and order query', () => {
     const tokenId = '1009'; // encoded
     const serialNumber = '960';
-    const transferQuery = [tokens.nftTransferHistorySelectQuery].join('\n');
-    const deletedQuery = [tokens.nftDeleteHistorySelectQuery].join('\n');
     const limit = '3';
     const order = orderFilterValues.ASC;
     const filters = [
       {key: filterKeys.LIMIT, operator: ' = ', value: limit},
       {key: filterKeys.ORDER, operator: ' = ', value: order},
     ];
-    const expectedQuery = `with serial_transfers as (
-        select nft_tr.consensus_timestamp,
-          nft_tr.receiver_account_id,
-          nft_tr.sender_account_id,
-          nft_tr.token_id
-        from nft_transfer nft_tr
-        where nft_tr.token_id = $1 and nft_tr.serial_number = $2
-      ),
-      token_transactions as (
-        select nft_tr.consensus_timestamp,
-          t.payer_account_id,
-          t.valid_start_ns,
-          nft_tr.receiver_account_id,
-          nft_tr.sender_account_id,
-          t.type,
-          t.nonce
-        from serial_transfers nft_tr
-        join transaction t on nft_tr.consensus_timestamp = t.consensus_timestamp and nft_tr.token_id = t.entity_id
-      ),
-      token_transfers as (
-        select nft_tr.consensus_timestamp,
-          t.payer_account_id,
-          t.valid_start_ns,
-          nft_tr.receiver_account_id,
-          nft_tr.sender_account_id,
-          t.type,
-          t.nonce
-        from serial_transfers nft_tr
-        join transaction t on nft_tr.consensus_timestamp = t.consensus_timestamp and t.entity_id is null
-      )
-      select *
-      from token_transactions
-      union
-      select *
-      from token_transfers
-      union
-      select t.consensus_timestamp as consensus_timestamp,
-        t.payer_account_id,
-        t.valid_start_ns,
-        null as receiver_account_id,
-        null as sender_account_id,
-        t.type,
-        t.nonce
-      from transaction t
-      where t.entity_id = $1 and t.type = 35 and t.result = 22
-      order by consensus_timestamp asc
-      limit $3`;
+
+    const expectedQuery = getExpectedQuery(order);
     const expectedParams = [tokenId, serialNumber, limit];
-    verifyExtractSqlFromNftTransferHistoryRequest(
-      tokenId,
-      serialNumber,
-      transferQuery,
-      deletedQuery,
-      expectedQuery,
-      expectedParams,
-      filters
-    );
+
+    const actual = tokens.extractSqlFromNftTransferHistoryRequest(tokenId, serialNumber, filters);
+    assertSqlQueryEqual(actual.query, expectedQuery);
+    expect(actual.params).toStrictEqual(expectedParams);
   });
 
   test('Verify timestamp query', () => {
     const tokenId = '1009'; // encoded
     const serialNumber = '960';
-    const transferQuery = [tokens.nftTransferHistorySelectQuery].join('\n');
-    const deletedQuery = [tokens.nftDeleteHistorySelectQuery].join('\n');
     const timestamp = 5;
     const filters = [{key: filterKeys.TIMESTAMP, operator: ' > ', value: timestamp}];
-    const expectedQuery = `with serial_transfers as (
-        select nft_tr.consensus_timestamp,
-          nft_tr.receiver_account_id,
-          nft_tr.sender_account_id,
-          nft_tr.token_id
-        from nft_transfer nft_tr
-        where nft_tr.token_id = $1 and nft_tr.serial_number = $2 and nft_tr.consensus_timestamp > $3
-      ),
-      token_transactions as (
-        select nft_tr.consensus_timestamp,
-          t.payer_account_id,
-          t.valid_start_ns,
-          nft_tr.receiver_account_id,
-          nft_tr.sender_account_id,
-          t.type,
-          t.nonce
-        from serial_transfers nft_tr
-        join transaction t on nft_tr.consensus_timestamp = t.consensus_timestamp and nft_tr.token_id = t.entity_id
-      ),
-      token_transfers as (
-        select nft_tr.consensus_timestamp,
-          t.payer_account_id,
-          t.valid_start_ns,
-          nft_tr.receiver_account_id,
-          nft_tr.sender_account_id,
-          t.type,
-          t.nonce
-        from serial_transfers nft_tr
-        join transaction t on nft_tr.consensus_timestamp = t.consensus_timestamp and t.entity_id is null
-      )
-      select *
-      from token_transactions
-      union
-      select *
-      from token_transfers
-      union
-      select t.consensus_timestamp as consensus_timestamp,
-        t.payer_account_id,
-        t.valid_start_ns,
-        null as receiver_account_id,
-        null as sender_account_id,
-        t.type,
-        t.nonce
-      from transaction t
-      where t.entity_id = $1 and t.type = 35 and t.result = 22 and t.consensus_timestamp > $3
-      order by consensus_timestamp desc
-      limit $4`;
+
+    const expectedQuery = getExpectedQuery(orderFilterValues.DESC, filters);
     const expectedParams = [tokenId, serialNumber, timestamp, defaultLimit];
-    verifyExtractSqlFromNftTransferHistoryRequest(
-      tokenId,
-      serialNumber,
-      transferQuery,
-      deletedQuery,
-      expectedQuery,
-      expectedParams,
-      filters
-    );
+
+    const actual = tokens.extractSqlFromNftTransferHistoryRequest(tokenId, serialNumber, filters);
+    assertSqlQueryEqual(actual.query, expectedQuery);
+    expect(actual.params).toStrictEqual(expectedParams);
   });
 });
 

--- a/hedera-mirror-rest/__tests__/tokens.test.js
+++ b/hedera-mirror-rest/__tests__/tokens.test.js
@@ -1249,6 +1249,7 @@ describe('token extractSqlFromNftTransferHistoryRequest tests', () => {
       'nft_tr.consensus_timestamp',
       't.consensus_timestamp'
     );
+    const limitQuery = `limit $${paramIndex}`;
     return `with serial_transfers as (
       select
         consensus_timestamp,
@@ -1258,6 +1259,8 @@ describe('token extractSqlFromNftTransferHistoryRequest tests', () => {
       from nft_transfer nft_tr
       where nft_tr.token_id = $1 and nft_tr.serial_number = $2
         ${(transferTimestampCondition && ' and ' + transferTimestampCondition) || ''}
+      order by consensus_timestamp ${order}
+      ${limitQuery}
     ), token_transactions as (
       select
         nft_tr.consensus_timestamp,
@@ -1295,7 +1298,7 @@ describe('token extractSqlFromNftTransferHistoryRequest tests', () => {
       valid_start_ns
     from token_deletion
     order by consensus_timestamp ${order}
-    limit $${paramIndex}`;
+    ${limitQuery}`;
   };
 
   const tokenId = '1009'; // encoded

--- a/hedera-mirror-rest/model/entity.js
+++ b/hedera-mirror-rest/model/entity.js
@@ -1,0 +1,71 @@
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+'use strict';
+
+const _ = require('lodash');
+
+class Entity {
+  /**
+   * Parses entity table columns into object
+   */
+  constructor(entity) {
+    Object.assign(
+      this,
+      _.mapKeys(entity, (v, k) => _.camelCase(k))
+    );
+  }
+
+  static historyTableName = 'entity_history';
+  static tableAlias = 'e';
+  static tableName = 'entity';
+
+  static ALIAS = 'alias';
+  static AUTO_RENEW_ACCOUNT_ID = 'auto_renew_account_id';
+  static AUTO_RENEW_PERIOD = 'auto_renew_period';
+  static CREATED_TIMESTAMP = 'created_timestamp';
+  static DELETED = 'deleted';
+  static EXPIRATION_TIMESTAMP = 'expiration_timestamp';
+  static ID = 'id';
+  static KEY = 'key';
+  static MAX_AUTOMATIC_TOKEN_ASSOCIATIONS = 'max_automatic_token_associations';
+  static MEMO = 'memo';
+  static NUM = 'num';
+  static PROXY_ACCOUNT_ID = 'proxy_account_id';
+  static PUBLIC_KEY = 'public_key';
+  static REALM = 'realm';
+  static RECEIVER_SIG_REQUIRED = 'receiver_sig_required';
+  static SHARD = 'shard';
+  static SUBMIT_KEY = 'submit_key';
+  static TIMESTAMP_RANGE = 'timestamp_range';
+  static TYPE = 'type';
+
+  /**
+   * Gets full column name with table alias prepended.
+   *
+   * @param {string} columnName
+   * @private
+   */
+  static getFullName(columnName) {
+    return `${this.tableAlias}.${columnName}`;
+  }
+}
+
+module.exports = Entity;

--- a/hedera-mirror-rest/model/index.js
+++ b/hedera-mirror-rest/model/index.js
@@ -27,6 +27,7 @@ module.exports = {
   ContractResult: require('./contractResult'),
   CryptoTransfer: require('./cryptoTransfer'),
   CustomFee: require('./customFee'),
+  Entity: require('./entity'),
   FileData: require('./fileData'),
   Nft: require('./nft'),
   NftTransfer: require('./nftTransfer'),

--- a/hedera-mirror-rest/package-lock.json
+++ b/hedera-mirror-rest/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@hashgraph/mirror-rest",
-      "version": "0.47.0-SNAPSHOT",
+      "version": "0.48.0-SNAPSHOT",
       "bundleDependencies": [
         "@awaitjs/express",
         "@godaddy/terminus",

--- a/hedera-mirror-rest/tokens.js
+++ b/hedera-mirror-rest/tokens.js
@@ -36,7 +36,7 @@ const {InvalidArgumentError} = require('./errors/invalidArgumentError');
 const {NotFoundError} = require('./errors/notFoundError');
 
 // models
-const {CustomFee, Nft, NftTransfer, Token, Transaction, TransactionResult, TransactionType} = require('./model');
+const {CustomFee, Entity, Nft, NftTransfer, Token, Transaction, TransactionType} = require('./model');
 
 // middleware
 const {httpStatusCodes} = require('./constants');
@@ -794,36 +794,34 @@ const getTokenInfo = async (query, params) => {
   return rows[0];
 };
 
-const tokenDeleteTransactionType = 'TOKENDELETION';
-
 /**
  * Extracts SQL query, params, order, and limit
- * Combine NFT CREATION and TRANSFERS details fron nft_transfer with DELETION details from nft
+ * Combine NFT TRANSFERS (mint, transfer, wipe account, burn) details from nft_transfer with DELETION details from nft
  *
  * @param {string} tokenId encoded token ID
  * @param {string} serialNumber nft serial number
- * @param {string} transferQuery pg SQL query for transfers
- * @param {string} deleteQuery pg SQL query for deletion transaction
  * @param {[]} filters parsed and validated filters
  * @return {{query: string, limit: number, params: [], order: 'asc'|'desc'}}
  */
-const extractSqlFromNftTransferHistoryRequest = (tokenId, serialNumber, transferQuery, deleteQuery, filters) => {
+const extractSqlFromNftTransferHistoryRequest = (tokenId, serialNumber, filters) => {
   let limit = defaultLimit;
   let order = constants.orderFilterValues.DESC;
 
   const params = [tokenId, serialNumber];
+  // if the nft token class is deleted, the lower of the timestamp_range is the consensus timestamp of the token
+  // delete transaction
+  const tokenDeleteConditions = [
+    `${Entity.getFullName(Entity.ID)} = $1`,
+    `${Entity.getFullName(Entity.DELETED)} is true`,
+  ];
   const transferConditions = [
     `${NftTransfer.getFullName(NftTransfer.TOKEN_ID)} = $1`,
     `${NftTransfer.getFullName(NftTransfer.SERIAL_NUMBER)} = $2`,
   ];
 
-  const deleteConditions = [
-    `${Transaction.getFullName(Transaction.ENTITY_ID)} = $1`,
-    `${Transaction.getFullName(Transaction.TYPE)} = ${TransactionType.getProtoId(tokenDeleteTransactionType)}`,
-    `${Transaction.getFullName(Transaction.RESULT)} = ${utils.resultSuccess}`,
-  ];
-
   // add applicable filters
+  const transferTimestampColumn = NftTransfer.getFullName(NftTransfer.CONSENSUS_TIMESTAMP);
+  const transactionTimestampColumn = Transaction.getFullName(Transaction.CONSENSUS_TIMESTAMP);
   for (const filter of filters) {
     switch (filter.key) {
       case constants.filterKeys.LIMIT:
@@ -832,68 +830,59 @@ const extractSqlFromNftTransferHistoryRequest = (tokenId, serialNumber, transfer
       case constants.filterKeys.ORDER:
         order = filter.value;
         break;
+      case constants.filterKeys.TIMESTAMP:
+        const paramCount = params.push(filter.value);
+        transferConditions.push(`${transferTimestampColumn} ${filter.operator} $${paramCount}`);
+        tokenDeleteConditions.push(`${transactionTimestampColumn} ${filter.operator} $${paramCount}`);
+        break;
       default:
-        const transferColumnKey = NftTransfer.FILTER_MAP[filter.key];
-        const transactionColumnKey = Transaction.FILTER_MAP[filter.key];
-
-        if (filter.key === constants.filterKeys.TIMESTAMP) {
-          if (!transferColumnKey || !transactionColumnKey) {
-            break;
-          }
-
-          const paramCount = params.push(filter.value);
-          transferConditions.push(`${transferColumnKey} ${filter.operator} $${paramCount}`);
-          deleteConditions.push(`${transactionColumnKey} ${filter.operator} $${paramCount}`);
-        }
-
         break;
     }
   }
 
-  const joinTransactionClause = `join ${Transaction.tableName} ${Transaction.tableAlias}
-    on ${NftTransfer.getFullName(NftTransfer.CONSENSUS_TIMESTAMP)} = ${Transaction.getFullName(
-    Transaction.CONSENSUS_TIMESTAMP
-  )}`;
-
-  const transferWhereQuery = `where ${transferConditions.join('\nand ')}`;
-
   const serialTransferCte = `serial_transfers as (
     select ${nftTransferHistoryCteSelectFields.join(',\n')}
     from ${NftTransfer.tableName} ${NftTransfer.tableAlias}
-    ${transferWhereQuery}
+    where ${transferConditions.join(' and ')}
   )`;
 
+  const joinTransactionClause = `join ${Transaction.tableName} ${Transaction.tableAlias}
+    on ${transferTimestampColumn} = ${transactionTimestampColumn}`;
   const tokenTransactionCte = `token_transactions as (
     select ${nftTransferHistorySelectFields.join(',\n')}
     from serial_transfers ${NftTransfer.tableAlias}
-    ${joinTransactionClause} and ${NftTransfer.getFullName(NftTransfer.TOKEN_ID)} = ${Transaction.getFullName(
-    Transaction.ENTITY_ID
-  )}
+    ${joinTransactionClause}
   )`;
 
-  const tokenTransferCte = `token_transfers as (
-    select ${nftTransferHistorySelectFields.join(',\n')}
-    from serial_transfers ${NftTransfer.tableAlias}
-    ${joinTransactionClause} and ${Transaction.getFullName(Transaction.ENTITY_ID)} is null
+  const tokenDeletionCte = `token_deletion as (
+    select
+      ${Transaction.getFullName(Transaction.CONSENSUS_TIMESTAMP)},
+      ${Transaction.getFullName(Transaction.NONCE)},
+      ${Transaction.getFullName(Transaction.PAYER_ACCOUNT_ID)},
+      ${Transaction.getFullName(Transaction.TYPE)},
+      ${Transaction.getFullName(Transaction.VALID_START_NS)}
+    from ${Entity.tableName} ${Entity.tableAlias}
+    join ${Transaction.tableName} ${Transaction.tableAlias}
+      on ${transactionTimestampColumn} = lower(${Entity.getFullName(Entity.TIMESTAMP_RANGE)})
+    where ${tokenDeleteConditions.join(' and ')}
   )`;
 
-  const cteQuery = `with ${serialTransferCte}, ${tokenTransactionCte}, ${tokenTransferCte}
-  select * from token_transactions
-  union
-  select * from token_transfers`;
+  const query = `with ${serialTransferCte}, ${tokenTransactionCte}, ${tokenDeletionCte}
+    select * from token_transactions
+    union
+    select
+      ${Transaction.CONSENSUS_TIMESTAMP},
+      null as ${NftTransfer.RECEIVER_ACCOUNT_ID},
+      null as ${NftTransfer.SENDER_ACCOUNT_ID},
+      ${Transaction.NONCE},
+      ${Transaction.PAYER_ACCOUNT_ID},
+      ${Transaction.TYPE},
+      ${Transaction.VALID_START_NS}
+    from token_deletion
+    order by ${Transaction.CONSENSUS_TIMESTAMP} ${order}
+    limit $${params.push(limit)}`;
 
-  const unionQuery = `union\n${deleteQuery}`;
-
-  const deleteWhereCondition = `where ${deleteConditions.join('\nand ')}`;
-
-  const orderQuery = `order by ${NftTransfer.CONSENSUS_TIMESTAMP} ${order}`;
-  const limitQuery = `limit $${params.push(limit)}`;
-
-  const finalQuery = [cteQuery, unionQuery, deleteWhereCondition, orderQuery, limitQuery]
-    .filter((q) => q !== '')
-    .join('\n');
-
-  return utils.buildPgSqlObject(finalQuery, params, order, limit);
+  return utils.buildPgSqlObject(query, params, order, limit);
 };
 
 const formatNftHistoryRow = (row) => {
@@ -904,39 +893,19 @@ const formatNftHistoryRow = (row) => {
 
 const nftTransferHistorySelectFields = [
   NftTransfer.getFullName(NftTransfer.CONSENSUS_TIMESTAMP),
-  Transaction.getFullName(Transaction.PAYER_ACCOUNT_ID),
-  Transaction.getFullName(Transaction.VALID_START_NS),
   NftTransfer.getFullName(NftTransfer.RECEIVER_ACCOUNT_ID),
   NftTransfer.getFullName(NftTransfer.SENDER_ACCOUNT_ID),
-  Transaction.getFullName(Transaction.TYPE),
   Transaction.getFullName(Transaction.NONCE),
-];
-const nftTransferHistorySelectQuery = [
-  'select',
-  nftTransferHistorySelectFields.join(',\n'),
-  `from ${NftTransfer.tableName} ${NftTransfer.tableAlias}`,
-].join('\n');
-
-const nftDeleteHistorySelectFields = [
-  `${Transaction.getFullName(Transaction.CONSENSUS_TIMESTAMP)} as ${NftTransfer.CONSENSUS_TIMESTAMP}`,
   Transaction.getFullName(Transaction.PAYER_ACCOUNT_ID),
-  Transaction.getFullName(Transaction.VALID_START_NS),
-  `null as ${NftTransfer.RECEIVER_ACCOUNT_ID}`,
-  `null as ${NftTransfer.SENDER_ACCOUNT_ID}`,
   Transaction.getFullName(Transaction.TYPE),
-  Transaction.getFullName(Transaction.NONCE),
+  Transaction.getFullName(Transaction.VALID_START_NS),
 ];
-const nftDeleteHistorySelectQuery = [
-  'select',
-  nftDeleteHistorySelectFields.join(',\n'),
-  `from ${Transaction.tableName} ${Transaction.tableAlias}`,
-].join('\n');
 
 const nftTransferHistoryCteSelectFields = [
-  NftTransfer.getFullName(NftTransfer.CONSENSUS_TIMESTAMP),
-  NftTransfer.getFullName(NftTransfer.RECEIVER_ACCOUNT_ID),
-  NftTransfer.getFullName(NftTransfer.SENDER_ACCOUNT_ID),
-  NftTransfer.getFullName(NftTransfer.TOKEN_ID),
+  NftTransfer.CONSENSUS_TIMESTAMP,
+  NftTransfer.RECEIVER_ACCOUNT_ID,
+  NftTransfer.SENDER_ACCOUNT_ID,
+  NftTransfer.TOKEN_ID,
 ];
 
 /**
@@ -951,13 +920,7 @@ const getNftTransferHistoryRequest = async (req, res) => {
 
   const filters = utils.buildAndValidateFilters(req.query, validateTokenQueryFilter);
 
-  const {query, params, limit, order} = extractSqlFromNftTransferHistoryRequest(
-    tokenId,
-    serialNumber,
-    nftTransferHistorySelectQuery,
-    nftDeleteHistorySelectQuery,
-    filters
-  );
+  const {query, params, limit, order} = extractSqlFromNftTransferHistoryRequest(tokenId, serialNumber, filters);
   if (logger.isTraceEnabled()) {
     logger.trace(`getNftTransferHistory query: ${query} ${JSON.stringify(params)}`);
   }
@@ -1030,8 +993,6 @@ if (utils.isTestEnv()) {
     formatTokenInfoRow,
     formatTokenRow,
     nftSelectQuery,
-    nftDeleteHistorySelectQuery,
-    nftTransferHistorySelectQuery,
     tokenAccountCte,
     tokenAccountJoinQuery,
     tokenBalancesSelectQuery,

--- a/hedera-mirror-rest/tokens.js
+++ b/hedera-mirror-rest/tokens.js
@@ -796,7 +796,7 @@ const getTokenInfo = async (query, params) => {
 
 /**
  * Extracts SQL query, params, order, and limit
- * Combine NFT TRANSFERS (mint, transfer, wipe account, burn) details from nft_transfer with DELETION details from nft
+ * Combine NFT transfers (mint, transfer, wipe account, burn) details from nft_transfer with DELETION details from nft
  *
  * @param {string} tokenId encoded token ID
  * @param {string} serialNumber nft serial number

--- a/hedera-mirror-rest/viewmodel/nftTransactionHistoryViewModel.js
+++ b/hedera-mirror-rest/viewmodel/nftTransactionHistoryViewModel.js
@@ -38,6 +38,7 @@ class NftTransactionHistoryViewModel {
       transactionModel.validStartNs
     );
     this.type = TransactionType.getName(transactionModel.type);
+    logger.trace(`type proto id - ${transactionModel.type}, type name - ${this.type}`);
   }
 }
 

--- a/hedera-mirror-rest/viewmodel/nftTransactionHistoryViewModel.js
+++ b/hedera-mirror-rest/viewmodel/nftTransactionHistoryViewModel.js
@@ -38,7 +38,6 @@ class NftTransactionHistoryViewModel {
       transactionModel.validStartNs
     );
     this.type = TransactionType.getName(transactionModel.type);
-    logger.trace(`type proto id - ${transactionModel.type}, type name - ${this.type}`);
   }
 }
 


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR fixes the nft transfer history rest api performance issue.

- Add a new index to `nft_transfer` table for faster query on (token_id, serial_number) with optional timestamp
- Combine `token_transfers` and `token_transactions` CTEs
- Rewrite the `token_deletion` to get the token delete transaction from the entity's deleted timestamp if any
- Limit the `nft_transfer` search space in the `serial_transfers` cte

**Related issue(s)**:

Fixes #2792 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
Please check the analysis in the ticket and the comments I added for the cause of the performance issue and why the changes can fix the issue.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
