### PR TITLE
Fix wrong next url block number in /blocks response

### DIFF
--- a/hedera-mirror-rest/__tests__/specs/blocks-02-limit-param.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/blocks-02-limit-param.spec.json
@@ -52,7 +52,7 @@
       }
     ]
   },
-  "urls": ["/api/v1/blocks?limit=1"],
+  "urls": ["/api/v1/blocks?limit=2"],
   "responseStatus": 200,
   "responseJson": {
     "blocks": [
@@ -70,10 +70,25 @@
           "from": "1676540001.234710000",
           "to": "1676540001.234810000"
         }
+      },
+      {
+        "count": 4,
+        "gas_used": 0,
+        "hapi_version": "0.22.3",
+        "hash": "0x67b077229142aacb6baf56f31093ebc1a01955da048811c9d26cf9ebb7a26627a241fb610b92936528bbd76b943200a8",
+        "logs_bloom": "0x",
+        "name": "2022-04-27T12_49_14.923546113Z.rcd",
+        "number": 18,
+        "previous_hash": "0xb0162e8a244dc05fbd6f321445b14dddf0e94b00eb169b58ff77b1b5206c12782457f7f1a2ae8cea890f378542ac7216",
+        "size": 6,
+        "timestamp": {
+          "from": "1676540001.234610000",
+          "to": "1676540001.234700000"
+        }
       }
     ],
     "links": {
-      "next": "/api/v1/blocks?limit=1&block.number=lt:19"
+      "next": "/api/v1/blocks?limit=2&block.number=lt:18"
     }
   }
 }

--- a/hedera-mirror-rest/__tests__/specs/blocks-03-limit-order-asc-params.spec.json
+++ b/hedera-mirror-rest/__tests__/specs/blocks-03-limit-order-asc-params.spec.json
@@ -88,7 +88,7 @@
       }
     ],
     "links": {
-      "next": "/api/v1/blocks?limit=2&order=asc&block.number=gt:16"
+      "next": "/api/v1/blocks?limit=2&order=asc&block.number=gt:17"
     }
   }
 }

--- a/hedera-mirror-rest/controllers/blockController.js
+++ b/hedera-mirror-rest/controllers/blockController.js
@@ -99,9 +99,7 @@ class BlockController extends BaseController {
       ? utils.getPaginationLink(
           req,
           blocks.length !== filters.limit,
-          {
-            [constants.filterKeys.BLOCK_NUMBER]: blocks[0].index,
-          },
+          {[constants.filterKeys.BLOCK_NUMBER]: _.last(blocks).index},
           filters.order
         )
       : null;


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR fixes the wrong block number in the next url of `/api/v1/blocks` response.

**Related issue(s)**:

Fixes #4069 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
