### PR TITLE
Cleanup duplicate entities in testnet (0.63)

### DIFF
--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/RecordItem.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/RecordItem.java
@@ -79,6 +79,9 @@ public class RecordItem implements StreamItem {
     private final EntityId payerAccountId = EntityId.of(getTransactionBody().getTransactionID().getAccountID());
 
     @Getter(lazy = true)
+    private boolean successful = checkSuccess();
+
+    @Getter(lazy = true)
     private final int transactionType = getTransactionType(getTransactionBody());
 
     // Mutable fields
@@ -131,7 +134,14 @@ public class RecordItem implements StreamItem {
         return record.hasParentConsensusTimestamp();
     }
 
-    public boolean isSuccessful() {
+
+    private boolean checkSuccess() {
+        // A child is only successful if its parent is as well. Consensus nodes have had issues in the past where that
+        // invariant did not hold true and children contract calls were not reverted on failure.
+        if (parent != null && !parent.isSuccessful()) {
+            return false;
+        }
+
         var status = record.getReceipt().getStatus();
         return status == ResponseCodeEnum.FEE_SCHEDULE_FILE_PART_UPLOADED ||
                 status == ResponseCodeEnum.SUCCESS ||

--- a/hedera-mirror-importer/src/main/resources/application.yml
+++ b/hedera-mirror-importer/src/main/resources/application.yml
@@ -90,7 +90,7 @@ spring:
   flyway:
     baselineOnMigrate: true
     connectRetries: 20
-    ignoreMigrationPatterns: "*:missing"
+    ignoreMigrationPatterns: [ "*:missing", "*:ignored" ]
     password: ${hedera.mirror.importer.db.ownerPassword}
     placeholders:
       api-password: ${hedera.mirror.importer.db.restPassword}

--- a/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.64.1.2__duplicate_entities.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.64.1.2__duplicate_entities.sql
@@ -1,0 +1,42 @@
+-- Cleans up bad data in testnet caused by consensus nodes failing to revert child records for unsuccessful parent transactions
+with duplicate as (
+    select c.id, c.created_timestamp
+    from contract c, entity e
+    where e.id = c.id
+),
+unreverted_child_contract as (
+    select child.entity_id
+    from duplicate dupe
+    left join transaction child on child.consensus_timestamp = dupe.created_timestamp and child.entity_id = dupe.id
+    left join transaction parent on child.parent_consensus_timestamp = parent.consensus_timestamp
+    where child.result in (22, 104, 220) and parent.result not in (22, 104, 220)
+),
+deleted_contract as (
+    delete from contract
+    using unreverted_child_contract
+    where id = entity_id
+    returning id as deleted_id
+)
+delete from contract_history
+using deleted_contract
+where id = deleted_id;
+
+-- Cleans up bad data in testnet caused by consensus nodes writing a "ERC-20/721 redirect" token id in the created_contract_ids
+with token_contract as (
+    select distinct unnest(created_contract_ids) as token_id
+    from contract_result
+    where array_length(created_contract_ids, 1) > 0
+),
+duplicate as (
+    select id as dupe_id from entity, token_contract
+    where id = token_id and type = 'TOKEN'
+),
+deleted_contract as (
+    delete from contract
+    using duplicate
+    where id = dupe_id
+    returning dupe_id
+)
+delete from contract_history
+using deleted_contract
+where id = dupe_id;


### PR DESCRIPTION
**Description**:

Cherry-pick of #4315 to `release/0.63`

* Cache RecordItem.isSuccessful() since it is called a dozen times per transaction
* Change transaction successful check to depend upon parent's success
* Change Flyway to ignore new migrations with older versions
* Migration to cleanup bad data in testnet:
  * Consensus nodes failing to revert child records for unsuccessful parent transactions
  * Consensus nodes writing a "ERC-20/721 redirect" token ID in the created_contract_ids

**Related issue(s)**:

Fixes #4314

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
