### PR TITLE
Migrate block numbers during v5 to v6 transition

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/record/RecordFileDownloader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/record/RecordFileDownloader.java
@@ -20,6 +20,7 @@ package com.hedera.mirror.importer.downloader.record;
  * ‍
  */
 
+import com.google.common.base.Stopwatch;
 import io.micrometer.core.instrument.MeterRegistry;
 import javax.inject.Named;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -35,20 +36,28 @@ import com.hedera.mirror.importer.leader.Leader;
 import com.hedera.mirror.importer.reader.record.ProtoRecordFileReader;
 import com.hedera.mirror.importer.reader.record.RecordFileReader;
 import com.hedera.mirror.importer.reader.signature.SignatureFileReader;
+import com.hedera.mirror.importer.repository.RecordFileRepository;
 
 @Named
 public class RecordFileDownloader extends Downloader<RecordFile> {
 
+    private final RecordFileRepository recordFileRepository;
+
     public RecordFileDownloader(
-            S3AsyncClient s3Client, AddressBookService addressBookService,
+            S3AsyncClient s3Client,
+            AddressBookService addressBookService,
             RecordDownloaderProperties downloaderProperties,
-            MeterRegistry meterRegistry, NodeSignatureVerifier nodeSignatureVerifier,
-            SignatureFileReader signatureFileReader, RecordFileReader recordFileReader,
+            MeterRegistry meterRegistry,
+            NodeSignatureVerifier nodeSignatureVerifier,
+            SignatureFileReader signatureFileReader,
+            RecordFileReader recordFileReader,
             StreamFileNotifier streamFileNotifier,
-            MirrorDateRangePropertiesProcessor mirrorDateRangePropertiesProcessor) {
+            MirrorDateRangePropertiesProcessor mirrorDateRangePropertiesProcessor,
+            RecordFileRepository recordFileRepository) {
         super(s3Client, addressBookService, downloaderProperties, meterRegistry,
                 nodeSignatureVerifier, signatureFileReader, recordFileReader, streamFileNotifier,
                 mirrorDateRangePropertiesProcessor);
+        this.recordFileRepository = recordFileRepository;
     }
 
     @Override
@@ -64,6 +73,16 @@ public class RecordFileDownloader extends Downloader<RecordFile> {
         // the protobuf RecordStreamFile, so only set the record file index to be last + 1 if it's pre-v6.
         if (recordFile.getVersion() < ProtoRecordFileReader.VERSION) {
             super.setStreamFileIndex(recordFile);
+        } else {
+            // Correct v5 block numbers once we receive a v6 block
+            lastStreamFile.get().ifPresent(last -> {
+                long offset = recordFile.getIndex() - last.getIndex();
+                if (offset != 1) {
+                    Stopwatch stopwatch = Stopwatch.createStarted();
+                    int count = recordFileRepository.updateIndex(offset);
+                    log.info("Updated {} blocks with offset {} in {}", count, offset, stopwatch);
+                }
+            });
         }
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/BlockNumberMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/BlockNumberMigration.java
@@ -86,13 +86,13 @@ public class BlockNumberMigration extends MirrorBaseJavaMigration {
         recordFileRepository.findById(correctConsensusEnd)
                 .map(RecordFile::getIndex)
                 .filter(blockNumber -> blockNumber != correctBlockNumber)
-                .ifPresent(blockNumber -> updateRecordFilesBlockNumber(correctBlockNumber, blockNumber));
+                .ifPresent(blockNumber -> updateIndex(correctBlockNumber, blockNumber));
     }
 
-    private void updateRecordFilesBlockNumber(long correctBlockNumber, long incorrectBlockNumber) {
+    private void updateIndex(long correctBlockNumber, long incorrectBlockNumber) {
         long offset = correctBlockNumber - incorrectBlockNumber;
         Stopwatch stopwatch = Stopwatch.createStarted();
-        long count = jdbcTemplate.update("update record_file set index = index + ?", offset);
+        int count = recordFileRepository.updateIndex(offset);
         log.info("Updated {} blocks with offset {} in {}", count, offset, stopwatch);
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/RecordFileRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/RecordFileRepository.java
@@ -23,6 +23,7 @@ package com.hedera.mirror.importer.repository;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.hedera.mirror.common.domain.transaction.RecordFile;
 
@@ -49,4 +50,9 @@ public interface RecordFileRepository extends StreamFileRepository<RecordFile, L
     @Override
     @Query("delete from RecordFile where consensusEnd <= ?1")
     int prune(long consensusTimestamp);
+
+    @Modifying
+    @Query(nativeQuery = true, value = "update record_file set index = index + ?1")
+    @Transactional
+    int updateIndex(long offset);
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/TestRecordFiles.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/TestRecordFiles.java
@@ -218,6 +218,7 @@ public class TestRecordFiles {
                 .nodeAccountId(nodeAccountId)
                 .name("2022-06-21T09_14_34.364804003Z.rcd")
                 .digestAlgorithm(DigestAlgorithm.SHA_384)
+                .index(0L)
                 .size(492)
                 .version(5)
                 .build();

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/AbstractDownloaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/AbstractDownloaderTest.java
@@ -679,7 +679,8 @@ public abstract class AbstractDownloaderTest {
     }
 
     protected void verifyStreamFiles(List<String> files) {
-        verifyStreamFiles(files, s -> {});
+        verifyStreamFiles(files, s -> {
+        });
     }
 
     protected void verifyStreamFiles(List<String> files, Consumer<StreamFile> extraAssert) {
@@ -751,6 +752,6 @@ public abstract class AbstractDownloaderTest {
      * @param instant the instant of the stream file
      */
     protected void expectLastStreamFile(Instant instant) {
-        expectLastStreamFile(null, null, instant);
+        expectLastStreamFile(null, 0L, instant);
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/record/AbstractRecordFileDownloaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/record/AbstractRecordFileDownloaderTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
+import org.mockito.Mock;
 
 import com.hedera.mirror.common.domain.transaction.RecordFile;
 import com.hedera.mirror.importer.downloader.AbstractLinkedStreamDownloaderTest;
@@ -37,9 +38,12 @@ import com.hedera.mirror.importer.reader.record.RecordFileReader;
 import com.hedera.mirror.importer.reader.record.RecordFileReaderImplV1;
 import com.hedera.mirror.importer.reader.record.RecordFileReaderImplV2;
 import com.hedera.mirror.importer.reader.record.RecordFileReaderImplV5;
+import com.hedera.mirror.importer.repository.RecordFileRepository;
 
 abstract class AbstractRecordFileDownloaderTest extends AbstractLinkedStreamDownloaderTest {
 
+    @Mock
+    protected RecordFileRepository recordFileRepository;
     private Map<String, RecordFile> recordFileMap;
 
     @Override
@@ -63,7 +67,8 @@ abstract class AbstractRecordFileDownloaderTest extends AbstractLinkedStreamDown
                 new RecordFileReaderImplV2(), new RecordFileReaderImplV5(), new ProtoRecordFileReader());
         return new RecordFileDownloader(s3AsyncClient, addressBookService,
                 (RecordDownloaderProperties) downloaderProperties, meterRegistry,
-                nodeSignatureVerifier, signatureFileReader, recordFileReader, streamFileNotifier, dateRangeProcessor);
+                nodeSignatureVerifier, signatureFileReader, recordFileReader, streamFileNotifier, dateRangeProcessor,
+                recordFileRepository);
     }
 
     @Override

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/RecordFileRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/RecordFileRepositoryTest.java
@@ -26,6 +26,8 @@ import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import com.hedera.mirror.common.domain.transaction.RecordFile;
+
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
 class RecordFileRepositoryTest extends AbstractRepositoryTest {
 
@@ -100,5 +102,22 @@ class RecordFileRepositoryTest extends AbstractRepositoryTest {
         recordFileRepository.prune(recordFile2.getConsensusEnd());
 
         assertThat(recordFileRepository.findAll()).containsExactly(recordFile3);
+    }
+
+    @Test
+    void updateIndex() {
+        var recordFile1 = domainBuilder.recordFile().persist();
+        var recordFile2 = domainBuilder.recordFile().persist();
+
+        assertThat(recordFileRepository.updateIndex(-2L)).isEqualTo(2);
+        assertThat(recordFileRepository.findById(recordFile1.getConsensusEnd()))
+                .get()
+                .extracting(RecordFile::getIndex)
+                .isEqualTo(recordFile1.getIndex() - 2);
+
+        assertThat(recordFileRepository.findById(recordFile2.getConsensusEnd()))
+                .get()
+                .extracting(RecordFile::getIndex)
+                .isEqualTo(recordFile2.getIndex() - 2);
     }
 }


### PR DESCRIPTION
**Description**:
Migrate block numbers during v5 to v6 transition

**Related issue(s)**:

Fixes #3959

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
