### PR TITLE
Flatten NFT transfer chain (0.57)

### DIFF
--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListenerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListenerTest.java
@@ -972,6 +972,48 @@ class SqlEntityListenerTest extends IntegrationTest {
     }
 
     @Test
+    void onNftTransferMultiReceiverSingleTimestamp() {
+        String tokenId = "0.0.1";
+        long timestamp = 1L;
+        long serialNumber = 5L;
+        String originalSenderId = "0.0.10";
+        String firstReceipientId = "0.0.11";
+        String secondReceipientId = "0.0.12";
+        String finalReceipientId = "0.0.13";
+        NftTransfer nftTransfer1 = getNftTransfer(timestamp, tokenId, serialNumber, firstReceipientId,
+                originalSenderId);
+        NftTransfer nftTransfer2 = getNftTransfer(timestamp, tokenId, serialNumber, secondReceipientId,
+                firstReceipientId);
+        NftTransfer nftTransfer3 = getNftTransfer(timestamp, tokenId, serialNumber, finalReceipientId,
+                secondReceipientId);
+
+        // when
+        sqlEntityListener.onNftTransfer(nftTransfer1);
+        sqlEntityListener.onNftTransfer(nftTransfer2);
+        sqlEntityListener.onNftTransfer(nftTransfer3);
+        completeFileAndCommit();
+
+        // then
+        NftTransfer mergedNftTransfer = getNftTransfer(timestamp, tokenId, serialNumber, finalReceipientId,
+                originalSenderId);
+        assertThat(nftTransferRepository.findAll()).containsExactlyInAnyOrder(mergedNftTransfer);
+    }
+
+    @Test
+    void onNftTransferDuplicates() {
+        NftTransfer nftTransfer1 = getNftTransfer(1L, "0.0.1", 1L, "0.0.2", "0.0.3");
+
+        // when
+        sqlEntityListener.onNftTransfer(nftTransfer1);
+        sqlEntityListener.onNftTransfer(nftTransfer1);
+        sqlEntityListener.onNftTransfer(nftTransfer1);
+        completeFileAndCommit();
+
+        // then
+        assertThat(nftTransferRepository.findAll()).containsExactlyInAnyOrder(nftTransfer1);
+    }
+
+    @Test
     void onToken() {
         Token token1 = getToken(EntityId.of("0.0.3", TOKEN), EntityId.of("0.0.5", ACCOUNT), 1L, 1L);
         Token token2 = getToken(EntityId.of("0.0.7", TOKEN), EntityId.of("0.0.11", ACCOUNT), 2L, 2L);


### PR DESCRIPTION
**Description**:
Cherry-pick of #3816 to `release/0.57`

* NftTransfer chain for multi recipients can be simplified
* Add merge logic in SqlEntityListener  to flatten

**Related issue(s)**:


**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
