### PR TITLE
Bump PostgreSQL JDBC from 42.3.6 to 42.4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,7 @@
         <log4j2.version>2.17.2</log4j2.version>
         <micrometer-jvm-extras.version>0.2.2</micrometer-jvm-extras.version>
         <msgpack.version>0.9.3</msgpack.version>
+        <postgresql.version>42.4.1</postgresql.version>
         <protobuf.version>3.21.4</protobuf.version>
         <release.version>0.63.0-SNAPSHOT</release.version> <!-- Used to replace release versions in all files -->
         <release.chartVersion>0.63.0-SNAPSHOT</release.chartVersion>


### PR DESCRIPTION
**Description**:

Bump PostgreSQL JDBC from 42.3.6 to 42.4.1 to address CVE-2022-31197

**Related issue(s)**:


**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
