### PR TITLE
Fix mainnet-public monitor alerts (0.64)

### DIFF
--- a/hedera-mirror-rest/monitoring/monitor_apis/account_tests.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/account_tests.js
@@ -23,16 +23,16 @@ import * as math from 'mathjs';
 import config from './config';
 
 import {
-  checkAPIResponseError,
-  checkRespObjDefined,
-  checkRespArrayLength,
   checkAccountId,
+  checkAPIResponseError,
   checkMandatoryParams,
+  checkRespArrayLength,
+  checkRespObjDefined,
+  CheckRunner,
   DEFAULT_LIMIT,
   getAPIResponse,
   getUrl,
   testRunner,
-  CheckRunner,
 } from './utils';
 
 const accountsPath = '/accounts';
@@ -111,14 +111,14 @@ const getAccountsWithTimeAndLimitParams = async (server) => {
   });
   let accounts = await getAPIResponse(url, jsonRespKey);
 
-  const checkRunnder = new CheckRunner()
+  const checkRunner = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
     .withCheckSpec(checkRespObjDefined, {message: 'accounts is undefined'})
     .withCheckSpec(checkRespArrayLength, {
       limit: 1,
       message: (accts) => `accounts.length of ${accts.length} was expected to be 1`,
     });
-  let result = checkRunnder.run(accounts);
+  let result = checkRunner.run(accounts);
   if (!result.passed) {
     return {url, ...result};
   }
@@ -131,7 +131,7 @@ const getAccountsWithTimeAndLimitParams = async (server) => {
   });
   accounts = await getAPIResponse(url, jsonRespKey);
 
-  result = checkRunnder.run(accounts);
+  result = checkRunner.run(accounts);
   if (!result.passed) {
     return {url, ...result};
   }

--- a/hedera-mirror-rest/monitoring/monitor_apis/common.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/common.js
@@ -21,7 +21,6 @@
 import config from './config';
 
 const currentResults = {}; // Results of current tests are stored here
