### PR TITLE
Allow ContractAction recipient not set

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/ContractResultServiceImpl.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/ContractResultServiceImpl.java
@@ -122,8 +122,6 @@ public class ContractResultServiceImpl implements ContractResultService {
             case RECIPIENT_CONTRACT -> contractAction.setRecipientContract(EntityId.of(action.getRecipientContract()));
             case INVALID_SOLIDITY_ADDRESS ->
                     contractAction.setRecipientAddress(action.getInvalidSolidityAddress().toByteArray());
-            default -> throw new InvalidDatasetException("Invalid recipient for contract action: " +
-                    action.getRecipientCase());
         }
 
         switch (action.getResultDataCase()) {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/ContractResultServiceImplIntegrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/ContractResultServiceImplIntegrationTest.java
@@ -24,6 +24,7 @@ import static com.hedera.mirror.common.domain.entity.EntityType.ACCOUNT;
 import static com.hedera.mirror.common.domain.entity.EntityType.CONTRACT;
 import static com.hedera.mirror.importer.domain.StreamFilename.FileType.DATA;
 import static com.hedera.services.stream.proto.ContractAction.CallerCase.CALLING_CONTRACT;
+import static com.hedera.services.stream.proto.ContractAction.RecipientCase.RECIPIENT_NOT_SET;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -185,16 +186,6 @@ class ContractResultServiceImplIntegrationTest extends IntegrationTest {
 
         assertThatThrownBy(() -> process(recordItem)).isInstanceOf(InvalidDatasetException.class)
                 .hasMessageContaining("Invalid caller");
-    }
-
-    @Test
-    void processContractActionInvalidRecipient() {
-        var recordItem = recordItemBuilder.contractCall()
-                .sidecarRecords(s -> s.get(1).getActionsBuilder().getContractActionsBuilder(0).clearRecipient())
-                .build();
-
-        assertThatThrownBy(() -> process(recordItem)).isInstanceOf(InvalidDatasetException.class)
-                .hasMessageContaining("Invalid recipient");
     }
 
     @Test
@@ -483,7 +474,8 @@ class ContractResultServiceImplIntegrationTest extends IntegrationTest {
                             .satisfies(c -> assertThat(c.getResultData()).isNotEmpty())
                             .satisfiesAnyOf(c -> assertThat(c.getRecipientContract()).isNotNull(),
                                     c -> assertThat(c.getRecipientAccount()).isNotNull(),
-                                    c -> assertThat(c.getRecipientAddress()).isNotEmpty());
+                                    c -> assertThat(c.getRecipientAddress()).isNotEmpty(),
+                                    c -> assertThat(contractAction.getRecipientCase()).isEqualTo(RECIPIENT_NOT_SET));
                 });
         assertThat(contractActions).isExhausted();
     }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/domain/RecordItemBuilder.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/domain/RecordItemBuilder.java
@@ -212,7 +212,13 @@ public class RecordItemBuilder {
                 .record(r -> r.setContractCreateResult(contractFunctionResult(contractId)
                         .addCreatedContractIDs(contractId)))
                 .sidecarRecords(r -> r.add(contractStateChanges(contractId)))
-                .sidecarRecords(r -> r.add(contractActions()))
+                .sidecarRecords(r -> {
+                    var contractActions = contractActions();
+                    contractActions.getActionsBuilder()
+                            .getContractActionsBuilderList()
+                            .forEach(ContractAction.Builder::clearRecipient);
+                    r.add(contractActions);
+                })
                 .sidecarRecords(r -> r.add(contractBytecode(contractId)));
     }
 

--- a/hedera-mirror-rest/__tests__/specs/contracts/results/actions/no-params.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/actions/no-params.json
@@ -142,8 +142,8 @@
         "index": 2,
         "input": "0xabcd",
         "recipient_account": null,
-        "recipient_address": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
-        "recipient_contract": 8002,
+        "recipient_address": null,
+        "recipient_contract": null,
         "result_data": "0x1234",
         "result_data_type": 11,
         "value": 200
@@ -224,9 +224,9 @@
         "gas_used": 900,
         "index": 2,
         "input": "0xabcd",
-        "to": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
-        "recipient": "0.0.8002",
-        "recipient_type": "CONTRACT",
+        "to": null,
+        "recipient": null,
+        "recipient_type": null,
         "result_data": "0x1234",
         "result_data_type": "OUTPUT",
         "value": 200

