### PR TITLE
Fix monitor onErrorDropped no valid nodes

### DIFF
--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/TransactionPublisher.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/TransactionPublisher.java
@@ -82,7 +82,7 @@ public class TransactionPublisher implements AutoCloseable {
 
         return clients.elementAt(clientIndex)
                 .flatMap(client -> getTransactionResponse(request, client)
-                        .flatMap(r -> processTransactionResponse(client, request, r))
+                        .flatMap(r -> processTransactionResponse(client, request, r)))
                         .map(PublishResponse.PublishResponseBuilder::build)
                         .doOnNext(response -> {
                             if (log.isTraceEnabled() || properties.isLogResponse()) {
@@ -92,7 +92,7 @@ public class TransactionPublisher implements AutoCloseable {
                         .timeout(properties.getTimeout())
                         .onErrorMap(t -> !(t instanceof PublishException), t -> new PublishException(request, t))
                         .doOnNext(scenario::onNext)
-                        .doOnError(scenario::onError));
+                        .doOnError(scenario::onError);
     }
 
     private Mono<TransactionResponse> getTransactionResponse(PublishRequest request, Client client) {

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/NodeSupplierTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/NodeSupplierTest.java
@@ -163,6 +163,7 @@ class NodeSupplierTest {
                 .expectNext(node)
                 .expectComplete()
                 .verify(Duration.ofMillis(100L));
+        assertThat(nodeSupplier.get()).isEqualTo(node);
     }
 
     @Test
@@ -173,7 +174,8 @@ class NodeSupplierTest {
                 .hasSize(1)
                 .first()
                 .returns(networkNode.getNodeAccountId(), NodeProperties::getAccountId)
-                .returns(networkNode.getServiceEndpoints().get(0).getIpAddressV4(), NodeProperties::getHost);
+                .returns(networkNode.getServiceEndpoints().get(0).getIpAddressV4(), NodeProperties::getHost)
+                .satisfies(node -> assertThat(nodeSupplier.get()).isEqualTo(node));
     }
 
     @Test
@@ -186,7 +188,8 @@ class NodeSupplierTest {
                 .hasSize(1)
                 .first()
                 .returns(networkNode.getNodeAccountId(), NodeProperties::getAccountId)
-                .returns(networkNode.getServiceEndpoints().get(0).getIpAddressV4(), NodeProperties::getHost);
+                .returns(networkNode.getServiceEndpoints().get(0).getIpAddressV4(), NodeProperties::getHost)
+                .satisfies(node -> assertThat(nodeSupplier.get()).isEqualTo(node));
     }
 
     @Test
@@ -226,7 +229,6 @@ class NodeSupplierTest {
     @Test
     @Timeout(3)
     void validationRecovers() {
-        nodeSupplier.updateValidationClient(monitorProperties.getNodes());
         // Given node validated as bad
         cryptoServiceStub.addTransactions(Mono.just(response(FREEZE_UPGRADE_IN_PROGRESS)));
         assertThat(nodeSupplier.validateNode(node)).isFalse();
@@ -257,7 +259,6 @@ class NodeSupplierTest {
         try {
             var node2 = new NodeProperties("0.0.4", "in-process:" + server3);
             monitorProperties.setNodes(Set.of(node, node2));
-            nodeSupplier.updateValidationClient(monitorProperties.getNodes());
 
             // Validate good node
             cryptoServiceStub.addQueries(Mono.just(receipt(SUCCESS)));
@@ -285,7 +286,6 @@ class NodeSupplierTest {
     void validationSucceeds() {
         cryptoServiceStub.addQueries(Mono.just(receipt(SUCCESS)));
         cryptoServiceStub.addTransactions(Mono.just(response(OK)));
-        nodeSupplier.updateValidationClient(monitorProperties.getNodes());
         assertThat(nodeSupplier.validateNode(node)).isTrue();
     }
 

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/TransactionPublisherTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/TransactionPublisherTest.java
@@ -36,6 +36,7 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
 import lombok.Data;
 import lombok.extern.log4j.Log4j2;
 import org.junit.jupiter.api.AfterEach;
@@ -49,6 +50,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 
 import com.hedera.hashgraph.sdk.PrivateKey;
@@ -269,6 +271,18 @@ class TransactionPublisherTest {
                         .isInstanceOf(PublishException.class)
                         .hasMessageContaining("Did not observe any item or terminal signal within 100ms")
                         .hasCauseInstanceOf(TimeoutException.class))
+                .verify(Duration.ofSeconds(1L));
+    }
+
+    @Test
+    @Timeout(3)
+    void publishNoValidNodes() {
+        PublishRequest request = request().build();
+        when(nodeSupplier.get()).thenThrow(new IllegalArgumentException("No valid nodes"));
+
+        transactionPublisher.publish(request)
+                .as(StepVerifier::create)
+                .expectErrorSatisfies(t -> assertThat(t).isInstanceOf(PublishException.class).hasCauseInstanceOf(IllegalArgumentException.class))
                 .verify(Duration.ofSeconds(1L));
     }
 


### PR DESCRIPTION
**Description**:

* Change node supplier to populate nodes on startup before validation
* Fix monitor not handling `No nodes available` error on startup
* Revert workaround for SDK thread leak since we're using SDK version with fix

**Related issue(s)**:

Fixes #4456

**Notes for reviewer**:

Not able to reproduce locally, but verified it fixed the race condition in staging.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
