### PR TITLE
Expand entity filtering to payer and transfers

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/TransactionFilterFields.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/TransactionFilterFields.java
@@ -23,7 +23,7 @@ package com.hedera.mirror.importer.domain;
 import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.transaction.TransactionType;
 import java.util.Collection;
-import java.util.Collections;
+import java.util.Set;
 
 import lombok.Value;
 
@@ -41,13 +41,5 @@ public class TransactionFilterFields {
     Collection<EntityId> entities;
     TransactionType transactionType;
 
-    public TransactionFilterFields(Collection<EntityId> entities, TransactionType transactionType) {
-        this.entities = entities;
-        this.transactionType = transactionType;
-    }
-
-    // for backwards compatibility with single-EntityId TransactionFilterFields
-    public TransactionFilterFields(EntityId entityId, TransactionType transactionType) {
-        this (Collections.singleton(entityId), transactionType);
-    }
+    public static final TransactionFilterFields EMPTY = new TransactionFilterFields(Set.of(), TransactionType.UNKNOWN);
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/TransactionFilterFields.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/TransactionFilterFields.java
@@ -22,6 +22,8 @@ package com.hedera.mirror.importer.domain;
 
 import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.transaction.TransactionType;
+import java.util.Collection;
+import java.util.Collections;
 
 import lombok.Value;
 
@@ -31,8 +33,21 @@ import lombok.Value;
 @Value
 public class TransactionFilterFields {
     /**
-     * Main entity associated with the transaction
+     * entities contains:
+     * (1) Main entity associated with the transaction
+     * (2) Transaction payer account (when present)
+     * (3) crypto transfer receivers/senders
      */
-    EntityId entity;
+    Collection<EntityId> entities;
     TransactionType transactionType;
+
+    public TransactionFilterFields(Collection<EntityId> entities, TransactionType transactionType) {
+        this.entities = entities;
+        this.transactionType = transactionType;
+    }
+
+    // for backwards compatibility with single-EntityId TransactionFilterFields
+    public TransactionFilterFields(EntityId entityId, TransactionType transactionType) {
+        this (Collections.singleton(entityId), transactionType);
+    }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/TransactionFilterFields.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/TransactionFilterFields.java
@@ -41,5 +41,5 @@ public class TransactionFilterFields {
     Collection<EntityId> entities;
     TransactionType transactionType;
 
-    public static final TransactionFilterFields EMPTY = new TransactionFilterFields(Set.of(), TransactionType.UNKNOWN);
+    public static final TransactionFilterFields EMPTY = new TransactionFilterFields(Set.of(), null);
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/CommonParserProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/CommonParserProperties.java
@@ -96,12 +96,12 @@ public class CommonParserProperties {
             return transaction.contains(t.getTransactionType());
         }
 
-        private boolean matches(Collection<EntityId> e) {
+        private boolean matches(Collection<EntityId> entities) {
             if (entity.isEmpty()) {
                 return true;
             }
 
-            return e != null && CollectionUtils.containsAny(entity, e);
+            return entities != null && CollectionUtils.containsAny(entity, entities);
         }
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/CommonParserProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/CommonParserProperties.java
@@ -56,6 +56,10 @@ public class CommonParserProperties {
     @Getter(lazy = true)
     private final Predicate<TransactionFilterFields> filter = includeFilter().and(excludeFilter());
 
+    public boolean hasFilter() {
+        return (!exclude.isEmpty()) || (!include.isEmpty());
+    }
+
     private Predicate<TransactionFilterFields> excludeFilter() {
         if (exclude.isEmpty()) {
             return t -> true;
@@ -89,7 +93,7 @@ public class CommonParserProperties {
         }
 
         private boolean matches(TransactionFilterFields t) {
-            if (transaction.isEmpty()) {
+            if (transaction.isEmpty() || t.getTransactionType() == null) {
                 return true;
             }
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/CommonParserProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/CommonParserProperties.java
@@ -29,6 +29,7 @@ import javax.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.Getter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.CollectionUtils;
 import org.springframework.validation.annotation.Validated;
 
 import com.hedera.mirror.common.domain.entity.EntityId;
@@ -84,7 +85,7 @@ public class CommonParserProperties {
         private Collection<TransactionType> transaction = new LinkedHashSet<>();
 
         public Predicate<TransactionFilterFields> getFilter() {
-            return t -> (matches(t) && matches(t.getEntity()));
+            return t -> (matches(t) && matches(t.getEntities()));
         }
 
         private boolean matches(TransactionFilterFields t) {
@@ -95,12 +96,12 @@ public class CommonParserProperties {
             return transaction.contains(t.getTransactionType());
         }
 
-        private boolean matches(EntityId e) {
+        private boolean matches(Collection<EntityId> e) {
             if (entity.isEmpty()) {
                 return true;
             }
 
-            return e != null && entity.contains(e);
+            return e != null && CollectionUtils.containsAny(entity, e);
         }
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListener.java
@@ -155,7 +155,6 @@ public class EntityRecordItemListener implements RecordItemListener {
             entities.add(payerAccountId);
         }
         if (body.hasCryptoTransfer()) {
-            // MYK: here
             // first, handle Hbar transfers from the "getTransfers()" list.
             List<AccountAmount> accountAmountsList = body.getCryptoTransfer().getTransfers().getAccountAmountsList();
             for (AccountAmount aa : accountAmountsList) {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListener.java
@@ -1178,25 +1178,8 @@ public class EntityRecordItemListener implements RecordItemListener {
 
     // regardless of transaction type, filter on entityId and payer account and transfer tokens/receivers/senders
     private TransactionFilterFields getTransactionFilterFields(EntityId entityId, RecordItem recordItem) {
-        if (commonParserProperties.getInclude().isEmpty() && commonParserProperties.getExclude().isEmpty()) {
+        if (!commonParserProperties.hasFilter()) {
             return TransactionFilterFields.EMPTY;
-        } else {
-            boolean hasEntityFilter = false;
-            for (CommonParserProperties.TransactionFilter filter : commonParserProperties.getInclude()) {
-                if (!filter.getEntity().isEmpty()) {
-                    hasEntityFilter = true;
-                    break;
-                }
-            }
-            for (CommonParserProperties.TransactionFilter filter : commonParserProperties.getExclude()) {
-                if (!filter.getEntity().isEmpty()) {
-                    hasEntityFilter = true;
-                    break;
-                }
-            }
-            if (!hasEntityFilter) {
-                return new TransactionFilterFields(Set.of(), TransactionType.of(recordItem.getTransactionType()));
-            }
         }
 
         var entities = new HashSet<EntityId>();
@@ -1204,14 +1187,14 @@ public class EntityRecordItemListener implements RecordItemListener {
         entities.add(recordItem.getPayerAccountId());
 
         recordItem.getRecord().getTransferList().getAccountAmountsList().forEach(accountAmount ->
-                entities.add(EntityId.of(accountAmount.getAccountID()))
+            entities.add(EntityId.of(accountAmount.getAccountID()))
         );
 
         recordItem.getRecord().getTokenTransferListsList().forEach(transfer -> {
             entities.add(EntityId.of(transfer.getToken()));
 
             transfer.getTransfersList().forEach(accountAmount ->
-                    entities.add(EntityId.of(accountAmount.getAccountID()))
+                entities.add(EntityId.of(accountAmount.getAccountID()))
             );
 
             transfer.getNftTransfersList().forEach(nftTransfer -> {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/CommonParserPropertiesTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/CommonParserPropertiesTest.java
@@ -8,9 +8,9 @@ package com.hedera.mirror.importer.parser.record;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,7 +24,6 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -160,14 +159,14 @@ class CommonParserPropertiesTest {
             return null;
         }
 
-		if (entityId.indexOf("/") > -1) {
-			String[] entityIds = entityId.split("/");
+        if (entityId.indexOf("/") > -1) {
+            String[] entityIds = entityId.split("/");
             EntityId[] createdEntities = new EntityId[entityIds.length];
             for (int i = 0; i < entityIds.length; i++) {
                 createdEntities[i] = EntityId.of(entityIds[i], EntityType.ACCOUNT);
             }
             return Arrays.asList(createdEntities);
-        } 
+        }
 
         return Collections.singleton(EntityId.of(entityId, EntityType.ACCOUNT));
     }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/CommonParserPropertiesTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/CommonParserPropertiesTest.java
@@ -20,7 +20,6 @@ package com.hedera.mirror.importer.parser.record;
  */
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
@@ -86,23 +85,6 @@ class CommonParserPropertiesTest {
 
         assertEquals(result, commonParserProperties.getFilter().test(
                 new TransactionFilterFields(entities(entityId), type)));
-    }
-
-    @DisplayName("Filter exception-causing entities using include")
-    @ParameterizedTest(name = "with entity {0} and type {1} resulting in exception")
-    @CsvSource({
-            "0.0.-1, UNKNOWN" // invalid entity id
-    })
-    void filterIncludeWithExpectedException(String entityId, TransactionType type) {
-        commonParserProperties.getInclude().add(filter("0.0.1", TransactionType.CONSENSUSSUBMITMESSAGE));
-        commonParserProperties.getInclude().add(filter("0.0.2", TransactionType.CRYPTOCREATEACCOUNT));
-        commonParserProperties.getInclude().add(filter("0.0.3", null));
-        commonParserProperties.getInclude().add(filter(null, TransactionType.FILECREATE));
-
-        Exception e = assertThrows(IllegalArgumentException.class, () -> {
-            commonParserProperties.getFilter().test(new TransactionFilterFields(entities(entityId), type));
-        });
-        assertEquals("Invalid entity ID: " + entityId, e.getMessage());
     }
 
     @DisplayName("Filter using exclude")

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/CommonParserPropertiesTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/CommonParserPropertiesTest.java
@@ -20,6 +20,7 @@ package com.hedera.mirror.importer.parser.record;
  */
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
@@ -48,6 +49,7 @@ class CommonParserPropertiesTest {
     @DisplayName("Filter empty")
     @Test
     void filterEmpty() {
+        assertFalse(commonParserProperties.hasFilter());
         assertTrue(commonParserProperties.getFilter().test(
                 new TransactionFilterFields(entities("0.0.1"), TransactionType.CONSENSUSSUBMITMESSAGE)));
         // also test empty filter against a collection of entity ids
@@ -82,6 +84,7 @@ class CommonParserPropertiesTest {
         commonParserProperties.getInclude().add(filter("0.0.2", TransactionType.CRYPTOCREATEACCOUNT));
         commonParserProperties.getInclude().add(filter("0.0.3", null));
         commonParserProperties.getInclude().add(filter(null, TransactionType.FILECREATE));
+        assertTrue(commonParserProperties.hasFilter());
 
         assertEquals(result, commonParserProperties.getFilter().test(
                 new TransactionFilterFields(entities(entityId), type)));


### PR DESCRIPTION
**Description**:
* Change `EntityId entity` to `Collection<EntityId> entities`  in `TransactionFilesFilter` and `CommonParserProperties` -- this does **not** change the way that the include/exclude rules are written or evaluated.
* Change CommonParserProperties.java accordingly.
* Add logic to `EntityRecordItemListener::onItem` to fill the `Set` of `EntityId`s
  with the existing one, plus the Payer Account Id and (for crypto transfers) senders
  and receivers.
* Add new tests (with TransactionFilterFields containing more than one EntityId) to `CommonParserPropertiesTest.java`.

**Related issue(s)**:

Fixes #4478

**Checklist**

- [x] Documented (Code comments)
- [x] Tested (existing + new unit tests in CommonParserPropertiesTest.java)