--- a/hedera-mirror-rest/__tests__/viewmodel/contractActionViewModel.test.js
+++ b/hedera-mirror-rest/__tests__/viewmodel/contractActionViewModel.test.js
@@ -1,0 +1,112 @@
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import {ContractActionViewModel} from '../../viewmodel';
+
+describe('ContractActionViewModel', () => {
+  const defaultContractAction = {
+    callDepth: 0,
+    callOperationType: 1,
+    callType: 1,
+    caller: 7,
+    callerType: 'ACCOUNT',
+    consensusTimestamp: 900123456789,
+    gas: 6000,
+    gasUsed: 3500,
+    index: 0,
+    input: Buffer.from([0x10, 0x11, 0x12, 0x13]),
+    recipientAccount: 9,
+    recipientAddress: null,
+    recipientContract: null,
+    resultData: Buffer.from([0x20, 0x21, 0x22, 0x23]),
+    resultDataType: 11,
+    value: 8000,
+  };
+
+  const defaultExpected = {
+    call_depth: 0,
+    call_operation_type: 'CALL',
+    call_type: 'CALL',
+    caller: '0.0.7',
+    caller_type: 'ACCOUNT',
+    from: '0x0000000000000000000000000000000000000007',
+    gas: 6000,
+    gas_used: 3500,
+    index: 0,
+    input: '0x10111213',
+    recipient: '0.0.9',
+    recipient_type: 'ACCOUNT',
+    result_data: '0x20212223',
+    result_data_type: 'OUTPUT',
+    timestamp: '900.123456789',
+    to: '0x0000000000000000000000000000000000000009',
+    value: 8000,
+  };
+
+  test('default', () => {
+    expect(new ContractActionViewModel(defaultContractAction)).toEqual(defaultExpected);
+  });
+
+  test('recipient contract', () => {
+    expect(
+      new ContractActionViewModel({
+        ...defaultContractAction,
+        recipientAccount: null,
+        recipientContract: 9,
+      })
+    ).toEqual({
+      ...defaultExpected,
+      recipient_type: 'CONTRACT',
+    });
+  });
+
+  test('recipient address', () => {
+    expect(
+      new ContractActionViewModel({
+        ...defaultContractAction,
+        recipientAccount: null,
+        recipientAddress: Buffer.from([0xab, 0xcd, 0xef]),
+      })
+    ).toEqual({
+      ...defaultExpected,
+      recipient: null,
+      recipient_type: null,
+      to: '0x0000000000000000000000000000000000abcdef',
+    });
+  });
+
+  test('null fields', () => {
+    expect(
+      new ContractActionViewModel({
+        ...defaultContractAction,
+        callOperationType: 5,
+        callType: 2,
+        recipientAccount: null,
+      })
+    ).toEqual({
+      ...defaultExpected,
+      call_operation_type: 'CREATE',
+      call_type: 'CREATE',
+      recipient: null,
+      recipient_type: null,
+      to: null,
+    });
+  });
+});

--- a/hedera-mirror-rest/api/v1/openapi.yml
+++ b/hedera-mirror-rest/api/v1/openapi.yml
@@ -1792,7 +1792,7 @@ components:
           type: string
           enum: [ ACCOUNT, CONTRACT ]
           example: ACCOUNT
-          nullable: false
+          nullable: true
         result_data:
           description: The hex encoded result data
           example: '0x123456'

--- a/hedera-mirror-rest/viewmodel/contractActionViewModel.js
+++ b/hedera-mirror-rest/viewmodel/contractActionViewModel.js
@@ -52,11 +52,11 @@ class ContractActionViewModel {
    * @param {ContractAction} contractAction
    */
   constructor(contractAction) {
-    const recipientIsAccount = !!contractAction.recipientAccount;
-    const recipientId = recipientIsAccount ? contractAction.recipientAccount : contractAction.recipientContract;
-    const recipient = EntityId.parse(recipientId);
     const callerId = EntityId.parse(contractAction.caller);
     const callOperationType = contractAction.callOperationType || 0;
+    const recipientId = contractAction.recipientAccount || contractAction.recipientContract;
+    const recipient = EntityId.parse(recipientId, {isNullable: true});
+    const recipientIsAccount = !!contractAction.recipientAccount;
 
     this.call_depth = contractAction.callDepth;
     this.call_operation_type = ContractActionViewModel.callOperationTypes[callOperationType];
@@ -69,12 +69,12 @@ class ContractActionViewModel {
     this.index = contractAction.index;
     this.input = utils.toHexStringNonQuantity(contractAction.input);
     this.recipient = recipient.toString();
-    this.recipient_type = recipientIsAccount ? entityTypes.ACCOUNT : entityTypes.CONTRACT;
+    this.recipient_type = recipientId && (recipientIsAccount ? entityTypes.ACCOUNT : entityTypes.CONTRACT);
     this.result_data = utils.toHexStringNonQuantity(contractAction.resultData);
     this.result_data_type = ContractActionViewModel.resultDataTypes[contractAction.resultDataType];
     this.timestamp = utils.nsToSecNs(contractAction.consensusTimestamp);
     this.to = contractAction.recipientAddress
-      ? utils.toHexString(Buffer.from(contractAction.recipientAddress), true, 40)
+      ? utils.toHexString(contractAction.recipientAddress, true, 40)
       : recipient.toEvmAddress();
     this.value = contractAction.value;
   }

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <gson.version>2.8.9</gson.version> <!-- Temporary until Apache jclouds supports gson 2.9 -->
         <guava.version>31.1-jre</guava.version>
         <headlong.version>7.0.0</headlong.version>
-        <hedera-protobuf.version>0.30.0-SNAPSHOT</hedera-protobuf.version>
+        <hedera-protobuf.version>0.30.0</hedera-protobuf.version>
         <hibernate-types.version>2.19.2</hibernate-types.version>
         <jacoco.version>0.8.8</jacoco.version>
         <java.version>17</java.version>


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

This PR fixes the bug in importer that assumes `ContractAction.recipient` is always set

- Allow `ContractAction.recipient` not set
- Change REST `ContractActionViewModel` to handle recipient not set

**Related issue(s)**:

Fixes #4520 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

`ContractAction` for `ContractCreate` doesn't have recipient
 
**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
