### PR TITLE
Set default operator to 0.0.2

### DIFF
--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/OperatorProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/OperatorProperties.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.monitor;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -29,8 +29,9 @@ import org.springframework.validation.annotation.Validated;
 public class OperatorProperties {
 
     @NotBlank
-    private String accountId;
+    private String accountId = "0.0.2";
 
     @NotBlank
-    private String privateKey;
+    private String privateKey =
+            "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137";
 }

--- a/hedera-mirror-rosetta/test/bdd-client/config.go
+++ b/hedera-mirror-rosetta/test/bdd-client/config.go
@@ -44,8 +44,8 @@ hedera:
         log:
           level: debug
         operators:
-          - id:
-            privateKey:
+          - id: 0.0.2
+            privateKey: 302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137
         server:
            dataRetry:
              backOff: 1s

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
@@ -71,10 +71,11 @@ public class AcceptanceTestProperties {
     private long operatorBalance = 15_000_000_000L;
 
     @NotBlank
-    private String operatorId;
+    private String operatorId = "0.0.2";
 
     @NotBlank
-    private String operatorKey;
+    private String operatorKey =
+            "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137";
 
     private boolean retrieveAddressBook = true;
 


### PR DESCRIPTION
**Description**:

Sets the default operator in monitor and acceptance tests to the genesis account 0.0.2

**Related issue(s)**:

**Notes for reviewer**:
This allows us to avoid boilerplate configuration in pre-prod environments.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
