### PR TITLE
Fix acceptance tests regression on startup

### DIFF
--- a/hedera-mirror-test/README.md
+++ b/hedera-mirror-test/README.md
@@ -39,7 +39,7 @@ uses [Spring Boot](https://spring.io/projects/spring-boot) properties to configu
 under `hedera.mirror.test.acceptance` include:
 
 - `backOffPeriod` - The number of milliseconds client should wait before retrying a retryable failure.
-- `createOperatorAccount` - Whether to create an operator account to run the acceptance tests 
+- `createOperatorAccount` - Whether to create an operator account to run the acceptance tests
 - `emitBackgroundMessages` - Flag to set if background messages should be emitted. For operations use in non-production
   `environments.
 - `feature`
@@ -66,8 +66,10 @@ under `hedera.mirror.test.acceptance` include:
 - `retrieveAddressBook` - Whether to download the address book from the network and use those nodes over the default
   nodes. Populating `hedera.mirror.test.acceptance.nodes` will take priority over this.
 - `sdk`
-  - `grpcDeadline` - The maximum amount of time to wait for a grpc call to complete. 
+  - `grpcDeadline` - The maximum amount of time to wait for a grpc call to complete.
   - `maxAttempts` - The maximum number of times the sdk should try to submit a transaction to the network.
+- `startupTimeout` - How long the startup probe should wait for the network as a whole to be healthy before failing the
+  tests
 - `webclient`
   - `connectionTimeout` - The timeout duration to wait to establish a connection with the server
   - `readTimeout` - The timeout duration to wait for data to be read.
@@ -114,7 +116,8 @@ hedera:
 
 #### Feature Tags
 
-Tags: Tags allow you to filter which Cucumber scenarios and files are run. By default, tests marked with the `@acceptance`
+Tags: Tags allow you to filter which Cucumber scenarios and files are run. By default, tests marked with
+the `@acceptance`
 tag are run. To run a different set of files different tags can be specified
 
 Test Suite Tags
@@ -143,7 +146,8 @@ To execute run
 
     ./mvnw clean integration-test --projects hedera-mirror-test/ -P=acceptance-tests -Dcucumber.filter.tags="<tag name>"
 
-> **_NOTE:_** Feature tags can be combined - See [Tag expressions](https://cucumber.io/docs/cucumber/api/). To run a subset of tags
+> **_NOTE:_** Feature tags can be combined - See [Tag expressions](https://cucumber.io/docs/cucumber/api/). To run a
+> subset of tags
 > - `@acceptance and @topicmessagesbase` - all token acceptance scenarios
 > - `@acceptance and not @tokenbase` - all acceptance except token scenarios
 

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/StartupProbe.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/StartupProbe.java
@@ -20,109 +20,136 @@ package com.hedera.mirror.test.e2e.acceptance.client;
  * ‍
  */
 
+import com.google.common.base.Stopwatch;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.stream.Collectors;
+import java.util.function.Supplier;
 import javax.inject.Named;
 import lombok.CustomLog;
+import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
-
-import com.google.common.base.Stopwatch;
-import com.google.common.base.Throwables;
-import com.google.common.util.concurrent.Uninterruptibles;
 import org.springframework.http.MediaType;
+import org.springframework.retry.RetryCallback;
+import org.springframework.retry.RetryContext;
+import org.springframework.retry.listener.RetryListenerSupport;
 import org.springframework.retry.support.RetryTemplate;
-import org.springframework.util.CollectionUtils;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.util.retry.Retry;
-import reactor.util.retry.RetryBackoffSpec;
 
-import com.hedera.hashgraph.sdk.AccountId;
 import com.hedera.hashgraph.sdk.Client;
-import com.hedera.hashgraph.sdk.PrivateKey;
+import com.hedera.hashgraph.sdk.Query;
 import com.hedera.hashgraph.sdk.SubscriptionHandle;
 import com.hedera.hashgraph.sdk.TopicCreateTransaction;
-import com.hedera.hashgraph.sdk.TopicId;
 import com.hedera.hashgraph.sdk.TopicMessageQuery;
 import com.hedera.hashgraph.sdk.TopicMessageSubmitTransaction;
+import com.hedera.hashgraph.sdk.Transaction;
 import com.hedera.hashgraph.sdk.TransactionId;
-import com.hedera.hashgraph.sdk.TransactionReceipt;
 import com.hedera.hashgraph.sdk.TransactionReceiptQuery;
 import com.hedera.hashgraph.sdk.TransactionResponse;
 import com.hedera.mirror.test.e2e.acceptance.config.AcceptanceTestProperties;
-import com.hedera.mirror.test.e2e.acceptance.props.NodeProperties;
-
-import static com.hedera.mirror.test.e2e.acceptance.config.AcceptanceTestProperties.HederaNetwork.OTHER;
 
 /**
  * StartupProbe -- a helper class to validate a SDKClient before using it.
  */
 @CustomLog
 @Named
+@RequiredArgsConstructor
 public class StartupProbe {
 
     private final AcceptanceTestProperties acceptanceTestProperties;
-    private final Duration startupTimeout;
     private final WebClient webClient;
+    private final RetryTemplate retryTemplate = RetryTemplate.builder()
+            .infiniteRetry()
+            .notRetryOn(TimeoutException.class)
+            .fixedBackoff(1000L)
+            .withListener(new RetryListenerSupport() {
+                @Override
+                public <T, E extends Throwable> void onError(RetryContext r, RetryCallback<T, E> c, Throwable t) {
+                    log.warn("Retry attempt #{} with error: {}", r.getRetryCount(), t.getMessage());
+                }
+            })
+            .build();
 
-    private boolean validated;
+    @SneakyThrows
+    public void validateEnvironment(Client client) {
+        var startupTimeout = acceptanceTestProperties.getStartupTimeout();
+        var stopwatch = Stopwatch.createStarted();
 
-    public StartupProbe(AcceptanceTestProperties acceptanceTestProperties, WebClient webClient) {
-        this.acceptanceTestProperties = acceptanceTestProperties;
-        this.webClient = webClient;
-        startupTimeout = acceptanceTestProperties.getStartupTimeout();
+        if (startupTimeout.equals(Duration.ZERO)) {
+            log.warn("Startup probe disabled");
+            return;
+        }
+
+        // step 1: Create a new topic for the subsequent HCS submit message action.
+        var transactionId = executeTransaction(client, stopwatch, () -> new TopicCreateTransaction()).transactionId;
+
+        // step 2: Query for the receipt of the HCS topic create (until successful or time runs out)
+        var topicId = executeQuery(client, stopwatch,
+                () -> new TransactionReceiptQuery().setTransactionId(transactionId)).topicId;
+
+        // step 3: Query the mirror node for the transaction by ID (until successful or time runs out)
+        callRestEndpoint(stopwatch, transactionId);
+
+        // step 4: Query the mirror node gRPC API for a HCS message, until successful or time runs out
+        CountDownLatch messageLatch = new CountDownLatch(1);
+        SubscriptionHandle subscription = null;
+
+        try {
+            subscription = retryTemplate.execute(x -> new TopicMessageQuery()
+                    .setTopicId(topicId)
+                    .setMaxAttempts(Integer.MAX_VALUE)
+                    .setRetryHandler(t -> true)
+                    .setStartTime(Instant.EPOCH)
+                    .subscribe(client, resp -> messageLatch.countDown()));
+
+            var transactionIdMessage = executeTransaction(client, stopwatch, () -> new TopicMessageSubmitTransaction()
+                    .setTopicId(topicId).setMessage("Mirror Node acceptance test")).transactionId;
+
+            executeQuery(client, stopwatch, () -> new TransactionReceiptQuery().setTransactionId(transactionIdMessage));
+
+            if (messageLatch.await(startupTimeout.minus(stopwatch.elapsed()).toNanos(), TimeUnit.NANOSECONDS)) {
+                log.info("Startup probe successful.");
+            } else {
+                throw new TimeoutException("Timer expired while waiting on message latch.");
+            }
+        } finally {
+            if (subscription != null) {
+                subscription.unsubscribe();
+            }
+        }
     }
 
     @SneakyThrows
-    public void validateEnvironment(Client client) throws TimeoutException {
-        // if we previously validated successfully, just immediately return.
-        if (validated) {
-            return;
-        }
-        // Any of these (before the "try") can throw IllegalArgumentException; if it does, retries wouldn't help,
-        // so exit early (with that exception) if it does happen.
-        AccountId operator = AccountId.fromString(acceptanceTestProperties.getOperatorId());
-        PrivateKey privateKey = PrivateKey.fromString(acceptanceTestProperties.getOperatorKey());
-
-        client.setOperator(operator, privateKey);  // this account pays for (and signs) all transactions run here.
-
-        Stopwatch stopwatch = Stopwatch.createStarted();
-        // step 1: Create a new topic for the subsequent HCS submit message action.
-        RetryTemplate retryTemplate = RetryTemplate.builder()
-                .infiniteRetry()
-                .notRetryOn(TimeoutException.class)
-                .fixedBackoff(1000L)
-                .build();
-        
-        TransactionResponse response = retryTemplate.execute(x -> new TopicCreateTransaction()
+    private TransactionResponse executeTransaction(Client client, Stopwatch stopwatch,
+                                                   Supplier<Transaction<?>> transaction) {
+        var startupTimeout = acceptanceTestProperties.getStartupTimeout();
+        return retryTemplate.execute(r -> transaction.get()
                 .setGrpcDeadline(acceptanceTestProperties.getSdkProperties().getGrpcDeadline())
                 .setMaxAttempts(Integer.MAX_VALUE)
                 .execute(client, startupTimeout.minus(stopwatch.elapsed())));
-        TransactionId transactionId = response.transactionId;
+    }
 
-        // step 2: Query for the receipt of that HCS submit transaction (until successful or time runs out)
-        TransactionReceipt transactionReceipt = retryTemplate.execute(x -> new TransactionReceiptQuery()
-                .setTransactionId(transactionId)
+    @SneakyThrows
+    private <T> T executeQuery(Client client, Stopwatch stopwatch, Supplier<Query<T, ?>> transaction) {
+        var startupTimeout = acceptanceTestProperties.getStartupTimeout();
+        return retryTemplate.execute(r -> transaction.get()
                 .setGrpcDeadline(acceptanceTestProperties.getSdkProperties().getGrpcDeadline())
                 .setMaxAttempts(Integer.MAX_VALUE)
                 .execute(client, startupTimeout.minus(stopwatch.elapsed())));
+    }
 
-        // step 3: Query the mirror node for the transaction by ID (until successful or time runs out)
-        // Instead of using MirrorNodeClient.getTransactions(restTransactionId), we directly call webClient.
-        // retry infinitely or until timeout (or success), not a maximum of properties.getMaxAttempts() times.
+    private void callRestEndpoint(Stopwatch stopwatch, TransactionId transactionId) {
+        var startupTimeout = acceptanceTestProperties.getStartupTimeout();
         var properties = acceptanceTestProperties.getRestPollingProperties();
-        RetryBackoffSpec retrySpec = Retry.backoff(Integer.MAX_VALUE, properties.getMinBackoff())
+        var retrySpec = Retry.backoff(Integer.MAX_VALUE, properties.getMinBackoff())
                 .maxBackoff(properties.getMaxBackoff())
                 .filter(properties::shouldRetry);
 
-        String restTransactionId = transactionId.accountId.toString() + "-"
-                + transactionId.validStart.getEpochSecond() + "-" + transactionId.validStart.getNano();
+        var restTransactionId =
+                transactionId.accountId + "-" + transactionId.validStart.getEpochSecond() + "-" + transactionId.validStart.getNano();
 
         String uri = "/transactions/" + restTransactionId;
         webClient.get()
@@ -134,49 +161,5 @@ public class StartupProbe {
                 .doOnError(x -> log.warn("Endpoint {} failed, returning: {}", uri, x.getMessage()))
                 .timeout(startupTimeout.minus(stopwatch.elapsed()))
                 .block();
-
-        // step 4: Query the mirror node gRPC API for a message on the topic created in step 2, until successful or
-        //         time runs out
-        TopicId topicId = transactionReceipt.topicId;
-        CountDownLatch messageLatch = new CountDownLatch(1);
-
-        SubscriptionHandle subscription = null;
-        try {
-            subscription = retryTemplate.execute(x -> new TopicMessageQuery()
-                    .setTopicId(topicId)
-                    .setMaxAttempts(Integer.MAX_VALUE)
-                    .setRetryHandler(t -> true)
-                    .setStartTime(Instant.EPOCH)
-                    .subscribe(client, resp -> {
-                        messageLatch.countDown();
-                    }));
-
-            TransactionResponse secondResponse = retryTemplate.execute(x -> new TopicMessageSubmitTransaction()
-                    .setTopicId(topicId)
-                    .setGrpcDeadline(acceptanceTestProperties.getSdkProperties().getGrpcDeadline())
-                    .setMaxAttempts(Integer.MAX_VALUE)
-                    .setMessage("Hello, HCS!")
-                    .execute(client, startupTimeout.minus(stopwatch.elapsed())));
-            TransactionId secondTransactionId = secondResponse.transactionId;
-
-            retryTemplate.execute(x -> new TransactionReceiptQuery()
-                    .setTransactionId(secondTransactionId)
-                    .setGrpcDeadline(acceptanceTestProperties.getSdkProperties().getGrpcDeadline())
-                    .setMaxAttempts(Integer.MAX_VALUE)
-                    .execute(client, startupTimeout.minus(stopwatch.elapsed())));
-
-            if (messageLatch.await(startupTimeout.minus(stopwatch.elapsed()).toNanos(), TimeUnit.NANOSECONDS)) {
-                log.info("Startup probe successful.");
-                validated = true;
-            } else {
-                throw new TimeoutException("Timer expired while waiting on message latch.");
-            }
-        } finally {
-            // clean up - cancel the subscription from step 4a
-            if (subscription != null) {
-                subscription.unsubscribe();
-            }
-        }
     }
-
 }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
@@ -28,6 +28,7 @@ import javax.validation.constraints.Max;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import lombok.Data;
+import org.hibernate.validator.constraints.time.DurationMin;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
@@ -79,6 +80,8 @@ public class AcceptanceTestProperties {
 
     private boolean retrieveAddressBook = true;
 
+    @DurationMin(seconds = 0L)
+    @NotNull
     private Duration startupTimeout = Duration.ofMinutes(30);
 
     public enum HederaNetwork {


### PR DESCRIPTION
**Description**:

* Add feature to disable startup probe when `startupTimeout` is zero
* Fix `Client` leak in `SDKClient.getNetworkMap`
* Fix crash on startup due to [buggy](https://github.com/hashgraph/hedera-sdk-java/issues/1182) `Client.close()`
* Refactor `StartupProbe` to reduce some duplication

**Related issue(s)**:

Fixes #4677

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
