### PR TITLE
Remove Crypto Allowance Adjust Acceptance Test

### DIFF
--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AccountFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AccountFeature.java
@@ -28,13 +28,10 @@ import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import io.cucumber.junit.platform.engine.Cucumber;
 import java.util.List;
-import junit.framework.AssertionFailedError;
 import lombok.Data;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
-import org.springframework.retry.annotation.Backoff;
-import org.springframework.retry.annotation.Retryable;
 import org.springframework.util.CollectionUtils;
 
 import com.hedera.hashgraph.sdk.AccountId;
@@ -155,9 +152,6 @@ public class AccountFeature extends AbstractFeature {
     }
 
     @Then("the mirror node REST API should return status {int} for the crypto transfer transaction")
-    @Retryable(value = {AssertionError.class, AssertionFailedError.class},
-            backoff = @Backoff(delayExpression = "#{@restPollingProperties.minBackoff.toMillis()}"),
-            maxAttemptsExpression = "#{@restPollingProperties.maxAttempts}")
     public void verifyMirrorAPICryptoTransferResponse(int status) {
         log.info("Verify transaction");
         String transactionId = networkTransactionResponse.getTransactionIdStringNoCheckSum();
@@ -190,9 +184,6 @@ public class AccountFeature extends AbstractFeature {
     }
 
     @Then("the mirror node REST API should confirm the approved {long} tℏ crypto transfer allowance")
-    @Retryable(value = {AssertionError.class, AssertionFailedError.class},
-            backoff = @Backoff(delayExpression = "#{@restPollingProperties.minBackoff.toMillis()}"),
-            maxAttemptsExpression = "#{@restPollingProperties.maxAttempts}")
     public void verifyMirrorAPIApprovedCryptoTransferResponse(long approvedAmount) {
         verifyMirrorTransactionsResponse(mirrorClient, HttpStatus.OK.value());
 
@@ -221,9 +212,6 @@ public class AccountFeature extends AbstractFeature {
     }
 
     @Then("the mirror node REST API should confirm the crypto allowance deletion")
-    @Retryable(value = {AssertionError.class, AssertionFailedError.class},
-            backoff = @Backoff(delayExpression = "#{@restPollingProperties.minBackoff.toMillis()}"),
-            maxAttemptsExpression = "#{@restPollingProperties.maxAttempts}")
     public void verifyCryptoAllowanceDelete() {
         log.info("Verify crypto allowance deletion transaction");
         verifyMirrorAPIApprovedCryptoTransferResponse(0);

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AccountFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AccountFeature.java
@@ -28,10 +28,13 @@ import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import io.cucumber.junit.platform.engine.Cucumber;
 import java.util.List;
+import junit.framework.AssertionFailedError;
 import lombok.Data;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.util.CollectionUtils;
 
 import com.hedera.hashgraph.sdk.AccountId;
@@ -152,6 +155,9 @@ public class AccountFeature extends AbstractFeature {
     }
 
     @Then("the mirror node REST API should return status {int} for the crypto transfer transaction")
+    @Retryable(value = {AssertionError.class, AssertionFailedError.class},
+            backoff = @Backoff(delayExpression = "#{@restPollingProperties.minBackoff.toMillis()}"),
+            maxAttemptsExpression = "#{@restPollingProperties.maxAttempts}")
     public void verifyMirrorAPICryptoTransferResponse(int status) {
         log.info("Verify transaction");
         String transactionId = networkTransactionResponse.getTransactionIdStringNoCheckSum();
@@ -184,6 +190,9 @@ public class AccountFeature extends AbstractFeature {
     }
 
     @Then("the mirror node REST API should confirm the approved {long} tℏ crypto transfer allowance")
+    @Retryable(value = {AssertionError.class, AssertionFailedError.class},
+            backoff = @Backoff(delayExpression = "#{@restPollingProperties.minBackoff.toMillis()}"),
+            maxAttemptsExpression = "#{@restPollingProperties.maxAttempts}")
     public void verifyMirrorAPIApprovedCryptoTransferResponse(long approvedAmount) {
         verifyMirrorTransactionsResponse(mirrorClient, HttpStatus.OK.value());
 
@@ -212,6 +221,9 @@ public class AccountFeature extends AbstractFeature {
     }
 
     @Then("the mirror node REST API should confirm the crypto allowance deletion")
+    @Retryable(value = {AssertionError.class, AssertionFailedError.class},
+            backoff = @Backoff(delayExpression = "#{@restPollingProperties.minBackoff.toMillis()}"),
+            maxAttemptsExpression = "#{@restPollingProperties.maxAttempts}")
     public void verifyCryptoAllowanceDelete() {
         log.info("Verify crypto allowance deletion transaction");
         verifyMirrorAPIApprovedCryptoTransferResponse(0);

--- a/hedera-mirror-test/src/test/resources/features/account/allowances/cryptoAllowance.feature
+++ b/hedera-mirror-test/src/test/resources/features/account/allowances/cryptoAllowance.feature
@@ -7,8 +7,6 @@ Feature: Account Crypto Allowance Coverage Feature
         Then the mirror node REST API should confirm the approved <approvedAmount> tℏ crypto transfer allowance
         When <senderName> transfers <transferAmount> tℏ from their approved balance to <recipientName>
         Then the mirror node REST API should return status <httpStatusCode> for the crypto transfer transaction
-        Given I adjust <senderName> transfer allowance to <updateApprovedAmount> tℏ
-        Then the mirror node REST API should confirm the approved <updateApprovedAmount> tℏ crypto transfer allowance
         When I delete the crypto allowance for <senderName>
         Then the mirror node REST API should confirm the crypto allowance deletion
         Examples:

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <grpc-spring-boot.version>2.11.0.RELEASE</grpc-spring-boot.version>
         <grpc.version>1.45.1</grpc.version>
         <guava.version>31.1-jre</guava.version>
-        <hedera-protobuf.version>0.25.0-SNAPSHOT</hedera-protobuf.version>
+        <hedera-protobuf.version>0.25.0</hedera-protobuf.version>
         <hibernate-types.version>2.14.1</hibernate-types.version>
         <jacoco.version>0.8.8</jacoco.version>
         <java.version>11</java.version>


### PR DESCRIPTION
**Description**:
Acceptance tests were failing with `io.grpc.StatusRuntimeException: UNIMPLEMENTED: Method not found: proto.CryptoService/adjustAllowance`. Service nodes changed from `adjustAllowance` to `adjustAllowances` and the changed wasn't captured in the protobuf used by `v0.54.0-rc1` version of the mirror node.

- Remove adjust test from acceptance tests
- Update protobuf version to non snapshot version `0.25.0`

**Related issue(s)**:

Fixes #3531 

**Notes for reviewer**:
Tested against integration

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
