### PR TITLE
Support consistent block number in rosetta

### DIFF
--- a/.github/workflows/charts.yml
+++ b/.github/workflows/charts.yml
@@ -56,7 +56,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         run: |
           # GITHUB_HEAD_REF is only set when the triggering event is either pull_request or pull_request_target. If so
-          # pass an extra helm set arg to provide the correct github ref
+          # extract the PR branch from GITHUB_HEAD_REF and later pass it as githubRef to the rosetta test pod template
           echo "GIT_REF=${GITHUB_HEAD_REF#refs/*/}" >> $GITHUB_ENV
 
       - name: Install chart

--- a/.github/workflows/charts.yml
+++ b/.github/workflows/charts.yml
@@ -59,4 +59,4 @@ jobs:
             GIT_REF=${$GITHUB_HEAD_REF#refs/*/}
             HELM_EXTRA_SET_ARGS="--helm-extra-set-args=\"--set=rosetta.test.githubRef=${GIT_REF}\""
           fi
-          ct install --config .github/ct.yaml --charts=charts/hedera-mirror "${helmExtraSetArgs}"
+          ct install --config .github/ct.yaml --charts=charts/hedera-mirror "${HELM_EXTRA_SET_ARGS}"

--- a/.github/workflows/charts.yml
+++ b/.github/workflows/charts.yml
@@ -53,4 +53,10 @@ jobs:
       - name: Install chart
         run: |
           yq -i '(.global.image.registry="registry:5000") | (.global.image.tag="${{ env.IMAGE_TAG }}")' charts/hedera-mirror/ci/*.yaml
-          ct install --config .github/ct.yaml --charts=charts/hedera-mirror
+          if [ -n "$GITHUB_HEAD_REF" ]; then
+            # GITHUB_HEAD_REF is only set when the triggering event is either pull_request or pull_request_target. If so
+            # pass an extra helm set arg to provide the correct github ref
+            GIT_REF=${$GITHUB_HEAD_REF#refs/*/}
+            HELM_EXTRA_SET_ARGS="--helm-extra-set-args=\"--set=rosetta.test.githubRef=${GIT_REF}\""
+          fi
+          ct install --config .github/ct.yaml --charts=charts/hedera-mirror "${helmExtraSetArgs}"

--- a/.github/workflows/charts.yml
+++ b/.github/workflows/charts.yml
@@ -60,5 +60,4 @@ jobs:
           echo "GIT_REF=${GITHUB_HEAD_REF#refs/*/}" >> $GITHUB_ENV
 
       - name: Install chart
-        run: |
         run: ct install --config .github/ct.yaml --charts=charts/hedera-mirror --helm-extra-set-args="--set=global.image.registry=registry:5000 --set=global.image.tag=${IMAGE_TAG} --set=rosetta.test.githubRef=${GIT_REF}"

--- a/.github/workflows/charts.yml
+++ b/.github/workflows/charts.yml
@@ -49,14 +49,21 @@ jobs:
 
       - name: Install ct
         uses: helm/chart-testing-action@v2.2.1
+        with:
+          version: v3.6.0
+
+      - name: Set GIT_REF for pull request
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          # GITHUB_HEAD_REF is only set when the triggering event is either pull_request or pull_request_target. If so
+          # pass an extra helm set arg to provide the correct github ref
+          echo "GIT_REF=${GITHUB_HEAD_REF#refs/*/}" >> $GITHUB_ENV
 
       - name: Install chart
         run: |
