### PR TITLE
Add passing RPS to k6 report

### DIFF
--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Publish helm chart
-        uses: stefanprodan/helm-gh-pages@v1
+        uses: stefanprodan/helm-gh-pages@v1.5.0
         with:
           target_dir: charts
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/hedera-mirror-test/k6/src/lib/common.js
+++ b/hedera-mirror-test/k6/src/lib/common.js
@@ -107,7 +107,7 @@ function getSequentialTestScenarios(tests) {
         }
       }
       thresholds[getMetricNameWithTags('http_reqs', tag)] = ['count>0'];
-      thresholds[getMetricNameWithTags(SCENARIO_DURATION_METRIC_NAME,tag)] = ['value>0'];
+      thresholds[getMetricNameWithTags(SCENARIO_DURATION_METRIC_NAME, tag)] = ['value>0'];
     }
   }
 
@@ -129,8 +129,8 @@ function getScenario(metricKey) {
 
 function markdownReport(data, isFirstColumnUrl, scenarios) {
   const firstColumnName = isFirstColumnUrl ? 'URL' : 'Scenario';
-  const header = `| ${firstColumnName} | VUS | Pass% | RPS | Avg. Req Duration | Comment |
-|----------|-----|-------|-----|-------------------|---------|`;
+  const header = `| ${firstColumnName} | VUS | Pass% | RPS | Pass RPS | Avg. Req Duration | Comment |
+|----------|-----|-------|-----|----------|-------------------|---------|`;
 
   // collect the metrics
   const {metrics} = data;
@@ -168,16 +168,17 @@ function markdownReport(data, isFirstColumnUrl, scenarios) {
     const httpReqs = scenarioMetric['http_reqs'].values.count;
     const duration = scenarioMetric['scenario_duration'].values.value; // in ms
     const rps = ((httpReqs * 1.0 / duration) * 1000).toFixed(2);
+    const passRps = (rps * passPercentage / 100.0).toFixed(2);
     const httpReqDuration = scenarioMetric['http_req_duration'].values.avg.toFixed(2);
 
     const firstColumn = isFirstColumnUrl ? scenarioUrls[scenario] : scenario;
-    markdown += `| ${firstColumn} | ${__ENV.DEFAULT_VUS} | ${passPercentage} | ${rps}/s | ${httpReqDuration}ms | |\n`;
+    markdown += `| ${firstColumn} | ${__ENV.DEFAULT_VUS} | ${passPercentage} | ${rps}/s | ${passRps}/s | ${httpReqDuration}ms | |\n`;
   }
 
   return markdown;
 }
 
-function TestScenarioBuilder () {
+function TestScenarioBuilder() {
   this._checks = {};
   this._name = null;
   this._request = null;

--- a/hedera-mirror-test/k6/src/lib/parameters.js
+++ b/hedera-mirror-test/k6/src/lib/parameters.js
@@ -82,7 +82,7 @@ export const computeAccountParameters = (configuration) =>
       return {
         DEFAULT_ACCOUNT_ID: firstAccount.account,
         DEFAULT_ACCOUNT_BALANCE: firstAccount.balance.balance || 0,
-        DEFAULT_PUBLIC_KEY: firstAccount.key
+        DEFAULT_PUBLIC_KEY: firstAccount.key.key
       };
     });
 


### PR DESCRIPTION
**Description**:
* Add passing RPS to k6 report
* Fix invalid version for `helm-gh-pages` action
* Fix invalid property in k6

**Related issue(s)**:

**Notes for reviewer**:
If you have a large amount of failing requests it doesn't make sense to include those as part of the total RPS. We should only take into account the passing proportion of the RPS.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
