### PR TITLE
Fix missing contract evm address

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListener.java
@@ -456,6 +456,7 @@ public class SqlEntityListener implements EntityListener, RecordStreamFileListen
     private Contract mergeContract(Contract previous, Contract current) {
         mergeAbstractEntity(previous, current);
 
+        current.setEvmAddress(previous.getEvmAddress());
         current.setFileId(previous.getFileId());
 
         if (current.getObtainerId() == null) {

--- a/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.55.5__missing_evm_address.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.55.5__missing_evm_address.sql
@@ -1,0 +1,17 @@
+-- fill the missing evm address due to the value not merged into the partial contract domain object in importer
+
+with history as (
+    select distinct id, evm_address
+    from contract_history
+    where evm_address is not null
+), current_updated as (
+    update contract c
+        set evm_address = h.evm_address
+    from history h
+    where c.id = h.id and c.evm_address is null
+    returning c.id, c.evm_address
+)
+update contract_history ch
+set evm_address = cu.evm_address
+from current_updated cu
+where ch.id = cu.id and ch.evm_address is null;

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/IntegrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/IntegrationTest.java
@@ -20,10 +20,8 @@ package com.hedera.mirror.importer;
  * ‍
  */
 
+import com.google.common.base.CaseFormat;
 import com.google.common.collect.Range;
-
-import com.hedera.mirror.common.converter.AccountIdConverter;
-
 import com.vladmihalcea.hibernate.type.range.guava.PostgreSQLGuavaRangeType;
 import java.sql.SQLException;
 import java.time.Instant;
@@ -42,13 +40,12 @@ import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.convert.support.DefaultConversionService;
 import org.springframework.jdbc.core.DataClassRowMapper;
-import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.JdbcOperations;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.test.context.jdbc.Sql;
 
+import com.hedera.mirror.common.converter.AccountIdConverter;
 import com.hedera.mirror.common.domain.entity.EntityId;
-import com.hedera.mirror.common.domain.entity.EntityIdEndec;
-import com.hedera.mirror.common.domain.entity.EntityType;
 import com.hedera.mirror.common.domain.transaction.NonFeeTransfer;
 import com.hedera.mirror.importer.config.IntegrationTestConfiguration;
 import com.hedera.mirror.importer.config.MirrorDateRangePropertiesProcessor;
@@ -70,13 +67,40 @@ public abstract class IntegrationTest {
     private Collection<CacheManager> cacheManagers;
 
     @Resource
-    private JdbcTemplate jdbcTemplate;
+    protected JdbcOperations jdbcOperations;
 
     @Resource
     private MirrorDateRangePropertiesProcessor mirrorDateRangePropertiesProcessor;
 
     @Resource
     private MirrorProperties mirrorProperties;
+
+    @BeforeEach
+    void logTest(TestInfo testInfo) {
+        reset();
+        log.info("Executing: {}", testInfo.getDisplayName());
+    }
+
+    protected <T> Collection<T> findHistory(Class<T> historyClass) {
+        return findHistory(historyClass, "id");
+    }
+
+    protected  <T> Collection<T> findHistory(Class<T> historyClass, String ids) {
+        String table = historyClass.getSimpleName();
+        table = CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, table);
+        String sql = String.format("select * from %s_history order by %s, timestamp_range asc", table, ids);
+        return jdbcOperations.query(sql, rowMapper(historyClass));
+    }
+
+    protected List<NonFeeTransfer> findNonFeeTransfers() {
+        return jdbcOperations.query(SELECT_NON_FEE_TRANSFERS_QUERY, NON_FEE_TRANSFER_ROW_MAPPER);
+    }
+
+    protected void reset() {
+        cacheManagers.forEach(c -> c.getCacheNames().forEach(name -> c.getCache(name).clear()));
+        mirrorDateRangePropertiesProcessor.clear();
+        mirrorProperties.setStartDate(Instant.EPOCH);
+    }
 
     protected static <T> RowMapper<T> rowMapper(Class<T> entityClass) {
         DefaultConversionService defaultConversionService = new DefaultConversionService();
@@ -96,21 +120,5 @@ public abstract class IntegrationTest {
         DataClassRowMapper dataClassRowMapper = new DataClassRowMapper<>(entityClass);
         dataClassRowMapper.setConversionService(defaultConversionService);
         return dataClassRowMapper;
-    }
-
-    protected List<NonFeeTransfer> findNonFeeTransfers() {
-        return jdbcTemplate.query(SELECT_NON_FEE_TRANSFERS_QUERY, NON_FEE_TRANSFER_ROW_MAPPER);
-    }
-
-    @BeforeEach
-    void logTest(TestInfo testInfo) {
-        reset();
-        log.info("Executing: {}", testInfo.getDisplayName());
-    }
-
-    protected void reset() {
-        cacheManagers.forEach(c -> c.getCacheNames().forEach(name -> c.getCache(name).clear()));
-        mirrorDateRangePropertiesProcessor.clear();
-        mirrorProperties.setStartDate(Instant.EPOCH);
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/MissingEvmAddressMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/MissingEvmAddressMigrationTest.java
@@ -1,0 +1,156 @@
+package com.hedera.mirror.importer.migration;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.Range;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Resource;
+import com.vladmihalcea.hibernate.type.range.guava.PostgreSQLGuavaRangeType;
+import lombok.SneakyThrows;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.test.context.TestPropertySource;
+
+import com.hedera.mirror.common.domain.DomainBuilder;
+import com.hedera.mirror.common.domain.contract.Contract;
+import com.hedera.mirror.importer.EnabledIfV1;
+import com.hedera.mirror.importer.IntegrationTest;
+import com.hedera.mirror.importer.TestUtils;
+import com.hedera.mirror.importer.repository.ContractRepository;
+
+@EnabledIfV1
+@Tag("migration")
+@TestPropertySource(properties = "spring.flyway.target=1.55.4")
+class MissingEvmAddressMigrationTest extends IntegrationTest {
+
+    @Resource
+    private ContractRepository contractRepository;
+
+    @Resource
+    private DomainBuilder domainBuilder;
+
+    @Value("classpath:db/migration/v1/V1.55.5__missing_evm_address.sql")
+    private File migrationSql;
+
+    @Test
+    void empty() {
+        migrate();
+        assertThat(contractRepository.findAll()).isEmpty();
+        assertThat(findHistory(Contract.class)).isEmpty();
+    }
+
+    @Test
+    void fillMissingEvmAddress() {
+        // given
+        List<Contract> expectedCurrentContracts = new ArrayList<>();
+        List<Contract> expectedHistoricalContracts = new ArrayList<>();
+
+        // current and historical contract rows without evm address
+        var contract1 = persistHistoricalContract(domainBuilder.contract().get(), true, 1L);
+        expectedHistoricalContracts.add(contract1);
+        contract1 = persistCurrentContract(contract1, false);
+        expectedCurrentContracts.add(contract1);
+
+        // the oldest historical contract row has evm address and subsequent contract rows including the current copy
+        // are missing evm address
+        var contract2 = persistHistoricalContract(domainBuilder.contract().get(), false, 3L);
+        byte[] evmAddress = contract2.getEvmAddress();
+        expectedHistoricalContracts.add(contract2);
+        contract2 = persistHistoricalContract(contract2, true, 3L);
+        contract2.setEvmAddress(evmAddress); // add the expected evm address after it's persisted
+        expectedHistoricalContracts.add(contract2);
+        contract2 = persistCurrentContract(contract2, true);
+        contract2.setEvmAddress(evmAddress);
+        expectedCurrentContracts.add(contract2);
+
+        // all contract rows have evm address
+        var contract3 = persistHistoricalContract(domainBuilder.contract().get(), false, 2L);
+        expectedHistoricalContracts.add(contract3);
+        contract3 = persistHistoricalContract(contract3, false, 2L);
+        expectedHistoricalContracts.add(contract3);
+        contract3 = persistCurrentContract(contract3, false);
+        expectedCurrentContracts.add(contract3);
+
+        // when
+        migrate();
+
+        // then
+        assertThat(contractRepository.findAll()).containsExactlyInAnyOrderElementsOf(expectedCurrentContracts);
+        assertThat(findHistory(Contract.class))
+                .usingRecursiveFieldByFieldElementComparatorOnFields("id", "evm_address", "timestamp_range")
+                .containsExactlyInAnyOrderElementsOf(expectedHistoricalContracts);
+    }
+
+    private Contract getHistoricalContract(Contract contract, boolean clearEvmAddress, long validDuration) {
+        var clone = TestUtils.clone(contract);
+        if (clearEvmAddress) {
+            clone.setEvmAddress(null);
+        }
+
+        if (clone.getTimestampUpper() == null) {
+            clone.setTimestampUpper(clone.getTimestampLower() + validDuration);
+        } else {
+            clone.setTimestampLower(clone.getTimestampUpper());
+            clone.setTimestampUpper(clone.getTimestampLower() + validDuration);
+        }
+
+        return clone;
+    }
+
+    @SneakyThrows
+    private void migrate() {
+        jdbcOperations.update(FileUtils.readFileToString(migrationSql, "UTF-8"));
+    }
+
+    private Contract persistCurrentContract(Contract contract, boolean clearEvmAddress) {
+        var clone = TestUtils.clone(contract);
+        if (clearEvmAddress) {
+            clone.setEvmAddress(null);
+        }
+        Long lower = clone.getTimestampUpper() == null ? clone.getCreatedTimestamp() : clone.getTimestampUpper();
+        clone.setTimestampRange(Range.atLeast(lower));
+        contractRepository.save(clone);
+        return clone;
+    }
+
+    private Contract persistHistoricalContract(Contract contract, boolean clearEvmAddress, long validDuration) {
+        var clone = getHistoricalContract(contract, clearEvmAddress, validDuration);
+        jdbcOperations.update(
+                "insert into contract_history (id, created_timestamp, evm_address, num, realm, shard, type, " +
+                        "timestamp_range) values (?,?,?,?,?,?,?::entity_type,?::int8range)",
+                clone.getId(),
+                clone.getCreatedTimestamp(),
+                clone.getEvmAddress(),
+                clone.getNum(),
+                clone.getRealm(),
+                clone.getShard(),
+                clone.getType().toString(),
+                PostgreSQLGuavaRangeType.INSTANCE.asString(clone.getTimestampRange())
+        );
+        return clone;
+    }
+}

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/MissingEvmAddressMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/MissingEvmAddressMigrationTest.java
@@ -105,22 +105,6 @@ class MissingEvmAddressMigrationTest extends IntegrationTest {
                 .containsExactlyInAnyOrderElementsOf(expectedHistoricalContracts);
     }
 
-    private Contract getHistoricalContract(Contract contract, boolean clearEvmAddress, long validDuration) {
-        var clone = TestUtils.clone(contract);
-        if (clearEvmAddress) {
-            clone.setEvmAddress(null);
-        }
-
-        if (clone.getTimestampUpper() == null) {
-            clone.setTimestampUpper(clone.getTimestampLower() + validDuration);
-        } else {
-            clone.setTimestampLower(clone.getTimestampUpper());
-            clone.setTimestampUpper(clone.getTimestampLower() + validDuration);
-        }
-
-        return clone;
-    }
-
     @SneakyThrows
     private void migrate() {
         jdbcOperations.update(FileUtils.readFileToString(migrationSql, "UTF-8"));
@@ -138,7 +122,18 @@ class MissingEvmAddressMigrationTest extends IntegrationTest {
     }
 
     private Contract persistHistoricalContract(Contract contract, boolean clearEvmAddress, long validDuration) {
-        var clone = getHistoricalContract(contract, clearEvmAddress, validDuration);
+        var clone = TestUtils.clone(contract);
+        if (clearEvmAddress) {
+            clone.setEvmAddress(null);
+        }
+
+        if (clone.getTimestampUpper() == null) {
+            clone.setTimestampUpper(clone.getTimestampLower() + validDuration);
+        } else {
+            clone.setTimestampLower(clone.getTimestampUpper());
+            clone.setTimestampUpper(clone.getTimestampLower() + validDuration);
+        }
+
         jdbcOperations.update(
                 "insert into contract_history (id, created_timestamp, evm_address, num, realm, shard, type, " +
                         "timestamp_range) values (?,?,?,?,?,?,?::entity_type,?::int8range)",

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/TransferTransactionPayerMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/TransferTransactionPayerMigrationTest.java
@@ -27,6 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.Range;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
+import com.vladmihalcea.hibernate.type.range.guava.PostgreSQLGuavaRangeType;
 import java.io.File;
 import java.io.IOException;
 import java.sql.PreparedStatement;
@@ -615,8 +616,7 @@ class TransferTransactionPayerMigrationTest extends IntegrationTest {
                     entity.getRealm(),
                     entity.getShard(),
                     entity.getType().getId(),
-                    String.format("(%d, %d)", entity.getCreatedTimestamp(), entity.getTimestampRange()
-                            .lowerEndpoint())
+                    PostgreSQLGuavaRangeType.INSTANCE.asString(entity.getTimestampRange())
             );
         }
     }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/batch/BatchUpserterTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/batch/BatchUpserterTest.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.importer.parser.batch;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -36,7 +36,6 @@ import lombok.SneakyThrows;
 import org.apache.commons.codec.binary.Hex;
 import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.Test;
-import org.springframework.jdbc.core.JdbcOperations;
 import org.springframework.transaction.support.TransactionOperations;
 
 import com.hedera.mirror.common.domain.DomainBuilder;
@@ -94,9 +93,6 @@ class BatchUpserterTest extends IntegrationTest {
 
     @Resource
     private EntityRepository entityRepository;
-
-    @Resource
-    private JdbcOperations jdbcOperations;
 
     @Resource
     private NftRepository nftRepository;
@@ -754,12 +750,6 @@ class BatchUpserterTest extends IntegrationTest {
                 batchPersister.persist(batch);
             }
         });
-    }
-
-    private <T> Collection<T> findHistory(Class<T> historyClass) {
-        String table = historyClass.getSimpleName().toLowerCase();
-        String sql = String.format("select * from %s_history order by id asc, timestamp_range asc", table);
-        return jdbcOperations.query(sql, rowMapper(historyClass));
     }
 
     private Entity getEntity(long id, Long createdTimestamp, long modifiedTimestamp, String memo) {


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

This PR fixes the missing contract evm address issue:

- Merge evm address from the previous contract object in SqlEntityListener
- Add a db migration to fill missing evm address 

**Related issue(s)**:

Fixes #3406

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

This should only occur when the contract create and the next change of the contract happen in the same record file. Any subsequent contract rows will all have an empty evm address. The db migration is built on the theory, in two steps:

1. update any current contract rows with empty evm address whose first historical row has evm address, and returning those contract id and evm address
2. update any historical contract rows with empty evm address and contract id matching those returned in step 1

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
