### PR TITLE
Add support for exchange rate rest api endpoint

### DIFF
--- a/hedera-mirror-rest/__tests__/controllers/contractController.test.js
+++ b/hedera-mirror-rest/__tests__/controllers/contractController.test.js
@@ -32,6 +32,7 @@ const contracts = require('../../controllers/contractController');
 const {assertSqlQueryEqual} = require('../testutils');
 const utils = require('../../utils');
 const {Contract} = require('../../model');
+const {FileDataService} = require('../../service');
 
 const contractFields = [
   Contract.AUTO_RENEW_ACCOUNT_ID,
@@ -293,7 +294,7 @@ describe('getContractByIdOrAddressQuery', () => {
         with contract as (
           ${queryForTable({table: 'contract', columnName})}
         ), contract_file as (
-            ${contracts.fileDataQuery}
+            ${FileDataService.getContractInitCodeFiledataQuery()}
         )
         ${mainQuery}`,
     },
@@ -313,7 +314,7 @@ describe('getContractByIdOrAddressQuery', () => {
             order by timestamp_range desc
             limit 1
         ), contract_file as (
-            ${contracts.fileDataQuery}
+            ${FileDataService.getContractInitCodeFiledataQuery()}
         )
         ${mainQuery}`,
     },
@@ -329,7 +330,7 @@ describe('getContractByIdOrAddressQuery', () => {
         with contract as (
           ${queryForTable({table: 'contract', columnName})}
         ), contract_file as (
-            ${contracts.fileDataQuery}
+            ${FileDataService.getContractInitCodeFiledataQuery()}
         )
         ${mainQuery}`,
     },
@@ -345,7 +346,7 @@ describe('getContractByIdOrAddressQuery', () => {
             order by timestamp_range desc
             limit 1
         ), contract_file as (
-            ${contracts.fileDataQuery}
+            ${FileDataService.getContractInitCodeFiledataQuery()}
         )
         ${mainQuery}`,
     },

--- a/hedera-mirror-rest/__tests__/controllers/networkController.test.js
+++ b/hedera-mirror-rest/__tests__/controllers/networkController.test.js
@@ -233,7 +233,7 @@ describe('extractExchangeRateQuery', () => {
         whereQuery: [
           {
             query: `${FileData.CONSENSUS_TIMESTAMP}  < `,
-            param: 1,
+            param: 2,
           },
         ],
       },

--- a/hedera-mirror-rest/__tests__/controllers/networkController.test.js
+++ b/hedera-mirror-rest/__tests__/controllers/networkController.test.js
@@ -193,22 +193,6 @@ describe('extractExchangeRateQuery', () => {
 
   const specs = [
     {
-      name: 'order asc',
-      input: {
-        filters: [
-          {
-            key: constants.filterKeys.ORDER,
-            operator: utils.opsMap.eq,
-            value: constants.orderFilterValues.ASC,
-          },
-        ],
-      },
-      expected: {
-        ...defaultExpected,
-        order: constants.orderFilterValues.ASC,
-      },
-    },
-    {
       name: 'no timestamp',
       input: {
         filters: [],

--- a/hedera-mirror-rest/__tests__/controllers/networkController.test.js
+++ b/hedera-mirror-rest/__tests__/controllers/networkController.test.js
@@ -22,6 +22,7 @@
 
 const constants = require('../../constants');
 const {NetworkController} = require('../../controllers');
+const {FileData} = require('../../model');
 const networkCtrl = require('../../controllers/networkController');
 const utils = require('../../utils');
 
@@ -179,6 +180,132 @@ describe('validateExtractNetworkNodesQuery throw', () => {
   specs.forEach((spec) => {
     test(`${spec.name}`, () => {
       expect(() => NetworkController.extractNetworkNodesQuery(spec.input.filters)).toThrowErrorMatchingSnapshot();
+    });
+  });
+});
+
+describe('extractExchangeRateQuery', () => {
+  const defaultExpected = {
+    limit: 1,
+    order: constants.orderFilterValues.DESC,
+    whereQuery: [],
+  };
+
+  const specs = [
+    {
+      name: 'order asc',
+      input: {
+        filters: [
+          {
+            key: constants.filterKeys.ORDER,
+            operator: utils.opsMap.eq,
+            value: constants.orderFilterValues.ASC,
+          },
+        ],
+      },
+      expected: {
+        ...defaultExpected,
+        order: constants.orderFilterValues.ASC,
+      },
+    },
+    {
+      name: 'no timestamp',
+      input: {
+        filters: [],
+      },
+      expected: {
+        ...defaultExpected,
+      },
+    },
+    {
+      name: 'le timestamp',
+      input: {
+        filters: [
+          {
+            key: constants.filterKeys.TIMESTAMP,
+            operator: utils.opsMap.lt,
+            value: 2,
+          },
+        ],
+      },
+      expected: {
+        ...defaultExpected,
+        whereQuery: [
+          {
+            query: `${FileData.CONSENSUS_TIMESTAMP}  < `,
+            param: 1,
+          },
+        ],
+      },
+    },
+    {
+      name: 'lte timestamp',
+      input: {
+        filters: [
+          {
+            key: constants.filterKeys.TIMESTAMP,
+            operator: utils.opsMap.lte,
+            value: 2,
+          },
+        ],
+      },
+      expected: {
+        ...defaultExpected,
+        whereQuery: [
+          {
+            query: `${FileData.CONSENSUS_TIMESTAMP}  <= `,
+            param: 2,
+          },
+        ],
+      },
+    },
+    {
+      name: 'gt timestamp',
+      input: {
+        filters: [
+          {
+            key: constants.filterKeys.TIMESTAMP,
+            operator: utils.opsMap.gt,
+            value: 2,
+          },
+        ],
+      },
+      expected: {
+        ...defaultExpected,
+        whereQuery: [
+          {
+            query: `${FileData.CONSENSUS_TIMESTAMP}  > `,
+            param: 2,
+          },
+        ],
+      },
+    },
+    {
+      name: 'gte timestamp',
+      input: {
+        filters: [
+          {
+            key: constants.filterKeys.TIMESTAMP,
+            operator: utils.opsMap.gte,
+            value: 2,
+          },
+        ],
+      },
+      expected: {
+        ...defaultExpected,
+        whereQuery: [
+          {
+            query: `${FileData.CONSENSUS_TIMESTAMP}  >= `,
+            param: 2,
+          },
+        ],
+      },
+    },
+  ];
+
+  specs.forEach((spec) => {
+    test(`${spec.name}`, () => {
+      expect(networkCtrl.extractExchangeRateQuery(spec.input.filters)).toEqual(spec.expected);
     });
   });
 });

--- a/hedera-mirror-rest/__tests__/controllers/networkController.test.js
+++ b/hedera-mirror-rest/__tests__/controllers/networkController.test.js
@@ -186,8 +186,6 @@ describe('validateExtractNetworkNodesQuery throw', () => {
 
 describe('extractExchangeRateQuery', () => {
   const defaultExpected = {
-    limit: 1,
-    order: constants.orderFilterValues.DESC,
     whereQuery: [],
   };
 

--- a/hedera-mirror-rest/__tests__/integrationDomainOps.js
+++ b/hedera-mirror-rest/__tests__/integrationDomainOps.js
@@ -1289,6 +1289,7 @@ module.exports = {
   loadContractResults,
   loadCryptoAllowances,
   loadEntities,
+  loadFileData,
   loadRecordFiles,
   loadTransactions,
   loadContractLogs,

--- a/hedera-mirror-rest/__tests__/model/exchangeRate.test.js
+++ b/hedera-mirror-rest/__tests__/model/exchangeRate.test.js
@@ -20,15 +20,13 @@
 
 'use strict';
 
-const {proto} = require('@hashgraph/proto');
-
 // models
 const {ExchangeRate} = require('../../model');
 
 describe('exchange rate proto parse', () => {
   const input = {
-    contents: '0a1008b0ea0110cac1181a0608a0a1d09306121008b0ea0110e18e191a0608b0bdd09306',
-    timestamp: 1651770056616171000,
+    file_data: '0a1008b0ea0110cac1181a0608a0a1d09306121008b0ea0110e18e191a0608b0bdd09306',
+    consensus_timestamp: 1651770056616171000,
   };
 
   const expectedOutput = {

--- a/hedera-mirror-rest/__tests__/model/exchangeRate.test.js
+++ b/hedera-mirror-rest/__tests__/model/exchangeRate.test.js
@@ -45,6 +45,6 @@ describe('exchange rate proto parse', () => {
   });
 
   test('invalid contents', () => {
-    expect(new ExchangeRate({file_data: '123456', consensus_timestamp: 1})).toThrowError(FileDecodeError);
+    expect(() => new ExchangeRate({file_data: '123456', consensus_timestamp: 1})).toThrowError(FileDecodeError);
   });
 });

--- a/hedera-mirror-rest/__tests__/model/exchangeRate.test.js
+++ b/hedera-mirror-rest/__tests__/model/exchangeRate.test.js
@@ -20,15 +20,28 @@
 
 'use strict';
 
-module.exports = {
-  ContractService: require('./contractService'),
-  CryptoAllowanceService: require('./cryptoAllowanceService'),
-  EntityService: require('./entityService'),
-  FileDataService: require('./fileDataService'),
-  NetworkNodeService: require('./networkNodeService'),
-  NftService: require('./nftService'),
-  RecordFileService: require('./recordFileService'),
-  TokenAllowanceService: require('./tokenAllowanceService'),
-  TokenService: require('./tokenService'),
-  TransactionService: require('./transactionService'),
-};
+const {proto} = require('@hashgraph/proto');
+
+// models
+const {ExchangeRate} = require('../../model');
+
+describe('exchange rate proto parse', () => {
+  const input = {
+    contents: '0a1008b0ea0110cac1181a0608a0a1d09306121008b0ea0110e18e191a0608b0bdd09306',
+    timestamp: 1651770056616171000,
+  };
+
+  const expectedOutput = {
+    current_cent: 401610,
+    current_expiration: 1651773600,
+    current_hbar: 30000,
+    next_cent: 411489,
+    next_expiration: 1651777200,
+    next_hbar: 30000,
+    timestamp: 1651770056616171000,
+  };
+
+  test('valid append', () => {
+    expect(new ExchangeRate(input)).toEqual(expectedOutput);
+  });
+});

--- a/hedera-mirror-rest/__tests__/model/exchangeRate.test.js
+++ b/hedera-mirror-rest/__tests__/model/exchangeRate.test.js
@@ -20,6 +20,7 @@
 
 'use strict';
 
+const {FileDecodeError} = require('../../errors/fileDecodeError');
 // models
 const {ExchangeRate} = require('../../model');
 
@@ -39,7 +40,11 @@ describe('exchange rate proto parse', () => {
     timestamp: 1651770056616171000,
   };
 
-  test('valid append', () => {
+  test('valid update', () => {
     expect(new ExchangeRate(input)).toEqual(expectedOutput);
+  });
+
+  test('invalid contents', () => {
+    expect(new ExchangeRate({file_data: '123456', consensus_timestamp: 1})).toThrowError(FileDecodeError);
   });
 });

--- a/hedera-mirror-rest/__tests__/service/fileDataService.test.js
+++ b/hedera-mirror-rest/__tests__/service/fileDataService.test.js
@@ -1,0 +1,109 @@
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+'use strict';
+
+const {FileDataService} = require('../../service');
+
+// add logger configuration support
+require('../testutils');
+
+const integrationDbOps = require('../integrationDbOps');
+const integrationDomainOps = require('../integrationDomainOps');
+
+const {defaultMochaStatements} = require('./defaultMochaStatements');
+defaultMochaStatements(jest, integrationDbOps, integrationDomainOps);
+
+const files = [
+  {
+    consensus_timestamp: 1,
+    entity_id: 112,
+    file_data: '0a1008b0ea0110cac1181a0608a0a1d09306121008b0ea0110e18e191a0608b0bdd09306',
+    transaction_type: 17,
+  },
+  {
+    consensus_timestamp: 2,
+    entity_id: 112,
+    file_data: '0a1008b0ea0110f5f3191a06089085d09306121008b0ea0110cac1181a0608a0a1d09306',
+    transaction_type: 16,
+  },
+  {
+    consensus_timestamp: 3,
+    entity_id: 112,
+    file_data: '0a1008b0ea0110e9c81a1a060880e9cf9306121008b0ea0110f5f3191a06089085d09306',
+    transaction_type: 19,
+  },
+  {
+    consensus_timestamp: 4,
+    entity_id: 112,
+    file_data: '0a1008b0ea0110f9bb1b1a0608f0cccf9306121008b0ea0110e9c81a1a060880e9cf9306',
+    transaction_type: 19,
+  },
+];
+
+describe('FileDataService.getExchangeRate tests', () => {
+  const nowNanoseconds = Date.now() * 1000000;
+  test('FileDataService.getExchangeRate - No match', async () => {
+    await expect(FileDataService.getExchangeRate(nowNanoseconds)).resolves.toBeNull();
+  });
+
+  const inputRecordFile = [
+    {
+      index: 1,
+      consensus_start: 1,
+      consensus_end: 3,
+      hash: 'dee34',
+    },
+  ];
+
+  const expectedPreviousFile = {
+    current_cent: 435305,
+    current_expiration: 1651766400,
+    current_hbar: 30000,
+    next_cent: 424437,
+    next_expiration: 1651770000,
+    next_hbar: 30000,
+    timestamp: 3,
+  };
+
+  const expectedLatestFile = {
+    current_cent: 450041,
+    current_expiration: 1651762800,
+    current_hbar: 30000,
+    next_cent: 435305,
+    next_expiration: 1651766400,
+    next_hbar: 30000,
+    timestamp: 4,
+  };
+
+  test('FileDataService.getExchangeRate - Row match w latest', async () => {
+    await integrationDomainOps.loadFileData(files);
+
+    await expect(FileDataService.getExchangeRate(nowNanoseconds)).resolves.toMatchObject(expectedLatestFile);
+  });
+
+  test('FileDataService.getExchangeRate - Row match w previous latest', async () => {
+    await integrationDomainOps.loadFileData(files);
+
+    await expect(FileDataService.getExchangeRate(expectedLatestFile.timestamp)).resolves.toMatchObject(
+      expectedPreviousFile
+    );
+  });
+});

--- a/hedera-mirror-rest/__tests__/service/fileDataService.test.js
+++ b/hedera-mirror-rest/__tests__/service/fileDataService.test.js
@@ -30,6 +30,7 @@ const integrationDbOps = require('../integrationDbOps');
 const integrationDomainOps = require('../integrationDomainOps');
 
 const {defaultMochaStatements} = require('./defaultMochaStatements');
+
 defaultMochaStatements(jest, integrationDbOps, integrationDomainOps);
 
 const files = [
@@ -62,7 +63,7 @@ const files = [
 const fileId = 112;
 describe('FileDataService.getExchangeRate tests', () => {
   test('FileDataService.getExchangeRate - No match', async () => {
-    await expect(FileDataService.getExchangeRate({order: 'desc', whereQuery: []})).resolves.toBeNull();
+    await expect(FileDataService.getExchangeRate({whereQuery: []})).resolves.toBeNull();
   });
 
   const expectedPreviousFile = {
@@ -88,9 +89,7 @@ describe('FileDataService.getExchangeRate tests', () => {
   test('FileDataService.getExchangeRate - Row match w latest', async () => {
     await integrationDomainOps.loadFileData(files);
 
-    await expect(FileDataService.getExchangeRate({order: 'desc', whereQuery: []})).resolves.toMatchObject(
-      expectedLatestFile
-    );
+    await expect(FileDataService.getExchangeRate({whereQuery: []})).resolves.toMatchObject(expectedLatestFile);
   });
 
   test('FileDataService.getExchangeRate - Row match w previous latest', async () => {
@@ -102,17 +101,13 @@ describe('FileDataService.getExchangeRate tests', () => {
         param: expectedPreviousFile.timestamp,
       },
     ];
-    await expect(FileDataService.getExchangeRate({order: 'desc', whereQuery: where})).resolves.toMatchObject(
-      expectedPreviousFile
-    );
+    await expect(FileDataService.getExchangeRate({whereQuery: where})).resolves.toMatchObject(expectedPreviousFile);
   });
 });
 
 describe('FileDataService.getLatestFileDataContents tests', () => {
   test('FileDataService.getLatestFileDataContents - No match', async () => {
-    await expect(
-      FileDataService.getLatestFileDataContents(fileId, {order: 'desc', whereQuery: []})
-    ).resolves.toBeNull();
+    await expect(FileDataService.getLatestFileDataContents(fileId, {whereQuery: []})).resolves.toBeNull();
   });
 
   const expectedPreviousFile = {
@@ -127,9 +122,9 @@ describe('FileDataService.getLatestFileDataContents tests', () => {
 
   test('FileDataService.getLatestFileDataContents - Row match w latest', async () => {
     await integrationDomainOps.loadFileData(files);
-    await expect(
-      FileDataService.getLatestFileDataContents(fileId, {order: 'desc', whereQuery: []})
-    ).resolves.toMatchObject(expectedLatestFile);
+    await expect(FileDataService.getLatestFileDataContents(fileId, {whereQuery: []})).resolves.toMatchObject(
+      expectedLatestFile
+    );
   });
 
   test('FileDataService.getLatestFileDataContents - Row match w previous latest', async () => {
@@ -141,8 +136,8 @@ describe('FileDataService.getLatestFileDataContents tests', () => {
         param: expectedPreviousFile.consensus_timestamp,
       },
     ];
-    await expect(
-      FileDataService.getLatestFileDataContents(fileId, {order: 'desc', whereQuery: where})
-    ).resolves.toMatchObject(expectedPreviousFile);
+    await expect(FileDataService.getLatestFileDataContents(fileId, {whereQuery: where})).resolves.toMatchObject(
+      expectedPreviousFile
+    );
   });
 });

--- a/hedera-mirror-rest/__tests__/service/fileDataService.test.js
+++ b/hedera-mirror-rest/__tests__/service/fileDataService.test.js
@@ -110,12 +110,14 @@ describe('FileDataService.getExchangeRate tests', () => {
 
 describe('FileDataService.getLatestFileDataContents tests', () => {
   test('FileDataService.getLatestFileDataContents - No match', async () => {
-    await expect(FileDataService.getLatestFileDataContents({order: 'desc', whereQuery: []})).resolves.toBeNull();
+    await expect(
+      FileDataService.getLatestFileDataContents(fileId, {order: 'desc', whereQuery: []})
+    ).resolves.toBeNull();
   });
 
   const expectedPreviousFile = {
-    consensus_timestamp: 3,
-    file_data: '0a1008b0ea0110e9c81a1a060880e9cf9306121008b0ea0110f5f3191a06089085d09306',
+    consensus_timestamp: 2,
+    file_data: files[0].file_data + files[1].file_data,
   };
 
   const expectedLatestFile = {
@@ -125,16 +127,9 @@ describe('FileDataService.getLatestFileDataContents tests', () => {
 
   test('FileDataService.getLatestFileDataContents - Row match w latest', async () => {
     await integrationDomainOps.loadFileData(files);
-
-    const where = [
-      {
-        query: `${FileData.ENTITY_ID} = `,
-        param: fileId,
-      },
-    ];
-    await expect(FileDataService.getLatestFileDataContents({order: 'desc', whereQuery: where})).resolves.toMatchObject(
-      expectedLatestFile
-    );
+    await expect(
+      FileDataService.getLatestFileDataContents(fileId, {order: 'desc', whereQuery: []})
+    ).resolves.toMatchObject(expectedLatestFile);
   });
 
   test('FileDataService.getLatestFileDataContents - Row match w previous latest', async () => {
@@ -142,16 +137,12 @@ describe('FileDataService.getLatestFileDataContents tests', () => {
 
     const where = [
       {
-        query: `${FileData.ENTITY_ID} = `,
-        param: fileId,
-      },
-      {
         query: `${FileData.CONSENSUS_TIMESTAMP} <= `,
         param: expectedPreviousFile.consensus_timestamp,
       },
     ];
-    await expect(FileDataService.getLatestFileDataContents({order: 'desc', whereQuery: where})).resolves.toMatchObject(
-      expectedPreviousFile
-    );
+    await expect(
+      FileDataService.getLatestFileDataContents(fileId, {order: 'desc', whereQuery: where})
+    ).resolves.toMatchObject(expectedPreviousFile);
   });
 });

--- a/hedera-mirror-rest/__tests__/service/fileDataService.test.js
+++ b/hedera-mirror-rest/__tests__/service/fileDataService.test.js
@@ -64,15 +64,6 @@ describe('FileDataService.getExchangeRate tests', () => {
     await expect(FileDataService.getExchangeRate(nowNanoseconds)).resolves.toBeNull();
   });
 
-  const inputRecordFile = [
-    {
-      index: 1,
-      consensus_start: 1,
-      consensus_end: 3,
-      hash: 'dee34',
-    },
-  ];
-
   const expectedPreviousFile = {
     current_cent: 435305,
     current_expiration: 1651766400,
@@ -102,8 +93,42 @@ describe('FileDataService.getExchangeRate tests', () => {
   test('FileDataService.getExchangeRate - Row match w previous latest', async () => {
     await integrationDomainOps.loadFileData(files);
 
-    await expect(FileDataService.getExchangeRate(expectedLatestFile.timestamp)).resolves.toMatchObject(
+    await expect(FileDataService.getExchangeRate(expectedLatestFile.timestamp - 1)).resolves.toMatchObject(
       expectedPreviousFile
     );
+  });
+});
+
+const fileId = 112;
+describe('FileDataService.getLatestFileDataContents tests', () => {
+  const nowNanoseconds = Date.now() * 1000000;
+  test('FileDataService.getLatestFileDataContents - No match', async () => {
+    await expect(FileDataService.getLatestFileDataContents(fileId, nowNanoseconds)).resolves.toBeNull();
+  });
+
+  const expectedPreviousFile = {
+    consensus_timestamp: 3,
+    file_data: '0a1008b0ea0110e9c81a1a060880e9cf9306121008b0ea0110f5f3191a06089085d09306',
+  };
+
+  const expectedLatestFile = {
+    consensus_timestamp: 4,
+    file_data: '0a1008b0ea0110f9bb1b1a0608f0cccf9306121008b0ea0110e9c81a1a060880e9cf9306',
+  };
+
+  test('FileDataService.getLatestFileDataContents - Row match w latest', async () => {
+    await integrationDomainOps.loadFileData(files);
+
+    await expect(FileDataService.getLatestFileDataContents(fileId, nowNanoseconds)).resolves.toMatchObject(
+      expectedLatestFile
+    );
+  });
+
+  test('FileDataService.getLatestFileDataContents - Row match w previous latest', async () => {
+    await integrationDomainOps.loadFileData(files);
+
+    await expect(
+      FileDataService.getLatestFileDataContents(fileId, expectedLatestFile.consensus_timestamp - 1)
+    ).resolves.toMatchObject(expectedPreviousFile);
   });
 });

--- a/hedera-mirror-rest/__tests__/specs/network-exchange-rate-01-no-args.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/network-exchange-rate-01-no-args.spec.json
@@ -1,0 +1,46 @@
+{
+  "description": "Network exchange rate with no args",
+  "setup": {
+    "filedata": [
+      {
+        "consensus_timestamp": 1234567890900800100,
+        "entity_id": 112,
+        "file_data": "0a1008b0ea0110cac1181a0608a0a1d09306121008b0ea0110e18e191a0608b0bdd09306",
+        "transaction_type": 17
+      },
+      {
+        "consensus_timestamp": 1234567890900800200,
+        "entity_id": 112,
+        "file_data": "0a1008b0ea0110f5f3191a06089085d09306121008b0ea0110cac1181a0608a0a1d09306",
+        "transaction_type": 16
+      },
+      {
+        "consensus_timestamp": 1234567890900800300,
+        "entity_id": 112,
+        "file_data": "0a1008b0ea0110e9c81a1a060880e9cf9306121008b0ea0110f5f3191a06089085d09306",
+        "transaction_type": 19
+      },
+      {
+        "consensus_timestamp": 1234567890900800400,
+        "entity_id": 112,
+        "file_data": "0a1008b0ea0110f9bb1b1a0608f0cccf9306121008b0ea0110e9c81a1a060880e9cf9306",
+        "transaction_type": 19
+      }
+    ]
+  },
+  "url": "/api/v1/network/exchangerate",
+  "responseStatus": 200,
+  "responseJson": {
+    "current_rate": {
+      "cent_equivalent": 450041,
+      "expiration_time": 1651762800,
+      "hbar_equivalent": 30000
+    },
+    "next_rate": {
+      "cent_equivalent": 435305,
+      "expiration_time": 1651766400,
+      "hbar_equivalent": 30000
+    },
+    "timestamp": "1234567890.900800400"
+  }
+}

--- a/hedera-mirror-rest/__tests__/specs/network-exchange-rate-02-timestamp-upper-bound.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/network-exchange-rate-02-timestamp-upper-bound.spec.json
@@ -1,0 +1,51 @@
+{
+  "description": "Network exchange rate with upper bound timestamp",
+  "setup": {
+    "filedata": [
+      {
+        "consensus_timestamp": 1234567890900800100,
+        "entity_id": 112,
+        "file_data": "0a1008b0ea0110cac1181a0608a0a1d09306121008b0ea0110e18e191a0608b0bdd09306",
+        "transaction_type": 17
+      },
+      {
+        "consensus_timestamp": 1234567890900800200,
+        "entity_id": 112,
+        "file_data": "0a1008b0ea0110f5f3191a06089085d09306121008b0ea0110cac1181a0608a0a1d09306",
+        "transaction_type": 16
+      },
+      {
+        "consensus_timestamp": 1234567890900800300,
+        "entity_id": 112,
+        "file_data": "0a1008b0ea0110e9c81a1a060880e9cf9306121008b0ea0110f5f3191a06089085d09306",
+        "transaction_type": 19
+      },
+      {
+        "consensus_timestamp": 1234567890900800400,
+        "entity_id": 112,
+        "file_data": "0a1008b0ea0110f9bb1b1a0608f0cccf9306121008b0ea0110e9c81a1a060880e9cf9306",
+        "transaction_type": 19
+      }
+    ]
+  },
+  "urls": [
+    "/api/v1/network/exchangerate?timestamp=1234567890.900800399",
+    "/api/v1/network/exchangerate?timestamp=eq:1234567890.900800399",
+    "/api/v1/network/exchangerate?timestamp=lt:1234567890.900800400",
+    "/api/v1/network/exchangerate?timestamp=lte:1234567890.900800399"
+  ],
+  "responseStatus": 200,
+  "responseJson": {
+    "current_rate": {
+      "cent_equivalent": 435305,
+      "expiration_time": 1651766400,
+      "hbar_equivalent": 30000
+    },
+    "next_rate": {
+      "cent_equivalent": 424437,
+      "expiration_time": 1651770000,
+      "hbar_equivalent": 30000
+    },
+    "timestamp": "1234567890.900800300"
+  }
+}

--- a/hedera-mirror-rest/__tests__/specs/network-exchange-rate-02-timestamp-upper-bound.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/network-exchange-rate-02-timestamp-upper-bound.spec.json
@@ -29,23 +29,23 @@
     ]
   },
   "urls": [
-    "/api/v1/network/exchangerate?timestamp=1234567890.900800399",
-    "/api/v1/network/exchangerate?timestamp=eq:1234567890.900800399",
-    "/api/v1/network/exchangerate?timestamp=lt:1234567890.900800400",
-    "/api/v1/network/exchangerate?timestamp=lte:1234567890.900800399"
+    "/api/v1/network/exchangerate?timestamp=1234567890.900800299",
+    "/api/v1/network/exchangerate?timestamp=eq:1234567890.900800299",
+    "/api/v1/network/exchangerate?timestamp=lt:1234567890.900800300",
+    "/api/v1/network/exchangerate?timestamp=lte:1234567890.900800299"
   ],
   "responseStatus": 200,
   "responseJson": {
     "current_rate": {
-      "cent_equivalent": 435305,
-      "expiration_time": 1651766400,
-      "hbar_equivalent": 30000
-    },
-    "next_rate": {
       "cent_equivalent": 424437,
       "expiration_time": 1651770000,
       "hbar_equivalent": 30000
     },
-    "timestamp": "1234567890.900800300"
+    "next_rate": {
+      "cent_equivalent": 401610,
+      "expiration_time": 1651773600,
+      "hbar_equivalent": 30000
+    },
+    "timestamp": "1234567890.900800200"
   }
 }

--- a/hedera-mirror-rest/__tests__/specs/network-exchange-rate-03-timestamp-lower-bound.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/network-exchange-rate-03-timestamp-lower-bound.spec.json
@@ -1,0 +1,49 @@
+{
+  "description": "Network exchange rate with lower bound timestamp",
+  "setup": {
+    "filedata": [
+      {
+        "consensus_timestamp": 1234567890900800100,
+        "entity_id": 112,
+        "file_data": "0a1008b0ea0110cac1181a0608a0a1d09306121008b0ea0110e18e191a0608b0bdd09306",
+        "transaction_type": 17
+      },
+      {
+        "consensus_timestamp": 1234567890900800200,
+        "entity_id": 112,
+        "file_data": "0a1008b0ea0110f5f3191a06089085d09306121008b0ea0110cac1181a0608a0a1d09306",
+        "transaction_type": 16
+      },
+      {
+        "consensus_timestamp": 1234567890900800300,
+        "entity_id": 112,
+        "file_data": "0a1008b0ea0110e9c81a1a060880e9cf9306121008b0ea0110f5f3191a06089085d09306",
+        "transaction_type": 19
+      },
+      {
+        "consensus_timestamp": 1234567890900800400,
+        "entity_id": 112,
+        "file_data": "0a1008b0ea0110f9bb1b1a0608f0cccf9306121008b0ea0110e9c81a1a060880e9cf9306",
+        "transaction_type": 19
+      }
+    ]
+  },
+  "urls": [
+    "/api/v1/network/exchangerate?timestamp=gt:1234567890.900800101",
+    "/api/v1/network/exchangerate?timestamp=gte:1234567890.900800100"
+  ],
+  "responseStatus": 200,
+  "responseJson": {
+    "current_rate": {
+      "cent_equivalent": 450041,
+      "expiration_time": 1651762800,
+      "hbar_equivalent": 30000
+    },
+    "next_rate": {
+      "cent_equivalent": 435305,
+      "expiration_time": 1651766400,
+      "hbar_equivalent": 30000
+    },
+    "timestamp": "1234567890.900800400"
+  }
+}

--- a/hedera-mirror-rest/__tests__/specs/network-exchange-rate-04-timestamp-invalid-params.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/network-exchange-rate-04-timestamp-invalid-params.spec.json
@@ -1,0 +1,21 @@
+{
+  "description": "Network exchange rate with invalid query params",
+  "setup": {},
+  "url": "/api/v1/network/exchangerate?timestamp=test&limit=c&order=d",
+  "responseStatus": 400,
+  "responseJson": {
+    "_status": {
+      "messages": [
+        {
+          "message": "Invalid parameter: timestamp"
+        },
+        {
+          "message": "Invalid parameter: limit"
+        },
+        {
+          "message": "Invalid parameter: order"
+        }
+      ]
+    }
+  }
+}

--- a/hedera-mirror-rest/__tests__/specs/network-exchange-rate-05-timestamp-ne.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/network-exchange-rate-05-timestamp-ne.spec.json
@@ -1,0 +1,15 @@
+{
+  "description": "Network exchange rate with no unsupported ne timestamp arg",
+  "setup": {},
+  "url": "/api/v1/network/exchangerate?timestamp=ne:4",
+  "responseStatus": 400,
+  "responseJson": {
+    "_status": {
+      "messages": [
+        {
+          "message": "Not equals (ne) operator is not supported for timestamp"
+        }
+      ]
+    }
+  }
+}

--- a/hedera-mirror-rest/__tests__/specs/network-exchange-rate-06-unserializable-contents.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/network-exchange-rate-06-unserializable-contents.spec.json
@@ -1,0 +1,42 @@
+{
+  "description": "Network exchange rate with file contents that aren't serializable",
+  "setup": {
+    "filedata": [
+      {
+        "consensus_timestamp": 1234567890900800100,
+        "entity_id": 112,
+        "file_data": "0a1008b0ea0110cac1181a0608a0a1d0",
+        "transaction_type": 17
+      },
+      {
+        "consensus_timestamp": 1234567890900800200,
+        "entity_id": 112,
+        "file_data": "9306121008b0ea0110e18e191a0608b0bdd09306",
+        "transaction_type": 16
+      },
+      {
+        "consensus_timestamp": 1234567890900800300,
+        "entity_id": 112,
+        "file_data": "0a1008b0ea0110e9c81a1a060880e9cf9306121008b0ea0110f5f3191a06089085d09306",
+        "transaction_type": 19
+      },
+      {
+        "consensus_timestamp": 1234567890900800400,
+        "entity_id": 112,
+        "file_data": "0a1008b0ea0110f9bb1b1a0608f0cccf9306121008b0ea0110e9c81a1a060880e9cf9306",
+        "transaction_type": 19
+      }
+    ]
+  },
+  "url": "/api/v1/network/exchangerate?timestamp=lt:1234567890.900800199",
+  "responseStatus": 500,
+  "responseJson": {
+    "_status": {
+      "messages": [
+        {
+          "message": "Internal error"
+        }
+      ]
+    }
+  }
+}

--- a/hedera-mirror-rest/controllers/contractController.js
+++ b/hedera-mirror-rest/controllers/contractController.js
@@ -39,12 +39,11 @@ const {
   Contract,
   ContractLog,
   ContractResult,
-  FileData,
   TransactionResult,
   RecordFile,
   Transaction,
 } = require('../model');
-const {ContractService, RecordFileService, TransactionService} = require('../service');
+const {ContractService, FileDataService, RecordFileService, TransactionService} = require('../service');
 const TransactionId = require('../transactionId');
 const utils = require('../utils');
 const {
@@ -77,34 +76,6 @@ const contractSelectFields = [
 const contractWithInitcodeSelectFields = [...contractSelectFields, Contract.getFullName(Contract.INITCODE)];
 
 const duplicateTransactionResult = TransactionResult.getProtoId('DUPLICATE_TRANSACTION');
-
-// the query finds the file content valid at the contract's created timestamp T by aggregating the contents of all the
-// file* txs from the latest FileCreate or FileUpdate transaction before T, to T
-// Note the 'contract' relation is the cte not the 'contract' table
-const fileDataQuery = `select
-      string_agg(
-          ${FileData.getFullName(FileData.FILE_DATA)}, ''
-          order by ${FileData.getFullName(FileData.CONSENSUS_TIMESTAMP)}
-      ) bytecode
-    from ${FileData.tableName} ${FileData.tableAlias}
-    join ${Contract.tableName} ${Contract.tableAlias}
-      on ${Contract.getFullName(Contract.FILE_ID)} = ${FileData.getFullName(FileData.ENTITY_ID)}
-    where ${FileData.getFullName(FileData.CONSENSUS_TIMESTAMP)} >= (
-      select ${FileData.getFullName(FileData.CONSENSUS_TIMESTAMP)}
-      from ${FileData.tableName} ${FileData.tableAlias}
-      join ${Contract.tableName} ${Contract.tableAlias}
-        on ${Contract.getFullName(Contract.FILE_ID)} = ${FileData.getFullName(FileData.ENTITY_ID)}
-          and ${FileData.getFullName(FileData.CONSENSUS_TIMESTAMP)} <= ${Contract.getFullName(
-  Contract.CREATED_TIMESTAMP
-)}
-      where ${FileData.getFullName(FileData.TRANSACTION_TYPE)} = 17
-        or (${FileData.getFullName(FileData.TRANSACTION_TYPE)} = 19 and length(${FileData.getFullName(
-  FileData.FILE_DATA
-)}) <> 0)
-      order by ${FileData.getFullName(FileData.CONSENSUS_TIMESTAMP)} desc
-      limit 1
-    ) and ${FileData.getFullName(FileData.CONSENSUS_TIMESTAMP)} <= ${Contract.getFullName(Contract.CREATED_TIMESTAMP)}
-      and ${Contract.getFullName(Contract.FILE_ID)} is not null`;
 
 /**
  * Extracts the sql where clause, params, order and limit values to be used from the provided contract query
@@ -288,7 +259,7 @@ const getContractByIdOrAddressQuery = ({timestampConditions, timestampParams, co
     ${tableUnionQueries.join('\n')}
   ),
   contract_file as (
-    ${fileDataQuery}
+    ${FileDataService.getContractInitCodeFiledataQuery()}
   )`;
 
   const selectFields = [
@@ -1010,7 +981,6 @@ if (utils.isTestEnv()) {
       checkTimestampsForTopics,
       extractSqlFromContractFilters,
       extractTimestampConditionsFromContractFilters,
-      fileDataQuery,
       formatContractRow,
       getContractByIdOrAddressQuery,
       getContractsQuery,

--- a/hedera-mirror-rest/controllers/networkController.js
+++ b/hedera-mirror-rest/controllers/networkController.js
@@ -145,8 +145,8 @@ class NetworkController extends BaseController {
             );
           }
 
+          // to ensure most recent occurence is found convert eq to lte
           if (utils.opsMap.eq === filter.operator) {
-            filter.value = filter.value;
             filter.operator = utils.opsMap.lte;
           }
 
@@ -173,9 +173,9 @@ class NetworkController extends BaseController {
     // extract filters from query param
     const filters = utils.buildAndValidateFilters(req.query);
 
-    let filterQueries = this.extractExchangeRateQuery(filters);
+    const filterQueries = this.extractExchangeRateQuery(filters);
 
-    let exchangeRate = await FileDataService.getExchangeRate(filterQueries);
+    const exchangeRate = await FileDataService.getExchangeRate(filterQueries);
 
     if (_.isNil(exchangeRate)) {
       throw new NotFoundError('Not found');

--- a/hedera-mirror-rest/controllers/networkController.js
+++ b/hedera-mirror-rest/controllers/networkController.js
@@ -30,9 +30,9 @@ const utils = require('../utils');
 
 const BaseController = require('./baseController');
 
-const {AddressBookEntry} = require('../model');
-const {NetworkNodeService} = require('../service');
-const {NetworkNodeViewModel, NetworkSupplyViewModel} = require('../viewmodel');
+const {AddressBookEntry, FileData} = require('../model');
+const {FileDataService, NetworkNodeService} = require('../service');
+const {ExchangeRateSetViewModel, NetworkNodeViewModel, NetworkSupplyViewModel} = require('../viewmodel');
 
 // errors
 const {InvalidArgumentError} = require('../errors/invalidArgumentError');
@@ -46,46 +46,6 @@ const networkNodesMaxSize = 25;
 class NetworkController extends BaseController {
   static totalSupply = 5000000000000000000n;
   static unreleasedSupplyAccounts = defaultUnreleasedSupplyAccounts.map((a) => entityId.parse(a).getEncodedId());
-
-  /**
-   * Handler function for /network/supply API.
-   * @param {Request} req HTTP request object
-   * @param {Response} res HTTP response object
-   * @return {Promise} Promise for PostgreSQL query
-   */
-  getSupply = async (req, res) => {
-    utils.validateReq(req);
-    const [tsQuery, tsParams] = utils.parseTimestampQueryParam(req.query, 'abf.consensus_timestamp', {
-      [utils.opsMap.eq]: utils.opsMap.lte,
-    });
-
-    const sqlQuery = `
-      select sum(balance) as unreleased_supply, max(consensus_timestamp) as consensus_timestamp
-      from account_balance
-      where consensus_timestamp = (
-        select max(consensus_timestamp)
-        from account_balance_file abf
-        where ${tsQuery !== '' ? tsQuery : '1=1'}
-      )
-        and account_id in (${NetworkController.unreleasedSupplyAccounts});`;
-
-    const query = utils.convertMySqlStyleQueryToPostgres(sqlQuery);
-
-    if (logger.isTraceEnabled()) {
-      logger.trace(`getSupply query: ${query} ${utils.JSONStringify(tsParams)}`);
-    }
-
-    return pool.queryQuietly(query, tsParams).then((result) => {
-      const {rows} = result;
-
-      if (rows.length !== 1 || !rows[0].consensus_timestamp) {
-        throw new NotFoundError('Not found');
-      }
-
-      res.locals[constants.responseDataLabel] = new NetworkSupplyViewModel(rows[0], NetworkController.totalSupply);
-      logger.debug(`getSupply returning ${result.rows.length} entries`);
-    });
-  };
 
   /**
    * Extracts SQL where conditions, params, order, and limit
@@ -164,6 +124,66 @@ class NetworkController extends BaseController {
     };
   };
 
+  extractExchangeRateQuery = (filters) => {
+    // get latest rate only
+    const filterQuery = {
+      order: constants.orderFilterValues.DESC,
+      limit: 1,
+      whereQuery: [],
+    };
+
+    for (const filter of filters) {
+      if (_.isNil(filter)) {
+        continue;
+      }
+
+      switch (filter.key) {
+        case constants.filterKeys.TIMESTAMP:
+          if (utils.opsMap.ne === filter.operator) {
+            throw new InvalidArgumentError(
+              `Not equals (ne) operator is not supported for ${constants.filterKeys.TIMESTAMP}`
+            );
+          }
+
+          if (utils.opsMap.eq === filter.operator) {
+            filter.value = filter.value;
+            filter.operator = utils.opsMap.lte;
+          }
+
+          filterQuery.whereQuery.push(FileDataService.getFilterWhereCondition(FileData.CONSENSUS_TIMESTAMP, filter));
+          break;
+        case constants.filterKeys.ORDER:
+          filterQuery.order = filter.value;
+          break;
+        default:
+          break;
+      }
+    }
+
+    return filterQuery;
+  };
+
+  /**
+   * Handler function for /network/exchangerate API
+   * @param {Request} req HTTP request object
+   * @param {Response} res HTTP response object
+   * @returns {Promise<void>}
+   */
+  getExchangeRate = async (req, res) => {
+    // extract filters from query param
+    const filters = utils.buildAndValidateFilters(req.query);
+
+    let filterQueries = this.extractExchangeRateQuery(filters);
+
+    let exchangeRate = await FileDataService.getExchangeRate(filterQueries);
+
+    if (_.isNil(exchangeRate)) {
+      throw new NotFoundError('Not found');
+    }
+
+    res.send(new ExchangeRateSetViewModel(exchangeRate));
+  };
+
   /**
    * Handler function for /network/nodes API
    * @param {Request} req HTTP request object
@@ -193,6 +213,46 @@ class NetworkController extends BaseController {
     }
 
     res.locals[constants.responseDataLabel] = response;
+  };
+
+  /**
+   * Handler function for /network/supply API.
+   * @param {Request} req HTTP request object
+   * @param {Response} res HTTP response object
+   * @return {Promise} Promise for PostgreSQL query
+   */
+  getSupply = async (req, res) => {
+    utils.validateReq(req);
+    const [tsQuery, tsParams] = utils.parseTimestampQueryParam(req.query, 'abf.consensus_timestamp', {
+      [utils.opsMap.eq]: utils.opsMap.lte,
+    });
+
+    const sqlQuery = `
+      select sum(balance) as unreleased_supply, max(consensus_timestamp) as consensus_timestamp
+      from account_balance
+      where consensus_timestamp = (
+        select max(consensus_timestamp)
+        from account_balance_file abf
+        where ${tsQuery !== '' ? tsQuery : '1=1'}
+      )
+        and account_id in (${NetworkController.unreleasedSupplyAccounts});`;
+
+    const query = utils.convertMySqlStyleQueryToPostgres(sqlQuery);
+
+    if (logger.isTraceEnabled()) {
+      logger.trace(`getSupply query: ${query} ${utils.JSONStringify(tsParams)}`);
+    }
+
+    return pool.queryQuietly(query, tsParams).then((result) => {
+      const {rows} = result;
+
+      if (rows.length !== 1 || !rows[0].consensus_timestamp) {
+        throw new NotFoundError('Not found');
+      }
+
+      res.locals[constants.responseDataLabel] = new NetworkSupplyViewModel(rows[0], NetworkController.totalSupply);
+      logger.debug(`getSupply returning ${result.rows.length} entries`);
+    });
   };
 }
 

--- a/hedera-mirror-rest/controllers/networkController.js
+++ b/hedera-mirror-rest/controllers/networkController.js
@@ -125,10 +125,8 @@ class NetworkController extends BaseController {
   };
 
   extractExchangeRateQuery = (filters) => {
-    // get latest rate only
+    // get latest rate only. Since logic pulls most recent items order and limit are ommitted in filterQuery
     const filterQuery = {
-      order: constants.orderFilterValues.DESC,
-      limit: 1,
       whereQuery: [],
     };
 

--- a/hedera-mirror-rest/controllers/networkController.js
+++ b/hedera-mirror-rest/controllers/networkController.js
@@ -152,9 +152,6 @@ class NetworkController extends BaseController {
 
           filterQuery.whereQuery.push(FileDataService.getFilterWhereCondition(FileData.CONSENSUS_TIMESTAMP, filter));
           break;
-        case constants.filterKeys.ORDER:
-          filterQuery.order = filter.value;
-          break;
         default:
           break;
       }
@@ -181,7 +178,7 @@ class NetworkController extends BaseController {
       throw new NotFoundError('Not found');
     }
 
-    res.send(new ExchangeRateSetViewModel(exchangeRate));
+    res.locals[constants.responseDataLabel] = new ExchangeRateSetViewModel(exchangeRate);
   };
 
   /**

--- a/hedera-mirror-rest/controllers/networkController.js
+++ b/hedera-mirror-rest/controllers/networkController.js
@@ -137,23 +137,19 @@ class NetworkController extends BaseController {
         continue;
       }
 
-      switch (filter.key) {
-        case constants.filterKeys.TIMESTAMP:
-          if (utils.opsMap.ne === filter.operator) {
-            throw new InvalidArgumentError(
-              `Not equals (ne) operator is not supported for ${constants.filterKeys.TIMESTAMP}`
-            );
-          }
+      if (filter.key === constants.filterKeys.TIMESTAMP) {
+        if (utils.opsMap.ne === filter.operator) {
+          throw new InvalidArgumentError(
+            `Not equals (ne) operator is not supported for ${constants.filterKeys.TIMESTAMP}`
+          );
+        }
 
-          // to ensure most recent occurence is found convert eq to lte
-          if (utils.opsMap.eq === filter.operator) {
-            filter.operator = utils.opsMap.lte;
-          }
+        // to ensure most recent occurence is found convert eq to lte
+        if (utils.opsMap.eq === filter.operator) {
+          filter.operator = utils.opsMap.lte;
+        }
 
-          filterQuery.whereQuery.push(FileDataService.getFilterWhereCondition(FileData.CONSENSUS_TIMESTAMP, filter));
-          break;
-        default:
-          break;
+        filterQuery.whereQuery.push(FileDataService.getFilterWhereCondition(FileData.CONSENSUS_TIMESTAMP, filter));
       }
     }
 

--- a/hedera-mirror-rest/errors/fileDecodeError.js
+++ b/hedera-mirror-rest/errors/fileDecodeError.js
@@ -26,7 +26,10 @@ const FileDecodeErrorMessage =
 class FileDecodeError extends Error {
   constructor(errorMessage) {
     super();
-    this.message = errorMessage === undefined ? FileDecodeErrorMessage : errorMessage;
+    this.message = FileDecodeErrorMessage;
+    if (errorMessage !== undefined) {
+      this.message += errorMessage === undefined ? '' : `. Error: '${errorMessage}'`;
+    }
   }
 }
 

--- a/hedera-mirror-rest/errors/fileDecodeError.js
+++ b/hedera-mirror-rest/errors/fileDecodeError.js
@@ -1,0 +1,35 @@
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+'use strict';
+
+const FileDecodeErrorMessage =
+  'Failed to decode file contents. Ensure timestamp filters cover the complete file create/update and append transactions';
+
+class FileDecodeError extends Error {
+  constructor(errorMessage) {
+    super();
+    this.message = errorMessage === undefined ? FileDecodeErrorMessage : errorMessage;
+  }
+}
+
+module.exports = {
+  FileDecodeError,
+};

--- a/hedera-mirror-rest/errors/fileDecodeError.js
+++ b/hedera-mirror-rest/errors/fileDecodeError.js
@@ -28,11 +28,9 @@ class FileDecodeError extends Error {
     super();
     this.message = FileDecodeErrorMessage;
     if (errorMessage !== undefined) {
-      this.message += errorMessage === undefined ? '' : `. Error: '${errorMessage}'`;
+      this.message += `. Error: '${errorMessage}'`;
     }
   }
 }
 
-module.exports = {
-  FileDecodeError,
-};
+module.exports = FileDecodeError;

--- a/hedera-mirror-rest/model/exchangeRate.js
+++ b/hedera-mirror-rest/model/exchangeRate.js
@@ -1,0 +1,44 @@
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http =//www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+'use strict';
+
+const {proto} = require('@hashgraph/proto');
+const _ = require('lodash');
+
+class ExchangeRate {
+  /**
+   * Parses exchange rate into object
+   * Curently from proto, eventually from excahnge_rate table
+   */
+  constructor(exchangeRate) {
+    const exchangeRateSet = proto.ExchangeRateSet.decode(Buffer.from(exchangeRate.contents, 'hex'));
+
+    this.current_cent = exchangeRateSet.currentRate.centEquiv;
+    this.current_expiration = exchangeRateSet.currentRate.expirationTime.seconds.low;
+    this.current_hbar = exchangeRateSet.currentRate.hbarEquiv;
+    this.next_cent = exchangeRateSet.nextRate.centEquiv;
+    this.next_expiration = exchangeRateSet.nextRate.expirationTime.seconds.low;
+    this.next_hbar = exchangeRateSet.nextRate.hbarEquiv;
+    this.timestamp = exchangeRate.consensus_timestamp;
+  }
+}
+
+module.exports = ExchangeRate;

--- a/hedera-mirror-rest/model/exchangeRate.js
+++ b/hedera-mirror-rest/model/exchangeRate.js
@@ -21,15 +21,21 @@
 'use strict';
 
 const {proto} = require('@hashgraph/proto');
-const _ = require('lodash');
+const {FileDecodeError} = require('../errors/fileDecodeError');
 
 class ExchangeRate {
   /**
    * Parses exchange rate into object
-   * Curently from proto, eventually from excahnge_rate table
+   * Curently from proto, eventually from exchange_rate table
    */
   constructor(exchangeRate) {
-    const exchangeRateSet = proto.ExchangeRateSet.decode(Buffer.from(exchangeRate.file_data, 'hex'));
+    let exchangeRateSet = {};
+
+    try {
+      exchangeRateSet = proto.ExchangeRateSet.decode(Buffer.from(exchangeRate.file_data, 'hex'));
+    } catch (error) {
+      throw new FileDecodeError();
+    }
 
     this.current_cent = exchangeRateSet.currentRate.centEquiv;
     this.current_expiration = exchangeRateSet.currentRate.expirationTime.seconds.low;

--- a/hedera-mirror-rest/model/exchangeRate.js
+++ b/hedera-mirror-rest/model/exchangeRate.js
@@ -29,7 +29,7 @@ class ExchangeRate {
    * Curently from proto, eventually from excahnge_rate table
    */
   constructor(exchangeRate) {
-    const exchangeRateSet = proto.ExchangeRateSet.decode(Buffer.from(exchangeRate.contents, 'hex'));
+    const exchangeRateSet = proto.ExchangeRateSet.decode(Buffer.from(exchangeRate.file_data, 'hex'));
 
     this.current_cent = exchangeRateSet.currentRate.centEquiv;
     this.current_expiration = exchangeRateSet.currentRate.expirationTime.seconds.low;

--- a/hedera-mirror-rest/model/exchangeRate.js
+++ b/hedera-mirror-rest/model/exchangeRate.js
@@ -34,7 +34,7 @@ class ExchangeRate {
     try {
       exchangeRateSet = proto.ExchangeRateSet.decode(Buffer.from(exchangeRate.file_data, 'hex'));
     } catch (error) {
-      throw new FileDecodeError(`${error.message}`);
+      throw new FileDecodeError(error.message);
     }
 
     this.current_cent = exchangeRateSet.currentRate.centEquiv;

--- a/hedera-mirror-rest/model/exchangeRate.js
+++ b/hedera-mirror-rest/model/exchangeRate.js
@@ -26,7 +26,7 @@ const {FileDecodeError} = require('../errors/fileDecodeError');
 class ExchangeRate {
   /**
    * Parses exchange rate into object
-   * Curently from proto, eventually from exchange_rate table
+   * Currently from proto, eventually from exchange_rate table
    */
   constructor(exchangeRate) {
     let exchangeRateSet = {};
@@ -34,7 +34,7 @@ class ExchangeRate {
     try {
       exchangeRateSet = proto.ExchangeRateSet.decode(Buffer.from(exchangeRate.file_data, 'hex'));
     } catch (error) {
-      throw new FileDecodeError();
+      throw new FileDecodeError(`${error.message}`);
     }
 
     this.current_cent = exchangeRateSet.currentRate.centEquiv;

--- a/hedera-mirror-rest/model/index.js
+++ b/hedera-mirror-rest/model/index.js
@@ -34,6 +34,7 @@ module.exports = {
   CustomFee: require('./customFee'),
   Entity: require('./entity'),
   EthereumTransaction: require('./ethereumTransaction'),
+  ExchangeRate: require('./exchangeRate'),
   FileData: require('./fileData'),
   NetworkNode: require('./networkNode'),
   Nft: require('./nft'),

--- a/hedera-mirror-rest/routes/networkRoute.js
+++ b/hedera-mirror-rest/routes/networkRoute.js
@@ -27,6 +27,7 @@ const {NetworkController} = require('../controllers');
 const router = Router();
 
 const resource = 'network';
+router.getAsync('/exchangerate', NetworkController.getExchangeRate);
 router.getAsync('/nodes', NetworkController.getNetworkNodes);
 router.getAsync('/supply', NetworkController.getSupply);
 

--- a/hedera-mirror-rest/service/baseService.js
+++ b/hedera-mirror-rest/service/baseService.js
@@ -21,11 +21,23 @@
 'use strict';
 
 const _ = require('lodash');
+const {JSONStringify} = require('../utils');
 
 /**
  * Base service class that other services should inherit from for their retrieval business logic
  */
 class BaseService {
+  buildWhereSqlStatement(whereQuery) {
+    let where = '';
+    const params = [];
+    for (let i = 1; i <= whereQuery.length; i++) {
+      where += `${i === 1 ? 'where' : 'and'} ${whereQuery[i - 1].query} $${i} `;
+      params.push(whereQuery[i - 1].param);
+    }
+
+    return {where, params};
+  }
+
   getLimitQuery(position) {
     return `limit $${position}`;
   }
@@ -38,6 +50,13 @@ class BaseService {
    */
   getOrderByQuery(...orderSpecs) {
     return 'order by ' + orderSpecs.map((spec) => `${spec}`).join(', ');
+  }
+
+  getFilterWhereCondition(key, filter) {
+    return {
+      query: `${key} ${filter.operator}`,
+      param: filter.value,
+    };
   }
 
   async getRows(query, params, functionName = '') {

--- a/hedera-mirror-rest/service/baseService.js
+++ b/hedera-mirror-rest/service/baseService.js
@@ -21,17 +21,19 @@
 'use strict';
 
 const _ = require('lodash');
-const {JSONStringify} = require('../utils');
 
 /**
  * Base service class that other services should inherit from for their retrieval business logic
  */
 class BaseService {
-  buildWhereSqlStatement(whereQuery) {
-    let where = '';
-    const params = [];
+  buildWhereSqlStatement(whereQuery, params = []) {
+    if (_.isEmpty(whereQuery)) {
+      return {where: '', params};
+    }
+
+    let where = params.length === 0 ? 'where' : 'and';
     for (let i = 1; i <= whereQuery.length; i++) {
-      where += `${i === 1 ? 'where' : 'and'} ${whereQuery[i - 1].query} $${i} `;
+      where += `${i === 1 ? '' : 'and'} ${whereQuery[i - 1].query} $${i + params.length} `;
       params.push(whereQuery[i - 1].param);
     }
 

--- a/hedera-mirror-rest/service/fileDataService.js
+++ b/hedera-mirror-rest/service/fileDataService.js
@@ -104,7 +104,7 @@ class FileDataService extends BaseService {
 
   getLatestFileDataContents = async (fileId, filterQueries) => {
     const {where, params} = super.buildWhereSqlStatement(filterQueries.whereQuery, [fileId]);
-    return await super.getSingleRow(this.getLatestFileContentsQuery(where), params, 'getLatestFileContents');
+    return super.getSingleRow(this.getLatestFileContentsQuery(where), params, 'getLatestFileContents');
   };
 
   getExchangeRate = async (filterQueries) => {

--- a/hedera-mirror-rest/service/fileDataService.js
+++ b/hedera-mirror-rest/service/fileDataService.js
@@ -38,7 +38,7 @@ class FileDataService extends BaseService {
 
   // retrieve the largest timestamp of the most recent create/update operation on the file
   // using this timestamp retrieve all recent file operations and combine contents for applicable file
-  static latestFileContentsQuery = `with lastest_create as (
+  static latestFileContentsQuery = `with latest_create as (
       select max(${FileData.CONSENSUS_TIMESTAMP}) as ${FileData.CONSENSUS_TIMESTAMP}
       from ${FileData.tableName}
       where ${FileData.ENTITY_ID} = $1 and ${FileData.TRANSACTION_TYPE} in (17, 19) ${
@@ -53,7 +53,7 @@ class FileDataService extends BaseService {
     FileData.CONSENSUS_TIMESTAMP
   )}) as ${FileData.FILE_DATA}
     from ${FileData.tableName} ${FileData.tableAlias}
-    join lastest_create l on ${FileData.getFullName(FileData.CONSENSUS_TIMESTAMP)} >= l.${FileData.CONSENSUS_TIMESTAMP}
+    join latest_create l on ${FileData.getFullName(FileData.CONSENSUS_TIMESTAMP)} >= l.${FileData.CONSENSUS_TIMESTAMP}
     where ${FileData.getFullName(FileData.ENTITY_ID)} = $1 and ${FileData.getFullName(
     FileData.TRANSACTION_TYPE
   )} in (16,17, 19)
@@ -104,8 +104,7 @@ class FileDataService extends BaseService {
 
   getLatestFileDataContents = async (fileId, filterQueries) => {
     const {where, params} = super.buildWhereSqlStatement(filterQueries.whereQuery, [fileId]);
-    const row = await super.getSingleRow(this.getLatestFileContentsQuery(where), params, 'getLatestFileContents');
-    return _.isNil(row) ? null : row;
+    return await super.getSingleRow(this.getLatestFileContentsQuery(where), params, 'getLatestFileContents');
   };
 
   getExchangeRate = async (filterQueries) => {

--- a/hedera-mirror-rest/service/fileDataService.js
+++ b/hedera-mirror-rest/service/fileDataService.js
@@ -1,0 +1,104 @@
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+'use strict';
+
+const {proto} = require('@hashgraph/proto');
+const _ = require('lodash');
+
+const BaseService = require('./baseService');
+const {Contract, ExchangeRate, FileData} = require('../model');
+
+/**
+ * File data retrieval business logic
+ */
+class FileDataService extends BaseService {
+  static exchangeRateFileId = 112;
+
+  static latestFileDataContentQuery = `select ${FileData.CONSENSUS_TIMESTAMP}, encode(${FileData.FILE_DATA}, 'escape') contents 
+    from ${FileData.tableName} where ${FileData.ENTITY_ID} = $1 and ${FileData.CONSENSUS_TIMESTAMP} < $2
+    order by ${FileData.CONSENSUS_TIMESTAMP} desc limit 1`;
+
+  // get most recent file by combining file data of matching entity since a given timestamp
+  static fileDataQuery = `with latest_update as (
+      select max(${FileData.CONSENSUS_TIMESTAMP}) as timestamp, ${FileData.ENTITY_ID}
+      from ${FileData.tableName}
+      where ${FileData.CONSENSUS_TIMESTAMP} < $1 and ${FileData.ENTITY_ID} = $2 and ${
+    FileData.TRANSACTION_TYPE
+  } in (16,17) and 
+      group by ${FileData.ENTITY_ID}
+    )
+    select encode(string_agg (${FileData.getFullName(FileData.FILE_DATA)}, ',' order by ${FileData.getFullName(
+    FileData.CONSENSUS_TIMESTAMP
+  )}), 'hex') as contents,
+      max(${FileData.getFullName(FileData.CONSENSUS_TIMESTAMP)}) as timestamp
+    from ${FileData.tableName} ${FileData.tableAlias}
+    join latest_update l on ${FileData.getFullName(FileData.ENTITY_ID)} = l.entity_id and ${FileData.getFullName(
+    FileData.CONSENSUS_TIMESTAMP
+  )} >= l.timestamp
+    where ${FileData.getFullName(FileData.ENTITY_ID)} = $2 and length(${FileData.getFullName(FileData.FILE_DATA)}) <> 0
+      and ${FileData.getFullName(FileData.TRANSACTION_TYPE)} in (16,17,19) and ${FileData.getFullName(
+    FileData.CONSENSUS_TIMESTAMP
+  )} >= l.timestamp
+    group by ${FileData.getFullName(FileData.ENTITY_ID)}`;
+
+  // contract byte code
+  static contractInitCodeFileDataQuery = `select
+      string_agg(
+          ${FileData.getFullName(FileData.FILE_DATA)}, ''
+          order by ${FileData.getFullName(FileData.CONSENSUS_TIMESTAMP)}
+      ) bytecode
+    from ${FileData.tableName} ${FileData.tableAlias}
+    join ${Contract.tableName} ${Contract.tableAlias}
+      on ${Contract.getFullName(Contract.FILE_ID)} = ${FileData.getFullName(FileData.ENTITY_ID)}
+    where ${FileData.getFullName(FileData.CONSENSUS_TIMESTAMP)} >= (
+      select ${FileData.getFullName(FileData.CONSENSUS_TIMESTAMP)}
+      from ${FileData.tableName} ${FileData.tableAlias}
+      join ${Contract.tableName} ${Contract.tableAlias}
+        on ${Contract.getFullName(Contract.FILE_ID)} = ${FileData.getFullName(FileData.ENTITY_ID)}
+          and ${FileData.getFullName(FileData.CONSENSUS_TIMESTAMP)} <= ${Contract.getFullName(
+    Contract.CREATED_TIMESTAMP
+  )}
+      where ${FileData.getFullName(FileData.TRANSACTION_TYPE)} = 17
+        or (${FileData.getFullName(FileData.TRANSACTION_TYPE)} = 19 and length(${FileData.getFullName(
+    FileData.FILE_DATA
+  )}) <> 0)
+      order by ${FileData.getFullName(FileData.CONSENSUS_TIMESTAMP)} desc
+      limit 1
+    ) and ${FileData.getFullName(FileData.CONSENSUS_TIMESTAMP)} <= ${Contract.getFullName(Contract.CREATED_TIMESTAMP)}
+      and ${Contract.getFullName(Contract.FILE_ID)} is not null`;
+
+  getFileContents = async (entity, timestamp) => {
+    const row = await super.getSingleRow(
+      FileDataService.latestFileDataContentQuery,
+      [entity, timestamp],
+      'getLatestFileContents'
+    );
+    return _.isNil(row) ? null : row;
+  };
+
+  getExchangeRate = async (timestamp) => {
+    const row = await this.getFileContents(FileDataService.exchangeRateFileId, timestamp);
+
+    return _.isNil(row) ? null : new ExchangeRate(row);
+  };
+}
+
+module.exports = new FileDataService();

--- a/hedera-mirror-rest/service/fileDataService.js
+++ b/hedera-mirror-rest/service/fileDataService.js
@@ -32,11 +32,12 @@ const utils = require('../utils');
 class FileDataService extends BaseService {
   static exchangeRateFileId = 112;
 
-  static latestFileDataContentQuery = `select ${FileData.CONSENSUS_TIMESTAMP}, encode(${FileData.FILE_DATA}, 'escape') ${FileData.FILE_DATA} 
-    from ${FileData.tableName}`;
-
+  // placeholders to support where filtering for inner and outer calls
   static filterInnerPlaceholder = '<filterInnerPlaceHolder>';
   static filterOuterPlaceholder = '<filterOuterPlaceHolder>';
+
+  // retrieve the largest timestamp of the most recent create/update operation on the file
+  // using this timestamp retrieve all recent file operations and combine contents for applicable file
   static latestFileContentsQuery = `with lastest_create as (
       select max(${FileData.CONSENSUS_TIMESTAMP}) as ${FileData.CONSENSUS_TIMESTAMP}
       from ${FileData.tableName}

--- a/hedera-mirror-rest/viewmodel/exchangeRateSetViewModel.js
+++ b/hedera-mirror-rest/viewmodel/exchangeRateSetViewModel.js
@@ -27,14 +27,17 @@ const ExchangeRateViewModel = require('./exchangeRateViewModel');
  * Exchange rate set view model
  */
 class ExchangeRateSetViewModel {
+  static currentLabel = 'current_';
+  static nextLabel = 'next_';
+
   /**
    * Constructs block view model
    *
    * @param {ExchangeRateSet} exchangeRateSet
    */
   constructor(exchangeRateSet) {
-    this.current_rate = new ExchangeRateViewModel(exchangeRateSet);
-    this.next_rate = new ExchangeRateViewModel(exchangeRateSet);
+    this.current_rate = new ExchangeRateViewModel(exchangeRateSet, ExchangeRateSetViewModel.currentLabel);
+    this.next_rate = new ExchangeRateViewModel(exchangeRateSet, ExchangeRateSetViewModel.nextLabel);
     this.timestamp = utils.nsToSecNs(exchangeRateSet.timestamp);
   }
 }

--- a/hedera-mirror-rest/viewmodel/exchangeRateSetViewModel.js
+++ b/hedera-mirror-rest/viewmodel/exchangeRateSetViewModel.js
@@ -31,7 +31,7 @@ class ExchangeRateSetViewModel {
   static nextLabel = 'next_';
 
   /**
-   * Constructs block view model
+   * Constructs exchange rate set view model
    *
    * @param {ExchangeRateSet} exchangeRateSet
    */

--- a/hedera-mirror-rest/viewmodel/exchangeRateSetViewModel.js
+++ b/hedera-mirror-rest/viewmodel/exchangeRateSetViewModel.js
@@ -20,15 +20,23 @@
 
 'use strict';
 
-module.exports = {
-  ContractService: require('./contractService'),
-  CryptoAllowanceService: require('./cryptoAllowanceService'),
-  EntityService: require('./entityService'),
-  FileDataService: require('./fileDataService'),
-  NetworkNodeService: require('./networkNodeService'),
-  NftService: require('./nftService'),
-  RecordFileService: require('./recordFileService'),
-  TokenAllowanceService: require('./tokenAllowanceService'),
-  TokenService: require('./tokenService'),
-  TransactionService: require('./transactionService'),
-};
+const utils = require('../utils');
+const ExchangeRateViewModel = require('./exchangeRateViewModel');
+
+/**
+ * Exchange rate set view model
+ */
+class ExchangeRateSetViewModel {
+  /**
+   * Constructs block view model
+   *
+   * @param {ExchangeRateSet} exchangeRateSet
+   */
+  constructor(exchangeRateSet) {
+    this.current_rate = new ExchangeRateViewModel(exchangeRateSet);
+    this.next_rate = new ExchangeRateViewModel(exchangeRateSet);
+    this.timestamp = utils.nsToSecNs(exchangeRateSet.timestamp);
+  }
+}
+
+module.exports = ExchangeRateSetViewModel;

--- a/hedera-mirror-rest/viewmodel/exchangeRateViewModel.js
+++ b/hedera-mirror-rest/viewmodel/exchangeRateViewModel.js
@@ -20,15 +20,22 @@
 
 'use strict';
 
-module.exports = {
-  ContractService: require('./contractService'),
-  CryptoAllowanceService: require('./cryptoAllowanceService'),
-  EntityService: require('./entityService'),
-  FileDataService: require('./fileDataService'),
-  NetworkNodeService: require('./networkNodeService'),
-  NftService: require('./nftService'),
-  RecordFileService: require('./recordFileService'),
-  TokenAllowanceService: require('./tokenAllowanceService'),
-  TokenService: require('./tokenService'),
-  TransactionService: require('./transactionService'),
-};
+const utils = require('../utils');
+
+/**
+ * Exchange rate view model
+ */
+class ExchangeRateViewModel {
+  /**
+   * Constructs block view model
+   *
+   * @param {ExchangeRate} exchangeRate
+   */
+  constructor(exchangeRate) {
+    this.cent_equivalent = exchangeRate.cent;
+    this.expiration_time = exchangeRate.expiration;
+    this.hbar_equivalent = exchangeRate.hbar;
+  }
+}
+
+module.exports = ExchangeRateViewModel;

--- a/hedera-mirror-rest/viewmodel/exchangeRateViewModel.js
+++ b/hedera-mirror-rest/viewmodel/exchangeRateViewModel.js
@@ -27,7 +27,7 @@ const utils = require('../utils');
  */
 class ExchangeRateViewModel {
   /**
-   * Constructs block view model
+   * Constructs exchange rate view model
    *
    * @param {ExchangeRate} exchangeRate
    */

--- a/hedera-mirror-rest/viewmodel/exchangeRateViewModel.js
+++ b/hedera-mirror-rest/viewmodel/exchangeRateViewModel.js
@@ -31,10 +31,10 @@ class ExchangeRateViewModel {
    *
    * @param {ExchangeRate} exchangeRate
    */
-  constructor(exchangeRate) {
-    this.cent_equivalent = exchangeRate.cent;
-    this.expiration_time = exchangeRate.expiration;
-    this.hbar_equivalent = exchangeRate.hbar;
+  constructor(exchangeRate, prefix) {
+    this.cent_equivalent = exchangeRate[`${prefix}cent`];
+    this.expiration_time = exchangeRate[`${prefix}expiration`];
+    this.hbar_equivalent = exchangeRate[`${prefix}hbar`];
   }
 }
 

--- a/hedera-mirror-rest/viewmodel/index.js
+++ b/hedera-mirror-rest/viewmodel/index.js
@@ -30,6 +30,8 @@ module.exports = {
   ContractResultStateChangeViewModel: require('./contractResultStateChangeViewModel'),
   ContractResultViewModel: require('./contractResultViewModel'),
   CryptoAllowanceViewModel: require('./cryptoAllowanceViewModel'),
+  ExchangeRateSetViewModel: require('./exchangeRateSetViewModel'),
+  ExchangeRateViewModel: require('./exchangeRateViewModel'),
   NetworkNodeViewModel: require('./networkNodeViewModel'),
   NetworkSupplyViewModel: require('./networkSupplyViewModel'),
   NftTransactionHistoryViewModel: require('./nftTransactionHistoryViewModel'),


### PR DESCRIPTION
**Description**:
Add Mirror Node support to retrieve the exchange rate details of the network

**Related issue(s)**:
- Add `ExchangeRateSetViewModel` and `ExchangeRateViewModel`
- Add `FileDataService` to handle  `file_data` row extraction logic
- Update `BaseService` with `buildWhereSqlStatement` and  `getFilterWhereCondition` methods currently in controller
- Add `exchangerate` to network route
- Update `networkController` with `network/exchangerate`
- Move `ContractController.fileDataQuery` to `FileDataService`

Fixes #3579 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
