### PR TITLE
Contract Actions rest api

### DIFF
--- a/hedera-mirror-rest/__tests__/specs/contracts/results/actions/all-params.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/actions/all-params.json
@@ -1,0 +1,202 @@
+{
+  "description": "Contract results actions api call with all possible params",
+  "setup": {
+    "contracts": [
+      {
+        "created_timestamp": "987654999123200",
+        "evm_address": "1d8bfdc5d46dc4f61d6b6115972536ebe6a8854c",
+        "file_id": "5001",
+        "key": [1, 1, 1],
+        "num": "8001",
+        "timestamp_range": "[987654999123200, 987654999123299]"
+      },
+      {
+        "created_timestamp": "987654999123200",
+        "evm_address": "70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "file_id": "5001",
+        "key": [1, 1, 1],
+        "num": "5001",
+        "timestamp_range": "[987654999123300,)"
+      }
+    ],
+    "contractresults": [
+      {
+        "amount": 20,
+        "bloom": [1, 1],
+        "call_result": [2, 2],
+        "consensus_timestamp": "1676540001234390005",
+        "contract_id": 5001,
+        "created_contract_ids": [],
+        "error_message": "Not enough gas",
+        "function_parameters": [3, 3],
+        "function_result": [4, 4],
+        "gas_limit": 1234556,
+        "gas_used": 987,
+        "payer_account_id": 6001,
+        "transaction_hash": "0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb98"
+      },
+      {
+        "amount": 30,
+        "bloom": [5, 5],
+        "call_result": [6, 6],
+        "consensus_timestamp": "1676540001234500005",
+        "contract_id": 5001,
+        "created_contract_ids": [7001],
+        "error_message": "",
+        "function_parameters": [7, 7],
+        "function_result": [8, 8],
+        "gas_limit": 987654,
+        "gas_used": 123,
+        "payer_account_id": 8001,
+        "transaction_hash": "0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb99"
+      }
+    ],
+    "transactions": [
+      {
+        "consensus_timestamp": "1676540001234390005",
+        "type": 11,
+        "result": 22,
+        "valid_start_ns": "1676540001234390005",
+        "valid_start_timestamp": "1676540001234390005",
+        "transaction_hash": "hash1",
+        "payerAccountId": 6001,
+        "index": 1,
+        "nonce": 0
+      },
+      {
+        "consensus_timestamp": "1676540001234500005",
+        "type": 11,
+        "result": 22,
+        "valid_start_ns": "1676540001234500005",
+        "valid_start_timestamp": "1676540001234500005",
+        "transaction_hash": "hash2",
+        "payerAccountId": 8001,
+        "index": 2,
+        "nonce": 0
+      }
+    ],
+    "recordFiles": [
+      {
+        "index": 10,
+        "count": 1,
+        "hapi_version_major": "0",
+        "hapi_version_minor": "22",
+        "hapi_version_patch": "3",
+        "name": "2022-04-27T12_09_24.499938763Z.rcd",
+        "prev_hash": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+        "consensus_start": 1676540001234390000,
+        "consensus_end": 1676540001234490000,
+        "hash": "fbd921184e229e2051280d827ba3b31599117af7eafba65dc0e5a998b70c48c0492bf793a150769b1b4fb2c9b7cb4c1c"
+      },
+      {
+        "index": 11,
+        "count": 1,
+        "hapi_version_major": "0",
+        "hapi_version_minor": "22",
+        "hapi_version_patch": "3",
+        "name": "2022-04-27T12_24_30.768994443Z.rcd",
+        "prev_hash": "fbd921184e229e2051280d827ba3b31599117af7eafba65dc0e5a998b70c48c0492bf793a150769b1b4fb2c9b7cb4c1c",
+        "consensus_start": 1676540001234500000,
+        "consensus_end": 1676540001234600000,
+        "hash": "b0162e8a244dc05fbd6f321445b14dddf0e94b00eb169b58ff77b1b5206c12782457f7f1a2ae8cea890f378542ac7216"
+      }
+    ],
+    "contractactions": [
+      {
+        "call_depth": 1,
+        "call_type": 1,
+        "caller": 5001,
+        "caller_type": "CONTRACT",
+        "consensus_timestamp": "1676540001234390005",
+        "gas": 1000,
+        "gas_used": 900,
+        "index": 1,
+        "input": "0xabcd",
+        "recipient_account": null,
+        "recipient_address": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "recipient_contract": 8001,
+        "result_data": "0x1234",
+        "result_data_type": 11,
+        "value": 100
+      },
+      {
+        "call_depth": 2,
+        "call_type": 2,
+        "caller": 5001,
+        "caller_type": "CONTRACT",
+        "consensus_timestamp": "1676540001234390005",
+        "gas": 1000,
+        "gas_used": 900,
+        "index": 2,
+        "input": "0xabcd",
+        "recipient_account": null,
+        "recipient_address": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "recipient_contract": 8002,
+        "result_data": "0x1234",
+        "result_data_type": 11,
+        "value": 200
+      },
+      {
+        "call_depth": 2,
+        "call_type": 2,
+        "caller": 5002,
+        "caller_type": "CONTRACT",
+        "consensus_timestamp": "1676540001234390010",
+        "gas": 1000,
+        "gas_used": 900,
+        "index": 3,
+        "input": "0xabcd",
+        "recipient_account": null,
+        "recipient_address": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "recipient_contract": 8002,
+        "result_data": "0x1234",
+        "result_data_type": 11,
+        "value": 200
+      },
+      {
+        "call_depth": 2,
+        "call_type": 2,
+        "caller": 5001,
+        "caller_type": "CONTRACT",
+        "consensus_timestamp": "1676540001234390010",
+        "gas": 1000,
+        "gas_used": 900,
+        "index": 4,
+        "input": "0xabcd",
+        "recipient_account": null,
+        "recipient_address": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "recipient_contract": 8002,
+        "result_data": "0x1234",
+        "result_data_type": 11,
+        "value": 200
+      }
+    ]
+  },
+  "urls": ["/api/v1/contracts/results/0.0.5001-1676540001-234390005/actions?index=lt:3&order=desc&limit=1"],
+  "responseStatus": 200,
+  "responseJson": {
+    "actions": [
+      {
+        "call_depth": 2,
+        "call_type": 2,
+        "caller": 5001,
+        "caller_type": "CONTRACT",
+        "from": "0x0000000000000000000000000000000000001389",
+        "timestamp": "1676540001234390005",
+        "gas": 1000,
+        "gas_used": 900,
+        "index": 2,
+        "input": "0xabcd",
+        "to": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "recipient": "0.0.8002",
+        "recipient_type": "CONTRACT",
+        "result_data": "0x1234",
+        "result_data_type": "OUTPUT",
+        "value": 200
+      }
+    ],
+    "links": {
+      "next": "/api/v1/contracts/results/0.0.5001-1676540001-234390005/actions?order=desc&limit=1&index=lt:2"
+    }
+  }
+}

