### PR TITLE
Bump GitHub Action versions

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Retrieve the Milestone
         id: milestone
         if: ${{ steps.version_parser.outputs.pre-release == '' }}
-        uses: julb/action-manage-milestone@v1
+        uses: julbme/gh-action-manage-milestone@v1
         with:
           title: ${{ steps.version_parser.outputs.version }}
         env:
@@ -62,7 +62,7 @@ jobs:
           EOF
 
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           ref: main
@@ -70,7 +70,7 @@ jobs:
 
       - name: Import GPG Key
         id: gpg_importer
-        uses: crazy-max/ghaction-import-gpg@v4.1.0
+        uses: crazy-max/ghaction-import-gpg@v5.1.0
         with:
           git_commit_gpgsign: true
           git_tag_gpgsign: true
@@ -79,7 +79,7 @@ jobs:
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Install JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           cache: 'maven'
           distribution: 'temurin'
@@ -136,7 +136,7 @@ jobs:
 
       - name: Close the Milestone
         if: ${{ steps.milestone.outputs.number != '' }}
-        uses: julb/action-manage-milestone@v1
+        uses: julbme/gh-action-manage-milestone@v1
         with:
           title: ${{ steps.version_parser.outputs.version }}
           state: closed
@@ -155,13 +155,13 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: main
 
       - name: Import GPG Key
         id: gpg_importer
-        uses: crazy-max/ghaction-import-gpg@v4.1.0
+        uses: crazy-max/ghaction-import-gpg@v5.1.0
         with:
           git_commit_gpgsign: true
           git_tag_gpgsign: true
@@ -170,7 +170,7 @@ jobs:
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Install JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           cache: 'maven'
           distribution: 'temurin'
@@ -185,7 +185,7 @@ jobs:
         run: ./mvnw package -Drelease.version=$NEXT_VERSION_SNAPSHOT -Drelease.chartVersion=$NEXT_CHART_VERSION_SNAPSHOT -Ddocker.tag.version=main -N -P=release
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v4
         with:
           body: ''
           branch: create-pull-request/${{ env.RELEASE_BRANCH }}

--- a/.github/workflows/charts.yml
+++ b/.github/workflows/charts.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install ct
-        uses: helm/chart-testing-action@v2.2.1
+        uses: helm/chart-testing-action@v2.3.0
 
       - name: Run lint
         run: ct lint --config .github/ct.yaml --all
@@ -26,12 +26,12 @@ jobs:
       IMAGE_TAG: ci-${{ github.sha }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Install JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           cache: 'maven'
           distribution: 'temurin'
@@ -41,16 +41,14 @@ jobs:
         run: curl --retry 3 -fsL https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
 
       - name: Create k3d cluster
-        run: k3d cluster create mirror --agents 1 --timeout 5m --registry-create registry:0.0.0.0:5001 --image rancher/k3s:v1.23.8-k3s2
+        run: k3d cluster create mirror --agents 1 --timeout 5m --registry-create registry:0.0.0.0:5001 --image rancher/k3s:v1.24.3-k3s1
         timeout-minutes: 3
 
       - name: Build images
         run: ./mvnw deploy -pl hedera-mirror-grpc,hedera-mirror-importer,hedera-mirror-rest,hedera-mirror-rosetta,hedera-mirror-web3 -Dmvn.golang.skip=true -Dskip.npm -DskipTests -Ddocker.push.repository=localhost:5001/mirrornode -Ddocker.tag.version=${IMAGE_TAG}
 
       - name: Install ct
-        uses: helm/chart-testing-action@v2.2.1
-        with:
-          version: v3.6.0
+        uses: helm/chart-testing-action@v2.3.0
 
       - name: Set GIT_REF for pull request
         if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         module: [ grpc, importer, monitor, rest, rosetta, web3 ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v0

--- a/.github/workflows/grpc-api.yml
+++ b/.github/workflows/grpc-api.yml
@@ -23,10 +23,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           cache: 'maven'
           distribution: 'temurin'
@@ -42,7 +42,7 @@ jobs:
 
       - name: Upload artifact
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ env.MODULE }}
           path: ./**/*.tgz

--- a/.github/workflows/importer.yml
+++ b/.github/workflows/importer.yml
@@ -23,10 +23,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           cache: 'maven'
           distribution: 'temurin'
