### PR TITLE
Optimize schedules query

### DIFF
--- a/hedera-mirror-rest/__tests__/schedules.test.js
+++ b/hedera-mirror-rest/__tests__/schedules.test.js
@@ -151,6 +151,17 @@ describe('schedule formatScheduleRow tests', () => {
         signatures: [],
       },
     },
+    {
+      description: 'null memo',
+      input: {
+        ...defaultInput,
+        memo: null,
+      },
+      expected: {
+        ...defaultExpected,
+        memo: null,
+      },
+    },
   ];
 
   testSpecs.forEach((testSpec) => {

--- a/hedera-mirror-rest/schedules.js
+++ b/hedera-mirror-rest/schedules.js
@@ -67,7 +67,7 @@ const filterColumnMap = {
   [constants.filterKeys.SCHEDULE_ID]: sqlQueryColumns.SCHEDULE_ID,
 };
 
-const entityIdJoinQuery = 'join entity e on e.id = s.schedule_id';
+const entityIdJoinQuery = 'left join entity e on e.id = s.schedule_id';
 const scheduleIdMatchQuery = 'where s.schedule_id = $1';
 const scheduleLimitQuery = (paramCount) => `limit $${paramCount}`;
 const scheduleOrderQuery = (order) => `order by s.schedule_id ${order}`;


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR fixes the slow schedules rest endpoint.

- Optimize the schedules sql query

**Related issue(s)**:

Fixes #3184

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

pg planner can't push down the limit to either table of the inner join. So when the tables get bigger, the query will slow down a lot.

postgresql explain analyze before:

```
 Limit  (cost=1.00..3135.79 rows=25 width=194) (actual time=2028.734..2031.566 rows=25 loops=1)
   ->  Nested Loop  (cost=1.00..3064353587.16 rows=24438292 width=194) (actual time=2028.733..2031.563 rows=25 loops=1)
         ->  Index Scan using entity_pkey on entity e  (cost=0.56..1166068.36 rows=27219730 width=57) (actual time=0.007..934.327 rows=519443 loops=1)
         ->  Index Scan using schedule_pkey on schedule s  (cost=0.44..0.48 rows=1 width=113) (actual time=0.002..0.002 rows=0 loops=519443)
               Index Cond: (schedule_id = e.id)
         SubPlan 1
           ->  Aggregate  (cost=124.79..124.80 rows=1 width=32) (actual time=0.035..0.035 rows=1 loops=25)
                 ->  Index Scan using transaction_signature__entity_id on transaction_signature ts  (cost=0.57..123.14 rows=110 width=85) (actual time=0.003..0.004 rows=4 loops=25)
                       Index Cond: (entity_id = s.schedule_id)
 Planning time: 2.820 ms
 Execution time: 2031.704 ms
(11 rows)
```

after:

```
 Limit  (cost=1.00..3137.51 rows=25 width=192) (actual time=0.191..1.458 rows=25 loops=1)
   ->  Nested Loop Left Join  (cost=1.00..3074248215.23 rows=24503744 width=192) (actual time=0.191..1.453 rows=25 loops=1)
         ->  Index Scan using schedule_pkey on schedule s  (cost=0.44..893120.72 rows=24503744 width=111) (actual time=0.010..0.025 rows=25 loops=1)
         ->  Index Scan using entity_pkey on entity e  (cost=0.56..0.61 rows=1 width=57) (actual time=0.007..0.007 rows=1 loops=25)
               Index Cond: (id = s.schedule_id)
         SubPlan 1
           ->  Aggregate  (cost=124.79..124.80 rows=1 width=32) (actual time=0.048..0.048 rows=1 loops=25)
                 ->  Index Scan using transaction_signature__entity_id on transaction_signature ts  (cost=0.57..123.14 rows=110 width=85) (actual time=0.004..0.006 rows=4 loops=25)
                       Index Cond: (entity_id = s.schedule_id)
 Planning time: 2.088 ms
 Execution time: 1.600 ms
(11 rows)
```

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
