### PR TITLE
Bump grpc-java from 1.43.1 to 1.43.2 (0.48)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <flyway.version>7.15.0</flyway.version>
         <git-commit-id-plugin.version>4.0.4</git-commit-id-plugin.version>
         <grpc-spring-boot.version>2.11.0.RELEASE</grpc-spring-boot.version>
-        <grpc.version>1.43.1</grpc.version>
+        <grpc.version>1.43.2</grpc.version>
         <guava.version>31.0.1-jre</guava.version>
         <hedera-protobuf.version>0.21.0</hedera-protobuf.version>
         <hedera-sdk.version>2.2.0-beta.2</hedera-sdk.version>


### PR DESCRIPTION
**Description**:
Bump grpc-java from 1.43.1 to 1.43.2

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
