### PR TITLE
Fix monitor stopped publishing

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -240,66 +240,66 @@ value, it is recommended to only populate overridden properties in the custom `a
 See the monitor [documentation](/docs/monitor/README.md) for more general information about configuring and using the
 monitor.
 
-Name                                                            | Default | Description
-----------------------------------------------------------------|---------| ---------------------------------------
-`hedera.mirror.monitor.mirrorNode.grpc.host`                    | ""      | The hostname of the mirror node's gRPC API
-`hedera.mirror.monitor.mirrorNode.grpc.port`                    | 5600    | The port of the mirror node's gRPC API
-`hedera.mirror.monitor.mirrorNode.rest.host`                    | ""      | The hostname of the mirror node's REST API
-`hedera.mirror.monitor.mirrorNode.rest.port`                    | 443     | The port of the mirror node's REST API
-`hedera.mirror.monitor.network`                                 | TESTNET | Which network to connect to. Automatically populates the main node & mirror node endpoints. Can be `MAINNET`, `PREVIEWNET`, `TESTNET` or `OTHER`
-`hedera.mirror.monitor.nodes[].accountId`                       | ""      | The main node's account ID
-`hedera.mirror.monitor.nodes[].host`                            | ""      | The main node's hostname
-`hedera.mirror.monitor.nodes[].port`                            | 50211   | The main node's port
-`hedera.mirror.monitor.nodeValidation.enabled`                  | true    | Whether to validate and remove invalid or down nodes permanently before publishing
-`hedera.mirror.monitor.nodeValidation.frequency`                | 30m     | The amount of time between validations of the network.
-`hedera.mirror.monitor.nodeValidation.maxAttempts`              | 4       | The number of times the monitor should attempt to receive a healthy response from a node before marking it as unhealthy.
-`hedera.mirror.monitor.nodeValidation.maxBackoff`               | 2s      | The maximum amount of time to wait in between attempts when trying to validate a node
-`hedera.mirror.monitor.nodeValidation.maxThreads`               | 25      | The maximum number of threads to use for node validation
-`hedera.mirror.monitor.nodeValidation.minBackoff`               | 500ms   | The minimum amount of time to wait in between attempts when trying to validate a node
-`hedera.mirror.monitor.nodeValidation.requestTimeout`           | 10s     | The amount of time to wait for a validation request before timing out
-`hedera.mirror.monitor.operator.accountId`                      | ""      | Operator account ID used to pay for transactions
-`hedera.mirror.monitor.operator.privateKey`                     | ""      | Operator ED25519 private key used to sign transactions in hex encoded DER format
-`hedera.mirror.monitor.publish.batchDivisor`                    | 100     | The divisor used to calculate batch size when generating transactions
-`hedera.mirror.monitor.publish.clients`                         | 4       | How many total SDK clients to publish transactions. Clients will be used in a round-robin fashion
-`hedera.mirror.monitor.publish.enabled`                         | true    | Whether to enable transaction publishing
-`hedera.mirror.monitor.publish.responseThreads`                 | 40      | How many threads to use to resolve the asynchronous responses
-`hedera.mirror.monitor.publish.scenarios`                       |         | A map of scenario name to publish scenarios. The name is used as a unique identifier in logs, metrics, and the REST API
-`hedera.mirror.monitor.publish.scenarios.<name>.duration`       |         | How long this scenario should publish transactions. Leave empty for infinite
-`hedera.mirror.monitor.publish.scenarios.<name>.enabled`        | true    | Whether this publish scenario is enabled
-`hedera.mirror.monitor.publish.scenarios.<name>.limit`          | 0       | How many transactions to publish before halting. 0 for unlimited
-`hedera.mirror.monitor.publish.scenarios.<name>.logResponse`    | false   | Whether to log the response from HAPI
-`hedera.mirror.monitor.publish.scenarios.<name>.properties`     | {}      | Key/value pairs used to configure the [`TransactionSupplier`](/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction) associated with this scenario type
-`hedera.mirror.monitor.publish.scenarios.<name>.receiptPercent` | 0.0     | The percentage of receipts to retrieve from HAPI. Accepts values between 0-1
-`hedera.mirror.monitor.publish.scenarios.<name>.recordPercent`  | 0.0     | The percentage of records to retrieve from HAPI. Accepts values between 0-1
-`hedera.mirror.monitor.publish.scenarios.<name>.retry.maxAttempts` | 1       | The maximum number of times a scenario transaction will be attempted
-`hedera.mirror.monitor.publish.scenarios.<name>.timeout`        | 12s     | How long to wait for the transaction result
-`hedera.mirror.monitor.publish.scenarios.<name>.tps`            | 1.0     | The rate at which transactions will publish
-`hedera.mirror.monitor.publish.scenarios.<name>.type`           |         | The type of transaction to publish. See the [`TransactionType`](/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/TransactionType.java) enum for a list of possible values
-`hedera.mirror.monitor.publish.statusFrequency`                 | 10s     | How often to log publishing statistics
-`hedera.mirror.monitor.publish.warmupPeriod`                    | 30s     | The amount of time the publisher should ramp up its rate before reaching its stable (maximum) rate
-`hedera.mirror.monitor.subscribe.clients`                       | 1       | How many SDK clients should be created to subscribe to mirror node APIs. Clients will be used in a round-robin fashion
-`hedera.mirror.monitor.subscribe.enabled`                       | true    | Whether to enable subscribing to mirror node APIs to verify published transactions
-`hedera.mirror.monitor.subscribe.grpc`                          |         | A map of scenario name to gRPC subscriber scenarios. The name is used as a unique identifier in logs, metrics, and the REST API
-`hedera.mirror.monitor.subscribe.grpc.<name>.duration`          |         | How long to stay subscribed to the API
-`hedera.mirror.monitor.subscribe.grpc.<name>.enabled`           | true    | Whether this subscribe scenario is enabled
-`hedera.mirror.monitor.subscribe.grpc.<name>.limit`             | 0       | How many transactions to receive before halting. 0 for unlimited
+Name                                                            | Default  | Description
+----------------------------------------------------------------|----------| ---------------------------------------
+`hedera.mirror.monitor.mirrorNode.grpc.host`                    | ""       | The hostname of the mirror node's gRPC API
+`hedera.mirror.monitor.mirrorNode.grpc.port`                    | 5600     | The port of the mirror node's gRPC API
+`hedera.mirror.monitor.mirrorNode.rest.host`                    | ""       | The hostname of the mirror node's REST API
+`hedera.mirror.monitor.mirrorNode.rest.port`                    | 443      | The port of the mirror node's REST API
+`hedera.mirror.monitor.network`                                 | TESTNET  | Which network to connect to. Automatically populates the main node & mirror node endpoints. Can be `MAINNET`, `PREVIEWNET`, `TESTNET` or `OTHER`
+`hedera.mirror.monitor.nodes[].accountId`                       | ""       | The main node's account ID
+`hedera.mirror.monitor.nodes[].host`                            | ""       | The main node's hostname
+`hedera.mirror.monitor.nodes[].port`                            | 50211    | The main node's port
+`hedera.mirror.monitor.nodeValidation.enabled`                  | true     | Whether to validate and remove invalid or down nodes permanently before publishing
+`hedera.mirror.monitor.nodeValidation.frequency`                | 30m      | The amount of time between validations of the network.
+`hedera.mirror.monitor.nodeValidation.maxAttempts`              | 8        | The number of times the monitor should attempt to receive a healthy response from a node before marking it as unhealthy.
+`hedera.mirror.monitor.nodeValidation.maxBackoff`               | 2s       | The maximum amount of time to wait in between attempts when trying to validate a node
+`hedera.mirror.monitor.nodeValidation.maxThreads`               | 25       | The maximum number of threads to use for node validation
+`hedera.mirror.monitor.nodeValidation.minBackoff`               | 500ms    | The minimum amount of time to wait in between attempts when trying to validate a node
+`hedera.mirror.monitor.nodeValidation.requestTimeout`           | 15s      | The amount of time to wait for a validation request before timing out
+`hedera.mirror.monitor.operator.accountId`                      | ""       | Operator account ID used to pay for transactions
+`hedera.mirror.monitor.operator.privateKey`                     | ""       | Operator ED25519 private key used to sign transactions in hex encoded DER format
+`hedera.mirror.monitor.publish.batchDivisor`                    | 100      | The divisor used to calculate batch size when generating transactions
+`hedera.mirror.monitor.publish.clients`                         | 4        | How many total SDK clients to publish transactions. Clients will be used in a round-robin fashion
+`hedera.mirror.monitor.publish.enabled`                         | true     | Whether to enable transaction publishing
+`hedera.mirror.monitor.publish.responseThreads`                 | 40       | How many threads to use to resolve the asynchronous responses
+`hedera.mirror.monitor.publish.scenarios`                       |          | A map of scenario name to publish scenarios. The name is used as a unique identifier in logs, metrics, and the REST API
+`hedera.mirror.monitor.publish.scenarios.<name>.duration`       |          | How long this scenario should publish transactions. Leave empty for infinite
+`hedera.mirror.monitor.publish.scenarios.<name>.enabled`        | true     | Whether this publish scenario is enabled
+`hedera.mirror.monitor.publish.scenarios.<name>.limit`          | 0        | How many transactions to publish before halting. 0 for unlimited
+`hedera.mirror.monitor.publish.scenarios.<name>.logResponse`    | false    | Whether to log the response from HAPI
+`hedera.mirror.monitor.publish.scenarios.<name>.properties`     | {}       | Key/value pairs used to configure the [`TransactionSupplier`](/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction) associated with this scenario type
+`hedera.mirror.monitor.publish.scenarios.<name>.receiptPercent` | 0.0      | The percentage of receipts to retrieve from HAPI. Accepts values between 0-1
+`hedera.mirror.monitor.publish.scenarios.<name>.recordPercent`  | 0.0      | The percentage of records to retrieve from HAPI. Accepts values between 0-1
+`hedera.mirror.monitor.publish.scenarios.<name>.retry.maxAttempts` | 1        | The maximum number of times a scenario transaction will be attempted
+`hedera.mirror.monitor.publish.scenarios.<name>.timeout`        | 12s      | How long to wait for the transaction result
+`hedera.mirror.monitor.publish.scenarios.<name>.tps`            | 1.0      | The rate at which transactions will publish
+`hedera.mirror.monitor.publish.scenarios.<name>.type`           |          | The type of transaction to publish. See the [`TransactionType`](/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/TransactionType.java) enum for a list of possible values
+`hedera.mirror.monitor.publish.statusFrequency`                 | 10s      | How often to log publishing statistics
+`hedera.mirror.monitor.publish.warmupPeriod`                    | 30s      | The amount of time the publisher should ramp up its rate before reaching its stable (maximum) rate
+`hedera.mirror.monitor.subscribe.clients`                       | 1        | How many SDK clients should be created to subscribe to mirror node APIs. Clients will be used in a round-robin fashion
+`hedera.mirror.monitor.subscribe.enabled`                       | true     | Whether to enable subscribing to mirror node APIs to verify published transactions
+`hedera.mirror.monitor.subscribe.grpc`                          |          | A map of scenario name to gRPC subscriber scenarios. The name is used as a unique identifier in logs, metrics, and the REST API
+`hedera.mirror.monitor.subscribe.grpc.<name>.duration`          |          | How long to stay subscribed to the API
+`hedera.mirror.monitor.subscribe.grpc.<name>.enabled`           | true     | Whether this subscribe scenario is enabled
+`hedera.mirror.monitor.subscribe.grpc.<name>.limit`             | 0        | How many transactions to receive before halting. 0 for unlimited
 `hedera.mirror.monitor.subscribe.grpc.<name>.retry.maxAttempts` | 2^63 - 1 | How many consecutive retry attempts before giving up connecting to the API
-`hedera.mirror.monitor.subscribe.grpc.<name>.retry.maxBackoff`  | 8s      | The maximum amount of time to wait between retry attempts
-`hedera.mirror.monitor.subscribe.grpc.<name>.retry.minBackoff`  | 500ms   | The initial amount of time to wait between retry attempts
-`hedera.mirror.monitor.subscribe.grpc.<name>.startTime`         |         | The start time passed to the gRPC API. Defaults to current time if not set
-`hedera.mirror.monitor.subscribe.grpc.<name>.subscribers`       | 1       | How many concurrent subscribers should be instantiated for this scenario
-`hedera.mirror.monitor.subscribe.grpc.<name>.topicId`           |         | Which topic to subscribe to
-`hedera.mirror.monitor.subscribe.rest`                          |         | A map of scenario name to REST subscriber scenarios. The name is used as a unique identifier in logs, metrics, and the REST API
-`hedera.mirror.monitor.subscribe.rest.<name>.duration`          |         | How long to stay subscribed to the API
-`hedera.mirror.monitor.subscribe.rest.<name>.enabled`           | true    | Whether this subscribe scenario is enabled
-`hedera.mirror.monitor.subscribe.rest.<name>.limit`             | 0       | How many transactions to receive before halting. 0 for unlimited
-`hedera.mirror.monitor.subscribe.rest.<name>.publishers`        | []      | A list of publisher scenario names to consider for sampling
-`hedera.mirror.monitor.subscribe.rest.<name>.retry.maxAttempts` | 16      | How many consecutive retry attempts before giving up connecting to the API
-`hedera.mirror.monitor.subscribe.rest.<name>.retry.maxBackoff`  | 1s      | The maximum amount of time to wait between retry attempts
-`hedera.mirror.monitor.subscribe.rest.<name>.retry.minBackoff`  | 500ms   | The initial amount of time to wait between retry attempts
-`hedera.mirror.monitor.subscribe.rest.<name>.samplePercent`     | 1.0     | The percentage of transactions to verify against the API. Accepts values between 0-1
-`hedera.mirror.monitor.subscribe.rest.<name>.timeout`           | 5s      | Maximum amount of time to wait for a API call to retrieve data
-`hedera.mirror.monitor.subscribe.statusFrequency`               | 10s     | How often to log subscription statistics
+`hedera.mirror.monitor.subscribe.grpc.<name>.retry.maxBackoff`  | 8s       | The maximum amount of time to wait between retry attempts
+`hedera.mirror.monitor.subscribe.grpc.<name>.retry.minBackoff`  | 500ms    | The initial amount of time to wait between retry attempts
+`hedera.mirror.monitor.subscribe.grpc.<name>.startTime`         |          | The start time passed to the gRPC API. Defaults to current time if not set
+`hedera.mirror.monitor.subscribe.grpc.<name>.subscribers`       | 1        | How many concurrent subscribers should be instantiated for this scenario
+`hedera.mirror.monitor.subscribe.grpc.<name>.topicId`           |          | Which topic to subscribe to
+`hedera.mirror.monitor.subscribe.rest`                          |          | A map of scenario name to REST subscriber scenarios. The name is used as a unique identifier in logs, metrics, and the REST API
+`hedera.mirror.monitor.subscribe.rest.<name>.duration`          |          | How long to stay subscribed to the API
+`hedera.mirror.monitor.subscribe.rest.<name>.enabled`           | true     | Whether this subscribe scenario is enabled
+`hedera.mirror.monitor.subscribe.rest.<name>.limit`             | 0        | How many transactions to receive before halting. 0 for unlimited
+`hedera.mirror.monitor.subscribe.rest.<name>.publishers`        | []       | A list of publisher scenario names to consider for sampling
+`hedera.mirror.monitor.subscribe.rest.<name>.retry.maxAttempts` | 16       | How many consecutive retry attempts before giving up connecting to the API
+`hedera.mirror.monitor.subscribe.rest.<name>.retry.maxBackoff`  | 1s       | The maximum amount of time to wait between retry attempts
+`hedera.mirror.monitor.subscribe.rest.<name>.retry.minBackoff`  | 500ms    | The initial amount of time to wait between retry attempts
+`hedera.mirror.monitor.subscribe.rest.<name>.samplePercent`     | 1.0      | The percentage of transactions to verify against the API. Accepts values between 0-1
+`hedera.mirror.monitor.subscribe.rest.<name>.timeout`           | 5s       | Maximum amount of time to wait for a API call to retrieve data
+`hedera.mirror.monitor.subscribe.statusFrequency`               | 10s      | How often to log subscription statistics
 
 ## REST API
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -240,66 +240,66 @@ value, it is recommended to only populate overridden properties in the custom `a
 See the monitor [documentation](/docs/monitor/README.md) for more general information about configuring and using the
 monitor.
 
