### PR TITLE
Remove rosetta token balance workaround

### DIFF
--- a/hedera-mirror-rosetta/app/domain/types/block.go
+++ b/hedera-mirror-rosetta/app/domain/types/block.go
@@ -33,7 +33,6 @@ type Block struct {
 	ConsensusStartNanos int64
 	Hash                string
 	Index               int64
-	LatestIndex         int64
 	ParentHash          string
 	ParentIndex         int64
 	Transactions        []*Transaction

--- a/hedera-mirror-rosetta/app/interfaces/account_repository.go
+++ b/hedera-mirror-rosetta/app/interfaces/account_repository.go
@@ -38,9 +38,8 @@ type AccountRepository interface {
 	// balance = balanceAtLatestBalanceSnapshotBeforeT1 + balanceChangeBetweenSnapshotAndT1
 	RetrieveBalanceAtBlock(ctx context.Context, accountId, consensusEnd int64) ([]types.Amount, *rTypes.Error)
 
-	// RetrieveEverOwnedTokensByBlockAfter returns the tokens the account has ever owned by the end of the block after
-	// consensusEnd
-	RetrieveEverOwnedTokensByBlockAfter(ctx context.Context, accountId, consensusEnd int64) (
+	// RetrieveEverOwnedTokensByBlock returns the tokens the account has ever owned by the block's consensusEnd
+	RetrieveEverOwnedTokensByBlock(ctx context.Context, accountId, consensusEnd int64) (
 		[]domain.Token,
 		*rTypes.Error,
 	)

--- a/hedera-mirror-rosetta/app/persistence/account_test.go
+++ b/hedera-mirror-rosetta/app/persistence/account_test.go
@@ -433,20 +433,8 @@ func (suite *accountRepositorySuite) TestRetrieveBalanceAtBlock() {
 
 func (suite *accountRepositorySuite) TestRetrieveBalanceAtBlockForDeletedAccount() {
 	// given
-	db.CreateDbRecords(dbClient, getAccountEntity(account, true, accountDeleteTimestamp), token1, token2, token3)
-	db.CreateDbRecords(dbClient, initialAccountBalance, initialTokenBalances)
-	// transfers before or at the snapshot timestamp should not affect balance calculation
-	db.CreateDbRecords(dbClient, cryptoTransfersLTESnapshot, tokenTransfersLTESnapshot, nftTransfersLTESnapshot)
-	db.CreateDbRecords(dbClient, cryptoTransfers, tokenTransfers, nftTransfers)
-
+	expected := suite.setupTestForDeletedAccount()
 	repo := NewAccountRepository(dbClient)
-
-	token1Amount := types.NewTokenAmount(*token1, initialTokenBalances[0].Balance+sum(token1TransferAmounts))
-	token2Amount := types.NewTokenAmount(*token2, initialTokenBalances[1].Balance+sum(token2TransferAmounts))
-	token3Amount := types.NewTokenAmount(*token3, initialTokenBalances[2].Balance+2).
-		SetSerialNumbers([]int64{1, 2, 3, 4})
-
-	expected := []types.Amount{&types.HbarAmount{}, token1Amount, token2Amount, token3Amount}
 
 	// when
 	// account is deleted before the second account balance file, so there is no balance info in the file. querying the
@@ -461,20 +449,8 @@ func (suite *accountRepositorySuite) TestRetrieveBalanceAtBlockForDeletedAccount
 
 func (suite *accountRepositorySuite) TestRetrieveBalanceAtBlockAtAccountDeletionTime() {
 	// given
-	db.CreateDbRecords(dbClient, getAccountEntity(account, true, accountDeleteTimestamp), token1, token2, token3)
-	db.CreateDbRecords(dbClient, initialAccountBalance, initialTokenBalances)
-	// transfers before or at the snapshot timestamp should not affect balance calculation
-	db.CreateDbRecords(dbClient, cryptoTransfersLTESnapshot, tokenTransfersLTESnapshot, nftTransfersLTESnapshot)
-	db.CreateDbRecords(dbClient, cryptoTransfers, tokenTransfers, nftTransfers)
-
+	expected := suite.setupTestForDeletedAccount()
 	repo := NewAccountRepository(dbClient)
-
-	token1Amount := types.NewTokenAmount(*token1, initialTokenBalances[0].Balance+sum(token1TransferAmounts))
-	token2Amount := types.NewTokenAmount(*token2, initialTokenBalances[1].Balance+sum(token2TransferAmounts))
-	token3Amount := types.NewTokenAmount(*token3, initialTokenBalances[2].Balance+2).
-		SetSerialNumbers([]int64{1, 2, 3, 4})
-
-	expected := []types.Amount{&types.HbarAmount{}, token1Amount, token2Amount, token3Amount}
 
 	// when
 	actual, err := repo.RetrieveBalanceAtBlock(defaultContext, account.EncodedId, accountDeleteTimestamp)
@@ -554,22 +530,8 @@ func (suite *accountRepositorySuite) TestRetrieveBalanceAtBlockDbConnectionError
 
 func (suite *accountRepositorySuite) TestRetrieveEverOwnedTokensByBlock() {
 	// given
-	currentBlockStart := recordFile.ConsensusStart
-	currentBlockEnd := recordFile.ConsensusEnd
-	nextBlockStart := currentBlockEnd + 1
 	db.CreateDbRecords(dbClient, recordFile, token1, token2, token3)
-	db.CreateDbRecords(
-		dbClient,
-		// account1's token associations
-		getTokenAccount(account, true, currentBlockStart-1, currentBlockStart-1, token1.TokenId),
-		getTokenAccount(account, false, currentBlockStart-1, currentBlockStart, token1.TokenId),
-		getTokenAccount(account, true, currentBlockEnd, currentBlockEnd, token2.TokenId),
-		getTokenAccount(account, false, currentBlockEnd, nextBlockStart, token2.TokenId),
-		getTokenAccount(account, true, nextBlockStart+1, nextBlockStart+1, token3.TokenId),
-		// account2's token associations
-		getTokenAccount(account2, true, currentBlockEnd-6, currentBlockEnd-6, token3.TokenId),
-		getTokenAccount(account2, true, currentBlockEnd-5, currentBlockEnd-5, token4.TokenId),
-	)
+	suite.createTokenAssociations()
 	expected := []domain.Token{
 		{
 			Decimals: token1.Decimals,
@@ -585,7 +547,7 @@ func (suite *accountRepositorySuite) TestRetrieveEverOwnedTokensByBlock() {
 	repo := NewAccountRepository(dbClient)
 
 	// when
-	actual, err := repo.RetrieveEverOwnedTokensByBlock(defaultContext, account.EncodedId, currentBlockEnd)
+	actual, err := repo.RetrieveEverOwnedTokensByBlock(defaultContext, account.EncodedId, recordFile.ConsensusEnd)
 
 	// then
 	assert.Nil(suite.T(), err)
@@ -594,26 +556,12 @@ func (suite *accountRepositorySuite) TestRetrieveEverOwnedTokensByBlock() {
 
 func (suite *accountRepositorySuite) TestRetrieveEverOwnedTokensByBlockNoTokenEntity() {
 	// given
-	currentBlockStart := recordFile.ConsensusStart
-	currentBlockEnd := recordFile.ConsensusEnd
-	nextBlockStart := currentBlockEnd + 1
 	db.CreateDbRecords(dbClient, recordFile)
-	db.CreateDbRecords(
-		dbClient,
-		// account1's token associations
-		getTokenAccount(account, true, currentBlockStart-1, currentBlockStart-1, token1.TokenId),
-		getTokenAccount(account, false, currentBlockStart-1, currentBlockStart, token1.TokenId),
-		getTokenAccount(account, true, currentBlockEnd, currentBlockEnd, token2.TokenId),
-		getTokenAccount(account, false, currentBlockEnd, nextBlockStart, token2.TokenId),
-		getTokenAccount(account, true, nextBlockStart+1, nextBlockStart+1, token3.TokenId),
-		// account2's token associations
-		getTokenAccount(account2, true, currentBlockEnd-6, currentBlockEnd-6, token3.TokenId),
-		getTokenAccount(account2, true, currentBlockEnd-5, currentBlockEnd-5, token4.TokenId),
-	)
+	suite.createTokenAssociations()
 	repo := NewAccountRepository(dbClient)
 
 	// when
-	actual, err := repo.RetrieveEverOwnedTokensByBlock(defaultContext, account.EncodedId, currentBlockEnd)
+	actual, err := repo.RetrieveEverOwnedTokensByBlock(defaultContext, account.EncodedId, recordFile.ConsensusEnd)
 
 	// then
 	assert.Nil(suite.T(), err)
@@ -630,6 +578,39 @@ func (suite *accountRepositorySuite) TestRetrieveEverOwnedTokensByBlockDbConnect
 	// then
 	assert.Equal(suite.T(), errors.ErrDatabaseError, err)
 	assert.Nil(suite.T(), actual)
+}
+
+func (suite *accountRepositorySuite) createTokenAssociations() {
+	currentBlockStart := recordFile.ConsensusStart
+	currentBlockEnd := recordFile.ConsensusEnd
+	nextBlockStart := currentBlockEnd + 1
+	db.CreateDbRecords(
+		dbClient,
+		// account1's token associations
+		getTokenAccount(account, true, currentBlockStart-1, currentBlockStart-1, token1.TokenId),
+		getTokenAccount(account, false, currentBlockStart-1, currentBlockStart, token1.TokenId),
+		getTokenAccount(account, true, currentBlockEnd, currentBlockEnd, token2.TokenId),
+		getTokenAccount(account, false, currentBlockEnd, nextBlockStart, token2.TokenId),
+		getTokenAccount(account, true, nextBlockStart+1, nextBlockStart+1, token3.TokenId),
+		// account2's token associations
+		getTokenAccount(account2, true, currentBlockEnd-6, currentBlockEnd-6, token3.TokenId),
+		getTokenAccount(account2, true, currentBlockEnd-5, currentBlockEnd-5, token4.TokenId),
+	)
+}
+
+func (suite *accountRepositorySuite) setupTestForDeletedAccount() []types.Amount {
+	db.CreateDbRecords(dbClient, getAccountEntity(account, true, accountDeleteTimestamp), token1, token2, token3)
+	db.CreateDbRecords(dbClient, initialAccountBalance, initialTokenBalances)
+	// transfers before or at the snapshot timestamp should not affect balance calculation
+	db.CreateDbRecords(dbClient, cryptoTransfersLTESnapshot, tokenTransfersLTESnapshot, nftTransfersLTESnapshot)
+	db.CreateDbRecords(dbClient, cryptoTransfers, tokenTransfers, nftTransfers)
+
+	token1Amount := types.NewTokenAmount(*token1, initialTokenBalances[0].Balance+sum(token1TransferAmounts))
+	token2Amount := types.NewTokenAmount(*token2, initialTokenBalances[1].Balance+sum(token2TransferAmounts))
+	token3Amount := types.NewTokenAmount(*token3, initialTokenBalances[2].Balance+2).
+		SetSerialNumbers([]int64{1, 2, 3, 4})
+
+	return []types.Amount{&types.HbarAmount{}, token1Amount, token2Amount, token3Amount}
 }
 
 func TestGetUpdatedTokenAmounts(t *testing.T) {

--- a/hedera-mirror-rosetta/app/persistence/account_test.go
+++ b/hedera-mirror-rosetta/app/persistence/account_test.go
@@ -557,8 +557,6 @@ func (suite *accountRepositorySuite) TestRetrieveEverOwnedTokensByBlock() {
 	currentBlockStart := recordFile.ConsensusStart
 	currentBlockEnd := recordFile.ConsensusEnd
 	nextBlockStart := currentBlockEnd + 1
-	// nextBlockStart := recordFile.ConsensusStart
-	// nextBlockEnd := recordFile.ConsensusEnd
 	db.CreateDbRecords(dbClient, recordFile, token1, token2, token3)
 	db.CreateDbRecords(
 		dbClient,

--- a/hedera-mirror-rosetta/app/persistence/account_test.go
+++ b/hedera-mirror-rosetta/app/persistence/account_test.go
@@ -374,7 +374,7 @@ var (
 			TokenId:            token3.TokenId,
 		},
 	}
-	nextRecordFile = &domain.RecordFile{
+	recordFile = &domain.RecordFile{
 		ConsensusStart: consensusTimestamp + 1,
 		ConsensusEnd:   consensusTimestamp + 10,
 		Count:          5,
@@ -552,18 +552,23 @@ func (suite *accountRepositorySuite) TestRetrieveBalanceAtBlockDbConnectionError
 	assert.Nil(suite.T(), actual)
 }
 
-func (suite *accountRepositorySuite) TestRetrieveEverOwnedTokensByBlockAfter() {
+func (suite *accountRepositorySuite) TestRetrieveEverOwnedTokensByBlock() {
 	// given
-	currentBlockEnd := nextRecordFile.ConsensusStart - 1
-	nextBlockStart := nextRecordFile.ConsensusStart
-	nextBlockEnd := nextRecordFile.ConsensusEnd
-	db.CreateDbRecords(dbClient, nextRecordFile, token1, token2, token3)
+	currentBlockStart := recordFile.ConsensusStart
+	currentBlockEnd := recordFile.ConsensusEnd
+	nextBlockStart := currentBlockEnd + 1
+	// nextBlockStart := recordFile.ConsensusStart
+	// nextBlockEnd := recordFile.ConsensusEnd
+	db.CreateDbRecords(dbClient, recordFile, token1, token2, token3)
 	db.CreateDbRecords(
 		dbClient,
-		getTokenAccount(account, true, currentBlockEnd-5, currentBlockEnd-5, token1.TokenId),
-		getTokenAccount(account, false, currentBlockEnd-5, currentBlockEnd-4, token1.TokenId),
-		getTokenAccount(account, true, nextBlockStart+1, nextBlockStart+1, token2.TokenId),
-		getTokenAccount(account, true, nextBlockEnd+1, nextBlockEnd+1, token3.TokenId),
+		// account1's token associations
+		getTokenAccount(account, true, currentBlockStart-1, currentBlockStart-1, token1.TokenId),
+		getTokenAccount(account, false, currentBlockStart-1, currentBlockStart, token1.TokenId),
+		getTokenAccount(account, true, currentBlockEnd, currentBlockEnd, token2.TokenId),
+		getTokenAccount(account, false, currentBlockEnd, nextBlockStart, token2.TokenId),
+		getTokenAccount(account, true, nextBlockStart+1, nextBlockStart+1, token3.TokenId),
+		// account2's token associations
 		getTokenAccount(account2, true, currentBlockEnd-6, currentBlockEnd-6, token3.TokenId),
 		getTokenAccount(account2, true, currentBlockEnd-5, currentBlockEnd-5, token4.TokenId),
 	)
@@ -582,44 +587,47 @@ func (suite *accountRepositorySuite) TestRetrieveEverOwnedTokensByBlockAfter() {
 	repo := NewAccountRepository(dbClient)
 
 	// when
-	actual, err := repo.RetrieveEverOwnedTokensByBlockAfter(defaultContext, account.EncodedId, currentBlockEnd)
+	actual, err := repo.RetrieveEverOwnedTokensByBlock(defaultContext, account.EncodedId, currentBlockEnd)
 
 	// then
 	assert.Nil(suite.T(), err)
 	assert.Equal(suite.T(), expected, actual)
 }
 
-func (suite *accountRepositorySuite) TestRetrieveEverOwnedTokensByBlockAfterNoTokenEntity() {
+func (suite *accountRepositorySuite) TestRetrieveEverOwnedTokensByBlockNoTokenEntity() {
 	// given
-	currentBlockEnd := nextRecordFile.ConsensusStart - 1
-	nextBlockStart := nextRecordFile.ConsensusStart
-	nextBlockEnd := nextRecordFile.ConsensusEnd
-	db.CreateDbRecords(dbClient, nextRecordFile)
+	currentBlockStart := recordFile.ConsensusStart
+	currentBlockEnd := recordFile.ConsensusEnd
+	nextBlockStart := currentBlockEnd + 1
+	db.CreateDbRecords(dbClient, recordFile)
 	db.CreateDbRecords(
 		dbClient,
-		getTokenAccount(account, true, currentBlockEnd-5, currentBlockEnd-5, token1.TokenId),
-		getTokenAccount(account, false, currentBlockEnd-5, currentBlockEnd-4, token1.TokenId),
-		getTokenAccount(account, true, nextBlockStart+1, nextBlockStart+1, token2.TokenId),
-		getTokenAccount(account, true, nextBlockEnd+1, nextBlockEnd+1, token3.TokenId),
+		// account1's token associations
+		getTokenAccount(account, true, currentBlockStart-1, currentBlockStart-1, token1.TokenId),
+		getTokenAccount(account, false, currentBlockStart-1, currentBlockStart, token1.TokenId),
+		getTokenAccount(account, true, currentBlockEnd, currentBlockEnd, token2.TokenId),
+		getTokenAccount(account, false, currentBlockEnd, nextBlockStart, token2.TokenId),
+		getTokenAccount(account, true, nextBlockStart+1, nextBlockStart+1, token3.TokenId),
+		// account2's token associations
 		getTokenAccount(account2, true, currentBlockEnd-6, currentBlockEnd-6, token3.TokenId),
 		getTokenAccount(account2, true, currentBlockEnd-5, currentBlockEnd-5, token4.TokenId),
 	)
 	repo := NewAccountRepository(dbClient)
 
 	// when
-	actual, err := repo.RetrieveEverOwnedTokensByBlockAfter(defaultContext, account.EncodedId, currentBlockEnd)
+	actual, err := repo.RetrieveEverOwnedTokensByBlock(defaultContext, account.EncodedId, currentBlockEnd)
 
 	// then
 	assert.Nil(suite.T(), err)
 	assert.Empty(suite.T(), actual)
 }
 
-func (suite *accountRepositorySuite) TestRetrieveEverOwnedTokensByBlockAfterDbConnectionError() {
+func (suite *accountRepositorySuite) TestRetrieveEverOwnedTokensByBlockDbConnectionError() {
 	// given
 	repo := NewAccountRepository(invalidDbClient)
 
 	// when
-	actual, err := repo.RetrieveEverOwnedTokensByBlockAfter(defaultContext, account.EncodedId, consensusEnd)
+	actual, err := repo.RetrieveEverOwnedTokensByBlock(defaultContext, account.EncodedId, consensusEnd)
 
 	// then
 	assert.Equal(suite.T(), errors.ErrDatabaseError, err)

--- a/hedera-mirror-rosetta/app/persistence/block_test.go
+++ b/hedera-mirror-rosetta/app/persistence/block_test.go
@@ -60,7 +60,6 @@ var (
 		ConsensusEndNanos:   100,
 		Hash:                "genesis_record_file_hash",
 		Index:               0,
-		LatestIndex:         1,
 		ParentHash:          "genesis_record_file_hash",
 		ParentIndex:         0,
 	}
@@ -69,7 +68,6 @@ var (
 		ConsensusEndNanos:   120,
 		Hash:                "second_record_file_hash",
 		Index:               1,
-		LatestIndex:         1,
 		ParentHash:          "genesis_record_file_hash",
 		ParentIndex:         0,
 	}
@@ -104,15 +102,15 @@ var (
 		NodeAccountID:  nodeAccountId,
 		PrevHash:       "some_hash",
 	}
-	thirdRecordFile = &domain.RecordFile{
-		ConsensusStart: 121,
-		ConsensusEnd:   130,
-		Hash:           "third_record_file_hash",
-		Index:          5,
-		Name:           "third_record_file",
-		NodeAccountID:  nodeAccountId,
-		PrevHash:       "second_record_file_hash",
-	}
+	// thirdRecordFile = &domain.RecordFile{
+	// 	ConsensusStart: 121,
+	// 	ConsensusEnd:   130,
+	// 	Hash:           "third_record_file_hash",
+	// 	Index:          5,
+	// 	Name:           "third_record_file",
+	// 	NodeAccountID:  nodeAccountId,
+	// 	PrevHash:       "second_record_file_hash",
+	// }
 )
 
 // run the suite
@@ -434,23 +432,10 @@ func (suite *blockRepositorySuite) TestRetrieveGenesisDbConnectionError() {
 	assert.Nil(suite.T(), actual)
 }
 
-func (suite *blockRepositorySuite) TestRetrieveSecondLatestGenesisBlock() {
-	// given
-	repo := NewBlockRepository(dbClient)
-
-	// when
-	actual, err := repo.RetrieveLatest(defaultContext)
-
-	// then
-	assert.Nil(suite.T(), err)
-	assert.Equal(suite.T(), expectedGenesisBlock, actual)
-}
-
 func (suite *blockRepositorySuite) TestRetrieveLatestNonGenesisBlock() {
 	// given
-	db.CreateDbRecords(dbClient, thirdRecordFile)
+	// db.CreateDbRecords(dbClient, thirdRecordFile)
 	expected := *expectedSecondBlock
-	expected.LatestIndex = 2
 	repo := NewBlockRepository(dbClient)
 
 	// when
@@ -471,21 +456,21 @@ func (suite *blockRepositorySuite) TestRetrieveLatestWithOnlyGenesisBlock() {
 	actual, err := repo.RetrieveLatest(defaultContext)
 
 	// then
-	assert.Equal(suite.T(), errors.ErrBlockNotFound, err)
-	assert.Nil(suite.T(), actual)
+	assert.Nil(suite.T(), err)
+	assert.Equal(suite.T(), actual, expectedGenesisBlock)
 }
 
 func (suite *blockRepositorySuite) TestRetrieveLatestWithBlockBeforeGenesis() {
 	// given
 	db.ExecSql(dbClient, truncateRecordFileSql)
-	db.CreateDbRecords(dbClient, recordFileBeforeGenesis, genesisRecordFile)
+	db.CreateDbRecords(dbClient, recordFileBeforeGenesis)
 	repo := NewBlockRepository(dbClient)
 
 	// when
 	actual, err := repo.RetrieveLatest(defaultContext)
 
 	// then
-	assert.Equal(suite.T(), errors.ErrBlockNotFound, err)
+	assert.Equal(suite.T(), errors.ErrNodeIsStarting, err)
 	assert.Nil(suite.T(), actual)
 }
 
@@ -542,13 +527,11 @@ func TestRecordFileToBlock(t *testing.T) {
 				ConsensusEnd:   200,
 				Hash:           "hash",
 				Index:          5,
-				LatestIndex:    9,
 				PrevHash:       "prev_hash",
 			},
 			&types.Block{
 				Index:               0,
 				Hash:                "hash",
-				LatestIndex:         4,
 				ParentIndex:         0,
 				ParentHash:          "hash",
 				ConsensusStartNanos: genesisConsensusStart,
@@ -562,13 +545,11 @@ func TestRecordFileToBlock(t *testing.T) {
 				ConsensusEnd:   300,
 				Hash:           "hash",
 				Index:          8,
-				LatestIndex:    9,
 				PrevHash:       "prev_hash",
 			},
 			&types.Block{
 				Index:               3,
 				Hash:                "hash",
-				LatestIndex:         4,
 				ParentIndex:         2,
 				ParentHash:          "prev_hash",
 				ConsensusStartNanos: 201,

--- a/hedera-mirror-rosetta/app/persistence/block_test.go
+++ b/hedera-mirror-rosetta/app/persistence/block_test.go
@@ -102,15 +102,6 @@ var (
 		NodeAccountID:  nodeAccountId,
 		PrevHash:       "some_hash",
 	}
-	// thirdRecordFile = &domain.RecordFile{
-	// 	ConsensusStart: 121,
-	// 	ConsensusEnd:   130,
-	// 	Hash:           "third_record_file_hash",
-	// 	Index:          5,
-	// 	Name:           "third_record_file",
-	// 	NodeAccountID:  nodeAccountId,
-	// 	PrevHash:       "second_record_file_hash",
-	// }
 )
 
 // run the suite

--- a/hedera-mirror-rosetta/app/persistence/block_test.go
+++ b/hedera-mirror-rosetta/app/persistence/block_test.go
@@ -449,7 +449,6 @@ func (suite *blockRepositorySuite) TestRetrieveGenesisDbConnectionError() {
 
 func (suite *blockRepositorySuite) TestRetrieveLatestNonGenesisBlock() {
 	// given
-	// db.CreateDbRecords(dbClient, thirdRecordFile)
 	expected := *expectedSecondBlock
 	repo := NewBlockRepository(dbClient)
 

--- a/hedera-mirror-rosetta/app/persistence/block_test.go
+++ b/hedera-mirror-rosetta/app/persistence/block_test.go
@@ -287,6 +287,18 @@ func (suite *blockRepositorySuite) TestFindByIdentifierNoRecordFile() {
 	assert.Nil(suite.T(), actual)
 }
 
+func (suite *blockRepositorySuite) TestFindByIdentifierNotFound() {
+	// given
+	repo := NewBlockRepository(dbClient)
+
+	// when
+	actual, err := repo.FindByIdentifier(defaultContext, 1000, "foobar")
+
+	// then
+	assert.Equal(suite.T(), errors.ErrBlockNotFound, err)
+	assert.Nil(suite.T(), actual)
+}
+
 func (suite *blockRepositorySuite) TestFindByIdentifierDbConnectionError() {
 	// given
 	repo := NewBlockRepository(invalidDbClient)
@@ -358,6 +370,18 @@ func (suite *blockRepositorySuite) TestFindByIndexNoRecordFile() {
 
 	// then
 	assert.Equal(suite.T(), errors.ErrNodeIsStarting, err)
+	assert.Nil(suite.T(), actual)
+}
+
+func (suite *blockRepositorySuite) TestFindByIndexNotFound() {
+	// given
+	repo := NewBlockRepository(dbClient)
+
+	// when
+	actual, err := repo.FindByIndex(defaultContext, 1000)
+
+	// then
+	assert.Equal(suite.T(), errors.ErrBlockNotFound, err)
 	assert.Nil(suite.T(), actual)
 }
 
@@ -491,7 +515,35 @@ func (suite *blockRepositorySuite) TestRetrieveLatestNoRecordFile() {
 	assert.Nil(suite.T(), actual)
 }
 
-func (suite *blockRepositorySuite) TestetrieveSecondLatestDbConnectionError() {
+func (suite *blockRepositorySuite) TestRetrieveLatestRecordFileTableInconsistent() {
+	// given
+	repo := NewBlockRepository(dbClient)
+
+	// when
+	actual, err := repo.RetrieveLatest(defaultContext)
+
+	// then
+	assert.Nil(suite.T(), err)
+	assert.Equal(suite.T(), expectedSecondBlock, actual)
+
+	// when
+	db.ExecSql(dbClient, truncateRecordFileSql)
+	actual, err = repo.RetrieveLatest(defaultContext)
+
+	// then
+	assert.Equal(suite.T(), errors.ErrBlockNotFound, err)
+	assert.Nil(suite.T(), actual)
+
+	// when
+	db.CreateDbRecords(dbClient, recordFileBeforeGenesis)
+	actual, err = repo.RetrieveLatest(defaultContext)
+
+	// then
+	assert.Equal(suite.T(), errors.ErrBlockNotFound, err)
+	assert.Nil(suite.T(), actual)
+}
+
+func (suite *blockRepositorySuite) TestRetrieveLatestDbConnectionError() {
 	// given
 	repo := NewBlockRepository(invalidDbClient)
 

--- a/hedera-mirror-rosetta/app/services/account_service.go
+++ b/hedera-mirror-rosetta/app/services/account_service.go
@@ -67,11 +67,6 @@ func (a *AccountAPIService) AccountBalance(
 		return nil, err
 	}
 
-	if block.LatestIndex-block.Index < 1 {
-		// only show info up to the second latest block
-		return nil, errors.ErrBlockNotFound
-	}
-
 	balances, err := a.accountRepo.RetrieveBalanceAtBlock(ctx, account.EncodedId, block.ConsensusEndNanos)
 	if err != nil {
 		return nil, err
@@ -107,14 +102,15 @@ func (a *AccountAPIService) AccountCoins(
 }
 
 // getAdditionalTokenBalances get the additional token balances with 0 amount for tokens the account has ever owned by
-// the end of the next block and not in the tokenSet
+// the end of the current block and not in the tokenSet, i.e., tokens the account has dissociated with while rosetta
+// validation requires an implementation to still show the 0 balance
 func (a *AccountAPIService) getAdditionalTokenBalances(
 	ctx context.Context,
 	accountId int64,
 	consensusEnd int64,
 	tokenSet map[int64]bool,
 ) ([]types.Amount, *rTypes.Error) {
-	tokens, err := a.accountRepo.RetrieveEverOwnedTokensByBlockAfter(ctx, accountId, consensusEnd)
+	tokens, err := a.accountRepo.RetrieveEverOwnedTokensByBlock(ctx, accountId, consensusEnd)
 	if err != nil {
 		return nil, err
 	}

--- a/hedera-mirror-rosetta/app/services/account_service_test.go
+++ b/hedera-mirror-rosetta/app/services/account_service_test.go
@@ -84,7 +84,6 @@ func genesisBlock() *types.Block {
 	return &types.Block{
 		Index:               0,
 		Hash:                "genesis",
-		LatestIndex:         0,
 		ConsensusStartNanos: 1000000,
 		ConsensusEndNanos:   20000000,
 		ParentIndex:         0,
@@ -162,7 +161,7 @@ func (suite *accountServiceSuite) TestAccountBalance() {
 	// given:
 	suite.mockBlockRepo.On("RetrieveLatest").Return(block(), mocks.NilError)
 	suite.mockAccountRepo.On("RetrieveBalanceAtBlock").Return(amount(), mocks.NilError)
-	suite.mockAccountRepo.On("RetrieveEverOwnedTokensByBlockAfter").Return([]domain.Token{}, mocks.NilError)
+	suite.mockAccountRepo.On("RetrieveEverOwnedTokensByBlock").Return([]domain.Token{}, mocks.NilError)
 
 	// when:
 	actual, err := suite.accountService.AccountBalance(nil, request(false))
@@ -180,7 +179,7 @@ func (suite *accountServiceSuite) TestAccountBalanceWithGenesisTokenBalance() {
 	expected := addGenesisTokenBalances(expectedAccountBalanceResponse(), token3, token4)
 	suite.mockBlockRepo.On("RetrieveLatest").Return(block(), mocks.NilError)
 	suite.mockAccountRepo.On("RetrieveBalanceAtBlock").Return(amount(), mocks.NilError)
-	suite.mockAccountRepo.On("RetrieveEverOwnedTokensByBlockAfter").Return(everOwnedTokens, mocks.NilError)
+	suite.mockAccountRepo.On("RetrieveEverOwnedTokensByBlock").Return(everOwnedTokens, mocks.NilError)
 
 	// when:
 	actual, err := suite.accountService.AccountBalance(nil, request(false))
@@ -196,7 +195,7 @@ func (suite *accountServiceSuite) TestAccountBalanceWithBlockIdentifier() {
 	// given:
 	suite.mockBlockRepo.On("FindByIdentifier").Return(block(), mocks.NilError)
 	suite.mockAccountRepo.On("RetrieveBalanceAtBlock").Return(amount(), mocks.NilError)
-	suite.mockAccountRepo.On("RetrieveEverOwnedTokensByBlockAfter").Return([]domain.Token{}, mocks.NilError)
+	suite.mockAccountRepo.On("RetrieveEverOwnedTokensByBlock").Return([]domain.Token{}, mocks.NilError)
 
 	// when:
 	actual, err := suite.accountService.AccountBalance(nil, request(true))
@@ -213,7 +212,7 @@ func (suite *accountServiceSuite) TestAccountBalanceWithBlockIdentifierAndAdditi
 	expected := addGenesisTokenBalances(expectedAccountBalanceResponse(), token3, token4)
 	suite.mockBlockRepo.On("FindByIdentifier").Return(block(), mocks.NilError)
 	suite.mockAccountRepo.On("RetrieveBalanceAtBlock").Return(amount(), mocks.NilError)
-	suite.mockAccountRepo.On("RetrieveEverOwnedTokensByBlockAfter").Return(everOwnedTokens, mocks.NilError)
+	suite.mockAccountRepo.On("RetrieveEverOwnedTokensByBlock").Return(everOwnedTokens, mocks.NilError)
 
 	// when:
 	actual, err := suite.accountService.AccountBalance(nil, request(true))
@@ -223,21 +222,6 @@ func (suite *accountServiceSuite) TestAccountBalanceWithBlockIdentifierAndAdditi
 	assert.Nil(suite.T(), err)
 	suite.mockBlockRepo.AssertNotCalled(suite.T(), "RetrieveLatest")
 	suite.mockBlockRepo.AssertNotCalled(suite.T(), "FindByHash")
-}
-
-func (suite *accountServiceSuite) TestAccountBalanceWithOnlyGenesisBlock() {
-	// given:
-	suite.mockBlockRepo.On("FindByIdentifier").Return(genesisBlock(), mocks.NilError)
-
-	// when:
-	actual, err := suite.accountService.AccountBalance(nil, request(true))
-
-	// then:
-	assert.NotNil(suite.T(), err)
-	assert.Nil(suite.T(), actual)
-	suite.mockBlockRepo.AssertNotCalled(suite.T(), "RetrieveLatest")
-	suite.mockAccountRepo.AssertNotCalled(suite.T(), "RetrieveBalanceAtBlock")
-	suite.mockAccountRepo.AssertNotCalled(suite.T(), "RetrieveEverOwnedTokensByBlockAfter")
 }
 
 func (suite *accountServiceSuite) TestAccountBalanceThrowsWhenRetrieveLatestFails() {
@@ -280,11 +264,11 @@ func (suite *accountServiceSuite) TestAccountBalanceThrowsWhenRetrieveBalanceAtB
 	assert.NotNil(suite.T(), err)
 }
 
-func (suite *accountServiceSuite) TestAccountBalanceThrowsWhenRetrieveEverOwnedTokensByBlockAfterFails() {
+func (suite *accountServiceSuite) TestAccountBalanceThrowsWhenRetrieveEverOwnedTokensByBlockFails() {
 	// given:
 	suite.mockBlockRepo.On("FindByIdentifier").Return(block(), mocks.NilError)
 	suite.mockAccountRepo.On("RetrieveBalanceAtBlock").Return(amount(), mocks.NilError)
-	suite.mockAccountRepo.On("RetrieveEverOwnedTokensByBlockAfter").Return([]domain.Token{}, &rTypes.Error{})
+	suite.mockAccountRepo.On("RetrieveEverOwnedTokensByBlock").Return([]domain.Token{}, &rTypes.Error{})
 
 	// when:
 	actual, err := suite.accountService.AccountBalance(nil, request(true))

--- a/hedera-mirror-rosetta/app/services/block_service_test.go
+++ b/hedera-mirror-rosetta/app/services/block_service_test.go
@@ -43,7 +43,6 @@ func block() *types.Block {
 	return &types.Block{
 		Index:               1,
 		Hash:                "12345",
-		LatestIndex:         5,
 		ConsensusStartNanos: 1000000,
 		ConsensusEndNanos:   20000000,
 		ParentIndex:         2,

--- a/hedera-mirror-rosetta/app/services/network_service_test.go
+++ b/hedera-mirror-rosetta/app/services/network_service_test.go
@@ -38,7 +38,6 @@ func dummyGenesisBlock() *types.Block {
 	return &types.Block{
 		Index:               1,
 		Hash:                "0x123jsjs",
-		LatestIndex:         3,
 		ConsensusStartNanos: 1000000,
 		ConsensusEndNanos:   20000000,
 		ParentIndex:         0,
@@ -50,7 +49,6 @@ func dummySecondLatestBlock() *types.Block {
 	return &types.Block{
 		Index:               2,
 		Hash:                "0x1323jsjs",
-		LatestIndex:         3,
 		ConsensusStartNanos: 40000000,
 		ConsensusEndNanos:   70000000,
 		ParentIndex:         1,

--- a/hedera-mirror-rosetta/scripts/validation/run-validation.sh
+++ b/hedera-mirror-rosetta/scripts/validation/run-validation.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
+ROSETTA_CLI_VERSION=${ROSETTA_CLI_VERSION:-}
+
 parent_path="$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )"
 cd "${parent_path}"
 network=${1:-demo}

--- a/hedera-mirror-rosetta/test/mocks/account_repository.go
+++ b/hedera-mirror-rosetta/test/mocks/account_repository.go
@@ -43,7 +43,7 @@ func (m *MockAccountRepository) RetrieveBalanceAtBlock(ctx context.Context, acco
 	return args.Get(0).([]types.Amount), args.Get(1).(*rTypes.Error)
 }
 
-func (m *MockAccountRepository) RetrieveEverOwnedTokensByBlockAfter(
+func (m *MockAccountRepository) RetrieveEverOwnedTokensByBlock(
 	ctx context.Context,
 	accountId int64,
 	consensusEnd int64,


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR removes the rosetta token balance workaround which was needed without the rosetta-sdk-go 0 token balance fix in v0.7.2:

- No more hiding the latest record file
- Get an account's ever owned tokens by the end of the current block instead of the end of the next block
- Add default for `ROSETTA_CLI_VERSION`

**Related issue(s)**:

Fixes #2997

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
~~Will run the `rosetta-cli` data check (balance reconciliation) in testnet with new token to confirm no regression.~~ Update, tested it locally and passed.
  
**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
