### PR TITLE
Fix monitor not publishing if error on startup

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -260,6 +260,7 @@ Name                                                            | Default | Desc
 `hedera.mirror.monitor.nodeValidation.requestTimeout`           | 15s     | The amount of time to wait for a validation request before timing out
 `hedera.mirror.monitor.operator.accountId`                      | ""      | Operator account ID used to pay for transactions
 `hedera.mirror.monitor.operator.privateKey`                     | ""      | Operator ED25519 private key used to sign transactions in hex encoded DER format
+`hedera.mirror.monitor.publish.async`                           | true    | Whether to use the SDK's asynchronous execution or synchronous. Synchronous requires more monitor responseThreads.
 `hedera.mirror.monitor.publish.batchDivisor`                    | 100     | The divisor used to calculate batch size when generating transactions
 `hedera.mirror.monitor.publish.clients`                         | 4       | How many total SDK clients to publish transactions. Clients will be used in a round-robin fashion
 `hedera.mirror.monitor.publish.enabled`                         | true    | Whether to enable transaction publishing

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -264,6 +264,7 @@ Name                                                            | Default | Desc
 `hedera.mirror.monitor.publish.batchDivisor`                    | 100     | The divisor used to calculate batch size when generating transactions
 `hedera.mirror.monitor.publish.clients`                         | 4       | How many total SDK clients to publish transactions. Clients will be used in a round-robin fashion
 `hedera.mirror.monitor.publish.enabled`                         | true    | Whether to enable transaction publishing
+`hedera.mirror.monitor.publish.nodeMaxBackoff`                  | 1m      | The maximum backoff time for any node in the network
 `hedera.mirror.monitor.publish.responseThreads`                 | 40      | How many threads to use to resolve the asynchronous responses
 `hedera.mirror.monitor.publish.scenarios`                       |         | A map of scenario name to publish scenarios. The name is used as a unique identifier in logs, metrics, and the REST API
 `hedera.mirror.monitor.publish.scenarios.<name>.duration`       |         | How long this scenario should publish transactions. Leave empty for infinite

--- a/hedera-mirror-monitor/pom.xml
+++ b/hedera-mirror-monitor/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <commons-math3.version>3.6.1</commons-math3.version>
-        <hedera-sdk.version>2.9.0</hedera-sdk.version>
+        <hedera-sdk.version>2.12.0</hedera-sdk.version>
         <meanbean.version>3.0.0-M9</meanbean.version>
         <springdoc.version>1.6.7</springdoc.version>
     </properties>

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/expression/ExpressionConverterImpl.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/expression/ExpressionConverterImpl.java
@@ -110,6 +110,7 @@ public class ExpressionConverterImpl implements ExpressionConverter {
                 scheduleCreateTransactionSupplier.setNodeAccountId(singleNodeProperty.getAccountId());
                 scheduleCreateTransactionSupplier
                         .setOperatorAccountId(monitorProperties.getOperator().getAccountId());
+                scheduleCreateTransactionSupplier.setSignatoryCount(0);
             }
 
             PublishScenarioProperties publishScenarioProperties = new PublishScenarioProperties();

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/expression/ExpressionConverterImpl.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/expression/ExpressionConverterImpl.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.monitor.expression;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -29,21 +29,11 @@ import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.inject.Named;
-
-import com.hedera.mirror.monitor.publish.transaction.AdminKeyable;
-import com.hedera.mirror.monitor.publish.transaction.TransactionSupplier;
-import com.hedera.mirror.monitor.publish.transaction.TransactionType;
-
-import com.hedera.mirror.monitor.publish.transaction.schedule.ScheduleCreateTransactionSupplier;
-import com.hedera.mirror.monitor.publish.transaction.token.TokenCreateTransactionSupplier;
-
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Value;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.StringUtils;
-import reactor.core.publisher.Mono;
-import reactor.util.retry.Retry;
 
 import com.hedera.hashgraph.sdk.PrivateKey;
 import com.hedera.hashgraph.sdk.TokenType;
