### PR TITLE
Remove Crypto Allowance Adjust Acceptance Test (0.54)

### DIFF
--- a/hedera-mirror-test/src/test/resources/features/account/allowances/cryptoAllowance.feature
+++ b/hedera-mirror-test/src/test/resources/features/account/allowances/cryptoAllowance.feature
@@ -7,8 +7,6 @@ Feature: Account Crypto Allowance Coverage Feature
         Then the mirror node REST API should confirm the approved <approvedAmount> tℏ crypto transfer allowance
         When <senderName> transfers <transferAmount> tℏ from their approved balance to <recipientName>
         Then the mirror node REST API should return status <httpStatusCode> for the crypto transfer transaction
-        Given I adjust <senderName> transfer allowance to <updateApprovedAmount> tℏ
-        Then the mirror node REST API should confirm the approved <updateApprovedAmount> tℏ crypto transfer allowance
         When I delete the crypto allowance for <senderName>
         Then the mirror node REST API should confirm the crypto allowance deletion
         Examples:

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <grpc-spring-boot.version>2.11.0.RELEASE</grpc-spring-boot.version>
         <grpc.version>1.45.1</grpc.version>
         <guava.version>31.1-jre</guava.version>
-        <hedera-protobuf.version>0.25.0-SNAPSHOT</hedera-protobuf.version>
+        <hedera-protobuf.version>0.25.0</hedera-protobuf.version>
         <hibernate-types.version>2.14.1</hibernate-types.version>
         <jacoco.version>0.8.7</jacoco.version>
         <java.version>11</java.version>


### PR DESCRIPTION
**Description**:
Acceptance tests were failing with `io.grpc.StatusRuntimeException: UNIMPLEMENTED: Method not found: proto.CryptoService/adjustAllowance`. Service nodes changed from `adjustAllowance` to `adjustAllowances` and the changed wasn't captured in the protobuf used by `v0.54.0-rc1` version of the mirror node.

- Remove adjust test from acceptance tests
- Update protobuf version to non snapshot version `0.25.0`

Signed-off-by: Nana-EC <nana.essilfie-conduah@hedera.com>


**Related issue(s)**:

Fixes #3531 

**Notes for reviewer**:


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