--- a/hedera-mirror-rest/__tests__/specs/contracts/results/actions/index-filter.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/actions/index-filter.json
@@ -1,0 +1,211 @@
+{
+  "description": "Contract results actions api call with index filter",
+  "setup": {
+    "contracts": [
+      {
+        "created_timestamp": "987654999123200",
+        "evm_address": "1d8bfdc5d46dc4f61d6b6115972536ebe6a8854c",
+        "file_id": "5001",
+        "key": [1, 1, 1],
+        "num": "8001",
+        "timestamp_range": "[987654999123200, 987654999123299]"
+      },
+      {
+        "created_timestamp": "987654999123200",
+        "evm_address": "70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "file_id": "5001",
+        "key": [1, 1, 1],
+        "num": "5001",
+        "timestamp_range": "[987654999123300,)"
+      }
+    ],
+    "contractresults": [
+      {
+        "amount": 20,
+        "bloom": [1, 1],
+        "call_result": [2, 2],
+        "consensus_timestamp": "1676540001234390005",
+        "contract_id": 5001,
+        "created_contract_ids": [],
+        "error_message": "Not enough gas",
+        "function_parameters": [3, 3],
+        "function_result": [4, 4],
+        "gas_limit": 1234556,
+        "gas_used": 987,
+        "payer_account_id": 6001,
+        "transaction_hash": "0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb98"
+      },
+      {
+        "amount": 30,
+        "bloom": [5, 5],
+        "call_result": [6, 6],
+        "consensus_timestamp": "1676540001234500005",
+        "contract_id": 5001,
+        "created_contract_ids": [7001],
+        "error_message": "",
+        "function_parameters": [7, 7],
+        "function_result": [8, 8],
+        "gas_limit": 987654,
+        "gas_used": 123,
+        "payer_account_id": 8001,
+        "transaction_hash": "0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb99"
+      }
+    ],
+    "transactions": [
+      {
+        "consensus_timestamp": "1676540001234390005",
+        "type": 11,
+        "result": 22,
+        "valid_start_ns": "1676540001234390005",
+        "valid_start_timestamp": "1676540001234390005",
+        "transaction_hash": "hash1",
+        "payerAccountId": 6001,
+        "index": 1,
+        "nonce": 0
+      },
+      {
+        "consensus_timestamp": "1676540001234500005",
+        "type": 11,
+        "result": 22,
+        "valid_start_ns": "1676540001234500005",
+        "valid_start_timestamp": "1676540001234500005",
+        "transaction_hash": "hash2",
+        "payerAccountId": 8001,
+        "index": 2,
+        "nonce": 0
+      }
+    ],
+    "recordFiles": [
+      {
+        "index": 10,
+        "count": 1,
+        "hapi_version_major": "0",
+        "hapi_version_minor": "22",
+        "hapi_version_patch": "3",
+        "name": "2022-04-27T12_09_24.499938763Z.rcd",
+        "prev_hash": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+        "consensus_start": 1676540001234390000,
+        "consensus_end": 1676540001234490000,
+        "hash": "fbd921184e229e2051280d827ba3b31599117af7eafba65dc0e5a998b70c48c0492bf793a150769b1b4fb2c9b7cb4c1c"
+      },
+      {
+        "index": 11,
+        "count": 1,
+        "hapi_version_major": "0",
+        "hapi_version_minor": "22",
+        "hapi_version_patch": "3",
+        "name": "2022-04-27T12_24_30.768994443Z.rcd",
+        "prev_hash": "fbd921184e229e2051280d827ba3b31599117af7eafba65dc0e5a998b70c48c0492bf793a150769b1b4fb2c9b7cb4c1c",
+        "consensus_start": 1676540001234500000,
+        "consensus_end": 1676540001234600000,
+        "hash": "b0162e8a244dc05fbd6f321445b14dddf0e94b00eb169b58ff77b1b5206c12782457f7f1a2ae8cea890f378542ac7216"
+      }
+    ],
+    "contractactions": [
+      {
+        "call_depth": 1,
+        "call_type": 1,
+        "caller": 5001,
+        "caller_type": "CONTRACT",
+        "consensus_timestamp": "1676540001234390005",
+        "gas": 1000,
+        "gas_used": 900,
+        "index": 1,
+        "input": "0xabcd",
+        "recipient_account": null,
+        "recipient_address": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "recipient_contract": 8001,
+        "result_data": "0x1234",
+        "result_data_type": 11,
+        "value": 100
+      },
+      {
+        "call_depth": 2,
+        "call_type": 2,
+        "caller": 5001,
+        "caller_type": "CONTRACT",
+        "consensus_timestamp": "1676540001234390005",
+        "gas": 1000,
+        "gas_used": 900,
+        "index": 2,
+        "input": "0xabcd",
+        "recipient_account": null,
+        "recipient_address": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "recipient_contract": 8002,
+        "result_data": "0x1234",
+        "result_data_type": 11,
+        "value": 200
+      },
+      {
+        "call_depth": 2,
+        "call_type": 2,
+        "caller": 5002,
+        "caller_type": "CONTRACT",
+        "consensus_timestamp": "1676540001234390010",
+        "gas": 1000,
+        "gas_used": 900,
+        "index": 3,
+        "input": "0xabcd",
+        "recipient_account": null,
+        "recipient_address": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "recipient_contract": 8002,
+        "result_data": "0x1234",
+        "result_data_type": 11,
+        "value": 200
+      },
+      {
+        "call_depth": 2,
+        "call_type": 2,
+        "caller": 5001,
+        "caller_type": "CONTRACT",
+        "consensus_timestamp": "1676540001234390010",
+        "gas": 1000,
+        "gas_used": 900,
+        "index": 4,
+        "input": "0xabcd",
+        "recipient_account": null,
+        "recipient_address": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "recipient_contract": 8002,
+        "result_data": "0x1234",
+        "result_data_type": 11,
+        "value": 200
+      }
+    ]
+  },
+  "urls": [
+    "/api/v1/contracts/results/0.0.5001-1676540001-234390005/actions?index=2",
+    "/api/v1/contracts/results/0.0.5001-1676540001-234390005/actions?index=eq:2",
+    "/api/v1/contracts/results/0.0.5001-1676540001-234390005/actions?index=gt:1",
+    "/api/v1/contracts/results/0.0.5001-1676540001-234390005/actions?index=gte:2",
+    "/api/v1/contracts/results/0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb98/actions?index=2",
+    "/api/v1/contracts/results/0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb98/actions?index=eq:2",
+    "/api/v1/contracts/results/0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb98/actions?index=gt:1",
+    "/api/v1/contracts/results/0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb98/actions?index=gte:2"
+  ],
+  "responseStatus": 200,
+  "responseJson": {
+    "actions": [
+      {
+        "call_depth": 2,
+        "call_type": 2,
+        "caller": 5001,
+        "caller_type": "CONTRACT",
+        "from": "0x0000000000000000000000000000000000001389",
+        "timestamp": "1676540001234390005",
+        "gas": 1000,
+        "gas_used": 900,
+        "index": 2,
+        "input": "0xabcd",
+        "to": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "recipient": "0.0.8002",
+        "recipient_type": "CONTRACT",
+        "result_data": "0x1234",
+        "result_data_type": "OUTPUT",
+        "value": 200
+      }
+    ],
+    "links": {
+      "next": null
+    }
+  }
+}

