### PR TITLE
Fix EVM address migration

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/AccountEvmAddressMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/AccountEvmAddressMigration.java
@@ -63,17 +63,22 @@ public class AccountEvmAddressMigration extends MirrorBaseJavaMigration {
     }
 
     @Override
+    public Integer getChecksum() {
+        return 1; // Change this if this migration should be rerun
+    }
+
+    @Override
     public String getDescription() {
         return "Populates evm_address for accounts with an ECDSA secp256k1 alias";
     }
 
     @Override
-    public MigrationVersion getVersion() {
-        return null;
+    public MigrationVersion getMinimumVersion() {
+        return MigrationVersion.fromVersion("1.58.6");
     }
 
     @Override
-    public Integer getChecksum() {
-        return 1; // Change this if this migration should be rerun
+    public MigrationVersion getVersion() {
+        return null;
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/AccountEvmAddressMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/AccountEvmAddressMigration.java
@@ -69,6 +69,11 @@ public class AccountEvmAddressMigration extends MirrorBaseJavaMigration {
 
     @Override
     public MigrationVersion getVersion() {
-        return MigrationVersion.fromVersion("1.58.7");
+        return null;
+    }
+
+    @Override
+    public Integer getChecksum() {
+        return 1; // Change this if this migration should be rerun
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/AccountEvmAddressMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/AccountEvmAddressMigrationTest.java
@@ -20,8 +20,8 @@ package com.hedera.mirror.importer.migration;
  * ‍
  */
 
-import static com.hedera.mirror.importer.util.UtilityTest.EVM_ADDRESS;
 import static com.hedera.mirror.importer.util.UtilityTest.ALIAS_ECDSA_SECP256K1;
+import static com.hedera.mirror.importer.util.UtilityTest.EVM_ADDRESS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import lombok.RequiredArgsConstructor;
@@ -30,15 +30,11 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcOperations;
-import org.springframework.test.context.TestPropertySource;
 
-import com.hedera.mirror.importer.EnabledIfV1;
 import com.hedera.mirror.importer.IntegrationTest;
 
-@EnabledIfV1
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
 @Tag("migration")
-@TestPropertySource(properties = "spring.flyway.target=1.58.6")
 class AccountEvmAddressMigrationTest extends IntegrationTest {
 
     private final JdbcOperations jdbcOperations;

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/util/UtilityTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/util/UtilityTest.java
@@ -49,8 +49,12 @@ public class UtilityTest {
     @Test
     void aliasToEvmAddress() {
         byte[] aliasEd25519 = Key.newBuilder().setEd25519(ByteString.copyFromUtf8("ab")).build().toByteArray();
-        byte[] invalidBytes = new byte[]{'a', 'b'};
+        byte[] aliasEcdsa2 = Hex.decode("3a2102ff806fecbd31b4c377293cba8d2b78725965a4990e0ff1b1b29a1d2c61402310");
+        byte[] evmAddress2 = Hex.decode("efa0d905af20199aa03aca71cfa5f7647f29f439");
+        byte[] invalidBytes = new byte[] {'a', 'b'};
+
         assertThat(Utility.aliasToEvmAddress(ALIAS_ECDSA_SECP256K1)).isEqualTo(EVM_ADDRESS);
+        assertThat(Utility.aliasToEvmAddress(aliasEcdsa2)).isEqualTo(evmAddress2);
         assertThat(Utility.aliasToEvmAddress(aliasEd25519)).isNull();
         assertThat(Utility.aliasToEvmAddress(null)).isNull();
         assertThat(Utility.aliasToEvmAddress(new byte[] {})).isNull();


### PR DESCRIPTION
**Description**:
* Change EVM address migration to repeatable migration
* Fix `Invalid point compression` error by removing unnecessary decompress key logic

**Related issue(s)**:

Fixes #3759

**Notes for reviewer**:
Tested against a full testnet dump of entity table.
Will cherry-pick to 0.56.2.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
