### PR TITLE
Change Rosetta reconciliation to use hardcoded balance offset (0.65)

### DIFF
--- a/hedera-mirror-rosetta/app/config/application.yml
+++ b/hedera-mirror-rosetta/app/config/application.yml
@@ -24,7 +24,7 @@ hedera:
         writeTimeout: 10000000000
       log:
         level: info
-      network: DEMO
+      network: demo
       nodes:
       nodeVersion: 0
       online: true

--- a/hedera-mirror-rosetta/app/config/config.go
+++ b/hedera-mirror-rosetta/app/config/config.go
@@ -95,6 +95,7 @@ func LoadConfig() (*Config, error) {
 	}
 
 	rosettaConfig := &config.Hedera.Mirror.Rosetta
+	rosettaConfig.Network = strings.ToLower(rosettaConfig.Network)
 	if len(nodeMap) != 0 {
 		rosettaConfig.Nodes = nodeMap
 	}

--- a/hedera-mirror-rosetta/app/config/config_test.go
+++ b/hedera-mirror-rosetta/app/config/config_test.go
@@ -54,7 +54,8 @@ hedera:
     rosetta:
       db:
         host: 192.168.120.51
-        port: 12000`
+        port: 12000
+      network: TESTNET`
 	serviceEndpoint = "192.168.0.1:50211"
 )
 
@@ -130,6 +131,7 @@ func TestLoadCustomConfigFromCwdAndEnvVar(t *testing.T) {
 	expected.Db.Host = "192.168.120.51"
 	expected.Db.Port = 12000
 	expected.Db.Username = "foobar"
+	expected.Network = "testnet"
 	assert.NoError(t, err)
 	assert.Equal(t, expected, config)
 }

--- a/hedera-mirror-rosetta/app/persistence/account.go
+++ b/hedera-mirror-rosetta/app/persistence/account.go
@@ -23,7 +23,6 @@ package persistence
 import (
 	"context"
 	"database/sql"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -87,14 +86,22 @@ const (
                                 ) as associations
                               ) as token_associations`
 	latestBalanceBeforeConsensus = "with" + genesisTimestampCte + `, abm as (
-                                      select consensus_timestamp as max, time_offset
-                                      from account_balance_file
-                                      where consensus_timestamp <= @timestamp
+                                      select
+                                        consensus_timestamp max,
+                                        (consensus_timestamp + time_offset + fixed_offset.value) adjusted_timestamp
+                                      from account_balance_file,
+                                        lateral (
+                                          select
+                                            case when consensus_timestamp >= @first_fixed_offset_timestamp then 53
+                                                 else 0
+                                            end value
+                                        ) fixed_offset
+                                      where consensus_timestamp + time_offset + fixed_offset.value <= @timestamp
                                       order by consensus_timestamp desc
                                       limit 1
                                     )
                                     select
