### PR TITLE
Fix mainnet-public monitor alerts

### DIFF
--- a/hedera-mirror-rest/monitoring/monitor_apis/account_tests.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/account_tests.js
@@ -23,16 +23,16 @@ import * as math from 'mathjs';
 import config from './config';
 
 import {
-  checkAPIResponseError,
-  checkRespObjDefined,
-  checkRespArrayLength,
   checkAccountId,
+  checkAPIResponseError,
   checkMandatoryParams,
+  checkRespArrayLength,
+  checkRespObjDefined,
+  CheckRunner,
   DEFAULT_LIMIT,
   getAPIResponse,
   getUrl,
   testRunner,
-  CheckRunner,
 } from './utils';
 
 const accountsPath = '/accounts';
@@ -111,14 +111,14 @@ const getAccountsWithTimeAndLimitParams = async (server) => {
   });
   let accounts = await getAPIResponse(url, jsonRespKey);
 
-  const checkRunnder = new CheckRunner()
+  const checkRunner = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
     .withCheckSpec(checkRespObjDefined, {message: 'accounts is undefined'})
     .withCheckSpec(checkRespArrayLength, {
       limit: 1,
       message: (accts) => `accounts.length of ${accts.length} was expected to be 1`,
     });
-  let result = checkRunnder.run(accounts);
+  let result = checkRunner.run(accounts);
   if (!result.passed) {
     return {url, ...result};
   }
@@ -131,7 +131,7 @@ const getAccountsWithTimeAndLimitParams = async (server) => {
   });
   accounts = await getAPIResponse(url, jsonRespKey);
 
-  result = checkRunnder.run(accounts);
+  result = checkRunner.run(accounts);
   if (!result.passed) {
     return {url, ...result};
   }

--- a/hedera-mirror-rest/monitoring/monitor_apis/common.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/common.js
@@ -21,7 +21,6 @@
 import config from './config';
 
 const currentResults = {}; // Results of current tests are stored here