--- a/hedera-mirror-rest/__tests__/specs/contracts/results/actions/limit-and-order-desc.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/actions/limit-and-order-desc.json
@@ -1,0 +1,202 @@
+{
+  "description": "Contract results actions api call with limit=1 and order=desc",
+  "setup": {
+    "contracts": [
+      {
+        "created_timestamp": "987654999123200",
+        "evm_address": "1d8bfdc5d46dc4f61d6b6115972536ebe6a8854c",
+        "file_id": "5001",
+        "key": [1, 1, 1],
+        "num": "8001",
+        "timestamp_range": "[987654999123200, 987654999123299]"
+      },
+      {
+        "created_timestamp": "987654999123200",
+        "evm_address": "70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "file_id": "5001",
+        "key": [1, 1, 1],
+        "num": "5001",
+        "timestamp_range": "[987654999123300,)"
+      }
+    ],
+    "contractresults": [
+      {
+        "amount": 20,
+        "bloom": [1, 1],
+        "call_result": [2, 2],
+        "consensus_timestamp": "1676540001234390005",
+        "contract_id": 5001,
+        "created_contract_ids": [],
+        "error_message": "Not enough gas",
+        "function_parameters": [3, 3],
+        "function_result": [4, 4],
+        "gas_limit": 1234556,
+        "gas_used": 987,
+        "payer_account_id": 6001,
+        "transaction_hash": "0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb98"
+      },
+      {
+        "amount": 30,
+        "bloom": [5, 5],
+        "call_result": [6, 6],
+        "consensus_timestamp": "1676540001234500005",
+        "contract_id": 5001,
+        "created_contract_ids": [7001],
+        "error_message": "",
+        "function_parameters": [7, 7],
+        "function_result": [8, 8],
+        "gas_limit": 987654,
+        "gas_used": 123,
+        "payer_account_id": 8001,
+        "transaction_hash": "0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb99"
+      }
+    ],
+    "transactions": [
+      {
+        "consensus_timestamp": "1676540001234390005",
+        "type": 11,
+        "result": 22,
+        "valid_start_ns": "1676540001234390005",
+        "valid_start_timestamp": "1676540001234390005",
+        "transaction_hash": "hash1",
+        "payerAccountId": 6001,
+        "index": 1,
+        "nonce": 0
+      },
+      {
+        "consensus_timestamp": "1676540001234500005",
+        "type": 11,
+        "result": 22,
+        "valid_start_ns": "1676540001234500005",
+        "valid_start_timestamp": "1676540001234500005",
+        "transaction_hash": "hash2",
+        "payerAccountId": 8001,
+        "index": 2,
+        "nonce": 0
+      }
+    ],
+    "recordFiles": [
+      {
+        "index": 10,
+        "count": 1,
+        "hapi_version_major": "0",
+        "hapi_version_minor": "22",
+        "hapi_version_patch": "3",
+        "name": "2022-04-27T12_09_24.499938763Z.rcd",
+        "prev_hash": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+        "consensus_start": 1676540001234390000,
+        "consensus_end": 1676540001234490000,
+        "hash": "fbd921184e229e2051280d827ba3b31599117af7eafba65dc0e5a998b70c48c0492bf793a150769b1b4fb2c9b7cb4c1c"
+      },
+      {
+        "index": 11,
+        "count": 1,
+        "hapi_version_major": "0",
+        "hapi_version_minor": "22",
+        "hapi_version_patch": "3",
+        "name": "2022-04-27T12_24_30.768994443Z.rcd",
+        "prev_hash": "fbd921184e229e2051280d827ba3b31599117af7eafba65dc0e5a998b70c48c0492bf793a150769b1b4fb2c9b7cb4c1c",
+        "consensus_start": 1676540001234500000,
+        "consensus_end": 1676540001234600000,
+        "hash": "b0162e8a244dc05fbd6f321445b14dddf0e94b00eb169b58ff77b1b5206c12782457f7f1a2ae8cea890f378542ac7216"
+      }
+    ],
+    "contractactions": [
+      {
+        "call_depth": 1,
+        "call_type": 1,
+        "caller": 5001,
+        "caller_type": "CONTRACT",
+        "consensus_timestamp": "1676540001234390005",
+        "gas": 1000,
+        "gas_used": 900,
+        "index": 1,
+        "input": "0xabcd",
+        "recipient_account": null,
+        "recipient_address": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "recipient_contract": 8001,
+        "result_data": "0x1234",
+        "result_data_type": 11,
+        "value": 100
+      },
+      {
+        "call_depth": 2,
+        "call_type": 2,
+        "caller": 5001,
+        "caller_type": "CONTRACT",
+        "consensus_timestamp": "1676540001234390005",
+        "gas": 1000,
+        "gas_used": 900,
+        "index": 2,
+        "input": "0xabcd",
+        "recipient_account": null,
+        "recipient_address": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "recipient_contract": 8002,
+        "result_data": "0x1234",
+        "result_data_type": 11,
+        "value": 200
+      },
+      {
+        "call_depth": 2,
+        "call_type": 2,
+        "caller": 5002,
+        "caller_type": "CONTRACT",
+        "consensus_timestamp": "1676540001234390010",
+        "gas": 1000,
+        "gas_used": 900,
+        "index": 3,
+        "input": "0xabcd",
+        "recipient_account": null,
+        "recipient_address": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "recipient_contract": 8002,
+        "result_data": "0x1234",
+        "result_data_type": 11,
+        "value": 200
+      },
+      {
+        "call_depth": 2,
+        "call_type": 2,
+        "caller": 5001,
+        "caller_type": "CONTRACT",
+        "consensus_timestamp": "1676540001234390010",
+        "gas": 1000,
+        "gas_used": 900,
+        "index": 4,
+        "input": "0xabcd",
+        "recipient_account": null,
+        "recipient_address": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "recipient_contract": 8002,
+        "result_data": "0x1234",
+        "result_data_type": 11,
+        "value": 200
+      }
+    ]
+  },
+  "urls": ["/api/v1/contracts/results/0.0.5001-1676540001-234390005/actions?limit=1&order=desc"],
+  "responseStatus": 200,
+  "responseJson": {
+    "actions": [
+      {
+        "call_depth": 2,
+        "call_type": 2,
+        "caller": 5001,
+        "caller_type": "CONTRACT",
+        "from": "0x0000000000000000000000000000000000001389",
+        "timestamp": "1676540001234390005",
+        "gas": 1000,
+        "gas_used": 900,
+        "index": 2,
+        "input": "0xabcd",
+        "to": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "recipient": "0.0.8002",
+        "recipient_type": "CONTRACT",
+        "result_data": "0x1234",
+        "result_data_type": "OUTPUT",
+        "value": 200
+      }
+    ],
+    "links": {
+      "next": "/api/v1/contracts/results/0.0.5001-1676540001-234390005/actions?limit=1&order=desc&index=lt:2"
+    }
+  }
+}

