### PR TITLE
Fix importer pod restart during long migration

### DIFF
--- a/charts/hedera-mirror-importer/templates/deployment.yaml
+++ b/charts/hedera-mirror-importer/templates/deployment.yaml
@@ -43,6 +43,7 @@ spec:
           readinessProbe: {{ toYaml .Values.readinessProbe | nindent 12 }}
           resources: {{ toYaml .Values.resources | nindent 12 }}
           securityContext: {{ toYaml .Values.securityContext | nindent 12 }}
+          startupProbe: {{ toYaml .Values.startupProbe | nindent 12 }}
           volumeMounts:
             {{- range $name, $config := .Values.volumeMounts }}
             - name: {{ $name }}

--- a/charts/hedera-mirror-importer/values.yaml
+++ b/charts/hedera-mirror-importer/values.yaml
@@ -468,6 +468,15 @@ serviceAccount:
   # The name of the service account to use. If not set and create is true, a name is generated using the fullname template
   name:
 
+startupProbe:
+  failureThreshold: 360
+  httpGet:
+    path: /actuator/health/readiness
+    port: http
+  initialDelaySeconds: 60
+  periodSeconds: 10
+  timeoutSeconds: 2
+
 terminationGracePeriodSeconds: 30
 
 tolerations: []

--- a/charts/hedera-mirror/values-prod.yaml
+++ b/charts/hedera-mirror/values-prod.yaml
@@ -52,6 +52,7 @@ postgresql:
     replicaCount: 2
   postgresql:
     priorityClassName: critical
+    upgradeRepmgrExtension: false
     replicaCount: 2
 
 redis:

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/MirrorImporterConfiguration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/MirrorImporterConfiguration.java
@@ -21,12 +21,9 @@ package com.hedera.mirror.importer.config;
  */
 
 import io.micrometer.core.instrument.MeterRegistry;
-import javax.annotation.PostConstruct;
 import javax.sql.DataSource;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnCloudPlatform;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -35,7 +32,6 @@ import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration;
 import org.springframework.boot.autoconfigure.flyway.FlywayConfigurationCustomizer;
 import org.springframework.boot.cloud.CloudPlatform;
-import org.springframework.context.SmartLifecycle;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.retry.annotation.EnableRetry;
@@ -62,18 +58,6 @@ public class MirrorImporterConfiguration {
     public static final String TOKEN_DISSOCIATE_BATCH_PERSISTER = "tokenDissociateTransferBatchPersister";
 
     private final MirrorProperties mirrorProperties;
-
-    @Autowired(required = false)
-    @Qualifier("webServerStartStop")
-    private SmartLifecycle webServerStartStop;
-
-    @PostConstruct
-    void init() {
-        // Start the web server ASAP so kubernetes probes are up before long-running migrations
-        if (webServerStartStop != null) {
-            webServerStartStop.start();
-        }
-    }
 
     @Bean
     @ConditionalOnCloudPlatform(CloudPlatform.KUBERNETES)


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

This PR fixes the importer pod restarted during long migration issue.

- Add `startupProbe` for importer and set the default timeout to 60mins
- Remove importer web server early start
- Fix failure to install charts with more than 1 postgresql replicas and upgradeRepmgrExtension = true 

**Related issue(s)**:

Fixes #3541 

Tested with a db migration which sleeps for 40mins.

The postgresql-ha chart will fail to install if replicas > 1 and  upgradeRepmgrExtension = true. It's required to scale down the replicas to 1, upgrade repmgr, then scale the replicas back.

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
