### PR TITLE
Remove Rosetta upload artifact step

### DIFF
--- a/.github/workflows/rosetta-api.yml
+++ b/.github/workflows/rosetta-api.yml
@@ -39,14 +39,6 @@ jobs:
         if: always()
         run: bash <(curl -s https://codecov.io/bash)
 
-      - name: Upload artifact
-        if: startsWith(github.ref, 'refs/tags/v')
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ env.MODULE }}
-          path: ./**/*.tgz
-          if-no-files-found: error
-
   image:
     if: github.event_name == 'push' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')
     runs-on: ubuntu-latest


### PR DESCRIPTION
**Description**:
Remove the Rosetta upload artifact step since tgz bundling was removed in 0.55

**Related issue(s)**:

**Notes for reviewer**:
See https://github.com/hashgraph/hedera-mirror-node/runs/6069653766?check_suite_focus=true

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