-const pids = {}; // PIDs for the monitoring test processes
 
 /**
  * Initializer for results
@@ -88,63 +87,35 @@ const getStatus = () => {
  */
 const getStatusByName = (name) => {
   let ret = {
-    numPassedTests: 0,
-    numFailedTests: 0,
-    success: false,
-    testResults: [],
-    message: 'Failed',
     httpCode: 400,
+    results: {
+      message: 'Failed',
+      numFailedTests: 0,
+      numPassedTests: 0,
+      success: false,
+      testResults: [],
+    },
   };
 
   // Return 404 (Not found) for illegal name of the serer
   if (name === undefined || name === null) {
     ret.httpCode = 404;
-    ret.message = `Not found. Net: ${name}`;
+    ret.results.message = `Name ${name} not found`;
     return ret;
   }
 
   // Return 404 (Not found) for if the server doesn't appear in our results table
-  if (!currentResults[name] || !currentResults[name].results) {
+  const currentResult = currentResults[name];
+  if (!currentResult || !currentResult.results) {
     ret.httpCode = 404;
-    ret.message = `Test results unavailable for server: ${name}`;
+    ret.results.message = `Test results unavailable for server: ${name}`;
     return ret;
   }
 
   // Return the results saved in the currentResults object
-  ret = currentResults[name];
-  ret.httpCode = currentResults[name].results.success ? 200 : 409;
+  ret = currentResult;
+  ret.httpCode = currentResult.results.success ? 200 : 409;
   return ret;
-};
-
-/**
- * Get the process pid for a given server
- * @param {Object} server the server for which the pid is requested
- * @return {Number} PID of the test process running for the given server
- */
-const getProcess = (server) => {
-  return pids[server.baseUrl];
-};
-
-/**
- * Stores the process pid for a given server
- * @param {Object} server the server for which the pid needs to be stored
- * @param {number} count
- * @return None
- */
-const saveProcess = (server, count) => {
-  pids[server.baseUrl] = {
-    id: server.name,
-    encountered: count,
-  };
-};
-
-/**
- * Deletes the process pid for a given server (when the test process returns)
- * @param {Object} server the server for which the pid needs to be deleted
- * @return None
- */
-const deleteProcess = (server) => {
-  delete pids[server.baseUrl];
 };
 
 export default {
@@ -153,7 +124,4 @@ export default {
   getServerCurrentResults,
   getStatus,
   getStatusByName,
-  getProcess,
-  saveProcess,
-  deleteProcess,
 };

--- a/hedera-mirror-rest/monitoring/monitor_apis/config.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/config.js
@@ -21,16 +21,15 @@
 import extend from 'extend';
 import fs from 'fs';
 import _ from 'lodash';
-import log4js from 'log4js';
+import logger from './logger';
 import path from 'path';
 import {fileURLToPath} from 'url';
-
-const logger = log4js.getLogger();
 
 const REQUIRED_FIELDS = [
   'servers',
   'interval',
   'shard',
+  'timeout',
   'account.intervalMultiplier',
   'balance.freshnessThreshold',
   'balance.intervalMultiplier',

--- a/hedera-mirror-rest/monitoring/monitor_apis/config/default.serverlist.json
+++ b/hedera-mirror-rest/monitoring/monitor_apis/config/default.serverlist.json
@@ -8,10 +8,11 @@
   ],
   "interval": 60,
   "retry": {
-    "maxAttempts": 10,
-    "minBackoff": 50
+    "maxAttempts": 2,
+    "minBackoff": 1000
   },
   "shard": 0,
+  "timeout": 30,
   "account": {
     "enabled": true,
     "intervalMultiplier": 1,

--- a/hedera-mirror-rest/monitoring/monitor_apis/logger.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/logger.js
@@ -1,0 +1,43 @@
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+// Logger
+import log4js from 'log4js';
+
+log4js.configure({
+  appenders: {
+    console: {
+      layout: {
+        pattern: '%d{yyyy-MM-ddThh:mm:ss.SSSO} %p %m',
+        type: 'pattern',
+      },
+      type: 'stdout',
+    },
+  },
+  categories: {
+    default: {
+      appenders: ['console'],
+      level: 'info',
+    },
+  },
+});
+global.logger = log4js.getLogger();
+
+export default logger;

--- a/hedera-mirror-rest/monitoring/monitor_apis/monitor.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/monitor.js
@@ -20,9 +20,8 @@
 
 import common from './common';
 import {runTests} from './monitor_tests';
-import * as utils from './utils';
 
-const retryCountMax = 3; // # of times a single process can retry
+let runCount = 0;
 
 /**
  * Main function to run the tests and save results
@@ -30,61 +29,44 @@ const retryCountMax = 3; // # of times a single process can retry
  * @return None
  */
 const runEverything = async (servers) => {
-  try {
-    if (servers.length === 0) {
+  const serverTests = [];
+  const startTime = Date.now();
+  const currentRun = ++runCount;
+  logger.info(`Running test #${currentRun}`);
+
+  servers.forEach((server) => {
+    server.run = currentRun;
+    if (server.running) {
+      logger.warn(`Skipping test run #${currentRun} for ${server.name} since a previous run is still in progress`);
       return;
     }
 
-    for (const server of servers) {
-      const processObj = common.getProcess(server);
+    server.running = true;
 
-      if (processObj === undefined) {
-        // execute test and store name
-        runTests(server).then((outJson) => {
-          let results;
-          if (outJson.testResults) {
-            results = outJson;
-            const total = results.testResults.length;
-            logger.info(`Completed tests run for ${server.name} with ${results.numPassedTests}/${total} tests passed`);
-          } else {
-            results = utils.createFailedResultJson(
-              `Test result unavailable`,
-              `Test results not available for: ${server.name}`
-            );
-            logger.warn(`Incomplete tests for ${server.name}`);
-          }
-
-          common.deleteProcess(server);
-          common.saveResults(server, results);
-        });
-
-        common.saveProcess(server, 1);
-      } else {
-        const results = utils.createFailedResultJson(
-          `Test result unavailable`,
-          `Previous tests are still running for: ${server.name}`
+    const serverTest = runTests(server)
+      .then((results) => {
+        const total = results.testResults.length;
+        const elapsed = Date.now() - startTime;
+        logger.info(
+          `Completed test run #${currentRun} for ${server.name} with ${results.numPassedTests}/${total} tests passed in ${elapsed} ms`
         );
-
-        // escape race condition, kill stored process and allow next process to attempt test
-        if (processObj.encountered >= retryCountMax) {
-          logger.warn(
-            `Previous tests for ${server.name} persisted for ${processObj.encountered} rounds. Clearing saved process.`
-          );
-          common.deleteProcess(server);
-        } else {
-          logger.info(
-            `Previous tests for ${server.name} still running after ${processObj.encountered} rounds. Incrementing count.`
-          );
-          common.saveProcess(server, processObj.encountered + 1);
-        }
-
         common.saveResults(server, results);
-        logger.warn(`Incomplete tests for ${server.name}`);
-      }
-    }
-  } catch (err) {
-    logger.error(`Error in runEverything: `, err);
-  }
+      })
+      .catch((error) => {
+        const elapsed = Date.now() - startTime;
+        logger.error(`Error running tests #${currentRun} for ${server.name} in ${elapsed} ms: ${error}`);
+      })
+      .finally(() => {
+        server.running = false;
+      });
+
+    serverTests.push(serverTest);
+  });
+
+  return Promise.all(serverTests).then(() => {
+    const elapsed = Date.now() - startTime;
+    logger.info(`Finished test run #${currentRun} in ${elapsed} ms`);
+  });
 };
 
 export {runEverything};

--- a/hedera-mirror-rest/monitoring/monitor_apis/monitor_tests.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/monitor_tests.js
@@ -50,7 +50,7 @@ const counters = {};
  * @param {Object} server object provided by the user
  * @return {Object} results object capturing tests for given endpoint
  */
-const runTests = (server) => {
+const runTests = async (server) => {
   const counter = server.name in counters ? counters[server.name] : 0;
   const skippedResource = [];
   const enabledTestModules = allTestModules.filter((testModule) => {

--- a/hedera-mirror-rest/monitoring/monitor_apis/transaction_tests.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/transaction_tests.js
@@ -25,15 +25,16 @@ import config from './config';
 import {
   checkAPIResponseError,
   checkElementsOrder,
-  checkRespObjDefined,
-  checkRespArrayLength,
   checkMandatoryParams,
   checkResourceFreshness,
+  checkRespArrayLength,
+  checkRespObj,
+  checkRespObjDefined,
+  CheckRunner,
   DEFAULT_LIMIT,
   getAPIResponse,
   getUrl,
   testRunner,
-  CheckRunner,
 } from './utils';
 
 const transactionsPath = '/transactions';
@@ -281,12 +282,18 @@ const getSuccessfulTransactionById = async (server) => {
   const singleTransactions = await getAPIResponse(url, jsonRespKey);
 
   // only verify the single successful transaction
-  result = checkRunner
-    .resetCheckSpec(checkRespArrayLength, {
+  result = new CheckRunner()
+    .withCheckSpec(checkAPIResponseError)
+    .withCheckSpec(checkRespObjDefined, {message: 'transactions is undefined'})
+    .withCheckSpec(checkRespArrayLength, {
       func: (length) => length >= 1,
       message: (elements) => `transactions.length of ${elements.length} was expected to be >= 1`,
     })
-    .run(singleTransactions.filter((tx) => tx.result === 'SUCCESS'));
+    .withCheckSpec(checkRespObj, {
+      predicate: (data) => data.filter((tx) => tx.result === 'SUCCESS').length === 1,
+      message: `Transactions array should have at least one successful transaction`,
+    })
+    .run(singleTransactions);
   if (!result.passed) {
     return {url, ...result};
   }


### PR DESCRIPTION
**Description**:

Cherry-pick of #4405 to `release/0.64`.

* Add a configurable API timeout property and reduce it from `60s` to `30s` by default
* Add run ID to logs to trace concurrent executions
* Change retry max attempts from `10` to `2`
* Change retry backoff from `50ms` to `1s`
* Change retry to retry `5xx` status in addition to `429`
* Fix retries exhausted not throwing an error
* Fix JSON response fields not ordered alphabetically
* Fix not logging configuration to stdout
* Fix `TypeError: Cannot read properties of undefined (reading 'numPassedTests')` for `/api/v1/status/:name` with non-existing name
* Fix `TypeError: singleTransactions.filter is not a function`
* Fix uncaught errors due to race condition in async behavior
* Remove brittle pid tracking in favor of a running flag on each server

**Related issue(s)**:

Relates to #4342

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
