### PR TITLE
Bump Spring Boot from 2.6.8 to 2.7.0

### DIFF
--- a/hedera-mirror-monitor/pom.xml
+++ b/hedera-mirror-monitor/pom.xml
@@ -43,7 +43,7 @@
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
-            <artifactId>grpc-okhttp</artifactId>
+            <artifactId>grpc-netty</artifactId>
             <version>${grpc.version}</version>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.8</version>
+        <version>2.7.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 


### PR DESCRIPTION
**Description**:

* Bump Spring Boot from 2.6.8 to 2.7.0
* Change monitor to use grpc-netty

**Related issue(s)**:

**Notes for reviewer**:
Spring Boot 2.7 dropped support for Okhttp 3.x which grpc-okhttp uses. Attempting to downgrade the okhttp version caused cascading failures in other dependencies. Easier to use grpc-netty despite it potentially being slower at higher TPS.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