-          yq -i '(.global.image.registry="registry:5000") | (.global.image.tag="${{ env.IMAGE_TAG }}")' charts/hedera-mirror/ci/*.yaml
-          if [ -n "$GITHUB_HEAD_REF" ]; then
-            # GITHUB_HEAD_REF is only set when the triggering event is either pull_request or pull_request_target. If so
-            # pass an extra helm set arg to provide the correct github ref
-            GIT_REF=${GITHUB_HEAD_REF#refs/*/}
-            HELM_EXTRA_SET_ARGS="--helm-extra-set-args=\"--set=rosetta.test.githubRef=${GIT_REF}\""
+          HELM_EXTRA_SET_ARGS="--set=global.image.registry=registry:5000 --set=global.image.tag=${IMAGE_TAG}"
+          if [ -n "$GIT_REF" ]; then
+               HELM_EXTRA_SET_ARGS="${HELM_EXTRA_SET_ARGS} --set=rosetta.test.githubRef=${GIT_REF}"
           fi
-          ct install --config .github/ct.yaml --charts=charts/hedera-mirror "${HELM_EXTRA_SET_ARGS}"
+          ct install --config .github/ct.yaml --charts=charts/hedera-mirror \
+            --helm-extra-set-args="${HELM_EXTRA_SET_ARGS}"

--- a/.github/workflows/charts.yml
+++ b/.github/workflows/charts.yml
@@ -61,9 +61,4 @@ jobs:
 
       - name: Install chart
         run: |
-          HELM_EXTRA_SET_ARGS="--set=global.image.registry=registry:5000 --set=global.image.tag=${IMAGE_TAG}"
-          if [ -n "$GIT_REF" ]; then
-               HELM_EXTRA_SET_ARGS="${HELM_EXTRA_SET_ARGS} --set=rosetta.test.githubRef=${GIT_REF}"
-          fi
-          ct install --config .github/ct.yaml --charts=charts/hedera-mirror \
-            --helm-extra-set-args="${HELM_EXTRA_SET_ARGS}"
+        run: ct install --config .github/ct.yaml --charts=charts/hedera-mirror --helm-extra-set-args="--set=global.image.registry=registry:5000 --set=global.image.tag=${IMAGE_TAG} --set=rosetta.test.githubRef=${GIT_REF}"

--- a/.github/workflows/charts.yml
+++ b/.github/workflows/charts.yml
@@ -56,7 +56,7 @@ jobs:
           if [ -n "$GITHUB_HEAD_REF" ]; then
             # GITHUB_HEAD_REF is only set when the triggering event is either pull_request or pull_request_target. If so
             # pass an extra helm set arg to provide the correct github ref
