### PR TITLE
Add `hedera-evm-api` dependency to `hedera-mirror-web3` module

### DIFF
--- a/hedera-mirror-web3/pom.xml
+++ b/hedera-mirror-web3/pom.xml
@@ -101,6 +101,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>com.hedera.evm</groupId>
+            <artifactId>hedera-evm-api</artifactId>
+            <version>{hedera-evm-api.version}</version>
+            <type>module</type>
+        </dependency>
 
         <!-- Test -->
         <dependency>
@@ -123,12 +129,6 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.hedera.evm</groupId>
-            <artifactId>hedera-evm-api</artifactId>
-            <version>{hedera-еvm-api.version}</version>
-            <type>module</type>
         </dependency>
     </dependencies>
 

--- a/hedera-mirror-web3/pom.xml
+++ b/hedera-mirror-web3/pom.xml
@@ -104,7 +104,7 @@
         <dependency>
             <groupId>com.hedera.evm</groupId>
             <artifactId>hedera-evm-api</artifactId>
-            <version>${hedera-evm-api.version}</version>
+            <version>${hedera-evm.version}</version>
         </dependency>
 
         <!-- Test -->

--- a/hedera-mirror-web3/pom.xml
+++ b/hedera-mirror-web3/pom.xml
@@ -104,8 +104,7 @@
         <dependency>
             <groupId>com.hedera.evm</groupId>
             <artifactId>hedera-evm-api</artifactId>
-            <version>{hedera-evm-api.version}</version>
-            <type>module</type>
+            <version>${hedera-evm-api.version}</version>
         </dependency>
 
         <!-- Test -->

--- a/hedera-mirror-web3/pom.xml
+++ b/hedera-mirror-web3/pom.xml
@@ -124,6 +124,12 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.hedera.evm</groupId>
+            <artifactId>hedera-evm-api</artifactId>
+            <version>{hedera-еvm-api.version}</version>
+            <type>module</type>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <gson.version>2.8.9</gson.version> <!-- Temporary until Apache jclouds supports gson 2.9 -->
         <guava.version>31.1-jre</guava.version>
         <headlong.version>7.0.0</headlong.version>
-        <hedera-еvm-api.version>0.31.0-SNAPSHOT</hedera-еvm-api.version>
+        <hedera-evm.version>0.31.0-SNAPSHOT</hedera-evm.version>
         <hedera-protobuf.version>0.31.0-SNAPSHOT</hedera-protobuf.version>
         <hibernate-types.version>2.19.2</hibernate-types.version>
         <jacoco.version>0.8.8</jacoco.version>

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
         <gson.version>2.8.9</gson.version> <!-- Temporary until Apache jclouds supports gson 2.9 -->
         <guava.version>31.1-jre</guava.version>
         <headlong.version>7.0.0</headlong.version>
+        <hedera-еvm-api.version>0.31.0-SNAPSHOT</hedera-еvm-api.version>
         <hedera-protobuf.version>0.31.0-SNAPSHOT</hedera-protobuf.version>
         <hibernate-types.version>2.19.2</hibernate-types.version>
         <jacoco.version>0.8.8</jacoco.version>


### PR DESCRIPTION
**Description**:

Add a `hedera-evm-api` dependency, so that REST APIs for executing `JSON RPC` calls (e.g. `eth_call`, `eth_estimateGas`) could be implemented using transaction processing from the hedera evm library.

**Related issue(s)**:

Fixes #4465

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
