### PR TITLE
Drop from_address in ethereum_transaction

### DIFF
--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/EthereumTransaction.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/EthereumTransaction.java
@@ -61,9 +61,6 @@ public class EthereumTransaction implements Persistable<Long> {
     @ToString.Exclude
     private byte[] data;
 
-    @ToString.Exclude
-    private byte[] fromAddress;
-
     // persisted in tinybar
     private Long gasLimit;
 

--- a/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/DomainBuilder.java
+++ b/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/DomainBuilder.java
@@ -314,7 +314,6 @@ public class DomainBuilder {
                 .chainId(bytes(1))
                 .consensusTimestamp(timestamp())
                 .data(bytes(100))
-                .fromAddress(bytes(20))
                 .gasLimit(Long.MAX_VALUE)
                 .gasPrice(bytes(32))
                 .hash(bytes(32))

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/EthereumTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/EthereumTransactionHandler.java
@@ -98,7 +98,6 @@ class EthereumTransactionHandler implements TransactionHandler {
         var transactionRecord = recordItem.getRecord();
         ethereumTransaction.setConsensusTimestamp(recordItem.getConsensusTimestamp());
         ethereumTransaction.setData(ethereumDataBytes);
-        ethereumTransaction.setFromAddress(DomainUtils.toEvmAddress(senderId));
         ethereumTransaction.setHash(DomainUtils.toBytes(transactionRecord.getEthereumHash()));
         ethereumTransaction.setMaxGasAllowance(body.getMaxGasAllowance());
         ethereumTransaction.setPayerAccountId(recordItem.getPayerAccountId());

--- a/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.59.0__ethereum_drop_sender.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.59.0__ethereum_drop_sender.sql
@@ -1,0 +1,6 @@
+-------------------
+-- Drop ethereum_transaction.from_address as sender can be null and duplicates contract_result.seder_id
+-------------------
+
+alter table if exists ethereum_transaction
+    drop column if exists from_address;

--- a/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.59.0__ethereum_drop_sender.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.59.0__ethereum_drop_sender.sql
@@ -1,5 +1,5 @@
 -------------------
--- Drop ethereum_transaction.from_address as sender can be null and duplicates contract_result.seder_id
+-- Drop ethereum_transaction.from_address as sender can be null and duplicates contract_result.sender_id
 -------------------
 
 alter table if exists ethereum_transaction

--- a/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.0__create_tables.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.0__create_tables.sql
@@ -247,7 +247,6 @@ create table if not exists ethereum_transaction
     chain_id                 bytea    null,
     consensus_timestamp      bigint   not null,
     data                     bytea    not null,
-    from_address             bytea    not null,
     gas_limit                bigint   not null,
     gas_price                bytea    null,
     hash                     bytea    not null,


### PR DESCRIPTION
Signed-off-by: Nana-EC <nana@swirldslabs.com>

**Description**:
`EthereumTransaction.Record.ContractFunctionResults.SenderId` can be null on failure cases.
We take this into account for `contract_result` but assumed a valid account for `ethereum_transaction`
Since this duplicates `contract_result.sender_id` we can drop the file and remove it from parsing logic

- Remove `from_address` from `EthereumTransaction` table and domain
- Update `EthereumTransactionHandler` to remove `fromAddress` set
- Update `DomainBuilder`

**Related issue(s)**:

Fixes #3728 

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
