### PR TITLE
Fix slow transactions by account ID REST API

### DIFF
--- a/hedera-mirror-rest/transactions.js
+++ b/hedera-mirror-rest/transactions.js
@@ -573,7 +573,7 @@ const getTransactions = async (req, res) => {
   }
 
   // Execute query
-  const {rows, sqlQuery} = await pool.queryQuietly(query.query, query.params);
+  const {rows, sqlQuery} = await pool.queryQuietly(query.query, query.params, constants.zeroRandomPageCostQueryHint);
   const transferList = createTransferLists(rows);
   const ret = {
     transactions: transferList.transactions,


### PR DESCRIPTION
**Description**:

Add a query hint to transactions REST API to set `random_page_cost` as `0`.

**Related issue(s)**:

Fixes #3208

**Notes for reviewer**:

If `random_page_cost` is different than `0`, the Postgres' query cost formula will make the query planner not use the index `crypto_transfer__entity_id_consensus_timestamp`, and this bad decision is leading to bad performance on the query for the route `/api/v1/transactions?account.id={account_id}`

The file [analyses.txt](https://github.com/hashgraph/hedera-mirror-node/files/8090694/analyses.txt) shows the query costs when there is a `random_page_cost` different than `0`.

The file  [analyses_with_0_page_cost.txt](https://github.com/hashgraph/hedera-mirror-node/files/8090693/analyses_with_0_page_cost.txt) shows the query costs when `random_page_cost` is equal to `0`.

It is possible to see that when `random_page_cost` is equal to `0` the query costs go down by about 5x.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
