### PR TITLE
Suppress CVE-2022-31569 false positive

### DIFF
--- a/suppressions.xml
+++ b/suppressions.xml
@@ -29,4 +29,9 @@
         <packageUrl regex="true">^pkg:maven/org\.apache\.logging\.log4j/log4j\-.*@.*$</packageUrl>
         <cve>CVE-2022-33915</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[ FP per issue #4671 ]]></notes>
+        <packageUrl regex="true">^pkg:.*$</packageUrl>
+        <cve>CVE-2022-31569</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
**Description**:
Suppress CVE-2022-31569 false positive

**Related issue(s)**:

**Notes for reviewer**:
Overly broad CVE that's for python, not Java.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
