### PR TITLE
Add a property to set API response headers

### DIFF
--- a/charts/hedera-mirror-grpc/templates/service.yaml
+++ b/charts/hedera-mirror-grpc/templates/service.yaml
@@ -11,7 +11,7 @@ spec:
       targetPort: grpc
       protocol: TCP
       name: grpc
-    - port: 8081
+    - port: 80
       targetPort: http
       protocol: TCP
       name: http

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -349,7 +349,9 @@ value, it is recommended to only populate overridden properties in the custom `a
 | `hedera.mirror.rest.metrics.config.uriPath`              | '/swagger'              | The REST API metrics uri path                                                                  |
 | `hedera.mirror.rest.openapi.specFileName`                | 'openapi'               | The file name of the OpenAPI spec file                                                         |
 | `hedera.mirror.rest.openapi.swaggerUIPath`               | '/docs'                 | Swagger UI path for your REST API                                                              |
-| `hedera.mirror.rest.response.compression`                | true                    | Whether GZIP compression should be enabled for response bodies                                 |
+| `hedera.mirror.rest.response.compression`                | true                    | Whether content negotiation should occur to compress response bodies if requested              |
+| `hedera.mirror.rest.response.headers.default`            | See application.yml     | The default headers to add to every response.                                                  |
+| `hedera.mirror.rest.response.headers.path`               | See application.yml     | The per path headers to add to every response. The key is the route name and the value is a header map. |
 | `hedera.mirror.rest.response.includeHostInLink`          | false                   | Whether to include the hostname and port in the next link in the response                      |
 | `hedera.mirror.rest.response.limit.default`              | 25                      | The default value for the limit parameter that controls the REST API response size             |
 | `hedera.mirror.rest.response.limit.max`                  | 100                     | The maximum size the limit parameter can be that controls the REST API response size           |

--- a/docs/rest/README.md
+++ b/docs/rest/README.md
@@ -3,3 +3,45 @@
 The REST API is the main API to retrieve data from the mirror node. Further documentation is available
 on [docs.hedera.com](https://docs.hedera.com/guides/docs/mirror-node-api/cryptocurrency-api) and via
 our [Swagger UI](https://mainnet-public.mirrornode.hedera.com/api/v1/docs/#/).
+
+## Database
+
+This section documents the tables used for different endpoints and query parameters. This information is useful for
+debugging purposes and for understanding the update cadence of the underlying data.
+
+| Endpoint                                        | Tables                                                                                                       | Notes                                                        |
+|-------------------------------------------------|--------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------|
+| `/api/v1/accounts`                              | `account_balance`, `contract`, `entity`, `token_balance`                                                     | Entity tables first used to filter, then joined w/ balances  |
+| `/api/v1/accounts?balance=false`                | `contract`, `entity`                                                                                         | Balance tables skipped                                       |
+| `/api/v1/accounts/:idOrAlias`                   | `account_balance`, `contract`, `crypto_transfer`, `entity`, `token_balance`, `token_transfer`, `transaction` | Transfers & transactions are present only for legacy reasons |
+| `/api/v1/accounts/:id/allowances/crypto`        | `crypto_allowance`                                                                                           |                                                              |
+| `/api/v1/accounts/:alias/allowances/crypto`     | `crypto_allowance`, `entity`                                                                                 | Separate alias lookup first                                  |
+| `/api/v1/accounts/:id/nfts`                     | `nft`                                                                                                        |                                                              |
+| `/api/v1/accounts/:alias/nfts`                  | `entity`, `nft`                                                                                              | Separate alias lookup first                                  |
+| `/api/v1/balances`                              | `account_balance`, `token_balance`                                                                           |                                                              |
+| `/api/v1/balances?account.publickey`            | `account_balance`, `contract`, `entity`, `token_balance`                                                     | Entity tables used to find by public key                     |
+| `/api/v1/contracts`                             | `contract`                                                                                                   |                                                              |
+| `/api/v1/contracts/:idOrAddress`                | `contract`, `file_data`                                                                                      | `file_data` used to get init bytecode                        |
+| `/api/v1/contracts/:idOrAddress?timestamp`      | `contract`, `contract_history`, `file_data`                                                                  | Union both contract tables to find latest timestamp in range |
+| `/api/v1/contracts/:id/results`                 | `contract_result`                                                                                            |                                                              |
+| `/api/v1/contracts/:address/results`            | `contract`, `contract_result`                                                                                | Separate EVM address lookup first                            |
+| `/api/v1/contracts/:id/results/:timestamp`      | `contract_log`, `contract_result`, `contract_state_change`, `record_file`, `transaction`                     |                                                              |
+| `/api/v1/contracts/:address/results/:timestamp` | `contract`, `contract_log`, `contract_result`, `contract_state_change`, `record_file`, `transaction`         | Separate EVM address lookup first                            |
+| `/api/v1/contracts/results/:transactionId`      | `contract_log`, `contract_result`, `contract_state_change`, `record_file`, `transaction`                     |                                                              |
+| `/api/v1/network/supply`                        | `account_balance`, `account_balance_file`                                                                    |                                                              |
+| `/api/v1/schedules`                             | `entity`, `schedule`, `transaction_signature`                                                                |                                                              |
+| `/api/v1/schedules/:id`                         | `entity`, `schedule`, `transaction_signature`                                                                |                                                              |
+| `/api/v1/tokens`                                | `entity`, `token`                                                                                            |                                                              |
+| `/api/v1/tokens?account.id`                     | `entity`, `token`, `token_account`                                                                           |                                                              |
+| `/api/v1/tokens/:id`                            | `custom_fee`, `entity`, `token`                                                                              |                                                              |
+| `/api/v1/tokens/:id/balances`                   | `token_balance`                                                                                              |                                                              |
+| `/api/v1/tokens/:id/balances?account.publickey` | `entity`, `token_balance`                                                                                    |                                                              |
+| `/api/v1/tokens/:id/nfts`                       | `entity`, `nft`                                                                                              |                                                              |
+| `/api/v1/tokens/:id/nfts/:serial`               | `entity`, `nft`                                                                                              |                                                              |
+| `/api/v1/tokens/:id/nfts/:serial/transactions`  | `nft_transfer`, `transaction`                                                                                |                                                              |
+| `/api/v1/topics/:id/messages`                   | `topic_message`                                                                                              |                                                              |
+| `/api/v1/topics/:id/messages/:number`           | `topic_message`                                                                                              |                                                              |
+| `/api/v1/topics/messages/:timestamp`            | `topic_message`                                                                                              |                                                              |
+| `/api/v1/transactions`                          | `crypto_transfer`, `token_transfer`, `transaction`                                                           | Transfers are present only for legacy reasons                |
+| `/api/v1/transactions/:id`                      | `assessed_custom_fee`, `crypto_transfer`, `nft_transfer`, `token_transfer`, `transaction`                    |                                                              |
+| `/api/v1/transactions/:id/stateproof`           | `address_book`, `address_book_entry`, `record_file`, `transaction`                                           | Also downloads RCD files from S3                             |

--- a/hedera-mirror-rest/__tests__/middleware/responseHandler.test.js
+++ b/hedera-mirror-rest/__tests__/middleware/responseHandler.test.js
@@ -1,0 +1,78 @@
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+'use strict';
+
+const {
+  response: {headers},
+} = require('../../config');
+const {NotFoundError} = require('../../errors/notFoundError');
+const {responseHandler} = require('../../middleware/responseHandler');
+require('../testutils'); // For logger init
+
+const responseData = {transactions: [], links: {next: null}};
+
+describe('Response middleware', () => {
+  let mockRequest;
+  let mockResponse;
+
+  beforeEach(() => {
+    mockRequest = {
+      ip: '127.0.0.1',
+      method: 'GET',
+      originalUrl: '/api/v1/transactions/0.0.10-1234567890-000000001',
+      requestStartTime: Date.now() - 5,
+      route: {
+        path: '/api/v1/transactions/:transactionId',
+      },
+    };
+    mockResponse = {
+      json: jest.fn(),
+      locals: {
+        mirrorRestData: responseData,
+        statusCode: 200,
+      },
+      set: jest.fn(),
+      status: jest.fn(),
+    };
+  });
+
+  test('No response data', async () => {
+    mockResponse.locals.mirrorRestData = undefined;
+    await expect(responseHandler(mockRequest, mockResponse, null)).rejects.toThrow(NotFoundError);
+  });
+
+  test('Custom headers', async () => {
+    await responseHandler(mockRequest, mockResponse, null);
+    expect(mockResponse.json).toBeCalledWith(responseData);
+    expect(mockResponse.set).toHaveBeenNthCalledWith(1, headers.default);
+    expect(mockResponse.set).toHaveBeenNthCalledWith(2, headers.path[mockRequest.route.path]);
+    expect(mockResponse.status).toBeCalledWith(mockResponse.locals.statusCode);
+  });
+
+  test('Default headers', async () => {
+    mockRequest.route.path = '/api/v1/transactions';
+    await responseHandler(mockRequest, mockResponse, null);
+    expect(mockResponse.json).toBeCalledWith(responseData);
+    expect(mockResponse.set).toHaveBeenNthCalledWith(1, headers.default);
+    expect(mockResponse.set).toHaveBeenNthCalledWith(2, undefined);
+    expect(mockResponse.status).toBeCalledWith(mockResponse.locals.statusCode);
+  });
+});

--- a/hedera-mirror-rest/api/v1/openapi.yml
+++ b/hedera-mirror-rest/api/v1/openapi.yml
@@ -102,7 +102,6 @@ paths:
           $ref: '#/components/responses/NotFoundError'
       tags:
         - accounts
-        - tokens
   /api/v1/accounts/{accountAliasOrAccountId}/allowances/crypto:
     get:
       summary: Get crypto allowances for an account info
@@ -126,7 +125,6 @@ paths:
           $ref: '#/components/responses/NotFoundError'
       tags:
         - accounts
-        - crypto
   /api/v1/balances:
     get:
       summary: List account balances
@@ -680,7 +678,6 @@ paths:
         - $ref: '#/components/parameters/orderQueryParam'
         - $ref: '#/components/parameters/accountPublicKeyQueryParam'
         - $ref: '#/components/parameters/timestampQueryParam'
-        - $ref: '#/components/parameters/publicKeyQueryParam'
         - $ref: '#/components/parameters/limitQueryParam'
       responses:
         200:

--- a/hedera-mirror-rest/config/application.yml
+++ b/hedera-mirror-rest/config/application.yml
@@ -98,6 +98,11 @@ hedera:
       port: 5551
       response:
         compression: true
+        headers:
+          default: { 'Cache-Control': 'public, max-age=1' }
+          path:
+            /api/v1/transactions/:transactionId: { 'Cache-Control': 'public, max-age=300' }
+            /api/v1/transactions/:transactionId/stateproof: { 'Cache-Control': 'public, max-age=600' }
         includeHostInLink: false
         limit:
           default: 25

--- a/hedera-mirror-rest/middleware/responseHandler.js
+++ b/hedera-mirror-rest/middleware/responseHandler.js
@@ -20,6 +20,9 @@
 
 'use strict';
 
+const {
+  response: {headers},
+} = require('../config');
 const constants = require('../constants');
 const {NotFoundError} = require('../errors/notFoundError');
 
@@ -31,10 +34,14 @@ const responseHandler = async (req, res, next) => {
     // unmatched route will have no response data, pass NotFoundError to next middleware
     throw new NotFoundError();
   } else {
+    res.set(headers.default);
+    res.set(headers.path[req.route.path]);
+
     // set response json
     const code = res.locals.statusCode;
     const data = res.locals[constants.responseDataLabel];
-    res.status(code).json(data);
+    res.status(code);
+    res.json(data);
 
     const startTime = res.locals[constants.requestStartTime];
     const elapsed = startTime ? Date.now() - startTime : 0;

--- a/hedera-mirror-rest/service/baseService.js
+++ b/hedera-mirror-rest/service/baseService.js
@@ -46,9 +46,6 @@ class BaseService {
   }
 
   async getSingleRow(query, params, functionName = '') {
-    if (logger.isTraceEnabled()) {
-      logger.trace(`${functionName} query: ${query}, params: ${params}`);
-    }
     const rows = await this.getRows(query, params, functionName);
     if (_.isEmpty(rows) || rows.length > 1) {
       return null;

--- a/hedera-mirror-test/k6/src/lib/common.js
+++ b/hedera-mirror-test/k6/src/lib/common.js
@@ -40,7 +40,7 @@ const scenario = {
   duration: __ENV.DEFAULT_DURATION,
   exec: 'run',
   executor: 'constant-vus',
-  gracefulStop: (__ENV.DEFAULT_GRACEFUL_STOP != null && __ENV.DEFAULT_GRACEFUL_STOP) || '15s',
+  gracefulStop: (__ENV.DEFAULT_GRACEFUL_STOP != null && __ENV.DEFAULT_GRACEFUL_STOP) || '5s',
   vus: __ENV.DEFAULT_VUS,
 };
 

--- a/hedera-mirror-test/k6/src/rest/test/balancesAccount.js
+++ b/hedera-mirror-test/k6/src/rest/test/balancesAccount.js
@@ -25,12 +25,13 @@ import {urlPrefix} from '../../lib/constants.js';
 import {isValidListResponse} from "./common.js";
 import {setupTestParameters} from "./bootstrapEnvParameters.js";
 
-const urlTag = '/balances';
+const urlTag = '/balances?account.id=eq:{accountId}';
+
 const {options, run} = new TestScenarioBuilder()
-  .name('balances_account') // use unique scenario name among all tests
+  .name('balancesAccount') // use unique scenario name among all tests
   .tags({url: urlTag})
   .request((testParameters) => {
-    const url = `${testParameters['BASE_URL']}${urlPrefix}${urlTag}?account.id=eq:${testParameters['DEFAULT_ACCOUNT_ID']}`;
+    const url = `${testParameters['BASE_URL']}${urlPrefix}/balances?account.id=eq:${testParameters['DEFAULT_ACCOUNT_ID']}`;
     return http.get(url);
   })
   .check('Balances for specific account OK', (r) => isValidListResponse(r, "balances"))

--- a/hedera-mirror-test/k6/src/rest/test/topicsIdMessagesSequence.js
+++ b/hedera-mirror-test/k6/src/rest/test/topicsIdMessagesSequence.js
@@ -22,7 +22,7 @@ import http from "k6/http";
 
 import {TestScenarioBuilder} from '../../lib/common.js';
 import {messageListName, urlPrefix} from '../../lib/constants.js';
-import {isValidListResponse} from "./common.js";
+import {isSuccess} from "./common.js";
 import {setupTestParameters} from "./bootstrapEnvParameters.js";
 
 const urlTag = '/topics/{id}/messages/{sequenceNumber}';
@@ -34,7 +34,7 @@ const {options, run} = new TestScenarioBuilder()
     const url = `${testParameters['BASE_URL']}${urlPrefix}/topics/${testParameters['DEFAULT_TOPIC_ID']}/messages/${testParameters['DEFAULT_TOPIC_SEQUENCE']}`;
     return http.get(url);
   })
-  .check('Topics id messages sequenceNumber OK', (r) => isValidListResponse(r, messageListName))
+  .check('Topics id messages sequenceNumber OK', (r) => isSuccess(r, messageListName))
   .build();
 
 


### PR DESCRIPTION
**Description**:

* Add a `hedera.mirror.rest.response.headers.default` property with cache set to max age of 1s
* Add a `hedera.mirror.rest.response.headers.path` property with custom cache headers per route
* Add a table to REST API README documenting the underlying tables accessed by each endpoint
* Change gRPC service port to 80 to match other services and fix NEG health check
* Change k6 graceful stop to 5s to speed up shorter duration tests
* Fix some routes showing up multiple times in Swagger UI due to extra tags
* Fix extra, unimplemented ` /api/v1/tokens/{tokenId}/balances?publickey=` query parameter in OpenAPI
* Fix failing check for `/topics/{id}/messages/{sequenceNumber}` k6 test
* Fix duplicate `/balances` item in k6 report due to non-unique URL tag
* Fix duplicate SQL query log in REST API

**Related issue(s)**:

Fixes #3475

**Notes for reviewer**:
Performance results in notion. The `1s` cache was enough to dramatically speed up most endpoints, so I didn't want to risk a higher max-age for those unless it's needed for performance or cost reasons. We will need to see production metrics or enhance our k6 tests to sample more IDs to understand that better.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