-const pids = {}; // PIDs for the monitoring test processes
 
 /**
  * Initializer for results
@@ -88,63 +87,35 @@ const getStatus = () => {
  */
 const getStatusByName = (name) => {
   let ret = {
-    numPassedTests: 0,
-    numFailedTests: 0,
-    success: false,
-    testResults: [],
-    message: 'Failed',
     httpCode: 400,
+    results: {
+      numFailedTests: 0,
+      numPassedTests: 0,
+      message: 'Failed',
+      success: false,
+      testResults: [],
+    },
   };
 
   // Return 404 (Not found) for illegal name of the serer
   if (name === undefined || name === null) {
     ret.httpCode = 404;
-    ret.message = `Not found. Net: ${name}`;
+    ret.results.message = `Not found. Net: ${name}`;
     return ret;
   }
 
   // Return 404 (Not found) for if the server doesn't appear in our results table
-  if (!currentResults[name] || !currentResults[name].results) {
+  const currentResult = currentResults[name];
+  if (!currentResult || !currentResult.results) {
     ret.httpCode = 404;
-    ret.message = `Test results unavailable for server: ${name}`;
+    ret.results.message = `Test results unavailable for server: ${name}`;
     return ret;
   }
 
   // Return the results saved in the currentResults object
-  ret = currentResults[name];
-  ret.httpCode = currentResults[name].results.success ? 200 : 409;
+  ret = currentResult;
+  ret.httpCode = currentResult.results.success ? 200 : 409;
   return ret;
-};
-
-/**
- * Get the process pid for a given server
- * @param {Object} server the server for which the pid is requested
- * @return {Number} PID of the test process running for the given server
- */
-const getProcess = (server) => {
-  return pids[server.baseUrl];
-};
-
-/**
- * Stores the process pid for a given server
- * @param {Object} server the server for which the pid needs to be stored
- * @param {number} count
- * @return None
- */
-const saveProcess = (server, count) => {
-  pids[server.baseUrl] = {
-    id: server.name,
-    encountered: count,
-  };
-};
-
-/**
- * Deletes the process pid for a given server (when the test process returns)
- * @param {Object} server the server for which the pid needs to be deleted
- * @return None
- */
-const deleteProcess = (server) => {
-  delete pids[server.baseUrl];
 };
 
 export default {
@@ -153,7 +124,4 @@ export default {
   getServerCurrentResults,
   getStatus,
   getStatusByName,
-  getProcess,
-  saveProcess,
-  deleteProcess,
 };

--- a/hedera-mirror-rest/monitoring/monitor_apis/config.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/config.js
@@ -21,16 +21,15 @@
 import extend from 'extend';
 import fs from 'fs';
 import _ from 'lodash';
-import log4js from 'log4js';
+import logger from './logger';
 import path from 'path';
 import {fileURLToPath} from 'url';
-
-const logger = log4js.getLogger();
 
 const REQUIRED_FIELDS = [
   'servers',
   'interval',
   'shard',
+  'timeout',
   'account.intervalMultiplier',
   'balance.freshnessThreshold',
   'balance.intervalMultiplier',

--- a/hedera-mirror-rest/monitoring/monitor_apis/config/default.serverlist.json
+++ b/hedera-mirror-rest/monitoring/monitor_apis/config/default.serverlist.json
@@ -12,6 +12,7 @@
     "minBackoff": 50
   },
   "shard": 0,
+  "timeout": 10,
   "account": {
     "enabled": true,
     "intervalMultiplier": 1,

--- a/hedera-mirror-rest/monitoring/monitor_apis/logger.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/logger.js
@@ -1,0 +1,43 @@
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+// Logger
+import log4js from 'log4js';
+
+log4js.configure({
+  appenders: {
+    console: {
+      layout: {
+        pattern: '%d{yyyy-MM-ddThh:mm:ss.SSSO} %p %m',
+        type: 'pattern',
+      },
+      type: 'stdout',
+    },
+  },
+  categories: {
+    default: {
+      appenders: ['console'],
+      level: 'info',
+    },
+  },
+});
+global.logger = log4js.getLogger();
+
+export default logger;

--- a/hedera-mirror-rest/monitoring/monitor_apis/monitor_tests.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/monitor_tests.js
@@ -50,7 +50,7 @@ const counters = {};
  * @param {Object} server object provided by the user
  * @return {Object} results object capturing tests for given endpoint
  */
-const runTests = (server) => {
+const runTests = async (server) => {
   const counter = server.name in counters ? counters[server.name] : 0;
   const skippedResource = [];
   const enabledTestModules = allTestModules.filter((testModule) => {

--- a/hedera-mirror-rest/monitoring/monitor_apis/utils.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/utils.js
@@ -109,7 +109,7 @@ const getAPIResponse = async (url, key = undefined) => {
     () => {
       controller.abort();
     },
-    60 * 1000 // in ms
+    config.timeout * 1000 // in ms
   );
 
   try {
@@ -131,13 +131,13 @@ const getAPIResponse = async (url, key = undefined) => {
 class ServerTestResult {
   constructor() {
     this.result = {
-      testResults: [],
-      numPassedTests: 0,
-      numFailedTests: 0,
-      success: true,
-      message: '',
-      startTime: Date.now(),
       endTime: 0,
+      message: '',
+      numFailedTests: 0,
+      numPassedTests: 0,
+      startTime: Date.now(),
+      success: true,
+      testResults: [],
     };
   }
 
@@ -174,11 +174,11 @@ const testRunner = (server, testClassResult, resource) => {
 
     const testResult = {
       at: start,
+      failureMessages: !result.passed ? [result.message] : [],
+      message: result.passed ? result.message : '',
+      resource,
       result: result.passed ? 'passed' : 'failed',
       url: result.url,
-      message: result.passed ? result.message : '',
-      failureMessages: !result.passed ? [result.message] : [],
-      resource,
     };
 
     if (!result.passed) {
@@ -187,38 +187,6 @@ const testRunner = (server, testClassResult, resource) => {
 
     testClassResult.addTestResult(testResult);
   };
-};
-
-/**
- * Helper function to create a json object for failed test results
- * @param {String} title Title in the jest output
- * @param {String} msg Message in the jest output
- * @return {Object} Constructed failed result object
- */
-const createFailedResultJson = (title, msg) => {
-  const failedResultJson = new ServerTestResult().result;
-  failedResultJson.numFailedTests = 1;
-  failedResultJson.success = false;
-  failedResultJson.message = 'Prerequisite tests failed';
-  failedResultJson.testResults = [
-    {
-      at: (new Date().getTime() / 1000).toFixed(3),
-      message: `${title}: ${msg}`,
-      result: 'failed',
-      assertionResults: [
-        {
-          ancestorTitles: title,
-          failureMessages: [],
-          fullName: `${title}: ${msg}`,
-          location: null,
-          status: 'failed',
-          title: msg,
-        },
-      ],
-    },
-  ];
-
-  return failedResultJson;
 };
 
 const checkAPIResponseError = (resp, option) => {
@@ -450,7 +418,6 @@ export {
   checkResourceFreshness,
   checkRespArrayLength,
   checkRespObjDefined,
-  createFailedResultJson,
   getAPIResponse,
   getUrl,
   testRunner,


### PR DESCRIPTION
**Description**:

* Add a configurable API timeout property and reduce it from 60s to 10s by default
* Add a run count to logs to trace concurrent executions
* Fix asynchronous test execution in various places
* Fix `TypeError: Cannot read properties of undefined (reading 'numPassedTests')` for `/api/v1/status/:name` with non-existing name
* Fix not logging configuration to stdout
* Fix JSON response fields not ordered alphabetically
* Remove brittle `pid` tracking in favor of a `running` flag on each server

**Related issue(s)**:

Fixes #4342

**Notes for reviewer**:

Will let it run over the weekend in integration against mainnet-public.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
