### PR TITLE
Add ethereum nonce and evm address to entity

### DIFF
--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/contract/Contract.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/contract/Contract.java
@@ -42,10 +42,6 @@ import com.hedera.mirror.common.domain.entity.EntityId;
 public class Contract extends AbstractEntity implements Aliasable {
 
     @Column(updatable = false)
-    @ToString.Exclude
-    private byte[] evmAddress;
-
-    @Column(updatable = false)
     @Convert(converter = FileIdConverter.class)
     private EntityId fileId;
 
@@ -59,6 +55,6 @@ public class Contract extends AbstractEntity implements Aliasable {
     @JsonIgnore
     @Override
     public byte[] getAlias() {
-        return evmAddress;
+        return getEvmAddress();
     }
 }

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/AbstractEntity.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/AbstractEntity.java
@@ -67,6 +67,10 @@ public abstract class AbstractEntity implements History {
 
     private Boolean deleted;
 
+    @Column(updatable = false)
+    @ToString.Exclude
+    private byte[] evmAddress;
+
     private Long expirationTimestamp;
 
     @Id

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/Entity.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/Entity.java
@@ -43,6 +43,8 @@ public class Entity extends AbstractEntity implements Aliasable  {
     @Convert(converter = AccountIdConverter.class)
     private EntityId autoRenewAccountId;
 
+    private Long ethereumNonce;
+
     private Boolean receiverSigRequired;
 
     @ToString.Exclude

--- a/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/DomainBuilder.java
+++ b/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/DomainBuilder.java
@@ -194,7 +194,7 @@ public class DomainBuilder {
                 .autoRenewPeriod(1800L)
                 .createdTimestamp(timestamp)
                 .deleted(false)
-                .evmAddress(create2EvmAddress())
+                .evmAddress(evmAddress())
                 .expirationTimestamp(timestamp + 30_000_000L)
                 .fileId(entityId(FILE))
                 .id(id)
@@ -286,6 +286,8 @@ public class DomainBuilder {
                 .autoRenewPeriod(1800L)
                 .createdTimestamp(timestamp)
                 .deleted(false)
+                .ethereumNonce(1L)
+                .evmAddress(evmAddress())
                 .expirationTimestamp(timestamp + 30_000_000L)
                 .id(id)
                 .key(key())
@@ -502,7 +504,7 @@ public class DomainBuilder {
         return bytes;
     }
 
-    public byte[] create2EvmAddress() {
+    public byte[] evmAddress() {
         return bytes(20);
     }
 

--- a/hedera-mirror-importer/pom.xml
+++ b/hedera-mirror-importer/pom.xml
@@ -17,6 +17,7 @@
     </parent>
 
     <properties>
+        <bouncycastle.version>1.71</bouncycastle.version>
         <commons-beanutils.version>1.9.4</commons-beanutils.version>
         <commons-compress.version>1.21</commons-compress.version>
         <commons-io.version>2.11.0</commons-io.version>
@@ -93,6 +94,11 @@
             <groupId>org.apache.velocity</groupId>
             <artifactId>velocity-engine-core</artifactId>
             <version>${velocity.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk18on</artifactId>
+            <version>${bouncycastle.version}</version>
         </dependency>
         <dependency>
             <groupId>org.flywaydb</groupId>

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/CacheConfiguration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/CacheConfiguration.java
@@ -41,7 +41,6 @@ public class CacheConfiguration {
 
     public static final String EXPIRE_AFTER_5M = "cacheManagerExpireAfter5m";
     public static final String CACHE_MANAGER_ALIAS = "cacheManagerAlias";
-    public static final String KEY_GENERATOR_ALIAS = "keyGeneratorAlias";
 
     @Bean(EXPIRE_AFTER_5M)
     @Primary
@@ -56,11 +55,5 @@ public class CacheConfiguration {
         CaffeineCacheManager caffeineCacheManager = new CaffeineCacheManager();
         caffeineCacheManager.setCacheSpecification("maximumSize=100000,expireAfterWrite=30m");
         return caffeineCacheManager;
-    }
-
-    @Bean(KEY_GENERATOR_ALIAS)
-    KeyGenerator keyGeneratorAlias() {
-        return (target, method, params) -> params.length >= 1 && params[0] instanceof byte[] ?
-                Arrays.hashCode((byte[]) params[0]) : SimpleKeyGenerator.generateKey(params);
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/AccountEvmAddressMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/AccountEvmAddressMigration.java
@@ -1,0 +1,73 @@
+package com.hedera.mirror.importer.migration;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import java.io.IOException;
+import java.util.Map;
+import javax.inject.Named;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.flywaydb.core.api.MigrationVersion;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
+
+import com.hedera.mirror.importer.util.Utility;
+
+@Log4j2
+@Named
+@RequiredArgsConstructor(onConstructor_ = {@Lazy})
+public class AccountEvmAddressMigration extends MirrorBaseJavaMigration {
+
+    private final NamedParameterJdbcOperations jdbcOperations;
+
+    @Override
+    protected void doMigrate() throws IOException {
+        updateAlias(false);
+        updateAlias(true);
+    }
+
+    private void updateAlias(boolean history) {
+        String suffix = history ? "_history" : "";
+        var query = String.format("select id, alias from entity%s where evm_address is null and length(alias) = 35",
+                suffix);
+        var update = String.format("update entity%s set evm_address = :evmAddress where id = :id", suffix);
+
+        jdbcOperations.query(query, rs -> {
+            long id = rs.getLong(1);
+            byte[] alias = rs.getBytes(2);
+            byte[] evmAddress = Utility.aliasToEvmAddress(alias);
+
+            if (evmAddress != null) {
+                jdbcOperations.update(update, Map.of("evmAddress", evmAddress, "id", id));
+            }
+        });
+    }
+
+    @Override
+    public String getDescription() {
+        return "Populates evm_address for accounts with an ECDSA secp256k1 alias";
+    }
+
+    @Override
+    public MigrationVersion getVersion() {
+        return MigrationVersion.fromVersion("1.58.6");
+    }
+}

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListener.java
@@ -434,6 +434,7 @@ public class SqlEntityListener implements EntityListener, RecordStreamFileListen
     private <T extends AbstractEntity> T mergeAbstractEntity(T previous, T current) {
         // Copy non-updatable fields from previous
         current.setCreatedTimestamp(previous.getCreatedTimestamp());
+        current.setEvmAddress(previous.getEvmAddress());
 
         if (current.getAutoRenewPeriod() == null) {
             current.setAutoRenewPeriod(previous.getAutoRenewPeriod());
@@ -466,7 +467,6 @@ public class SqlEntityListener implements EntityListener, RecordStreamFileListen
     private Contract mergeContract(Contract previous, Contract current) {
         mergeAbstractEntity(previous, current);
 
-        current.setEvmAddress(previous.getEvmAddress());
         current.setFileId(previous.getFileId());
         current.setInitcode(previous.getInitcode());
 
@@ -491,6 +491,10 @@ public class SqlEntityListener implements EntityListener, RecordStreamFileListen
 
         if (current.getAutoRenewAccountId() == null) {
             current.setAutoRenewAccountId(previous.getAutoRenewAccountId());
+        }
+
+        if (current.getEthereumNonce() == null) {
+            current.setEthereumNonce(previous.getEthereumNonce());
         }
 
         if (current.getMaxAutomaticTokenAssociations() == null) {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoCreateTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoCreateTransactionHandler.java
@@ -29,17 +29,18 @@ import com.hedera.mirror.common.domain.transaction.RecordItem;
 import com.hedera.mirror.common.domain.transaction.Transaction;
 import com.hedera.mirror.common.domain.transaction.TransactionType;
 import com.hedera.mirror.common.util.DomainUtils;
+import com.hedera.mirror.importer.domain.EntityIdService;
 import com.hedera.mirror.importer.parser.record.entity.EntityListener;
-import com.hedera.mirror.importer.repository.EntityRepository;
+import com.hedera.mirror.importer.util.Utility;
 
 @Named
 class CryptoCreateTransactionHandler extends AbstractEntityCrudTransactionHandler<Entity> {
 
-    private final EntityRepository entityRepository;
+    private final EntityIdService entityIdService;
 
-    CryptoCreateTransactionHandler(EntityListener entityListener, EntityRepository entityRepository) {
+    CryptoCreateTransactionHandler(EntityListener entityListener, EntityIdService entityIdService) {
         super(entityListener, TransactionType.CRYPTOCREATEACCOUNT);
-        this.entityRepository = entityRepository;
+        this.entityIdService = entityIdService;
     }
 
     @Override
@@ -59,7 +60,8 @@ class CryptoCreateTransactionHandler extends AbstractEntityCrudTransactionHandle
         if (recordItem.getRecord().getAlias() != ByteString.EMPTY) {
             var alias = DomainUtils.toBytes(recordItem.getRecord().getAlias());
             entity.setAlias(alias);
-            entityRepository.storeAlias(alias, entity.getId());
+            entity.setEvmAddress(Utility.aliasToEvmAddress(alias));
+            entityIdService.notify(entity);
         }
 
         if (transactionBody.hasAutoRenewPeriod()) {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/EntityRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/EntityRepository.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.importer.repository;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,27 +20,14 @@ package com.hedera.mirror.importer.repository;
  * ‍
  */
 
-import static com.hedera.mirror.importer.config.CacheConfiguration.CACHE_MANAGER_ALIAS;
-import static com.hedera.mirror.importer.config.CacheConfiguration.KEY_GENERATOR_ALIAS;
-
 import java.util.Optional;
-import org.springframework.cache.annotation.CacheConfig;
-import org.springframework.cache.annotation.CachePut;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 
 import com.hedera.mirror.common.domain.entity.Entity;
 
-@CacheConfig(cacheManager = CACHE_MANAGER_ALIAS, cacheNames = "entityAlias", keyGenerator = KEY_GENERATOR_ALIAS)
 public interface EntityRepository extends CrudRepository<Entity, Long> {
 
-    @Cacheable(unless = "#result == null")
     @Query(value = "select id from entity where alias = ?1 and deleted <> true", nativeQuery = true)
     Optional<Long> findByAlias(byte[] alias);
-
-    @CachePut
-    default Long storeAlias(byte[] alias, Long id) {
-        return id;
-    }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/util/Utility.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/util/Utility.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.importer.util;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,11 +23,14 @@ package com.hedera.mirror.importer.util;
 import com.google.common.collect.Iterables;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.GeneratedMessageV3;
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.TextFormat;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ContractLoginfo;
+import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TransactionID;
+import java.math.BigInteger;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -35,14 +38,62 @@ import java.time.Instant;
 import java.util.Arrays;
 import lombok.experimental.UtilityClass;
 import lombok.extern.log4j.Log4j2;
+import org.bouncycastle.asn1.x9.X9IntegerConverter;
+import org.bouncycastle.jcajce.provider.digest.Keccak;
+import org.bouncycastle.math.ec.ECCurve;
+import org.bouncycastle.math.ec.ECPoint;
+import org.bouncycastle.math.ec.custom.sec.SecP256K1Curve;
 
 import com.hedera.mirror.common.util.DomainUtils;
+import com.hedera.mirror.importer.exception.ParserException;
 
 @Log4j2
 @UtilityClass
 public class Utility {
 
     public static final Instant MAX_INSTANT_LONG = Instant.ofEpochSecond(0, Long.MAX_VALUE);
+    private static final ECCurve SECP256K1_CURVE = new SecP256K1Curve();
+    private static final X9IntegerConverter X9_CONVERTER = new X9IntegerConverter();
+
+    /**
+     * Converts an ECDSA secp256k1 alias to a 20 byte EVM address by taking the keccak hash of it. Logic copied from
+     * services' AliasManager.
+     *
+     * @param alias the bytes representing a serialized Key protobuf
+     * @return the 20 byte EVM address
+     */
+    public static byte[] aliasToEvmAddress(byte[] alias) {
+        try {
+            if (alias == null || alias.length == 0) {
+                return null;
+            }
+
+            var key = Key.parseFrom(alias);
+
+            if (key.getKeyCase() == Key.KeyCase.ECDSA_SECP256K1) {
+                var rawCompressedKey = DomainUtils.toBytes(key.getECDSASecp256K1());
+                BigInteger x = new BigInteger(rawCompressedKey, 1, 32);
+                ECPoint ecPoint = decompressKey(x, (rawCompressedKey[0] & 0x1) == 0x1);
+                byte[] uncompressedKeyDer = ecPoint.getEncoded(false);
+                byte[] uncompressedKeyRaw = new byte[64];
+                System.arraycopy(uncompressedKeyDer, 1, uncompressedKeyRaw, 0, 64);
+                byte[] hashedKey = new Keccak.Digest256().digest(uncompressedKeyRaw);
+
+                return Arrays.copyOfRange(hashedKey, 12, 32);
+            }
+
+            return null;
+        } catch (InvalidProtocolBufferException e) {
+            throw new ParserException(e);
+        }
+    }
+
+    // Decompress a compressed public key (x coordinate and low-bit of y-coordinate).
+    private static ECPoint decompressKey(BigInteger x, boolean yBit) {
+        final byte[] compEnc = X9_CONVERTER.integerToBytes(x, X9_CONVERTER.getByteLength(SECP256K1_CURVE) + 1);
+        compEnc[0] = (byte) (yBit ? 0x03 : 0x02);
+        return SECP256K1_CURVE.decodePoint(compEnc);
+    }
 
     /**
      * @return Timestamp from an instant
@@ -103,7 +154,7 @@ public class Utility {
         }
         return Arrays.copyOfRange(topic, firstNonZero, topic.length);
     }
-    
+
     /**
      * Generates a TransactionID object
      *

--- a/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.58.5__ethereum_nonce.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.58.5__ethereum_nonce.sql
@@ -1,0 +1,7 @@
+alter table if exists entity
+    add column if not exists ethereum_nonce bigint null,
+    add column if not exists evm_address bytea null;
+
+alter table if exists entity_history
+    add column if not exists ethereum_nonce bigint null,
+    add column if not exists evm_address bytea null;

--- a/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.0__create_tables.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.0__create_tables.sql
@@ -212,6 +212,8 @@ create table if not exists entity
     auto_renew_period                bigint            null,
     created_timestamp                bigint            null,
     deleted                          boolean           null,
+    ethereum_nonce                   bigint            null,
+    evm_address                      bytea             null,
     expiration_timestamp             bigint            null,
     id                               bigint            not null,
     key                              bytea             null,

--- a/hedera-mirror-importer/src/main/resources/db/scripts/v2/csvRestoreTables.sql
+++ b/hedera-mirror-importer/src/main/resources/db/scripts/v2/csvRestoreTables.sql
@@ -32,9 +32,9 @@
 
 \copy custom_fee (amount, amount_denominator, collector_account_id, created_timestamp, denominating_token_id, maximum_amount, minimum_amount, token_id) from custom_fee.csv csv;
 
-\copy entity (alias, auto_renew_account_id, auto_renew_period, created_timestamp, deleted, expiration_timestamp, id, key, memo, num, public_key, proxy_account_id, realm, shard, submit_key, type, receiver_sig_required, max_automatic_token_associations, timestamp_range) from entity.csv csv;
+\copy entity (alias, auto_renew_account_id, auto_renew_period, created_timestamp, deleted, expiration_timestamp, id, key, memo, num, public_key, proxy_account_id, realm, shard, submit_key, type, receiver_sig_required, max_automatic_token_associations, timestamp_range, ethereum_nonce, evm_address) from entity.csv csv;
 
-\copy entity_history (alias, auto_renew_account_id, auto_renew_period, created_timestamp, deleted, expiration_timestamp, id, key, memo, num, public_key, proxy_account_id, realm, shard, submit_key, type, receiver_sig_required, max_automatic_token_associations, timestamp_range) from entity_history.csv csv;
+\copy entity_history (alias, auto_renew_account_id, auto_renew_period, created_timestamp, deleted, expiration_timestamp, id, key, memo, num, public_key, proxy_account_id, realm, shard, submit_key, type, receiver_sig_required, max_automatic_token_associations, timestamp_range, ethereum_nonce, evm_address) from entity_history.csv csv;
 
 \copy ethereum_transaction (access_list, call_data_id, call_data, chain_id, consensus_timestamp, data, from_address, gas_limit, gas_price, hash, max_fee_per_gas, max_gas_allowance, max_priority_fee_per_gas, nonce, payer_account_id, recovery_id, signature_r, signature_s, signature_v, to_address, type, value) from ethereum_transaction.csv csv;
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/ContractResultServiceImplIntegrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/ContractResultServiceImplIntegrationTest.java
@@ -58,6 +58,7 @@ import com.hedera.mirror.importer.repository.ContractStateChangeRepository;
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
 class ContractResultServiceImplIntegrationTest extends IntegrationTest {
     private static final ContractID CONTRACT_ID = ContractID.newBuilder().setContractNum(901).build();
+
     private final ContractLogRepository contractLogRepository;
     private final ContractResultRepository contractResultRepository;
     private final ContractResultService contractResultService;
@@ -131,7 +132,7 @@ class ContractResultServiceImplIntegrationTest extends IntegrationTest {
     @Test
     void contractResultZeroStateChanges() {
         RecordItem recordItem = recordItemBuilder.contractCreate().record(x -> x
-                .setContractCreateResult(recordItemBuilder.contractFunctionResult(CONTRACT_ID).clearStateChanges()))
+                        .setContractCreateResult(recordItemBuilder.contractFunctionResult(CONTRACT_ID).clearStateChanges()))
                 .receipt(r -> r.setContractID(CONTRACT_ID))
                 .build();
         ContractFunctionResult contractFunctionResult = recordItem.getRecord().getContractCreateResult();
@@ -260,9 +261,9 @@ class ContractResultServiceImplIntegrationTest extends IntegrationTest {
             String filename = StreamFilename.getFilename(StreamType.RECORD, DATA, instant);
             long consensusStart = recordItem.getConsensusTimestamp();
             RecordFile recordFile = domainBuilder.recordFile().customize(x -> x
-                    .consensusStart(consensusStart)
-                    .consensusEnd(consensusStart + 1)
-                    .name(filename))
+                            .consensusStart(consensusStart)
+                            .consensusEnd(consensusStart + 1)
+                            .name(filename))
                     .get();
 
             recordStreamFileListener.onStart();

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/AccountEvmAddressMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/AccountEvmAddressMigrationTest.java
@@ -1,0 +1,109 @@
+package com.hedera.mirror.importer.migration;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import static com.hedera.mirror.importer.util.UtilityTest.EVM_ADDRESS;
+import static com.hedera.mirror.importer.util.UtilityTest.ALIAS_ECDSA_SECP256K1;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import lombok.RequiredArgsConstructor;
+import org.bouncycastle.util.encoders.Hex;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcOperations;
+import org.springframework.test.context.TestPropertySource;
+
+import com.hedera.mirror.importer.EnabledIfV1;
+import com.hedera.mirror.importer.IntegrationTest;
+
+@EnabledIfV1
+@RequiredArgsConstructor(onConstructor = @__(@Autowired))
+@Tag("migration")
+@TestPropertySource(properties = "spring.flyway.target=1.58.5")
+class AccountEvmAddressMigrationTest extends IntegrationTest {
+
+    private final JdbcOperations jdbcOperations;
+    private final AccountEvmAddressMigration migration;
+
+    @Test
+    void noAliases() throws Exception {
+        insertEntity(1L, null, null);
+        migration.doMigrate();
+        assertThat(findEvmAddress(1L)).isNull();
+    }
+
+    @Test
+    void evmAddressAlreadySet() throws Exception {
+        insertEntity(1L, ALIAS_ECDSA_SECP256K1, EVM_ADDRESS);
+        migration.doMigrate();
+        assertThat(findEvmAddress(1L)).isEqualTo(EVM_ADDRESS);
+    }
+
+    @Test
+    void aliasEd25519() throws Exception {
+        byte[] aliasEd25519 = Hex.decode("1220000038746a20d630ceb81a24bd43798159108ec144e185c1c60a5e39fb933e2a");
+        insertEntity(1L, aliasEd25519, null);
+        migration.doMigrate();
+        assertThat(findEvmAddress(1L)).isNull();
+    }
+
+    @Test
+    void evmAddressSet() throws Exception {
+        insertEntity(1L, ALIAS_ECDSA_SECP256K1, null);
+        insertEntity(2L, ALIAS_ECDSA_SECP256K1, null);
+        migration.doMigrate();
+        assertThat(findEvmAddress(1L)).isEqualTo(EVM_ADDRESS);
+        assertThat(findEvmAddress(2L)).isEqualTo(EVM_ADDRESS);
+    }
+
+    @Test
+    void history() throws Exception {
+        insertEntityHistory(1L, ALIAS_ECDSA_SECP256K1, null);
+        insertEntityHistory(2L, ALIAS_ECDSA_SECP256K1, EVM_ADDRESS);
+        migration.doMigrate();
+        assertThat(findHistoryEvmAddress(1L)).isEqualTo(EVM_ADDRESS);
+        assertThat(findHistoryEvmAddress(2L)).isEqualTo(EVM_ADDRESS);
+    }
+
+    private byte[] findEvmAddress(long id) {
+        return jdbcOperations.queryForObject("select evm_address from entity where id = ?", byte[].class, id);
+    }
+
+    private byte[] findHistoryEvmAddress(long id) {
+        return jdbcOperations.queryForObject("select evm_address from entity_history where id = ?", byte[].class, id);
+    }
+
+    private void insertEntity(long id, byte[] alias, byte[] evmAddress) {
+        doInsertEntity(false, id, alias, evmAddress);
+    }
+
+    private void insertEntityHistory(long id, byte[] alias, byte[] evmAddress) {
+        doInsertEntity(true, id, alias, evmAddress);
+    }
+
+    private void doInsertEntity(boolean history, long id, byte[] alias, byte[] evmAddress) {
+        String suffix = history ? "_history" : "";
+        String sql = String.format("insert into entity%s (alias, created_timestamp, evm_address, id, num, realm, " +
+                "shard, timestamp_range, type) values (?,1,?,?,?,0,0,'[1,)','ACCOUNT')", suffix);
+        jdbcOperations.update(sql, alias, evmAddress, id, id);
+    }
+}

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/MissingEvmAddressMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/MissingEvmAddressMigrationTest.java
@@ -125,7 +125,7 @@ class MissingEvmAddressMigrationTest extends IntegrationTest {
         var createdTimestamp = timestamp.getAndIncrement();
         return MigrationContract.builder()
                 .createdTimestamp(createdTimestamp)
-                .evmAddress(domainBuilder.create2EvmAddress())
+                .evmAddress(domainBuilder.evmAddress())
                 .id(contractId)
                 .num(contractId)
                 .timestampRange(Range.atLeast(createdTimestamp))
@@ -164,14 +164,16 @@ class MissingEvmAddressMigrationTest extends IntegrationTest {
             contract.setEvmAddress(null);
         }
 
-        var lower = contract.getTimestampUpper() == null ? contract.getCreatedTimestamp() : contract.getTimestampUpper();
+        var lower = contract.getTimestampUpper() == null ? contract.getCreatedTimestamp() :
+                contract.getTimestampUpper();
         contract.setTimestampRange(Range.atLeast(lower));
 
         persistContract(contract);
         return contract;
     }
 
-    private MigrationContract persistHistoricalContract(MigrationContract contract, boolean clearEvmAddress, long validDuration) {
+    private MigrationContract persistHistoricalContract(MigrationContract contract, boolean clearEvmAddress,
+                                                        long validDuration) {
         contract = clone(contract);
         if (clearEvmAddress) {
             contract.setEvmAddress(null);

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/domain/RecordItemBuilder.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/domain/RecordItemBuilder.java
@@ -42,6 +42,7 @@ import com.hederahashgraph.api.proto.java.ContractStateChange;
 import com.hederahashgraph.api.proto.java.ContractUpdateTransactionBody;
 import com.hederahashgraph.api.proto.java.CryptoAllowance;
 import com.hederahashgraph.api.proto.java.CryptoApproveAllowanceTransactionBody;
+import com.hederahashgraph.api.proto.java.CryptoCreateTransactionBody;
 import com.hederahashgraph.api.proto.java.CryptoDeleteAllowanceTransactionBody;
 import com.hederahashgraph.api.proto.java.CryptoTransferTransactionBody;
 import com.hederahashgraph.api.proto.java.Duration;
@@ -248,6 +249,20 @@ public class RecordItemBuilder {
                 .addNftAllowances(builder.getNftAllowances(0))
                 .addNftAllowances(builder.getNftAllowances(2).toBuilder().setApprovedForAll(BoolValue.of(false)));
         return new Builder<>(TransactionType.CRYPTOAPPROVEALLOWANCE, builder);
+    }
+
+    public Builder<CryptoCreateTransactionBody.Builder> cryptoCreate() {
+        var builder = CryptoCreateTransactionBody.newBuilder()
+                .setAutoRenewPeriod(duration(30))
+                .setInitialBalance(1000L)
+                .setKey(key())
+                .setMaxAutomaticTokenAssociations(2)
+                .setMemo(text(16))
+                .setProxyAccountID(accountId())
+                .setRealmID(REALM_ID)
+                .setReceiverSigRequired(false)
+                .setShardID(SHARD_ID);
+        return new Builder<>(TransactionType.CRYPTOCREATEACCOUNT, builder);
     }
 
     public Builder<CryptoDeleteAllowanceTransactionBody.Builder> cryptoDeleteAllowance() {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/AbstractEntityRecordItemListenerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/AbstractEntityRecordItemListenerTest.java
@@ -472,7 +472,7 @@ public abstract class AbstractEntityRecordItemListenerTest extends IntegrationTe
         builder.addCreatedContractIDs(CONTRACT_ID);
         builder.addCreatedContractIDs(CREATED_CONTRACT_ID);
         builder.setErrorMessage("call error message");
-        builder.setEvmAddress(BytesValue.of(DomainUtils.fromBytes(domainBuilder.create2EvmAddress())));
+        builder.setEvmAddress(BytesValue.of(DomainUtils.fromBytes(domainBuilder.evmAddress())));
         builder.setFunctionParameters(ByteString.copyFromUtf8("function parameters"));
         builder.setGas(20);
         builder.setGasUsed(30);

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerContractTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerContractTest.java
@@ -131,7 +131,7 @@ class EntityRecordItemListenerContractTest extends AbstractEntityRecordItemListe
     @Test
     void contractCreateWithEvmAddress() {
         // no child tx, creates a single contract with evm address set
-        byte[] evmAddress = domainBuilder.create2EvmAddress();
+        byte[] evmAddress = domainBuilder.evmAddress();
         RecordItem recordItem = recordItemBuilder.contractCreate(CONTRACT_ID)
                 .record(r -> r.setContractCreateResult(r.getContractCreateResultBuilder()
                         .clearCreatedContractIDs()
@@ -160,7 +160,7 @@ class EntityRecordItemListenerContractTest extends AbstractEntityRecordItemListe
     @Test
     void contractCreateWithEvmAddressAndChildCreate() {
         // given contractCreate with child contractCreate
-        var parentEvmAddress = domainBuilder.create2EvmAddress();
+        var parentEvmAddress = domainBuilder.evmAddress();
         var parentRecordItem = recordItemBuilder.contractCreate()
                 .record(r -> r.setContractCreateResult(r.getContractCreateResultBuilder()
                         .clearStateChanges()
@@ -173,7 +173,7 @@ class EntityRecordItemListenerContractTest extends AbstractEntityRecordItemListe
         var childContractId = contractCreateResult.getCreatedContractIDsList().stream()
                 .filter(c -> !c.equals(contractCreateResult.getContractID()))
                 .findFirst().get();
-        var childEvmAddress = domainBuilder.create2EvmAddress();
+        var childEvmAddress = domainBuilder.evmAddress();
         var childConsensusTimestamp = TestUtils.toTimestamp(parentRecordItem.getConsensusTimestamp() + 1);
         var childTransactionId = parentRecordItem.getRecord().getTransactionID().toBuilder().setNonce(1);
         var childRecordItem = recordItemBuilder.contractCreate(childContractId)
@@ -557,7 +557,7 @@ class EntityRecordItemListenerContractTest extends AbstractEntityRecordItemListe
                 .hapiVersion(HAPI_VERSION_0_23_0)
                 .build();
 
-        var childEvmAddress = domainBuilder.create2EvmAddress();
+        var childEvmAddress = domainBuilder.evmAddress();
         var record = parentRecordItem.getRecord();
         var childConsensusTimestamp = TestUtils.toTimestamp(parentRecordItem.getConsensusTimestamp() + 1);
         var childContractId = record.getContractCallResult().getCreatedContractIDs(0);
@@ -1138,7 +1138,7 @@ class EntityRecordItemListenerContractTest extends AbstractEntityRecordItemListe
             case PARSABLE_EVM:
                 return DomainUtils.toEvmAddress(contractId);
             case CREATE2_EVM:
-                return domainBuilder.create2EvmAddress();
+                return domainBuilder.evmAddress();
             default:
                 return null;
         }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerCryptoTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerCryptoTest.java
@@ -29,6 +29,9 @@ import com.google.protobuf.BoolValue;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Int32Value;
 import com.google.protobuf.StringValue;
+
+import com.hedera.mirror.importer.util.UtilityTest;
+
 import com.hederahashgraph.api.proto.java.AccountAmount;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.CryptoAddLiveHashTransactionBody;
@@ -95,8 +98,7 @@ class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItemListene
     private static final AccountID accountId1 = AccountID.newBuilder().setAccountNum(1001).build();
     private static final long[] additionalTransfers = {5000};
     private static final long[] additionalTransferAmounts = {1001, 1002};
-    private static final ByteString ALIAS_KEY = ByteString.copyFromUtf8(
-            "0a2212200aa8e21064c61eab86e2a9c164565b4e7a9a4146106e0a6cd03a8c395a110fff");
+    private static final ByteString ALIAS_KEY = DomainUtils.fromBytes(UtilityTest.ALIAS_ECDSA_SECP256K1);
 
     @Resource
     private ContractRepository contractRepository;

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListenerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListenerTest.java
@@ -193,7 +193,7 @@ class SqlEntityListenerTest extends IntegrationTest {
         // given
         Contract contract1 = domainBuilder.contract().get();
         Contract contract2 = domainBuilder.contract()
-                .customize(c -> c.evmAddress(null).fileId(null).initcode(domainBuilder.bytes(1024)))
+                .customize(c -> c.fileId(null).initcode(domainBuilder.bytes(1024)).evmAddress(null))
                 .get();
 
         // when

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractCallTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractCallTransactionHandlerTest.java
@@ -34,11 +34,8 @@ import com.hedera.mirror.common.domain.contract.ContractResult;
 import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.entity.EntityType;
 import com.hedera.mirror.common.util.DomainUtils;
-import com.hedera.mirror.importer.parser.record.entity.EntityProperties;
 
 class ContractCallTransactionHandlerTest extends AbstractTransactionHandlerTest {
-
-    private final EntityProperties entityProperties = new EntityProperties();
 
     @BeforeEach
     void beforeEach() {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoCreateTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoCreateTransactionHandlerTest.java
@@ -20,6 +20,9 @@ package com.hedera.mirror.importer.parser.record.transactionhandler;
  * ‍
  */
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Message;
 import com.hederahashgraph.api.proto.java.AccountID;
@@ -28,15 +31,22 @@ import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionReceipt;
 import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import com.hedera.mirror.common.domain.entity.AbstractEntity;
+import com.hedera.mirror.common.domain.entity.Entity;
+import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.entity.EntityType;
+import com.hedera.mirror.common.domain.transaction.Transaction;
+import com.hedera.mirror.common.util.DomainUtils;
+import com.hedera.mirror.importer.util.UtilityTest;
 
 class CryptoCreateTransactionHandlerTest extends AbstractTransactionHandlerTest {
 
     @Override
     protected TransactionHandler getTransactionHandler() {
-        return new CryptoCreateTransactionHandler(entityListener, entityRepository);
+        return new CryptoCreateTransactionHandler(entityListener, entityIdService);
     }
 
     @Override
@@ -85,5 +95,22 @@ class CryptoCreateTransactionHandlerTest extends AbstractTransactionHandlerTest 
         );
 
         return testSpecs;
+    }
+
+    @Test
+    void updateAlias() {
+        var alias = UtilityTest.ALIAS_ECDSA_SECP256K1;
+        var recordItem = recordItemBuilder.cryptoCreate().record(r -> r.setAlias(DomainUtils.fromBytes(alias))).build();
+        var transaction = new Transaction();
+        transaction.setEntityId(EntityId.of(0L, 0L, 100L, EntityType.ACCOUNT));
+
+        transactionHandler.updateTransaction(transaction, recordItem);
+
+        ArgumentCaptor<Entity> captor = ArgumentCaptor.forClass(Entity.class);
+        verify(entityIdService).notify(captor.capture());
+        assertThat(captor.getValue())
+                .isNotNull()
+                .returns(alias, Entity::getAlias)
+                .returns(UtilityTest.EVM_ADDRESS, Entity::getEvmAddress);
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/EntityRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/EntityRepositoryTest.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.importer.repository;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,7 +24,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.protobuf.ByteString;
 import com.hederahashgraph.api.proto.java.Key;
-import java.util.Arrays;
 import java.util.List;
 import javax.annotation.Resource;
 import org.junit.jupiter.api.Test;
@@ -102,30 +101,9 @@ class EntityRepositoryTest extends AbstractRepositoryTest {
 
     @Test
     void findByAlias() {
-        Entity entity = domainBuilder.entity().get();
+        Entity entity = domainBuilder.entity().persist();
         byte[] alias = entity.getAlias();
 
-        // Cache and DB return nothing on empty table
-        assertThat(entityRepository.findByAlias(alias)).isNotPresent();
-
-        // DB state is reflected in cache
-        entityRepository.save(entity);
-        assertThat(entityRepository.findByAlias(alias)).get().isEqualTo(entity.getId());
-
-        // Cache returns ID after DB is cleared
-        entityRepository.deleteAll();
-        assertThat(entityRepository.findByAlias(alias)).get().isEqualTo(entity.getId());
-
-        // A new byte[] with the same data retrieves the same value from the cache
-        byte[] aliasCopy = Arrays.copyOf(alias, alias.length);
-        assertThat(entityRepository.findByAlias(aliasCopy)).get().isEqualTo(entity.getId());
-    }
-
-    @Test
-    void storeAlias() {
-        Entity entity = domainBuilder.entity().get();
-        byte[] alias = entity.getAlias();
-        entityRepository.storeAlias(alias, entity.getId());
         assertThat(entityRepository.findByAlias(alias)).get().isEqualTo(entity.getId());
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/UpsertQueryGeneratorFactoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/UpsertQueryGeneratorFactoryTest.java
@@ -85,15 +85,15 @@ class UpsertQueryGeneratorFactoryTest extends IntegrationTest {
 
     @Test
     void entity() {
-        String allColumns = "alias,auto_renew_account_id,auto_renew_period,created_timestamp,deleted," +
-                "expiration_timestamp,id,key,max_automatic_token_associations,memo,num,proxy_account_id,public_key," +
-                "realm,receiver_sig_required,shard,submit_key,timestamp_range,type";
-        String nullableColumns = "alias,auto_renew_account_id,auto_renew_period,created_timestamp,deleted," +
-                "expiration_timestamp,key,max_automatic_token_associations,proxy_account_id,public_key," +
+        String allColumns = "alias,auto_renew_account_id,auto_renew_period,created_timestamp,deleted,ethereum_nonce," +
+                "evm_address,expiration_timestamp,id,key,max_automatic_token_associations,memo,num,proxy_account_id," +
+                "public_key,realm,receiver_sig_required,shard,submit_key,timestamp_range,type";
+        String nullableColumns = "alias,auto_renew_account_id,auto_renew_period,created_timestamp,deleted,ethereum_nonce," +
+                "evm_address,expiration_timestamp,key,max_automatic_token_associations,proxy_account_id,public_key," +
                 "receiver_sig_required,submit_key";
-        String updatableColumns = "auto_renew_account_id,auto_renew_period,deleted,expiration_timestamp,key," +
-                "max_automatic_token_associations,memo,proxy_account_id,public_key,receiver_sig_required,submit_key," +
-                "timestamp_range";
+        String updatableColumns = "auto_renew_account_id,auto_renew_period,deleted,ethereum_nonce,expiration_timestamp," +
+                "key,max_automatic_token_associations,memo,proxy_account_id,public_key,receiver_sig_required," +
+                "submit_key,timestamp_range";
 
         assertThat(factory.createEntity(Entity.class))
                 .isNotNull()
@@ -105,7 +105,7 @@ class UpsertQueryGeneratorFactoryTest extends IntegrationTest {
                 .returns(nullableColumns, e -> e.columns(UpsertColumn::isNullable, "{0}"))
                 .returns(updatableColumns, e -> e.columns(UpsertColumn::isUpdatable, "{0}"))
                 .extracting(UpsertEntity::getColumns, InstanceOfAssertFactories.ITERABLE)
-                .hasSize(19);
+                .hasSize(21);
     }
 
     @Test

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/util/UtilityTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/util/UtilityTest.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.importer.util;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,20 +21,42 @@ package com.hedera.mirror.importer.util;
  */
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ContractLoginfo;
+import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TransactionID;
 import java.time.Instant;
+import org.bouncycastle.util.encoders.Hex;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
-class UtilityTest {
+import com.hedera.mirror.importer.exception.ParserException;
+
+public class UtilityTest {
+
+    public static final byte[] ALIAS_ECDSA_SECP256K1 = Hex.decode(
+            "3a21033a514176466fa815ed481ffad09110a2d344f6c9b78c1d14afc351c3a51be33d");
+    public static final byte[] EVM_ADDRESS = Hex.decode("a94f5374fce5edbc8e2a8697c15331677e6ebf0b");
+
+    @Test
+    void aliasToEvmAddress() {
+        byte[] aliasEd25519 = Key.newBuilder().setEd25519(ByteString.copyFromUtf8("ab")).build().toByteArray();
+        assertThat(Utility.aliasToEvmAddress(ALIAS_ECDSA_SECP256K1)).isEqualTo(EVM_ADDRESS);
+        assertThat(Utility.aliasToEvmAddress(aliasEd25519)).isNull();
+        assertThat(Utility.aliasToEvmAddress(null)).isNull();
+        assertThat(Utility.aliasToEvmAddress(new byte[] {})).isNull();
+        assertThatThrownBy(() -> Utility.aliasToEvmAddress(Hex.decode("ab")))
+                .isInstanceOf(ParserException.class)
+                .hasRootCauseExactlyInstanceOf(InvalidProtocolBufferException.class);
+    }
 
     @Test
     void getTopic() {
@@ -88,4 +110,3 @@ class UtilityTest {
         );
     }
 }
-


### PR DESCRIPTION
**Description**:
* Add `ethereum_nonce` to `entity` and `entity_history`
* Add `evm_address` to `entity` and `entity_history`
* Populate EVM address on account creation if alias is an ECDSA secp256k1 key
* Backfill EVM address for existing accounts with ECDSA alias
* Remove extra layer of caching in `EntityIdService`

**Related issue(s)**:

Fixes #3592 

**Notes for reviewer**:
Logic to update ethereum nonce up to date on the account will be added in the next sprint.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
