### PR TITLE
Add a retry middleware to reduce 502 errors

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -107,7 +107,8 @@ a [Standalone NEG](https://cloud.google.com/kubernetes-engine/docs/how-to/standa
          cloud.google.com/neg: '{"exposed_ports": {"443": {"name": "<tls_neg_name>"}}}'
    ```
 
-   > **_Note:_** Ensure the NEG names are cluster unique to support shared NEGs across separate globally distributed clusters
+   > **_Note:_** Ensure the NEG names are cluster unique to support shared NEGs across separate globally distributed
+   > clusters
 
    The annotation will ensure that a NEG is created for each name specified, with the endpoints pointing to the Traefik
    pod IPs in your cluster on the configured port. These ports should match the ports exposed by Traefik in the common
@@ -137,7 +138,6 @@ test:
         test:
           acceptance:
             network:
-            # Do not use use 0.0.2 or 0.0.50 for operator to ensure crypto transfers are not waived
             operatorId:
             operatorKey:
 ```

--- a/charts/hedera-mirror-common/Chart.yaml
+++ b/charts/hedera-mirror-common/Chart.yaml
@@ -3,25 +3,25 @@ appVersion: "main"
 dependencies:
   - name: loki
     condition: loki.enabled
-    version: 2.12.2
+    version: 2.16.0
     repository: https://grafana.github.io/helm-charts
   - condition: prometheus-adapter.enabled
     name: prometheus-adapter
     repository: https://prometheus-community.github.io/helm-charts
-    version: 3.3.1
+    version: 3.4.0
   - alias: prometheus
     condition: prometheus.enabled
     name: kube-prometheus-stack
     repository: https://prometheus-community.github.io/helm-charts
-    version: 36.2.1
+    version: 39.11.0
   - name: promtail
     condition: promtail.enabled
-    version: 6.0.1
+    version: 6.3.0
     repository: https://grafana.github.io/helm-charts
   - condition: traefik.enabled
     name: traefik
     repository: https://helm.traefik.io/traefik
-    version: 10.24.0
+    version: 10.24.1
 description: Hedera Mirror Node common components installed globally for use across namespaces
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067

--- a/charts/hedera-mirror-common/dashboards/kubernetes-cluster-monitoring-via-prometheus_rev2.json
+++ b/charts/hedera-mirror-common/dashboards/kubernetes-cluster-monitoring-via-prometheus_rev2.json
@@ -728,7 +728,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum (rate (container_cpu_usage_seconds_total{image!=\"\",kubernetes_io_hostname=~\"^$Node$\",namespace=~\"$namespace\"}[$interval])) by (pod)",
+          "expr": "sum (rate (container_cpu_usage_seconds_total{kubernetes_io_hostname=~\"^$Node$\",namespace=~\"$namespace\"}[$interval])) by (pod)",
           "format": "time_series",
           "interval": "10s",
           "intervalFactor": 1,
@@ -953,7 +953,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(rate(container_cpu_cfs_throttled_seconds_total{kubernetes_io_hostname=~\"^$Node$\", container!=\"\",namespace=~\"$namespace\"}[$interval])) by (container, pod)",
+          "expr": "sum(rate(container_cpu_cfs_throttled_seconds_total{kubernetes_io_hostname=~\"^$Node$\",namespace=~\"$namespace\"}[$interval])) by (container, pod)",
           "interval": "10s",
           "legendFormat": "{{ pod }}/{{container}}",
           "refId": "B"
@@ -1064,7 +1064,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(rate(container_cpu_usage_seconds_total{image!=\"\",container!=\"POD\",kubernetes_io_hostname=~\"^$Node$\",namespace=~\"$namespace\"}[$interval])) by (container, pod)",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{container!=\"POD\",kubernetes_io_hostname=~\"^$Node$\",namespace=~\"$namespace\"}[$interval])) by (container, pod)",
           "format": "time_series",
           "hide": false,
           "interval": "10s",
@@ -1195,7 +1195,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum (container_memory_working_set_bytes{image!=\"\",kubernetes_io_hostname=~\"^$Node$\",namespace=~\"$namespace\"}) by (pod)",
+          "expr": "sum (container_memory_working_set_bytes{kubernetes_io_hostname=~\"^$Node$\",namespace=~\"$namespace\"}) by (pod)",
           "format": "time_series",
           "interval": "10s",
           "intervalFactor": 1,
@@ -1309,7 +1309,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(container_memory_working_set_bytes{kubernetes_io_hostname=~\"^$Node$\",namespace=~\"$namespace\"}) by (pod, container) / sum(kube_pod_container_resource_limits{kubernetes_io_hostname=~\"^$Node$\",namespace=~\"$namespace\"}) by (pod, container)",
+          "expr": "sum(container_memory_working_set_bytes{kubernetes_io_hostname=~\"^$Node$\",namespace=~\"$namespace\"}) by (pod) / sum(kube_pod_container_resource_limits{kubernetes_io_hostname=~\"^$Node$\",namespace=~\"$namespace\"}) by (pod)",
           "interval": "10s",
           "legendFormat": "{{ pod }}",
           "refId": "B"
@@ -1417,7 +1417,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum (container_memory_working_set_bytes{image!=\"\",container!=\"POD\",kubernetes_io_hostname=~\"^$Node$\",namespace=~\"$namespace\"}) by (container, pod)",
+          "expr": "sum (container_memory_working_set_bytes{container!=\"POD\",kubernetes_io_hostname=~\"^$Node$\",namespace=~\"$namespace\"}) by (container, pod)",
           "format": "time_series",
           "interval": "10s",
           "intervalFactor": 1,

--- a/charts/hedera-mirror-grpc/templates/middleware.yaml
+++ b/charts/hedera-mirror-grpc/templates/middleware.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.ingress.enabled .Values.ingress.middleware.enabled -}}
+{{- if and .Values.global.middleware .Values.middleware -}}
 apiVersion: traefik.containo.us/v1alpha1
 kind: Middleware
 metadata:
@@ -8,54 +8,19 @@ metadata:
 spec:
   chain:
     middlewares:
-    - name: {{ include "hedera-mirror-grpc.fullname" . }}-ip-whitelist
-    - name: {{ include "hedera-mirror-grpc.fullname" . }}-connection-limit
-    - name: {{ include "hedera-mirror-grpc.fullname" . }}-rate-limit
-    - name: {{ include "hedera-mirror-grpc.fullname" . }}-circuit-breaker
+{{- range .Values.middleware }}
+      - name: {{ include "hedera-mirror-grpc.fullname" $ }}-{{ keys . | first | kebabcase }}
+{{- end }}
 
+{{- range .Values.middleware }}
 ---
 apiVersion: traefik.containo.us/v1alpha1
 kind: Middleware
 metadata:
-  labels: {{ include "hedera-mirror-grpc.labels" . | nindent 4 }}
-  name: {{ include "hedera-mirror-grpc.fullname" . }}-ip-whitelist
-  namespace: {{ include "hedera-mirror-grpc.namespace" . }}
+  labels: {{ include "hedera-mirror-grpc.labels" $ | nindent 4 }}
+  name: {{ include "hedera-mirror-grpc.fullname" $ }}-{{ keys . | first | kebabcase }}
+  namespace: {{ include "hedera-mirror-grpc.namespace" $ }}
 spec:
-  ipWhiteList:
-    sourceRange: {{ toYaml .Values.ingress.middleware.ipWhitelist | nindent 6 }}
-
----
-apiVersion: traefik.containo.us/v1alpha1
-kind: Middleware
-metadata:
-  labels: {{ include "hedera-mirror-grpc.labels" . | nindent 4 }}
-  name: {{ include "hedera-mirror-grpc.fullname" . }}-connection-limit
-  namespace: {{ include "hedera-mirror-grpc.namespace" . }}
-spec:
-  inFlightReq:
-    amount: {{ .Values.ingress.middleware.connectionsPerIP }}
-    sourceCriterion:
-      ipStrategy:
-        depth: 1
-
----
-apiVersion: traefik.containo.us/v1alpha1
-kind: Middleware
-metadata:
-  labels: {{- include "hedera-mirror-grpc.labels" . | nindent 4 }}
-  name: {{ include "hedera-mirror-grpc.fullname" . }}-circuit-breaker
-  namespace: {{ include "hedera-mirror-grpc.namespace" . }}
-spec:
-  circuitBreaker:
-    expression: {{ .Values.ingress.middleware.circuitBreaker }}
-
----
-apiVersion: traefik.containo.us/v1alpha1
-kind: Middleware
-metadata:
-  labels: {{- include "hedera-mirror-grpc.labels" . | nindent 4 }}
-  name: {{ include "hedera-mirror-grpc.fullname" . }}-rate-limit
-  namespace: {{ include "hedera-mirror-grpc.namespace" . }}
-spec:
-  rateLimit: {{ toYaml .Values.ingress.middleware.rateLimit | nindent 4 }}
-{{- end -}}
+  {{- . | toYaml | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/charts/hedera-mirror-grpc/values.yaml
+++ b/charts/hedera-mirror-grpc/values.yaml
@@ -60,6 +60,7 @@ fullnameOverride: ""
 
 global:
   image: {}
+  middleware: false
   namespaceOverride: ""
   podAnnotations: {}
 
@@ -94,16 +95,6 @@ ingress:
         - "/com.hedera.mirror.api.proto.ConsensusService"
         - "/com.hedera.mirror.api.proto.NetworkService"
         - "/grpc.reflection.v1alpha.ServerReflection"
-  middleware:
-    circuitBreaker: NetworkErrorRatio() > 0.10 || ResponseCodeRatio(500, 600, 0, 600) > 0.25
-    connectionsPerIP: 5
-    enabled: false
-    ipWhitelist:
-      - 0.0.0.0/0
-    rateLimit:
-      average: 20
-      sourceCriterion:
-        requestHost: true
   tls:
     enabled: false
     secretName: ""
@@ -117,6 +108,17 @@ livenessProbe:
   initialDelaySeconds: 50
   periodSeconds: 10
   timeoutSeconds: 2
+
+middleware:
+  - circuitBreaker:
+      expression: NetworkErrorRatio() > 0.10 || ResponseCodeRatio(500, 600, 0, 600) > 0.25
+  - rateLimit:
+      average: 5
+      sourceCriterion:
+        requestHost: true
+  - retry:
+      attempts: 3
+      initialInterval: 250ms
 
 nodeSelector: {}
 

--- a/charts/hedera-mirror-rest/templates/middleware.yaml
+++ b/charts/hedera-mirror-rest/templates/middleware.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.ingress.enabled .Values.ingress.middleware.enabled -}}
+{{- if and .Values.global.middleware .Values.middleware -}}
 apiVersion: traefik.containo.us/v1alpha1
 kind: Middleware
 metadata:
@@ -8,54 +8,19 @@ metadata:
 spec:
   chain:
     middlewares:
-    - name: {{ include "hedera-mirror-rest.fullname" . }}-ip-whitelist
-    - name: {{ include "hedera-mirror-rest.fullname" . }}-connection-limit
-    - name: {{ include "hedera-mirror-rest.fullname" . }}-rate-limit
-    - name: {{ include "hedera-mirror-rest.fullname" . }}-circuit-breaker
+{{- range .Values.middleware }}
+      - name: {{ include "hedera-mirror-rest.fullname" $ }}-{{ keys . | first | kebabcase }}
+{{- end }}
 
+{{- range .Values.middleware }}
 ---
 apiVersion: traefik.containo.us/v1alpha1
 kind: Middleware
 metadata:
-  labels: {{ include "hedera-mirror-rest.labels" . | nindent 4 }}
-  name: {{ include "hedera-mirror-rest.fullname" . }}-ip-whitelist
-  namespace: {{ include "hedera-mirror-rest.namespace" . }}
+  labels: {{ include "hedera-mirror-rest.labels" $ | nindent 4 }}
+  name: {{ include "hedera-mirror-rest.fullname" $ }}-{{ keys . | first | kebabcase }}
+  namespace: {{ include "hedera-mirror-rest.namespace" $ }}
 spec:
-  ipWhiteList:
-    sourceRange: {{ toYaml .Values.ingress.middleware.ipWhitelist | nindent 6 }}
-
----
-apiVersion: traefik.containo.us/v1alpha1
-kind: Middleware
-metadata:
-  labels: {{ include "hedera-mirror-rest.labels" . | nindent 4 }}
-  name: {{ include "hedera-mirror-rest.fullname" . }}-connection-limit
-  namespace: {{ include "hedera-mirror-rest.namespace" . }}
-spec:
-  inFlightReq:
-    amount: {{ .Values.ingress.middleware.connectionsPerIP }}
-    sourceCriterion:
-      ipStrategy:
-        depth: 1
-
----
-apiVersion: traefik.containo.us/v1alpha1
-kind: Middleware
-metadata:
-  labels: {{ include "hedera-mirror-rest.labels" . | nindent 4 }}
-  name: {{ include "hedera-mirror-rest.fullname" . }}-rate-limit
-  namespace: {{ include "hedera-mirror-rest.namespace" . }}
-spec:
-  rateLimit: {{ toYaml .Values.ingress.middleware.rateLimit | nindent 4 }}
-
----
-apiVersion: traefik.containo.us/v1alpha1
-kind: Middleware
-metadata:
-  labels: {{ include "hedera-mirror-rest.labels" . | nindent 4 }}
-  name: {{ include "hedera-mirror-rest.fullname" . }}-circuit-breaker
-  namespace: {{ include "hedera-mirror-rest.namespace" . }}
-spec:
-  circuitBreaker:
-    expression: {{ .Values.ingress.middleware.circuitBreaker }}
-{{- end -}}
+  {{- . | toYaml | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/charts/hedera-mirror-rest/values.yaml
+++ b/charts/hedera-mirror-rest/values.yaml
@@ -52,6 +52,7 @@ fullnameOverride: ""
 
 global:
   image: {}
+  middleware: false
   namespaceOverride: ""
   podAnnotations: {}
 
@@ -77,21 +78,12 @@ image:
 imagePullSecrets: []
 
 ingress:
-  annotations: {}
+  annotations:
+    traefik.ingress.kubernetes.io/router.middlewares: '{{ include "hedera-mirror-rest.namespace" . }}-{{ include "hedera-mirror-rest.fullname" . }}@kubernetescrd'
   enabled: true
   hosts:
     - host: ""
       paths: ["/api/v1"]
-  middleware:
-    circuitBreaker: NetworkErrorRatio() > 0.25 || ResponseCodeRatio(500, 600, 0, 600) > 0.25
-    connectionsPerIP: 5
-    enabled: false
-    ipWhitelist:
-      - 0.0.0.0/0
-    rateLimit:
-      average: 20
-      sourceCriterion:
-        requestHost: true
   tls:
     enabled: false
     secretName: ""
@@ -104,6 +96,13 @@ livenessProbe:
     port: http
   initialDelaySeconds: 25
   timeoutSeconds: 2
+
+middleware:
+  - circuitBreaker:
+      expression: NetworkErrorRatio() > 0.25 || ResponseCodeRatio(500, 600, 0, 600) > 0.25
+  - retry:
+      attempts: 10
+      initialInterval: 100ms
 
 nodeSelector: {}
 

--- a/charts/hedera-mirror-rosetta/templates/middleware.yaml
+++ b/charts/hedera-mirror-rosetta/templates/middleware.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.ingress.enabled .Values.ingress.middleware.enabled -}}
+{{- if and .Values.global.middleware .Values.middleware -}}
 apiVersion: traefik.containo.us/v1alpha1
 kind: Middleware
 metadata:
@@ -8,66 +8,19 @@ metadata:
 spec:
   chain:
     middlewares:
-    - name: {{ include "hedera-mirror-rosetta.fullname" . }}-ip-whitelist
-    - name: {{ include "hedera-mirror-rosetta.fullname" . }}-connection-limit
-    - name: {{ include "hedera-mirror-rosetta.fullname" . }}-rate-limit
-    - name: {{ include "hedera-mirror-rosetta.fullname" . }}-circuit-breaker
-    - name: {{ include "hedera-mirror-rosetta.fullname" . }}-strip-prefix
+{{- range .Values.middleware }}
+      - name: {{ include "hedera-mirror-rosetta.fullname" $ }}-{{ keys . | first | kebabcase }}
+{{- end }}
 
+{{- range .Values.middleware }}
 ---
 apiVersion: traefik.containo.us/v1alpha1
 kind: Middleware
 metadata:
-  labels: {{ include "hedera-mirror-rosetta.labels" . | nindent 4 }}
-  name: {{ include "hedera-mirror-rosetta.fullname" . }}-ip-whitelist
-  namespace: {{ include "hedera-mirror-rosetta.namespace" . }}
+  labels: {{ include "hedera-mirror-rosetta.labels" $ | nindent 4 }}
+  name: {{ include "hedera-mirror-rosetta.fullname" $ }}-{{ keys . | first | kebabcase }}
+  namespace: {{ include "hedera-mirror-rosetta.namespace" $ }}
 spec:
-  ipWhiteList:
-    sourceRange: {{ toYaml .Values.ingress.middleware.ipWhitelist | nindent 6 }}
-
----
-apiVersion: traefik.containo.us/v1alpha1
-kind: Middleware
-metadata:
-  labels: {{ include "hedera-mirror-rosetta.labels" . | nindent 4 }}
-  name: {{ include "hedera-mirror-rosetta.fullname" . }}-connection-limit
-  namespace: {{ include "hedera-mirror-rosetta.namespace" . }}
-spec:
-  inFlightReq:
-    amount: {{ .Values.ingress.middleware.connectionsPerIP }}
-    sourceCriterion:
-      ipStrategy:
-        depth: 1
-
----
-apiVersion: traefik.containo.us/v1alpha1
-kind: Middleware
-metadata:
-  labels: {{ include "hedera-mirror-rosetta.labels" . | nindent 4 }}
-  name: {{ include "hedera-mirror-rosetta.fullname" . }}-rate-limit
-  namespace: {{ include "hedera-mirror-rosetta.namespace" . }}
-spec:
-  rateLimit: {{ toYaml .Values.ingress.middleware.rateLimit | nindent 4 }}
-
----
-apiVersion: traefik.containo.us/v1alpha1
-kind: Middleware
-metadata:
-  labels: {{ include "hedera-mirror-rosetta.labels" . | nindent 4 }}
-  name: {{ include "hedera-mirror-rosetta.fullname" . }}-circuit-breaker
-  namespace: {{ include "hedera-mirror-rosetta.namespace" . }}
-spec:
-  circuitBreaker:
-    expression: {{ .Values.ingress.middleware.circuitBreaker }}
-
----
-apiVersion: traefik.containo.us/v1alpha1
-kind: Middleware
-metadata:
-  labels: {{ include "hedera-mirror-rosetta.labels" . | nindent 4 }}
-  name: {{ include "hedera-mirror-rosetta.fullname" . }}-strip-prefix
-  namespace: {{ include "hedera-mirror-rosetta.namespace" . }}
-spec:
-  stripPrefix:
-    prefixes: {{ toYaml .Values.ingress.middleware.stripPrefix | nindent 6 }}
-{{- end -}}
+  {{- . | toYaml | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/charts/hedera-mirror-rosetta/values.yaml
+++ b/charts/hedera-mirror-rosetta/values.yaml
@@ -46,6 +46,7 @@ fullnameOverride: ""
 
 global:
   image: {}
+  middleware: false
   namespaceOverride: ""
   podAnnotations: {}
 
@@ -85,18 +86,6 @@ ingress:
         - "/rosetta/mempool"
         - "/rosetta/network"
         - "/rosetta/search"
-  middleware:
-    circuitBreaker: NetworkErrorRatio() > 0.25 || ResponseCodeRatio(500, 600, 0, 600) > 0.25
-    connectionsPerIP: 5
-    enabled: false
-    ipWhitelist:
-      - 0.0.0.0/0
-    rateLimit:
-      average: 10
-      sourceCriterion:
-        requestHost: true
-    stripPrefix:
-      - "/rosetta"
   tls:
     enabled: false
     secretName: ""
@@ -111,6 +100,25 @@ livenessProbe:
   initialDelaySeconds: 30
   periodSeconds: 10
   timeoutSeconds: 2
+
+middleware:
+  - circuitBreaker:
+      expression: NetworkErrorRatio() > 0.25 || ResponseCodeRatio(500, 600, 0, 600) > 0.25
+  - inFlightReq:
+      amount: 5
+      sourceCriterion:
+        ipStrategy:
+          depth: 1
+  - rateLimit:
+      average: 10
+      sourceCriterion:
+        requestHost: true
+  - retry:
+      attempts: 3
+      initialInterval: 100ms
+  - stripPrefix:
+      prefixes:
+        - "/rosetta"
 
 nodeSelector: {}
 

--- a/charts/hedera-mirror-web3/templates/middleware.yaml
+++ b/charts/hedera-mirror-web3/templates/middleware.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.ingress.enabled .Values.ingress.middleware.enabled -}}
+{{- if and .Values.global.middleware .Values.middleware -}}
 apiVersion: traefik.containo.us/v1alpha1
 kind: Middleware
 metadata:
@@ -8,54 +8,19 @@ metadata:
 spec:
   chain:
     middlewares:
-    - name: {{ include "hedera-mirror-web3.fullname" . }}-ip-whitelist
-    - name: {{ include "hedera-mirror-web3.fullname" . }}-connection-limit
-    - name: {{ include "hedera-mirror-web3.fullname" . }}-rate-limit
-    - name: {{ include "hedera-mirror-web3.fullname" . }}-circuit-breaker
+{{- range .Values.middleware }}
+      - name: {{ include "hedera-mirror-web3.fullname" $ }}-{{ keys . | first | kebabcase }}
+{{- end }}
 
+{{- range .Values.middleware }}
 ---
 apiVersion: traefik.containo.us/v1alpha1
 kind: Middleware
 metadata:
-  labels: {{ include "hedera-mirror-web3.labels" . | nindent 4 }}
-  name: {{ include "hedera-mirror-web3.fullname" . }}-ip-whitelist
-  namespace: {{ include "hedera-mirror-web3.namespace" . }}
+  labels: {{ include "hedera-mirror-web3.labels" $ | nindent 4 }}
+  name: {{ include "hedera-mirror-web3.fullname" $ }}-{{ keys . | first | kebabcase }}
+  namespace: {{ include "hedera-mirror-web3.namespace" $ }}
 spec:
-  ipWhiteList:
-    sourceRange: {{ toYaml .Values.ingress.middleware.ipWhitelist | nindent 6 }}
-
----
-apiVersion: traefik.containo.us/v1alpha1
-kind: Middleware
-metadata:
-  labels: {{ include "hedera-mirror-web3.labels" . | nindent 4 }}
-  name: {{ include "hedera-mirror-web3.fullname" . }}-connection-limit
-  namespace: {{ include "hedera-mirror-web3.namespace" . }}
-spec:
-  inFlightReq:
-    amount: {{ .Values.ingress.middleware.connectionsPerIP }}
-    sourceCriterion:
-      ipStrategy:
-        depth: 1
-
----
-apiVersion: traefik.containo.us/v1alpha1
-kind: Middleware
-metadata:
-  labels: {{- include "hedera-mirror-web3.labels" . | nindent 4 }}
-  name: {{ include "hedera-mirror-web3.fullname" . }}-circuit-breaker
-  namespace: {{ include "hedera-mirror-web3.namespace" . }}
-spec:
-  circuitBreaker:
-    expression: {{ .Values.ingress.middleware.circuitBreaker }}
-
----
-apiVersion: traefik.containo.us/v1alpha1
-kind: Middleware
-metadata:
-  labels: {{- include "hedera-mirror-web3.labels" . | nindent 4 }}
-  name: {{ include "hedera-mirror-web3.fullname" . }}-rate-limit
-  namespace: {{ include "hedera-mirror-web3.namespace" . }}
-spec:
-  rateLimit: {{ toYaml .Values.ingress.middleware.rateLimit | nindent 4 }}
-{{- end -}}
+  {{- . | toYaml | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/charts/hedera-mirror-web3/values.yaml
+++ b/charts/hedera-mirror-web3/values.yaml
@@ -47,6 +47,7 @@ fullnameOverride: ""
 
 global:
   image: {}
+  middleware: false
   namespaceOverride: ""
   podAnnotations: {}
 
@@ -79,16 +80,6 @@ ingress:
     - host: ""
       paths:
         - "/web3"
-  middleware:
-    circuitBreaker: NetworkErrorRatio() > 0.10 || ResponseCodeRatio(500, 600, 0, 600) > 0.25
-    connectionsPerIP: 5
-    enabled: false
-    ipWhitelist:
-      - 0.0.0.0/0
-    rateLimit:
-      average: 20
-      sourceCriterion:
-        requestHost: true
   tls:
     enabled: false
     secretName: ""
@@ -102,6 +93,22 @@ livenessProbe:
   initialDelaySeconds: 50
   periodSeconds: 10
   timeoutSeconds: 2
+
+middleware:
+  - circuitBreaker:
+      expression: NetworkErrorRatio() > 0.10 || ResponseCodeRatio(500, 600, 0, 600) > 0.25
+  - inFlightReq:
+      amount: 5
+      sourceCriterion:
+        ipStrategy:
+          depth: 1
+  - rateLimit:
+      average: 10
+      sourceCriterion:
+        requestHost: true
+  - retry:
+      attempts: 3
+      initialInterval: 100ms
 
 nodeSelector: {}
 

--- a/charts/hedera-mirror/Chart.yaml
+++ b/charts/hedera-mirror/Chart.yaml
@@ -22,11 +22,11 @@ dependencies:
     condition: postgresql.enabled
     name: postgresql-ha
     repository: https://charts.bitnami.com/bitnami
-    version: 9.2.0
+    version: 9.4.1
   - condition: redis.enabled
     name: redis
     repository: https://charts.bitnami.com/bitnami
-    version: 16.13.1
+    version: 17.1.3
   - alias: rest
     condition: rest.enabled
     name: hedera-mirror-rest

--- a/charts/hedera-mirror/values-prod.yaml
+++ b/charts/hedera-mirror/values-prod.yaml
@@ -3,6 +3,9 @@ alertmanager:
   inhibitRules:
     enabled: true
 
+global:
+  middleware: true
+
 grpc:
   alertmanager:
     inhibitRules:
@@ -10,9 +13,6 @@ grpc:
   hpa:
     enabled: true
     minReplicas: 2
-  ingress:
-    middleware:
-      enabled: true
   podDisruptionBudget:
     enabled: true
   priorityClassName: medium
@@ -84,9 +84,6 @@ rosetta:
       enabled: true
   hpa:
     minReplicas: 2
-  ingress:
-    middleware:
-      enabled: true
   podDisruptionBudget:
     enabled: true
   priorityClassName: medium
@@ -102,9 +99,6 @@ web3:
   hpa:
     enabled: true
     minReplicas: 2
-  ingress:
-    middleware:
-      enabled: true
   podDisruptionBudget:
     enabled: true
   priorityClassName: medium

--- a/charts/hedera-mirror/values.yaml
+++ b/charts/hedera-mirror/values.yaml
@@ -172,11 +172,11 @@ postgresql:
       create: true
     resources:
       limits:
-        cpu: 200m
-        memory: 256Mi
+        cpu: 300m
+        memory: 750Mi
       requests:
-        cpu: 100m
-        memory: 128Mi
+        cpu: 150m
+        memory: 256Mi
   postgresql:
     existingSecret: mirror-passwords
     extraEnvVarsSecret: mirror-passwords
@@ -239,11 +239,11 @@ redis:
       enabled: true
     resources:
       limits:
-        cpu: 100m
-        memory: 50Mi
+        cpu: 150m
+        memory: 256Mi
       requests:
-        cpu: 50m
-        memory: 25Mi
+        cpu: 75m
+        memory: 75Mi
   serviceAccount:
     create: true
 


### PR DESCRIPTION
**Description**:

* Add a retry middleware to reduce 502 Bad Gateway errors
* Bump chart dependencies
* Change chart middleware to a generic list to allow for better customization
* Fix `Kubernetes / Pods / USE` dashboard
* Fix Pgpool crashing locally with OOMKilled
* Fix Redis Sentinel crashing locally with OOMKilled

**Related issue(s)**:

Fixes #4417

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
