### PR TITLE
Add contract state change support to common and importer modules

### DIFF
--- a/docs/design/smart-contracts.md
+++ b/docs/design/smart-contracts.md
@@ -112,6 +112,7 @@ create table if not exists contract_log
   contract_id         bigint not null,
   data                bytea  not null,
   index               int    not null,
+  payer_account_id    bigint not null,
   root_contract_id    bigint null,
   topic0              bytea  null,
   topic1              bytea  null,
@@ -134,6 +135,7 @@ create table if not exists contract_access
   consensus_timestamp bigint      not null,
   contract_id         bigint      not null,
   initial_contract_id bigint      not null,
+  payer_account_id    bigint      not null,
   storage_keys        bytea array not null,
   primary key (consensus_timestamp, initial_contract_id, contract_id)
 );
@@ -148,6 +150,7 @@ create table if not exists contract_state_change
 (
   consensus_timestamp bigint not null,
   contract_id         bigint not null,
+  payer_account_id    bigint not null,
   slot                bytea  not null,
   value_read          bytea  not null,
   value_written       bytea  null,

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/contract/ContractStateChange.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/contract/ContractStateChange.java
@@ -80,8 +80,6 @@ public class ContractStateChange implements Persistable<ContractStateChange.Id> 
     }
 
     @Data
