### PR TITLE
Kubernetes tracing and metrics improvements

### DIFF
--- a/charts/hedera-mirror-common/values.yaml
+++ b/charts/hedera-mirror-common/values.yaml
@@ -340,7 +340,7 @@ traefik:
   deployment:
     kind: DaemonSet
   enabled: true
-  globalArguments: # Expose X-Forwarded-For header for tracing
+  globalArguments:  # Expose X-Forwarded-For header for tracing
     - --entryPoints.web.forwardedHeaders.insecure
     - --entryPoints.websecure.forwardedHeaders.insecure
   logs:

--- a/charts/hedera-mirror-common/values.yaml
+++ b/charts/hedera-mirror-common/values.yaml
@@ -346,6 +346,8 @@ traefik:
   logs:
     access:
       enabled: true
+      filters:
+        statuscodes: 300-599
   podDisruptionBudget:
     enabled: true
     minAvailable: 1

--- a/charts/hedera-mirror-common/values.yaml
+++ b/charts/hedera-mirror-common/values.yaml
@@ -3,7 +3,7 @@ global:
   rbac:
     pspEnabled: false
 
-labels: { }
+labels: {}
 
 loki:
   enabled: true
@@ -174,7 +174,7 @@ prometheus:
         group_wait: 30s
         receiver: 'null'
         repeat_interval: 7d
-        routes: [ ]
+        routes: []
       templates:
         - '/etc/alertmanager/config/slack.tmpl'
     enabled: true
@@ -248,11 +248,11 @@ prometheus:
       cAdvisorMetricRelabelings:
         - action: drop
           regex: container_(memory_failures_total|tasks_state)
-          sourceLabels: [ __name__ ]
+          sourceLabels: [__name__]
       metricRelabelings:
         - action: drop
           regex: .*_bucket
-          sourceLabels: [ __name__ ]
+          sourceLabels: [__name__]
   kubeProxy:
     enabled: false
   kubeScheduler:
@@ -313,7 +313,7 @@ promtail:
     lokiAddress: http://{{ .Release.Name }}-loki:3100/loki/api/v1/push
     snippets:
       pipelineStages:
-        - docker: { }
+        - docker: {}
   enabled: true
   rbac:
     pspEnabled: false
@@ -362,5 +362,5 @@ traefik:
       cpu: 250m
       memory: 150Mi
   service:
-    spec: { }
+    spec: {}
     type: ClusterIP

--- a/charts/hedera-mirror-common/values.yaml
+++ b/charts/hedera-mirror-common/values.yaml
@@ -3,7 +3,7 @@ global:
   rbac:
     pspEnabled: false
 
-labels: {}
+labels: { }
 
 loki:
   enabled: true
@@ -174,7 +174,7 @@ prometheus:
         group_wait: 30s
         receiver: 'null'
         repeat_interval: 7d
-        routes: []
+        routes: [ ]
       templates:
         - '/etc/alertmanager/config/slack.tmpl'
     enabled: true
@@ -248,11 +248,11 @@ prometheus:
       cAdvisorMetricRelabelings:
         - action: drop
           regex: container_(memory_failures_total|tasks_state)
-          sourceLabels: [__name__]
+          sourceLabels: [ __name__ ]
       metricRelabelings:
         - action: drop
           regex: .*_bucket
-          sourceLabels: [__name__]
+          sourceLabels: [ __name__ ]
   kubeProxy:
     enabled: false
   kubeScheduler:
@@ -313,7 +313,7 @@ promtail:
     lokiAddress: http://{{ .Release.Name }}-loki:3100/loki/api/v1/push
     snippets:
       pipelineStages:
-        - docker: {}
+        - docker: { }
   enabled: true
   rbac:
     pspEnabled: false
@@ -340,7 +340,9 @@ traefik:
   deployment:
     kind: DaemonSet
   enabled: true
-  globalArguments: []
+  globalArguments: # Expose X-Forwarded-For header for tracing
+    - --entryPoints.web.forwardedHeaders.insecure
+    - --entryPoints.websecure.forwardedHeaders.insecure
   logs:
     access:
       enabled: true
