### PR TITLE
Fix importer helm deployment

### DIFF
--- a/charts/hedera-mirror/values-prod.yaml
+++ b/charts/hedera-mirror/values-prod.yaml
@@ -33,9 +33,6 @@ importer:
   prometheusRules:
     enabled: true
   replicas: 1
-  updateStrategy:
-    rollingUpdate:
-      maxSurge: 0
 
 monitor:
   alertmanager:


### PR DESCRIPTION
**Description**:

Fix deploy to integration failing with the error `spec.strategy.rollingUpdate: Forbidden: may not be specified when strategy 'type' is 'Recreate'`

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
