### PR TITLE
Rosetta limit the number of transactions in block response

### DIFF
--- a/.github/workflows/rosetta-api.yml
+++ b/.github/workflows/rosetta-api.yml
@@ -142,6 +142,7 @@ jobs:
         run: |
           ONLINE_CONTAINER_ID=$(docker run -d -e HEDERA_MIRROR_IMPORTER_STARTDATE=$STARTDATE \
             -e NETWORK=testnet \
+            -e HEDERA_MIRROR_ROSETTA_RESPONSE_MAXTRANSACTIONSINBLOCK=4 \
             -v /tmp/application_importer.yml:/app/importer/application.yml \
             -v /tmp/application_rosetta.yml:/app/rosetta/application.yml \
             -p 5700:5700 "${MODULE}:latest")

--- a/hedera-mirror-rosetta/app/config/application.yml
+++ b/hedera-mirror-rosetta/app/config/application.yml
@@ -30,5 +30,7 @@ hedera:
       online: true
       port: 5700
       realm: 0
+      response:
+        maxTransactionsInBlock: 6000
       shard: 0
       shutdownTimeout: 10s

--- a/hedera-mirror-rosetta/app/config/types.go
+++ b/hedera-mirror-rosetta/app/config/types.go
@@ -41,6 +41,7 @@ type Config struct {
 	Online          bool
 	Port            uint16
 	Realm           int64
+	Response        Response
 	Shard           int64
 	ShutdownTimeout time.Duration `yaml:"shutdownTimeout"`
 }
@@ -91,4 +92,8 @@ type Pool struct {
 	MaxIdleConnections int `yaml:"maxIdleConnections"`
 	MaxLifetime        int `yaml:"maxLifetime"`
 	MaxOpenConnections int `yaml:"maxOpenConnections"`
+}
+
+type Response struct {
+	MaxTransactionsInBlock int `yaml:"maxTransactionsInBlock"`
 }

--- a/hedera-mirror-rosetta/app/services/block_service.go
+++ b/hedera-mirror-rosetta/app/services/block_service.go
@@ -37,7 +37,8 @@ import (
 type blockAPIService struct {
 	accountRepo interfaces.AccountRepository
 	BaseService
-	entityCache *cache.Cache[int64, types.AccountId]
+	entityCache            *cache.Cache[int64, types.AccountId]
+	maxTransactionsInBlock int
 }
 
 // NewBlockAPIService creates a new instance of a blockAPIService.
@@ -45,13 +46,19 @@ func NewBlockAPIService(
 	accountRepo interfaces.AccountRepository,
 	baseService BaseService,
 	entityCacheConfig config.Cache,
+	maxTransactionsInBlock int,
 	serverContext context.Context,
 ) server.BlockAPIServicer {
 	entityCache := cache.NewContext(
 		serverContext,
 		cache.AsLRU[int64, types.AccountId](lru.WithCapacity(entityCacheConfig.MaxSize)),
 	)
-	return &blockAPIService{accountRepo: accountRepo, BaseService: baseService, entityCache: entityCache}
+	return &blockAPIService{
+		accountRepo:            accountRepo,
+		BaseService:            baseService,
+		entityCache:            entityCache,
+		maxTransactionsInBlock: maxTransactionsInBlock,
+	}
 }
 
 // Block implements the /block endpoint.
@@ -68,11 +75,20 @@ func (s *blockAPIService) Block(
 		return nil, err
 	}
 
+	var otherTransactions []*rTypes.TransactionIdentifier
+	if len(block.Transactions) > s.maxTransactionsInBlock {
+		otherTransactions = make([]*rTypes.TransactionIdentifier, 0, len(block.Transactions)-s.maxTransactionsInBlock)
+		for _, transaction := range block.Transactions[s.maxTransactionsInBlock:] {
+			otherTransactions = append(otherTransactions, &rTypes.TransactionIdentifier{Hash: transaction.Hash})
+		}
+		block.Transactions = block.Transactions[0:s.maxTransactionsInBlock]
+	}
+
 	if err = s.updateOperationAccountAlias(ctx, block.Transactions...); err != nil {
 		return nil, err
 	}
 
-	return &rTypes.BlockResponse{Block: block.ToRosetta()}, nil
+	return &rTypes.BlockResponse{Block: block.ToRosetta(), OtherTransactions: otherTransactions}, nil
 }
 
 // BlockTransaction implements the /block/transaction endpoint.

--- a/hedera-mirror-rosetta/app/services/block_service_test.go
+++ b/hedera-mirror-rosetta/app/services/block_service_test.go
@@ -76,7 +76,10 @@ func blockRequest() *rTypes.BlockRequest {
 	}
 }
 
