### PR TITLE
Use hedera network alias in Rosetta

### DIFF
--- a/hedera-mirror-rosetta/app/domain/types/public_key.go
+++ b/hedera-mirror-rosetta/app/domain/types/public_key.go
@@ -23,6 +23,7 @@ package types
 import (
 	"fmt"
 
+	"github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/app/tools"
 	"github.com/hashgraph/hedera-protobufs-go/services"
 	"github.com/hashgraph/hedera-sdk-go/v2"
@@ -44,29 +45,63 @@ func (pk PublicKey) IsEmpty() bool {
 	return len(pk.PublicKey.Bytes()) == 0
 }
 
-func (pk PublicKey) ToAlias() ([]byte, error) {
+func (pk PublicKey) ToAlias() (_ []byte, zeroCurveType types.CurveType, _ error) {
 	rawKey := pk.PublicKey.BytesRaw()
 	var key services.Key
+	var curveType types.CurveType
 	switch keySize := len(rawKey); keySize {
 	case ed25519PublicKeySize:
+		curveType = types.Edwards25519
 		key = services.Key{Key: &services.Key_Ed25519{Ed25519: rawKey}}
 	case ecdsaSecp256k1PublicKeySize:
+		curveType = types.Secp256k1
 		key = services.Key{Key: &services.Key_ECDSASecp256K1{ECDSASecp256K1: rawKey}}
 	default:
-		return nil, errors.New(fmt.Sprintf("Unknown public key type with %d raw bytes", keySize))
+		return nil, zeroCurveType, errors.New(fmt.Sprintf("Unknown public key type with %d raw bytes", keySize))
 	}
 
 	// HIP-32 defines the alias as "a byte array (protobuf bytes) that is formed by serializing a protobuf Key
 	// that represents a primitive public key (not a threshold key or key list, etc.)".
 	alias, err := proto.Marshal(&key)
 	if err != nil {
-		return nil, errors.New(fmt.Sprintf("Failed to marshal proto Key: %s", err))
+		return nil, zeroCurveType, errors.New(fmt.Sprintf("Failed to marshal proto Key: %s", err))
 	}
-	return alias, nil
+	return alias, curveType, nil
 }
 
 func (pk *PublicKey) UnmarshalJSON(data []byte) error {
 	var err error
 	pk.PublicKey, err = hedera.PublicKeyFromString(tools.SafeUnquote(string(data)))
 	return err
+}
+
+func NewPublicKeyFromAlias(alias []byte) (zeroCurveType types.CurveType, zeroPublicKey PublicKey, _ error) {
+	if len(alias) == 0 {
+		return zeroCurveType, zeroPublicKey, errors.Errorf("Empty alias provided")
+	}
+
+	var key services.Key
+	if err := proto.Unmarshal(alias, &key); err != nil {
+		return zeroCurveType, zeroPublicKey, err
+	}
+
+	var curveType types.CurveType
+	var rawKey []byte
+	switch value := key.GetKey().(type) {
+	case *services.Key_Ed25519:
+		curveType = types.Edwards25519
+		rawKey = value.Ed25519
+	case *services.Key_ECDSASecp256K1:
+		curveType = types.Secp256k1
+		rawKey = value.ECDSASecp256K1
+	default:
+		return zeroCurveType, zeroPublicKey, errors.Errorf("Unsupported key type")
+	}
+
+	publicKey, err := hedera.PublicKeyFromBytes(rawKey)
+	if err != nil {
+		return zeroCurveType, zeroPublicKey, err
+	}
+
+	return curveType, PublicKey{publicKey}, nil
 }

--- a/hedera-mirror-rosetta/app/persistence/account.go
+++ b/hedera-mirror-rosetta/app/persistence/account.go
@@ -207,7 +207,7 @@ func (ar *accountRepository) GetAccountId(ctx context.Context, accountId types.A
 	defer cancel()
 
 	var entity domain.Entity
-	if err := db.Raw(selectCurrentCryptoEntityByAlias, sql.Named("alias", accountId.GetNetworkAlias())).First(&entity).Error; err != nil {
+	if err := db.Raw(selectCurrentCryptoEntityByAlias, sql.Named("alias", accountId.GetAlias())).First(&entity).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return zero, hErrors.ErrAccountNotFound
 		}
@@ -309,11 +309,11 @@ func (ar *accountRepository) getCryptoEntity(ctx context.Context, accountId type
 	if accountId.HasAlias() {
 		query = selectCryptoEntityByAlias
 		args = []interface{}{
-			sql.Named("alias", accountId.GetNetworkAlias()),
+			sql.Named("alias", accountId.GetAlias()),
 			sql.Named("consensus_end", getInclusiveInt8Range(consensusEnd, consensusEnd)),
 		}
 		notFoundError = hErrors.AddErrorDetails(hErrors.ErrAccountNotFound, "reason",
-			fmt.Sprintf("Account with the alias '%s' not found", hex.EncodeToString(accountId.GetNetworkAlias())))
+			fmt.Sprintf("Account with the alias '%s' not found", hex.EncodeToString(accountId.GetAlias())))
 	} else {
 		query = selectCryptoEntityById
 		args = []interface{}{sql.Named("id", accountId.GetId())}

--- a/hedera-mirror-rosetta/app/services/account_service_test.go
+++ b/hedera-mirror-rosetta/app/services/account_service_test.go
@@ -22,7 +22,6 @@ package services
 
 import (
 	"encoding/hex"
-	"github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/app/tools"
 	"testing"
 
 	"github.com/coinbase/rosetta-sdk-go/server"
@@ -167,7 +166,7 @@ func (suite *accountServiceSuite) TestAliasAccountBalance() {
 	// given:
 	accountId := "0.0.100"
 	_, pk := tdomain.GenEd25519KeyPair()
-	alias := tools.SafeAddHexPrefix(hex.EncodeToString(pk.BytesRaw()))
+	alias := ed25519AliasPrefix + hex.EncodeToString(pk.BytesRaw())
 	metadata := map[string]interface{}{"account_id": accountId}
 	suite.mockBlockRepo.On("RetrieveLatest").Return(block(), mocks.NilError)
 	suite.mockAccountRepo.On("RetrieveBalanceAtBlock").Return(amount(), accountId, mocks.NilError)

--- a/hedera-mirror-rosetta/app/services/block_service_test.go
+++ b/hedera-mirror-rosetta/app/services/block_service_test.go
@@ -35,15 +35,16 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-const ed25519NetworkAliasHex = "0x12205a081255a92b7c262bc2ea3ab7114b8a815345b3cc40f800b2b40914afecc44e"
+const ed25519AliasHex = "0x12205a081255a92b7c262bc2ea3ab7114b8a815345b3cc40f800b2b40914afecc44e"
 
 var (
-	ed25519NetworkAlias = hexutil.MustDecode(ed25519NetworkAliasHex)
-	account             = types.NewAccountIdFromEntityId(domain.MustDecodeEntityId(500))
-	accountAlias, _     = types.NewAccountIdFromEntity(domain.Entity{Alias: ed25519NetworkAlias, Id: domain.MustDecodeEntityId(500)})
-	entityId            = domain.MustDecodeEntityId(600)
-	hbarAmount          = types.HbarAmount{Value: 300}
-	statusSuccess       = types.TransactionResults[22]
+	ed25519Alias    = hexutil.MustDecode(ed25519AliasHex)
+	accountEntityId = domain.MustDecodeEntityId(500)
+	account         = types.NewAccountIdFromEntityId(accountEntityId)
+	accountAlias, _ = types.NewAccountIdFromEntity(domain.Entity{Alias: ed25519Alias, Id: accountEntityId})
+	entityId        = domain.MustDecodeEntityId(600)
+	hbarAmount      = types.HbarAmount{Value: 300}
+	statusSuccess   = types.TransactionResults[22]
 )
 
 func block() *types.Block {

--- a/hedera-mirror-rosetta/app/services/construction_service.go
+++ b/hedera-mirror-rosetta/app/services/construction_service.go
@@ -124,7 +124,8 @@ func (c *constructionAPIService) ConstructionDerive(
 	if publicKey.CurveType != rTypes.Edwards25519 {
 		return nil, errors.ErrInvalidPublicKey
 	}
-	accountId, err := types.NewAccountIdFromAlias(request.PublicKey.Bytes, c.systemShard, c.systemRealm)
+
+	accountId, err := types.NewAccountIdFromPublicKeyBytes(request.PublicKey.Bytes, c.systemShard, c.systemRealm)
 	if err != nil || accountId.GetCurveType() != rTypes.Edwards25519 {
 		return nil, errors.ErrInvalidPublicKey
 	}

--- a/hedera-mirror-rosetta/app/services/construction_service_test.go
+++ b/hedera-mirror-rosetta/app/services/construction_service_test.go
@@ -45,6 +45,7 @@ const (
 	defaultSendAmount    = -1000
 	defaultReceiveAmount = 1000
 	defaultNetwork       = "testnet"
+	ed25519AliasPrefix   = "0x1220"
 )
 
 var (
@@ -71,7 +72,7 @@ var (
 	payerId                = hedera.AccountID{Account: 100}
 	publicKeyStr           = "eba8cc093a83a4ca5e813e30d8c503babb35c22d57d34b6ec5ac0303a6aaba77" // without ed25519PubKeyPrefix
 	privateKey, _          = hedera.PrivateKeyFromString("302e020100300506032b6570042204207904b9687878e08e101723f7b724cd61a42bbff93923177bf3fcc2240b0dd3bc")
-	aliasStr               = "0x" + publicKeyStr
+	aliasStr               = ed25519AliasPrefix + publicKeyStr
 	aliasAccount, _        = types.NewAccountIdFromString(aliasStr, 0, 0)
 	validSignedTransaction = "0x0aaa012aa7010a3d0a140a0c08feafcb840610ae86c0db03120418d8c307120218041880c2d72f2202087872180a160a090a0418d8c30710cf0f0a090a0418fec40710d00f12660a640a20eba8cc093a83a4ca5e813e30d8c503babb35c22d57d34b6ec5ac0303a6aaba771a40793de745bc19dd8fe8e817891f51b8fe1e259c2e6428bd7fa075b181585a2d40e3666a7c9a1873abb5433ffe1414502836d8d37082eaf94a648b530e9fa78108"
 )
@@ -440,7 +441,7 @@ func TestConstructionDerive(t *testing.T) {
 				CurveType: rTypes.Edwards25519,
 			},
 			expected: &rTypes.ConstructionDeriveResponse{
-				AccountIdentifier: &rTypes.AccountIdentifier{Address: "0x" + hex.EncodeToString(ed25519PublicKey.BytesRaw())},
+				AccountIdentifier: &rTypes.AccountIdentifier{Address: ed25519AliasPrefix + hex.EncodeToString(ed25519PublicKey.BytesRaw())},
 			},
 		},
 		{

--- a/hedera-mirror-rosetta/test/bdd-client/scenario/crypto.go
+++ b/hedera-mirror-rosetta/test/bdd-client/scenario/crypto.go
@@ -261,7 +261,7 @@ func (c *cryptoFeature) generateKey() error {
 	}
 	c.newAccountKey = &sk
 	operatorAccountId := testClient.GetOperator(0).Id
-	c.aliasAccountId, err = types2.NewAccountIdFromAlias(sk.PublicKey().BytesRaw(), int64(operatorAccountId.Shard), int64(operatorAccountId.Realm))
+	c.aliasAccountId, err = types2.NewAccountIdFromPublicKeyBytes(sk.PublicKey().BytesRaw(), int64(operatorAccountId.Shard), int64(operatorAccountId.Realm))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

This PR changes the account alias to be the same as the hedera network alias in Rosetta. 

**Related issue(s)**:

Fixes #4189 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
