### PR TITLE
Fix monitor expression retry

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -266,12 +266,13 @@ Name                                                            | Default | Desc
 `hedera.mirror.monitor.nodes[].host`                            | ""      | The main node's hostname
 `hedera.mirror.monitor.nodes[].port`                            | 50211   | The main node's port
 `hedera.mirror.monitor.nodeValidation.enabled`                  | true    | Whether to validate and remove invalid or down nodes permanently before publishing
-`hedera.mirror.monitor.nodeValidation.frequency`                | 30m     | The amount of time between validations of the network.
+`hedera.mirror.monitor.nodeValidation.frequency`                | 1d      | The amount of time between validations of the network.
 `hedera.mirror.monitor.nodeValidation.maxAttempts`              | 8       | The number of times the monitor should attempt to receive a healthy response from a node before marking it as unhealthy.
 `hedera.mirror.monitor.nodeValidation.maxBackoff`               | 2s      | The maximum amount of time to wait in between attempts when trying to validate a node
 `hedera.mirror.monitor.nodeValidation.maxThreads`               | 25      | The maximum number of threads to use for node validation
 `hedera.mirror.monitor.nodeValidation.minBackoff`               | 500ms   | The minimum amount of time to wait in between attempts when trying to validate a node
 `hedera.mirror.monitor.nodeValidation.requestTimeout`           | 15s     | The amount of time to wait for a validation request before timing out
+`hedera.mirror.monitor.nodeValidation.retryBackoff`             | 2m      | The fixed amount of time to wait in between unsuccessful node validations that result in no valid nodes
 `hedera.mirror.monitor.operator.accountId`                      | ""      | Operator account ID used to pay for transactions
 `hedera.mirror.monitor.operator.privateKey`                     | ""      | Operator ED25519 private key used to sign transactions in hex encoded DER format
 `hedera.mirror.monitor.publish.async`                           | true    | Whether to use the SDK's asynchronous execution or synchronous. Synchronous requires more monitor responseThreads.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/NodeValidationProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/NodeValidationProperties.java
@@ -36,7 +36,7 @@ public class NodeValidationProperties {
 
     @DurationMin(seconds = 30)
     @NotNull
-    private Duration frequency = Duration.ofMinutes(30L);
+    private Duration frequency = Duration.ofDays(1L);
 
     @Min(1)
     private int maxAttempts = 8;
@@ -53,6 +53,10 @@ public class NodeValidationProperties {
     @DurationMax(seconds = 10)
     @NotNull
     private Duration minBackoff = Duration.ofMillis(500);
+
+    @DurationMin(millis = 100L)
+    @NotNull
+    private Duration retryBackoff = Duration.ofMinutes(2L);
 
     // requestTimeout should be longer than the total retry time controlled by maxAttempts and backoffs
     // the default would result in a max of 11.5s without considering any network delay

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/SubscribeMetrics.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/SubscribeMetrics.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.monitor.subscribe;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -28,6 +28,7 @@ import java.time.Instant;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import javax.inject.Named;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -84,10 +85,16 @@ public class SubscribeMetrics {
     @Scheduled(fixedDelayString = "${hedera.mirror.monitor.subscribe.statusFrequency:10000}")
     public void status() {
         if (subscribeProperties.isEnabled()) {
+            var running = new AtomicBoolean(false);
             durationMetrics.keySet()
                     .stream()
                     .filter(Scenario::isRunning)
+                    .peek(s -> running.set(true))
                     .forEach(this::status);
+
+            if (!running.get()) {
+                log.info("No subscribers");
+            }
         }
     }
 

--- a/hedera-mirror-monitor/src/main/resources/application.yml
+++ b/hedera-mirror-monitor/src/main/resources/application.yml
@@ -71,6 +71,10 @@ spring:
         paths: /usr/etc/${spring.application.name}
   lifecycle:
     timeout-per-shutdown-phase: 20s
+  task:
+    scheduling:
+      pool:
+        size: 4
 springdoc:
   api-docs:
     path: /api/v1/docs/openapi

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/expression/ExpressionConverterImplTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/expression/ExpressionConverterImplTest.java
@@ -56,11 +56,11 @@ import com.hedera.mirror.monitor.publish.transaction.TransactionType;
 @MockitoSettings(strictness = Strictness.STRICT_STUBS)
 class ExpressionConverterImplTest {
 
-    @Mock
-    private TransactionPublisher transactionPublisher;
-
     @Spy
     private final MonitorProperties monitorProperties = new MonitorProperties();
+
+    @Mock
+    private TransactionPublisher transactionPublisher;
 
     @InjectMocks
     private ExpressionConverterImpl expressionConverter;
@@ -119,7 +119,8 @@ class ExpressionConverterImplTest {
     @Test
     void errorPublishing() throws InvalidProtocolBufferException {
         TransactionType type = TransactionType.CONSENSUS_CREATE_TOPIC;
-        when(transactionPublisher.publish(any())).thenReturn(Mono.error(new TimeoutException("timeout")))
+        when(transactionPublisher.publish(any()))
+                .thenReturn(Mono.error(new TimeoutException("timeout")))
                 .thenReturn(response(type, 100));
         assertThat(expressionConverter.convert("${topic.foo}")).isEqualTo("0.0.100");
     }

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/PublishMetricsTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/PublishMetricsTest.java
@@ -131,7 +131,10 @@ class PublishMetricsTest {
 
         clearLog();
         publishMetrics.status();
-        assertThat(logOutput).asString().isEmpty();
+        assertThat(logOutput)
+                .asString()
+                .hasLineCount(1)
+                .contains("No publishers");
     }
 
     @Test
@@ -177,7 +180,10 @@ class PublishMetricsTest {
 
         clearLog();
         publishMetrics.status();
-        assertThat(logOutput).asString().isEmpty();
+        assertThat(logOutput)
+                .asString()
+                .hasLineCount(1)
+                .contains("No publishers");
     }
 
     void onError(Throwable throwable, String status) {

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/SubscribeMetricsTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/SubscribeMetricsTest.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.monitor.subscribe;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -158,14 +158,17 @@ class SubscribeMetricsTest {
         subscribeMetrics.onNext(response(testSubscription));
         subscribeMetrics.status();
 
-        assertThat(logOutput).asString().isEmpty();
+        assertThat(logOutput)
+                .asString()
+                .hasLineCount(1)
+                .contains("No subscribers");
     }
 
     private SubscribeResponse response(Scenario scenario) {
         Instant timestamp = Instant.now().minusSeconds(5L);
         return SubscribeResponse.builder()
                 .publishedTimestamp(timestamp)
-                .consensusTimestamp(timestamp.plusSeconds(1L * scenario.getCount()))
+                .consensusTimestamp(timestamp.plusSeconds(scenario.getCount()))
                 .receivedTimestamp(timestamp.plusSeconds(2L * scenario.getCount()))
                 .scenario(scenario)
                 .build();


### PR DESCRIPTION
**Description**:

* Add a shorter retry for when there's no valid nodes
* Change node validation from every 30 min to 1 day to reduce costs
* Change status logs to print even when no publishers or subscribers
* Fix expression converter retry thread starvation
* Workaround [thread leak](https://github.com/hashgraph/hedera-sdk-java/issues/1084) in SDK by creating a shared validation client

**Related issue(s)**:

Fixes #4289

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
