### PR TITLE
Remove empty operator values in helm tests

### DIFF
--- a/charts/hedera-mirror/values.yaml
+++ b/charts/hedera-mirror/values.yaml
@@ -307,11 +307,7 @@ test:
       mirror:
         test:
           acceptance:
-            # grpc endpoint
             mirrorNodeAddress: "{{ .Release.Name }}-grpc:5600"
-            # Do not use use 0.0.2 or 0.0.50 for operator to ensure crypto transfers are not waived
-            operatorId:
-            operatorKey:
             rest:
               baseUrl: "http://{{ .Release.Name }}-rest/api/v1"
   cucumberTags: "@acceptance"


### PR DESCRIPTION
**Description**:

Fix not being able to use default acceptance test operator in Helm tests

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
