### PR TITLE
Fix REST API autoscaling

### DIFF
--- a/charts/hedera-mirror-rest/values.yaml
+++ b/charts/hedera-mirror-rest/values.yaml
@@ -198,7 +198,7 @@ resources:
     cpu: 750m
     memory: 350Mi
   requests:
-    cpu: 150m
+    cpu: 300m
     memory: 64Mi
 
 revisionHistoryLimit: 3


### PR DESCRIPTION
**Description**:

* Fix REST API autoscaling unnecessarily by increasing CPU requests. Kubernetes uses CPU requests to calculate percent utilized.

**Related issue(s)**:

Fixes #4261

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
