### PR TITLE
Fix OpenAPI for topic message by timestamp

### DIFF
--- a/hedera-mirror-rest/api/v1/openapi.yml
+++ b/hedera-mirror-rest/api/v1/openapi.yml
@@ -784,7 +784,7 @@ paths:
           $ref: '#/components/responses/NotFoundError'
       tags:
         - topics
-  /api/v1/topics/messages/{consensusTimestamp}:
+  /api/v1/topics/messages/{timestamp}:
     get:
       summary: Get topic message by consensusTimestamp
       description: Returns a topic message the given the consensusTimestamp.


### PR DESCRIPTION
**Description**:
Fix REST API using wrong path parameter name for topic message by timestamp

**Related issue(s)**:

Fixes #4351

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
