### PR TITLE
Remove console.log() in REST API

### DIFF
--- a/hedera-mirror-rest/config.js
+++ b/hedera-mirror-rest/config.js
@@ -27,6 +27,9 @@ import {fileURLToPath} from 'url';
 
 import {cloudProviders, defaultBucketNames, networks} from './constants';
 import {InvalidConfigError} from './errors';
+import configureLogger from './logger';
+
+configureLogger();
 
 const defaultConfigName = 'application';
 const config = {};
@@ -51,10 +54,10 @@ function load(configPath, configName) {
 function loadYaml(configFile) {
   try {
     const doc = yaml.load(fs.readFileSync(configFile, 'utf8'));
-    console.log(`Loaded configuration source: ${configFile}`);
+    logger.info(`Loaded configuration source: ${configFile}`);
     extend(true, config, doc);
   } catch (err) {
-    console.log(`Skipping configuration ${configFile}: ${err}`);
+    logger.warn(`Skipping configuration ${configFile}: ${err}`);
   }
 }
 
@@ -91,7 +94,7 @@ function setConfigValue(propertyPath, value) {
         } else {
           current[k] = convertType(value);
           const cleanedValue = property.includes('password') || property.includes('key') ? '******' : value;
-          console.log(`Override config with environment variable ${propertyPath}=${cleanedValue}`);
+          logger.info(`Override config with environment variable ${propertyPath}=${cleanedValue}`);
           return;
         }
       }
@@ -182,6 +185,7 @@ if (!loaded) {
   parseStateProofStreamsConfig();
   parseMaxTimestampRange();
   loaded = true;
+  configureLogger(getConfig().log.level);
 }
 
 export default getConfig();

--- a/hedera-mirror-rest/logger.js
+++ b/hedera-mirror-rest/logger.js
@@ -1,0 +1,49 @@
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import httpContext from 'express-http-context';
+import log4js from 'log4js';
+import * as constants from './constants.js';
+
+const configureLogger = (logLevel = 'info') => {
+  log4js.configure({
+    appenders: {
+      console: {
+        layout: {
+          pattern: '%d{yyyy-MM-ddThh:mm:ss.SSSO} %p %x{requestId} %m',
+          type: 'pattern',
+          tokens: {
+            requestId: (e) => httpContext.get(constants.requestIdLabel) || 'Startup',
+          },
+        },
+        type: 'stdout',
+      },
+    },
+    categories: {
+      default: {
+        appenders: ['console'],
+        level: logLevel,
+      },
+    },
+  });
+  global.logger = log4js.getLogger();
+};
+
+export default configureLogger;

--- a/hedera-mirror-rest/server.js
+++ b/hedera-mirror-rest/server.js
@@ -27,7 +27,6 @@ import bodyParser from 'body-parser';
 import cors from 'cors';
 import httpContext from 'express-http-context';
 import fs from 'fs';
-import log4js from 'log4js';
 import compression from 'compression';
 
 // local files
@@ -56,30 +55,6 @@ import {
 
 // routes
 import {AccountRoutes, ContractRoutes, NetworkRoutes, BlockRoutes} from './routes';
-
-// Logger
-const logger = log4js.getLogger();
-log4js.configure({
-  appenders: {
-    console: {
-      layout: {
-        pattern: '%d{yyyy-MM-ddThh:mm:ss.SSSO} %p %x{requestId} %m',
-        type: 'pattern',
-        tokens: {
-          requestId: (e) => httpContext.get(constants.requestIdLabel) || 'Startup',
-        },
-      },
-      type: 'stdout',
-    },
-  },
-  categories: {
-    default: {
-      appenders: ['console'],
-      level: config.log.level,
-    },
-  },
-});
-global.logger = log4js.getLogger();
 
 // use a dummy port for jest unit tests
 const port = isTestEnv() ? 3000 : config.port;


### PR DESCRIPTION
**Description**:

* Remove use of `console.log()` in REST API
* Use temporary logger until desired log level can be read from config file

**Related issue(s)**:


**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