@@ -42,7 +42,7 @@ jobs:
 
       - name: Upload artifact
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ env.MODULE }}
           path: ./**/*.tgz

--- a/.github/workflows/monitor.yml
+++ b/.github/workflows/monitor.yml
@@ -20,10 +20,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           cache: 'maven'
           distribution: 'temurin'

--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -8,10 +8,10 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           cache: 'maven'
           distribution: 'temurin'
@@ -35,7 +35,7 @@ jobs:
     needs: publish
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: deploy
 

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -15,13 +15,13 @@ jobs:
     name: Publish images
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Get tag
         run: echo "TAG=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV
 
       - name: Install JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           cache: 'maven'
           distribution: 'temurin'
@@ -42,13 +42,13 @@ jobs:
         run: ./mvnw dependency:copy-dependencies license:download-licenses package -DskipTests -pl ${MODULE} -Dmvn.golang.skip=true -Dskip.npm
 
       - name: Setup QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
 
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Build and push images
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Publish helm chart
         uses: stefanprodan/helm-gh-pages@v1.5.0

--- a/.github/workflows/rest-api.yml
+++ b/.github/workflows/rest-api.yml
@@ -24,17 +24,17 @@ jobs:
     timeout-minutes: 18
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           cache: 'maven'
           distribution: 'temurin'
           java-version: 17
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           key: ${{ runner.os }}-node-${{ hashFiles('./package-lock.json', './check-state-proof/package-lock.json', 'monitoring/monitor_apis/package-lock.json') }}
           path: |
@@ -57,7 +57,7 @@ jobs:
 
       - name: Upload artifact
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ env.MODULE }}
           path: ./**/*.tgz

--- a/.github/workflows/rosetta-api.yml
+++ b/.github/workflows/rosetta-api.yml
@@ -23,14 +23,14 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           cache: 'maven'
           distribution: 'temurin'
           java-version: 17
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -94,7 +94,7 @@ jobs:
     timeout-minutes: 15
     env:
       OFFLINE_URL: http://localhost:5700
-      ROSETTA_CLI_VERSION: v0.7.5
+      ROSETTA_CLI_VERSION: v0.8.0
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -103,7 +103,7 @@ jobs:
 
       - name: Get Changed Files
         id: changed-files-module
-        uses: tj-actions/changed-files@v22.2
+        uses: tj-actions/changed-files@v27
         with:
           files: |
             .github/workflows/rosetta-api.yml
@@ -243,6 +243,7 @@ jobs:
           rm -fr tmp
 
       - name: Run Gosec Security Scanner
-        uses: securego/gosec@v2.11.0
+        uses: securego/gosec@v2.13.1
         with:
           args: ./...
+

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,17 +13,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           cache: 'maven'
           distribution: 'temurin'
           java-version: 17
 
       - name: NPM cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           key: ${{ runner.os }}-node-${{ hashFiles('./package-lock.json', './check-state-proof/package-lock.json', 'monitoring/monitor_apis/package-lock.json') }}
           path: |
@@ -39,7 +39,7 @@ jobs:
 
       - name: Upload report
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: dependency-check-report
           path: target/dependency-check-report.html
@@ -50,19 +50,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 
       - name: Install JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           cache: 'maven'
           distribution: 'temurin'
           java-version: 17
 
       - name: Cache SonarCloud dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar

--- a/.github/workflows/web3.yml
+++ b/.github/workflows/web3.yml
@@ -23,10 +23,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           cache: 'maven'
           distribution: 'temurin'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -9,12 +9,12 @@ on:
 
 jobs:
   build:
-    runs-on: windows-2019
+    runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           cache: 'maven'
           distribution: 'temurin'

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -439,6 +439,10 @@ Name                                                 | Default             | Des
 `hedera.mirror.rosetta.db.port`                      | 5432                | The port used to connect to the database
 `hedera.mirror.rosetta.db.statementTimeout`          | 20                  | The number of seconds to wait before timing out a query statement
 `hedera.mirror.rosetta.db.username`                  | mirror_rosetta      | The username the processor uses to connect to the database
