### PR TITLE
Container security improvements

### DIFF
--- a/charts/hedera-mirror-common/Chart.yaml
+++ b/charts/hedera-mirror-common/Chart.yaml
@@ -3,25 +3,25 @@ appVersion: "main"
 dependencies:
   - name: loki
     condition: loki.enabled
-    version: 2.8.4
+    version: 2.10.1
     repository: https://grafana.github.io/helm-charts
   - condition: prometheus-adapter.enabled
     name: prometheus-adapter
     repository: https://prometheus-community.github.io/helm-charts
-    version: 3.0.0
+    version: 3.0.3
   - alias: prometheus
     condition: prometheus.enabled
     name: kube-prometheus-stack
     repository: https://prometheus-community.github.io/helm-charts
-    version: 25.0.0
+    version: 34.1.1
   - name: promtail
     condition: promtail.enabled
-    version: 3.9.1
+    version: 3.11.0
     repository: https://grafana.github.io/helm-charts
   - condition: traefik.enabled
     name: traefik
     repository: https://helm.traefik.io/traefik
-    version: 10.9.0
+    version: 10.15.0
 description: Hedera Mirror Node common components installed globally for use across namespaces
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067

--- a/charts/hedera-mirror-common/values.yaml
+++ b/charts/hedera-mirror-common/values.yaml
@@ -1,7 +1,5 @@
 global:
   namespaceOverride: ""
-  rbac:
-    pspEnabled: false
 
 labels: {}
 
@@ -214,8 +212,6 @@ prometheus:
     defaultDashboardsEnabled: true
     plugins:
       - camptocamp-prometheus-alertmanager-datasource
-    rbac:
-      pspEnabled: false
     resources:
       limits:
         cpu: 300m
@@ -224,8 +220,6 @@ prometheus:
         cpu: 150m
         memory: 75Mi
   kube-state-metrics:
-    podSecurityPolicy:
-      enabled: false
     resources:
       limits:
         cpu: 10m
@@ -259,8 +253,6 @@ prometheus:
     enabled: false
   prometheus-node-exporter:
     hostNetwork: false
-    rbac:
-      pspEnabled: false
     resources:
       limits:
         cpu: 100m
@@ -315,8 +307,6 @@ promtail:
       pipelineStages:
         - docker: {}
   enabled: true
-  rbac:
-    pspEnabled: false
   resources:
     limits:
       cpu: 125m

--- a/charts/hedera-mirror-grpc/values.yaml
+++ b/charts/hedera-mirror-grpc/values.yaml
@@ -128,6 +128,11 @@ podDisruptionBudget:
 
 podSecurityContext:
   fsGroup: 1000
+  runAsGroup: 1000
+  runAsNonRoot: true
+  runAsUser: 1000
+  seccompProfile:
+    type: RuntimeDefault
 
 priorityClassName: ""
 
@@ -272,12 +277,10 @@ resources:
 revisionHistoryLimit: 3
 
 securityContext:
+  allowPrivilegeEscalation: false
   capabilities:
     drop: [ALL]
   readOnlyRootFilesystem: true
-  runAsGroup: 1000
-  runAsNonRoot: true
-  runAsUser: 1000
 
 service:
   annotations:

--- a/charts/hedera-mirror-importer/values.yaml
+++ b/charts/hedera-mirror-importer/values.yaml
@@ -168,6 +168,11 @@ podMonitor:
 
 podSecurityContext:
   fsGroup: 1000
+  runAsGroup: 1000
+  runAsNonRoot: true
+  runAsUser: 1000
+  seccompProfile:
+    type: RuntimeDefault
 
 priorityClassName: ""
 
@@ -453,12 +458,10 @@ resources:
 revisionHistoryLimit: 3
 
 securityContext:
+  allowPrivilegeEscalation: false
   capabilities:
     drop: [ALL]
   readOnlyRootFilesystem: true
-  runAsGroup: 1000
-  runAsNonRoot: true
-  runAsUser: 1000
 
 serviceAccount:
   create: true

