### PR TITLE
Add a migration readiness probe

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/MigrationHealthIndicator.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/MigrationHealthIndicator.java
@@ -33,11 +33,14 @@ import org.springframework.boot.actuate.health.HealthIndicator;
 @RequiredArgsConstructor
 public class MigrationHealthIndicator extends BaseCallback implements HealthIndicator {
 
+    private static final Health DOWN = Health.down().build();
+    private static final Health UP = Health.up().build();
+
     private final AtomicBoolean complete = new AtomicBoolean(false);
 
     @Override
     public Health health() {
-        return complete.get() ? Health.up().build() : Health.down().build();
+        return complete.get() ? UP : DOWN;
     }
 
     @Override

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/MigrationHealthIndicator.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/MigrationHealthIndicator.java
@@ -1,0 +1,52 @@
+package com.hedera.mirror.importer.config;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.inject.Named;
+import lombok.RequiredArgsConstructor;
+import org.flywaydb.core.api.callback.BaseCallback;
+import org.flywaydb.core.api.callback.Context;
+import org.flywaydb.core.api.callback.Event;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+
+@Named
+@RequiredArgsConstructor
+public class MigrationHealthIndicator extends BaseCallback implements HealthIndicator {
+
+    private final AtomicBoolean complete = new AtomicBoolean(false);
+
+    @Override
+    public Health health() {
+        return complete.get() ? Health.up().build() : Health.down().build();
+    }
+
+    @Override
+    public void handle(Event event, Context context) {
+        complete.set(true);
+    }
+
+    @Override
+    public boolean supports(Event event, Context context) {
+        return event == Event.AFTER_MIGRATE;
+    }
+}

--- a/hedera-mirror-importer/src/main/resources/application.yml
+++ b/hedera-mirror-importer/src/main/resources/application.yml
@@ -48,7 +48,7 @@ management:
         liveness:
           include: ping
         readiness:
-          include: db, diskSpace, ping, redis, streamFileActivity
+          include: db, migration, ping, redis
 server:
   shutdown: graceful
 spring:

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/config/MigrationHealthIndicatorTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/config/MigrationHealthIndicatorTest.java
@@ -1,0 +1,57 @@
+package com.hedera.mirror.importer.config;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.flywaydb.core.api.callback.Event;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Status;
+
+class MigrationHealthIndicatorTest {
+
+    private final MigrationHealthIndicator migrationHealthIndicator = new MigrationHealthIndicator();
+
+    @Test
+    void healthDownWhenMigrationsRunning() {
+        assertThat(migrationHealthIndicator.health())
+                .isNotNull()
+                .extracting(Health::getStatus)
+                .isEqualTo(Status.DOWN);
+    }
+
+    @Test
+    void healthUpWhenMigrationsComplete() {
+        migrationHealthIndicator.handle(Event.AFTER_MIGRATE, null);
+        assertThat(migrationHealthIndicator.health())
+                .isNotNull()
+                .extracting(Health::getStatus)
+                .isEqualTo(Status.UP);
+    }
+
+    @Test
+    void supports() {
+        assertThat(migrationHealthIndicator.supports(null, null)).isFalse();
+        assertThat(migrationHealthIndicator.supports(Event.AFTER_BASELINE, null)).isFalse();
+        assertThat(migrationHealthIndicator.supports(Event.AFTER_MIGRATE, null)).isTrue();
+    }
+}


### PR DESCRIPTION
**Description**:
* Add a migration readiness probe that returns `UP` after all migrations completed
* Remove buggy `streamFileActivity` readiness probe
* Remove unnecessary `diskSpace` check since we no longer use the filesystem

**Related issue(s)**:

**Notes for reviewer**:
This will mark importer pods as unready until it completes its database migrations. Doing this will ensure Helm doesn't finish its release and run its tests before the migrations are completed.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
