### PR TITLE
Flatten Nft transfer chain

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListener.java
@@ -105,7 +105,6 @@ public class SqlEntityListener implements EntityListener, RecordStreamFileListen
     private final Collection<FileData> fileData;
     private final Collection<LiveHash> liveHashes;
     private final Collection<NftAllowance> nftAllowances;
-    private final Collection<NftTransfer> nftTransfers;
     private final Collection<NonFeeTransfer> nonFeeTransfers;
     private final Collection<TokenAccount> tokenAccounts;
     private final Collection<TokenAllowance> tokenAllowances;
@@ -157,7 +156,6 @@ public class SqlEntityListener implements EntityListener, RecordStreamFileListen
         fileData = new ArrayList<>();
         liveHashes = new ArrayList<>();
         nftAllowances = new ArrayList<>();
-        nftTransfers = new ArrayList<>();
         nonFeeTransfers = new ArrayList<>();
         tokenAccounts = new ArrayList<>();
         tokenAllowances = new ArrayList<>();
@@ -222,7 +220,6 @@ public class SqlEntityListener implements EntityListener, RecordStreamFileListen
             nftAllowances.clear();
             nftAllowanceState.clear();
             nftTransferState.clear();
-            nftTransfers.clear();
             schedules.clear();
             topicMessages.clear();
             tokenAccounts.clear();

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListener.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import javax.inject.Named;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.BeanCreationNotAllowedException;
@@ -563,7 +564,7 @@ public class SqlEntityListener implements EntityListener, RecordStreamFileListen
 
     private NftTransfer mergeNftTransfer(NftTransfer cachedNftTransfer, NftTransfer newNftTransfer) {
         // flatten multi receiver transfers
-        if (newNftTransfer.getReceiverAccountId() != null && cachedNftTransfer.getReceiverAccountId() != newNftTransfer.getReceiverAccountId()) {
+        if (!Objects.equals(cachedNftTransfer.getReceiverAccountId(), newNftTransfer.getReceiverAccountId())) {
             cachedNftTransfer.setReceiverAccountId(newNftTransfer.getReceiverAccountId());
         }
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListenerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListenerTest.java
@@ -972,6 +972,34 @@ class SqlEntityListenerTest extends IntegrationTest {
     }
 
     @Test
+    void onNftTransferMultiReceiverSingleTimestamp() {
+        String tokenId = "0.0.1";
+        long timestamp = 1L;
+        long serialNumber = 5L;
+        String originalSenderId = "0.0.10";
+        String firstReceipientId = "0.0.11";
+        String secondReceipientId = "0.0.12";
+        String finalReceipientId = "0.0.13";
+        NftTransfer nftTransfer1 = getNftTransfer(timestamp, tokenId, serialNumber, firstReceipientId,
+                originalSenderId);
+        NftTransfer nftTransfer2 = getNftTransfer(timestamp, tokenId, serialNumber, secondReceipientId,
+                firstReceipientId);
+        NftTransfer nftTransfer3 = getNftTransfer(timestamp, tokenId, serialNumber, finalReceipientId,
+                secondReceipientId);
+
+        // when
+        sqlEntityListener.onNftTransfer(nftTransfer1);
+        sqlEntityListener.onNftTransfer(nftTransfer2);
+        sqlEntityListener.onNftTransfer(nftTransfer3);
+        completeFileAndCommit();
+
+        // then
+        NftTransfer mergedNftTransfer = getNftTransfer(timestamp, tokenId, serialNumber, finalReceipientId,
+                originalSenderId);
+        assertThat(nftTransferRepository.findAll()).containsExactlyInAnyOrder(mergedNftTransfer);
+    }
+
+    @Test
     void onToken() {
         Token token1 = getToken(EntityId.of("0.0.3", TOKEN), EntityId.of("0.0.5", ACCOUNT), 1L, 1L);
         Token token2 = getToken(EntityId.of("0.0.7", TOKEN), EntityId.of("0.0.11", ACCOUNT), 2L, 2L);

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListenerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListenerTest.java
@@ -1000,6 +1000,20 @@ class SqlEntityListenerTest extends IntegrationTest {
     }
 
     @Test
+    void onNftTransferDuplicates() {
+        NftTransfer nftTransfer1 = getNftTransfer(1L, "0.0.1", 1L, "0.0.2", "0.0.3");
+
+        // when
+        sqlEntityListener.onNftTransfer(nftTransfer1);
+        sqlEntityListener.onNftTransfer(nftTransfer1);
+        sqlEntityListener.onNftTransfer(nftTransfer1);
+        completeFileAndCommit();
+
+        // then
+        assertThat(nftTransferRepository.findAll()).containsExactlyInAnyOrder(nftTransfer1);
+    }
+
+    @Test
     void onToken() {
         Token token1 = getToken(EntityId.of("0.0.3", TOKEN), EntityId.of("0.0.5", ACCOUNT), 1L, 1L);
         Token token2 = getToken(EntityId.of("0.0.7", TOKEN), EntityId.of("0.0.11", ACCOUNT), 2L, 2L);


### PR DESCRIPTION
Signed-off-by: Nana-EC <nana@swirldslabs.com>

**Description**:
NftTransfer chain for multi recipients can be simplified
- Add merge logic in SqlEntityListener  to flatten

**Related issue(s)**:

Fixes #

**Notes for reviewer**:


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