--- a/charts/hedera-mirror-monitor/values.yaml
+++ b/charts/hedera-mirror-monitor/values.yaml
@@ -111,6 +111,11 @@ podAnnotations: {}
 
 podSecurityContext:
   fsGroup: 1000
+  runAsGroup: 1000
+  runAsNonRoot: true
+  runAsUser: 1000
+  seccompProfile:
+    type: RuntimeDefault
 
 priorityClassName: ""
 
@@ -204,7 +209,7 @@ prometheusRules:
       description: "Publish TPS dropped to {{ $value }} for '{{ $labels.scenario }}' scenario for {{ $labels.namespace }}/{{ $labels.pod }}"
       summary: "Publishing stopped"
     enabled: true
-    expr: sum(rate(hedera_mirror_monitor_publish_submit_seconds_sum{application="hedera-mirror-monitor"}[2m])) by (namespace, pod, scenario) / sum(rate(hedera_mirror_monitor_publish_submit_seconds_count{application="hedera-mirror-monitor"}[2m])) by (namespace, pod, scenario) <= 0
+    expr: (sum(rate(hedera_mirror_monitor_publish_submit_seconds_sum{application="hedera-mirror-monitor"}[2m])) by (namespace, pod, scenario) / sum(rate(hedera_mirror_monitor_publish_submit_seconds_count{application="hedera-mirror-monitor"}[2m])) by (namespace, pod, scenario) > 0 or on() vector(0)) <= 0
     for: 2m
     labels:
       severity: critical
@@ -239,7 +244,7 @@ prometheusRules:
       description: "TPS dropped to {{ $value }} for '{{ $labels.scenario }}' #{{ $labels.subscriber }} scenario for {{ $labels.namespace }}/{{ $labels.pod }}"
       summary: "Subscription stopped"
     enabled: true
-    expr: sum(rate(hedera_mirror_monitor_subscribe_e2e_seconds_sum{application="hedera-mirror-monitor"}[2m])) by (namespace, pod, subscriber, scenario) / sum(rate(hedera_mirror_monitor_subscribe_e2e_seconds_count{application="hedera-mirror-monitor"}[2m])) by (namespace, pod, subscriber, scenario) <= 0
+    expr: (sum(rate(hedera_mirror_monitor_subscribe_e2e_seconds_sum{application="hedera-mirror-monitor"}[2m])) by (namespace, pod, subscriber, scenario) / sum(rate(hedera_mirror_monitor_subscribe_e2e_seconds_count{application="hedera-mirror-monitor"}[2m])) by (namespace, pod, subscriber, scenario) > 0 or on() vector(0)) <= 0
     for: 2m
     labels:
       severity: critical
@@ -269,12 +274,10 @@ resources:
 revisionHistoryLimit: 3
 
 securityContext:
+  allowPrivilegeEscalation: false
   capabilities:
     drop: [ALL]
   readOnlyRootFilesystem: true
-  runAsGroup: 1000
-  runAsNonRoot: true
-  runAsUser: 1000
 
 service:
   annotations: {}

--- a/charts/hedera-mirror-rest/templates/tests/configmap.yaml
+++ b/charts/hedera-mirror-rest/templates/tests/configmap.yaml
@@ -36,16 +36,5 @@ data:
     @test "Has transactions" {
       has_data "transactions"
     }
-
-    {{ if .Values.test.checkRecent -}}
-    @test "Has recent transactions" {
-      local timestamp=$(curl -s "${URI}/transactions?limit=1" | jq -re '.transactions[0].consensus_timestamp')
-
-      until [[ $(curl -s "${URI}/transactions?limit=1" | jq -re '.transactions[0].consensus_timestamp') > "${timestamp}" ]]; do
-        echo "Waiting for new transactions" >&3
-        sleep 1
-      done
-    }
-    {{- end }}
 {{- end -}}
 

--- a/charts/hedera-mirror-rest/values.yaml
+++ b/charts/hedera-mirror-rest/values.yaml
@@ -116,6 +116,11 @@ podDisruptionBudget:
 
 podSecurityContext:
   fsGroup: 1000