--- a/hedera-mirror-rest/__tests__/specs/contracts/results/actions/limit.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/actions/limit.json
@@ -1,0 +1,202 @@
+{
+  "description": "Contract results actions api call with limit=1",
+  "setup": {
+    "contracts": [
+      {
+        "created_timestamp": "987654999123200",
+        "evm_address": "1d8bfdc5d46dc4f61d6b6115972536ebe6a8854c",
+        "file_id": "5001",
+        "key": [1, 1, 1],
+        "num": "8001",
+        "timestamp_range": "[987654999123200, 987654999123299]"
+      },
+      {
+        "created_timestamp": "987654999123200",
+        "evm_address": "70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "file_id": "5001",
+        "key": [1, 1, 1],
+        "num": "5001",
+        "timestamp_range": "[987654999123300,)"
+      }
+    ],
+    "contractresults": [
+      {
+        "amount": 20,
+        "bloom": [1, 1],
+        "call_result": [2, 2],
+        "consensus_timestamp": "1676540001234390005",
+        "contract_id": 5001,
+        "created_contract_ids": [],
+        "error_message": "Not enough gas",
+        "function_parameters": [3, 3],
+        "function_result": [4, 4],
+        "gas_limit": 1234556,
+        "gas_used": 987,
+        "payer_account_id": 6001,
+        "transaction_hash": "0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb98"
+      },
+      {
+        "amount": 30,
+        "bloom": [5, 5],
+        "call_result": [6, 6],
+        "consensus_timestamp": "1676540001234500005",
+        "contract_id": 5001,
+        "created_contract_ids": [7001],
+        "error_message": "",
+        "function_parameters": [7, 7],
+        "function_result": [8, 8],
+        "gas_limit": 987654,
+        "gas_used": 123,
+        "payer_account_id": 8001,
+        "transaction_hash": "0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb99"
+      }
+    ],
+    "transactions": [
+      {
+        "consensus_timestamp": "1676540001234390005",
+        "type": 11,
+        "result": 22,
+        "valid_start_ns": "1676540001234390005",
+        "valid_start_timestamp": "1676540001234390005",
+        "transaction_hash": "hash1",
+        "payerAccountId": 6001,
+        "index": 1,
+        "nonce": 0
+      },
+      {
+        "consensus_timestamp": "1676540001234500005",
+        "type": 11,
+        "result": 22,
+        "valid_start_ns": "1676540001234500005",
+        "valid_start_timestamp": "1676540001234500005",
+        "transaction_hash": "hash2",
+        "payerAccountId": 8001,
+        "index": 2,
+        "nonce": 0
+      }
+    ],
+    "recordFiles": [
+      {
+        "index": 10,
+        "count": 1,
+        "hapi_version_major": "0",
+        "hapi_version_minor": "22",
+        "hapi_version_patch": "3",
+        "name": "2022-04-27T12_09_24.499938763Z.rcd",
+        "prev_hash": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+        "consensus_start": 1676540001234390000,
+        "consensus_end": 1676540001234490000,
+        "hash": "fbd921184e229e2051280d827ba3b31599117af7eafba65dc0e5a998b70c48c0492bf793a150769b1b4fb2c9b7cb4c1c"
+      },
+      {
+        "index": 11,
+        "count": 1,
+        "hapi_version_major": "0",
+        "hapi_version_minor": "22",
+        "hapi_version_patch": "3",
+        "name": "2022-04-27T12_24_30.768994443Z.rcd",
+        "prev_hash": "fbd921184e229e2051280d827ba3b31599117af7eafba65dc0e5a998b70c48c0492bf793a150769b1b4fb2c9b7cb4c1c",
+        "consensus_start": 1676540001234500000,
+        "consensus_end": 1676540001234600000,
+        "hash": "b0162e8a244dc05fbd6f321445b14dddf0e94b00eb169b58ff77b1b5206c12782457f7f1a2ae8cea890f378542ac7216"
+      }
+    ],
+    "contractactions": [
+      {
+        "call_depth": 1,
+        "call_type": 1,
+        "caller": 5001,
+        "caller_type": "CONTRACT",
+        "consensus_timestamp": "1676540001234390005",
+        "gas": 1000,
+        "gas_used": 900,
+        "index": 1,
+        "input": "0xabcd",
+        "recipient_account": null,
+        "recipient_address": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "recipient_contract": 8001,
+        "result_data": "0x1234",
+        "result_data_type": 11,
+        "value": 100
+      },
+      {
+        "call_depth": 2,
+        "call_type": 2,
+        "caller": 5001,
+        "caller_type": "CONTRACT",
+        "consensus_timestamp": "1676540001234390005",
+        "gas": 1000,
+        "gas_used": 900,
+        "index": 2,
+        "input": "0xabcd",
+        "recipient_account": null,
+        "recipient_address": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "recipient_contract": 8002,
+        "result_data": "0x1234",
+        "result_data_type": 11,
+        "value": 200
+      },
+      {
+        "call_depth": 2,
+        "call_type": 2,
+        "caller": 5002,
+        "caller_type": "CONTRACT",
+        "consensus_timestamp": "1676540001234390010",
+        "gas": 1000,
+        "gas_used": 900,
+        "index": 3,
+        "input": "0xabcd",
+        "recipient_account": null,
+        "recipient_address": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "recipient_contract": 8002,
+        "result_data": "0x1234",
+        "result_data_type": 11,
+        "value": 200
+      },
+      {
+        "call_depth": 2,
+        "call_type": 2,
+        "caller": 5001,
+        "caller_type": "CONTRACT",
+        "consensus_timestamp": "1676540001234390010",
+        "gas": 1000,
+        "gas_used": 900,
+        "index": 4,
+        "input": "0xabcd",
+        "recipient_account": null,
+        "recipient_address": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "recipient_contract": 8002,
+        "result_data": "0x1234",
+        "result_data_type": 11,
+        "value": 200
+      }
+    ]
+  },
+  "urls": ["/api/v1/contracts/results/0.0.5001-1676540001-234390005/actions?limit=1"],
+  "responseStatus": 200,
+  "responseJson": {
+    "actions": [
+      {
+        "call_depth": 1,
+        "call_type": 1,
+        "caller": 5001,
+        "caller_type": "CONTRACT",
+        "from": "0x0000000000000000000000000000000000001389",
+        "timestamp": "1676540001234390005",
+        "gas": 1000,
+        "gas_used": 900,
+        "index": 1,
+        "input": "0xabcd",
+        "to": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "recipient": "0.0.8001",
+        "recipient_type": "CONTRACT",
+        "result_data": "0x1234",
+        "result_data_type": "OUTPUT",
+        "value": 100
+      }
+    ],
+    "links": {
+      "next": "/api/v1/contracts/results/0.0.5001-1676540001-234390005/actions?limit=1&index=gt:1"
+    }
+  }
+}

--- a/hedera-mirror-rest/__tests__/specs/contracts/results/actions/no-params.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/actions/no-params.json
@@ -1,0 +1,223 @@
+{
+  "description": "Contract results actions api call with no params specified",
+  "setup": {
+    "contracts": [
+      {
+        "created_timestamp": "987654999123200",
+        "evm_address": "1d8bfdc5d46dc4f61d6b6115972536ebe6a8854c",
+        "file_id": "5001",
+        "key": [1, 1, 1],
+        "num": "8001",
+        "timestamp_range": "[987654999123200, 987654999123299]"
+      },
+      {
+        "created_timestamp": "987654999123200",
+        "evm_address": "70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "file_id": "5001",
+        "key": [1, 1, 1],
+        "num": "5001",
+        "timestamp_range": "[987654999123300,)"
+      }
+    ],
+    "contractresults": [
+      {
+        "amount": 20,
+        "bloom": [1, 1],
+        "call_result": [2, 2],
+        "consensus_timestamp": "1676540001234390005",
+        "contract_id": 5001,
+        "created_contract_ids": [],
+        "error_message": "Not enough gas",
+        "function_parameters": [3, 3],
+        "function_result": [4, 4],
+        "gas_limit": 1234556,
+        "gas_used": 987,
+        "payer_account_id": 6001,
+        "transaction_hash": "0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb98"
+      },
+      {
+        "amount": 30,
+        "bloom": [5, 5],
+        "call_result": [6, 6],
+        "consensus_timestamp": "1676540001234500005",
+        "contract_id": 5001,
+        "created_contract_ids": [7001],
+        "error_message": "",
+        "function_parameters": [7, 7],
+        "function_result": [8, 8],
+        "gas_limit": 987654,
+        "gas_used": 123,
+        "payer_account_id": 8001,
+        "transaction_hash": "0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb99"
+      }
+    ],
+    "transactions": [
+      {
+        "consensus_timestamp": "1676540001234390005",
+        "type": 11,
+        "result": 22,
+        "valid_start_ns": "1676540001234390005",
+        "valid_start_timestamp": "1676540001234390005",
+        "transaction_hash": "hash1",
+        "payerAccountId": 6001,
+        "index": 1,
+        "nonce": 0
+      },
+      {
+        "consensus_timestamp": "1676540001234500005",
+        "type": 11,
+        "result": 22,
+        "valid_start_ns": "1676540001234500005",
+        "valid_start_timestamp": "1676540001234500005",
+        "transaction_hash": "hash2",
+        "payerAccountId": 8001,
+        "index": 2,
+        "nonce": 0
+      }
+    ],
+    "recordFiles": [
+      {
+        "index": 10,
+        "count": 1,
+        "hapi_version_major": "0",
+        "hapi_version_minor": "22",
+        "hapi_version_patch": "3",
+        "name": "2022-04-27T12_09_24.499938763Z.rcd",
+        "prev_hash": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+        "consensus_start": 1676540001234390000,
+        "consensus_end": 1676540001234490000,
+        "hash": "fbd921184e229e2051280d827ba3b31599117af7eafba65dc0e5a998b70c48c0492bf793a150769b1b4fb2c9b7cb4c1c"
+      },
+      {
+        "index": 11,
+        "count": 1,
+        "hapi_version_major": "0",
+        "hapi_version_minor": "22",
+        "hapi_version_patch": "3",
+        "name": "2022-04-27T12_24_30.768994443Z.rcd",
+        "prev_hash": "fbd921184e229e2051280d827ba3b31599117af7eafba65dc0e5a998b70c48c0492bf793a150769b1b4fb2c9b7cb4c1c",
+        "consensus_start": 1676540001234500000,
+        "consensus_end": 1676540001234600000,
+        "hash": "b0162e8a244dc05fbd6f321445b14dddf0e94b00eb169b58ff77b1b5206c12782457f7f1a2ae8cea890f378542ac7216"
+      }
+    ],
+    "contractactions": [
+      {
+        "call_depth": 1,
+        "call_type": 1,
+        "caller": 5001,
+        "caller_type": "CONTRACT",
+        "consensus_timestamp": "1676540001234390005",
+        "gas": 1000,
+        "gas_used": 900,
+        "index": 1,
+        "input": "0xabcd",
+        "recipient_account": null,
+        "recipient_address": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "recipient_contract": 8001,
+        "result_data": "0x1234",
+        "result_data_type": 11,
+        "value": 100
+      },
+      {
+        "call_depth": 2,
+        "call_type": 2,
+        "caller": 5001,
+        "caller_type": "CONTRACT",
+        "consensus_timestamp": "1676540001234390005",
+        "gas": 1000,
+        "gas_used": 900,
+        "index": 2,
+        "input": "0xabcd",
+        "recipient_account": null,
+        "recipient_address": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "recipient_contract": 8002,
+        "result_data": "0x1234",
+        "result_data_type": 11,
+        "value": 200
+      },
+      {
+        "call_depth": 2,
+        "call_type": 2,
+        "caller": 5002,
+        "caller_type": "CONTRACT",
+        "consensus_timestamp": "1676540001234390010",
+        "gas": 1000,
+        "gas_used": 900,
+        "index": 3,
+        "input": "0xabcd",
+        "recipient_account": null,
+        "recipient_address": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "recipient_contract": 8002,
+        "result_data": "0x1234",
+        "result_data_type": 11,
+        "value": 200
+      },
+      {
+        "call_depth": 2,
+        "call_type": 2,
+        "caller": 5001,
+        "caller_type": "CONTRACT",
+        "consensus_timestamp": "1676540001234390010",
+        "gas": 1000,
+        "gas_used": 900,
+        "index": 4,
+        "input": "0xabcd",
+        "recipient_account": null,
+        "recipient_address": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "recipient_contract": 8002,
+        "result_data": "0x1234",
+        "result_data_type": 11,
+        "value": 200
+      }
+    ]
+  },
+  "urls": [
+    "/api/v1/contracts/results/0.0.5001-1676540001-234390005/actions",
+    "/api/v1/contracts/results/0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb98/actions"
+  ],
+  "responseStatus": 200,
+  "responseJson": {
+    "actions": [
+      {
+        "call_depth": 1,
+        "call_type": 1,
+        "caller": 5001,
+        "caller_type": "CONTRACT",
+        "from": "0x0000000000000000000000000000000000001389",
+        "timestamp": "1676540001234390005",
+        "gas": 1000,
+        "gas_used": 900,
+        "index": 1,
+        "input": "0xabcd",
+        "to": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "recipient": "0.0.8001",
+        "recipient_type": "CONTRACT",
+        "result_data": "0x1234",
+        "result_data_type": "OUTPUT",
+        "value": 100
+      },
+      {
+        "call_depth": 2,
+        "call_type": 2,
+        "caller": 5001,
+        "caller_type": "CONTRACT",
+        "from": "0x0000000000000000000000000000000000001389",
+        "timestamp": "1676540001234390005",
+        "gas": 1000,
+        "gas_used": 900,
+        "index": 2,
+        "input": "0xabcd",
+        "to": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "recipient": "0.0.8002",
+        "recipient_type": "CONTRACT",
+        "result_data": "0x1234",
+        "result_data_type": "OUTPUT",
+        "value": 200
+      }
+    ],
+    "links": {
+      "next": null
+    }
+  }
+}

