### PR TITLE
Disable importer leader election

### DIFF
--- a/charts/hedera-mirror-importer/values.yaml
+++ b/charts/hedera-mirror-importer/values.yaml
@@ -458,9 +458,8 @@ terminationGracePeriodSeconds: 30
 
 tolerations: []
 
-# Will have more than one replica in production, so need a rolling update to ensure at least one pod is ready
 updateStrategy:
-  type: RollingUpdate
+  type: Recreate
 
 # Volumes to add to the container. The key is the volume name and the value is the volume mount definition. The same keys should also appear in volumes below.
 volumeMounts:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -78,6 +78,7 @@ value, it is recommended to only populate overridden properties in the custom `a
 | `hedera.mirror.importer.endDate`                                     | 2262-04-11T23:47:16.854775807Z | The end date (inclusive) of the data to import. Items after this date will be ignored. Format: YYYY-MM-ddTHH:mm:ss.nnnnnnnnnZ |
 | `hedera.mirror.importer.importHistoricalAccountInfo`                 | true                    | Import historical account information that occurred before the last stream reset. Skipped if `startDate` is unset or after 2019-09-14T00:00:10Z. |
 | `hedera.mirror.importer.initialAddressBook`                          | ""                      | The path to the bootstrap address book used to override the built-in address book              |
+| `hedera.mirror.importer.leaderElection`                              | false                   | Whether leader election should be used in Kubernetes environments to ensure only one replica processes data at a time |
 | `hedera.mirror.importer.network`                                     | DEMO                    | Which Hedera network to use. Can be either `DEMO`, `MAINNET`, `TESTNET`, `PREVIEWNET` or `OTHER` |
 | `hedera.mirror.importer.parser.balance.batchSize`                    | 200000                  | The number of balances to store in memory before saving to the database                        |
 | `hedera.mirror.importer.parser.balance.enabled`                      | true                    | Whether to enable balance file parsing                                                         |
@@ -276,9 +277,9 @@ Name                                                            | Default | Desc
 `hedera.mirror.monitor.subscribe.grpc.<name>.duration`          |         | How long to stay subscribed to the API
 `hedera.mirror.monitor.subscribe.grpc.<name>.enabled`           | true    | Whether this subscribe scenario is enabled
 `hedera.mirror.monitor.subscribe.grpc.<name>.limit`             | 0       | How many transactions to receive before halting. 0 for unlimited
-`hedera.mirror.monitor.subscribe.grpc.<name>.retry.maxAttempts` | 16      | How many consecutive retry attempts before giving up connecting to the API
+`hedera.mirror.monitor.subscribe.grpc.<name>.retry.maxAttempts` | 2^63 - 1 | How many consecutive retry attempts before giving up connecting to the API
 `hedera.mirror.monitor.subscribe.grpc.<name>.retry.maxBackoff`  | 8s      | The maximum amount of time to wait between retry attempts
-`hedera.mirror.monitor.subscribe.grpc.<name>.retry.minBackoff`  | 250ms   | The initial amount of time to wait between retry attempts
+`hedera.mirror.monitor.subscribe.grpc.<name>.retry.minBackoff`  | 500ms   | The initial amount of time to wait between retry attempts
 `hedera.mirror.monitor.subscribe.grpc.<name>.startTime`         |         | The start time passed to the gRPC API. Defaults to current time if not set
 `hedera.mirror.monitor.subscribe.grpc.<name>.subscribers`       | 1       | How many concurrent subscribers should be instantiated for this scenario
 `hedera.mirror.monitor.subscribe.grpc.<name>.topicId`           |         | Which topic to subscribe to
@@ -288,8 +289,8 @@ Name                                                            | Default | Desc
 `hedera.mirror.monitor.subscribe.rest.<name>.limit`             | 0       | How many transactions to receive before halting. 0 for unlimited
 `hedera.mirror.monitor.subscribe.rest.<name>.publishers`        | []      | A list of publisher scenario names to consider for sampling
 `hedera.mirror.monitor.subscribe.rest.<name>.retry.maxAttempts` | 16      | How many consecutive retry attempts before giving up connecting to the API
-`hedera.mirror.monitor.subscribe.rest.<name>.retry.maxBackoff`  | 8s      | The maximum amount of time to wait between retry attempts
-`hedera.mirror.monitor.subscribe.rest.<name>.retry.minBackoff`  | 250ms   | The initial amount of time to wait between retry attempts
+`hedera.mirror.monitor.subscribe.rest.<name>.retry.maxBackoff`  | 1s      | The maximum amount of time to wait between retry attempts
+`hedera.mirror.monitor.subscribe.rest.<name>.retry.minBackoff`  | 500ms   | The initial amount of time to wait between retry attempts
 `hedera.mirror.monitor.subscribe.rest.<name>.samplePercent`     | 1.0     | The percentage of transactions to verify against the API. Accepts values between 0-1
 `hedera.mirror.monitor.subscribe.rest.<name>.timeout`           | 5s      | Maximum amount of time to wait for a API call to retrieve data
 `hedera.mirror.monitor.subscribe.statusFrequency`               | 10s     | How often to log subscription statistics

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/MirrorProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/MirrorProperties.java
@@ -43,12 +43,14 @@ public class MirrorProperties {
     @NotNull
     private Path dataPath = Paths.get(".", "data");
 
+    @NotNull
+    private Instant endDate = Utility.MAX_INSTANT_LONG;
+
     private boolean importHistoricalAccountInfo = true;
 
     private Path initialAddressBook;
 
-    @NotNull
-    private Instant verifyHashAfter = Instant.EPOCH;
+    private boolean leaderElection = false;
 
     @NotNull
     private HederaNetwork network = HederaNetwork.DEMO;
@@ -56,27 +58,30 @@ public class MirrorProperties {
     @Min(0)
     private long shard = 0L;
 
-    private Long topicRunningHashV2AddedTimestamp;
-
     private Instant startDate;
 
     @DurationMin(seconds = 0L)
     @NotNull
     private Duration startDateAdjustment = Duration.ofSeconds(30L);
 
+    private Long topicRunningHashV2AddedTimestamp;
+
     @NotNull
-    private Instant endDate = Utility.MAX_INSTANT_LONG;
+    private Instant verifyHashAfter = Instant.EPOCH;
 
     @Getter
     @RequiredArgsConstructor
     public enum HederaNetwork {
-        DEMO("hedera-demo-streams", true),
-        MAINNET("hedera-mainnet-streams", false),
-        TESTNET("hedera-stable-testnet-streams-2020-08-27", false),
-        PREVIEWNET("hedera-preview-testnet-streams", false),
-        OTHER("", false); // Pre-prod or ad hoc environments
+        DEMO("hedera-demo-streams"),
+        MAINNET("hedera-mainnet-streams"),
+        PREVIEWNET("hedera-preview-testnet-streams"),
+        OTHER(""), // Pre-prod or ad hoc environments
+        TESTNET("hedera-stable-testnet-streams-2020-08-27");
 
         private final String bucketName;
-        private final Boolean allowAnonymousAccess;
+
+        public boolean isAllowAnonymousAccess() {
+            return this == DEMO;
+        }
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/CommonDownloaderProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/CommonDownloaderProperties.java
@@ -41,20 +41,20 @@ public class CommonDownloaderProperties {
 
     private String accessKey;
 
+    private Boolean allowAnonymousAccess;
+
     private String bucketName;
 
-    public String getBucketName() {
-        return StringUtils.isNotBlank(bucketName) ? bucketName : mirrorProperties.getNetwork().getBucketName();
-    }
+    @NotNull
+    private CloudProvider cloudProvider = CloudProvider.S3;
 
     @Max(1)
     @Min(0)
     private float consensusRatio = (float) 1 / 3;
 
-    @NotNull
-    private CloudProvider cloudProvider = CloudProvider.S3;
-
     private String endpointOverride;
+
+    private String gcpProjectId;
 
     @Min(0)
     private int maxConcurrency = 1000; // aws sdk default = 50
@@ -63,21 +63,22 @@ public class CommonDownloaderProperties {
 
     private String secretKey;
 
-    private String gcpProjectId;
+    public String getBucketName() {
+        return StringUtils.isNotBlank(bucketName) ? bucketName : mirrorProperties.getNetwork().getBucketName();
+    }
 
-    private Boolean allowAnonymousAccess;
-
+    /*
+     * If the cloud provider is GCP, it must use the static provider.  If the static credentials are both present,
+     * force the mirror node to use the static provider.
+     */
     public boolean isStaticCredentials() {
-        //If the cloud provider is GCP, it must use the static provider.  If the static credentials are both present,
-        //force the mirror node to use the static provider.
         return cloudProvider == CommonDownloaderProperties.CloudProvider.GCP ||
-                (StringUtils.isNotBlank(accessKey) && StringUtils
-                        .isNotBlank(secretKey));
+                (StringUtils.isNotBlank(accessKey) && StringUtils.isNotBlank(secretKey));
     }
 
     public boolean isAnonymousCredentials() {
         return allowAnonymousAccess != null ? allowAnonymousAccess : mirrorProperties.getNetwork()
-                .getAllowAnonymousAccess();
+                .isAllowAnonymousAccess();
     }
 
     @Getter

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/ScenarioProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/ScenarioProperties.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.monitor;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -53,10 +53,10 @@ public abstract class ScenarioProperties {
 
         @NotNull
         @DurationMin(millis = 500L)
-        private Duration maxBackoff = Duration.ofSeconds(8L);
+        private Duration maxBackoff = Duration.ofSeconds(1L);
 
         @NotNull
         @DurationMin(millis = 100L)
-        private Duration minBackoff = Duration.ofMillis(250L);
+        private Duration minBackoff = Duration.ofMillis(500L);
     }
 }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/grpc/GrpcSubscriber.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/grpc/GrpcSubscriber.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.monitor.subscribe.grpc;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -81,12 +81,12 @@ class GrpcSubscriber implements MirrorSubscriber {
         AbstractSubscriberProperties.RetryProperties retry = subscriberProperties.getRetry();
 
         return Flux.defer(() -> grpcClient.subscribe(subscription))
-                .doOnError(t -> log.error("Error subscribing {}: ", subscription, t))
                 .retryWhen(Retry.backoff(retry.getMaxAttempts(), retry.getMinBackoff())
                         .maxBackoff(retry.getMaxBackoff())
                         .filter(this::shouldRetry)
                         .doBeforeRetry(r -> log.warn("Retry attempt #{} after failure: {}",
                                 r.totalRetries() + 1, StringUtils.substringBefore(r.failure().getMessage(), "\n"))))
+                .doOnError(t -> log.error("Error subscribing {}: ", subscription, t))
                 .doOnSubscribe(s -> log.info("Starting subscriber {}: {}", subscription, subscriberProperties));
     }
 

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/grpc/GrpcSubscriberProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/grpc/GrpcSubscriberProperties.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.monitor.subscribe.grpc;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,6 +20,7 @@ package com.hedera.mirror.monitor.subscribe.grpc;
  * ‍
  */
 
+import java.time.Duration;
 import java.time.Instant;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
@@ -37,6 +38,11 @@ public class GrpcSubscriberProperties extends AbstractSubscriberProperties {
 
     @NotBlank
     private String topicId;
+
+    public GrpcSubscriberProperties() {
+        retry.setMaxAttempts(Long.MAX_VALUE); // gRPC subscription only occurs once so retry indefinitely
+        retry.setMaxBackoff(Duration.ofSeconds(8L));
+    }
 
     public Instant getEndTime() {
         return startTime.plus(duration);

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/rest/RestSubscription.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/rest/RestSubscription.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.monitor.subscribe.rest;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -47,10 +47,11 @@ class RestSubscription extends AbstractScenario<RestSubscriberProperties, Mirror
 
     @Override
     public void onError(Throwable t) {
-        log.warn("Error subscribing to REST API: {}", t.getMessage());
+        String message = t.getMessage();
 
         if (Exceptions.isRetryExhausted(t) && t.getCause() != null) {
             t = t.getCause();
+            message += " " + t.getMessage();
         }
 
         String error = t.getClass().getSimpleName();
@@ -59,6 +60,7 @@ class RestSubscription extends AbstractScenario<RestSubscriberProperties, Mirror
             error = String.valueOf(((WebClientResponseException) t).getStatusCode().value());
         }
 
+        log.warn("Subscription {} failed: {}", this, message);
         errors.add(error);
     }
 

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/grpc/GrpcSubscriberTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/grpc/GrpcSubscriberTest.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.monitor.subscribe.grpc;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -160,7 +160,7 @@ class GrpcSubscriberTest {
     @Test
     void retriesExhausted() {
         grpcSubscriberProperties.getRetry().setMaxAttempts(2);
-        when(grpcClient.subscribe(any())).thenReturn(Flux.error(new IllegalStateException()));
+        when(grpcClient.subscribe(any())).thenReturn(Flux.error(new IllegalStateException("failure")));
         grpcSubscriber.subscribe()
                 .as(StepVerifier::create)
                 .expectNextCount(0L)


### PR DESCRIPTION
**Description**:
* Fix importer rolling update allowing multiple pods to be running during upgrades
* Fix monitor gRPC subscription from giving up before server recovers
* Fix monitor gRPC retries always printing stack trace
* Fix monitor REST failure not printing scenario or underlying cause
* Fix monitor REST retries backing up and causing thread exhaustion
* Workaround broken leader election by disabling it by default

**Related issue(s)**:

**Notes for reviewer**:
Tested a custom image in integration k8s.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
