### PR TITLE
Fix rest API showing ecdsa public key as ProtobufEncoded key

### DIFF
--- a/hedera-mirror-common/src/test/java/com/hedera/mirror/common/util/DomainUtilsTest.java
+++ b/hedera-mirror-common/src/test/java/com/hedera/mirror/common/util/DomainUtilsTest.java
@@ -46,7 +46,21 @@ import com.hedera.mirror.common.exception.InvalidEntityException;
 
 class DomainUtilsTest {
 
-    private static final String KEY = "c83755a935e442f18f12fbb9ecb5bc416417059ddb3c15aac32c1702e7da6734";
+    private static final String ED25519_KEY = "60beee88a761e079f71b03b5fe041979369e96450a7455b203a2578c8a7d4852";
+    private static final String ECDSA_384_KEY = "0000001365636473612d736861322d6e69737470333834000000086e697374703338" +
+            "340000006104414e37848e6bbf0824d32e434c315eac3c23300db659f6058ed160ff8f6e80e2353d280b95c876b9f97b785f0a0f" +
+            "c8f76842241c2484966791344fd54bc103ce57380052abade51b5b4cf21fad404fe6a1ee7228bff3cd2fbfd617802d8f625b";
+    private static final String ECDSA_SECP256K1_KEY = "0347ba1b98360d856fb796ecbcbde934055b9e0967e5e40d0abeb3fd68bf83" +
+            "82c2";
+    private static final String RSA_3072_KEY = "308201a2300d06092a864886f70d01010105000382018f003082018a0282018100c34" +
+            "471f9db1efd5345cb664ed7bb980a8a859f41a51c4a009a91a1db51401af9dea56ce00ca09050c0d02f49ee58b68b24760f077c4" +
+            "079f4345ea2e78f4e8f52518a437dc3db47b611ce0574b56d064899892b7378d65491e65676cdf3f2f2b07f34f8bec515f3d4037" +
+            "6b3a0a13615c8fc8348091091bb8dcd3a617de7b1bd5958c66ca108632e208955a6d2b6bc3421175cc2a2a67a5cafd8562dc7360" +
+            "0006bb44b4796dceb7430c0c62cb0ae1618e391c1284e8e750a40991aa4c4dee6e450c26d2347b9e20865f9cad3de21033ad9aa3" +
+            "eee092b9fc3df3fc35533b16530204bc171ef7573138fd212bd559fe2071295542cb40090415bf397bbf474adb6bacba32fe13c0" +
+            "817a8f202e659588c5608a12fc2707795b3b621434305b7d4f6d6271ebe62a7afd98c2f662f4ed5f8c4bd0ee603b896e53e2ca2d" +
+            "ed7495515c1e88a40f58fd6f94f8d9f14613470ba873d395293ea5542ddea56550f44d5760f57394693a889a43ab6f73b3a55448" +
+            "8ecadacc328cb02594a2a5e9e46602010e2430203010001";
 
     @Test
     void getPublicKeyWhenNull() {
@@ -60,26 +74,26 @@ class DomainUtilsTest {
 
     @Test
     void getPublicKeyWhenEd25519() throws Exception {
-        var bytes = Key.newBuilder().setEd25519(ByteString.copyFrom(Hex.decodeHex(KEY))).build().toByteArray();
-        assertThat(DomainUtils.getPublicKey(bytes)).isEqualTo(KEY);
+        var bytes = Key.newBuilder().setEd25519(ByteString.copyFrom(Hex.decodeHex(ED25519_KEY))).build().toByteArray();
+        assertThat(DomainUtils.getPublicKey(bytes)).isEqualTo(ED25519_KEY);
     }
 
     @Test
     void getPublicKeyWhenECDSASecp256K1() throws Exception {
-        var bytes = Key.newBuilder().setECDSASecp256K1(ByteString.copyFrom(Hex.decodeHex(KEY))).build().toByteArray();
-        assertThat(DomainUtils.getPublicKey(bytes)).isEqualTo(KEY);
+        var bytes = Key.newBuilder().setECDSASecp256K1(ByteString.copyFrom(Hex.decodeHex(ECDSA_SECP256K1_KEY))).build().toByteArray();
+        assertThat(DomainUtils.getPublicKey(bytes)).isEqualTo(ECDSA_SECP256K1_KEY);
     }
 
     @Test
     void getPublicKeyWhenECDSA384() throws Exception {
-        var bytes = Key.newBuilder().setECDSA384(ByteString.copyFrom(Hex.decodeHex(KEY))).build().toByteArray();
-        assertThat(DomainUtils.getPublicKey(bytes)).isEqualTo(KEY);
+        var bytes = Key.newBuilder().setECDSA384(ByteString.copyFrom(Hex.decodeHex(ECDSA_384_KEY))).build().toByteArray();
+        assertThat(DomainUtils.getPublicKey(bytes)).isEqualTo(ECDSA_384_KEY);
     }
 
     @Test
     void getPublicKeyWhenRSA3072() throws Exception {
-        var bytes = Key.newBuilder().setRSA3072(ByteString.copyFrom(Hex.decodeHex(KEY))).build().toByteArray();
-        assertThat(DomainUtils.getPublicKey(bytes)).isEqualTo(KEY);
+        var bytes = Key.newBuilder().setRSA3072(ByteString.copyFrom(Hex.decodeHex(RSA_3072_KEY))).build().toByteArray();
+        assertThat(DomainUtils.getPublicKey(bytes)).isEqualTo(RSA_3072_KEY);
     }
 
     @Test
@@ -96,15 +110,15 @@ class DomainUtilsTest {
 
     @Test
     void getPublicKeyWhenSimpleKeyList() throws Exception {
-        var key = Key.newBuilder().setECDSASecp256K1(ByteString.copyFrom(Hex.decodeHex(KEY))).build();
+        var key = Key.newBuilder().setECDSASecp256K1(ByteString.copyFrom(Hex.decodeHex(ECDSA_SECP256K1_KEY))).build();
         var keyList = KeyList.newBuilder().addKeys(key).build();
         var bytes = Key.newBuilder().setKeyList(keyList).build().toByteArray();
-        assertThat(DomainUtils.getPublicKey(bytes)).isEqualTo(KEY);
+        assertThat(DomainUtils.getPublicKey(bytes)).isEqualTo(ECDSA_SECP256K1_KEY);
     }
 
     @Test
     void getPublicKeyWhenMaxDepth() throws Exception {
-        var primitiveKey = Key.newBuilder().setEd25519(ByteString.copyFrom(Hex.decodeHex(KEY))).build();
+        var primitiveKey = Key.newBuilder().setEd25519(ByteString.copyFrom(Hex.decodeHex(ED25519_KEY))).build();
         var keyList2 = KeyList.newBuilder().addKeys(primitiveKey).build();
         var key2 = Key.newBuilder().setKeyList(keyList2).build();
         var keyList1 = KeyList.newBuilder().addKeys(key2).build();
@@ -114,7 +128,7 @@ class DomainUtilsTest {
 
     @Test
     void getPublicKeyWhenKeyList() throws Exception {
-        var key = Key.newBuilder().setEd25519(ByteString.copyFrom(Hex.decodeHex(KEY))).build();
+        var key = Key.newBuilder().setEd25519(ByteString.copyFrom(Hex.decodeHex(ED25519_KEY))).build();
         var keyList = KeyList.newBuilder().addKeys(key).addKeys(key).build();
         var bytes = Key.newBuilder().setKeyList(keyList).build().toByteArray();
         assertThat(DomainUtils.getPublicKey(bytes)).isNull();
@@ -122,16 +136,16 @@ class DomainUtilsTest {
 
     @Test
     void getPublicKeyWhenSimpleThreshHoldKey() throws Exception {
-        var key = Key.newBuilder().setEd25519(ByteString.copyFrom(Hex.decodeHex(KEY))).build();
+        var key = Key.newBuilder().setEd25519(ByteString.copyFrom(Hex.decodeHex(ED25519_KEY))).build();
         var keyList = KeyList.newBuilder().addKeys(key).build();
         var tk = ThresholdKey.newBuilder().setThreshold(1).setKeys(keyList).build();
         var bytes = Key.newBuilder().setThresholdKey(tk).build().toByteArray();
-        assertThat(DomainUtils.getPublicKey(bytes)).isEqualTo(KEY);
+        assertThat(DomainUtils.getPublicKey(bytes)).isEqualTo(ED25519_KEY);
     }
 
     @Test
     void getPublicKeyWhenThreshHoldKey() throws Exception {
-        var key = Key.newBuilder().setEd25519(ByteString.copyFrom(Hex.decodeHex(KEY))).build();
+        var key = Key.newBuilder().setEd25519(ByteString.copyFrom(Hex.decodeHex(ED25519_KEY))).build();
         var keyList = KeyList.newBuilder().addKeys(key).addKeys(key).build();
         var tk = ThresholdKey.newBuilder().setThreshold(1).setKeys(keyList).build();
         var bytes = Key.newBuilder().setThresholdKey(tk).build().toByteArray();

--- a/hedera-mirror-rest/__tests__/integrationDomainOps.js
+++ b/hedera-mirror-rest/__tests__/integrationDomainOps.js
@@ -287,6 +287,9 @@ const addEntity = async (defaults, entity) => {
   };
   entity.id = EntityId.of(BigInt(entity.shard), BigInt(entity.realm), BigInt(entity.num)).getEncodedId();
   entity.alias = base32.decode(entity.alias);
+  if (typeof entity.key === 'string') {
+    entity.key = Buffer.from(entity.key, 'hex');
+  }
 
   await insertDomainObject('entity', insertFields, entity);
 };

--- a/hedera-mirror-rest/__tests__/specs/accounts-01-no-args.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/accounts-01-no-args.spec.json
@@ -3,22 +3,28 @@
   "setup": {
     "accounts": [
       {
-        "num": 1
+        "num": 1,
+        "key": "1220bfc9d4a344389324119eed485eb3a875b1e5a54bd189d2fd5ad88ce1d3473dee"
       },
       {
-        "num": 2
+        "num": 2,
+        "key": "32240a221220bfc9d4a344389324119eed485eb3a875b1e5a54bd189d2fd5ad88ce1d3473dee"
       },
       {
-        "num": 3
+        "num": 3,
+        "key": "2a28080112240a221220bfc9d4a344389324119eed485eb3a875b1e5a54bd189d2fd5ad88ce1d3473dee"
       },
       {
-        "num": 4
+        "num": 4,
+        "key": "3a21023673dc1b97f1e2a99041867be087ec040374636b8e7486789112e95f09018401"
       },
       {
-        "num": 5
+        "num": 5,
+        "key": "32250a233a21023673dc1b97f1e2a99041867be087ec040374636b8e7486789112e95f09018401"
       },
       {
-        "num": 6
+        "num": 6,
+        "key": "2a29080112250a233a21023673dc1b97f1e2a99041867be087ec040374636b8e7486789112e95f09018401"
       },
       {
         "num": 9,
@@ -156,7 +162,10 @@
         "deleted": false,
         "expiry_timestamp": null,
         "auto_renew_period": null,
-        "key": null,
+        "key": {
+          "_type": "ED25519",
+          "key": "bfc9d4a344389324119eed485eb3a875b1e5a54bd189d2fd5ad88ce1d3473dee"
+        },
         "max_automatic_token_associations": 0,
         "memo": "entity memo",
         "receiver_sig_required": false
@@ -180,7 +189,10 @@
         "alias": null,
         "expiry_timestamp": null,
         "auto_renew_period": null,
-        "key": null,
+        "key": {
+          "_type": "ED25519",
+          "key": "bfc9d4a344389324119eed485eb3a875b1e5a54bd189d2fd5ad88ce1d3473dee"
+        },
         "deleted": false,
         "max_automatic_token_associations": 0,
         "memo": "entity memo",
@@ -196,7 +208,10 @@
         "alias": null,
         "expiry_timestamp": null,
         "auto_renew_period": null,
-        "key": null,
+        "key": {
+          "_type": "ED25519",
+          "key": "bfc9d4a344389324119eed485eb3a875b1e5a54bd189d2fd5ad88ce1d3473dee"
+        },
         "deleted": false,
         "max_automatic_token_associations": 0,
         "memo": "entity memo",
@@ -212,7 +227,10 @@
         "alias": null,
         "expiry_timestamp": null,
         "auto_renew_period": null,
-        "key": null,
+        "key": {
+          "_type": "ECDSA_SECP256K1",
+          "key": "023673dc1b97f1e2a99041867be087ec040374636b8e7486789112e95f09018401"
+        },
         "deleted": false,
         "max_automatic_token_associations": 0,
         "memo": "entity memo",
@@ -237,7 +255,10 @@
         "alias": null,
         "expiry_timestamp": null,
         "auto_renew_period": null,
-        "key": null,
+        "key": {
+          "_type": "ECDSA_SECP256K1",
+          "key": "023673dc1b97f1e2a99041867be087ec040374636b8e7486789112e95f09018401"
+        },
         "deleted": false,
         "max_automatic_token_associations": 0,
         "memo": "entity memo",
@@ -253,7 +274,10 @@
         "alias": null,
         "expiry_timestamp": null,
         "auto_renew_period": null,
-        "key": null,
+        "key": {
+          "_type": "ECDSA_SECP256K1",
+          "key": "023673dc1b97f1e2a99041867be087ec040374636b8e7486789112e95f09018401"
+        },
         "deleted": false,
         "max_automatic_token_associations": 0,
         "memo": "entity memo",

--- a/hedera-mirror-rest/__tests__/utils.test.js
+++ b/hedera-mirror-rest/__tests__/utils.test.js
@@ -127,11 +127,13 @@ describe('Utils encodeKey', () => {
   };
 
   const getKeyListBytes = (protoKey) => {
-    return proto.KeyList.encode({keys: [protoKey]}).finish();
+    const key = {keyList: proto.KeyList.create({keys: [protoKey]})};
+    return getPrimitiveKeyBytes(key);
   };
 
   const getThresholdKeyBytes = (protoKey) => {
-    return proto.ThresholdKey.encode({keys: {keys: [protoKey]}, threshold: 1}).finish();
+    const key = {thresholdKey: proto.ThresholdKey.create({keys: {keys: [protoKey]}, threshold: 1})};
+    return getPrimitiveKeyBytes(key);
   };
 
   test('Null', () => expect(utils.encodeKey(null)).toBe(null));

--- a/hedera-mirror-rest/utils.js
+++ b/hedera-mirror-rest/utils.js
@@ -735,8 +735,8 @@ const toHexString = (byteArray, addPrefix = false, padLength = undefined) => {
 
 // These match protobuf encoded hex strings. The prefixes listed check if it's a primitive key, a key list with one
 // primitive key, or a 1/1 threshold key, respectively.
-const PATTERN_ECDSA = /^(3a20|32240a223a20|2a28080112240a223a20)([A-Fa-f0-9]{66})$/;
-const PATTERN_ED25519 = /^(1220|32240a221220|2a28080112240a221220)([A-Fa-f0-9]{64})$/;
+const PATTERN_ECDSA = /^(3a21|0a233a21|080112250a233a21)([A-Fa-f0-9]{66})$/;
+const PATTERN_ED25519 = /^(1220|0a221220|080112240a221220)([A-Fa-f0-9]{64})$/;
 
 /**
  * Converts a key for returning in JSON output

--- a/hedera-mirror-rest/utils.js
+++ b/hedera-mirror-rest/utils.js
@@ -735,8 +735,8 @@ const toHexString = (byteArray, addPrefix = false, padLength = undefined) => {
 
 // These match protobuf encoded hex strings. The prefixes listed check if it's a primitive key, a key list with one
 // primitive key, or a 1/1 threshold key, respectively.
-const PATTERN_ECDSA = /^(3a21|0a233a21|080112250a233a21)([A-Fa-f0-9]{66})$/;
-const PATTERN_ED25519 = /^(1220|0a221220|080112240a221220)([A-Fa-f0-9]{64})$/;
+const PATTERN_ECDSA = /^(3a21|32250a233a21|2a29080112250a233a21)([A-Fa-f0-9]{66})$/;
+const PATTERN_ED25519 = /^(1220|32240a221220|2a28080112240a221220)([A-Fa-f0-9]{64})$/;
 
 /**
  * Converts a key for returning in JSON output


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR fixes the prefix to determine if an ECDSA SECP256K1 public key can be extracted from a protobuf key when the protobuf key is 1) a primitive key, or 2) a key with a key list of a single key, or 3) a key with a 1:1 threshold key 

**Related issue(s)**:

Fixes #3405

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
