### PR TITLE
Use db owner in java migration when needed

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/JdbcTemplateConfiguration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/JdbcTemplateConfiguration.java
@@ -1,0 +1,54 @@
+package com.hedera.mirror.importer.config;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import javax.sql.DataSource;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import com.hedera.mirror.importer.db.DBProperties;
+
+@Configuration
+public class JdbcTemplateConfiguration {
+
+    public static final String JDBC_TEMPLATE_OWNER = "owner";
+
+    @Bean
+    @Primary
+    public JdbcTemplate jdbcTemplate(DataSource dataSource) {
+        return new JdbcTemplate(dataSource);
+    }
+
+    @Bean(JDBC_TEMPLATE_OWNER)
+    public JdbcTemplate jdbcTemplate(DBProperties dbProperties) {
+        String jdbcUrl = String.format("jdbc:postgresql://%s:%d/%s?tcpKeepAlive=true", dbProperties.getHost(),
+                dbProperties.getPort(), dbProperties.getName());
+        var datasource = DataSourceBuilder.create()
+                .password(dbProperties.getOwnerPassword())
+                .url(jdbcUrl)
+                .username(dbProperties.getOwner())
+                .build();
+        return new JdbcTemplate(datasource);
+    }
+}

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/Owner.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/Owner.java
@@ -1,0 +1,33 @@
+package com.hedera.mirror.importer.config;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.beans.factory.annotation.Qualifier;
+
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER})
+public @interface Owner {
+}

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/BackfillTransactionHashMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/BackfillTransactionHashMigration.java
@@ -20,9 +20,12 @@ package com.hedera.mirror.importer.migration;
  * ‍
  */
 
+import static com.hedera.mirror.importer.config.JdbcTemplateConfiguration.JDBC_TEMPLATE_OWNER;
+
 import com.google.common.base.Stopwatch;
 import java.io.IOException;
 import javax.inject.Named;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.jdbc.core.JdbcTemplate;
 
