### PR TITLE
Simplify upsert metrics

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/MetricsExecutionInterceptor.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/MetricsExecutionInterceptor.java
@@ -20,8 +20,6 @@ package com.hedera.mirror.importer.config;
  * ‍
  */
 
-import com.hedera.mirror.common.domain.entity.EntityType;
-
 import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
@@ -43,8 +41,9 @@ import software.amazon.awssdk.core.interceptor.ExecutionAttribute;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 
-import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.StreamType;
+import com.hedera.mirror.common.domain.entity.EntityId;
+import com.hedera.mirror.common.domain.entity.EntityType;
 
 /**
  * Intercepts requests to the S3 API and records relevant metrics before continuing.
@@ -55,6 +54,7 @@ import com.hedera.mirror.common.domain.StreamType;
 public class MetricsExecutionInterceptor implements ExecutionInterceptor {
 
     private static final Pattern ENTITY_ID_PATTERN = Pattern.compile("(\\d{1,10}\\.\\d{1,10}\\.\\d{1,10})");
+    private static final Pattern SIDECAR_PATTERN = Pattern.compile(".*Z_\\d+\\.rcd.*");
     private static final ExecutionAttribute<ResponseSizeSubscriber> SIZE = new ExecutionAttribute("size");
     private static final ExecutionAttribute<Instant> START_TIME = new ExecutionAttribute("start-time");
 
@@ -124,6 +124,8 @@ public class MetricsExecutionInterceptor implements ExecutionInterceptor {
             return "list";
         } else if (uri.contains(StreamType.SIGNATURE_SUFFIX)) {
             return "signature";
+        } else if (SIDECAR_PATTERN.matcher(uri).matches()) {
+            return "sidecar";
         } else {
             return "signed";
         }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/ContractResultServiceImpl.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/ContractResultServiceImpl.java
@@ -20,6 +20,7 @@ package com.hedera.mirror.importer.domain;
  * ‍
  */
 
+import com.google.common.base.Stopwatch;
 import com.google.protobuf.ByteString;
 import com.hederahashgraph.api.proto.java.ContractFunctionResult;
 import com.hederahashgraph.api.proto.java.ContractID;