@@ -360,5 +362,5 @@ traefik:
       cpu: 250m
       memory: 150Mi
   service:
-    spec: {}
+    spec: { }
     type: ClusterIP

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -311,7 +311,7 @@ The following table lists the available properties along with their default valu
 value, it is recommended to only populate overridden properties in the custom `application.yml`.
 
 | Name                                                     | Default                 | Description                                                                                    |
-| -------------------------------------------------------- | ----------------------- | ---------------------------------------------------------------------------------------------- |
+| -------------------------------------------------------- |-------------------------| ---------------------------------------------------------------------------------------------- |
 | `hedera.mirror.rest.cache.entityId.maxAge`               | 1800                    | The number of seconds until the entityId cache entry expires                                   |
 | `hedera.mirror.rest.cache.entityId.maxSize`              | 100000                  | The maximum number of entries in the entityId cache                                            |
 | `hedera.mirror.rest.db.host`                             | 127.0.0.1               | The IP or hostname used to connect to the database                                             |
@@ -321,15 +321,18 @@ value, it is recommended to only populate overridden properties in the custom `a
 | `hedera.mirror.rest.db.pool.maxConnections`              | 10                      | The maximum number of clients the database pool can contain                                    |
 | `hedera.mirror.rest.db.pool.statementTimeout`            | 20000                   | The number of milliseconds to wait before timing out a query statement                         |
 | `hedera.mirror.rest.db.port`                             | 5432                    | The port used to connect to the database                                                       |
-| `hedera.mirror.rest.db.username`                         | mirror_api              | The username the processor uses to connect to the database                                     |
 | `hedera.mirror.rest.db.sslMode`                          | DISABLE                 | The ssl level of protection against Eavesdropping, Man-in-the-middle (MITM) and Impersonation on the db connection. Accepts either DISABLE, ALLOW, PREFER, REQUIRE, VERIFY_CA or VERIFY_FULL. |
 | `hedera.mirror.rest.db.tls.ca`                           | ""                      | The path to the certificate authority used by the database for secure connections              |
 | `hedera.mirror.rest.db.tls.cert`                         | ""                      | The path to the public key the client should use to securely connect to the database           |
 | `hedera.mirror.rest.db.tls.enabled`                      | false                   | Whether TLS should be used for the database connection                                         |
 | `hedera.mirror.rest.db.tls.key`                          | ""                      | The path to the private key the client should use to securely connect to the database          |
-| `hedera.mirror.rest.log.level`                           | debug                   | The logging level. Can be trace, debug, info, warn, error or fatal.                            |
+| `hedera.mirror.rest.db.username`                         | mirror_api              | The username the processor uses to connect to the database                                     |
+| `hedera.mirror.rest.log.level`                           | info                    | The logging level. Can be trace, debug, info, warn, error or fatal.                            |
 | `hedera.mirror.rest.maxRepeatedQueryParameters`          | 100                     | The maximum number of times any query parameter can be repeated in the uri                     |
 | `hedera.mirror.rest.maxTimestampRange`                   | 7d                      | The maximum amount of time a timestamp range query param can span for some APIs.               |
+| `hedera.mirror.rest.metrics.enabled`                     | true                    | Whether metrics should be collected and exposed for scraping                                   |
+| `hedera.mirror.rest.metrics.config`                      | See application.yml     | The configuration to pass to Swagger stats (https://swaggerstats.io/guide/conf.html#options)   |
+| `hedera.mirror.rest.metrics.ipMetrics`                   | false                   | Whether metrics should be associated with a masked client IP label                             |
 | `hedera.mirror.rest.network.unreleasedSupplyAccounts`    | [0.0.2, 0.0.42, ...]    | An array of account IDs whose aggregated balance subtracted from the total supply is the released supply |
 | `hedera.mirror.rest.port`                                | 5551                    | The REST API port                                                                              |
 | `hedera.mirror.rest.metrics.enabled`                     | true                    | Whether metrics are enabled for the REST API                                                   |
@@ -339,6 +342,7 @@ value, it is recommended to only populate overridden properties in the custom `a
 | `hedera.mirror.rest.metrics.config.uriPath`              | '/swagger'              | The REST API metrics uri path                                                                  |
 | `hedera.mirror.rest.openapi.specFileName`                | 'openapi'               | The file name of the OpenAPI spec file                                                         |
 | `hedera.mirror.rest.openapi.swaggerUIPath`               | '/docs'                 | Swagger UI path for your REST API                                                              |
