### PR TITLE
Fix rosetta workflow bdd test build failure

### DIFF
--- a/.github/workflows/rosetta-api.yml
+++ b/.github/workflows/rosetta-api.yml
@@ -87,7 +87,6 @@ jobs:
         online-only: [ 'true', 'false' ]
     timeout-minutes: 15
     env:
-      GOROOT: ${{ env.GOROOT_1_18_X64 }}
       OFFLINE_URL: http://localhost:5700
       ROSETTA_CLI_VERSION: v0.7.3
     steps:
@@ -182,6 +181,8 @@ jobs:
         if: steps.changed-files-module.outputs.any_changed == 'true'
         working-directory: ./hedera-mirror-rosetta/test/bdd-client
         run: |
+          export GOROOT=$GOROOT_1_18_X64
+          export PATH=$GOROOT/bin:$PATH
           jq -r '.[] | {"privateKey": .privkey, "id": .account_identifier.address}' /tmp/accounts.json | \
             jq -s '. | {operators: .} | .server.offlineUrl="${{ env.OFFLINE_URL }}" | {test: .} | {rosetta: .}
               | {mirror: .} | {hedera: .}' | \

--- a/.github/workflows/rosetta-api.yml
+++ b/.github/workflows/rosetta-api.yml
@@ -87,6 +87,7 @@ jobs:
         online-only: [ 'true', 'false' ]
     timeout-minutes: 15
     env:
+      GOROOT: ${{ env.GOROOT_1_18_X64 }}
       OFFLINE_URL: http://localhost:5700
       ROSETTA_CLI_VERSION: v0.7.3
     steps:

--- a/hedera-mirror-rosetta/test/bdd-client/README.md
+++ b/hedera-mirror-rosetta/test/bdd-client/README.md
@@ -104,4 +104,3 @@ The following table lists the available properties along with their default valu
 | `hedera.mirror.rosetta.test.server.onlineUrl`           | http://localhost:5700 | The url of the online rosetta server                                       |
 | `hedera.mirror.rosetta.test.server.submitRetry.backOff` | 200ms                 | The amount of time to wait between submit request retries                  |
 | `hedera.mirror.rosetta.test.server.submitRetry.max`     | 5                     | The max retries of a submit request                                        |
-

--- a/hedera-mirror-rosetta/test/bdd-client/README.md
+++ b/hedera-mirror-rosetta/test/bdd-client/README.md
@@ -104,3 +104,4 @@ The following table lists the available properties along with their default valu
 | `hedera.mirror.rosetta.test.server.onlineUrl`           | http://localhost:5700 | The url of the online rosetta server                                       |
 | `hedera.mirror.rosetta.test.server.submitRetry.backOff` | 200ms                 | The amount of time to wait between submit request retries                  |
 | `hedera.mirror.rosetta.test.server.submitRetry.max`     | 5                     | The max retries of a submit request                                        |
+


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

This PR fixes the build failure in rosetta-api workflow bdd test step.

**Related issue(s)**:

Fixes #3517

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

Most likely the issue is the github runner ubuntu 20.04 LTS image provdes by default go 1.15 and the recent godog upgrade changed to use `os.ReadFile` which is added since go1.16, so we get a build error in the workflow bdd test step. The fix is set `PATH` to switch to go1.18 in the runner image.

Can check the bdd test is passing here: https://github.com/hashgraph/hedera-mirror-node/runs/5841334127?check_suite_focus=true

Had to make a dummy change to a file inside the `hedera-mirror-rosetta` folder to trigger the bdd test step.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
