### PR TITLE
Fix NPE in StreamFileParser when items was reset to null

### DIFF
--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/StreamFile.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/StreamFile.java
@@ -25,9 +25,9 @@ import reactor.core.publisher.Flux;
 
 import com.hedera.mirror.common.domain.entity.EntityId;
 
-public interface StreamFile<T extends StreamItem> extends Cloneable {
+public interface StreamFile<T extends StreamItem> {
 
-    StreamFile<T> clone();
+    StreamFile<T> copy();
 
     byte[] getBytes();
 

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/StreamFile.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/StreamFile.java
@@ -25,9 +25,9 @@ import reactor.core.publisher.Flux;
 
 import com.hedera.mirror.common.domain.entity.EntityId;
 
-public interface StreamFile<T extends StreamItem> {
+public interface StreamFile<T extends StreamItem> extends Cloneable {
 
-    StreamFile<T> copy();
+    StreamFile<T> clone();
 
     byte[] getBytes();
 

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/StreamFile.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/StreamFile.java
@@ -27,6 +27,8 @@ import com.hedera.mirror.common.domain.entity.EntityId;
 
 public interface StreamFile<T extends StreamItem> {
 
+    StreamFile<T> copy();
+
     byte[] getBytes();
 
     void setBytes(byte[] bytes);

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/balance/AccountBalanceFile.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/balance/AccountBalanceFile.java
@@ -73,7 +73,7 @@ public class AccountBalanceFile implements StreamFile<AccountBalance> {
     private int timeOffset;
 
     @Override
-    public StreamFile<AccountBalance> clone() {
+    public StreamFile<AccountBalance> copy() {
         return this.toBuilder().build();
     }
 

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/balance/AccountBalanceFile.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/balance/AccountBalanceFile.java
@@ -38,7 +38,7 @@ import com.hedera.mirror.common.domain.StreamFile;
 import com.hedera.mirror.common.domain.StreamType;
 import com.hedera.mirror.common.domain.entity.EntityId;
 
-@Builder
+@Builder(toBuilder = true)
 @Data
 @Entity
 @AllArgsConstructor(access = AccessLevel.PRIVATE) // For Builder
@@ -75,6 +75,11 @@ public class AccountBalanceFile implements StreamFile<AccountBalance> {
     @Override
     public Long getConsensusEnd() {
         return consensusTimestamp;
+    }
+
+    @Override
+    public StreamFile<AccountBalance> copy() {
+        return this.toBuilder().build();
     }
 
     @Override

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/balance/AccountBalanceFile.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/balance/AccountBalanceFile.java
@@ -73,13 +73,13 @@ public class AccountBalanceFile implements StreamFile<AccountBalance> {
     private int timeOffset;
 
     @Override
-    public Long getConsensusEnd() {
-        return consensusTimestamp;
+    public StreamFile<AccountBalance> clone() {
+        return this.toBuilder().build();
     }
 
     @Override
-    public StreamFile<AccountBalance> copy() {
-        return this.toBuilder().build();
+    public Long getConsensusEnd() {
+        return consensusTimestamp;
     }
 
     @Override

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/event/EventFile.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/event/EventFile.java
@@ -41,7 +41,7 @@ import com.hedera.mirror.common.domain.StreamType;
 import com.hedera.mirror.common.domain.entity.EntityId;
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@Builder
+@Builder(toBuilder = true)
 @Data
 @Entity
 @NoArgsConstructor
@@ -84,6 +84,11 @@ public class EventFile implements StreamFile<EventItem> {
     private String previousHash;
 
     private int version;
+
+    @Override
+    public StreamFile<EventItem> copy() {
+        return this.toBuilder().build();
+    }
 
     @Override
     public StreamType getType() {

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/event/EventFile.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/event/EventFile.java
@@ -86,7 +86,7 @@ public class EventFile implements StreamFile<EventItem> {
     private int version;
 
     @Override
-    public StreamFile<EventItem> copy() {
+    public StreamFile<EventItem> clone() {
         return this.toBuilder().build();
     }
 

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/event/EventFile.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/event/EventFile.java
@@ -86,7 +86,7 @@ public class EventFile implements StreamFile<EventItem> {
     private int version;
 
     @Override
-    public StreamFile<EventItem> clone() {
+    public StreamFile<EventItem> copy() {
         return this.toBuilder().build();
     }
 

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/RecordFile.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/RecordFile.java
@@ -135,7 +135,7 @@ public class RecordFile implements StreamFile<RecordItem> {
     private int version;
 
     @Override
-    public StreamFile<RecordItem> clone() {
+    public StreamFile<RecordItem> copy() {
         return this.toBuilder().build();
     }
 

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/RecordFile.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/RecordFile.java
@@ -135,7 +135,7 @@ public class RecordFile implements StreamFile<RecordItem> {
     private int version;
 
     @Override
-    public StreamFile<RecordItem> copy() {
+    public StreamFile<RecordItem> clone() {
         return this.toBuilder().build();
     }
 

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/RecordFile.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/RecordFile.java
@@ -135,6 +135,11 @@ public class RecordFile implements StreamFile<RecordItem> {
     private int version;
 
     @Override
+    public StreamFile<RecordItem> copy() {
+        return this.toBuilder().build();
+    }
+
+    @Override
     public StreamType getType() {
         return StreamType.RECORD;
     }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/Downloader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/Downloader.java
@@ -504,10 +504,10 @@ public abstract class Downloader<T extends StreamFile> {
         downloadLatencyMetric.record(Duration.between(consensusEnd, Instant.now()));
 
         // Cache a copy of the streamFile with bytes and items set to null so as not to keep them in memory
-        var copy = (T) streamFile.copy();
-        copy.setBytes(null);
-        copy.setItems(null);
-        lastStreamFile.set(Optional.of(copy));
+        var clone = (T) streamFile.clone();
+        clone.setBytes(null);
+        clone.setItems(null);
+        lastStreamFile.set(Optional.of(clone));
     }
 
     /**

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/Downloader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/Downloader.java
@@ -25,7 +25,6 @@ import static com.hedera.mirror.importer.domain.StreamFilename.FileType.SIGNATUR
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.maxBy;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
@@ -91,7 +90,6 @@ public abstract class Downloader<T extends StreamFile> {
     protected final StreamFileReader<T, ?> streamFileReader;
     protected final StreamFileNotifier streamFileNotifier;
     protected final MirrorDateRangePropertiesProcessor mirrorDateRangePropertiesProcessor;
-    @VisibleForTesting
     protected final AtomicReference<Optional<T>> lastStreamFile = new AtomicReference<>(Optional.empty());
     protected final S3AsyncClient s3Client;
     private final AddressBookService addressBookService;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/Downloader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/Downloader.java
@@ -504,10 +504,10 @@ public abstract class Downloader<T extends StreamFile> {
         downloadLatencyMetric.record(Duration.between(consensusEnd, Instant.now()));
 
         // Cache a copy of the streamFile with bytes and items set to null so as not to keep them in memory
-        var clone = (T) streamFile.clone();
-        clone.setBytes(null);
-        clone.setItems(null);
-        lastStreamFile.set(Optional.of(clone));
+        var copy = (T) streamFile.copy();
+        copy.setBytes(null);
+        copy.setItems(null);
+        lastStreamFile.set(Optional.of(copy));
     }
 
     /**

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/AbstractStreamFileParser.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/AbstractStreamFileParser.java
@@ -91,16 +91,9 @@ public abstract class AbstractStreamFileParser<T extends StreamFile> implements 
                 timer.record(stopwatch.elapsed());
             }
         }
-
-        postParse(streamFile);
     }
 
     protected abstract void doParse(T streamFile);
-
-    private void postParse(T streamFile) {
-        streamFile.setBytes(null);
-        streamFile.setItems(null);
-    }
 
     private boolean shouldParse(T streamFile) {
         if (!parserProperties.isEnabled()) {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/AbstractDownloaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/AbstractDownloaderTest.java
@@ -709,6 +709,17 @@ public abstract class AbstractDownloaderTest {
         for (var extraAssert : extraAsserts) {
             streamFileAssert.allSatisfy(extraAssert::accept);
         }
+
+        if (!files.isEmpty()) {
+            var lastFilename = files.get(files.size() - 1);
+            var lastStreamFile = (Optional<StreamFile>) downloader.lastStreamFile.get();
+            assertThat(lastStreamFile)
+                    .isNotEmpty()
+                    .get()
+                    .returns(null, StreamFile::getBytes)
+                    .returns(null, StreamFile::getItems)
+                    .returns(lastFilename, StreamFile::getName);
+        }
     }
 
     private Instant chooseFileInstant(String choice) {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/AbstractStreamFileParserTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/AbstractStreamFileParserTest.java
@@ -40,8 +40,6 @@ public abstract class AbstractStreamFileParserTest<T extends StreamFileParser> {
 
     protected ParserProperties parserProperties;
 
-    protected abstract void assertParsed(StreamFile streamFile, boolean parsed, boolean dbError);
-
     protected abstract T getParser();
 
     protected abstract StreamFile getStreamFile();
@@ -67,7 +65,6 @@ public abstract class AbstractStreamFileParserTest<T extends StreamFileParser> {
 
         // then
         assertParsed(streamFile, true, false);
-        assertPostParseStreamFile(streamFile, true);
     }
 
     @Test
@@ -81,7 +78,6 @@ public abstract class AbstractStreamFileParserTest<T extends StreamFileParser> {
 
         // then
         assertParsed(streamFile, false, false);
-        assertPostParseStreamFile(streamFile, true);
     }
 
     @Test
@@ -95,7 +91,6 @@ public abstract class AbstractStreamFileParserTest<T extends StreamFileParser> {
 
         // then
         assertParsed(streamFile, false, false);
-        assertPostParseStreamFile(streamFile, true);
     }
 
     @Test
@@ -111,16 +106,10 @@ public abstract class AbstractStreamFileParserTest<T extends StreamFileParser> {
 
         // then
         assertParsed(streamFile, false, true);
-        assertPostParseStreamFile(streamFile, false);
     }
 
-    public void assertPostParseStreamFile(StreamFile streamFile, boolean success) {
-        if (success) {
-            assertThat(streamFile.getBytes()).isNull();
-            assertThat(streamFile.getItems()).isNull();
-        } else {
-            assertThat(streamFile.getBytes()).isNotNull();
-            assertThat(streamFile.getItems()).isNotNull();
-        }
+    protected void assertParsed(StreamFile streamFile, boolean parsed, boolean dbError) {
+        assertThat(streamFile.getBytes()).isNotNull();
+        assertThat(streamFile.getItems()).isNotNull();
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/event/EventFileParserTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/event/EventFileParserTest.java
@@ -63,8 +63,9 @@ class EventFileParserTest extends AbstractStreamFileParserTest<EventFileParser> 
 
     @Override
     protected void assertParsed(StreamFile streamFile, boolean parsed, boolean dbError) {
-        EventFile eventFile = (EventFile) streamFile;
+        super.assertParsed(streamFile, parsed, dbError);
 
+        EventFile eventFile = (EventFile) streamFile;
         if (parsed) {
             verify(eventFileRepository).save(eventFile);
         } else {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileParserTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileParserTest.java
@@ -85,8 +85,9 @@ class RecordFileParserTest extends AbstractStreamFileParserTest<RecordFileParser
 
     @Override
     protected void assertParsed(StreamFile streamFile, boolean parsed, boolean dbError) {
-        RecordFile recordFile = (RecordFile) streamFile;
+        super.assertParsed(streamFile, parsed, dbError);
 
+        RecordFile recordFile = (RecordFile) streamFile;
         if (parsed) {
             verify(recordItemListener).onItem(recordItem);
             verify(recordStreamFileListener).onEnd(recordFile);
@@ -135,7 +136,6 @@ class RecordFileParserTest extends AbstractStreamFileParserTest<RecordFileParser
         parser.parse(recordFile);
         verifyNoInteractions(recordItemListener);
         verify(recordStreamFileListener).onEnd(recordFile);
-        assertPostParseStreamFile(recordFile, true);
     }
 
     @ParameterizedTest(name = "endDate with offset {0}ns")
@@ -157,7 +157,6 @@ class RecordFileParserTest extends AbstractStreamFileParserTest<RecordFileParser
             verify(recordItemListener).onItem(firstItem);
         }
         verify(recordStreamFileListener).onEnd(recordFile);
-        assertPostParseStreamFile(recordFile, true);
     }
 
     @Test
@@ -226,7 +225,6 @@ class RecordFileParserTest extends AbstractStreamFileParserTest<RecordFileParser
             verify(recordItemListener).onItem(firstItem);
         }
         verify(recordStreamFileListener).onEnd(recordFile);
-        assertPostParseStreamFile(recordFile, true);
     }
 
     @Test
@@ -245,8 +243,6 @@ class RecordFileParserTest extends AbstractStreamFileParserTest<RecordFileParser
         // then
         assertParsed(streamFile1, true, false);
         assertParsed(streamFile2, true, false);
-        assertPostParseStreamFile(streamFile1, true);
-        assertPostParseStreamFile(streamFile2, true);
         verify(recordFileRepository).updateIndex(offset - 1);
     }
 
@@ -265,7 +261,6 @@ class RecordFileParserTest extends AbstractStreamFileParserTest<RecordFileParser
 
         // then
         assertParsed(streamFile2, true, false);
-        assertPostParseStreamFile(streamFile2, true);
         verify(recordFileRepository).updateIndex(offset - 1);
     }
 
@@ -285,8 +280,6 @@ class RecordFileParserTest extends AbstractStreamFileParserTest<RecordFileParser
         // then
         assertParsed(streamFile1, true, false);
         assertParsed(streamFile2, true, false);
-        assertPostParseStreamFile(streamFile1, true);
-        assertPostParseStreamFile(streamFile2, true);
         verify(recordFileRepository, never()).updateIndex(anyLong());
     }
 
@@ -304,8 +297,6 @@ class RecordFileParserTest extends AbstractStreamFileParserTest<RecordFileParser
         // then
         assertParsed(streamFile1, true, false);
         assertParsed(streamFile2, true, false);
-        assertPostParseStreamFile(streamFile1, true);
-        assertPostParseStreamFile(streamFile2, true);
         verify(recordFileRepository, never()).updateIndex(anyLong());
     }
 


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

This PR fixes the NPE bug in parser.

- Remove `AbstractStreamFileParser.postParse`
- Set the cloned `StreamFile` object with `bytes` and `items` cleared as the cached `lastStreamFile` in downloader

**Related issue(s)**:

Fixes #4148 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
