### PR TITLE
Add blocks API to monitor dashboard

### DIFF
--- a/hedera-mirror-rest/monitoring/monitor_apis/block_tests.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/block_tests.js
@@ -1,0 +1,94 @@
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import _ from 'lodash';
+import * as math from 'mathjs';
+import config from './config';
+
+import {
+  checkAPIResponseError,
+  checkRespObjDefined,
+  checkRespArrayLength,
+  checkMandatoryParams,
+  checkResourceFreshness,
+  DEFAULT_LIMIT,
+  getAPIResponse,
+  getUrl,
+  testRunner,
+  CheckRunner,
+} from './utils';
+
+const blocksPath = '/blocks';
+const resource = 'block';
+const resourceLimit = config[resource].limit || DEFAULT_LIMIT;
+const jsonRespKey = 'blocks';
+const mandatoryParams = ['count', 'gas_used', 'hapi_version', 'hash', 'name', 'number', 'previous_hash', 'size'];
+
+/**
+ * Verify base blocks call
+ * @param {String} server API host endpoint
+ */
+const getBlockCheck = async (server) => {
+  console.log('MYK: debug: starting getBlockCheck');
+  const url = getUrl(server, blocksPath, {limit: resourceLimit});
+  const blocks = await getAPIResponse(url, jsonRespKey);
+
+  const result = new CheckRunner()
+    .withCheckSpec(checkAPIResponseError)
+    .withCheckSpec(checkRespObjDefined, {message: 'blocks is undefined'})
+    .withCheckSpec(checkRespArrayLength, {
+      limit: resourceLimit,
+      message: (elements, limit) => `blocks.length of ${elements.length} is less than limit ${limit}`,
+    })
+    .withCheckSpec(checkMandatoryParams, {
+      params: mandatoryParams,
+      message: 'block object is missing some mandatory fields',
+    })
+    .run(blocks);
+  if (!result.passed) {
+    return {url, ...result};
+  }
+
+  return {
+    url,
+    passed: true,
+    message: 'Successfully called blocks and performed account check',
+  };
+};
+
+/**
+ * Run all block tests in an asynchronous fashion waiting for all tests to complete
+ *
+ * @param {Object} server object provided by the user
+ * @param {ServerTestResult} testResult shared server test result object capturing tests for given endpoint
+ */
+const runTests = async (server, testResult) => {
+  const runTest = testRunner(server, testResult, resource);
+  return Promise.all([
+    /*
+    runTest(getBlockCheck),
+*/
+  ]);
+};
+
+export default {
+  resource,
+  runTests,
+};

--- a/hedera-mirror-rest/monitoring/monitor_apis/block_tests.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/block_tests.js
@@ -19,7 +19,6 @@
  */
 
 import _ from 'lodash';
-import * as math from 'mathjs';
 import config from './config';
 
 import {

--- a/hedera-mirror-rest/monitoring/monitor_apis/block_tests.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/block_tests.js
@@ -43,11 +43,13 @@ const mandatoryParams = [
   'gas_used',
   'hapi_version',
   'hash',
+  'logs_bloom',
   'name',
   'number',
   'previous_hash',
   'size',
-  'timestamp',
+  'timestamp.from',
+  'timestamp.to',
 ];
 
 /**

--- a/hedera-mirror-rest/monitoring/monitor_apis/config.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/config.js
@@ -33,6 +33,7 @@ const REQUIRED_FIELDS = [
   'account.intervalMultiplier',
   'balance.freshnessThreshold',
   'balance.intervalMultiplier',
+  'block.freshnessThreshold',
   'network.intervalMultiplier',
   'stateproof.intervalMultiplier',
   'transaction.freshnessThreshold',

--- a/hedera-mirror-rest/monitoring/monitor_apis/config.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/config.js
@@ -34,6 +34,7 @@ const REQUIRED_FIELDS = [
   'balance.freshnessThreshold',
   'balance.intervalMultiplier',
   'block.freshnessThreshold',
+  'block.intervalMultiplier',
   'network.intervalMultiplier',
   'stateproof.intervalMultiplier',
   'transaction.freshnessThreshold',

--- a/hedera-mirror-rest/monitoring/monitor_apis/config/default.serverlist.json
+++ b/hedera-mirror-rest/monitoring/monitor_apis/config/default.serverlist.json
@@ -2,8 +2,8 @@
   "port": 3000,
   "servers": [
     {
-      "baseUrl": "http://127.0.0.1:5551",
-      "name": "local"
+      "baseUrl": "http://testnet.mirrornode.hedera.com",
+      "name": "testnet"
     }
   ],
   "interval": 60,
@@ -22,6 +22,11 @@
     "enabled": true,
     "freshnessThreshold": 1000,
     "intervalMultiplier": 1,
+    "limit": 10
+  },
+  "block": {
+    "enabled": true,
+    "freshnessThreshold": 1000,
     "limit": 10
   },
   "network": {

--- a/hedera-mirror-rest/monitoring/monitor_apis/config/default.serverlist.json
+++ b/hedera-mirror-rest/monitoring/monitor_apis/config/default.serverlist.json
@@ -2,7 +2,7 @@
   "port": 3000,
   "servers": [
     {
-      "baseUrl": "http://testnet.mirrornode.hedera.com",
+      "baseUrl": "https://testnet.mirrornode.hedera.com",
       "name": "testnet"
     }
   ],
@@ -27,6 +27,7 @@
   "block": {
     "enabled": true,
     "freshnessThreshold": 1000,
+    "intervalMultiplier": 1,
     "limit": 10
   },
   "network": {

--- a/hedera-mirror-rest/monitoring/monitor_apis/config/default.serverlist.json
+++ b/hedera-mirror-rest/monitoring/monitor_apis/config/default.serverlist.json
@@ -2,8 +2,8 @@
   "port": 3000,
   "servers": [
     {
-      "baseUrl": "https://testnet.mirrornode.hedera.com",
-      "name": "testnet"
+      "baseUrl": "http://127.0.0.1:5551",
+      "name": "local"
     }
   ],
   "interval": 60,
@@ -26,7 +26,7 @@
   },
   "block": {
     "enabled": true,
-    "freshnessThreshold": 1000,
+    "freshnessThreshold": 50,
     "intervalMultiplier": 1,
     "limit": 10
   },

--- a/hedera-mirror-rest/monitoring/monitor_apis/monitor_tests.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/monitor_tests.js
@@ -24,6 +24,7 @@ import * as utils from './utils';
 
 import accountTests from './account_tests';
 import balanceTests from './balance_tests';
+import blockTests from './block_tests';
 import networkTests from './network_tests';
 import stateproofTests from './stateproof_tests';
 import tokenTests from './token_tests';
@@ -33,6 +34,7 @@ import transactionTests from './transaction_tests';
 const allTestModules = [
   accountTests,
   balanceTests,
+  blockTests,
   networkTests,
   stateproofTests,
   tokenTests,


### PR DESCRIPTION
**Description**:

* Add blocks API to monitor dashboard
* Add properties to control blocks API check

**Related issue(s)**:

Fixes #4651
Part of #4050

**Notes for reviewer**:
When running the API monitor, two additional tests now appear, for Resource "block":

- Successfully retrieved block from with 1000 seconds ago (the Freshness test)
- Successfully called blocks for single block

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
