### PR TITLE
Fix acceptance tests regression

### DIFF
--- a/hedera-mirror-test/src/main/java/com/hedera/mirror/rest/MirrorTestApplication.java
+++ b/hedera-mirror-test/src/main/java/com/hedera/mirror/rest/MirrorTestApplication.java
@@ -1,0 +1,33 @@
+package com.hedera.mirror.test;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class MirrorTestApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(MirrorTestApplication.class, args);
+    }
+}
+


### PR DESCRIPTION
**Description**:

Revert deletion of `MirrorTestApplication` since it breaks acceptance tests

**Related issue(s)**:

**Notes for reviewer**:

Thought I had tested this approach would work on my gradle branch awhile back. Turns out Cucumber and Spring Boot in general requires a main class to enable component scanning. Will have to figure out another approach to make `hedera-mirror-test` work with Gradle.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
