### PR TITLE
Fix helm acceptance tests in preprod

### DIFF
--- a/charts/hedera-mirror-rest/templates/tests/configmap.yaml
+++ b/charts/hedera-mirror-rest/templates/tests/configmap.yaml
@@ -33,7 +33,7 @@ data:
     @test "Has accounts" {
       has_data "accounts"
     }
-    {{- end -}}
+    {{- end }}
 
     {{ if .Values.test.checks.transactions -}}
     @test "Has transactions" {

--- a/charts/hedera-mirror-rest/templates/tests/configmap.yaml
+++ b/charts/hedera-mirror-rest/templates/tests/configmap.yaml
@@ -4,7 +4,7 @@ kind: ConfigMap
 metadata:
   annotations:
     helm.sh/hook: test-success
-    helm.sh/hook-delete-policy: before-hook-creation,hook-failed,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels: {{- include "hedera-mirror-rest.labels" . | nindent 4 }}
   name: {{ include "hedera-mirror-rest.fullname" . }}-test
   namespace: {{ include "hedera-mirror-rest.namespace" . }}
@@ -29,12 +29,16 @@ data:
       done
     }
 
+    {{ if .Values.test.checks.accounts -}}
     @test "Has accounts" {
       has_data "accounts"
     }
+    {{- end -}}
 
+    {{ if .Values.test.checks.transactions -}}
     @test "Has transactions" {
       has_data "transactions"
     }
+    {{- end -}}
 {{- end -}}
 

--- a/charts/hedera-mirror-rest/templates/tests/pod.yaml
+++ b/charts/hedera-mirror-rest/templates/tests/pod.yaml
@@ -4,7 +4,7 @@ kind: Pod
 metadata:
   annotations:
     helm.sh/hook: test-success
-    helm.sh/hook-delete-policy: before-hook-creation,hook-failed,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels: {{- include "hedera-mirror-rest.labels" . | nindent 4 }}
   name: {{ include "hedera-mirror-rest.fullname" . }}-test
   namespace: {{ include "hedera-mirror-rest.namespace" . }}

--- a/charts/hedera-mirror-rest/values.yaml
+++ b/charts/hedera-mirror-rest/values.yaml
@@ -226,6 +226,9 @@ serviceMonitor:
 terminationGracePeriodSeconds: 60
 
 test:
+  checks:
+    accounts: true
+    transactions: true
   enabled: true
   image:
     pullPolicy: IfNotPresent

--- a/charts/hedera-mirror-rosetta/templates/tests/pod.yaml
+++ b/charts/hedera-mirror-rosetta/templates/tests/pod.yaml
@@ -4,7 +4,7 @@ kind: Pod
 metadata:
   annotations:
     helm.sh/hook: test-success
-    helm.sh/hook-delete-policy: before-hook-creation,hook-failed,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels: {{- include "hedera-mirror-rosetta.labels" . | nindent 4 }}
   name: {{ include "hedera-mirror-rosetta.fullname" . }}-test
   namespace: {{ include "hedera-mirror-rosetta.namespace" . }}

--- a/charts/hedera-mirror-web3/templates/tests/pod.yaml
+++ b/charts/hedera-mirror-web3/templates/tests/pod.yaml
@@ -4,7 +4,7 @@ kind: Pod
 metadata:
   annotations:
     helm.sh/hook: test-success
-    helm.sh/hook-delete-policy: before-hook-creation,hook-failed,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels: {{- include "hedera-mirror-web3.labels" . | nindent 4 }}
   name: {{ include "hedera-mirror-web3.fullname" . }}-test
   namespace: {{ include "hedera-mirror-web3.namespace" . }}

--- a/charts/hedera-mirror/templates/tests/pod.yaml
+++ b/charts/hedera-mirror/templates/tests/pod.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ include "hedera-mirror.namespace" . }}
   annotations:
     helm.sh/hook: test-success
-    helm.sh/hook-delete-policy: before-hook-creation,hook-failed,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 spec:
   containers:
     - name: acceptance-tests
@@ -18,8 +18,9 @@ spec:
         - '-c'
           # Copying the contents of the secret to the directory the image reads from without overwriting the existing yml.
         - |
+          {{ $branch := .Values.test.git.branch | default .Chart.AppVersion -}}
           apk add -qu git openjdk17-jre
