### PR TITLE
Create a startup probe for acceptance tests

### DIFF
--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/MirrorNodeClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/MirrorNodeClient.java
@@ -65,7 +65,7 @@ public class MirrorNodeClient {
         var properties = acceptanceTestProperties.getRestPollingProperties();
         retrySpec = Retry.backoff(properties.getMaxAttempts(), properties.getMinBackoff())
                 .maxBackoff(properties.getMaxBackoff())
-                .filter(this::shouldRetryRestCall);
+                .filter(properties::shouldRetry);
     }
 
     public SubscriptionResponse subscribeToTopic(SDKClient sdkClient, TopicMessageQuery topicMessageQuery) throws Throwable {
@@ -207,12 +207,6 @@ public class MirrorNodeClient {
     public void unSubscribeFromTopic(SubscriptionHandle subscription) {
         subscription.unsubscribe();
         log.info("Unsubscribed from {}", subscription);
-    }
-
-    protected boolean shouldRetryRestCall(Throwable t) {
-        return acceptanceTestProperties.getRestPollingProperties().getRetryableExceptions()
-                .stream()
-                .anyMatch(ex -> ex.isInstance(t) || ex.isInstance(Throwables.getRootCause(t)));
     }
 
     private <T> T callRestEndpoint(String uri, Class<T> classType, Object... uriVariables) {

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/SDKClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/SDKClient.java
@@ -65,19 +65,15 @@ public class SDKClient implements AutoCloseable {
     @Getter
     private final ExpandedAccountId expandedOperatorAccountId;
 
-    public SDKClient(AcceptanceTestProperties acceptanceTestProperties, MirrorNodeClient mirrorNodeClient)
-            throws InterruptedException {
+    public SDKClient(AcceptanceTestProperties acceptanceTestProperties, MirrorNodeClient mirrorNodeClient,
+            StartupProbe startupProbe)
+            throws InterruptedException, TimeoutException {
         this.mirrorNodeClient = mirrorNodeClient;
         maxTransactionFee = Hbar.fromTinybars(acceptanceTestProperties.getMaxTinyBarTransactionFee());
         this.acceptanceTestProperties = acceptanceTestProperties;
-        this.startupProbe = new StartupProbe(acceptanceTestProperties, mirrorNodeClient);
-        // the call must be made before any network activity in this constructor
-        try {
-            this.startupProbe.validateEnvironment();
-        } catch (TimeoutException e) {
-            log.error("Startup probe unsuccessful: {}", e.getMessage(), e);
-            throw new RuntimeException(e);
-        }
+        this.startupProbe = startupProbe;
+        // this next call must be made before any network activity in this constructor
+        startupProbe.validateEnvironment();
         this.client = getValidatedClient();
         expandedOperatorAccountId = getOperatorAccount();
         this.client.setOperator(expandedOperatorAccountId.getAccountId(), expandedOperatorAccountId.getPrivateKey());

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/SDKClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/SDKClient.java
@@ -77,8 +77,6 @@ public class SDKClient implements AutoCloseable {
         // Client in next line is only used by the Startup probe.  Validated Client for SDKClient set afterwards.
         try (Client unvalidatedClient = toClient(network)) {
             startupProbe.validateEnvironment(unvalidatedClient);
-        } catch (Exception e) {
-            log.warn("Startup Probe Failed: {}", e.getMessage());
         } 
         this.client = getValidatedClient();
         expandedOperatorAccountId = getOperatorAccount();

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/StartupProbe.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/StartupProbe.java
@@ -25,16 +25,22 @@ import java.time.Instant;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import javax.inject.Named;
 import lombok.CustomLog;
+import lombok.SneakyThrows;
 
+import com.google.common.base.Stopwatch;
+import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.Uninterruptibles;
+import org.springframework.http.MediaType;
+import org.springframework.retry.support.RetryTemplate;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.util.retry.Retry;
+import reactor.util.retry.RetryBackoffSpec;
 
 import com.hedera.hashgraph.sdk.AccountId;
 import com.hedera.hashgraph.sdk.Client;
-import com.hedera.hashgraph.sdk.PrecheckStatusException;
 import com.hedera.hashgraph.sdk.PrivateKey;
-import com.hedera.hashgraph.sdk.ReceiptStatusException;
-import com.hedera.hashgraph.sdk.Status;
 import com.hedera.hashgraph.sdk.TopicCreateTransaction;
 import com.hedera.hashgraph.sdk.TopicId;
 import com.hedera.hashgraph.sdk.TopicMessageQuery;
@@ -43,33 +49,27 @@ import com.hedera.hashgraph.sdk.TransactionId;
 import com.hedera.hashgraph.sdk.TransactionReceipt;
 import com.hedera.hashgraph.sdk.TransactionResponse;
 import com.hedera.mirror.test.e2e.acceptance.config.AcceptanceTestProperties;
-import com.hedera.mirror.test.e2e.acceptance.props.MirrorTransaction;
-import com.hedera.mirror.test.e2e.acceptance.response.MirrorTransactionsResponse;
 
 /**
  * StartupProbe -- a helper class to validate a SDKClient before using it.
  */
 @CustomLog
+@Named
 public class StartupProbe {
 
     private final AcceptanceTestProperties acceptanceTestProperties;
-    private final int maxRetries;
-    private final MirrorNodeClient mirrorNodeClient;
-    private final Instant startInstant;
-    private final Instant timeoutInstant;
+    private final Duration startupTimeout;
+    private final WebClient webClient;
 
-    private int retries = 1;
     private boolean validated;
 
-    public StartupProbe(AcceptanceTestProperties acceptanceTestProperties, MirrorNodeClient mirrorNodeClient) {
-        startInstant = Instant.now();
+    public StartupProbe(AcceptanceTestProperties acceptanceTestProperties, WebClient webClient) {
         this.acceptanceTestProperties = acceptanceTestProperties;
-        this.mirrorNodeClient = mirrorNodeClient;
-        maxRetries = acceptanceTestProperties.getMaxRetries();
-        Duration startupTimeout = acceptanceTestProperties.getStartupTimeout();
-        timeoutInstant = startInstant.plusNanos(startupTimeout.toNanos());
+        this.webClient = webClient;
+        startupTimeout = acceptanceTestProperties.getStartupTimeout();
     }
 
+    @SneakyThrows
     public void validateEnvironment() throws TimeoutException {
         // if we previously validated successfully, just immediately return.
         if (validated) {
@@ -82,155 +82,82 @@ public class StartupProbe {
         PrivateKey privateKey = PrivateKey.fromString(acceptanceTestProperties.getOperatorKey());
         client.setOperator(operator, privateKey);  // this account pays for (and signs) all transactions run here.
 
+        Stopwatch stopwatch = Stopwatch.createStarted();
         // step 1: Create a new topic for the subsequent HCS submit message action.
-        TransactionResponse transactionResponse = null;
-        TransactionId transactionId = null;
-        boolean createdTopic = false;
-	for ( ; retries <= maxRetries; retries++) {
-            try {
-                transactionResponse = new TopicCreateTransaction().execute(client);
-                transactionId = transactionResponse.transactionId;
-                createdTopic = true;
-                break;
-            } catch (PrecheckStatusException pse) {
-                log.warn("PrecheckStatusException on trying to create new topic, attempt #{}", retries, pse);
-                throw new IllegalArgumentException(pse.getMessage());
-            } catch (TimeoutException te) {
-                log.warn("TimeoutException on trying to create new topic, attempt #{}", retries, te);
-                if (Instant.now().compareTo(timeoutInstant) >= 0) {
-                    throw new TimeoutException("Ran out of time on first HAPI call - creating new topic: "
-                            + te.getMessage());
-                }
-            }
-        }
-
-        if (!createdTopic) {
-            throw new IllegalArgumentException("StartupProbe (first HAPI call) : Could not create new topic after "
-                    + maxRetries + " retries");
-        }
+        RetryTemplate retryTemplate = RetryTemplate.builder()
+                .infiniteRetry()
+                .notRetryOn(TimeoutException.class)
+                .fixedBackoff(1000L)
+                .build();
+        
+        TransactionResponse response = retryTemplate.execute(x -> new TopicCreateTransaction()
+            .setGrpcDeadline(Duration.ofSeconds(10L))
+            .setMaxAttempts(Integer.MAX_VALUE)
+            .execute(client, startupTimeout.minus(stopwatch.elapsed())));
+        TransactionId transactionId = response.transactionId;
 
         // step 2: Query for the receipt of that HCS submit transaction (until successful or time runs out)
-        TransactionReceipt transactionReceipt = null;
-        boolean gotReceipt = false;
-	for ( retries = 1; retries <= maxRetries; retries++) {
-            try {
-                Duration remainingTime = Duration.between(Instant.now(), timeoutInstant);
-                transactionReceipt = transactionResponse.getReceipt(client, remainingTime);
-                if (transactionReceipt.status != Status.SUCCESS) {
-                    log.warn("Calling transactionResponse.getReceipt resulted in status " + transactionReceipt.status
-                             + ", not SUCCESS, on try #{}; retrying.", retries);
-                    continue;
-                }
-                gotReceipt = true;
-                break;
-            } catch (PrecheckStatusException pse) {
-                log.warn("PrecheckStatusException on trying to get submit transaction receipt, attempt #{}", retries, pse);
-                throw new IllegalArgumentException("PrecheckStatusException on second HAPI call (getting transaction"
-                        + " receipt): " + pse.getMessage());
-            } catch (ReceiptStatusException rse) {
-                log.warn("ReceiptStatusException on trying to get submit transaction receipt, attempt #{}", retries, rse);
-                // try again
-            } catch (TimeoutException te) {
-                log.warn("TimeoutException on trying to get submit transaction receipt, attempt #{}", retries, te);
-                if (Instant.now().compareTo(timeoutInstant) >= 0) {
-                    throw new TimeoutException("Ran out of time on second HAPI call - getting submit transaction "
-                            + " receipt:" + te.getMessage());
-                }
-            }
-        }
-
-        if (!gotReceipt) {
-            throw new IllegalArgumentException("StartupProbe Could not retrieve receipt after " + maxRetries
-                    + " retries");
-        }
+        TransactionReceipt transactionReceipt = response.getReceipt(client,
+                startupTimeout.minus(stopwatch.elapsed()));
 
         // step 3: Query the mirror node for the transaction by ID (until successful or time runs out)
+        // Instead of using MirrorNodeClient.getTransactions(restTransactionId), we directly call webClient.
+        // retry infinitely or until timeout (or success), not a maximum of properties.getMaxAttempts() times.
+        var properties = acceptanceTestProperties.getRestPollingProperties();
+        RetryBackoffSpec retrySpec = Retry.backoff(Integer.MAX_VALUE, properties.getMinBackoff())
+                .maxBackoff(properties.getMaxBackoff())
+                .filter(this::shouldRetryRestCall);
+
         String restTransactionId = transactionId.accountId.toString() + "-" + transactionId.validStart.getEpochSecond()
                 + "-" + transactionId.validStart.getNano();
-        MirrorTransactionsResponse mirrorTransactionsResponse = null;
-        boolean gotRestApiResponse = false;
-	// call to mirrorNodeClient will automatically retry (up to maxRetries times) on exceptions, so no need to loop
-        try {
-            mirrorTransactionsResponse = mirrorNodeClient.getTransactions(restTransactionId);
-            for (MirrorTransaction mirrorTransaction : mirrorTransactionsResponse.getTransactions()) {
-                if (mirrorTransaction.getResult().equalsIgnoreCase("SUCCESS")) {
-                    gotRestApiResponse = true;
-                    break;
-                }
-            }
-        } catch (Exception e) {
-            log.warn("Exception on REST API call to get transaction by id (after #{} retries)", maxRetries, e);
-            if (Instant.now().compareTo(timeoutInstant) >= 0) {
-                throw new TimeoutException("Ran out of time on the REST API call - getting transaction by id: "
-                        + e.getMessage());
-            }
-        }
 
-        if (!gotRestApiResponse) {
-            throw new IllegalArgumentException("StartupProbe Could not successfully make API call after " + maxRetries
-                    + " retries");
-        }
+        webClient.get()
+                .uri("/transactions/", restTransactionId)
+                .accept(MediaType.APPLICATION_JSON)
+                .retrieve()
+                .bodyToMono(String.class)
+                .retryWhen(retrySpec)
+                .doOnError(x -> log.error("Endpoint failed, returning: {}", x.getMessage()))
+                .timeout(startupTimeout.minus(stopwatch.elapsed()))
+                .block();
 
         // step 4: Query the mirror node gRPC API for a message on the topic created in step 2, until successful or
         //         time runs out
         TopicId topicId = transactionReceipt.topicId;
         AtomicBoolean messageReceived = new AtomicBoolean();
 
-        boolean subscribedWithGrpc = false;
-	for ( retries = 1; retries <= maxRetries; retries++) {
-            try {
-                new TopicMessageQuery()
-                    .setTopicId(topicId)
-                    .subscribe(client, resp -> {
-                        messageReceived.set(true);
-                    });
-                subscribedWithGrpc = true;
-            } catch (RuntimeException e) {
-                log.warn("RuntimeException on try #{}/{} to subscribe using GRPC API call", retries, maxRetries, e);
-                // try again
-            }
-        }
+        retryTemplate.execute(x -> new TopicMessageQuery()
+                .setTopicId(topicId)
+                .subscribe(client, resp -> {
+                    messageReceived.set(true);
+                }));
 
-        if (!subscribedWithGrpc) {
-            throw new IllegalArgumentException("StartupProbe Could not successfully make GRPC API subscription call "
-                    + "after " + maxRetries + " retries");
-        }
-
-	for ( retries = 1; retries <= maxRetries; retries++) {
-            try {
-                Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
-                if (messageReceived.get()) {  // we already had a previous success - no need to submit more trabsactions
-                    break;
-                }
+        retryTemplate.execute(x -> {
+            int counter = 0;
+            while (!(messageReceived.get()) && startupTimeout.minus(stopwatch.elapsed()).toMillis() > 0) {
                 new TopicMessageSubmitTransaction()
                     .setTopicId(topicId)
-                    .setMessage("Hello, HCS! " + retries)
-                    .execute(client)
+                    .setMessage("Hello, HCS! " + ++counter)
+                    .execute(client, startupTimeout.minus(stopwatch.elapsed()))
                     .getReceipt(client);
-
                 Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
-                if (Instant.now().compareTo(timeoutInstant) >= 0) {
-                    throw new TimeoutException("Ran out of time on second HAPI call - getting submit transaction "
-                            + " receipt.");
-                }
-            } catch (PrecheckStatusException pse) {
-                log.warn("PrecheckStatusException on GRPC API call to submit a transaction", pse);
-                throw new IllegalArgumentException("PrecheckStatusException on GRPC call (submitting transaction):"
-                        + pse.getMessage());
-            } catch (ReceiptStatusException rse) {
-                log.warn("ReceiptStatusException on trying to get receipt from GRPC API call", rse);
-                // try again
             }
-        }
+            return null;
+        });
 
-        // make sure at least one message got through
-        if (!messageReceived.get()) {
-            throw new IllegalArgumentException("StartupProbe Could not successfully receive GRPC message after "
-                    + maxRetries + " retries");
+        if (messageReceived.get()) {
+            log.info("Startup probe successful.");
+            validated = true;
+        } else {
+            throw new TimeoutException("Timer expired while trying to receive topic messages.");
         }
+    }
 
-        log.info("successful for all stages - HAPI, REST API, and gRPC API."); // ideally, the only line logged.
-        validated = true;
+    // used by the retrySpec created in validateEnvironment(); this routine copied from MirrorNodeClient.java.
+    private boolean shouldRetryRestCall(Throwable t) {
+        return acceptanceTestProperties.getRestPollingProperties().getRetryableExceptions()
+                .stream()
+                .anyMatch(ex -> ex.isInstance(t) || ex.isInstance(Throwables.getRootCause(t)));
     }
 
 }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/StartupProbe.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/StartupProbe.java
@@ -150,6 +150,8 @@ public class StartupProbe {
                 }));
 
         TransactionResponse secondResponse = retryTemplate.execute(x -> new TopicMessageSubmitTransaction()
+                .setGrpcDeadline(acceptanceTestProperties.getSdkProperties().getGrpcDeadline())
+                .setMaxAttempts(Integer.MAX_VALUE)
                 .setTopicId(topicId)
                 .setMessage("Hello, HCS!")
                 .execute(client, startupTimeout.minus(stopwatch.elapsed())));

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/StartupProbe.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/StartupProbe.java
@@ -22,18 +22,10 @@ package com.hedera.mirror.test.e2e.acceptance.client;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
 import lombok.extern.log4j.Log4j2;
-import org.apache.commons.lang3.RandomUtils;
-import org.springframework.util.CollectionUtils;
 
 import com.hedera.hashgraph.sdk.AccountId;
 import com.hedera.hashgraph.sdk.Client;
@@ -49,10 +41,7 @@ import com.hedera.hashgraph.sdk.TransactionId;
 import com.hedera.hashgraph.sdk.TransactionReceipt;
 import com.hedera.hashgraph.sdk.TransactionResponse;
 import com.hedera.mirror.test.e2e.acceptance.config.AcceptanceTestProperties;
-import com.hedera.mirror.test.e2e.acceptance.config.AcceptanceTestProperties.HederaNetwork;
-import com.hedera.mirror.test.e2e.acceptance.props.ExpandedAccountId;
 import com.hedera.mirror.test.e2e.acceptance.props.MirrorTransaction;
-import com.hedera.mirror.test.e2e.acceptance.props.NodeProperties;
 import com.hedera.mirror.test.e2e.acceptance.response.MirrorTransactionsResponse;
 
 @Log4j2
@@ -207,7 +196,7 @@ public class StartupProbe {
 
 	for ( retries = 1; retries <= maxRetries; retries++) {
             try {
-                Thread.sleep(1000);
+                TimeUnit.SECONDS.sleep(1);
                 if (messageReceived.get()) {  // we already had a previous success - no need to submit more trabsactions
                     break;
                 }
@@ -217,7 +206,7 @@ public class StartupProbe {
                     .execute(client)
                     .getReceipt(client);
 
-                Thread.sleep(1500);
+                TimeUnit.SECONDS.sleep(1);
             } catch (PrecheckStatusException pse) {
                 log.warn("PrecheckStatusException on GRPC API call to submit a transaction", pse);
                 throw new IllegalArgumentException("PrecheckStatusException on GRPC call (submitting transaction):"

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/StartupProbe.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/StartupProbe.java
@@ -1,0 +1,248 @@
+package com.hedera.mirror.test.e2e.acceptance.client;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+import lombok.extern.log4j.Log4j2;
+import org.apache.commons.lang3.RandomUtils;
+import org.springframework.util.CollectionUtils;
+
+import com.hedera.hashgraph.sdk.AccountId;
+import com.hedera.hashgraph.sdk.Client;
+import com.hedera.hashgraph.sdk.PrecheckStatusException;
+import com.hedera.hashgraph.sdk.PrivateKey;
+import com.hedera.hashgraph.sdk.ReceiptStatusException;
+import com.hedera.hashgraph.sdk.Status;
+import com.hedera.hashgraph.sdk.TopicCreateTransaction;
+import com.hedera.hashgraph.sdk.TopicId;
+import com.hedera.hashgraph.sdk.TopicMessageQuery;
+import com.hedera.hashgraph.sdk.TopicMessageSubmitTransaction;
+import com.hedera.hashgraph.sdk.TransactionId;
+import com.hedera.hashgraph.sdk.TransactionReceipt;
+import com.hedera.hashgraph.sdk.TransactionResponse;
+import com.hedera.mirror.test.e2e.acceptance.config.AcceptanceTestProperties;
+import com.hedera.mirror.test.e2e.acceptance.config.AcceptanceTestProperties.HederaNetwork;
+import com.hedera.mirror.test.e2e.acceptance.props.ExpandedAccountId;
+import com.hedera.mirror.test.e2e.acceptance.props.MirrorTransaction;
+import com.hedera.mirror.test.e2e.acceptance.props.NodeProperties;
+import com.hedera.mirror.test.e2e.acceptance.response.MirrorTransactionsResponse;
+
+@Log4j2
+/**
+ * StartupProbe -- a helper class to validate a SDKClient before using it.
+ */
+public class StartupProbe {
+
+    private final AcceptanceTestProperties acceptanceTestProperties;
+    private final int maxRetries;
+    private final MirrorNodeClient mirrorNodeClient;
+    private final Instant startInstant;
+    private final Instant timeoutInstant;
+
+    private int retries = 1;
+    private boolean validated;
+
+    public StartupProbe(AcceptanceTestProperties acceptanceTestProperties, MirrorNodeClient mirrorNodeClient) {
+        startInstant = Instant.now();
+        this.acceptanceTestProperties = acceptanceTestProperties;
+        this.mirrorNodeClient = mirrorNodeClient;
+        maxRetries = acceptanceTestProperties.getMaxRetries();
+        Duration startupTimeout = acceptanceTestProperties.getStartupTimeout();
+        timeoutInstant = startInstant.plusNanos(startupTimeout.toNanos());
+    }
+
+    public void validateEnvironment() throws TimeoutException {
+        // if we previously validated successfully, just immediately return.
+        if (validated) {
+            return;
+        }
+        // any of these can throw IllegalArgumentException; if it does, retries wouldn't help, so exit early (with that
+        // exception) if it happens.
+        Client client = Client.forName(acceptanceTestProperties.getNetwork().toString().toLowerCase());
+        AccountId operator = AccountId.fromString(acceptanceTestProperties.getOperatorId());
+        PrivateKey privateKey = PrivateKey.fromString(acceptanceTestProperties.getOperatorKey());
+        client.setOperator(operator, privateKey);  // this account pays for (and signs) all transactions run here.
+
+        // step 1: Create a new topic for the subsequent HCS submit message action.
+        TransactionResponse transactionResponse = null;
+        TransactionId transactionId = null;
+        boolean createdTopic = false;
+	for ( ; retries <= maxRetries; retries++) {
+            try {
+                transactionResponse = new TopicCreateTransaction().execute(client);
+                transactionId = transactionResponse.transactionId;
+                createdTopic = true;
+                break;
+            } catch (PrecheckStatusException pse) {
+                log.warn("PrecheckStatusException on trying to create new topic, attempt #{}", retries, pse);
+                throw new IllegalArgumentException(pse.getMessage());
+            } catch (TimeoutException te) {
+                log.warn("TimeoutException on trying to create new topic, attempt #{}", retries, te);
+                if (Instant.now().compareTo(timeoutInstant) >= 0) {
+                    throw new TimeoutException("Ran out of time on first HAPI call - creating new topic: "
+                            + te.getMessage());
+                }
+            }
+        }
+
+        if (!createdTopic) {
+            throw new IllegalArgumentException("StartupProbe (first HAPI call) : Could not create new topic after "
+                    + maxRetries + " retries");
+        }
+
+        // step 2: Query for the receipt of that HCS submit transaction (until successful or time runs out)
+        TransactionReceipt transactionReceipt = null;
+        boolean gotReceipt = false;
+	for ( retries = 1; retries <= maxRetries; retries++) {
+            try {
+                Duration remainingTime = Duration.between(Instant.now(), timeoutInstant);
+                transactionReceipt = transactionResponse.getReceipt(client, remainingTime);
+                if (transactionReceipt.status != Status.SUCCESS) {
+                    log.warn("Calling transactionResponse.getReceipt resulted in status " + transactionReceipt.status
+                             + ", not SUCCESS, on try #{}; retrying.", retries);
+                    continue;
+                }
+                gotReceipt = true;
+                break;
+            } catch (PrecheckStatusException pse) {
+                log.warn("PrecheckStatusException on trying to get submit transaction receipt, attempt #{}", retries, pse);
+                throw new IllegalArgumentException("PrecheckStatusException on second HAPI call (getting transaction"
+                        + " receipt): " + pse.getMessage());
+            } catch (ReceiptStatusException rse) {
+                log.warn("ReceiptStatusException on trying to get submit transaction receipt, attempt #{}", retries, rse);
+                // try again
+            } catch (TimeoutException te) {
+                log.warn("TimeoutException on trying to get submit transaction receipt, attempt #{}", retries, te);
+                if (Instant.now().compareTo(timeoutInstant) >= 0) {
+                    throw new TimeoutException("Ran out of time on second HAPI call - getting submit transaction "
+                            + " receipt:" + te.getMessage());
+                }
+            }
+        }
+
+        if (!gotReceipt) {
+            throw new IllegalArgumentException("StartupProbe Could not retrieve receipt after " + maxRetries
+                    + " retries");
+        }
+
+        // step 3: Query the mirror node for the transaction by ID (until successful or time runs out)
+        String restTransactionId = transactionId.accountId.toString() + "-" + transactionId.validStart.getEpochSecond()
+                + "-" + transactionId.validStart.getNano();
+        MirrorTransactionsResponse mirrorTransactionsResponse = null;
+        boolean gotRestApiResponse = false;
+	// call to mirrorNodeClient will automatically retry (up to maxRetries times) on exceptions, so no need to loop
+        try {
+            mirrorTransactionsResponse = mirrorNodeClient.getTransactions(restTransactionId);
+            for (MirrorTransaction mirrorTransaction : mirrorTransactionsResponse.getTransactions()) {
+                if (mirrorTransaction.getResult().equalsIgnoreCase("SUCCESS")) {
+                    gotRestApiResponse = true;
+                    break;
+                }
+            }
+        } catch (Exception e) {
+            log.warn("Exception on REST API call to get transaction by id (after #{} retries)", maxRetries, e);
+            if (Instant.now().compareTo(timeoutInstant) >= 0) {
+                throw new TimeoutException("Ran out of time on the REST API call - getting transaction by id: "
+                        + e.getMessage());
+            }
+        }
+
+        if (!gotRestApiResponse) {
+            throw new IllegalArgumentException("StartupProbe Could not successfully make API call after " + maxRetries
+                    + " retries");
+        }
+
+        // step 4: Query the mirror node gRPC API for a message on the topic created in step 2, until successful or
+        //         time runs out
+        TopicId topicId = transactionReceipt.topicId;
+        AtomicBoolean messageReceived = new AtomicBoolean();
+
+        boolean subscribedWithGrpc = false;
+	for ( retries = 1; retries <= maxRetries; retries++) {
+            try {
+                new TopicMessageQuery()
+                    .setTopicId(topicId)
+                    .subscribe(client, resp -> {
+                        messageReceived.set(true);
+                    });
+                subscribedWithGrpc = true;
+            } catch (RuntimeException e) {
+                log.warn("RuntimeException on try #{}/{} to subscribe using GRPC API call", retries, maxRetries, e);
+                // try again
+            }
+        }
+
+        if (!subscribedWithGrpc) {
+            throw new IllegalArgumentException("StartupProbe Could not successfully make GRPC API subscription call "
+                    + "after " + maxRetries + " retries");
+        }
+
+	for ( retries = 1; retries <= maxRetries; retries++) {
+            try {
+                Thread.sleep(1000);
+                if (messageReceived.get()) {  // we already had a previous success - no need to submit more trabsactions
+                    break;
+                }
+                new TopicMessageSubmitTransaction()
+                    .setTopicId(topicId)
+                    .setMessage("Hello, HCS! " + retries)
+                    .execute(client)
+                    .getReceipt(client);
+
+                Thread.sleep(1500);
+            } catch (PrecheckStatusException pse) {
+                log.warn("PrecheckStatusException on GRPC API call to submit a transaction", pse);
+                throw new IllegalArgumentException("PrecheckStatusException on GRPC call (submitting transaction):"
+                        + pse.getMessage());
+            } catch (ReceiptStatusException rse) {
+                log.warn("ReceiptStatusException on trying to get receipt from GRPC API call", rse);
+                // try again
+            } catch (InterruptedException ie) {
+                log.warn("InterruptedException on trying to get submit transaction receipt", ie);
+                Thread.currentThread().interrupt();
+                if (Instant.now().compareTo(timeoutInstant) >= 0) {
+                    throw new TimeoutException("Ran out of time on second HAPI call - getting submit transaction "
+                            + " receipt:" + ie.getMessage());
+                }
+            }
+        }
+
+        // make sure at least one message got through
+        if (!messageReceived.get()) {
+            throw new IllegalArgumentException("StartupProbe Could not successfully receive GRPC message after "
+                    + maxRetries + " retries");
+        }
+
+        log.info("successful for all stages - HAPI, REST API, and gRPC API."); // ideally, the only line logged.
+        validated = true;
+    }
+
+}

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/StartupProbe.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/StartupProbe.java
@@ -141,18 +141,18 @@ public class StartupProbe {
         CountDownLatch messageLatch = new CountDownLatch(1);
 
         SubscriptionHandle subscription = retryTemplate.execute(x -> new TopicMessageQuery()
+                .setTopicId(topicId)
                 .setMaxAttempts(Integer.MAX_VALUE)
                 .setRetryHandler(t -> true)
                 .setStartTime(Instant.EPOCH)
-                .setTopicId(topicId)
                 .subscribe(client, resp -> {
                     messageLatch.countDown();
                 }));
 
         TransactionResponse secondResponse = retryTemplate.execute(x -> new TopicMessageSubmitTransaction()
+                .setTopicId(topicId)
                 .setGrpcDeadline(acceptanceTestProperties.getSdkProperties().getGrpcDeadline())
                 .setMaxAttempts(Integer.MAX_VALUE)
-                .setTopicId(topicId)
                 .setMessage("Hello, HCS!")
                 .execute(client, startupTimeout.minus(stopwatch.elapsed())));
         TransactionId secondTransactionId = secondResponse.transactionId;

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/StartupProbe.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/StartupProbe.java
@@ -25,7 +25,8 @@ import java.time.Instant;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
-import lombok.extern.log4j.Log4j2;
+import lombok.CustomLog;
+
 import com.google.common.util.concurrent.Uninterruptibles;
 
 import com.hedera.hashgraph.sdk.AccountId;
@@ -45,10 +46,10 @@ import com.hedera.mirror.test.e2e.acceptance.config.AcceptanceTestProperties;
 import com.hedera.mirror.test.e2e.acceptance.props.MirrorTransaction;
 import com.hedera.mirror.test.e2e.acceptance.response.MirrorTransactionsResponse;
 
-@Log4j2
 /**
  * StartupProbe -- a helper class to validate a SDKClient before using it.
  */
+@CustomLog
 public class StartupProbe {
 
     private final AcceptanceTestProperties acceptanceTestProperties;

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/StartupProbe.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/StartupProbe.java
@@ -77,79 +77,80 @@ public class StartupProbe {
         }
         // any of these can throw IllegalArgumentException; if it does, retries wouldn't help, so exit early (with that
         // exception) if it happens.
-        Client client = Client.forName(acceptanceTestProperties.getNetwork().toString().toLowerCase());
         AccountId operator = AccountId.fromString(acceptanceTestProperties.getOperatorId());
         PrivateKey privateKey = PrivateKey.fromString(acceptanceTestProperties.getOperatorKey());
-        client.setOperator(operator, privateKey);  // this account pays for (and signs) all transactions run here.
+        try (Client client = Client.forName(acceptanceTestProperties.getNetwork().toString().toLowerCase())) {
+            client.setOperator(operator, privateKey);  // this account pays for (and signs) all transactions run here.
 
-        Stopwatch stopwatch = Stopwatch.createStarted();
-        // step 1: Create a new topic for the subsequent HCS submit message action.
-        RetryTemplate retryTemplate = RetryTemplate.builder()
-                .infiniteRetry()
-                .notRetryOn(TimeoutException.class)
-                .fixedBackoff(1000L)
-                .build();
+            Stopwatch stopwatch = Stopwatch.createStarted();
+            // step 1: Create a new topic for the subsequent HCS submit message action.
+            RetryTemplate retryTemplate = RetryTemplate.builder()
+                    .infiniteRetry()
+                    .notRetryOn(TimeoutException.class)
+                    .fixedBackoff(1000L)
+                    .build();
         
-        TransactionResponse response = retryTemplate.execute(x -> new TopicCreateTransaction()
-            .setGrpcDeadline(Duration.ofSeconds(10L))
-            .setMaxAttempts(Integer.MAX_VALUE)
-            .execute(client, startupTimeout.minus(stopwatch.elapsed())));
-        TransactionId transactionId = response.transactionId;
+            TransactionResponse response = retryTemplate.execute(x -> new TopicCreateTransaction()
+                .setGrpcDeadline(Duration.ofSeconds(10L))
+                .setMaxAttempts(Integer.MAX_VALUE)
+                .execute(client, startupTimeout.minus(stopwatch.elapsed())));
+            TransactionId transactionId = response.transactionId;
 
-        // step 2: Query for the receipt of that HCS submit transaction (until successful or time runs out)
-        TransactionReceipt transactionReceipt = response.getReceipt(client,
-                startupTimeout.minus(stopwatch.elapsed()));
+            // step 2: Query for the receipt of that HCS submit transaction (until successful or time runs out)
+            TransactionReceipt transactionReceipt = response.getReceipt(client,
+                    startupTimeout.minus(stopwatch.elapsed()));
 
-        // step 3: Query the mirror node for the transaction by ID (until successful or time runs out)
-        // Instead of using MirrorNodeClient.getTransactions(restTransactionId), we directly call webClient.
-        // retry infinitely or until timeout (or success), not a maximum of properties.getMaxAttempts() times.
-        var properties = acceptanceTestProperties.getRestPollingProperties();
-        RetryBackoffSpec retrySpec = Retry.backoff(Integer.MAX_VALUE, properties.getMinBackoff())
-                .maxBackoff(properties.getMaxBackoff())
-                .filter(this::shouldRetryRestCall);
+            // step 3: Query the mirror node for the transaction by ID (until successful or time runs out)
+            // Instead of using MirrorNodeClient.getTransactions(restTransactionId), we directly call webClient.
+            // retry infinitely or until timeout (or success), not a maximum of properties.getMaxAttempts() times.
+            var properties = acceptanceTestProperties.getRestPollingProperties();
+            RetryBackoffSpec retrySpec = Retry.backoff(Integer.MAX_VALUE, properties.getMinBackoff())
+                    .maxBackoff(properties.getMaxBackoff())
+                    .filter(this::shouldRetryRestCall);
 
-        String restTransactionId = transactionId.accountId.toString() + "-" + transactionId.validStart.getEpochSecond()
-                + "-" + transactionId.validStart.getNano();
+            String restTransactionId = transactionId.accountId.toString() + "-"
+                    + transactionId.validStart.getEpochSecond() + "-" + transactionId.validStart.getNano();
 
-        webClient.get()
-                .uri("/transactions/", restTransactionId)
-                .accept(MediaType.APPLICATION_JSON)
-                .retrieve()
-                .bodyToMono(String.class)
-                .retryWhen(retrySpec)
-                .doOnError(x -> log.error("Endpoint failed, returning: {}", x.getMessage()))
-                .timeout(startupTimeout.minus(stopwatch.elapsed()))
-                .block();
+            webClient.get()
+                    .uri("/transactions/", restTransactionId)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .retryWhen(retrySpec)
+                    .doOnError(x -> log.error("Endpoint failed, returning: {}", x.getMessage()))
+                    .timeout(startupTimeout.minus(stopwatch.elapsed()))
+                    .block();
 
-        // step 4: Query the mirror node gRPC API for a message on the topic created in step 2, until successful or
-        //         time runs out
-        TopicId topicId = transactionReceipt.topicId;
-        AtomicBoolean messageReceived = new AtomicBoolean();
+            // step 4: Query the mirror node gRPC API for a message on the topic created in step 2, until successful or
+            //         time runs out
+            TopicId topicId = transactionReceipt.topicId;
+            AtomicBoolean messageReceived = new AtomicBoolean();
 
-        retryTemplate.execute(x -> new TopicMessageQuery()
-                .setTopicId(topicId)
-                .subscribe(client, resp -> {
-                    messageReceived.set(true);
-                }));
-
-        retryTemplate.execute(x -> {
-            int counter = 0;
-            while (!(messageReceived.get()) && startupTimeout.minus(stopwatch.elapsed()).toMillis() > 0) {
-                new TopicMessageSubmitTransaction()
+            retryTemplate.execute(x -> new TopicMessageQuery()
                     .setTopicId(topicId)
-                    .setMessage("Hello, HCS! " + ++counter)
-                    .execute(client, startupTimeout.minus(stopwatch.elapsed()))
-                    .getReceipt(client);
-                Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
-            }
-            return null;
-        });
+                    .subscribe(client, resp -> {
+                        messageReceived.set(true);
+                    }));
 
-        if (messageReceived.get()) {
-            log.info("Startup probe successful.");
-            validated = true;
-        } else {
-            throw new TimeoutException("Timer expired while trying to receive topic messages.");
+            retryTemplate.execute(x -> {
+                int counter = 0;
+                while (!(messageReceived.get()) && startupTimeout.minus(stopwatch.elapsed()).toMillis() > 0) {
+                    new TopicMessageSubmitTransaction()
+                            .setTopicId(topicId)
+                            .setMessage("Hello, HCS! " + ++counter)
+                            .execute(client, startupTimeout.minus(stopwatch.elapsed()))
+                            .getReceipt(client);
+                    Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
+                }
+                return null;
+            });
+
+            if (messageReceived.get()) {
+                log.info("Startup probe successful.");
+                validated = true;
+            } else {
+                throw new TimeoutException("Timer expired while trying to receive topic messages.");
+            }
         }
     }
 

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
@@ -79,6 +79,8 @@ public class AcceptanceTestProperties {
 
     private boolean retrieveAddressBook = true;
 
+    private Duration startupTimeout = Duration.ofMinutes(30);
+
     public enum HederaNetwork {
         MAINNET,
         OTHER,

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/RestPollingProperties.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/RestPollingProperties.java
@@ -43,15 +43,15 @@ public class RestPollingProperties {
 
     @Min(1)
     @Max(60)
-    private int maxAttempts = 60;
+    private int maxAttempts = 10;
 
     @NotNull
     @DurationMin(millis = 500L)
-    private Duration maxBackoff = Duration.ofSeconds(8L);
+    private Duration maxBackoff = Duration.ofSeconds(4L);
 
     @NotNull
     @DurationMin(millis = 100L)
-    private Duration minBackoff = Duration.ofMillis(250L);
+    private Duration minBackoff = Duration.ofMillis(500L);
 
     @NotNull
     private Set<Class> retryableExceptions = Set.of(Exception.class);

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/RestPollingProperties.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/RestPollingProperties.java
@@ -20,6 +20,7 @@ package com.hedera.mirror.test.e2e.acceptance.config;
  * ‍
  */
 
+import com.google.common.base.Throwables;
 import java.time.Duration;
 import java.util.Set;
 import javax.validation.constraints.Max;
@@ -55,4 +56,9 @@ public class RestPollingProperties {
 
     @NotNull
     private Set<Class> retryableExceptions = Set.of(Exception.class);
+
+    public boolean shouldRetry(Throwable t) {
+        return retryableExceptions.stream()
+                .anyMatch(ex -> ex.isInstance(t) || ex.isInstance(Throwables.getRootCause(t)));
+    }
 }


### PR DESCRIPTION
**Description**:

This PR creates a startup probe as part of the `SDKClient` constructor.

* Create a `StartupProbe` class, call it from inside the `SDKClient` constructor.
* Add a `hedera.mirror.test.acceptance.startupTimeout=30m` property.
* Reduce `hedera.mirror.test.acceptance.rest.maxAttempts` to `10`.
* Reduce `hedera.mirror.test.acceptance.rest.maxBackoff` to `4s`.
* Increase `hedera.mirror.test.acceptance.rest.minBackoff` to `500ms`.

**Related issue(s)**:

Fixes #4579 

**Notes for reviewer**:
When running the acceptance tests (e.g.
`./mvnw clean integration-test --projects hedera-mirror-test/ -P=acceptance-tests -Dcucumber.filter.tags=@acceptance`), you will see one new log message:
`INFO ForkJoinPool-2-worker-3 c.h.m.t.e.a.c.StartupProbe successful for all stages - HAPI, REST API, and gRPC API.` output to stdout.  This occurs within the first page of output of the acceptance tests, ahead of the acceptance tests obtaining the address book and validating each node/
**Checklist**

- [x] Documented (Code comments)
- [x] Tested (integration) via running the acceptance tests for both `testnet` and `previewnet`