-Name                                                            | Default  | Description
-----------------------------------------------------------------|----------| ---------------------------------------
-`hedera.mirror.monitor.mirrorNode.grpc.host`                    | ""       | The hostname of the mirror node's gRPC API
-`hedera.mirror.monitor.mirrorNode.grpc.port`                    | 5600     | The port of the mirror node's gRPC API
-`hedera.mirror.monitor.mirrorNode.rest.host`                    | ""       | The hostname of the mirror node's REST API
-`hedera.mirror.monitor.mirrorNode.rest.port`                    | 443      | The port of the mirror node's REST API
-`hedera.mirror.monitor.network`                                 | TESTNET  | Which network to connect to. Automatically populates the main node & mirror node endpoints. Can be `MAINNET`, `PREVIEWNET`, `TESTNET` or `OTHER`
-`hedera.mirror.monitor.nodes[].accountId`                       | ""       | The main node's account ID
-`hedera.mirror.monitor.nodes[].host`                            | ""       | The main node's hostname
-`hedera.mirror.monitor.nodes[].port`                            | 50211    | The main node's port
-`hedera.mirror.monitor.nodeValidation.enabled`                  | true     | Whether to validate and remove invalid or down nodes permanently before publishing
-`hedera.mirror.monitor.nodeValidation.frequency`                | 30m      | The amount of time between validations of the network.
-`hedera.mirror.monitor.nodeValidation.maxAttempts`              | 8        | The number of times the monitor should attempt to receive a healthy response from a node before marking it as unhealthy.
-`hedera.mirror.monitor.nodeValidation.maxBackoff`               | 2s       | The maximum amount of time to wait in between attempts when trying to validate a node
-`hedera.mirror.monitor.nodeValidation.maxThreads`               | 25       | The maximum number of threads to use for node validation
-`hedera.mirror.monitor.nodeValidation.minBackoff`               | 500ms    | The minimum amount of time to wait in between attempts when trying to validate a node
-`hedera.mirror.monitor.nodeValidation.requestTimeout`           | 15s      | The amount of time to wait for a validation request before timing out
-`hedera.mirror.monitor.operator.accountId`                      | ""       | Operator account ID used to pay for transactions
-`hedera.mirror.monitor.operator.privateKey`                     | ""       | Operator ED25519 private key used to sign transactions in hex encoded DER format
-`hedera.mirror.monitor.publish.batchDivisor`                    | 100      | The divisor used to calculate batch size when generating transactions
-`hedera.mirror.monitor.publish.clients`                         | 4        | How many total SDK clients to publish transactions. Clients will be used in a round-robin fashion
-`hedera.mirror.monitor.publish.enabled`                         | true     | Whether to enable transaction publishing
-`hedera.mirror.monitor.publish.responseThreads`                 | 40       | How many threads to use to resolve the asynchronous responses
-`hedera.mirror.monitor.publish.scenarios`                       |          | A map of scenario name to publish scenarios. The name is used as a unique identifier in logs, metrics, and the REST API
-`hedera.mirror.monitor.publish.scenarios.<name>.duration`       |          | How long this scenario should publish transactions. Leave empty for infinite
-`hedera.mirror.monitor.publish.scenarios.<name>.enabled`        | true     | Whether this publish scenario is enabled
-`hedera.mirror.monitor.publish.scenarios.<name>.limit`          | 0        | How many transactions to publish before halting. 0 for unlimited
-`hedera.mirror.monitor.publish.scenarios.<name>.logResponse`    | false    | Whether to log the response from HAPI
-`hedera.mirror.monitor.publish.scenarios.<name>.properties`     | {}       | Key/value pairs used to configure the [`TransactionSupplier`](/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction) associated with this scenario type
-`hedera.mirror.monitor.publish.scenarios.<name>.receiptPercent` | 0.0      | The percentage of receipts to retrieve from HAPI. Accepts values between 0-1
-`hedera.mirror.monitor.publish.scenarios.<name>.recordPercent`  | 0.0      | The percentage of records to retrieve from HAPI. Accepts values between 0-1
-`hedera.mirror.monitor.publish.scenarios.<name>.retry.maxAttempts` | 1        | The maximum number of times a scenario transaction will be attempted
-`hedera.mirror.monitor.publish.scenarios.<name>.timeout`        | 12s      | How long to wait for the transaction result
-`hedera.mirror.monitor.publish.scenarios.<name>.tps`            | 1.0      | The rate at which transactions will publish
-`hedera.mirror.monitor.publish.scenarios.<name>.type`           |          | The type of transaction to publish. See the [`TransactionType`](/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/TransactionType.java) enum for a list of possible values
-`hedera.mirror.monitor.publish.statusFrequency`                 | 10s      | How often to log publishing statistics
-`hedera.mirror.monitor.publish.warmupPeriod`                    | 30s      | The amount of time the publisher should ramp up its rate before reaching its stable (maximum) rate
-`hedera.mirror.monitor.subscribe.clients`                       | 1        | How many SDK clients should be created to subscribe to mirror node APIs. Clients will be used in a round-robin fashion
-`hedera.mirror.monitor.subscribe.enabled`                       | true     | Whether to enable subscribing to mirror node APIs to verify published transactions
-`hedera.mirror.monitor.subscribe.grpc`                          |          | A map of scenario name to gRPC subscriber scenarios. The name is used as a unique identifier in logs, metrics, and the REST API
-`hedera.mirror.monitor.subscribe.grpc.<name>.duration`          |          | How long to stay subscribed to the API
-`hedera.mirror.monitor.subscribe.grpc.<name>.enabled`           | true     | Whether this subscribe scenario is enabled
-`hedera.mirror.monitor.subscribe.grpc.<name>.limit`             | 0        | How many transactions to receive before halting. 0 for unlimited
+Name                                                            | Default | Description
+----------------------------------------------------------------|---------| ---------------------------------------
+`hedera.mirror.monitor.mirrorNode.grpc.host`                    | ""      | The hostname of the mirror node's gRPC API
+`hedera.mirror.monitor.mirrorNode.grpc.port`                    | 5600    | The port of the mirror node's gRPC API
+`hedera.mirror.monitor.mirrorNode.rest.host`                    | ""      | The hostname of the mirror node's REST API
+`hedera.mirror.monitor.mirrorNode.rest.port`                    | 443     | The port of the mirror node's REST API
+`hedera.mirror.monitor.network`                                 | TESTNET | Which network to connect to. Automatically populates the main node & mirror node endpoints. Can be `MAINNET`, `PREVIEWNET`, `TESTNET` or `OTHER`
+`hedera.mirror.monitor.nodes[].accountId`                       | ""      | The main node's account ID
+`hedera.mirror.monitor.nodes[].host`                            | ""      | The main node's hostname
+`hedera.mirror.monitor.nodes[].port`                            | 50211   | The main node's port
+`hedera.mirror.monitor.nodeValidation.enabled`                  | true    | Whether to validate and remove invalid or down nodes permanently before publishing
+`hedera.mirror.monitor.nodeValidation.frequency`                | 30m     | The amount of time between validations of the network.
+`hedera.mirror.monitor.nodeValidation.maxAttempts`              | 8       | The number of times the monitor should attempt to receive a healthy response from a node before marking it as unhealthy.
+`hedera.mirror.monitor.nodeValidation.maxBackoff`               | 2s      | The maximum amount of time to wait in between attempts when trying to validate a node
+`hedera.mirror.monitor.nodeValidation.maxThreads`               | 25      | The maximum number of threads to use for node validation
+`hedera.mirror.monitor.nodeValidation.minBackoff`               | 500ms   | The minimum amount of time to wait in between attempts when trying to validate a node
+`hedera.mirror.monitor.nodeValidation.requestTimeout`           | 15s     | The amount of time to wait for a validation request before timing out
+`hedera.mirror.monitor.operator.accountId`                      | ""      | Operator account ID used to pay for transactions
+`hedera.mirror.monitor.operator.privateKey`                     | ""      | Operator ED25519 private key used to sign transactions in hex encoded DER format
+`hedera.mirror.monitor.publish.batchDivisor`                    | 100     | The divisor used to calculate batch size when generating transactions
+`hedera.mirror.monitor.publish.clients`                         | 4       | How many total SDK clients to publish transactions. Clients will be used in a round-robin fashion
+`hedera.mirror.monitor.publish.enabled`                         | true    | Whether to enable transaction publishing
+`hedera.mirror.monitor.publish.responseThreads`                 | 40      | How many threads to use to resolve the asynchronous responses
+`hedera.mirror.monitor.publish.scenarios`                       |         | A map of scenario name to publish scenarios. The name is used as a unique identifier in logs, metrics, and the REST API
+`hedera.mirror.monitor.publish.scenarios.<name>.duration`       |         | How long this scenario should publish transactions. Leave empty for infinite
+`hedera.mirror.monitor.publish.scenarios.<name>.enabled`        | true    | Whether this publish scenario is enabled
+`hedera.mirror.monitor.publish.scenarios.<name>.limit`          | 0       | How many transactions to publish before halting. 0 for unlimited
+`hedera.mirror.monitor.publish.scenarios.<name>.logResponse`    | false   | Whether to log the response from HAPI
+`hedera.mirror.monitor.publish.scenarios.<name>.properties`     | {}      | Key/value pairs used to configure the [`TransactionSupplier`](/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction) associated with this scenario type
+`hedera.mirror.monitor.publish.scenarios.<name>.receiptPercent` | 0.0     | The percentage of receipts to retrieve from HAPI. Accepts values between 0-1
+`hedera.mirror.monitor.publish.scenarios.<name>.recordPercent`  | 0.0     | The percentage of records to retrieve from HAPI. Accepts values between 0-1
+`hedera.mirror.monitor.publish.scenarios.<name>.retry.maxAttempts` | 1       | The maximum number of times a scenario transaction will be attempted
+`hedera.mirror.monitor.publish.scenarios.<name>.timeout`        | 12s     | How long to wait for the transaction result
+`hedera.mirror.monitor.publish.scenarios.<name>.tps`            | 1.0     | The rate at which transactions will publish
+`hedera.mirror.monitor.publish.scenarios.<name>.type`           |         | The type of transaction to publish. See the [`TransactionType`](/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/TransactionType.java) enum for a list of possible values
+`hedera.mirror.monitor.publish.statusFrequency`                 | 10s     | How often to log publishing statistics
+`hedera.mirror.monitor.publish.warmupPeriod`                    | 30s     | The amount of time the publisher should ramp up its rate before reaching its stable (maximum) rate
+`hedera.mirror.monitor.subscribe.clients`                       | 1       | How many SDK clients should be created to subscribe to mirror node APIs. Clients will be used in a round-robin fashion
+`hedera.mirror.monitor.subscribe.enabled`                       | true    | Whether to enable subscribing to mirror node APIs to verify published transactions
+`hedera.mirror.monitor.subscribe.grpc`                          |         | A map of scenario name to gRPC subscriber scenarios. The name is used as a unique identifier in logs, metrics, and the REST API
+`hedera.mirror.monitor.subscribe.grpc.<name>.duration`          |         | How long to stay subscribed to the API
+`hedera.mirror.monitor.subscribe.grpc.<name>.enabled`           | true    | Whether this subscribe scenario is enabled
+`hedera.mirror.monitor.subscribe.grpc.<name>.limit`             | 0       | How many transactions to receive before halting. 0 for unlimited
 `hedera.mirror.monitor.subscribe.grpc.<name>.retry.maxAttempts` | 2^63 - 1 | How many consecutive retry attempts before giving up connecting to the API
