### PR TITLE
Rosetta limit the number of transactions in block response (0.65)

### DIFF
--- a/.github/workflows/rosetta-api.yml
+++ b/.github/workflows/rosetta-api.yml
@@ -142,6 +142,7 @@ jobs:
         run: |
           ONLINE_CONTAINER_ID=$(docker run -d -e HEDERA_MIRROR_IMPORTER_STARTDATE=$STARTDATE \
             -e NETWORK=testnet \
+            -e HEDERA_MIRROR_ROSETTA_RESPONSE_MAXTRANSACTIONSINBLOCK=4 \
             -v /tmp/application_importer.yml:/app/importer/application.yml \
             -v /tmp/application_rosetta.yml:/app/rosetta/application.yml \
             -p 5700:5700 "${MODULE}:latest")

--- a/hedera-mirror-rosetta/app/config/application.yml
+++ b/hedera-mirror-rosetta/app/config/application.yml
@@ -30,4 +30,6 @@ hedera:
       online: true
       port: 5700
       realm: 0
+      response:
+        maxTransactionsInBlock: 6000
       shard: 0

--- a/hedera-mirror-rosetta/app/config/types.go
+++ b/hedera-mirror-rosetta/app/config/types.go
@@ -41,6 +41,7 @@ type Config struct {
 	Online      bool
 	Port        uint16
 	Realm       int64
+	Response    Response
 	Shard       int64
 }
 
@@ -90,4 +91,8 @@ type Pool struct {
 	MaxIdleConnections int `yaml:"maxIdleConnections"`
 	MaxLifetime        int `yaml:"maxLifetime"`
 	MaxOpenConnections int `yaml:"maxOpenConnections"`
+}
+
+type Response struct {
+	MaxTransactionsInBlock int `yaml:"maxTransactionsInBlock"`
 }

--- a/hedera-mirror-rosetta/app/services/block_service.go
+++ b/hedera-mirror-rosetta/app/services/block_service.go
@@ -37,7 +37,8 @@ import (
 type blockAPIService struct {
 	accountRepo interfaces.AccountRepository
 	BaseService
-	entityCache *cache.Cache[int64, types.AccountId]
+	entityCache            *cache.Cache[int64, types.AccountId]
+	maxTransactionsInBlock int
 }
 
 // NewBlockAPIService creates a new instance of a blockAPIService.
@@ -45,9 +46,15 @@ func NewBlockAPIService(
 	accountRepo interfaces.AccountRepository,
 	baseService BaseService,
 	entityCacheConfig config.Cache,
+	maxTransactionsInBlock int,
 ) server.BlockAPIServicer {
 	entityCache := cache.New(cache.AsLRU[int64, types.AccountId](lru.WithCapacity(entityCacheConfig.MaxSize)))
-	return &blockAPIService{accountRepo: accountRepo, BaseService: baseService, entityCache: entityCache}
+	return &blockAPIService{
+		accountRepo:            accountRepo,
+		BaseService:            baseService,
+		entityCache:            entityCache,
+		maxTransactionsInBlock: maxTransactionsInBlock,
+	}
 }
 
 // Block implements the /block endpoint.
@@ -64,11 +71,20 @@ func (s *blockAPIService) Block(
 		return nil, err
 	}
 
+	var otherTransactions []*rTypes.TransactionIdentifier
+	if len(block.Transactions) > s.maxTransactionsInBlock {
+		otherTransactions = make([]*rTypes.TransactionIdentifier, 0, len(block.Transactions)-s.maxTransactionsInBlock)
+		for _, transaction := range block.Transactions[s.maxTransactionsInBlock:] {
+			otherTransactions = append(otherTransactions, &rTypes.TransactionIdentifier{Hash: transaction.Hash})
+		}
+		block.Transactions = block.Transactions[0:s.maxTransactionsInBlock]
+	}
+
 	if err = s.updateOperationAccountAlias(ctx, block.Transactions...); err != nil {
 		return nil, err
 	}
 
-	return &rTypes.BlockResponse{Block: block.ToRosetta()}, nil
+	return &rTypes.BlockResponse{Block: block.ToRosetta(), OtherTransactions: otherTransactions}, nil
 }
 
 // BlockTransaction implements the /block/transaction endpoint.

--- a/hedera-mirror-rosetta/main.go
+++ b/hedera-mirror-rosetta/main.go
@@ -89,7 +89,12 @@ func newBlockchainOnlineRouter(
 	networkAPIService := services.NewNetworkAPIService(baseService, addressBookEntryRepo, network, version)
 	networkAPIController := server.NewNetworkAPIController(networkAPIService, asserter)
 
-	blockAPIService := services.NewBlockAPIService(accountRepo, baseService, rosettaConfig.Cache[config.EntityCacheKey])
+	blockAPIService := services.NewBlockAPIService(
+		accountRepo,
+		baseService,
+		rosettaConfig.Cache[config.EntityCacheKey],
+		rosettaConfig.Response.MaxTransactionsInBlock,
+	)
 	blockAPIController := server.NewBlockAPIController(blockAPIService, asserter)
 
 	mempoolAPIService := services.NewMempoolAPIService()

--- a/hedera-mirror-rosetta/test/bdd-client/client/client.go
+++ b/hedera-mirror-rosetta/test/bdd-client/client/client.go
@@ -169,6 +169,23 @@ func (c Client) FindTransaction(ctx context.Context, hash string) (*types.Transa
 			}
 		}
 
+		for _, txId := range blockResponse.OtherTransactions {
+			if txId.Hash == hash {
+				log.Infof("Found transaction %s in block %d other transactions list", hash, blockIndex)
+				blockTransactionRequest := &types.BlockTransactionRequest{
+					NetworkIdentifier:     c.network,
+					BlockIdentifier:       blockResponse.Block.BlockIdentifier,
+					TransactionIdentifier: txId,
+				}
+				blockTransactionResponse, rosettaErr, err := blockApi.BlockTransaction(ctx, blockTransactionRequest)
+				if rosettaErr != nil || err != nil {
+					return false, rosettaErr, err
+				}
+				transaction = blockTransactionResponse.Transaction
+				return true, nil, nil
+			}
+		}
+
 		// only increase blockIndex when the block is successfully retrieved
 		log.Infof("Transaction %s not found in block %d", hash, blockIndex)
 		blockIndex += 1


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR ports the changes for #4512 to `release/0.65`

- Limit the number of transactions in block response and present the extra transaction hashes in OtherTransactions
- Add Response.MaxTransactionsInBlock config property

**Related issue(s)**:

Relates to #4512 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
