### PR TITLE
Handle empty weibars in EthereumTransaction

### DIFF
--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/converter/WeiBarTinyBarConverter.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/converter/WeiBarTinyBarConverter.java
@@ -23,12 +23,19 @@ package com.hedera.mirror.common.converter;
 import java.math.BigInteger;
 
 public class WeiBarTinyBarConverter {
+
     public static final WeiBarTinyBarConverter INSTANCE = new WeiBarTinyBarConverter();
     public static final Long WEIBARS_TO_TINYBARS = 10_000_000_000L;
     public static final BigInteger WEIBARS_TO_TINYBARS_BIGINT = BigInteger.valueOf(WEIBARS_TO_TINYBARS);
 
     public byte[] weiBarToTinyBar(byte[] weibar) {
-        return weibar == null ? null : new BigInteger(weibar).divide(WEIBARS_TO_TINYBARS_BIGINT).toByteArray();
+        if (weibar == null || weibar.length == 0) {
+            return weibar;
+        }
+
+        return new BigInteger(weibar)
+                .divide(WEIBARS_TO_TINYBARS_BIGINT)
+                .toByteArray();
     }
 
     public Long weiBarToTinyBar(Long weibar) {

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/converter/WeiBarTinyBarConverter.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/converter/WeiBarTinyBarConverter.java
@@ -21,6 +21,7 @@ package com.hedera.mirror.common.converter;
  */
 
 import java.math.BigInteger;
+import org.apache.commons.lang3.ArrayUtils;
 
 public class WeiBarTinyBarConverter {
 
@@ -28,17 +29,18 @@ public class WeiBarTinyBarConverter {
     public static final Long WEIBARS_TO_TINYBARS = 10_000_000_000L;
     public static final BigInteger WEIBARS_TO_TINYBARS_BIGINT = BigInteger.valueOf(WEIBARS_TO_TINYBARS);
 
-    public byte[] weiBarToTinyBar(byte[] weibar) {
-        if (weibar == null || weibar.length == 0) {
+    public byte[] convert(byte[] weibar, boolean signed) {
+        if (ArrayUtils.isEmpty(weibar)) {
             return weibar;
         }
 
-        return new BigInteger(weibar)
+        var bigInteger = signed ? new BigInteger(weibar) : new BigInteger(1, weibar);
+        return bigInteger
                 .divide(WEIBARS_TO_TINYBARS_BIGINT)
                 .toByteArray();
     }
 
-    public Long weiBarToTinyBar(Long weibar) {
+    public Long convert(Long weibar) {
         return weibar == null ? null : weibar / WEIBARS_TO_TINYBARS;
     }
 }

--- a/hedera-mirror-common/src/test/java/com/hedera/mirror/common/converter/WeiBarTinyBarConverterTest.java
+++ b/hedera-mirror-common/src/test/java/com/hedera/mirror/common/converter/WeiBarTinyBarConverterTest.java
@@ -25,23 +25,33 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class WeiBarTinyBarConverterTest {
+
     private static final WeiBarTinyBarConverter converter = WeiBarTinyBarConverter.INSTANCE;
     private static final Long defaultGas = 1234567890123L;
-    private static final byte[] defaultGasBytes = BigInteger.valueOf(defaultGas).toByteArray();
 
     @Test
-    void byteArrayWeiBarToTinyBar() {
+    void convertBytes() {
         var emptyBytes = new byte[] {};
-        Assertions.assertThat(converter.weiBarToTinyBar((byte[]) null)).isNull();
-        Assertions.assertThat(converter.weiBarToTinyBar(emptyBytes)).isSameAs(emptyBytes);
-        Assertions.assertThat(converter.weiBarToTinyBar(defaultGasBytes))
-                .isEqualTo(BigInteger.valueOf(123).toByteArray());
+        var bigInteger = BigInteger.valueOf(defaultGas);
+        var expectedBytes = BigInteger.valueOf(123).toByteArray();
+        var expectedNegativeBytes = BigInteger.valueOf(-123).toByteArray();
+
+        Assertions.assertThat(converter.convert(null, true)).isNull();
+        Assertions.assertThat(converter.convert(null, false)).isNull();
+        Assertions.assertThat(converter.convert(emptyBytes, true)).isSameAs(emptyBytes);
+        Assertions.assertThat(converter.convert(emptyBytes, false)).isSameAs(emptyBytes);
+        Assertions.assertThat(converter.convert(bigInteger.toByteArray(), true)).isEqualTo(expectedBytes);
+        Assertions.assertThat(converter.convert(bigInteger.toByteArray(), false)).isEqualTo(expectedBytes);
+        Assertions.assertThat(converter.convert(bigInteger.negate().toByteArray(), true))
+                .isEqualTo(expectedNegativeBytes);
+        Assertions.assertThat(converter.convert(bigInteger.negate().toByteArray(), false))
+                .isNotEqualTo(expectedBytes)
+                .isNotEqualTo(expectedNegativeBytes);
     }
 
     @Test
-    void longWeiBarToTinyBar() {
-        Assertions.assertThat(converter.weiBarToTinyBar((Long) null)).isNull();
-        Assertions.assertThat(converter.weiBarToTinyBar(defaultGas))
-                .isEqualTo(123L);
+    void convertLong() {
+        Assertions.assertThat(converter.convert(null)).isNull();
+        Assertions.assertThat(converter.convert(defaultGas)).isEqualTo(123L);
     }
 }

--- a/hedera-mirror-common/src/test/java/com/hedera/mirror/common/converter/WeiBarTinyBarConverterTest.java
+++ b/hedera-mirror-common/src/test/java/com/hedera/mirror/common/converter/WeiBarTinyBarConverterTest.java
@@ -20,10 +20,9 @@ package com.hedera.mirror.common.converter;
  * ‍
  */
 
+import java.math.BigInteger;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-
-import java.math.BigInteger;
 
 class WeiBarTinyBarConverterTest {
     private static final WeiBarTinyBarConverter converter = WeiBarTinyBarConverter.INSTANCE;
@@ -32,7 +31,9 @@ class WeiBarTinyBarConverterTest {
 
     @Test
     void byteArrayWeiBarToTinyBar() {
+        var emptyBytes = new byte[] {};
         Assertions.assertThat(converter.weiBarToTinyBar((byte[]) null)).isNull();
+        Assertions.assertThat(converter.weiBarToTinyBar(emptyBytes)).isSameAs(emptyBytes);
         Assertions.assertThat(converter.weiBarToTinyBar(defaultGasBytes))
                 .isEqualTo(BigInteger.valueOf(123).toByteArray());
     }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/ConvertEthereumTransactionValueMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/ConvertEthereumTransactionValueMigration.java
@@ -67,7 +67,7 @@ public class ConvertEthereumTransactionValueMigration extends MirrorBaseJavaMigr
         jdbcTemplate.query(SELECT_NON_NULL_VALUE_SQL, rs -> {
             var consensusTimestamp = rs.getLong(1);
             var weibar = rs.getBytes(2);
-            var tinybar = converter.weiBarToTinyBar(weibar);
+            var tinybar = converter.convert(weibar, true);
             jdbcTemplate.update(SET_TINYBAR_VALUE_SQL,
                     Map.of("consensusTimestamp", consensusTimestamp, "value", tinybar));
             count.incrementAndGet();

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/EthereumTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/EthereumTransactionHandler.java
@@ -119,10 +119,10 @@ class EthereumTransactionHandler implements TransactionHandler {
 
     private void convertGasWeiToTinyBars(EthereumTransaction transaction) {
         var converter = WeiBarTinyBarConverter.INSTANCE;
-        transaction.setGasLimit(converter.weiBarToTinyBar(transaction.getGasLimit()));
-        transaction.setGasPrice(converter.weiBarToTinyBar(transaction.getGasPrice()));
-        transaction.setMaxFeePerGas(converter.weiBarToTinyBar(transaction.getMaxFeePerGas()));
-        transaction.setMaxPriorityFeePerGas(converter.weiBarToTinyBar(transaction.getMaxPriorityFeePerGas()));
-        transaction.setValue(converter.weiBarToTinyBar(transaction.getValue()));
+        transaction.setGasLimit(converter.convert(transaction.getGasLimit()));
+        transaction.setGasPrice(converter.convert(transaction.getGasPrice(), false));
+        transaction.setMaxFeePerGas(converter.convert(transaction.getMaxFeePerGas(), false));
+        transaction.setMaxPriorityFeePerGas(converter.convert(transaction.getMaxPriorityFeePerGas(), false));
+        transaction.setValue(converter.convert(transaction.getValue(), true));
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/EthereumTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/EthereumTransactionHandlerTest.java
@@ -157,6 +157,32 @@ class EthereumTransactionHandlerTest extends AbstractTransactionHandlerTest {
         verify(entityListener, never()).onEntity(any());
     }
 
+    @Test
+    void updateTransactionEmptyWeiBars() {
+        boolean create = true;
+        var emptyBytes = new byte[] {};
+        var ethereumTransaction = domainBuilder.ethereumTransaction(create).get();
+        ethereumTransaction.setGasLimit(null);
+        ethereumTransaction.setGasPrice(emptyBytes);
+        ethereumTransaction.setMaxFeePerGas(emptyBytes);
+        ethereumTransaction.setMaxPriorityFeePerGas(emptyBytes);
+        ethereumTransaction.setValue(emptyBytes);
+        doReturn(ethereumTransaction).when(ethereumTransactionParser).decode(any());
+
+        var recordItem = recordItemBuilder.ethereumTransaction(create).build();
+
+        var transaction = new Transaction();
+        transactionHandler.updateTransaction(transaction, recordItem);
+
+        verify(entityListener).onEthereumTransaction(ethereumTransaction);
+        assertThat(ethereumTransaction)
+                .returns(null, EthereumTransaction::getGasLimit)
+                .returns(emptyBytes, EthereumTransaction::getGasPrice)
+                .returns(emptyBytes, EthereumTransaction::getMaxFeePerGas)
+                .returns(emptyBytes, EthereumTransaction::getMaxPriorityFeePerGas)
+                .returns(emptyBytes, EthereumTransaction::getValue);
+    }
+
     @ValueSource(booleans = {true, false})
     @ParameterizedTest
     void updateTransactionSkipNonceOnFailure(boolean create) {


### PR DESCRIPTION
**Description**:
* Fix handling of empty weibars for `EthereumTransaction`
* Fix handling of unsigned big integers for `EthereumTransaction`

**Related issue(s)**:

Fixes #4025

**Notes for reviewer**:
Also verified it works with actual problem RCD from previewnet

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
