### PR TITLE
Fix node scale down issues

### DIFF
--- a/charts/hedera-mirror-grpc/values.yaml
+++ b/charts/hedera-mirror-grpc/values.yaml
@@ -311,8 +311,6 @@ updateStrategy:
 volumeMounts:
   config:
     mountPath: /usr/etc/hedera
-  tmp:
-    mountPath: /tmp  # Vertx needs a writable cache directory
 
 # Volume mounts to add to the container. The key is the volume name and the value is the volume definition. Evaluated as a template.
 volumes:
@@ -320,5 +318,3 @@ volumes:
     secret:
       defaultMode: 420
       secretName: '{{ include "hedera-mirror-grpc.fullname" . }}'
-  tmp:
-    emptyDir: {}

--- a/charts/hedera-mirror-rest/values.yaml
+++ b/charts/hedera-mirror-rest/values.yaml
@@ -199,7 +199,7 @@ resources:
     memory: 350Mi
   requests:
     cpu: 150m
-    memory: 100Mi
+    memory: 64Mi
 
 revisionHistoryLimit: 3
 

--- a/charts/hedera-mirror-rest/values.yaml
+++ b/charts/hedera-mirror-rest/values.yaml
@@ -198,8 +198,8 @@ resources:
     cpu: 750m
     memory: 350Mi
   requests:
-    cpu: 50m
-    memory: 64Mi
+    cpu: 150m
+    memory: 100Mi
 
 revisionHistoryLimit: 3
 

--- a/charts/hedera-mirror/values-prod.yaml
+++ b/charts/hedera-mirror/values-prod.yaml
@@ -25,8 +25,6 @@ importer:
   alertmanager:
     inhibitRules:
       enabled: true
-  podDisruptionBudget:
-    enabled: true
   podMonitor:
     enabled: true
   priorityClassName: high

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/listener/AbstractTopicListenerTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/listener/AbstractTopicListenerTest.java
@@ -25,11 +25,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Resource;
-
-import com.hedera.mirror.common.domain.entity.EntityId;
-
-import com.hedera.mirror.common.domain.entity.EntityType;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -39,6 +34,8 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
+import com.hedera.mirror.common.domain.entity.EntityId;
+import com.hedera.mirror.common.domain.entity.EntityType;
 import com.hedera.mirror.grpc.GrpcIntegrationTest;
 import com.hedera.mirror.grpc.domain.DomainBuilder;
 import com.hedera.mirror.grpc.domain.TopicMessage;
