### PR TITLE
Workaround CREATE2 invalid contract ID issue (0.51)

### DIFF
--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/util/DomainUtils.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/util/DomainUtils.java
@@ -25,6 +25,7 @@ import static com.hedera.mirror.common.domain.entity.EntityType.CONTRACT;
 import com.google.protobuf.ByteOutput;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.UnsafeByteOperations;
+import com.hederahashgraph.api.proto.java.ContractID;
 import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.KeyList;
 import com.hederahashgraph.api.proto.java.Timestamp;
@@ -243,16 +244,32 @@ public class DomainUtils {
         return null;
     }
 
+    public static byte[] toEvmAddress(ContractID contractId) {
+        if (contractId == null || contractId == ContractID.getDefaultInstance()) {
+            throw new InvalidEntityException("Invalid ContractID");
+        }
+
+        if (contractId.getContractCase() == ContractID.ContractCase.EVM_ADDRESS) {
+            return toBytes(contractId.getEvmAddress());
+        }
+
+        return toEvmAddress((int) contractId.getShardNum(), contractId.getRealmNum(), contractId.getContractNum());
+    }
+
     public static byte[] toEvmAddress(EntityId contractId) {
         if (EntityId.isEmpty(contractId)) {
             throw new InvalidEntityException("Empty contractId");
         }
 
+        return toEvmAddress(contractId.getShardNum().intValue(), contractId.getRealmNum(), contractId.getEntityNum());
+    }
+
+    private static byte[] toEvmAddress(int shard, long realm, long num) {
         byte[] evmAddress = new byte[EVM_ADDRESS_LENGTH];
         ByteBuffer buffer = ByteBuffer.wrap(evmAddress);
-        buffer.putInt(contractId.getShardNum().intValue());
-        buffer.putLong(contractId.getRealmNum());
-        buffer.putLong(contractId.getEntityNum());
+        buffer.putInt(shard);
+        buffer.putLong(realm);
+        buffer.putLong(num);
         return evmAddress;
     }
 

--- a/hedera-mirror-common/src/test/java/com/hedera/mirror/common/util/DomainUtilsTest.java
+++ b/hedera-mirror-common/src/test/java/com/hedera/mirror/common/util/DomainUtilsTest.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Internal;
 import com.google.protobuf.UnsafeByteOperations;
+import com.hederahashgraph.api.proto.java.ContractID;
 import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.KeyList;
 import com.hederahashgraph.api.proto.java.ThresholdKey;
@@ -285,16 +286,24 @@ class DomainUtilsTest {
     }
 
     @Test
