### PR TITLE
Use shard.realm.num account id as transaction payer in Rosetta

### DIFF
--- a/hedera-mirror-rosetta/app/interfaces/account_repository.go
+++ b/hedera-mirror-rosetta/app/interfaces/account_repository.go
@@ -34,6 +34,9 @@ type AccountRepository interface {
 	// doesn't have an alias
 	GetAccountAlias(ctx context.Context, accountId types.AccountId) (types.AccountId, *rTypes.Error)
 
+	// GetAccountId returns the `shard.realm.num` format of the account from its alias if exists
+	GetAccountId(ctx context.Context, accountId types.AccountId) (types.AccountId, *rTypes.Error)
+
 	// RetrieveBalanceAtBlock returns the hbar balance and token balances of the account at a given block (provided by
 	// consensusEnd timestamp).
 	// balance = balanceAtLatestBalanceSnapshot + balanceChangeBetweenSnapshotAndBlock

--- a/hedera-mirror-rosetta/app/persistence/account.go
+++ b/hedera-mirror-rosetta/app/persistence/account.go
@@ -120,6 +120,8 @@ const (
                                  from entity_history
                                  where alias = @alias and timestamp_range @> @consensus_end
                                  order by timestamp_range desc`
+	selectCurrentCryptoEntityByAlias = `select id from entity
+                                 where alias = @alias and (deleted is null or deleted is false)`
 	selectCryptoEntityById = `select id, deleted, timestamp_range
                               from entity
                               where type = 'ACCOUNT' and id = @id
@@ -191,6 +193,29 @@ func (ar *accountRepository) GetAccountAlias(ctx context.Context, accountId type
 	}
 
 	return zero, hErrors.ErrInternalServerError
+}
+
+func (ar *accountRepository) GetAccountId(ctx context.Context, accountId types.AccountId) (
+	zero types.AccountId,
+	_ *rTypes.Error,
+) {
+	if !accountId.HasAlias() {
+		return accountId, nil
+	}
+
+	db, cancel := ar.dbClient.GetDbWithContext(ctx)
+	defer cancel()
+
+	var entity domain.Entity
+	if err := db.Raw(selectCurrentCryptoEntityByAlias, sql.Named("alias", accountId.GetNetworkAlias())).First(&entity).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return zero, hErrors.ErrAccountNotFound
+		}
+
+		return zero, hErrors.ErrDatabaseError
+	}
+
+	return types.NewAccountIdFromEntityId(entity.Id), nil
 }
 
 func (ar *accountRepository) RetrieveBalanceAtBlock(

--- a/hedera-mirror-rosetta/app/persistence/account_test.go
+++ b/hedera-mirror-rosetta/app/persistence/account_test.go
@@ -364,6 +364,32 @@ func (suite *accountRepositorySuite) TestGetAccountAliasDbConnectionError() {
 	assert.Equal(suite.T(), types.AccountId{}, actual)
 }
 
+func (suite *accountRepositorySuite) TestGetAccountId() {
+	// given
+	aliasAccountId, _ := types.NewAccountIdFromString(account4Alias, 0, 0)
+	repo := NewAccountRepository(dbClient)
+
+	// when
+	actual, err := repo.GetAccountId(defaultContext, aliasAccountId)
+
+	// then
+	assert.NotNil(suite.T(), err)
+	assert.Equal(suite.T(), types.AccountId{}, actual)
+}
+
+func (suite *accountRepositorySuite) TestGetAccountIdDbConnectionError() {
+	// given
+	aliasAccountId, _ := types.NewAccountIdFromString(account4Alias, 0, 0)
+	repo := NewAccountRepository(invalidDbClient)
+
+	// when
+	actual, err := repo.GetAccountId(defaultContext, aliasAccountId)
+
+	// then
+	assert.NotNil(suite.T(), err)
+	assert.Equal(suite.T(), types.AccountId{}, actual)
+}
+
 func (suite *accountRepositorySuite) TestRetrieveBalanceAtBlock() {
 	// given
 	// tokens created at or before first account balance snapshot will not show up in account balance response
@@ -724,6 +750,38 @@ func (suite *accountRepositoryWithAliasSuite) TestGetAccountAliasThrowWhenInvali
 	repo := NewAccountRepository(dbClient)
 	actual, err := repo.GetAccountAlias(defaultContext, accountId)
 	assert.NotNil(suite.T(), err)
+	assert.Equal(suite.T(), types.AccountId{}, actual)
+}
+
+func (suite *accountRepositoryWithAliasSuite) TestGetAccountId() {
+	// given
+	aliasAccountId, err := types.NewAccountIdFromString(account4Alias, 0, 0)
+	assert.NoError(suite.T(), err)
+	repo := NewAccountRepository(dbClient)
+	expected := types.NewAccountIdFromEntityId(domain.MustDecodeEntityId(account4))
+
+	// when
+	actual, rErr := repo.GetAccountId(defaultContext, aliasAccountId)
+
+	// then
+	assert.Nil(suite.T(), rErr)
+	assert.Equal(suite.T(), expected, actual)
+}
+
+func (suite *accountRepositoryWithAliasSuite) TestGetAccountIdDeleted() {
+	// given
+	tdomain.NewEntityBuilder(dbClient, account4, 1, domain.EntityTypeAccount).
+		Deleted(true).
+		ModifiedTimestamp(accountDeleteTimestamp).
+		Persist()
+	aliasAccountId, _ := types.NewAccountIdFromString(account4Alias, 0, 0)
+	repo := NewAccountRepository(dbClient)
+
+	// when
+	actual, rErr := repo.GetAccountId(defaultContext, aliasAccountId)
+
+	// then
+	assert.NotNil(suite.T(), rErr)
 	assert.Equal(suite.T(), types.AccountId{}, actual)
 }
 

--- a/hedera-mirror-rosetta/app/persistence/account_test.go
+++ b/hedera-mirror-rosetta/app/persistence/account_test.go
@@ -377,6 +377,19 @@ func (suite *accountRepositorySuite) TestGetAccountId() {
 	assert.Equal(suite.T(), types.AccountId{}, actual)
 }
 
+func (suite *accountRepositorySuite) TestGetAccountIdNumericAccount() {
+	// given
+	accountId := types.NewAccountIdFromEntityId(domain.MustDecodeEntityId(account1))
+	repo := NewAccountRepository(dbClient)
+
+	// when
+	actual, err := repo.GetAccountId(defaultContext, accountId)
+
+	// then
+	assert.Nil(suite.T(), err)
+	assert.Equal(suite.T(), accountId, actual)
+}
+
 func (suite *accountRepositorySuite) TestGetAccountIdDbConnectionError() {
 	// given
 	aliasAccountId, _ := types.NewAccountIdFromString(account4Alias, 0, 0)

--- a/hedera-mirror-rosetta/app/services/construction_service.go
+++ b/hedera-mirror-rosetta/app/services/construction_service.go
@@ -27,6 +27,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/big"
+	"strings"
 	"time"
 
 	"github.com/coinbase/rosetta-sdk-go/server"
@@ -44,15 +45,19 @@ import (
 )
 
 const (
-	defaultValidDurationSeconds     = 180
+	maxValidDurationSeconds         = 180
+	defaultValidDurationSeconds     = maxValidDurationSeconds
+	metadataKeyAccountMap           = "account_map"
 	metadataKeyValidDurationSeconds = "valid_duration"
 	metadataKeyValidStartNanos      = "valid_start_nanos"
+	optionKeyAccountAliases         = "account_aliases"
 	optionKeyOperationType          = "operation_type"
 )
 
 // constructionAPIService implements the server.ConstructionAPIServicer interface.
 type constructionAPIService struct {
 	BaseService
+	accountRepo              interfaces.AccountRepository
 	defaultMaxTransactionFee map[string]hedera.Hbar
 	hederaClient             *hedera.Client
 	nodeAccountIds           []hedera.AccountID
@@ -95,7 +100,7 @@ func (c *constructionAPIService) ConstructionCombine(
 			return nil, errors.ErrInvalidSignatureVerification
 		}
 
-		if rErr := addSignature(transaction, pubKey, signature.Bytes); rErr != nil {
+		if rErr = addSignature(transaction, pubKey, signature.Bytes); rErr != nil {
 			return nil, rErr
 		}
 	}
@@ -148,13 +153,14 @@ func (c *constructionAPIService) ConstructionHash(
 
 // ConstructionMetadata implements the /construction/metadata endpoint.
 func (c *constructionAPIService) ConstructionMetadata(
-	_ context.Context,
+	ctx context.Context,
 	request *rTypes.ConstructionMetadataRequest,
 ) (*rTypes.ConstructionMetadataResponse, *rTypes.Error) {
 	options := request.Options
 	if options == nil || options[optionKeyOperationType] == nil {
 		return nil, errors.ErrInvalidOptions
 	}
+
 	operationType, ok := options[optionKeyOperationType].(string)
 	if !ok {
 		return nil, errors.ErrInvalidOptions
@@ -165,10 +171,38 @@ func (c *constructionAPIService) ConstructionMetadata(
 		return nil, err
 	}
 
-	return &rTypes.ConstructionMetadataResponse{
-		Metadata:     make(map[string]interface{}),
+	response := &rTypes.ConstructionMetadataResponse{
+		Metadata:     map[string]interface{}{},
 		SuggestedFee: []*rTypes.Amount{maxFee.ToRosetta()},
-	}, nil
+	}
+
+	if options[optionKeyAccountAliases] != nil {
+		if !c.BaseService.IsOnline() {
+			return nil, errors.ErrEndpointNotSupportedInOfflineMode
+		}
+
+		accountAliases, ok := options[optionKeyAccountAliases].(string)
+		if !ok {
+			return nil, errors.ErrInvalidOptions
+		}
+
+		var accountMap []string
+		for _, accountAlias := range strings.Split(accountAliases, ",") {
+			accountId, err := types.NewAccountIdFromString(accountAlias, c.systemShard, c.systemRealm)
+			if err != nil {
+				return nil, errors.ErrInvalidAccount
+			}
+
+			if found, rErr := c.accountRepo.GetAccountId(ctx, accountId); rErr != nil {
+				return nil, rErr
+			} else {
+				accountMap = append(accountMap, fmt.Sprintf("%s:%s", accountAlias, found))
+			}
+		}
+		response.Metadata[metadataKeyAccountMap] = strings.Join(accountMap, ",")
+	}
+
+	return response, nil
 }
 
 // ConstructionParse implements the /construction/parse endpoint.
@@ -224,7 +258,12 @@ func (c *constructionAPIService) ConstructionPayloads(
 		return nil, rErr
 	}
 
-	payer := signers[0].ToSdkAccountId()
+	// signers[0] is always the payer account id
+	payer, rErr := c.getSdkPayerAccountId(signers[0], request.Metadata[metadataKeyAccountMap])
+	if rErr != nil {
+		return nil, rErr
+	}
+
 	if rErr = updateTransaction(
 		transaction,
 		transactionSetNodeAccountId(c.getRandomNodeAccountId()),
@@ -280,10 +319,18 @@ func (c *constructionAPIService) ConstructionPreprocess(
 		requiredPublicKeys = append(requiredPublicKeys, &rTypes.AccountIdentifier{Address: signer.String()})
 	}
 
-	return &rTypes.ConstructionPreprocessResponse{
+	response := &rTypes.ConstructionPreprocessResponse{
 		Options:            map[string]interface{}{optionKeyOperationType: operations[0].Type},
 		RequiredPublicKeys: requiredPublicKeys,
-	}, nil
+	}
+
+	// the first signer is always the payer account
+	payer := signers[0]
+	if payer.HasAlias() {
+		response.Options[optionKeyAccountAliases] = fmt.Sprintf("%s", payer)
+	}
+
+	return response, nil
 }
 
 // ConstructionSubmit implements the /construction/submit endpoint.
@@ -359,6 +406,44 @@ func (c *constructionAPIService) getOperationSlice(operations []*rTypes.Operatio
 	return operationSlice, nil
 }
 
+func (c *constructionAPIService) getSdkPayerAccountId(payerAccountId types.AccountId, accountMapMetadata interface{}) (
+	hedera.AccountID,
+	*rTypes.Error,
+) {
+	var payer hedera.AccountID
+	if !payerAccountId.HasAlias() {
+		payer = payerAccountId.ToSdkAccountId()
+	} else {
+		// look up the account map metadata for the alias account's `shard.realm.num` account id
+		if accountMapMetadata == nil {
+			return payer, errors.ErrAccountNotFound
+		}
+
+		accountMap, ok := accountMapMetadata.(string)
+		if !ok {
+			return payer, errors.ErrAccountNotFound
+		}
+
+		payerAlias := payerAccountId.String()
+		for _, aliasMap := range strings.Split(accountMap, ",") {
+			if strings.HasPrefix(aliasMap, payerAlias) {
+				var err error
+				mapping := strings.Split(aliasMap, ":")
+				if payer, err = hedera.AccountIDFromString(mapping[1]); err != nil {
+					return payer, errors.ErrInvalidAccount
+				}
+				break
+			}
+		}
+
+		if payer.Account == 0 {
+			return hedera.AccountID{}, errors.ErrAccountNotFound
+		}
+	}
+
+	return payer, nil
+}
+
 func (c *constructionAPIService) getRandomNodeAccountId() hedera.AccountID {
 	index, err := rand.Int(rand.Reader, c.nodeAccountIdsLen)
 	if err != nil {
@@ -388,11 +473,12 @@ func (c *constructionAPIService) getIntMetadataValue(metadata map[string]interfa
 
 func isValidTransactionValidDuration(validDuration int64) bool {
 	// A value of 0 indicates validDuration is unset
-	return validDuration >= 0 && validDuration <= 180
+	return validDuration >= 0 && validDuration <= maxValidDurationSeconds
 }
 
 // NewConstructionAPIService creates a new instance of a constructionAPIService.
 func NewConstructionAPIService(
+	accountRepo interfaces.AccountRepository,
 	baseService BaseService,
 	network string,
 	nodes config.NodeMap,
@@ -425,6 +511,7 @@ func NewConstructionAPIService(
 	}
 
 	return &constructionAPIService{
+		accountRepo:        accountRepo,
 		BaseService:        baseService,
 		hederaClient:       hederaClient,
 		nodeAccountIds:     nodeAccountIds,

--- a/hedera-mirror-rosetta/main.go
+++ b/hedera-mirror-rosetta/main.go
@@ -96,6 +96,7 @@ func newBlockchainOnlineRouter(
 	mempoolAPIController := server.NewMempoolAPIController(mempoolAPIService, asserter)
 
 	constructionAPIService, err := services.NewConstructionAPIService(
+		accountRepo,
 		baseService,
 		network.Network,
 		rosettaConfig.Nodes,
@@ -139,6 +140,7 @@ func newBlockchainOfflineRouter(
 	baseService := services.NewOfflineBaseService()
 
 	constructionAPIService, err := services.NewConstructionAPIService(
+		nil,
 		baseService,
 		network.Network,
 		rosettaConfig.Nodes,

--- a/hedera-mirror-rosetta/test/bdd-client/client/client.go
+++ b/hedera-mirror-rosetta/test/bdd-client/client/client.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	rosettaAsserter "github.com/coinbase/rosetta-sdk-go/asserter"
@@ -203,6 +204,10 @@ func (c Client) Submit(ctx context.Context, operations []*types.Operation, signe
 		signers = map[string]hedera.PrivateKey{operator.Id.String(): operator.PrivateKey}
 	} else {
 		for signerId := range signers {
+			if strings.HasPrefix(signerId, "0x") {
+				continue
+			}
+
 			accountId, _ := hedera.AccountIDFromString(signerId)
 			operatorKey, ok := c.privateKeys[accountId]
 			if ok {
@@ -231,7 +236,7 @@ func (c Client) Submit(ctx context.Context, operations []*types.Operation, signe
 			NetworkIdentifier: c.network,
 			Options:           preprocessResponse.Options,
 		}
-		_, rosettaErr, err = onlineConstructor.ConstructionMetadata(ctx, metadataRequest)
+		metadataResponse, rosettaErr, err := onlineConstructor.ConstructionMetadata(ctx, metadataRequest)
 		if err1 := c.handleError("Failed to handle metadata request", rosettaErr, err); err1 != nil {
 			return false, rosettaErr, err
 		}
@@ -240,6 +245,7 @@ func (c Client) Submit(ctx context.Context, operations []*types.Operation, signe
 		payloadsRequest := &types.ConstructionPayloadsRequest{
 			NetworkIdentifier: c.network,
 			Operations:        operations,
+			Metadata:          metadataResponse.Metadata,
 		}
 		payloadsResponse, rosettaErr, err := offlineConstructor.ConstructionPayloads(ctx, payloadsRequest)
 		if err1 := c.handleError("Failed to handle payloads request", rosettaErr, err); err1 != nil {

--- a/hedera-mirror-rosetta/test/bdd-client/features/crypto.feature
+++ b/hedera-mirror-rosetta/test/bdd-client/features/crypto.feature
@@ -5,9 +5,12 @@ Feature: Crypto related transactions
     When I create a crypto account
     Then the DATA API should show the CryptoCreate transaction
 
-  Scenario: Validate auto account creation with CryptoTransfer transaction
+  @alias
+  Scenario: Validate auto account creation with CryptoTransfer transaction and then transfer funds from the alias account
     When I transfer some hbar to a new alias
     Then the DATA API should show the CryptoTransfer transaction and new account id
+    When I transfer some hbar from the alias
+    Then the DATA API should show the CryptoTransfer transaction from the alias
 
   Scenario: Validate CryptoTransfer transaction
     When I transfer some hbar to the treasury account

--- a/hedera-mirror-rosetta/test/bdd-client/scenario/crypto.go
+++ b/hedera-mirror-rosetta/test/bdd-client/scenario/crypto.go
@@ -22,20 +22,19 @@ package scenario
 
 import (
 	"context"
-	"encoding/hex"
-	"github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/app/tools"
 
 	"github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/cucumber/godog"
+	types2 "github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/app/domain/types"
 	"github.com/hashgraph/hedera-sdk-go/v2"
 	log "github.com/sirupsen/logrus"
 )
 
 type cryptoFeature struct {
 	*baseFeature
-	aliasAddress  string
-	newAccountId  *hedera.AccountID // new account created during test
-	newAccountKey *hedera.PrivateKey
+	aliasAccountId types2.AccountId
+	newAccountId   *hedera.AccountID // new account created during test
+	newAccountKey  *hedera.PrivateKey
 }
 
 func (c *cryptoFeature) createCryptoAccount(ctx context.Context) error {
@@ -93,7 +92,7 @@ func (c *cryptoFeature) createCryptoAccountByAlias(ctx context.Context) error {
 		return err
 	}
 
-	log.Infof("Transfer some hbar to new alias %s", c.aliasAddress)
+	log.Infof("Transfer some hbar to new alias %s", c.aliasAccountId)
 	operations := []*types.Operation{
 		{
 			OperationIdentifier: &types.OperationIdentifier{Index: 0},
@@ -107,7 +106,7 @@ func (c *cryptoFeature) createCryptoAccountByAlias(ctx context.Context) error {
 		},
 		{
 			OperationIdentifier: &types.OperationIdentifier{Index: 1},
-			Account:             &types.AccountIdentifier{Address: c.aliasAddress},
+			Account:             c.aliasAccountId.ToRosetta(),
 			Amount: &types.Amount{
 				Value:    "1000000000",
 				Currency: currencyHbar,
@@ -118,7 +117,7 @@ func (c *cryptoFeature) createCryptoAccountByAlias(ctx context.Context) error {
 	return c.submit(ctx, operations, nil)
 }
 
-func (c *cryptoFeature) verifyCryptoTransferAliasTransaction(ctx context.Context) error {
+func (c *cryptoFeature) verifyCryptoTransferToAliasTransaction(ctx context.Context) error {
 	transaction, err := c.findTransaction(ctx, operationTypeCryptoTransfer)
 	if err != nil {
 		return err
@@ -133,7 +132,7 @@ func (c *cryptoFeature) verifyCryptoTransferAliasTransaction(ctx context.Context
 		return err
 	}
 
-	resp, err := testClient.GetAccountBalance(ctx, &types.AccountIdentifier{Address: c.aliasAddress})
+	resp, err := testClient.GetAccountBalance(ctx, c.aliasAccountId.ToRosetta())
 	if err != nil {
 		return err
 	}
@@ -147,6 +146,52 @@ func (c *cryptoFeature) verifyCryptoTransferAliasTransaction(ctx context.Context
 	log.Infof("Successfully retrieved new account %s from account balance endpoint", accountIdStr)
 
 	return nil
+}
+
+func (c *cryptoFeature) transferFromAlias(ctx context.Context) error {
+	operations := []*types.Operation{
+		{
+			OperationIdentifier: &types.OperationIdentifier{Index: 0},
+			Account:             c.aliasAccountId.ToRosetta(),
+			Amount:              &types.Amount{Value: "-1", Currency: currencyHbar},
+			Type:                operationTypeCryptoTransfer,
+		},
+		{
+			OperationIdentifier: &types.OperationIdentifier{Index: 1},
+			Account:             getRosettaAccountIdentifier(testClient.GetOperator(0).Id),
+			Amount:              &types.Amount{Value: "1", Currency: currencyHbar},
+			Type:                operationTypeCryptoTransfer,
+		},
+	}
+
+	return c.submit(ctx, operations, map[string]hedera.PrivateKey{
+		c.aliasAccountId.String(): *c.newAccountKey,
+	})
+}
+func (c *cryptoFeature) verifyCryptoTransferFromAliasTransaction(ctx context.Context) error {
+	transaction, err := c.findTransaction(ctx, operationTypeCryptoTransfer)
+	if err != nil {
+		return err
+	}
+
+	expectedAccountAmounts := []accountAmount{
+		{
+			Account: c.aliasAccountId.ToRosetta(),
+			Amount:  &types.Amount{Value: "-1", Currency: currencyHbar},
+		},
+		{
+			Account: getRosettaAccountIdentifier(testClient.GetOperator(0).Id),
+			Amount:  &types.Amount{Value: "1", Currency: currencyHbar},
+		},
+	}
+
+	return assertTransactionAll(
+		transaction,
+		assertTransactionOpSuccess,
+		assertTransactionOpCount(2, gte),
+		assertTransactionOpTypesContains(operationTypeCryptoTransfer, operationTypeFee),
+		assertTransactionIncludesTransfers(expectedAccountAmounts),
+	)
 }
 
 func (c *cryptoFeature) transferHbarToTreasury(ctx context.Context) error {
@@ -202,7 +247,6 @@ func (c *cryptoFeature) cleanup(ctx context.Context, s *godog.Scenario, err erro
 		testClient.DeleteAccount(*c.newAccountId, c.newAccountKey) // #nosec
 	}
 
-	c.aliasAddress = ""
 	c.newAccountId = nil
 	c.newAccountKey = nil
 
@@ -216,7 +260,11 @@ func (c *cryptoFeature) generateKey() error {
 		return err
 	}
 	c.newAccountKey = &sk
-	c.aliasAddress = tools.SafeAddHexPrefix(hex.EncodeToString(sk.PublicKey().BytesRaw()))
+	operatorAccountId := testClient.GetOperator(0).Id
+	c.aliasAccountId, err = types2.NewAccountIdFromAlias(sk.PublicKey().BytesRaw(), int64(operatorAccountId.Shard), int64(operatorAccountId.Realm))
+	if err != nil {
+		return err
+	}
 	log.Debug("Generated private key for new account")
 	return nil
 }
@@ -231,7 +279,11 @@ func initializeCryptoScenario(ctx *godog.ScenarioContext) {
 
 	ctx.Step("I transfer some hbar to a new alias", crypto.createCryptoAccountByAlias)
 	ctx.Step("the DATA API should show the CryptoTransfer transaction and new account id",
-		crypto.verifyCryptoTransferAliasTransaction)
+		crypto.verifyCryptoTransferToAliasTransaction)
+
+	ctx.Step("I transfer some hbar from the alias", crypto.transferFromAlias)
+	ctx.Step("^the DATA API should show the CryptoTransfer transaction from the alias$",
+		crypto.verifyCryptoTransferFromAliasTransaction)
 
 	ctx.Step("I transfer some hbar to the treasury account", crypto.transferHbarToTreasury)
 	ctx.Step("^the DATA API should show the CryptoTransfer transaction$", crypto.verifyCryptoTransferTransaction)

--- a/hedera-mirror-rosetta/test/mocks/account_repository.go
+++ b/hedera-mirror-rosetta/test/mocks/account_repository.go
@@ -42,6 +42,14 @@ func (m *MockAccountRepository) GetAccountAlias(ctx context.Context, accountId t
 	return args.Get(0).(types.AccountId), args.Get(1).(*rTypes.Error)
 }
 
+func (m *MockAccountRepository) GetAccountId(ctx context.Context, accountId types.AccountId) (
+	types.AccountId,
+	*rTypes.Error,
+) {
+	args := m.Called(ctx, accountId)
+	return args.Get(0).(types.AccountId), args.Get(1).(*rTypes.Error)
+}
+
 func (m *MockAccountRepository) RetrieveBalanceAtBlock(
 	ctx context.Context,
 	accountId types.AccountId,


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR fixes the bug that an alias account can't be the payer of the transaction in Rosetta server.

- Pass the transaction payer account in `ConstructionPreprocessResponse.Options` from `/construction/preprocess` to `/construction/metadata` if it's an alias account
- Look up alias account to `shard.realm.num` account id in `/construction/metadata` and add it to `ConstructionMetadataResponse.Metadata`
- Update bdd test client to copy `ConstructionMetadataResponse.Metadata` to `ConstructionPayloadsRequest.Metadata`
- Add bdd test for transfer from alias account

**Related issue(s)**:

Fixes #4170 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
