### PR TITLE
Dedup allowances in crypto approve allowance transaction handler

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoApproveAllowanceTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoApproveAllowanceTransactionHandler.java
@@ -98,15 +98,15 @@ class CryptoApproveAllowanceTransactionHandler implements TransactionHandler {
             cryptoAllowance.setSpender(EntityId.of(cryptoApproval.getSpender()).getId());
             cryptoAllowance.setTimestampLower(recordItem.getConsensusTimestamp());
 
-            if (!cryptoAllowanceState.containsKey(cryptoAllowance.getId())) {
+            if (cryptoAllowanceState.putIfAbsent(cryptoAllowance.getId(), cryptoAllowance) == null) {
                 entityListener.onCryptoAllowance(cryptoAllowance);
-                cryptoAllowanceState.put(cryptoAllowance.getId(), cryptoAllowance);
             }
         }
     }
 
     private void parseNftAllowances(List<com.hederahashgraph.api.proto.java.NftAllowance> nftAllowances,
                                     RecordItem recordItem) {
+        var consensusTimestamp = recordItem.getConsensusTimestamp();
         var payerAccountId = recordItem.getPayerAccountId();
         var nftAllowanceState = new HashMap<NftAllowance.Id, NftAllowance>();
         var nftSerialAllowanceState = new HashMap<NftId, Nft>();
@@ -135,7 +135,7 @@ class CryptoApproveAllowanceTransactionHandler implements TransactionHandler {
                 nftAllowance.setPayerAccountId(payerAccountId);
                 nftAllowance.setSpender(spender.getId());
                 nftAllowance.setTokenId(tokenId.getId());
-                nftAllowance.setTimestampLower(recordItem.getConsensusTimestamp());
+                nftAllowance.setTimestampLower(consensusTimestamp);
 
                 if (!nftAllowanceState.containsKey(nftAllowance.getId())) {
                     entityListener.onNftAllowance(nftAllowance);
@@ -151,12 +151,11 @@ class CryptoApproveAllowanceTransactionHandler implements TransactionHandler {
                 Nft nft = new Nft(serialNumber, tokenId);
                 nft.setAccountId(ownerAccountId);
                 nft.setDelegatingSpender(delegatingSpender);
-                nft.setModifiedTimestamp(recordItem.getConsensusTimestamp());
+                nft.setModifiedTimestamp(consensusTimestamp);
                 nft.setSpender(spender);
 
-                if (!nftSerialAllowanceState.containsKey(nft.getId())) {
+                if (nftSerialAllowanceState.putIfAbsent(nft.getId(), nft) == null) {
                     entityListener.onNft(nft);
-                    nftSerialAllowanceState.put(nft.getId(), nft);
                 }
             }
         }
@@ -187,9 +186,8 @@ class CryptoApproveAllowanceTransactionHandler implements TransactionHandler {
             tokenAllowance.setTokenId(EntityId.of(tokenApproval.getTokenId()).getId());
             tokenAllowance.setTimestampLower(recordItem.getConsensusTimestamp());
 
-            if (!tokenAllowanceState.containsKey(tokenAllowance.getId())) {
+            if (tokenAllowanceState.putIfAbsent(tokenAllowance.getId(), tokenAllowance) == null) {
                 entityListener.onTokenAllowance(tokenAllowance);
-                tokenAllowanceState.put(tokenAllowance.getId(), tokenAllowance);
             }
         }
     }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoApproveAllowanceTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoApproveAllowanceTransactionHandler.java
@@ -77,11 +77,11 @@ class CryptoApproveAllowanceTransactionHandler implements TransactionHandler {
 
     private void parseCryptoAllowances(List<com.hederahashgraph.api.proto.java.CryptoAllowance> cryptoAllowances,
                                        RecordItem recordItem) {
-        var iterator = cryptoAllowances.listIterator(cryptoAllowances.size());
-        var payerAccountId = recordItem.getPayerAccountId();
         var cryptoAllowanceState = new HashMap<CryptoAllowance.Id, CryptoAllowance>();
+        var payerAccountId = recordItem.getPayerAccountId();
 
         // iterate the crypto allowance list in reverse order and honor the last allowance for the same owner and spender
+        var iterator = cryptoAllowances.listIterator(cryptoAllowances.size());
         while (iterator.hasPrevious()) {
             var cryptoApproval = iterator.previous();
             EntityId ownerAccountId = getOwnerAccountId(cryptoApproval.getOwner(), payerAccountId);
@@ -107,7 +107,6 @@ class CryptoApproveAllowanceTransactionHandler implements TransactionHandler {
 
     private void parseNftAllowances(List<com.hederahashgraph.api.proto.java.NftAllowance> nftAllowances,
                                       RecordItem recordItem) {
-        var iterator = nftAllowances.listIterator(nftAllowances.size());
         var payerAccountId = recordItem.getPayerAccountId();
         var nftAllowanceState = new HashMap<NftAllowance.Id, NftAllowance>();
         var nftSerialAllowanceState = new HashMap<NftId, Nft>();
@@ -115,6 +114,7 @@ class CryptoApproveAllowanceTransactionHandler implements TransactionHandler {
         // iterate the nft allowance list in reverse order and honor the last allowance for either
         // the same owner, spender, and token for approved for all allowances, or the last serial allowance for
         // the same owner, spender, token, and serial
+        var iterator = nftAllowances.listIterator(nftAllowances.size());
         while (iterator.hasPrevious()) {
             var nftApproval = iterator.previous();
             EntityId ownerAccountId = getOwnerAccountId(nftApproval.getOwner(), payerAccountId);
@@ -164,12 +164,12 @@ class CryptoApproveAllowanceTransactionHandler implements TransactionHandler {
 
     private void parseTokenAllowances(List<com.hederahashgraph.api.proto.java.TokenAllowance> tokenAllowances,
                                        RecordItem recordItem) {
-        var iterator = tokenAllowances.listIterator(tokenAllowances.size());
         var payerAccountId = recordItem.getPayerAccountId();
         var tokenAllowanceState = new HashMap<TokenAllowance.Id, TokenAllowance>();
 
         // iterate the token allowance list in reverse order and honor the last allowance for the same owner, spender,
         // and token
+        var iterator = tokenAllowances.listIterator(tokenAllowances.size());
         while (iterator.hasPrevious()) {
             var tokenApproval = iterator.previous();
             EntityId ownerAccountId = getOwnerAccountId(tokenApproval.getOwner(), payerAccountId);

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoApproveAllowanceTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoApproveAllowanceTransactionHandler.java
@@ -77,6 +77,7 @@ class CryptoApproveAllowanceTransactionHandler implements TransactionHandler {
 
     private void parseCryptoAllowances(List<com.hederahashgraph.api.proto.java.CryptoAllowance> cryptoAllowances,
                                        RecordItem recordItem) {
+        var consensusTimestamp = recordItem.getConsensusTimestamp();
         var cryptoAllowanceState = new HashMap<CryptoAllowance.Id, CryptoAllowance>();
         var payerAccountId = recordItem.getPayerAccountId();
 
@@ -96,7 +97,7 @@ class CryptoApproveAllowanceTransactionHandler implements TransactionHandler {
             cryptoAllowance.setOwner(ownerAccountId.getId());
             cryptoAllowance.setPayerAccountId(payerAccountId);
             cryptoAllowance.setSpender(EntityId.of(cryptoApproval.getSpender()).getId());
-            cryptoAllowance.setTimestampLower(recordItem.getConsensusTimestamp());
+            cryptoAllowance.setTimestampLower(consensusTimestamp);
 
             if (cryptoAllowanceState.putIfAbsent(cryptoAllowance.getId(), cryptoAllowance) == null) {
                 entityListener.onCryptoAllowance(cryptoAllowance);
@@ -137,15 +138,13 @@ class CryptoApproveAllowanceTransactionHandler implements TransactionHandler {
                 nftAllowance.setTokenId(tokenId.getId());
                 nftAllowance.setTimestampLower(consensusTimestamp);
 
-                if (!nftAllowanceState.containsKey(nftAllowance.getId())) {
+                if (nftAllowanceState.putIfAbsent(nftAllowance.getId(), nftAllowance) == null) {
                     entityListener.onNftAllowance(nftAllowance);
-                    nftAllowanceState.put(nftAllowance.getId(), nftAllowance);
                 }
             }
 
             EntityId delegatingSpender = EntityId.of(nftApproval.getDelegatingSpender());
             for (var serialNumber : nftApproval.getSerialNumbersList()) {
-                // nft instance allowance update doesn't set nft modifiedTimestamp
                 // services allows the same serial number of a nft token appears in multiple nft allowances to
                 // different spenders. The last spender will be granted such allowance.
                 Nft nft = new Nft(serialNumber, tokenId);
@@ -163,6 +162,7 @@ class CryptoApproveAllowanceTransactionHandler implements TransactionHandler {
 
     private void parseTokenAllowances(List<com.hederahashgraph.api.proto.java.TokenAllowance> tokenAllowances,
                                       RecordItem recordItem) {
+        var consensusTimestamp = recordItem.getConsensusTimestamp();
         var payerAccountId = recordItem.getPayerAccountId();
         var tokenAllowanceState = new HashMap<TokenAllowance.Id, TokenAllowance>();
 
@@ -184,7 +184,7 @@ class CryptoApproveAllowanceTransactionHandler implements TransactionHandler {
             tokenAllowance.setPayerAccountId(payerAccountId);
             tokenAllowance.setSpender(EntityId.of(tokenApproval.getSpender()).getId());
             tokenAllowance.setTokenId(EntityId.of(tokenApproval.getTokenId()).getId());
-            tokenAllowance.setTimestampLower(recordItem.getConsensusTimestamp());
+            tokenAllowance.setTimestampLower(consensusTimestamp);
 
             if (tokenAllowanceState.putIfAbsent(tokenAllowance.getId(), tokenAllowance) == null) {
                 entityListener.onTokenAllowance(tokenAllowance);

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoApproveAllowanceTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoApproveAllowanceTransactionHandler.java
@@ -106,7 +106,7 @@ class CryptoApproveAllowanceTransactionHandler implements TransactionHandler {
     }
 
     private void parseNftAllowances(List<com.hederahashgraph.api.proto.java.NftAllowance> nftAllowances,
-                                      RecordItem recordItem) {
+                                    RecordItem recordItem) {
         var payerAccountId = recordItem.getPayerAccountId();
         var nftAllowanceState = new HashMap<NftAllowance.Id, NftAllowance>();
         var nftSerialAllowanceState = new HashMap<NftId, Nft>();
@@ -163,7 +163,7 @@ class CryptoApproveAllowanceTransactionHandler implements TransactionHandler {
     }
 
     private void parseTokenAllowances(List<com.hederahashgraph.api.proto.java.TokenAllowance> tokenAllowances,
-                                       RecordItem recordItem) {
+                                      RecordItem recordItem) {
         var payerAccountId = recordItem.getPayerAccountId();
         var tokenAllowanceState = new HashMap<TokenAllowance.Id, TokenAllowance>();
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/domain/RecordItemBuilder.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/domain/RecordItemBuilder.java
@@ -236,6 +236,11 @@ public class RecordItemBuilder {
                         .setOwner(accountId())
                         .setSpender(accountId())
                         .setTokenId(tokenId()));
+        // duplicate allowances
+        builder.addCryptoAllowances(builder.getCryptoAllowances(0))
+                .addTokenAllowances(builder.getTokenAllowances(0))
+                .addNftAllowances(builder.getNftAllowances(0))
+                .addNftAllowances(builder.getNftAllowances(2).toBuilder().setApprovedForAll(BoolValue.of(false)));
         return new Builder<>(TransactionType.CRYPTOAPPROVEALLOWANCE, builder);
     }
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerCryptoTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerCryptoTest.java
@@ -1053,6 +1053,10 @@ class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItemListene
                 .setSpender(spender2)
                 .setTokenId(tokenId)
                 .build());
+
+        // duplicate nft allowance
+        nftAllowances.add(nftAllowances.get(nftAllowances.size() - 1));
+
         // serial number 2's allowance is granted twice, the allowance should be granted to spender2 since it appears
         // after the nft allowance to spender1
         expectedNfts.add(nft2.toBuilder().modifiedTimestamp(timestamp).spender(EntityId.of(spender2)).build());

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoApproveAllowanceTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoApproveAllowanceTransactionHandlerTest.java
@@ -20,7 +20,6 @@ package com.hedera.mirror.importer.parser.record.transactionhandler;
  * ‍
  */
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
@@ -29,20 +28,19 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.Range;
+import com.google.protobuf.BoolValue;
 import com.google.protobuf.ByteString;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.CryptoApproveAllowanceTransactionBody;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
+import com.hederahashgraph.api.proto.java.TokenID;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 
 import com.hedera.mirror.common.domain.entity.CryptoAllowance;
 import com.hedera.mirror.common.domain.entity.EntityId;
@@ -50,10 +48,12 @@ import com.hedera.mirror.common.domain.entity.EntityType;
 import com.hedera.mirror.common.domain.entity.NftAllowance;
 import com.hedera.mirror.common.domain.entity.TokenAllowance;
 import com.hedera.mirror.common.domain.token.Nft;
+import com.hedera.mirror.common.domain.token.NftId;
 import com.hedera.mirror.common.domain.transaction.RecordItem;
 import com.hedera.mirror.common.domain.transaction.Transaction;
 import com.hedera.mirror.common.exception.InvalidEntityException;
 import com.hedera.mirror.common.util.DomainUtils;
+import com.hedera.mirror.importer.TestUtils;
 import com.hedera.mirror.importer.parser.PartialDataAction;
 import com.hedera.mirror.importer.parser.record.RecordParserProperties;
 
@@ -61,14 +61,57 @@ class CryptoApproveAllowanceTransactionHandlerTest extends AbstractTransactionHa
 
     private Map<ByteString, EntityId> aliasMap;
 
-    @Captor
-    private ArgumentCaptor<NftAllowance> nftAllowanceCaptor;
+    private long consensusTimestamp;
+
+    private CryptoAllowance expectedCryptoAllowance;
+
+    private Nft expectedNft;
+
+    private NftAllowance expectedNftAllowance;
+
+    private TokenAllowance expectedTokenAllowance;
 
     private RecordParserProperties recordParserProperties;
+
+    private EntityId payerAccountId;
 
     @BeforeEach
     void beforeEach() {
         aliasMap = new HashMap<>();
+
+        consensusTimestamp = DomainUtils.timestampInNanosMax(recordItemBuilder.timestamp());
+        payerAccountId = EntityId.of(recordItemBuilder.accountId());
+        expectedCryptoAllowance = CryptoAllowance.builder()
+                .owner(recordItemBuilder.accountId().getAccountNum())
+                .payerAccountId(payerAccountId)
+                .spender(recordItemBuilder.accountId().getAccountNum()).amount(100L)
+                .timestampRange(Range.atLeast(consensusTimestamp))
+                .build();
+        var nftTokenId = recordItemBuilder.tokenId().getTokenNum();
+        expectedNft = Nft.builder()
+                .id(new NftId(1L, EntityId.of(nftTokenId, EntityType.TOKEN)))
+                .accountId(EntityId.of(recordItemBuilder.accountId()))
+                .delegatingSpender(EntityId.EMPTY)
+                .modifiedTimestamp(consensusTimestamp)
+                .spender(EntityId.of(recordItemBuilder.accountId()))
+                .build();
+        expectedNftAllowance = NftAllowance.builder()
+                .approvedForAll(true)
+                .owner(expectedNft.getAccountId().getId())
+                .payerAccountId(payerAccountId)
+                .spender(expectedNft.getSpender().getId())
+                .timestampRange(Range.atLeast(consensusTimestamp))
+                .tokenId(nftTokenId)
+                .build();
+        expectedTokenAllowance = TokenAllowance.builder()
+                .amount(200L)
+                .owner(recordItemBuilder.accountId().getAccountNum())
+                .payerAccountId(payerAccountId)
+                .spender(recordItemBuilder.accountId().getAccountNum())
+                .timestampRange(Range.atLeast(consensusTimestamp))
+                .tokenId(recordItemBuilder.tokenId().getTokenNum())
+                .build();
+
         when(entityIdService.lookup(any(AccountID.class))).thenAnswer(invocation -> {
             var accountId = invocation.getArgument(0, AccountID.class);
             if (accountId == AccountID.getDefaultInstance()) {
@@ -118,25 +161,34 @@ class CryptoApproveAllowanceTransactionHandlerTest extends AbstractTransactionHa
 
     @Test
     void updateTransactionSuccessful() {
-        var recordItem = recordItemBuilder.cryptoApproveAllowance().build();
-        var timestamp = recordItem.getConsensusTimestamp();
-        var transaction = domainBuilder.transaction().customize(t -> t.consensusTimestamp(timestamp)).get();
+        var recordItem = recordItemBuilder.cryptoApproveAllowance()
+                .transactionBody(this::customizeTransactionBody)
+                .transactionBodyWrapper(this::setTransactionPayer)
+                .record(r -> r.setConsensusTimestamp(TestUtils.toTimestamp(consensusTimestamp)))
+                .build();
+        var transaction = domainBuilder.transaction()
+                .customize(t -> t.consensusTimestamp(consensusTimestamp)).get();
         transactionHandler.updateTransaction(transaction, recordItem);
-        assertAllowances(recordItem, owner -> assertThat(owner).isPositive());
+        assertAllowances(null);
     }
 
     @Test
     void updateTransactionSuccessfulWithImplicitOwner() {
-        var recordItem = recordItemBuilder.cryptoApproveAllowance().transactionBody(b -> {
-            b.getCryptoAllowancesBuilderList().forEach(builder -> builder.clearOwner());
-            b.getNftAllowancesBuilderList().forEach(builder -> builder.clearOwner());
-            b.getTokenAllowancesBuilderList().forEach(builder -> builder.clearOwner());
-        }).build();
+        var recordItem = recordItemBuilder.cryptoApproveAllowance()
+                .transactionBody(this::customizeTransactionBody)
+                .transactionBody(b -> {
+                    b.getCryptoAllowancesBuilderList().forEach(builder -> builder.clearOwner());
+                    b.getNftAllowancesBuilderList().forEach(builder -> builder.clearOwner());
+                    b.getTokenAllowancesBuilderList().forEach(builder -> builder.clearOwner());
+                })
+                .transactionBodyWrapper(this::setTransactionPayer)
+                .record(r -> r.setConsensusTimestamp(TestUtils.toTimestamp(consensusTimestamp)))
+                .build();
         var effectiveOwner = recordItem.getPayerAccountId().getId();
-        var timestamp = recordItem.getConsensusTimestamp();
-        var transaction = domainBuilder.transaction().customize(t -> t.consensusTimestamp(timestamp)).get();
+        var transaction = domainBuilder.transaction()
+                .customize(t -> t.consensusTimestamp(consensusTimestamp)).get();
         transactionHandler.updateTransaction(transaction, recordItem);
-        assertAllowances(recordItem, owner -> assertThat(owner).isEqualTo(effectiveOwner));
+        assertAllowances(effectiveOwner);
     }
 
     @ParameterizedTest(name = "{0}")
@@ -175,54 +227,94 @@ class CryptoApproveAllowanceTransactionHandlerTest extends AbstractTransactionHa
         var alias = DomainUtils.fromBytes(domainBuilder.key());
         var ownerEntityId = EntityId.of(recordItemBuilder.accountId());
         aliasMap.put(alias, ownerEntityId);
-        var recordItem = recordItemBuilder.cryptoApproveAllowance().transactionBody(b -> {
-            b.getCryptoAllowancesBuilderList().forEach(builder -> builder.getOwnerBuilder().setAlias(alias));
-            b.getNftAllowancesBuilderList().forEach(builder -> builder.getOwnerBuilder().setAlias(alias));
-            b.getTokenAllowancesBuilderList().forEach(builder -> builder.getOwnerBuilder().setAlias(alias));
-        }).build();
+        var recordItem = recordItemBuilder.cryptoApproveAllowance()
+                .transactionBody(this::customizeTransactionBody)
+                .transactionBody(b -> {
+                    b.getCryptoAllowancesBuilderList().forEach(builder -> builder.getOwnerBuilder().setAlias(alias));
+                    b.getNftAllowancesBuilderList().forEach(builder -> builder.getOwnerBuilder().setAlias(alias));
+                    b.getTokenAllowancesBuilderList().forEach(builder -> builder.getOwnerBuilder().setAlias(alias));
+                })
+                .transactionBodyWrapper(this::setTransactionPayer)
+                .record(r -> r.setConsensusTimestamp(TestUtils.toTimestamp(consensusTimestamp)))
+                .build();
         var timestamp = recordItem.getConsensusTimestamp();
         var transaction = domainBuilder.transaction().customize(t -> t.consensusTimestamp(timestamp)).get();
         transactionHandler.updateTransaction(transaction, recordItem);
-        assertAllowances(recordItem, owner -> assertThat(owner).isEqualTo(ownerEntityId.getId()));
+        assertAllowances(ownerEntityId.getId());
     }
 
-    private void assertAllowances(RecordItem recordItem, Consumer<Long> assertOwner) {
-        var timestamp = recordItem.getConsensusTimestamp();
-        verify(entityListener).onCryptoAllowance(assertArg(t -> assertThat(t)
-                .isNotNull()
-                .satisfies(a -> assertThat(a.getAmount()).isPositive())
-                .satisfies(a -> assertOwner.accept(a.getOwner()))
-                .returns(recordItem.getPayerAccountId(), CryptoAllowance::getPayerAccountId)
-                .returns(timestamp, CryptoAllowance::getTimestampLower)));
+    private void assertAllowances(Long effectiveOwner) {
+        if (effectiveOwner != null) {
+            expectedCryptoAllowance.setOwner(effectiveOwner);
+            expectedNft.setAccountId(EntityId.of(effectiveOwner, EntityType.ACCOUNT));
+            expectedNftAllowance.setOwner(effectiveOwner);
+            expectedTokenAllowance.setOwner(effectiveOwner);
+        }
 
-        verify(entityListener, times(3)).onNftAllowance(nftAllowanceCaptor.capture());
-        assertThat(nftAllowanceCaptor.getAllValues())
-                .allSatisfy(n -> assertAll(
-                        () -> assertOwner.accept(n.getOwner()),
-                        () -> assertThat(n.getSpender()).isPositive(),
-                        () -> assertThat(n.getTokenId()).isPositive(),
-                        () -> assertThat(n.getPayerAccountId()).isEqualTo(recordItem.getPayerAccountId()),
-                        () -> assertThat(n.getTimestampRange()).isEqualTo(Range.atLeast(timestamp))
-                ))
-                .extracting("approvedForAll")
-                .containsExactly(false, true, false);
+        verify(entityListener, times(1)).onCryptoAllowance(assertArg(t -> assertEquals(expectedCryptoAllowance, t)));
+        verify(entityListener, times(1)).onNft(assertArg(t -> assertEquals(expectedNft, t)));
+        verify(entityListener, times(1)).onNftAllowance(assertArg(t -> assertEquals(expectedNftAllowance, t)));
+        verify(entityListener, times(1)).onTokenAllowance(assertArg(t -> assertEquals(expectedTokenAllowance, t)));
+    }
 
-        verify(entityListener, times(4)).onNft(assertArg(t -> assertThat(t)
-                .isNotNull()
-                .satisfies(a -> assertOwner.accept(a.getAccountId().getId()))
-                .satisfies(a -> assertThat(a.getDelegatingSpender()).isEqualTo(EntityId.EMPTY))
-                .returns(timestamp, Nft::getModifiedTimestamp)
-                .satisfies(a -> assertThat(a.getId().getSerialNumber()).isPositive())
-                .satisfies(a -> assertThat(a.getId().getTokenId()).isNotNull())
-                .satisfies(a -> assertThat(a.getSpender()).isNotNull())));
+    private void customizeTransactionBody(CryptoApproveAllowanceTransactionBody.Builder builder) {
+        builder.clear();
 
-        verify(entityListener).onTokenAllowance(assertArg(t -> assertThat(t)
-                .isNotNull()
-                .satisfies(a -> assertThat(a.getAmount()).isPositive())
-                .satisfies(a -> assertOwner.accept(a.getOwner()))
-                .satisfies(a -> assertThat(a.getSpender()).isNotNull())
-                .satisfies(a -> assertThat(a.getTokenId()).isPositive())
-                .returns(recordItem.getPayerAccountId(), TokenAllowance::getPayerAccountId)
-                .returns(timestamp, TokenAllowance::getTimestampLower)));
+        // duplicate with different amount
+        builder.addCryptoAllowances(com.hederahashgraph.api.proto.java.CryptoAllowance.newBuilder()
+                .setAmount(expectedCryptoAllowance.getAmount() - 10)
+                .setOwner(AccountID.newBuilder().setAccountNum(expectedCryptoAllowance.getOwner()))
+                .setSpender(AccountID.newBuilder().setAccountNum(expectedCryptoAllowance.getSpender()))
+        );
+        // the last one is honored
+        builder.addCryptoAllowances(com.hederahashgraph.api.proto.java.CryptoAllowance.newBuilder()
+                .setAmount(expectedCryptoAllowance.getAmount())
+                .setOwner(AccountID.newBuilder().setAccountNum(expectedCryptoAllowance.getOwner()))
+                .setSpender(AccountID.newBuilder().setAccountNum(expectedCryptoAllowance.getSpender()))
+        );
+
+        // duplicate nft allowance by serial
+        builder.addNftAllowances(com.hederahashgraph.api.proto.java.NftAllowance.newBuilder()
+                .setOwner(AccountID.newBuilder().setAccountNum(expectedNft.getAccountId().getEntityNum()))
+                .addSerialNumbers(expectedNft.getId().getSerialNumber())
+                .setSpender(AccountID.newBuilder().setAccountNum(expectedNft.getSpender().getEntityNum() + 1))
+                .setTokenId(TokenID.newBuilder().setTokenNum(expectedNft.getId().getTokenId().getEntityNum()))
+        );
+        // duplicate nft approved for all allowance, approved for all flag is flipped from the last one
+        builder.addNftAllowances(com.hederahashgraph.api.proto.java.NftAllowance.newBuilder()
+                .setApprovedForAll(BoolValue.of(!expectedNftAllowance.isApprovedForAll()))
+                .setOwner(AccountID.newBuilder().setAccountNum(expectedNft.getAccountId().getEntityNum()))
+                .addSerialNumbers(expectedNft.getId().getSerialNumber())
+                .setSpender(AccountID.newBuilder().setAccountNum(expectedNft.getSpender().getEntityNum()))
+                .setTokenId(TokenID.newBuilder().setTokenNum(expectedNft.getId().getTokenId().getEntityNum()))
+        );
+        // the last one is honored
+        builder.addNftAllowances(com.hederahashgraph.api.proto.java.NftAllowance.newBuilder()
+                .setApprovedForAll(BoolValue.of(expectedNftAllowance.isApprovedForAll()))
+                .setOwner(AccountID.newBuilder().setAccountNum(expectedNft.getAccountId().getEntityNum()))
+                .addSerialNumbers(expectedNft.getId().getSerialNumber())
+                .setSpender(AccountID.newBuilder().setAccountNum(expectedNft.getSpender().getEntityNum()))
+                .setTokenId(TokenID.newBuilder().setTokenNum(expectedNft.getId().getTokenId().getEntityNum()))
+        );
+
+        // duplicate token allowance
+        builder.addTokenAllowances(com.hederahashgraph.api.proto.java.TokenAllowance.newBuilder()
+                .setAmount(expectedTokenAllowance.getAmount() - 10)
+                .setOwner(AccountID.newBuilder().setAccountNum(expectedTokenAllowance.getOwner()))
+                .setSpender(AccountID.newBuilder().setAccountNum(expectedTokenAllowance.getSpender()))
+                .setTokenId(TokenID.newBuilder().setTokenNum(expectedTokenAllowance.getTokenId()))
+        );
+        // the last one is honored
+        builder.addTokenAllowances(com.hederahashgraph.api.proto.java.TokenAllowance.newBuilder()
+                .setAmount(expectedTokenAllowance.getAmount())
+                .setOwner(AccountID.newBuilder().setAccountNum(expectedTokenAllowance.getOwner()))
+                .setSpender(AccountID.newBuilder().setAccountNum(expectedTokenAllowance.getSpender()))
+                .setTokenId(TokenID.newBuilder().setTokenNum(expectedTokenAllowance.getTokenId()))
+        );
+    }
+
+    private void setTransactionPayer(TransactionBody.Builder builder) {
+        builder.getTransactionIDBuilder()
+                .setAccountID(AccountID.newBuilder().setAccountNum(payerAccountId.getEntityNum()));
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoApproveAllowanceTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoApproveAllowanceTransactionHandlerTest.java
@@ -205,7 +205,7 @@ class CryptoApproveAllowanceTransactionHandlerTest extends AbstractTransactionHa
                         () -> assertThat(n.getTimestampRange()).isEqualTo(Range.atLeast(timestamp))
                 ))
                 .extracting("approvedForAll")
-                .containsExactlyInAnyOrder(false, true, true);
+                .containsExactly(false, true, false);
 
         verify(entityListener, times(4)).onNft(assertArg(t -> assertThat(t)
                 .isNotNull()


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR fixes the bug exposed in stable testnet by dedup allowances in crypto approve allowance transaction handler.

**Related issue(s)**:

Fixes #3662

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

Services changed to allow duplicate allowances in a crypto approve allowance transaction. The duplicate allowances can cause mirirornode importer to violate postgresql "ON CONFLICT DO UPDATE cannot affect row a second time" constraint.

The duplicate allowances result in rows in the temp table where the first `n - 1` have an empty `timestamp_range` and the last allowance has an open-ended `timestamp_range`, the upsert sql then will try to insert all such rows to the current table (e.g., `nft_allowance`), thus it violates the postgresql constraint.
 
**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
