### PR TITLE
Fix rosetta all-in-one docker image persistent data location

### DIFF
--- a/docs/rosetta/README.md
+++ b/docs/rosetta/README.md
@@ -84,12 +84,15 @@ Configure and run the server in online mode:
    the [backup](/docs/database.md#backup) section of the database upgrade documentation. The container database should
    be empty otherwise the restore process will be skipped.
 
-5. Run the server from the all-in-one docker image with the appropriate `NETWORK` specified:
+5. To use custom passwords for the database owner (used by importer) and the rosetta user (used by rosetta server), set
+   env variables `OWNER_PASSWORD` and `ROSETTA_PASSWORD` accordingly.
+
+6. Run the server from the all-in-one docker image with the appropriate `NETWORK` specified:
 
 ```shell
 docker run -d -e MODE=online -e NETWORK=testnet \
--v ${PWD}/application.yml:/app/importer/application.yml \
--p 5432:5432 -p 5700:5700 hedera-mirror-rosetta:0.49.1
+  -v ${PWD}/application.yml:/app/importer/application.yml \
+  -p 5432:5432 -p 5700:5700 hedera-mirror-rosetta:0.49.1
 ```
 
 The server should be reachable at http://localhost:5700. Note the server can also run in offline mode by

--- a/hedera-mirror-rosetta/build/Dockerfile
+++ b/hedera-mirror-rosetta/build/Dockerfile
@@ -7,8 +7,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 # GIT_REF can be a branch or a tag
 ARG GIT_REF=main
 RUN apt-get update && apt-get install -y gcc git openjdk-11-jdk-headless
-# RUN git clone -b ${GIT_REF} --depth 1 https://github.com/hashgraph/hedera-mirror-node
-RUN git clone -b ${GIT_REF} --depth 1 https://github.com/xin-hedera/hedera-mirror-node
+RUN git clone -b ${GIT_REF} --depth 1 https://github.com/hashgraph/hedera-mirror-node
 WORKDIR /hedera-mirror-node
 RUN ./mvnw clean package -DskipTests -pl hedera-mirror-importer,hedera-mirror-rosetta
 WORKDIR /app

--- a/hedera-mirror-rosetta/build/Dockerfile
+++ b/hedera-mirror-rosetta/build/Dockerfile
@@ -7,7 +7,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 # GIT_REF can be a branch or a tag
 ARG GIT_REF=main
 RUN apt-get update && apt-get install -y gcc git openjdk-11-jdk-headless
-RUN git clone -b ${GIT_REF} --depth 1 https://github.com/hashgraph/hedera-mirror-node
+# RUN git clone -b ${GIT_REF} --depth 1 https://github.com/hashgraph/hedera-mirror-node
+RUN git clone -b ${GIT_REF} --depth 1 https://github.com/xin-hedera/hedera-mirror-node
 WORKDIR /hedera-mirror-node
 RUN ./mvnw clean package -DskipTests -pl hedera-mirror-importer,hedera-mirror-rosetta
 WORKDIR /app
@@ -23,11 +24,12 @@ RUN mkdir importer rosetta scripts \
 
 FROM ubuntu:20.04 as runner
 
-# ---------------------- Install Deps & PosgreSQL ------------------------ #
+# ---------------------- Install Deps & PostgreSQL ------------------------ #
 # Add the PostgreSQL PGP key to verify their Debian packages.
 # It should be the same key as https://www.postgresql.org/media/keys/ACCC4CF8.asc
 ARG DEBIAN_FRONTEND=noninteractive
-ENV PG_VERSION=13
+ENV PG_CLUSTER_NAME=rosetta
+ENV PG_VERSION=14
 RUN apt-get update \
     && apt-get install -y ca-certificates curl gnupg lsb-release \
     && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8 \
@@ -41,21 +43,17 @@ COPY --from=builder /app /app
 RUN useradd -s /bin/bash importer && useradd -s /bin/bash rosetta
 
 ENV PATH="/usr/lib/postgresql/${PG_VERSION}/bin:${PATH}"
-ENV PGCONF="/var/lib/postgresql/${PG_VERSION}/main"
-ENV PGDATA=${PGCONF}
+ENV PGDATA="/data"
+ENV PGCONF=${PGDATA}
+RUN rm -fr /etc/postgresql/${PG_VERSION}/main
+VOLUME /data
 
-USER postgres
-RUN cp -r /etc/postgresql/${PG_VERSION}/main/* ${PGCONF} \
-    && rm -fr /etc/postgresql/${PG_VERSION}/main \
-    && ln -s ${PGCONF} /etc/postgresql/${PG_VERSION}/main \
-    && cp /app/pg_hba.conf ${PGCONF}/ \
-    && cp /app/postgresql.conf ${PGCONF}/conf.d
-# Init db script
-RUN /etc/init.d/postgresql start && /app/scripts/init.sh && /etc/init.d/postgresql stop
+# Set stats_temp_directory to the default, i.e., "pg_stat_tmp" relative to the postgresql.conf file
+RUN sed -i 's/^stats_temp_directory/#stats_temp_directory/g' /etc/postgresql-common/createcluster.conf
 
 USER root
 WORKDIR /app
 
 # Expose the ports (DB)(Rosetta)
 EXPOSE 5432 5700
-ENTRYPOINT [ "./run_supervisord.sh" ]
+ENTRYPOINT [ "./entrypoint.sh" ]

--- a/hedera-mirror-rosetta/build/postgresql-restore.conf
+++ b/hedera-mirror-rosetta/build/postgresql-restore.conf
@@ -1,5 +1,6 @@
 checkpoint_timeout = 30min
 listen_addresses = '*'
+log_checkpoints = on
 maintenance_work_mem = 2GB
 max_parallel_maintenance_workers = 4
 max_wal_size = 512GB

--- a/hedera-mirror-rosetta/build/supervisord.conf
+++ b/hedera-mirror-rosetta/build/supervisord.conf
@@ -23,8 +23,9 @@ autorestart=true
 redirect_stderr=true
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
-stopwaitsecs=100
-priority=1
+stopsignal=INT
+stopwaitsecs=30
+priority=10
 
 [program:importer]
 command=java -Xms512m -Xmx4g -XX:+CrashOnOutOfMemoryError -DLog4jContextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector -jar /app/importer/hedera-mirror-importer.jar --spring.config.additional-location=file:/app/importer/
@@ -33,7 +34,7 @@ autorestart=true
 redirect_stderr=true
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
-stopwaitsecs=90
+stopwaitsecs=60
 priority=10
 environment=HEDERA_MIRROR_IMPORTER_PARSER_RECORD_ENTITY_PERSIST_NONFEETRANSFERS=true,HEDERA_MIRROR_IMPORTER_PARSER_RECORD_ENTITY_PERSIST_TOPICS=false,HEDERA_MIRROR_IMPORTER_PARSER_RECORD_ENTITY_REDIS_ENABLED=false
 


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
It's required by rosetta spec that persistent data must be stored at `/data`.

- move postgres initialization to entrypoint.sh
- move both postgres data and conf files to /data
- allow customizing OWNER_PASSWORD and ROSETTA_PASSWORD
- change postgres stop signal to SIGINT for fast shutdown
- upgrade to pg14

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

[Rosetta doc](https://www.rosetta-api.org/docs/standard_storage_location.html)

Link to the draft PR: https://github.com/hashgraph/hedera-mirror-node/pull/3332

Tests:

- tested locally, with and without volume bind to `/data`
- tested locally with a new container created with existing `data` directory 
- tested locally with db restore
- tested locally with custom `OWNER_PASSWORD` and `ROSETTA_PASSWORD` 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
