### PR TITLE
Fix rosetta-api workflow failure caused by rosetta-cli breaking changes

### DIFF
--- a/.github/workflows/rosetta-api.yml
+++ b/.github/workflows/rosetta-api.yml
@@ -88,7 +88,7 @@ jobs:
     timeout-minutes: 15
     env:
       OFFLINE_URL: http://localhost:5700
-      ROSETTA_CLI_VERSION: v0.7.3
+      ROSETTA_CLI_VERSION: v0.7.5
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/hedera-mirror-rosetta/app/services/account_service.go
+++ b/hedera-mirror-rosetta/app/services/account_service.go
@@ -94,5 +94,5 @@ func (a *AccountAPIService) AccountCoins(
 	_ context.Context,
 	_ *rTypes.AccountCoinsRequest,
 ) (*rTypes.AccountCoinsResponse, *rTypes.Error) {
-	return &rTypes.AccountCoinsResponse{}, nil
+	return nil, errors.ErrNotImplemented
 }

--- a/hedera-mirror-rosetta/app/services/account_service_test.go
+++ b/hedera-mirror-rosetta/app/services/account_service_test.go
@@ -262,6 +262,6 @@ func (suite *accountServiceSuite) TestAccountCoins() {
 	result, err := suite.accountService.AccountCoins(defaultContext, &rTypes.AccountCoinsRequest{})
 
 	// then:
-	assert.Nil(suite.T(), err)
-	assert.Equal(suite.T(), &rTypes.AccountCoinsResponse{}, result)
+	assert.Equal(suite.T(), errors.ErrNotImplemented, err)
+	assert.Nil(suite.T(), result)
 }

--- a/hedera-mirror-rosetta/app/services/mempool_service.go
+++ b/hedera-mirror-rosetta/app/services/mempool_service.go
@@ -22,6 +22,7 @@ package services
 
 import (
 	"context"
+	"github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/app/errors"
 
 	"github.com/coinbase/rosetta-sdk-go/server"
 	"github.com/coinbase/rosetta-sdk-go/types"
@@ -40,7 +41,7 @@ func (m *mempoolAPIService) Mempool(
 	_ context.Context,
 	_ *types.NetworkRequest,
 ) (*types.MempoolResponse, *types.Error) {
-	return &types.MempoolResponse{TransactionIdentifiers: []*types.TransactionIdentifier{}}, nil
+	return nil, errors.ErrNotImplemented
 }
 
 // MempoolTransaction implements the /mempool/transaction endpoint
@@ -48,5 +49,5 @@ func (m *mempoolAPIService) MempoolTransaction(
 	_ context.Context,
 	_ *types.MempoolTransactionRequest,
 ) (*types.MempoolTransactionResponse, *types.Error) {
-	return &types.MempoolTransactionResponse{}, nil
+	return nil, errors.ErrNotImplemented
 }

--- a/hedera-mirror-rosetta/app/services/mempool_service_test.go
+++ b/hedera-mirror-rosetta/app/services/mempool_service_test.go
@@ -21,6 +21,7 @@
 package services
 
 import (
+	"github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/app/errors"
 	"testing"
 
 	rTypes "github.com/coinbase/rosetta-sdk-go/types"
@@ -38,8 +39,8 @@ func TestMempool(t *testing.T) {
 	res, e := NewMempoolAPIService().Mempool(defaultContext, &rTypes.NetworkRequest{})
 
 	// then:
-	assert.Nil(t, e)
-	assert.Equal(t, &rTypes.MempoolResponse{TransactionIdentifiers: []*rTypes.TransactionIdentifier{}}, res)
+	assert.Equal(t, errors.ErrNotImplemented, e)
+	assert.Nil(t, res)
 }
 
 func TestMempoolTransaction(t *testing.T) {
@@ -47,6 +48,6 @@ func TestMempoolTransaction(t *testing.T) {
 	res, e := NewMempoolAPIService().MempoolTransaction(defaultContext, &rTypes.MempoolTransactionRequest{})
 
 	// then:
-	assert.Nil(t, e)
-	assert.Equal(t, &rTypes.MempoolTransactionResponse{}, res)
+	assert.Equal(t, errors.ErrNotImplemented, e)
+	assert.Nil(t, res)
 }

--- a/hedera-mirror-rosetta/scripts/validation/demo/validation.json
+++ b/hedera-mirror-rosetta/scripts/validation/demo/validation.json
@@ -13,7 +13,7 @@
   "tip_delay": 300,
   "data": {
     "balance_tracking_disabled": false,
-    "historical_balance_enabled": true,
+    "historical_balance_disabled": false,
     "inactive_discrepancy_search_disabled": false,
     "reconciliation_disabled": false,
     "start_index": 1,

--- a/hedera-mirror-rosetta/scripts/validation/mainnet/validation.json
+++ b/hedera-mirror-rosetta/scripts/validation/mainnet/validation.json
@@ -19,6 +19,7 @@
   "tip_delay": 20,
   "data": {
     "active_reconciliation_concurrency": 64,
+    "historical_balance_disabled": false,
     "inactive_reconciliation_concurrency": 4,
     "inactive_reconciliation_frequency": 250,
     "pruning_disabled": true,

--- a/hedera-mirror-rosetta/scripts/validation/testnet/validation.json
+++ b/hedera-mirror-rosetta/scripts/validation/testnet/validation.json
@@ -25,7 +25,7 @@
   },
   "data": {
     "balance_tracking_disabled": false,
-    "historical_balance_enabled": true,
+    "historical_balance_disabled": false,
     "inactive_discrepancy_search_disabled": false,
     "reconciliation_disabled": false,
     "start_index": 1,


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR fixes the rosetta-api workflow failure caused by breaking changes in rosetta-cli v0.7.4

- bump up to rosetta-cli v0.7.5
- adapt breaking rosetta-cli config changes
- revert `/account/coins`, `/mempool`, and `/mempool/transaction` to return not implemented error

**Related issue(s)**:

Fixes #3510 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

will port to release 0.54 once approved & merged

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
