### PR TITLE
03591 add new fields to schedules

### DIFF
--- a/hedera-mirror-rest/__tests__/integrationDomainOps.js
+++ b/hedera-mirror-rest/__tests__/integrationDomainOps.js
@@ -945,6 +945,7 @@ const addSchedule = async (schedule) => {
     creator_account_id: '0.0.1024',
     payer_account_id: '0.0.1024',
     transaction_body: Buffer.from([1, 1, 2, 2, 3, 3]),
+    wait_for_expiry: false,
     ...schedule,
   };
 
@@ -954,8 +955,10 @@ const addSchedule = async (schedule) => {
                            executed_timestamp,
                            payer_account_id,
                            schedule_id,
-                           transaction_body)
-     VALUES ($1, $2, $3, $4, $5, $6)`,
+                           transaction_body,
+                           expiration_time,
+                           wait_for_expiry)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
     [
       schedule.consensus_timestamp,
       EntityId.parse(schedule.creator_account_id).getEncodedId().toString(),
@@ -963,6 +966,8 @@ const addSchedule = async (schedule) => {
       EntityId.parse(schedule.payer_account_id).getEncodedId().toString(),
       EntityId.parse(schedule.schedule_id).getEncodedId().toString(),
       schedule.transaction_body,
+      schedule.expiration_time,
+      schedule.wait_for_expiry,
     ]
   );
 };

--- a/hedera-mirror-rest/__tests__/schedules.test.js
+++ b/hedera-mirror-rest/__tests__/schedules.test.js
@@ -35,6 +35,7 @@ describe('schedule formatScheduleRow tests', () => {
     consensus_timestamp: '1234567890000000001',
     creator_account_id: '100',
     deleted: false,
+    expiration_time: '1234567890.000000000',
     executed_timestamp: '1234567890000000002',
     memo: 'Created per council decision dated 1/21/21',
     payer_account_id: '101',
@@ -54,6 +55,7 @@ describe('schedule formatScheduleRow tests', () => {
       },
     ],
     transaction_body: Buffer.from([0x29, 0xde, 0xad, 0xbe, 0xef]),
+    wait_for_expiry: true,
   };
   const defaultExpected = {
     admin_key: {
@@ -63,6 +65,7 @@ describe('schedule formatScheduleRow tests', () => {
     consensus_timestamp: '1234567890.000000001',
     creator_account_id: '0.0.100',
     deleted: false,
+    expiration_time: '1234567890.000000000',
     executed_timestamp: '1234567890.000000002',
     memo: 'Created per council decision dated 1/21/21',
     payer_account_id: '0.0.101',
@@ -82,6 +85,7 @@ describe('schedule formatScheduleRow tests', () => {
       },
     ],
     transaction_body: 'Kd6tvu8=',
+    wait_for_expiry: true,
   };
 
   const testSpecs = [

--- a/hedera-mirror-rest/__tests__/specs/schedules-01-specific-id.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/schedules-01-specific-id.spec.json
@@ -18,10 +18,12 @@
     "schedules": [
       {
         "consensus_timestamp": "1234567890000000001",
+        "expiration_time": "1234567890000000099",
         "creator_account_id": "0.0.1024",
         "executed_timestamp": "1234567890000000100",
         "payer_account_id": "0.0.1024",
-        "schedule_id": "0.0.2000"
+        "schedule_id": "0.0.2000",
+        "wait_for_expiry": true
       }
     ],
     "transactionsignatures": [
@@ -51,6 +53,7 @@
     "consensus_timestamp": "1234567890.000000001",
     "creator_account_id": "0.0.1024",
     "deleted": false,
+    "expiration_time": "1234567890000000099",
     "executed_timestamp": "1234567890.000000100",
     "memo": "Created per council decision dated 02/01/21",
     "payer_account_id": "0.0.1024",
@@ -69,6 +72,7 @@
         "type": "ED25519"
       }
     ],
-    "transaction_body": "AQECAgMD"
+    "transaction_body": "AQECAgMD",
+    "wait_for_expiry": true
   }
 }

--- a/hedera-mirror-rest/__tests__/specs/schedules-02-specific-schedule-number-not-executed-yet.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/schedules-02-specific-schedule-number-not-executed-yet.spec.json
@@ -45,6 +45,7 @@
     "consensus_timestamp": "1234567890.000000001",
     "creator_account_id": "0.0.1024",
     "deleted": false,
+    "expiration_time": null,
     "executed_timestamp": null,
     "memo": "Created per council decision dated 02/01/21",
     "payer_account_id": "0.0.1024",
@@ -63,6 +64,7 @@
         "type": "ED25519"
       }
     ],
-    "transaction_body": "AQECAgMD"
+    "transaction_body": "AQECAgMD",
+    "wait_for_expiry": false
   }
 }

--- a/hedera-mirror-rest/__tests__/specs/schedules-06-specific-id-no-signatures.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/schedules-06-specific-id-no-signatures.spec.json
@@ -19,9 +19,11 @@
       {
         "consensus_timestamp": "1234567890000000001",
         "creator_account_id": "0.0.1024",
+        "expiration_time": "1234567890000000002",
         "executed_timestamp": "1234567890000000100",
         "payer_account_id": "0.0.1024",
-        "schedule_id": "0.0.2000"
+        "schedule_id": "0.0.2000",
+        "wait_for_expiry": true
       }
     ]
   },
@@ -35,11 +37,13 @@
     "consensus_timestamp": "1234567890.000000001",
     "creator_account_id": "0.0.1024",
     "deleted": false,
+    "expiration_time": "1234567890000000002",
     "executed_timestamp": "1234567890.000000100",
     "memo": "Created per council decision dated 02/01/21",
     "payer_account_id": "0.0.1024",
     "schedule_id": "0.0.2000",
     "signatures": [],
-    "transaction_body": "AQECAgMD"
+    "transaction_body": "AQECAgMD",
+    "wait_for_expiry": true
   }
 }

--- a/hedera-mirror-rest/__tests__/specs/schedules-07-no-args.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/schedules-07-no-args.spec.json
@@ -33,9 +33,11 @@
       {
         "consensus_timestamp": "1234567890000010001",
         "creator_account_id": "0.0.1024",
+        "expiration_time": "1234567890000001000",
         "executed_timestamp": "1234567890000001100",
         "payer_account_id": "0.0.1024",
-        "schedule_id": "0.0.2000"
+        "schedule_id": "0.0.2000",
+        "wait_for_expiry": true
       },
       {
         "consensus_timestamp": "1234567890000020002",
@@ -102,6 +104,8 @@
         "consensus_timestamp": "1234567890.000010001",
         "creator_account_id": "0.0.1024",
         "deleted": false,
+        "creator_account_id": "0.0.1024",
+        "expiration_time": "1234567890000001000",
         "executed_timestamp": "1234567890.000001100",
         "memo": "Created per council decision dated 02/01/21",
         "payer_account_id": "0.0.1024",
@@ -120,7 +124,8 @@
             "type": "ECDSA_SECP256K1"
           }
         ],
-        "transaction_body": "AQECAgMD"
+        "transaction_body": "AQECAgMD",
+        "wait_for_expiry": true
       },
       {
         "admin_key": {
@@ -130,6 +135,7 @@
         "consensus_timestamp": "1234567890.000020002",
         "creator_account_id": "0.0.1024",
         "deleted": false,
+        "expiration_time": null,
         "executed_timestamp": "1234767890.000002102",
         "memo": "Created per mirror team decision dated 02/02/21",
         "payer_account_id": "0.0.1024",
@@ -148,7 +154,8 @@
             "type": "ECDSA_SECP256K1"
           }
         ],
-        "transaction_body": "AQECAgMD"
+        "transaction_body": "AQECAgMD",
+        "wait_for_expiry": false
       },
       {
         "admin_key": {
@@ -158,6 +165,7 @@
         "consensus_timestamp": "1234567890.000030003",
         "creator_account_id": "0.0.1024",
         "deleted": false,
+        "expiration_time": null,
         "executed_timestamp": "1234967890.000003103",
         "memo": "Created per product team decision dated 02/03/21",
         "payer_account_id": "0.0.1024",
@@ -170,7 +178,8 @@
             "type": "ECDSA_SECP256K1"
           }
         ],
-        "transaction_body": "AQECAgMD"
+        "transaction_body": "AQECAgMD",
+        "wait_for_expiry": false
       }
     ],
     "links": {

--- a/hedera-mirror-rest/__tests__/specs/schedules-08-order-desc.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/schedules-08-order-desc.spec.json
@@ -116,12 +116,14 @@
         "consensus_timestamp": "1234567890.000030004",
         "creator_account_id": "0.0.1024",
         "deleted": true,
+        "expiration_time": null,
         "executed_timestamp": null,
         "memo": "Created per product team decision dated 02/03/21",
         "payer_account_id": "0.0.1024",
         "schedule_id": "0.0.4001",
         "signatures": [],
-        "transaction_body": "AQECAgMD"
+        "transaction_body": "AQECAgMD",
+        "wait_for_expiry": false
       },
       {
         "admin_key": {
@@ -131,6 +133,7 @@
         "consensus_timestamp": "1234567890.000030003",
         "creator_account_id": "0.0.1024",
         "deleted": false,
+        "expiration_time": null,
         "executed_timestamp": "1234967890.000003103",
         "memo": "Created per product team decision dated 02/03/21",
         "payer_account_id": "0.0.1024",
@@ -143,7 +146,8 @@
             "type": "ED25519"
           }
         ],
-        "transaction_body": "AQECAgMD"
+        "transaction_body": "AQECAgMD",
+        "wait_for_expiry": false
       },
       {
         "admin_key": {
@@ -153,6 +157,7 @@
         "consensus_timestamp": "1234567890.000020002",
         "creator_account_id": "0.0.1024",
         "deleted": false,
+        "expiration_time": null,
         "executed_timestamp": "1234767890.000002102",
         "memo": "Created per mirror team decision dated 02/02/21",
         "payer_account_id": "0.0.1024",
@@ -171,7 +176,8 @@
             "type": "ED25519"
           }
         ],
-        "transaction_body": "AQECAgMD"
+        "transaction_body": "AQECAgMD",
+        "wait_for_expiry": false
       },
       {
         "admin_key": {
@@ -181,6 +187,7 @@
         "consensus_timestamp": "1234567890.000010001",
         "creator_account_id": "0.0.1024",
         "deleted": false,
+        "expiration_time": null,
         "executed_timestamp": "1234567890.000001100",
         "memo": "Created per council decision dated 02/01/21",
         "payer_account_id": "0.0.1024",
@@ -199,7 +206,8 @@
             "type": "ED25519"
           }
         ],
-        "transaction_body": "AQECAgMD"
+        "transaction_body": "AQECAgMD",
+        "wait_for_expiry": false
       }
     ],
     "links": {

--- a/hedera-mirror-rest/__tests__/specs/schedules-09-limit.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/schedules-09-limit.spec.json
@@ -138,6 +138,7 @@
             "consensus_timestamp": "1234567890.000010001",
             "creator_account_id": "0.0.3333",
             "deleted": false,
+            "expiration_time": null,
             "executed_timestamp": "1234567890.000001100",
             "memo": "Created per council decision dated 02/01/21",
             "payer_account_id": "0.0.1024",
@@ -156,7 +157,8 @@
                 "type": "ED25519"
               }
             ],
-            "transaction_body": "AQECAgMD"
+            "transaction_body": "AQECAgMD",
+            "wait_for_expiry": false
           },
           {
             "admin_key": {
@@ -166,6 +168,7 @@
             "consensus_timestamp": "1234567890.000020002",
             "creator_account_id": "0.0.1024",
             "deleted": false,
+            "expiration_time": null,
             "executed_timestamp": "1234767890.000002102",
             "memo": "Created per mirror team decision dated 02/02/21",
             "payer_account_id": "0.0.3333",
@@ -184,7 +187,8 @@
                 "type": "ED25519"
               }
             ],
-            "transaction_body": "AQECAgMD"
+            "transaction_body": "AQECAgMD",
+            "wait_for_expiry": false
           }
         ],
         "links": {
@@ -205,6 +209,7 @@
             "consensus_timestamp": "1234567890.000010001",
             "creator_account_id": "0.0.3333",
             "deleted": false,
+            "expiration_time": null,
             "executed_timestamp": "1234567890.000001100",
             "memo": "Created per council decision dated 02/01/21",
             "payer_account_id": "0.0.1024",
@@ -223,7 +228,8 @@
                 "type": "ED25519"
               }
             ],
-            "transaction_body": "AQECAgMD"
+            "transaction_body": "AQECAgMD",
+            "wait_for_expiry": false
           },
           {
             "admin_key": {
@@ -233,6 +239,7 @@
             "consensus_timestamp": "1234567890.000020002",
             "creator_account_id": "0.0.1024",
             "deleted": false,
+            "expiration_time": null,
             "executed_timestamp": "1234767890.000002102",
             "memo": "Created per mirror team decision dated 02/02/21",
             "payer_account_id": "0.0.3333",
@@ -251,7 +258,8 @@
                 "type": "ED25519"
               }
             ],
-            "transaction_body": "AQECAgMD"
+            "transaction_body": "AQECAgMD",
+            "wait_for_expiry": false
           },
           {
             "admin_key": {
@@ -261,6 +269,7 @@
             "consensus_timestamp": "1234567890.000030003",
             "creator_account_id": "0.0.3333",
             "deleted": false,
+            "expiration_time": null,
             "executed_timestamp": "1234967890.000003103",
             "memo": "Created per product team decision dated 02/03/21",
             "payer_account_id": "0.0.1024",
@@ -273,7 +282,8 @@
                 "type": "ED25519"
               }
             ],
-            "transaction_body": "AQECAgMD"
+            "transaction_body": "AQECAgMD",
+            "wait_for_expiry": false
           },
           {
             "admin_key": {
@@ -283,12 +293,14 @@
             "consensus_timestamp": "1234567890.000040004",
             "creator_account_id": "0.0.5555",
             "deleted": false,
+            "expiration_time": null,
             "executed_timestamp": null,
             "memo": "Created per product team decision dated 02/03/21",
             "payer_account_id": "0.0.1030",
             "schedule_id": "0.0.5000",
             "signatures": [],
-            "transaction_body": "AQECAgMD"
+            "transaction_body": "AQECAgMD",
+            "wait_for_expiry": false
           }
         ],
         "links": {

--- a/hedera-mirror-rest/__tests__/specs/schedules-10-account-id.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/schedules-10-account-id.spec.json
@@ -47,9 +47,11 @@
       {
         "consensus_timestamp": "1234567890000030003",
         "creator_account_id": "0.0.3333",
+        "expiration_time": "1234967890000003003",
         "executed_timestamp": "1234967890000003103",
         "payer_account_id": "0.0.1024",
-        "schedule_id": "0.0.4000"
+        "schedule_id": "0.0.4000",
+        "wait_for_expiry": true
       }
     ],
     "transactionsignatures": [
@@ -102,6 +104,7 @@
         "consensus_timestamp": "1234567890.000010001",
         "creator_account_id": "0.0.3333",
         "deleted": false,
+        "expiration_time": null,
         "executed_timestamp": "1234567890.000001100",
         "memo": "Created per council decision dated 02/01/21",
         "payer_account_id": "0.0.1024",
@@ -120,7 +123,8 @@
             "type": "ED25519"
           }
         ],
-        "transaction_body": "AQECAgMD"
+        "transaction_body": "AQECAgMD",
+        "wait_for_expiry": false
       },
       {
         "admin_key": {
@@ -130,6 +134,7 @@
         "consensus_timestamp": "1234567890.000030003",
         "creator_account_id": "0.0.3333",
         "deleted": false,
+        "expiration_time": "1234967890000003003",
         "executed_timestamp": "1234967890.000003103",
         "memo": "Created per product team decision dated 02/03/21",
         "payer_account_id": "0.0.1024",
@@ -142,7 +147,8 @@
             "type": "ED25519"
           }
         ],
-        "transaction_body": "AQECAgMD"
+        "transaction_body": "AQECAgMD",
+        "wait_for_expiry": true
       }
     ],
     "links": {

--- a/hedera-mirror-rest/__tests__/specs/schedules-11-schedule-id.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/schedules-11-schedule-id.spec.json
@@ -106,6 +106,7 @@
         "consensus_timestamp": "1234567890.000010001",
         "creator_account_id": "0.0.1024",
         "deleted": false,
+        "expiration_time": null,
         "executed_timestamp": "1234567890.000001100",
         "memo": "Created per council decision dated 02/01/21",
         "payer_account_id": "0.0.1024",
@@ -124,7 +125,8 @@
             "type": "ED25519"
           }
         ],
-        "transaction_body": "AQECAgMD"
+        "transaction_body": "AQECAgMD",
+        "wait_for_expiry": false
       }
     ],
     "links": {

--- a/hedera-mirror-rest/__tests__/specs/schedules-12-all-params.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/schedules-12-all-params.spec.json
@@ -102,6 +102,7 @@
         "consensus_timestamp": "1234567890.000030003",
         "creator_account_id": "0.0.1024",
         "deleted": false,
+        "expiration_time": null,
         "executed_timestamp": null,
         "memo": "Created per product team decision dated 02/03/21",
         "payer_account_id": "0.0.1024",
@@ -114,7 +115,8 @@
             "type": "ED25519"
           }
         ],
-        "transaction_body": "AQECAgMD"
+        "transaction_body": "AQECAgMD",
+        "wait_for_expiry": false
       }
     ],
     "links": {

--- a/hedera-mirror-rest/__tests__/specs/schedules-15-schedule-id-range.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/schedules-15-schedule-id-range.spec.json
@@ -102,6 +102,7 @@
         "consensus_timestamp": "1234567890.000020002",
         "creator_account_id": "0.0.1024",
         "deleted": false,
+        "expiration_time": null,
         "executed_timestamp": "1234767890.000002102",
         "memo": "Created per mirror team decision dated 02/02/21",
         "payer_account_id": "0.0.1024",
@@ -120,7 +121,8 @@
             "type": "ED25519"
           }
         ],
-        "transaction_body": "AQECAgMD"
+        "transaction_body": "AQECAgMD",
+        "wait_for_expiry": false
       },
       {
         "admin_key": {
@@ -130,6 +132,7 @@
         "consensus_timestamp": "1234567890.000030003",
         "creator_account_id": "0.0.1024",
         "deleted": false,
+        "expiration_time": null,
         "executed_timestamp": "1234967890.000003103",
         "memo": "Created per product team decision dated 02/03/21",
         "payer_account_id": "0.0.1024",
@@ -142,7 +145,8 @@
             "type": "ED25519"
           }
         ],
-        "transaction_body": "AQECAgMD"
+        "transaction_body": "AQECAgMD",
+        "wait_for_expiry": false
       }
     ],
     "links": {

--- a/hedera-mirror-rest/__tests__/specs/schedules-16-specific-id-deleted.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/schedules-16-specific-id-deleted.spec.json
@@ -35,11 +35,13 @@
     "consensus_timestamp": "1234567890.000000001",
     "creator_account_id": "0.0.1024",
     "deleted": true,
+    "expiration_time": null,
     "executed_timestamp": null,
     "memo": "Created per council decision dated 02/01/21",
     "payer_account_id": "0.0.1024",
     "schedule_id": "0.0.2000",
     "signatures": [],
-    "transaction_body": "AQECAgMD"
+    "transaction_body": "AQECAgMD",
+    "wait_for_expiry": false
   }
 }

--- a/hedera-mirror-rest/api/v1/openapi.yml
+++ b/hedera-mirror-rest/api/v1/openapi.yml
@@ -1776,6 +1776,10 @@ components:
           example: false
         executed_timestamp:
           $ref: '#/components/schemas/TimestampNullable'
+        expiration_time:
+          type: string
+          example: "1234567890000030003"
+          nullable: true
         memo:
           type: string
           example: 'created on 02/10/2021'
@@ -1791,6 +1795,8 @@ components:
           type: string
           format: byte
           example: Kd6tvu8=
+        wait_for_expiry:
+          type: boolean
     Schedules:
       type: array
       items:

--- a/hedera-mirror-rest/schedules.js
+++ b/hedera-mirror-rest/schedules.js
@@ -36,11 +36,13 @@ const scheduleSelectFields = [
   's.consensus_timestamp',
   's.creator_account_id',
   'e.deleted',
+  's.expiration_time',
   's.executed_timestamp',
   'e.memo',
   's.payer_account_id',
   's.schedule_id',
   's.transaction_body',
+  's.wait_for_expiry',
   `(
     select json_agg(
       json_build_object(
@@ -110,11 +112,13 @@ const formatScheduleRow = (row) => {
     consensus_timestamp: utils.nsToSecNs(row.consensus_timestamp),
     creator_account_id: EntityId.parse(row.creator_account_id).toString(),
     executed_timestamp: utils.nsToSecNs(row.executed_timestamp),
+    expiration_time: row.expiration_time,
     memo: row.memo,
     payer_account_id: EntityId.parse(row.payer_account_id).toString(),
     schedule_id: EntityId.parse(row.schedule_id).toString(),
     signatures,
     transaction_body: utils.encodeBase64(row.transaction_body),
+    wait_for_expiry: row.wait_for_expiry,
   };
 };
 


### PR DESCRIPTION
**Description**:
Adds `wait_for_expiry` and `expiration_time` to `/api/v1/schedules` and `/api/v1/schedules/{id}`

**Related issue(s)**:

Fixes #
https://github.com/hashgraph/hedera-mirror-node/issues/3591

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
