### PR TITLE
Bump hedera-protobufs from 0.23.0-alpha.2 to 0.23.1

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,11 +1,14 @@
-# We upload three separate reports: js, java and go
+# We upload multiple separate reports, one for each GitHub action
 codecov:
-    notify:
-        after_n_builds: 3
+  notify:
+    after_n_builds: 8
 comment:
-    after_n_builds: 3
+  after_n_builds: 8
 coverage:
-    status:
-        project:
-            default:
-                threshold: 1.0
+  status:
+    project:
+      default:
+        threshold: 1.0
+ignore:
+  - "hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/**/*"
+

--- a/hedera-mirror-protobuf/src/main/proto/com/hedera/mirror/api/proto/network_service.proto
+++ b/hedera-mirror-protobuf/src/main/proto/com/hedera/mirror/api/proto/network_service.proto
@@ -26,7 +26,6 @@ option java_multiple_files = true; // Required for the reactor-grpc generator to
 option java_package = "com.hedera.mirror.api.proto";
 
 import "basic_types.proto";
-import "timestamp.proto";
 
 // Request object to query an address book for its list of nodes
 message AddressBookQuery {

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <grpc-spring-boot.version>2.11.0.RELEASE</grpc-spring-boot.version>
         <grpc.version>1.44.0</grpc.version>
         <guava.version>31.0.1-jre</guava.version>
-        <hedera-protobuf.version>0.23.0</hedera-protobuf.version>
+        <hedera-protobuf.version>0.23.1</hedera-protobuf.version>
         <hibernate-types.version>2.14.0</hibernate-types.version>
         <jacoco.version>0.8.7</jacoco.version>
         <java.version>11</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <grpc-spring-boot.version>2.11.0.RELEASE</grpc-spring-boot.version>
         <grpc.version>1.44.0</grpc.version>
         <guava.version>31.0.1-jre</guava.version>
-        <hedera-protobuf.version>0.23.0-alpha.2</hedera-protobuf.version>
+        <hedera-protobuf.version>0.23.0</hedera-protobuf.version>
         <hibernate-types.version>2.14.0</hibernate-types.version>
         <jacoco.version>0.8.7</jacoco.version>
         <java.version>11</java.version>
@@ -139,14 +139,6 @@
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
-        </repository>
-        <repository>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <id>sdk-staging</id>
-            <name>SDK Staging</name>
-            <url>https://oss.sonatype.org/content/repositories/comhederahashgraph-1397</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
**Description**:
* Bump hedera-protobufs from 0.23.0-alpha.2 to 0.23.1
* Fix codecov notifying/commenting before all reports are uploaded
* Exclude domain POJOs from code coverage

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