--- a/hedera-mirror-rest/__tests__/specs/contracts/results/actions/order-asc.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/actions/order-asc.json
@@ -1,0 +1,223 @@
+{
+  "description": "Contract results actions api call with order=ASC",
+  "setup": {
+    "contracts": [
+      {
+        "created_timestamp": "987654999123200",
+        "evm_address": "1d8bfdc5d46dc4f61d6b6115972536ebe6a8854c",
+        "file_id": "5001",
+        "key": [1, 1, 1],
+        "num": "8001",
+        "timestamp_range": "[987654999123200, 987654999123299]"
+      },
+      {
+        "created_timestamp": "987654999123200",
+        "evm_address": "70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "file_id": "5001",
+        "key": [1, 1, 1],
+        "num": "5001",
+        "timestamp_range": "[987654999123300,)"
+      }
+    ],
+    "contractresults": [
+      {
+        "amount": 20,
+        "bloom": [1, 1],
+        "call_result": [2, 2],
+        "consensus_timestamp": "1676540001234390005",
+        "contract_id": 5001,
+        "created_contract_ids": [],
+        "error_message": "Not enough gas",
+        "function_parameters": [3, 3],
+        "function_result": [4, 4],
+        "gas_limit": 1234556,
+        "gas_used": 987,
+        "payer_account_id": 6001,
+        "transaction_hash": "0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb98"
+      },
+      {
+        "amount": 30,
+        "bloom": [5, 5],
+        "call_result": [6, 6],
+        "consensus_timestamp": "1676540001234500005",
+        "contract_id": 5001,
+        "created_contract_ids": [7001],
+        "error_message": "",
+        "function_parameters": [7, 7],
+        "function_result": [8, 8],
+        "gas_limit": 987654,
+        "gas_used": 123,
+        "payer_account_id": 8001,
+        "transaction_hash": "0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb99"
+      }
+    ],
+    "transactions": [
+      {
+        "consensus_timestamp": "1676540001234390005",
+        "type": 11,
+        "result": 22,
+        "valid_start_ns": "1676540001234390005",
+        "valid_start_timestamp": "1676540001234390005",
+        "transaction_hash": "hash1",
+        "payerAccountId": 6001,
+        "index": 1,
+        "nonce": 0
+      },
+      {
+        "consensus_timestamp": "1676540001234500005",
+        "type": 11,
+        "result": 22,
+        "valid_start_ns": "1676540001234500005",
+        "valid_start_timestamp": "1676540001234500005",
+        "transaction_hash": "hash2",
+        "payerAccountId": 8001,
+        "index": 2,
+        "nonce": 0
+      }
+    ],
+    "recordFiles": [
+      {
+        "index": 10,
+        "count": 1,
+        "hapi_version_major": "0",
+        "hapi_version_minor": "22",
+        "hapi_version_patch": "3",
+        "name": "2022-04-27T12_09_24.499938763Z.rcd",
+        "prev_hash": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+        "consensus_start": 1676540001234390000,
+        "consensus_end": 1676540001234490000,
+        "hash": "fbd921184e229e2051280d827ba3b31599117af7eafba65dc0e5a998b70c48c0492bf793a150769b1b4fb2c9b7cb4c1c"
+      },
+      {
+        "index": 11,
+        "count": 1,
+        "hapi_version_major": "0",
+        "hapi_version_minor": "22",
+        "hapi_version_patch": "3",
+        "name": "2022-04-27T12_24_30.768994443Z.rcd",
+        "prev_hash": "fbd921184e229e2051280d827ba3b31599117af7eafba65dc0e5a998b70c48c0492bf793a150769b1b4fb2c9b7cb4c1c",
+        "consensus_start": 1676540001234500000,
+        "consensus_end": 1676540001234600000,
+        "hash": "b0162e8a244dc05fbd6f321445b14dddf0e94b00eb169b58ff77b1b5206c12782457f7f1a2ae8cea890f378542ac7216"
+      }
+    ],
+    "contractactions": [
+      {
+        "call_depth": 1,
+        "call_type": 1,
+        "caller": 5001,
+        "caller_type": "CONTRACT",
+        "consensus_timestamp": "1676540001234390005",
+        "gas": 1000,
+        "gas_used": 900,
+        "index": 1,
+        "input": "0xabcd",
+        "recipient_account": null,
+        "recipient_address": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "recipient_contract": 8001,
+        "result_data": "0x1234",
+        "result_data_type": 11,
+        "value": 100
+      },
+      {
+        "call_depth": 2,
+        "call_type": 2,
+        "caller": 5001,
+        "caller_type": "CONTRACT",
+        "consensus_timestamp": "1676540001234390005",
+        "gas": 1000,
+        "gas_used": 900,
+        "index": 2,
+        "input": "0xabcd",
+        "recipient_account": null,
+        "recipient_address": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "recipient_contract": 8002,
+        "result_data": "0x1234",
+        "result_data_type": 11,
+        "value": 200
+      },
+      {
+        "call_depth": 2,
+        "call_type": 2,
+        "caller": 5002,
+        "caller_type": "CONTRACT",
+        "consensus_timestamp": "1676540001234390010",
+        "gas": 1000,
+        "gas_used": 900,
+        "index": 3,
+        "input": "0xabcd",
+        "recipient_account": null,
+        "recipient_address": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "recipient_contract": 8002,
+        "result_data": "0x1234",
+        "result_data_type": 11,
+        "value": 200
+      },
+      {
+        "call_depth": 2,
+        "call_type": 2,
+        "caller": 5001,
+        "caller_type": "CONTRACT",
+        "consensus_timestamp": "1676540001234390010",
+        "gas": 1000,
+        "gas_used": 900,
+        "index": 4,
+        "input": "0xabcd",
+        "recipient_account": null,
+        "recipient_address": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "recipient_contract": 8002,
+        "result_data": "0x1234",
+        "result_data_type": 11,
+        "value": 200
+      }
+    ]
+  },
+  "urls": [
+    "/api/v1/contracts/results/0.0.5001-1676540001-234390005/actions?order=asc",
+    "/api/v1/contracts/results/0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb98/actions?order=asc"
+  ],
+  "responseStatus": 200,
+  "responseJson": {
+    "actions": [
+      {
+        "call_depth": 1,
+        "call_type": 1,
+        "caller": 5001,
+        "caller_type": "CONTRACT",
+        "from": "0x0000000000000000000000000000000000001389",
+        "timestamp": "1676540001234390005",
+        "gas": 1000,
+        "gas_used": 900,
+        "index": 1,
+        "input": "0xabcd",
+        "to": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "recipient": "0.0.8001",
+        "recipient_type": "CONTRACT",
+        "result_data": "0x1234",
+        "result_data_type": "OUTPUT",
+        "value": 100
+      },
+      {
+        "call_depth": 2,
+        "call_type": 2,
+        "caller": 5001,
+        "caller_type": "CONTRACT",
+        "from": "0x0000000000000000000000000000000000001389",
+        "timestamp": "1676540001234390005",
+        "gas": 1000,
+        "gas_used": 900,
+        "index": 2,
+        "input": "0xabcd",
+        "to": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "recipient": "0.0.8002",
+        "recipient_type": "CONTRACT",
+        "result_data": "0x1234",
+        "result_data_type": "OUTPUT",
+        "value": 200
+      }
+    ],
+    "links": {
+      "next": null
+    }
+  }
+}

