### PR TITLE
Add max memo length property for Monitor transactions

### DIFF
--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishScenario.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishScenario.java
@@ -29,7 +29,6 @@ import com.hedera.mirror.monitor.ScenarioProtocol;
 public class PublishScenario extends AbstractScenario<PublishScenarioProperties, PublishResponse> {
 
     private final String memo;
-    private static final int TIMESTAMP_LENGTH = 13;
 
     public PublishScenario(PublishScenarioProperties properties) {
         super(1, properties);
@@ -38,8 +37,8 @@ public class PublishScenario extends AbstractScenario<PublishScenarioProperties,
     }
 
     public String getMemo() {
-        var memo = System.currentTimeMillis() + " " + this.memo;
-        return StringUtils.truncate(memo, properties.getMaxMemoLength());
+        var memoMessage = System.currentTimeMillis() + " " + this.memo;
+        return StringUtils.truncate(memoMessage, properties.getMaxMemoLength());
     }
 
     @Override

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishScenario.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishScenario.java
@@ -21,6 +21,7 @@ package com.hedera.mirror.monitor.publish;
  */
 
 import java.util.Objects;
+import org.apache.commons.lang3.StringUtils;
 
 import com.hedera.mirror.monitor.AbstractScenario;
 import com.hedera.mirror.monitor.ScenarioProtocol;
@@ -33,14 +34,12 @@ public class PublishScenario extends AbstractScenario<PublishScenarioProperties,
     public PublishScenario(PublishScenarioProperties properties) {
         super(1, properties);
         String hostname = Objects.requireNonNullElse(System.getenv("HOSTNAME"), "unknown");
-        String memoMessage = String.format(" Monitor %s on %s", properties.getName(), hostname);
-        int maxMemoLength = properties.getMaxMemoLength();
-        this.memo = memoMessage.length() + TIMESTAMP_LENGTH > maxMemoLength ?
-                memoMessage.substring(0, maxMemoLength - TIMESTAMP_LENGTH) : memoMessage;
+        this.memo = String.format("Monitor %s on %s", properties.getName(), hostname);
     }
 
     public String getMemo() {
-        return System.currentTimeMillis() + memo;
+        var memo = System.currentTimeMillis() + " " + this.memo;
+        return StringUtils.truncate(memo, properties.getMaxMemoLength());
     }
 
     @Override

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishScenario.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishScenario.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.monitor.publish;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -28,15 +28,20 @@ import com.hedera.mirror.monitor.ScenarioProtocol;
 public class PublishScenario extends AbstractScenario<PublishScenarioProperties, PublishResponse> {
 
     private final String memo;
+    private static final int TIMESTAMP_LENGTH = 13;
 
     public PublishScenario(PublishScenarioProperties properties) {
         super(1, properties);
         String hostname = Objects.requireNonNullElse(System.getenv("HOSTNAME"), "unknown");
-        this.memo = String.format("Monitor %s on %s", properties.getName(), hostname);
+        String memoMessage = String.format(" Monitor %s on %s", properties.getName(), hostname);
+        System.out.println(TIMESTAMP_LENGTH);
+        int maxMemoLength = properties.getMaxMemoLength();
+        this.memo = memoMessage.length() + TIMESTAMP_LENGTH > maxMemoLength ?
+                memoMessage.substring(0, maxMemoLength - TIMESTAMP_LENGTH) : memoMessage;
     }
 
     public String getMemo() {
-        return System.currentTimeMillis() + " " + memo;
+        return System.currentTimeMillis() + this.memo;
     }
 
     @Override

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishScenario.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishScenario.java
@@ -34,14 +34,13 @@ public class PublishScenario extends AbstractScenario<PublishScenarioProperties,
         super(1, properties);
         String hostname = Objects.requireNonNullElse(System.getenv("HOSTNAME"), "unknown");
         String memoMessage = String.format(" Monitor %s on %s", properties.getName(), hostname);
-        System.out.println(TIMESTAMP_LENGTH);
         int maxMemoLength = properties.getMaxMemoLength();
         this.memo = memoMessage.length() + TIMESTAMP_LENGTH > maxMemoLength ?
                 memoMessage.substring(0, maxMemoLength - TIMESTAMP_LENGTH) : memoMessage;
     }
 
     public String getMemo() {
-        return System.currentTimeMillis() + this.memo;
+        return System.currentTimeMillis() + memo;
     }
 
     @Override

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishScenarioProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishScenarioProperties.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.monitor.publish;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -38,6 +38,10 @@ import com.hedera.mirror.monitor.publish.transaction.TransactionType;
 public class PublishScenarioProperties extends ScenarioProperties {
 
     private boolean logResponse = false;
+
+    // Maximum length of the transaction memo string
+    @Min(13) // 13 is the length of the memo timestamp
+    private int maxMemoLength = 100;
 
     @NotNull
     private Map<String, String> properties = new LinkedHashMap<>();

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishScenarioProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishScenarioProperties.java
@@ -41,6 +41,7 @@ public class PublishScenarioProperties extends ScenarioProperties {
 
     // Maximum length of the transaction memo string
     @Min(13) // 13 is the length of the memo timestamp
+    @Max(100)
     private int maxMemoLength = 100;
 
     @NotNull

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/generator/ConfigurableTransactionGeneratorTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/generator/ConfigurableTransactionGeneratorTest.java
@@ -46,7 +46,7 @@ import com.hedera.mirror.monitor.publish.transaction.TransactionType;
 
 class ConfigurableTransactionGeneratorTest {
 
-    private static final int MAX_MEMO_SIZE = 32;
+    private static final int MEMO_SIZE = 32;
     private static final int SAMPLE_SIZE = 10_000;
     private static final String TOPIC_ID = "0.0.1000";
 
@@ -58,13 +58,23 @@ class ConfigurableTransactionGeneratorTest {
         properties = new PublishScenarioProperties();
         properties.setReceiptPercent(1);
         properties.setRecordPercent(1);
-        properties.setMaxMemoLength(MAX_MEMO_SIZE);
+        properties.setMaxMemoLength(MEMO_SIZE);
         properties.setName("test");
         properties.setProperties(Map.of("topicId", TOPIC_ID));
         properties.setTps(100_000);
         properties.setType(TransactionType.CONSENSUS_SUBMIT_MESSAGE);
         generator = Suppliers.memoize(() -> new ConfigurableTransactionGenerator(p -> p,
                 p -> Collections.unmodifiableMap(p), properties));
+    }
+
+    @Test
+    void nonTruncatedMemo() {
+        properties.setMaxMemoLength(100);
+        List<PublishRequest> publishRequests = generator.get().next();
+        assertThat(publishRequests)
+                .allSatisfy(publishRequest -> assertThat(publishRequest.getTransaction().getTransactionMemo())
+                        .containsPattern(Pattern.compile("\\d+ Monitor test on \\w+"))
+                        .hasSizeGreaterThan(MEMO_SIZE));
     }
 
     @Test
@@ -215,7 +225,7 @@ class ConfigurableTransactionGeneratorTest {
                         .hasFieldOrPropertyWithValue("transaction.topicId", TopicId.fromString(TOPIC_ID))
                         .satisfies(r -> assertThat(r.getTransaction().getTransactionMemo())
                                 .containsPattern(Pattern.compile("\\d+ Monitor test on \\w+"))
-                                .hasSize(MAX_MEMO_SIZE))
+                                .hasSize(MEMO_SIZE))
                 );
     }
 

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/generator/ConfigurableTransactionGeneratorTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/generator/ConfigurableTransactionGeneratorTest.java
@@ -46,6 +46,7 @@ import com.hedera.mirror.monitor.publish.transaction.TransactionType;
 
 class ConfigurableTransactionGeneratorTest {
 
+    private static final int MAX_MEMO_SIZE = 32;
     private static final int SAMPLE_SIZE = 10_000;
     private static final String TOPIC_ID = "0.0.1000";
 
@@ -57,6 +58,7 @@ class ConfigurableTransactionGeneratorTest {
         properties = new PublishScenarioProperties();
         properties.setReceiptPercent(1);
         properties.setRecordPercent(1);
+        properties.setMaxMemoLength(MAX_MEMO_SIZE);
         properties.setName("test");
         properties.setProperties(Map.of("topicId", TOPIC_ID));
         properties.setTps(100_000);
@@ -212,7 +214,8 @@ class ConfigurableTransactionGeneratorTest {
                         .hasFieldOrPropertyWithValue("record", true)
                         .hasFieldOrPropertyWithValue("transaction.topicId", TopicId.fromString(TOPIC_ID))
                         .satisfies(r -> assertThat(r.getTransaction().getTransactionMemo())
-                                .containsPattern(Pattern.compile("\\d+ Monitor test on \\w+")))
+                                .containsPattern(Pattern.compile("\\d+ Monitor test on \\w+"))
+                                .hasSize(MAX_MEMO_SIZE))
                 );
     }
 

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/generator/ConfigurableTransactionGeneratorTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/generator/ConfigurableTransactionGeneratorTest.java
@@ -72,6 +72,7 @@ class ConfigurableTransactionGeneratorTest {
         properties.setMaxMemoLength(100);
         List<PublishRequest> publishRequests = generator.get().next();
         assertThat(publishRequests)
+                .isNotEmpty()
                 .allSatisfy(publishRequest -> assertThat(publishRequest.getTransaction().getTransactionMemo())
                         .containsPattern(Pattern.compile("\\d+ Monitor test on \\w+"))
                         .hasSizeGreaterThan(MEMO_SIZE));


### PR DESCRIPTION
Added maxMemoLength property to reduce the size of memo fields in the monitor test transactions.

**Related issue(s)**:

Fixes #3659

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