+`hedera.mirror.rosetta.http.idleTimeout`             | 10000000000         | The maximum amount of time in nanoseconds to wait for the next request when keep-alives are enabled
+`hedera.mirror.rosetta.http.readHeaderTimeout`       | 3000000000          | The maximum amount of time in nanoseconds to read request headers
+`hedera.mirror.rosetta.http.readTimeout`             | 5000000000          | The maximum duration in nanoseconds for reading the entire request, including the body
+`hedera.mirror.rosetta.http.writeTimeout`            | 10000000000         | The maximum duration in nanoseconds before timing out writes of the response
 `hedera.mirror.rosetta.log.level`                    | info                | The log level
 `hedera.mirror.rosetta.network`                      | DEMO                | Which Hedera network to use. Can be either `DEMO`, `MAINNET`, `PREVIEWNET`, `TESTNET` or `OTHER`
 `hedera.mirror.rosetta.nodes`                        | {}                  | A map of main nodes with its service endpoint as the key and the node account id as its value

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/batch/BatchInserter.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/batch/BatchInserter.java
@@ -91,7 +91,7 @@ public class BatchInserter implements BatchPersister {
         sql = String.format("COPY %s(%s) FROM STDIN WITH CSV", this.tableName, columnsCsv);
         insertDurationMetric = Timer.builder("hedera.mirror.importer.parse.insert")
                 .description("Time to insert transactions into table")
-                .tag("table", tableName)
+                .tag("table", this.tableName)
                 .register(meterRegistry);
     }
 

--- a/hedera-mirror-rosetta/app/config/application.yml
+++ b/hedera-mirror-rosetta/app/config/application.yml
@@ -17,6 +17,11 @@ hedera:
         username: mirror_rosetta
       feature:
         subNetworkIdentifier: false
+      http:
+        idleTimeout: 10000000000
+        readHeaderTimeout: 3000000000
+        readTimeout: 5000000000
+        writeTimeout: 10000000000
       log:
         level: info
       network: DEMO

--- a/hedera-mirror-rosetta/app/config/types.go
+++ b/hedera-mirror-rosetta/app/config/types.go
@@ -22,6 +22,7 @@ package config
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/hashgraph/hedera-sdk-go/v2"
 )
@@ -32,6 +33,7 @@ type Config struct {
 	Cache       map[string]Cache
 	Db          Db
 	Feature     Feature
+	Http        Http
 	Log         Log
 	Network     string
 	Nodes       NodeMap
@@ -69,6 +71,13 @@ func (db Db) GetDsn() string {
 
 type Feature struct {
 	SubNetworkIdentifier bool `yaml:"subNetworkIdentifier"`
+}
+
+type Http struct {
+	IdleTimeout       time.Duration `yaml:"idleTimeout"`
+	ReadTimeout       time.Duration `yaml:"readTimeout"`
+	ReadHeaderTimeout time.Duration `yaml:"readHeaderTimeout"`
+	WriteTimeout      time.Duration `yaml:"writeTimeout"`
 }
 
 type Log struct {

--- a/hedera-mirror-rosetta/main.go
+++ b/hedera-mirror-rosetta/main.go
@@ -228,6 +228,15 @@ func main() {
 	metricsMiddleware := middleware.MetricsMiddleware(router)
 	tracingMiddleware := middleware.TracingMiddleware(metricsMiddleware)
 	corsMiddleware := server.CorsMiddleware(tracingMiddleware)
+	httpServer := &http.Server{
+		Addr:              fmt.Sprintf(":%d", rosettaConfig.Port),
+		Handler:           corsMiddleware,
+		IdleTimeout:       rosettaConfig.Http.IdleTimeout,
+		ReadHeaderTimeout: rosettaConfig.Http.ReadHeaderTimeout,
+		ReadTimeout:       rosettaConfig.Http.ReadTimeout,
+		WriteTimeout:      rosettaConfig.Http.WriteTimeout,
+	}
+
 	log.Infof("Listening on port %d", rosettaConfig.Port)
-	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", rosettaConfig.Port), corsMiddleware))
+	log.Fatal(httpServer.ListenAndServe())
 }


### PR DESCRIPTION
**Description**:

* Bump securego version to fix failing workflow
* Bump all GitHub Action versions
* Fix [G114 (CWE)](https://deepsource.io/directory/analyzers/go/issues/GO-S2114): `Use of net/http serve function that has no support for setting timeouts`
* Fix table insert metrics using domain class name instead of table name

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