@@ -49,7 +52,8 @@ public class BackfillTransactionHashMigration extends RepeatableMigration {
     private final JdbcTemplate jdbcTemplate;
 
     @Lazy
-    public BackfillTransactionHashMigration(EntityProperties entityProperties, JdbcTemplate jdbcTemplate,
+    public BackfillTransactionHashMigration(EntityProperties entityProperties,
+                                            @Qualifier(JDBC_TEMPLATE_OWNER) JdbcTemplate jdbcTemplate,
                                             MirrorProperties mirrorProperties) {
         super(mirrorProperties.getMigration());
         this.entityProperties = entityProperties;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/BackfillTransactionHashMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/BackfillTransactionHashMigration.java
@@ -20,16 +20,14 @@ package com.hedera.mirror.importer.migration;
  * ‍
  */
 
-import static com.hedera.mirror.importer.config.JdbcTemplateConfiguration.JDBC_TEMPLATE_OWNER;
-
 import com.google.common.base.Stopwatch;
 import java.io.IOException;
 import javax.inject.Named;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 import com.hedera.mirror.importer.MirrorProperties;
+import com.hedera.mirror.importer.config.Owner;
 import com.hedera.mirror.importer.parser.record.entity.EntityProperties;
 
 @Named
@@ -53,7 +51,7 @@ public class BackfillTransactionHashMigration extends RepeatableMigration {
 
     @Lazy
     public BackfillTransactionHashMigration(EntityProperties entityProperties,
-                                            @Qualifier(JDBC_TEMPLATE_OWNER) JdbcTemplate jdbcTemplate,
+                                            @Owner JdbcTemplate jdbcTemplate,
                                             MirrorProperties mirrorProperties) {
         super(mirrorProperties.getMigration());
         this.entityProperties = entityProperties;

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/AddAddressBookServiceEndpointsMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/AddAddressBookServiceEndpointsMigrationTest.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.importer.migration;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,6 +20,7 @@ package com.hedera.mirror.importer.migration;
  * ‍
  */
 
+import static com.hedera.mirror.importer.config.JdbcTemplateConfiguration.JDBC_TEMPLATE_OWNER;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
@@ -27,29 +28,32 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
-import javax.annotation.Resource;
+import lombok.RequiredArgsConstructor;
 import org.apache.commons.io.FileUtils;
 import org.assertj.core.api.IterableAssert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jdbc.core.JdbcOperations;
 import org.springframework.test.context.TestPropertySource;
 
-import com.hedera.mirror.importer.EnabledIfV1;
-import com.hedera.mirror.importer.IntegrationTest;
-import com.hedera.mirror.importer.addressbook.AddressBookServiceImpl;
 import com.hedera.mirror.common.domain.addressbook.AddressBook;
 import com.hedera.mirror.common.domain.addressbook.AddressBookEntry;
 import com.hedera.mirror.common.domain.addressbook.AddressBookServiceEndpoint;
 import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.entity.EntityType;
+import com.hedera.mirror.importer.EnabledIfV1;
+import com.hedera.mirror.importer.IntegrationTest;
+import com.hedera.mirror.importer.addressbook.AddressBookServiceImpl;
 import com.hedera.mirror.importer.repository.AddressBookEntryRepository;
 import com.hedera.mirror.importer.repository.AddressBookRepository;
 import com.hedera.mirror.importer.repository.AddressBookServiceEndpointRepository;
 
 @EnabledIfV1
+@RequiredArgsConstructor(onConstructor = @__(@Autowired))
 @Tag("migration")
 @TestPropertySource(properties = "spring.flyway.target=1.37.0")
 class AddAddressBookServiceEndpointsMigrationTest extends IntegrationTest {
@@ -59,20 +63,12 @@ class AddAddressBookServiceEndpointsMigrationTest extends IntegrationTest {
     private final int basePort = 443;
     private final int nodeAccountOffset = 3;
 
-    @Resource
-    private AddressBookRepository addressBookRepository;
-
-    @Resource
-    private AddressBookEntryRepository addressBookEntryRepository;
-
-    @Resource
-    private AddressBookServiceEndpointRepository addressBookServiceEndpointRepository;
-
-    @Resource
-    private JdbcOperations jdbcOperations;
-
+    private final AddressBookRepository addressBookRepository;
+    private final AddressBookEntryRepository addressBookEntryRepository;
+    private final AddressBookServiceEndpointRepository addressBookServiceEndpointRepository;
+    private final @Qualifier(JDBC_TEMPLATE_OWNER) JdbcOperations jdbcOperations;
     @Value("classpath:db/migration/v1/V1.37.1__add_address_book_service_endpoints.sql")
-    private File sql;
+    private final File sql;
 
     private int addressBookEntryIdCounter;
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/AddAddressBookServiceEndpointsMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/AddAddressBookServiceEndpointsMigrationTest.java
@@ -20,7 +20,6 @@ package com.hedera.mirror.importer.migration;
  * ‍
  */
 
-import static com.hedera.mirror.importer.config.JdbcTemplateConfiguration.JDBC_TEMPLATE_OWNER;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
@@ -35,7 +34,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jdbc.core.JdbcOperations;
 import org.springframework.test.context.TestPropertySource;
@@ -48,6 +46,7 @@ import com.hedera.mirror.common.domain.entity.EntityType;
 import com.hedera.mirror.importer.EnabledIfV1;
 import com.hedera.mirror.importer.IntegrationTest;
 import com.hedera.mirror.importer.addressbook.AddressBookServiceImpl;
+import com.hedera.mirror.importer.config.Owner;
 import com.hedera.mirror.importer.repository.AddressBookEntryRepository;
 import com.hedera.mirror.importer.repository.AddressBookRepository;
 import com.hedera.mirror.importer.repository.AddressBookServiceEndpointRepository;
@@ -66,7 +65,7 @@ class AddAddressBookServiceEndpointsMigrationTest extends IntegrationTest {
     private final AddressBookRepository addressBookRepository;
     private final AddressBookEntryRepository addressBookEntryRepository;
     private final AddressBookServiceEndpointRepository addressBookServiceEndpointRepository;
-    private final @Qualifier(JDBC_TEMPLATE_OWNER) JdbcOperations jdbcOperations;
+    private final @Owner JdbcOperations jdbcOperations;
     @Value("classpath:db/migration/v1/V1.37.1__add_address_book_service_endpoints.sql")
     private final File sql;
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/AddRootContractIdMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/AddRootContractIdMigrationTest.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.importer.migration;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,6 +20,7 @@ package com.hedera.mirror.importer.migration;
  * ‍
  */
 
+import static com.hedera.mirror.importer.config.JdbcTemplateConfiguration.JDBC_TEMPLATE_OWNER;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
@@ -32,6 +33,7 @@ import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jdbc.core.BeanPropertyRowMapper;
 import org.springframework.jdbc.core.JdbcOperations;
@@ -46,6 +48,7 @@ import com.hedera.mirror.importer.IntegrationTest;
 class AddRootContractIdMigrationTest extends IntegrationTest {
 
     @Resource
+    @Qualifier(JDBC_TEMPLATE_OWNER)
     private JdbcOperations jdbcOperations;
 
     @Value("classpath:db/migration/v1/V1.51.1__contract_logs_root_id.sql")

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/AddRootContractIdMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/AddRootContractIdMigrationTest.java
@@ -20,7 +20,6 @@ package com.hedera.mirror.importer.migration;
  * ‍
  */
 
-import static com.hedera.mirror.importer.config.JdbcTemplateConfiguration.JDBC_TEMPLATE_OWNER;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
@@ -33,7 +32,6 @@ import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jdbc.core.BeanPropertyRowMapper;
 import org.springframework.jdbc.core.JdbcOperations;
@@ -41,6 +39,7 @@ import org.springframework.test.context.TestPropertySource;
 
 import com.hedera.mirror.importer.EnabledIfV1;
 import com.hedera.mirror.importer.IntegrationTest;
+import com.hedera.mirror.importer.config.Owner;
 
 @EnabledIfV1
 @Tag("migration")
@@ -48,7 +47,7 @@ import com.hedera.mirror.importer.IntegrationTest;
 class AddRootContractIdMigrationTest extends IntegrationTest {
 
     @Resource
-    @Qualifier(JDBC_TEMPLATE_OWNER)
+    @Owner
     private JdbcOperations jdbcOperations;
 
     @Value("classpath:db/migration/v1/V1.51.1__contract_logs_root_id.sql")

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/BackfillTransactionHashMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/BackfillTransactionHashMigrationTest.java
@@ -20,7 +20,6 @@ package com.hedera.mirror.importer.migration;
  * ‍
  */
 
-import static com.hedera.mirror.importer.config.JdbcTemplateConfiguration.JDBC_TEMPLATE_OWNER;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
@@ -34,13 +33,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 import com.hedera.mirror.common.domain.transaction.TransactionHash;
 import com.hedera.mirror.importer.EnabledIfV1;
 import com.hedera.mirror.importer.IntegrationTest;
 import com.hedera.mirror.importer.MirrorProperties;
+import com.hedera.mirror.importer.config.Owner;
 import com.hedera.mirror.importer.parser.record.entity.EntityProperties;
 import com.hedera.mirror.importer.repository.TransactionHashRepository;
 
@@ -53,7 +52,7 @@ class BackfillTransactionHashMigrationTest extends IntegrationTest {
     private static final String MIGRATION_NAME = "backfillTransactionHashMigration";
 
     private final EntityProperties entityProperties;
-    private final @Qualifier(JDBC_TEMPLATE_OWNER) JdbcTemplate jdbcTemplate;
+    private final @Owner JdbcTemplate jdbcTemplate;
     private final MirrorProperties mirrorProperties;
     private final TransactionHashRepository transactionHashRepository;
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/BackfillTransactionHashMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/BackfillTransactionHashMigrationTest.java
@@ -20,6 +20,7 @@ package com.hedera.mirror.importer.migration;
  * ‍
  */
 
+import static com.hedera.mirror.importer.config.JdbcTemplateConfiguration.JDBC_TEMPLATE_OWNER;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
@@ -33,6 +34,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 import com.hedera.mirror.common.domain.transaction.TransactionHash;
@@ -51,7 +53,7 @@ class BackfillTransactionHashMigrationTest extends IntegrationTest {
     private static final String MIGRATION_NAME = "backfillTransactionHashMigration";
 
     private final EntityProperties entityProperties;
-    private final JdbcTemplate jdbcTemplate;
+    private final @Qualifier(JDBC_TEMPLATE_OWNER) JdbcTemplate jdbcTemplate;
     private final MirrorProperties mirrorProperties;
     private final TransactionHashRepository transactionHashRepository;
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/CleanupEntityMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/CleanupEntityMigrationTest.java
@@ -20,7 +20,6 @@ package com.hedera.mirror.importer.migration;
  * ‍
  */
 
-import static com.hedera.mirror.importer.config.JdbcTemplateConfiguration.JDBC_TEMPLATE_OWNER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -36,7 +35,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jdbc.core.JdbcOperations;
 import org.springframework.test.context.TestPropertySource;
@@ -50,6 +48,7 @@ import com.hedera.mirror.common.domain.transaction.TransactionType;
 import com.hedera.mirror.importer.EnabledIfV1;
 import com.hedera.mirror.importer.IntegrationTest;
 import com.hedera.mirror.importer.MirrorProperties;
+import com.hedera.mirror.importer.config.Owner;
 import com.hedera.mirror.importer.repository.EntityRepository;
 import com.hedera.mirror.importer.repository.TransactionRepository;
 
@@ -59,7 +58,7 @@ import com.hedera.mirror.importer.repository.TransactionRepository;
 @TestPropertySource(properties = "spring.flyway.target=1.35.5")
 class CleanupEntityMigrationTest extends IntegrationTest {
 
-    private final @Qualifier(JDBC_TEMPLATE_OWNER) JdbcOperations jdbcOperations;
+    private final @Owner JdbcOperations jdbcOperations;
     @Value("classpath:db/migration/v1/V1.36.2__entities_update.sql")
     private final File migrationSql;
     private final EntityRepository entityRepository;

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/CleanupEntityMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/CleanupEntityMigrationTest.java
@@ -20,6 +20,7 @@ package com.hedera.mirror.importer.migration;
  * ‍
  */
 
+import static com.hedera.mirror.importer.config.JdbcTemplateConfiguration.JDBC_TEMPLATE_OWNER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -28,12 +29,14 @@ import java.io.File;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Optional;
-import javax.annotation.Resource;
+import lombok.RequiredArgsConstructor;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jdbc.core.JdbcOperations;
 import org.springframework.test.context.TestPropertySource;
@@ -51,24 +54,17 @@ import com.hedera.mirror.importer.repository.EntityRepository;
 import com.hedera.mirror.importer.repository.TransactionRepository;
 
 @EnabledIfV1
+@RequiredArgsConstructor(onConstructor = @__(@Autowired))
 @Tag("migration")
 @TestPropertySource(properties = "spring.flyway.target=1.35.5")
 class CleanupEntityMigrationTest extends IntegrationTest {
 
-    @Resource
-    private JdbcOperations jdbcOperations;
-
+    private final @Qualifier(JDBC_TEMPLATE_OWNER) JdbcOperations jdbcOperations;
     @Value("classpath:db/migration/v1/V1.36.2__entities_update.sql")
-    private File migrationSql;
-
-    @Resource
-    private EntityRepository entityRepository;
-
-    @Resource
-    private MirrorProperties mirrorProperties;
-
-    @Resource
-    private TransactionRepository transactionRepository;
+    private final File migrationSql;
+    private final EntityRepository entityRepository;
+    private final MirrorProperties mirrorProperties;
+    private final TransactionRepository transactionRepository;
 
     @BeforeEach
     void before() {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/ContractLogsConvertTopicsToBytesMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/ContractLogsConvertTopicsToBytesMigrationTest.java
@@ -20,7 +20,6 @@ package com.hedera.mirror.importer.migration;
  * ‍
  */
 
-import static com.hedera.mirror.importer.config.JdbcTemplateConfiguration.JDBC_TEMPLATE_OWNER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -35,7 +34,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jdbc.core.BeanPropertyRowMapper;
 import org.springframework.jdbc.core.JdbcOperations;
@@ -43,6 +41,7 @@ import org.springframework.test.context.TestPropertySource;
 
 import com.hedera.mirror.importer.EnabledIfV1;
 import com.hedera.mirror.importer.IntegrationTest;
+import com.hedera.mirror.importer.config.Owner;
 
 @EnabledIfV1
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
@@ -50,7 +49,7 @@ import com.hedera.mirror.importer.IntegrationTest;
 @TestPropertySource(properties = "spring.flyway.target=1.51.1")
 class ContractLogsConvertTopicsToBytesMigrationTest extends IntegrationTest {
 
-    private final @Qualifier(JDBC_TEMPLATE_OWNER) JdbcOperations jdbcOperations;
+    private final @Owner JdbcOperations jdbcOperations;
     @Value("classpath:db/migration/v1/V1.51.2__contract_logs_convert_topics_to_bytes.sql")
     private final File migrationSql;
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/ContractLogsConvertTopicsToBytesMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/ContractLogsConvertTopicsToBytesMigrationTest.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.importer.migration;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,19 +20,22 @@ package com.hedera.mirror.importer.migration;
  * ‍
  */
 
+import static com.hedera.mirror.importer.config.JdbcTemplateConfiguration.JDBC_TEMPLATE_OWNER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.File;
 import java.util.Arrays;
 import java.util.List;
-import javax.annotation.Resource;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jdbc.core.BeanPropertyRowMapper;
 import org.springframework.jdbc.core.JdbcOperations;
@@ -42,15 +45,14 @@ import com.hedera.mirror.importer.EnabledIfV1;
 import com.hedera.mirror.importer.IntegrationTest;
 
 @EnabledIfV1
+@RequiredArgsConstructor(onConstructor = @__(@Autowired))
 @Tag("migration")
 @TestPropertySource(properties = "spring.flyway.target=1.51.1")
 class ContractLogsConvertTopicsToBytesMigrationTest extends IntegrationTest {
 
-    @Resource
-    private JdbcOperations jdbcOperations;
-
+    private final @Qualifier(JDBC_TEMPLATE_OWNER) JdbcOperations jdbcOperations;
     @Value("classpath:db/migration/v1/V1.51.2__contract_logs_convert_topics_to_bytes.sql")
-    private File migrationSql;
+    private final File migrationSql;
 
     @AfterEach
     void cleanup() {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/RemoveEntityTypeMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/RemoveEntityTypeMigrationTest.java
@@ -26,7 +26,6 @@ import static com.hedera.mirror.common.domain.entity.EntityType.FILE;
 import static com.hedera.mirror.common.domain.entity.EntityType.SCHEDULE;
 import static com.hedera.mirror.common.domain.entity.EntityType.TOKEN;
 import static com.hedera.mirror.common.domain.entity.EntityType.TOPIC;
-import static com.hedera.mirror.importer.config.JdbcTemplateConfiguration.JDBC_TEMPLATE_OWNER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -43,7 +42,6 @@ import lombok.SneakyThrows;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.jdbc.core.BeanPropertyRowMapper;
@@ -55,6 +53,7 @@ import com.hedera.mirror.common.converter.RangeToStringSerializer;
 import com.hedera.mirror.common.domain.entity.EntityType;
 import com.hedera.mirror.importer.EnabledIfV1;
 import com.hedera.mirror.importer.IntegrationTest;
+import com.hedera.mirror.importer.config.Owner;
 
 @EnabledIfV1
 @Tag("migration")
@@ -63,7 +62,7 @@ import com.hedera.mirror.importer.IntegrationTest;
 class RemoveEntityTypeMigrationTest extends IntegrationTest {
 
     @Resource
-    @Qualifier(JDBC_TEMPLATE_OWNER)
+    @Owner
     private JdbcOperations jdbcOperations;
 
     @Value("classpath:db/migration/v1/V1.47.1__remove_t_entity_types.sql")

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/RemoveEntityTypeMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/RemoveEntityTypeMigrationTest.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.importer.migration;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,6 +26,7 @@ import static com.hedera.mirror.common.domain.entity.EntityType.FILE;
 import static com.hedera.mirror.common.domain.entity.EntityType.SCHEDULE;
 import static com.hedera.mirror.common.domain.entity.EntityType.TOKEN;
 import static com.hedera.mirror.common.domain.entity.EntityType.TOPIC;
+import static com.hedera.mirror.importer.config.JdbcTemplateConfiguration.JDBC_TEMPLATE_OWNER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -42,6 +43,7 @@ import lombok.SneakyThrows;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.jdbc.core.BeanPropertyRowMapper;
@@ -49,10 +51,10 @@ import org.springframework.jdbc.core.JdbcOperations;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 
-import com.hedera.mirror.importer.EnabledIfV1;
-import com.hedera.mirror.importer.IntegrationTest;
 import com.hedera.mirror.common.converter.RangeToStringSerializer;
 import com.hedera.mirror.common.domain.entity.EntityType;
+import com.hedera.mirror.importer.EnabledIfV1;
+import com.hedera.mirror.importer.IntegrationTest;
 
 @EnabledIfV1
 @Tag("migration")
@@ -61,6 +63,7 @@ import com.hedera.mirror.common.domain.entity.EntityType;
 class RemoveEntityTypeMigrationTest extends IntegrationTest {
 
     @Resource
+    @Qualifier(JDBC_TEMPLATE_OWNER)
     private JdbcOperations jdbcOperations;
 
     @Value("classpath:db/migration/v1/V1.47.1__remove_t_entity_types.sql")

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/RemoveInvalidEntityMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/RemoveInvalidEntityMigrationTest.java
@@ -20,8 +20,8 @@ package com.hedera.mirror.importer.migration;
  * ‍
  */
 
+import static com.hedera.mirror.importer.config.JdbcTemplateConfiguration.JDBC_TEMPLATE_OWNER;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
@@ -30,11 +30,13 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-import javax.annotation.Resource;
+import lombok.RequiredArgsConstructor;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jdbc.core.JdbcOperations;
 import org.springframework.test.context.TestPropertySource;
@@ -51,21 +53,16 @@ import com.hedera.mirror.importer.MirrorProperties;
 import com.hedera.mirror.importer.repository.TransactionRepository;
 
 @EnabledIfV1
+@RequiredArgsConstructor(onConstructor = @__(@Autowired))
 @Tag("migration")
 @TestPropertySource(properties = "spring.flyway.target=1.31.1")
 class RemoveInvalidEntityMigrationTest extends IntegrationTest {
 
-    @Resource
-    private JdbcOperations jdbcOperations;
-
+    private final @Qualifier(JDBC_TEMPLATE_OWNER) JdbcOperations jdbcOperations;
     @Value("classpath:db/migration/v1/V1.31.2__remove_invalid_entities.sql")
-    private File migrationSql;
-
-    @Resource
-    private MirrorProperties mirrorProperties;
-
-    @Resource
-    private TransactionRepository transactionRepository;
+    private final File migrationSql;
+    private final MirrorProperties mirrorProperties;
+    private final TransactionRepository transactionRepository;
 
     @BeforeEach
     void before() {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/RemoveInvalidEntityMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/RemoveInvalidEntityMigrationTest.java
@@ -20,7 +20,6 @@ package com.hedera.mirror.importer.migration;
  * ‍
  */
 
-import static com.hedera.mirror.importer.config.JdbcTemplateConfiguration.JDBC_TEMPLATE_OWNER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -36,7 +35,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jdbc.core.JdbcOperations;
 import org.springframework.test.context.TestPropertySource;
@@ -50,6 +48,7 @@ import com.hedera.mirror.common.domain.transaction.TransactionType;
 import com.hedera.mirror.importer.EnabledIfV1;
 import com.hedera.mirror.importer.IntegrationTest;
 import com.hedera.mirror.importer.MirrorProperties;
+import com.hedera.mirror.importer.config.Owner;
 import com.hedera.mirror.importer.repository.TransactionRepository;
 
 @EnabledIfV1
@@ -58,7 +57,7 @@ import com.hedera.mirror.importer.repository.TransactionRepository;
 @TestPropertySource(properties = "spring.flyway.target=1.31.1")
 class RemoveInvalidEntityMigrationTest extends IntegrationTest {
 
-    private final @Qualifier(JDBC_TEMPLATE_OWNER) JdbcOperations jdbcOperations;
+    private final @Owner JdbcOperations jdbcOperations;
     @Value("classpath:db/migration/v1/V1.31.2__remove_invalid_entities.sql")
     private final File migrationSql;
     private final MirrorProperties mirrorProperties;

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/SupportDeletedTokenDissociateMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/SupportDeletedTokenDissociateMigrationTest.java
@@ -24,6 +24,7 @@ import static com.hedera.mirror.common.domain.entity.EntityType.ACCOUNT;
 import static com.hedera.mirror.common.domain.entity.EntityType.TOKEN;
 import static com.hedera.mirror.common.domain.token.TokenTypeEnum.FUNGIBLE_COMMON;
 import static com.hedera.mirror.common.domain.token.TokenTypeEnum.NON_FUNGIBLE_UNIQUE;
+import static com.hedera.mirror.importer.config.JdbcTemplateConfiguration.JDBC_TEMPLATE_OWNER;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
@@ -38,6 +39,7 @@ import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jdbc.core.JdbcOperations;
 import org.springframework.test.context.TestPropertySource;
@@ -71,6 +73,7 @@ class SupportDeletedTokenDissociateMigrationTest extends IntegrationTest {
     private static final EntityId NODE_ACCOUNT_ID = EntityId.of(0, 0, 3, EntityType.ACCOUNT);
 
     @Resource
+    @Qualifier(JDBC_TEMPLATE_OWNER)
     private JdbcOperations jdbcOperations;
 
     @Value("classpath:db/migration/v1/V1.45.0__support_deleted_token_dissociate.sql")
@@ -276,7 +279,7 @@ class SupportDeletedTokenDissociateMigrationTest extends IntegrationTest {
 
 
     private MigrationNft nft(EntityId accountId, long createdTimestamp, boolean deleted, long modifiedTimestamp,
-                    long serialNumber, EntityId tokenId) {
+                             long serialNumber, EntityId tokenId) {
         var nft = new MigrationNft();
         nft.setAccountId(accountId != null ? accountId.getId() : null);
         nft.setCreatedTimestamp(createdTimestamp);

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/SupportDeletedTokenDissociateMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/SupportDeletedTokenDissociateMigrationTest.java
@@ -24,7 +24,6 @@ import static com.hedera.mirror.common.domain.entity.EntityType.ACCOUNT;
 import static com.hedera.mirror.common.domain.entity.EntityType.TOKEN;
 import static com.hedera.mirror.common.domain.token.TokenTypeEnum.FUNGIBLE_COMMON;
 import static com.hedera.mirror.common.domain.token.TokenTypeEnum.NON_FUNGIBLE_UNIQUE;
-import static com.hedera.mirror.importer.config.JdbcTemplateConfiguration.JDBC_TEMPLATE_OWNER;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
@@ -39,7 +38,6 @@ import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jdbc.core.JdbcOperations;
 import org.springframework.test.context.TestPropertySource;
@@ -60,6 +58,7 @@ import com.hedera.mirror.common.domain.token.TokenTypeEnum;
 import com.hedera.mirror.common.domain.transaction.Transaction;
 import com.hedera.mirror.importer.EnabledIfV1;
 import com.hedera.mirror.importer.IntegrationTest;
+import com.hedera.mirror.importer.config.Owner;
 import com.hedera.mirror.importer.repository.TokenAccountRepository;
 
 @EnabledIfV1
@@ -73,7 +72,7 @@ class SupportDeletedTokenDissociateMigrationTest extends IntegrationTest {
     private static final EntityId NODE_ACCOUNT_ID = EntityId.of(0, 0, 3, EntityType.ACCOUNT);
 
     @Resource
-    @Qualifier(JDBC_TEMPLATE_OWNER)
+    @Owner
     private JdbcOperations jdbcOperations;
 
     @Value("classpath:db/migration/v1/V1.45.0__support_deleted_token_dissociate.sql")

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/TopicMessagePayerAccountIdMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/TopicMessagePayerAccountIdMigrationTest.java
@@ -20,7 +20,6 @@ package com.hedera.mirror.importer.migration;
  * ‍
  */
 
-import static com.hedera.mirror.importer.config.JdbcTemplateConfiguration.JDBC_TEMPLATE_OWNER;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
@@ -33,7 +32,6 @@ import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jdbc.core.BeanPropertyRowMapper;
 import org.springframework.jdbc.core.JdbcOperations;
@@ -41,6 +39,7 @@ import org.springframework.test.context.TestPropertySource;
 
 import com.hedera.mirror.importer.EnabledIfV1;
 import com.hedera.mirror.importer.IntegrationTest;
+import com.hedera.mirror.importer.config.Owner;
 
 @EnabledIfV1
 @Tag("migration")
@@ -48,7 +47,7 @@ import com.hedera.mirror.importer.IntegrationTest;
 class TopicMessagePayerAccountIdMigrationTest extends IntegrationTest {
 
     @Resource
-    @Qualifier(JDBC_TEMPLATE_OWNER)
+    @Owner
     private JdbcOperations jdbcOperations;
 
     @Value("classpath:db/migration/v1/V1.53.0__topic_message_add_payer_account_id_and_initial_transaction_id.sql")

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/TopicMessagePayerAccountIdMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/TopicMessagePayerAccountIdMigrationTest.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.importer.migration;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,6 +20,7 @@ package com.hedera.mirror.importer.migration;
  * ‍
  */
 
+import static com.hedera.mirror.importer.config.JdbcTemplateConfiguration.JDBC_TEMPLATE_OWNER;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
@@ -32,6 +33,7 @@ import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jdbc.core.BeanPropertyRowMapper;
 import org.springframework.jdbc.core.JdbcOperations;
@@ -46,6 +48,7 @@ import com.hedera.mirror.importer.IntegrationTest;
 class TopicMessagePayerAccountIdMigrationTest extends IntegrationTest {
 
     @Resource
+    @Qualifier(JDBC_TEMPLATE_OWNER)
     private JdbcOperations jdbcOperations;
 
     @Value("classpath:db/migration/v1/V1.53.0__topic_message_add_payer_account_id_and_initial_transaction_id.sql")

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/TransferTransactionPayerMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/TransferTransactionPayerMigrationTest.java
@@ -21,6 +21,7 @@ package com.hedera.mirror.importer.migration;
  */
 
 import static com.hedera.mirror.common.domain.entity.EntityType.TOKEN;
+import static com.hedera.mirror.importer.config.JdbcTemplateConfiguration.JDBC_TEMPLATE_OWNER;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_TX_FEE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -33,16 +34,18 @@ import java.io.IOException;
 import java.sql.PreparedStatement;
 import java.util.Arrays;
 import java.util.List;
-import javax.annotation.Resource;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jdbc.core.JdbcOperations;
 import org.springframework.test.context.TestPropertySource;
@@ -68,37 +71,23 @@ import com.hedera.mirror.importer.repository.TokenTransferRepository;
 import com.hedera.mirror.importer.repository.TransactionRepository;
 
 @EnabledIfV1
+@RequiredArgsConstructor(onConstructor = @__(@Autowired))
 @Tag("migration")
 @TestPropertySource(properties = "spring.flyway.target=1.46.6")
 class TransferTransactionPayerMigrationTest extends IntegrationTest {
 
+    private static final EntityId NODE_ACCOUNT_ID = EntityId.of(0, 0, 3, EntityType.ACCOUNT);
     private static final EntityId PAYER_ID = EntityId.of(0, 0, 10001, EntityType.ACCOUNT);
 
-    private static final EntityId NODE_ACCOUNT_ID = EntityId.of(0, 0, 3, EntityType.ACCOUNT);
-
-    @Resource
-    private JdbcOperations jdbcOperations;
-
+    private final @Qualifier(JDBC_TEMPLATE_OWNER) JdbcOperations jdbcOperations;
     @Value("classpath:db/migration/v1/V1.47.0__add_transfer_payer.sql")
-    private File migrationSql;
-
-    @Resource
-    private EntityRepository entityRepository;
-
-    @Resource
-    private TransactionRepository transactionRepository;
-
-    @Resource
-    private CryptoTransferRepository cryptoTransferRepository;
-
-    @Resource
-    private NftTransferRepository nftTransferRepository;
-
-    @Resource
-    private NonFeeTransferRepository nonFeeTransferRepository;
-
-    @Resource
-    private TokenTransferRepository tokenTransferRepository;
+    private final File migrationSql;
+    private final EntityRepository entityRepository;
+    private final TransactionRepository transactionRepository;
+    private final CryptoTransferRepository cryptoTransferRepository;
+    private final NftTransferRepository nftTransferRepository;
+    private final NonFeeTransferRepository nonFeeTransferRepository;
+    private final TokenTransferRepository tokenTransferRepository;
 
     @BeforeEach
     void before() {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/TransferTransactionPayerMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/TransferTransactionPayerMigrationTest.java
@@ -21,7 +21,6 @@ package com.hedera.mirror.importer.migration;
  */
 
 import static com.hedera.mirror.common.domain.entity.EntityType.TOKEN;
-import static com.hedera.mirror.importer.config.JdbcTemplateConfiguration.JDBC_TEMPLATE_OWNER;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_TX_FEE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -45,7 +44,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jdbc.core.JdbcOperations;
 import org.springframework.test.context.TestPropertySource;
@@ -63,6 +61,7 @@ import com.hedera.mirror.common.domain.transaction.NonFeeTransfer;
 import com.hedera.mirror.common.domain.transaction.TransactionType;
 import com.hedera.mirror.importer.EnabledIfV1;
 import com.hedera.mirror.importer.IntegrationTest;
+import com.hedera.mirror.importer.config.Owner;
 import com.hedera.mirror.importer.repository.CryptoTransferRepository;
 import com.hedera.mirror.importer.repository.EntityRepository;
 import com.hedera.mirror.importer.repository.NftTransferRepository;
@@ -79,7 +78,7 @@ class TransferTransactionPayerMigrationTest extends IntegrationTest {
     private static final EntityId NODE_ACCOUNT_ID = EntityId.of(0, 0, 3, EntityType.ACCOUNT);
     private static final EntityId PAYER_ID = EntityId.of(0, 0, 10001, EntityType.ACCOUNT);
 
-    private final @Qualifier(JDBC_TEMPLATE_OWNER) JdbcOperations jdbcOperations;
+    private final @Owner JdbcOperations jdbcOperations;
     @Value("classpath:db/migration/v1/V1.47.0__add_transfer_payer.sql")
     private final File migrationSql;
     private final EntityRepository entityRepository;

--- a/hedera-mirror-importer/src/test/resources/config/application.yml
+++ b/hedera-mirror-importer/src/test/resources/config/application.yml
@@ -4,10 +4,12 @@ hedera:
       db:
         # https://github.com/testcontainers/testcontainers-spring-boot#embedded-postgresql
         host: ${embedded.postgresql.host}
+        name: ${embedded.postgresql.database}
+        owner: ${embedded.postgresql.user}
+        ownerPassword: ${embedded.postgresql.password}
+        password: mirror_importer_pass
         port: ${embedded.postgresql.port}
-        name: ${embedded.postgresql.schema}
-        username: ${embedded.postgresql.user}
-        password: ${embedded.postgresql.password}
+        username: mirror_importer
       downloader:
         bucketName: test
       importHistoricalAccountInfo: false
@@ -25,12 +27,10 @@ hedera:
 
 spring:
   flyway:
-    password: ${hedera.mirror.importer.db.password}
     placeholders:
       compressionAge: 9223372036854775807 # use long max to avoid compression during test
     # disable repeatable migrations to avoid failures when running them with old version
     repeatableSqlMigrationPrefix: DISABLED
-    user: ${hedera.mirror.importer.db.username}
   redis:
     host: ${embedded.redis.host}
     password: ${embedded.redis.password}

--- a/hedera-mirror-importer/src/test/resources/config/bootstrap.yml
+++ b/hedera-mirror-importer/src/test/resources/config/bootstrap.yml
@@ -5,6 +5,10 @@ embedded:
       # so it is enabled only for those tests.
       enabled: false
   postgresql:
+    database: mirror_node
     docker-image: postgres:14-alpine
+    initScriptPath: db/scripts/init.sql
+    password: mirror_node_pass
+    user: mirror_node
   redis:
     docker-image: redis:6.2.3-alpine

--- a/hedera-mirror-importer/src/test/resources/db/migration/v1/V1.10.0.1__fix_regular_db_user_privileges.sql
+++ b/hedera-mirror-importer/src/test/resources/db/migration/v1/V1.10.0.1__fix_regular_db_user_privileges.sql
@@ -1,0 +1,2 @@
+revoke all on all tables in schema public from ${db-user};
+alter default privileges in schema public revoke all on tables from ${db-user};

--- a/hedera-mirror-importer/src/test/resources/db/migration/v1/V1.10.0.1__fix_regular_db_user_privileges.sql
+++ b/hedera-mirror-importer/src/test/resources/db/migration/v1/V1.10.0.1__fix_regular_db_user_privileges.sql
@@ -1,2 +1,3 @@
+-- revoke excessive privileges granted to db-user in migration V1.10.0
 revoke all on all tables in schema public from ${db-user};
 alter default privileges in schema public revoke all on tables from ${db-user};

--- a/hedera-mirror-importer/src/test/resources/db/scripts/init.sql
+++ b/hedera-mirror-importer/src/test/resources/db/scripts/init.sql
@@ -13,13 +13,9 @@ revoke create on schema public from public;
 -- Grant readonly privileges
 grant connect on database mirror_node to readonly;
 grant select on all tables in schema public to readonly;
-grant select on all sequences in schema public to readonly;
 grant usage on schema public to readonly;
 alter default privileges in schema public grant select on tables to readonly;
-alter default privileges in schema public grant select on sequences to readonly;
 
 -- Grant readwrite privileges
 grant insert, update, delete on all tables in schema public to readwrite;
-grant usage on all sequences in schema public to readwrite;
 alter default privileges in schema public grant insert, update, delete on tables to readwrite;
-alter default privileges in schema public grant usage on sequences to readwrite;

--- a/hedera-mirror-importer/src/test/resources/db/scripts/init.sql
+++ b/hedera-mirror-importer/src/test/resources/db/scripts/init.sql
@@ -1,0 +1,25 @@
+-- Create roles
+create role readonly;
+create role readwrite in role readonly;
+
+-- Create user mirror_importer
+create user mirror_importer with login password 'mirror_importer_pass' in role readwrite;
+
+-- Create schema
+create schema if not exists public authorization mirror_node;
+grant usage on schema public to public;
+revoke create on schema public from public;
+
+-- Grant readonly privileges
+grant connect on database mirror_node to readonly;
+grant select on all tables in schema public to readonly;
+grant select on all sequences in schema public to readonly;
+grant usage on schema public to readonly;
+alter default privileges in schema public grant select on tables to readonly;
+alter default privileges in schema public grant select on sequences to readonly;
+
+-- Grant readwrite privileges
+grant insert, update, delete on all tables in schema public to readwrite;
+grant usage on all sequences in schema public to readwrite;
+alter default privileges in schema public grant insert, update, delete on tables to readwrite;
+alter default privileges in schema public grant usage on sequences to readwrite;

--- a/lombok.config
+++ b/lombok.config
@@ -1,6 +1,7 @@
 lombok.anyConstructor.addConstructorProperties = true
 lombok.equalsAndHashCode.callSuper = call
 lombok.toString.callSuper = call
+lombok.copyableAnnotations += com.hedera.mirror.importer.config.Owner
 lombok.copyableAnnotations += org.springframework.beans.factory.annotation.Qualifier
 lombok.copyableAnnotations += org.springframework.beans.factory.annotation.Value
 lombok.log.custom.declaration = org.slf4j.Logger org.slf4j.LoggerFactory.getLogger(TYPE)


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR improves the importer integration test to use different db users for migration and regular processing

- Create db owner `mirror_node` and importer user `mirror_importer` in postgres test container
- Create a separate `JdbcTemplate` bean with db owner credentials
- Use the db owner `JdbcTemplate` bean in java migrations when needed

**Related issue(s)**:

Fixes #4474
Fixes #4475

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
