### PR TITLE
Improve perf of Rosetta get genesis balance script

### DIFF
--- a/docs/rosetta/README.md
+++ b/docs/rosetta/README.md
@@ -115,7 +115,7 @@ genesis account balance file. Once the `get-genesis-balance.sh testnet` command 
 
 The `get-genesis-balance.sh` script takes the following form
 
-`./get-genesis-balance.sh <network> <account_limit> <starting_timestamp> <transfer_window_ns>`
+`./get-genesis-balance.sh <network> <account_limit> <transfer_window_ns>`
 
 - `network` - The Hedera network to validate against. Options include `demo` or `testnet` with a default of `demo`
 - `account_limit` - The max number of accounts to list in the file. Default is 20.

--- a/docs/rosetta/README.md
+++ b/docs/rosetta/README.md
@@ -105,27 +105,20 @@ rosetta-cli tests. Please refer to [the official guide](https://docs.cloud.coinb
 for the options.
 
 You can run the rosetta-cli `check:data` command as is. The data configuration section is set with `"start_index": 1`
-to work around the known `rosetta-cli` performance issue of loading large genesis account balance file. As an
-alternative, use the [script](/hedera-mirror-rosetta/scripts/validation/get-genesis-balance.sh) to get the genesis
-account balance file. Once the `get-genesis-balance.sh testnet` command is executed, it'll write the file to
+to work around the known `rosetta-cli` performance issue of loading large genesis account balance file.
+
+#### Genesis Balance File
+
+As an alternative, run the [script](/hedera-mirror-rosetta/scripts/validation/get-genesis-balance.sh) script to get the
+genesis account balance file. Once the `get-genesis-balance.sh testnet` command is executed, it'll write the file to
 `testnet/data_genesis_balances.json`. Note the script uses PostgreSQL's command line client psql to query the
-
-#### balance validation json
-
-In order to run the rosetta-cli `check:data` command or `check:construction` commands a genesis balance file is needed
-as a basic for validation. To obtain this run
-the [script](/hedera-mirror-rosetta/scripts/validation/get-genesis-balance.sh)
-with the associated
-[configuration file](/hedera-mirror-rosetta/scripts/validation/testnet/validation.json) to get the genesis account
-balance file.
 
 The `get-genesis-balance.sh` script takes the following form
 
 `./get-genesis-balance.sh <network> <account_limit> <starting_timestamp> <transfer_window_ns>`
 
-- `network` - The Hedera network to validate against. Option include `demo, testnet` with default of `demo`
+- `network` - The Hedera network to validate against. Options include `demo` or `testnet` with a default of `demo`
 - `account_limit` - The max number of accounts to list in the file. Default is 20.
-- `starting_timestamp` - The timestamp after which to take the first account balance file. Default is 0.
 - `transfer_window_ns` - The additional ns duration added to the `starting_timestamp` to search for accounts when an
   account limit is used. Default is 1 week i.e. 604800000000000 ns
 

--- a/docs/rosetta/README.md
+++ b/docs/rosetta/README.md
@@ -106,10 +106,41 @@ for the options.
 
 You can run the rosetta-cli `check:data` command as is. The data configuration section is set with `"start_index": 1`
 to work around the known `rosetta-cli` performance issue of loading large genesis account balance file. As an
-alternative, use the [script](/hedera-mirror-rosetta/scripts/validation/get-genesis-balance.sh) to get the
-genesis account balance file. Once the `get-genesis-balance.sh testnet` command is executed, it'll write the file to
+alternative, use the [script](/hedera-mirror-rosetta/scripts/validation/get-genesis-balance.sh) to get the genesis
+account balance file. Once the `get-genesis-balance.sh testnet` command is executed, it'll write the file to
 `testnet/data_genesis_balances.json`. Note the script uses PostgreSQL's command line client psql to query the
+
+#### balance validation json
+
+In order to run the rosetta-cli `check:data` command or `check:construction` commands a genesis balance file is needed
+as a basic for validation. To obtain this run
+the [script](/hedera-mirror-rosetta/scripts/validation/get-genesis-balance.sh)
+with the associated
+[configuration file](/hedera-mirror-rosetta/scripts/validation/testnet/validation.json) to get the genesis account
+balance file.
+
+The `get-genesis-balance.sh` script takes the following form
+
+`./get-genesis-balance.sh <network> <account_limit> <starting_timestamp> <transfer_window_ns>`
+
+- `network` - The Hedera network to validate against. Option include `demo, testnet` with default of `demo`
+- `account_limit` - The max number of accounts to list in the file. Default is 20.
+- `starting_timestamp` - The timestamp after which to take the first account balance file. Default is 0.
+- `transfer_window_ns` - The additional ns duration added to the `starting_timestamp` to search for accounts when an
+  account limit is used. Default is 1 week i.e. 604800000000000 ns
+
+Once the `get-genesis-balance.sh testnet` command is executed, it'll write the file
+to `testnet/data_genesis_balances.json`. Note the script uses PostgreSQL's command line client psql to query the
 database for genesis account balance information, so please install psql beforehand.
+
+#### check:data
+
+In order to run the rosetta-cli `check:data` command, run the following after obtaining the `data_genesis_balances.json`
+file.
+
+`./run-validation.sh testnet data`
+
+#### check:construction
 
 In order to run the rosetta-cli `check:construction` command with the DSL spec in `testnet`/`testnet.ros`, you need two
 testnet accounts with the private keys and set `prefunded_accounts` in `testnet/validation.json` as follows:
@@ -150,6 +181,10 @@ testnet accounts with the private keys and set `prefunded_accounts` in `testnet/
   }
 }
 ```
+
+After updating the `validation.json` file run
+
+`./run-validation.sh testnet construction`
 
 ## Acceptance Tests
 

--- a/hedera-mirror-rosetta/scripts/validation/get-genesis-balance.sh
+++ b/hedera-mirror-rosetta/scripts/validation/get-genesis-balance.sh
@@ -35,9 +35,9 @@ EOF
 
 network=${1:-demo}
 parent_path="$(cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P)"
-psql_cmd="psql -h localhost -U mirror_rosetta mirror_node -p 6432 -t -P format=unaligned"
+psql_cmd="psql -h localhost -U mirror_rosetta mirror_node -t -P format=unaligned"
 
-echo "localhost:6432:mirror_node:mirror_rosetta:mirror_rosetta_pass" > ~/.pgpass && chmod 0600 ~/.pgpass
+echo "localhost:5432:mirror_node:mirror_rosetta:mirror_rosetta_pass" > ~/.pgpass && chmod 0600 ~/.pgpass
 
 SECONDS=0
 while [[ $SECONDS -lt 120 ]];

--- a/hedera-mirror-rosetta/scripts/validation/get-genesis-balance.sh
+++ b/hedera-mirror-rosetta/scripts/validation/get-genesis-balance.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
+# handle input argument defaults
+network=${1:-demo}
+account_limit=${2:-20}
+starting_timestamp=${3:-0}
+
 currency=$(cat <<EOF
 {
   "symbol": "HBAR",
@@ -11,14 +16,22 @@ currency=$(cat <<EOF
 }
 EOF
 )
-genesis_timestamp_query="select consensus_timestamp from account_balance_file order by consensus_timestamp asc limit 2"
 
-genesis_hbar_balance_query=$(cat <<EOF
-\set ON_ERROR_STOP on
+genesis_timestamp_query=$(cat <<EOF
+select consensus_timestamp
+from account_balance_file
+where consensus_timestamp > :starting_timestamp
+order by consensus_timestamp asc
+limit 1
+EOF
+)
+
+one_week_ns=604800000000000
+applicable_accounts_query=$(cat <<EOF
 with recent_crypto_accounts as (
  select distinct(entity_id)
- from crypto_transfer where consensus_timestamp > :genesis_timestamp and consensus_timestamp <= :second_timestamp
- limit 20
+ from crypto_transfer where consensus_timestamp > :genesis_timestamp and consensus_timestamp <= :genesis_timestamp + :one_week_ns
+ limit :account_limit
 ),
 genesis_balance as (
   select account_id, balance
@@ -28,12 +41,47 @@ genesis_balance as (
   where balance <> 0 and ab.consensus_timestamp = :genesis_timestamp
   group by account_id,balance
 )
+EOF
+)
+
+if [[ "$account_limit" == "0" ]]; then
+  echo "Account limit removed, all accounts with non-zero balance account in initial balance file will be considered"
+  applicable_accounts_query=$(cat <<EOF
+    with genesis_balance as (
+      select account_id, balance
+      from account_balance
+      where balance <> 0 and consensus_timestamp = :genesis_timestamp
+      group by account_id, balance
+    )
+EOF
+  )
+fi
+
+genesis_hbar_balance_query=$(cat <<EOF
+\set ON_ERROR_STOP on
+${applicable_accounts_query}
 select json_agg(json_build_object('id', account_id::text, 'value', balance::text))
 from genesis_balance
 EOF
 )
 
-network=${1:-demo}
+genesis_token_balance_query=$(cat <<EOF
+\set ON_ERROR_STOP on
+select json_agg(json_build_object(
+  'id', account_id::text,
+  'token', tb.token_id::text,
+  'decimals', t.decimals,
+  'value', balance::text,
+  'type', t.type
+))
+from token_balance tb
+join token t on t.token_id = tb.token_id
+where tb.consensus_timestamp = :genesis_timestamp and
+  tb.account_id in (:account_ids) and
+  balance <> 0
+EOF
+)
+
 parent_path="$(cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P)"
 psql_cmd="psql -h localhost -U mirror_rosetta mirror_node -t -P format=unaligned"
 
@@ -42,12 +90,16 @@ echo "localhost:5432:mirror_node:mirror_rosetta:mirror_rosetta_pass" > ~/.pgpass
 SECONDS=0
 while [[ $SECONDS -lt 120 ]];
 do
-  first_two_timestamps=($($psql_cmd -c "$genesis_timestamp_query"))
-  genesis_timestamp=${first_two_timestamps[0]}
-  second_timestamp=${first_two_timestamps[1]}
+  genesis_timestamp=$(echo "$genesis_timestamp_query" | $psql_cmd -v starting_timestamp="$starting_timestamp")
+  echo "Retrieved genesis balance file timestamp ${genesis_timestamp}"
+  if [[ -z "$genesis_timestamp" ]]; then
+    echo "Failed to get genesis timestamp"
+    exit 1
+  fi
+
   if [[ -n "$genesis_timestamp" ]]; then
     # get genesis hbar balances from genesis account balance file
-    account_balances=$(echo "$genesis_hbar_balance_query" | $psql_cmd -v genesis_timestamp="$genesis_timestamp" -v second_timestamp="$second_timestamp")
+    account_balances=$(echo "$genesis_hbar_balance_query" | $psql_cmd -v genesis_timestamp="$genesis_timestamp" -v one_week_ns="$one_week_ns" -v account_limit="$account_limit")
     echo "account balances - $(echo "$account_balances" | jq . )"
     break
   fi
@@ -55,11 +107,6 @@ do
   echo "${SECONDS}s elapsed, retry getting genesis timestamp in 5 seconds"
   sleep 5
 done
-
-if [[ -z "$genesis_timestamp" ]]; then
-  echo "Failed to get genesis timestamp"
-  exit 1
-fi
 
 hbar_json=$(echo "$account_balances" | \
   jq --argjson currency "$currency" \

--- a/hedera-mirror-rosetta/scripts/validation/get-genesis-balance.sh
+++ b/hedera-mirror-rosetta/scripts/validation/get-genesis-balance.sh
@@ -31,6 +31,7 @@ applicable_accounts_query=$(cat <<EOF
 with recent_crypto_accounts as (
  select distinct(entity_id)
  from crypto_transfer where consensus_timestamp > :genesis_timestamp and consensus_timestamp <= :genesis_timestamp + :transfer_window_ns
+ order by entity_id asc
  limit :account_limit
 ),
 genesis_balance as (


### PR DESCRIPTION
**Description**:
The `hedera-mirror-rosetta/scripts/validation/get-genesis-balance.sh` script performs heavy lifting logic to get a genesis script. This sometimes runs slow in large environments and needs streamlining.

- Update `genesis_timestamp_query` to 
  - use order and limit instead of `min()`
  - Add `recent_crypto_accounts` CTE to pull the recent account used in a crypto transfer since balance file
  - Update `genesis_balance` to use result of `recent_crypto_accounts`
  - Add timestamp gated logic to query to speed up
  - Add support for `account_limit` and  `transfer_window_ns` params
- Update README 
  - with explanation of additional params support
  - split out sections for easier reading

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
Before: 121 s
After: 24 s

Table size 


table_name | row_estimate | index | toast | table | total
-- | -- | -- | -- | -- | --
crypto_transfer | 2.3496112e+07 | 1767 MB | NULL | 2510 MB | 4277 MB
account_balance | 2.624885e+07 | 1926 MB | 8192 bytes | 1412 MB | 3338 MB
transaction | 6.438296e+06 | 691 MB | 8192 bytes | 1571 MB | 2262 MB
token_balance | 8.535088e+06 | 356 MB | NULL | 529 MB | 886 MB
token_transfer | 1.620688e+06 | 199 MB | NULL | 180 MB | 379 MB
account_balance_file | 362 | 64 kB | 8192 bytes | 112 kB | 184 kB
nft | 9 | 32 kB | 8192 bytes | 8192 bytes | 48 kB
token | 0 | 16 kB | 8192 bytes | 8192 bytes | 32 kB

---
Run against mainnet data
Before: 14197s
After: 72s

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
