### PR TITLE
Fix circular bean reference on startup (0.52)

### DIFF
--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/MirrorGrpcApplication.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/MirrorGrpcApplication.java
@@ -21,12 +21,13 @@ package com.hedera.mirror.grpc;
  */
 
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.actuate.autoconfigure.metrics.redis.LettuceMetricsAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import reactor.core.scheduler.Schedulers;
 
 @ConfigurationPropertiesScan
-@SpringBootApplication
+@SpringBootApplication(exclude = LettuceMetricsAutoConfiguration.class)
 public class MirrorGrpcApplication {
 
     public static void main(String[] args) {

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/config/MetricsConfiguration.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/config/MetricsConfiguration.java
@@ -22,25 +22,12 @@ package com.hedera.mirror.grpc.config;
 
 import io.github.mweirauch.micrometer.jvm.extras.ProcessMemoryMetrics;
 import io.github.mweirauch.micrometer.jvm.extras.ProcessThreadMetrics;
-import io.lettuce.core.metrics.MicrometerCommandLatencyRecorder;
-import io.lettuce.core.metrics.MicrometerOptions;
-import io.lettuce.core.resource.ClientResources;
-import io.lettuce.core.resource.DefaultClientResources;
-import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.MeterBinder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 class MetricsConfiguration {
-
-    // Override default ClientResources to disable histogram metrics
-    @Bean(destroyMethod = "shutdown")
-    ClientResources clientResources(MeterRegistry meterRegistry) {
-        MicrometerOptions options = MicrometerOptions.builder().build();
-        var commandLatencyRecorder = new MicrometerCommandLatencyRecorder(meterRegistry, options);
-        return DefaultClientResources.builder().commandLatencyRecorder(commandLatencyRecorder).build();
-    }
 
     @Bean
     MeterBinder processMemoryMetrics() {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/MirrorImporterApplication.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/MirrorImporterApplication.java
@@ -21,11 +21,12 @@ package com.hedera.mirror.importer;
  */
 
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.actuate.autoconfigure.metrics.redis.LettuceMetricsAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @ConfigurationPropertiesScan
-@SpringBootApplication
+@SpringBootApplication(exclude = LettuceMetricsAutoConfiguration.class)
 public class MirrorImporterApplication {
 
     public static void main(String[] args) {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/MetricsConfiguration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/MetricsConfiguration.java
@@ -22,12 +22,8 @@ package com.hedera.mirror.importer.config;
 
 import io.github.mweirauch.micrometer.jvm.extras.ProcessMemoryMetrics;
 import io.github.mweirauch.micrometer.jvm.extras.ProcessThreadMetrics;
-import io.lettuce.core.metrics.MicrometerCommandLatencyRecorder;
-import io.lettuce.core.metrics.MicrometerOptions;
-import io.lettuce.core.resource.ClientResources;
-import io.lettuce.core.resource.DefaultClientResources;
-import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.BaseUnits;
 import io.micrometer.core.instrument.binder.MeterBinder;
 import io.micrometer.core.instrument.binder.db.PostgreSQLDatabaseMetrics;
@@ -55,14 +51,6 @@ class MetricsConfiguration {
     private final DataSource dataSource;
     private final DBProperties dbProperties;
     private final MeterRegistry meterRegistry;
-
-    // Override default ClientResources to disable histogram metrics
-    @Bean(destroyMethod = "shutdown")
-    ClientResources clientResources() {
-        MicrometerOptions options = MicrometerOptions.builder().build();
-        var commandLatencyRecorder = new MicrometerCommandLatencyRecorder(meterRegistry, options);
-        return DefaultClientResources.builder().commandLatencyRecorder(commandLatencyRecorder).build();
-    }
 
     @Bean
     MeterBinder processMemoryMetrics() {


### PR DESCRIPTION
**Description**:
Fix circular bean reference on startup. Now instead of overriding auto-configured clientResources I disable LettuceMetricsAutoConfiguration and use the customizer interface to customize Redis metrics.

**Related issue(s)**:

**Notes for reviewer**:
Cherry pick of #3357 to `release/0.52`

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
