### PR TITLE
Add `hedera-evm` dependency to `hedera-mirror-web3`

### DIFF
--- a/hedera-mirror-web3/pom.xml
+++ b/hedera-mirror-web3/pom.xml
@@ -32,6 +32,13 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!--FUTURE WORK MOVE hedera-evm TO CENTRAL REPO-->
+        <dependency>
+            <groupId>com.hedera</groupId>
+            <artifactId>hedera-evm</artifactId>
+            <version>0.29.0-SNAPSHOT</version>
+            <type>jar.lastUpdated</type>
+        </dependency>
         <dependency>
             <groupId>io.github.mweirauch</groupId>
             <artifactId>micrometer-jvm-extras</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,12 @@
     </dependencyManagement>
 
     <repositories>
+        <!--FUTURE WORK REMOVE local-maven-repo-->
+        <repository>
+            <id>local-maven-repo</id>
+            <name>Maven Local Repository</name>
+            <url>file:/Users/ivankavaldzhiev/.m2/repository</url>
+        </repository>
         <repository>
             <id>besu-repository</id>
             <url>https://hyperledger.jfrog.io/artifactory/besu-maven/</url>


### PR DESCRIPTION
**Description**:
Add dependency to `hedera-evm` in `hedera-mirror-web3` module, so that REST API for `eth_call` could be implemented.

FUTURE WORK: Substitute local maven repo by uploading `hedera-evm` dependency in a remote repo.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
