### PR TITLE
Increase max data retries in rosetta bdd-test

### DIFF
--- a/hedera-mirror-rosetta/test/bdd-client/README.md
+++ b/hedera-mirror-rosetta/test/bdd-client/README.md
@@ -97,7 +97,7 @@ The following table lists the available properties along with their default valu
 | `hedera.mirror.rosetta.test.operators[].id`             |                       | The operator account id, in the format of shard.realm.num                  |
 | `hedera.mirror.rosetta.test.operators[].privateKey`     |                       | The operator's private key in hex                                          |
 | `hedera.mirror.rosetta.test.server.dataRetry.backOff`   | 1s                    | The amount of time to wait between data request retries, if the request can be retried. |
-| `hedera.mirror.rosetta.test.server.dataRetry.max`       | 20                    | The max retries of a data request                                          |
+| `hedera.mirror.rosetta.test.server.dataRetry.max`       | 60                    | The max retries of a data request                                          |
 | `hedera.mirror.rosetta.test.server.httpTimeout`         | 25s                   | The timeout of an http request sent to the rosetta server                  |
 | `hedera.mirror.rosetta.test.server.network`             | {}                    | A map of main nodes with its service endpoint as the key and the node account id as its value |
 | `hedera.mirror.rosetta.test.server.offlineUrl`          | http://localhost:5701 | The url of the offline rosetta server                                      |

--- a/hedera-mirror-rosetta/test/bdd-client/config.go
+++ b/hedera-mirror-rosetta/test/bdd-client/config.go
@@ -49,7 +49,7 @@ hedera:
         server:
            dataRetry:
              backOff: 1s
-             max: 20
+             max: 60
            offlineUrl: http://localhost:5701
            onlineUrl: http://localhost:5700
            httpTimeout: 25s


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR increases the default rosetta bdd-test max data retries to 60 (effectively 60s) so it's more resilient to transient high latency events.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
The rosetta github workflow failed multiple times on main, the log shows there's high cloud storage latency (one instance is ~23s when downloading signatures from node 0.0.4). So increase the max data retries should make the test more resillient.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
