### PR TITLE
Increase default gas limit used by acceptance tests

### DIFF
--- a/hedera-mirror-test/README.md
+++ b/hedera-mirror-test/README.md
@@ -55,6 +55,8 @@ under `hedera.mirror.test.acceptance` include:
   `environments.
 - `existingTopicNum` - A pre-existing default topic number that can be used when no topicId is specified in a test. Used
   initially by `@subscribeonly` test.
+- `featureProperties`
+  - `maxContractFunctionGas` - The maximum amount of gas an account is willing to pay for a contract function call.
 - `maxRetries` - The number of times client should retryable on supported failures.
 - `maxTinyBarTransactionFee` - The maximum transaction fee you're willing to pay on a transaction.
 - `messageTimeout` - The number of seconds to wait on messages representing transactions (default is 20).

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
@@ -46,6 +46,8 @@ public class AcceptanceTestProperties {
     @NotNull
     private Long existingTopicNum;
 
+    private final FeatureProperties featureProperties;
+
     @Max(5)
     private int maxRetries = 2;
 

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/FeatureProperties.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/FeatureProperties.java
@@ -1,0 +1,40 @@
+package com.hedera.mirror.test.e2e.acceptance.config;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+@Component
+@ConfigurationProperties(prefix = "hedera.mirror.test.acceptance.feature")
+@Data
+@Validated
+public class FeatureProperties {
+    // To-do: move feature logic related properties from AcceptanceTestProperties here
+
+    @Min(1)
+    @Max(5_000_000)
+    private long maxContractFunctionGas = 3_000_000;
+}

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ContractFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ContractFeature.java
@@ -57,7 +57,7 @@ import com.hedera.mirror.test.e2e.acceptance.util.FeatureInputHandler;
 @Log4j2
 @Cucumber
 public class ContractFeature extends AbstractFeature {
-    private final static long maxFunctionGas = 300_000;
+    private final static long maxFunctionGas = 3_000_000;
     private final ObjectMapper mapper = new ObjectMapper()
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
             .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ContractFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ContractFeature.java
@@ -57,7 +57,6 @@ import com.hedera.mirror.test.e2e.acceptance.util.FeatureInputHandler;
 @Log4j2
 @Cucumber
 public class ContractFeature extends AbstractFeature {
-    private final static long maxFunctionGas = 3_000_000;
     private final ObjectMapper mapper = new ObjectMapper()
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
             .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
@@ -166,7 +165,8 @@ public class ContractFeature extends AbstractFeature {
         persistContractBytes(byteCode.replaceFirst("0x", ""));
         networkTransactionResponse = contractClient.createContract(
                 fileId,
-                maxFunctionGas,
+                contractClient.getSdkClient().getAcceptanceTestProperties().getFeatureProperties()
+                        .getMaxContractFunctionGas(),
                 initialBalance == 0 ? null : Hbar.fromTinybars(initialBalance),
                 null);
 
@@ -236,7 +236,9 @@ public class ContractFeature extends AbstractFeature {
         assertThat(contractResult.getErrorMessage()).isBlank();
         assertThat(contractResult.getFrom()).isEqualTo(FeatureInputHandler.solidityAddress(
                 contractClient.getSdkClient().getExpandedOperatorAccountId().getAccountId()));
-        assertThat(contractResult.getGasLimit()).isEqualTo(maxFunctionGas);
+        assertThat(contractResult.getGasLimit())
+                .isEqualTo(contractClient.getSdkClient().getAcceptanceTestProperties().getFeatureProperties()
+                        .getMaxContractFunctionGas());
         assertThat(contractResult.getGasUsed()).isPositive();
         assertThat(contractResult.getTo()).isEqualTo(FeatureInputHandler.solidityAddress(contractId));
 
@@ -264,7 +266,8 @@ public class ContractFeature extends AbstractFeature {
     private void executeCreateChildTransaction(int transferAmount) {
         networkTransactionResponse = contractClient.executeContract(
                 contractId,
-                maxFunctionGas,
+                contractClient.getSdkClient().getAcceptanceTestProperties().getFeatureProperties()
+                        .getMaxContractFunctionGas(),
                 "createChild",
                 new ContractFunctionParameters()
                         .addUint256(BigInteger.valueOf(transferAmount)),


### PR DESCRIPTION
Signed-off-by: Nana-EC <nana.essilfie-conduah@hedera.com>

**Description**:
In recent service version releases the gas cost has increased.
In cases where a system account is used this gas limit has exceeded the default gas limit used by acceptance tests

- Increase default gas limit to support gas cost for system accounts with far off expiration

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
