### PR TITLE
Fix circular bean reference on startup

### DIFF
--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/MirrorGrpcApplication.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/MirrorGrpcApplication.java
@@ -21,12 +21,13 @@ package com.hedera.mirror.grpc;
  */
 
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.actuate.autoconfigure.metrics.redis.LettuceMetricsAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import reactor.core.scheduler.Schedulers;
 
 @ConfigurationPropertiesScan
-@SpringBootApplication
+@SpringBootApplication(exclude = LettuceMetricsAutoConfiguration.class)
 public class MirrorGrpcApplication {
 
     public static void main(String[] args) {

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/config/MetricsConfiguration.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/config/MetricsConfiguration.java
@@ -22,25 +22,12 @@ package com.hedera.mirror.grpc.config;
 
 import io.github.mweirauch.micrometer.jvm.extras.ProcessMemoryMetrics;
 import io.github.mweirauch.micrometer.jvm.extras.ProcessThreadMetrics;
-import io.lettuce.core.metrics.MicrometerCommandLatencyRecorder;
-import io.lettuce.core.metrics.MicrometerOptions;
-import io.lettuce.core.resource.ClientResources;
-import io.lettuce.core.resource.DefaultClientResources;
-import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.MeterBinder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 class MetricsConfiguration {
-
-    // Override default ClientResources to disable histogram metrics
-    @Bean(destroyMethod = "shutdown")
-    ClientResources clientResources(MeterRegistry meterRegistry) {
-        MicrometerOptions options = MicrometerOptions.builder().build();
-        var commandLatencyRecorder = new MicrometerCommandLatencyRecorder(meterRegistry, options);
-        return DefaultClientResources.builder().commandLatencyRecorder(commandLatencyRecorder).build();
-    }
 
     @Bean
     MeterBinder processMemoryMetrics() {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/MirrorImporterApplication.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/MirrorImporterApplication.java
@@ -21,11 +21,12 @@ package com.hedera.mirror.importer;
  */
 
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.actuate.autoconfigure.metrics.redis.LettuceMetricsAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @ConfigurationPropertiesScan
-@SpringBootApplication
+@SpringBootApplication(exclude = LettuceMetricsAutoConfiguration.class)
 public class MirrorImporterApplication {
 
     public static void main(String[] args) {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/MetricsConfiguration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/MetricsConfiguration.java
@@ -22,12 +22,8 @@ package com.hedera.mirror.importer.config;
 
 import io.github.mweirauch.micrometer.jvm.extras.ProcessMemoryMetrics;
 import io.github.mweirauch.micrometer.jvm.extras.ProcessThreadMetrics;
-import io.lettuce.core.metrics.MicrometerCommandLatencyRecorder;
-import io.lettuce.core.metrics.MicrometerOptions;
-import io.lettuce.core.resource.ClientResources;
-import io.lettuce.core.resource.DefaultClientResources;
-import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.BaseUnits;
 import io.micrometer.core.instrument.binder.MeterBinder;
 import io.micrometer.core.instrument.binder.db.PostgreSQLDatabaseMetrics;
@@ -55,14 +51,6 @@ class MetricsConfiguration {
     private final DataSource dataSource;
     private final DBProperties dbProperties;
     private final MeterRegistry meterRegistry;
-
-    // Override default ClientResources to disable histogram metrics
-    @Bean(destroyMethod = "shutdown")
-    ClientResources clientResources() {
-        MicrometerOptions options = MicrometerOptions.builder().build();
-        var commandLatencyRecorder = new MicrometerCommandLatencyRecorder(meterRegistry, options);
-        return DefaultClientResources.builder().commandLatencyRecorder(commandLatencyRecorder).build();
-    }
 
     @Bean
     MeterBinder processMemoryMetrics() {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/RedisConfiguration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/RedisConfiguration.java
@@ -21,7 +21,16 @@ package com.hedera.mirror.importer.config;
  */
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.lettuce.core.metrics.MicrometerCommandLatencyRecorder;
+import io.lettuce.core.metrics.MicrometerOptions;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.msgpack.jackson.dataformat.MessagePackFactory;
+import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.data.redis.ClientResourcesBuilderCustomizer;
+import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -32,8 +41,17 @@ import org.springframework.data.redis.serializer.RedisSerializer;
 
 import com.hedera.mirror.common.domain.topic.StreamMessage;
 
+@AutoConfigureBefore(RedisAutoConfiguration.class)
+@AutoConfigureAfter({MetricsAutoConfiguration.class, CompositeMeterRegistryAutoConfiguration.class})
 @Configuration
-public class RedisConfiguration {
+class RedisConfiguration {
+
+    // Override default auto-configuration to disable histogram metrics
+    @Bean
+    ClientResourcesBuilderCustomizer lettuceMetrics(MeterRegistry meterRegistry) {
+        MicrometerOptions options = MicrometerOptions.builder().histogram(false).build();
+        return (client) -> client.commandLatencyRecorder(new MicrometerCommandLatencyRecorder(meterRegistry, options));
+    }
 
     @Bean
     RedisSerializer<StreamMessage> redisSerializer() {


### PR DESCRIPTION
**Description**:
Fix circular bean reference on startup. Now instead of overriding auto-configured `clientResources` I disable `LettuceMetricsAutoConfiguration ` and use the customizer interface to customize Redis metrics.

**Related issue(s)**:

**Notes for reviewer**:
Tested fix on integration and it now starts successfully. Here's the logs from before the fix:
```bash
Mar 03 19:54:08 mirrornode-integration-parser-1 java[29941]: ***************************
Mar 03 19:54:08 mirrornode-integration-parser-1 java[29941]: APPLICATION FAILED TO START
Mar 03 19:54:08 mirrornode-integration-parser-1 java[29941]: ***************************
Mar 03 19:54:08 mirrornode-integration-parser-1 java[29941]: Description:
Mar 03 19:54:08 mirrornode-integration-parser-1 java[29941]: The dependencies of some of the beans in the application context form a cycle:
Mar 03 19:54:08 mirrornode-integration-parser-1 java[29941]:    flyway defined in class path resource [org/springframework/boot/autoconfigure/flyway/FlywayAutoConfiguration$FlywayConfiguration.class]
Mar 03 19:54:08 mirrornode-integration-parser-1 java[29941]:       ↓
Mar 03 19:54:08 mirrornode-integration-parser-1 java[29941]:    mirrorImporterConfiguration
Mar 03 19:54:08 mirrornode-integration-parser-1 java[29941]:       ↓
Mar 03 19:54:08 mirrornode-integration-parser-1 java[29941]:    httpHandler defined in class path resource [org/springframework/boot/autoconfigure/web/reactive/HttpHandlerAutoConfiguration$AnnotationConfig.class]
Mar 03 19:54:08 mirrornode-integration-parser-1 java[29941]:       ↓
Mar 03 19:54:08 mirrornode-integration-parser-1 java[29941]:    webHandler defined in class path resource [org/springframework/boot/autoconfigure/web/reactive/WebFluxAutoConfiguration$EnableWebFluxConfiguration.class]
Mar 03 19:54:08 mirrornode-integration-parser-1 java[29941]:       ↓
Mar 03 19:54:08 mirrornode-integration-parser-1 java[29941]:    healthEndpointWebFluxHandlerMapping defined in class path resource [org/springframework/boot/actuate/autoconfigure/health/HealthEndpointReactiveWebExtensionConfiguration$WebFluxAdditionalHealthEndpointPathsConfiguration.class]
Mar 03 19:54:08 mirrornode-integration-parser-1 java[29941]:       ↓
Mar 03 19:54:08 mirrornode-integration-parser-1 java[29941]:    healthEndpoint defined in class path resource [org/springframework/boot/actuate/autoconfigure/health/HealthEndpointConfiguration.class]
Mar 03 19:54:08 mirrornode-integration-parser-1 java[29941]:       ↓
Mar 03 19:54:08 mirrornode-integration-parser-1 java[29941]:    healthContributorRegistry defined in class path resource [org/springframework/boot/actuate/autoconfigure/health/HealthEndpointConfiguration.class]
Mar 03 19:54:08 mirrornode-integration-parser-1 java[29941]:       ↓
Mar 03 19:54:08 mirrornode-integration-parser-1 java[29941]:    org.springframework.boot.actuate.autoconfigure.redis.RedisReactiveHealthContributorAutoConfiguration
Mar 03 19:54:08 mirrornode-integration-parser-1 java[29941]:       ↓
Mar 03 19:54:08 mirrornode-integration-parser-1 java[29941]:    redisConnectionFactory defined in class path resource [org/springframework/boot/autoconfigure/data/redis/LettuceConnectionConfiguration.class]
Mar 03 19:54:08 mirrornode-integration-parser-1 java[29941]: ┌─────┐
Mar 03 19:54:08 mirrornode-integration-parser-1 java[29941]: |  metricsConfiguration defined in URL [jar:file:/usr/lib/hedera-mirror-importer/hedera-mirror-importer.jar!/BOOT-INF/classes!/com/hedera/mirror/importer/config/MetricsConfiguration.class]
Mar 03 19:54:08 mirrornode-integration-parser-1 java[29941]: ↑     ↓
Mar 03 19:54:08 mirrornode-integration-parser-1 java[29941]: |  compositeMeterRegistry defined in class path resource [org/springframework/boot/actuate/autoconfigure/metrics/CompositeMeterRegistryConfiguration.class]
Mar 03 19:54:08 mirrornode-integration-parser-1 java[29941]: └─────┘
Mar 03 19:54:08 mirrornode-integration-parser-1 java[29941]: Action:
Mar 03 19:54:08 mirrornode-integration-parser-1 java[29941]: Despite circular references being allowed, the dependency cycle between beans could not be broken. Update your application to remove the dependency cycle.
```

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
