### PR TITLE
Upgrade java base image from Ubuntu 20.04 to 22.04

### DIFF
--- a/hedera-mirror-grpc/Dockerfile
+++ b/hedera-mirror-grpc/Dockerfile
@@ -1,9 +1,9 @@
-FROM eclipse-temurin:17.0.3_7-jre-focal as builder
+FROM eclipse-temurin:17.0.3_7-jre as builder
 WORKDIR /app
 COPY target/ ./
 RUN java -Djarmode=layertools -jar *.jar extract
 
-FROM eclipse-temurin:17.0.3_7-jre-focal
+FROM eclipse-temurin:17.0.3_7-jre
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80 -XX:TieredStopAtLevel=1"
 EXPOSE 5600
 HEALTHCHECK --interval=10s --retries=3 --start-period=50s --timeout=2s CMD curl -f http://localhost:8081/actuator/health/liveness

--- a/hedera-mirror-importer/Dockerfile
+++ b/hedera-mirror-importer/Dockerfile
@@ -1,9 +1,9 @@
-FROM eclipse-temurin:17.0.3_7-jre-focal as builder
+FROM eclipse-temurin:17.0.3_7-jre as builder
 WORKDIR /app
 COPY target/ ./
 RUN java -Djarmode=layertools -jar *.jar extract
 
-FROM eclipse-temurin:17.0.3_7-jre-focal
+FROM eclipse-temurin:17.0.3_7-jre
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80 -XX:TieredStopAtLevel=1"
 HEALTHCHECK --interval=30s --retries=3 --start-period=60s --timeout=2s CMD curl -f http://localhost:8080/actuator/health/liveness
 USER 1000:1000

--- a/hedera-mirror-monitor/Dockerfile
+++ b/hedera-mirror-monitor/Dockerfile
@@ -1,9 +1,9 @@
-FROM eclipse-temurin:17.0.3_7-jre-focal as builder
+FROM eclipse-temurin:17.0.3_7-jre as builder
 WORKDIR /app
 COPY target/*.jar ./
 RUN java -Djarmode=layertools -jar *.jar extract
 
-FROM eclipse-temurin:17.0.3_7-jre-focal
+FROM eclipse-temurin:17.0.3_7-jre
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80 -XX:TieredStopAtLevel=1"
 EXPOSE 8082
 HEALTHCHECK --interval=10s --retries=5 --start-period=60s --timeout=2s CMD curl -f http://localhost:8082/actuator/health/liveness

--- a/hedera-mirror-web3/Dockerfile
+++ b/hedera-mirror-web3/Dockerfile
@@ -1,9 +1,9 @@
-FROM eclipse-temurin:17.0.3_7-jre-focal as builder
+FROM eclipse-temurin:17.0.3_7-jre as builder
 WORKDIR /app
 COPY target/*.jar ./
 RUN java -Djarmode=layertools -jar *.jar extract
 
-FROM eclipse-temurin:17.0.3_7-jre-focal
+FROM eclipse-temurin:17.0.3_7-jre
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80 -XX:TieredStopAtLevel=1"
 EXPOSE 8545
 HEALTHCHECK --interval=10s --retries=3 --start-period=50s --timeout=2s CMD curl -f http://localhost:8545/actuator/health/liveness


### PR DESCRIPTION
**Description**:
Upgrade java base image from Ubuntu 20.04.4 LTS (Focal) to Ubuntu 22.04 LTS (Jammy)

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
