### PR TITLE
Cleanup duplicate entities in testnet

### DIFF
--- a/hedera-mirror-importer/src/main/resources/application.yml
+++ b/hedera-mirror-importer/src/main/resources/application.yml
@@ -90,7 +90,7 @@ spring:
   flyway:
     baselineOnMigrate: true
     connectRetries: 20
-    ignoreMigrationPatterns: "*:missing"
+    ignoreMigrationPatterns: [ "*:missing", "*:ignored" ]
     password: ${hedera.mirror.importer.db.ownerPassword}
     placeholders:
       api-password: ${hedera.mirror.importer.db.restPassword}

--- a/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.64.1.2__duplicate_entities.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.64.1.2__duplicate_entities.sql
@@ -1,0 +1,30 @@
+-- Cleans up bad data in testnet caused by consensus nodes failing to revert child records for unsuccessful parent transactions
+with duplicate as (
+    select c.id, c.created_timestamp
+    from contract c, entity e
+    where e.id = c.id
+),
+unreverted_child_contract as (
+    select child.entity_id
+    from duplicate dupe
+    left join transaction child on child.consensus_timestamp = dupe.created_timestamp and child.entity_id = dupe.id
+    left join transaction parent on child.parent_consensus_timestamp = parent.consensus_timestamp
+    where child.result in (22, 104, 220) and parent.result not in (22, 104, 220)
+)
+delete from contract
+using unreverted_child_contract
+where id = entity_id;
+
+-- Cleans up bad data in testnet caused by consensus nodes writing a "ERC-20/721 redirect" token id in the created_contract_ids
+with token_contract as (
+    select distinct unnest(created_contract_ids) as token_id
+    from contract_result
+    where array_length(created_contract_ids, 1) > 0
+),
+duplicate as (
+    select id as dupe_id from entity, token_contract
+    where id = token_id and type = 'TOKEN'
+)
+delete from contract
+using duplicate
+where id = dupe_id;

--- a/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.64.1.2__duplicate_entities.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.64.1.2__duplicate_entities.sql
@@ -10,10 +10,16 @@ unreverted_child_contract as (
     left join transaction child on child.consensus_timestamp = dupe.created_timestamp and child.entity_id = dupe.id
     left join transaction parent on child.parent_consensus_timestamp = parent.consensus_timestamp
     where child.result in (22, 104, 220) and parent.result not in (22, 104, 220)
+),
+deleted_contract as (
+    delete from contract
+    using unreverted_child_contract
+    where id = entity_id
+    returning id as deleted_id
 )
-delete from contract
-using unreverted_child_contract
-where id = entity_id;
+delete from contract_history
+using deleted_contract
+where id = deleted_id;
 
 -- Cleans up bad data in testnet caused by consensus nodes writing a "ERC-20/721 redirect" token id in the created_contract_ids
 with token_contract as (
@@ -24,7 +30,13 @@ with token_contract as (
 duplicate as (
     select id as dupe_id from entity, token_contract
     where id = token_id and type = 'TOKEN'
+),
+deleted_contract as (
+    delete from contract
+    using duplicate
+    where id = dupe_id
+    returning dupe_id
 )
-delete from contract
-using duplicate
+delete from contract_history
+using deleted_contract
 where id = dupe_id;


### PR DESCRIPTION
**Description**:

* Cache `RecordItem.isSuccessful()` since it is called a dozen times per transaction
* Change transaction successful check to depend upon parent's success
* Change Flyway to ignore new migrations with older versions
* Migration to cleanup bad data in testnet:
  * Consensus nodes failing to revert child records for unsuccessful parent transactions
  * Consensus nodes writing a "ERC-20/721 redirect" token ID in the `created_contract_ids`

**Related issue(s)**:

Fixes #4314

**Notes for reviewer**:

Tested `ignoreMigrationPatterns: [ "*:missing", "*:ignored" ]` with various scenarios. It allows us to inject a new migration with an older version and still work regardless of whether the importer has executed a migration with a higher number or not.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
