### PR TITLE
Add NetworkService to grpc ingress

### DIFF
--- a/charts/hedera-mirror-grpc/values.yaml
+++ b/charts/hedera-mirror-grpc/values.yaml
@@ -91,6 +91,7 @@ ingress:
     - host: ""
       paths:
         - "/com.hedera.mirror.api.proto.ConsensusService"
+        - "/com.hedera.mirror.api.proto.NetworkService"
         - "/grpc.reflection.v1alpha.ServerReflection"
   middleware:
     circuitBreaker: NetworkErrorRatio() > 0.10 || ResponseCodeRatio(500, 600, 0, 600) > 0.25


### PR DESCRIPTION
**Description**:
Fix Helm deployment not exposing new address book API via Ingress

**Related issue(s)**:

**Notes for reviewer**:
Will cherry pick to `release/0.49`

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
