### PR TITLE
Fix importer performance regression

### DIFF
--- a/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.65.2__transaction_hash_index.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.65.2__transaction_hash_index.sql
@@ -1,1 +1,1 @@
-create index if not exists transaction__hash_prefix on transaction (substring(transaction_hash from 1 for 32));
+create index if not exists transaction__hash on transaction using hash (transaction_hash);

--- a/hedera-mirror-rest/__tests__/specs/transactions/{id}/no-params.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions/{id}/no-params.json
@@ -1,11 +1,5 @@
 {
   "description": "Transaction api calls for a specific transaction using transaction id or hash",
-  "extendedDescription": [
-    "The first test is a query using a specific transaction id. The second test suite queries by transaction hash.",
-    "Note the last transaction's hash only differs than the hash in search in the last 4 bytes. The test verifies that",
-    "the rest api only returns the exact matching transaction hash even though the database also returns the last",
-    "transaction since its hash prefix is a match"
-  ],
   "setup": {
     "accounts": [
       {

--- a/hedera-mirror-rest/__tests__/transactions.test.js
+++ b/hedera-mirror-rest/__tests__/transactions.test.js
@@ -738,7 +738,7 @@ describe('extractSqlFromTransactionsByIdOrHashRequest', () => {
     const defaultTransactionHashBase64Url = 'rovr8cn6DzCTVuSAV_YEevfN5jA30FCdFt3Dsg4IUVi_3xTRU0XBsYsZm3L-1Kxv';
     const defaultTransactionHash = Buffer.from(defaultTransactionHashBase64, 'base64');
     const defaultTransactionHashHex = defaultTransactionHash.toString('hex');
-    const defaultTransactionHashParams = [defaultTransactionHash.subarray(0, 32)];
+    const defaultTransactionHashParams = [defaultTransactionHash];
 
     const defaultTransactionIdStr = '0.0.200-123456789-987654321';
     const defaultTransactionIdParams = [200, '123456789987654321'];
@@ -885,7 +885,7 @@ describe('extractSqlFromTransactionsByIdOrHashRequest', () => {
     order by t.consensus_timestamp asc`;
     };
 
-    const getTransactionHashQuery = () => getQuery('substring(t.transaction_hash from 1 for 32) = $1');
+    const getTransactionHashQuery = () => getQuery('t.transaction_hash = $1');
 
     const getTransactionIdQuery = (extraConditions) => {
       return getQuery('t.payer_account_id = $1 and t.valid_start_ns = $2', extraConditions);

--- a/hedera-mirror-rest/model/transaction.js
+++ b/hedera-mirror-rest/model/transaction.js
@@ -22,7 +22,6 @@ import {filterKeys} from '../constants';
 
 class Transaction {
   static BASE64_HASH_SIZE = 64;
-  static HASH_PREFIX_SIZE = 32;
   static HEX_HASH_SIZE = 96;
   static HEX_HASH_WITH_PREFIX_SIZE = this.HEX_HASH_SIZE + 2;
 


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

This PR fixes the importer performance regression caused by the new btree index over transaction_hash.

- Use postgresql hash index on transaction_hash

**Related issue(s)**:

Fixes #4308

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

Tested the fix with perfnet record files:

```
2022-08-18T08:39:35.324-0600 INFO scheduling-3 c.h.m.i.p.b.BatchInserter Copied 20000 rows to transaction table in 260.0 ms
2022-08-18T08:39:36.252-0600 INFO scheduling-3 c.h.m.i.p.b.BatchInserter Copied 20000 rows to transaction table in 260.3 ms
2022-08-18T08:39:37.095-0600 INFO scheduling-3 c.h.m.i.p.b.BatchInserter Copied 20000 rows to transaction table in 262.8 ms
2022-08-18T08:39:37.730-0600 INFO scheduling-3 c.h.m.i.p.b.BatchInserter Copied 20000 rows to transaction table in 265.1 ms
2022-08-18T08:39:38.421-0600 INFO scheduling-3 c.h.m.i.p.b.BatchInserter Copied 20000 rows to transaction table in 262.9 ms
2022-08-18T08:39:39.464-0600 INFO scheduling-3 c.h.m.i.p.b.BatchInserter Copied 20000 rows to transaction table in 285.7 ms
2022-08-18T08:39:41.813-0600 INFO scheduling-3 c.h.m.i.p.b.BatchInserter Copied 20000 rows to transaction table in 260.1 ms
2022-08-18T08:39:42.504-0600 INFO scheduling-3 c.h.m.i.p.b.BatchInserter Copied 20000 rows to transaction table in 290.2 ms
2022-08-18T08:39:43.833-0600 INFO scheduling-3 c.h.m.i.p.b.BatchInserter Copied 20000 rows to transaction table in 260.8 ms
2022-08-18T08:39:44.830-0600 INFO scheduling-3 c.h.m.i.p.b.BatchInserter Copied 20000 rows to transaction table in 262.9 ms
2022-08-18T08:39:45.818-0600 INFO scheduling-3 c.h.m.i.p.b.BatchInserter Copied 20000 rows to transaction table in 264.6 ms
2022-08-18T08:39:46.684-0600 INFO scheduling-3 c.h.m.i.p.b.BatchInserter Copied 20000 rows to transaction table in 279.3 ms
2022-08-18T08:39:47.787-0600 INFO scheduling-3 c.h.m.i.p.b.BatchInserter Copied 20000 rows to transaction table in 403.4 ms
2022-08-18T08:39:48.714-0600 INFO scheduling-3 c.h.m.i.p.b.BatchInserter Copied 20000 rows to transaction table in 330.1 ms
2022-08-18T08:39:49.456-0600 INFO scheduling-3 c.h.m.i.p.b.BatchInserter Copied 20000 rows to transaction table in 269.3 ms
2022-08-18T08:39:50.280-0600 INFO scheduling-3 c.h.m.i.p.b.BatchInserter Copied 20000 rows to transaction table in 456.8 ms
2022-08-18T08:39:50.927-0600 INFO scheduling-3 c.h.m.i.p.b.BatchInserter Copied 20000 rows to transaction table in 257.9 ms
2022-08-18T08:39:53.420-0600 INFO scheduling-3 c.h.m.i.p.b.BatchInserter Copied 20000 rows to transaction table in 361.2 ms
2022-08-18T08:39:54.837-0600 INFO scheduling-3 c.h.m.i.p.b.BatchInserter Copied 20000 rows to transaction table in 296.5 ms
```

`transaction` table and indexes storage stats for db with data from perfnet:

```
 Table Name  |                 Index Name                 | Total Size | Total Size of all Indexes | Table Size | Index Size | Estimated table row count
-------------+--------------------------------------------+------------+---------------------------+------------+------------+---------------------------
 transaction | transaction_pkey                           | 55 GB      | 21 GB                     | 33 GB      | 3000 MB    |                 118458672
 transaction | transaction__transaction_id                | 55 GB      | 21 GB                     | 33 GB      | 5645 MB    |                 118458672
 transaction | transaction__payer_account_id_consensus_ns | 55 GB      | 21 GB                     | 33 GB      | 4212 MB    |                 118458672
 transaction | transaction__type_consensus_timestamp      | 55 GB      | 21 GB                     | 33 GB      | 4219 MB    |                 118458672
 transaction | transaction__hash                          | 55 GB      | 21 GB                     | 33 GB      | 4676 MB    |                 118458672
```

same storage stats for db with data from mainnet:

```
 Table Name  |                 Index Name                 | Total Size | Total Size of all Indexes | Table Size | Index Size | Estimated table row count
-------------+--------------------------------------------+------------+---------------------------+------------+------------+---------------------------
 transaction | transaction__type_consensus_timestamp      | 1163 GB    | 581 GB                    | 582 GB     | 139 GB     |                2413293056
 transaction | transaction__transaction_id                | 1163 GB    | 581 GB                    | 582 GB     | 138 GB     |                2413293056
 transaction | transaction__payer_account_id_consensus_ns | 1163 GB    | 581 GB                    | 582 GB     | 140 GB     |                2413293056
 transaction | transaction_pkey                           | 1163 GB    | 581 GB                    | 582 GB     | 100 GB     |                2413293056
 transaction | transaction__hash                          | 1163 GB    | 581 GB                    | 582 GB     | 64 GB      |                2413293056
```

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