-    void toEvmAddress() {
+    void toEvmAddressEntityId() {
         EntityId contractId = EntityId.of(1, 2, 255, EntityType.CONTRACT);
         String expected = "00000001000000000000000200000000000000FF";
         assertThat(DomainUtils.toEvmAddress(contractId)).asHexString().isEqualTo(expected);
+        assertThrows(InvalidEntityException.class, () -> DomainUtils.toEvmAddress((EntityId) null));
+        assertThrows(InvalidEntityException.class, () -> DomainUtils.toEvmAddress(EntityId.EMPTY));
     }
 
     @Test
-    void toEvmAddressThrows() {
-        assertThrows(InvalidEntityException.class, () -> DomainUtils.toEvmAddress(null));
-        assertThrows(InvalidEntityException.class, () -> DomainUtils.toEvmAddress(EntityId.EMPTY));
+    void toEvmAddressContractID() throws Exception {
+        String expected = "00000001000000000000000200000000000000FF";
+        ContractID contractId = ContractID.newBuilder().setShardNum(1).setRealmNum(2).setContractNum(255).build();
+        ContractID contractIdEvm = ContractID.newBuilder()
+                .setEvmAddress(DomainUtils.fromBytes(Hex.decodeHex(expected))).build();
+        assertThat(DomainUtils.toEvmAddress(contractId)).asHexString().isEqualTo(expected);
+        assertThat(DomainUtils.toEvmAddress(contractIdEvm)).asHexString().isEqualTo(expected);
+        assertThrows(InvalidEntityException.class, () -> DomainUtils.toEvmAddress((ContractID) null));
+        assertThrows(InvalidEntityException.class, () -> DomainUtils.toEvmAddress(ContractID.getDefaultInstance()));
     }
 
     @Test

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/AbstractContractCallTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/AbstractContractCallTransactionHandler.java
@@ -27,6 +27,8 @@ import com.hederahashgraph.api.proto.java.StorageChange;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.apache.commons.codec.binary.Hex;
 
 import com.hedera.mirror.common.domain.contract.Contract;
 import com.hedera.mirror.common.domain.contract.ContractLog;
@@ -35,12 +37,14 @@ import com.hedera.mirror.common.domain.contract.ContractStateChange;
 import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.transaction.RecordFile;
 import com.hedera.mirror.common.domain.transaction.RecordItem;
+import com.hedera.mirror.common.exception.InvalidEntityException;
 import com.hedera.mirror.common.util.DomainUtils;
 import com.hedera.mirror.importer.domain.EntityIdService;
 import com.hedera.mirror.importer.parser.record.entity.EntityListener;
 import com.hedera.mirror.importer.parser.record.entity.EntityProperties;
 import com.hedera.mirror.importer.util.Utility;
 
+@Log4j2
 @RequiredArgsConstructor
 abstract class AbstractContractCallTransactionHandler implements TransactionHandler {
 
@@ -53,18 +57,21 @@ abstract class AbstractContractCallTransactionHandler implements TransactionHand
                                           ContractFunctionResult functionResult) {
         // set function result related properties where applicable
         if (functionResult != ContractFunctionResult.getDefaultInstance()) {
+            var rootContractId = contractResult.getContractId();
             long consensusTimestamp = recordItem.getConsensusTimestamp();
             List<Long> createdContractIds = new ArrayList<>();
             boolean persist = shouldPersistCreatedContractIDs(recordItem);
 
             for (ContractID createdContractId : functionResult.getCreatedContractIDsList()) {
                 EntityId contractId = entityIdService.lookup(createdContractId);
-                createdContractIds.add(contractId.getId());
 
-                // The parent contract ID can also sometimes appear in the created contract IDs list, so exclude it
-                if (persist && !EntityId.isEmpty(contractId) && !contractId.equals(
-                        contractResult.getContractId())) {
-                    doUpdateEntity(getContract(contractId, consensusTimestamp), recordItem);
+                if (!EntityId.isEmpty(contractId)) {
+                    createdContractIds.add(contractId.getId());
+
+                    // The parent contract ID can also sometimes appear in the created contract IDs list, so exclude it
+                    if (persist && !contractId.equals(contractResult.getContractId())) {
+                        doUpdateEntity(getContract(contractId, consensusTimestamp), recordItem);
+                    }
                 }
             }
 
@@ -82,10 +89,10 @@ abstract class AbstractContractCallTransactionHandler implements TransactionHand
                 ContractLog contractLog = new ContractLog();
                 contractLog.setBloom(DomainUtils.toBytes(contractLoginfo.getBloom()));
                 contractLog.setConsensusTimestamp(consensusTimestamp);
-                contractLog.setContractId(entityIdService.lookup(contractLoginfo.getContractID()));
+                contractLog.setContractId(lookup(rootContractId, contractLoginfo.getContractID()));
                 contractLog.setData(DomainUtils.toBytes(contractLoginfo.getData()));
                 contractLog.setIndex(index);
-                contractLog.setRootContractId(contractResult.getContractId());
+                contractLog.setRootContractId(rootContractId);
                 contractLog.setPayerAccountId(contractResult.getPayerAccountId());
                 contractLog.setTopic0(Utility.getTopic(contractLoginfo, 0));
                 contractLog.setTopic1(Utility.getTopic(contractLoginfo, 1));
@@ -99,7 +106,7 @@ abstract class AbstractContractCallTransactionHandler implements TransactionHand
             for (int stateIndex = 0; stateIndex < functionResult.getStateChangesCount(); ++stateIndex) {
                 var contractStateChangeInfo = functionResult.getStateChanges(stateIndex);
 
-                var contractId = entityIdService.lookup(contractStateChangeInfo.getContractID());
+                var contractId = lookup(rootContractId, contractStateChangeInfo.getContractID());
                 for (int storageIndex = 0; storageIndex < contractStateChangeInfo
                         .getStorageChangesCount(); ++storageIndex) {
                     StorageChange storageChange = contractStateChangeInfo.getStorageChanges(storageIndex);
@@ -125,6 +132,53 @@ abstract class AbstractContractCallTransactionHandler implements TransactionHand
 
         // Always persist a contract result whether partial or complete
         entityListener.onContractResult(contractResult);
+    }
+
+    /**
+     * This method works around a services issue that occurs when events emitted by a CREATE2 contract produce an
+     * invalid ContractID. The EVM generated logs contain the 20 byte CREATE2 EVM address and services does not properly
+     * convert this back to the 'shard.realm.num' format that should always be present in the record. A similar issue
+     * occurs for state changes.
+     * <p>
+     * We work around this issue by converting the invalid 'shard.realm.num' format back to an EVM address and look it
+     * up in the database. If the invalid contract ID is produced by a CREATE2 constructor invocation, it won't be
+     * present in the database yet and our only recourse is to fall back to using the root contract ID.
+     * <p>
+     * This issue never made it to mainnet, so this code should be deleted after testnet is reset.
+     *
+     * @param rootContractId The contract create or call that initiated the transaction.
+     * @param contractId     The contract ID that appears somewhere in the ContractFunctionResult.
+     * @return The converted entity ID.
+     */
+    private EntityId lookup(EntityId rootContractId, ContractID contractId) {
+        try {
+            // We won't always get a negative or very large number to cause an InvalidEntityException
+            if (contractId.getShardNum() != 0 || contractId.getRealmNum() != 0) {
+                return fallbackLookup(rootContractId, contractId);
+            }
+            return entityIdService.lookup(contractId);
+        } catch (RuntimeException e) {
+            if (e.getCause() instanceof InvalidEntityException) {
+                return fallbackLookup(rootContractId, contractId);
+            }
+            throw e;
+        }
+    }
+
+    private EntityId fallbackLookup(EntityId rootContractId, ContractID contractId) {
+        byte[] evmAddress = DomainUtils.toEvmAddress(contractId);
+        log.warn("Invalid ContractID {}.{}.{}. Attempting conversion to EVM address: {}",
+                contractId.getShardNum(), contractId.getRealmNum(), contractId.getContractNum(),
+                Hex.encodeHexString(evmAddress));
+
+        var evmAddressId = ContractID.newBuilder()
+                .setShardNum(rootContractId.getShardNum())
+                .setRealmNum(rootContractId.getRealmNum())
+                .setEvmAddress(DomainUtils.fromBytes(evmAddress))
+                .build();
+
+        var entityId = entityIdService.lookup(evmAddressId);
+        return !EntityId.isEmpty(entityId) ? entityId : rootContractId;
     }
 
     protected abstract void doUpdateEntity(Contract contract, RecordItem recordItem);

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractCallTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractCallTransactionHandlerTest.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.importer.parser.record.transactionhandler;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,7 +21,12 @@ package com.hedera.mirror.importer.parser.record.transactionhandler;
  */
 
 import static com.hedera.mirror.common.domain.entity.EntityType.CONTRACT;
+import static com.hedera.mirror.common.util.DomainUtils.fromBytes;
+import static com.hedera.mirror.common.util.DomainUtils.toEvmAddress;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.hederahashgraph.api.proto.java.ContractCallTransactionBody;
@@ -29,9 +34,13 @@ import com.hederahashgraph.api.proto.java.ContractID;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
+import com.hedera.mirror.common.domain.contract.ContractResult;
 import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.entity.EntityType;
+import com.hedera.mirror.common.exception.InvalidEntityException;
 import com.hedera.mirror.importer.parser.record.entity.EntityProperties;
 
 class ContractCallTransactionHandlerTest extends AbstractTransactionHandlerTest {
@@ -69,5 +78,43 @@ class ContractCallTransactionHandlerTest extends AbstractTransactionHandlerTest 
         when(entityIdService.lookup(contractIdReceipt, contractIdBody)).thenReturn(expectedEntityId);
         EntityId entityId = transactionHandler.getEntity(recordItem);
         assertThat(entityId).isEqualTo(expectedEntityId);
+    }
+
+    @CsvSource({
+            "-1,-1,-1,1000,1000",
+            "1,1,1,1000,1000",
+            "0,0,9223372036854775807,1000,1000",
+            "0,0,-1,0,2",
+    })
+    @ParameterizedTest
+    void create2ContractIdWorkaround(long shard, long realm, long num, long resolvedNum, long expectedNum) {
+        var invalidContractId = ContractID.newBuilder()
+                .setShardNum(shard)
+                .setRealmNum(realm)
+                .setContractNum(num)
+                .build();
+        var evmAddress = ContractID.newBuilder().setEvmAddress(fromBytes(toEvmAddress(invalidContractId))).build();
+        var expectedId = EntityId.of(expectedNum, CONTRACT);
+        var resolvedId = EntityId.of(resolvedNum, CONTRACT);
+
+        var transaction = domainBuilder.transaction().get();
+        var recordItem = recordItemBuilder.contractCall()
+                .record(r -> {
+                    r.getContractCallResultBuilder().getLogInfoBuilder(0).setContractID(invalidContractId);
+                    r.getContractCallResultBuilder().getStateChangesBuilder(0).setContractID(invalidContractId);
+                    r.getContractCallResultBuilder().removeLogInfo(1);
+                })
+                .build();
+
+        if (shard == 0 && realm == 0) {
+            when(entityIdService.lookup(invalidContractId)).thenThrow(new RuntimeException(new InvalidEntityException("")));
+        }
+        when(entityIdService.lookup(evmAddress)).thenReturn(resolvedId);
+        transactionHandler.updateTransaction(transaction, recordItem);
+
+        verify(entityListener).onContractLog(assertArg(l -> assertThat(l.getContractId()).isEqualTo(expectedId)));
+        verify(entityListener, times(2)).onContractStateChange(assertArg(s ->
+                assertThat(s.getContractId()).isEqualTo(expectedId.getId())));
+        verify(entityListener).onContractResult(isA(ContractResult.class));
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractCreateTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractCreateTransactionHandlerTest.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.importer.parser.record.transactionhandler;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,6 +21,12 @@ package com.hedera.mirror.importer.parser.record.transactionhandler;
  */
 
 import static com.hedera.mirror.common.domain.entity.EntityType.CONTRACT;
+import static com.hedera.mirror.common.util.DomainUtils.fromBytes;
+import static com.hedera.mirror.common.util.DomainUtils.toEvmAddress;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.protobuf.ByteString;
@@ -29,17 +35,22 @@ import com.google.protobuf.Descriptors;
 import com.google.protobuf.Message;
 import com.hederahashgraph.api.proto.java.ContractCreateTransactionBody;
 import com.hederahashgraph.api.proto.java.ContractFunctionResult;
+import com.hederahashgraph.api.proto.java.ContractID;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionReceipt;
 import com.hederahashgraph.api.proto.java.TransactionRecord;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import com.hedera.mirror.common.domain.contract.Contract;
+import com.hedera.mirror.common.domain.contract.ContractResult;
 import com.hedera.mirror.common.domain.entity.AbstractEntity;
 import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.entity.EntityType;
+import com.hedera.mirror.common.exception.InvalidEntityException;
 import com.hedera.mirror.importer.TestUtils;
 import com.hedera.mirror.importer.parser.record.entity.EntityProperties;
 
@@ -104,5 +115,43 @@ class ContractCreateTransactionHandlerTest extends AbstractTransactionHandlerTes
     @Override
     protected EntityType getExpectedEntityIdType() {
         return CONTRACT;
+    }
+
+    @CsvSource({
+            "-1,-1,-1,1000,1000",
+            "1,1,1,1000,1000",
+            "0,0,9223372036854775807,1000,1000",
+            "0,0,-1,0,2",
+    })
+    @ParameterizedTest
+    void create2ContractIdWorkaround(long shard, long realm, long num, long resolvedNum, long expectedNum) {
+        var invalidContractId = ContractID.newBuilder()
+                .setShardNum(shard)
+                .setRealmNum(realm)
+                .setContractNum(num)
+                .build();
+        var evmAddress = ContractID.newBuilder().setEvmAddress(fromBytes(toEvmAddress(invalidContractId))).build();
+        var expectedId = EntityId.of(expectedNum, CONTRACT);
+        var resolvedId = EntityId.of(resolvedNum, CONTRACT);
+
+        var transaction = domainBuilder.transaction().customize(t -> t.entityId(expectedId)).get();
+        var recordItem = recordItemBuilder.contractCreate()
+                .record(r -> {
+                    r.getContractCreateResultBuilder().getLogInfoBuilder(0).setContractID(invalidContractId);
+                    r.getContractCreateResultBuilder().getStateChangesBuilder(0).setContractID(invalidContractId);
+                    r.getContractCreateResultBuilder().removeLogInfo(1);
+                })
+                .build();
+
+        if (shard == 0 && realm == 0) {
+            when(entityIdService.lookup(invalidContractId)).thenThrow(new RuntimeException(new InvalidEntityException("")));
+        }
+        when(entityIdService.lookup(evmAddress)).thenReturn(resolvedId);
+        transactionHandler.updateTransaction(transaction, recordItem);
+
+        verify(entityListener).onContractLog(assertArg(l -> assertThat(l.getContractId()).isEqualTo(expectedId)));
+        verify(entityListener, times(2)).onContractStateChange(assertArg(s ->
+                assertThat(s.getContractId()).isEqualTo(expectedId.getId())));
+        verify(entityListener).onContractResult(isA(ContractResult.class));
     }
 }


### PR DESCRIPTION
**Description**:
Cherry pick of #3335 to `release/0.51`

* Workaround CREATE2 contract call invalid ID issue by re-encoding the shard.realm.num as an EVM address and looking it up in the database
* Workaround CREATE2 contract create invalid ID issue by falling back to the root contract ID

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
