### PR TITLE
Remove crypto transfer for initial balance

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListener.java
@@ -52,6 +52,7 @@ import com.hederahashgraph.api.proto.java.TokenWipeAccountTransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionRecord;
 import com.hederahashgraph.api.proto.java.TransferList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -169,11 +170,7 @@ public class EntityRecordItemListener implements RecordItemListener {
         transactionHandler.updateTransaction(transaction, recordItem);
 
         if (txRecord.hasTransferList() && entityProperties.getPersist().isCryptoTransferAmounts()) {
-            if (body.hasCryptoCreateAccount() && recordItem.isSuccessful()) {
-                 insertCryptoCreateTransferList(consensusTimestamp, recordItem);
-            } else {
-                insertTransferList(consensusTimestamp, txRecord.getTransferList(), recordItem.getPayerAccountId());
-            }
+            insertTransferList(consensusTimestamp, txRecord.getTransferList(), recordItem.getPayerAccountId());
         }
 
         // handle scheduled transaction, even on failure
@@ -414,20 +411,6 @@ public class EntityRecordItemListener implements RecordItemListener {
             CryptoTransfer cryptoTransfer = new CryptoTransfer(consensusTimestamp, aa.getAmount(), account);
             cryptoTransfer.setIsApproval(aa.getIsApproval());
             cryptoTransfer.setPayerAccountId(payerAccountId);
-            entityListener.onCryptoTransfer(cryptoTransfer);
-        }
-    }
-
-    private void insertCryptoCreateTransferList(long consensusTimestamp, RecordItem recordItem) {
-        var record = recordItem.getRecord();
-        TransferList transferList = record.getTransferList();
-
-        for (int i = 0; i < transferList.getAccountAmountsCount(); ++i) {
-            var aa = transferList.getAccountAmounts(i);
-            var account = EntityId.of(aa.getAccountID());
-            CryptoTransfer cryptoTransfer = new CryptoTransfer(consensusTimestamp, aa.getAmount(), account);
-            cryptoTransfer.setIsApproval(aa.getIsApproval());
-            cryptoTransfer.setPayerAccountId(recordItem.getPayerAccountId());
             entityListener.onCryptoTransfer(cryptoTransfer);
         }
     }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListener.java
