### PR TITLE
Add hashType to HashMismatchException message

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/Downloader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/Downloader.java
@@ -78,6 +78,9 @@ import com.hedera.mirror.importer.util.Utility;
 
 public abstract class Downloader<T extends StreamFile> {
     public static final String STREAM_CLOSE_LATENCY_METRIC_NAME = "hedera.mirror.stream.close.latency";
+    private static final String HASH_TYPE_FILE = "File";
+    private static final String HASH_TYPE_METADATA = "Metadata";
+    private static final String HASH_TYPE_RUNNING = "Running";
 
     protected final Logger log = LogManager.getLogger(getClass());
     protected final DownloaderProperties downloaderProperties;
@@ -507,11 +510,12 @@ public abstract class Downloader<T extends StreamFile> {
         String expectedPrevHash = lastStreamFile.get().map(StreamFile::getHash).orElse(null);
 
         if (!verifyHashChain(streamFile, expectedPrevHash)) {
-            throw new HashMismatchException(filename, expectedPrevHash, streamFile.getPreviousHash(), "Running");
+            throw new HashMismatchException(filename, expectedPrevHash, streamFile
+                    .getPreviousHash(), HASH_TYPE_RUNNING);
         }
 
-        verifyHash(filename, streamFile.getFileHash(), signature.getFileHashAsHex(), "File");
-        verifyHash(filename, streamFile.getMetadataHash(), signature.getMetadataHashAsHex(), "Metadata");
+        verifyHash(filename, streamFile.getFileHash(), signature.getFileHashAsHex(), HASH_TYPE_FILE);
+        verifyHash(filename, streamFile.getMetadataHash(), signature.getMetadataHashAsHex(), HASH_TYPE_METADATA);
     }
 
     /**

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/exception/HashMismatchException.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/exception/HashMismatchException.java
@@ -22,7 +22,7 @@ package com.hedera.mirror.importer.exception;
 
 public class HashMismatchException extends ImporterException {
 
-    private static final String MESSAGE = "%s hash mismatch on for file %s. Expected = %s, Actual = %s";
+    private static final String MESSAGE = "%s hash mismatch for file %s. Expected = %s, Actual = %s";
     private static final long serialVersionUID = -1093315700008851731L;
 
     public HashMismatchException(String filename, String expectedHash, String actualHash, String hashType) {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/exception/HashMismatchException.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/exception/HashMismatchException.java
@@ -22,10 +22,10 @@ package com.hedera.mirror.importer.exception;
 
 public class HashMismatchException extends ImporterException {
 
-    private static final String MESSAGE = "Hash mismatch for file %s. Expected = %s, Actual = %s";
+    private static final String MESSAGE = "%s hash mismatch on for file %s. Expected = %s, Actual = %s";
     private static final long serialVersionUID = -1093315700008851731L;
 
-    public HashMismatchException(String filename, String expectedHash, String actualHash) {
-        super(String.format(MESSAGE, filename, expectedHash, actualHash));
+    public HashMismatchException(String filename, String expectedHash, String actualHash, String hashType) {
+        super(String.format(MESSAGE, hashType, filename, expectedHash, actualHash));
     }
 }


### PR DESCRIPTION
**Description**:
The mirror node performs verification on 3 different hash types (running hash, file hash, metadata hash) and throws a `HashMismatchException` on any of those failures.
Given the 3 checks are performed back to back in the `Downloader` class it's difficult to determine which hash failed verification.

- Add hashType to HashMismatchException message to make troubleshooting easier

**Related issue(s)**:

Fixes #

**Notes for reviewer**:


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
