### PR TITLE
Fix OpenAPI bugs related to path parameters

### DIFF
--- a/hedera-mirror-rest/api/v1/openapi.yml
+++ b/hedera-mirror-rest/api/v1/openapi.yml
@@ -93,7 +93,7 @@ paths:
       description: Return the contract information given an id
       operationId: getContractById
       parameters:
-        - $ref: '#/components/parameters/entityIdPathParam'
+        - $ref: '#/components/parameters/contractIdPathParam'
         - $ref: '#/components/parameters/timestampQueryParam'
       responses:
         200:
@@ -114,8 +114,7 @@ paths:
       description: Returns a list of all ContractResults for a contract's function executions.
       operationId: listContractResults
       parameters:
-        - $ref: '#/components/parameters/entityIdPathParam'
-        - $ref: '#/components/parameters/fromQueryParam'
+        - $ref: '#/components/parameters/contractIdPathParam'
         - $ref: '#/components/parameters/limitQueryParam'
         - $ref: '#/components/parameters/orderQueryParamDesc'
         - $ref: '#/components/parameters/timestampQueryParam'
@@ -136,7 +135,7 @@ paths:
       description: Returns a single ContractResult for a contract's function executions at a specific timestamp.
       operationId: getContractResultByIdAndTimestamp
       parameters:
-        - $ref: '#/components/parameters/entityIdPathParam'
+        - $ref: '#/components/parameters/contractIdPathParam'
         - $ref: '#/components/parameters/timestampPathParam'
       responses:
         200:
@@ -182,7 +181,7 @@ paths:
         and span a time range of at most seven days.
       operationId: listContractLogs
       parameters:
-        - $ref: '#/components/parameters/entityIdPathParam'
+        - $ref: '#/components/parameters/contractIdPathParam'
         - $ref: '#/components/parameters/logIndexQueryParam'
         - $ref: '#/components/parameters/limitQueryParam'
         - $ref: '#/components/parameters/orderQueryParam'
@@ -249,7 +248,7 @@ paths:
       description: Returns schedule information based on the given schedule id
       operationId: getScheduleById
       parameters:
-        - $ref: '#/components/parameters/entityIdPathParam'
+        - $ref: '#/components/parameters/scheduleIdPathParam'
       responses:
         200:
           description: OK
@@ -347,7 +346,7 @@ paths:
       description: Returns the list of topic messages for the given topic id.
       operationId: listTopicMessagesById
       parameters:
-        - $ref: '#/components/parameters/entityIdPathParam'
+        - $ref: '#/components/parameters/topicIdPathParam'
         - name: sequencenumber
           in: query
           example: 2
@@ -380,7 +379,7 @@ paths:
       description: Returns a single topic message the given topic id and sequence number.
       operationId: getTopicMessageByIdAndSequenceNumber
       parameters:
-        - $ref: '#/components/parameters/entityIdPathParam'
+        - $ref: '#/components/parameters/topicIdPathParam'
         - name: sequencenumber
           in: path
           required: true
@@ -450,7 +449,7 @@ paths:
       description: Returns token entity information given the id
       operationId: getTokenById
       parameters:
-        - $ref: '#/components/parameters/entityIdPathParam'
+        - $ref: '#/components/parameters/tokenIdPathParam'
         - $ref: '#/components/parameters/tokenInfoTimestampQueryParam'
       responses:
         200:
@@ -579,7 +578,7 @@ paths:
       description: Returns a list of token balances given the id. This represents the Token supply distribution across the network
       operationId: listTokenBalancesById
       parameters:
-        - $ref: '#/components/parameters/entityIdPathParam'
+        - $ref: '#/components/parameters/tokenIdPathParam'
         - $ref: '#/components/parameters/accountIdQueryParam'
         - $ref: '#/components/parameters/accountBalanceQueryParam'
         - $ref: '#/components/parameters/orderQueryParam'
@@ -604,10 +603,10 @@ paths:
       description: Returns a list of non-fungible tokens
       operationId: listNfts
       parameters:
+        - $ref: '#/components/parameters/tokenIdPathParam'
         - $ref: '#/components/parameters/accountIdQueryParam'
         - $ref: '#/components/parameters/limitQueryParam'
         - $ref: '#/components/parameters/orderQueryParam'
-        - $ref: '#/components/parameters/entityIdPathParam'
       responses:
         200:
           description: OK
@@ -627,8 +626,8 @@ paths:
       description: Returns information for a non-fungible token
       operationId: listNftBySerialnumber
       parameters:
+        - $ref: '#/components/parameters/tokenIdPathParam'
         - $ref: '#/components/parameters/serialNumberPathParam'
-        - $ref: '#/components/parameters/entityIdPathParam'
       responses:
         200:
           description: OK
@@ -648,8 +647,8 @@ paths:
       description: Returns a list of transactions for a given non-fungible token
       operationId: listNftTransactions
       parameters:
+        - $ref: '#/components/parameters/tokenIdPathParam'
         - $ref: '#/components/parameters/serialNumberPathParam'
-        - $ref: '#/components/parameters/entityIdPathParam'
       responses:
         200:
           description: OK
@@ -2026,11 +2025,40 @@ components:
           value: lte:0.0.700
       schema:
         $ref: '#/components/schemas/EntityIdQuery'
+    # Path parameters for different IDs.
+    contractIdPathParam:
+      name: contractId
+      in: path
+      required: true
+      description: Contract id
+      schema:
+        $ref: '#/components/schemas/EntityId'
     entityIdPathParam:
       name: entityId
       in: path
       required: true
       description: Entity id
+      schema:
+        $ref: '#/components/schemas/EntityId'
+    scheduleIdPathParam:
+      name: scheduleId
+      in: path
+      required: true
+      description: Schedule id
+      schema:
+        $ref: '#/components/schemas/EntityId'
+    tokenIdPathParam:
+      name: tokenId
+      in: path
+      required: true
+      description: Token id
+      schema:
+        $ref: '#/components/schemas/EntityId'
+    topicIdPathParam:
+      name: topicId
+      in: path
+      required: true
+      description: Topic id
       schema:
         $ref: '#/components/schemas/EntityId'
     fromQueryParam:

--- a/hedera-mirror-rest/api/v1/openapi.yml
+++ b/hedera-mirror-rest/api/v1/openapi.yml
@@ -115,6 +115,7 @@ paths:
       operationId: listContractResults
       parameters:
         - $ref: '#/components/parameters/contractIdPathParam'
+        - $ref: '#/components/parameters/fromQueryParam'
         - $ref: '#/components/parameters/limitQueryParam'
         - $ref: '#/components/parameters/orderQueryParamDesc'
         - $ref: '#/components/parameters/timestampQueryParam'


### PR DESCRIPTION
Signed-off-by: Long Nguyen <longnguyen@circle.com>

**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR modifies the `openapi.yaml` spec to fix two bugs.

Fixes
1. The `fromQueryPathParam` is not valid at all and breaks generated Java code. This is for the  `/api/v1/contracts/{contractId}/results` endpoint, which does not use such a parameter. See https://docs.hedera.com/guides/docs/mirror-node-api/cryptocurrency-api#contract-results.
2. It is *not* possible to use the arbitrarily defined `entityIdPathParam` ref for everything. OpenAPI does not know how to replace the name argument, and there is no way to override specific fields after using a ref either. You end up having wrong code that doesn't even call out with the proper arguments. We need to duplicate the schema, but with different names (since we can't override names). See https://github.com/OAI/OpenAPI-Specification/issues/2026.

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
Please be careful with OpenAPI updates in the future.