### PR TITLE
Update transactions openapi spec

### DIFF
--- a/hedera-mirror-rest/api/v1/openapi.yml
+++ b/hedera-mirror-rest/api/v1/openapi.yml
@@ -1987,14 +1987,19 @@ components:
                   - serial_number
                   - token_id
       example:
-        consensus_timestamp: "1234567890.000000007"
-        transaction_hash: "vigzKe2J7fv4ktHBbNTSzQmKq7Lzdq1/lJMmHT+a2KgvdhAuadlvS4eKeqKjIRmW"
-        valid_start_timestamp: "1234567890.000000006"
-        charged_tx_fee: 7
-        memo_base64: null
+        assessed_custom_fees:
+          - amount: 100
+            collector_account_id: 0.0.10
+            effective_payer_account_ids:
+              - 0.0.8
+              - 0.0.72
+            token_id: 0.0.90001
         bytes: null
-        result: SUCCESS
+        charged_tx_fee: 7
+        consensus_timestamp: "1234567890.000000007"
         entity_id: "0.0.2281979"
+        max_fee: 33
+        memo_base64: null
         name: CRYPTOTRANSFER
         nft_transfers:
           - receiver_account_id: 0.0.121
@@ -2005,18 +2010,13 @@ components:
             sender_account_id: 0.0.422
             serial_number: 2
             token_id: 0.0.123
-        max_fee: 33
-        valid_duration_seconds: 11
         node: 0.0.3
-        transaction_id: 0.0.8-1234567890-000000006
+        nonce: 0
+        parent_consensus_timestamp: "1234567890.000000007"
+        result: SUCCESS
         scheduled: false
-        transfers:
-          - account: 0.0.3
-            amount: 2
-          - account: 0.0.8
-            amount: -3
-          - account: 0.0.98
-            amount: 1
+        transaction_hash: "vigzKe2J7fv4ktHBbNTSzQmKq7Lzdq1/lJMmHT+a2KgvdhAuadlvS4eKeqKjIRmW"
+        transaction_id: 0.0.8-1234567890-000000006
         token_transfers:
           - token_id: 0.0.90000
             account: 0.0.9
@@ -2024,13 +2024,15 @@ components:
           - token_id: 0.0.90000
             account: 0.0.8
             amount: -1200
-        assessed_custom_fees:
-          - amount: 100
-            collector_account_id: 0.0.10
-            effective_payer_account_ids:
-              - 0.0.8
-              - 0.0.72
-            token_id: 0.0.90001
+        transfers:
+          - account: 0.0.3
+            amount: 2
+          - account: 0.0.8
+            amount: -3
+          - account: 0.0.98
+            amount: 1
+        valid_duration_seconds: 11
+        valid_start_timestamp: "1234567890.000000006"
     TransactionDetails:
       type: array
       items:

--- a/hedera-mirror-rest/api/v1/openapi.yml
+++ b/hedera-mirror-rest/api/v1/openapi.yml
@@ -1883,110 +1883,6 @@ components:
           type: string
         scheduled:
           type: boolean
