### PR TITLE
Fix cleanup workflow

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,12 @@
+changelog:
+  exclude:
+    labels: ["wontfix", "question", "duplicate", "invalid"]
+  categories:
+    - title: "Enhancements"
+      labels: ["enhancement", "epic"]
+    - title: "Bug Fixes"
+      labels: ["bug"]
+    - title: "Documentation"
+      labels: ["documentation"]
+    - title: "Dependency Upgrades"
+      labels: ["dependencies"]

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -30,8 +30,8 @@ jobs:
           DELETE_BEFORE=$(date -d "-7 days" '+%FT%T')
           IMAGE_PATH=gcr.io/mirrornode/hedera-mirror-${{ matrix.module }}
           DIGESTS=$(gcloud container images list-tags "${IMAGE_PATH}" --limit=1000 --sort-by=TIMESTAMP \
-            --filter="-tags:* AND timestamp.datetime < '${DELETE_BEFORE}'" --format="get(digest)")
+            --filter="tags:main-* AND timestamp.datetime < '${DELETE_BEFORE}'" --format="get(digest)")
 
           for digest in ${DIGESTS[*]}; do
-            gcloud container images delete -q "${IMAGE_PATH}@${digest}"
+            gcloud container images delete --force-delete-tags -q "${IMAGE_PATH}@${digest}"
           done

--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -29,7 +29,7 @@ jobs:
         run: gcloud auth configure-docker gcr.io,marketplace.gcr.io
 
       - name: Build and push images
-        run: ./mvnw deploy -DskipTests -Dmvn.golang.skip=true -Dskip.npm -Ddocker.tag.version=main
+        run: ./mvnw deploy -DskipTests -Dmvn.golang.skip=true -Dskip.npm -Ddocker.tag.version=main -Ddocker.tags.0=main-${{ github.sha }}
 
   deploy:
     needs: publish

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -11,6 +11,7 @@ jobs:
         module: [ grpc, importer, monitor, rest, rosetta, web3 ]
     env:
       MODULE: hedera-mirror-${{ matrix.module }}
+      IMAGE: gcr.io/mirrornode/hedera-mirror-${{ matrix.module }}
     name: Publish images
     runs-on: ubuntu-latest
     steps:
@@ -54,7 +55,7 @@ jobs:
           context: ${{env.MODULE}}
           platforms: linux/amd64, linux/arm64
           push: true
-          tags: gcr.io/mirrornode/${{env.MODULE}}:${{env.TAG}}
+          tags: ${{env.IMAGE}}:${{env.TAG}},${{env.IMAGE}}:latest
 
   chart:
     name: Publish charts

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
         <disruptor.version>3.4.4</disruptor.version> <!-- Used for asynchronous logging -->
         <docker-maven-plugin.version>0.40.1</docker-maven-plugin.version>
         <docker.architecture>amd64</docker.architecture>
+        <docker.imagePropertyConfiguration>override</docker.imagePropertyConfiguration>
         <docker.os>linux</docker.os>
         <docker.push.repository>gcr.io/mirrornode</docker.push.repository>
         <docker.resources>${project.build.directory}/container</docker.resources>


### PR DESCRIPTION
**Description**:
* Add a `latest` tag to production images
* Add a `main-${{github.sha}}` tag to all images from `main`
* Add a `release.yml` to customize GitHub release notes [generation](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes)
* Fix cleanup workflow by changing to remove `main-` tagged images

**Related issue(s)**:

Fixes #3629

**Notes for reviewer**:
See [cleanup](https://github.com/hashgraph/hedera-mirror-node/runs/6976289975?check_suite_focus=true) job for a successful run.

Existing untagged images will need to be cleaned up manually.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