@@ -170,7 +170,7 @@ public class EntityRecordItemListener implements RecordItemListener {
 
         if (txRecord.hasTransferList() && entityProperties.getPersist().isCryptoTransferAmounts()) {
             if (body.hasCryptoCreateAccount() && recordItem.isSuccessful()) {
-                insertCryptoCreateTransferList(consensusTimestamp, recordItem);
+                 insertCryptoCreateTransferList(consensusTimestamp, recordItem);
             } else {
                 insertTransferList(consensusTimestamp, txRecord.getTransferList(), recordItem.getPayerAccountId());
             }
@@ -420,10 +420,6 @@ public class EntityRecordItemListener implements RecordItemListener {
 
     private void insertCryptoCreateTransferList(long consensusTimestamp, RecordItem recordItem) {
         var record = recordItem.getRecord();
-        var body = recordItem.getTransactionBody();
-        long initialBalance = body.getCryptoCreateAccount().getInitialBalance();
-        EntityId createdAccount = EntityId.of(record.getReceipt().getAccountID());
-        boolean addInitialBalance = true;
         TransferList transferList = record.getTransferList();
 
         for (int i = 0; i < transferList.getAccountAmountsCount(); ++i) {
@@ -433,22 +429,6 @@ public class EntityRecordItemListener implements RecordItemListener {
             cryptoTransfer.setIsApproval(aa.getIsApproval());
             cryptoTransfer.setPayerAccountId(recordItem.getPayerAccountId());
             entityListener.onCryptoTransfer(cryptoTransfer);
-
-            // Don't manually add an initial balance transfer if the transfer list contains it already
-            if (initialBalance == aa.getAmount() && createdAccount.equals(account)) {
-                addInitialBalance = false;
-            }
-        }
-
-        if (addInitialBalance) {
-            CryptoTransfer transferOut = new CryptoTransfer(consensusTimestamp, -initialBalance, recordItem
-                    .getPayerAccountId());
-            transferOut.setPayerAccountId(recordItem.getPayerAccountId());
-            entityListener.onCryptoTransfer(transferOut);
-
-            CryptoTransfer transferIn = new CryptoTransfer(consensusTimestamp, initialBalance, createdAccount);
-            transferIn.setPayerAccountId(recordItem.getPayerAccountId());
-            entityListener.onCryptoTransfer(transferIn);
         }
     }
 

--- a/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.55.2__remove_crypto_transfer_with_zero_amount.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.55.2__remove_crypto_transfer_with_zero_amount.sql
@@ -1,3 +1,11 @@
 -- remove crypto transfers with amount equals 0.
 
-delete from crypto_transfer where amount = 0
+with crypto_creates as (
+	select consensus_timestamp
+	from transaction
+	where type = 11
+)
+delete
+from crypto_transfer ct using crypto_creates cc
+where ct.consensus_timestamp = cs.consensus_timestamp
+  and amount = 0;

--- a/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.55.2__remove_crypto_transfer_with_zero_amount.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.55.2__remove_crypto_transfer_with_zero_amount.sql
@@ -4,6 +4,7 @@ with crypto_creates as (
 	select consensus_timestamp
 	from transaction
 	where type = 11
+	  and result = 22
 )
 delete
 from crypto_transfer ct using crypto_creates cc

--- a/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.55.2__remove_crypto_transfer_with_zero_amount.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.55.2__remove_crypto_transfer_with_zero_amount.sql
@@ -1,0 +1,3 @@
+-- remove crypto transfers with amount equals 0.
+
+delete from crypto_transfer where amount = 0

--- a/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.55.2__remove_crypto_transfer_with_zero_amount.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.55.2__remove_crypto_transfer_with_zero_amount.sql
@@ -8,5 +8,6 @@ with crypto_creates as (
 )
 delete
 from crypto_transfer ct using crypto_creates cc
-where ct.consensus_timestamp = cs.consensus_timestamp
+where ct.consensus_timestamp = cc.consensus_timestamp
   and amount = 0;
+

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/AbstractEntityRecordItemListenerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/AbstractEntityRecordItemListenerTest.java
@@ -46,8 +46,6 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Consumer;
 import javax.annotation.Resource;
-import org.assertj.core.api.Condition;
-import org.jclouds.openstack.swift.v1.domain.Account;
 import org.springframework.transaction.support.TransactionTemplate;
 
 import com.hedera.mirror.common.domain.DigestAlgorithm;

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/AbstractEntityRecordItemListenerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/AbstractEntityRecordItemListenerTest.java
@@ -46,6 +46,8 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Consumer;
 import javax.annotation.Resource;
+import org.assertj.core.api.Condition;
+import org.jclouds.openstack.swift.v1.domain.Account;
 import org.springframework.transaction.support.TransactionTemplate;
 
 import com.hedera.mirror.common.domain.DigestAlgorithm;
@@ -292,13 +294,14 @@ public abstract class AbstractEntityRecordItemListenerTest extends IntegrationTe
         recordBuilder.getReceiptBuilder().setStatusValue(status);
 
         // Give from payer to treasury and node
-        long[] transferAccounts = {PAYER.getAccountNum(), TREASURY.getAccountNum(), NODE.getAccountNum()};
-        long[] transferAmounts = {-2000, 1000, 1000};
+        long[] transferAccounts = { PAYER.getAccountNum(), TREASURY.getAccountNum(), NODE.getAccountNum() };
+        long[] transferAmounts = { -2000, 1000, 1000 };
         TransferList.Builder transferList = recordBuilder.getTransferListBuilder();
         for (int i = 0; i < transferAccounts.length; i++) {
             // Irrespective of transaction success, node and network fees are present.
             transferList.addAccountAmounts(accountAmount(transferAccounts[i], transferAmounts[i]));
         }
+
         if (transactionBody.hasCryptoTransfer() && status == ResponseCodeEnum.SUCCESS.getNumber()) {
             for (var aa : transactionBody.getCryptoTransfer().getTransfers().getAccountAmountsList()) {
                 // handle alias case.
@@ -339,6 +342,13 @@ public abstract class AbstractEntityRecordItemListenerTest extends IntegrationTe
     protected AccountAmount.Builder accountAliasAmount(ByteString alias, long amount) {
         return AccountAmount.newBuilder().setAccountID(AccountID.newBuilder().setAlias(alias))
                 .setAmount(amount);
+    }
+
+    protected boolean isAccountAmountReceiverAccountAmount(final CryptoTransfer cryptoTransfer,
+            final AccountAmount receiver) {
+        final CryptoTransfer.Id cryptoTransferId = cryptoTransfer.getId();
+        return cryptoTransferId.getEntityId().getEntityNum() == receiver.getAccountID().getAccountNum() &&
+                cryptoTransferId.getAmount() == receiver.getAmount();
     }
 
     protected TransactionBody getTransactionBody(com.hederahashgraph.api.proto.java.Transaction transaction) {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerCryptoTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerCryptoTest.java
@@ -78,7 +78,6 @@ import com.hedera.mirror.importer.repository.NftAllowanceRepository;
 import com.hedera.mirror.importer.repository.TokenAllowanceRepository;
 import com.hedera.mirror.importer.util.Utility;
 
-@Tag("entity-record-item-listener")
 class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItemListenerTest {
     private static final long INITIAL_BALANCE = 1000L;
     private static final AccountID accountId1 = AccountID.newBuilder().setAccountNum(1001).build();

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerCryptoTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerCryptoTest.java
@@ -57,7 +57,6 @@ import org.assertj.core.api.Condition;
 import org.assertj.core.api.IterableAssert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;


### PR DESCRIPTION
**Description**:
Removes the the creation of crypto transfers that were being made specifically for the initial balance of a crypto account.
Only adds a crypto transfer per account amount in `TransferList`.

Removes the creation of crypto transfer for the initial balance.
Fixes unit tests that were taking the previous rules into consideration.
Create unit test specifically for the new rule.

**Related issue(s)**:

Fixes #770 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