@@ -55,6 +45,11 @@ import com.hedera.mirror.monitor.publish.PublishResponse;
 import com.hedera.mirror.monitor.publish.PublishScenario;
 import com.hedera.mirror.monitor.publish.PublishScenarioProperties;
 import com.hedera.mirror.monitor.publish.TransactionPublisher;
+import com.hedera.mirror.monitor.publish.transaction.AdminKeyable;
+import com.hedera.mirror.monitor.publish.transaction.TransactionSupplier;
+import com.hedera.mirror.monitor.publish.transaction.TransactionType;
+import com.hedera.mirror.monitor.publish.transaction.schedule.ScheduleCreateTransactionSupplier;
+import com.hedera.mirror.monitor.publish.transaction.token.TokenCreateTransactionSupplier;
 
 @Log4j2
 @Named
@@ -122,20 +117,19 @@ public class ExpressionConverterImpl implements ExpressionConverter {
             publishScenarioProperties.setTimeout(Duration.ofSeconds(30L));
             publishScenarioProperties.setType(type.getTransactionType());
             PublishScenario scenario = new PublishScenario(publishScenarioProperties);
+
+            var transaction = transactionSupplier.get()
+                    .setMaxAttempts(Integer.MAX_VALUE)
+                    .setTransactionMemo(scenario.getMemo());
+
             PublishRequest request = PublishRequest.builder()
                     .receipt(true)
                     .scenario(scenario)
                     .timestamp(Instant.now())
-                    .transaction(transactionSupplier.get())
+                    .transaction(transaction)
                     .build();
 
-            Retry retrySpec = Retry.backoff(Long.MAX_VALUE, Duration.ofMillis(500L))
-                    .maxBackoff(Duration.ofSeconds(8L))
-                    .doBeforeRetry(r -> log.warn("Retry attempt #{} after failure: {}",
-                            r.totalRetries() + 1, r.failure().getMessage()));
-
-            String createdId = Mono.defer(() -> transactionPublisher.publish(request))
-                    .retryWhen(retrySpec)
+            String createdId = transactionPublisher.publish(request)
                     .map(PublishResponse::getReceipt)
                     .map(type.getIdExtractor()::apply)
                     .toFuture()

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishProperties.java
@@ -48,6 +48,9 @@ public class PublishProperties {
     private boolean enabled = true;
 
     @NotNull
+    private Duration nodeMaxBackoff = Duration.ofMinutes(1L);
+
+    @NotNull
     private Map<String, PublishScenarioProperties> scenarios = new LinkedHashMap<>();
 
     @DurationMin(seconds = 1L)

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishProperties.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.monitor.publish;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -36,6 +36,8 @@ import org.springframework.validation.annotation.Validated;
 @Validated
 @ConfigurationProperties("hedera.mirror.monitor.publish")
 public class PublishProperties {
+
+    private boolean async = true;
 
     @Min(100)
     private int batchDivisor = 100;

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/TransactionPublisher.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/TransactionPublisher.java
@@ -123,13 +123,12 @@ public class TransactionPublisher implements AutoCloseable {
 
         // set transaction node where applicable
         if (transaction.getNodeAccountIds() == null) {
-            var currentNodes = this.nodes; // Save a reference in case a COW occurs
-            if (currentNodes.isEmpty()) {
+            if (nodes.isEmpty()) {
                 return Mono.error(new IllegalArgumentException("No valid nodes available"));
             }
 
-            int nodeIndex = secureRandom.nextInt(currentNodes.size());
-            var node = currentNodes.get(nodeIndex);
+            int nodeIndex = secureRandom.nextInt(nodes.size());
+            var node = nodes.get(nodeIndex);
             transaction.setNodeAccountIds(node.getAccountIds());
         }
 

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/TransactionPublisher.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/TransactionPublisher.java
@@ -120,7 +120,6 @@ public class TransactionPublisher implements AutoCloseable {
 
     private Mono<TransactionResponse> getTransactionResponse(PublishRequest request, Client client) {
         Transaction<?> transaction = request.getTransaction();
-        transaction.setTransactionMemo(request.getScenario().getMemo());
 
         // set transaction node where applicable
         if (transaction.getNodeAccountIds() == null) {

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/TransactionPublisher.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/TransactionPublisher.java
@@ -150,8 +150,7 @@ public class TransactionPublisher implements AutoCloseable {
             // TransactionId.getRecord() is inefficient doing a get receipt, a cost query, then the get record
             TransactionRecordQuery transactionRecordQuery = new TransactionRecordQuery()
                     .setQueryPayment(Hbar.from(1, HbarUnit.HBAR))
-                    .setTransactionId(transactionId)
-                    .setMaxAttempts(10);
+                    .setTransactionId(transactionId);
             return execute(client, transactionRecordQuery)
                     .map(r -> builder.record(r).receipt(r.receipt));
         } else if (request.isReceipt()) {
@@ -245,7 +244,7 @@ public class TransactionPublisher implements AutoCloseable {
         PrivateKey operatorPrivateKey = PrivateKey.fromString(monitorProperties.getOperator().getPrivateKey());
 
         Client client = Client.forNetwork(nodes);
-        client.setNodeMaxBackoff(Duration.ofMinutes(1L));
+        client.setNodeMaxBackoff(publishProperties.getNodeMaxBackoff());
         client.setOperator(operatorId, operatorPrivateKey);
         return client;
     }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/generator/ConfigurableTransactionGenerator.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/generator/ConfigurableTransactionGenerator.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.monitor.publish.generator;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -35,9 +35,6 @@ import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
 import javax.validation.Validation;
 import javax.validation.Validator;
-
-import com.hedera.mirror.monitor.publish.transaction.TransactionSupplier;
-
 import lombok.Getter;
 import lombok.extern.log4j.Log4j2;
 import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
@@ -49,6 +46,7 @@ import com.hedera.mirror.monitor.properties.ScenarioPropertiesAggregator;
 import com.hedera.mirror.monitor.publish.PublishRequest;
 import com.hedera.mirror.monitor.publish.PublishScenario;
 import com.hedera.mirror.monitor.publish.PublishScenarioProperties;
+import com.hedera.mirror.monitor.publish.transaction.TransactionSupplier;
 
 @Log4j2
 public class ConfigurableTransactionGenerator implements TransactionGenerator {
@@ -97,11 +95,14 @@ public class ConfigurableTransactionGenerator implements TransactionGenerator {
 
         List<PublishRequest> publishRequests = new ArrayList<>();
         for (long i = 0; i < actual; i++) {
+            var transaction = transactionSupplier.get().get()
+                    .setMaxAttempts((int) properties.getRetry().getMaxAttempts())
+                    .setTransactionMemo(scenario.getMemo());
+
             PublishRequest publishRequest = builder.receipt(shouldGenerate(properties.getReceiptPercent()))
                     .record(shouldGenerate(properties.getRecordPercent()))
                     .timestamp(Instant.now())
-                    .transaction(transactionSupplier.get().get()
-                            .setMaxAttempts((int) properties.getRetry().getMaxAttempts()))
+                    .transaction(transaction)
                     .build();
             publishRequests.add(publishRequest);
         }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/consensus/ConsensusSubmitMessageTransactionSupplier.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/consensus/ConsensusSubmitMessageTransactionSupplier.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.monitor.publish.transaction.consensus;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -55,12 +55,15 @@ public class ConsensusSubmitMessageTransactionSupplier implements TransactionSup
     @Getter(lazy = true)
     private final TopicId consensusTopicId = TopicId.fromString(topicId);
 
+    @Getter(lazy = true)
+    private final String generatedMessage = !message.isEmpty() ? message :
+            new String(Utility.generateMessage(messageSize), StandardCharsets.US_ASCII);
+
     @Override
     public TopicMessageSubmitTransaction get() {
         return new TopicMessageSubmitTransaction()
                 .setMaxTransactionFee(Hbar.fromTinybars(maxTransactionFee))
-                .setMessage(!message.isEmpty() ? message.getBytes(StandardCharsets.UTF_8) : Utility
-                        .generateMessage(messageSize))
+                .setMessage(getGeneratedMessage())
                 .setTopicId(getConsensusTopicId());
     }
 }

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/schedule/ScheduleCreateTransactionSupplier.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/schedule/ScheduleCreateTransactionSupplier.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.monitor.publish.transaction.schedule;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,24 +20,18 @@ package com.hedera.mirror.monitor.publish.transaction.schedule;
  * ‍
  */
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
 import lombok.Data;
 import lombok.Getter;
 import lombok.extern.log4j.Log4j2;
 
-import com.hedera.hashgraph.sdk.AccountCreateTransaction;
 import com.hedera.hashgraph.sdk.AccountId;
 import com.hedera.hashgraph.sdk.Hbar;
 import com.hedera.hashgraph.sdk.Key;
-import com.hedera.hashgraph.sdk.KeyList;
-import com.hedera.hashgraph.sdk.PrivateKey;
 import com.hedera.hashgraph.sdk.PublicKey;
 import com.hedera.hashgraph.sdk.ScheduleCreateTransaction;
-import com.hedera.hashgraph.sdk.TransactionId;
+import com.hedera.hashgraph.sdk.TransferTransaction;
 import com.hedera.mirror.monitor.publish.transaction.AdminKeyable;
 import com.hedera.mirror.monitor.publish.transaction.TransactionSupplier;
 import com.hedera.mirror.monitor.util.Utility;
@@ -49,24 +43,10 @@ public class ScheduleCreateTransactionSupplier implements TransactionSupplier<Sc
     private String adminKey;
 
     @Getter(lazy = true)
-    private final Key adminPublicKey = PublicKey.fromString(adminKey);
-
-    @Getter(lazy = true)
-    private final List<PrivateKey> fullSignatoryList = createSignatoryKeys();
-
-    @Min(1)
-    private long initialBalance = 10_000_000;
-
-    private boolean logKeys = false;
+    private final Key adminPublicKey = adminKey != null ? PublicKey.fromString(adminKey) : null;
 
     @Min(1)
     private long maxTransactionFee = 1_000_000_000;
-
-    @NotBlank
-    private String nodeAccountId;
-
-    @Getter(lazy = true)
-    private final AccountId nodeId = AccountId.fromString(nodeAccountId);
 
     @NotBlank
     private String operatorAccountId;
@@ -74,97 +54,27 @@ public class ScheduleCreateTransactionSupplier implements TransactionSupplier<Sc
     @Getter(lazy = true)
     private final AccountId operatorId = AccountId.fromString(operatorAccountId);
 
+    @NotBlank
     private String payerAccount;
 
     @Getter(lazy = true)
-    private final AccountId payerAccountId = createPayerAccountId();
-
-    @Getter(lazy = true)
-    private final List<PrivateKey> signingKeys = createSigningKeys();
-
-    private boolean receiverSignatureRequired = true;
-
-    @Min(0)
-    private int signatoryCount = 1;
-
-    @Min(0)
-    private int totalSignatoryCount = 1;
+    private final AccountId payerAccountId = AccountId.fromString(payerAccount);
 
     @Override
     public ScheduleCreateTransaction get() {
-        Hbar maxTransactionFeeInHbar = Hbar.fromTinybars(getMaxTransactionFee());
-        String accountMemo = Utility.getMemo("Mirror node created test account");
-        AccountCreateTransaction innerTransaction = new AccountCreateTransaction()
-                .setInitialBalance(Hbar.fromTinybars(getInitialBalance()))
-                .setKey(getPublicKeys())
-                .setAccountMemo(accountMemo)
-                .setMaxTransactionFee(maxTransactionFeeInHbar)
-                .setReceiverSignatureRequired(receiverSignatureRequired)
-                .setTransactionMemo(accountMemo);
+        Hbar maxTransactionFee = Hbar.fromTinybars(getMaxTransactionFee());
+        TransferTransaction innerTransaction = new TransferTransaction()
+                .setMaxTransactionFee(maxTransactionFee)
+                .addHbarTransfer(getOperatorId(), Hbar.fromTinybars(1L).negated())
+                .addHbarTransfer(getPayerAccountId(), Hbar.fromTinybars(1L));
 
-        // set nodeAccountId and freeze inner transaction
-        TransactionId transactionId = TransactionId.generate(getOperatorId());
-        innerTransaction.setTransactionId(transactionId.setScheduled(true));
-
-        ScheduleCreateTransaction scheduleCreateTransaction = innerTransaction
-                .schedule()
-                .setMaxTransactionFee(maxTransactionFeeInHbar)
+        ScheduleCreateTransaction scheduleCreateTransaction = new ScheduleCreateTransaction()
+                .setAdminKey(getAdminPublicKey())
+                .setMaxTransactionFee(maxTransactionFee)
+                .setPayerAccountId(getPayerAccountId())
                 .setScheduleMemo(Utility.getMemo("Mirror node created test schedule"))
-                .setTransactionId(transactionId);
-
-        if (adminKey != null) {
-            scheduleCreateTransaction.setAdminKey(getAdminPublicKey());
-        }
-
-        if (payerAccount != null) {
-            scheduleCreateTransaction.setPayerAccountId(getPayerAccountId());
-        }
-
-        // add initial set of required signatures to ScheduleCreate transaction
-        if (totalSignatoryCount > 0) {
-            scheduleCreateTransaction.setNodeAccountIds(Collections.singletonList(getNodeId()));
-            getSigningKeys().forEach(pk -> {
-                byte[] signature = pk.signTransaction(scheduleCreateTransaction);
-                scheduleCreateTransaction.addSignature(
-                        pk.getPublicKey(),
-                        signature);
-            });
-            log.debug("Added {} signatures to ScheduleCreate", totalSignatoryCount);
-        }
+                .setScheduledTransaction(innerTransaction);
 
         return scheduleCreateTransaction;
-    }
-
-    private KeyList getPublicKeys() {
-        KeyList keys = new KeyList();
-        getFullSignatoryList().forEach(key -> keys.add(key.getPublicKey()));
-
-        return keys;
-    }
-
-    private int getNumberOfSignatories() {
-        return Math.min(signatoryCount, totalSignatoryCount);
-    }
-
-    private List<PrivateKey> createSigningKeys() {
-        return getFullSignatoryList().subList(0, getNumberOfSignatories());
-    }
-
-    private List<PrivateKey> createSignatoryKeys() {
-        List<PrivateKey> keys = new ArrayList<>();
-        for (int i = 0; i < totalSignatoryCount; i++) {
-            PrivateKey privateKey = PrivateKey.generate();
-            if (logKeys) {
-                log.info("privateKey {}: {}", i, privateKey);
-                log.info("publicKey {}: {}", i, privateKey.getPublicKey());
-            }
-            keys.add(privateKey);
-        }
-
-        return keys;
-    }
-
-    private AccountId createPayerAccountId() {
-        return payerAccount == null ? null : AccountId.fromString(payerAccount);
     }
 }

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/expression/ExpressionConverterImplTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/expression/ExpressionConverterImplTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import java.util.Map;
+import java.util.concurrent.TimeoutException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -116,10 +117,11 @@ class ExpressionConverterImplTest {
     }
 
     @Test
-    void errorPublishing() {
-        RuntimeException error = new RuntimeException("error");
-        when(transactionPublisher.publish(any())).thenReturn(Mono.error(error));
-        assertThatThrownBy(() -> expressionConverter.convert("${topic.foo}")).hasRootCause(error);
+    void errorPublishing() throws InvalidProtocolBufferException {
+        TransactionType type = TransactionType.CONSENSUS_CREATE_TOPIC;
+        when(transactionPublisher.publish(any())).thenReturn(Mono.error(new TimeoutException()))
+                .thenReturn(response(type, 100));
+        assertThat(expressionConverter.convert("${topic.foo}")).isEqualTo("0.0.100");
     }
 
     @Test

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/expression/ExpressionConverterImplTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/expression/ExpressionConverterImplTest.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.monitor.expression;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -28,9 +28,6 @@ import static org.mockito.Mockito.when;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import java.util.Map;
-
-import com.hedera.mirror.monitor.publish.transaction.TransactionType;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -53,6 +50,7 @@ import com.hedera.mirror.monitor.MonitorProperties;
 import com.hedera.mirror.monitor.publish.PublishRequest;
 import com.hedera.mirror.monitor.publish.PublishResponse;
 import com.hedera.mirror.monitor.publish.TransactionPublisher;
+import com.hedera.mirror.monitor.publish.transaction.TransactionType;
 
 @MockitoSettings(strictness = Strictness.STRICT_STUBS)
 class ExpressionConverterImplTest {
@@ -118,11 +116,10 @@ class ExpressionConverterImplTest {
     }
 
     @Test
-    void errorPublishing() throws InvalidProtocolBufferException {
-        TransactionType type = TransactionType.CONSENSUS_CREATE_TOPIC;
-        when(transactionPublisher.publish(any())).thenReturn(Mono.error(new RuntimeException()))
-                .thenReturn(response(type, 100));
-        assertThat(expressionConverter.convert("${topic.foo}")).isEqualTo("0.0.100");
+    void errorPublishing() {
+        RuntimeException error = new RuntimeException("error");
+        when(transactionPublisher.publish(any())).thenReturn(Mono.error(error));
+        assertThatThrownBy(() -> expressionConverter.convert("${topic.foo}")).hasRootCause(error);
     }
 
     @Test

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/expression/ExpressionConverterImplTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/expression/ExpressionConverterImplTest.java
@@ -119,7 +119,7 @@ class ExpressionConverterImplTest {
     @Test
     void errorPublishing() throws InvalidProtocolBufferException {
         TransactionType type = TransactionType.CONSENSUS_CREATE_TOPIC;
-        when(transactionPublisher.publish(any())).thenReturn(Mono.error(new TimeoutException()))
+        when(transactionPublisher.publish(any())).thenReturn(Mono.error(new TimeoutException("timeout")))
                 .thenReturn(response(type, 100));
         assertThat(expressionConverter.convert("${topic.foo}")).isEqualTo("0.0.100");
     }

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/TransactionPublisherTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/TransactionPublisherTest.java
@@ -33,12 +33,11 @@ import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
-import java.util.LinkedList;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeoutException;
-import java.util.regex.Pattern;
 import lombok.Data;
 import lombok.extern.log4j.Log4j2;
 import org.junit.jupiter.api.AfterEach;
@@ -126,9 +125,6 @@ class TransactionPublisherTest {
                 })
                 .expectComplete()
                 .verify(Duration.ofSeconds(1L));
-
-        assertThat(request.getTransaction().getTransactionMemo())
-                .containsPattern(Pattern.compile("\\d+ Monitor test on \\w+"));
     }
 
     @Test
@@ -414,8 +410,8 @@ class TransactionPublisherTest {
     @Data
     private class CryptoServiceStub extends CryptoServiceGrpc.CryptoServiceImplBase {
 
-        private Queue<Mono<TransactionResponse>> transactions = new LinkedList<>();
-        private Queue<Mono<Response>> queries = new LinkedList<>();
+        private Queue<Mono<TransactionResponse>> transactions = new ConcurrentLinkedQueue<>();
+        private Queue<Mono<Response>> queries = new ConcurrentLinkedQueue<>();
 
         void addQueries(Mono<Response>... query) {
             queries.addAll(Arrays.asList(query));

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/generator/ConfigurableTransactionGeneratorTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/generator/ConfigurableTransactionGeneratorTest.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.monitor.publish.generator;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,10 +32,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
+import java.util.regex.Pattern;
 import javax.validation.ConstraintViolationException;
-
-import com.hedera.mirror.monitor.publish.transaction.TransactionType;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -44,6 +42,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import com.hedera.hashgraph.sdk.TopicId;
 import com.hedera.mirror.monitor.publish.PublishRequest;
 import com.hedera.mirror.monitor.publish.PublishScenarioProperties;
+import com.hedera.mirror.monitor.publish.transaction.TransactionType;
 
 class ConfigurableTransactionGeneratorTest {
 
@@ -204,13 +203,17 @@ class ConfigurableTransactionGeneratorTest {
     }
 
     private void assertRequests(List<PublishRequest> publishRequests, int size) {
-        assertThat(publishRequests).hasSize(size).allSatisfy(publishRequest -> assertThat(publishRequest)
-                .isNotNull()
-                .hasNoNullFieldsOrProperties()
-                .hasFieldOrPropertyWithValue("receipt", true)
-                .hasFieldOrPropertyWithValue("record", true)
-                .hasFieldOrPropertyWithValue("transaction.topicId", TopicId.fromString(TOPIC_ID))
-        );
+        assertThat(publishRequests)
+                .hasSize(size)
+                .allSatisfy(publishRequest -> assertThat(publishRequest)
+                        .isNotNull()
+                        .hasNoNullFieldsOrProperties()
+                        .hasFieldOrPropertyWithValue("receipt", true)
+                        .hasFieldOrPropertyWithValue("record", true)
+                        .hasFieldOrPropertyWithValue("transaction.topicId", TopicId.fromString(TOPIC_ID))
+                        .satisfies(r -> assertThat(r.getTransaction().getTransactionMemo())
+                                .containsPattern(Pattern.compile("\\d+ Monitor test on \\w+")))
+                );
     }
 
     private void assertRequests(List<PublishRequest> publishRequests) {

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/schedule/ScheduleCreateTransactionSupplierTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/schedule/ScheduleCreateTransactionSupplierTest.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.monitor.publish.transaction.schedule;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,7 +25,6 @@ import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
 
 import org.junit.jupiter.api.Test;
 
-import com.hedera.hashgraph.sdk.AccountId;
 import com.hedera.hashgraph.sdk.PrivateKey;
 import com.hedera.hashgraph.sdk.PublicKey;
 import com.hedera.hashgraph.sdk.ScheduleCreateTransaction;
@@ -33,29 +32,17 @@ import com.hedera.mirror.monitor.publish.transaction.AbstractTransactionSupplier
 
 class ScheduleCreateTransactionSupplierTest extends AbstractTransactionSupplierTest {
 
-    private static final AccountId NODE_ACCOUNT_ID = AccountId.fromString("0.0.5");
-
     @Test
     void createWithMinimumData() {
-
         ScheduleCreateTransactionSupplier scheduleCreateTransactionSupplier = new ScheduleCreateTransactionSupplier();
-        scheduleCreateTransactionSupplier.setNodeAccountId(NODE_ACCOUNT_ID.toString());
         scheduleCreateTransactionSupplier.setOperatorAccountId(ACCOUNT_ID.toString());
+        scheduleCreateTransactionSupplier.setPayerAccount(ACCOUNT_ID_2.toString());
         ScheduleCreateTransaction actual = scheduleCreateTransactionSupplier.get();
 
         assertThat(actual)
-
                 .returns(null, a -> a.getAdminKey())
                 .returns(MAX_TRANSACTION_FEE_HBAR, ScheduleCreateTransaction::getMaxTransactionFee)
-                .returns(1, a -> a.getNodeAccountIds().size())
-                .returns(NODE_ACCOUNT_ID, a -> a.getNodeAccountIds().get(0))
-                .returns(null, a -> scheduleCreateTransactionSupplier.getPayerAccountId())
-                .returns(1, a -> a.getSignatures().get(NODE_ACCOUNT_ID).size())
-                .returns(1, a -> a.getTransactionHashPerNode().size())
-                .returns(true, a -> a.getTransactionId().getScheduled())
-                .satisfies(a -> assertThat(a.getTransactionHash()).isNotNull())
-                .satisfies(a -> assertThat(a.getTransactionHashPerNode().get(NODE_ACCOUNT_ID)).isNotNull())
-                .satisfies(a -> assertThat(a.getTransactionId().toString()).contains(ACCOUNT_ID.toString()))
+                .returns(ACCOUNT_ID_2, ScheduleCreateTransaction::getPayerAccountId)
                 .extracting(ScheduleCreateTransaction::getScheduleMemo, STRING)
                 .contains("Mirror node created test schedule");
     }
@@ -66,28 +53,15 @@ class ScheduleCreateTransactionSupplierTest extends AbstractTransactionSupplierT
 
         ScheduleCreateTransactionSupplier scheduleCreateTransactionSupplier = new ScheduleCreateTransactionSupplier();
         scheduleCreateTransactionSupplier.setAdminKey(adminKey.toString());
-        scheduleCreateTransactionSupplier.setInitialBalance(1);
         scheduleCreateTransactionSupplier.setMaxTransactionFee(1);
-        scheduleCreateTransactionSupplier.setNodeAccountId(NODE_ACCOUNT_ID.toString());
         scheduleCreateTransactionSupplier.setOperatorAccountId(ACCOUNT_ID.toString());
         scheduleCreateTransactionSupplier.setPayerAccount(ACCOUNT_ID_2.toString());
-        scheduleCreateTransactionSupplier.setReceiverSignatureRequired(false);
-        scheduleCreateTransactionSupplier.setSignatoryCount(2);
-        scheduleCreateTransactionSupplier.setTotalSignatoryCount(2);
         ScheduleCreateTransaction actual = scheduleCreateTransactionSupplier.get();
 
         assertThat(actual)
                 .returns(adminKey, a -> a.getAdminKey())
-                .returns(2, a -> a.getSignatures().get(NODE_ACCOUNT_ID).size())
                 .returns(ONE_TINYBAR, ScheduleCreateTransaction::getMaxTransactionFee)
-                .returns(1, a -> a.getNodeAccountIds().size())
-                .returns(NODE_ACCOUNT_ID, a -> a.getNodeAccountIds().get(0))
                 .returns(ACCOUNT_ID_2, ScheduleCreateTransaction::getPayerAccountId)
-                .returns(1, a -> a.getTransactionHashPerNode().size())
-                .returns(true, a -> a.getTransactionId().getScheduled())
-                .satisfies(a -> assertThat(a.getTransactionHash()).isNotNull())
-                .satisfies(a -> assertThat(a.getTransactionHashPerNode().get(NODE_ACCOUNT_ID)).isNotNull())
-                .satisfies(a -> assertThat(a.getTransactionId().toString()).contains(ACCOUNT_ID.toString()))
                 .extracting(ScheduleCreateTransaction::getScheduleMemo, STRING)
                 .contains("Mirror node created test schedule");
     }


### PR DESCRIPTION
**Description**:

* Add a property to control whether publishing should be synchronous or asynchronous
* Bump SDK version
* Fix error modifying frozen transaction by not updating memo every retry
* Fix node back off too high causing a large delay in recovery of down nodes
* Fix schedule expression creation
* Fix schedule publishing and simplify it
* Fix race condition in tests
* Fix transaction expired errors if nodes down during expression creation
* Improve performance of HCS submit message by caching generated message

**Related issue(s)**:

Fixes #3617

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