-            GIT_REF=${$GITHUB_HEAD_REF#refs/*/}
+            GIT_REF=${GITHUB_HEAD_REF#refs/*/}
             HELM_EXTRA_SET_ARGS="--helm-extra-set-args=\"--set=rosetta.test.githubRef=${GIT_REF}\""
           fi
           ct install --config .github/ct.yaml --charts=charts/hedera-mirror "${HELM_EXTRA_SET_ARGS}"

--- a/.github/workflows/rosetta-api.yml
+++ b/.github/workflows/rosetta-api.yml
@@ -162,7 +162,11 @@ jobs:
             '.construction.prefunded_accounts=$accounts[0] | .construction.offline_url="${{ env.OFFLINE_URL }}"' \
             validation.json > /tmp/validation.json
 
-          mv /tmp/validation.json validation.json
+          # set start index to genesis index + 1
+          body="{\"network_identifier\": $(cat validation.json  | jq -c -M '.network')}"
+          startIndex=$(curl -sL -d "${body}" http://localhost:5700/network/status | jq '.genesis_block_identifier.index+1')
+          echo "Setting data start_index to $startIndex"
+          jq --argjson startIndex $startIndex '.data.start_index=$startIndex' /tmp/validation.json > validation.json
 
       - name: Run Rosetta CLI Validation
         working-directory: ./hedera-mirror-rosetta/scripts/validation

--- a/charts/hedera-mirror-rosetta/templates/tests/pod.yaml
+++ b/charts/hedera-mirror-rosetta/templates/tests/pod.yaml
@@ -15,7 +15,7 @@ spec:
       imagePullPolicy: {{ .Values.test.image.pullPolicy }}
       args:
         - run
-        - https://raw.githubusercontent.com/hashgraph/hedera-mirror-node/{{ regexReplaceAll "(\\d+\\.\\d+\\.\\d+(-\\w+)?)" .Chart.AppVersion "v${1}" }}/hedera-mirror-rosetta/scripts/validation/postman/rosetta-api-postman.json
+        - https://raw.githubusercontent.com/hashgraph/hedera-mirror-node/{{ .Values.test.githubRef }}/hedera-mirror-rosetta/scripts/validation/postman/rosetta-api-postman.json
         - --env-var
         - base_url=http://{{ include "hedera-mirror-rosetta.fullname" . }}:{{ .Values.service.port }}
       securityContext:

--- a/charts/hedera-mirror-rosetta/templates/tests/pod.yaml
+++ b/charts/hedera-mirror-rosetta/templates/tests/pod.yaml
@@ -15,7 +15,7 @@ spec:
       imagePullPolicy: {{ .Values.test.image.pullPolicy }}
       args:
         - run
-        - https://raw.githubusercontent.com/hashgraph/hedera-mirror-node/{{ .Values.test.githubRef }}/hedera-mirror-rosetta/scripts/validation/postman/rosetta-api-postman.json
+        - https://raw.githubusercontent.com/hashgraph/hedera-mirror-node/{{ regexReplaceAll "(\\d+\\.\\d+\\.\\d+(-\\w+)?)" (.Values.test.githubRef | default .Chart.AppVersion) "v${1}" }}/hedera-mirror-rosetta/scripts/validation/postman/rosetta-api-postman.json
         - --env-var
         - base_url=http://{{ include "hedera-mirror-rosetta.fullname" . }}:{{ .Values.service.port }}
       securityContext:

--- a/charts/hedera-mirror-rosetta/values.yaml
+++ b/charts/hedera-mirror-rosetta/values.yaml
@@ -227,6 +227,7 @@ test:
     pullPolicy: IfNotPresent
     repository: postman/newman
     tag: 5.3.1-alpine
+  githubRef: '{{ regexReplaceAll "(\\d+\\.\\d+\\.\\d+(-\\w+)?)" .Chart.AppVersion "v${1}"'
 
 tolerations: []
 

--- a/charts/hedera-mirror-rosetta/values.yaml
+++ b/charts/hedera-mirror-rosetta/values.yaml
@@ -223,7 +223,7 @@ terminationGracePeriodSeconds: 60
 
 test:
   enabled: true
-  githubRef:
+  githubRef: ""
   image:
     pullPolicy: IfNotPresent
     repository: postman/newman

--- a/charts/hedera-mirror-rosetta/values.yaml
+++ b/charts/hedera-mirror-rosetta/values.yaml
@@ -223,11 +223,11 @@ terminationGracePeriodSeconds: 60
 
 test:
   enabled: true
+  githubRef:
   image:
     pullPolicy: IfNotPresent
     repository: postman/newman
     tag: 5.3.1-alpine
-  githubRef:
 
 tolerations: []
 

--- a/charts/hedera-mirror-rosetta/values.yaml
+++ b/charts/hedera-mirror-rosetta/values.yaml
@@ -227,7 +227,7 @@ test:
     pullPolicy: IfNotPresent
     repository: postman/newman
     tag: 5.3.1-alpine
-  githubRef: '{{ regexReplaceAll "(\\d+\\.\\d+\\.\\d+(-\\w+)?)" .Chart.AppVersion "v${1}"'
+  githubRef:
 
 tolerations: []
 

--- a/hedera-mirror-rosetta/app/persistence/block_test.go
+++ b/hedera-mirror-rosetta/app/persistence/block_test.go
@@ -135,7 +135,7 @@ type blockRepositorySuite struct {
 
 func (suite *blockRepositorySuite) SetupTest() {
 	suite.integrationTest.SetupTest()
-	db.CreateDbRecords(dbClient, accountBalanceFiles, recordFiles)
+	db.CreateDbRecords(dbClient, accountBalanceFiles, recordFiles, recordFileBeforeGenesis)
 }
 
 func (suite *blockRepositorySuite) TestFindByHashGenesisBlock() {

--- a/hedera-mirror-rosetta/app/persistence/block_test.go
+++ b/hedera-mirror-rosetta/app/persistence/block_test.go
@@ -31,6 +31,8 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
+const genesisBlockIndex int64 = 3
+
 var (
 	accountBalanceFiles = []*domain.AccountBalanceFile{
 		{
@@ -59,25 +61,25 @@ var (
 		ConsensusStartNanos: 91,
 		ConsensusEndNanos:   109,
 		Hash:                "genesis_record_file_hash",
-		Index:               0,
+		Index:               genesisBlockIndex,
 		ParentHash:          "genesis_record_file_hash",
-		ParentIndex:         0,
+		ParentIndex:         genesisBlockIndex,
 	}
 	expectedSecondBlock = &types.Block{
 		ConsensusStartNanos: 110,
 		ConsensusEndNanos:   129,
 		Hash:                "second_record_file_hash",
-		Index:               1,
+		Index:               genesisBlockIndex + 1,
 		ParentHash:          "genesis_record_file_hash",
-		ParentIndex:         0,
+		ParentIndex:         genesisBlockIndex,
 	}
 	expectedThirdBlock = &types.Block{
 		ConsensusStartNanos: 130,
 		ConsensusEndNanos:   145,
 		Hash:                "third_record_file_hash",
-		Index:               2,
+		Index:               genesisBlockIndex + 2,
 		ParentHash:          "second_record_file_hash",
-		ParentIndex:         1,
+		ParentIndex:         genesisBlockIndex + 1,
 	}
 	nodeEntityId = domain.MustDecodeEntityId(3)
 	recordFiles  = []*domain.RecordFile{
@@ -85,7 +87,7 @@ var (
 			ConsensusStart: 80,
 			ConsensusEnd:   100,
 			Hash:           "genesis_record_file_hash",
-			Index:          3,
+			Index:          genesisBlockIndex,
 			Name:           "genesis_record_file",
 			NodeAccountID:  nodeEntityId,
 			PrevHash:       "previous_record_file_hash",
@@ -94,7 +96,7 @@ var (
 			ConsensusStart: 110,
 			ConsensusEnd:   120,
 			Hash:           "second_record_file_hash",
-			Index:          4,
+			Index:          genesisBlockIndex + 1,
 			Name:           "second_record_file",
 			NodeAccountID:  nodeEntityId,
 			PrevHash:       "genesis_record_file_hash",
@@ -103,7 +105,7 @@ var (
 			ConsensusStart: 130,
 			ConsensusEnd:   145,
 			Hash:           "third_record_file_hash",
-			Index:          5,
+			Index:          genesisBlockIndex + 2,
 			Name:           "third_record_file",
 			NodeAccountID:  nodeEntityId,
 			PrevHash:       "second_record_file_hash",
@@ -114,7 +116,7 @@ var (
 		ConsensusStart: 50,
 		ConsensusEnd:   79,
 		Hash:           "previous_record_file_hash",
-		Index:          2,
+		Index:          genesisBlockIndex - 1,
 		Name:           "previous_record_file",
 		NodeAccountID:  nodeEntityId,
 		PrevHash:       "some_hash",
@@ -158,6 +160,18 @@ func (suite *blockRepositorySuite) TestFindByHashNonGenesisBlock() {
 	// then
 	assert.Nil(suite.T(), err)
 	assert.Equal(suite.T(), expectedSecondBlock, actual)
+}
+
+func (suite *blockRepositorySuite) TestFindByHashBlockBeforeGenesis() {
+	// given
+	repo := NewBlockRepository(dbClient)
+
+	// when
+	actual, err := repo.FindByHash(defaultContext, recordFileBeforeGenesis.Hash)
+
+	// then
+	assert.Equal(suite.T(), errors.ErrBlockNotFound, err)
+	assert.Nil(suite.T(), actual)
 }
 
 func (suite *blockRepositorySuite) TestFindByHashNoAccountBalanceFile() {
@@ -215,7 +229,7 @@ func (suite *blockRepositorySuite) TestFindByIdentifierGenesisBlock() {
 	repo := NewBlockRepository(dbClient)
 
 	// when
-	actual, err := repo.FindByIdentifier(defaultContext, 0, expectedGenesisBlock.Hash)
+	actual, err := repo.FindByIdentifier(defaultContext, genesisBlockIndex, expectedGenesisBlock.Hash)
 
 	// then
 	assert.Nil(suite.T(), err)
@@ -232,6 +246,18 @@ func (suite *blockRepositorySuite) TestFindByIdentifierNonGenesisBlock() {
 	// then
 	assert.Nil(suite.T(), err)
 	assert.Equal(suite.T(), expectedSecondBlock, actual)
+}
+
+func (suite *blockRepositorySuite) TestFindByIdentifierBlockBeforeGenesis() {
+	// given
+	repo := NewBlockRepository(dbClient)
+
+	// when
+	actual, err := repo.FindByIdentifier(defaultContext, recordFileBeforeGenesis.Index, recordFileBeforeGenesis.Hash)
+
+	// then
+	assert.Equal(suite.T(), errors.ErrBlockNotFound, err)
+	assert.Nil(suite.T(), actual)
 }
 
 func (suite *blockRepositorySuite) TestFindByIdentifierInvalidArgument() {
@@ -333,7 +359,7 @@ func (suite *blockRepositorySuite) TestFindByIndexGenesisBlock() {
 	repo := NewBlockRepository(dbClient)
 
 	// when
-	actual, err := repo.FindByIndex(defaultContext, 0)
+	actual, err := repo.FindByIndex(defaultContext, genesisBlockIndex)
 
 	// then
 	assert.Nil(suite.T(), err)
@@ -350,6 +376,18 @@ func (suite *blockRepositorySuite) TestFindByIndexNonGenesisBlock() {
 	// then
 	assert.Nil(suite.T(), err)
 	assert.Equal(suite.T(), expectedSecondBlock, actual)
+}
+
+func (suite *blockRepositorySuite) TestFindByIndexBlockBeforeGenesis() {
+	// given
+	repo := NewBlockRepository(dbClient)
+
+	// when
+	actual, err := repo.FindByIndex(defaultContext, recordFileBeforeGenesis.Index)
+
+	// then
+	assert.Equal(suite.T(), errors.ErrBlockNotFound, err)
+	assert.Nil(suite.T(), actual)
 }
 
 func (suite *blockRepositorySuite) TestFindByIndexInvalidIndex() {
@@ -575,7 +613,6 @@ func (suite *blockRepositorySuite) TestRetrieveLatestDbConnectionError() {
 
 func TestRecordFileToBlock(t *testing.T) {
 	genesisConsensusStart := int64(110)
-	genesisIndex := int64(5)
 	tests := []struct {
 		name     string
 		input    recordBlock
@@ -587,13 +624,13 @@ func TestRecordFileToBlock(t *testing.T) {
 				ConsensusStart: 100,
 				ConsensusEnd:   200,
 				Hash:           "hash",
-				Index:          5,
+				Index:          genesisBlockIndex,
 				PrevHash:       "prev_hash",
 			},
 			&types.Block{
-				Index:               0,
+				Index:               genesisBlockIndex,
 				Hash:                "hash",
-				ParentIndex:         0,
+				ParentIndex:         genesisBlockIndex,
 				ParentHash:          "hash",
 				ConsensusStartNanos: genesisConsensusStart,
 				ConsensusEndNanos:   200,
@@ -609,9 +646,9 @@ func TestRecordFileToBlock(t *testing.T) {
 				PrevHash:       "prev_hash",
 			},
 			&types.Block{
-				Index:               3,
+				Index:               8,
 				Hash:                "hash",
-				ParentIndex:         2,
+				ParentIndex:         7,
 				ParentHash:          "prev_hash",
 				ConsensusStartNanos: 201,
 				ConsensusEndNanos:   300,
@@ -621,7 +658,7 @@ func TestRecordFileToBlock(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, tt.input.ToBlock(genesisConsensusStart, genesisIndex))
+			assert.Equal(t, tt.expected, tt.input.ToBlock(genesisConsensusStart, genesisBlockIndex))
 		})
 	}
 }

--- a/hedera-mirror-rosetta/scripts/validation/postman/rosetta-api-postman.json
+++ b/hedera-mirror-rosetta/scripts/validation/postman/rosetta-api-postman.json
@@ -143,6 +143,10 @@
                   "    pm.response.to.have.status(200);",
                   "    pm.response.to.be.ok;",
                   "    pm.response.to.be.json;",
+                  "    // set genesis index",
+                  "    const jsonData = pm.response.json();",
+                  "    const genesisIndex = jsonData.genesis_block_identifier.index;",
+                  "    pm.globals.set(\"genesis_index\", genesisIndex);",
                   "});"
                 ],
                 "type": "text/javascript"
@@ -188,8 +192,9 @@
               "script": {
                 "id": "df376a22-cf8a-4663-bae8-1cf87d2f5d67",
                 "exec": [
+                  "const genesisIndex = pm.globals.get(\"genesis_index\");",
                   "const networkId = pm.globals.get(\"network_identifier\");",
-                  "",
+                  "pm.variables.set('genesisIndex', genesisIndex);",
                   "pm.variables.set('networkId', JSON.stringify(networkId.network_identifier));"
                 ],
                 "type": "text/javascript"
@@ -222,7 +227,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"network_identifier\": {{networkId}},\n    \"account_identifier\": {\n        \"address\": \"0.0.98\",\n        \"metadata\": {}\n    },\n    \"block_identifier\": {\n        \"index\": 1\n    }\n}",
+              "raw": "{\n    \"network_identifier\": {{networkId}},\n    \"account_identifier\": {\n        \"address\": \"0.0.98\",\n        \"metadata\": {}\n    },\n    \"block_identifier\": {\n        \"index\": {{genesisIndex}}\n    }\n}",
               "options": {
                 "raw": {
                   "language": "json"
@@ -256,8 +261,9 @@
               "script": {
                 "id": "d17cd4d5-94c6-4435-95ee-544d036a0514",
                 "exec": [
+                  "const genesisIndex = pm.globals.get(\"genesis_index\");",
                   "const networkId = pm.globals.get(\"network_identifier\");",
-                  "",
+                  "pm.variables.set('genesisIndex', genesisIndex);",
                   "pm.variables.set('networkId', JSON.stringify(networkId.network_identifier));"
                 ],
                 "type": "text/javascript"
@@ -293,7 +299,7 @@
             "header": [],
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"network_identifier\": {{networkId}},\n    \"block_identifier\": {\n        \"index\": 2\n    }\n}",
+              "raw": "{\n    \"network_identifier\": {{networkId}},\n    \"block_identifier\": {\n        \"index\": {{genesisIndex}}\n    }\n}",
               "options": {
                 "raw": {
                   "language": "json"


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR adds consistent block number support in rosetta

- Use record file index as block index in rosetta api
- Update rosetta github workflow to use genesis block index + 1 for start index of data validation
- Update rosetta postman tests to query genesis block index dynamically
- Update charts workflow and rosetta helm chart to use postman test suite from the PR branch

**Related issue(s)**:

Fixes #3819

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
After we implement data retention, when old data is removed, rosetta server will report block not found error when handling requests for those blocks, however the genesis block index will not change. Once rosetta server restarts, the genesis block index will change to the index of the first record file with consensus end > first account balance file's timestamp.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
