### PR TITLE
Fix BalanceReconciliationServiceTest failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The Hedera Mirror Node acts as an archive node and stores historical data for th
 
 ## Overview
 
-Mirror nodes  receive information from the Hedera nodes and can provide value-added services such as APIs, auditing,
+Mirror nodes receive information from the Hedera nodes and can provide value-added services such as APIs, auditing,
 analytics, visibility services, security threat modeling, data monetization services, etc. Mirror nodes can also run
 additional business logic to support applications built using the Hedera network.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The Hedera Mirror Node acts as an archive node and stores historical data for th
 
 ## Overview
 
-Mirror nodes receive information from the Hedera nodes and can provide value-added services such as APIs, auditing,
+Mirror nodes  receive information from the Hedera nodes and can provide value-added services such as APIs, auditing,
 analytics, visibility services, security threat modeling, data monetization services, etc. Mirror nodes can also run
 additional business logic to support applications built using the Hedera network.
 


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR fixes the `BalanceReconciliationServiceTest` failure

- use the injected `meterRegistry` to create the gauge

**Related issue(s)**:

Fixes #4697 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
For some unknown reason, the `status` object from the `meterRegistry` used in the test case is not the one created and kept in `BalanceReconciliationService` and it only happens in CI.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
