### PR TITLE
Update acceptance tests to use evmAddress (v0.50)

### DIFF
--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/response/MirrorContractResponse.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/response/MirrorContractResponse.java
@@ -34,6 +34,7 @@ public class MirrorContractResponse {
     private String createdTimestamp;
     private String creatorAccountId;
     private boolean deleted;
+    private String evmAddress;
     private String executedTimestamp;
     private String expirationTimestamp;
     private String fileId;
@@ -42,6 +43,5 @@ public class MirrorContractResponse {
     private String payerAccountId;
     private String proxyAccountId;
     private String scheduleId;
-    private String solidityAddress;
     private MirrorTimestampRange timestamp;
 }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ContractFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ContractFeature.java
@@ -187,7 +187,7 @@ public class ContractFeature extends AbstractFeature {
         assertThat(mirrorContract.isDeleted()).isEqualTo(isDeleted);
         assertThat(mirrorContract.getFileId()).isEqualTo(fileId.toString());
         assertThat(mirrorContract.getMemo()).isNotBlank();
-        String address = mirrorContract.getSolidityAddress();
+        String address = mirrorContract.getEvmAddress();
         assertThat(address).isNotBlank().isNotEqualTo("0x").isNotEqualTo("0x0000000000000000000000000000000000000000");
         assertThat(mirrorContract.getTimestamp()).isNotNull();
         assertThat(mirrorContract.getTimestamp().getFrom()).isNotNull();
@@ -234,13 +234,13 @@ public class ContractFeature extends AbstractFeature {
         String[] createdIds = contractResult.getCreatedContractIds();
         assertThat(createdIds).isNotEmpty();
         assertThat(contractResult.getErrorMessage()).isBlank();
-        assertThat(contractResult.getFrom()).isEqualTo(FeatureInputHandler.solidityAddress(
+        assertThat(contractResult.getFrom()).isEqualTo(FeatureInputHandler.evmAddress(
                 contractClient.getSdkClient().getExpandedOperatorAccountId().getAccountId()));
         assertThat(contractResult.getGasLimit())
                 .isEqualTo(contractClient.getSdkClient().getAcceptanceTestProperties().getFeatureProperties()
                         .getMaxContractFunctionGas());
         assertThat(contractResult.getGasUsed()).isPositive();
-        assertThat(contractResult.getTo()).isEqualTo(FeatureInputHandler.solidityAddress(contractId));
+        assertThat(contractResult.getTo()).isEqualTo(FeatureInputHandler.evmAddress(contractId));
 
         int amount = 0; // no payment in contract construction phase
         int numCreatedIds = 2; // parent and child contract

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/util/FeatureInputHandler.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/util/FeatureInputHandler.java
@@ -42,15 +42,15 @@ public class FeatureInputHandler {
         return refDate;
     }
 
-    public static String solidityAddress(AccountId accountId) {
-        return FeatureInputHandler.solidityAddress(accountId.shard, accountId.realm, accountId.num);
+    public static String evmAddress(AccountId accountId) {
+        return FeatureInputHandler.evmAddress(accountId.shard, accountId.realm, accountId.num);
     }
 
-    public static String solidityAddress(ContractId contractId) {
-        return FeatureInputHandler.solidityAddress(contractId.shard, contractId.realm, contractId.num);
+    public static String evmAddress(ContractId contractId) {
+        return FeatureInputHandler.evmAddress(contractId.shard, contractId.realm, contractId.num);
     }
 
-    public static String solidityAddress(long shard, long realm, long num) {
+    public static String evmAddress(long shard, long realm, long num) {
         return String.format("0x%08x%016x%016x", shard, realm, num);
     }
 }


### PR DESCRIPTION



**Description**:
In v0.50 we updated the REST contract response to use `evmAddress` instead of `solidityAddress`.

- Update `MirrorContractResponse` with property change
- Update `FeatureInputHandler` methods for address parsing

Signed-off-by: Nana-EC <nana.essilfie-conduah@hedera.com>

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