+| `hedera.mirror.rest.response.compression`                | true                    | Whether GZIP compression should be enabled for response bodies                                 |
 | `hedera.mirror.rest.response.includeHostInLink`          | false                   | Whether to include the hostname and port in the next link in the response                      |
 | `hedera.mirror.rest.response.limit.default`              | 25                      | The default value for the limit parameter that controls the REST API response size             |
 | `hedera.mirror.rest.response.limit.max`                  | 100                     | The maximum size the limit parameter can be that controls the REST API response size           |

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/MetricsConfiguration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/MetricsConfiguration.java
@@ -22,6 +22,11 @@ package com.hedera.mirror.importer.config;
 
 import io.github.mweirauch.micrometer.jvm.extras.ProcessMemoryMetrics;
 import io.github.mweirauch.micrometer.jvm.extras.ProcessThreadMetrics;
+import io.lettuce.core.metrics.MicrometerCommandLatencyRecorder;
+import io.lettuce.core.metrics.MicrometerOptions;
+import io.lettuce.core.resource.ClientResources;
+import io.lettuce.core.resource.DefaultClientResources;
+import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.MeterBinder;
 import io.micrometer.core.instrument.binder.db.DatabaseTableMetrics;
 import io.micrometer.core.instrument.binder.db.PostgreSQLDatabaseMetrics;
