### PR TITLE
Fix monitor not handling REST API failures on startup

### DIFF
--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/rest/RestApiClient.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/rest/RestApiClient.java
@@ -55,6 +55,7 @@ public class RestApiClient {
                 .uri(uri.replace(PREFIX, StringUtils.EMPTY), parameters)
                 .retrieve()
                 .bodyToMono(responseClass)
+                .onErrorResume(t -> Mono.error(t)) // Needed for some reason to avoid onErrorDropped
                 .name("rest")
                 .metrics();
     }


### PR DESCRIPTION
**Description**:

* Add retry to node refresh
* Add synchronization to `NodeSupplier.refresh()` to order concurrent calls between publisher and refresh thread
* Fix `RestApiClient` error propagation so connect exceptions aren't ignored

**Related issue(s)**:

Fixes #4294

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
