### PR TITLE
Fix balance monitor api tests

### DIFF
--- a/hedera-mirror-rest/monitoring/monitor_apis/balance_tests.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/balance_tests.js
@@ -74,48 +74,6 @@ const getBalancesCheck = async (server) => {
 };
 
 /**
- * Verify balances call with time and limit query params provided
- * @param {String} server API host endpoint
- */
-const getBalancesWithTimeAndLimitParams = async (server) => {
-  let url = getUrl(server, balancesPath, {limit: 1});
-  const resp = await getAPIResponse(url);
-  let balances = resp instanceof Error ? resp : resp.balances;
-
-  const checkRunner = new CheckRunner()
-    .withCheckSpec(checkAPIResponseError)
-    .withCheckSpec(checkRespObjDefined, {message: 'balances is undefined'})
-    .withCheckSpec(checkRespArrayLength, {
-      limit: 1,
-      message: (elements) => `balances.length of ${elements.length} was expected to be 1`,
-    });
-  let result = checkRunner.run(balances);
-  if (!result.passed) {
-    return {url, ...result};
-  }
-
-  const {timestamp} = resp;
-  const plusOne = math.add(math.bignumber(timestamp), math.bignumber(1));
-  const minusOne = math.subtract(math.bignumber(timestamp), math.bignumber(1));
-  url = getUrl(server, balancesPath, {
-    timestamp: [`gt:${minusOne.toString()}`, `lt:${plusOne.toString()}`],
-    limit: 1,
-  });
-  balances = await getAPIResponse(url, jsonRespKey);
-
-  result = checkRunner.run(balances);
-  if (!result.passed) {
-    return {url, ...result};
-  }
-
-  return {
-    url,
-    passed: true,
-    message: 'Successfully called balances with time and limit params',
-  };
-};
-
-/**
  * Verify single balance can be retrieved
  * @param {String} server API host endpoint
  */
@@ -168,7 +126,12 @@ const getSingleBalanceById = async (server) => {
  * @param {String} server API host endpoint
  */
 const checkBalanceFreshness = async (server) => {
-  return checkResourceFreshness(server, balancesPath, resource, (data) => data.timestamp);
+  const now = new Date().getTime() / 1000;
+  return checkResourceFreshness(server, balancesPath, resource, (data) => data.timestamp, undefined, {
+    timestamp: now,
+    limit: 1,
+    order: 'desc',
+  });
 };
 
 /**
@@ -179,12 +142,7 @@ const checkBalanceFreshness = async (server) => {
  */
 const runTests = async (server, testResult) => {
   const runTest = testRunner(server, testResult, resource);
-  return Promise.all([
-    runTest(getBalancesCheck),
-    runTest(getBalancesWithTimeAndLimitParams),
-    runTest(getSingleBalanceById),
-    runTest(checkBalanceFreshness),
-  ]);
+  return Promise.all([runTest(getBalancesCheck), runTest(getSingleBalanceById), runTest(checkBalanceFreshness)]);
 };
 
 export default {

--- a/hedera-mirror-rest/monitoring/monitor_apis/balance_tests.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/balance_tests.js
@@ -19,7 +19,6 @@
  */
 
 import _ from 'lodash';
-import * as math from 'mathjs';
 import config from './config';
 
 import {

--- a/hedera-mirror-rest/monitoring/monitor_apis/utils.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/utils.js
@@ -332,13 +332,16 @@ const checkElementsOrder = (elements, option) => {
  * @param jsonRespKey json response key to extract data from json response
  * @return {Promise<>}
  */
-const checkResourceFreshness = async (server, path, resource, timestamp, jsonRespKey) => {
+const checkResourceFreshness = async (server, path, resource, timestamp, jsonRespKey, query = undefined) => {
   const {freshnessThreshold} = config[resource];
   if (freshnessThreshold === 0) {
     return {skipped: true};
   }
+  if (query === undefined) {
+    query = {limit: 1, order: 'desc'};
+  }
 
-  const url = getUrl(server, path, {limit: 1, order: 'desc'});
+  const url = getUrl(server, path, query);
   const resp = await getAPIResponse(url, jsonRespKey);
 
   const checkRunner = new CheckRunner()

--- a/hedera-mirror-rest/monitoring/monitor_apis/utils.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/utils.js
@@ -332,13 +332,17 @@ const checkElementsOrder = (elements, option) => {
  * @param jsonRespKey json response key to extract data from json response
  * @return {Promise<>}
  */
-const checkResourceFreshness = async (server, path, resource, timestamp, jsonRespKey, query = undefined) => {
+const checkResourceFreshness = async (
+  server,
+  path,
+  resource,
+  timestamp,
+  jsonRespKey,
+  query = {limit: 1, order: 'desc'}
+) => {
   const {freshnessThreshold} = config[resource];
   if (freshnessThreshold === 0) {
     return {skipped: true};
-  }
-  if (query === undefined) {
-    query = {limit: 1, order: 'desc'};
   }
 
   const url = getUrl(server, path, query);


### PR DESCRIPTION
**Description**:

Fix balance monitor api tests to reflect the fact that balances are now 'live' and not tied to the REST API `/balances` response timestamp.

* Change `checkBalanceFreshness` call to specify timestamp = <now>
* Remove `getBalancesWithTimeAndLimitParams` check since it no longer makes sense with live balances.

**Related issue(s)**:

Fixes #4674

**Notes for reviewer**:

```console
0|server  | 2022-10-17T17:15:59.111-07:00 INFO Running test #1
0|server  | 2022-10-17T17:15:59.126-07:00 INFO Server running on port: 3000
0|server  | 2022-10-17T17:15:59.746-07:00 INFO Completed test run #1 for testnet with 17/17 tests passed in 635 ms
0|server  | 2022-10-17T17:15:59.746-07:00 INFO Finished test run #1 in 635 ms
0|server  | 2022-10-17T17:17:00.334-07:00 INFO Completed test run #2 for testnet with 17/17 tests passed in 587 ms
0|server  | 2022-10-17T17:17:00.334-07:00 INFO Finished test run #2 in 587 ms
```

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (using testnet api_monitor)