+  runAsGroup: 1000
+  runAsNonRoot: true
+  runAsUser: 1000
+  seccompProfile:
+    type: RuntimeDefault
 
 priorityClassName: ""
 
@@ -199,12 +204,10 @@ resources:
 revisionHistoryLimit: 3
 
 securityContext:
+  allowPrivilegeEscalation: false
   capabilities:
     drop: [ALL]
   readOnlyRootFilesystem: true
-  runAsGroup: 1000
-  runAsNonRoot: true
-  runAsUser: 1000
 
 service:
   annotations: {}
@@ -223,12 +226,11 @@ serviceMonitor:
 terminationGracePeriodSeconds: 60
 
 test:
-  checkRecent: true
   enabled: true
   image:
     pullPolicy: IfNotPresent
     repository: bats/bats
-    tag: 1.5.0
+    tag: 1.6.0
 
 tolerations: []
 

--- a/charts/hedera-mirror-rosetta/templates/tests/pod.yaml
+++ b/charts/hedera-mirror-rosetta/templates/tests/pod.yaml
@@ -18,6 +18,18 @@ spec:
         - https://raw.githubusercontent.com/hashgraph/hedera-mirror-node/{{ regexReplaceAll "(\\d+\\.\\d+\\.\\d+(-\\w+)?)" .Chart.AppVersion "v${1}" }}/hedera-mirror-rosetta/scripts/validation/postman/rosetta-api-postman.json
         - --env-var
         - base_url=http://{{ include "hedera-mirror-rosetta.fullname" . }}:{{ .Values.service.port }}
-  terminationGracePeriodSeconds: 1
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ALL]
+        readOnlyRootFilesystem: true
   restartPolicy: Never
+  securityContext:
+    fsGroup: 1000
+    runAsGroup: 1000
+    runAsNonRoot: true
+    runAsUser: 1000
+    seccompProfile:
+      type: RuntimeDefault
+  terminationGracePeriodSeconds: 1
 {{- end -}}

--- a/charts/hedera-mirror-rosetta/values.yaml
+++ b/charts/hedera-mirror-rosetta/values.yaml
@@ -122,6 +122,11 @@ podDisruptionBudget:
 
 podSecurityContext:
   fsGroup: 1000
+  runAsGroup: 1000
+  runAsNonRoot: true
+  runAsUser: 1000
+  seccompProfile:
+    type: RuntimeDefault
 
 priorityClassName: ""
 
@@ -194,12 +199,10 @@ resources:
 revisionHistoryLimit: 3
 
 securityContext:
+  allowPrivilegeEscalation: false
   capabilities:
     drop: [ALL]
   readOnlyRootFilesystem: true
-  runAsGroup: 1000
-  runAsNonRoot: true
-  runAsUser: 1000
 
 service:
   annotations: {}
@@ -222,7 +225,7 @@ test:
   image:
     pullPolicy: IfNotPresent
     repository: postman/newman
-    tag: 5.3.0
+    tag: 5.3.1-alpine
 
 tolerations: []
 

--- a/charts/hedera-mirror-web3/templates/tests/pod.yaml
+++ b/charts/hedera-mirror-web3/templates/tests/pod.yaml
@@ -18,6 +18,18 @@ spec:
         - https://raw.githubusercontent.com/hashgraph/hedera-mirror-node/{{ regexReplaceAll "(\\d+\\.\\d+\\.\\d+(-\\w+)?)" .Chart.AppVersion "v${1}" }}/hedera-mirror-web3/postman.json
         - --env-var
         - baseUrl=http://{{ include "hedera-mirror-web3.fullname" . }}:{{ .Values.service.port }}
-  terminationGracePeriodSeconds: 1
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ALL]
+        readOnlyRootFilesystem: true
   restartPolicy: Never
+  securityContext:
+    fsGroup: 1000
+    runAsGroup: 1000
+    runAsNonRoot: true
+    runAsUser: 1000
+    seccompProfile:
+      type: RuntimeDefault
+  terminationGracePeriodSeconds: 1
 {{- end -}}

