### PR TITLE
Fix column transaction_hash of relation contract_result contains null…

### DIFF
--- a/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.65.4.1__contract_result_hash.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.65.4.1__contract_result_hash.sql
@@ -20,5 +20,4 @@ from results r
 where r.consensus_timestamp = contract_result.consensus_timestamp;
 
 alter table if exists contract_result
-    alter column transaction_hash set not null,
     alter column transaction_result set not null;


### PR DESCRIPTION
**Description**:
Fix column transaction_hash of relation contract_result contains null values

**Related issue(s)**:

Fixes #4469

**Notes for reviewer**:
Tested 
* Upgrade from v0.63.0 to v0.64.1 with null data.
* Upgrade from v0.64.1 to a v0.64.2 with the renamed and modified migration

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
