### PR TITLE
Update block number mapping in migration to latest values

### DIFF
--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/BlockNumberMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/BlockNumberMigrationTest.java
@@ -20,6 +20,9 @@ package com.hedera.mirror.importer.migration;
  * ‍
  */
 
+import static com.hedera.mirror.importer.MirrorProperties.HederaNetwork.PREVIEWNET;
+import static com.hedera.mirror.importer.MirrorProperties.HederaNetwork.TESTNET;
+import static com.hedera.mirror.importer.migration.BlockNumberMigration.BLOCK_NUMBER_MAPPING;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
@@ -27,8 +30,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.assertj.core.api.AbstractListAssert;
-import org.assertj.core.api.ObjectAssert;
 import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -36,22 +37,37 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import com.hedera.mirror.common.domain.transaction.RecordFile;
 import com.hedera.mirror.importer.IntegrationTest;
+import com.hedera.mirror.importer.MirrorProperties;
 import com.hedera.mirror.importer.repository.RecordFileRepository;
 
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
 @Tag("migration")
-public class BlockNumberMigrationTest extends IntegrationTest {
+class BlockNumberMigrationTest extends IntegrationTest {
+
+    private static final long CORRECT_CONSENSUS_END = BLOCK_NUMBER_MAPPING.get(TESTNET).getKey();
+    private static final long CORRECT_BLOCK_NUMBER = BLOCK_NUMBER_MAPPING.get(TESTNET).getValue();
 
     private final BlockNumberMigration blockNumberMigration;
-
+    private final MirrorProperties mirrorProperties;
     private final RecordFileRepository recordFileRepository;
 
-    private static final long CORRECT_CONSENSUS_END = 1651523056529307198L;
+    @Test
+    void unsupportedNetwork() {
+        var previousNetwork = mirrorProperties.getNetwork();
+        mirrorProperties.setNetwork(PREVIEWNET);
+        List<Tuple> expectedBlockNumbersAndConsensusEnd = insertDefaultRecordFiles(Set.of(CORRECT_CONSENSUS_END))
+                .stream()
+                .map(recordFile -> Tuple.tuple(recordFile.getConsensusEnd(), recordFile.getIndex()))
+                .collect(Collectors.toList());
 
-    private static final long CORRECT_BLOCK_NUMBER = 20494237L;
+        blockNumberMigration.doMigrate();
+
+        assertConsensusEndAndBlockNumber(expectedBlockNumbersAndConsensusEnd);
+        mirrorProperties.setNetwork(previousNetwork);
+    }
 
     @Test
-    public void theCorrectOffsetMustBeAddedToTheBlockNumbers() {
+    void theCorrectOffsetMustBeAddedToTheBlockNumbers() {
         List<RecordFile> defaultRecordFiles = insertDefaultRecordFiles();
         long offset = CORRECT_BLOCK_NUMBER - 8L;
         List<Tuple> expectedBlockNumbersAndConsensusEnd = defaultRecordFiles.stream()
@@ -64,7 +80,7 @@ public class BlockNumberMigrationTest extends IntegrationTest {
     }
 
     @Test
-    public void ifCorrectConsensusEndNotFoundDoNothing() {
+    void ifCorrectConsensusEndNotFoundDoNothing() {
         List<Tuple> expectedBlockNumbersAndConsensusEnd = insertDefaultRecordFiles(Set.of(CORRECT_CONSENSUS_END))
                 .stream()
                 .map(recordFile -> Tuple.tuple(recordFile.getConsensusEnd(), recordFile.getIndex()))
@@ -76,7 +92,7 @@ public class BlockNumberMigrationTest extends IntegrationTest {
     }
 
     @Test
-    public void ifBlockNumberIsAlreadyCorrectDoNothing() {
+    void ifBlockNumberIsAlreadyCorrectDoNothing() {
         List<Tuple> expectedBlockNumbersAndConsensusEnd = insertDefaultRecordFiles(Set.of(CORRECT_CONSENSUS_END))
                 .stream()
                 .map(recordFile -> Tuple.tuple(recordFile.getConsensusEnd(), recordFile.getIndex()))
@@ -88,16 +104,16 @@ public class BlockNumberMigrationTest extends IntegrationTest {
                         .index(CORRECT_BLOCK_NUMBER)
                 )
                 .persist();
-        expectedBlockNumbersAndConsensusEnd.add(Tuple.tuple(targetRecordFile.getConsensusEnd(), targetRecordFile.getIndex()));
+        expectedBlockNumbersAndConsensusEnd.add(Tuple.tuple(targetRecordFile.getConsensusEnd(),
+                targetRecordFile.getIndex()));
 
         blockNumberMigration.doMigrate();
 
         assertConsensusEndAndBlockNumber(expectedBlockNumbersAndConsensusEnd);
     }
 
-    private AbstractListAssert<?, List<? extends Tuple>, Tuple, ObjectAssert<Tuple>> assertConsensusEndAndBlockNumber(
-            List<Tuple> expectedBlockNumbersAndConsensusEnd){
-        return assertThat(recordFileRepository.findAll())
+    private void assertConsensusEndAndBlockNumber(List<Tuple> expectedBlockNumbersAndConsensusEnd) {
+        assertThat(recordFileRepository.findAll())
                 .hasSize(expectedBlockNumbersAndConsensusEnd.size())
                 .extracting(RecordFile::getConsensusEnd, RecordFile::getIndex)
                 .containsExactlyInAnyOrder(expectedBlockNumbersAndConsensusEnd.toArray(Tuple[]::new));
@@ -108,21 +124,18 @@ public class BlockNumberMigrationTest extends IntegrationTest {
     }
 
     private List<RecordFile> insertDefaultRecordFiles(Set<Long> skipRecordFileWithConsensusEnd) {
-        long[] consensusEnd = {1570800761443132000L,CORRECT_CONSENSUS_END,1570801906238879002L};
-        long[] blockNumber = {0L,8L,9L};
+        long[] consensusEnd = {1570800761443132000L, CORRECT_CONSENSUS_END, 1570801906238879002L};
+        long[] blockNumber = {0L, 8L, 9L};
         var recordFiles = new ArrayList<RecordFile>(consensusEnd.length);
 
         for (int i = 0; i < consensusEnd.length; i++) {
-            if(skipRecordFileWithConsensusEnd.contains(consensusEnd[i])){
+            if (skipRecordFileWithConsensusEnd.contains(consensusEnd[i])) {
                 continue;
             }
             final long currConsensusEnd = consensusEnd[i];
             final long currBlockNumber = blockNumber[i];
             RecordFile recordFile = domainBuilder.recordFile()
-                    .customize(builder -> builder
-                            .consensusEnd(currConsensusEnd)
-                            .index(currBlockNumber)
-                    )
+                    .customize(builder -> builder.consensusEnd(currConsensusEnd).index(currBlockNumber))
                     .persist();
             recordFiles.add(recordFile);
         }


### PR DESCRIPTION
**Description**:
* Add some extra logging and test coverage
* Bump migration checksum to force a re-run
* Update block number mapping in migration to latest values

**Related issue(s)**:

**Notes for reviewer**:
We said we would keep the migration up to date in each release until record file v6 exposes the official block number.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