--- a/charts/hedera-mirror-web3/values.yaml
+++ b/charts/hedera-mirror-web3/values.yaml
@@ -113,6 +113,11 @@ podDisruptionBudget:
 
 podSecurityContext:
   fsGroup: 1000
+  runAsGroup: 1000
+  runAsNonRoot: true
+  runAsUser: 1000
+  seccompProfile:
+    type: RuntimeDefault
 
 priorityClassName: ""
 
@@ -257,12 +262,10 @@ resources:
 revisionHistoryLimit: 3
 
 securityContext:
+  allowPrivilegeEscalation: false
   capabilities:
     drop: [ALL]
   readOnlyRootFilesystem: true
-  runAsGroup: 1000
-  runAsNonRoot: true
-  runAsUser: 1000
 
 service:
   annotations: {}
@@ -285,7 +288,7 @@ test:
   image:
     pullPolicy: IfNotPresent
     repository: postman/newman
-    tag: 5.3.0
+    tag: 5.3.1-alpine
 
 tolerations: []
 

--- a/charts/hedera-mirror/Chart.yaml
+++ b/charts/hedera-mirror/Chart.yaml
@@ -22,11 +22,11 @@ dependencies:
     condition: postgresql.enabled
     name: postgresql-ha
     repository: https://charts.bitnami.com/bitnami
-    version: 8.1.2
+    version: 8.6.3
   - condition: redis.enabled
     name: redis
     repository: https://charts.bitnami.com/bitnami
-    version: 15.3.3
+    version: 16.5.4
   - alias: rest
     condition: rest.enabled
     name: hedera-mirror-rest
@@ -45,7 +45,7 @@ dependencies:
     condition: timescaledb.enabled
     name: timescaledb-single
     repository: https://raw.githubusercontent.com/timescale/timescaledb-kubernetes/master/charts/repo/
-    version: 0.10.0
+    version: 0.11.0
   - alias: web3
     condition: web3.enabled
     name: hedera-mirror-web3

--- a/charts/hedera-mirror/templates/secret-redis.yaml
+++ b/charts/hedera-mirror/templates/secret-redis.yaml
@@ -16,6 +16,6 @@ stringData:
 
   {{- if and .Values.redis.enabled .Values.redis.sentinel.enabled }}
   SPRING_REDIS_SENTINEL_MASTER: "{{ .Values.redis.sentinel.masterSet }}"
-  SPRING_REDIS_SENTINEL_NODES: "{{ print $redisHost ":" .Values.redis.sentinel.service.sentinelPort }}"
+  SPRING_REDIS_SENTINEL_NODES: "{{ print $redisHost ":" .Values.redis.sentinel.service.ports.sentinel }}"
   SPRING_REDIS_SENTINEL_PASSWORD: "{{ $redisPassword }}"
   {{- end -}}

--- a/charts/hedera-mirror/values.yaml
+++ b/charts/hedera-mirror/values.yaml
@@ -181,7 +181,7 @@ postgresql:
     debug: true
   postgresqlImage:
     debug: true
-    tag: 13.5.0-debian-10-r35
+    tag: 13.6.0-debian-10-r37
   postgresql:
     existingSecret: mirror-passwords
     extraEnvVarsSecret: mirror-passwords
@@ -239,6 +239,8 @@ redis:
   sentinel:
     enabled: true
     masterSet: mirror
+    persistence:
+      enabled: true
     resources:
       limits:
         cpu: 100m

--- a/charts/marketplace/gcp/release.sh
+++ b/charts/marketplace/gcp/release.sh
@@ -20,7 +20,7 @@ fi
 
 target_tag="${target_tag#v}" # Strip v prefix if present
 target_tag_minor="${target_tag%\.*}"
-bats_tag="1.5.0"
+bats_tag="1.6.0"
 postgresql_tag="12.9.0-debian-10-r36"
 registry="gcr.io/mirror-node-public/hedera-mirror-node"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
   db:
-    image: postgres:13.5-alpine
+    image: postgres:14.2-alpine
     environment:
       PGDATA: /var/lib/postgresql/data
       POSTGRES_HOST_AUTH_METHOD: scram-sha-256

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -84,7 +84,7 @@ npm test
 #### Prerequisites
 
 ``
-Go 1.17+
+Go 1.18+
 ``
 
 To start the Rosetta API ensure you have the necessary [configuration](configuration.md#rosetta-api) populated and run:

--- a/hedera-mirror-rest/Dockerfile
+++ b/hedera-mirror-rest/Dockerfile
@@ -1,16 +1,16 @@
-FROM node:16.13.0-alpine3.14
+FROM node:16.14.2-alpine3.15
 LABEL maintainer="mirrornode@hedera.com"
 
 # Setup
+ENV NODE_ENV production
+EXPOSE 5551
 WORKDIR /home/node/app/
 RUN chown -R node:node .
 COPY --chown=node:node . ./
 USER node
 
 # Build
-ENV NODE_ENV production
 RUN npm ci --only=production && npm cache clean --force --loglevel=error
 
 # Run
-EXPOSE 5551
 CMD ["node", "server.js"]

--- a/hedera-mirror-rosetta/Dockerfile
+++ b/hedera-mirror-rosetta/Dockerfile
@@ -1,10 +1,12 @@
-FROM golang:1.17.7-alpine as build
+FROM golang:1.18.0-alpine as build
+ARG VERSION=development
 WORKDIR /app
 COPY . .
-ARG VERSION=development
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s -X main.Version=${VERSION}" -o hedera-mirror-rosetta
 
 FROM scratch
+EXPOSE 5700
+USER 1000:1000
 WORKDIR /app
 COPY --from=build /app/hedera-mirror-rosetta .
 CMD ["./hedera-mirror-rosetta"]

--- a/hedera-mirror-rosetta/go.mod
+++ b/hedera-mirror-rosetta/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta
 
-go 1.17
+go 1.18
 
 require (
 	github.com/coinbase/rosetta-sdk-go v0.7.4

--- a/hedera-mirror-rosetta/pom.xml
+++ b/hedera-mirror-rosetta/pom.xml
@@ -43,7 +43,7 @@
                 <version>2.3.9</version>
                 <configuration>
                     <goPath>${go.dir}/path</goPath>
-                    <goVersion>1.17</goVersion>
+                    <goVersion>1.18</goVersion>
                     <hideBanner>true</hideBanner>
                     <storeFolder>${go.dir}/store</storeFolder>
                     <useEnvVars>true</useEnvVars>

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
         <dependency-check.version>7.0.0</dependency-check.version>
         <disruptor.version>3.4.4</disruptor.version> <!-- Used for asynchronous logging -->
         <docker-maven-plugin.version>0.39.1</docker-maven-plugin.version>
+        <docker.base.image>eclipse-temurin:11.0.14.1_1-jre-focal</docker.base.image>
         <docker.push.repository>gcr.io/mirrornode</docker.push.repository>
         <docker.resources>${project.build.directory}/container</docker.resources>
         <docker.tag.version>${release.version}</docker.tag.version>
@@ -257,7 +258,11 @@
                             <jvmFlags>
                                 <jvmFlag>-XX:MaxRAMPercentage=80</jvmFlag>
                             </jvmFlags>
+                            <user>1000:1000</user>
                         </container>
+                        <from>
+                            <image>${docker.base.image}</image>
+                        </from>
                         <to>
                             <image>${docker.push.repository}/${project.artifactId}:${docker.tag.version}</image>
                         </to>


### PR DESCRIPTION
**Description**:
* Bump chart dependencies
* Bump Go to 1.18
* Changes to conform to Kubernetes [restricted](https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted) pod security standard
* Change docker images to run as non-root
* Fix `MonitorPublishStopped` & `MonitorSubscribeStopped` not alerting when rate dropped to zero
* Fix jib warning `does not use a specific image digest - build may not be reproducible`
* Remove unused and brittle `rest.test.checkRecent` chart test

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
