### PR TITLE
Fix failing actions

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Login to Google Container Registry
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           service_account_key: ${{ secrets.GCR_KEY }}

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,8 +1,10 @@
 name: Cleanup
 
 on:
-  schedule:
-    - cron: "0 0 * * *" # Daily at midnight
+  pull_request:
+    branches: [ main ]
+#  schedule:
+#    - cron: "0 0 * * *" # Daily at midnight
 
 jobs:
   images:

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -15,11 +15,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Login to Google Container Registry
-        uses: google-github-actions/setup-gcloud@v0
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v0
         with:
-          project_id: ${{ secrets.GCP_PROJECT_ID }}
-          service_account_key: ${{ secrets.GCR_KEY }}
+          credentials_json: '${{ secrets.GCR_KEY }}'
+
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v0
 
       - name: Configure Docker
         run: gcloud auth configure-docker gcr.io,marketplace.gcr.io

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,10 +1,8 @@
 name: Cleanup
 
 on:
-  pull_request:
-    branches: [ main ]
-#  schedule:
-#    - cron: "0 0 * * *" # Daily at midnight
+  schedule:
+    - cron: "0 0 * * *" # Daily at midnight
 
 jobs:
   images:

--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -18,7 +18,7 @@ jobs:
           java-version: 11
 
       - name: Login to Google Container Registry
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           service_account_key: ${{ secrets.GCR_KEY }}

--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -17,11 +17,13 @@ jobs:
           distribution: 'temurin'
           java-version: 11
 
-      - name: Login to Google Container Registry
-        uses: google-github-actions/setup-gcloud@v0
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v0
         with:
-          project_id: ${{ secrets.GCP_PROJECT_ID }}
-          service_account_key: ${{ secrets.GCR_KEY }}
+          credentials_json: '${{ secrets.GCR_KEY }}'
+
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v0
 
       - name: Configure Docker
         run: gcloud auth configure-docker gcr.io,marketplace.gcr.io

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -19,7 +19,7 @@ jobs:
           java-version: 11
 
       - name: Login to Google Container Registry
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           service_account_key: ${{ secrets.GCR_KEY }}

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -18,11 +18,13 @@ jobs:
           distribution: 'temurin'
           java-version: 11
 
-      - name: Login to Google Container Registry
-        uses: google-github-actions/setup-gcloud@v0
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v0
         with:
-          project_id: ${{ secrets.GCP_PROJECT_ID }}
-          service_account_key: ${{ secrets.GCR_KEY }}
+          credentials_json: '${{ secrets.GCR_KEY }}'
+
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v0
 
       - name: Configure Docker
         run: gcloud auth configure-docker gcr.io,marketplace.gcr.io
@@ -39,7 +41,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Publish helm chart
-        uses: stefanprodan/helm-gh-pages@master
+        uses: stefanprodan/helm-gh-pages@v1
         with:
           target_dir: charts
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rosetta-api.yml
+++ b/.github/workflows/rosetta-api.yml
@@ -228,6 +228,6 @@ jobs:
           rm -fr tmp
 
       - name: Run Gosec Security Scanner
-        uses: securego/gosec@v2
+        uses: securego/gosec@v2.11.0
         with:
           args: ./...

--- a/.github/workflows/rosetta-api.yml
+++ b/.github/workflows/rosetta-api.yml
@@ -228,6 +228,6 @@ jobs:
           rm -fr tmp
 
       - name: Run Gosec Security Scanner
-        uses: securego/gosec@master
+        uses: securego/gosec@v2
         with:
           args: ./...

--- a/hedera-mirror-rest/package-lock.json
+++ b/hedera-mirror-rest/package-lock.json
@@ -20,7 +20,6 @@
         "express-http-context",
         "express-openapi-validator",
         "extend",
-        "follow-redirects",
         "ip-anonymize",
         "js-yaml",
         "json-schema",
@@ -29,6 +28,7 @@
         "long",
         "mathjs",
         "mem",
+        "minimist",
         "parse-duration",
         "pg",
         "pg-range",
@@ -54,7 +54,6 @@
         "express-http-context": "^1.2.4",
         "express-openapi-validator": "^4.13.6",
         "extend": "^3.0.2",
-        "follow-redirects": "^1.14.9",
         "ip-anonymize": "^0.1.0",
         "js-yaml": "^4.1.0",
         "json-schema": "^0.4.0",