--- a/hedera-mirror-rest/__tests__/specs/contracts/results/actions/order-desc.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/actions/order-desc.json
@@ -1,0 +1,223 @@
+{
+  "description": "Contract results actions api call with order=DESC",
+  "setup": {
+    "contracts": [
+      {
+        "created_timestamp": "987654999123200",
+        "evm_address": "1d8bfdc5d46dc4f61d6b6115972536ebe6a8854c",
+        "file_id": "5001",
+        "key": [1, 1, 1],
+        "num": "8001",
+        "timestamp_range": "[987654999123200, 987654999123299]"
+      },
+      {
+        "created_timestamp": "987654999123200",
+        "evm_address": "70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "file_id": "5001",
+        "key": [1, 1, 1],
+        "num": "5001",
+        "timestamp_range": "[987654999123300,)"
+      }
+    ],
+    "contractresults": [
+      {
+        "amount": 20,
+        "bloom": [1, 1],
+        "call_result": [2, 2],
+        "consensus_timestamp": "1676540001234390005",
+        "contract_id": 5001,
+        "created_contract_ids": [],
+        "error_message": "Not enough gas",
+        "function_parameters": [3, 3],
+        "function_result": [4, 4],
+        "gas_limit": 1234556,
+        "gas_used": 987,
+        "payer_account_id": 6001,
+        "transaction_hash": "0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb98"
+      },
+      {
+        "amount": 30,
+        "bloom": [5, 5],
+        "call_result": [6, 6],
+        "consensus_timestamp": "1676540001234500005",
+        "contract_id": 5001,
+        "created_contract_ids": [7001],
+        "error_message": "",
+        "function_parameters": [7, 7],
+        "function_result": [8, 8],
+        "gas_limit": 987654,
+        "gas_used": 123,
+        "payer_account_id": 8001,
+        "transaction_hash": "0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb99"
+      }
+    ],
+    "transactions": [
+      {
+        "consensus_timestamp": "1676540001234390005",
+        "type": 11,
+        "result": 22,
+        "valid_start_ns": "1676540001234390005",
+        "valid_start_timestamp": "1676540001234390005",
+        "transaction_hash": "hash1",
+        "payerAccountId": 6001,
+        "index": 1,
+        "nonce": 0
+      },
+      {
+        "consensus_timestamp": "1676540001234500005",
+        "type": 11,
+        "result": 22,
+        "valid_start_ns": "1676540001234500005",
+        "valid_start_timestamp": "1676540001234500005",
+        "transaction_hash": "hash2",
+        "payerAccountId": 8001,
+        "index": 2,
+        "nonce": 0
+      }
+    ],
+    "recordFiles": [
+      {
+        "index": 10,
+        "count": 1,
+        "hapi_version_major": "0",
+        "hapi_version_minor": "22",
+        "hapi_version_patch": "3",
+        "name": "2022-04-27T12_09_24.499938763Z.rcd",
+        "prev_hash": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+        "consensus_start": 1676540001234390000,
+        "consensus_end": 1676540001234490000,
+        "hash": "fbd921184e229e2051280d827ba3b31599117af7eafba65dc0e5a998b70c48c0492bf793a150769b1b4fb2c9b7cb4c1c"
+      },
+      {
+        "index": 11,
+        "count": 1,
+        "hapi_version_major": "0",
+        "hapi_version_minor": "22",
+        "hapi_version_patch": "3",
+        "name": "2022-04-27T12_24_30.768994443Z.rcd",
+        "prev_hash": "fbd921184e229e2051280d827ba3b31599117af7eafba65dc0e5a998b70c48c0492bf793a150769b1b4fb2c9b7cb4c1c",
+        "consensus_start": 1676540001234500000,
+        "consensus_end": 1676540001234600000,
+        "hash": "b0162e8a244dc05fbd6f321445b14dddf0e94b00eb169b58ff77b1b5206c12782457f7f1a2ae8cea890f378542ac7216"
+      }
+    ],
+    "contractactions": [
+      {
+        "call_depth": 1,
+        "call_type": 1,
+        "caller": 5001,
+        "caller_type": "CONTRACT",
+        "consensus_timestamp": "1676540001234390005",
+        "gas": 1000,
+        "gas_used": 900,
+        "index": 1,
+        "input": "0xabcd",
+        "recipient_account": null,
+        "recipient_address": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "recipient_contract": 8001,
+        "result_data": "0x1234",
+        "result_data_type": 11,
+        "value": 100
+      },
+      {
+        "call_depth": 2,
+        "call_type": 2,
+        "caller": 5001,
+        "caller_type": "CONTRACT",
+        "consensus_timestamp": "1676540001234390005",
+        "gas": 1000,
+        "gas_used": 900,
+        "index": 2,
+        "input": "0xabcd",
+        "recipient_account": null,
+        "recipient_address": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "recipient_contract": 8002,
+        "result_data": "0x1234",
+        "result_data_type": 11,
+        "value": 200
+      },
+      {
+        "call_depth": 2,
+        "call_type": 2,
+        "caller": 5002,
+        "caller_type": "CONTRACT",
+        "consensus_timestamp": "1676540001234390010",
+        "gas": 1000,
+        "gas_used": 900,
+        "index": 3,
+        "input": "0xabcd",
+        "recipient_account": null,
+        "recipient_address": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "recipient_contract": 8002,
+        "result_data": "0x1234",
+        "result_data_type": 11,
+        "value": 200
+      },
+      {
+        "call_depth": 2,
+        "call_type": 2,
+        "caller": 5001,
+        "caller_type": "CONTRACT",
+        "consensus_timestamp": "1676540001234390010",
+        "gas": 1000,
+        "gas_used": 900,
+        "index": 4,
+        "input": "0xabcd",
+        "recipient_account": null,
+        "recipient_address": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "recipient_contract": 8002,
+        "result_data": "0x1234",
+        "result_data_type": 11,
+        "value": 200
+      }
+    ]
+  },
+  "urls": [
+    "/api/v1/contracts/results/0.0.5001-1676540001-234390005/actions?order=desc",
+    "/api/v1/contracts/results/0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb98/actions?order=desc"
+  ],
+  "responseStatus": 200,
+  "responseJson": {
+    "actions": [
+      {
+        "call_depth": 2,
+        "call_type": 2,
+        "caller": 5001,
+        "caller_type": "CONTRACT",
+        "from": "0x0000000000000000000000000000000000001389",
+        "timestamp": "1676540001234390005",
+        "gas": 1000,
+        "gas_used": 900,
+        "index": 2,
+        "input": "0xabcd",
+        "to": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "recipient": "0.0.8002",
+        "recipient_type": "CONTRACT",
+        "result_data": "0x1234",
+        "result_data_type": "OUTPUT",
+        "value": 200
+      },
+      {
+        "call_depth": 1,
+        "call_type": 1,
+        "caller": 5001,
+        "caller_type": "CONTRACT",
+        "from": "0x0000000000000000000000000000000000001389",
+        "timestamp": "1676540001234390005",
+        "gas": 1000,
+        "gas_used": 900,
+        "index": 1,
+        "input": "0xabcd",
+        "to": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "recipient": "0.0.8001",
+        "recipient_type": "CONTRACT",
+        "result_data": "0x1234",
+        "result_data_type": "OUTPUT",
+        "value": 100
+      }
+    ],
+    "links": {
+      "next": null
+    }
+  }
+}