-func expectedBlockResponse(transactions ...*rTypes.Transaction) *rTypes.BlockResponse {
+func expectedBlockResponse(
+	transactions []*rTypes.Transaction,
+	otherTransactions []*rTypes.TransactionIdentifier,
+) *rTypes.BlockResponse {
 	return &rTypes.BlockResponse{
 		Block: &rTypes.Block{
 			BlockIdentifier: &rTypes.BlockIdentifier{
@@ -91,7 +94,7 @@ func expectedBlockResponse(transactions ...*rTypes.Transaction) *rTypes.BlockRes
 			Transactions: transactions,
 			Metadata:     nil,
 		},
-		OtherTransactions: nil,
+		OtherTransactions: otherTransactions,
 	}
 }
 
@@ -176,7 +179,13 @@ func (suite *blockServiceSuite) SetupTest() {
 	suite.mockTransactionRepo = &mocks.MockTransactionRepository{}
 
 	baseService := NewOnlineBaseService(suite.mockBlockRepo, suite.mockTransactionRepo)
-	suite.blockService = NewBlockAPIService(suite.mockAccountRepo, baseService, config.Cache{MaxSize: 1024}, suite.ctx)
+	suite.blockService = NewBlockAPIService(
+		suite.mockAccountRepo,
+		baseService,
+		config.Cache{MaxSize: 1024},
+		4,
+		suite.ctx,
+	)
 }
 
 func (suite *blockServiceSuite) TestNewBlockAPIService() {
@@ -189,9 +198,39 @@ func (suite *blockServiceSuite) TestBlock() {
 		makeTransaction(nil, "123"),
 		makeTransaction(&entityId, "246"),
 	}
-	expected := expectedBlockResponse(
+	expected := expectedBlockResponse([]*rTypes.Transaction{
 		expectedTransaction(account, nil, "123"),
 		expectedTransaction(account, &entityId, "246"),
+	}, nil)
+	suite.mockAccountRepo.On("GetAccountAlias").Return(account, mocks.NilError)
+	suite.mockBlockRepo.On("FindByIdentifier").Return(block(), mocks.NilError)
+	suite.mockTransactionRepo.On("FindBetween").Return(exampleTransactions, mocks.NilError)
+
+	// when:
+	actual, e := suite.blockService.Block(nil, blockRequest())
+
+	// then:
+	assert.Nil(suite.T(), e)
+	assert.Equal(suite.T(), expected, actual)
+	suite.mockAccountRepo.AssertNumberOfCalls(suite.T(), "GetAccountAlias", 1)
+}
+
+func (suite *blockServiceSuite) TestBlockWithCappedTransactions() {
+	// given:
+	exampleTransactions := []*types.Transaction{
+		makeTransaction(nil, "123"),
+		makeTransaction(&entityId, "246"),
+		makeTransaction(nil, "333"),
+		makeTransaction(nil, "444"),
+		makeTransaction(nil, "555"),
+	}
+	expected := expectedBlockResponse([]*rTypes.Transaction{
+		expectedTransaction(account, nil, "123"),
+		expectedTransaction(account, &entityId, "246"),
+		expectedTransaction(account, nil, "333"),
+		expectedTransaction(account, nil, "444"),
+	},
+		[]*rTypes.TransactionIdentifier{{Hash: "555"}},
 	)
 	suite.mockAccountRepo.On("GetAccountAlias").Return(account, mocks.NilError)
 	suite.mockBlockRepo.On("FindByIdentifier").Return(block(), mocks.NilError)
@@ -212,10 +251,10 @@ func (suite *blockServiceSuite) TestBlockWithAccountAlias() {
 		makeTransaction(nil, "123"),
 		makeTransaction(&entityId, "246"),
 	}
-	expected := expectedBlockResponse(
+	expected := expectedBlockResponse([]*rTypes.Transaction{
 		expectedTransaction(accountAlias, nil, "123"),
 		expectedTransaction(accountAlias, &entityId, "246"),
-	)
+	}, nil)
 	suite.mockAccountRepo.On("GetAccountAlias").Return(accountAlias, mocks.NilError)
 	suite.mockBlockRepo.On("FindByIdentifier").Return(block(), mocks.NilError)
 	suite.mockTransactionRepo.On("FindBetween").Return(exampleTransactions, mocks.NilError)

--- a/hedera-mirror-rosetta/test/bdd-client/client/client.go
+++ b/hedera-mirror-rosetta/test/bdd-client/client/client.go
@@ -169,6 +169,23 @@ func (c Client) FindTransaction(ctx context.Context, hash string) (*types.Transa
 			}
 		}
 
+		for _, txId := range blockResponse.OtherTransactions {
+			if txId.Hash == hash {
+				log.Infof("Found transaction %s in block %d other transactions list", hash, blockIndex)
+				blockTransactionRequest := &types.BlockTransactionRequest{
+					NetworkIdentifier:     c.network,
+					BlockIdentifier:       blockResponse.Block.BlockIdentifier,
+					TransactionIdentifier: txId,
+				}
+				blockTransactionResponse, rosettaErr, err := blockApi.BlockTransaction(ctx, blockTransactionRequest)
+				if rosettaErr != nil || err != nil {
+					return false, rosettaErr, err
+				}
+				transaction = blockTransactionResponse.Transaction
+				return true, nil, nil
+			}
+		}
+
 		// only increase blockIndex when the block is successfully retrieved
 		log.Infof("Transaction %s not found in block %d", hash, blockIndex)
 		blockIndex += 1


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR implements the feature to support max number of transactions in rosetta block response

- Limit the number of transactions in block response and present the extra transaction hashes in OtherTransactions
- Add Response.MaxTransactionInBlock config property
- Fix issue in graceful shutdown

**Related issue(s)**:

Fixes #4512

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
