### PR TITLE
Fix rosetta all-in-one docker image to conform to rosetta storage location requirement

### DIFF
--- a/docs/rosetta/README.md
+++ b/docs/rosetta/README.md
@@ -84,12 +84,15 @@ Configure and run the server in online mode:
    the [backup](/docs/database.md#backup) section of the database upgrade documentation. The container database should
    be empty otherwise the restore process will be skipped.
 
-5. Run the server from the all-in-one docker image with the appropriate `NETWORK` specified:
+5. To use custom passwords for the database owner (used by importer) and the rosetta user (used by rosetta server), set
+   env variables `OWNER_PASSWORD` and `ROSETTA_PASSWORD` accordingly.
+
+6. Run the server from the all-in-one docker image with the appropriate `NETWORK` specified:
 
 ```shell
 docker run -d -e MODE=online -e NETWORK=testnet \
--v ${PWD}/application.yml:/app/importer/application.yml \
--p 5432:5432 -p 5700:5700 hedera-mirror-rosetta:0.49.1
+  -v ${PWD}/application.yml:/app/importer/application.yml \
+  -p 5432:5432 -p 5700:5700 hedera-mirror-rosetta:0.49.1
 ```
 
 The server should be reachable at http://localhost:5700. Note the server can also run in offline mode by

--- a/hedera-mirror-rosetta/build/Dockerfile
+++ b/hedera-mirror-rosetta/build/Dockerfile
@@ -43,9 +43,13 @@ COPY --from=builder /app /app
 RUN useradd -s /bin/bash importer && useradd -s /bin/bash rosetta
 
 ENV PATH="/usr/lib/postgresql/${PG_VERSION}/bin:${PATH}"
-ENV PGCONF="/data/conf"
-ENV PGDATA="/data/data"
+ENV PGDATA="/data"
+ENV PGCONF=${PGDATA}
 RUN rm -fr /etc/postgresql/${PG_VERSION}/main
+VOLUMN /data
+
+# Set stats_temp_directory to the default with is "pg_stat_tmp" relative to the postgresql.conf file
+RUN sed -i 's/^stats_temp_directory/#stats_temp_directory/g' /etc/postgresql-common/createcluster.conf
 
 USER root
 WORKDIR /app

--- a/hedera-mirror-rosetta/build/Dockerfile
+++ b/hedera-mirror-rosetta/build/Dockerfile
@@ -27,7 +27,7 @@ FROM ubuntu:20.04 as runner
 # Add the PostgreSQL PGP key to verify their Debian packages.
 # It should be the same key as https://www.postgresql.org/media/keys/ACCC4CF8.asc
 ARG DEBIAN_FRONTEND=noninteractive
-ENV PG_VERSION=13
+ENV PG_VERSION=14
 RUN apt-get update \
     && apt-get install -y ca-certificates curl gnupg lsb-release \
     && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8 \
@@ -41,21 +41,12 @@ COPY --from=builder /app /app
 RUN useradd -s /bin/bash importer && useradd -s /bin/bash rosetta
 
 ENV PATH="/usr/lib/postgresql/${PG_VERSION}/bin:${PATH}"
-ENV PGCONF="/var/lib/postgresql/${PG_VERSION}/main"
+ENV PGCONF="/data"
 ENV PGDATA=${PGCONF}
-
-USER postgres
-RUN cp -r /etc/postgresql/${PG_VERSION}/main/* ${PGCONF} \
-    && rm -fr /etc/postgresql/${PG_VERSION}/main \
-    && ln -s ${PGCONF} /etc/postgresql/${PG_VERSION}/main \
-    && cp /app/pg_hba.conf ${PGCONF}/ \
-    && cp /app/postgresql.conf ${PGCONF}/conf.d
-# Init db script
-RUN /etc/init.d/postgresql start && /app/scripts/init.sh && /etc/init.d/postgresql stop
 
 USER root
 WORKDIR /app
 
 # Expose the ports (DB)(Rosetta)
 EXPOSE 5432 5700
-ENTRYPOINT [ "./run_supervisord.sh" ]
+ENTRYPOINT [ "./entrypoint.sh" ]

--- a/hedera-mirror-rosetta/build/Dockerfile
+++ b/hedera-mirror-rosetta/build/Dockerfile
@@ -24,7 +24,7 @@ RUN mkdir importer rosetta scripts \
 
 FROM ubuntu:20.04 as runner
 
-# ---------------------- Install Deps & PosgreSQL ------------------------ #
+# ---------------------- Install Deps & PostgreSQL ------------------------ #
 # Add the PostgreSQL PGP key to verify their Debian packages.
 # It should be the same key as https://www.postgresql.org/media/keys/ACCC4CF8.asc
 ARG DEBIAN_FRONTEND=noninteractive
@@ -46,9 +46,9 @@ ENV PATH="/usr/lib/postgresql/${PG_VERSION}/bin:${PATH}"
 ENV PGDATA="/data"
 ENV PGCONF=${PGDATA}
 RUN rm -fr /etc/postgresql/${PG_VERSION}/main
-VOLUMN /data
+VOLUME /data
 
-# Set stats_temp_directory to the default with is "pg_stat_tmp" relative to the postgresql.conf file
+# Set stats_temp_directory to the default, i.e., "pg_stat_tmp" relative to the postgresql.conf file
 RUN sed -i 's/^stats_temp_directory/#stats_temp_directory/g' /etc/postgresql-common/createcluster.conf
 
 USER root

--- a/hedera-mirror-rosetta/build/Dockerfile
+++ b/hedera-mirror-rosetta/build/Dockerfile
@@ -44,8 +44,7 @@ RUN useradd -s /bin/bash importer && useradd -s /bin/bash rosetta
 
 ENV PATH="/usr/lib/postgresql/${PG_VERSION}/bin:${PATH}"
 ENV PGDATA="/data"
-ENV PGCONF=$PGDATA
-RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 700 "$PGDATA"
+ENV PGCONF=${PGDATA}
 RUN rm -fr /etc/postgresql/${PG_VERSION}/main
 VOLUME /data
 

--- a/hedera-mirror-rosetta/build/Dockerfile
+++ b/hedera-mirror-rosetta/build/Dockerfile
@@ -44,7 +44,8 @@ RUN useradd -s /bin/bash importer && useradd -s /bin/bash rosetta
 
 ENV PATH="/usr/lib/postgresql/${PG_VERSION}/bin:${PATH}"
 ENV PGDATA="/data"
-ENV PGCONF=${PGDATA}
+ENV PGCONF=$PGDATA
+RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 700 "$PGDATA"
 RUN rm -fr /etc/postgresql/${PG_VERSION}/main
 VOLUME /data
 

--- a/hedera-mirror-rosetta/build/Dockerfile
+++ b/hedera-mirror-rosetta/build/Dockerfile
@@ -7,7 +7,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 # GIT_REF can be a branch or a tag
 ARG GIT_REF=main
 RUN apt-get update && apt-get install -y gcc git openjdk-11-jdk-headless
-RUN git clone -b ${GIT_REF} --depth 1 https://github.com/hashgraph/hedera-mirror-node
+# RUN git clone -b ${GIT_REF} --depth 1 https://github.com/hashgraph/hedera-mirror-node
+RUN git clone -b ${GIT_REF} --depth 1 https://github.com/xin-hedera/hedera-mirror-node
 WORKDIR /hedera-mirror-node
 RUN ./mvnw clean package -DskipTests -pl hedera-mirror-importer,hedera-mirror-rosetta
 WORKDIR /app
@@ -27,6 +28,7 @@ FROM ubuntu:20.04 as runner
 # Add the PostgreSQL PGP key to verify their Debian packages.
 # It should be the same key as https://www.postgresql.org/media/keys/ACCC4CF8.asc
 ARG DEBIAN_FRONTEND=noninteractive
+ENV PG_CLUSTER_NAME=rosetta
 ENV PG_VERSION=14
 RUN apt-get update \
     && apt-get install -y ca-certificates curl gnupg lsb-release \
@@ -41,8 +43,9 @@ COPY --from=builder /app /app
 RUN useradd -s /bin/bash importer && useradd -s /bin/bash rosetta
 
 ENV PATH="/usr/lib/postgresql/${PG_VERSION}/bin:${PATH}"
-ENV PGCONF="/data"
-ENV PGDATA=${PGCONF}
+ENV PGCONF="/data/conf"
+ENV PGDATA="/data/data"
+RUN rm -fr /etc/postgresql/${PG_VERSION}/main
 
 USER root
 WORKDIR /app

--- a/hedera-mirror-rosetta/build/entrypoint.sh
+++ b/hedera-mirror-rosetta/build/entrypoint.sh
@@ -31,6 +31,7 @@ function init_db() {
   fi
 
   echo "Creating cluster '${PG_CLUSTER_NAME}' with data dir '${PGDATA}'"
+  mkdir -p "${PGDATA}" && chown -R postgres:postgres "${PGDATA}"
   su postgres -c "pg_createcluster -d ${PGDATA} --start-conf auto ${PG_VERSION} ${PG_CLUSTER_NAME}"
   # mv conf to $PGDATA and link it
   cp -pr ${PG_CLUSTER_CONF}/* ${PGDATA}

--- a/hedera-mirror-rosetta/build/entrypoint.sh
+++ b/hedera-mirror-rosetta/build/entrypoint.sh
@@ -30,7 +30,7 @@ function init_db() {
     return
   fi
 
-  echo "Creating cluster '${PG_CLUSTER_NAME}' with config dir '${PGCONF}' and data dir '${PGDATA}'"
+  echo "Creating cluster '${PG_CLUSTER_NAME}' with data dir '${PGDATA}'"
   mkdir -p "${PGDATA}" && chown -R postgres:postgres "${PGDATA}"
   su postgres -c "pg_createcluster -d ${PGDATA} --start-conf auto ${PG_VERSION} ${PG_CLUSTER_NAME}"
   # mv conf to $PGDATA and link it

--- a/hedera-mirror-rosetta/build/entrypoint.sh
+++ b/hedera-mirror-rosetta/build/entrypoint.sh
@@ -25,19 +25,19 @@ function init_db() {
   PG_CLUSTER_CONF=/etc/postgresql/${PG_VERSION}/${PG_CLUSTER_NAME}
   if [[ -f "${PGDATA}/PG_VERSION" ]]; then
     # relink the config dir just in case it's a newly created container with existing mapped /data dir
-    ln -sf ${PGCONF} ${PG_CLUSTER_CONF}
+    ln -sTf ${PGDATA} ${PG_CLUSTER_CONF}
     echo "Database is already initialzed"
     return
   fi
 
   echo "Creating cluster '${PG_CLUSTER_NAME}' with config dir '${PGCONF}' and data dir '${PGDATA}'"
-  mkdir -p "${PGCONF}" "${PGDATA}" && chown -R postgres:postgres "${PGCONF}" "${PGDATA}"
+  mkdir -p "${PGDATA}" && chown -R postgres:postgres "${PGDATA}"
   su postgres -c "pg_createcluster -d ${PGDATA} --start-conf auto ${PG_VERSION} ${PG_CLUSTER_NAME}"
-  # mv conf to $PGCONF and link it
-  cp -pr ${PG_CLUSTER_CONF}/* ${PGCONF} && \
+  # mv conf to $PGDATA and link it
+  cp -pr ${PG_CLUSTER_CONF}/* ${PGDATA} && \
     rm -fr ${PG_CLUSTER_CONF} && \
-    ln -s ${PGCONF} ${PG_CLUSTER_CONF}
-  su postgres -c 'cp /app/pg_hba.conf ${PGCONF} && cp /app/postgresql.conf ${PGCONF}/conf.d'
+    ln -s ${PGDATA} ${PG_CLUSTER_CONF}
+  su postgres -c 'cp /app/pg_hba.conf ${PGDATA} && cp /app/postgresql.conf ${PGDATA}/conf.d'
 
   /etc/init.d/postgresql start && \
     su postgres -c 'PATH=/usr/lib/postgresql/${PG_VERSION}/bin:${PATH} /app/scripts/init.sh' && \

--- a/hedera-mirror-rosetta/build/entrypoint.sh
+++ b/hedera-mirror-rosetta/build/entrypoint.sh
@@ -21,16 +21,19 @@ function cleanup() {
 
 function init_db() {
   echo "Initializing database"
+
+  PG_CLUSTER_CONF=/etc/postgresql/${PG_VERSION}/${PG_CLUSTER_NAME}
   if [[ -f "${PGDATA}/PG_VERSION" ]]; then
+    # relink the config dir just in case it's a newly created container with existing mapped /data dir
+    ln -sf ${PGCONF} ${PG_CLUSTER_CONF}
     echo "Database is already initialzed"
     return
   fi
 
-  echo "Creating cluster '${PG_CLUSTER_NAME}' with data directory '${PGDATA}'"
+  echo "Creating cluster '${PG_CLUSTER_NAME}' with config dir '${PGCONF}' and data dir '${PGDATA}'"
   mkdir -p "${PGCONF}" "${PGDATA}" && chown -R postgres:postgres "${PGCONF}" "${PGDATA}"
   su postgres -c "pg_createcluster -d ${PGDATA} --start-conf auto ${PG_VERSION} ${PG_CLUSTER_NAME}"
   # mv conf to $PGCONF and link it
-  PG_CLUSTER_CONF=/etc/postgresql/${PG_VERSION}/${PG_CLUSTER_NAME}
   cp -pr ${PG_CLUSTER_CONF}/* ${PGCONF} && \
     rm -fr ${PG_CLUSTER_CONF} && \
     ln -s ${PGCONF} ${PG_CLUSTER_CONF}

--- a/hedera-mirror-rosetta/build/entrypoint.sh
+++ b/hedera-mirror-rosetta/build/entrypoint.sh
@@ -31,17 +31,16 @@ function init_db() {
   fi
 
   echo "Creating cluster '${PG_CLUSTER_NAME}' with data dir '${PGDATA}'"
-  mkdir -p "${PGDATA}" && chown -R postgres:postgres "${PGDATA}"
   su postgres -c "pg_createcluster -d ${PGDATA} --start-conf auto ${PG_VERSION} ${PG_CLUSTER_NAME}"
   # mv conf to $PGDATA and link it
-  cp -pr ${PG_CLUSTER_CONF}/* ${PGDATA} && \
-    rm -fr ${PG_CLUSTER_CONF} && \
-    ln -s ${PGDATA} ${PG_CLUSTER_CONF}
+  cp -pr ${PG_CLUSTER_CONF}/* ${PGDATA}
+  rm -fr ${PG_CLUSTER_CONF}
+  ln -s ${PGDATA} ${PG_CLUSTER_CONF}
   su postgres -c 'cp /app/pg_hba.conf ${PGDATA} && cp /app/postgresql.conf ${PGDATA}/conf.d'
 
-  /etc/init.d/postgresql start && \
-    su postgres -c 'PATH=/usr/lib/postgresql/${PG_VERSION}/bin:${PATH} /app/scripts/init.sh' && \
-    /etc/init.d/postgresql stop
+  /etc/init.d/postgresql start
+  su postgres -c 'PATH=/usr/lib/postgresql/${PG_VERSION}/bin:${PATH} /app/scripts/init.sh'
+  /etc/init.d/postgresql stop
 
   echo "Initialized database"
 }

--- a/hedera-mirror-rosetta/build/postgresql-restore.conf
+++ b/hedera-mirror-rosetta/build/postgresql-restore.conf
@@ -1,5 +1,6 @@
 checkpoint_timeout = 30min
 listen_addresses = '*'
+log_checkpoints = on
 maintenance_work_mem = 2GB
 max_parallel_maintenance_workers = 4
 max_wal_size = 512GB

--- a/hedera-mirror-rosetta/build/supervisord.conf
+++ b/hedera-mirror-rosetta/build/supervisord.conf
@@ -24,7 +24,7 @@ redirect_stderr=true
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 stopsignal=INT
-stopwaitsecs=10
+stopwaitsecs=30
 priority=1
 
 [program:importer]

--- a/hedera-mirror-rosetta/build/supervisord.conf
+++ b/hedera-mirror-rosetta/build/supervisord.conf
@@ -17,7 +17,7 @@ serverurl=unix:///tmp/supervisor.sock
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 [program:postgres]
-command=postgres
+command=postgres -D %(ENV_PGDATA)s -c config_file=%(ENV_PGCONF)s/postgresql.conf
 user=postgres
 autorestart=true
 redirect_stderr=true

--- a/hedera-mirror-rosetta/build/supervisord.conf
+++ b/hedera-mirror-rosetta/build/supervisord.conf
@@ -25,7 +25,7 @@ stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 stopsignal=INT
 stopwaitsecs=30
-priority=1
+priority=10
 
 [program:importer]
 command=java -Xms512m -Xmx4g -XX:+CrashOnOutOfMemoryError -DLog4jContextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector -jar /app/importer/hedera-mirror-importer.jar --spring.config.additional-location=file:/app/importer/

--- a/hedera-mirror-rosetta/build/supervisord.conf
+++ b/hedera-mirror-rosetta/build/supervisord.conf
@@ -17,13 +17,14 @@ serverurl=unix:///tmp/supervisor.sock
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 [program:postgres]
-command=postgres -D %(ENV_PGDATA)s -c config_file=%(ENV_PGCONF)s/postgresql.conf
+command=postgres
 user=postgres
 autorestart=true
 redirect_stderr=true
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
-stopwaitsecs=100
+stopsignal=INT
+stopwaitsecs=10
 priority=1
 
 [program:importer]
@@ -33,7 +34,7 @@ autorestart=true
 redirect_stderr=true
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
-stopwaitsecs=90
+stopwaitsecs=60
 priority=10
 environment=HEDERA_MIRROR_IMPORTER_PARSER_RECORD_ENTITY_PERSIST_NONFEETRANSFERS=true,HEDERA_MIRROR_IMPORTER_PARSER_RECORD_ENTITY_PERSIST_TOPICS=false,HEDERA_MIRROR_IMPORTER_PARSER_RECORD_ENTITY_REDIS_ENABLED=false
 

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <grpc-spring-boot.version>2.11.0.RELEASE</grpc-spring-boot.version>
         <grpc.version>1.44.0</grpc.version>
         <guava.version>31.0.1-jre</guava.version>
-        <hedera-protobuf.version>0.23.0-alpha.2</hedera-protobuf.version>
+        <hedera-protobuf.version>0.23.1</hedera-protobuf.version>
         <hibernate-types.version>2.14.0</hibernate-types.version>
         <jacoco.version>0.8.7</jacoco.version>
         <java.version>11</java.version>


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
Rosetta spec requires that all persistent data must be written to the `/data` directory. This PR updates the all-in-one image related files to conform to the requirement

- move postgres initialization to `entrypoint.sh`
- move both postgres data and conf files to `/data`
- allow customizing `OWNER_PASSWORD` and `ROSETTA_PASSWORD`
- change postgres stop signal to SIGINT for fast shutdown
- upgrade to pg14

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

rosetta standard storage location reqirement:

https://www.rosetta-api.org/docs/standard_storage_location.html#easy-single-volume-mounting

This PR is for review only. Will port it over so can merge to main. I need to work on `release/0.50` since it's the version being tested.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