--- a/hedera-mirror-rest/controllers/contractController.js
+++ b/hedera-mirror-rest/controllers/contractController.js
@@ -1050,10 +1050,10 @@ class ContractController extends BaseController {
   };
 
   getContractActions = async (req, res) => {
-    // Support args: index, limit, order
+    // Supported args: index, limit, order
     const filters = utils.buildAndValidateFilters(req.query);
     const order = filters.order || orderFilterValues.ASC;
-    const limit = filters.order || defaultLimit;
+    const limit = filters.limit || defaultLimit;
     const index = filters.index;
 
     // extract filters from query param
@@ -1064,11 +1064,7 @@ class ContractController extends BaseController {
       const hash = Buffer.from(transactionIdOrHash.replace('0x', '').substring(64), 'hex');
       rows = ContractService.getContractActionsByHash(hash);
     } else {
-      const transactionId = TransactionId.fromString(transactionIdOrHash);
-
-      // get transactions using id
-      // TODO get contract actions by tx_id
-      // const rows = await ContractService.getActionsByTxId(transactionIdOrHash);
+      rows = await ContractService.getContractActionsByTransactionId(transactionIdOrHash);
     }
 
     const actions = rows.map((row) => new ContractActionViewModel(row));

--- a/hedera-mirror-rest/model/contractAction.js
+++ b/hedera-mirror-rest/model/contractAction.js
@@ -20,35 +20,35 @@
 
 import _ from 'lodash';
 
-class ContractResult {
+class ContractAction {
   /**
    * Parses contract_result table columns into object
    */
-  constructor(contractResult) {
+  constructor(contractAction) {
     Object.assign(
       this,
-      _.mapKeys(contractResult, (v, k) => _.camelCase(k))
+      _.mapKeys(contractAction, (v, k) => _.camelCase(k))
     );
   }
 
-  static tableAlias = 'cr';
-  static tableName = 'contract_result';
+  static tableAlias = 'cact';
+  static tableName = 'contract_action';
 
-  static AMOUNT = 'amount';
-  static BLOOM = 'bloom';
-  static CALL_RESULT = 'call_result';
+  static CALL_DEPTH = 'call_depth';
+  static CALL_TYPE = 'call_type';
+  static CALLER = 'caller';
+  static CALLER_TYPE = 'caller_type';
   static CONSENSUS_TIMESTAMP = 'consensus_timestamp';
-  static CONTRACT_ID = 'contract_id';
-  static CREATED_CONTRACT_IDS = 'created_contract_ids';
-  static ERROR_MESSAGE = 'error_message';
-  static FAILED_INITCODE = 'failed_initcode';
-  static FUNCTION_PARAMETERS = 'function_parameters';
-  static FUNCTION_RESULT = 'function_result';
-  static GAS_LIMIT = 'gas_limit';
+  static GAS = 'gas';
   static GAS_USED = 'gas_used';
-  static PAYER_ACCOUNT_ID = 'payer_account_id';
-  static SENDER_ID = 'sender_id';
-  static TRANSACTION_HASH = 'transaction_hash';
+  static INDEX = 'index';
+  static INPUT = 'input';
+  static RECEPIENT_ACCOUNT = 'recipient_account';
+  static RECEPIENT_ADDRESS = 'recipient_address';
+  static RECEPIENT_CONTRACT = 'recipient_contract';
+  static RESULT_DATA = 'result_data';
+  static RESULT_DATA_TYPE = 'result_data_type';
+  static VALUE = 'value';
 
   /**
    * Gets full column name with table alias prepended.
@@ -61,4 +61,4 @@ class ContractResult {
   }
 }
 
-export default ContractResult;
+export default ContractAction;

--- a/hedera-mirror-rest/model/index.js
+++ b/hedera-mirror-rest/model/index.js
@@ -24,6 +24,7 @@ import AddressBookServiceEndpoint from './addressBookServiceEndpoint';
 import AssessedCustomFee from './assessedCustomFee';
 import Contract from './contract';
 import CryptoAllowance from './cryptoAllowance';
+import ContractAction from './contractAction.js';
 import ContractLog from './contractLog';
 import ContractResult from './contractResult';
 import ContractStateChange from './contractStateChange';
@@ -60,6 +61,7 @@ export {
   AssessedCustomFee,
   Contract,
   CryptoAllowance,
+  ContractAction,
   ContractLog,
   ContractResult,
   ContractStateChange,

--- a/hedera-mirror-rest/routes/contractRoute.js
+++ b/hedera-mirror-rest/routes/contractRoute.js
@@ -31,10 +31,10 @@ router.getAsync('/:contractId', ContractController.getContractById);
 router.getAsync('/:contractId/results', ContractController.getContractResultsById);
 router.getAsync('/:contractId/results/logs', ContractController.getContractLogsById);
 router.getAsync('/:contractId/results/:consensusTimestamp([0-9.]+)', ContractController.getContractResultsByTimestamp);
-router.getAsync('/:contractId/results/:transactionIdOrHash/actions', ContractController.getContractActions);
 router.getAsync('/results', ContractController.getContractResults);
 router.getAsync('/results/logs', ContractController.getContractLogs);
 router.getAsync('/results/:transactionIdOrHash', ContractController.getContractResultsByTransactionIdOrHash);
+router.getAsync('/results/:transactionIdOrHash/actions', ContractController.getContractActions);
 
 export default {
   resource,

--- a/hedera-mirror-rest/routes/contractRoute.js
+++ b/hedera-mirror-rest/routes/contractRoute.js
@@ -31,6 +31,7 @@ router.getAsync('/:contractId', ContractController.getContractById);
 router.getAsync('/:contractId/results', ContractController.getContractResultsById);
 router.getAsync('/:contractId/results/logs', ContractController.getContractLogsById);
 router.getAsync('/:contractId/results/:consensusTimestamp([0-9.]+)', ContractController.getContractResultsByTimestamp);
+router.getAsync('/:contractId/results/:transactionIdOrHash/actions', ContractController.getContractActions);
 router.getAsync('/results', ContractController.getContractResults);
 router.getAsync('/results/logs', ContractController.getContractLogs);
 router.getAsync('/results/:transactionIdOrHash', ContractController.getContractResultsByTransactionIdOrHash);

--- a/hedera-mirror-rest/service/contractService.js
+++ b/hedera-mirror-rest/service/contractService.js
@@ -372,9 +372,10 @@ class ContractService extends BaseService {
   }
 
   async getContractActionsByTransactionId(transactionId, filters, order, limit) {
-    const [entityId, ...timestampParts] = transactionId.split('-');
-    const timestamp = timestampParts.join('-');
-    let params = [entityId, timestamp];
+    const [entityIdString, ...timestampParts] = transactionId.split('-');
+    const entityId = entityIdString.split('.')[2];
+    const timestamp = timestampParts.join('');
+    let params = [timestamp, entityId];
     return this.getContractActions(ContractService.contractActionsByTxIdQuery, params, filters, order, limit);
   }
 
@@ -395,7 +396,7 @@ class ContractService extends BaseService {
     let query = [baseQuery, whereClause, orderClause, limitClause].join('\n');
 
     const rows = await super.getRows(query, params, 'getActionsByHash');
-    return rows.map((row) => new ContractStateChange(row));
+    return rows.map((row) => new ContractAction(row));
   }
 }
 

--- a/hedera-mirror-rest/service/contractService.js
+++ b/hedera-mirror-rest/service/contractService.js
@@ -381,9 +381,15 @@ class ContractService extends BaseService {
 
   async getContractActions(baseQuery, params = [], filters = {}, order = orderFilterValues.ASC, limit = 25) {
     let whereClause = ``;
-    if (filters && filters.index) {
-      whereClause = `and ${ContractAction.getFullName(ContractAction.INDEX)} = $${params.length + 1}`;
-      params.push(filters.index);
+    if (filters && filters.length) {
+      for (const filter of filters) {
+        if (filter.key === 'index') {
+          whereClause += `\nand ${ContractAction.getFullName(ContractAction.INDEX)}${filter.operator}$${
+            params.length + 1
+          }`;
+          params.push(filter.value);
+        }
+      }
     }
 
     const orderClause = super.getOrderByQuery(OrderSpec.from(ContractAction.getFullName(ContractAction.INDEX), order));

--- a/hedera-mirror-rest/utils.js
+++ b/hedera-mirror-rest/utils.js
@@ -162,6 +162,8 @@ const isValidBlockHash = (query) => {
   return blockHashPattern.test(query);
 };
 
+const isValidTransactionHash = isValidBlockHash;
+
 const ethHashPattern = /^(0x)?([0-9A-Fa-f]{64})$/;
 const isValidEthHash = (hash) => {
   if (hash === undefined) {
@@ -1455,6 +1457,7 @@ export {
   isTestEnv,
   isValidBlockHash,
   isValidEthHash,
+  isValidTransactionHash,
   isValidOperatorQuery,
   isValidPublicKeyQuery,
   isValidTimestampParam,

--- a/hedera-mirror-rest/viewmodel/contractActionViewModel.js
+++ b/hedera-mirror-rest/viewmodel/contractActionViewModel.js
@@ -19,11 +19,18 @@
  */
 
 import EntityId from '../entityId';
+import * as utils from '../utils.js';
 
 /**
  * Contract actions view model
  */
 class ContractActionViewModel {
+  static resultDataTypes = {
+    11: 'OUTPUT',
+    12: 'REVERT_REASON',
+    13: 'ERROR',
+  };
+
   /**
    * Constructs contractAction view model
    *
@@ -32,21 +39,27 @@ class ContractActionViewModel {
   constructor(contractAction) {
     const recipientIsAccount = !!contractAction.recipient_account;
 
-    this.call_depth = contractAction.call_depth;
-    this.call_type = contractAction.call_type;
+    this.call_depth = contractAction.callDepth;
+    this.call_type = contractAction.callType;
     this.caller = contractAction.caller;
-    this.caller_type = contractAction.caller_type;
-    this.from = EntityId.parse(contractAction.caller).toEvmAddress();
+    this.caller_type = contractAction.callerType;
+    this.from = contractAction.caller ? EntityId.parse(contractAction.caller).toEvmAddress() : null;
     this.gas = contractAction.gas;
-    this.gas_used = contractAction.gas_used;
+    this.gas_used = contractAction.gasUsed;
     this.index = contractAction.index;
-    this.input = contractAction.input;
-    this.recipient = recipientIsAccount ? contractAction.recipient_account : contractAction.recipient_contract;
+    this.input = contractAction.input ? utils.addHexPrefix(Buffer.from(contractAction.input).toString('hex')) : null;
+    this.recipient = recipientIsAccount
+      ? EntityId.parse(contractAction.recipientAccount).toString()
+      : EntityId.parse(contractAction.recipientContract).toString();
     this.recipient_type = recipientIsAccount ? 'ACCOUNT' : 'CONTRACT';
-    this.result_data = contractAction.result_data;
-    this.result_data_type = contractAction.result_data_type;
-    this.timestamp = contractAction.consensus_timestamp;
-    this.to = contractAction.recipient_address;
+    this.result_data = contractAction.resultData
+      ? utils.addHexPrefix(Buffer.from(contractAction.resultData).toString('hex'))
+      : null;
+    this.result_data_type = ContractActionViewModel.resultDataTypes[contractAction.resultDataType];
+    this.timestamp = contractAction.consensusTimestamp.toString();
+    this.to = contractAction.recipientAddress
+      ? utils.addHexPrefix(Buffer.from(contractAction.recipientAddress).toString('hex'))
+      : null;
     this.value = contractAction.value;
   }
 }

--- a/hedera-mirror-rest/viewmodel/contractActionViewModel.js
+++ b/hedera-mirror-rest/viewmodel/contractActionViewModel.js
@@ -1,0 +1,54 @@
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import EntityId from '../entityId';
+
+/**
+ * Contract actions view model
+ */
+class ContractActionViewModel {
+  /**
+   * Constructs contractAction view model
+   *
+   * @param {ContractAction} contractAction
+   */
+  constructor(contractAction) {
+    const recipientIsAccount = !!contractAction.recipient_account;
+
+    this.call_depth = contractAction.call_depth;
+    this.call_type = contractAction.call_type;
+    this.caller = contractAction.caller;
+    this.caller_type = contractAction.caller_type;
+    this.from = EntityId.parse(contractAction.caller).toEvmAddress();
+    this.gas = contractAction.gas;
+    this.gas_used = contractAction.gas_used;
+    this.index = contractAction.index;
+    this.input = contractAction.input;
+    this.recipient = recipientIsAccount ? contractAction.recipient_account : contractAction.recipient_contract;
+    this.recipient_type = recipientIsAccount ? 'ACCOUNT' : 'CONTRACT';
+    this.result_data = contractAction.result_data;
+    this.result_data_type = contractAction.result_data_type;
+    this.timestamp = contractAction.consensus_timestamp;
+    this.to = contractAction.recipient_address;
+    this.value = contractAction.value;
+  }
+}
+
+export default ContractActionViewModel;

--- a/hedera-mirror-rest/viewmodel/index.js
+++ b/hedera-mirror-rest/viewmodel/index.js
@@ -22,6 +22,7 @@ import AddressBookServiceEndpointViewModel from './addressBookServiceEndpointVie
 import AssessedCustomFeeViewModel from './assessedCustomFeeViewModel';
 import CustomFeeViewModel from './customFeeViewModel';
 import ContractViewModel from './contractViewModel';
+import ContractActionViewModel from './contractActionViewModel';
 import ContractBytecodeViewModel from './contractBytecodeViewModel';
 import ContractLogViewModel from './contractLogViewModel';
 import ContractResultDetailsViewModel from './contractResultDetailsViewModel';
@@ -47,6 +48,7 @@ export {
   AssessedCustomFeeViewModel,
   CustomFeeViewModel,
   ContractViewModel,
+  ContractActionViewModel,
   ContractBytecodeViewModel,
   ContractLogViewModel,
   ContractResultDetailsViewModel,


### PR DESCRIPTION
**Description**:
Add a rest api endpoint for reading contract actions: `/api/v1/contracts/results/{transactionIdOrHash}/actions`

Possible arguments are: `index`, `order` and `limit`. Allows using all filter operators - `eq`, `gt`, `gte`, `lt`, `lte`.



**Related issue(s)**:

Fixes #4201 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
