### PR TITLE
Remove JVM option causing ingestion issue in containerized env

### DIFF
--- a/hedera-mirror-grpc/Dockerfile
+++ b/hedera-mirror-grpc/Dockerfile
@@ -4,7 +4,7 @@ COPY target/ ./
 RUN java -Djarmode=layertools -jar *.jar extract
 
 FROM eclipse-temurin:17.0.3_7-jre
-ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80 -XX:TieredStopAtLevel=1"
+ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80"
 EXPOSE 5600
 HEALTHCHECK --interval=10s --retries=3 --start-period=50s --timeout=2s CMD curl -f http://localhost:8081/actuator/health/liveness
 USER 1000:1000

--- a/hedera-mirror-importer/Dockerfile
+++ b/hedera-mirror-importer/Dockerfile
@@ -4,7 +4,7 @@ COPY target/ ./
 RUN java -Djarmode=layertools -jar *.jar extract
 
 FROM eclipse-temurin:17.0.3_7-jre
-ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80 -XX:TieredStopAtLevel=1"
+ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80"
 HEALTHCHECK --interval=30s --retries=3 --start-period=60s --timeout=2s CMD curl -f http://localhost:8080/actuator/health/liveness
 USER 1000:1000
 WORKDIR /app

--- a/hedera-mirror-monitor/Dockerfile
+++ b/hedera-mirror-monitor/Dockerfile
@@ -4,7 +4,7 @@ COPY target/*.jar ./
 RUN java -Djarmode=layertools -jar *.jar extract
 
 FROM eclipse-temurin:17.0.3_7-jre
-ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80 -XX:TieredStopAtLevel=1"
+ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80"
 EXPOSE 8082
 HEALTHCHECK --interval=10s --retries=5 --start-period=60s --timeout=2s CMD curl -f http://localhost:8082/actuator/health/liveness
 USER 1000:1000

--- a/hedera-mirror-web3/Dockerfile
+++ b/hedera-mirror-web3/Dockerfile
@@ -4,7 +4,7 @@ COPY target/*.jar ./
 RUN java -Djarmode=layertools -jar *.jar extract
 
 FROM eclipse-temurin:17.0.3_7-jre
-ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80 -XX:TieredStopAtLevel=1"
+ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80"
 EXPOSE 8545
 HEALTHCHECK --interval=10s --retries=3 --start-period=50s --timeout=2s CMD curl -f http://localhost:8545/actuator/health/liveness
 USER 1000:1000


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
Remove the anti-optimization JVM option `-XX:TieredStopAtLevel=1`

**Related issue(s)**:

Fixes #4350 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

Logs showing improved performance after remove the JVM option

```
2022-09-09T10:19:30.363-0600 INFO scheduling-5 c.h.m.i.p.b.BatchInserter Copied 60008 rows to crypto_transfer table in 256.5 ms
2022-09-09T10:19:30.590-0600 INFO scheduling-5 c.h.m.i.p.b.BatchInserter Copied 19992 rows to topic_message table in 225.0 ms
2022-09-09T10:19:30.627-0600 INFO scheduling-2 c.h.m.i.r.r.CompositeRecordFileReader Read 18724 items successfully from v6 record file 2022-09-04T13_06_28.006353064Z.rcd.gz in 457.7 ms
2022-09-09T10:19:30.819-0600 INFO scheduling-5 c.h.m.i.p.b.BatchInserter Copied 20000 rows to transaction table in 227.1 ms
2022-09-09T10:19:30.827-0600 INFO scheduling-5 c.h.m.i.p.b.BatchInserter Copied 30 rows to entity_temp table in 8.010 ms
2022-09-09T10:19:30.829-0600 INFO scheduling-5 c.h.m.i.p.r.e.s.SqlEntityListener Completed batch inserts in 722.3 ms
2022-09-09T10:19:30.874-0600 INFO pool-5-thread-1 c.h.m.i.p.r.e.r.RedisEntityListener Finished notifying 19992 messages in 767.6 ms
2022-09-09T10:19:30.885-0600 INFO scheduling-5 c.h.m.i.p.b.BatchInserter Copied 7709 rows to crypto_transfer table in 38.45 ms
2022-09-09T10:19:30.928-0600 INFO scheduling-5 c.h.m.i.p.b.BatchInserter Copied 2567 rows to topic_message table in 43.20 ms
2022-09-09T10:19:30.960-0600 INFO scheduling-5 c.h.m.i.p.b.BatchInserter Copied 2569 rows to transaction table in 31.18 ms
2022-09-09T10:19:30.968-0600 INFO scheduling-5 c.h.m.i.p.b.BatchInserter Copied 26 rows to entity_temp table in 7.608 ms
2022-09-09T10:19:30.968-0600 INFO scheduling-5 c.h.m.i.p.r.e.s.SqlEntityListener Completed batch inserts in 122.6 ms
2022-09-09T10:19:30.972-0600 INFO scheduling-5 c.h.m.i.p.r.RecordFileParser Successfully processed 22569 items from 2022-09-04T13_06_06.004607319Z.rcd.gz in 999.0 ms
2022-09-09T10:19:30.974-0600 INFO pool-5-thread-1 c.h.m.i.p.r.e.r.RedisEntityListener Finished notifying 2567 messages in 100.2 ms
2022-09-09T10:19:31.312-0600 INFO scheduling-5 c.h.m.i.p.b.BatchInserter Copied 56643 rows to crypto_transfer table in 241.7 ms
2022-09-09T10:19:31.529-0600 INFO scheduling-5 c.h.m.i.p.b.BatchInserter Copied 18873 rows to topic_message table in 216.1 ms
2022-09-09T10:19:31.766-0600 INFO pool-5-thread-1 c.h.m.i.p.r.e.r.RedisEntityListener Finished notifying 18873 messages in 696.5 ms
2022-09-09T10:19:31.939-0600 INFO scheduling-5 c.h.m.i.p.b.BatchInserter Copied 18879 rows to transaction table in 407.0 ms
2022-09-09T10:19:31.946-0600 INFO scheduling-5 c.h.m.i.p.b.BatchInserter Copied 30 rows to entity_temp table in 6.909 ms
2022-09-09T10:19:31.946-0600 INFO scheduling-5 c.h.m.i.p.r.e.s.SqlEntityListener Completed batch inserts in 876.2 ms
2022-09-09T10:19:31.948-0600 INFO scheduling-5 c.h.m.i.p.r.RecordFileParser Successfully processed 18879 items from 2022-09-04T13_06_08.011526175Z.rcd.gz in 958.3 ms
2022-09-09T10:19:31.965-0600 INFO scheduling-2 c.h.m.i.r.r.CompositeRecordFileReader Read 22871 items successfully from v6 record file 2022-09-04T13_06_30.008787692Z.rcd.gz in 725.5 ms
2022-09-09T10:19:32.305-0600 INFO scheduling-5 c.h.m.i.p.b.BatchInserter Copied 60010 rows to crypto_transfer table in 254.1 ms
2022-09-09T10:19:32.514-0600 INFO scheduling-5 c.h.m.i.p.b.BatchInserter Copied 19987 rows to topic_message table in 209.1 ms
2022-09-09T10:19:32.519-0600 INFO scheduling-2 c.h.m.i.r.r.CompositeRecordFileReader Read 19567 items successfully from v6 record file 2022-09-04T13_06_32.002614302Z.rcd.gz in 289.2 ms
2022-09-09T10:19:32.637-0600 INFO pool-5-thread-1 c.h.m.i.p.r.e.r.RedisEntityListener Finished notifying 19987 messages in 586.1 ms
2022-09-09T10:19:32.740-0600 INFO scheduling-5 c.h.m.i.p.b.BatchInserter Copied 20000 rows to transaction table in 225.8 ms
2022-09-09T10:19:32.748-0600 INFO scheduling-5 c.h.m.i.p.b.BatchInserter Copied 30 rows to entity_temp table in 7.750 ms
2022-09-09T10:19:32.748-0600 INFO scheduling-5 c.h.m.i.p.r.e.s.SqlEntityListener Completed batch inserts in 697.6 ms
2022-09-09T10:19:32.761-0600 INFO scheduling-5 c.h.m.i.p.b.BatchInserter Copied 1584 rows to crypto_transfer table in 9.865 ms
2022-09-09T10:19:32.768-0600 INFO scheduling-5 c.h.m.i.p.b.BatchInserter Copied 528 rows to topic_message table in 6.625 ms
2022-09-09T10:19:32.775-0600 INFO scheduling-5 c.h.m.i.p.b.BatchInserter Copied 528 rows to transaction table in 7.205 ms
2022-09-09T10:19:32.776-0600 INFO pool-5-thread-1 c.h.m.i.p.r.e.r.RedisEntityListener Finished notifying 528 messages in 24.93 ms
2022-09-09T10:19:32.783-0600 INFO scheduling-5 c.h.m.i.p.b.BatchInserter Copied 13 rows to entity_temp table in 7.001 ms
2022-09-09T10:19:32.783-0600 INFO scheduling-5 c.h.m.i.p.r.e.s.SqlEntityListener Completed batch inserts in 31.70 ms
2022-09-09T10:19:32.784-0600 INFO scheduling-5 c.h.m.i.p.r.RecordFileParser Successfully processed 20528 items from 2022-09-04T13_06_10.007640959Z.rcd.gz in 819.0 ms
2022-09-09T10:19:33.257-0600 INFO scheduling-5 c.h.m.i.p.b.BatchInserter Copied 60004 rows to crypto_transfer table in 367.8 ms
2022-09-09T10:19:33.565-0600 INFO scheduling-5 c.h.m.i.p.b.BatchInserter Copied 19996 rows to topic_message table in 307.5 ms
2022-09-09T10:19:33.692-0600 INFO scheduling-2 c.h.m.i.r.r.CompositeRecordFileReader Read 19673 items successfully from v6 record file 2022-09-04T13_06_34.009008113Z.rcd.gz in 516.5 ms
2022-09-09T10:19:33.785-0600 INFO pool-5-thread-1 c.h.m.i.p.r.e.r.RedisEntityListener Finished notifying 19996 messages in 895.9 ms
2022-09-09T10:19:33.791-0600 INFO scheduling-5 c.h.m.i.p.b.BatchInserter Copied 20000 rows to transaction table in 225.9 ms
2022-09-09T10:19:33.799-0600 INFO scheduling-5 c.h.m.i.p.b.BatchInserter Copied 30 rows to entity_temp table in 7.123 ms
2022-09-09T10:19:33.799-0600 INFO scheduling-5 c.h.m.i.p.r.e.s.SqlEntityListener Completed batch inserts in 909.3 ms
2022-09-09T10:19:33.848-0600 INFO scheduling-5 c.h.m.i.p.b.BatchInserter Copied 8591 rows to crypto_transfer table in 38.31 ms
2022-09-09T10:19:33.881-0600 INFO scheduling-5 c.h.m.i.p.b.BatchInserter Copied 2861 rows to topic_message table in 32.07 ms
2022-09-09T10:19:33.886-0600 INFO pool-5-thread-1 c.h.m.i.p.r.e.r.RedisEntityListener Finished notifying 2861 messages in 75.80 ms
2022-09-09T10:19:33.918-0600 INFO scheduling-5 c.h.m.i.p.b.BatchInserter Copied 2863 rows to transaction table in 36.56 ms
2022-09-09T10:19:33.925-0600 INFO scheduling-5 c.h.m.i.p.b.BatchInserter Copied 27 rows to entity_temp table in 7.514 ms
2022-09-09T10:19:33.925-0600 INFO scheduling-5 c.h.m.i.p.r.e.s.SqlEntityListener Completed batch inserts in 115.4 ms
2022-09-09T10:19:33.927-0600 INFO scheduling-5 c.h.m.i.p.r.RecordFileParser Successfully processed 22863 items from 2022-09-04T13_06_12.018769339Z.rcd.gz in 1.118 s
2022-09-09T10:19:34.270-0600 INFO scheduling-5 c.h.m.i.p.b.BatchInserter Copied 57345 rows to crypto_transfer table in 242.8 ms
2022-09-09T10:19:34.474-0600 INFO scheduling-5 c.h.m.i.p.b.BatchInserter Copied 19103 rows to topic_message table in 204.0 ms
2022-09-09T10:19:34.648-0600 INFO pool-5-thread-1 c.h.m.i.p.r.e.r.RedisEntityListener Finished notifying 19103 messages in 621.3 ms
2022-09-09T10:19:34.692-0600 INFO scheduling-5 c.h.m.i.p.b.BatchInserter Copied 19112 rows to transaction table in 217.7 ms
2022-09-09T10:19:34.699-0600 INFO scheduling-5 c.h.m.i.p.b.BatchInserter Copied 30 rows to entity_temp table in 6.873 ms
2022-09-09T10:19:34.699-0600 INFO scheduling-5 c.h.m.i.p.r.e.s.SqlEntityListener Completed batch inserts in 672.1 ms
2022-09-09T10:19:34.701-0600 INFO scheduling-5 c.h.m.i.p.r.RecordFileParser Successfully processed 19112 items from 2022-09-04T13_06_14.010722332Z.rcd.gz in 744.4 ms
```

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
