### PR TITLE
Bump log4j from 2.17.1 to 2.17.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
         <jacoco.version>0.8.8</jacoco.version>
         <java.version>17</java.version>
         <javax.version>1</javax.version>
+        <log4j2.version>2.17.2</log4j2.version>
         <micrometer-jvm-extras.version>0.2.2</micrometer-jvm-extras.version>
         <msgpack.version>0.9.2</msgpack.version>
         <protobuf.version>3.21.2</protobuf.version>

--- a/suppressions.xml
+++ b/suppressions.xml
@@ -24,4 +24,9 @@
         <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-web@.*$</packageUrl>
         <cve>CVE-2016-1000027</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[FP per issue #4637]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.logging\.log4j/log4j\-.*@.*$</packageUrl>
+        <cve>CVE-2022-33915</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
**Description**:

* Add a suppression for CVE-2022-33915 false positive
* Bump log4j from 2.17.1 to 2.17.2

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