-        transaction_hash:
-          type: string
-          format: byte
-        transaction_id:
-          type: string
-        transfers:
-          type: array
-          items:
-            type: object
-            properties:
-              account:
-                $ref: '#/components/schemas/EntityId'
-              amount:
-                type: number
-            required:
-              - account
-              - amount
-        valid_duration_seconds:
-          type: string
-        valid_start_timestamp:
-          $ref: '#/components/schemas/Timestamp'
-      example:
-        consensus_timestamp: "1234567890.000000007"
-        transaction_hash: "vigzKe2J7fv4ktHBbNTSzQmKq7Lzdq1/lJMmHT+a2KgvdhAuadlvS4eKeqKjIRmW"
-        valid_start_timestamp: "1234567890.000000006"
-        charged_tx_fee: 7
-        memo_base64: null
-        bytes: null
-        result: SUCCESS
-        entity_id: "0.0.2281979"
-        name: CRYPTOTRANSFER
-        max_fee: 33
-        valid_duration_seconds: 11
-        node: 0.0.3
-        transaction_id: 0.0.8-1234567890-000000006
-        scheduled: false
-        transfers:
-          - account: 0.0.3
-            amount: 2
-          - account: 0.0.8
-            amount: -3
-          - account: 0.0.98
-            amount: 1
-    TransactionDetail:
-      type: object
-      properties:
-        assessed_custom_fees:
-          type: array
-          items:
-            type: object
-            properties:
-              amount:
-                type: number
-              collector_account_id:
-                $ref: '#/components/schemas/EntityId'
-              effective_payer_account_ids:
-                type: array
-                items:
-                  $ref: '#/components/schemas/EntityId'
-              token_id:
-                $ref: '#/components/schemas/EntityId'
-        bytes:
-          type: string
-          format: byte
-          nullable: true
-        charged_tx_fee:
-          type: number
-        consensus_timestamp:
-          $ref: '#/components/schemas/Timestamp'
-        entity_id:
-          $ref: '#/components/schemas/EntityId'
-        max_fee:
-          type: string
-        memo_base64:
-          nullable: true
-        name:
-          $ref: '#/components/schemas/TransactionTypes'
-        nft_transfers:
-          type: array
-          items:
-            type: object
-            properties:
-              receiver_account_id:
-                $ref: '#/components/schemas/EntityId'
-              sender_account_id:
-                $ref: '#/components/schemas/EntityId'
-              serial_number:
-                type: number
-              token_id:
-                $ref: '#/components/schemas/EntityId'
-            required:
-              - serial_number
-              - token_id
-        node:
-          $ref: '#/components/schemas/EntityId'
-        nonce:
-          type: integer
-          minimum: 0
-        parent_consensus_timestamp:
-          $ref: '#/components/schemas/TimestampNullable'
-        result:
-          type: string
-        scheduled:
-          type: boolean
         token_transfers:
           type: array
           items:
@@ -2023,6 +1919,73 @@ components:
           type: string
         valid_start_timestamp:
           $ref: '#/components/schemas/Timestamp'
+      example:
+        bytes: null
+        charged_tx_fee: 7
+        consensus_timestamp: "1234567890.000000007"
+        entity_id: "0.0.2281979"
+        max_fee: 33
+        memo_base64: null
+        name: CRYPTOTRANSFER
+        node: 0.0.3
+        nonce: 0
+        parent_consensus_timestamp: "1234567890.000000007"
+        result: SUCCESS
+        scheduled: false
+        transaction_hash: "vigzKe2J7fv4ktHBbNTSzQmKq7Lzdq1/lJMmHT+a2KgvdhAuadlvS4eKeqKjIRmW"
+        transaction_id: 0.0.8-1234567890-000000006
+        token_transfers:
+          - token_id: 0.0.90000
+            account: 0.0.9
+            amount: 1200
+          - token_id: 0.0.90000
+            account: 0.0.8
+            amount: -1200
+        transfers:
+          - account: 0.0.3
+            amount: 2
+          - account: 0.0.8
+            amount: -3
+          - account: 0.0.98
+            amount: 1
+        valid_duration_seconds: 11
+        valid_start_timestamp: "1234567890.000000006"
+    TransactionDetail:
+      allOf:
+        - $ref: '#/components/schemas/Transaction'
+        - type: object
+          properties:
+            assessed_custom_fees:
+              type: array
+              items:
+                type: object
+                properties:
+                  amount:
+                    type: number
+                  collector_account_id:
+                    $ref: '#/components/schemas/EntityId'
+                  effective_payer_account_ids:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/EntityId'
+                  token_id:
+                    $ref: '#/components/schemas/EntityId'
+            nft_transfers:
+              type: array
+              items:
+                type: object
+                properties:
+                  receiver_account_id:
+                    $ref: '#/components/schemas/EntityId'
+                  sender_account_id:
+                    $ref: '#/components/schemas/EntityId'
+                  serial_number:
+                    type: number
+                  token_id:
+                    $ref: '#/components/schemas/EntityId'
+                required:
+                  - serial_number
+                  - token_id
       example:
         consensus_timestamp: "1234567890.000000007"
         transaction_hash: "vigzKe2J7fv4ktHBbNTSzQmKq7Lzdq1/lJMmHT+a2KgvdhAuadlvS4eKeqKjIRmW"

