### PR TITLE
Update Signature Count Consensus Calculation

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/NodeStakeRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/NodeStakeRepository.java
@@ -35,8 +35,7 @@ public interface NodeStakeRepository extends CrudRepository<NodeStake, NodeStake
 
     String NODE_STAKE_CACHE = "node_stake";
 
-    @Cacheable(cacheManager = EXPIRE_AFTER_24H, cacheNames = NODE_STAKE_CACHE,
-            unless = "#result == null or #result.size() == 0")
+    @Cacheable(cacheManager = EXPIRE_AFTER_24H, cacheNames = NODE_STAKE_CACHE)
     @Query(value = "select * from node_stake where consensus_timestamp = (select max(consensus_timestamp) from " +
             "node_stake)", nativeQuery = true)
     List<NodeStake> findLatest();

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/IntegrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/IntegrationTest.java
@@ -99,7 +99,7 @@ public abstract class IntegrationTest {
         return findHistory(historyClass, ids, null);
     }
 
-    protected  <T> Collection<T> findHistory(Class<T> historyClass, String ids, String table) {
+    protected <T> Collection<T> findHistory(Class<T> historyClass, String ids, String table) {
         if (StringUtils.isEmpty(table)) {
             table = CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, historyClass.getSimpleName());
         }
@@ -108,6 +108,21 @@ public abstract class IntegrationTest {
 
     protected List<NonFeeTransfer> findNonFeeTransfers() {
         return jdbcOperations.query(SELECT_NON_FEE_TRANSFERS_QUERY, NON_FEE_TRANSFER_ROW_MAPPER);
+    }
+
+    protected void nodeStakes(long... stakes) {
+        var timestamp = domainBuilder.timestamp();
+        int nodeId = 100;
+        for (long stake : stakes) {
+            final int finalNodeId = nodeId;
+            domainBuilder.nodeStake()
+                    .customize(n -> n
+                            .nodeId(finalNodeId)
+                            .consensusTimestamp(timestamp)
+                            .stake(stake))
+                    .persist();
+            nodeId++;
+        }
     }
 
     protected void reset() {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/NodeSignatureVerifierTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/NodeSignatureVerifierTest.java
@@ -35,6 +35,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Resource;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -68,7 +69,7 @@ class NodeSignatureVerifierTest extends IntegrationTest {
     @Mock
     private CommonDownloaderProperties commonDownloaderProperties;
     private NodeSignatureVerifier nodeSignatureVerifier;
-    @Mock
+    @Resource
     private NodeStakeRepository nodeStakeRepository;
 
     @SneakyThrows
@@ -91,8 +92,11 @@ class NodeSignatureVerifierTest extends IntegrationTest {
         signer.initSign(privateKey);
         Map<String, PublicKey> nodeAccountIDPubKeyMap = new HashMap();
         nodeAccountIDPubKeyMap.put("0.0.3", publicKey);
+        nodeStakes(0);
         when(addressBookService.getCurrent()).thenReturn(currentAddressBook);
         when(currentAddressBook.getNodeAccountIDPubKeyMap()).thenReturn(nodeAccountIDPubKeyMap);
+        var nodeIdNodeAccountIdMap = Map.of(100L, nodeId);
+        when(currentAddressBook.getNodeIdNodeAccountIdMap()).thenReturn(nodeIdNodeAccountIdMap);
         when(commonDownloaderProperties.getConsensusRatio()).thenReturn(BigDecimal.ONE.divide(BigDecimal.valueOf(3),
                 19, RoundingMode.DOWN));
     }
@@ -161,6 +165,8 @@ class NodeSignatureVerifierTest extends IntegrationTest {
         nodeAccountIDPubKeyMap.put("0.0.6", publicKey);
 
         when(currentAddressBook.getNodeAccountIDPubKeyMap()).thenReturn(nodeAccountIDPubKeyMap);
+        when(currentAddressBook.getNodeIdNodeAccountIdMap()).thenReturn(Map.of(100L, nodeId, 101L,
+                nodeId, 102L, nodeId, 103L, nodeId));
 
         List<FileStreamSignature> fileStreamSignatures = Arrays.asList(buildBareBonesFileStreamSignature());
         Exception e = assertThrows(SignatureVerificationException.class, () -> nodeSignatureVerifier
@@ -182,6 +188,8 @@ class NodeSignatureVerifierTest extends IntegrationTest {
         nodeAccountIDPubKeyMap.put("0.0.10", publicKey);
 
         when(currentAddressBook.getNodeAccountIDPubKeyMap()).thenReturn(nodeAccountIDPubKeyMap);
+        when(currentAddressBook.getNodeIdNodeAccountIdMap()).thenReturn(Map.of(100L, nodeId, 101L,
+                nodeId, 102L, nodeId, 103L, nodeId, 104L, nodeId, 105L, nodeId, 106L, nodeId, 107L, nodeId));
         when(commonDownloaderProperties.getConsensusRatio()).thenReturn(BigDecimal.ZERO);
 
         byte[] fileHash = TestUtils.generateRandomByteArray(48);
@@ -207,6 +215,8 @@ class NodeSignatureVerifierTest extends IntegrationTest {
         nodeAccountIDPubKeyMap.put("0.0.10", publicKey);
 
         when(currentAddressBook.getNodeAccountIDPubKeyMap()).thenReturn(nodeAccountIDPubKeyMap);
+        when(currentAddressBook.getNodeIdNodeAccountIdMap()).thenReturn(Map.of(100L, nodeId, 101L, nodeId, 102L, nodeId,
+                103L, nodeId, 104L, nodeId, 105L, nodeId, 106L, nodeId, 107L, nodeId));
         when(commonDownloaderProperties.getConsensusRatio()).thenReturn(BigDecimal.ZERO);
 
         Exception e = assertThrows(SignatureVerificationException.class, () -> nodeSignatureVerifier
@@ -222,6 +232,8 @@ class NodeSignatureVerifierTest extends IntegrationTest {
         nodeAccountIDPubKeyMap.put("0.0.4", publicKey);
         nodeAccountIDPubKeyMap.put("0.0.5", publicKey);
         when(currentAddressBook.getNodeAccountIDPubKeyMap()).thenReturn(nodeAccountIDPubKeyMap);
+        when(currentAddressBook.getNodeIdNodeAccountIdMap()).thenReturn(Map.of(100L, nodeId, 101L, nodeId, 102L,
+                nodeId));
 
         byte[] fileHash = TestUtils.generateRandomByteArray(48);
         byte[] fileHashSignature = signHash(fileHash);
@@ -239,6 +251,8 @@ class NodeSignatureVerifierTest extends IntegrationTest {
         nodeAccountIDPubKeyMap.put("0.0.4", publicKey);
         nodeAccountIDPubKeyMap.put("0.0.5", publicKey);
         when(currentAddressBook.getNodeAccountIDPubKeyMap()).thenReturn(nodeAccountIDPubKeyMap);
+        when(currentAddressBook.getNodeIdNodeAccountIdMap()).thenReturn(Map.of(100L, nodeId, 101L, nodeId, 102L,
+                nodeId));
 
         byte[] fileHash = TestUtils.generateRandomByteArray(48);
         byte[] fileHashSignature = signHash(fileHash);
@@ -265,7 +279,11 @@ class NodeSignatureVerifierTest extends IntegrationTest {
         nodeAccountIDPubKeyMap.put("0.0.3", publicKey);
         nodeAccountIDPubKeyMap.put("0.0.4", publicKey);
         nodeAccountIDPubKeyMap.put("0.0.5", publicKey);
+        nodeStakes(0, 0, 0);
         when(currentAddressBook.getNodeAccountIDPubKeyMap()).thenReturn(nodeAccountIDPubKeyMap);
+        when(currentAddressBook.getNodeIdNodeAccountIdMap()).thenReturn(Map.of(100L, nodeId, 101L,
+                EntityId.of(0L, 0L, 4L, EntityType.ACCOUNT), 102L,
+                EntityId.of(0L, 0L, 5L, EntityType.ACCOUNT)));
         when(commonDownloaderProperties.getConsensusRatio()).thenReturn(BigDecimal.ONE);
 
         byte[] fileHash = TestUtils.generateRandomByteArray(48);


### PR DESCRIPTION
**Description**:
On Mainnet and Testnet, when Node Stakes are not being used for consensus, the NodeStakes Repository returns a list of Node Stakes that all contain a staking amount of 0. This is used to indicate that Signatures should be counted. This PR updates the means of counting signatures to accept stakes of 0 as a substitute for counting a signature. 

Also this PR updates the caching for NodeStakeRepository to cache empty results and it modifies the debug logging in the event that consensus cannot be reached. 

**Related issue(s)**:

Fixes #4418

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
