### PR TITLE
Add UNKNOWN to OpenAPI transaction types

### DIFF
--- a/hedera-mirror-rest/api/v1/openapi.yml
+++ b/hedera-mirror-rest/api/v1/openapi.yml
@@ -2568,6 +2568,7 @@ components:
         - TOKENUPDATE
         - TOKENWIPE
         - UNCHECKEDSUBMIT
+        - UNKNOWN
         - UTILPRNG
     Tokens:
       type: array


### PR DESCRIPTION
**Description**:

* Add `UNKNOWN` to OpenAPI transaction types

**Related issue(s)**:

**Notes for reviewer**:
This fixes mirror nodes using the OpenAPI generated model/client who encounter a transaction type that they have not yet updated to handle. Our API will return `UNKNOWN` in this scenario but the OpenAPI deserializer will error since it doesn't have that value in its enum list.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
