### PR TITLE
Avoid accidentally replacing semantic version in rosetta chart test pod template

### DIFF
--- a/charts/hedera-mirror-rosetta/templates/tests/pod.yaml
+++ b/charts/hedera-mirror-rosetta/templates/tests/pod.yaml
@@ -15,7 +15,7 @@ spec:
       imagePullPolicy: {{ .Values.test.image.pullPolicy }}
       args:
         - run
-        - https://raw.githubusercontent.com/hashgraph/hedera-mirror-node/{{ regexReplaceAll "(\\d+\\.\\d+\\.\\d+(-\\w+)?)" (.Values.test.githubRef | default .Chart.AppVersion) "v${1}" }}/hedera-mirror-rosetta/scripts/validation/postman/rosetta-api-postman.json
+        - https://raw.githubusercontent.com/hashgraph/hedera-mirror-node/{{ .Values.test.githubRef | default (regexReplaceAll "(\\d+\\.\\d+\\.\\d+(-\\w+)?)" .Chart.AppVersion "v${1}") }}/hedera-mirror-rosetta/scripts/validation/postman/rosetta-api-postman.json
         - --env-var
         - base_url=http://{{ include "hedera-mirror-rosetta.fullname" . }}:{{ .Values.service.port }}
       securityContext:


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR fixes the regression introduced by my pervious PR #3915 which breaks almost all charts workflow runs for dependabot PRs.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
The change introduced in PR #3915 will accidentally replace any semantic version string in the git branch name, and almost all dependabot PRs have semantic versions, that's why the charts workflow runs are all failing.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