-                                      abm.max + abm.time_offset as consensus_timestamp,
+                                      adjusted_timestamp as consensus_timestamp,
                                       coalesce(ab.balance, 0) balance,
                                       coalesce((
                                         select json_agg(json_build_object(
@@ -156,12 +163,16 @@ type tokenAssociation struct {
 
 // accountRepository struct that has connection to the Database
 type accountRepository struct {
-	dbClient interfaces.DbClient
+	dbClient                        interfaces.DbClient
+	firstFixedOffsetTimestampSqlArg sql.NamedArg
 }
 
 // NewAccountRepository creates an instance of a accountRepository struct
-func NewAccountRepository(dbClient interfaces.DbClient) interfaces.AccountRepository {
-	return &accountRepository{dbClient}
+func NewAccountRepository(dbClient interfaces.DbClient, network string) interfaces.AccountRepository {
+	return &accountRepository{
+		dbClient:                        dbClient,
+		firstFixedOffsetTimestampSqlArg: getFirstAccountBalanceFileFixedOffsetTimestampSqlNamedArg(network),
+	}
 }
 
 func (ar *accountRepository) GetAccountAlias(ctx context.Context, accountId types.AccountId) (
@@ -223,6 +234,10 @@ func (ar *accountRepository) RetrieveBalanceAtBlock(
 	entity, err := ar.getCryptoEntity(ctx, accountId, consensusEnd)
 	if err != nil {
 		return nil, entityIdString, err
+	}
+
+	if entity == nil && accountId.HasAlias() {
+		return types.AmountSlice{&types.HbarAmount{}}, entityIdString, nil
 	}
 
 	balanceChangeEndTimestamp := consensusEnd
@@ -301,15 +316,12 @@ func (ar *accountRepository) getCryptoEntity(ctx context.Context, accountId type
 
 	var query string
 	var args []interface{}
-	var notFoundError *rTypes.Error
 	if accountId.HasAlias() {
 		query = selectCryptoEntityByAlias
 		args = []interface{}{
 			sql.Named("alias", accountId.GetAlias()),
 			sql.Named("consensus_end", getInclusiveInt8Range(consensusEnd, consensusEnd)),
 		}
-		notFoundError = hErrors.AddErrorDetails(hErrors.ErrAccountNotFound, "reason",
-			fmt.Sprintf("Account with the alias '%s' not found", hex.EncodeToString(accountId.GetAlias())))
 	} else {
 		query = selectCryptoEntityById
 		args = []interface{}{sql.Named("id", accountId.GetId())}
@@ -326,7 +338,7 @@ func (ar *accountRepository) getCryptoEntity(ctx context.Context, accountId type
 	}
 
 	if len(entities) == 0 {
-		return nil, notFoundError
+		return nil, nil
 	}
 
 	// if it's by alias, return the first match which is the current one owns the alias, even though it may be deleted
@@ -348,6 +360,7 @@ func (ar *accountRepository) getLatestBalanceSnapshot(ctx context.Context, accou
 		latestBalanceBeforeConsensus,
 		sql.Named("account_id", accountId),
 		sql.Named("timestamp", timestamp),
+		ar.firstFixedOffsetTimestampSqlArg,
 	).First(cb).Error; err != nil {
 		log.Errorf(
 			databaseErrorFormat,
@@ -395,6 +408,7 @@ func (ar *accountRepository) getBalanceChange(ctx context.Context, accountId, co
 		sql.Named("account_id", accountId),
 		sql.Named("start", consensusStart),
 		sql.Named("end", consensusEnd),
+		ar.firstFixedOffsetTimestampSqlArg,
 	).First(change).Error; err != nil {
 		log.Errorf(
 			databaseErrorFormat,
@@ -446,6 +460,7 @@ func (ar *accountRepository) getNftBalance(
 		sql.Named("account_id", accountId),
 		sql.Named("start", consensusStart),
 		sql.Named("end", consensusEnd),
+		ar.firstFixedOffsetTimestampSqlArg,
 	).Scan(&nftTransfers).Error; err != nil {
 		log.Errorf(
 			databaseErrorFormat,

--- a/hedera-mirror-rosetta/app/persistence/account_test.go
+++ b/hedera-mirror-rosetta/app/persistence/account_test.go
@@ -56,16 +56,17 @@ const (
 )
 
 const (
-	accountDeleteTimestamp   int64 = 280
-	consensusTimestamp       int64 = 200
-	dissociateTimestamp            = consensusTimestamp + 1
-	account1CreatedTimestamp int64 = 50
-	account2DeletedTimestamp       = account1CreatedTimestamp - 1
-	account2CreatedTimestamp       = account2DeletedTimestamp - 9
-	firstSnapshotTimestamp   int64 = 100
-	initialAccountBalance    int64 = 12345
-	secondSnapshotTimestamp        = consensusTimestamp - 20
-	thirdSnapshotTimestamp   int64 = 400
+	accountDeleteTimestamp   = secondSnapshotTimestamp + 180
+	account1CreatedTimestamp = firstSnapshotTimestamp - 100
+	account2DeletedTimestamp = account1CreatedTimestamp - 1
+	account2CreatedTimestamp = account2DeletedTimestamp - 9
+	consensusTimestamp       = firstSnapshotTimestamp + 200
+	dissociateTimestamp      = consensusTimestamp + 1
+	// timestamp of the first testnet account balance file with HAPI 0.27.0
+	firstSnapshotTimestamp  int64 = 1656693000269913000
+	initialAccountBalance   int64 = 12345
+	secondSnapshotTimestamp       = consensusTimestamp - 20
+	thirdSnapshotTimestamp        = secondSnapshotTimestamp + 200
 
 	// account3, account4, and account5 are for GetAccountAlias tests
 	account3CreatedTimestamp = consensusTimestamp + 100
@@ -336,7 +337,7 @@ func (suite *accountRepositorySuite) TestGetAccountAlias() {
 		{encodedId: account4, expected: fmt.Sprintf("0.0.%d", account4)},
 	}
 
-	repo := NewAccountRepository(dbClient)
+	repo := NewAccountRepository(dbClient, "")
 
 	for _, tt := range tests {
 		name := fmt.Sprintf("%d", tt.encodedId)
@@ -352,7 +353,7 @@ func (suite *accountRepositorySuite) TestGetAccountAlias() {
 func (suite *accountRepositorySuite) TestGetAccountAliasDbConnectionError() {
 	// given
 	accountId := types.NewAccountIdFromEntityId(domain.MustDecodeEntityId(account3))
-	repo := NewAccountRepository(invalidDbClient)
+	repo := NewAccountRepository(invalidDbClient, "")
 
 	// when
 	actual, err := repo.GetAccountAlias(defaultContext, accountId)
@@ -365,7 +366,7 @@ func (suite *accountRepositorySuite) TestGetAccountAliasDbConnectionError() {
 func (suite *accountRepositorySuite) TestGetAccountId() {
 	// given
 	aliasAccountId, _ := types.NewAccountIdFromAlias(account4Alias, 0, 0)
-	repo := NewAccountRepository(dbClient)
+	repo := NewAccountRepository(dbClient, "")
 
 	// when
 	actual, err := repo.GetAccountId(defaultContext, aliasAccountId)
@@ -378,7 +379,7 @@ func (suite *accountRepositorySuite) TestGetAccountId() {
 func (suite *accountRepositorySuite) TestGetAccountIdNumericAccount() {
 	// given
 	accountId := types.NewAccountIdFromEntityId(domain.MustDecodeEntityId(account1))
-	repo := NewAccountRepository(dbClient)
+	repo := NewAccountRepository(dbClient, "")
 
 	// when
 	actual, err := repo.GetAccountId(defaultContext, accountId)
@@ -391,7 +392,7 @@ func (suite *accountRepositorySuite) TestGetAccountIdNumericAccount() {
 func (suite *accountRepositorySuite) TestGetAccountIdDbConnectionError() {
 	// given
 	aliasAccountId, _ := types.NewAccountIdFromAlias(account4Alias, 0, 0)
-	repo := NewAccountRepository(invalidDbClient)
+	repo := NewAccountRepository(invalidDbClient, "")
 
 	// when
 	actual, err := repo.GetAccountId(defaultContext, aliasAccountId)
@@ -402,34 +403,26 @@ func (suite *accountRepositorySuite) TestGetAccountIdDbConnectionError() {
 }
 
 func (suite *accountRepositorySuite) TestRetrieveBalanceAtBlock() {
+	suite.testRetrieveBalanceAtBlockNoFixedOffset("")
+}
+
+func (suite *accountRepositorySuite) TestRetrieveBalanceAtBlockMainnet() {
+	suite.testRetrieveBalanceAtBlockNoFixedOffset(mainnet)
+}
+
+func (suite *accountRepositorySuite) TestRetrieveBalanceAtBlockTestnet() {
 	// given
 	// tokens created at or before first account balance snapshot will not show up in account balance response
 	// transfers before or at the snapshot timestamp should not affect balance calculation
 	accountId := suite.accountId
-	repo := NewAccountRepository(dbClient)
+	repo := NewAccountRepository(dbClient, testnet)
 
-	hbarAmount := &types.HbarAmount{Value: initialAccountBalance + sum(cryptoTransferAmounts)}
-	token1Amount := types.NewTokenAmount(token1, sum(token1TransferAmounts[:2]))
-	token2Amount := types.NewTokenAmount(token2, sum(token2TransferAmounts[:2]))
-	token3Amount := types.NewTokenAmount(token3, 2)
-	token4Amount := types.NewTokenAmount(token4, 0)
-	expectedAmounts := types.AmountSlice{hbarAmount, token1Amount, token2Amount, token3Amount, token4Amount}
+	hbarAmount := &types.HbarAmount{Value: initialAccountBalance}
+	expectedAmounts := types.AmountSlice{hbarAmount}
 
 	// when
 	// query
 	actualAmounts, accountIdString, err := repo.RetrieveBalanceAtBlock(defaultContext, accountId, consensusTimestamp)
-
-	// then
-	assert.Nil(suite.T(), err)
-	assert.Equal(suite.T(), suite.accountIdString, accountIdString)
-	assert.ElementsMatch(suite.T(), expectedAmounts, actualAmounts)
-
-	// when
-	// query at dissociateTimestamp, balances for token2 and token3 should be 0
-	actualAmounts, accountIdString, err = repo.RetrieveBalanceAtBlock(defaultContext, accountId, dissociateTimestamp)
-	token2Amount = types.NewTokenAmount(token2, 0)
-	token3Amount = types.NewTokenAmount(token3, 0)
-	expectedAmounts = types.AmountSlice{hbarAmount, token1Amount, token2Amount, token3Amount, token4Amount}
 
 	// then
 	assert.Nil(suite.T(), err)
@@ -487,7 +480,7 @@ func (suite *accountRepositorySuite) TestRetrieveBalanceAtBlockAfterSecondSnapsh
 	token3Amount := types.NewTokenAmount(token3, 3)
 	token4Amount := types.NewTokenAmount(token4, 0)
 	expectedAmount := types.AmountSlice{hbarAmount, token1Amount, token2Amount, token3Amount, token4Amount}
-	repo := NewAccountRepository(dbClient)
+	repo := NewAccountRepository(dbClient, "")
 
 	// when
 	actualAmounts, accountIdString, err := repo.RetrieveBalanceAtBlock(
@@ -516,7 +509,7 @@ func (suite *accountRepositorySuite) TestRetrieveBalanceAtBlockForDeletedAccount
 		types.NewTokenAmount(token3, 0),
 		types.NewTokenAmount(token4, 0),
 	}
-	repo := NewAccountRepository(dbClient)
+	repo := NewAccountRepository(dbClient, "")
 
 	// when
 	// account is deleted before the third account balance file, so there is no balance info in the file. querying the
@@ -548,7 +541,7 @@ func (suite *accountRepositorySuite) TestRetrieveBalanceAtBlockAtAccountDeletion
 		types.NewTokenAmount(token3, 0),
 		types.NewTokenAmount(token4, 0),
 	}
-	repo := NewAccountRepository(dbClient)
+	repo := NewAccountRepository(dbClient, "")
 
 	// when
 	actualAmounts, accountIdString, err := repo.RetrieveBalanceAtBlock(
@@ -573,7 +566,7 @@ func (suite *accountRepositorySuite) TestRetrieveBalanceAtBlockNoAccountEntity()
 	token3Amount := types.NewTokenAmount(token3, 2)
 	token4Amount := types.NewTokenAmount(token4, 0)
 	expectedAmounts := types.AmountSlice{hbarAmount, token1Amount, token2Amount, token3Amount, token4Amount}
-	repo := NewAccountRepository(dbClient)
+	repo := NewAccountRepository(dbClient, "")
 
 	// when
 	actualAmounts, accountIdString, err := repo.RetrieveBalanceAtBlock(
@@ -592,7 +585,7 @@ func (suite *accountRepositorySuite) TestRetrieveBalanceAtBlockNoTokenEntity() {
 	// given
 	accountId := suite.accountId
 	db.ExecSql(dbClient, truncateTokenSql)
-	repo := NewAccountRepository(dbClient)
+	repo := NewAccountRepository(dbClient, "")
 
 	// no token entities, so only hbar balance
 	hbarAmount := &types.HbarAmount{Value: initialAccountBalance + sum(cryptoTransferAmounts)}
@@ -623,7 +616,7 @@ func (suite *accountRepositorySuite) TestRetrieveBalanceAtBlockNoInitialBalance(
 	token4Amount := types.NewTokenAmount(token4, 0)
 	expectedAmounts := types.AmountSlice{hbarAmount, token1Amount, token2Amount, token3Amount, token4Amount}
 
-	repo := NewAccountRepository(dbClient)
+	repo := NewAccountRepository(dbClient, "")
 
 	// when
 	actualAmounts, accountIdString, err := repo.RetrieveBalanceAtBlock(
@@ -642,7 +635,7 @@ func (suite *accountRepositorySuite) TestRetrieveBalanceAtBlockNoAccountBalanceF
 	// given
 	db.ExecSql(dbClient, truncateAccountBalanceFileSql)
 	accountId := suite.accountId
-	repo := NewAccountRepository(dbClient)
+	repo := NewAccountRepository(dbClient, "")
 
 	// when
 	actualAmounts, accountIdString, err := repo.RetrieveBalanceAtBlock(
@@ -660,7 +653,7 @@ func (suite *accountRepositorySuite) TestRetrieveBalanceAtBlockNoAccountBalanceF
 func (suite *accountRepositorySuite) TestRetrieveBalanceAtBlockDbConnectionError() {
 	// given
 	accountId := suite.accountId
-	repo := NewAccountRepository(invalidDbClient)
+	repo := NewAccountRepository(invalidDbClient, "")
 
 	// when
 	actualAmounts, accountIdString, err := repo.RetrieveBalanceAtBlock(
@@ -673,6 +666,42 @@ func (suite *accountRepositorySuite) TestRetrieveBalanceAtBlockDbConnectionError
 	assert.Equal(suite.T(), errors.ErrDatabaseError, err)
 	assert.Empty(suite.T(), accountIdString)
 	assert.Nil(suite.T(), actualAmounts)
+}
+
+func (suite *accountRepositorySuite) testRetrieveBalanceAtBlockNoFixedOffset(network string) {
+	// given
+	// tokens created at or before first account balance snapshot will not show up in account balance response
+	// transfers before or at the snapshot timestamp should not affect balance calculation
+	accountId := suite.accountId
+	repo := NewAccountRepository(dbClient, network)
+
+	hbarAmount := &types.HbarAmount{Value: initialAccountBalance + sum(cryptoTransferAmounts)}
+	token1Amount := types.NewTokenAmount(token1, sum(token1TransferAmounts[:2]))
+	token2Amount := types.NewTokenAmount(token2, sum(token2TransferAmounts[:2]))
+	token3Amount := types.NewTokenAmount(token3, 2)
+	token4Amount := types.NewTokenAmount(token4, 0)
+	expectedAmounts := types.AmountSlice{hbarAmount, token1Amount, token2Amount, token3Amount, token4Amount}
+
+	// when
+	// query
+	actualAmounts, accountIdString, err := repo.RetrieveBalanceAtBlock(defaultContext, accountId, consensusTimestamp)
+
+	// then
+	assert.Nil(suite.T(), err)
+	assert.Equal(suite.T(), suite.accountIdString, accountIdString)
+	assert.ElementsMatch(suite.T(), expectedAmounts, actualAmounts)
+
+	// when
+	// query at dissociateTimestamp, balances for token2 and token3 should be 0
+	actualAmounts, accountIdString, err = repo.RetrieveBalanceAtBlock(defaultContext, accountId, dissociateTimestamp)
+	token2Amount = types.NewTokenAmount(token2, 0)
+	token3Amount = types.NewTokenAmount(token3, 0)
+	expectedAmounts = types.AmountSlice{hbarAmount, token1Amount, token2Amount, token3Amount, token4Amount}
+
+	// then
+	assert.Nil(suite.T(), err)
+	assert.Equal(suite.T(), suite.accountIdString, accountIdString)
+	assert.ElementsMatch(suite.T(), expectedAmounts, actualAmounts)
 }
 
 func sum(amounts []int64) int64 {
@@ -743,7 +772,7 @@ func (suite *accountRepositoryWithAliasSuite) TestGetAccountAlias() {
 		{encodedId: account4, expectedAlias: account4Alias},
 	}
 
-	repo := NewAccountRepository(dbClient)
+	repo := NewAccountRepository(dbClient, "")
 
 	for _, tt := range tests {
 		name := fmt.Sprintf("%d", tt.encodedId)
@@ -758,7 +787,7 @@ func (suite *accountRepositoryWithAliasSuite) TestGetAccountAlias() {
 
 func (suite *accountRepositoryWithAliasSuite) TestGetAccountAliasThrowWhenInvalidAlias() {
 	accountId := types.NewAccountIdFromEntityId(domain.MustDecodeEntityId(account5))
-	repo := NewAccountRepository(dbClient)
+	repo := NewAccountRepository(dbClient, "")
 	actual, err := repo.GetAccountAlias(defaultContext, accountId)
 	assert.NotNil(suite.T(), err)
 	assert.Equal(suite.T(), types.AccountId{}, actual)
@@ -768,7 +797,7 @@ func (suite *accountRepositoryWithAliasSuite) TestGetAccountId() {
 	// given
 	aliasAccountId, err := types.NewAccountIdFromAlias(account4Alias, 0, 0)
 	assert.NoError(suite.T(), err)
-	repo := NewAccountRepository(dbClient)
+	repo := NewAccountRepository(dbClient, "")
 	expected := types.NewAccountIdFromEntityId(domain.MustDecodeEntityId(account4))
 
 	// when
@@ -786,7 +815,7 @@ func (suite *accountRepositoryWithAliasSuite) TestGetAccountIdDeleted() {
 		ModifiedTimestamp(accountDeleteTimestamp).
 		Persist()
 	aliasAccountId, _ := types.NewAccountIdFromAlias(account4Alias, 0, 0)
-	repo := NewAccountRepository(dbClient)
+	repo := NewAccountRepository(dbClient, "")
 
 	// when
 	actual, rErr := repo.GetAccountId(defaultContext, aliasAccountId)
@@ -797,11 +826,9 @@ func (suite *accountRepositoryWithAliasSuite) TestGetAccountIdDeleted() {
 }
 
 func (suite *accountRepositoryWithAliasSuite) TestRetrieveBalanceAtBlockNoAccountEntity() {
-	// whey querying by alias and the account is not found, error is returned since without the alias to shard.realm.num
-	// mapping, no balance info for the account can be retrieved
-	// given
+	// whey querying by alias and the account is not found, expect 0 hbar balance returned
 	db.ExecSql(dbClient, truncateEntitySql)
-	repo := NewAccountRepository(dbClient)
+	repo := NewAccountRepository(dbClient, "")
 
 	// when
 	actualAmounts, accountIdString, err := repo.RetrieveBalanceAtBlock(
@@ -811,7 +838,7 @@ func (suite *accountRepositoryWithAliasSuite) TestRetrieveBalanceAtBlockNoAccoun
 	)
 
 	// then
-	assert.NotNil(suite.T(), err)
+	assert.Nil(suite.T(), err)
+	assert.Equal(suite.T(), types.AmountSlice{&types.HbarAmount{}}, actualAmounts)
 	assert.Empty(suite.T(), accountIdString)
-	assert.Nil(suite.T(), actualAmounts)
 }

--- a/hedera-mirror-rosetta/app/persistence/block_test.go
+++ b/hedera-mirror-rosetta/app/persistence/block_test.go
@@ -142,7 +142,7 @@ func (suite *blockRepositorySuite) SetupTest() {
 
 func (suite *blockRepositorySuite) TestFindByHashGenesisBlock() {
 	// given
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, "")
 
 	// when
 	actual, err := repo.FindByHash(defaultContext, genesisRecordFile.Hash)
@@ -154,7 +154,7 @@ func (suite *blockRepositorySuite) TestFindByHashGenesisBlock() {
 
 func (suite *blockRepositorySuite) TestFindByHashNonGenesisBlock() {
 	// given
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, "")
 
 	// when
 	actual, err := repo.FindByHash(defaultContext, expectedSecondBlock.Hash)
@@ -166,7 +166,7 @@ func (suite *blockRepositorySuite) TestFindByHashNonGenesisBlock() {
 
 func (suite *blockRepositorySuite) TestFindByHashBlockBeforeGenesis() {
 	// given
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, "")
 
 	// when
 	actual, err := repo.FindByHash(defaultContext, recordFileBeforeGenesis.Hash)
@@ -179,7 +179,7 @@ func (suite *blockRepositorySuite) TestFindByHashBlockBeforeGenesis() {
 func (suite *blockRepositorySuite) TestFindByHashNoAccountBalanceFile() {
 	// given
 	db.ExecSql(dbClient, truncateAccountBalanceFileSql)
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, "")
 
 	// when
 	actual, err := repo.FindByHash(defaultContext, genesisRecordFile.Hash)
@@ -192,7 +192,7 @@ func (suite *blockRepositorySuite) TestFindByHashNoAccountBalanceFile() {
 func (suite *blockRepositorySuite) TestFindByHashNoRecordFile() {
 	// given
 	db.ExecSql(dbClient, truncateRecordFileSql)
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, "")
 
 	// when
 	actual, err := repo.FindByHash(defaultContext, genesisRecordFile.Hash)
@@ -204,7 +204,7 @@ func (suite *blockRepositorySuite) TestFindByHashNoRecordFile() {
 
 func (suite *blockRepositorySuite) TestFindByHashEmptyHash() {
 	// given
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, "")
 
 	// when
 	actual, err := repo.FindByHash(defaultContext, "")
@@ -216,7 +216,7 @@ func (suite *blockRepositorySuite) TestFindByHashEmptyHash() {
 
 func (suite *blockRepositorySuite) TestFindByHashDbConnectionError() {
 	// given
-	repo := NewBlockRepository(invalidDbClient)
+	repo := NewBlockRepository(invalidDbClient, "")
 
 	// when
 	actual, err := repo.FindByHash(defaultContext, genesisRecordFile.Hash)
@@ -228,7 +228,7 @@ func (suite *blockRepositorySuite) TestFindByHashDbConnectionError() {
 
 func (suite *blockRepositorySuite) TestFindByIdentifierGenesisBlock() {
 	// given
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, "")
 
 	// when
 	actual, err := repo.FindByIdentifier(defaultContext, genesisBlockIndex, expectedGenesisBlock.Hash)
@@ -240,7 +240,7 @@ func (suite *blockRepositorySuite) TestFindByIdentifierGenesisBlock() {
 
 func (suite *blockRepositorySuite) TestFindByIdentifierNonGenesisBlock() {
 	// given
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, "")
 
 	// when
 	actual, err := repo.FindByIdentifier(defaultContext, expectedSecondBlock.Index, expectedSecondBlock.Hash)
@@ -252,7 +252,7 @@ func (suite *blockRepositorySuite) TestFindByIdentifierNonGenesisBlock() {
 
 func (suite *blockRepositorySuite) TestFindByIdentifierBlockBeforeGenesis() {
 	// given
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, "")
 
 	// when
 	actual, err := repo.FindByIdentifier(defaultContext, recordFileBeforeGenesis.Index, recordFileBeforeGenesis.Hash)
@@ -280,7 +280,7 @@ func (suite *blockRepositorySuite) TestFindByIdentifierInvalidArgument() {
 			"",
 		},
 	}
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, "")
 
 	for _, tt := range tests {
 		suite.T().Run(tt.name, func(t *testing.T) {
@@ -296,7 +296,7 @@ func (suite *blockRepositorySuite) TestFindByIdentifierInvalidArgument() {
 
 func (suite *blockRepositorySuite) TestFindByIdentifierIndexHashMismatch() {
 	// given
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, "")
 
 	// when
 	actual, err := repo.FindByIdentifier(defaultContext, expectedGenesisBlock.Index, expectedSecondBlock.Hash)
@@ -309,7 +309,7 @@ func (suite *blockRepositorySuite) TestFindByIdentifierIndexHashMismatch() {
 func (suite *blockRepositorySuite) TestFindByIdentifierNoAccountBalanceFile() {
 	// given
 	db.ExecSql(dbClient, truncateAccountBalanceFileSql)
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, "")
 
 	// when
 	actual, err := repo.FindByIdentifier(defaultContext, 0, expectedGenesisBlock.Hash)
@@ -322,7 +322,7 @@ func (suite *blockRepositorySuite) TestFindByIdentifierNoAccountBalanceFile() {
 func (suite *blockRepositorySuite) TestFindByIdentifierNoRecordFile() {
 	// given
 	db.ExecSql(dbClient, truncateRecordFileSql)
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, "")
 
 	// when
 	actual, err := repo.FindByIdentifier(defaultContext, 0, expectedGenesisBlock.Hash)
@@ -334,7 +334,7 @@ func (suite *blockRepositorySuite) TestFindByIdentifierNoRecordFile() {
 
 func (suite *blockRepositorySuite) TestFindByIdentifierNotFound() {
 	// given
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, "")
 
 	// when
 	actual, err := repo.FindByIdentifier(defaultContext, 1000, "foobar")
@@ -346,7 +346,7 @@ func (suite *blockRepositorySuite) TestFindByIdentifierNotFound() {
 
 func (suite *blockRepositorySuite) TestFindByIdentifierDbConnectionError() {
 	// given
-	repo := NewBlockRepository(invalidDbClient)
+	repo := NewBlockRepository(invalidDbClient, "")
 
 	// when
 	actual, err := repo.FindByIdentifier(defaultContext, 0, expectedGenesisBlock.Hash)
@@ -358,7 +358,7 @@ func (suite *blockRepositorySuite) TestFindByIdentifierDbConnectionError() {
 
 func (suite *blockRepositorySuite) TestFindByIndexGenesisBlock() {
 	// given
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, "")
 
 	// when
 	actual, err := repo.FindByIndex(defaultContext, genesisBlockIndex)
@@ -370,7 +370,7 @@ func (suite *blockRepositorySuite) TestFindByIndexGenesisBlock() {
 
 func (suite *blockRepositorySuite) TestFindByIndexNonGenesisBlock() {
 	// given
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, "")
 
 	// when
 	actual, err := repo.FindByIndex(defaultContext, expectedSecondBlock.Index)
@@ -382,7 +382,7 @@ func (suite *blockRepositorySuite) TestFindByIndexNonGenesisBlock() {
 
 func (suite *blockRepositorySuite) TestFindByIndexBlockBeforeGenesis() {
 	// given
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, "")
 
 	// when
 	actual, err := repo.FindByIndex(defaultContext, recordFileBeforeGenesis.Index)
@@ -394,7 +394,7 @@ func (suite *blockRepositorySuite) TestFindByIndexBlockBeforeGenesis() {
 
 func (suite *blockRepositorySuite) TestFindByIndexInvalidIndex() {
 	// given
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, "")
 
 	// when
 	actual, err := repo.FindByIndex(defaultContext, -1)
@@ -407,7 +407,7 @@ func (suite *blockRepositorySuite) TestFindByIndexInvalidIndex() {
 func (suite *blockRepositorySuite) TestFineByIndexNoAccountBalanceFile() {
 	// given
 	db.ExecSql(dbClient, truncateAccountBalanceFileSql)
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, "")
 
 	// when
 	actual, err := repo.FindByIndex(defaultContext, 0)
@@ -420,7 +420,7 @@ func (suite *blockRepositorySuite) TestFineByIndexNoAccountBalanceFile() {
 func (suite *blockRepositorySuite) TestFindByIndexNoRecordFile() {
 	// given
 	db.ExecSql(dbClient, truncateRecordFileSql)
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, "")
 
 	// when
 	actual, err := repo.FindByIndex(defaultContext, 0)
@@ -432,7 +432,7 @@ func (suite *blockRepositorySuite) TestFindByIndexNoRecordFile() {
 
 func (suite *blockRepositorySuite) TestFindByIndexNotFound() {
 	// given
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, "")
 
 	// when
 	actual, err := repo.FindByIndex(defaultContext, 1000)
@@ -444,7 +444,7 @@ func (suite *blockRepositorySuite) TestFindByIndexNotFound() {
 
 func (suite *blockRepositorySuite) TestFindByIndexDbConnectionError() {
 	// given
-	repo := NewBlockRepository(invalidDbClient)
+	repo := NewBlockRepository(invalidDbClient, "")
 
 	// when
 	actual, err := repo.FindByIndex(defaultContext, 0)
@@ -456,7 +456,7 @@ func (suite *blockRepositorySuite) TestFindByIndexDbConnectionError() {
 
 func (suite *blockRepositorySuite) TestRetrieveGenesis() {
 	// given
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, "")
 
 	// when
 	actual, err := repo.RetrieveGenesis(defaultContext)
@@ -490,7 +490,7 @@ func (suite *blockRepositorySuite) TestRetrieveGenesisIndexOverflowInt4() {
 			expected := *expectedGenesisBlock
 			expected.Index = genesisIndex
 			expected.ParentIndex = genesisIndex
-			repo := NewBlockRepository(dbClient)
+			repo := NewBlockRepository(dbClient, "")
 
 			// when
 			actual, err := repo.RetrieveGenesis(defaultContext)
@@ -505,7 +505,7 @@ func (suite *blockRepositorySuite) TestRetrieveGenesisIndexOverflowInt4() {
 func (suite *blockRepositorySuite) TestRetrieveGenesisNoAccountBalanceFile() {
 	// given
 	db.ExecSql(dbClient, truncateAccountBalanceFileSql)
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, "")
 
 	// when
 	actual, err := repo.RetrieveGenesis(defaultContext)
@@ -518,7 +518,7 @@ func (suite *blockRepositorySuite) TestRetrieveGenesisNoAccountBalanceFile() {
 func (suite *blockRepositorySuite) TestRetrieveGenesisNoRecordFile() {
 	// given
 	db.ExecSql(dbClient, truncateRecordFileSql)
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, "")
 
 	// when
 	actual, err := repo.RetrieveGenesis(defaultContext)
@@ -530,7 +530,7 @@ func (suite *blockRepositorySuite) TestRetrieveGenesisNoRecordFile() {
 
 func (suite *blockRepositorySuite) TestRetrieveGenesisDbConnectionError() {
 	// given
-	repo := NewBlockRepository(invalidDbClient)
+	repo := NewBlockRepository(invalidDbClient, "")
 
 	// when
 	actual, err := repo.RetrieveGenesis(defaultContext)
@@ -543,7 +543,7 @@ func (suite *blockRepositorySuite) TestRetrieveGenesisDbConnectionError() {
 func (suite *blockRepositorySuite) TestRetrieveLatestNonGenesisBlock() {
 	// given
 	expected := expectedThirdBlock
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, "")
 
 	// when
 	actual, err := repo.RetrieveLatest(defaultContext)
@@ -557,7 +557,7 @@ func (suite *blockRepositorySuite) TestRetrieveLatestWithOnlyGenesisBlock() {
 	// given
 	db.ExecSql(dbClient, truncateRecordFileSql)
 	db.CreateDbRecords(dbClient, genesisRecordFile)
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, "")
 	expected := *expectedGenesisBlock
 	expected.ConsensusEndNanos = recordFiles[0].ConsensusEnd
 
@@ -573,7 +573,7 @@ func (suite *blockRepositorySuite) TestRetrieveLatestWithBlockBeforeGenesis() {
 	// given
 	db.ExecSql(dbClient, truncateRecordFileSql)
 	db.CreateDbRecords(dbClient, recordFileBeforeGenesis)
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, "")
 
 	// when
 	actual, err := repo.RetrieveLatest(defaultContext)
@@ -586,7 +586,7 @@ func (suite *blockRepositorySuite) TestRetrieveLatestWithBlockBeforeGenesis() {
 func (suite *blockRepositorySuite) TestRetrieveLatestNoAccountBalanceFile() {
 	// given
 	db.ExecSql(dbClient, truncateAccountBalanceFileSql)
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, "")
 
 	// when
 	actual, err := repo.RetrieveLatest(defaultContext)
@@ -599,7 +599,7 @@ func (suite *blockRepositorySuite) TestRetrieveLatestNoAccountBalanceFile() {
 func (suite *blockRepositorySuite) TestRetrieveLatestNoRecordFile() {
 	// given
 	db.ExecSql(dbClient, truncateRecordFileSql)
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, "")
 
 	// when
 	actual, err := repo.RetrieveLatest(defaultContext)
@@ -611,7 +611,7 @@ func (suite *blockRepositorySuite) TestRetrieveLatestNoRecordFile() {
 
 func (suite *blockRepositorySuite) TestRetrieveLatestRecordFileTableInconsistent() {
 	// given
-	repo := NewBlockRepository(dbClient)
+	repo := NewBlockRepository(dbClient, "")
 
 	// when
 	actual, err := repo.RetrieveLatest(defaultContext)
@@ -639,7 +639,7 @@ func (suite *blockRepositorySuite) TestRetrieveLatestRecordFileTableInconsistent
 
 func (suite *blockRepositorySuite) TestRetrieveLatestDbConnectionError() {
 	// given
-	repo := NewBlockRepository(invalidDbClient)
+	repo := NewBlockRepository(invalidDbClient, "")
 
 	// when
 	actual, err := repo.RetrieveLatest(defaultContext)

--- a/hedera-mirror-rosetta/app/persistence/common_test.go
+++ b/hedera-mirror-rosetta/app/persistence/common_test.go
@@ -1,0 +1,59 @@
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+package persistence
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetFirstAccountBalanceFileFixedOffsetTimestampSqlNamedArg(t *testing.T) {
+	tests := []struct {
+		network  string
+		expected sql.NamedArg
+	}{
+		{
+			network:  "mainnet",
+			expected: sql.Named(firstFixedOffsetTimestampSqlArgName, sql.NullInt64{Int64: 1658420100626004000, Valid: true}),
+		},
+		{
+			network:  "testnet",
+			expected: sql.Named(firstFixedOffsetTimestampSqlArgName, sql.NullInt64{Int64: 1656693000269913000, Valid: true}),
+		},
+		{
+			network:  "",
+			expected: sql.Named(firstFixedOffsetTimestampSqlArgName, sql.NullInt64{}),
+		},
+		{
+			network:  "demo",
+			expected: sql.Named(firstFixedOffsetTimestampSqlArgName, sql.NullInt64{}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.network, func(t *testing.T) {
+			actual := getFirstAccountBalanceFileFixedOffsetTimestampSqlNamedArg(tt.network)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}

--- a/hedera-mirror-rosetta/main.go
+++ b/hedera-mirror-rosetta/main.go
@@ -79,10 +79,10 @@ func newBlockchainOnlineRouter(
 	rosettaConfig *config.Config,
 	version *rTypes.Version,
 ) (http.Handler, error) {
-	accountRepo := persistence.NewAccountRepository(dbClient)
+	accountRepo := persistence.NewAccountRepository(dbClient, rosettaConfig.Network)
 	addressBookEntryRepo := persistence.NewAddressBookEntryRepository(dbClient)
-	blockRepo := persistence.NewBlockRepository(dbClient)
-	transactionRepo := persistence.NewTransactionRepository(dbClient)
+	blockRepo := persistence.NewBlockRepository(dbClient, rosettaConfig.Network)
+	transactionRepo := persistence.NewTransactionRepository(dbClient, rosettaConfig.Network)
 
 	baseService := services.NewOnlineBaseService(blockRepo, transactionRepo)
 

--- a/hedera-mirror-rosetta/test/db/db.go
+++ b/hedera-mirror-rosetta/test/db/db.go
@@ -234,7 +234,7 @@ func runFlywayMigration(pool *dockertest.Pool, network *dockertest.Network, para
 	// run the container with tty and entrypoint "bin/sh" so it will stay alive in background
 	options := &dockertest.RunOptions{
 		Repository: "flyway/flyway",
-		Tag:        "8.5-alpine",
+		Tag:        "9",
 		Entrypoint: []string{"/bin/sh"},
 		Networks:   []*dockertest.Network{network},
 		Mounts:     []string{migrationPath + ":/flyway/sql"},


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR ports the fix for #4482 to `release/0.65`

- Add fixed account balance file offset for mainnet and testnet
- Switch to flyway multi-arch docker image
- Report 0 balance for blocks in which an alias account doesn't exist

**Related issue(s)**:

Relates to #4482

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
