### PR TITLE
Upgrade to use the v3 codecov github action for github workflows. (#4…

### DIFF
--- a/.github/workflows/grpc-api.yml
+++ b/.github/workflows/grpc-api.yml
@@ -37,8 +37,8 @@ jobs:
         working-directory: .
 
       - name: Upload coverage report
+        uses: codecov/codecov-action@v3
         if: always()
-        run: bash <(curl -s https://codecov.io/bash)
 
       - name: Upload artifact
         if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/importer.yml
+++ b/.github/workflows/importer.yml
@@ -37,8 +37,8 @@ jobs:
         working-directory: .
 
       - name: Upload coverage report
+        uses: codecov/codecov-action@v3
         if: always()
-        run: bash <(curl -s https://codecov.io/bash)
 
       - name: Upload artifact
         if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/monitor.yml
+++ b/.github/workflows/monitor.yml
@@ -34,5 +34,6 @@ jobs:
         working-directory: .
 
       - name: Upload coverage report
+        uses: codecov/codecov-action@v3
         if: always()
-        run: bash <(curl -s https://codecov.io/bash)
+

--- a/.github/workflows/rosetta-api.yml
+++ b/.github/workflows/rosetta-api.yml
@@ -43,8 +43,8 @@ jobs:
           GOPATH: ~/go
 
       - name: Upload coverage report
+        uses: codecov/codecov-action@v3
         if: always()
-        run: bash <(curl -s https://codecov.io/bash)
 
   image:
     if: github.event_name == 'push' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')

--- a/.github/workflows/web3.yml
+++ b/.github/workflows/web3.yml
@@ -37,5 +37,5 @@ jobs:
         working-directory: .
 
       - name: Upload coverage report
+        uses: codecov/codecov-action@v3
         if: always()
-        run: bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
**Description**:

Upgrade to use the v3 codecov github action for github workflows.

This PR modifies the workflow files in order to support ...
* Change codecov version to v3
* Remove ```bash <(curl -s https://codecov.io/bash)```


**Related issue(s)**:

Fixes # https://github.com/hashgraph/hedera-mirror-node/issues/4551

**Notes for reviewer**:
This should fix the failing code coverage vuilds.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