-`hedera.mirror.monitor.subscribe.grpc.<name>.retry.maxBackoff`  | 8s       | The maximum amount of time to wait between retry attempts
-`hedera.mirror.monitor.subscribe.grpc.<name>.retry.minBackoff`  | 500ms    | The initial amount of time to wait between retry attempts
-`hedera.mirror.monitor.subscribe.grpc.<name>.startTime`         |          | The start time passed to the gRPC API. Defaults to current time if not set
-`hedera.mirror.monitor.subscribe.grpc.<name>.subscribers`       | 1        | How many concurrent subscribers should be instantiated for this scenario
-`hedera.mirror.monitor.subscribe.grpc.<name>.topicId`           |          | Which topic to subscribe to
-`hedera.mirror.monitor.subscribe.rest`                          |          | A map of scenario name to REST subscriber scenarios. The name is used as a unique identifier in logs, metrics, and the REST API
-`hedera.mirror.monitor.subscribe.rest.<name>.duration`          |          | How long to stay subscribed to the API
-`hedera.mirror.monitor.subscribe.rest.<name>.enabled`           | true     | Whether this subscribe scenario is enabled
-`hedera.mirror.monitor.subscribe.rest.<name>.limit`             | 0        | How many transactions to receive before halting. 0 for unlimited
-`hedera.mirror.monitor.subscribe.rest.<name>.publishers`        | []       | A list of publisher scenario names to consider for sampling
-`hedera.mirror.monitor.subscribe.rest.<name>.retry.maxAttempts` | 16       | How many consecutive retry attempts before giving up connecting to the API
-`hedera.mirror.monitor.subscribe.rest.<name>.retry.maxBackoff`  | 1s       | The maximum amount of time to wait between retry attempts
-`hedera.mirror.monitor.subscribe.rest.<name>.retry.minBackoff`  | 500ms    | The initial amount of time to wait between retry attempts
-`hedera.mirror.monitor.subscribe.rest.<name>.samplePercent`     | 1.0      | The percentage of transactions to verify against the API. Accepts values between 0-1
-`hedera.mirror.monitor.subscribe.rest.<name>.timeout`           | 5s       | Maximum amount of time to wait for a API call to retrieve data
-`hedera.mirror.monitor.subscribe.statusFrequency`               | 10s      | How often to log subscription statistics
+`hedera.mirror.monitor.subscribe.grpc.<name>.retry.maxBackoff`  | 8s      | The maximum amount of time to wait between retry attempts
+`hedera.mirror.monitor.subscribe.grpc.<name>.retry.minBackoff`  | 500ms   | The initial amount of time to wait between retry attempts
+`hedera.mirror.monitor.subscribe.grpc.<name>.startTime`         |         | The start time passed to the gRPC API. Defaults to current time if not set
+`hedera.mirror.monitor.subscribe.grpc.<name>.subscribers`       | 1       | How many concurrent subscribers should be instantiated for this scenario
+`hedera.mirror.monitor.subscribe.grpc.<name>.topicId`           |         | Which topic to subscribe to
+`hedera.mirror.monitor.subscribe.rest`                          |         | A map of scenario name to REST subscriber scenarios. The name is used as a unique identifier in logs, metrics, and the REST API
+`hedera.mirror.monitor.subscribe.rest.<name>.duration`          |         | How long to stay subscribed to the API
+`hedera.mirror.monitor.subscribe.rest.<name>.enabled`           | true    | Whether this subscribe scenario is enabled
+`hedera.mirror.monitor.subscribe.rest.<name>.limit`             | 0       | How many transactions to receive before halting. 0 for unlimited
+`hedera.mirror.monitor.subscribe.rest.<name>.publishers`        | []      | A list of publisher scenario names to consider for sampling
+`hedera.mirror.monitor.subscribe.rest.<name>.retry.maxAttempts` | 16      | How many consecutive retry attempts before giving up connecting to the API
+`hedera.mirror.monitor.subscribe.rest.<name>.retry.maxBackoff`  | 1s      | The maximum amount of time to wait between retry attempts
+`hedera.mirror.monitor.subscribe.rest.<name>.retry.minBackoff`  | 500ms   | The initial amount of time to wait between retry attempts
+`hedera.mirror.monitor.subscribe.rest.<name>.samplePercent`     | 1.0     | The percentage of transactions to verify against the API. Accepts values between 0-1
+`hedera.mirror.monitor.subscribe.rest.<name>.timeout`           | 5s      | Maximum amount of time to wait for a API call to retrieve data
+`hedera.mirror.monitor.subscribe.statusFrequency`               | 10s     | How often to log subscription statistics
 
 ## REST API
 