-          git clone --branch {{ if regexMatch "^\\d+\\.\\d+\\.\\d+.*$" .Chart.AppVersion }}v{{end}}{{ .Chart.AppVersion }} --depth 1 https://github.com/hashgraph/hedera-mirror-node.git
+          git clone --branch {{ if regexMatch "^\\d+\\.\\d+\\.\\d+.*$" $branch }}v{{end}}{{ $branch }} --depth 1 {{ .Values.test.git.repository }}
           cd hedera-mirror-node
           cp /etc/secrets/* hedera-mirror-test/src/test/resources/
           ./mvnw integration-test --projects hedera-mirror-test/ -P=acceptance-tests -Dcucumber.filter.tags="{{ .Values.test.cucumberTags }}"

--- a/charts/hedera-mirror/templates/tests/secret.yaml
+++ b/charts/hedera-mirror/templates/tests/secret.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ include "hedera-mirror.namespace" . }}
   annotations:
     helm.sh/hook: test-success
-    helm.sh/hook-delete-policy: before-hook-creation,hook-failed,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 type: Opaque
 stringData:
   # application-default.yml as application.yml will overwrite the existing yml in the hedera-mirror-test image.

--- a/charts/hedera-mirror/values.yaml
+++ b/charts/hedera-mirror/values.yaml
@@ -316,6 +316,9 @@ test:
               baseUrl: "http://{{ .Release.Name }}-rest/api/v1"
   cucumberTags: "@acceptance"
   enabled: false
+  git:
+    branch: ""  # Default to Chart app version
+    repository: https://github.com/hashgraph/hedera-mirror-node.git
   image:
     pullPolicy: IfNotPresent
     repository: alpine

--- a/hedera-mirror-test/pom.xml
+++ b/hedera-mirror-test/pom.xml
@@ -18,7 +18,7 @@
     <properties>
         <cucumber.version>7.4.1</cucumber.version>
         <cucumber-reporting.version>7.3.0</cucumber-reporting.version>
-        <hedera-sdk.version>2.15.0</hedera-sdk.version>
+        <hedera-sdk.version>2.16.3</hedera-sdk.version>
         <junit-platform.version>1.8.2</junit-platform.version>
         <skipTests>true</skipTests>
     </properties>

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AbstractNetworkClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AbstractNetworkClient.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.test.e2e.acceptance.client;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -43,7 +43,9 @@ import com.hedera.mirror.test.e2e.acceptance.response.NetworkTransactionResponse
 
 @Data
 public abstract class AbstractNetworkClient {
+
     private static final int MEMO_BYTES_MAX_LENGTH = 100;
+
     protected final Client client;
     protected final Logger log = LogManager.getLogger(getClass());
     protected final SDKClient sdkClient;
@@ -51,7 +53,7 @@ public abstract class AbstractNetworkClient {
 
     public AbstractNetworkClient(SDKClient sdkClient, RetryTemplate retryTemplate) {
         this.sdkClient = sdkClient;
-        client = sdkClient.getClient();
+        this.client = sdkClient.getClient();
         this.retryTemplate = retryTemplate;
     }
 
@@ -96,7 +98,7 @@ public abstract class AbstractNetworkClient {
 
     public NetworkTransactionResponse executeTransactionAndRetrieveReceipt(Transaction transaction, KeyList keyList,
                                                                            ExpandedAccountId payer) {
-        long startBalance = getBalance();
+        long startBalance = log.isTraceEnabled() ? getBalance() : 0L;
         TransactionId transactionId = executeTransaction(transaction, keyList, payer);
         TransactionReceipt transactionReceipt = null;
 
@@ -106,7 +108,10 @@ public abstract class AbstractNetworkClient {
             log.error("Failed to get transaction receipt for {}: {}", transactionId, e.getMessage());
         }
 
-        log.trace("Executed transaction {} cost {} tℏ", transactionId, startBalance - getBalance());
+        if (log.isTraceEnabled()) {
+            log.trace("Executed transaction {} cost {} tℏ", transactionId, startBalance - getBalance());
+        }
+
         return new NetworkTransactionResponse(transactionId, transactionReceipt);
     }
 

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/ContractClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/ContractClient.java
@@ -21,8 +21,6 @@ package com.hedera.mirror.test.e2e.acceptance.client;
  */
 
 import javax.inject.Named;
-import org.springframework.beans.factory.config.ConfigurableBeanFactory;
-import org.springframework.context.annotation.Scope;
 import org.springframework.retry.support.RetryTemplate;
 
 import com.hedera.hashgraph.sdk.AccountId;
