### PR TITLE
Port workaround for the missing disappearing token transfer issue

### DIFF
--- a/.github/workflows/rosetta-api.yml
+++ b/.github/workflows/rosetta-api.yml
@@ -135,7 +135,7 @@ jobs:
             -e NETWORK=testnet \
             -v /tmp/application_importer.yml:/app/importer/application.yml \
             -v /tmp/application_rosetta.yml:/app/rosetta/application.yml \
-            -p 5432:5432 -p 5700:5700 "${MODULE}:latest")
+            -p 5700:5700 "${MODULE}:latest")
           echo "ONLINE_CONTAINER_ID=$ONLINE_CONTAINER_ID" >> $GITHUB_ENV
 
       - name: Run Mirror Node in Offline Mode
@@ -151,9 +151,6 @@ jobs:
         run: ./scripts/wait-for-mirror-node.sh
         env:
           MAX_WAIT_SECONDS: 240
-
-      - name: Get Genesis Account Balances
-        run: ./scripts/validation/get-genesis-balance.sh testnet
 
       - name: Rosetta CLI Configuration
         run: |

--- a/docs/rosetta/README.md
+++ b/docs/rosetta/README.md
@@ -88,7 +88,7 @@ Configure and run the server in online mode:
 
 ```shell
 docker run -d -e MODE=online -e NETWORK=testnet \
--v ./application.yml:/app/importer/application.yml \
+-v ${PWD}/application.yml:/app/importer/application.yml \
 -p 5432:5432 -p 5700:5700 hedera-mirror-rosetta:0.49.1
 ```
 
@@ -100,11 +100,15 @@ This can be done using the shell
 script [wait-for-mirror-node.sh](/hedera-mirror-rosetta/scripts/wait-for-mirror-node.sh). The script will report that
 mirror node syncing has started when the genesis information is available.
 
