### PR TITLE
Fix acceptance test freezing (0.66)

### DIFF
--- a/hedera-mirror-test/README.md
+++ b/hedera-mirror-test/README.md
@@ -66,7 +66,7 @@ under `hedera.mirror.test.acceptance` include:
 - `retrieveAddressBook` - Whether to download the address book from the network and use those nodes over the default
   nodes. Populating `hedera.mirror.test.acceptance.nodes` will take priority over this.
 - `sdk`
-  - `grpcDeadline` - The maximum amount of time to wait for a grpc call to complete. 
+  - `grpcDeadline` - The maximum amount of time to wait for a grpc call to complete.
   - `maxAttempts` - The maximum number of times the sdk should try to submit a transaction to the network.
 - `webclient`
   - `connectionTimeout` - The timeout duration to wait to establish a connection with the server

--- a/hedera-mirror-test/README.md
+++ b/hedera-mirror-test/README.md
@@ -39,13 +39,14 @@ uses [Spring Boot](https://spring.io/projects/spring-boot) properties to configu
 under `hedera.mirror.test.acceptance` include:
 
 - `backOffPeriod` - The number of milliseconds client should wait before retrying a retryable failure.
+- `createOperatorAccount` - Whether to create an operator account to run the acceptance tests 
 - `emitBackgroundMessages` - Flag to set if background messages should be emitted. For operations use in non-production
   `environments.
-- `featureProperties`
+- `feature`
   - `maxContractFunctionGas` - The maximum amount of gas an account is willing to pay for a contract function call.
-- `maxRetries` - The number of times client should retryable on supported failures.
-- `maxTinyBarTransactionFee` - The maximum transaction fee you're willing to pay on a transaction.
-- `messageTimeout` - The number of seconds to wait on messages representing transactions (default is 20).
+- `maxRetries` - The number of times client should retry on supported failures.
+- `maxTinyBarTransactionFee` - The maximum transaction fee.
+- `messageTimeout` - The time to wait on messages representing transactions (default is 20 seconds).
 - `mirrorNodeAddress` - The mirror node grpc server endpoint including IP address and port. Refer to
   public [documentation](https://docs.hedera.com/guides/mirrornet/hedera-mirror-node) for a list of available endpoints.
 - `network` - The desired Hedera network environment to point to. Options currently include `MAINNET`, `PREVIEWNET`,
@@ -64,7 +65,8 @@ under `hedera.mirror.test.acceptance` include:
   - `retryableExceptions` - List of retryable exception class types
 - `retrieveAddressBook` - Whether to download the address book from the network and use those nodes over the default
   nodes. Populating `hedera.mirror.test.acceptance.nodes` will take priority over this.
-- `sdkProperties`
+- `sdk`
+  - `grpcDeadline` - The maximum amount of time to wait for a grpc call to complete. 
   - `maxAttempts` - The maximum number of times the sdk should try to submit a transaction to the network.
 - `webclient`
   - `connectionTimeout` - The timeout duration to wait to establish a connection with the server

--- a/hedera-mirror-test/src/test/java/com/hedera/hashgraph/sdk/Client.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/hashgraph/sdk/Client.java
@@ -1,0 +1,1103 @@
+/*-
+ *
+ * Hedera Java SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.hedera.hashgraph.sdk;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.io.File;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Managed client for use on the Hedera Hashgraph network.
+ */
+public final class Client implements AutoCloseable, WithPing, WithPingAll {
+    static final int DEFAULT_MAX_ATTEMPTS = 10;
+    static final Duration DEFAULT_MAX_BACKOFF = Duration.ofSeconds(8L);
+    static final Duration DEFAULT_MIN_BACKOFF = Duration.ofMillis(250L);
+    static final Duration DEFAULT_MAX_NODE_BACKOFF = Duration.ofHours(1L);
+    static final Duration DEFAULT_MIN_NODE_BACKOFF = Duration.ofSeconds(8L);
+    static final Duration DEFAULT_CLOSE_TIMEOUT = Duration.ofSeconds(30L);
+    static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofMinutes(2L);
+    private static final Hbar DEFAULT_MAX_QUERY_PAYMENT = new Hbar(1);
+    final ExecutorService executor;
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+    @Nullable
+    Hbar defaultMaxTransactionFee = null;
+    Hbar defaultMaxQueryPayment = DEFAULT_MAX_QUERY_PAYMENT;
+
+    Network network;
+    MirrorNetwork mirrorNetwork;
+
+    @Nullable
+    private Operator operator;
+
+    private Duration requestTimeout = DEFAULT_REQUEST_TIMEOUT;
+    private Duration closeTimeout = DEFAULT_CLOSE_TIMEOUT;
+
+    private int maxAttempts = DEFAULT_MAX_ATTEMPTS;
+
+    private volatile Duration maxBackoff = DEFAULT_MAX_BACKOFF;
+
+    private volatile Duration minBackoff = DEFAULT_MIN_BACKOFF;
+
+    private boolean autoValidateChecksums = false;
+
+    private boolean defaultRegenerateTransactionId = true;
+
+    /**
+     * Constructor.
+     *
+     * @param executor      the executor
+     * @param network       the network
+     * @param mirrorNetwork the mirror network
+     */
+    @VisibleForTesting
+    Client(ExecutorService executor, Network network, MirrorNetwork mirrorNetwork) {
+        this.executor = executor;
+        this.network = network;
+        this.mirrorNetwork = mirrorNetwork;
+    }
+
+    /**
+     * Extract the executor.
+     *
+     * @return the executor service
+     */
+    static ExecutorService createExecutor() {
+        var threadFactory = new ThreadFactoryBuilder()
+                .setNameFormat("hedera-sdk-%d")
+                .setDaemon(true)
+                .build();
+
+        return Executors.newFixedThreadPool(
+                Math.max(Runtime.getRuntime().availableProcessors(), 2),
+                threadFactory);
+    }
+
+    /**
+     * Construct a client given a set of nodes.
+     *
+     * <p>It is the responsibility of the caller to ensure that all nodes in the map are part of the
+     * same Hedera network. Failure to do so will result in undefined behavior.
+     *
+     * <p>The client will load balance all requests to Hedera using a simple round-robin scheme to
+     * chose nodes to send transactions to. For one transaction, at most 1/3 of the nodes will be tried.
+     *
+     * @param networkMap the map of node IDs to node addresses that make up the network.
+     * @return {@link com.hedera.hashgraph.sdk.Client}
+     */
+    public static Client forNetwork(Map<String, AccountId> networkMap) {
+        var executor = createExecutor();
+        var network = Network.forNetwork(executor, networkMap);
+        var mirrorNetwork = MirrorNetwork.forNetwork(executor, new ArrayList<>());
+
+        return new Client(executor, network, mirrorNetwork);
+    }
+
+    /**
+     * Set up the client for the selected network.
+     *
+     * @param name the selected network
+     * @return the configured client
+     */
+    public static Client forName(String name) {
+        switch (name) {
+            case "mainnet":
+                return Client.forMainnet();
+            case "testnet":
+                return Client.forTestnet();
+            case "previewnet":
+                return Client.forPreviewnet();
+            default:
+                throw new IllegalArgumentException("Name must be one-of `mainnet`, `testnet`, or `previewnet`");
+        }
+    }
+
+    /**
+     * Construct a Hedera client pre-configured for <a
+     * href="https://docs.hedera.com/guides/mainnet/address-book#mainnet-address-book">Mainnet access</a>.
+     *
+     * @return {@link com.hedera.hashgraph.sdk.Client}
+     */
+    public static Client forMainnet() {
+        var executor = createExecutor();
+        var network = Network.forMainnet(executor);
+        var mirrorNetwork = MirrorNetwork.forMainnet(executor);
+
+        return new Client(executor, network, mirrorNetwork);
+    }
+
+    /**
+     * Construct a Hedera client pre-configured for <a href="https://docs.hedera.com/guides/testnet/nodes">Testnet
+     * access</a>.
+     *
+     * @return {@link com.hedera.hashgraph.sdk.Client}
+     */
+    public static Client forTestnet() {
+        var executor = createExecutor();
+        var network = Network.forTestnet(executor);
+        var mirrorNetwork = MirrorNetwork.forTestnet(executor);
+
+        return new Client(executor, network, mirrorNetwork);
+    }
+
+    /**
+     * Construct a Hedera client pre-configured for <a
+     * href="https://docs.hedera.com/guides/testnet/testnet-nodes#previewnet-node-public-keys">Preview Testnet
+     * nodes</a>.
+     *
+     * @return {@link com.hedera.hashgraph.sdk.Client}
+     */
+    public static Client forPreviewnet() {
+        var executor = createExecutor();
+        var network = Network.forPreviewnet(executor);
+        var mirrorNetwork = MirrorNetwork.forPreviewnet(executor);
+
+        return new Client(executor, network, mirrorNetwork);
+    }
+
+    /**
+     * Configure a client based off the given JSON string.
+     *
+     * @param json The json string containing the client configuration
+     * @return {@link com.hedera.hashgraph.sdk.Client}
+     */
+    public static Client fromConfig(String json) throws Exception {
+        return fromConfig(new StringReader(json));
+    }
+
+    /**
+     * Configure a client based off the given JSON reader.
+     *
+     * @param json The Reader containing the client configuration
+     * @return {@link com.hedera.hashgraph.sdk.Client}
+     */
+    public static Client fromConfig(Reader json) throws Exception {
+        Config config = new Gson().fromJson(json, Config.class);
+        Client client;
+
+        if (config.network == null) {
+            throw new Exception("Network is not set in provided json object");
+        } else if (config.network.isJsonObject()) {
+            var networks = config.network.getAsJsonObject();
+            Map<String, AccountId> nodes = new HashMap<>(networks.size());
+            for (Map.Entry<String, JsonElement> entry : networks.entrySet()) {
+                nodes.put(entry.getValue().toString().replace("\"", ""), AccountId.fromString(entry.getKey()
+                        .replace("\"", "")));
+            }
+            client = Client.forNetwork(nodes);
+            if (config.networkName != null) {
+                var networkNameString = config.networkName.getAsString();
+                try {
+                    client.setNetworkName(NetworkName.fromString(networkNameString));
+                } catch (Exception ignored) {
+                    throw new IllegalArgumentException("networkName in config was \"" + networkNameString + "\", " +
+                            "expected either \"mainnet\", \"testnet\" or \"previewnet\"");
+                }
+            }
+        } else {
+            String networks = config.network.getAsString();
+            switch (networks) {
+                case "mainnet":
+                    client = Client.forMainnet();
+                    break;
+                case "testnet":
+                    client = Client.forTestnet();
+                    break;
+                case "previewnet":
+                    client = Client.forPreviewnet();
+                    break;
+                default:
+                    throw new JsonParseException("Illegal argument for network.");
+            }
+        }
+
+        if (config.operator != null) {
+            AccountId operatorAccount = AccountId.fromString(config.operator.accountId);
+            PrivateKey privateKey = PrivateKey.fromString(config.operator.privateKey);
+
+            client.setOperator(operatorAccount, privateKey);
+        }
+
+        //already set in previous set network if?
+        if (config.mirrorNetwork != null) {
+            if (config.mirrorNetwork.isJsonArray()) {
+                var mirrors = config.mirrorNetwork.getAsJsonArray();
+                List<String> listMirrors = new ArrayList<>(mirrors.size());
+                for (var i = 0; i < mirrors.size(); i++) {
+                    listMirrors.add(mirrors.get(i).getAsString().replace("\"", ""));
+                }
+                client.setMirrorNetwork(listMirrors);
+            } else {
+                String mirror = config.mirrorNetwork.getAsString();
+                switch (mirror) {
+                    case "mainnet":
+                        client.setMirrorNetwork(List.of("mainnet-public.mirrornode.hedera.com:5600"));
+                        break;
+                    case "testnet":
+                        client.setMirrorNetwork(List.of("hcs.testnet.mirrornode.hedera.com:5600"));
+                        break;
+                    case "previewnet":
+                        client.setMirrorNetwork(List.of("hcs.previewnet.mirrornode.hedera.com:5600"));
+                        break;
+                    default:
+                        throw new JsonParseException("Illegal argument for mirrorNetwork.");
+                }
+            }
+        }
+
+        return client;
+    }
+
+    /**
+     * Configure a client based on a JSON file at the given path.
+     *
+     * @param fileName The string containing the file path
+     * @return {@link com.hedera.hashgraph.sdk.Client}
+     * @throws IOException if IO operations fail
+     */
+    public static Client fromConfigFile(String fileName) throws Exception {
+        return fromConfigFile(new File(fileName));
+    }
+
+    /**
+     * Configure a client based on a JSON file.
+     *
+     * @param file The file containing the client configuration
+     * @return {@link com.hedera.hashgraph.sdk.Client}
+     * @throws IOException if IO operations fail
+     */
+    public static Client fromConfigFile(File file) throws Exception {
+        return fromConfig(Files.newBufferedReader(file.toPath(), StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Extract the mirror network node list.
+     *
+     * @return the list of mirror nodes
+     */
+    synchronized public List<String> getMirrorNetwork() {
+        return mirrorNetwork.getNetwork();
+    }
+
+    /**
+     * Set the mirror network nodes.
+     *
+     * @param network list of network nodes
+     * @return {@code this}
+     * @throws InterruptedException when a thread is interrupted while it's waiting, sleeping, or otherwise occupied
+     */
+    public synchronized Client setMirrorNetwork(List<String> network) throws InterruptedException {
+        try {
+            this.mirrorNetwork.setNetwork(network);
+        } catch (TimeoutException e) {
+            throw new RuntimeException(e);
+        }
+
+        return this;
+    }
+
+    /**
+     * Extract the network.
+     *
+     * @return the client's network
+     */
+    synchronized public Map<String, AccountId> getNetwork() {
+        return network.getNetwork();
+    }
+
+    /**
+     * Replace all nodes in this Client with a new set of nodes (e.g. for an Address Book update).
+     * <p>
+     *
+     * @param network a map of node account ID to node URL.
+     * @return {@code this} for fluent API usage.
+     */
+    public synchronized Client setNetwork(Map<String, AccountId> network) throws InterruptedException,
+            TimeoutException {
+        this.network.setNetwork(network);
+        return this;
+    }
+
+    /**
+     * Is tls enabled.
+     *
+     * @return is tls enabled
+     */
+    public boolean isTransportSecurity() {
+        return network.isTransportSecurity();
+    }
+
+    /**
+     * Set if transport security should be used.
+     * <p>
+     * If transport security is enabled all connections to nodes will use TLS, and the server's certificate hash will be
+     * compared to the hash stored in the {@link NodeAddressBook} for the given network.
+     * <p>
+     * *Note*: If transport security is enabled, but {@link Client#isVerifyCertificates()} is disabled then server
+     * certificates will not be verified.
+     *
+     * @param transportSecurity - enable or disable transport security
+     * @return {@code this} for fluent API usage.
+     */
+    public Client setTransportSecurity(boolean transportSecurity) throws InterruptedException {
+        network.setTransportSecurity(transportSecurity);
+        mirrorNetwork.setTransportSecurity(transportSecurity);
+        return this;
+    }
+
+    /**
+     * Is certificate verification enabled.
+     *
+     * @return is certificate verification enabled
+     */
+    public boolean isVerifyCertificates() {
+        return network.isVerifyCertificates();
+    }
+
+    /**
+     * Set if server certificates should be verified against an existing address book
+     *
+     * @param verifyCertificates - enable or disable certificate verification
+     * @return {@code this}
+     */
+    public Client setVerifyCertificates(boolean verifyCertificates) {
+        network.setVerifyCertificates(verifyCertificates);
+        return this;
+    }
+
+    /**
+     * Send a ping to the given node.
+     *
+     * @param nodeAccountId Account ID of the node to ping
+     */
+    @Override
+    public Void ping(AccountId nodeAccountId) {
+        try {
+            new AccountBalanceQuery()
+                    .setAccountId(nodeAccountId)
+                    .setNodeAccountIds(Collections.singletonList(nodeAccountId))
+                    .execute(this);
+        } catch (Exception e) {
+            logger.debug("pinging account {} failed with exception {}", nodeAccountId, e.getMessage());
+        }
+
+        return null;
+    }
+
+    /**
+     * Send a ping to the given node.
+     *
+     * @param nodeAccountId Account ID of the node to ping
+     */
+    @Override
+    public synchronized CompletableFuture<Void> pingAsync(AccountId nodeAccountId) {
+        return new AccountBalanceQuery()
+                .setAccountId(nodeAccountId)
+                .setNodeAccountIds(Collections.singletonList(nodeAccountId))
+                .executeAsync(this)
+                .handle((balance, e) -> {
+                    // Do nothing
+                    return null;
+                });
+    }
+
+    /**
+     * Sends pings to all nodes in the client's network. Synchronizes well with setMaxAttempts(1) to remove all dead
+     * nodes from the network.
+     */
+    @Override
+    public synchronized Void pingAll() {
+        for (var nodeAccountId : network.getNetwork().values()) {
+            ping(nodeAccountId);
+        }
+
+        return null;
+    }
+
+    /**
+     * Sends pings to all nodes in the client's network. Synchronizes well with setMaxAttempts(1) to remove all dead
+     * nodes from the network.
+     */
+    @Override
+    public synchronized CompletableFuture<Void> pingAllAsync() {
+        var network = this.network.getNetwork();
+        var list = new ArrayList<CompletableFuture<Void>>(network.size());
+
+        for (var nodeAccountId : network.values()) {
+            list.add(pingAsync(nodeAccountId));
+        }
+
+        return CompletableFuture.allOf(list.toArray(new CompletableFuture<?>[0])).thenApply((v) -> null);
+    }
+
+    /**
+     * Set the account that will, by default, be paying for transactions and queries built with this client.
+     * <p>
+     * The operator account ID is used to generate the default transaction ID for all transactions executed with this
+     * client.
+     * <p>
+     * The operator private key is used to sign all transactions executed by this client.
+     *
+     * @param accountId  The AccountId of the operator
+     * @param privateKey The PrivateKey of the operator
+     * @return {@code this}
+     */
+    public synchronized Client setOperator(AccountId accountId, PrivateKey privateKey) {
+        return setOperatorWith(accountId, privateKey.getPublicKey(), privateKey::sign);
+    }
+
+    /**
+     * Sets the account that will, by default, by paying for transactions and queries built with this client.
+     * <p>
+     * The operator account ID is used to generate a default transaction ID for all transactions executed with this
+     * client.
+     * <p>
+     * The `transactionSigner` is invoked to sign all transactions executed by this client.
+     *
+     * @param accountId         The AccountId of the operator
+     * @param publicKey         The PrivateKey of the operator
+     * @param transactionSigner The signer for the operator
+     * @return {@code this}
+     */
+    public synchronized Client setOperatorWith(AccountId accountId, PublicKey publicKey,
+                                               Function<byte[], byte[]> transactionSigner) {
+        if (getNetworkName() != null) {
+            try {
+                accountId.validateChecksum(this);
+            } catch (BadEntityIdException exc) {
+                throw new IllegalArgumentException(
+                        "Tried to set the client operator account ID to an account ID with an invalid checksum: " + exc.getMessage()
+                );
+            }
+        }
+
+        this.operator = new Operator(accountId, publicKey, transactionSigner);
+        return this;
+    }
+
+    /**
+     * Current name of the network; corresponds to ledger ID in entity ID checksum calculations.
+     *
+     * @return the network name
+     * @deprecated use {@link #getLedgerId()} instead
+     */
+    @Nullable
+    @Deprecated
+    public synchronized NetworkName getNetworkName() {
+        var ledgerId = network.getLedgerId();
+        return ledgerId == null ? null : ledgerId.toNetworkName();
+    }
+
+    /**
+     * Set the network name to a particular value. Useful when constructing a network which is a subset of an existing
+     * known network.
+     *
+     * @param networkName the desired network
+     * @return {@code this}
+     * @deprecated use {@link #setLedgerId(LedgerId)} instead
+     */
+    @Deprecated
+    public synchronized Client setNetworkName(@Nullable NetworkName networkName) {
+        this.network.setLedgerId(networkName == null ? null : LedgerId.fromNetworkName(networkName));
+        return this;
+    }
+
+    /**
+     * Current LedgerId of the network; corresponds to ledger ID in entity ID checksum calculations.
+     *
+     * @return the ledger id
+     */
+    @Nullable
+    public synchronized LedgerId getLedgerId() {
+        return network.getLedgerId();
+    }
+
+    /**
+     * Set the LedgerId to a particular value. Useful when constructing a network which is a subset of an existing known
+     * network.
+     *
+     * @param ledgerId the desired ledger id
+     * @return {@code this}
+     */
+    public synchronized Client setLedgerId(@Nullable LedgerId ledgerId) {
+        this.network.setLedgerId(ledgerId);
+        return this;
+    }
+
+    /**
+     * Max number of attempts a request executed with this client will do.
+     *
+     * @return the maximus attempts
+     */
+    public synchronized int getMaxAttempts() {
+        return maxAttempts;
+    }
+
+    /**
+     * Set the max number of attempts a request executed with this client will do.
+     *
+     * @param maxAttempts the desired max attempts
+     * @return {@code this}
+     */
+    public synchronized Client setMaxAttempts(int maxAttempts) {
+        if (maxAttempts <= 0) {
+            throw new IllegalArgumentException("maxAttempts must be greater than zero");
+        }
+        this.maxAttempts = maxAttempts;
+        return this;
+    }
+
+    /**
+     * The maximum amount of time to wait between retries
+     *
+     * @return maxBackoff
+     */
+    @SuppressFBWarnings(
+            value = "EI_EXPOSE_REP",
+            justification = "A Duration can't actually be mutated"
+    )
+    public Duration getMaxBackoff() {
+        return maxBackoff;
+    }
+
+    /**
+     * The maximum amount of time to wait between retries. Every retry attempt will increase the wait time exponentially
+     * until it reaches this time.
+     *
+     * @param maxBackoff The maximum amount of time to wait between retries
+     * @return {@code this}
+     */
+    @SuppressFBWarnings(
+            value = "EI_EXPOSE_REP2",
+            justification = "A Duration can't actually be mutated"
+    )
+    public Client setMaxBackoff(Duration maxBackoff) {
+        if (maxBackoff == null || maxBackoff.toNanos() < 0) {
+            throw new IllegalArgumentException("maxBackoff must be a positive duration");
+        } else if (maxBackoff.compareTo(minBackoff) < 0) {
+            throw new IllegalArgumentException("maxBackoff must be greater than or equal to minBackoff");
+        }
+        this.maxBackoff = maxBackoff;
+        return this;
+    }
+
+    /**
+     * The minimum amount of time to wait between retries
+     *
+     * @return minBackoff
+     */
+    @SuppressFBWarnings(
+            value = "EI_EXPOSE_REP",
+            justification = "A Duration can't actually be mutated"
+    )
+    public Duration getMinBackoff() {
+        return minBackoff;
+    }
+
+    /**
+     * The minimum amount of time to wait between retries. When retrying, the delay will start at this time and increase
+     * exponentially until it reaches the maxBackoff.
+     *
+     * @param minBackoff The minimum amount of time to wait between retries
+     * @return {@code this}
+     */
+    @SuppressFBWarnings(
+            value = "EI_EXPOSE_REP2",
+            justification = "A Duration can't actually be mutated"
+    )
+    public Client setMinBackoff(Duration minBackoff) {
+        if (minBackoff == null || minBackoff.toNanos() < 0) {
+            throw new IllegalArgumentException("minBackoff must be a positive duration");
+        } else if (minBackoff.compareTo(maxBackoff) > 0) {
+            throw new IllegalArgumentException("minBackoff must be less than or equal to maxBackoff");
+        }
+        this.minBackoff = minBackoff;
+        return this;
+    }
+
+    /**
+     * Max number of times any node in the network can receive a bad gRPC status before being removed from the network.
+     *
+     * @return the maximum node attempts
+     */
+    public synchronized int getMaxNodeAttempts() {
+        return network.getMaxNodeAttempts();
+    }
+
+    /**
+     * Set the max number of times any node in the network can receive a bad gRPC status before being removed from the
+     * network.
+     *
+     * @param maxNodeAttempts the desired minimum attempts
+     * @return {@code this}
+     */
+    public synchronized Client setMaxNodeAttempts(int maxNodeAttempts) {
+        this.network.setMaxNodeAttempts(maxNodeAttempts);
+        return this;
+    }
+
+    /**
+     * The minimum backoff time for any node in the network.
+     *
+     * @return the wait time
+     * @deprecated - Use {@link Client#getNodeMaxBackoff()} instead
+     */
+    @Deprecated
+    public synchronized Duration getNodeWaitTime() {
+        return getNodeMinBackoff();
+    }
+
+    /**
+     * Set the minimum backoff time for any node in the network.
+     *
+     * @param nodeWaitTime the wait time
+     * @return the updated client
+     * @deprecated - Use {@link Client#setNodeMinBackoff(Duration)} ()} instead
+     */
+    @Deprecated
+    public synchronized Client setNodeWaitTime(Duration nodeWaitTime) {
+        return setNodeMinBackoff(nodeWaitTime);
+    }
+
+    /**
+     * The minimum backoff time for any node in the network.
+     *
+     * @return the minimum backoff time
+     */
+    public synchronized Duration getNodeMinBackoff() {
+        return network.getMinNodeBackoff();
+    }
+
+    /**
+     * Set the minimum backoff time for any node in the network.
+     *
+     * @param minBackoff the desired minimum backoff time
+     * @return {@code this}
+     */
+    public synchronized Client setNodeMinBackoff(Duration minBackoff) {
+        network.setMinNodeBackoff(minBackoff);
+        return this;
+    }
+
+    /**
+     * The maximum backoff time for any node in the network.
+     *
+     * @return the maximum node backoff time
+     */
+    public synchronized Duration getNodeMaxBackoff() {
+        return network.getMaxNodeBackoff();
+    }
+
+    /**
+     * Set the maximum backoff time for any node in the network.
+     *
+     * @param maxBackoff the desired max backoff time
+     * @return {@code this}
+     */
+    public synchronized Client setNodeMaxBackoff(Duration maxBackoff) {
+        network.setMaxNodeBackoff(maxBackoff);
+        return this;
+    }
+
+    /**
+     * Extract the minimum node readmit time.
+     *
+     * @return the minimum node readmit time
+     */
+    public Duration getMinNodeReadmitTime() {
+        return network.getMinNodeReadmitTime();
+    }
+
+    /**
+     * Assign the minimum node readmit time.
+     *
+     * @param minNodeReadmitTime the requested duration
+     * @return {@code this}
+     */
+    public Client setMinNodeReadmitTime(Duration minNodeReadmitTime) {
+        network.setMinNodeReadmitTime(minNodeReadmitTime);
+        return this;
+    }
+
+    /**
+     * Extract the node readmit time.
+     *
+     * @return the maximum node readmit time
+     */
+    public Duration getMaxNodeReadmitTime() {
+        return network.getMaxNodeReadmitTime();
+    }
+
+    /**
+     * Assign the maximum node readmit time.
+     *
+     * @param maxNodeReadmitTime the maximum node readmit time
+     * @return {@code this}
+     */
+    public Client setMaxNodeReadmitTime(Duration maxNodeReadmitTime) {
+        network.setMaxNodeReadmitTime(maxNodeReadmitTime);
+        return this;
+    }
+
+    /**
+     * Set the max amount of nodes that will be chosen per request. By default, the request will use 1/3rd the network
+     * nodes per request.
+     *
+     * @param maxNodesPerTransaction the desired number of nodes
+     * @return {@code this}
+     */
+    public synchronized Client setMaxNodesPerTransaction(int maxNodesPerTransaction) {
+        this.network.setMaxNodesPerRequest(maxNodesPerTransaction);
+        return this;
+    }
+
+    /**
+     * Enable or disable automatic entity ID checksum validation.
+     *
+     * @param value the desired value
+     * @return {@code this}
+     */
+    public synchronized Client setAutoValidateChecksums(boolean value) {
+        autoValidateChecksums = value;
+        return this;
+    }
+
+    /**
+     * Is automatic entity ID checksum validation enabled.
+     *
+     * @return is validation enabled
+     */
+    public synchronized boolean isAutoValidateChecksumsEnabled() {
+        return autoValidateChecksums;
+    }
+
+    /**
+     * Get the ID of the operator. Useful when the client was constructed from file.
+     *
+     * @return {AccountId}
+     */
+    @Nullable
+    public synchronized AccountId getOperatorAccountId() {
+        if (operator == null) {
+            return null;
+        }
+
+        return operator.accountId;
+    }
+
+    /**
+     * Get the key of the operator. Useful when the client was constructed from file.
+     *
+     * @return {PublicKey}
+     */
+    @Nullable
+    public synchronized PublicKey getOperatorPublicKey() {
+        if (operator == null) {
+            return null;
+        }
+
+        return operator.publicKey;
+    }
+
+    /**
+     * The default maximum fee used for transactions.
+     *
+     * @return the max transaction fee
+     */
+    @Nullable
+    public synchronized Hbar getDefaultMaxTransactionFee() {
+        return defaultMaxTransactionFee;
+    }
+
+    /**
+     * Set the maximum fee to be paid for transactions executed by this client.
+     * <p>
+     * Because transaction fees are always maximums, this will simply add a call to
+     * {@link Transaction#setMaxTransactionFee(Hbar)} on every new transaction. The actual fee assessed for a given
+     * transaction may be less than this value, but never greater.
+     *
+     * @param defaultMaxTransactionFee The Hbar to be set
+     * @return {@code this}
+     */
+    public synchronized Client setDefaultMaxTransactionFee(Hbar defaultMaxTransactionFee) {
+        Objects.requireNonNull(defaultMaxTransactionFee);
+        if (defaultMaxTransactionFee.toTinybars() < 0) {
+            throw new IllegalArgumentException("maxTransactionFee must be non-negative");
+        }
+
+        this.defaultMaxTransactionFee = defaultMaxTransactionFee;
+        return this;
+    }
+
+    /**
+     * Set the maximum fee to be paid for transactions executed by this client.
+     * <p>
+     * Because transaction fees are always maximums, this will simply add a call to
+     * {@link Transaction#setMaxTransactionFee(Hbar)} on every new transaction. The actual fee assessed for a given
+     * transaction may be less than this value, but never greater.
+     *
+     * @deprecated Use {@link #setDefaultMaxTransactionFee(Hbar)} instead.
+     */
+    @Deprecated
+    public synchronized Client setMaxTransactionFee(Hbar maxTransactionFee) {
+        return setDefaultMaxTransactionFee(maxTransactionFee);
+    }
+
+    /**
+     * Extract the maximum query payment.
+     *
+     * @return the default maximum query payment
+     */
+    public synchronized Hbar getDefaultMaxQueryPayment() {
+        return defaultMaxQueryPayment;
+    }
+
+    /**
+     * Set the maximum default payment allowable for queries.
+     * <p>
+     * When a query is executed without an explicit {@link Query#setQueryPayment(Hbar)} call, the client will first
+     * request the cost of the given query from the node it will be submitted to and attach a payment for that amount
+     * from the operator account on the client.
+     * <p>
+     * If the returned value is greater than this value, a {@link MaxQueryPaymentExceededException} will be thrown from
+     * {@link Query#execute(Client)} or returned in the second callback of
+     * {@link Query#executeAsync(Client, Consumer, Consumer)}.
+     * <p>
+     * Set to 0 to disable automatic implicit payments.
+     *
+     * @param defaultMaxQueryPayment The Hbar to be set
+     * @return {@code this}
+     */
+    public synchronized Client setDefaultMaxQueryPayment(Hbar defaultMaxQueryPayment) {
+        Objects.requireNonNull(defaultMaxQueryPayment);
+        if (defaultMaxQueryPayment.toTinybars() < 0) {
+            throw new IllegalArgumentException("defaultMaxQueryPayment must be non-negative");
+        }
+
+        this.defaultMaxQueryPayment = defaultMaxQueryPayment;
+        return this;
+    }
+
+    /**
+     * @deprecated Use {@link #setDefaultMaxQueryPayment(Hbar)} instead.
+     */
+    @Deprecated
+    public synchronized Client setMaxQueryPayment(Hbar maxQueryPayment) {
+        return setDefaultMaxQueryPayment(maxQueryPayment);
+    }
+
+    /**
+     * Should the transaction id be regenerated?
+     *
+     * @return the default regenerate transaction id
+     */
+    public synchronized boolean getDefaultRegenerateTransactionId() {
+        return defaultRegenerateTransactionId;
+    }
+
+    /**
+     * Assign the default regenerate transaction id.
+     *
+     * @param regenerateTransactionId should there be a regenerated transaction id
+     * @return {@code this}
+     */
+    public synchronized Client setDefaultRegenerateTransactionId(boolean regenerateTransactionId) {
+        this.defaultRegenerateTransactionId = regenerateTransactionId;
+        return this;
+    }
+
+    /**
+     * Maximum amount of time a request can run
+     *
+     * @return the timeout value
+     */
+    @Override
+    @SuppressFBWarnings(
+            value = "EI_EXPOSE_REP",
+            justification = "A Duration can't actually be mutated"
+    )
+    public synchronized Duration getRequestTimeout() {
+        return requestTimeout;
+    }
+
+    /**
+     * Set the maximum amount of time a request can run. Used only in async variants of methods.
+     *
+     * @param requestTimeout the timeout value
+     * @return {@code this}
+     */
+    @SuppressFBWarnings(
+            value = "EI_EXPOSE_REP2",
+            justification = "A Duration can't actually be mutated"
+    )
+    public synchronized Client setRequestTimeout(Duration requestTimeout) {
+        this.requestTimeout = Objects.requireNonNull(requestTimeout);
+        return this;
+    }
+
+    /**
+     * Maximum amount of time closing a network can take.
+     *
+     * @return the timeout value
+     */
+    @SuppressFBWarnings(
+            value = "EI_EXPOSE_REP",
+            justification = "A Duration can't actually be mutated"
+    )
+    public Duration getCloseTimeout() {
+        return closeTimeout;
+    }
+
+    /**
+     * Set the maximum amount of time closing a network can take.
+     *
+     * @param closeTimeout the timeout value
+     * @return {@code this}
+     */
+    @SuppressFBWarnings(
+            value = "EI_EXPOSE_REP2",
+            justification = "A Duration can't actually be mutated"
+    )
+    public Client setCloseTimeout(Duration closeTimeout) {
+        this.closeTimeout = Objects.requireNonNull(closeTimeout);
+        network.setCloseTimeout(closeTimeout);
+        mirrorNetwork.setCloseTimeout(closeTimeout);
+        return this;
+    }
+
+    /**
+     * Extract the operator.
+     *
+     * @return the operator
+     */
+    @Nullable
+    synchronized Operator getOperator() {
+        return this.operator;
+    }
+
+    /**
+     * Initiates an orderly shutdown of all channels (to the Hedera network) in which preexisting transactions or
+     * queries continue but more would be immediately cancelled.
+     *
+     * <p>After this method returns, this client can be re-used. Channels will be re-established as
+     * needed.
+     */
+    @Override
+    public synchronized void close() throws TimeoutException {
+        close(closeTimeout);
+    }
+
+    /**
+     * Initiates an orderly shutdown of all channels (to the Hedera network) in which preexisting transactions or
+     * queries continue but more would be immediately cancelled.
+     *
+     * <p>After this method returns, this client can be re-used. Channels will be re-established as
+     * needed.
+     *
+     * @param timeout The Duration to be set
+     */
+    public synchronized void close(Duration timeout) throws TimeoutException {
+        var closeDeadline = Instant.now().plus(timeout);
+        network.beginClose();
+        mirrorNetwork.beginClose();
+        executor.shutdown();
+
+        try {
+            if (!executor.awaitTermination(timeout.getSeconds(), TimeUnit.SECONDS)) {
+                logger.warn("There are still tasks running, trying to shutdown the executor now");
+                executor.shutdownNow(); // Cancel currently executing tasks
+            }
+        } catch (InterruptedException ex) {
+            // (Re-)Cancel if current thread also interrupted
+            executor.shutdownNow();
+            // Preserve interrupt status
+            Thread.currentThread().interrupt();
+        }
+
+        var networkError = network.awaitClose(closeDeadline, null);
+        var mirrorNetworkError = mirrorNetwork.awaitClose(closeDeadline, networkError);
+
+        if (mirrorNetworkError != null) {
+            if (mirrorNetworkError instanceof TimeoutException) {
+                throw (TimeoutException) mirrorNetworkError;
+            } else {
+                throw new RuntimeException(mirrorNetworkError);
+            }
+        }
+    }
+
+    static class Operator {
+        final AccountId accountId;
+        final PublicKey publicKey;
+        final Function<byte[], byte[]> transactionSigner;
+
+        Operator(AccountId accountId, PublicKey publicKey, Function<byte[], byte[]> transactionSigner) {
+            this.accountId = accountId;
+            this.publicKey = publicKey;
+            this.transactionSigner = transactionSigner;
+        }
+    }
+
+    private static class Config {
+        @Nullable
+        private JsonElement network;
+
+        @Nullable
+        private JsonElement networkName;
+
+        @Nullable
+        private ConfigOperator operator;
+
+        @Nullable
+        private JsonElement mirrorNetwork;
+
+        private static class ConfigOperator {
+            private final String accountId = "";
+            private final String privateKey = "";
+        }
+    }
+}

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AccountClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AccountClient.java
@@ -24,11 +24,9 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.inject.Named;
 import lombok.RequiredArgsConstructor;
-import lombok.SneakyThrows;
 import org.springframework.retry.support.RetryTemplate;
 
 import com.hedera.hashgraph.sdk.AccountAllowanceApproveTransaction;
-import com.hedera.hashgraph.sdk.AccountBalanceQuery;
 import com.hedera.hashgraph.sdk.AccountCreateTransaction;
 import com.hedera.hashgraph.sdk.AccountId;
 import com.hedera.hashgraph.sdk.Hbar;
@@ -84,23 +82,6 @@ public class AccountClient extends AbstractNetworkClient {
         }
 
         return accountId;
-    }
-
-    @Override
-    public long getBalance() {
-        return getBalance(sdkClient.getExpandedOperatorAccountId());
-    }
-
-    @SneakyThrows
-    public long getBalance(ExpandedAccountId accountId) {
-        Hbar balance = new AccountBalanceQuery()
-                .setAccountId(accountId.getAccountId())
-                .execute(client)
-                .hbars;
-
-        log.info("{} balance is {}", accountId, balance);
-
-        return balance.toTinybars();
     }
 
     public TransferTransaction getCryptoTransferTransaction(AccountId sender, AccountId recipient, Hbar hbarAmount,

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/FileClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/FileClient.java
@@ -21,7 +21,6 @@ package com.hedera.mirror.test.e2e.acceptance.client;
  */
 
 import javax.inject.Named;
-import lombok.SneakyThrows;
 import org.springframework.retry.support.RetryTemplate;
 
 import com.hedera.hashgraph.sdk.FileAppendTransaction;
@@ -107,10 +106,7 @@ public class FileClient extends AbstractNetworkClient {
         return networkTransactionResponse;
     }
 
-    @SneakyThrows
     public FileInfo getFileInfo(FileId fileId) {
-        return retryTemplate.execute(x -> new FileInfoQuery()
-                .setFileId(fileId)
-                .execute(client));
+        return executeQuery(() -> new FileInfoQuery().setFileId(fileId));
     }
 }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/SDKClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/SDKClient.java
@@ -89,6 +89,7 @@ public class SDKClient implements AutoCloseable {
             try {
                 new AccountDeleteTransaction()
                         .setAccountId(createdAccountId)
+                        .setGrpcDeadline(acceptanceTestProperties.getSdkProperties().getGrpcDeadline())
                         .setTransferAccountId(operatorId)
                         .execute(client);
                 log.info("Deleted temporary operator account {}", createdAccountId);
@@ -192,12 +193,13 @@ public class SDKClient implements AutoCloseable {
         try (Client client = toClient(Map.of(endpoint, nodeAccountId))) {
             new AccountBalanceQuery()
                     .setAccountId(nodeAccountId)
+                    .setGrpcDeadline(acceptanceTestProperties.getSdkProperties().getGrpcDeadline())
                     .setNodeAccountIds(List.of(nodeAccountId))
                     .execute(client, Duration.ofSeconds(10L));
-            log.debug("Validated node: {}", nodeAccountId);
+            log.info("Validated node: {}", nodeAccountId);
             valid = true;
         } catch (Exception e) {
-            log.warn("Unable to validate node {}: ", nodeAccountId, e.getMessage());
+            log.warn("Unable to validate node {}: {}", nodeAccountId, e.getMessage());
         }
 
         return valid;

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/ScheduleClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/ScheduleClient.java
@@ -22,7 +22,6 @@ package com.hedera.mirror.test.e2e.acceptance.client;
 
 import java.util.List;
 import javax.inject.Named;
-import lombok.SneakyThrows;
 import org.springframework.retry.support.RetryTemplate;
 
 import com.hedera.hashgraph.sdk.KeyList;
@@ -110,12 +109,7 @@ public class ScheduleClient extends AbstractNetworkClient {
         return networkTransactionResponse;
     }
 
-    @SneakyThrows
     public ScheduleInfo getScheduleInfo(ScheduleId scheduleId) {
-        return retryTemplate.execute(x ->
-                new ScheduleInfoQuery()
-                        .setScheduleId(scheduleId)
-                        .setNodeAccountIds(List.of(sdkClient.getRandomNodeAccountId()))
-                        .execute(client));
+        return executeQuery(() -> new ScheduleInfoQuery().setScheduleId(scheduleId));
     }
 }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TokenClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TokenClient.java
@@ -23,7 +23,6 @@ package com.hedera.mirror.test.e2e.acceptance.client;
 import java.time.Duration;
 import java.util.List;
 import javax.inject.Named;
-import lombok.SneakyThrows;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.springframework.retry.support.RetryTemplate;
 
@@ -509,15 +508,12 @@ public class TokenClient extends AbstractNetworkClient {
         return response;
     }
 
-    @SneakyThrows
     public long getTokenBalance(AccountId accountId, TokenId tokenId) {
-        long balance = new AccountBalanceQuery()
-                .setAccountId(accountId)
-                .execute(client)
-                .tokens.get(tokenId);
-
+        // AccountBalanceQuery is free
+        var query = new AccountBalanceQuery().setAccountId(accountId);
+        var accountBalance = executeQuery(() -> query);
+        long balance = accountBalance.tokens.get(tokenId);
         log.debug("{}'s token balance is {} {} tokens", accountId, balance, tokenId);
-
         return balance;
     }
 }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TopicClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TopicClient.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.inject.Named;
-import lombok.SneakyThrows;
 import org.apache.commons.lang3.ArrayUtils;
 import org.springframework.retry.support.RetryTemplate;
 
@@ -186,12 +185,7 @@ public class TopicClient extends AbstractNetworkClient {
         return recordPublishInstants.get(0L);
     }
 
-    @SneakyThrows
     public TopicInfo getTopicInfo(TopicId topicId) {
-        return retryTemplate.execute(x ->
-                new TopicInfoQuery()
-                        .setTopicId(topicId)
-                        .setNodeAccountIds(List.of(sdkClient.getRandomNodeAccountId()))
-                        .execute(client));
+        return executeQuery(() -> new TopicInfoQuery().setTopicId(topicId));
     }
 }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
@@ -31,6 +31,7 @@ import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
+import com.hedera.hashgraph.sdk.Hbar;
 import com.hedera.mirror.test.e2e.acceptance.props.NodeProperties;
 
 @Named
@@ -54,8 +55,7 @@ public class AcceptanceTestProperties {
     @Max(5)
     private int maxRetries = 2;
 
-    @NotNull
-    private Long maxTinyBarTransactionFee = 2_000_000_000L;
+    private long maxTinyBarTransactionFee = Hbar.from(40).toTinybars();
 
     @NotNull
     private Duration messageTimeout = Duration.ofSeconds(20);
@@ -68,7 +68,7 @@ public class AcceptanceTestProperties {
 
     private Set<NodeProperties> nodes = new LinkedHashSet<>();
 
-    private long operatorBalance = 18_000_000_000L;
+    private long operatorBalance = Hbar.from(200).toTinybars();
 
     @NotBlank
     private String operatorId = "0.0.2";

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/SdkProperties.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/SdkProperties.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.test.e2e.acceptance.config;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,9 +20,12 @@ package com.hedera.mirror.test.e2e.acceptance.config;
  * ‍
  */
 
+import java.time.Duration;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
 import lombok.Data;
+import org.hibernate.validator.constraints.time.DurationMin;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.annotation.Validated;
@@ -32,7 +35,10 @@ import org.springframework.validation.annotation.Validated;
 @Data
 @Validated
 public class SdkProperties {
-    // To-do: move sdk related properties from AcceptanceTestProperties here
+
+    @DurationMin(seconds = 5L)
+    @NotNull
+    private Duration grpcDeadline = Duration.ofSeconds(10L);
 
     @Min(1)
     @Max(60)

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TopicFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TopicFeature.java
@@ -165,8 +165,7 @@ public class TopicFeature {
         Instant startTime = FeatureInputHandler.messageQueryDateStringToInstant(startTimestamp, testInstantReference);
         log.debug("Subscribe TopicMessageQuery startTime : {}", startTime);
 
-        topicMessageQuery
-                .setStartTime(startTime);
+        topicMessageQuery.setStartTime(startTime);
 
         log.debug("Set TopicMessageQuery with topic: {}, startTime: {}", consensusTopicId, startTime);
     }


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

This PR ports the fix for acceptance test freezing issue to `release/0.66`

- Switch to a fixed thread pool executor with at least 2 threads and shutdown the pool in Client.close
- Add `hedera.mirror.test.acceptance.sdk.grpcDeadline=10s` and set it for all SDK transaction and query execution
- Move query execution to `AbstractNetworkClient`
- Increase default max transaction fee and operator balance

**Related issue(s)**:

Relates to #4610

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
