### PR TITLE
Rosetta support transaction memo

### DIFF
--- a/hedera-mirror-rosetta/app/domain/types/block_test.go
+++ b/hedera-mirror-rosetta/app/domain/types/block_test.go
@@ -59,7 +59,7 @@ func expectedBlock() *types.Block {
 			{
 				TransactionIdentifier: &types.TransactionIdentifier{Hash: "somehash"},
 				Operations:            []*types.Operation{},
-				Metadata:              nil,
+				Metadata:              map[string]interface{}{},
 			},
 		},
 	}

--- a/hedera-mirror-rosetta/app/domain/types/constants.go
+++ b/hedera-mirror-rosetta/app/domain/types/constants.go
@@ -23,6 +23,8 @@ package types
 import "github.com/coinbase/rosetta-sdk-go/types"
 
 const (
+	MetadataKeyMemo = "memo"
+
 	OperationTypeCryptoCreateAccount = "CRYPTOCREATEACCOUNT"
 	OperationTypeCryptoTransfer      = "CRYPTOTRANSFER"
 	OperationTypeTokenAssociate      = "TOKENASSOCIATE"

--- a/hedera-mirror-rosetta/app/domain/types/transaction.go
+++ b/hedera-mirror-rosetta/app/domain/types/transaction.go
@@ -29,15 +29,21 @@ import (
 type Transaction struct {
 	EntityId   *domain.EntityId
 	Hash       string
+	Memo       []byte
 	Operations OperationSlice
 }
 
 // ToRosetta returns Rosetta type Transaction from the current domain type Transaction
 func (t *Transaction) ToRosetta() *types.Transaction {
 	operations := t.Operations.ToRosetta()
-	var metadata map[string]interface{}
+	metadata := make(map[string]interface{})
+
 	if t.EntityId != nil {
-		metadata = map[string]interface{}{"entity_id": t.EntityId.String()}
+		metadata["entity_id"] = t.EntityId.String()
+	}
+
+	if len(t.Memo) != 0 {
+		metadata[MetadataKeyMemo] = string(t.Memo)
 	}
 
 	return &types.Transaction{

--- a/hedera-mirror-rosetta/app/domain/types/transaction_test.go
+++ b/hedera-mirror-rosetta/app/domain/types/transaction_test.go
@@ -37,6 +37,7 @@ func exampleTransaction() *Transaction {
 	return &Transaction{
 		EntityId: &entityId,
 		Hash:     "somehash",
+		Memo:     []byte("transfer"),
 		Operations: OperationSlice{
 			{
 				AccountId: AccountId{},
@@ -63,6 +64,7 @@ func expectedTransaction() *types.Transaction {
 		},
 		Metadata: map[string]interface{}{
 			"entity_id": entityId.String(),
+			"memo":      "transfer",
 		},
 	}
 }
@@ -80,12 +82,39 @@ func TestToRosettaTransaction(t *testing.T) {
 
 func TestToRosettaTransactionNoEntityId(t *testing.T) {
 	// given
-	expected := expectedTransaction()
-	expected.Metadata = nil
-
-	// when
 	transaction := exampleTransaction()
 	transaction.EntityId = nil
+	expected := expectedTransaction()
+	delete(expected.Metadata, "entity_id")
+
+	// when
+	actual := transaction.ToRosetta()
+
+	// then
+	assert.Equal(t, expected, actual)
+}
+func TestToRosettaTransactionNilMemo(t *testing.T) {
+	// given
+	transaction := exampleTransaction()
+	transaction.Memo = nil
+	expected := expectedTransaction()
+	delete(expected.Metadata, "memo")
+
+	// when
+	actual := transaction.ToRosetta()
+
+	// then
+	assert.Equal(t, expected, actual)
+}
+
+func TestToRosettaTransactionEmptyMemo(t *testing.T) {
+	// given
+	transaction := exampleTransaction()
+	transaction.Memo = []byte{}
+	expected := expectedTransaction()
+	delete(expected.Metadata, "memo")
+
+	// when
 	actual := transaction.ToRosetta()
 
 	// then

--- a/hedera-mirror-rosetta/app/errors/errors.go
+++ b/hedera-mirror-rosetta/app/errors/errors.go
@@ -65,6 +65,7 @@ const (
 	InvalidCurrency                   = "Invalid currency"
 	InvalidCurveType                  = "Invalid curve type"
 	InvalidOptions                    = "Invalid options"
+	InvalidTransactionMemo            = "Invalid transaction memo"
 	InternalServerError               = "Internal Server Error"
 )
 
@@ -108,6 +109,7 @@ var (
 	ErrEndpointNotSupportedInOfflineMode = newError(EndpointNotSupportedInOfflineMode, 136, false)
 	ErrInvalidCurveType                  = newError(InvalidCurveType, 137, false)
 	ErrInvalidOptions                    = newError(InvalidOptions, 138, false)
+	ErrInvalidTransactionMemo            = newError(InvalidTransactionMemo, 139, false)
 	ErrInternalServerError               = newError(InternalServerError, 500, true)
 
 	Errors = make([]*types.Error, 0)

--- a/hedera-mirror-rosetta/app/persistence/testmain_test.go
+++ b/hedera-mirror-rosetta/app/persistence/testmain_test.go
@@ -71,11 +71,13 @@ func addTransaction(
 	nonFeeTransfers []domain.NonFeeTransfer,
 	tokenTransfers []domain.TokenTransfer,
 	nftTransfers []domain.NftTransfer,
+	memo []byte,
 ) {
 	tx := &domain.Transaction{
 		ConsensusTimestamp:   consensusTimestamp,
 		ChargedTxFee:         17,
 		EntityId:             entityId,
+		Memo:                 memo,
 		NodeAccountId:        nodeAccountId,
 		Nonce:                0,
 		PayerAccountId:       payerAccountId,

--- a/hedera-mirror-rosetta/app/persistence/transaction.go
+++ b/hedera-mirror-rosetta/app/persistence/transaction.go
@@ -141,6 +141,7 @@ const (
 	selectTransactionsInTimestampRange = "with" + genesisTimestampCte + `select
                                             t.consensus_timestamp,
                                             t.entity_id,
+                                            t.memo,
                                             t.payer_account_id,
                                             t.result,
                                             t.transaction_hash as hash,
@@ -213,6 +214,7 @@ type transaction struct {
 	ConsensusTimestamp int64
 	EntityId           *domain.EntityId
 	Hash               []byte
+	Memo               []byte
 	PayerAccountId     domain.EntityId
 	Result             int16
 	Type               int16
@@ -415,7 +417,8 @@ func (tr *transactionRepository) constructTransaction(sameHashTransactions []*tr
 	*types.Transaction,
 	*rTypes.Error,
 ) {
-	tResult := &types.Transaction{Hash: sameHashTransactions[0].getHashString()}
+	firstTransaction := sameHashTransactions[0]
+	tResult := &types.Transaction{Hash: firstTransaction.getHashString(), Memo: firstTransaction.Memo}
 	operations := make(types.OperationSlice, 0)
 	success := types.TransactionResults[transactionResultSuccess]
 

--- a/hedera-mirror-rosetta/app/services/block_service_test.go
+++ b/hedera-mirror-rosetta/app/services/block_service_test.go
@@ -110,6 +110,7 @@ func expectedTransaction(accountId types.AccountId, entityId *domain.EntityId, h
 				Amount:              hbarAmount.ToRosetta(),
 			},
 		},
+		Metadata: map[string]interface{}{},
 	}
 	if entityId != nil {
 		response.Metadata = map[string]interface{}{"entity_id": entityId.String()}

--- a/hedera-mirror-rosetta/app/services/network_service_test.go
+++ b/hedera-mirror-rosetta/app/services/network_service_test.go
@@ -159,6 +159,7 @@ func (suite *offlineNetworkServiceSuite) TestNetworkOptions() {
 		errors.ErrEndpointNotSupportedInOfflineMode,
 		errors.ErrInvalidCurveType,
 		errors.ErrInvalidOptions,
+		errors.ErrInvalidTransactionMemo,
 		errors.ErrInternalServerError,
 	}
 

--- a/hedera-mirror-rosetta/go.mod
+++ b/hedera-mirror-rosetta/go.mod
@@ -119,4 +119,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
+replace github.com/hashgraph/hedera-sdk-go/v2 => github.com/xin-hedera/hedera-sdk-go/v2 v2.8.0-beta.1.0.20220913034050-c1eb810845f7
+
 replace google.golang.org/protobuf => google.golang.org/protobuf v1.26.1-0.20210525005349-febffdd88e85

--- a/hedera-mirror-rosetta/go.sum
+++ b/hedera-mirror-rosetta/go.sum
@@ -392,8 +392,6 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashgraph/hedera-protobufs-go v0.2.1-0.20220726083815-59ae9e528f56 h1:h7nacfId1o2KPZV45w57Qvbr9rH9b2qC3IAX+6ohIfE=
 github.com/hashgraph/hedera-protobufs-go v0.2.1-0.20220726083815-59ae9e528f56/go.mod h1:P0QU+a1kwZlqFNfG44/YhgR2njoDbAtDrYz3zR5lq3U=
-github.com/hashgraph/hedera-sdk-go/v2 v2.17.2 h1:Px6H++zS0/B6iSZUnWBAXcPlPAJ/XISQyAIU5yegja0=
-github.com/hashgraph/hedera-sdk-go/v2 v2.17.2/go.mod h1:gprKw72kUZNa5FBr9x0LJkIbqp4BGVQ0OHaO4haI0zE=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/api v1.3.0/go.mod h1:MmDNSzIMUjNpY/mQ398R4bk2FnqQLoPndWW5VkKPlCE=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
@@ -899,6 +897,8 @@ github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:
 github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
+github.com/xin-hedera/hedera-sdk-go/v2 v2.8.0-beta.1.0.20220913034050-c1eb810845f7 h1:SWbr71sYlEn+w3HNRWI3yf3KByLYxqNNg9yjnm7V55w=
+github.com/xin-hedera/hedera-sdk-go/v2 v2.8.0-beta.1.0.20220913034050-c1eb810845f7/go.mod h1:gprKw72kUZNa5FBr9x0LJkIbqp4BGVQ0OHaO4haI0zE=
 github.com/xlab/treeprint v0.0.0-20180616005107-d6fb6747feb6/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
 github.com/youmark/pkcs8 v0.0.0-20201027041543-1326539a0a0a h1:fZHgsYlfvtyqToslyjUt3VOPF4J7aK/3MPcK7xp3PDk=

--- a/hedera-mirror-rosetta/test/bdd-client/client/client.go
+++ b/hedera-mirror-rosetta/test/bdd-client/client/client.go
@@ -207,10 +207,12 @@ func (c Client) GetOperator(index int) Operator {
 
 // Submit submits the operations to the network, goes through the construction preprocess, metadata, payloads, combine,
 // and submit workflow. Note payloads signing happens between payloads and combine.
-func (c Client) Submit(ctx context.Context, operations []*types.Operation, signers map[string]hedera.PrivateKey) (
-	string,
-	error,
-) {
+func (c Client) Submit(
+	ctx context.Context,
+	memo string,
+	operations []*types.Operation,
+	signers map[string]hedera.PrivateKey,
+) (string, error) {
 	var txHash string
 
 	offlineConstructor := c.offlineClient.ConstructionAPI
@@ -239,8 +241,13 @@ func (c Client) Submit(ctx context.Context, operations []*types.Operation, signe
 
 	trySubmit := func() (bool, *types.Error, error) {
 		// preprocess
+		metadata := make(map[string]interface{})
+		if len(memo) != 0 {
+			metadata["memo"] = memo
+		}
 		preprocessRequest := &types.ConstructionPreprocessRequest{
 			NetworkIdentifier: c.network,
+			Metadata:          metadata,
 			Operations:        operations,
 		}
 		preprocessResponse, rosettaErr, err := offlineConstructor.ConstructionPreprocess(ctx, preprocessRequest)

--- a/hedera-mirror-rosetta/test/bdd-client/scenario/asserter.go
+++ b/hedera-mirror-rosetta/test/bdd-client/scenario/asserter.go
@@ -69,6 +69,18 @@ func assertTransactionAll(transaction *types.Transaction, funcs ...assertTransac
 	return t.err
 }
 
+func assertTransactionMemo(memo string) assertTransactionFunc {
+	return func(t *asserter, transaction *types.Transaction) {
+		if len(memo) == 0 {
+			assert.NotContains(t, transaction.Metadata, "memo")
+		} else {
+			assert.IsType(t, memo, transaction.Metadata["memo"])
+			actual, _ := transaction.Metadata["memo"].(string)
+			assert.Equal(t, memo, actual)
+		}
+	}
+}
+
 func assertTransactionOpTypesContains(expectedOpTypes ...string) assertTransactionFunc {
 	return func(t *asserter, transaction *types.Transaction) {
 		var actualOpTypes []string

--- a/hedera-mirror-rosetta/test/bdd-client/scenario/base.go
+++ b/hedera-mirror-rosetta/test/bdd-client/scenario/base.go
@@ -46,11 +46,12 @@ func (b *baseFeature) findTransaction(ctx context.Context, operationType string)
 
 func (b *baseFeature) submit(
 	ctx context.Context,
+	memo string,
 	operations []*types.Operation,
 	signers map[string]hedera.PrivateKey,
 ) (err error) {
 	operationType := operations[0].Type
-	b.transactionHash, err = testClient.Submit(ctx, operations, signers)
+	b.transactionHash, err = testClient.Submit(ctx, memo, operations, signers)
 	if err != nil {
 		log.Errorf("Failed to submit %s transaction: %s", operationType, err)
 	} else {

--- a/hedera-mirror-rosetta/test/bdd-client/scenario/crypto.go
+++ b/hedera-mirror-rosetta/test/bdd-client/scenario/crypto.go
@@ -56,7 +56,7 @@ func (c *cryptoFeature) createCryptoAccount(ctx context.Context) error {
 		},
 	}
 
-	return c.submit(ctx, operations, nil)
+	return c.submit(ctx, "", operations, nil)
 }
 
 func (c *cryptoFeature) verifyCryptoCreateTransaction(ctx context.Context) error {
@@ -68,6 +68,7 @@ func (c *cryptoFeature) verifyCryptoCreateTransaction(ctx context.Context) error
 	if err = assertTransactionAll(
 		transaction,
 		assertTransactionOpSuccess,
+		assertTransactionMemo(""),
 		assertTransactionOpCount(1, gte),
 		assertTransactionOpTypesContains(operationTypeCryptoCreateAccount, operationTypeFee),
 		assertTransactionMetadataAndType("entity_id", ""),
@@ -114,7 +115,7 @@ func (c *cryptoFeature) createCryptoAccountByAlias(ctx context.Context) error {
 			Type: operationTypeCryptoTransfer,
 		},
 	}
-	return c.submit(ctx, operations, nil)
+	return c.submit(ctx, "", operations, nil)
 }
 
 func (c *cryptoFeature) verifyCryptoTransferToAliasTransaction(ctx context.Context) error {
@@ -164,7 +165,7 @@ func (c *cryptoFeature) transferFromAlias(ctx context.Context) error {
 		},
 	}
 
-	return c.submit(ctx, operations, map[string]hedera.PrivateKey{
+	return c.submit(ctx, "", operations, map[string]hedera.PrivateKey{
 		c.aliasAccountId.String(): *c.newAccountKey,
 	})
 }
@@ -210,7 +211,7 @@ func (c *cryptoFeature) transferHbarToTreasury(ctx context.Context) error {
 		},
 	}
 
-	return c.submit(ctx, operations, nil)
+	return c.submit(ctx, "hbar transfer", operations, nil)
 }
 
 func (c *cryptoFeature) verifyCryptoTransferTransaction(ctx context.Context) error {
@@ -233,6 +234,7 @@ func (c *cryptoFeature) verifyCryptoTransferTransaction(ctx context.Context) err
 	return assertTransactionAll(
 		transaction,
 		assertTransactionOpSuccess,
+		assertTransactionMemo("hbar transfer"),
 		assertTransactionOpCount(2, gte),
 		assertTransactionOpTypesContains(operationTypeCryptoTransfer, operationTypeFee),
 		assertTransactionIncludesTransfers(expectedAccountAmounts),

--- a/hedera-mirror-rosetta/test/bdd-client/scenario/token.go
+++ b/hedera-mirror-rosetta/test/bdd-client/scenario/token.go
@@ -90,7 +90,7 @@ func (t *tokenFeature) createToken(ctx context.Context, tokenType string) error 
 		},
 	}
 
-	return t.submit(ctx, operations, nil)
+	return t.submit(ctx, "", operations, nil)
 }
 
 func (t *tokenFeature) verifyTokenCreateTransaction(ctx context.Context) error {
@@ -141,7 +141,7 @@ func (t *tokenFeature) tokenAssociateOrDissociate(ctx context.Context, associate
 		},
 	}
 
-	return t.submit(ctx, operations, getSigners(operator))
+	return t.submit(ctx, "", operations, getSigners(operator))
 }
 
 func (t *tokenFeature) verifyTokenAssociateOrDissociate(ctx context.Context, associate bool) error {
@@ -202,7 +202,7 @@ func (t *tokenFeature) tokenFreezeOrUnfreezeAccount(ctx context.Context, freeze 
 		},
 	}
 
-	return t.submit(ctx, operations, getSigners(admin))
+	return t.submit(ctx, "", operations, getSigners(admin))
 }
 
 func (t *tokenFeature) verifyTokenFreezeOrUnfreezeAccount(ctx context.Context, freeze bool) error {
@@ -262,7 +262,7 @@ func (t *tokenFeature) tokenKycGrantOrRevokeAccount(ctx context.Context, grant b
 		},
 	}
 
-	return t.submit(ctx, operations, getSigners(admin))
+	return t.submit(ctx, "", operations, getSigners(admin))
 }
 
 func (t *tokenFeature) verifyTokenKycGrantOrRevokeAccount(ctx context.Context, grant bool) error {
@@ -390,7 +390,7 @@ func (t *tokenFeature) tokenTransfer(ctx context.Context) error {
 		t.normalOperator.Id)
 
 	operations := t.getTokenTransferOperations()
-	return t.submit(ctx, operations, getSigners(t.adminOperator))
+	return t.submit(ctx, "", operations, getSigners(t.adminOperator))
 }
 
 func (t *tokenFeature) verifyTokenTransfer(ctx context.Context) error {
@@ -444,7 +444,7 @@ func (t *tokenFeature) tokenBurnOrMint(ctx context.Context, burn bool) error {
 		},
 	}
 
-	return t.submit(ctx, operations, getSigners(admin))
+	return t.submit(ctx, "", operations, getSigners(admin))
 }
 
 func (t *tokenFeature) verifyTokenBurnOrMint(ctx context.Context, burn bool) error {
@@ -551,7 +551,7 @@ func (t *tokenFeature) tokenWipeAccount(ctx context.Context) error {
 		}
 	}
 
-	return t.submit(ctx, []*types.Operation{operation}, getSigners(admin))
+	return t.submit(ctx, "", []*types.Operation{operation}, getSigners(admin))
 }
 
 func (t *tokenFeature) verifyTokenWipeAccount(ctx context.Context) error {
@@ -607,7 +607,7 @@ func (t *tokenFeature) tokenDelete(ctx context.Context) error {
 		},
 	}
 
-	return t.submit(ctx, operations, getSigners(t.adminOperator))
+	return t.submit(ctx, "", operations, getSigners(t.adminOperator))
 }
 
 func (t *tokenFeature) verifyTokenDelete(ctx context.Context) error {
@@ -644,7 +644,7 @@ func (t *tokenFeature) tokenUpdate(ctx context.Context) error {
 		},
 	}
 
-	return t.submit(ctx, operations, getSigners(t.adminOperator))
+	return t.submit(ctx, "", operations, getSigners(t.adminOperator))
 }
 
 func (t *tokenFeature) verifyTokenUpdate(ctx context.Context) error {


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR adds hedera transaction memo support to rosetta

- Parse and set `memo` in `Transaction.Metadata` in Data API if available
- Set transaction memo to `ConstructionPayloadRequest.Metadata["memo"]` if available
- Copy and pass along the memo metadata in Construction API per rosetta guideline
- Update bdd test client to test transaction memo

**Related issue(s)**:

Fixes #4568 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

The code coverage miss is because there isn't a way to test the error returned from SDK functions.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