@@ -281,6 +282,9 @@ public class ContractResultServiceImpl implements ContractResultService {
         var sidecarRecords = recordItem.getSidecarRecords();
         long consensusTimestamp = recordItem.getConsensusTimestamp();
         var payerAccountId = recordItem.getPayerAccountId();
+        var stopwatch = Stopwatch.createStarted();
+        var migrations = 0;
+
         for (var sidecarRecord : sidecarRecords) {
             if (sidecarRecord.hasStateChanges()) {
                 var stateChanges = sidecarRecord.getStateChanges();
@@ -299,9 +303,14 @@ public class ContractResultServiceImpl implements ContractResultService {
                     failedInitcode = sidecarRecord.getBytecode().getInitcode();
                 }
             }
+
+            if (sidecarRecord.getMigration()) {
+                ++migrations;
+            }
         }
 
         sidecarContractMigration.migrate(contractBytecodes);
+        log.info("{} Sidecar records processed with {} migrations in {}", sidecarRecords.size(), migrations, stopwatch);
         return failedInitcode;
     }
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/GenericUpsertQueryGenerator.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/GenericUpsertQueryGenerator.java
@@ -64,7 +64,7 @@ public class GenericUpsertQueryGenerator implements UpsertQueryGenerator {
      * @return the upsert query
      */
     @Override
-    public String getInsertQuery() {
+    public String getUpsertQuery() {
         VelocityEngine velocityEngine = new VelocityEngine();
         velocityEngine.setProperty(RuntimeConstants.RESOURCE_LOADERS, RuntimeConstants.RESOURCE_LOADER_CLASS);
         velocityEngine.setProperty("resource.loader.class.class", ClasspathResourceLoader.class.getName());
@@ -92,11 +92,6 @@ public class GenericUpsertQueryGenerator implements UpsertQueryGenerator {
         StringWriter writer = new StringWriter();
         template.merge(velocityContext, writer);
         return writer.toString();
-    }
-
-    @Override
-    public String getUpdateQuery() {
-        return "";
     }
 
     private String closeRange(String input) {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/TokenAccountUpsertQueryGenerator.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/TokenAccountUpsertQueryGenerator.java
@@ -40,7 +40,7 @@ public class TokenAccountUpsertQueryGenerator implements UpsertQueryGenerator {
     }
 
     @Override
-    public String getInsertQuery() {
+    public String getUpsertQuery() {
         return """
                 with last as (
                   select distinct on (token_account.account_id, token_account.token_id) token_account.*
@@ -84,10 +84,5 @@ public class TokenAccountUpsertQueryGenerator implements UpsertQueryGenerator {
                 where token_account_temp.created_timestamp is not null or last.created_timestamp is not null
                 order by token_account_temp.modified_timestamp
                 """;
-    }
-
-    @Override
-    public String getUpdateQuery() {
-        return null;
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/TokenDissociateTransferUpsertQueryGenerator.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/TokenDissociateTransferUpsertQueryGenerator.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.importer.repository.upsert;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -63,17 +63,12 @@ public class TokenDissociateTransferUpsertQueryGenerator implements UpsertQueryG
     }
 
     @Override
-    public String getInsertQuery() {
+    public String getUpsertQuery() {
         return INSERT_SQL;
     }
 
     @Override
     public String getTemporaryTableName() {
         return TEMP_TABLE_NAME;
-    }
-
-    @Override
-    public String getUpdateQuery() {
-        return "";
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/UpsertQueryGenerator.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/UpsertQueryGenerator.java
@@ -33,11 +33,9 @@ public interface UpsertQueryGenerator {
 
     String getFinalTableName();
 
-    String getInsertQuery();
-
     default String getTemporaryTableName() {
         return getFinalTableName() + TEMP_SUFFIX;
     }
 
-    String getUpdateQuery();
+    String getUpsertQuery();
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/batch/BatchUpserterTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/batch/BatchUpserterTest.java
@@ -61,7 +61,6 @@ import com.hedera.mirror.common.domain.token.TokenSupplyTypeEnum;
 import com.hedera.mirror.common.domain.token.TokenTransfer;
 import com.hedera.mirror.common.domain.token.TokenTypeEnum;
 import com.hedera.mirror.importer.IntegrationTest;
-import com.hedera.mirror.importer.repository.ContractRepository;
 import com.hedera.mirror.importer.repository.CryptoAllowanceRepository;
 import com.hedera.mirror.importer.repository.EntityRepository;
 import com.hedera.mirror.importer.repository.NftAllowanceRepository;
@@ -81,7 +80,6 @@ class BatchUpserterTest extends IntegrationTest {
             .build();
 
     private final BatchPersister batchPersister;
-    private final ContractRepository contractRepository;
     private final CryptoAllowanceRepository cryptoAllowanceRepository;
     private final EntityRepository entityRepository;
     private final NftRepository nftRepository;

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/GenericUpsertQueryGeneratorTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/GenericUpsertQueryGeneratorTest.java
@@ -70,14 +70,14 @@ class GenericUpsertQueryGeneratorTest extends IntegrationTest {
         var sql = "case when total_supply >= 0 then total_supply else e_total_supply + coalesce(total_supply, 0) end";
         UpsertQueryGenerator generator = factory.get(Token.class);
         assertThat(generator).isInstanceOf(GenericUpsertQueryGenerator.class);
-        assertThat(format(generator.getInsertQuery())).containsIgnoringWhitespaces(sql);
+        assertThat(format(generator.getUpsertQuery())).containsIgnoringWhitespaces(sql);
     }
 
     @Test
     void getInsertQueryHistory() {
         UpsertQueryGenerator generator = factory.get(Entity.class);
         assertThat(generator).isInstanceOf(GenericUpsertQueryGenerator.class);
-        assertThat(format(generator.getInsertQuery())).isEqualTo(format("""
+        assertThat(format(generator.getUpsertQuery())).isEqualTo(format("""
                 with existing as (
                   select
                     e.alias as e_alias,
@@ -378,7 +378,7 @@ class GenericUpsertQueryGeneratorTest extends IntegrationTest {
     void getInsertQueryNoHistory() {
         UpsertQueryGenerator generator = factory.get(Schedule.class);
         assertThat(generator).isInstanceOf(GenericUpsertQueryGenerator.class);
-        assertThat(format(generator.getInsertQuery())).isEqualTo(format("""
+        assertThat(format(generator.getUpsertQuery())).isEqualTo(format("""
                 with existing as (
                   select
                     e.consensus_timestamp as e_consensus_timestamp,
@@ -418,12 +418,6 @@ class GenericUpsertQueryGeneratorTest extends IntegrationTest {
                 on conflict (schedule_id) do update
                   set executed_timestamp = excluded.executed_timestamp
                 """));
-    }
-
-    @Test
-    void getUpdateQuery() {
-        UpsertQueryGenerator generator = factory.get(Entity.class);
-        assertThat(format(generator.getUpdateQuery())).isEmpty();
     }
 
     private String format(String sql) {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/TokenAccountUpsertQueryGeneratorTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/TokenAccountUpsertQueryGeneratorTest.java
@@ -53,7 +53,7 @@ class TokenAccountUpsertQueryGeneratorTest extends IntegrationTest {
     void insertQuery() {
         var entityMetadata = entityMetadataRegistry.lookup(TokenAccount.class);
         var columns = entityMetadata.columns("{0}");
-        var insertQuery = upsertQueryGenerator.getInsertQuery();
+        var insertQuery = upsertQueryGenerator.getUpsertQuery();
         assertThat(insertQuery).isNotBlank().containsIgnoringWhitespaces(columns);
     }
 
@@ -61,10 +61,5 @@ class TokenAccountUpsertQueryGeneratorTest extends IntegrationTest {
     void temporaryTableName() {
         var temporaryTableName = upsertQueryGenerator.getTemporaryTableName();
         assertThat(temporaryTableName).isEqualTo("token_account_temp");
-    }
-
-    @Test
-    void updateQuery() {
-        assertThat(upsertQueryGenerator.getUpdateQuery()).isNull();
     }
 }


### PR DESCRIPTION
**Description**:

* Add a contract traceability migration log to track execution status
* Fix sidecar download metrics
* Remove unused upsert update query and metric
* Remove `hedera.mirror.importer.parse.upsert.copy` metric in favor of tracking via `total - upsert`

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
