### PR TITLE
Crypto Allowance acceptance tests

### DIFF
--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AccountClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AccountClient.java
@@ -217,10 +217,7 @@ public class AccountClient extends AbstractNetworkClient {
     public NetworkTransactionResponse approveCryptoAllowance(AccountId spender, Hbar hbarAmount) {
 
         var ownerAccountId = sdkClient.getExpandedOperatorAccountId().getAccountId();
-        log.debug(
-                "Approve spender {} an allowance of {} tℏ on {}'s account",
-                spender,
-                hbarAmount.toTinybars(),
+        log.debug("Approve spender {} an allowance of {} tℏ on {}'s account", spender, hbarAmount.toTinybars(),
                 ownerAccountId);
 
         var transaction = new AccountAllowanceApproveTransaction()

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/MirrorNodeClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/MirrorNodeClient.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.test.e2e.acceptance.client;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -38,6 +38,7 @@ import com.hedera.mirror.test.e2e.acceptance.config.RestPollingProperties;
 import com.hedera.mirror.test.e2e.acceptance.response.MirrorContractResponse;
 import com.hedera.mirror.test.e2e.acceptance.response.MirrorContractResultResponse;
 import com.hedera.mirror.test.e2e.acceptance.response.MirrorContractResultsResponse;
+import com.hedera.mirror.test.e2e.acceptance.response.MirrorCryptoAllowanceResponse;
 import com.hedera.mirror.test.e2e.acceptance.response.MirrorNftResponse;
 import com.hedera.mirror.test.e2e.acceptance.response.MirrorNftTransactionsResponse;
 import com.hedera.mirror.test.e2e.acceptance.response.MirrorScheduleResponse;
@@ -116,6 +117,23 @@ public class MirrorNodeClient extends AbstractNetworkClient {
         }
 
         return subscriptionResponse;
+    }
+
+    public MirrorCryptoAllowanceResponse getAccountCryptoAllowance(String accountId) {
+        log.debug("Verify account '{}''s crypto allowance is returned by Mirror Node", accountId);
+        return callRestEndpoint(
+                "/accounts/{accountId}/allowances/crypto",
+                MirrorCryptoAllowanceResponse.class,
+                accountId);
+    }
+
+    public MirrorCryptoAllowanceResponse getAccountCryptoAllowanceBySpender(String accountId, String spenderId) {
+        log.debug("Verify account '{}''s crypto allowance for {} is returned by Mirror Node", accountId, spenderId);
+        return callRestEndpoint(
+                "/accounts/{accountId}/allowances/crypto?spender.id={spenderId}",
+                MirrorCryptoAllowanceResponse.class,
+                accountId,
+                spenderId);
     }
 
     public MirrorContractResponse getContractInfo(String contractId) {

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/ExpandedAccountId.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/ExpandedAccountId.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.test.e2e.acceptance.props;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -41,5 +41,11 @@ public class ExpandedAccountId {
         accountId = AccountId.fromString(operatorId);
         privateKey = PrivateKey.fromString(operatorKey);
         publicKey = privateKey.getPublicKey();
+    }
+
+    public ExpandedAccountId(AccountId account) {
+        accountId = account;
+        privateKey = null;
+        publicKey = null;
     }
 }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorCryptoAllowance.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorCryptoAllowance.java
@@ -1,0 +1,28 @@
+package com.hedera.mirror.test.e2e.acceptance.props;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import lombok.Data;
+
+@Data
+public class MirrorCryptoAllowance extends MirrorTransferAllowance {
+    private long amount;
+}

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorTransferAllowance.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorTransferAllowance.java
@@ -1,0 +1,35 @@
+package com.hedera.mirror.test.e2e.acceptance.props;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import lombok.Data;
+
+@Data
+public class MirrorTransferAllowance {
+
+    private String owner;
+
+    private String payerAccountId;
+
+    private String spender;
+
+    private MirrorTimestampRange timestamp;
+}

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/response/MirrorCryptoAllowanceResponse.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/response/MirrorCryptoAllowanceResponse.java
@@ -1,0 +1,32 @@
+package com.hedera.mirror.test.e2e.acceptance.response;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import java.util.List;
+import lombok.Data;
+
+import com.hedera.mirror.test.e2e.acceptance.props.MirrorCryptoAllowance;
+import com.hedera.mirror.test.e2e.acceptance.props.MirrorTransferAllowance;
+
+@Data
+public class MirrorCryptoAllowanceResponse extends MirrorTransferAllowance {
+    List<MirrorCryptoAllowance> allowances;
+}

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AccountFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AccountFeature.java
@@ -193,7 +193,6 @@ public class AccountFeature extends AbstractFeature {
                 mirrorClient.getAccountCryptoAllowanceBySpender(ownerString, spenderString);
 
         // verify valid set of allowance
-        mirrorCryptoAllowanceResponse.getAllowances();
         assertThat(mirrorCryptoAllowanceResponse.getAllowances())
                 .isNotEmpty()
                 .first()

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AccountFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AccountFeature.java
@@ -132,7 +132,7 @@ public class AccountFeature extends AbstractFeature {
         setCryptoAllowance(senderAccountId.getAccountId(), -amount, false);
     }
 
-    @When("{string} transfers {long} tℏ to {string}")
+    @When("{string} transfers {long} tℏ from their approved balance to {string}")
     public void transferFromAllowance(String senderAccountName, long amount, String receiverAccountName) {
         senderAccountId = accountClient
                 .getAccount(AccountClient.AccountNameEnum.valueOf(senderAccountName));

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ScheduleFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ScheduleFeature.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.test.e2e.acceptance.steps;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -106,7 +106,8 @@ public class ScheduleFeature {
                 .getCryptoTransferTransaction(
                         accountClient.getTokenTreasuryAccount().getAccountId(),
                         recipient.getAccountId(),
-                        Hbar.fromTinybars(DEFAULT_TINY_HBAR));
+                        Hbar.fromTinybars(DEFAULT_TINY_HBAR),
+                        false);
 
         createNewSchedule(scheduledTransaction, null);
     }
@@ -157,7 +158,8 @@ public class ScheduleFeature {
                 .getCryptoTransferTransaction(
                         newAccountId.getAccountId(),
                         accountClient.getSdkClient().getExpandedOperatorAccountId().getAccountId(),
-                        Hbar.fromTinybars(DEFAULT_TINY_HBAR));
+                        Hbar.fromTinybars(DEFAULT_TINY_HBAR),
+                        false);
 
         // add sender private key to ensure only Alice's signature is the only signature left that is required
         privateKeyList.add(newAccountId.getPrivateKey());

--- a/hedera-mirror-test/src/test/resources/features/account/allowances/cryptoAllowance.feature
+++ b/hedera-mirror-test/src/test/resources/features/account/allowances/cryptoAllowance.feature
@@ -1,7 +1,7 @@
-@accounts @allowance @fullsuite
+@cryptoallowance @allowance @fullsuite
 Feature: Account Crypto Allowance Coverage Feature
 
-    @critical @release @acceptance @cryptoallowance
+    @critical @release @acceptance
     Scenario Outline: Validate approval CryptoTransfer
         Given I approve <senderName> to transfer up to <approvedAmount> tℏ
         Then the mirror node REST API should confirm the approved <approvedAmount> tℏ crypto transfer allowance
@@ -14,3 +14,8 @@ Feature: Account Crypto Allowance Coverage Feature
         Examples:
             | senderName | approvedAmount | recipientName | transferAmount | httpStatusCode | updateApprovedAmount |
             | "ALICE"    | 10000          | "BOB"         | 2500           | 200            | 5000                 |
+
+    @critical @release @acceptance
+    Scenario: Validate allowance cleanup
+        Given I remove all my allowances from my account
+        Then the mirror node REST API should confirm no granted allowances remain

--- a/hedera-mirror-test/src/test/resources/features/account/allowances/cryptoAllowance.feature
+++ b/hedera-mirror-test/src/test/resources/features/account/allowances/cryptoAllowance.feature
@@ -5,7 +5,7 @@ Feature: Account Crypto Allowance Coverage Feature
     Scenario Outline: Validate approval CryptoTransfer
         Given I approve <senderName> to transfer up to <approvedAmount> tℏ
         Then the mirror node REST API should confirm the approved <approvedAmount> tℏ crypto transfer allowance
-        When <senderName> transfers <transferAmount> tℏ to <recipientName>
+        When <senderName> transfers <transferAmount> tℏ from their approved balance to <recipientName>
         Then the mirror node REST API should return status <httpStatusCode> for the crypto transfer transaction
         Given I adjust <senderName> transfer allowance to <updateApprovedAmount> tℏ
         Then the mirror node REST API should confirm the approved <updateApprovedAmount> tℏ crypto transfer allowance

--- a/hedera-mirror-test/src/test/resources/features/account/allowances/cryptoAllowance.feature
+++ b/hedera-mirror-test/src/test/resources/features/account/allowances/cryptoAllowance.feature
@@ -1,0 +1,16 @@
+@accounts @allowance @fullsuite
+Feature: Account Crypto Allowance Coverage Feature
+
+    @critical @release @acceptance @cryptoallowance
+    Scenario Outline: Validate approval CryptoTransfer
+        Given I approve <senderName> to transfer up to <approvedAmount> tℏ
+        Then the mirror node REST API should confirm the approved <approvedAmount> tℏ crypto transfer allowance
+        When <senderName> transfers <transferAmount> tℏ to <recipientName>
+        Then the mirror node REST API should return status <httpStatusCode> for the crypto transfer transaction
+        Given I adjust <senderName> transfer allowance to <updateApprovedAmount> tℏ
+        Then the mirror node REST API should confirm the approved <updateApprovedAmount> tℏ crypto transfer allowance
+        When I delete the crypto allowance for <senderName>
+        Then the mirror node REST API should confirm the crypto allowance deletion
+        Examples:
+            | senderName | approvedAmount | recipientName | transferAmount | httpStatusCode | updateApprovedAmount |
+            | "ALICE"    | 10000          | "BOB"         | 2500           | 200            | 5000                 |


### PR DESCRIPTION
**Description**:
The current acceptance tests are yet to provide coverage for allowance test cases

- Update `AccountClient`
  -  `approveCryptoAllowance` and `adjustCryptoAllowance` for crypto cases
  -  `getAccountAllowanceApproveTransaction` and `getAccountAllowanceAdjustTransaction` for general scenarios
- Update `AccountFeature` with scenarios to approve and adjust crypto allowance
- Add `MirrorTransferAllowance` base prop for all allowance objects
- Add `MirrorCryptoAllowance` object
- Add `cryptoAllowance.feature` scenarios

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
- Run scenarios against previewnet
- Provides a base for future allowance acceptance tests

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