@@ -39,11 +37,10 @@ import com.hedera.hashgraph.sdk.TransactionRecord;
 import com.hedera.mirror.test.e2e.acceptance.response.NetworkTransactionResponse;
 
 @Named
-@Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE)
 public class ContractClient extends AbstractNetworkClient {
+
     public ContractClient(SDKClient sdkClient, RetryTemplate retryTemplate) {
         super(sdkClient, retryTemplate);
-        log.debug("Creating Contract Client");
     }
 
     public NetworkTransactionResponse createContract(FileId fileId, long gas, Hbar payableAmount,

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/FileClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/FileClient.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.test.e2e.acceptance.client;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,8 +22,6 @@ package com.hedera.mirror.test.e2e.acceptance.client;
 
 import javax.inject.Named;
 import lombok.SneakyThrows;
-import org.springframework.beans.factory.config.ConfigurableBeanFactory;
-import org.springframework.context.annotation.Scope;
 import org.springframework.retry.support.RetryTemplate;
 
 import com.hedera.hashgraph.sdk.FileAppendTransaction;
@@ -37,11 +35,10 @@ import com.hedera.hashgraph.sdk.KeyList;
 import com.hedera.mirror.test.e2e.acceptance.response.NetworkTransactionResponse;
 
 @Named
-@Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE)
 public class FileClient extends AbstractNetworkClient {
+
     public FileClient(SDKClient sdkClient, RetryTemplate retryTemplate) {
         super(sdkClient, retryTemplate);
-        log.debug("Creating File Client");
     }
 
     public NetworkTransactionResponse createFile(byte[] content) {

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/SDKClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/SDKClient.java
@@ -130,12 +130,8 @@ public class SDKClient implements AutoCloseable {
                 .collect(Collectors.toMap(NodeProperties::getEndpoint, p -> AccountId.fromString(p.getAccountId())));
     }
 
-    private synchronized ExpandedAccountId getOperatorAccount() {
+    private ExpandedAccountId getOperatorAccount() {
         try {
-            if (expandedOperatorAccountId != null) {
-                return expandedOperatorAccountId;
-            }
-
             if (acceptanceTestProperties.isCreateOperatorAccount()) {
                 PrivateKey privateKey = PrivateKey.generateED25519();
                 PublicKey publicKey = privateKey.getPublicKey();

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/SDKClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/SDKClient.java
@@ -20,6 +20,8 @@ package com.hedera.mirror.test.e2e.acceptance.client;
  * ‍
  */
 
+import static com.hedera.mirror.test.e2e.acceptance.config.AcceptanceTestProperties.HederaNetwork.OTHER;
+
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -37,9 +39,13 @@ import org.apache.commons.lang3.RandomUtils;
 import org.springframework.util.CollectionUtils;
 
 import com.hedera.hashgraph.sdk.AccountBalanceQuery;
+import com.hedera.hashgraph.sdk.AccountCreateTransaction;
+import com.hedera.hashgraph.sdk.AccountDeleteTransaction;
 import com.hedera.hashgraph.sdk.AccountId;
 import com.hedera.hashgraph.sdk.Client;
 import com.hedera.hashgraph.sdk.Hbar;
+import com.hedera.hashgraph.sdk.PrivateKey;
+import com.hedera.hashgraph.sdk.PublicKey;
 import com.hedera.mirror.test.e2e.acceptance.config.AcceptanceTestProperties;
 import com.hedera.mirror.test.e2e.acceptance.props.ExpandedAccountId;
 import com.hedera.mirror.test.e2e.acceptance.props.NodeProperties;
@@ -63,10 +69,9 @@ public class SDKClient implements AutoCloseable {
         this.mirrorNodeClient = mirrorNodeClient;
         maxTransactionFee = Hbar.fromTinybars(acceptanceTestProperties.getMaxTinyBarTransactionFee());
         this.acceptanceTestProperties = acceptanceTestProperties;
-        expandedOperatorAccountId = new ExpandedAccountId(
-                acceptanceTestProperties.getOperatorId(),
-                acceptanceTestProperties.getOperatorKey());
         this.client = getValidatedClient();
+        expandedOperatorAccountId = getOperatorAccount();
+        this.client.setOperator(expandedOperatorAccountId.getAccountId(), expandedOperatorAccountId.getPrivateKey());
         validateNetworkMap = this.client.getNetwork();
     }
 
@@ -77,6 +82,21 @@ public class SDKClient implements AutoCloseable {
 
     @Override
     public void close() throws TimeoutException {
+        var createdAccountId = expandedOperatorAccountId.getAccountId();
+        var operatorId = AccountId.fromString(acceptanceTestProperties.getOperatorId());
+
+        if (!operatorId.equals(createdAccountId)) {
+            try {
+                new AccountDeleteTransaction()
+                        .setAccountId(createdAccountId)
+                        .setTransferAccountId(operatorId)
+                        .execute(client);
+                log.info("Deleted temporary operator account {}", createdAccountId);
+            } catch (Exception e) {
+                log.warn("Unable to delete temporary operator account {}", createdAccountId, e);
+            }
+        }
+
         client.close();
     }
 
@@ -97,6 +117,10 @@ public class SDKClient implements AutoCloseable {
             }
         }
 
+        if (network == OTHER && CollectionUtils.isEmpty(customNodes)) {
+            throw new IllegalArgumentException("nodes must not be empty when network is OTHER");
+        }
+
         Client client = Client.forName(network.toString().toLowerCase());
         return client.getNetwork();
     }
@@ -104,6 +128,34 @@ public class SDKClient implements AutoCloseable {
     private Map<String, AccountId> getNetworkMap(Set<NodeProperties> nodes) {
         return nodes.stream()
                 .collect(Collectors.toMap(NodeProperties::getEndpoint, p -> AccountId.fromString(p.getAccountId())));
+    }
+
+    private synchronized ExpandedAccountId getOperatorAccount() {
+        try {
+            if (expandedOperatorAccountId != null) {
+                return expandedOperatorAccountId;
+            }
+
+            if (acceptanceTestProperties.isCreateOperatorAccount()) {
+                PrivateKey privateKey = PrivateKey.generateED25519();
+                PublicKey publicKey = privateKey.getPublicKey();
+                var accountId = new AccountCreateTransaction()
+                        .setInitialBalance(Hbar.fromTinybars(acceptanceTestProperties.getOperatorBalance()))
+                        .setKey(publicKey)
+                        .setMaxTransactionFee(getMaxTransactionFee())
+                        .execute(client)
+                        .getReceipt(client)
+                        .accountId;
+                log.info("Created operator account {} with public key {}", accountId, publicKey);
+                return new ExpandedAccountId(accountId, privateKey, publicKey);
+            }
+        } catch (Exception e) {
+            log.warn("Unable to create a regular operator account. Falling back to existing operator");
+        }
+
+        var operatorId = acceptanceTestProperties.getOperatorId();
+        var operatorKey = acceptanceTestProperties.getOperatorKey();
+        return new ExpandedAccountId(operatorId, operatorKey);
     }
 
     private Client getValidatedClient() throws InterruptedException {
@@ -130,8 +182,10 @@ public class SDKClient implements AutoCloseable {
     }
 
     private Client toClient(Map<String, AccountId> network) throws InterruptedException {
+        var operatorId = AccountId.fromString(acceptanceTestProperties.getOperatorId());
+        var operatorKey = PrivateKey.fromString(acceptanceTestProperties.getOperatorKey());
         Client client = Client.forNetwork(network);
-        client.setOperator(expandedOperatorAccountId.getAccountId(), expandedOperatorAccountId.getPrivateKey());
+        client.setOperator(operatorId, operatorKey);
         client.setMirrorNetwork(List.of(acceptanceTestProperties.getMirrorNodeAddress()));
         return client;
     }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/ScheduleClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/ScheduleClient.java
@@ -23,8 +23,6 @@ package com.hedera.mirror.test.e2e.acceptance.client;
 import java.util.List;
 import javax.inject.Named;
 import lombok.SneakyThrows;
-import org.springframework.beans.factory.config.ConfigurableBeanFactory;
-import org.springframework.context.annotation.Scope;
 import org.springframework.retry.support.RetryTemplate;
 
 import com.hedera.hashgraph.sdk.KeyList;
@@ -40,12 +38,10 @@ import com.hedera.mirror.test.e2e.acceptance.props.ExpandedAccountId;
 import com.hedera.mirror.test.e2e.acceptance.response.NetworkTransactionResponse;
 
 @Named
-@Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE)
 public class ScheduleClient extends AbstractNetworkClient {
 
     public ScheduleClient(SDKClient sdkClient, RetryTemplate retryTemplate) {
         super(sdkClient, retryTemplate);
-        log.debug("Creating Schedule Client");
     }
 
     public NetworkTransactionResponse createSchedule(ExpandedAccountId payerAccountId, Transaction transaction,

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TokenClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TokenClient.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.test.e2e.acceptance.client;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,8 +25,6 @@ import java.util.List;
 import javax.inject.Named;
 import lombok.SneakyThrows;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.springframework.beans.factory.config.ConfigurableBeanFactory;
-import org.springframework.context.annotation.Scope;
 import org.springframework.retry.support.RetryTemplate;
 
 import com.hedera.hashgraph.sdk.AccountBalanceQuery;
@@ -59,12 +57,10 @@ import com.hedera.mirror.test.e2e.acceptance.props.ExpandedAccountId;
 import com.hedera.mirror.test.e2e.acceptance.response.NetworkTransactionResponse;
 
 @Named
-@Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE)
 public class TokenClient extends AbstractNetworkClient {
 
     public TokenClient(SDKClient sdkClient, RetryTemplate retryTemplate) {
         super(sdkClient, retryTemplate);
-        log.debug("Creating Token Client");
     }
 
     public NetworkTransactionResponse createToken(ExpandedAccountId expandedAccountId, String symbol, int freezeStatus,

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TopicClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TopicClient.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.test.e2e.acceptance.client;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,14 +25,12 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import javax.inject.Named;
 import lombok.SneakyThrows;
 import org.apache.commons.lang3.ArrayUtils;
-import org.springframework.beans.factory.config.ConfigurableBeanFactory;
-import org.springframework.context.annotation.Scope;
 import org.springframework.retry.support.RetryTemplate;
 
 import com.hedera.hashgraph.sdk.KeyList;
@@ -51,16 +49,15 @@ import com.hedera.mirror.test.e2e.acceptance.props.ExpandedAccountId;
 import com.hedera.mirror.test.e2e.acceptance.response.NetworkTransactionResponse;
 
 @Named
-@Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE)
 public class TopicClient extends AbstractNetworkClient {
+
     private static final Duration autoRenewPeriod = Duration.ofSeconds(8000000);
+
     private final Map<Long, Instant> recordPublishInstants;
-    private TopicId defaultTopicId = null;
 
     public TopicClient(SDKClient sdkClient, RetryTemplate retryTemplate) {
         super(sdkClient, retryTemplate);
-        recordPublishInstants = new HashMap<>();
-        log.debug("Creating Topic Client");
+        recordPublishInstants = new ConcurrentHashMap<>();
     }
 
     public NetworkTransactionResponse createTopic(ExpandedAccountId adminAccount, PublicKey submitKey) {
@@ -137,27 +134,6 @@ public class TopicClient extends AbstractNetworkClient {
         }
 
         return transactionReceiptList;
-    }
-
-    public TopicMessageSubmitTransaction getTopicMessageSubmitTransaction(TopicId topicId, byte[] message) {
-        return new TopicMessageSubmitTransaction()
-                .setTopicId(topicId)
-                .setMessage(message);
-    }
-
-    public TopicId getDefaultTopicId() {
-        if (defaultTopicId == null) {
-            NetworkTransactionResponse networkTransactionResponse = createTopic(sdkClient
-                    .getExpandedOperatorAccountId(), null);
-            defaultTopicId = networkTransactionResponse.getReceipt().topicId;
-            log.debug("Created TopicId: '{}' for use in current test session", defaultTopicId);
-        }
-
-        return defaultTopicId;
-    }
-
-    public void publishMessageToDefaultTopic() {
-        publishMessagesToTopic(getDefaultTopicId(), "Background message", null, 1, false);
     }
 
     public TransactionId publishMessageToTopic(TopicId topicId, byte[] message, KeyList submitKeys) {

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
@@ -41,6 +41,8 @@ public class AcceptanceTestProperties {
     @NotNull
     private Duration backOffPeriod = Duration.ofMillis(5000);
 
+    private boolean createOperatorAccount = true;
+
     private boolean emitBackgroundMessages = false;
 
     private final FeatureProperties featureProperties;
@@ -62,6 +64,8 @@ public class AcceptanceTestProperties {
 
     private Set<NodeProperties> nodes = new LinkedHashSet<>();
 
+    private long operatorBalance = 30_000_000_000L;
+
     @NotBlank
     private String operatorId;
 
@@ -75,13 +79,6 @@ public class AcceptanceTestProperties {
     private final SdkProperties sdkProperties;
 
     private final WebClientProperties webClientProperties;
-
-    public Set<NodeProperties> getNodes() {
-        if (network == HederaNetwork.OTHER && nodes.isEmpty()) {
-            throw new IllegalArgumentException("nodes must not be empty");
-        }
-        return nodes;
-    }
 
     public enum HederaNetwork {
         MAINNET,

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/response/MirrorContractResultResponse.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/response/MirrorContractResultResponse.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.test.e2e.acceptance.response;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -27,6 +27,6 @@ import com.hedera.mirror.test.e2e.acceptance.props.MirrorContractResult;
 @Data
 public class MirrorContractResultResponse extends MirrorContractResult {
     private String blockHash;
-    private Integer blockNumber;
+    private Long blockNumber;
     private String hash;
 }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TokenFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TokenFeature.java
@@ -318,8 +318,6 @@ public class TokenFeature {
             maxAttemptsExpression = "#{@restPollingProperties.maxAttempts}")
     public void verifyTokenPauseStatus(String status) {
         verifyTokenPauseStatus(tokenIds.get(0), status);
-
-        publishBackgroundMessages();
     }
 
     @Then("the mirror node REST API should return status {int}")
@@ -328,8 +326,6 @@ public class TokenFeature {
             maxAttemptsExpression = "#{@restPollingProperties.maxAttempts}")
     public void verifyMirrorAPIResponses(int status) {
         verifyTransactions(status);
-
-        publishBackgroundMessages();
     }
 
     @Then("^the mirror node REST API should return status (.*) for token (:?(.*) )?serial number " +
@@ -342,7 +338,6 @@ public class TokenFeature {
         Long serialNumber = tokenSerialNumbers.get(tokenId).get(getIndexOrDefault(serialNumberIndex));
         verifyTransactions(status);
         verifyNftTransactions(tokenId, serialNumber);
-        publishBackgroundMessages();
     }
 
     @Then("^the mirror node REST API should return status (.*) for token (:?(.*) )?fund flow$")
@@ -364,7 +359,6 @@ public class TokenFeature {
         verifyTransactions(status, assessedCustomFees);
         verifyToken(tokenId);
         verifyTokenTransfers(tokenId);
-        publishBackgroundMessages();
     }
 
     @Then("^the mirror node REST API should return status (.*) for token (:?(.*) )?serial number (:?(.*) )?full flow$")
@@ -379,7 +373,6 @@ public class TokenFeature {
         verifyNft(tokenId, serialNumber);
         verifyNftTransfers(tokenId, serialNumber);
         verifyNftTransactions(tokenId, serialNumber);
-        publishBackgroundMessages();
     }
 
     @Then("the mirror node REST API should confirm token update")
@@ -388,9 +381,6 @@ public class TokenFeature {
             maxAttemptsExpression = "#{@restPollingProperties.maxAttempts}")
     public void verifyMirrorTokenUpdateFlow() {
         verifyTokenUpdate(tokenIds.get(0));
-
-        // publish background message to network to reduce possibility of stale info in low TPS environment
-        topicClient.publishMessageToDefaultTopic();
     }
 
     @Then("the mirror node REST API should return status {int} for transaction {string}")
@@ -409,9 +399,6 @@ public class TokenFeature {
         if (status == HttpStatus.OK.value()) {
             assertThat(mirrorTransaction.getResult()).isEqualTo("SUCCESS");
         }
-
-        // publish background message to network to reduce possibility of stale info in low TPS environment
-        topicClient.publishMessageToDefaultTopic();
     }
 
     @Then("the mirror node REST API should confirm token {int} with custom fees schedule")
@@ -737,15 +724,6 @@ public class TokenFeature {
                                 .build()
                 )
                 .isEqualTo(expected);
-    }
-
-    private void publishBackgroundMessages() {
-        // publish background message to network to reduce possibility of stale info in low TPS environment
-        try {
-            topicClient.publishMessageToDefaultTopic();
-        } catch (Exception ex) {
-            log.trace("Encountered issue published background messages to default topic", ex);
-        }
     }
 
     private int getIndexOrDefault(Integer index) {


### PR DESCRIPTION
**Description**:

* Add an option to disable individual REST API helm checks
* Add an option to override the git branch and repository for Helm acceptance tests
* Add an option to create a non-system operator account to fix errors when using a system operator account
* Bump SDK version to 2.16.3
* Change test clients to be singletons
* Fix account balance retrieval occurring unconditionally before and after every transaction
* Fix block number modeled as an integer
* Fix error when network set to `OTHER` and retrieving address book
* Fix various synchronization issues
* Remove `hook-failed` delete policy annotation so Helm test failures can be investigated
* Remove background topic message publishing

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
