### PR TITLE
Set importer replicas to 1 to workaround leader election bugs

### DIFF
--- a/charts/hedera-mirror/values-prod.yaml
+++ b/charts/hedera-mirror/values-prod.yaml
@@ -32,7 +32,7 @@ importer:
   priorityClassName: high
   prometheusRules:
     enabled: true
-  replicas: 2
+  replicas: 1
   updateStrategy:
     rollingUpdate:
       maxSurge: 0


### PR DESCRIPTION
**Description**:
Set importer replicas to 1 to workaround leader election [bugs](https://github.com/hashgraph/hedera-mirror-node/issues/3131)

**Related issue(s)**:

Related to https://github.com/hashgraph/hedera-mirror-node/issues/3131

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
