### PR TITLE
Upgrade to use the v3 codecov github action for github workflows.

### DIFF
--- a/.github/workflows/grpc-api.yml
+++ b/.github/workflows/grpc-api.yml
@@ -38,10 +38,6 @@ jobs:
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v3
-        if: always()
-        run: bash <(curl -s https://codecov.io/bash)
-        with:
-          fail_ci_if_error: true
 
       - name: Upload artifact
         if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/grpc-api.yml
+++ b/.github/workflows/grpc-api.yml
@@ -37,8 +37,11 @@ jobs:
         working-directory: .
 
       - name: Upload coverage report
+        uses: codecov/codecov-action@v3
         if: always()
         run: bash <(curl -s https://codecov.io/bash)
+        with:
+          fail_ci_if_error: true
 
       - name: Upload artifact
         if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/grpc-api.yml
+++ b/.github/workflows/grpc-api.yml
@@ -38,6 +38,7 @@ jobs:
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v3
+        if: always()
 
       - name: Upload artifact
         if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/importer.yml
+++ b/.github/workflows/importer.yml
@@ -38,10 +38,6 @@ jobs:
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v3
-        if: always()
-        run: bash <(curl -s https://codecov.io/bash)
-        with:
-          fail_ci_if_error: true
 
       - name: Upload artifact
         if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/importer.yml
+++ b/.github/workflows/importer.yml
@@ -37,8 +37,11 @@ jobs:
         working-directory: .
 
       - name: Upload coverage report
+        uses: codecov/codecov-action@v3
         if: always()
         run: bash <(curl -s https://codecov.io/bash)
+        with:
+          fail_ci_if_error: true
 
       - name: Upload artifact
         if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/importer.yml
+++ b/.github/workflows/importer.yml
@@ -38,6 +38,7 @@ jobs:
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v3
+        if: always()
 
       - name: Upload artifact
         if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/monitor.yml
+++ b/.github/workflows/monitor.yml
@@ -35,7 +35,3 @@ jobs:
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v3
-        if: always()
-        run: bash <(curl -s https://codecov.io/bash)
-        with:
-          fail_ci_if_error: true

--- a/.github/workflows/monitor.yml
+++ b/.github/workflows/monitor.yml
@@ -34,5 +34,8 @@ jobs:
         working-directory: .
 
       - name: Upload coverage report
+        uses: codecov/codecov-action@v3
         if: always()
         run: bash <(curl -s https://codecov.io/bash)
+        with:
+          fail_ci_if_error: true

--- a/.github/workflows/monitor.yml
+++ b/.github/workflows/monitor.yml
@@ -35,3 +35,5 @@ jobs:
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v3
+        if: always()
+

--- a/.github/workflows/rosetta-api.yml
+++ b/.github/workflows/rosetta-api.yml
@@ -44,10 +44,6 @@ jobs:
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v3
-        if: always()
-        run: bash <(curl -s https://codecov.io/bash)
-        with:
-          fail_ci_if_error: true
 
   image:
     if: github.event_name == 'push' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')

--- a/.github/workflows/rosetta-api.yml
+++ b/.github/workflows/rosetta-api.yml
@@ -43,8 +43,11 @@ jobs:
           GOPATH: ~/go
 
       - name: Upload coverage report
+        uses: codecov/codecov-action@v3
         if: always()
         run: bash <(curl -s https://codecov.io/bash)
+        with:
+          fail_ci_if_error: true
 
   image:
     if: github.event_name == 'push' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')

--- a/.github/workflows/rosetta-api.yml
+++ b/.github/workflows/rosetta-api.yml
@@ -44,6 +44,7 @@ jobs:
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v3
+        if: always()
 
   image:
     if: github.event_name == 'push' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')

--- a/.github/workflows/web3.yml
+++ b/.github/workflows/web3.yml
@@ -38,3 +38,4 @@ jobs:
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v3
+        if: always()

--- a/.github/workflows/web3.yml
+++ b/.github/workflows/web3.yml
@@ -37,5 +37,8 @@ jobs:
         working-directory: .
 
       - name: Upload coverage report
+        uses: codecov/codecov-action@v3
         if: always()
         run: bash <(curl -s https://codecov.io/bash)
+        with:
+          fail_ci_if_error: true

--- a/.github/workflows/web3.yml
+++ b/.github/workflows/web3.yml
@@ -38,7 +38,3 @@ jobs:
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v3
-        if: always()
-        run: bash <(curl -s https://codecov.io/bash)
-        with:
-          fail_ci_if_error: true


### PR DESCRIPTION
**Description**:
Codecov bash uploader has been deprecated starting February 2022. We need to upgrade our workflows to use the codecov v3 GitHub Actions.

* Update workflows to use `codecov/codecov-action@v3`

**Related issue(s)**:

Fixes #4551

**Notes for reviewer**:
Check for all code coverage jobs to pass.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