--- a/hedera-mirror-rest/api/v1/openapi.yml
+++ b/hedera-mirror-rest/api/v1/openapi.yml
@@ -935,7 +935,7 @@ components:
       type: object
       properties:
         transactions:
-          $ref: '#/components/schemas/Transactions'
+          $ref: '#/components/schemas/TransactionDetails'
     TransactionsResponse:
       type: object
       properties:
@@ -1856,6 +1856,79 @@ components:
     Transaction:
       type: object
       properties:
+        bytes:
+          type: string
+          format: byte
+          nullable: true
+        charged_tx_fee:
+          type: number
+        consensus_timestamp:
+          $ref: '#/components/schemas/Timestamp'
+        entity_id:
+          $ref: '#/components/schemas/EntityId'
+        max_fee:
+          type: string
+        memo_base64:
+          nullable: true
+        name:
+          $ref: '#/components/schemas/TransactionTypes'
+        node:
+          $ref: '#/components/schemas/EntityId'
+        nonce:
+          type: integer
+          minimum: 0
+        parent_consensus_timestamp:
+          $ref: '#/components/schemas/TimestampNullable'
+        result:
+          type: string
+        scheduled:
+          type: boolean
+        transaction_hash:
+          type: string
+          format: byte
+        transaction_id:
+          type: string
+        transfers:
+          type: array
+          items:
+            type: object
+            properties:
+              account:
+                $ref: '#/components/schemas/EntityId'
+              amount:
+                type: number
+            required:
+              - account
+              - amount
+        valid_duration_seconds:
+          type: string
+        valid_start_timestamp:
+          $ref: '#/components/schemas/Timestamp'
+      example:
+        consensus_timestamp: "1234567890.000000007"
+        transaction_hash: "vigzKe2J7fv4ktHBbNTSzQmKq7Lzdq1/lJMmHT+a2KgvdhAuadlvS4eKeqKjIRmW"
+        valid_start_timestamp: "1234567890.000000006"
+        charged_tx_fee: 7
+        memo_base64: null
+        bytes: null
+        result: SUCCESS
+        entity_id: "0.0.2281979"
+        name: CRYPTOTRANSFER
+        max_fee: 33
+        valid_duration_seconds: 11
+        node: 0.0.3
+        transaction_id: 0.0.8-1234567890-000000006
+        scheduled: false
+        transfers:
+          - account: 0.0.3
+            amount: 2
+          - account: 0.0.8
+            amount: -3
+          - account: 0.0.98
+            amount: 1
+    TransactionDetail:
+      type: object
+      properties:
         assessed_custom_fees:
           type: array
           items:
@@ -1995,6 +2068,10 @@ components:
               - 0.0.8
               - 0.0.72
             token_id: 0.0.90001
+    TransactionDetails:
+      type: array
+      items:
+        $ref: '#/components/schemas/TransactionDetail'
     TransactionId:
       type: object
       properties:


### PR DESCRIPTION
**Description**:
The OpenAPI spec does not currently reflect the fact that `nft_transfers` and `assessed_custom_fees` are only returned in the `/api/v1/transactions/{transactionId}` and not in the `/api/v1/transactions`

Due to the heavy lifting done the listTransactions response omits some list properties 

- Add `TransactionDetail` object that adds `nft_transfers` and `assessed_custom_fees` to the base Transaction object
- Add `TransactionDetails` object and use in the `TransactionIdResponse`
- Alphabetically order and add missing properties in `Transaction` object example

**Related issue(s)**:

Fixes #3378 

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
