### PR TITLE
Rename FileStreamSignature to StreamFileSignature

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamFileSignature.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamFileSignature.java
@@ -41,12 +41,12 @@ import com.hedera.mirror.importer.reader.signature.ProtoSignatureFileReader;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @NoArgsConstructor
 @ToString(exclude = {"bytes", "fileHash", "fileHashSignature", "metadataHash", "metadataHashSignature"})
-public class FileStreamSignature implements Comparable<FileStreamSignature> {
+public class StreamFileSignature implements Comparable<StreamFileSignature> {
 
     private static final String COMPRESSED_EXTENSION = ".gz";
-    private static final Comparator<FileStreamSignature> COMPARATOR = Comparator
-            .comparing(FileStreamSignature::getNode)
-            .thenComparing(FileStreamSignature::getFilename);
+    private static final Comparator<StreamFileSignature> COMPARATOR = Comparator
+            .comparing(StreamFileSignature::getNode)
+            .thenComparing(StreamFileSignature::getFilename);
 
     private byte[] bytes;
     private byte[] fileHash;
@@ -63,7 +63,7 @@ public class FileStreamSignature implements Comparable<FileStreamSignature> {
     private byte version;
 
     @Override
-    public int compareTo(FileStreamSignature other) {
+    public int compareTo(StreamFileSignature other) {
         return COMPARATOR.compare(this, other);
     }
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/ConsensusValidator.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/ConsensusValidator.java
@@ -22,8 +22,8 @@ package com.hedera.mirror.importer.downloader;
 
 import java.util.Collection;
 
-import com.hedera.mirror.importer.domain.FileStreamSignature;
+import com.hedera.mirror.importer.domain.StreamFileSignature;
 
 public interface ConsensusValidator {
-    void validate(Collection<FileStreamSignature> signatures);
+    void validate(Collection<StreamFileSignature> signatures);
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/ConsensusValidatorImpl.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/ConsensusValidatorImpl.java
@@ -26,12 +26,10 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.Collection;
 import javax.inject.Named;
-
-import com.hedera.mirror.importer.domain.StreamFileSignature;
-
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 
+import com.hedera.mirror.importer.domain.StreamFileSignature;
 import com.hedera.mirror.importer.domain.StreamFilename;
 import com.hedera.mirror.importer.exception.SignatureVerificationException;
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/ConsensusValidatorImpl.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/ConsensusValidatorImpl.java
@@ -26,10 +26,12 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.Collection;
 import javax.inject.Named;
+
+import com.hedera.mirror.importer.domain.StreamFileSignature;
+
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 
-import com.hedera.mirror.importer.domain.FileStreamSignature;
 import com.hedera.mirror.importer.domain.StreamFilename;
 import com.hedera.mirror.importer.exception.SignatureVerificationException;
 
@@ -52,8 +54,8 @@ public class ConsensusValidatorImpl implements ConsensusValidator {
      * @throws SignatureVerificationException
      */
     @Override
-    public void validate(Collection<FileStreamSignature> signatures) throws SignatureVerificationException {
-        Multimap<String, FileStreamSignature> signatureHashMap = HashMultimap.create();
+    public void validate(Collection<StreamFileSignature> signatures) throws SignatureVerificationException {
+        Multimap<String, StreamFileSignature> signatureHashMap = HashMultimap.create();
         StreamFilename filename = null;
         BigDecimal stakeRequiredForConsensus = null;
         long totalStake = 0L;
@@ -65,7 +67,7 @@ public class ConsensusValidatorImpl implements ConsensusValidator {
                 stakeRequiredForConsensus = getStakeRequiredForConsensus(totalStake);
             }
 
-            if (signature.getStatus() == FileStreamSignature.SignatureStatus.VERIFIED) {
+            if (signature.getStatus() == StreamFileSignature.SignatureStatus.VERIFIED) {
                 signatureHashMap.put(signature.getFileHashAsHex(), signature);
             }
         }
@@ -88,7 +90,7 @@ public class ConsensusValidatorImpl implements ConsensusValidator {
 
             if (canReachConsensus(stake, stakeRequiredForConsensus)) {
                 consensusCount += validatedSignatures.size();
-                validatedSignatures.forEach(s -> s.setStatus(FileStreamSignature.SignatureStatus.CONSENSUS_REACHED));
+                validatedSignatures.forEach(s -> s.setStatus(StreamFileSignature.SignatureStatus.CONSENSUS_REACHED));
             }
 
             if (debugStake < stake) {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/NodeSignatureVerifier.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/NodeSignatureVerifier.java
@@ -23,12 +23,10 @@ package com.hedera.mirror.importer.downloader;
 import java.security.Signature;
 import java.util.Collection;
 import javax.inject.Named;
-
-import com.hedera.mirror.importer.domain.StreamFileSignature;
-
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 
+import com.hedera.mirror.importer.domain.StreamFileSignature;
 import com.hedera.mirror.importer.domain.StreamFileSignature.SignatureStatus;
 import com.hedera.mirror.importer.exception.SignatureVerificationException;
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/NodeSignatureVerifier.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/NodeSignatureVerifier.java
@@ -23,11 +23,13 @@ package com.hedera.mirror.importer.downloader;
 import java.security.Signature;
 import java.util.Collection;
 import javax.inject.Named;
+
+import com.hedera.mirror.importer.domain.StreamFileSignature;
+
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 
-import com.hedera.mirror.importer.domain.FileStreamSignature;
-import com.hedera.mirror.importer.domain.FileStreamSignature.SignatureStatus;
+import com.hedera.mirror.importer.domain.StreamFileSignature.SignatureStatus;
 import com.hedera.mirror.importer.exception.SignatureVerificationException;
 
 @Named
@@ -52,11 +54,11 @@ public class NodeSignatureVerifier {
      * @param signatures a list of signature files which have the same filename
      * @throws SignatureVerificationException
      */
-    public void verify(Collection<FileStreamSignature> signatures) throws SignatureVerificationException {
+    public void verify(Collection<StreamFileSignature> signatures) throws SignatureVerificationException {
 
-        for (FileStreamSignature fileStreamSignature : signatures) {
-            if (verifySignature(fileStreamSignature)) {
-                fileStreamSignature.setStatus(SignatureStatus.VERIFIED);
+        for (StreamFileSignature streamFileSignature : signatures) {
+            if (verifySignature(streamFileSignature)) {
+                streamFileSignature.setStatus(SignatureStatus.VERIFIED);
             }
         }
 
@@ -66,42 +68,42 @@ public class NodeSignatureVerifier {
     /**
      * check whether the given signature is valid
      *
-     * @param fileStreamSignature the data that was signed
+     * @param streamFileSignature the data that was signed
      * @return true if the signature is valid
      */
-    private boolean verifySignature(FileStreamSignature fileStreamSignature) {
-        var publicKey = fileStreamSignature.getNode().getPublicKey();
+    private boolean verifySignature(StreamFileSignature streamFileSignature) {
+        var publicKey = streamFileSignature.getNode().getPublicKey();
 
         if (publicKey == null) {
-            log.warn("Missing PublicKey for node {}", fileStreamSignature.getNode());
+            log.warn("Missing PublicKey for node {}", streamFileSignature.getNode());
             return false;
         }
 
-        if (fileStreamSignature.getFileHashSignature() == null) {
-            log.error("Missing signature data: {}", fileStreamSignature);
+        if (streamFileSignature.getFileHashSignature() == null) {
+            log.error("Missing signature data: {}", streamFileSignature);
             return false;
         }
 
         try {
-            log.trace("Verifying signature: {}", fileStreamSignature);
+            log.trace("Verifying signature: {}", streamFileSignature);
 
-            Signature sig = Signature.getInstance(fileStreamSignature.getSignatureType().getAlgorithm(),
-                    fileStreamSignature.getSignatureType().getProvider());
+            Signature sig = Signature.getInstance(streamFileSignature.getSignatureType().getAlgorithm(),
+                    streamFileSignature.getSignatureType().getProvider());
             sig.initVerify(publicKey);
-            sig.update(fileStreamSignature.getFileHash());
+            sig.update(streamFileSignature.getFileHash());
 
-            if (!sig.verify(fileStreamSignature.getFileHashSignature())) {
+            if (!sig.verify(streamFileSignature.getFileHashSignature())) {
                 return false;
             }
 
-            if (fileStreamSignature.getMetadataHashSignature() != null) {
-                sig.update(fileStreamSignature.getMetadataHash());
-                return sig.verify(fileStreamSignature.getMetadataHashSignature());
+            if (streamFileSignature.getMetadataHashSignature() != null) {
+                sig.update(streamFileSignature.getMetadataHash());
+                return sig.verify(streamFileSignature.getMetadataHashSignature());
             }
 
             return true;
         } catch (Exception e) {
-            log.error("Failed to verify signature with public key {}: {}", publicKey, fileStreamSignature, e);
+            log.error("Failed to verify signature with public key {}: {}", publicKey, streamFileSignature, e);
         }
         return false;
     }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/signature/CompositeSignatureFileReader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/signature/CompositeSignatureFileReader.java
@@ -23,14 +23,12 @@ package com.hedera.mirror.importer.reader.signature;
 import java.io.DataInputStream;
 import java.io.IOException;
 import javax.inject.Named;
-
-import com.hedera.mirror.importer.domain.StreamFileSignature;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.context.annotation.Primary;
 
 import com.hedera.mirror.importer.domain.StreamFileData;
+import com.hedera.mirror.importer.domain.StreamFileSignature;
 import com.hedera.mirror.importer.exception.SignatureFileParsingException;
 
 @Log4j2

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/signature/CompositeSignatureFileReader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/signature/CompositeSignatureFileReader.java
@@ -23,11 +23,13 @@ package com.hedera.mirror.importer.reader.signature;
 import java.io.DataInputStream;
 import java.io.IOException;
 import javax.inject.Named;
+
+import com.hedera.mirror.importer.domain.StreamFileSignature;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.context.annotation.Primary;
 
-import com.hedera.mirror.importer.domain.FileStreamSignature;
 import com.hedera.mirror.importer.domain.StreamFileData;
 import com.hedera.mirror.importer.exception.SignatureFileParsingException;
 
@@ -42,7 +44,7 @@ public class CompositeSignatureFileReader implements SignatureFileReader {
     private final ProtoSignatureFileReader protoSignatureFileReader;
 
     @Override
-    public FileStreamSignature read(StreamFileData signatureFileData) {
+    public StreamFileSignature read(StreamFileData signatureFileData) {
         try (DataInputStream dataInputStream = new DataInputStream(signatureFileData.getInputStream())) {
             byte version = dataInputStream.readByte();
             SignatureFileReader fileReader;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/signature/ProtoSignatureFileReader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/signature/ProtoSignatureFileReader.java
@@ -27,8 +27,8 @@ import java.io.IOException;
 import javax.inject.Named;
 
 import com.hedera.mirror.common.util.DomainUtils;
-import com.hedera.mirror.importer.domain.FileStreamSignature;
 import com.hedera.mirror.importer.domain.StreamFileData;
+import com.hedera.mirror.importer.domain.StreamFileSignature;
 import com.hedera.mirror.importer.exception.InvalidStreamFileException;
 import com.hedera.services.stream.proto.SignatureFile;
 
@@ -38,7 +38,7 @@ public class ProtoSignatureFileReader implements SignatureFileReader {
     public static final byte VERSION = 6;
 
     @Override
-    public FileStreamSignature read(StreamFileData signatureFileData) {
+    public StreamFileSignature read(StreamFileData signatureFileData) {
         var filename = signatureFileData.getFilename();
         try {
             var signatureFile = readSignatureFile(signatureFileData);
@@ -46,18 +46,18 @@ public class ProtoSignatureFileReader implements SignatureFileReader {
             var fileSignature = signatureFile.getFileSignature();
             var metadataSignature = signatureFile.getMetadataSignature();
 
-            var fileStreamSignature = new FileStreamSignature();
-            fileStreamSignature.setBytes(signatureFileData.getBytes());
-            fileStreamSignature.setFileHash(DomainUtils.getHashBytes(fileSignature.getHashObject()));
-            fileStreamSignature.setFileHashSignature(DomainUtils.toBytes(fileSignature.getSignature()));
-            fileStreamSignature.setFilename(signatureFileData.getStreamFilename());
-            fileStreamSignature.setMetadataHash(DomainUtils.getHashBytes(metadataSignature.getHashObject()));
-            fileStreamSignature.setMetadataHashSignature(DomainUtils.toBytes(metadataSignature.getSignature()));
-            fileStreamSignature.setSignatureType(
-                    FileStreamSignature.SignatureType.valueOf(fileSignature.getType().toString()));
-            fileStreamSignature.setVersion(VERSION);
+            var streamFileSignature = new StreamFileSignature();
+            streamFileSignature.setBytes(signatureFileData.getBytes());
+            streamFileSignature.setFileHash(DomainUtils.getHashBytes(fileSignature.getHashObject()));
+            streamFileSignature.setFileHashSignature(DomainUtils.toBytes(fileSignature.getSignature()));
+            streamFileSignature.setFilename(signatureFileData.getStreamFilename());
+            streamFileSignature.setMetadataHash(DomainUtils.getHashBytes(metadataSignature.getHashObject()));
+            streamFileSignature.setMetadataHashSignature(DomainUtils.toBytes(metadataSignature.getSignature()));
+            streamFileSignature.setSignatureType(
+                    StreamFileSignature.SignatureType.valueOf(fileSignature.getType().toString()));
+            streamFileSignature.setVersion(VERSION);
 
-            return fileStreamSignature;
+            return streamFileSignature;
         } catch (IllegalArgumentException | IOException e) {
             throw new InvalidStreamFileException(filename, e);
         }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/signature/SignatureFileReader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/signature/SignatureFileReader.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.importer.reader.signature;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,8 +20,8 @@ package com.hedera.mirror.importer.reader.signature;
  * ‍
  */
 
-import com.hedera.mirror.importer.domain.FileStreamSignature;
 import com.hedera.mirror.importer.domain.StreamFileData;
+import com.hedera.mirror.importer.domain.StreamFileSignature;
 
 public interface SignatureFileReader {
     /**
@@ -29,7 +29,7 @@ public interface SignatureFileReader {
      * signature 2. Extract signature from the file.
      *
      * @param signatureFileData {@link StreamFileData} object for the signature file
-     * @return FileStreamSignature containing the hash of the corresponding RecordStream file and the signature
+     * @return streamFileSignature containing the hash of the corresponding RecordStream file and the signature
      */
-    FileStreamSignature read(StreamFileData signatureFileData);
+    StreamFileSignature read(StreamFileData signatureFileData);
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/signature/SignatureFileReaderV2.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/signature/SignatureFileReaderV2.java
@@ -24,8 +24,8 @@ import java.io.IOException;
 import javax.inject.Named;
 
 import com.hedera.mirror.common.domain.DigestAlgorithm;
-import com.hedera.mirror.importer.domain.FileStreamSignature;
-import com.hedera.mirror.importer.domain.FileStreamSignature.SignatureType;
+import com.hedera.mirror.importer.domain.StreamFileSignature;
+import com.hedera.mirror.importer.domain.StreamFileSignature.SignatureType;
 import com.hedera.mirror.importer.domain.StreamFileData;
 import com.hedera.mirror.importer.exception.InvalidStreamFileException;
 import com.hedera.mirror.importer.exception.SignatureFileParsingException;
@@ -40,7 +40,7 @@ public class SignatureFileReaderV2 implements SignatureFileReader {
     private static final byte VERSION = 2;
 
     @Override
-    public FileStreamSignature read(StreamFileData signatureFileData) {
+    public StreamFileSignature read(StreamFileData signatureFileData) {
         String filename = signatureFileData.getFilename();
 
         try (ValidatedDataInputStream vdis = new ValidatedDataInputStream(
@@ -56,15 +56,15 @@ public class SignatureFileReaderV2 implements SignatureFileReader {
                 throw new SignatureFileParsingException("Extra data discovered in signature file " + filename);
             }
 
-            FileStreamSignature fileStreamSignature = new FileStreamSignature();
-            fileStreamSignature.setBytes(signatureFileData.getBytes());
-            fileStreamSignature.setFileHash(fileHash);
-            fileStreamSignature.setFileHashSignature(signature);
-            fileStreamSignature.setFilename(signatureFileData.getStreamFilename());
-            fileStreamSignature.setSignatureType(SignatureType.SHA_384_WITH_RSA);
-            fileStreamSignature.setVersion(VERSION);
+            StreamFileSignature streamFileSignature = new StreamFileSignature();
+            streamFileSignature.setBytes(signatureFileData.getBytes());
+            streamFileSignature.setFileHash(fileHash);
+            streamFileSignature.setFileHashSignature(signature);
+            streamFileSignature.setFilename(signatureFileData.getStreamFilename());
+            streamFileSignature.setSignatureType(SignatureType.SHA_384_WITH_RSA);
+            streamFileSignature.setVersion(VERSION);
 
-            return fileStreamSignature;
+            return streamFileSignature;
         } catch (InvalidStreamFileException | IOException e) {
             throw new SignatureFileParsingException(e);
         }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/signature/SignatureFileReaderV5.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/signature/SignatureFileReaderV5.java
@@ -24,14 +24,12 @@ import static com.hedera.mirror.common.domain.DigestAlgorithm.SHA_384;
 
 import java.io.IOException;
 import javax.inject.Named;
-
-import com.hedera.mirror.importer.domain.StreamFileSignature;
-
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
-import com.hedera.mirror.importer.domain.StreamFileSignature.SignatureType;
 import com.hedera.mirror.importer.domain.StreamFileData;
+import com.hedera.mirror.importer.domain.StreamFileSignature;
+import com.hedera.mirror.importer.domain.StreamFileSignature.SignatureType;
 import com.hedera.mirror.importer.exception.InvalidStreamFileException;
 import com.hedera.mirror.importer.exception.SignatureFileParsingException;
 import com.hedera.mirror.importer.reader.AbstractStreamObject;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/signature/SignatureFileReaderV5.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/signature/SignatureFileReaderV5.java
@@ -24,11 +24,13 @@ import static com.hedera.mirror.common.domain.DigestAlgorithm.SHA_384;
 
 import java.io.IOException;
 import javax.inject.Named;
+
+import com.hedera.mirror.importer.domain.StreamFileSignature;
+
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
-import com.hedera.mirror.importer.domain.FileStreamSignature;
-import com.hedera.mirror.importer.domain.FileStreamSignature.SignatureType;
+import com.hedera.mirror.importer.domain.StreamFileSignature.SignatureType;
 import com.hedera.mirror.importer.domain.StreamFileData;
 import com.hedera.mirror.importer.exception.InvalidStreamFileException;
 import com.hedera.mirror.importer.exception.SignatureFileParsingException;
@@ -42,7 +44,7 @@ public class SignatureFileReaderV5 implements SignatureFileReader {
     protected static final byte VERSION = 5;
 
     @Override
-    public FileStreamSignature read(StreamFileData signatureFileData) {
+    public StreamFileSignature read(StreamFileData signatureFileData) {
         String filename = signatureFileData.getFilename();
 
         try (ValidatedDataInputStream vdis = new ValidatedDataInputStream(
@@ -62,17 +64,17 @@ public class SignatureFileReaderV5 implements SignatureFileReader {
                 throw new SignatureFileParsingException("Extra data discovered in signature file " + filename);
             }
 
-            FileStreamSignature fileStreamSignature = new FileStreamSignature();
-            fileStreamSignature.setBytes(signatureFileData.getBytes());
-            fileStreamSignature.setFileHash(fileHashObject.getHash());
-            fileStreamSignature.setFileHashSignature(fileHashSignatureObject.getSignature());
-            fileStreamSignature.setFilename(signatureFileData.getStreamFilename());
-            fileStreamSignature.setMetadataHash(metadataHashObject.getHash());
-            fileStreamSignature.setMetadataHashSignature(metadataHashSignatureObject.getSignature());
-            fileStreamSignature.setSignatureType(fileHashSignatureObject.getSignatureType());
-            fileStreamSignature.setVersion(VERSION);
+            StreamFileSignature streamFileSignature = new StreamFileSignature();
+            streamFileSignature.setBytes(signatureFileData.getBytes());
+            streamFileSignature.setFileHash(fileHashObject.getHash());
+            streamFileSignature.setFileHashSignature(fileHashSignatureObject.getSignature());
+            streamFileSignature.setFilename(signatureFileData.getStreamFilename());
+            streamFileSignature.setMetadataHash(metadataHashObject.getHash());
+            streamFileSignature.setMetadataHashSignature(metadataHashSignatureObject.getSignature());
+            streamFileSignature.setSignatureType(fileHashSignatureObject.getSignatureType());
+            streamFileSignature.setVersion(VERSION);
 
-            return fileStreamSignature;
+            return streamFileSignature;
         } catch (InvalidStreamFileException | IOException e) {
             throw new SignatureFileParsingException(e);
         }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/StreamFileSignatureTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/StreamFileSignatureTest.java
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
-class FileStreamSignatureTest {
+class StreamFileSignatureTest {
 
     @ParameterizedTest
     @CsvSource({
@@ -36,9 +36,9 @@ class FileStreamSignatureTest {
             "2020-06-03T16_45_00.100200345Z.rcd_sig, 6, 2020-06-03T16_45_00.100200345Z.rcd.gz"
     })
     void getDataFilename(String filename, byte version, String expected) {
-        var fileStreamSignature = new FileStreamSignature();
-        fileStreamSignature.setFilename(new StreamFilename(filename));
-        fileStreamSignature.setVersion(version);
-        assertThat(fileStreamSignature.getDataFilename().getFilename()).isEqualTo(expected);
+        var streamFileSignature = new StreamFileSignature();
+        streamFileSignature.setFilename(new StreamFilename(filename));
+        streamFileSignature.setVersion(version);
+        assertThat(streamFileSignature.getDataFilename().getFilename()).isEqualTo(expected);
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/ConsensusValidatorImplTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/ConsensusValidatorImplTest.java
@@ -33,9 +33,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-
-import com.hedera.mirror.importer.domain.StreamFileSignature;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -45,6 +42,7 @@ import com.hedera.mirror.common.domain.DomainBuilder;
 import com.hedera.mirror.common.domain.StreamType;
 import com.hedera.mirror.importer.MirrorProperties;
 import com.hedera.mirror.importer.domain.ConsensusNodeStub;
+import com.hedera.mirror.importer.domain.StreamFileSignature;
 import com.hedera.mirror.importer.domain.StreamFileSignature.SignatureType;
 import com.hedera.mirror.importer.domain.StreamFilename;
 import com.hedera.mirror.importer.exception.SignatureVerificationException;

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/ConsensusValidatorImplTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/ConsensusValidatorImplTest.java
@@ -21,9 +21,9 @@ package com.hedera.mirror.importer.downloader;
  */
 
 import static com.hedera.mirror.common.util.DomainUtils.TINYBARS_IN_ONE_HBAR;
-import static com.hedera.mirror.importer.domain.FileStreamSignature.SignatureStatus.CONSENSUS_REACHED;
-import static com.hedera.mirror.importer.domain.FileStreamSignature.SignatureStatus.DOWNLOADED;
-import static com.hedera.mirror.importer.domain.FileStreamSignature.SignatureStatus.VERIFIED;
+import static com.hedera.mirror.importer.domain.StreamFileSignature.SignatureStatus.CONSENSUS_REACHED;
+import static com.hedera.mirror.importer.domain.StreamFileSignature.SignatureStatus.DOWNLOADED;
+import static com.hedera.mirror.importer.domain.StreamFileSignature.SignatureStatus.VERIFIED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -33,6 +33,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+
+import com.hedera.mirror.importer.domain.StreamFileSignature;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -42,8 +45,7 @@ import com.hedera.mirror.common.domain.DomainBuilder;
 import com.hedera.mirror.common.domain.StreamType;
 import com.hedera.mirror.importer.MirrorProperties;
 import com.hedera.mirror.importer.domain.ConsensusNodeStub;
-import com.hedera.mirror.importer.domain.FileStreamSignature;
-import com.hedera.mirror.importer.domain.FileStreamSignature.SignatureType;
+import com.hedera.mirror.importer.domain.StreamFileSignature.SignatureType;
 import com.hedera.mirror.importer.domain.StreamFilename;
 import com.hedera.mirror.importer.exception.SignatureVerificationException;
 
@@ -86,7 +88,7 @@ class ConsensusValidatorImplTest {
         consensusValidator.validate(signatures);
         assertThat(signatures)
                 .hasSize(signatures.size())
-                .map(FileStreamSignature::getStatus)
+                .map(StreamFileSignature::getStatus)
                 .containsOnly(CONSENSUS_REACHED);
     }
 
@@ -99,7 +101,7 @@ class ConsensusValidatorImplTest {
         consensusValidator.validate(signatures);
         assertThat(signatures)
                 .hasSize(signatures.size())
-                .map(FileStreamSignature::getStatus)
+                .map(StreamFileSignature::getStatus)
                 .containsOnly(CONSENSUS_REACHED);
     }
 
@@ -110,21 +112,21 @@ class ConsensusValidatorImplTest {
         consensusValidator.validate(signatures);
         assertThat(signatures)
                 .hasSize(signatures.size())
-                .map(FileStreamSignature::getStatus)
+                .map(StreamFileSignature::getStatus)
                 .containsOnly(CONSENSUS_REACHED);
     }
 
     @ParameterizedTest
-    @EnumSource(value = FileStreamSignature.SignatureStatus.class, names = {"DOWNLOADED", "CONSENSUS_REACHED",
+    @EnumSource(value = StreamFileSignature.SignatureStatus.class, names = {"DOWNLOADED", "CONSENSUS_REACHED",
             "NOT_FOUND"})
-    void notVerified(FileStreamSignature.SignatureStatus status) {
+    void notVerified(StreamFileSignature.SignatureStatus status) {
         var signatures = signatures(3, 3, 3);
         signatures.forEach(s -> s.setStatus(status));
         assertThatThrownBy(() -> consensusValidator.validate(signatures))
                 .isInstanceOf(SignatureVerificationException.class)
                 .hasMessageContaining("Consensus not reached for file");
         assertThat(signatures)
-                .map(FileStreamSignature::getStatus)
+                .map(StreamFileSignature::getStatus)
                 .containsOnly(status);
     }
 
@@ -137,13 +139,13 @@ class ConsensusValidatorImplTest {
         consensusValidator.validate(signatures);
         assertThat(signatures)
                 .hasSize(signatures.size())
-                .map(FileStreamSignature::getStatus)
+                .map(StreamFileSignature::getStatus)
                 .containsOnly(CONSENSUS_REACHED);
     }
 
     @Test
     void noSignatures() {
-        List<FileStreamSignature> emptyList = Collections.emptyList();
+        List<StreamFileSignature> emptyList = Collections.emptyList();
         assertConsensusNotReached(emptyList);
     }
 
@@ -154,7 +156,7 @@ class ConsensusValidatorImplTest {
 
         consensusValidator.validate(signatures);
         assertThat(signatures)
-                .map(FileStreamSignature::getStatus)
+                .map(StreamFileSignature::getStatus)
                 .doesNotContain(CONSENSUS_REACHED);
     }
 
@@ -167,7 +169,7 @@ class ConsensusValidatorImplTest {
 
         consensusValidator.validate(signatures);
         assertThat(signatures)
-                .map(FileStreamSignature::getStatus)
+                .map(StreamFileSignature::getStatus)
                 .containsExactly(CONSENSUS_REACHED, CONSENSUS_REACHED, VERIFIED, VERIFIED, VERIFIED);
     }
 
@@ -177,7 +179,7 @@ class ConsensusValidatorImplTest {
         var signatures = signatures(0, 0, 0);
         consensusValidator.validate(signatures);
         assertThat(signatures)
-                .map(FileStreamSignature::getStatus)
+                .map(StreamFileSignature::getStatus)
                 .containsOnly(CONSENSUS_REACHED);
     }
 
@@ -192,17 +194,17 @@ class ConsensusValidatorImplTest {
         assertConsensusNotReached(signatures);
     }
 
-    private void assertConsensusNotReached(List<FileStreamSignature> signatures) {
+    private void assertConsensusNotReached(List<StreamFileSignature> signatures) {
         assertThatThrownBy(() -> consensusValidator.validate(signatures))
                 .isInstanceOf(SignatureVerificationException.class)
                 .hasMessageContaining("Consensus not reached for file");
         assertThat(signatures)
-                .map(FileStreamSignature::getStatus)
+                .map(StreamFileSignature::getStatus)
                 .doesNotContain(CONSENSUS_REACHED);
     }
 
-    private List<FileStreamSignature> signatures(long... stakes) {
-        List<FileStreamSignature> signatures = new ArrayList<>();
+    private List<StreamFileSignature> signatures(long... stakes) {
+        List<StreamFileSignature> signatures = new ArrayList<>();
         long totalStake = Arrays.stream(stakes).sum();
         if (totalStake == 0) {
             stakes = Arrays.stream(stakes).map(s -> 1L).toArray();
@@ -217,12 +219,12 @@ class ConsensusValidatorImplTest {
                     .totalStake(totalStake)
                     .build();
 
-            var signature = new FileStreamSignature();
+            var signature = new StreamFileSignature();
             signature.setFileHash(fileHash);
             signature.setFilename(StreamFilename.EPOCH);
             signature.setNode(node);
             signature.setSignatureType(SignatureType.SHA_384_WITH_RSA);
-            signature.setStatus(FileStreamSignature.SignatureStatus.VERIFIED);
+            signature.setStatus(StreamFileSignature.SignatureStatus.VERIFIED);
             signature.setStreamType(StreamType.RECORD);
             signatures.add(signature);
         }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/signature/ProtoSignatureFileReaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/signature/ProtoSignatureFileReaderTest.java
@@ -34,8 +34,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import com.hedera.mirror.common.util.DomainUtils;
 import com.hedera.mirror.importer.TestUtils;
-import com.hedera.mirror.importer.domain.FileStreamSignature;
 import com.hedera.mirror.importer.domain.StreamFileData;
+import com.hedera.mirror.importer.domain.StreamFileSignature;
 import com.hedera.mirror.importer.exception.InvalidStreamFileException;
 import com.hedera.services.stream.proto.HashAlgorithm;
 import com.hedera.services.stream.proto.HashObject;
@@ -76,18 +76,18 @@ class ProtoSignatureFileReaderTest extends AbstractSignatureFileReaderTest {
                            String metadataHashAsHex, String metadataSignatureAsHex) {
         var signatureFile = TestUtils.getResource(Path.of("data", "signature", "v6", filename).toString());
         var streamFileData = StreamFileData.from(signatureFile);
-        var fileStreamSignature = protoSignatureFileReader.read(streamFileData);
+        var streamFileSignature = protoSignatureFileReader.read(streamFileData);
 
-        assertThat(fileStreamSignature)
+        assertThat(streamFileSignature)
                 .isNotNull()
-                .returns(streamFileData.getBytes(), FileStreamSignature::getBytes)
+                .returns(streamFileData.getBytes(), StreamFileSignature::getBytes)
                 .returns(filename, s -> s.getFilename().toString())
-                .returns(entireFileHashAsHex, FileStreamSignature::getFileHashAsHex)
+                .returns(entireFileHashAsHex, StreamFileSignature::getFileHashAsHex)
                 .returns(entireFileSignatureHex, f -> DomainUtils.bytesToHex(f.getFileHashSignature()))
-                .returns(metadataHashAsHex, FileStreamSignature::getMetadataHashAsHex)
+                .returns(metadataHashAsHex, StreamFileSignature::getMetadataHashAsHex)
                 .returns(metadataSignatureAsHex, f -> DomainUtils.bytesToHex(f.getMetadataHashSignature()))
-                .returns(FileStreamSignature.SignatureType.SHA_384_WITH_RSA, FileStreamSignature::getSignatureType)
-                .returns(VERSION, FileStreamSignature::getVersion);
+                .returns(StreamFileSignature.SignatureType.SHA_384_WITH_RSA, StreamFileSignature::getSignatureType)
+                .returns(VERSION, StreamFileSignature::getVersion);
     }
 
     @Test

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/signature/SignatureFileReaderV2Test.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/signature/SignatureFileReaderV2Test.java
@@ -30,9 +30,6 @@ import java.io.File;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
-
-import com.hedera.mirror.importer.domain.StreamFileSignature;
-
 import org.apache.commons.codec.binary.Base64;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Test;
@@ -41,6 +38,7 @@ import org.junit.jupiter.api.TestFactory;
 import com.hedera.mirror.common.domain.DigestAlgorithm;
 import com.hedera.mirror.importer.TestUtils;
 import com.hedera.mirror.importer.domain.StreamFileData;
+import com.hedera.mirror.importer.domain.StreamFileSignature;
 
 class SignatureFileReaderV2Test extends AbstractSignatureFileReaderTest {
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/signature/SignatureFileReaderV2Test.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/signature/SignatureFileReaderV2Test.java
@@ -30,6 +30,9 @@ import java.io.File;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
+
+import com.hedera.mirror.importer.domain.StreamFileSignature;
+
 import org.apache.commons.codec.binary.Base64;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Test;
@@ -37,7 +40,6 @@ import org.junit.jupiter.api.TestFactory;
 
 import com.hedera.mirror.common.domain.DigestAlgorithm;
 import com.hedera.mirror.importer.TestUtils;
-import com.hedera.mirror.importer.domain.FileStreamSignature;
 import com.hedera.mirror.importer.domain.StreamFileData;
 
 class SignatureFileReaderV2Test extends AbstractSignatureFileReaderTest {
@@ -60,13 +62,13 @@ class SignatureFileReaderV2Test extends AbstractSignatureFileReaderTest {
     @Test
     void testReadValidFile() {
         StreamFileData streamFileData = StreamFileData.from(signatureFile);
-        FileStreamSignature fileStreamSignature = fileReaderV2.read(streamFileData);
-        assertNotNull(fileStreamSignature);
-        assertThat(fileStreamSignature.getBytes()).isNotEmpty().isEqualTo(streamFileData.getBytes());
-        assertArrayEquals(Base64.decodeBase64(entireFileHashBase64.getBytes()), fileStreamSignature.getFileHash());
-        assertArrayEquals(Base64.decodeBase64(entireFileSignatureBase64.getBytes()), fileStreamSignature
+        StreamFileSignature streamFileSignature = fileReaderV2.read(streamFileData);
+        assertNotNull(streamFileSignature);
+        assertThat(streamFileSignature.getBytes()).isNotEmpty().isEqualTo(streamFileData.getBytes());
+        assertArrayEquals(Base64.decodeBase64(entireFileHashBase64.getBytes()), streamFileSignature.getFileHash());
+        assertArrayEquals(Base64.decodeBase64(entireFileSignatureBase64.getBytes()), streamFileSignature
                 .getFileHashSignature());
-        assertEquals(VERSION, fileStreamSignature.getVersion());
+        assertEquals(VERSION, streamFileSignature.getVersion());
     }
 
     @SuppressWarnings("java:S2699")

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/signature/SignatureFileReaderV5Test.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/signature/SignatureFileReaderV5Test.java
@@ -37,8 +37,8 @@ import org.junit.jupiter.api.TestFactory;
 
 import com.hedera.mirror.common.domain.DigestAlgorithm;
 import com.hedera.mirror.importer.TestUtils;
-import com.hedera.mirror.importer.domain.FileStreamSignature;
-import com.hedera.mirror.importer.domain.FileStreamSignature.SignatureType;
+import com.hedera.mirror.importer.domain.StreamFileSignature;
+import com.hedera.mirror.importer.domain.StreamFileSignature.SignatureType;
 import com.hedera.mirror.importer.domain.StreamFileData;
 
 class SignatureFileReaderV5Test extends AbstractSignatureFileReaderTest {
@@ -77,15 +77,15 @@ class SignatureFileReaderV5Test extends AbstractSignatureFileReaderTest {
     @Test
     void testReadValidFile() {
         StreamFileData streamFileData = StreamFileData.from(signatureFile);
-        FileStreamSignature fileStreamSignature = fileReaderV5.read(streamFileData);
+        StreamFileSignature streamFileSignature = fileReaderV5.read(streamFileData);
 
-        assertNotNull(fileStreamSignature);
-        assertThat(fileStreamSignature.getBytes()).isNotEmpty().isEqualTo(streamFileData.getBytes());
-        assertArrayEquals(base64Codec.decode(entireFileHashBase64), fileStreamSignature.getFileHash());
-        assertArrayEquals(base64Codec.decode(entireFileSignatureBase64), fileStreamSignature.getFileHashSignature());
-        assertArrayEquals(base64Codec.decode(metadataHashBase64), fileStreamSignature.getMetadataHash());
-        assertArrayEquals(base64Codec.decode(metadataSignatureBase64), fileStreamSignature.getMetadataHashSignature());
-        assertEquals(VERSION, fileStreamSignature.getVersion());
+        assertNotNull(streamFileSignature);
+        assertThat(streamFileSignature.getBytes()).isNotEmpty().isEqualTo(streamFileData.getBytes());
+        assertArrayEquals(base64Codec.decode(entireFileHashBase64), streamFileSignature.getFileHash());
+        assertArrayEquals(base64Codec.decode(entireFileSignatureBase64), streamFileSignature.getFileHashSignature());
+        assertArrayEquals(base64Codec.decode(metadataHashBase64), streamFileSignature.getMetadataHash());
+        assertArrayEquals(base64Codec.decode(metadataSignatureBase64), streamFileSignature.getMetadataHashSignature());
+        assertEquals(VERSION, streamFileSignature.getVersion());
     }
 
     @SuppressWarnings("java:S2699")


### PR DESCRIPTION
**Description**:

Rename `FileStreamSignature` to `StreamFileSignature`

**Related issue(s)**:

Fixes #4595

**Notes for reviewer**:
No logic change, just a simple renaming done through the IDE

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