@@ -57,12 +54,10 @@ public abstract class AbstractTopicListenerTest extends GrpcIntegrationTest {
 
     @Resource
     protected CompositeTopicListener topicListener;
+    private Duration defaultInterval;
+    private ListenerProperties.ListenerType defaultType;
 
     protected abstract ListenerProperties.ListenerType getType();
-
-    private Duration defaultInterval;
-
-    private ListenerProperties.ListenerType defaultType;
 
     @BeforeEach
     void setup() {

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/listener/NotifyingTopicListenerTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/listener/NotifyingTopicListenerTest.java
@@ -37,6 +37,8 @@ import com.hedera.mirror.grpc.domain.TopicMessageFilter;
 
 class NotifyingTopicListenerTest extends AbstractSharedTopicListenerTest {
 
+    private static boolean WARMED_UP = false;
+
     @Resource
     private NotifyingTopicListener topicListener;
 
@@ -49,12 +51,15 @@ class NotifyingTopicListenerTest extends AbstractSharedTopicListenerTest {
     }
 
     @BeforeEach
-    void setup() {
+    void warmup() {
         // Warm up the database connection
-        topicListener.listen(TopicMessageFilter.builder().startTime(Instant.EPOCH).build())
-                .as(StepVerifier::create)
-                .thenAwait(Duration.ofMillis(250))
-                .thenCancel();
+        if (!WARMED_UP) {
+            topicListener.listen(TopicMessageFilter.builder().startTime(Instant.EPOCH).build())
+                    .as(StepVerifier::create)
+                    .thenAwait(Duration.ofMillis(250))
+                    .thenCancel();
+            WARMED_UP = true;
+        }
     }
 
     // Test deserialization from JSON to verify contract with PostgreSQL listen/notify

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/listener/NotifyingTopicListenerTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/listener/NotifyingTopicListenerTest.java
@@ -56,7 +56,7 @@ class NotifyingTopicListenerTest extends AbstractSharedTopicListenerTest {
         if (!WARMED_UP) {
             topicListener.listen(TopicMessageFilter.builder().startTime(Instant.EPOCH).build())
                     .as(StepVerifier::create)
-                    .thenAwait(Duration.ofMillis(250))
+                    .thenAwait(Duration.ofMillis(1000))
                     .thenCancel();
             WARMED_UP = true;
         }

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/listener/NotifyingTopicListenerTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/listener/NotifyingTopicListenerTest.java
@@ -37,8 +37,6 @@ import com.hedera.mirror.grpc.domain.TopicMessageFilter;
 
 class NotifyingTopicListenerTest extends AbstractSharedTopicListenerTest {
 
-    private static boolean WARMED_UP = false;
-
     @Resource
     private NotifyingTopicListener topicListener;
 
@@ -53,13 +51,7 @@ class NotifyingTopicListenerTest extends AbstractSharedTopicListenerTest {
     @BeforeEach
     void warmup() {
         // Warm up the database connection
-        if (!WARMED_UP) {
-            topicListener.listen(TopicMessageFilter.builder().startTime(Instant.EPOCH).build())
-                    .as(StepVerifier::create)
-                    .thenAwait(Duration.ofMillis(1000))
-                    .thenCancel();
-            WARMED_UP = true;
-        }
+        topicListener.channel.block(Duration.ofSeconds(1));
     }
 
     // Test deserialization from JSON to verify contract with PostgreSQL listen/notify

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/listener/NotifyingTopicListenerTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/listener/NotifyingTopicListenerTest.java
@@ -23,16 +23,15 @@ package com.hedera.mirror.grpc.listener;
 import java.time.Duration;
 import java.time.Instant;
 import javax.annotation.Resource;
-
-import com.hedera.mirror.common.domain.entity.EntityId;
-import com.hedera.mirror.common.domain.entity.EntityType;
-
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.jdbc.core.JdbcTemplate;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
+import com.hedera.mirror.common.domain.entity.EntityId;
+import com.hedera.mirror.common.domain.entity.EntityType;
 import com.hedera.mirror.grpc.domain.TopicMessage;
 import com.hedera.mirror.grpc.domain.TopicMessageFilter;
 
@@ -47,6 +46,15 @@ class NotifyingTopicListenerTest extends AbstractSharedTopicListenerTest {
     @Override
     protected ListenerProperties.ListenerType getType() {
         return ListenerProperties.ListenerType.NOTIFY;
+    }
+
+    @BeforeEach
+    void setup() {
+        // Warm up the database connection
+        topicListener.listen(TopicMessageFilter.builder().startTime(Instant.EPOCH).build())
+                .as(StepVerifier::create)
+                .thenAwait(Duration.ofMillis(250))
+                .thenCancel();
     }
 
     // Test deserialization from JSON to verify contract with PostgreSQL listen/notify


### PR DESCRIPTION
**Description**:
* Fix error `Pod is blocking scale down because it has local storage`
* Fix scale down issue due to importer PodDisruptionBudget
* Fix gRPC `NotifyingTopicListener` connecting on startup even when not enabled
* Fix `KubeHpaMaxedOut` alert firing due to premature scale up

**Related issue(s)**:

**Notes for reviewer**:
I've seen the scale down error occur both when node auto-provisioning kicked in to scale up/down nodes due to resource exhaustion and when there was a GKE upgrade. The fix is to both disable Vert.x caching and to remove the temp volume. We only use Vert.x for async pgnotify, which is disabled by default, and we don't even need the classpath caching for that.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
