### PR TITLE
Fix incorrect column default in EntityMetadataRegistry 

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/ColumnMetadata.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/ColumnMetadata.java
@@ -24,6 +24,7 @@ import java.text.MessageFormat;
 import java.util.Comparator;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
+import lombok.ToString;
 import lombok.Value;
 import org.apache.commons.lang3.StringUtils;
 
@@ -33,10 +34,12 @@ import com.hedera.mirror.common.domain.UpsertColumn;
 class ColumnMetadata implements Comparable<ColumnMetadata> {
 
     private final Object defaultValue;
+    @ToString.Exclude
     private final Function<Object, Object> getter;
     private final boolean id;
     private final String name;
     private final boolean nullable;
+    @ToString.Exclude
     private final BiConsumer<Object, Object> setter;
     private final Class<?> type;
     private final boolean updatable;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/EntityMetadataRegistry.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/EntityMetadataRegistry.java
@@ -40,7 +40,6 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EntityManager;
 import javax.persistence.Id;
-import javax.persistence.Query;
 import javax.persistence.Table;
 import javax.persistence.metamodel.Attribute;
 import javax.persistence.metamodel.EmbeddableType;
@@ -52,6 +51,7 @@ import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.StringUtils;
 import org.hibernate.metamodel.model.domain.spi.SingularPersistentAttribute;
 import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.jdbc.core.JdbcOperations;
 
 import com.hedera.mirror.common.domain.UpsertColumn;
 import com.hedera.mirror.common.domain.Upsertable;
@@ -63,6 +63,7 @@ public class EntityMetadataRegistry {
 
     private final EntityManager entityManager;
     private final Map<Class<?>, EntityMetadata> entityMetadata = new ConcurrentHashMap<>();
+    private final JdbcOperations jdbcOperations;
 
     public EntityMetadata lookup(Class<?> domainClass) {
         return entityMetadata.computeIfAbsent(domainClass, this::create);
@@ -128,16 +129,21 @@ public class EntityMetadataRegistry {
      * Looks up column defaults in the information_schema.columns table.
      */
     private Map<String, InformationSchemaColumns> getColumnSchema(String tableName) {
-        String sql = "select column_name, regexp_replace(column_default, '::.*', '') as column_default, " +
-                "is_nullable = 'YES' as nullable from information_schema.columns where table_name = ?";
+        String sql = """
+                select column_name, regexp_replace(column_default, '::.*', '') as column_default,
+                is_nullable = 'YES' as nullable from information_schema.columns where table_name = ?
+                """;
 
-        Query query = entityManager.createNativeQuery(sql, InformationSchemaColumns.class);
-        query.setParameter(1, tableName);
-        var schema = (Map<String, InformationSchemaColumns>) query.getResultList()
-                .stream()
+        var columnSchemas = jdbcOperations.query(sql, (rs, rowNum) -> {
+            var columnSchema = new InformationSchemaColumns();
+            columnSchema.setColumnName(rs.getString(1));
+            columnSchema.setColumnDefault(rs.getString(2));
+            columnSchema.setNullable(rs.getBoolean(3));
+            return columnSchema;
+        }, tableName);
+        var schema = columnSchemas.stream()
                 .collect(Collectors.toMap(InformationSchemaColumns::getColumnName, Function.identity()));
-
-        if (schema == null || schema.isEmpty()) {
+        if (schema.isEmpty()) {
             throw new IllegalStateException("Missing information schema for " + tableName);
         }
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/EntityMetadataRegistry.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/EntityMetadataRegistry.java
@@ -37,9 +37,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.inject.Named;
 import javax.persistence.Column;
-import javax.persistence.Entity;
 import javax.persistence.EntityManager;
-import javax.persistence.Id;
 import javax.persistence.Table;
 import javax.persistence.metamodel.Attribute;
 import javax.persistence.metamodel.EmbeddableType;
@@ -199,9 +197,7 @@ public class EntityMetadataRegistry {
     }
 
     @Data
-    @Entity(name = "columns")
     static class InformationSchemaColumns {
-        @Id
         private String columnName;
         private String columnDefault;
         private boolean nullable;

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/EntityMetadataRegistryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/EntityMetadataRegistryTest.java
@@ -25,10 +25,13 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.stream.Stream;
+import javax.persistence.Id;
+import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Persistable;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.hedera.mirror.common.domain.UpsertColumn;
@@ -106,6 +109,11 @@ class EntityMetadataRegistryTest extends IntegrationTest {
     }
 
     @Test
+    void nonExisting() {
+        assertThatThrownBy(() -> registry.lookup(NonExisting.class)).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
     void notUpsertable() {
         assertThatThrownBy(() -> registry.lookup(Object.class)).isInstanceOf(UnsupportedOperationException.class);
     }
@@ -134,5 +142,18 @@ class EntityMetadataRegistryTest extends IntegrationTest {
 
     @Upsertable
     private static class NonEntity {
+    }
+
+    @Data
+    @javax.persistence.Entity
+    @Upsertable
+    private static class NonExisting implements Persistable<Integer> {
+        @Id
+        private Integer id;
+
+        @Override
+        public boolean isNew() {
+            return true;
+        }
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/EntityMetadataRegistryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/EntityMetadataRegistryTest.java
@@ -24,10 +24,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.hedera.mirror.common.domain.UpsertColumn;
 import com.hedera.mirror.common.domain.Upsertable;
@@ -81,6 +83,26 @@ class EntityMetadataRegistryTest extends IntegrationTest {
                 .satisfies(cm -> assertThat(cm.getGetter().apply(entity)).isEqualTo(entity.getAlias()))
                 .satisfies(cm -> assertThatCode(() -> cm.getSetter().accept(entity, newValue))
                         .satisfies(d -> assertThat(entity.getAlias()).isEqualTo(newValue)));
+    }
+
+    @Test
+    @Transactional
+    void lookupSameColumnNameFromMultipleDomainClasses() {
+        // The test case reproduces the issue in the ticket https://github.com/hashgraph/hedera-mirror-node/issues/4265
+        // With the entity manager cache, if we look up two domain classes metadata in the same session, for columns with
+        // the same name, the defaults of the first domain class will override those of the second. For example,
+        // without the fix, entity.type's default will be "'FUNGIBLE_COMMON'"
+        // given, when
+        var tokenMetadata = registry.lookup(Token.class);
+        var entityMetadata = registry.lookup(Entity.class);
+
+        // then
+        var typeDefaultValues = Stream.of(entityMetadata, tokenMetadata)
+                .flatMap(m -> m.getColumns().stream())
+                .filter(c -> "type".equals(c.getName()))
+                .map(ColumnMetadata::getDefaultValue)
+                .toList();
+        assertThat(typeDefaultValues).containsExactly(null, "'FUNGIBLE_COMMON'");
     }
 
     @Test


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR fixes the incorrect column default in EntityMetadataRegistry which causes the importer unable to processing transactions when transactions happen in some specific orders.

**Related issue(s)**:

Fixes #4265

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

The bug is triggered if since the start of the importer, during a record file parsing (in a database transaction), `Contract` metadata is loaded first, any other domain class metadata loaded in the same db transaction, for which if there is a `type` column, its default is set to `'CONTRACT'`. This is because the entity class `InformationSchemaColumns` has `columnName` as its `Id` column, EntityManager cache is in play so querying any other `type` column will return the cached entity object.
 
**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
