### PR TITLE
Fix slow monitor startup (0.66)

### DIFF
--- a/charts/hedera-mirror-monitor/values.yaml
+++ b/charts/hedera-mirror-monitor/values.yaml
@@ -102,7 +102,7 @@ livenessProbe:
   httpGet:
     path: /actuator/health/liveness
     port: http
-  initialDelaySeconds: 60
+  initialDelaySeconds: 90
   periodSeconds: 10
   timeoutSeconds: 2
 
@@ -266,7 +266,7 @@ replicas: 1
 
 resources:
   limits:
-    cpu: 300m
+    cpu: 500m
     memory: 768Mi
   requests:
     cpu: 100m


### PR DESCRIPTION
**Description**:

Cherry-pick of #4681 to `release/0.66`.

* Increase liveness probe to 90 seconds to give more time to start
* Increase CPU limit to 0.5 to improve startup time

**Related issue(s)**:

Fixes #4679

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