@@ -63,6 +62,7 @@
         "long": "^5.2.0",
         "mathjs": "^10.4.0",
         "mem": "^8.1.1",
+        "minimist": "^1.2.6",
         "parse-duration": "^1.0.2",
         "pg": "~8.7.3",
         "pg-range": "^1.1.1",
@@ -91,7 +91,6 @@
         "jest-extended": "^2.0.0",
         "jest-junit": "^13.0.0",
         "mock-req-res": "^1.2.0",
-        "node-fetch": "^2.6.7",
         "node-flywaydb": "^3.0.7",
         "nodemon": "^2.0.15",
         "pg-format": "^1.0.4",
@@ -5065,13 +5064,13 @@
       "version": "1.14.9",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
       "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
-      "inBundle": true,
       "engines": {
         "node": ">=4.0"
       },
@@ -7789,9 +7788,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "inBundle": true
     },
     "node_modules/mkdirp": {
@@ -15406,7 +15405,8 @@
     "follow-redirects": {
       "version": "1.14.9",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
-      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
+      "dev": true
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -17429,9 +17429,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "mkdirp": {
       "version": "1.0.4",

--- a/hedera-mirror-rest/package.json
+++ b/hedera-mirror-rest/package.json
@@ -16,7 +16,7 @@
   },
   "author": "Hedera Mirror Node Team",
   "comments": {
-    "dependencies": "follow-redirects, node-fetch & json-schema are transitive dependencies but we explicitly mark them as a dependency to bring in a non-vulnerable version"
+    "dependencies": "minimist & json-schema are transitive dependencies but we explicitly mark them as a dependency to bring in a non-vulnerable version"
   },
   "license": "Apache-2.0",
   "dependencies": {
@@ -32,7 +32,6 @@
     "express-http-context": "^1.2.4",
     "express-openapi-validator": "^4.13.6",
     "extend": "^3.0.2",
-    "follow-redirects": "^1.14.9",
     "ip-anonymize": "^0.1.0",
     "js-yaml": "^4.1.0",
     "json-schema": "^0.4.0",
@@ -41,6 +40,7 @@
     "long": "^5.2.0",
     "mathjs": "^10.4.0",
     "mem": "^8.1.1",
+    "minimist": "^1.2.6",
     "parse-duration": "^1.0.2",
     "pg": "~8.7.3",
     "pg-range": "^1.1.1",
@@ -64,7 +64,6 @@
     "express-http-context",
     "express-openapi-validator",
     "extend",
-    "follow-redirects",
     "ip-anonymize",
     "js-yaml",
     "json-schema",
@@ -73,6 +72,7 @@
     "long",
     "mathjs",
     "mem",
+    "minimist",
     "parse-duration",
     "pg",
     "pg-range",
@@ -100,7 +100,6 @@
     "jest-circus": "^27.4.6",
     "jest-extended": "^2.0.0",
     "jest-junit": "^13.0.0",
-    "node-fetch": "^2.6.7",
     "mock-req-res": "^1.2.0",
     "node-flywaydb": "^3.0.7",
     "nodemon": "^2.0.15",


### PR DESCRIPTION
**Description**:

* Bump `minimist` from `1.2.5` to `1.2.6` to fix a vulnerability
* Fix `gosec` and `helm-gh-pages` actions not using a tagged version
* Fix `setup-gcloud` action failing due to moving from master to main
* Fix `setup-gcloud` action warning `"service_account_key" has been deprecated`
* Remove manual dependencies on `node-fetch` & `follow-redirects` since the parent packages have been updated to a non-vulnerable version

**Related issue(s)**:

**Notes for reviewer**:

https://github.com/hashgraph/hedera-mirror-node/runs/5635747973?check_suite_focus=true
```
Error: On 2022-04-05, the default branch will be renamed from "master" to "main". Your action is currently pinned to "@master". Even though GitHub creates redirects for renamed branches, testing found that this rename breaks existing GitHub Actions workflows that are pinned to the old branch name.

We strongly advise updating your GitHub Action YAML from:

    uses: 'google-github-actions/setup-gcloud@master'

to:

    uses: 'google-github-actions/setup-gcloud@v0'

While not recommended, you can still pin to the "master" branch by setting the environment variable "SETUP_GCLOUD_I_UNDERSTAND_USING_MASTER_WILL_BREAK_MY_WORKFLOW_ON_2022_04_05=1". However, on 2022-04-05 when the branch is renamed, all your workflows will begin failing with an obtuse and difficult to diagnose error message.
```


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
