### PR TITLE
Fix use of shard and realm in contracts REST API

### DIFF
--- a/hedera-mirror-rest/__tests__/specs/contracts-06-specific-id-not-found.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts-06-specific-id-not-found.spec.json
@@ -1,7 +1,22 @@
 {
   "description": "Contract api calls for a specific contract using contract id, not found",
-  "setup": {},
-  "url": ["/api/v1/contracts/0.0.6001", "/api/v1/contracts/60f3f640a8508fc6a86d45df051962668e1e8ac7"],
+  "setup": {
+    "contracts": [
+      {
+        "created_timestamp": "987654000123456",
+        "file_id": "5001",
+        "key": [1, 1, 1],
+        "num": "924569",
+        "timestamp_range": "[987654000123456,)"
+      }
+    ]
+  },
+  "urls": [
+    "/api/v1/contracts/0.0.6001",
+    "/api/v1/contracts/60f3f640a8508fc6a86d45df051962668e1e8ac7",
+    "/api/v1/contracts/1.1.924569",
+    "/api/v1/contracts/24.42.924569"
+  ],
   "responseStatus": 404,
   "responseJson": {
     "_status": {

--- a/hedera-mirror-rest/controllers/contractController.js
+++ b/hedera-mirror-rest/controllers/contractController.js
@@ -233,7 +233,9 @@ const getContractByIdOrAddressQuery = ({timestampConditions, timestampParams, co
     params.push(...evmAddressParams);
     conditions.push(...evmAddressConditions);
   } else {
-    const encodedId = EntityId.parse(_.last(contractIdParam.split('.'))).getEncodedId();
+    // Passing the entire contract id instead of just the num part from shard.realm.num
+    // The contract ID string can be shard.realm.num, realm.num when shard=0 in application.yml or the encoded entity ID string.
+    const encodedId = EntityId.parse(contractIdParam).getEncodedId();
     params.push(encodedId);
     conditions.push(`${Contract.getFullName(Contract.ID)} = $${params.length}`);
   }


### PR DESCRIPTION
**Description**:
Changing contract Id function getContractByIdOrAddressQuery to accept… entire contract id in the format shard.realm.num

**Related issue(s)**:
Fixes #3809

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