--- a/hedera-mirror-monitor/pom.xml
+++ b/hedera-mirror-monitor/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <commons-math3.version>3.6.1</commons-math3.version>
-        <hedera-sdk.version>2.7.0</hedera-sdk.version>
+        <hedera-sdk.version>2.9.0</hedera-sdk.version>
         <meanbean.version>3.0.0-M9</meanbean.version>
         <springdoc.version>1.6.6</springdoc.version>
     </properties>

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/NodeValidationProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/NodeValidationProperties.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.monitor;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -39,7 +39,7 @@ public class NodeValidationProperties {
     private Duration frequency = Duration.ofMinutes(30L);
 
     @Min(1)
-    private int maxAttempts = 4;
+    private int maxAttempts = 8;
 
     @DurationMin(millis = 250)
     @DurationMax(seconds = 10)
@@ -54,7 +54,9 @@ public class NodeValidationProperties {
     @NotNull
     private Duration minBackoff = Duration.ofMillis(500);
 
+    // requestTimeout should be longer than the total retry time controlled by maxAttempts and backoffs
+    // the default would result in a max of 11.5s without considering any network delay
     @DurationMin(millis = 500)
     @NotNull
-    private Duration requestTimeout = Duration.ofSeconds(10L);
+    private Duration requestTimeout = Duration.ofSeconds(15L);
 }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/config/MonitorConfiguration.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/config/MonitorConfiguration.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.monitor.config;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishMetrics.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishMetrics.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.monitor.publish;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -64,24 +64,28 @@ public class PublishMetrics {
     }
 
     private void recordMetric(PublishRequest request, PublishResponse response, String status) {
-        String node = Optional.of(request.getTransaction().getNodeAccountIds())
-                .filter(l -> !l.isEmpty())
-                .map(l -> l.get(0))
-                .map(AccountId::toString)
-                .orElse(UNKNOWN);
-        long startTime = request.getTimestamp().toEpochMilli();
-        long endTime = response != null ? response.getTimestamp().toEpochMilli() : System.currentTimeMillis();
-        Tags tags = new Tags(node, request.getScenario(), status);
+        try {
+            String node = Optional.ofNullable(request.getTransaction().getNodeAccountIds())
+                    .filter(l -> !l.isEmpty())
+                    .map(l -> l.get(0))
+                    .map(AccountId::toString)
+                    .orElse(UNKNOWN);
+            long startTime = request.getTimestamp().toEpochMilli();
+            long endTime = response != null ? response.getTimestamp().toEpochMilli() : System.currentTimeMillis();
+            Tags tags = new Tags(node, request.getScenario(), status);
 
-        Timer submitTimer = submitTimers.computeIfAbsent(tags, this::newSubmitMetric);
-        submitTimer.record(endTime - startTime, TimeUnit.MILLISECONDS);
+            Timer submitTimer = submitTimers.computeIfAbsent(tags, this::newSubmitMetric);
+            submitTimer.record(endTime - startTime, TimeUnit.MILLISECONDS);
 
-        durationGauges.computeIfAbsent(tags, this::newDurationMetric);
+            durationGauges.computeIfAbsent(tags, this::newDurationMetric);
 
-        if (response != null && response.getReceipt() != null) {
-            long elapsed = System.currentTimeMillis() - startTime;
-            Timer handleTimer = handleTimers.computeIfAbsent(tags, this::newHandleMetric);
-            handleTimer.record(elapsed, TimeUnit.MILLISECONDS);
+            if (response != null && response.getReceipt() != null) {
+                long elapsed = System.currentTimeMillis() - startTime;
+                Timer handleTimer = handleTimers.computeIfAbsent(tags, this::newHandleMetric);
+                handleTimer.record(elapsed, TimeUnit.MILLISECONDS);
+            }
+        } catch (Exception ex) {
+            log.error("Unexpected error when recording metric", ex);
         }
     }
 

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishRequest.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishRequest.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.monitor.publish;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,7 +26,7 @@ import lombok.Value;
 
 import com.hedera.hashgraph.sdk.Transaction;
 
-@Builder
+@Builder(toBuilder = true)
 @Value
 public class PublishRequest {
     private final boolean receipt;

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishResponse.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishResponse.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.monitor.publish;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -29,7 +29,7 @@ import com.hedera.hashgraph.sdk.TransactionId;
 import com.hedera.hashgraph.sdk.TransactionReceipt;
 import com.hedera.hashgraph.sdk.TransactionRecord;
 
-@Builder
+@Builder(toBuilder = true)
 @Value
 public class PublishResponse {
 

--- a/hedera-mirror-test/pom.xml
+++ b/hedera-mirror-test/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>com.hedera.hashgraph</groupId>
             <artifactId>sdk</artifactId>
-            <version>2.7.0</version>
+            <version>2.9.0</version>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>


### PR DESCRIPTION
**Description**:
- Use `Optional.ofNullable` to handle null `Transaction.nodeAccountIds` to avoid NPE
- Increase default node validation `maxAttempts` and `requestTimeout` to accommodate higher C2C and avoid falsely marking nodes as unavailable
- Catch unexpected exceptions in `PublishMetrics.recordMetric()`
- Bump up to SDK `v2.9.0`
 
**Related issue(s)**:

Fixes #3404 

**Notes for reviewer**:
The default node validation config of 4 maxAttempts and 0.5s min / 2s max backoffs would result in a max of (0.5s + 1s + 2s) = 3.5s retry timeout. The mainnet 0.23.x upgrade on 03/10/22 resulted in higher c2c at around 4s. The impact to monitor node validation is we see way less available nodes than with 0.22.x.

For mainnet-na, the available nodes reduced to 0 at one point (not sure if it's becoz at the time all nodes were down or all nodes had high c2c), this trigerred a NPE from Optional.of(Transaction.nodeAccountIds), and then caused unhandled error in the flux flow so the monitor publishing stopped.

For mainnet-eu, it's just that the monitor never hit the 0-node available situation so it continued publishing topic messages.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