-    @AllArgsConstructor
-    @NoArgsConstructor
     public static class Id implements Serializable {
         private static final long serialVersionUID = -3677350664183037811L;
         private long consensusTimestamp;

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/contract/ContractStateChange.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/contract/ContractStateChange.java
@@ -4,7 +4,7 @@ package com.hedera.mirror.common.domain.contract;
  * ‌
  * Hedera Mirror Node
  * ​
- * Copyright (C) 2019 - 2021 Hedera Hashgraph, LLC
+ * Copyright (C) 2019 - 2022 Hedera Hashgraph, LLC
  * ​
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/contract/ContractStateChange.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/contract/ContractStateChange.java
@@ -1,0 +1,91 @@
+package com.hedera.mirror.common.domain.contract;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.io.Serializable;
+import javax.persistence.Convert;
+import javax.persistence.IdClass;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.springframework.data.domain.Persistable;
+
+import com.hedera.mirror.common.converter.AccountIdConverter;
+import com.hedera.mirror.common.converter.ContractIdConverter;
+import com.hedera.mirror.common.domain.entity.EntityId;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE) // For Builder
+@Builder
+@Data
+@javax.persistence.Entity
+@IdClass(ContractStateChange.Id.class)
+@NoArgsConstructor
+public class ContractStateChange implements Persistable<ContractStateChange.Id> {
+
+    @javax.persistence.Id
+    private long consensusTimestamp;
+
+    @Convert(converter = ContractIdConverter.class)
+    private EntityId contractId;
+
+    @Convert(converter = AccountIdConverter.class)
+    private EntityId payerAccountId;
+
+    @javax.persistence.Id
+    @ToString.Exclude
+    private byte[] slot;
+
+    @ToString.Exclude
+    private byte[] valueRead;
+
+    @ToString.Exclude
+    private byte[] valueWritten;
+
+    @Override
+    @JsonIgnore
+    public Id getId() {
+        Id id = new Id();
+        id.setConsensusTimestamp(consensusTimestamp);
+        id.setContractId(contractId);
+        id.setSlot(slot);
+        return id;
+    }
+
+    @JsonIgnore
+    @Override
+    public boolean isNew() {
+        return true;
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Id implements Serializable {
+        private static final long serialVersionUID = -3677350664183037811L;
+        private long consensusTimestamp;
+        private EntityId contractId;
+        private byte[] slot;
+    }
+}

--- a/hedera-mirror-common/src/test/java/com/hedera/mirror/common/converter/ContractIdConverterTest.java
+++ b/hedera-mirror-common/src/test/java/com/hedera/mirror/common/converter/ContractIdConverterTest.java
@@ -1,0 +1,30 @@
+package com.hedera.mirror.common.converter;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import org.junit.jupiter.api.BeforeAll;
+
+class ContractIdConverterTest extends AbstractEntityConverterTest {
+    @BeforeAll
+    static void beforeAll() {
+        converter = new ContractIdConverter();
+    }
+}

--- a/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/DomainBuilder.java
+++ b/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/DomainBuilder.java
@@ -56,6 +56,7 @@ import com.hedera.mirror.common.domain.addressbook.AddressBookServiceEndpoint;
 import com.hedera.mirror.common.domain.contract.Contract;
 import com.hedera.mirror.common.domain.contract.ContractLog;
 import com.hedera.mirror.common.domain.contract.ContractResult;
+import com.hedera.mirror.common.domain.contract.ContractStateChange;
 import com.hedera.mirror.common.domain.entity.Entity;
 import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.entity.EntityType;
@@ -200,6 +201,17 @@ public class DomainBuilder {
                 .gasLimit(200L)
                 .gasUsed(100L)
                 .payerAccountId(entityId(ACCOUNT));
+        return new DomainWrapperImpl<>(builder, builder::build);
+    }
+
+    public DomainWrapper<ContractStateChange, ContractStateChange.ContractStateChangeBuilder> contractStateChange() {
+        ContractStateChange.ContractStateChangeBuilder builder = ContractStateChange.builder()
+                .consensusTimestamp(timestamp())
+                .contractId(entityId(CONTRACT))
+                .payerAccountId(entityId(ACCOUNT))
+                .slot(bytes(128))
+                .valueRead(bytes(64))
+                .valueWritten(bytes(64));
         return new DomainWrapperImpl<>(builder, builder::build);
     }
 
@@ -358,16 +370,19 @@ public class DomainBuilder {
         private final B builder;
         private final Supplier<T> supplier;
 
+        @Override
         public DomainWrapper<T, B> customize(Consumer<B> customizer) {
             customizer.accept(builder);
             return this;
         }
 
+        @Override
         public T get() {
             return supplier.get();
         }
 
         // The DomainBuilder can be used without an active ApplicationContext. If so, this method shouldn't be used.
+        @Override
         public T persist() {
             T entity = get();
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/CompositeEntityListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/CompositeEntityListener.java
@@ -30,20 +30,21 @@ import org.springframework.context.annotation.Primary;
 import com.hedera.mirror.common.domain.contract.Contract;
 import com.hedera.mirror.common.domain.contract.ContractLog;
 import com.hedera.mirror.common.domain.contract.ContractResult;
+import com.hedera.mirror.common.domain.contract.ContractStateChange;
 import com.hedera.mirror.common.domain.entity.Entity;
 import com.hedera.mirror.common.domain.file.FileData;
 import com.hedera.mirror.common.domain.schedule.Schedule;
-import com.hedera.mirror.common.domain.transaction.AssessedCustomFee;
-import com.hedera.mirror.common.domain.transaction.CryptoTransfer;
-import com.hedera.mirror.common.domain.transaction.CustomFee;
-import com.hedera.mirror.common.domain.transaction.LiveHash;
 import com.hedera.mirror.common.domain.token.Nft;
 import com.hedera.mirror.common.domain.token.NftTransfer;
-import com.hedera.mirror.common.domain.transaction.NonFeeTransfer;
 import com.hedera.mirror.common.domain.token.Token;
 import com.hedera.mirror.common.domain.token.TokenAccount;
 import com.hedera.mirror.common.domain.token.TokenTransfer;
 import com.hedera.mirror.common.domain.topic.TopicMessage;
+import com.hedera.mirror.common.domain.transaction.AssessedCustomFee;
+import com.hedera.mirror.common.domain.transaction.CryptoTransfer;
+import com.hedera.mirror.common.domain.transaction.CustomFee;
+import com.hedera.mirror.common.domain.transaction.LiveHash;
+import com.hedera.mirror.common.domain.transaction.NonFeeTransfer;
 import com.hedera.mirror.common.domain.transaction.Transaction;
 import com.hedera.mirror.common.domain.transaction.TransactionSignature;
 import com.hedera.mirror.importer.exception.ImporterException;
@@ -82,6 +83,11 @@ public class CompositeEntityListener implements EntityListener {
     @Override
     public void onContractResult(ContractResult contractResult) throws ImporterException {
         onEach(EntityListener::onContractResult, contractResult);
+    }
+
+    @Override
+    public void onContractStateChange(ContractStateChange contractStateChange) throws ImporterException {
+        onEach(EntityListener::onContractStateChange, contractStateChange);
     }
 
     @Override

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityListener.java
@@ -23,20 +23,21 @@ package com.hedera.mirror.importer.parser.record.entity;
 import com.hedera.mirror.common.domain.contract.Contract;
 import com.hedera.mirror.common.domain.contract.ContractLog;
 import com.hedera.mirror.common.domain.contract.ContractResult;
+import com.hedera.mirror.common.domain.contract.ContractStateChange;
 import com.hedera.mirror.common.domain.entity.Entity;
 import com.hedera.mirror.common.domain.file.FileData;
 import com.hedera.mirror.common.domain.schedule.Schedule;
-import com.hedera.mirror.common.domain.transaction.AssessedCustomFee;
-import com.hedera.mirror.common.domain.transaction.CryptoTransfer;
-import com.hedera.mirror.common.domain.transaction.CustomFee;
-import com.hedera.mirror.common.domain.transaction.LiveHash;
 import com.hedera.mirror.common.domain.token.Nft;
 import com.hedera.mirror.common.domain.token.NftTransfer;
-import com.hedera.mirror.common.domain.transaction.NonFeeTransfer;
 import com.hedera.mirror.common.domain.token.Token;
 import com.hedera.mirror.common.domain.token.TokenAccount;
 import com.hedera.mirror.common.domain.token.TokenTransfer;
 import com.hedera.mirror.common.domain.topic.TopicMessage;
+import com.hedera.mirror.common.domain.transaction.AssessedCustomFee;
+import com.hedera.mirror.common.domain.transaction.CryptoTransfer;
+import com.hedera.mirror.common.domain.transaction.CustomFee;
+import com.hedera.mirror.common.domain.transaction.LiveHash;
+import com.hedera.mirror.common.domain.transaction.NonFeeTransfer;
 import com.hedera.mirror.common.domain.transaction.Transaction;
 import com.hedera.mirror.common.domain.transaction.TransactionSignature;
 import com.hedera.mirror.importer.exception.ImporterException;
@@ -57,6 +58,9 @@ public interface EntityListener {
     }
 
     default void onContractLog(ContractLog contractLog) {
+    }
+
+    default void onContractStateChange(ContractStateChange contractStateChange) {
     }
 
     default void onContractResult(ContractResult contractResult) throws ImporterException {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListener.java
@@ -37,25 +37,26 @@ import org.springframework.core.annotation.Order;
 import com.hedera.mirror.common.domain.contract.Contract;
 import com.hedera.mirror.common.domain.contract.ContractLog;
 import com.hedera.mirror.common.domain.contract.ContractResult;
+import com.hedera.mirror.common.domain.contract.ContractStateChange;
 import com.hedera.mirror.common.domain.entity.AbstractEntity;
 import com.hedera.mirror.common.domain.entity.Entity;
 import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.file.FileData;
 import com.hedera.mirror.common.domain.schedule.Schedule;
-import com.hedera.mirror.common.domain.transaction.AssessedCustomFee;
-import com.hedera.mirror.common.domain.transaction.CryptoTransfer;
-import com.hedera.mirror.common.domain.transaction.CustomFee;
-import com.hedera.mirror.common.domain.transaction.LiveHash;
 import com.hedera.mirror.common.domain.token.Nft;
 import com.hedera.mirror.common.domain.token.NftId;
 import com.hedera.mirror.common.domain.token.NftTransfer;
-import com.hedera.mirror.common.domain.transaction.NonFeeTransfer;
-import com.hedera.mirror.common.domain.transaction.RecordFile;
 import com.hedera.mirror.common.domain.token.Token;
 import com.hedera.mirror.common.domain.token.TokenAccount;
 import com.hedera.mirror.common.domain.token.TokenAccountKey;
 import com.hedera.mirror.common.domain.token.TokenTransfer;
 import com.hedera.mirror.common.domain.topic.TopicMessage;
+import com.hedera.mirror.common.domain.transaction.AssessedCustomFee;
+import com.hedera.mirror.common.domain.transaction.CryptoTransfer;
+import com.hedera.mirror.common.domain.transaction.CustomFee;
+import com.hedera.mirror.common.domain.transaction.LiveHash;
+import com.hedera.mirror.common.domain.transaction.NonFeeTransfer;
+import com.hedera.mirror.common.domain.transaction.RecordFile;
 import com.hedera.mirror.common.domain.transaction.Transaction;
 import com.hedera.mirror.common.domain.transaction.TransactionSignature;
 import com.hedera.mirror.importer.exception.ImporterException;
@@ -85,6 +86,7 @@ public class SqlEntityListener implements EntityListener, RecordStreamFileListen
     private final Collection<Contract> contracts;
     private final Collection<ContractLog> contractLogs;
     private final Collection<ContractResult> contractResults;
+    private final Collection<ContractStateChange> contractStateChanges;
     private final Collection<CryptoTransfer> cryptoTransfers;
     private final Collection<CustomFee> customFees;
     private final Collection<Entity> entities;
@@ -127,6 +129,7 @@ public class SqlEntityListener implements EntityListener, RecordStreamFileListen
         contracts = new ArrayList<>();
         contractLogs = new ArrayList<>();
         contractResults = new ArrayList<>();
+        contractStateChanges = new ArrayList<>();
         cryptoTransfers = new ArrayList<>();
         customFees = new ArrayList<>();
         entities = new ArrayList<>();
@@ -177,6 +180,7 @@ public class SqlEntityListener implements EntityListener, RecordStreamFileListen
             contractState.clear();
             contractLogs.clear();
             contractResults.clear();
+            contractStateChanges.clear();
             cryptoTransfers.clear();
             customFees.clear();
             entities.clear();
@@ -212,6 +216,7 @@ public class SqlEntityListener implements EntityListener, RecordStreamFileListen
             batchPersister.persist(assessedCustomFees);
             batchPersister.persist(contractLogs);
             batchPersister.persist(contractResults);
+            batchPersister.persist(contractStateChanges);
             batchPersister.persist(cryptoTransfers);
             batchPersister.persist(customFees);
             batchPersister.persist(fileData);
@@ -266,6 +271,11 @@ public class SqlEntityListener implements EntityListener, RecordStreamFileListen
     @Override
     public void onContractResult(ContractResult contractResult) throws ImporterException {
         contractResults.add(contractResult);
+    }
+
+    @Override
+    public void onContractStateChange(ContractStateChange contractStateChange) {
+        contractStateChanges.add(contractStateChange);
     }
 
     @Override

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/AbstractContractCallTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/AbstractContractCallTransactionHandler.java
@@ -94,13 +94,13 @@ abstract class AbstractContractCallTransactionHandler implements TransactionHand
         }
 
         // contract call state changes
-        for (int index = 0; index < functionResult.getStateChangesCount(); ++index) {
-            com.hederahashgraph.api.proto.java.ContractStateChange contractStateChangeInfo = functionResult
-                    .getStateChanges(index);
+        for (int stateIndex = 0; stateIndex < functionResult.getStateChangesCount(); ++stateIndex) {
+            var contractStateChangeInfo = functionResult.getStateChanges(stateIndex);
 
             var contractId = EntityId.of(contractStateChangeInfo.getContractID());
-            for (int i = 0; i < contractStateChangeInfo.getStorageChangesCount(); ++i) {
-                StorageChange storageChange = contractStateChangeInfo.getStorageChanges(index);
+            for (int storageIndex = 0; storageIndex < contractStateChangeInfo
+                    .getStorageChangesCount(); ++storageIndex) {
+                StorageChange storageChange = contractStateChangeInfo.getStorageChanges(storageIndex);
 
                 ContractStateChange contractStateChange = new ContractStateChange();
                 contractStateChange.setConsensusTimestamp(consensusTimestamp);
@@ -111,7 +111,7 @@ abstract class AbstractContractCallTransactionHandler implements TransactionHand
 
                 // If a value of zero is written the valueWritten will be present but the inner value will be absent.
                 // If a value was read and not written this value will not be present.
-                if (storageChange.isInitialized()) {
+                if (storageChange.hasValueWritten()) {
                     contractStateChange
                             .setValueWritten(DomainUtils.toBytes(storageChange.getValueWritten().getValue()));
                 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/AbstractContractCallTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/AbstractContractCallTransactionHandler.java
@@ -23,6 +23,7 @@ package com.hedera.mirror.importer.parser.record.transactionhandler;
 import com.hederahashgraph.api.proto.java.ContractFunctionResult;
 import com.hederahashgraph.api.proto.java.ContractID;
 import com.hederahashgraph.api.proto.java.ContractLoginfo;
+import com.hederahashgraph.api.proto.java.StorageChange;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -30,6 +31,7 @@ import lombok.RequiredArgsConstructor;
 import com.hedera.mirror.common.domain.contract.Contract;
 import com.hedera.mirror.common.domain.contract.ContractLog;
 import com.hedera.mirror.common.domain.contract.ContractResult;
+import com.hedera.mirror.common.domain.contract.ContractStateChange;
 import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.transaction.RecordItem;
 import com.hedera.mirror.common.util.DomainUtils;
@@ -71,6 +73,7 @@ abstract class AbstractContractCallTransactionHandler implements TransactionHand
         contractResult.setGasUsed(functionResult.getGasUsed());
         entityListener.onContractResult(contractResult);
 
+        // contract call logs
         for (int index = 0; index < functionResult.getLogInfoCount(); ++index) {
             ContractLoginfo contractLoginfo = functionResult.getLogInfo(index);
 
@@ -88,6 +91,33 @@ abstract class AbstractContractCallTransactionHandler implements TransactionHand
             contractLog.setTopic3(Utility.getTopic(contractLoginfo, 3));
 
             entityListener.onContractLog(contractLog);
+        }
+
+        // contract call state changes
+        for (int index = 0; index < functionResult.getStateChangesCount(); ++index) {
+            com.hederahashgraph.api.proto.java.ContractStateChange contractStateChangeInfo = functionResult
+                    .getStateChanges(index);
+
+            var contractId = EntityId.of(contractStateChangeInfo.getContractID());
+            for (int i = 0; i < contractStateChangeInfo.getStorageChangesCount(); ++i) {
+                StorageChange storageChange = contractStateChangeInfo.getStorageChanges(index);
+
+                ContractStateChange contractStateChange = new ContractStateChange();
+                contractStateChange.setConsensusTimestamp(consensusTimestamp);
+                contractStateChange.setContractId(contractId);
+                contractStateChange.setPayerAccountId(contractResult.getPayerAccountId());
+                contractStateChange.setSlot(DomainUtils.toBytes(storageChange.getSlot()));
+                contractStateChange.setValueRead(DomainUtils.toBytes(storageChange.getValueRead()));
+
+                // If a value of zero is written the valueWritten will be present but the inner value will be absent.
+                // If a value was read and not written this value will not be present.
+                if (storageChange.isInitialized()) {
+                    contractStateChange
+                            .setValueWritten(DomainUtils.toBytes(storageChange.getValueWritten().getValue()));
+                }
+
+                entityListener.onContractStateChange(contractStateChange);
+            }
         }
     }
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/ContractStateChangeRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/ContractStateChangeRepository.java
@@ -1,0 +1,28 @@
+package com.hedera.mirror.importer.repository;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import org.springframework.data.repository.CrudRepository;
+
+import com.hedera.mirror.common.domain.contract.ContractStateChange;
+
+public interface ContractStateChangeRepository extends CrudRepository<ContractStateChange, ContractStateChange.Id> {
+}

--- a/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.54.0__add_contract_state_change.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.54.0__add_contract_state_change.sql
@@ -1,0 +1,14 @@
+-------------------
+-- Add contract_state_change table to improve smart contract traceability
+-------------------
+
+create table if not exists contract_state_change
+(
+    consensus_timestamp bigint not null,
+    contract_id         bigint not null,
+    payer_account_id    bigint not null,
+    slot                bytea  not null,
+    value_read          bytea  not null,
+    value_written       bytea  null,
+    primary key (consensus_timestamp, contract_id, slot)
+);

--- a/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.0__create_tables.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.0__create_tables.sql
@@ -142,6 +142,17 @@ create table if not exists contract_result
 );
 comment on table contract_result is 'Crypto contract execution results';
 
+create table if not exists contract_state_change
+(
+    consensus_timestamp bigint not null,
+    contract_id         bigint not null,
+    payer_account_id    bigint not null,
+    slot                bytea  not null,
+    value_read          bytea  not null,
+    value_written       bytea  null
+);
+comment on table contract_result is 'Contract execution state changes';
+
 -- crypto_transfer
 create table if not exists crypto_transfer
 (

--- a/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.1__distribution.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.1__distribution.sql
@@ -19,6 +19,8 @@ select create_distributed_table('contract_log', 'payer_account_id', colocate_wit
 
 select create_distributed_table('contract_result', 'payer_account_id', colocate_with => 'entity');
 
+select create_distributed_table('contract_state_change', 'payer_account_id', colocate_with => 'entity');
+
 select create_distributed_table('custom_fee', 'token_id', colocate_with => 'entity');
 
 select create_distributed_table('entity_history', 'id', colocate_with => 'entity');

--- a/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.3__index_init.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.3__index_init.sql
@@ -60,6 +60,10 @@ alter table if exists contract_result
 create index if not exists contract_result__id_payer_timestamp
     on contract_result (contract_id, payer_account_id, consensus_timestamp);
 
+-- contract_state_change
+alter table if exists contract_state_change
+    add constraint contract_state_change__pk primary key (consensus_timestamp, contract_id, slot, payer_account_id);
+
 -- crypto_transfer
 create index if not exists crypto_transfer__consensus_timestamp
     on crypto_transfer (consensus_timestamp);

--- a/hedera-mirror-importer/src/main/resources/db/scripts/v2/csvBackupTables.sql
+++ b/hedera-mirror-importer/src/main/resources/db/scripts/v2/csvBackupTables.sql
@@ -22,6 +22,8 @@
 
 \copy contract_result to contract_result.csv delimiter ',' csv;
 
+\copy contract_state_change to contract_state_change.csv delimiter ',' csv;
+
 \copy crypto_transfer to crypto_transfer.csv delimiter ',' csv;
 
 \copy custom_fee to custom_fee.csv delimiter ',' csv;

--- a/hedera-mirror-importer/src/main/resources/db/scripts/v2/csvRestoreTables.sql
+++ b/hedera-mirror-importer/src/main/resources/db/scripts/v2/csvRestoreTables.sql
@@ -20,7 +20,9 @@
 
 \copy contract_log (bloom, consensus_timestamp, contract_id, data, index, topic0, topic1, topic2, topic3, root_contract_id) from contract_log.csv csv;
 
-\copy contract_result (amount, bloom, call_result, consensus_timestamp, contract_id, created_contract_ids, error_message, function_parameters, function_result, gas_limit, gas_used) from contract_result.csv csv;
+\copy contract_result (amount, bloom, call_result, consensus_timestamp, contract_id, created_contract_ids, error_message, function_parameters, function_result, gas_limit, gas_used, payer_account_id) from contract_result.csv csv;
+
+\copy contract_state_change (consensus_timestamp, contract_id, payer_account_id, slot, value_read, value_written) from contract_state_change.csv csv;
 
 \copy crypto_transfer (entity_id, consensus_timestamp, amount) from crypto_transfer.csv csv;
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/domain/RecordItemBuilder.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/domain/RecordItemBuilder.java
@@ -25,6 +25,7 @@ import static com.hedera.mirror.common.domain.DomainBuilder.KEY_LENGTH_ED25519;
 import static com.hederahashgraph.api.proto.java.TokenType.FUNGIBLE_COMMON;
 
 import com.google.protobuf.ByteString;
+import com.google.protobuf.BytesValue;
 import com.google.protobuf.GeneratedMessageV3;
 import com.hederahashgraph.api.proto.java.AccountAmount;
 import com.hederahashgraph.api.proto.java.AccountID;
@@ -42,6 +43,7 @@ import com.hederahashgraph.api.proto.java.ShardID;
 import com.hederahashgraph.api.proto.java.SignatureMap;
 import com.hederahashgraph.api.proto.java.SignaturePair;
 import com.hederahashgraph.api.proto.java.SignedTransaction;
+import com.hederahashgraph.api.proto.java.StorageChange;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TokenID;
 import com.hederahashgraph.api.proto.java.TokenMintTransactionBody;
@@ -138,6 +140,34 @@ public class RecordItemBuilder {
                         .addTopic(bytes(32))
                         .addTopic(bytes(32))
                         .addTopic(bytes(32))
+                        .build())
+                .addStateChanges(com.hederahashgraph.api.proto.java.ContractStateChange.newBuilder()
+                        .setContractID(contractId)
+                        .addStorageChanges(StorageChange.newBuilder()
+                                .setSlot(ByteString
+                                        .copyFromUtf8("0x000000000000000000"))
+                                .setValueRead(ByteString
+                                        .copyFromUtf8(
+                                                "0xaf846d22986843e3d25981b94ce181adc556b334ccfdd8225762d7f709841df0"))
+                                .build())
+                        .addStorageChanges(StorageChange.newBuilder()
+                                .setSlot(ByteString
+                                        .copyFromUtf8("0x000000000000000001"))
+                                .setValueRead(ByteString
+                                        .copyFromUtf8(
+                                                "0xaf846d22986843e3d25981b94ce181adc556b334ccfdd8225762d7f709841df0"))
+                                .setValueWritten(BytesValue.of(ByteString
+                                        .copyFromUtf8(
+                                                "0x000000000000000000000000000000000000000000c2a8c408d0e29d623347c5")))
+                                .build())
+                        .addStorageChanges(StorageChange.newBuilder()
+                                .setSlot(ByteString
+                                        .copyFromUtf8("0x00000000000000002"))
+                                .setValueRead(ByteString
+                                        .copyFromUtf8(
+                                                "0xaf846d22986843e3d25981b94ce181adc556b334ccfdd8225762d7f709841df0"))
+                                .setValueWritten(BytesValue.of(ByteString.copyFromUtf8("0")))
+                                .build())
                         .build());
     }
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerContractTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerContractTest.java
@@ -642,8 +642,11 @@ class EntityRecordItemListenerContractTest extends AbstractEntityRecordItemListe
                 byte[] slot = DomainUtils.toBytes(storageChange.getSlot());
                 byte[] valueWritten = storageChange.hasValueWritten() ? storageChange.getValueWritten().getValue()
                         .toByteArray() : null;
-                assertThat(contractStateChangeRepository.findById(new ContractStateChange.Id(consensusTimestamp,
-                        contractId, slot)))
+                assertThat(contractStateChangeRepository.findById(ContractStateChange.builder()
+                        .consensusTimestamp(consensusTimestamp)
+                        .contractId(contractId)
+                        .slot(slot)
+                        .build().getId()))
                         .isPresent()
                         .get()
                         .returns(consensusTimestamp, ContractStateChange::getConsensusTimestamp)

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListenerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListenerTest.java
@@ -47,6 +47,7 @@ import com.hedera.mirror.common.domain.DomainBuilder;
 import com.hedera.mirror.common.domain.contract.Contract;
 import com.hedera.mirror.common.domain.contract.ContractLog;
 import com.hedera.mirror.common.domain.contract.ContractResult;
+import com.hedera.mirror.common.domain.contract.ContractStateChange;
 import com.hedera.mirror.common.domain.entity.Entity;
 import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.entity.EntityType;
@@ -78,6 +79,7 @@ import com.hedera.mirror.importer.TestUtils;
 import com.hedera.mirror.importer.repository.ContractLogRepository;
 import com.hedera.mirror.importer.repository.ContractRepository;
 import com.hedera.mirror.importer.repository.ContractResultRepository;
+import com.hedera.mirror.importer.repository.ContractStateChangeRepository;
 import com.hedera.mirror.importer.repository.CryptoTransferRepository;
 import com.hedera.mirror.importer.repository.EntityRepository;
 import com.hedera.mirror.importer.repository.FileDataRepository;
@@ -108,6 +110,7 @@ class SqlEntityListenerTest extends IntegrationTest {
     private final ContractRepository contractRepository;
     private final ContractLogRepository contractLogRepository;
     private final ContractResultRepository contractResultRepository;
+    private final ContractStateChangeRepository contractStateChangeRepository;
     private final JdbcOperations jdbcOperations;
     private final LiveHashRepository liveHashRepository;
     private final NftRepository nftRepository;
@@ -252,6 +255,19 @@ class SqlEntityListenerTest extends IntegrationTest {
 
         // then
         assertThat(contractResultRepository.findAll()).containsExactlyInAnyOrder(contractResult);
+    }
+
+    @Test
+    void onContractStateChange() {
+        // given
+        ContractStateChange contractStateChange = domainBuilder.contractStateChange().get();
+
+        // when
+        sqlEntityListener.onContractStateChange(contractStateChange);
+        completeFileAndCommit();
+
+        // then
+        assertThat(contractStateChangeRepository.findAll()).containsExactlyInAnyOrder(contractStateChange);
     }
 
     @Test

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/ContractStateChangeRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/ContractStateChangeRepositoryTest.java
@@ -1,0 +1,41 @@
+package com.hedera.mirror.importer.repository;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.annotation.Resource;
+import org.junit.jupiter.api.Test;
+
+import com.hedera.mirror.common.domain.contract.ContractStateChange;
+
+class ContractStateChangeRepositoryTest extends AbstractRepositoryTest {
+
+    @Resource
+    private ContractStateChangeRepository contractStateChangeRepository;
+
+    @Test
+    void save() {
+        ContractStateChange contractStateChange = domainBuilder.contractStateChange().persist();
+        assertThat(contractStateChangeRepository.findById(contractStateChange.getId())).get()
+                .isEqualTo(contractStateChange);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,8 @@
         <grpc-spring-boot.version>2.11.0.RELEASE</grpc-spring-boot.version>
         <grpc.version>1.43.2</grpc.version>
         <guava.version>31.0.1-jre</guava.version>
-        <hedera-protobuf.version>0.22.0</hedera-protobuf.version>
+        <hedera-protobuf.version>0.23.0-SNAPSHOT</hedera-protobuf.version>
+        <hedera-sdk.version>2.2.0-beta.2</hedera-sdk.version>
         <hibernate-types.version>2.14.0</hibernate-types.version>
         <jacoco.version>0.8.7</jacoco.version>
         <java.version>11</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,6 @@
         <grpc.version>1.43.2</grpc.version>
         <guava.version>31.0.1-jre</guava.version>
         <hedera-protobuf.version>0.23.0-SNAPSHOT</hedera-protobuf.version>
-        <hedera-sdk.version>2.2.0-beta.2</hedera-sdk.version>
         <hibernate-types.version>2.14.0</hibernate-types.version>
         <jacoco.version>0.8.7</jacoco.version>
         <java.version>11</java.version>


### PR DESCRIPTION
**Description**:
[HIP-260](https://hips.hedera.com/HIP/hip-260.html) Smart Contract Traceability adds new information to the transaction record to track contract state changes.

- Add v1 db migration to create `contract_state_change` table
- Update V2.0.x migrations files with `contract_state_change` table logic
- Add `ContractStateChange` domain to common module
- Update `EntityListener` interface and implementations with `onContractStateChange()` logic
- Update `AbstractContractCallTransactionHandler` with `ContractStateChange` population logic
- Update entityListener tests with contractStateChange details

**Related issue(s)**:

Partially addresses #3160 

**Notes for reviewer**:
Yet to 
- [x] Update v2 migration scripts with new table
- [x] Rebase with main for newly pushed changes

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
