### PR TITLE
Fix rest stateproof downloading taking too long

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -318,54 +318,57 @@ recursively merged into) the current configuration:
 The following table lists the available properties along with their default values. Unless you need to set a non-default
 value, it is recommended to only populate overridden properties in the custom `application.yml`.
 
-| Name                                                     | Default                 | Description                                                                                    |
-| -------------------------------------------------------- |-------------------------| ---------------------------------------------------------------------------------------------- |
-| `hedera.mirror.rest.cache.entityId.maxAge`               | 1800                    | The number of seconds until the entityId cache entry expires                                   |
-| `hedera.mirror.rest.cache.entityId.maxSize`              | 100000                  | The maximum number of entries in the entityId cache                                            |
-| `hedera.mirror.rest.db.host`                             | 127.0.0.1               | The IP or hostname used to connect to the database                                             |
-| `hedera.mirror.rest.db.name`                             | mirror_node             | The name of the database                                                                       |
-| `hedera.mirror.rest.db.password`                         | mirror_api_pass         | The database password the processor uses to connect.                                           |
-| `hedera.mirror.rest.db.pool.connectionTimeout`           | 20000                   | The number of milliseconds to wait before timing out when connecting a new database client     |
-| `hedera.mirror.rest.db.pool.maxConnections`              | 10                      | The maximum number of clients the database pool can contain                                    |
-| `hedera.mirror.rest.db.pool.statementTimeout`            | 20000                   | The number of milliseconds to wait before timing out a query statement                         |
-| `hedera.mirror.rest.db.port`                             | 5432                    | The port used to connect to the database                                                       |
-| `hedera.mirror.rest.db.sslMode`                          | DISABLE                 | The ssl level of protection against Eavesdropping, Man-in-the-middle (MITM) and Impersonation on the db connection. Accepts either DISABLE, ALLOW, PREFER, REQUIRE, VERIFY_CA or VERIFY_FULL. |
-| `hedera.mirror.rest.db.tls.ca`                           | ""                      | The path to the certificate authority used by the database for secure connections              |
-| `hedera.mirror.rest.db.tls.cert`                         | ""                      | The path to the public key the client should use to securely connect to the database           |
-| `hedera.mirror.rest.db.tls.enabled`                      | false                   | Whether TLS should be used for the database connection                                         |
-| `hedera.mirror.rest.db.tls.key`                          | ""                      | The path to the private key the client should use to securely connect to the database          |
-| `hedera.mirror.rest.db.username`                         | mirror_api              | The username the processor uses to connect to the database                                     |
-| `hedera.mirror.rest.log.level`                           | info                    | The logging level. Can be trace, debug, info, warn, error or fatal.                            |
-| `hedera.mirror.rest.maxRepeatedQueryParameters`          | 100                     | The maximum number of times any query parameter can be repeated in the uri                     |
-| `hedera.mirror.rest.maxTimestampRange`                   | 7d                      | The maximum amount of time a timestamp range query param can span for some APIs.               |
-| `hedera.mirror.rest.metrics.enabled`                     | true                    | Whether metrics should be collected and exposed for scraping                                   |
-| `hedera.mirror.rest.metrics.config`                      | See application.yml     | The configuration to pass to Swagger stats (https://swaggerstats.io/guide/conf.html#options)   |
-| `hedera.mirror.rest.metrics.ipMetrics`                   | false                   | Whether metrics should be associated with a masked client IP label                             |
-| `hedera.mirror.rest.network.unreleasedSupplyAccounts`    | [0.0.2, 0.0.42, ...]    | An array of account IDs whose aggregated balance subtracted from the total supply is the released supply |
-| `hedera.mirror.rest.port`                                | 5551                    | The REST API port                                                                              |
-| `hedera.mirror.rest.metrics.enabled`                     | true                    | Whether metrics are enabled for the REST API                                                   |
-| `hedera.mirror.rest.metrics.config.authentication`       | true                    | Whether access to metrics for the REST API is authenticated                                    |
-| `hedera.mirror.rest.metrics.config.username`             | mirror_api_metrics      | The REST API metrics username to access the dashboard                                          |
-| `hedera.mirror.rest.metrics.config.password`             | mirror_api_metrics_pass | The REST API metrics password to access the dashboard                                          |
-| `hedera.mirror.rest.metrics.config.uriPath`              | '/swagger'              | The REST API metrics uri path                                                                  |
-| `hedera.mirror.rest.openapi.specFileName`                | 'openapi'               | The file name of the OpenAPI spec file                                                         |
-| `hedera.mirror.rest.openapi.swaggerUIPath`               | '/docs'                 | Swagger UI path for your REST API                                                              |
-| `hedera.mirror.rest.response.compression`                | true                    | Whether content negotiation should occur to compress response bodies if requested              |
-| `hedera.mirror.rest.response.headers.default`            | See application.yml     | The default headers to add to every response.                                                  |
-| `hedera.mirror.rest.response.headers.path`               | See application.yml     | The per path headers to add to every response. The key is the route name and the value is a header map. |
-| `hedera.mirror.rest.response.includeHostInLink`          | false                   | Whether to include the hostname and port in the next link in the response                      |
-| `hedera.mirror.rest.response.limit.default`              | 25                      | The default value for the limit parameter that controls the REST API response size             |
-| `hedera.mirror.rest.response.limit.max`                  | 100                     | The maximum size the limit parameter can be that controls the REST API response size           |
-| `hedera.mirror.rest.shard`                               | 0                       | The default shard number that this mirror node participates in                                 |
-| `hedera.mirror.rest.stateproof.enabled`                  | false                   | Whether to enable stateproof REST API or not                                                   |
-| `hedera.mirror.rest.stateproof.streams.accessKey`        | ""                      | The cloud storage access key                                                                   |
-| `hedera.mirror.rest.stateproof.streams.bucketName`       |                         | The cloud storage bucket name to download streamed files. This value takes priority over network hardcoded bucket names regardless of `hedera.mirror.rest.stateproof.streams.network` |
-| `hedera.mirror.rest.stateproof.streams.cloudProvider`    | S3                      | The cloud provider to download files from. Either `S3` or `GCP`                                |
-| `hedera.mirror.rest.stateproof.streams.endpointOverride` |                         | Can be specified to download streams from a source other than S3 and GCP. Should be S3 compatible |
-| `hedera.mirror.rest.stateproof.streams.gcpProjectId`     |                         | GCP project id to bill for requests to GCS bucket which has Requester Pays enabled.            |
-| `hedera.mirror.rest.stateproof.streams.network`          | DEMO                    | Which Hedera network to use. Can be either `DEMO`, `MAINNET`, `TESTNET`, `PREVIEWNET` or `OTHER` |
-| `hedera.mirror.rest.stateproof.streams.region`           | us-east-1               | The region associated with the bucket                                                          |
-| `hedera.mirror.rest.stateproof.streams.secretKey`        | ""                      | The cloud storage secret key                                                                   |
+| Name                                                               | Default                 | Description                                                                                    |
+| -------------------------------------------------------------------|-------------------------| ---------------------------------------------------------------------------------------------- |
+| `hedera.mirror.rest.cache.entityId.maxAge`                         | 1800                    | The number of seconds until the entityId cache entry expires                                   |
+| `hedera.mirror.rest.cache.entityId.maxSize`                        | 100000                  | The maximum number of entries in the entityId cache                                            |
+| `hedera.mirror.rest.db.host`                                       | 127.0.0.1               | The IP or hostname used to connect to the database                                             |
+| `hedera.mirror.rest.db.name`                                       | mirror_node             | The name of the database                                                                       |
+| `hedera.mirror.rest.db.password`                                   | mirror_api_pass         | The database password the processor uses to connect.                                           |
+| `hedera.mirror.rest.db.pool.connectionTimeout`                     | 20000                   | The number of milliseconds to wait before timing out when connecting a new database client     |
+| `hedera.mirror.rest.db.pool.maxConnections`                        | 10                      | The maximum number of clients the database pool can contain                                    |
+| `hedera.mirror.rest.db.pool.statementTimeout`                      | 20000                   | The number of milliseconds to wait before timing out a query statement                         |
+| `hedera.mirror.rest.db.port`                                       | 5432                    | The port used to connect to the database                                                       |
+| `hedera.mirror.rest.db.sslMode`                                    | DISABLE                 | The ssl level of protection against Eavesdropping, Man-in-the-middle (MITM) and Impersonation on the db connection. Accepts either DISABLE, ALLOW, PREFER, REQUIRE, VERIFY_CA or VERIFY_FULL. |
+| `hedera.mirror.rest.db.tls.ca`                                     | ""                      | The path to the certificate authority used by the database for secure connections              |
+| `hedera.mirror.rest.db.tls.cert`                                   | ""                      | The path to the public key the client should use to securely connect to the database           |
+| `hedera.mirror.rest.db.tls.enabled`                                | false                   | Whether TLS should be used for the database connection                                         |
+| `hedera.mirror.rest.db.tls.key`                                    | ""                      | The path to the private key the client should use to securely connect to the database          |
+| `hedera.mirror.rest.db.username`                                   | mirror_api              | The username the processor uses to connect to the database                                     |
+| `hedera.mirror.rest.log.level`                                     | info                    | The logging level. Can be trace, debug, info, warn, error or fatal.                            |
+| `hedera.mirror.rest.maxRepeatedQueryParameters`                    | 100                     | The maximum number of times any query parameter can be repeated in the uri                     |
+| `hedera.mirror.rest.maxTimestampRange`                             | 7d                      | The maximum amount of time a timestamp range query param can span for some APIs.               |
+| `hedera.mirror.rest.metrics.enabled`                               | true                    | Whether metrics should be collected and exposed for scraping                                   |
+| `hedera.mirror.rest.metrics.config`                                | See application.yml     | The configuration to pass to Swagger stats (https://swaggerstats.io/guide/conf.html#options)   |
+| `hedera.mirror.rest.metrics.ipMetrics`                             | false                   | Whether metrics should be associated with a masked client IP label                             |
+| `hedera.mirror.rest.network.unreleasedSupplyAccounts`              | [0.0.2, 0.0.42, ...]    | An array of account IDs whose aggregated balance subtracted from the total supply is the released supply |
+| `hedera.mirror.rest.port`                                          | 5551                    | The REST API port                                                                              |
+| `hedera.mirror.rest.metrics.enabled`                               | true                    | Whether metrics are enabled for the REST API                                                   |
+| `hedera.mirror.rest.metrics.config.authentication`                 | true                    | Whether access to metrics for the REST API is authenticated                                    |
+| `hedera.mirror.rest.metrics.config.username`                       | mirror_api_metrics      | The REST API metrics username to access the dashboard                                          |
+| `hedera.mirror.rest.metrics.config.password`                       | mirror_api_metrics_pass | The REST API metrics password to access the dashboard                                          |
+| `hedera.mirror.rest.metrics.config.uriPath`                        | '/swagger'              | The REST API metrics uri path                                                                  |
+| `hedera.mirror.rest.openapi.specFileName`                          | 'openapi'               | The file name of the OpenAPI spec file                                                         |
+| `hedera.mirror.rest.openapi.swaggerUIPath`                         | '/docs'                 | Swagger UI path for your REST API                                                              |
+| `hedera.mirror.rest.response.compression`                          | true                    | Whether content negotiation should occur to compress response bodies if requested              |
+| `hedera.mirror.rest.response.headers.default`                      | See application.yml     | The default headers to add to every response.                                                  |
+| `hedera.mirror.rest.response.headers.path`                         | See application.yml     | The per path headers to add to every response. The key is the route name and the value is a header map. |
+| `hedera.mirror.rest.response.includeHostInLink`                    | false                   | Whether to include the hostname and port in the next link in the response                      |
+| `hedera.mirror.rest.response.limit.default`                        | 25                      | The default value for the limit parameter that controls the REST API response size             |
+| `hedera.mirror.rest.response.limit.max`                            | 100                     | The maximum size the limit parameter can be that controls the REST API response size           |
+| `hedera.mirror.rest.shard`                                         | 0                       | The default shard number that this mirror node participates in                                 |
+| `hedera.mirror.rest.stateproof.enabled`                            | false                   | Whether to enable stateproof REST API or not                                                   |
+| `hedera.mirror.rest.stateproof.streams.accessKey`                  | ""                      | The cloud storage access key                                                                   |
+| `hedera.mirror.rest.stateproof.streams.bucketName`                 |                         | The cloud storage bucket name to download streamed files. This value takes priority over network hardcoded bucket names regardless of `hedera.mirror.rest.stateproof.streams.network` |
+| `hedera.mirror.rest.stateproof.streams.cloudProvider`              | S3                      | The cloud provider to download files from. Either `S3` or `GCP`                                |
+| `hedera.mirror.rest.stateproof.streams.endpointOverride`           |                         | Can be specified to download streams from a source other than S3 and GCP. Should be S3 compatible |
+| `hedera.mirror.rest.stateproof.streams.gcpProjectId`               |                         | GCP project id to bill for requests to GCS bucket which has Requester Pays enabled.            |
+| `hedera.mirror.rest.stateproof.streams.httpOptions.connectTimeout` | 2000                    | The number of milliseconds to wait to establish a connection                                   |
+| `hedera.mirror.rest.stateproof.streams.httpOptions.timeout`        | 5000                    | The number of milliseconds a request can take before automatically being terminated            |
+| `hedera.mirror.rest.stateproof.streams.maxRetries`                 | 3                       | The maximum amount of retries to perform for a cloud storage download request.                  |
+| `hedera.mirror.rest.stateproof.streams.network`                    | DEMO                    | Which Hedera network to use. Can be either `DEMO`, `MAINNET`, `TESTNET`, `PREVIEWNET` or `OTHER` |
+| `hedera.mirror.rest.stateproof.streams.region`                     | us-east-1               | The region associated with the bucket                                                          |
+| `hedera.mirror.rest.stateproof.streams.secretKey`                  | ""                      | The cloud storage secret key                                                                   |
 
 ### Enable State Proof Alpha
 

--- a/hedera-mirror-rest/__tests__/config.test.js
+++ b/hedera-mirror-rest/__tests__/config.test.js
@@ -207,6 +207,11 @@ describe('Override stateproof config', () => {
       accessKey: null,
       endpointOverride: null,
       gcpProjectId: null,
+      httpOptions: {
+        connectTimeout: 2000,
+        timeout: 5000,
+      },
+      maxRetries: 3,
       secretKey: null,
     };
     Object.assign(streamsConfig, override);

--- a/hedera-mirror-rest/__tests__/s3client.test.js
+++ b/hedera-mirror-rest/__tests__/s3client.test.js
@@ -154,6 +154,14 @@ describe('createS3Client with valid config', () => {
       name: 'valid config with empty secretKey',
       override: {secretKey: ''},
     },
+    {
+      name: 'valid config with maxRetries 10',
+      override: {maxRetries: 10},
+    },
+    {
+      name: 'valid config with updated httpOptions',
+      override: {httpOptions: {connectTimeout: 10, timeout: 50}},
+    },
   ];
 
   testSpecs.forEach((spec) => {

--- a/hedera-mirror-rest/config/application.yml
+++ b/hedera-mirror-rest/config/application.yml
@@ -117,6 +117,10 @@ hedera:
           cloudProvider: 'S3'
           endpointOverride:
           gcpProjectId:
+          httpOptions:
+            connectTimeout: 2000 # The number of milliseconds to wait to establish a connection
+            timeout: 5000 # The number of milliseconds a request can take before automatically being terminated
+          maxRetries: 3
           network: 'DEMO'
           region: 'us-east-1'
           secretKey:

--- a/hedera-mirror-rest/config/application.yml
+++ b/hedera-mirror-rest/config/application.yml
@@ -118,8 +118,8 @@ hedera:
           endpointOverride:
           gcpProjectId:
           httpOptions:
-            connectTimeout: 2000 # The number of milliseconds to wait to establish a connection
-            timeout: 5000 # The number of milliseconds a request can take before automatically being terminated
+            connectTimeout: 2000
+            timeout: 5000
           maxRetries: 3
           network: 'DEMO'
           region: 'us-east-1'

--- a/hedera-mirror-rest/s3client.js
+++ b/hedera-mirror-rest/s3client.js
@@ -65,7 +65,8 @@ class S3Client {
 }
 
 const buildS3ConfigFromStreamsConfig = () => {
-  const {cloudProvider, endpointOverride, gcpProjectId, accessKey, secretKey, region} = config.stateproof.streams;
+  const {accessKey, cloudProvider, endpointOverride, gcpProjectId, httpOptions, maxRetries, secretKey, region} =
+    config.stateproof.streams;
   const hasEndpointOverride = !!endpointOverride;
   const isGCP = cloudProvider === cloudProviders.GCP;
 
@@ -74,6 +75,8 @@ const buildS3ConfigFromStreamsConfig = () => {
 
   const s3Config = {
     endpoint,
+    httpOptions,
+    maxRetries,
     region,
     s3ForcePathStyle,
   };


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR fixes the rest stateproof downloading from s3 taking too long issue.

- Add s3 maxRetries, http connect timeout, and http request timeout config options

**Related issue(s)**:

Fixes #3536

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

For some reason, mainnet primary rest service stateproof api started to take > 2 minutes to download a single sigature file from s3. Did a tcpdump and the packets show that the tcp SYN from the s3 client was ignored, most likely due to some aws s3 protection mechanism. Checked AWS javascript SDK and found the default timeout is 120 secs which matches the time in rest service log.

With the customized config, the s3 download usually succeeds with just 1 retry, and the time taken is just a little over 2 secs.

Before:

```
[AWS s3 200 129.437s 1 retries] getObject({
  Bucket: 'hedera-mainnet-streams',
  Key: 'recordstreams/record0.0.25/2022-04-05T21_09_10.315761000Z.rcd_sig',
  RequestPayer: 'requester'
})
```

after:

```
[AWS s3 200 2.256s 1 retries] getObject({
  Bucket: 'hedera-mainnet-streams',
  Key: 'recordstreams/record0.0.18/2022-04-05T21_09_10.315761000Z.rcd_sig',
  RequestPayer: 'requester'
})
```

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