-In order to run the rosetta-cli `check:data` command, run the
-[script](/hedera-mirror-rosetta/scripts/validation/get-genesis-balance.sh) with the associated
-[configuration file](/hedera-mirror-rosetta/scripts/validation/testnet/validation.json) to get the genesis account
-balance file. Once the `get-genesis-balance.sh testnet` command is executed, it'll write the file
-to `testnet/data_genesis_balances.json`. Note the script uses PostgreSQL's command line client psql to query the
+A sample [configuration file](/hedera-mirror-rosetta/scripts/validation/testnet/validation.json) is provided to run
+rosetta-cli tests. Please refer to [the official guide](https://docs.cloud.coinbase.com/rosetta/docs/configuration-file)
+for the options.
+
+You can run the rosetta-cli `check:data` command as is. The data configuration section is set with `"start_index": 1`
+to work around the known `rosetta-cli` performance issue of loading large genesis account balance file. As an
+alternative, use the [script](/hedera-mirror-rosetta/scripts/validation/get-genesis-balance.sh) to get the
+genesis account balance file. Once the `get-genesis-balance.sh testnet` command is executed, it'll write the file to
+`testnet/data_genesis_balances.json`. Note the script uses PostgreSQL's command line client psql to query the
 database for genesis account balance information, so please install psql beforehand.
 
 In order to run the rosetta-cli `check:construction` command with the DSL spec in `testnet`/`testnet.ros`, you need two

--- a/hedera-mirror-rosetta/app/interfaces/account_repository.go
+++ b/hedera-mirror-rosetta/app/interfaces/account_repository.go
@@ -25,7 +25,6 @@ import (
 
 	rTypes "github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/app/domain/types"
-	"github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/app/persistence/domain"
 )
 
 // AccountRepository Interface that all AccountRepository structs must implement
@@ -37,10 +36,4 @@ type AccountRepository interface {
 	// if the account is deleted at T1 and T1 <= consensusEnd, the balance is calculated as
 	// balance = balanceAtLatestBalanceSnapshotBeforeT1 + balanceChangeBetweenSnapshotAndT1
 	RetrieveBalanceAtBlock(ctx context.Context, accountId, consensusEnd int64) ([]types.Amount, *rTypes.Error)
-
-	// RetrieveEverOwnedTokensByBlock returns the tokens the account has ever owned by the block's consensusEnd
-	RetrieveEverOwnedTokensByBlock(ctx context.Context, accountId, consensusEnd int64) (
-		[]domain.Token,
-		*rTypes.Error,
-	)
 }

--- a/hedera-mirror-rosetta/app/persistence/account_test.go
+++ b/hedera-mirror-rosetta/app/persistence/account_test.go
@@ -28,364 +28,47 @@ import (
 	"github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/app/errors"
 	"github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/app/persistence/domain"
 	"github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/test/db"
-	"github.com/jackc/pgtype"
+	tdomain "github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/test/domain"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
 
-var (
-	account                       = domain.MustDecodeEntityId(9000)
-	account2                      = domain.MustDecodeEntityId(9001)
-	treasury                      = domain.MustDecodeEntityId(9500)
-	payer                         = domain.MustDecodeEntityId(2002)
+const (
+	account1 = int64(9000) + iota
+	treasury
+)
+
+const (
+	encodedTokenId1 = int64(1000) + iota
+	encodedTokenId2
+	encodedTokenId3
+	encodedTokenId4
+	encodedTokenId5
+	encodedTokenId6
+)
+
+const (
 	accountDeleteTimestamp  int64 = 280
 	consensusTimestamp      int64 = 200
+	dissociateTimestamp           = consensusTimestamp + 1
 	firstSnapshotTimestamp  int64 = 100
-	secondSnapshotTimestamp int64 = 300
-	cryptoTransferAmounts         = []int64{150, -178}
-	defaultContext                = context.Background()
-	token1                        = &domain.Token{
-		TokenId:           domain.MustDecodeEntityId(1001),
-		CreatedTimestamp:  10,
-		Decimals:          8,
-		InitialSupply:     100000,
-		ModifiedTimestamp: 10,
-		Name:              "token1",
-		SupplyType:        domain.TokenSupplyTypeInfinite,
-		Symbol:            "token1",
-		TotalSupply:       200000,
-		TreasuryAccountId: treasury,
-		Type:              domain.TokenTypeFungibleCommon,
-	}
-	token2 = &domain.Token{
-		TokenId:           domain.MustDecodeEntityId(1002),
-		CreatedTimestamp:  12,
-		Decimals:          9,
-		InitialSupply:     200000,
-		ModifiedTimestamp: 12,
-		Name:              "token2",
-		SupplyType:        domain.TokenSupplyTypeInfinite,
-		Symbol:            "token2",
-		TotalSupply:       800000,
-		TreasuryAccountId: treasury,
-		Type:              domain.TokenTypeFungibleCommon,
-	}
-	token3 = &domain.Token{
-		TokenId:           domain.MustDecodeEntityId(1003),
-		CreatedTimestamp:  15,
-		Decimals:          0,
-		InitialSupply:     0,
-		ModifiedTimestamp: 15,
-		Name:              "token3",
-		SupplyType:        domain.TokenSupplyTypeFinite,
-		Symbol:            "token3",
-		TotalSupply:       500,
-		TreasuryAccountId: treasury,
-		Type:              domain.TokenTypeNonFungibleUnique,
-	}
-	token4 = &domain.Token{
-		TokenId:           domain.MustDecodeEntityId(1004),
-		CreatedTimestamp:  16,
-		Decimals:          0,
-		InitialSupply:     0,
-		ModifiedTimestamp: 16,
-		Name:              "token4",
-		SupplyType:        domain.TokenSupplyTypeFinite,
-		Symbol:            "token4",
-		TotalSupply:       500,
-		TreasuryAccountId: treasury,
-		Type:              domain.TokenTypeNonFungibleUnique,
-	}
-	token1TransferAmounts   = []int64{10, -5, 153}
-	token2TransferAmounts   = []int64{20, -7, 157}
-	firstAccountBalanceFile = &domain.AccountBalanceFile{
-		ConsensusTimestamp: firstSnapshotTimestamp,
-		Count:              100,
-		LoadStart:          1600,
-		LoadEnd:            1650,
-		FileHash:           "filehash1",
-		Name:               "account balance file 1",
-		NodeAccountId:      domain.MustDecodeEntityId(3),
-	}
-	secondAccountBalanceFile = &domain.AccountBalanceFile{
-		ConsensusTimestamp: secondSnapshotTimestamp,
-		Count:              100,
-		LoadStart:          3600,
-		LoadEnd:            3650,
-		FileHash:           "filehash2",
-		Name:               "account balance file 2",
-		NodeAccountId:      domain.MustDecodeEntityId(3),
-	}
-	initialTokenBalances = []domain.TokenBalance{
-		{
-			AccountId:          account,
-			ConsensusTimestamp: firstSnapshotTimestamp,
-			Balance:            112,
-			TokenId:            token1.TokenId,
-		},
-		{
-			AccountId:          account,
-			ConsensusTimestamp: firstSnapshotTimestamp,
-			Balance:            280,
-			TokenId:            token2.TokenId,
-		},
-		{
-			AccountId:          account,
-			ConsensusTimestamp: firstSnapshotTimestamp,
-			Balance:            2,
-			TokenId:            token3.TokenId,
-		},
-	}
-	initialAccountBalance = &domain.AccountBalance{
-		ConsensusTimestamp: firstSnapshotTimestamp,
-		Balance:            12345,
-		AccountId:          account,
-	}
-	// the third crypto transfer is after consensusTimestamp, the last transfer happens when account is deleted, brings
-	// account's hbar balance to 0
-	cryptoTransfers = []domain.CryptoTransfer{
-		{
-			EntityId:           account,
-			Amount:             cryptoTransferAmounts[0],
-			ConsensusTimestamp: firstSnapshotTimestamp + 1,
-			PayerAccountId:     payer,
-		},
-		{
-			EntityId:           account,
-			Amount:             cryptoTransferAmounts[1],
-			ConsensusTimestamp: firstSnapshotTimestamp + 5,
-			PayerAccountId:     payer,
-		},
-		{
-			EntityId:           account,
-			Amount:             155,
-			ConsensusTimestamp: consensusTimestamp + 1,
-			PayerAccountId:     payer,
-		},
-		{
-			EntityId:           account,
-			Amount:             -(initialAccountBalance.Balance + sum(cryptoTransferAmounts) + 155),
-			ConsensusTimestamp: accountDeleteTimestamp,
-			PayerAccountId:     account2,
-		},
-	}
-	// crypto transfers at or before snapshot timestamp
-	cryptoTransfersLTESnapshot = []domain.CryptoTransfer{
-		{
-			EntityId:           account,
-			Amount:             110,
-			ConsensusTimestamp: firstSnapshotTimestamp - 1,
-			PayerAccountId:     payer,
-		},
-		{
-			EntityId:           account,
-			Amount:             170,
-			ConsensusTimestamp: firstSnapshotTimestamp,
-			PayerAccountId:     payer,
-		},
-	}
-	// the last transfer of each token is after consensusTimestamp
-	tokenTransfers = []domain.TokenTransfer{
-		{
-			AccountId:          account,
-			Amount:             token1TransferAmounts[0],
-			ConsensusTimestamp: firstSnapshotTimestamp + 2,
-			PayerAccountId:     payer,
-			TokenId:            token1.TokenId,
-		},
-		{
-			AccountId:          account,
-			Amount:             token1TransferAmounts[1],
-			ConsensusTimestamp: firstSnapshotTimestamp + 4,
-			PayerAccountId:     payer,
-			TokenId:            token1.TokenId,
-		},
-		{
-			AccountId:          account,
-			Amount:             token1TransferAmounts[2],
-			ConsensusTimestamp: consensusTimestamp + 1,
-			PayerAccountId:     payer,
-			TokenId:            token1.TokenId,
-		},
-		{
-			AccountId:          account,
-			Amount:             token2TransferAmounts[0],
-			ConsensusTimestamp: firstSnapshotTimestamp + 5,
-			PayerAccountId:     payer,
-			TokenId:            token2.TokenId,
-		},
-		{
-			AccountId:          account,
-			Amount:             token2TransferAmounts[1],
-			ConsensusTimestamp: firstSnapshotTimestamp + 8,
-			PayerAccountId:     payer,
-			TokenId:            token2.TokenId,
-		},
-		{
-			AccountId:          account,
-			Amount:             token2TransferAmounts[2],
-			ConsensusTimestamp: consensusTimestamp + 1,
-			PayerAccountId:     payer,
-			TokenId:            token2.TokenId,
-		},
-	}
-	// token transfers at or before the first snapshot timestamp
-	tokenTransfersLTESnapshot = []*domain.TokenTransfer{
-		{
-			AccountId:          account,
-			Amount:             17,
-			ConsensusTimestamp: firstSnapshotTimestamp - 1,
-			PayerAccountId:     payer,
-			TokenId:            token1.TokenId,
-		},
-		{
-			AccountId:          account,
-			Amount:             -2,
-			ConsensusTimestamp: firstSnapshotTimestamp,
-			PayerAccountId:     payer,
-			TokenId:            token1.TokenId,
-		},
-		{
-			AccountId:          account,
-			Amount:             25,
-			ConsensusTimestamp: firstSnapshotTimestamp - 1,
-			PayerAccountId:     payer,
-			TokenId:            token2.TokenId,
-		},
-		{
-			AccountId:          account,
-			Amount:             -9,
-			ConsensusTimestamp: firstSnapshotTimestamp,
-			PayerAccountId:     payer,
-			TokenId:            token2.TokenId,
-		},
-	}
-	// the net change for account is 2 (received 3 [5, 4, 3], and sent 1 [5])
-	nftTransfers = []domain.NftTransfer{
-		{
-			ConsensusTimestamp: firstSnapshotTimestamp + 1,
-			PayerAccountId:     payer,
-			ReceiverAccountId:  &account,
-			SenderAccountId:    &treasury,
-			SerialNumber:       3,
-			TokenId:            token3.TokenId,
-		},
-		{
-			ConsensusTimestamp: firstSnapshotTimestamp + 2,
-			PayerAccountId:     payer,
-			ReceiverAccountId:  &account,
-			SenderAccountId:    &treasury,
-			SerialNumber:       4,
-			TokenId:            token3.TokenId,
-		},
-		{
-			ConsensusTimestamp: firstSnapshotTimestamp + 3,
-			PayerAccountId:     payer,
-			ReceiverAccountId:  &account,
-			SenderAccountId:    &treasury,
-			SerialNumber:       5,
-			TokenId:            token3.TokenId,
-		},
-		{
-			ConsensusTimestamp: firstSnapshotTimestamp + 4,
-			PayerAccountId:     payer,
-			ReceiverAccountId:  &treasury,
-			SenderAccountId:    &account,
-			SerialNumber:       5,
-			TokenId:            token3.TokenId,
-		},
-		// nft transfers for token4 between account2 and treasury which should not affect query for account
-		{
-			ConsensusTimestamp: firstSnapshotTimestamp + 5,
-			PayerAccountId:     payer,
-			ReceiverAccountId:  &treasury,
-			SerialNumber:       1,
-			TokenId:            token4.TokenId,
-		},
-		{
-			ConsensusTimestamp: firstSnapshotTimestamp + 5,
-			PayerAccountId:     payer,
-			ReceiverAccountId:  &treasury,
-			SerialNumber:       2,
-			TokenId:            token4.TokenId,
-		},
-		{
-			ConsensusTimestamp: firstSnapshotTimestamp + 5,
-			PayerAccountId:     payer,
-			ReceiverAccountId:  &treasury,
-			SerialNumber:       3,
-			TokenId:            token4.TokenId,
-		},
-		{
-			ConsensusTimestamp: firstSnapshotTimestamp + 5,
-			PayerAccountId:     payer,
-			ReceiverAccountId:  &treasury,
-			SerialNumber:       4,
-			TokenId:            token4.TokenId,
-		},
-		{
-			ConsensusTimestamp: firstSnapshotTimestamp + 5,
-			PayerAccountId:     payer,
-			ReceiverAccountId:  &treasury,
-			SerialNumber:       5,
-			TokenId:            token4.TokenId,
-		},
-		{
-			ConsensusTimestamp: firstSnapshotTimestamp + 6,
-			PayerAccountId:     payer,
-			ReceiverAccountId:  &account2,
-			SenderAccountId:    &treasury,
-			SerialNumber:       1,
-			TokenId:            token4.TokenId,
-		},
-		{
-			ConsensusTimestamp: firstSnapshotTimestamp + 6,
-			PayerAccountId:     payer,
-			ReceiverAccountId:  &account2,
-			SenderAccountId:    &treasury,
-			SerialNumber:       2,
-			TokenId:            token4.TokenId,
-		},
-		{
-			ConsensusTimestamp: firstSnapshotTimestamp + 7,
-			PayerAccountId:     payer,
-			ReceiverAccountId:  &treasury,
-			SenderAccountId:    &account2,
-			SerialNumber:       1,
-			TokenId:            token4.TokenId,
-		},
-	}
-	// nft transfers at or before snapshot timestamp
-	nftTransfersLTESnapshot = []domain.NftTransfer{
-		{
-			ConsensusTimestamp: firstSnapshotTimestamp - 2,
-			PayerAccountId:     payer,
-			ReceiverAccountId:  &account,
-			SenderAccountId:    &treasury,
-			SerialNumber:       1,
-			TokenId:            token3.TokenId,
-		},
-		{
-			ConsensusTimestamp: firstSnapshotTimestamp - 2,
-			PayerAccountId:     payer,
-			ReceiverAccountId:  &account,
-			SenderAccountId:    &treasury,
-			SerialNumber:       2,
-			TokenId:            token3.TokenId,
-		},
-	}
-	recordFile = &domain.RecordFile{
-		ConsensusStart: consensusTimestamp + 1,
-		ConsensusEnd:   consensusTimestamp + 10,
-		Count:          5,
-		FileHash:       "filehash",
-		Hash:           "hash",
-		Index:          5,
-		Name:           "next_record_file.rcd",
-		NodeAccountID:  domain.MustDecodeEntityId(3),
-		PrevHash:       "prevhash",
-		Version:        5,
-	}
+	initialAccountBalance   int64 = 12345
+	secondSnapshotTimestamp       = consensusTimestamp - 20
+	thirdSnapshotTimestamp  int64 = 400
+)
+
+var (
+	cryptoTransferAmounts = []int64{150, -178}
+	defaultContext        = context.Background()
+	token1TransferAmounts = []int64{10, -5, 153}
+	token2TransferAmounts = []int64{20, -7}
+	token3ReceivedSerials = []int64{3, 4, 5}
+	token3SentSerials     = []int64{5}
+
+	token1 domain.Token
+	token2 domain.Token
+	token3 domain.Token
+	token4 domain.Token
 )
 
 // run the suite
@@ -400,31 +83,281 @@ type accountRepositorySuite struct {
 
 func (suite *accountRepositorySuite) SetupTest() {
 	suite.integrationTest.SetupTest()
-	db.CreateDbRecords(dbClient, firstAccountBalanceFile, secondAccountBalanceFile)
+	associatedTokenAccounts := make([]domain.TokenAccount, 0)
+
+	tdomain.NewEntityBuilder(dbClient, account1, 1, domain.EntityTypeAccount).Persist()
+
+	// persist tokens and tokenAccounts
+	token1 = tdomain.NewTokenBuilder(dbClient, encodedTokenId1, firstSnapshotTimestamp+1, treasury).Persist()
+	ta := tdomain.NewTokenAccountBuilder(dbClient, account1, encodedTokenId1, token1.CreatedTimestamp+2).Persist()
+	associatedTokenAccounts = append(associatedTokenAccounts, ta)
+
+	token2 = tdomain.NewTokenBuilder(dbClient, encodedTokenId2, firstSnapshotTimestamp+2, treasury).Persist()
+	ta2 := tdomain.NewTokenAccountBuilder(dbClient, account1, encodedTokenId2, token2.CreatedTimestamp+2).Persist()
+	tdomain.NewTokenAccountBuilderFromExisting(dbClient, ta2).
+		Associated(false, dissociateTimestamp).
+		Persist()
+
+	token3 = tdomain.NewTokenBuilder(dbClient, encodedTokenId3, firstSnapshotTimestamp+3, treasury).
+		Type(domain.TokenTypeNonFungibleUnique).
+		Persist()
+	ta3 := tdomain.NewTokenAccountBuilder(dbClient, account1, encodedTokenId3, token3.CreatedTimestamp+2).Persist()
+	tdomain.NewTokenAccountBuilderFromExisting(dbClient, ta3).
+		Associated(false, dissociateTimestamp).
+		Persist()
+
+	// account1's token4 balance is always 0
+	token4 = tdomain.NewTokenBuilder(dbClient, encodedTokenId4, firstSnapshotTimestamp+4, treasury).
+		Type(domain.TokenTypeNonFungibleUnique).
+		Persist()
+	ta = tdomain.NewTokenAccountBuilder(dbClient, account1, encodedTokenId4, token4.CreatedTimestamp+2).Persist()
+	associatedTokenAccounts = append(associatedTokenAccounts, ta)
+
+	// token5 is created before firstSnapshotTimestamp
+	tdomain.NewTokenBuilder(dbClient, encodedTokenId5, firstSnapshotTimestamp-1, treasury).Persist()
+	ta = tdomain.NewTokenAccountBuilder(dbClient, account1, encodedTokenId5, firstSnapshotTimestamp+2).Persist()
+	associatedTokenAccounts = append(associatedTokenAccounts, ta)
+
+	// token6 is created at firstSnapshotTimestamp
+	tdomain.NewTokenBuilder(dbClient, encodedTokenId6, firstSnapshotTimestamp, treasury).
+		Type(domain.TokenTypeNonFungibleUnique).
+		Persist()
+	ta = tdomain.NewTokenAccountBuilder(dbClient, account1, encodedTokenId6, firstSnapshotTimestamp+3).Persist()
+	associatedTokenAccounts = append(associatedTokenAccounts, ta)
+
+	// account balance files
+	tdomain.NewAccountBalanceFileBuilder(dbClient, firstSnapshotTimestamp).
+		AddAccountBalance(account1, initialAccountBalance).
+		AddTokenBalance(account1, encodedTokenId5, 12).
+		AddTokenBalance(account1, encodedTokenId6, 5).
+		Persist()
+	tdomain.NewAccountBalanceFileBuilder(dbClient, thirdSnapshotTimestamp).Persist()
+
+	// crypto transfers happened at <= first snapshot timestamp
+	tdomain.NewCryptoTransferBuilder(dbClient).
+		Amount(110).
+		EntityId(account1).
+		Timestamp(firstSnapshotTimestamp - 1).
+		Persist()
+	tdomain.NewCryptoTransferBuilder(dbClient).
+		Amount(170).
+		EntityId(account1).
+		Timestamp(firstSnapshotTimestamp).
+		Persist()
+
+	// crypto transfers happened at > first snapshot timestamp
+	tdomain.NewCryptoTransferBuilder(dbClient).
+		Amount(cryptoTransferAmounts[0]).
+		EntityId(account1).
+		Timestamp(firstSnapshotTimestamp + 1).
+		Persist()
+	tdomain.NewCryptoTransferBuilder(dbClient).
+		Amount(cryptoTransferAmounts[1]).
+		EntityId(account1).
+		Timestamp(firstSnapshotTimestamp + 5).
+		Persist()
+	tdomain.NewCryptoTransferBuilder(dbClient).
+		Amount(155).
+		EntityId(account1).
+		Timestamp(dissociateTimestamp + 1).
+		Persist()
+	tdomain.NewCryptoTransferBuilder(dbClient).
+		Amount(-(initialAccountBalance + sum(cryptoTransferAmounts) + 155)).
+		EntityId(account1).
+		Timestamp(accountDeleteTimestamp).
+		Persist()
+
+	// token transfers happened at <= first snapshot timestamp
+	tdomain.NewTokenTransferBuilder(dbClient).
+		Amount(17).
+		AccountId(account1).
+		Timestamp(firstSnapshotTimestamp - 1).
+		TokenId(encodedTokenId5).
+		Persist()
+	tdomain.NewTokenTransferBuilder(dbClient).
+		Amount(-2).
+		AccountId(account1).
+		Timestamp(firstSnapshotTimestamp).
+		TokenId(encodedTokenId5).
+		Persist()
+
+	// token transfers happened at > first snapshot timestamp
+	// token1 transfers, the last transfer happened at after dissociate timestamp
+	transferTimestamps := []int64{token1.CreatedTimestamp + 2, token1.CreatedTimestamp + 3, dissociateTimestamp + 1}
+	for i, amount := range token1TransferAmounts {
+		tdomain.NewTokenTransferBuilder(dbClient).
+			AccountId(account1).
+			Amount(amount).
+			Timestamp(transferTimestamps[i]).
+			TokenId(encodedTokenId1).
+			Persist()
+	}
+	// token2 transfers
+	transferTimestamps = []int64{token2.CreatedTimestamp + 2, token2.CreatedTimestamp + 3}
+	for i, amount := range token2TransferAmounts {
+		tdomain.NewTokenTransferBuilder(dbClient).
+			AccountId(account1).
+			Amount(amount).
+			Timestamp(transferTimestamps[i]).
+			TokenId(encodedTokenId2).
+			Persist()
+	}
+	// token5 transfer will not affect balance since token5 is created before first snapshot
+	tdomain.NewTokenTransferBuilder(dbClient).AccountId(account1).
+		Amount(100).
+		Timestamp(firstSnapshotTimestamp + 10).
+		TokenId(encodedTokenId5).
+		Persist()
+
+	// nft transfers happened at <= first snapshot timestamp
+	tdomain.NewNftTransferBuilder(dbClient).
+		SenderAccountId(treasury).
+		ReceiverAccountId(account1).
+		SerialNumber(1).
+		Timestamp(firstSnapshotTimestamp - 1).
+		TokenId(encodedTokenId6).
+		Persist()
+	tdomain.NewNftTransferBuilder(dbClient).
+		SenderAccountId(treasury).
+		ReceiverAccountId(account1).
+		SerialNumber(2).
+		Timestamp(firstSnapshotTimestamp).
+		TokenId(encodedTokenId6).
+		Persist()
+
+	// nft transfers happened at > first snapshot timestamp
+	// the net change for account is 2 (received 3 [3, 4, 5], and sent 1 [5])
+	transferTimestamp := token3.CreatedTimestamp + 3
+	for _, serial := range token3ReceivedSerials {
+		tdomain.NewNftTransferBuilder(dbClient).
+			ReceiverAccountId(account1).
+			SenderAccountId(treasury).
+			SerialNumber(serial).
+			Timestamp(transferTimestamp).
+			TokenId(encodedTokenId3).
+			Persist()
+		transferTimestamp++
+	}
+	// add a self transfer
+	tdomain.NewNftTransferBuilder(dbClient).
+		ReceiverAccountId(account1).
+		SenderAccountId(account1).
+		SerialNumber(token3ReceivedSerials[0]).
+		Timestamp(transferTimestamp).
+		TokenId(encodedTokenId3).
+		Persist()
+	transferTimestamp++
+	// transfer serial 5 from account1 to treasury
+	for _, serial := range token3SentSerials {
+		tdomain.NewNftTransferBuilder(dbClient).
+			ReceiverAccountId(treasury).
+			SenderAccountId(account1).
+			SerialNumber(serial).
+			Timestamp(transferTimestamp).
+			TokenId(encodedTokenId3).
+			Persist()
+		transferTimestamp++
+	}
+	// token6 transfer will not affect balance since token6 is created before first snapshot
+	tdomain.NewNftTransferBuilder(dbClient).
+		ReceiverAccountId(account1).
+		SenderAccountId(treasury).
+		SerialNumber(1).
+		Timestamp(firstSnapshotTimestamp + 10).
+		TokenId(encodedTokenId6).
+		Persist()
+
+	// dissociate other tokens before account delete timestamp
+	for _, ta := range associatedTokenAccounts {
+		tdomain.NewTokenAccountBuilderFromExisting(dbClient, ta).
+			Associated(false, accountDeleteTimestamp-1).
+			Persist()
+	}
 }
 
 func (suite *accountRepositorySuite) TestRetrieveBalanceAtBlock() {
 	// given
-	db.CreateDbRecords(dbClient, getAccountEntity(account, false, 1), token1, token2, token3)
-	db.CreateDbRecords(dbClient, initialAccountBalance, initialTokenBalances)
+	// tokens created at or before first account balance snapshot will not show up in account balance response
 	// transfers before or at the snapshot timestamp should not affect balance calculation
-	db.CreateDbRecords(dbClient, cryptoTransfersLTESnapshot, tokenTransfersLTESnapshot, nftTransfersLTESnapshot)
-	db.CreateDbRecords(dbClient, cryptoTransfers, tokenTransfers, nftTransfers)
-
 	repo := NewAccountRepository(dbClient)
 
-	hbarAmount := &types.HbarAmount{Value: initialAccountBalance.Balance + sum(cryptoTransferAmounts)}
-	token1Amount := types.NewTokenAmount(*token1, initialTokenBalances[0].Balance+sum(token1TransferAmounts[:2]))
-	token2Amount := types.NewTokenAmount(*token2, initialTokenBalances[1].Balance+sum(token2TransferAmounts[:2]))
-	token3Amount := types.NewTokenAmount(*token3, initialTokenBalances[2].Balance+2).
-		SetSerialNumbers([]int64{1, 2, 3, 4})
-
-	expected := []types.Amount{hbarAmount, token1Amount, token2Amount, token3Amount}
+	hbarAmount := &types.HbarAmount{Value: initialAccountBalance + sum(cryptoTransferAmounts)}
+	token1Amount := types.NewTokenAmount(token1, sum(token1TransferAmounts[:2]))
+	token2Amount := types.NewTokenAmount(token2, sum(token2TransferAmounts[:2]))
+	token3Amount := types.NewTokenAmount(token3, 2)
+	token4Amount := types.NewTokenAmount(token4, 0)
+	expected := []types.Amount{hbarAmount, token1Amount, token2Amount, token3Amount, token4Amount}
 
 	// when
-	// account is deleted, however when querying its balance before when it's deleted, it should work as if the account
-	// wasn't deleted
-	actual, err := repo.RetrieveBalanceAtBlock(defaultContext, account.EncodedId, consensusTimestamp)
+	// query
+	actual, err := repo.RetrieveBalanceAtBlock(defaultContext, account1, consensusTimestamp)
+
+	// then
+	assert.Nil(suite.T(), err)
+	assert.ElementsMatch(suite.T(), expected, actual)
+
+	// when
+	// query at dissociateTimestamp, balances for token2 and token3 should be 0
+	actual, err = repo.RetrieveBalanceAtBlock(defaultContext, account1, dissociateTimestamp)
+	token2Amount = types.NewTokenAmount(token2, 0)
+	token3Amount = types.NewTokenAmount(token3, 0)
+	expected = []types.Amount{hbarAmount, token1Amount, token2Amount, token3Amount, token4Amount}
+
+	// then
+	assert.Nil(suite.T(), err)
+	assert.ElementsMatch(suite.T(), expected, actual)
+}
+
+func (suite *accountRepositorySuite) TestRetrieveBalanceAtBlockAfterSecondSnapshot() {
+	// given
+	// remove any transfers in db. with the balance info in the second snapshot, this test verifies the account balance
+	// is computed with additional transfers applied on top of the snapshot
+	db.ExecSql(dbClient, truncateCryptoTransferFileSql, truncateNftTransferSql, truncateTokenTransferSql)
+	tdomain.NewAccountBalanceFileBuilder(dbClient, secondSnapshotTimestamp).
+		AddAccountBalance(account1, initialAccountBalance+sum(cryptoTransferAmounts)).
+		AddTokenBalance(account1, encodedTokenId1, sum(token1TransferAmounts[:2])).
+		AddTokenBalance(account1, encodedTokenId2, sum(token2TransferAmounts[:2])).
+		AddTokenBalance(account1, encodedTokenId3, 2).
+		AddTokenBalance(account1, encodedTokenId4, 0).
+		Persist()
+	// extra transfers
+	tdomain.NewTokenTransferBuilder(dbClient).
+		AccountId(account1).
+		Amount(10).
+		Timestamp(secondSnapshotTimestamp + 2).
+		TokenId(encodedTokenId1).
+		Persist()
+	tdomain.NewTokenTransferBuilder(dbClient).
+		AccountId(account1).
+		Amount(12).
+		Timestamp(secondSnapshotTimestamp + 3).
+		TokenId(encodedTokenId2).
+		Persist()
+	tdomain.NewNftTransferBuilder(dbClient).
+		ReceiverAccountId(account1).
+		SenderAccountId(treasury).
+		SerialNumber(6).
+		Timestamp(secondSnapshotTimestamp + 4).
+		TokenId(encodedTokenId3).
+		Persist()
+	// add a self transfer
+	tdomain.NewNftTransferBuilder(dbClient).
+		ReceiverAccountId(account1).
+		SenderAccountId(account1).
+		SerialNumber(6).
+		Timestamp(secondSnapshotTimestamp + 5).
+		TokenId(encodedTokenId3).
+		Persist()
+	hbarAmount := &types.HbarAmount{Value: initialAccountBalance + sum(cryptoTransferAmounts)}
+	token1Amount := types.NewTokenAmount(token1, sum(token1TransferAmounts[:2])+10)
+	token2Amount := types.NewTokenAmount(token2, sum(token2TransferAmounts[:2])+12)
+	token3Amount := types.NewTokenAmount(token3, 3)
+	token4Amount := types.NewTokenAmount(token4, 0)
+	expected := []types.Amount{hbarAmount, token1Amount, token2Amount, token3Amount, token4Amount}
+	repo := NewAccountRepository(dbClient)
+
+	// when
+	actual, err := repo.RetrieveBalanceAtBlock(defaultContext, account1, secondSnapshotTimestamp+6)
 
 	// then
 	assert.Nil(suite.T(), err)
@@ -433,14 +366,24 @@ func (suite *accountRepositorySuite) TestRetrieveBalanceAtBlock() {
 
 func (suite *accountRepositorySuite) TestRetrieveBalanceAtBlockForDeletedAccount() {
 	// given
-	expected := suite.setupTestForDeletedAccount()
+	tdomain.NewEntityBuilder(dbClient, account1, 1, domain.EntityTypeAccount).
+		Deleted(true).
+		ModifiedTimestamp(accountDeleteTimestamp).
+		Persist()
+	expected := []types.Amount{
+		&types.HbarAmount{},
+		types.NewTokenAmount(token1, 0),
+		types.NewTokenAmount(token2, 0),
+		types.NewTokenAmount(token3, 0),
+		types.NewTokenAmount(token4, 0),
+	}
 	repo := NewAccountRepository(dbClient)
 
 	// when
-	// account is deleted before the second account balance file, so there is no balance info in the file. querying the
-	// account balance for a timestamp after the second account balance file should then return the balance at the time
+	// account is deleted before the third account balance file, so there is no balance info in the file. querying the
+	// account balance for a timestamp after the third account balance file should then return the balance at the time
 	// the account is deleted
-	actual, err := repo.RetrieveBalanceAtBlock(defaultContext, account.EncodedId, secondSnapshotTimestamp+10)
+	actual, err := repo.RetrieveBalanceAtBlock(defaultContext, account1, thirdSnapshotTimestamp+10)
 
 	// then
 	assert.Nil(suite.T(), err)
@@ -449,11 +392,40 @@ func (suite *accountRepositorySuite) TestRetrieveBalanceAtBlockForDeletedAccount
 
 func (suite *accountRepositorySuite) TestRetrieveBalanceAtBlockAtAccountDeletionTime() {
 	// given
-	expected := suite.setupTestForDeletedAccount()
+	tdomain.NewEntityBuilder(dbClient, account1, 1, domain.EntityTypeAccount).
+		Deleted(true).
+		ModifiedTimestamp(accountDeleteTimestamp).
+		Persist()
+	expected := []types.Amount{
+		&types.HbarAmount{},
+		types.NewTokenAmount(token1, 0),
+		types.NewTokenAmount(token2, 0),
+		types.NewTokenAmount(token3, 0),
+		types.NewTokenAmount(token4, 0),
+	}
 	repo := NewAccountRepository(dbClient)
 
 	// when
-	actual, err := repo.RetrieveBalanceAtBlock(defaultContext, account.EncodedId, accountDeleteTimestamp)
+	actual, err := repo.RetrieveBalanceAtBlock(defaultContext, account1, accountDeleteTimestamp)
+
+	// then
+	assert.Nil(suite.T(), err)
+	assert.ElementsMatch(suite.T(), expected, actual)
+}
+
+func (suite *accountRepositorySuite) TestRetrieveBalanceAtBlockNoAccountEntity() {
+	// given
+	db.ExecSql(dbClient, truncateEntitySql)
+	hbarAmount := &types.HbarAmount{Value: initialAccountBalance + sum(cryptoTransferAmounts)}
+	token1Amount := types.NewTokenAmount(token1, sum(token1TransferAmounts[:2]))
+	token2Amount := types.NewTokenAmount(token2, sum(token2TransferAmounts[:2]))
+	token3Amount := types.NewTokenAmount(token3, 2)
+	token4Amount := types.NewTokenAmount(token4, 0)
+	expected := []types.Amount{hbarAmount, token1Amount, token2Amount, token3Amount, token4Amount}
+	repo := NewAccountRepository(dbClient)
+
+	// when
+	actual, err := repo.RetrieveBalanceAtBlock(defaultContext, account1, consensusTimestamp)
 
 	// then
 	assert.Nil(suite.T(), err)
@@ -462,19 +434,15 @@ func (suite *accountRepositorySuite) TestRetrieveBalanceAtBlockAtAccountDeletion
 
 func (suite *accountRepositorySuite) TestRetrieveBalanceAtBlockNoTokenEntity() {
 	// given
-	db.CreateDbRecords(dbClient, initialAccountBalance, initialTokenBalances)
-	// transfers before or at the snapshot timestamp should not affect balance calculation
-	db.CreateDbRecords(dbClient, cryptoTransfersLTESnapshot, tokenTransfersLTESnapshot)
-	db.CreateDbRecords(dbClient, cryptoTransfers, tokenTransfers)
-
+	db.ExecSql(dbClient, truncateTokenSql)
 	repo := NewAccountRepository(dbClient)
 
 	// no token entities, so only hbar balance
-	hbarAmount := &types.HbarAmount{Value: initialAccountBalance.Balance + sum(cryptoTransferAmounts)}
+	hbarAmount := &types.HbarAmount{Value: initialAccountBalance + sum(cryptoTransferAmounts)}
 	expected := []types.Amount{hbarAmount}
 
 	// when
-	actual, err := repo.RetrieveBalanceAtBlock(defaultContext, account.EncodedId, consensusTimestamp)
+	actual, err := repo.RetrieveBalanceAtBlock(defaultContext, account1, consensusTimestamp)
 
 	// then
 	assert.Nil(suite.T(), err)
@@ -483,20 +451,19 @@ func (suite *accountRepositorySuite) TestRetrieveBalanceAtBlockNoTokenEntity() {
 
 func (suite *accountRepositorySuite) TestRetrieveBalanceAtBlockNoInitialBalance() {
 	// given
-	// account is not deleted
-	db.CreateDbRecords(dbClient, getAccountEntity(account, false, 1), token1, token2, token3)
-	db.CreateDbRecords(dbClient, cryptoTransfers, tokenTransfers, nftTransfers)
+	db.ExecSql(dbClient, truncateAccountBalanceSql, truncateTokenBalanceSql)
+
+	hbarAmount := &types.HbarAmount{Value: sum(cryptoTransferAmounts)}
+	token1Amount := types.NewTokenAmount(token1, sum(token1TransferAmounts[:2]))
+	token2Amount := types.NewTokenAmount(token2, sum(token2TransferAmounts[:2]))
+	token3Amount := types.NewTokenAmount(token3, 2)
+	token4Amount := types.NewTokenAmount(token4, 0)
+	expected := []types.Amount{hbarAmount, token1Amount, token2Amount, token3Amount, token4Amount}
 
 	repo := NewAccountRepository(dbClient)
 
-	hbarAmount := &types.HbarAmount{Value: sum(cryptoTransferAmounts)}
-	token1Amount := types.NewTokenAmount(*token1, sum(token1TransferAmounts[:2]))
-	token2Amount := types.NewTokenAmount(*token2, sum(token2TransferAmounts[:2]))
-	token3Amount := types.NewTokenAmount(*token3, 2).SetSerialNumbers([]int64{3, 4})
-	expected := []types.Amount{hbarAmount, token1Amount, token2Amount, token3Amount}
-
 	// when
-	actual, err := repo.RetrieveBalanceAtBlock(defaultContext, account.EncodedId, consensusTimestamp)
+	actual, err := repo.RetrieveBalanceAtBlock(defaultContext, account1, consensusTimestamp)
 
 	// then
 	assert.Nil(suite.T(), err)
@@ -509,7 +476,7 @@ func (suite *accountRepositorySuite) TestRetrieveBalanceAtBlockNoAccountBalanceF
 	repo := NewAccountRepository(dbClient)
 
 	// when
-	actual, err := repo.RetrieveBalanceAtBlock(defaultContext, account.EncodedId, consensusTimestamp)
+	actual, err := repo.RetrieveBalanceAtBlock(defaultContext, account1, consensusTimestamp)
 
 	// then
 	assert.NotNil(suite.T(), err)
@@ -521,192 +488,11 @@ func (suite *accountRepositorySuite) TestRetrieveBalanceAtBlockDbConnectionError
 	repo := NewAccountRepository(invalidDbClient)
 
 	// when
-	actual, err := repo.RetrieveBalanceAtBlock(defaultContext, account.EncodedId, consensusTimestamp)
+	actual, err := repo.RetrieveBalanceAtBlock(defaultContext, account1, consensusTimestamp)
 
 	// then
 	assert.Equal(suite.T(), errors.ErrDatabaseError, err)
 	assert.Nil(suite.T(), actual)
-}
-
-func (suite *accountRepositorySuite) TestRetrieveEverOwnedTokensByBlock() {
-	// given
-	db.CreateDbRecords(dbClient, recordFile, token1, token2, token3)
-	suite.createTokenAssociations()
-	expected := []domain.Token{
-		{
-			Decimals: token1.Decimals,
-			TokenId:  token1.TokenId,
-			Type:     domain.TokenTypeFungibleCommon,
-		},
-		{
-			Decimals: token2.Decimals,
-			TokenId:  token2.TokenId,
-			Type:     domain.TokenTypeFungibleCommon,
-		},
-	}
-	repo := NewAccountRepository(dbClient)
-
-	// when
-	actual, err := repo.RetrieveEverOwnedTokensByBlock(defaultContext, account.EncodedId, recordFile.ConsensusEnd)
-
-	// then
-	assert.Nil(suite.T(), err)
-	assert.Equal(suite.T(), expected, actual)
-}
-
-func (suite *accountRepositorySuite) TestRetrieveEverOwnedTokensByBlockNoTokenEntity() {
-	// given
-	db.CreateDbRecords(dbClient, recordFile)
-	suite.createTokenAssociations()
-	repo := NewAccountRepository(dbClient)
-
-	// when
-	actual, err := repo.RetrieveEverOwnedTokensByBlock(defaultContext, account.EncodedId, recordFile.ConsensusEnd)
-
-	// then
-	assert.Nil(suite.T(), err)
-	assert.Empty(suite.T(), actual)
-}
-
-func (suite *accountRepositorySuite) TestRetrieveEverOwnedTokensByBlockDbConnectionError() {
-	// given
-	repo := NewAccountRepository(invalidDbClient)
-
-	// when
-	actual, err := repo.RetrieveEverOwnedTokensByBlock(defaultContext, account.EncodedId, consensusEnd)
-
-	// then
-	assert.Equal(suite.T(), errors.ErrDatabaseError, err)
-	assert.Nil(suite.T(), actual)
-}
-
-func (suite *accountRepositorySuite) createTokenAssociations() {
-	currentBlockStart := recordFile.ConsensusStart
-	currentBlockEnd := recordFile.ConsensusEnd
-	nextBlockStart := currentBlockEnd + 1
-	db.CreateDbRecords(
-		dbClient,
-		// account1's token associations
-		getTokenAccount(account, true, currentBlockStart-1, currentBlockStart-1, token1.TokenId),
-		getTokenAccount(account, false, currentBlockStart-1, currentBlockStart, token1.TokenId),
-		getTokenAccount(account, true, currentBlockEnd, currentBlockEnd, token2.TokenId),
-		getTokenAccount(account, false, currentBlockEnd, nextBlockStart, token2.TokenId),
-		getTokenAccount(account, true, nextBlockStart+1, nextBlockStart+1, token3.TokenId),
-		// account2's token associations
-		getTokenAccount(account2, true, currentBlockEnd-6, currentBlockEnd-6, token3.TokenId),
-		getTokenAccount(account2, true, currentBlockEnd-5, currentBlockEnd-5, token4.TokenId),
-	)
-}
-
-func (suite *accountRepositorySuite) setupTestForDeletedAccount() []types.Amount {
-	db.CreateDbRecords(dbClient, getAccountEntity(account, true, accountDeleteTimestamp), token1, token2, token3)
-	db.CreateDbRecords(dbClient, initialAccountBalance, initialTokenBalances)
-	// transfers before or at the snapshot timestamp should not affect balance calculation
-	db.CreateDbRecords(dbClient, cryptoTransfersLTESnapshot, tokenTransfersLTESnapshot, nftTransfersLTESnapshot)
-	db.CreateDbRecords(dbClient, cryptoTransfers, tokenTransfers, nftTransfers)
-
-	token1Amount := types.NewTokenAmount(*token1, initialTokenBalances[0].Balance+sum(token1TransferAmounts))
-	token2Amount := types.NewTokenAmount(*token2, initialTokenBalances[1].Balance+sum(token2TransferAmounts))
-	token3Amount := types.NewTokenAmount(*token3, initialTokenBalances[2].Balance+2).
-		SetSerialNumbers([]int64{1, 2, 3, 4})
-
-	return []types.Amount{&types.HbarAmount{}, token1Amount, token2Amount, token3Amount}
-}
-
-func TestGetUpdatedTokenAmounts(t *testing.T) {
-	token3EntityId := domain.EntityId{EncodedId: 2007, EntityNum: 2007}
-	tests := []struct {
-		name           string
-		tokenAmountMap map[int64]*types.TokenAmount
-		tokenValues    []*types.TokenAmount
-		expected       []types.Amount
-	}{
-		{
-			"empty tokenAmountMap and tokenValues",
-			map[int64]*types.TokenAmount{},
-			[]*types.TokenAmount{},
-			[]types.Amount{},
-		},
-		{
-			"empty tokenValues",
-			map[int64]*types.TokenAmount{
-				token1.TokenId.EncodedId: {Decimals: token1.Decimals, TokenId: token1.TokenId, Value: 200},
-			},
-			[]*types.TokenAmount{},
-			[]types.Amount{
-				&types.TokenAmount{Decimals: token1.Decimals, TokenId: token1.TokenId, Value: 200},
-			},
-		},
-		{
-			"empty tokenAmountMap",
-			map[int64]*types.TokenAmount{},
-			[]*types.TokenAmount{
-				{Decimals: token1.Decimals, TokenId: token1.TokenId, Value: 200},
-			},
-			[]types.Amount{
-				&types.TokenAmount{Decimals: token1.Decimals, TokenId: token1.TokenId, Value: 200},
-			},
-		},
-		{
-			"non-empty tokenAmountMap and tokenValues",
-			map[int64]*types.TokenAmount{
-				token1.TokenId.EncodedId: {Decimals: token1.Decimals, TokenId: token1.TokenId, Value: 200},
-				token2.TokenId.EncodedId: {Decimals: token2.Decimals, TokenId: token2.TokenId, Value: 220},
-			},
-			[]*types.TokenAmount{
-				{Decimals: token1.Decimals, TokenId: token1.TokenId, Value: -20},
-				{Decimals: token2.Decimals, TokenId: token2.TokenId, Value: 30},
-				{Decimals: 12, TokenId: token3EntityId, Value: 70},
-			},
-			[]types.Amount{
-				&types.TokenAmount{Decimals: token1.Decimals, TokenId: token1.TokenId, Value: 180},
-				&types.TokenAmount{Decimals: token2.Decimals, TokenId: token2.TokenId, Value: 250},
-				&types.TokenAmount{Decimals: 12, TokenId: token3EntityId, Value: 70},
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			actual := getUpdatedTokenAmounts(tt.tokenAmountMap, tt.tokenValues)
-			assert.ElementsMatch(t, tt.expected, actual)
-		})
-	}
-}
-
-func getAccountEntity(id domain.EntityId, deleted bool, modifiedTimestamp int64) *domain.Entity {
-	return &domain.Entity{
-		Deleted: &deleted,
-		Id:      id,
-		Memo:    "test account",
-		Num:     id.EntityNum,
-		Realm:   id.RealmNum,
-		Shard:   id.ShardNum,
-		Type:    "ACCOUNT",
-		TimestampRange: pgtype.Int8range{
-			Lower:     pgtype.Int8{Int: modifiedTimestamp, Status: pgtype.Present},
-			Upper:     pgtype.Int8{Status: pgtype.Null},
-			LowerType: pgtype.Inclusive,
-			UpperType: pgtype.Unbounded,
-			Status:    pgtype.Present,
-		},
-	}
-}
-
-func getTokenAccount(
-	accountId domain.EntityId,
-	associated bool,
-	createdTimestamp int64,
-	modifiedTimestamp int64,
-	tokenId domain.EntityId,
-) *domain.TokenAccount {
-	return &domain.TokenAccount{
-		AccountId:         accountId,
-		Associated:        associated,
-		CreatedTimestamp:  createdTimestamp,
-		ModifiedTimestamp: modifiedTimestamp,
-		TokenId:           tokenId,
-	}
 }
 
 func sum(amounts []int64) int64 {

--- a/hedera-mirror-rosetta/app/persistence/block.go
+++ b/hedera-mirror-rosetta/app/persistence/block.go
@@ -58,16 +58,16 @@ const (
 
 	// selectGenesis - Selects the first block whose consensus_end is after the genesis account balance
 	// timestamp. Return the record file with adjusted consensus start
-	selectGenesis string = `select
+	selectGenesis string = "with" + genesisTimestampCte + `select
                               hash,
                               index,
                               case
-                                when genesis.min >= rf.consensus_start then genesis.min + 1
+                                when genesis.timestamp >= rf.consensus_start then genesis.timestamp + 1
                                 else rf.consensus_start
                               end consensus_start
                             from record_file rf
-                            join (select min(consensus_timestamp) from account_balance_file) genesis
-                              on consensus_end > genesis.min
+                            join genesis
+                              on consensus_end > genesis.timestamp
                             order by consensus_end
                             limit 1`
 

--- a/hedera-mirror-rosetta/app/persistence/common.go
+++ b/hedera-mirror-rosetta/app/persistence/common.go
@@ -2,7 +2,7 @@
  * ‌
  * Hedera Mirror Node
  * ​
- * Copyright (C) 2019 - 2021 Hedera Hashgraph, LLC
+ * Copyright (C) 2019 - 2022 Hedera Hashgraph, LLC
  * ​
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,21 +18,12 @@
  * ‍
  */
 
-package domain
+package persistence
 
-import (
-	"testing"
-
-	"github.com/jackc/pgtype"
-	"github.com/stretchr/testify/assert"
+const (
+	genesisTimestampQuery = `select consensus_timestamp as timestamp
+                             from account_balance_file
+                             order by consensus_timestamp
+                             limit 1`
+	genesisTimestampCte = " genesis as (" + genesisTimestampQuery + ") "
 )
-
-func TestEntityTableName(t *testing.T) {
-	assert.Equal(t, "entity", Entity{}.TableName())
-}
-
-func TestEntityGetModifiedTimestamp(t *testing.T) {
-	timestamp := int64(100)
-	entity := Entity{TimestampRange: pgtype.Int8range{Lower: pgtype.Int8{Int: timestamp, Status: pgtype.Present}}}
-	assert.Equal(t, timestamp, entity.GetModifiedTimestamp())
-}

--- a/hedera-mirror-rosetta/app/persistence/domain/entity.go
+++ b/hedera-mirror-rosetta/app/persistence/domain/entity.go
@@ -22,7 +22,15 @@ package domain
 
 import "github.com/jackc/pgtype"
 
-const entityTableName = "entity"
+const (
+	EntityTypeAccount  = "ACCOUNT"
+	EntityTypeFile     = "FILE"
+	EntityTypeSchedule = "SCHEDULE"
+	EntityTypeToken    = "TOKEN"
+	EntityTypeTopic    = "TOPIC"
+
+	entityTableName = "entity"
+)
 
 type Entity struct {
 	AutoRenewAccountId            *EntityId
@@ -43,6 +51,10 @@ type Entity struct {
 	SubmitKey                     []byte
 	TimestampRange                pgtype.Int8range
 	Type                          string
+}
+
+func (e Entity) GetModifiedTimestamp() int64 {
+	return e.TimestampRange.Lower.Int
 }
 
 func (Entity) TableName() string {

--- a/hedera-mirror-rosetta/app/persistence/domain/nft.go
+++ b/hedera-mirror-rosetta/app/persistence/domain/nft.go
@@ -2,7 +2,7 @@
  * ‌
  * Hedera Mirror Node
  * ​
- * Copyright (C) 2019 - 2021 Hedera Hashgraph, LLC
+ * Copyright (C) 2019 - 2022 Hedera Hashgraph, LLC
  * ​
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,19 +20,19 @@
 
 package domain
 
-import (
-	"testing"
+const tableNameNft = "nft"
 
-	"github.com/jackc/pgtype"
-	"github.com/stretchr/testify/assert"
-)
-
-func TestEntityTableName(t *testing.T) {
-	assert.Equal(t, "entity", Entity{}.TableName())
+type Nft struct {
+	AccountId         *EntityId
+	CreatedTimestamp  *int64
+	Deleted           *bool
+	ModifiedTimestamp int64
+	Metadata          []byte
+	SerialNumber      int64    `gorm:"primaryKey"`
+	TokenId           EntityId `gorm:"primaryKey"`
 }
 
-func TestEntityGetModifiedTimestamp(t *testing.T) {
-	timestamp := int64(100)
-	entity := Entity{TimestampRange: pgtype.Int8range{Lower: pgtype.Int8{Int: timestamp, Status: pgtype.Present}}}
-	assert.Equal(t, timestamp, entity.GetModifiedTimestamp())
+// TableName returns nft table name
+func (Nft) TableName() string {
+	return tableNameNft
 }

--- a/hedera-mirror-rosetta/app/persistence/domain/nft_test.go
+++ b/hedera-mirror-rosetta/app/persistence/domain/nft_test.go
@@ -2,7 +2,7 @@
  * ‌
  * Hedera Mirror Node
  * ​
- * Copyright (C) 2019 - 2021 Hedera Hashgraph, LLC
+ * Copyright (C) 2019 - 2022 Hedera Hashgraph, LLC
  * ​
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,16 +23,9 @@ package domain
 import (
 	"testing"
 
-	"github.com/jackc/pgtype"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestEntityTableName(t *testing.T) {
-	assert.Equal(t, "entity", Entity{}.TableName())
-}
-
-func TestEntityGetModifiedTimestamp(t *testing.T) {
-	timestamp := int64(100)
-	entity := Entity{TimestampRange: pgtype.Int8range{Lower: pgtype.Int8{Int: timestamp, Status: pgtype.Present}}}
-	assert.Equal(t, timestamp, entity.GetModifiedTimestamp())
+func TestNftTableName(t *testing.T) {
+	assert.Equal(t, "nft", Nft{}.TableName())
 }

--- a/hedera-mirror-rosetta/app/persistence/testmain_test.go
+++ b/hedera-mirror-rosetta/app/persistence/testmain_test.go
@@ -34,8 +34,15 @@ import (
 )
 
 const (
+	truncateAccountBalanceSql     = "truncate account_balance"
 	truncateAccountBalanceFileSql = "truncate account_balance_file"
+	truncateCryptoTransferFileSql = "truncate crypto_transfer"
+	truncateEntitySql             = "truncate entity"
+	truncateNftTransferSql        = "truncate nft_transfer"
 	truncateRecordFileSql         = "truncate record_file"
+	truncateTokenSql              = "truncate token"
+	truncateTokenBalanceSql       = "truncate token_balance"
+	truncateTokenTransferSql      = "truncate token_transfer"
 )
 
 var (

--- a/hedera-mirror-rosetta/build/postgresql.conf
+++ b/hedera-mirror-rosetta/build/postgresql.conf
@@ -1,4 +1,8 @@
+checkpoint_timeout = 30min
 listen_addresses = '*'
+log_checkpoints = on
+max_connections = 200
+max_wal_size = 32GB
 password_encryption = scram-sha-256
-max_wal_size = 8GB
-work_mem = 256MB
+random_page_cost = 1.1
+work_mem = 512MB

--- a/hedera-mirror-rosetta/build/run_supervisord.sh
+++ b/hedera-mirror-rosetta/build/run_supervisord.sh
@@ -3,12 +3,12 @@ set -eo pipefail
 
 function run_offline_mode() {
   echo "Running in offline mode"
-  supervisord --configuration /app/supervisord-offline.conf
+  exec supervisord --configuration /app/supervisord-offline.conf
 }
 
 function run_online_mode() {
   echo "Running in online mode"
-  supervisord --configuration /app/supervisord.conf
+  exec supervisord --configuration /app/supervisord.conf
 }
 
 function cleanup() {
@@ -60,7 +60,6 @@ function main() {
     export HEDERA_MIRROR_IMPORTER_NETWORK="${NETWORK}"
     export HEDERA_MIRROR_ROSETTA_NETWORK="${NETWORK}"
   fi
-
 
   case "${MODE}" in
     "offline")

--- a/hedera-mirror-rosetta/build/supervisord-offline.conf
+++ b/hedera-mirror-rosetta/build/supervisord-offline.conf
@@ -8,6 +8,13 @@ nodaemon=true               ; start in foreground if true; default false
 
 [unix_http_server]
 file=/tmp/supervisor.sock
+chown=nobody:nogroup
+
+[supervisorctl]
+serverurl=unix:///tmp/supervisor.sock
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 [program:rosetta]
 command=/app/rosetta/hedera-mirror-rosetta
@@ -17,5 +24,4 @@ autorestart=true
 redirect_stderr=true
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
-stopsignal=SIGTERM
 environment=HEDERA_MIRROR_ROSETTA_ONLINE=false

--- a/hedera-mirror-rosetta/build/supervisord.conf
+++ b/hedera-mirror-rosetta/build/supervisord.conf
@@ -8,7 +8,13 @@ nodaemon=true               ; start in foreground if true; default false
 
 [unix_http_server]
 file=/tmp/supervisor.sock
-user=dummy
+chown=nobody:nogroup
+
+[supervisorctl]
+serverurl=unix:///tmp/supervisor.sock
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 [program:postgres]
 command=postgres
@@ -17,6 +23,7 @@ autorestart=true
 redirect_stderr=true
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
+stopwaitsecs=100
 priority=1
 
 [program:importer]
@@ -26,8 +33,9 @@ autorestart=true
 redirect_stderr=true
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
+stopwaitsecs=90
 priority=10
-environment=HEDERA_MIRROR_IMPORTER_PARSER_RECORD_ENTITY_PERSIST_NONFEETRANSFERS=true,HEDERA_MIRROR_IMPORTER_PARSER_RECORD_ENTITY_PERSIST_TOPICS=false,HEDERA_MIRROR_IMPORTER_PARSER_RECORD_ENTITY_REDIS_ENABLED=false,HEDERA_MIRROR_IMPORTER_STARTDATE=1970-01-01T00:00:00Z
+environment=HEDERA_MIRROR_IMPORTER_PARSER_RECORD_ENTITY_PERSIST_NONFEETRANSFERS=true,HEDERA_MIRROR_IMPORTER_PARSER_RECORD_ENTITY_PERSIST_TOPICS=false,HEDERA_MIRROR_IMPORTER_PARSER_RECORD_ENTITY_REDIS_ENABLED=false
 
 [program:rosetta]
 command=/app/rosetta/hedera-mirror-rosetta
@@ -37,5 +45,4 @@ autorestart=true
 redirect_stderr=true
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
-stopsignal=SIGTERM
 priority=100

--- a/hedera-mirror-rosetta/scripts/validation/demo/validation.json
+++ b/hedera-mirror-rosetta/scripts/validation/demo/validation.json
@@ -6,16 +6,17 @@
       "network": "shard 0 realm 0"
     }
   },
-  "retry_elapsed_time": 5,
   "online_url": "http://localhost:5700",
-  "data_directory": "",
-  "http_timeout": 10,
+  "http_timeout": 15,
+  "max_retries": 5,
+  "retry_elapsed_time": 100,
   "tip_delay": 300,
   "data": {
-    "reconciliation_disabled": false,
-    "inactive_discrepancy_search_disabled": false,
     "balance_tracking_disabled": false,
-    "bootstrap_balances": "./data_genesis_balances.json",
+    "historical_balance_enabled": true,
+    "inactive_discrepancy_search_disabled": false,
+    "reconciliation_disabled": false,
+    "start_index": 1,
     "end_conditions": {
       "reconciliation_coverage": {
         "coverage": 0.95

--- a/hedera-mirror-rosetta/scripts/validation/mainnet/README.md
+++ b/hedera-mirror-rosetta/scripts/validation/mainnet/README.md
@@ -1,0 +1,18 @@
+# Validation Configuration
+
+The [configuration file](./validation.json) is tailored to run rosetta-cli `check:data` for mainnet with large amount
+of data in a performant way.
+
+- `start_index` is set to 1 to work around the known rosetta-cli performance issue of loading large genesis account
+  balance JSON file
+- memory limit is disabled to improve both block syncing and account reconciliation speed
+- pruning is disabled to avoid the badger db overhead during such operation
+- query timeout and retry is tuned to avoid rosetta-cli to abort early when the rosetta server is under heavy load thus
+  can't answer queries in time intermittently
+- the `check:data` progress is saved in db in the `./data` directory, so it can be resumed when interrupted
+
+It's recommended to run rosetta-cli with at least 16 vCPUs and 100GB memory.
+
+Occasionally rosetta-cli will consume too much memory and get killed by the system OOM killer. When that happens, before
+resuming, remove `"start_index": 1` from the configuration file so rosetta-cli will not wipe the saved state and restart
+from index 1.

--- a/hedera-mirror-rosetta/scripts/validation/mainnet/validation.json
+++ b/hedera-mirror-rosetta/scripts/validation/mainnet/validation.json
@@ -1,0 +1,30 @@
+{
+  "network": {
+    "blockchain": "Hedera",
+    "network": "mainnet",
+    "sub_network_identifier": {
+      "network": "shard 0 realm 0"
+    }
+  },
+  "data_directory": "./data",
+  "retry_elapsed_time": 7500,
+  "online_url": "http://localhost:5700",
+  "http_timeout": 300,
+  "max_online_connections": 256,
+  "max_retries": 25,
+  "max_sync_concurrency": 32,
+  "memory_limit_disabled": true,
+  "seen_block_workers": 32,
+  "serial_block_workers": 32,
+  "tip_delay": 20,
+  "data": {
+    "active_reconciliation_concurrency": 64,
+    "inactive_reconciliation_concurrency": 4,
+    "inactive_reconciliation_frequency": 250,
+    "pruning_disabled": true,
+    "start_index": 1,
+    "end_conditions": {
+      "tip": true
+    }
+  }
+}

--- a/hedera-mirror-rosetta/scripts/validation/testnet/validation.json
+++ b/hedera-mirror-rosetta/scripts/validation/testnet/validation.json
@@ -6,10 +6,10 @@
       "network": "shard 0 realm 0"
     }
   },
-  "retry_elapsed_time": 5,
   "online_url": "http://localhost:5700",
-  "data_directory": "",
   "http_timeout": 15,
+  "max_retries": 5,
+  "retry_elapsed_time": 100,
   "tip_delay": 20,
   "construction": {
     "broadcast_limit": 1,
@@ -24,10 +24,11 @@
     "stale_depth": 8
   },
   "data": {
-    "reconciliation_disabled": false,
-    "inactive_discrepancy_search_disabled": false,
     "balance_tracking_disabled": false,
-    "bootstrap_balances": "./data_genesis_balances.json",
+    "historical_balance_enabled": true,
+    "inactive_discrepancy_search_disabled": false,
+    "reconciliation_disabled": false,
+    "start_index": 1,
     "end_conditions": {
       "reconciliation_coverage": {
         "coverage": 0.95

--- a/hedera-mirror-rosetta/test/db/db.go
+++ b/hedera-mirror-rosetta/test/db/db.go
@@ -68,8 +68,10 @@ func CreateDbRecords(dbClient interfaces.DbClient, records ...interface{}) {
 	}
 }
 
-func ExecSql(dbClient interfaces.DbClient, sql string) {
-	dbClient.GetDb().Exec(sql)
+func ExecSql(dbClient interfaces.DbClient, sqls ...string) {
+	for _, s := range sqls {
+		dbClient.GetDb().Exec(s)
+	}
 }
 
 // GetDbConfig returns the db config of the session

--- a/hedera-mirror-rosetta/test/domain/account_balance_file_builder.go
+++ b/hedera-mirror-rosetta/test/domain/account_balance_file_builder.go
@@ -1,0 +1,83 @@
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+package domain
+
+import (
+	"fmt"
+
+	"github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/app/interfaces"
+	"github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/app/persistence/domain"
+)
+
+var defaultNodeAccountId = domain.MustDecodeEntityId(3)
+
+type AccountBalanceFileBuilder struct {
+	accountBalances    []domain.AccountBalance
+	consensusTimestamp int64
+	dbClient           interfaces.DbClient
+	tokenBalances      []domain.TokenBalance
+}
+
+func (b *AccountBalanceFileBuilder) AddAccountBalance(accountId, balance int64) *AccountBalanceFileBuilder {
+	b.accountBalances = append(b.accountBalances, domain.AccountBalance{
+		AccountId:          domain.MustDecodeEntityId(accountId),
+		Balance:            balance,
+		ConsensusTimestamp: b.consensusTimestamp,
+	})
+	return b
+}
+
+func (b *AccountBalanceFileBuilder) AddTokenBalance(accountId, tokenId, balance int64) *AccountBalanceFileBuilder {
+	b.tokenBalances = append(b.tokenBalances, domain.TokenBalance{
+		AccountId:          domain.MustDecodeEntityId(accountId),
+		Balance:            balance,
+		ConsensusTimestamp: b.consensusTimestamp,
+		TokenId:            domain.MustDecodeEntityId(tokenId),
+	})
+	return b
+}
+
+func (b *AccountBalanceFileBuilder) Persist() {
+	db := b.dbClient.GetDb()
+
+	accountBalanceFile := domain.AccountBalanceFile{
+		ConsensusTimestamp: b.consensusTimestamp,
+		FileHash:           fmt.Sprintf("%d", b.consensusTimestamp),
+		Name:               fmt.Sprintf("account_balance_file_%d", b.consensusTimestamp),
+		NodeAccountId:      defaultNodeAccountId,
+	}
+	db.Create(&accountBalanceFile)
+	if len(b.accountBalances) != 0 {
+		db.Create(b.accountBalances)
+	}
+	if len(b.tokenBalances) != 0 {
+		db.Create(b.tokenBalances)
+	}
+}
+
+func NewAccountBalanceFileBuilder(dbClient interfaces.DbClient, consensusTimestamp int64) *AccountBalanceFileBuilder {
+	return &AccountBalanceFileBuilder{
+		accountBalances:    make([]domain.AccountBalance, 0),
+		consensusTimestamp: consensusTimestamp,
+		dbClient:           dbClient,
+		tokenBalances:      make([]domain.TokenBalance, 0),
+	}
+}

--- a/hedera-mirror-rosetta/test/domain/crypto_transfer_builder.go
+++ b/hedera-mirror-rosetta/test/domain/crypto_transfer_builder.go
@@ -1,0 +1,59 @@
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+package domain
+
+import (
+	"github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/app/interfaces"
+	"github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/app/persistence/domain"
+)
+
+var defaultPayer = domain.MustDecodeEntityId(211)
+
+type CryptoTransferBuilder struct {
+	dbClient       interfaces.DbClient
+	cryptoTransfer domain.CryptoTransfer
+}
+
+func (b *CryptoTransferBuilder) Amount(amount int64) *CryptoTransferBuilder {
+	b.cryptoTransfer.Amount = amount
+	return b
+}
+
+func (b *CryptoTransferBuilder) EntityId(entityId int64) *CryptoTransferBuilder {
+	b.cryptoTransfer.EntityId = domain.MustDecodeEntityId(entityId)
+	return b
+}
+
+func (b *CryptoTransferBuilder) Timestamp(timestamp int64) *CryptoTransferBuilder {
+	b.cryptoTransfer.ConsensusTimestamp = timestamp
+	return b
+}
+
+func (b *CryptoTransferBuilder) Persist() {
+	b.dbClient.GetDb().Create(&b.cryptoTransfer)
+}
+
+func NewCryptoTransferBuilder(dbClient interfaces.DbClient) *CryptoTransferBuilder {
+	return &CryptoTransferBuilder{
+		dbClient:       dbClient,
+		cryptoTransfer: domain.CryptoTransfer{PayerAccountId: defaultPayer},
+	}
+}

--- a/hedera-mirror-rosetta/test/domain/entity_builder.go
+++ b/hedera-mirror-rosetta/test/domain/entity_builder.go
@@ -1,0 +1,93 @@
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+package domain
+
+import (
+	"github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/app/interfaces"
+	"github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/app/persistence/domain"
+	"github.com/jackc/pgtype"
+	"gorm.io/gorm/clause"
+)
+
+type EntityBuilder struct {
+	dbClient interfaces.DbClient
+	entity   domain.Entity
+}
+
+func (b *EntityBuilder) Deleted(deleted bool) *EntityBuilder {
+	b.entity.Deleted = &deleted
+	return b
+}
+
+func (b *EntityBuilder) ModifiedAfter(delta int64) *EntityBuilder {
+	b.entity.TimestampRange = getTimestampRangeWithLower(*b.entity.CreatedTimestamp + delta)
+	return b
+}
+
+func (b *EntityBuilder) ModifiedTimestamp(timestamp int64) *EntityBuilder {
+	b.entity.TimestampRange = getTimestampRangeWithLower(timestamp)
+	return b
+}
+
+func (b *EntityBuilder) Persist() domain.Entity {
+	b.dbClient.GetDb().Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "id"}},
+		DoUpdates: clause.AssignmentColumns([]string{"deleted", "timestamp_range"}),
+	}).Create(&b.entity)
+	return b.entity
+}
+
+func NewEntityBuilder(dbClient interfaces.DbClient, id, timestamp int64, entityType string) *EntityBuilder {
+	entityId := domain.MustDecodeEntityId(id)
+	entity := domain.Entity{
+		CreatedTimestamp: &timestamp,
+		Id:               entityId,
+		Num:              entityId.EntityNum,
+		Realm:            entityId.RealmNum,
+		Shard:            entityId.ShardNum,
+		TimestampRange:   getTimestampRangeWithLower(timestamp),
+		Type:             entityType,
+	}
+	return &EntityBuilder{dbClient: dbClient, entity: entity}
+}
+
+func NewEntityBuilderFromToken(dbClient interfaces.DbClient, token domain.Token) *EntityBuilder {
+	entity := domain.Entity{
+		CreatedTimestamp: &token.CreatedTimestamp,
+		Id:               token.TokenId,
+		Num:              token.TokenId.EntityNum,
+		Realm:            token.TokenId.RealmNum,
+		Shard:            token.TokenId.ShardNum,
+		TimestampRange:   getTimestampRangeWithLower(token.CreatedTimestamp),
+		Type:             domain.EntityTypeToken,
+	}
+	return &EntityBuilder{dbClient: dbClient, entity: entity}
+}
+
+func getTimestampRangeWithLower(lower int64) pgtype.Int8range {
+	return pgtype.Int8range{
+		Lower:     pgtype.Int8{Int: lower, Status: pgtype.Present},
+		Upper:     pgtype.Int8{Status: pgtype.Null},
+		LowerType: pgtype.Inclusive,
+		UpperType: pgtype.Unbounded,
+		Status:    pgtype.Present,
+	}
+}

--- a/hedera-mirror-rosetta/test/domain/nft_builder.go
+++ b/hedera-mirror-rosetta/test/domain/nft_builder.go
@@ -1,0 +1,62 @@
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+package domain
+
+import (
+	"github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/app/interfaces"
+	"github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/app/persistence/domain"
+)
+
+type NftBuilder struct {
+	dbClient interfaces.DbClient
+	nft      domain.Nft
+}
+
+func (b *NftBuilder) AccountId(accountId int64) *NftBuilder {
+	account := domain.MustDecodeEntityId(accountId)
+	b.nft.AccountId = &account
+	return b
+}
+
+func (b *NftBuilder) Deleted(deleted bool) *NftBuilder {
+	b.nft.Deleted = &deleted
+	return b
+}
+
+func (b *NftBuilder) ModifiedTimestamp(timestamp int64) *NftBuilder {
+	b.nft.ModifiedTimestamp = timestamp
+	return b
+}
+
+func (b *NftBuilder) Persist() domain.Nft {
+	b.dbClient.GetDb().Create(&b.nft)
+	return b.nft
+}
+
+func NewNftBuilder(dbClient interfaces.DbClient, tokenId, serialNumber, timestamp int64) *NftBuilder {
+	nft := domain.Nft{
+		CreatedTimestamp:  &timestamp,
+		ModifiedTimestamp: timestamp,
+		SerialNumber:      serialNumber,
+		TokenId:           domain.MustDecodeEntityId(tokenId),
+	}
+	return &NftBuilder{dbClient: dbClient, nft: nft}
+}

--- a/hedera-mirror-rosetta/test/domain/nft_transfer_builder.go
+++ b/hedera-mirror-rosetta/test/domain/nft_transfer_builder.go
@@ -1,0 +1,69 @@
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+package domain
+
+import (
+	"github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/app/interfaces"
+	"github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/app/persistence/domain"
+)
+
+type NftTransferBuilder struct {
+	dbClient    interfaces.DbClient
+	nftTransfer domain.NftTransfer
+}
+
+func (b *NftTransferBuilder) ReceiverAccountId(receiver int64) *NftTransferBuilder {
+	accountId := domain.MustDecodeEntityId(receiver)
+	b.nftTransfer.ReceiverAccountId = &accountId
+	return b
+}
+
+func (b *NftTransferBuilder) SenderAccountId(sender int64) *NftTransferBuilder {
+	accountId := domain.MustDecodeEntityId(sender)
+	b.nftTransfer.SenderAccountId = &accountId
+	return b
+}
+
+func (b *NftTransferBuilder) SerialNumber(serialNumber int64) *NftTransferBuilder {
+	b.nftTransfer.SerialNumber = serialNumber
+	return b
+}
+
+func (b *NftTransferBuilder) Timestamp(timestamp int64) *NftTransferBuilder {
+	b.nftTransfer.ConsensusTimestamp = timestamp
+	return b
+}
+
+func (b *NftTransferBuilder) TokenId(tokenId int64) *NftTransferBuilder {
+	b.nftTransfer.TokenId = domain.MustDecodeEntityId(tokenId)
+	return b
+}
+
+func (b *NftTransferBuilder) Persist() {
+	b.dbClient.GetDb().Create(&b.nftTransfer)
+}
+
+func NewNftTransferBuilder(dbClient interfaces.DbClient) *NftTransferBuilder {
+	return &NftTransferBuilder{
+		dbClient:    dbClient,
+		nftTransfer: domain.NftTransfer{PayerAccountId: defaultPayer},
+	}
+}

--- a/hedera-mirror-rosetta/test/domain/token_account_builder.go
+++ b/hedera-mirror-rosetta/test/domain/token_account_builder.go
@@ -1,0 +1,66 @@
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+package domain
+
+import (
+	"github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/app/interfaces"
+	"github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/app/persistence/domain"
+)
+
+type TokenAccountBuilder struct {
+	dbClient     interfaces.DbClient
+	tokenAccount domain.TokenAccount
+}
+
+func (b *TokenAccountBuilder) CreatedTimestamp(createdTimestamp int64) *TokenAccountBuilder {
+	b.tokenAccount.CreatedTimestamp = createdTimestamp
+	b.tokenAccount.ModifiedTimestamp = createdTimestamp
+	return b
+}
+
+func (b *TokenAccountBuilder) Associated(associated bool, modifiedTimestamp int64) *TokenAccountBuilder {
+	b.tokenAccount.Associated = associated
+	b.tokenAccount.ModifiedTimestamp = modifiedTimestamp
+	return b
+}
+
+func (b *TokenAccountBuilder) Persist() domain.TokenAccount {
+	b.dbClient.GetDb().Create(&b.tokenAccount)
+	return b.tokenAccount
+}
+
+func NewTokenAccountBuilder(dbClient interfaces.DbClient, accountId, tokenId, timestamp int64) *TokenAccountBuilder {
+	tokenAccount := domain.TokenAccount{
+		AccountId:         domain.MustDecodeEntityId(accountId),
+		Associated:        true,
+		CreatedTimestamp:  timestamp,
+		ModifiedTimestamp: timestamp,
+		TokenId:           domain.MustDecodeEntityId(tokenId),
+	}
+	return &TokenAccountBuilder{dbClient: dbClient, tokenAccount: tokenAccount}
+}
+
+func NewTokenAccountBuilderFromExisting(
+	dbClient interfaces.DbClient,
+	tokenAccount domain.TokenAccount,
+) *TokenAccountBuilder {
+	return &TokenAccountBuilder{dbClient: dbClient, tokenAccount: tokenAccount}
+}

--- a/hedera-mirror-rosetta/test/domain/token_builder.go
+++ b/hedera-mirror-rosetta/test/domain/token_builder.go
@@ -1,0 +1,82 @@
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+package domain
+
+import (
+	"fmt"
+
+	"github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/app/interfaces"
+	"github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/app/persistence/domain"
+)
+
+type TokenBuilder struct {
+	dbClient interfaces.DbClient
+	token    domain.Token
+}
+
+func (b *TokenBuilder) CreatedTimestamp(createdTimestamp int64) *TokenBuilder {
+	b.token.CreatedTimestamp = createdTimestamp
+	b.token.ModifiedTimestamp = createdTimestamp
+	return b
+}
+
+func (b *TokenBuilder) Decimals(decimals int64) *TokenBuilder {
+	b.token.Decimals = decimals
+	return b
+}
+
+func (b *TokenBuilder) InitialSupply(initialSupply int64) *TokenBuilder {
+	b.token.InitialSupply = initialSupply
+	return b
+}
+
+func (b *TokenBuilder) ModifiedTimestamp(modifiedTimestamp int64) *TokenBuilder {
+	b.token.ModifiedTimestamp = modifiedTimestamp
+	return b
+}
+
+func (b *TokenBuilder) Type(tokenType string) *TokenBuilder {
+	b.token.Type = tokenType
+	return b
+}
+
+func (b *TokenBuilder) Persist() domain.Token {
+	token := b.token
+	b.dbClient.GetDb().Create(&token)
+	return b.token
+}
+
+func NewTokenBuilder(dbClient interfaces.DbClient, tokenId, createdTimestamp, treasury int64) *TokenBuilder {
+	token := domain.Token{
+		CreatedTimestamp:  createdTimestamp,
+		ModifiedTimestamp: createdTimestamp,
+		Name:              fmt.Sprintf("%d_name", tokenId),
+		SupplyType:        domain.TokenSupplyTypeInfinite,
+		Symbol:            fmt.Sprintf("%d_symbol", tokenId),
+		TokenId:           domain.MustDecodeEntityId(tokenId),
+		TreasuryAccountId: domain.MustDecodeEntityId(treasury),
+		Type:              domain.TokenTypeFungibleCommon,
+	}
+	return &TokenBuilder{
+		dbClient: dbClient,
+		token:    token,
+	}
+}

--- a/hedera-mirror-rosetta/test/domain/token_transfer_builder.go
+++ b/hedera-mirror-rosetta/test/domain/token_transfer_builder.go
@@ -1,0 +1,62 @@
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+package domain
+
+import (
+	"github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/app/interfaces"
+	"github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/app/persistence/domain"
+)
+
+type TokenTransferBuilder struct {
+	dbClient      interfaces.DbClient
+	tokenTransfer domain.TokenTransfer
+}
+
+func (b *TokenTransferBuilder) AccountId(accountId int64) *TokenTransferBuilder {
+	b.tokenTransfer.AccountId = domain.MustDecodeEntityId(accountId)
+	return b
+}
+
+func (b *TokenTransferBuilder) Amount(amount int64) *TokenTransferBuilder {
+	b.tokenTransfer.Amount = amount
+	return b
+}
+
+func (b *TokenTransferBuilder) Timestamp(timestamp int64) *TokenTransferBuilder {
+	b.tokenTransfer.ConsensusTimestamp = timestamp
+	return b
+}
+
+func (b *TokenTransferBuilder) TokenId(tokenId int64) *TokenTransferBuilder {
+	b.tokenTransfer.TokenId = domain.MustDecodeEntityId(tokenId)
+	return b
+}
+
+func (b *TokenTransferBuilder) Persist() {
+	b.dbClient.GetDb().Create(&b.tokenTransfer)
+}
+
+func NewTokenTransferBuilder(dbClient interfaces.DbClient) *TokenTransferBuilder {
+	return &TokenTransferBuilder{
+		dbClient:      dbClient,
+		tokenTransfer: domain.TokenTransfer{PayerAccountId: defaultPayer},
+	}
+}

--- a/hedera-mirror-rosetta/test/domain/transaction_builder.go
+++ b/hedera-mirror-rosetta/test/domain/transaction_builder.go
@@ -1,0 +1,71 @@
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+package domain
+
+import (
+	"github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/app/interfaces"
+	"github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/app/persistence/domain"
+	"github.com/thanhpk/randstr"
+)
+
+type TransactionBuilder struct {
+	dbClient    interfaces.DbClient
+	transaction domain.Transaction
+}
+
+func (b *TransactionBuilder) ConsensusTimestamp(timestamp int64) *TransactionBuilder {
+	b.transaction.ConsensusTimestamp = timestamp
+	return b
+}
+
+func (b *TransactionBuilder) EntityId(encodedId int64) *TransactionBuilder {
+	entityId := domain.MustDecodeEntityId(encodedId)
+	b.transaction.EntityId = &entityId
+	return b
+}
+
+func (b *TransactionBuilder) Result(result int16) *TransactionBuilder {
+	b.transaction.Result = result
+	return b
+}
+
+func (b *TransactionBuilder) Type(txnType int16) *TransactionBuilder {
+	b.transaction.Type = txnType
+	return b
+}
+
+func (b *TransactionBuilder) Persist() domain.Transaction {
+	b.dbClient.GetDb().Create(&b.transaction)
+	return b.transaction
+}
+
+func NewTransactionBuilder(dbClient interfaces.DbClient, payer, validStartNs int64) *TransactionBuilder {
+	transaction := domain.Transaction{
+		ConsensusTimestamp:   validStartNs + 1,
+		PayerAccountId:       domain.MustDecodeEntityId(payer),
+		Result:               22,
+		TransactionHash:      randstr.Bytes(8),
+		Type:                 domain.TransactionTypeCryptoTransfer,
+		ValidDurationSeconds: 120,
+		ValidStartNs:         validStartNs,
+	}
+	return &TransactionBuilder{dbClient: dbClient, transaction: transaction}
+}

--- a/hedera-mirror-rosetta/test/mocks/account_repository.go
+++ b/hedera-mirror-rosetta/test/mocks/account_repository.go
@@ -25,7 +25,6 @@ import (
 
 	rTypes "github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/app/domain/types"
-	"github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/app/persistence/domain"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -41,13 +40,4 @@ func (m *MockAccountRepository) RetrieveBalanceAtBlock(ctx context.Context, acco
 ) {
 	args := m.Called()
 	return args.Get(0).([]types.Amount), args.Get(1).(*rTypes.Error)
-}
-
-func (m *MockAccountRepository) RetrieveEverOwnedTokensByBlock(
-	ctx context.Context,
-	accountId int64,
-	consensusEnd int64,
-) ([]domain.Token, *rTypes.Error) {
-	args := m.Called()
-	return args.Get(0).([]domain.Token), args.Get(1).(*rTypes.Error)
 }


### PR DESCRIPTION

**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR ports the workaround to `release/0.50`.

- Add workaround for the missing disappearing token transfer issue
- Improve nft balance tracking performance
- Only show token related data for tokens created after genesis timestmap
- Update rosetta-cli check:data configuration to sync from index 1
- Remove genesis token balance retrieval logic in get-genesis-balance.sh
- Update rosetta github workflow to not generate genesis balance JSON file
- Fix bug that importer start date can't be changed
- Enable supervisorctl
- Fix issue that the supervisord process doesn't get SIGTERM sent by docker stop
- Set stopwaitsecs for importer and postgres for graceful shutdown
- Update postgres config for normal operation

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
