### PR TITLE
Fix js monitor false alert with empty hbar transfers transaction

### DIFF
--- a/hedera-mirror-rest/monitoring/monitor_apis/transaction_tests.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/transaction_tests.js
@@ -53,9 +53,19 @@ const mandatoryParams = [
   'transfers',
 ];
 
+const mergeArrays = (...arrayList) => {
+  return arrayList
+    .filter((array) => array != null)
+    .reduce((previous, current) => {
+      previous.push(...current);
+      return previous;
+    }, []);
+};
+
 const checkTransactionTransfers = (transactions, option) => {
   const {accountId, message} = option;
-  const {transfers} = transactions[0];
+  const transaction = transactions[0];
+  const transfers = mergeArrays(transaction.transfers, transaction.token_transfers);
   if (!transfers || !transfers.some((xfer) => xfer.account === accountId)) {
     return {
       passed: false,
@@ -91,9 +101,12 @@ const getTransactionsWithAccountCheck = async (server) => {
     return {url, ...result};
   }
 
+  const transaction = transactions[0];
+  const transfers = mergeArrays(transaction.transfers, transaction.token_transfers);
+
   const highestAccount = _.max(
     _.map(
-      _.filter(transactions[0].transfers, (xfer) => xfer.amount > 0),
+      _.filter(transfers, (xfer) => xfer.amount > 0),
       (xfer) => xfer.account
     )
   );
@@ -102,7 +115,7 @@ const getTransactionsWithAccountCheck = async (server) => {
     return {
       url,
       passed: false,
-      message: 'accNum is 0',
+      message: 'no account found in transaction transfers list and token_transfers list',
     };
   }
 


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

Fix the false alert by also looking into the `token_transfers` list for an account.

**Related issue(s)**:

Fixes #3983 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

The check first queries `/api/v1/transactions?type=credit` and tries to find the highest account from `transactions[0].transfers` list. When there's a child `CryptoTransfer` tx with only token transfers (the tx fee is paid in the parent `ContractCall` tx), it'll fail to find any account at all.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