@@ -46,6 +51,14 @@ class MetricsConfiguration {
 
     private final DataSource dataSource;
     private final DataSourceProperties dataSourceProperties;
+
+    // Override default ClientResources to disable histogram metrics
+    @Bean(destroyMethod = "shutdown")
+    ClientResources clientResources(MeterRegistry meterRegistry) {
+        MicrometerOptions options = MicrometerOptions.builder().build();
+        var commandLatencyRecorder = new MicrometerCommandLatencyRecorder(meterRegistry, options);
+        return DefaultClientResources.builder().commandLatencyRecorder(commandLatencyRecorder).build();
+    }
 
     @Bean
     MeterBinder processMemoryMetrics() {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/serializer/ProtoJsonSerializer.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/serializer/ProtoJsonSerializer.java
@@ -28,11 +28,13 @@ import com.google.protobuf.util.JsonFormat;
 import java.io.IOException;
 
 public class ProtoJsonSerializer extends JsonSerializer<Message> {
+
+    private static final JsonFormat.Printer PRINTER = JsonFormat.printer()
+            .includingDefaultValueFields()
+            .omittingInsignificantWhitespace();
+
     @Override
     public void serialize(Message message, JsonGenerator gen, SerializerProvider serializers) throws IOException {
-        gen.writeRawValue(JsonFormat.printer()
-                .includingDefaultValueFields()
-                .omittingInsignificantWhitespace()
-                .print(message));
+        gen.writeRawValue(PRINTER.print(message));
     }
 }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/config/LoggingFilter.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/config/LoggingFilter.java
@@ -26,8 +26,8 @@ import javax.inject.Named;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Level;
-import org.reactivestreams.Publisher;
 import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.util.CollectionUtils;
 import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.server.WebFilter;
@@ -38,35 +38,46 @@ import reactor.core.publisher.Mono;
 @Named
 public class LoggingFilter implements WebFilter {
 
+    static final String X_FORWARDED_FOR = "X-Forwarded-For";
     private static final String ACTUATOR_PATH = "/actuator/";
     private static final String LOCALHOST = "127.0.0.1";
-    private static final String X_FORWARDED_FOR = "X-Forwarded-For";
+    private static final String LOG_FORMAT = "{} {} {} in {} ms: {}";
 
     @Override
     public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
-        return chain.filter(exchange).transformDeferred(call -> doFilter(exchange, call));
+        long start = System.currentTimeMillis();
+        return chain.filter(exchange).transformDeferred(call ->
+                call.doOnEach(signal -> doFilter(exchange, signal.getThrowable(), start))
+                        .doOnCancel(() -> doFilter(exchange, new CancelledException(), start)));
     }
 
-    private Publisher<Void> doFilter(ServerWebExchange exchange, Mono<Void> call) {
-        long startTime = System.currentTimeMillis();
-        return call.doOnSuccess(done -> onSuccess(exchange, startTime))
-                .doOnError(cause -> onError(exchange, startTime, cause));
+    private void doFilter(ServerWebExchange exchange, Throwable cause, long start) {
+        ServerHttpResponse response = exchange.getResponse();
+        if (response.isCommitted() || cause instanceof CancelledException) {
+            logRequest(exchange, start, cause);
+        } else {
+            response.beforeCommit(() -> {
+                logRequest(exchange, start, cause);
+                return Mono.empty();
+            });
+        }
     }
 
-    private void onSuccess(ServerWebExchange exchange, long startTime) {
+    private void logRequest(ServerWebExchange exchange, long startTime, Throwable cause) {
         long elapsed = System.currentTimeMillis() - startTime;
         ServerHttpRequest request = exchange.getRequest();
         URI uri = request.getURI();
-        Level level = StringUtils.startsWith(uri.getPath(), ACTUATOR_PATH) ? Level.DEBUG : Level.INFO;
-        log.log(level, "{} {} {} in {} ms: {}", getClient(request), request.getMethod(), uri, elapsed,
-                exchange.getResponse().getStatusCode());
-    }
+        Object message = exchange.getResponse().getStatusCode();
+        Level level = Level.INFO;
 
-    private void onError(ServerWebExchange exchange, long startTime, Throwable t) {
-        long elapsed = System.currentTimeMillis() - startTime;
-        ServerHttpRequest request = exchange.getRequest();
-        log.warn("{} {} {} in {} ms: {}", getClient(request), request.getMethod(), request.getURI(), elapsed,
-                t.getMessage());
+        if (cause != null) {
+            level = Level.WARN;
+            message = cause.getMessage();
+        } else if (StringUtils.startsWith(uri.getPath(), ACTUATOR_PATH)) {
+            level = Level.DEBUG;
+        }
+
+        log.log(level, LOG_FORMAT, getClient(request), request.getMethod(), uri, elapsed, message);
     }
 
     private String getClient(ServerHttpRequest request) {
@@ -83,5 +94,13 @@ public class LoggingFilter implements WebFilter {
         }
 
         return LOCALHOST;
+    }
+
+    private static class CancelledException extends RuntimeException {
+        private static final String MESSAGE = "cancelled";
+
+        CancelledException() {
+            super(MESSAGE);
+        }
     }
 }

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/PublishMetricsTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/PublishMetricsTest.java
@@ -37,6 +37,7 @@ import java.util.concurrent.TimeoutException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.Logger;
 import org.apache.logging.log4j.core.appender.WriterAppender;
+import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.assertj.core.api.ObjectAssert;
 import org.junit.jupiter.api.AfterEach;
@@ -77,6 +78,7 @@ class PublishMetricsTest {
 
         logOutput = new StringWriter();
         writerAppender = WriterAppender.newBuilder()
+                .setLayout(PatternLayout.newBuilder().withPattern("%p|%m%n").build())
                 .setName("stringAppender")
                 .setTarget(logOutput)
                 .build();
@@ -166,6 +168,7 @@ class PublishMetricsTest {
         assertThat(logOutput)
                 .asString()
                 .hasLineCount(1)
+                .contains("INFO")
                 .contains("Scenario " + SCENARIO_NAME + " published 0 transactions in")
                 .contains("Errors: {" + status + "=1}");
     }
@@ -179,6 +182,7 @@ class PublishMetricsTest {
         assertThat(logOutput)
                 .asString()
                 .hasLineCount(1)
+                .contains("INFO")
                 .contains("Scenario " + SCENARIO_NAME + " published 1 transactions in")
                 .contains("Errors: {}");
     }

--- a/hedera-mirror-rest/__tests__/config.test.js
+++ b/hedera-mirror-rest/__tests__/config.test.js
@@ -59,7 +59,7 @@ afterEach(() => {
 const assertCustomConfig = (actual, customConfig) => {
   // fields custom doesn't override
   expect(actual.response.includeHostInLink).toBe(false);
-  expect(actual.log.level).toBe('debug');
+  expect(actual.log.level).toBe('info');
 
   // fields overridden by custom
   expect(actual.shard).toBe(customConfig.hedera.mirror.rest.shard);
@@ -72,7 +72,7 @@ describe('Load YAML configuration:', () => {
     const config = require('../config');
     expect(config.shard).toBe(0);
     expect(config.response.includeHostInLink).toBe(false);
-    expect(config.log.level).toBe('debug');
+    expect(config.log.level).toBe('info');
   });
 
   test('./application.yml', () => {
@@ -103,9 +103,9 @@ describe('Load environment configuration:', () => {
   });
 
   test('String', () => {
-    process.env = {HEDERA_MIRROR_REST_LOG_LEVEL: 'info'};
+    process.env = {HEDERA_MIRROR_REST_LOG_LEVEL: 'warn'};
     const config = require('../config');
-    expect(config.log.level).toBe('info');
+    expect(config.log.level).toBe('warn');
   });
 
   test('Boolean', () => {

--- a/hedera-mirror-rest/config/application.yml
+++ b/hedera-mirror-rest/config/application.yml
@@ -23,17 +23,17 @@ hedera:
           key: ''
         username: mirror_api
       log:
-        level: debug
+        level: info
       maxRepeatedQueryParameters: 100
       maxTimestampRange: 7d
       metrics:
         enabled: true
         config:
           authentication: true
-          durationBuckets: [ 100, 250, 500, 1000, 2500, 5000 ]
+          durationBuckets: [ 25, 100, 250, 500 ]
           password: password
-          requestSizeBuckets: [ 64, 256, 1024 ]
-          responseSizeBuckets: [ 512, 1024, 10240, 25600, 51200 ]
+          requestSizeBuckets: [ ]
+          responseSizeBuckets: [ 100, 250, 500, 1000 ]
           swaggerOnly: true,
           username: metrics
           uriPath: '/swagger'
@@ -107,12 +107,11 @@ hedera:
         addressBookHistory: false
         enabled: false
         streams:
-          network: 'DEMO'
+          accessKey:
+          bucketName:
           cloudProvider: 'S3'
           endpointOverride:
           gcpProjectId:
+          network: 'DEMO'
           region: 'us-east-1'
-          accessKey:
           secretKey:
-          bucketName:
-

--- a/hedera-mirror-rest/constants.js
+++ b/hedera-mirror-rest/constants.js
@@ -76,6 +76,7 @@ const transactionColumns = {
 };
 
 const requestIdLabel = 'requestId';
+const requestStartTime = 'requestStartTime';
 const responseDataLabel = 'mirrorRestData';
 
 const orderFilterValues = {
@@ -186,6 +187,7 @@ module.exports = {
   queryParamOperators,
   recordStreamPrefix,
   requestIdLabel,
+  requestStartTime,
   responseDataLabel,
   tokenTypeFilter,
   transactionColumns,

--- a/hedera-mirror-rest/middleware/httpErrorHandler.js
+++ b/hedera-mirror-rest/middleware/httpErrorHandler.js
@@ -21,6 +21,7 @@
 'use strict';
 
 const {httpStatusCodes} = require('../constants');
+const constants = require('../constants');
 
 const defaultStatusCode = httpStatusCodes.INTERNAL_ERROR;
 
@@ -36,13 +37,17 @@ const errorMap = {
 const handleError = async (err, req, res, next) => {
   const statusCode = errorMap[err.constructor.name] || defaultStatusCode;
   let errorMessage;
+  const startTime = res.locals[constants.requestStartTime];
+  const elapsed = startTime ? Date.now() - startTime : 0;
 
   if (shouldReturnMessage(statusCode)) {
     errorMessage = err.message;
-    logger.warn(`${statusCode} processing ${req.originalUrl}: ${err.constructor.name} ${errorMessage}`);
+    logger.warn(
+      `${req.ip} ${req.method} ${req.originalUrl} in ${elapsed} ms: ${statusCode} ${err.constructor.name} ${errorMessage}`
+    );
   } else {
     errorMessage = statusCode.message;
-    logger.error(`${statusCode} processing ${req.originalUrl}: `, err);
+    logger.error(`${req.ip} ${req.method} ${req.originalUrl} in ${elapsed} ms: ${statusCode}`, err);
   }
 
   res.status(statusCode.code).json(errorMessageFormat(errorMessage));

--- a/hedera-mirror-rest/middleware/requestHandler.js
+++ b/hedera-mirror-rest/middleware/requestHandler.js
@@ -29,10 +29,10 @@ const {httpStatusCodes} = require('../constants');
 const requestLogger = async (req, res, next) => {
   const requestId = await randomString(8);
   httpContext.set(constants.requestIdLabel, requestId);
-  logger.info(`${req.ip} ${req.method} ${req.originalUrl}`);
 
   // set default http OK code for reference
   res.locals.statusCode = httpStatusCodes.OK.code;
+  res.locals[constants.requestStartTime] = Date.now();
 };
 
 /**

--- a/hedera-mirror-rest/middleware/responseHandler.js
+++ b/hedera-mirror-rest/middleware/responseHandler.js
@@ -32,7 +32,13 @@ const responseHandler = async (req, res, next) => {
     throw new NotFoundError();
   } else {
     // set response json
-    res.status(res.locals.statusCode).json(res.locals[constants.responseDataLabel]);
+    const code = res.locals.statusCode;
+    const data = res.locals[constants.responseDataLabel];
+    res.status(code).json(data);
+
+    const startTime = res.locals[constants.requestStartTime];
+    const elapsed = startTime ? Date.now() - startTime : 0;
+    logger.info(`${req.ip} ${req.method} ${req.originalUrl} in ${elapsed} ms: ${code}`);
   }
 };
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/config/LoggingFilter.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/config/LoggingFilter.java
@@ -37,10 +37,10 @@ import reactor.core.publisher.Mono;
 @Named
 class LoggingFilter implements WebFilter {
 
+    static final String X_FORWARDED_FOR = "X-Forwarded-For";
     private static final String ACTUATOR_PATH = "/actuator/";
     private static final String LOCALHOST = "127.0.0.1";
     private static final String LOG_FORMAT = "{} {} {} in {} ms: {}";
-    private static final String X_FORWARDED_FOR = "X-Forwarded-For";
 
     @Override
     public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {


### PR DESCRIPTION
**Description**:

* Add missing REST configuration to docs
* Change REST API to log at info level by default to reduce log volume
* Change REST API to generate a consistent trace log for all responses
* Change Traefik to only log non-2xx requests to reduce log volume
* Fix client IP not showing up in any trace logs
* Fix Lettuce histogram metrics enabled by default and generating ~10K series
* Fix monitor not tracing requests in some scenarios and add test coverage
* Improve GCP Pub/Sub performance by reusing printer across transactions
* Remove some REST API metric buckets to reduce number of overall time series

**Related issue(s)**:

**Notes for reviewer**:

REST API output will now appear consistently in the below format:

`INFO 9e4e7ca3 ::1 GET /api/v1/transactions?limit=2 in 37 ms: 200`

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
