### PR TITLE
Fix monitor validation issues

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -232,64 +232,66 @@ value, it is recommended to only populate overridden properties in the custom `a
 See the monitor [documentation](/docs/monitor/monitor.md) for more general information about configuring and using the
 monitor.
 
-Name                                                            | Default    | Description
-----------------------------------------------------------------| -----------| ---------------------------------------
-`hedera.mirror.monitor.mirrorNode.grpc.host`                    | ""         | The hostname of the mirror node's gRPC API
-`hedera.mirror.monitor.mirrorNode.grpc.port`                    | 5600       | The port of the mirror node's gRPC API
-`hedera.mirror.monitor.mirrorNode.rest.host`                    | ""         | The hostname of the mirror node's REST API
-`hedera.mirror.monitor.mirrorNode.rest.port`                    | 443        | The port of the mirror node's REST API
-`hedera.mirror.monitor.network`                                 | TESTNET    | Which network to connect to. Automatically populates the main node & mirror node endpoints. Can be `MAINNET`, `PREVIEWNET`, `TESTNET` or `OTHER`
-`hedera.mirror.monitor.nodes[].accountId`                       | ""         | The main node's account ID
-`hedera.mirror.monitor.nodes[].host`                            | ""         | The main node's hostname
-`hedera.mirror.monitor.nodes[].port`                            | 50211      | The main node's port
-`hedera.mirror.monitor.nodeValidation.enabled`                  | true       | Whether to validate and remove invalid or down nodes permanently before publishing
-`hedera.mirror.monitor.nodeValidation.frequency`                | 5m         | The amount of time between validations of the network.
-`hedera.mirror.monitor.nodeValidation.maxAttempts`              | 20         | The number of times the monitor should attempt to receive a healthy response from a node before marking it as unhealthy.
-`hedera.mirror.monitor.nodeValidation.maxBackoff`               | 2s         | The maximum amount of time to wait in between attempts when trying to validate a node
-`hedera.mirror.monitor.nodeValidation.minBackoff`               | 500ms      | The minimum amount of time to wait in between attempts when trying to validate a node
-`hedera.mirror.monitor.operator.accountId`                      | ""         | Operator account ID used to pay for transactions
-`hedera.mirror.monitor.operator.privateKey`                     | ""         | Operator ED25519 private key used to sign transactions in hex encoded DER format
-`hedera.mirror.monitor.publish.batchDivisor`                    | 100        | The divisor used to calculate batch size when generating transactions
-`hedera.mirror.monitor.publish.clients`                         | 4          | How many total SDK clients to publish transactions. Clients will be used in a round-robin fashion
-`hedera.mirror.monitor.publish.enabled`                         | true       | Whether to enable transaction publishing
-`hedera.mirror.monitor.publish.responseThreads`                 | 40         | How many threads to use to resolve the asynchronous responses
-`hedera.mirror.monitor.publish.scenarios`                       |            | A map of scenario name to publish scenarios. The name is used as a unique identifier in logs, metrics, and the REST API
-`hedera.mirror.monitor.publish.scenarios.<name>.duration`       |            | How long this scenario should publish transactions. Leave empty for infinite
-`hedera.mirror.monitor.publish.scenarios.<name>.enabled`        | true       | Whether this publish scenario is enabled
-`hedera.mirror.monitor.publish.scenarios.<name>.limit`          | 0          | How many transactions to publish before halting. 0 for unlimited
-`hedera.mirror.monitor.publish.scenarios.<name>.logResponse`    | false      | Whether to log the response from HAPI
-`hedera.mirror.monitor.publish.scenarios.<name>.properties`     | {}         | Key/value pairs used to configure the [`TransactionSupplier`](/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction) associated with this scenario type
-`hedera.mirror.monitor.publish.scenarios.<name>.receiptPercent` | 0.0        | The percentage of receipts to retrieve from HAPI. Accepts values between 0-1
-`hedera.mirror.monitor.publish.scenarios.<name>.recordPercent`  | 0.0        | The percentage of records to retrieve from HAPI. Accepts values between 0-1
-`hedera.mirror.monitor.publish.scenarios.<name>.retry.maxAttempts` | 1          | The maximum number of times a scenario transaction will be attempted
-`hedera.mirror.monitor.publish.scenarios.<name>.timeout`        | 12s        | How long to wait for the transaction result
-`hedera.mirror.monitor.publish.scenarios.<name>.tps`            | 1.0        | The rate at which transactions will publish
-`hedera.mirror.monitor.publish.scenarios.<name>.type`           |            | The type of transaction to publish. See the [`TransactionType`](/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/TransactionType.java) enum for a list of possible values
-`hedera.mirror.monitor.publish.statusFrequency`                 | 10s        | How often to log publishing statistics
-`hedera.mirror.monitor.publish.warmupPeriod`                    | 30s        | The amount of time the publisher should ramp up its rate before reaching its stable (maximum) rate
-`hedera.mirror.monitor.subscribe.clients`                       | 1          | How many SDK clients should be created to subscribe to mirror node APIs. Clients will be used in a round-robin fashion
-`hedera.mirror.monitor.subscribe.enabled`                       | true       | Whether to enable subscribing to mirror node APIs to verify published transactions
-`hedera.mirror.monitor.subscribe.grpc`                          |            | A map of scenario name to gRPC subscriber scenarios. The name is used as a unique identifier in logs, metrics, and the REST API
-`hedera.mirror.monitor.subscribe.grpc.<name>.duration`          |            | How long to stay subscribed to the API
-`hedera.mirror.monitor.subscribe.grpc.<name>.enabled`           | true       | Whether this subscribe scenario is enabled
-`hedera.mirror.monitor.subscribe.grpc.<name>.limit`             | 0          | How many transactions to receive before halting. 0 for unlimited
-`hedera.mirror.monitor.subscribe.grpc.<name>.retry.maxAttempts` | 16         | How many consecutive retry attempts before giving up connecting to the API
-`hedera.mirror.monitor.subscribe.grpc.<name>.retry.maxBackoff`  | 8s         | The maximum amount of time to wait between retry attempts
-`hedera.mirror.monitor.subscribe.grpc.<name>.retry.minBackoff`  | 250ms      | The initial amount of time to wait between retry attempts
-`hedera.mirror.monitor.subscribe.grpc.<name>.startTime`         |            | The start time passed to the gRPC API. Defaults to current time if not set
-`hedera.mirror.monitor.subscribe.grpc.<name>.subscribers`       | 1          | How many concurrent subscribers should be instantiated for this scenario
-`hedera.mirror.monitor.subscribe.grpc.<name>.topicId`           |            | Which topic to subscribe to
-`hedera.mirror.monitor.subscribe.rest`                          |            | A map of scenario name to REST subscriber scenarios. The name is used as a unique identifier in logs, metrics, and the REST API
-`hedera.mirror.monitor.subscribe.rest.<name>.duration`          |            | How long to stay subscribed to the API
-`hedera.mirror.monitor.subscribe.rest.<name>.enabled`           | true       | Whether this subscribe scenario is enabled
-`hedera.mirror.monitor.subscribe.rest.<name>.limit`             | 0          | How many transactions to receive before halting. 0 for unlimited
-`hedera.mirror.monitor.subscribe.rest.<name>.publishers`        | []         | A list of publisher scenario names to consider for sampling
-`hedera.mirror.monitor.subscribe.rest.<name>.retry.maxAttempts` | 16         | How many consecutive retry attempts before giving up connecting to the API
-`hedera.mirror.monitor.subscribe.rest.<name>.retry.maxBackoff`  | 8s         | The maximum amount of time to wait between retry attempts
-`hedera.mirror.monitor.subscribe.rest.<name>.retry.minBackoff`  | 250ms      | The initial amount of time to wait between retry attempts
-`hedera.mirror.monitor.subscribe.rest.<name>.samplePercent`     | 1.0        | The percentage of transactions to verify against the API. Accepts values between 0-1
-`hedera.mirror.monitor.subscribe.rest.<name>.timeout`           | 5s         | Maximum amount of time to wait for a API call to retrieve data
-`hedera.mirror.monitor.subscribe.statusFrequency`               | 10s        | How often to log subscription statistics
+Name                                                            | Default | Description
+----------------------------------------------------------------|---------| ---------------------------------------
+`hedera.mirror.monitor.mirrorNode.grpc.host`                    | ""      | The hostname of the mirror node's gRPC API
+`hedera.mirror.monitor.mirrorNode.grpc.port`                    | 5600    | The port of the mirror node's gRPC API
+`hedera.mirror.monitor.mirrorNode.rest.host`                    | ""      | The hostname of the mirror node's REST API
+`hedera.mirror.monitor.mirrorNode.rest.port`                    | 443     | The port of the mirror node's REST API
+`hedera.mirror.monitor.network`                                 | TESTNET | Which network to connect to. Automatically populates the main node & mirror node endpoints. Can be `MAINNET`, `PREVIEWNET`, `TESTNET` or `OTHER`
+`hedera.mirror.monitor.nodes[].accountId`                       | ""      | The main node's account ID
+`hedera.mirror.monitor.nodes[].host`                            | ""      | The main node's hostname
+`hedera.mirror.monitor.nodes[].port`                            | 50211   | The main node's port
+`hedera.mirror.monitor.nodeValidation.enabled`                  | true    | Whether to validate and remove invalid or down nodes permanently before publishing
+`hedera.mirror.monitor.nodeValidation.frequency`                | 30m     | The amount of time between validations of the network.
+`hedera.mirror.monitor.nodeValidation.maxAttempts`              | 4       | The number of times the monitor should attempt to receive a healthy response from a node before marking it as unhealthy.
+`hedera.mirror.monitor.nodeValidation.maxBackoff`               | 2s      | The maximum amount of time to wait in between attempts when trying to validate a node
+`hedera.mirror.monitor.nodeValidation.maxThreads`               | 25      | The maximum number of threads to use for node validation
+`hedera.mirror.monitor.nodeValidation.minBackoff`               | 500ms   | The minimum amount of time to wait in between attempts when trying to validate a node
+`hedera.mirror.monitor.nodeValidation.requestTimeout`           | 10s     | The amount of time to wait for a validation request before timing out
+`hedera.mirror.monitor.operator.accountId`                      | ""      | Operator account ID used to pay for transactions
+`hedera.mirror.monitor.operator.privateKey`                     | ""      | Operator ED25519 private key used to sign transactions in hex encoded DER format
+`hedera.mirror.monitor.publish.batchDivisor`                    | 100     | The divisor used to calculate batch size when generating transactions
+`hedera.mirror.monitor.publish.clients`                         | 4       | How many total SDK clients to publish transactions. Clients will be used in a round-robin fashion
+`hedera.mirror.monitor.publish.enabled`                         | true    | Whether to enable transaction publishing
+`hedera.mirror.monitor.publish.responseThreads`                 | 40      | How many threads to use to resolve the asynchronous responses
+`hedera.mirror.monitor.publish.scenarios`                       |         | A map of scenario name to publish scenarios. The name is used as a unique identifier in logs, metrics, and the REST API
+`hedera.mirror.monitor.publish.scenarios.<name>.duration`       |         | How long this scenario should publish transactions. Leave empty for infinite
+`hedera.mirror.monitor.publish.scenarios.<name>.enabled`        | true    | Whether this publish scenario is enabled
+`hedera.mirror.monitor.publish.scenarios.<name>.limit`          | 0       | How many transactions to publish before halting. 0 for unlimited
+`hedera.mirror.monitor.publish.scenarios.<name>.logResponse`    | false   | Whether to log the response from HAPI
+`hedera.mirror.monitor.publish.scenarios.<name>.properties`     | {}      | Key/value pairs used to configure the [`TransactionSupplier`](/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction) associated with this scenario type
+`hedera.mirror.monitor.publish.scenarios.<name>.receiptPercent` | 0.0     | The percentage of receipts to retrieve from HAPI. Accepts values between 0-1
+`hedera.mirror.monitor.publish.scenarios.<name>.recordPercent`  | 0.0     | The percentage of records to retrieve from HAPI. Accepts values between 0-1
+`hedera.mirror.monitor.publish.scenarios.<name>.retry.maxAttempts` | 1       | The maximum number of times a scenario transaction will be attempted
+`hedera.mirror.monitor.publish.scenarios.<name>.timeout`        | 12s     | How long to wait for the transaction result
+`hedera.mirror.monitor.publish.scenarios.<name>.tps`            | 1.0     | The rate at which transactions will publish
+`hedera.mirror.monitor.publish.scenarios.<name>.type`           |         | The type of transaction to publish. See the [`TransactionType`](/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/TransactionType.java) enum for a list of possible values
+`hedera.mirror.monitor.publish.statusFrequency`                 | 10s     | How often to log publishing statistics
+`hedera.mirror.monitor.publish.warmupPeriod`                    | 30s     | The amount of time the publisher should ramp up its rate before reaching its stable (maximum) rate
+`hedera.mirror.monitor.subscribe.clients`                       | 1       | How many SDK clients should be created to subscribe to mirror node APIs. Clients will be used in a round-robin fashion
+`hedera.mirror.monitor.subscribe.enabled`                       | true    | Whether to enable subscribing to mirror node APIs to verify published transactions
+`hedera.mirror.monitor.subscribe.grpc`                          |         | A map of scenario name to gRPC subscriber scenarios. The name is used as a unique identifier in logs, metrics, and the REST API
+`hedera.mirror.monitor.subscribe.grpc.<name>.duration`          |         | How long to stay subscribed to the API
+`hedera.mirror.monitor.subscribe.grpc.<name>.enabled`           | true    | Whether this subscribe scenario is enabled
+`hedera.mirror.monitor.subscribe.grpc.<name>.limit`             | 0       | How many transactions to receive before halting. 0 for unlimited
+`hedera.mirror.monitor.subscribe.grpc.<name>.retry.maxAttempts` | 16      | How many consecutive retry attempts before giving up connecting to the API
+`hedera.mirror.monitor.subscribe.grpc.<name>.retry.maxBackoff`  | 8s      | The maximum amount of time to wait between retry attempts
+`hedera.mirror.monitor.subscribe.grpc.<name>.retry.minBackoff`  | 250ms   | The initial amount of time to wait between retry attempts
+`hedera.mirror.monitor.subscribe.grpc.<name>.startTime`         |         | The start time passed to the gRPC API. Defaults to current time if not set
+`hedera.mirror.monitor.subscribe.grpc.<name>.subscribers`       | 1       | How many concurrent subscribers should be instantiated for this scenario
+`hedera.mirror.monitor.subscribe.grpc.<name>.topicId`           |         | Which topic to subscribe to
+`hedera.mirror.monitor.subscribe.rest`                          |         | A map of scenario name to REST subscriber scenarios. The name is used as a unique identifier in logs, metrics, and the REST API
+`hedera.mirror.monitor.subscribe.rest.<name>.duration`          |         | How long to stay subscribed to the API
+`hedera.mirror.monitor.subscribe.rest.<name>.enabled`           | true    | Whether this subscribe scenario is enabled
+`hedera.mirror.monitor.subscribe.rest.<name>.limit`             | 0       | How many transactions to receive before halting. 0 for unlimited
+`hedera.mirror.monitor.subscribe.rest.<name>.publishers`        | []      | A list of publisher scenario names to consider for sampling
+`hedera.mirror.monitor.subscribe.rest.<name>.retry.maxAttempts` | 16      | How many consecutive retry attempts before giving up connecting to the API
+`hedera.mirror.monitor.subscribe.rest.<name>.retry.maxBackoff`  | 8s      | The maximum amount of time to wait between retry attempts
+`hedera.mirror.monitor.subscribe.rest.<name>.retry.minBackoff`  | 250ms   | The initial amount of time to wait between retry attempts
+`hedera.mirror.monitor.subscribe.rest.<name>.samplePercent`     | 1.0     | The percentage of transactions to verify against the API. Accepts values between 0-1
+`hedera.mirror.monitor.subscribe.rest.<name>.timeout`           | 5s      | Maximum amount of time to wait for a API call to retrieve data
+`hedera.mirror.monitor.subscribe.statusFrequency`               | 10s     | How often to log subscription statistics
 
 ## REST API
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/performance/EntityRecordItemListenerPerformanceCryptoTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/performance/EntityRecordItemListenerPerformanceCryptoTest.java
@@ -48,7 +48,6 @@ import com.hedera.mirror.importer.util.Utility;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class EntityRecordItemListenerPerformanceCryptoTest extends AbstractEntityRecordItemListenerTest {
     private static final long INITIAL_BALANCE = 1000L;
-    private static final int CONNECTED_ENTITY_COUNT = 4;
 
     private List<RecordItem> insertRecordItemList;
     private List<RecordItem> updateRecordItemList;
@@ -75,14 +74,14 @@ class EntityRecordItemListenerPerformanceCryptoTest extends AbstractEntityRecord
     }
 
     @Test
-    @Timeout(2)
+    @Timeout(4)
     void insertHighCreateEntityCount() {
         parseRecordItemsAndCommit(insertRecordItemList);
         assertThat(entityRepository.findAll()).hasSize(insertRecordItemList.size());
     }
 
     @Test
-    @Timeout(5)
+    @Timeout(10)
     void insertHighCreateAndUpdateEntityCount() {
         Instant startTime = Instant.now();
         parseRecordItemsAndCommit(insertRecordItemList);

--- a/hedera-mirror-monitor/pom.xml
+++ b/hedera-mirror-monitor/pom.xml
@@ -16,6 +16,7 @@
 
     <properties>
         <commons-math3.version>3.6.1</commons-math3.version>
+        <hedera-sdk.version>2.6.0</hedera-sdk.version>
         <meanbean.version>3.0.0-M9</meanbean.version>
         <springdoc.version>1.6.4</springdoc.version>
     </properties>

--- a/hedera-mirror-monitor/src/main/java/com/hedera/hashgraph/sdk/ManagedNode.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/hashgraph/sdk/ManagedNode.java
@@ -1,0 +1,342 @@
+package com.hedera.hashgraph.sdk;
+
+import com.google.errorprone.annotations.Var;
+import io.grpc.ChannelCredentials;
+import io.grpc.ConnectivityState;
+import io.grpc.Grpc;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.TlsChannelCredentials;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import java.time.Duration;
+import java.util.Objects;
+
+import javax.annotation.Nullable;
+import java.util.concurrent.CompletableFuture;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+abstract class ManagedNode<N extends ManagedNode<N, KeyT>, KeyT> implements Comparable<ManagedNode<N, KeyT>> {
+    private static final int GET_STATE_INTERVAL_MILLIS = 50;
+    private static final int GET_STATE_TIMEOUT_MILLIS = 10000;
+    private static final int GET_STATE_MAX_ATTEMPTS = GET_STATE_TIMEOUT_MILLIS / GET_STATE_INTERVAL_MILLIS;
+    private boolean hasConnected = false;
+
+    protected final ExecutorService executor;
+
+    /**
+     * Address of this node
+     */
+    protected final ManagedNodeAddress address;
+
+    /**
+     * Timestamp of when the last time this node was used in milliseconds.
+     * This field is used for healthy-ness calculation.
+     */
+    protected long lastUsed = 0;
+
+    /**
+     * Amount of times this node has been used. "Used" means the channel was used to submit a request.
+     * This field is used for healthy-ness calculation
+     */
+    protected long useCount = 0;
+
+    /**
+     * Timestamp of when this node will be considered healthy again
+     */
+    protected long backoffUntil;
+
+    /**
+     * The current backoff duration. Uses exponential backoff so think 1s, 2s, 4s, 8s, etc until maxBackoff is hit
+     */
+    protected Duration currentBackoff;
+
+    /**
+     * Minimum backoff used by node when receiving a bad gRPC status
+     */
+    protected Duration minBackoff;
+
+    /**
+     * Maximum backoff used by node when receiving a bad gRPC status
+     */
+    protected Duration maxBackoff;
+
+    /**
+     * Number of times this node has received a bad gRPC status
+     */
+    protected long attempts;
+
+    @Nullable
+    protected ManagedChannel channel = null;
+
+    protected ManagedNode(ManagedNodeAddress address, ExecutorService executor) {
+        this.executor = executor;
+        this.address = address;
+        this.currentBackoff = Client.DEFAULT_MIN_BACKOFF;
+        this.minBackoff = Client.DEFAULT_MIN_BACKOFF;
+        this.maxBackoff = Client.DEFAULT_MAX_BACKOFF;
+    }
+
+    protected ManagedNode(N node, ManagedNodeAddress address) {
+        this.address = address;
+
+        this.executor = node.executor;
+        this.minBackoff = node.minBackoff;
+        this.maxBackoff = node.maxBackoff;
+        this.backoffUntil = node.backoffUntil;
+        this.currentBackoff = node.currentBackoff;
+        this.attempts = node.attempts;
+        this.lastUsed = node.lastUsed;
+        this.useCount = node.useCount;
+    }
+
+    /**
+     * Create an insecure version of this node
+     *
+     * @return
+     */
+    abstract N toInsecure();
+
+    /**
+     * Create a secure version of this node
+     * @return
+     */
+    abstract N toSecure();
+
+    abstract KeyT getKey();
+
+    /**
+     * Get the address of this node
+     *
+     * @return
+     */
+    ManagedNodeAddress getAddress() {
+        return address;
+    }
+
+    /**
+     * Get the minimum backoff
+     * @return
+     */
+    Duration getMinBackoff() {
+        return minBackoff;
+    }
+
+    /**
+     * Set the minimum backoff
+     *
+     * @param minBackoff
+     * @return
+     */
+    N setMinBackoff(Duration minBackoff) {
+        this.minBackoff = minBackoff;
+
+        // noinspection unchecked
+        return (N) this;
+    }
+
+    /**
+     * Get the maximum backoff
+     * @return
+     */
+    Duration getMaxBackoff() {
+        return maxBackoff;
+    }
+
+    /**
+     * Set the minimum backoff
+     *
+     * @param maxBackoff
+     * @return
+     */
+    N setMaxBackoff(Duration maxBackoff) {
+        this.maxBackoff = ManagedNode.this.maxBackoff;
+
+        // noinspection unchecked
+        return (N) this;
+    }
+
+    /**
+     * Get the number of times this node has received a bad gRPC status
+     * @return
+     */
+    long getAttempts() {
+        return attempts;
+    }
+
+    /**
+     * Determines if this is node is healthy.
+     * Healthy means the node has either not received any bad gRPC statuses, or if it has received bad gRPC status then
+     * the node backed off for a period of time.
+     *
+     * @return
+     */
+    boolean isHealthy() {
+        return backoffUntil < System.currentTimeMillis();
+    }
+
+    /**
+     * Used when a node has received a bad gRPC status
+     */
+    synchronized void increaseDelay() {
+        this.attempts++;
+        this.backoffUntil = System.currentTimeMillis() + this.currentBackoff.toMillis();
+        this.currentBackoff = Duration.ofMillis(Math.min(this.currentBackoff.toMillis() * 2, this.maxBackoff.toMillis()));
+    }
+
+    /**
+     * Used when a node has not received a bad gRPC status.
+     * This means on each request that doesn't get a bad gRPC status the current backoff will be lowered. The point of
+     * this is to allow a node which has been performing poorly (receiving several bad gRPC status) to become used again
+     * once it stops receiving bad gRPC statuses.
+     */
+    synchronized void decreaseDelay() {
+        this.currentBackoff = Duration.ofMillis(Math.max(this.currentBackoff.toMillis() / 2, minBackoff.toMillis()));
+    }
+
+    /**
+     * Get the amount of time the node has to wait until it's healthy again
+     *
+     * @return
+     */
+    long getRemainingTimeForBackoff() {
+        return backoffUntil - System.currentTimeMillis();
+    }
+
+    /**
+     * Create TLS credentials when transport security is enabled
+     *
+     * @return
+     */
+    ChannelCredentials getChannelCredentials() {
+        return TlsChannelCredentials.create();
+    }
+
+    /**
+     * Get the gRPC channel for this node
+     *
+     * @return
+     */
+    synchronized ManagedChannel getChannel() {
+        useCount++;
+        lastUsed = System.currentTimeMillis();
+
+        if (channel != null) {
+            return channel;
+        }
+
+        ManagedChannelBuilder<?> channelBuilder;
+
+        if (address.isInProcess()) {
+            channelBuilder = InProcessChannelBuilder.forName(Objects.requireNonNull(address.getName()));
+        } else if (address.isTransportSecurity() || address.getPort() == 443) {
+            channelBuilder = Grpc.newChannelBuilder(address.toString(), getChannelCredentials());
+
+            if (address.getPort() != 443) {
+                channelBuilder = channelBuilder.overrideAuthority("127.0.0.1");
+            }
+        } else {
+            channelBuilder = ManagedChannelBuilder.forTarget(address.toString()).usePlaintext();
+        }
+
+        channel = channelBuilder
+                .keepAliveTimeout(10, TimeUnit.SECONDS)
+                .userAgent(getUserAgent())
+                .executor(executor)
+                .build();
+
+        return channel;
+    }
+
+    boolean channelFailedToConnect() {
+        if (hasConnected) {
+            return false;
+        }
+        hasConnected = (getChannel().getState(true) == ConnectivityState.READY);
+        try {
+            for (@Var int i = 0; i < GET_STATE_MAX_ATTEMPTS && !hasConnected; i++) {
+                TimeUnit.MILLISECONDS.sleep(GET_STATE_INTERVAL_MILLIS);
+                hasConnected = (getChannel().getState(true) == ConnectivityState.READY);
+            }
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        return !hasConnected;
+    }
+
+    private CompletableFuture<Boolean> channelFailedToConnectAsync(int i, ConnectivityState state) {
+        hasConnected = (state == ConnectivityState.READY);
+        if (i >= GET_STATE_MAX_ATTEMPTS || hasConnected) {
+            return CompletableFuture.completedFuture(!hasConnected);
+        }
+        return Delayer.delayFor(GET_STATE_INTERVAL_MILLIS, executor).thenCompose(ignored -> {
+            return channelFailedToConnectAsync(i + 1, getChannel().getState(true));
+        });
+    }
+
+    CompletableFuture<Boolean> channelFailedToConnectAsync() {
+        if (hasConnected) {
+            return CompletableFuture.completedFuture(false);
+        }
+        return channelFailedToConnectAsync(0, getChannel().getState(true));
+    }
+
+    /**
+     * Close the current nodes channel
+     *
+     * @param timeout
+     * @throws InterruptedException
+     */
+    synchronized void close(Duration timeout) throws InterruptedException {
+        if (channel != null) {
+            channel.shutdown();
+            channel.awaitTermination(timeout.getSeconds(), TimeUnit.SECONDS);
+            channel = null;
+        }
+    }
+
+    /**
+     * Compares one node to another. The order is determined by health. If both nodes are healthy then their {@link ManagedNode#useCount}
+     * and {@link ManagedNode#lastUsed} values are used to determine order. The node which is used less will be
+     * considered more healthy, and if the use count is the same, then the node which was used least recently will be
+     * considered more healthy.
+     *
+     * @param node
+     * @return
+     */
+    @Override
+    public int compareTo(ManagedNode<N, KeyT> node) {
+        if (this.isHealthy() && node.isHealthy()) {
+            return compareToSameHealth(node);
+        } else if (this.isHealthy() && !node.isHealthy()) {
+            return -1;
+        } else if (!this.isHealthy() && node.isHealthy()) {
+            return 1;
+        } else {
+            return compareToSameHealth(node);
+        }
+    }
+
+    private int compareToSameHealth(ManagedNode<N, KeyT> node) {
+        if (this.useCount < node.useCount) {
+            return -1;
+        } else if (this.useCount > node.useCount) {
+            return 1;
+        } else {
+            if (this.lastUsed < node.lastUsed) {
+                return -1;
+            } else if (this.lastUsed > node.lastUsed) {
+                return 1;
+            } else {
+                return 0;
+            }
+        }
+    }
+
+    private String getUserAgent() {
+        var thePackage = getClass().getPackage();
+        var implementationVersion = thePackage != null ? thePackage.getImplementationVersion() : null;
+        return "hedera-sdk-java/" + ((implementationVersion != null) ? ("v" + implementationVersion) : "DEV");
+    }
+}

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/HederaNetwork.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/HederaNetwork.java
@@ -73,7 +73,10 @@ public enum HederaNetwork {
                 new NodeProperties("0.0.21", "34.76.140.109"),
                 new NodeProperties("0.0.22", "34.64.141.166"),
                 new NodeProperties("0.0.23", "35.232.244.145"),
-                new NodeProperties("0.0.24", "34.89.103.38")
+                new NodeProperties("0.0.24", "34.89.103.38"),
+                new NodeProperties("0.0.25", "34.93.112.7"),
+                new NodeProperties("0.0.26", "34.87.150.174"),
+                new NodeProperties("0.0.27", "34.125.200.96")
         );
     }
 

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/NodeProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/NodeProperties.java
@@ -20,30 +20,39 @@ package com.hedera.mirror.monitor;
  * ‍
  */
 
+import java.util.List;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
 import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import org.springframework.validation.annotation.Validated;
+
+import com.hedera.hashgraph.sdk.AccountId;
 
 @Data
 @NoArgsConstructor
 @Validated
 public class NodeProperties {
 
-    public NodeProperties(String accountId, String host) {
-        this.accountId = accountId;
-        this.host = host;
-    }
-
     @NotBlank
     private String accountId;
+
+    @Getter(lazy = true)
+    @ToString.Exclude
+    private final List<AccountId> accountIds = List.of(AccountId.fromString(getAccountId()));
 
     @NotBlank
     private String host;
 
     @Min(0)
     private int port = 50211;
+
+    public NodeProperties(String accountId, String host) {
+        this.accountId = accountId;
+        this.host = host;
+    }
 
     public String getEndpoint() {
         // Allow for in-process testing of gRPC stubs
@@ -53,4 +62,3 @@ public class NodeProperties {
         return host + ":" + port;
     }
 }
-

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/NodeValidationProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/NodeValidationProperties.java
@@ -36,7 +36,10 @@ public class NodeValidationProperties {
 
     @DurationMin(seconds = 30)
     @NotNull
-    private Duration frequency = Duration.ofDays(365); // Effectively disable for now due to #2914
+    private Duration frequency = Duration.ofMinutes(30L);
+
+    @Min(1)
+    private int maxAttempts = 4;
 
     @DurationMin(millis = 250)
     @DurationMax(seconds = 10)
@@ -44,10 +47,14 @@ public class NodeValidationProperties {
     private Duration maxBackoff = Duration.ofSeconds(2);
 
     @Min(1)
-    private int maxAttempts = 20;
+    private int maxThreads = 25;
 
     @DurationMin(millis = 250)
     @DurationMax(seconds = 10)
     @NotNull
     private Duration minBackoff = Duration.ofMillis(500);
+
+    @DurationMin(millis = 500)
+    @NotNull
+    private Duration requestTimeout = Duration.ofSeconds(10L);
 }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/TransactionPublisher.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/TransactionPublisher.java
@@ -208,6 +208,7 @@ public class TransactionPublisher implements AutoCloseable {
             Status receiptStatus = new TransferTransaction()
                     .addHbarTransfer(nodeAccountId, hbar)
                     .addHbarTransfer(client.getOperatorAccountId(), hbar.negated())
+                    .setNodeAccountIds(node.getAccountIds())
                     .execute(client, properties.getRequestTimeout())
                     .getReceipt(client, properties.getRequestTimeout())
                     .status;

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/TransactionPublisher.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/TransactionPublisher.java
@@ -124,13 +124,13 @@ public class TransactionPublisher implements AutoCloseable {
 
         // set transaction node where applicable
         if (transaction.getNodeAccountIds() == null) {
-            var nodes = this.nodes; // Save a reference in case a write occurs
-            if (nodes.isEmpty()) {
+            var currentNodes = this.nodes; // Save a reference in case a COW occurs
+            if (currentNodes.isEmpty()) {
                 throw new PublishException(request, new IllegalArgumentException("No valid nodes available"));
             }
 
-            int nodeIndex = secureRandom.nextInt(nodes.size());
-            var node = nodes.get(nodeIndex);
+            int nodeIndex = secureRandom.nextInt(currentNodes.size());
+            var node = currentNodes.get(nodeIndex);
             transaction.setNodeAccountIds(node.getAccountIds());
         }
 

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/TransactionPublisherTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/TransactionPublisherTest.java
@@ -20,13 +20,12 @@ package com.hedera.mirror.monitor.publish;
  * ‍
  */
 
+import static com.hedera.hashgraph.sdk.proto.ResponseCodeEnum.ACCOUNT_DELETED;
 import static com.hedera.hashgraph.sdk.proto.ResponseCodeEnum.OK;
 import static com.hedera.hashgraph.sdk.proto.ResponseCodeEnum.SUCCESS;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 import io.grpc.Server;
-import io.grpc.Status;
 import io.grpc.inprocess.InProcessServerBuilder;
 import io.grpc.stub.StreamObserver;
 import java.io.IOException;
@@ -82,6 +81,7 @@ class TransactionPublisherTest {
         publishScenarioProperties.setType(TransactionType.CRYPTO_TRANSFER);
         monitorProperties = new MonitorProperties();
         monitorProperties.setNodes(Set.of(new NodeProperties("0.0.3", "in-process:test")));
+        monitorProperties.getNodeValidation().setEnabled(false);
         OperatorProperties operatorProperties = monitorProperties.getOperator();
         operatorProperties.setAccountId("0.0.100");
         operatorProperties.setPrivateKey(PrivateKey.generate().toString());
@@ -109,8 +109,7 @@ class TransactionPublisherTest {
     @Timeout(3)
     void publish() {
         PublishRequest request = request().build();
-        cryptoServiceStub.addQueries(Mono.just(receipt(SUCCESS)));
-        cryptoServiceStub.addTransactions(Mono.just(response(OK)), Mono.just(response(OK)));
+        cryptoServiceStub.addTransactions(Mono.just(response(OK)));
 
         transactionPublisher.publish(request)
                 .as(StepVerifier::create)
@@ -134,8 +133,7 @@ class TransactionPublisherTest {
     @Timeout(3)
     void publishWithLogResponse() {
         publishScenarioProperties.setLogResponse(true);
-        cryptoServiceStub.addQueries(Mono.just(receipt(SUCCESS)));
-        cryptoServiceStub.addTransactions(Mono.just(response(OK)), Mono.just(response(OK)));
+        cryptoServiceStub.addTransactions(Mono.just(response(OK)));
 
         transactionPublisher.publish(request().build())
                 .as(StepVerifier::create)
@@ -147,8 +145,8 @@ class TransactionPublisherTest {
     @Test
     @Timeout(3)
     void publishWithReceipt() {
-        cryptoServiceStub.addQueries(Mono.just(receipt(SUCCESS)), Mono.just(receipt(SUCCESS)));
-        cryptoServiceStub.addTransactions(Mono.just(response(OK)), Mono.just(response(OK)));
+        cryptoServiceStub.addQueries(Mono.just(receipt(SUCCESS)));
+        cryptoServiceStub.addTransactions(Mono.just(response(OK)));
 
         transactionPublisher.publish(request().receipt(true).build())
                 .as(StepVerifier::create)
@@ -164,8 +162,8 @@ class TransactionPublisherTest {
     @Test
     @Timeout(3)
     void publishWithRecord() {
-        cryptoServiceStub.addQueries(Mono.just(receipt(SUCCESS)), Mono.just(record(SUCCESS)));
-        cryptoServiceStub.addTransactions(Mono.just(response(OK)), Mono.just(response(OK)));
+        cryptoServiceStub.addQueries(Mono.just(record(SUCCESS)));
+        cryptoServiceStub.addTransactions(Mono.just(response(OK)));
 
         transactionPublisher.publish(request().record(true).build())
                 .as(StepVerifier::create)
@@ -182,8 +180,7 @@ class TransactionPublisherTest {
     @Timeout(3)
     void publishPreCheckError() {
         ResponseCodeEnum errorResponseCode = ResponseCodeEnum.INSUFFICIENT_ACCOUNT_BALANCE;
-        cryptoServiceStub.addQueries(Mono.just(receipt(SUCCESS)));
-        cryptoServiceStub.addTransactions(Mono.just(response(OK)), Mono.just(response(errorResponseCode)));
+        cryptoServiceStub.addTransactions(Mono.just(response(errorResponseCode)));
 
         transactionPublisher.publish(request().build())
                 .as(StepVerifier::create)
@@ -196,9 +193,7 @@ class TransactionPublisherTest {
     @Test
     @Timeout(3)
     void publishRetrySuccessful() {
-        cryptoServiceStub.addQueries(Mono.just(receipt(SUCCESS)));
-        cryptoServiceStub.addTransactions(Mono.just(response(OK)),
-                Mono.just(response(ResponseCodeEnum.PLATFORM_TRANSACTION_NOT_CREATED)),
+        cryptoServiceStub.addTransactions(Mono.just(response(ResponseCodeEnum.PLATFORM_TRANSACTION_NOT_CREATED)),
                 Mono.just(response(ResponseCodeEnum.OK)));
 
         transactionPublisher.publish(request().build())
@@ -210,35 +205,35 @@ class TransactionPublisherTest {
 
     @Test
     @Timeout(3)
-    void publishWithRevalidate() {
-        //Disable validation and do it manually for this test
-        monitorProperties.getNodeValidation().setFrequency(Duration.ofSeconds(60));
-        cryptoServiceStub.addQueries(Mono.just(receipt(SUCCESS)));
-        cryptoServiceStub.addTransactions(Mono.just(response(OK)), Mono.just(response(OK)));
-
+    void validationRecovers() {
+        // Initialize publisher internals with first transaction
+        cryptoServiceStub.addTransactions(Mono.just(response(OK)));
         transactionPublisher.publish(request().build())
                 .as(StepVerifier::create)
                 .expectNextCount(1L)
                 .expectComplete()
                 .verify(Duration.ofSeconds(1L));
 
-        //Set node to unhealthy and confirm message can't be published
-        monitorProperties.setNodes(Set.of(
-                new NodeProperties("0.0.3", "invalid:test"))); // Illegal DNS to avoid SDK retry
-
-        assertThrows(IllegalArgumentException.class, transactionPublisher::validateNodes);
+        // Validate node as down manually
+        NodeProperties nodeProperties = monitorProperties.getNodes().iterator().next();
+        cryptoServiceStub.addQueries(Mono.just(receipt(ACCOUNT_DELETED)));
+        cryptoServiceStub.addTransactions(Mono.just(response(OK)));
+        assertThat(transactionPublisher.validateNode(nodeProperties)).isFalse();
 
         transactionPublisher.publish(request().build())
                 .as(StepVerifier::create)
-                .expectError(PublishException.class)
+                .expectErrorSatisfies(t -> assertThat(t)
+                        .isInstanceOf(PublishException.class)
+                        .hasMessageContaining("No valid nodes available")
+                        .hasCauseInstanceOf(IllegalArgumentException.class))
                 .verify(Duration.ofSeconds(1L));
 
-        //Set node back to healthy, confirm publishing resumes.
-        monitorProperties.setNodes(Set.of(new NodeProperties("0.0.3", "in-process:test")));
+        // Node recovers
         cryptoServiceStub.addQueries(Mono.just(receipt(SUCCESS)));
-        cryptoServiceStub.addTransactions(Mono.just(response(OK)), Mono.just(response(OK)));
-        transactionPublisher.validateNodes();
+        cryptoServiceStub.addTransactions(Mono.just(response(OK)));
+        assertThat(transactionPublisher.validateNode(nodeProperties)).isTrue();
 
+        cryptoServiceStub.addTransactions(Mono.just(response(OK)));
         transactionPublisher.publish(request().build())
                 .as(StepVerifier::create)
                 .expectNextCount(1L)
@@ -250,9 +245,7 @@ class TransactionPublisherTest {
     @Timeout(3)
     void publishRetryError() {
         ResponseCodeEnum errorResponseCode = ResponseCodeEnum.PLATFORM_TRANSACTION_NOT_CREATED;
-        cryptoServiceStub.addQueries(Mono.just(receipt(SUCCESS)));
-        cryptoServiceStub.addTransactions(Mono.just(response(OK)),
-                Mono.just(response(errorResponseCode)),
+        cryptoServiceStub.addTransactions(Mono.just(response(errorResponseCode)),
                 Mono.just(response(errorResponseCode)));
 
         transactionPublisher.publish(request().build())
@@ -269,9 +262,7 @@ class TransactionPublisherTest {
     @Timeout(3)
     void publishTimeout() {
         publishScenarioProperties.setTimeout(Duration.ofMillis(100L));
-        cryptoServiceStub.addQueries(Mono.just(receipt(SUCCESS)));
-        cryptoServiceStub.addTransactions(Mono.just(response(OK)),
-                Mono.delay(Duration.ofMillis(500L)).thenReturn(response(OK)));
+        cryptoServiceStub.addTransactions(Mono.delay(Duration.ofMillis(500L)).thenReturn(response(OK)));
 
         transactionPublisher.publish(request().build())
                 .as(StepVerifier::create)
@@ -284,47 +275,25 @@ class TransactionPublisherTest {
 
     @Test
     @Timeout(3)
-    void noValidNodes() {
-        cryptoServiceStub.addTransactions(Mono.error(Status.INTERNAL.asRuntimeException()));
-        transactionPublisher.publish(request().build())
-                .as(StepVerifier::create)
-                .expectError(IllegalArgumentException.class)
-                .verify(Duration.ofSeconds(1L));
-    }
+    void someValidNodes() {
+        NodeProperties node1 = new NodeProperties("0.0.3", "in-process:test");
+        NodeProperties node2 = new NodeProperties("0.0.4", "invalid:test");
+        monitorProperties.setNodes(Set.of(node1, node2));
 
-    @Test
-    @Timeout(3)
-    void skipNodeValidation() {
-        monitorProperties.getNodeValidation().setEnabled(false);
+        // Initialize publisher internals with first transaction
         cryptoServiceStub.addTransactions(Mono.just(response(OK)));
-
-        transactionPublisher.publish(request().build())
+        PublishRequest publishRequest = request().build();
+        publishRequest.getTransaction().setNodeAccountIds(node1.getAccountIds());
+        transactionPublisher.publish(publishRequest)
                 .as(StepVerifier::create)
                 .expectNextCount(1L)
                 .expectComplete()
                 .verify(Duration.ofSeconds(1L));
-    }
 
-    @Test
-    @Timeout(3)
-    void nodeValidationFailsReceipt() {
-        cryptoServiceStub.addQueries(Mono.just(receipt(ResponseCodeEnum.ACCOUNT_DELETED)));
+        // Validate one of the nodes as down manually
+        assertThat(transactionPublisher.validateNode(node2)).isFalse();
+
         cryptoServiceStub.addTransactions(Mono.just(response(OK)));
-
-        transactionPublisher.publish(request().build())
-                .as(StepVerifier::create)
-                .expectError(IllegalArgumentException.class)
-                .verify(Duration.ofSeconds(1L));
-    }
-
-    @Test
-    @Timeout(3)
-    void someValidNodes() {
-        monitorProperties.setNodes(Set.of(new NodeProperties("0.0.3", "in-process:test"),
-                new NodeProperties("0.0.4", "invalid:1"))); // Illegal DNS to avoid SDK retry
-        cryptoServiceStub.addQueries(Mono.just(receipt(SUCCESS)));
-        cryptoServiceStub.addTransactions(Mono.just(response(OK)), Mono.just(response(OK)));
-
         transactionPublisher.publish(request().build())
                 .as(StepVerifier::create)
                 .expectNextCount(1L)

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AbstractNetworkClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AbstractNetworkClient.java
@@ -103,8 +103,9 @@ public abstract class AbstractNetworkClient {
         try {
             transactionReceipt = getTransactionReceipt(transactionId);
         } catch (Exception e) {
-            log.error("TransactionReceipt retrieval Exception: {}", e.getMessage());
+            log.error("Failed to get transaction receipt for {}: {}", transactionId, e.getMessage());
         }
+
         log.trace("Executed transaction {} cost {} tℏ", transactionId, startBalance - getBalance());
         return new NetworkTransactionResponse(transactionId, transactionReceipt);
     }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
@@ -71,7 +71,7 @@ public class AcceptanceTestProperties {
 
     private final RestPollingProperties restPollingProperties;
 
-    private boolean retrieveAddressBook = true;
+    private boolean retrieveAddressBook = false;
 
     private final SdkProperties sdkProperties;
 

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,6 @@
         <grpc.version>1.43.2</grpc.version>
         <guava.version>31.0.1-jre</guava.version>
         <hedera-protobuf.version>0.22.0</hedera-protobuf.version>
-        <hedera-sdk.version>2.2.0-beta.2</hedera-sdk.version>
         <hibernate-types.version>2.14.0</hibernate-types.version>
         <jacoco.version>0.8.7</jacoco.version>
         <java.version>11</java.version>


### PR DESCRIPTION
**Description**:
* Add `hedera.mirror.monitor.nodeValidation.maxThreads=25` property
* Add `hedera.mirror.monitor.nodeValidation.requestTimeout=10s` property
* Add new mainnet nodes
* Bump `hedera-sdk-java` to 2.6.0 for monitor
* Change monitor to validate nodes in parallel
* Disable `hedera.mirror.test.acceptance.retrieveAddressBook` since it doesn't currently work with service endpoints
* Fix `EntityRecordItemListenerPerformanceCryptoTest` sporadically timing out
* Fix node validation blocking subscribe and re-enable it
* Fix node validation taking too long
* Workaround SDK bug with a modified `ManagedNode` class https://github.com/hashgraph/hedera-sdk-java/issues/855

**Related issue(s)**:

Fixes #2642
Fixes #2914
Fixes #3157

**Notes for reviewer**:
Acceptance tests had failures when used with SDK 2.6.0 so it's not updated

Log of the changes running against mainnet showing that total time to validate 22 nodes (including 3 down nodes) was around 6 seconds.

```console
2022-01-18T23:08:26.346-0600 INFO main c.h.m.m.s.g.GrpcClientSDK Connecting 1 clients to mainnet-public.mirrornode.hedera.com:443
2022-01-18T23:08:26.683-0600 INFO main c.h.m.m.s.r.RestSubscriber Connecting to mirror node https://mainnet-public.mirrornode.hedera.com:443/api/v1
2022-01-18T23:08:26.917-0600 INFO single-1 c.h.m.m.c.MonitorConfiguration Starting publisher flow
2022-01-18T23:08:26.962-0600 INFO parallel-45 c.h.m.m.c.MonitorConfiguration Starting subscribe flow
2022-01-18T23:08:26.976-0600 INFO parallel-45 c.h.m.m.s.g.GrpcClientSDK Starting 'hcs' scenario to client 0
2022-01-18T23:08:27.083-0600 INFO resolver-1 c.h.m.m.p.TransactionPublisher Starting node validation
2022-01-18T23:08:27.191-0600 INFO validator-51 c.h.m.m.p.TransactionPublisher Validating node 0.0.4
2022-01-18T23:08:27.191-0600 INFO validator-63 c.h.m.m.p.TransactionPublisher Validating node 0.0.9
2022-01-18T23:08:27.191-0600 INFO validator-66 c.h.m.m.p.TransactionPublisher Validating node 0.0.11
2022-01-18T23:08:27.191-0600 INFO validator-47 c.h.m.m.p.TransactionPublisher Validating node 0.0.3
2022-01-18T23:08:27.191-0600 INFO validator-56 c.h.m.m.p.TransactionPublisher Validating node 0.0.19
2022-01-18T23:08:27.191-0600 INFO validator-59 c.h.m.m.p.TransactionPublisher Validating node 0.0.21
2022-01-18T23:08:27.191-0600 INFO validator-57 c.h.m.m.p.TransactionPublisher Validating node 0.0.24
2022-01-18T23:08:27.192-0600 INFO validator-61 c.h.m.m.p.TransactionPublisher Validating node 0.0.12
2022-01-18T23:08:27.192-0600 INFO validator-46 c.h.m.m.p.TransactionPublisher Validating node 0.0.13
2022-01-18T23:08:27.192-0600 INFO validator-52 c.h.m.m.p.TransactionPublisher Validating node 0.0.18
2022-01-18T23:08:27.191-0600 INFO validator-50 c.h.m.m.p.TransactionPublisher Validating node 0.0.7
2022-01-18T23:08:27.192-0600 INFO validator-64 c.h.m.m.p.TransactionPublisher Validating node 0.0.20
2022-01-18T23:08:27.192-0600 INFO validator-65 c.h.m.m.p.TransactionPublisher Validating node 0.0.8
2022-01-18T23:08:27.191-0600 INFO validator-67 c.h.m.m.p.TransactionPublisher Validating node 0.0.17
2022-01-18T23:08:27.192-0600 INFO validator-49 c.h.m.m.p.TransactionPublisher Validating node 0.0.14
2022-01-18T23:08:27.192-0600 INFO validator-48 c.h.m.m.p.TransactionPublisher Validating node 0.0.16
2022-01-18T23:08:27.192-0600 INFO validator-58 c.h.m.m.p.TransactionPublisher Validating node 0.0.6
2022-01-18T23:08:27.192-0600 INFO validator-55 c.h.m.m.p.TransactionPublisher Validating node 0.0.22
2022-01-18T23:08:27.192-0600 INFO validator-62 c.h.m.m.p.TransactionPublisher Validating node 0.0.23
2022-01-18T23:08:27.192-0600 INFO validator-60 c.h.m.m.p.TransactionPublisher Validating node 0.0.15
2022-01-18T23:08:27.192-0600 INFO validator-54 c.h.m.m.p.TransactionPublisher Validating node 0.0.10
2022-01-18T23:08:27.192-0600 INFO validator-53 c.h.m.m.p.TransactionPublisher Validating node 0.0.5
2022-01-18T23:08:27.373-0600 WARN validator-57 c.h.h.s.TransferTransaction Retrying node 0.0.24 in 250 ms after failure during attempt #1: UNAVAILABLE
2022-01-18T23:08:27.373-0600 WARN hedera-sdk-3 c.h.h.s.TopicMessageSubmitTransaction Retrying node 0.0.24 in 250 ms after failure during attempt #1: UNAVAILABLE
2022-01-18T23:08:27.603-0600 WARN validator-56 c.h.h.s.TransferTransaction Retrying node 0.0.19 in 250 ms after failure during attempt #1: UNAVAILABLE: HTTP status code 503
2022-01-18T23:08:27.614-0600 WARN validator-48 c.h.h.s.TransferTransaction Retrying node 0.0.16 in 250 ms after failure during attempt #1: UNAVAILABLE: HTTP status code 503
2022-01-18T23:08:27.874-0600 WARN validator-57 c.h.h.s.TransferTransaction Retrying node 0.0.24 in 500 ms after failure during attempt #2: UNAVAILABLE
2022-01-18T23:08:27.994-0600 INFO main c.h.m.m.MonitorApplication Started MonitorApplication in 3.748 seconds (JVM running for 4.518)
2022-01-18T23:08:28.003-0600 INFO scheduling-1 c.h.m.m.p.PublishMetrics Scenario pinger published 0 transactions in 1s at 0.0/s. Errors: {ConnectException=1}
2022-01-18T23:08:28.215-0600 WARN validator-56 c.h.h.s.TransferTransaction Retrying node 0.0.19 in 500 ms after failure during attempt #2: UNAVAILABLE: HTTP status code 503
2022-01-18T23:08:28.241-0600 WARN validator-48 c.h.h.s.TransferTransaction Retrying node 0.0.16 in 500 ms after failure during attempt #2: UNAVAILABLE: HTTP status code 503
2022-01-18T23:08:28.881-0600 WARN validator-57 c.h.h.s.TransferTransaction Retrying node 0.0.24 in 1000 ms after failure during attempt #3: UNAVAILABLE
2022-01-18T23:08:29.330-0600 WARN validator-56 c.h.h.s.TransferTransaction Retrying node 0.0.19 in 1000 ms after failure during attempt #3: UNAVAILABLE: HTTP status code 503
2022-01-18T23:08:29.368-0600 WARN validator-48 c.h.h.s.TransferTransaction Retrying node 0.0.16 in 1000 ms after failure during attempt #3: UNAVAILABLE: HTTP status code 503
2022-01-18T23:08:30.887-0600 WARN validator-57 c.h.h.s.TransferTransaction Retrying node 0.0.24 in 2000 ms after failure during attempt #4: UNAVAILABLE
2022-01-18T23:08:31.444-0600 WARN validator-56 c.h.h.s.TransferTransaction Retrying node 0.0.19 in 2000 ms after failure during attempt #4: UNAVAILABLE: HTTP status code 503
2022-01-18T23:08:31.463-0600 INFO validator-67 c.h.m.m.p.TransactionPublisher Validated node 0.0.17 successfully
2022-01-18T23:08:31.470-0600 INFO validator-62 c.h.m.m.p.TransactionPublisher Validated node 0.0.23 successfully
2022-01-18T23:08:31.491-0600 WARN validator-48 c.h.h.s.TransferTransaction Retrying node 0.0.16 in 2000 ms after failure during attempt #4: UNAVAILABLE: HTTP status code 503
2022-01-18T23:08:31.531-0600 INFO validator-51 c.h.m.m.p.TransactionPublisher Validated node 0.0.4 successfully
2022-01-18T23:08:31.535-0600 INFO validator-53 c.h.m.m.p.TransactionPublisher Validated node 0.0.5 successfully
2022-01-18T23:08:31.737-0600 INFO validator-49 c.h.m.m.p.TransactionPublisher Validated node 0.0.14 successfully
2022-01-18T23:08:31.817-0600 INFO validator-64 c.h.m.m.p.TransactionPublisher Validated node 0.0.20 successfully
2022-01-18T23:08:31.880-0600 INFO validator-55 c.h.m.m.p.TransactionPublisher Validated node 0.0.22 successfully
2022-01-18T23:08:32.019-0600 INFO validator-59 c.h.m.m.p.TransactionPublisher Validated node 0.0.21 successfully
2022-01-18T23:08:32.039-0600 INFO validator-61 c.h.m.m.p.TransactionPublisher Validated node 0.0.12 successfully
2022-01-18T23:08:32.159-0600 INFO validator-52 c.h.m.m.p.TransactionPublisher Validated node 0.0.18 successfully
2022-01-18T23:08:32.216-0600 INFO validator-47 c.h.m.m.p.TransactionPublisher Validated node 0.0.3 successfully
2022-01-18T23:08:32.304-0600 INFO validator-50 c.h.m.m.p.TransactionPublisher Validated node 0.0.7 successfully
2022-01-18T23:08:32.320-0600 INFO validator-65 c.h.m.m.p.TransactionPublisher Validated node 0.0.8 successfully
2022-01-18T23:08:32.356-0600 INFO validator-60 c.h.m.m.p.TransactionPublisher Validated node 0.0.15 successfully
2022-01-18T23:08:32.474-0600 INFO validator-66 c.h.m.m.p.TransactionPublisher Validated node 0.0.11 successfully
2022-01-18T23:08:32.641-0600 INFO validator-63 c.h.m.m.p.TransactionPublisher Validated node 0.0.9 successfully
2022-01-18T23:08:32.682-0600 INFO validator-54 c.h.m.m.p.TransactionPublisher Validated node 0.0.10 successfully
2022-01-18T23:08:32.714-0600 INFO validator-58 c.h.m.m.p.TransactionPublisher Validated node 0.0.6 successfully
2022-01-18T23:08:32.736-0600 INFO validator-46 c.h.m.m.p.TransactionPublisher Validated node 0.0.13 successfully
2022-01-18T23:08:32.892-0600 WARN validator-57 c.h.m.m.p.TransactionPublisher Unable to validate node NodeProperties(accountId=0.0.24, accountIds=[0.0.24], host=34.89.103.38, port=50211):  com.hedera.hashgraph.sdk.MaxAttemptsExceededException: 
2022-01-18T23:08:33.446-0600 WARN validator-56 c.h.m.m.p.TransactionPublisher Unable to validate node NodeProperties(accountId=0.0.19, accountIds=[0.0.19], host=34.89.87.138, port=50211):  com.hedera.hashgraph.sdk.MaxAttemptsExceededException: 
2022-01-18T23:08:33.497-0600 WARN validator-48 c.h.m.m.p.TransactionPublisher Unable to validate node NodeProperties(accountId=0.0.16, accountIds=[0.0.16], host=34.91.181.183, port=50211):  com.hedera.hashgraph.sdk.MaxAttemptsExceededException: 
2022-01-18T23:08:33.498-0600 INFO validator-48 c.h.m.m.p.TransactionPublisher 19 of 22 nodes are functional
2022-01-18T23:08:34.788-0600 INFO parallel-71 c.h.m.m.s.g.GrpcClientSDK Starting 'hcs' scenario to client 0
```

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
