### PR TITLE
Rosetta show failed transaction status (0.67)

### DIFF
--- a/hedera-mirror-rosetta/app/persistence/domain/non_fee_transfer.go
+++ b/hedera-mirror-rosetta/app/persistence/domain/non_fee_transfer.go
@@ -25,7 +25,7 @@ const tableNameNonFeeTransfer = "non_fee_transfer"
 type NonFeeTransfer struct {
 	Amount             int64
 	ConsensusTimestamp int64
-	EntityId           EntityId
+	EntityId           *EntityId
 	PayerAccountId     EntityId
 }
 

--- a/hedera-mirror-rosetta/app/persistence/transaction_test.go
+++ b/hedera-mirror-rosetta/app/persistence/transaction_test.go
@@ -693,9 +693,9 @@ func (suite *transactionRepositorySuite) setupDb(createTokenEntity bool) []*type
 			PayerAccountId: firstEntityId},
 	}
 	nonFeeTransfers := []domain.NonFeeTransfer{
-		{Amount: -135, ConsensusTimestamp: consensusTimestamp, EntityId: firstEntityId,
+		{Amount: -135, ConsensusTimestamp: consensusTimestamp, EntityId: &firstEntityId,
 			PayerAccountId: firstEntityId},
-		{Amount: 135, ConsensusTimestamp: consensusTimestamp, EntityId: secondEntityId,
+		{Amount: 135, ConsensusTimestamp: consensusTimestamp, EntityId: &secondEntityId,
 			PayerAccountId: firstEntityId},
 	}
 	addTransaction(dbClient, consensusTimestamp, nil, &nodeEntityId, firstEntityId, 22,
@@ -758,9 +758,9 @@ func (suite *transactionRepositorySuite) setupDb(createTokenEntity bool) []*type
 			PayerAccountId: firstEntityId},
 	}
 	nonFeeTransfers = []domain.NonFeeTransfer{
-		{Amount: -215, ConsensusTimestamp: consensusTimestamp, EntityId: firstEntityId,
+		{Amount: -215, ConsensusTimestamp: consensusTimestamp, EntityId: &firstEntityId,
 			PayerAccountId: firstEntityId},
-		{Amount: 215, ConsensusTimestamp: consensusTimestamp, EntityId: secondEntityId,
+		{Amount: 215, ConsensusTimestamp: consensusTimestamp, EntityId: &secondEntityId,
 			PayerAccountId: firstEntityId},
 	}
 	tokenTransfers := []domain.TokenTransfer{
@@ -997,6 +997,8 @@ func (suite *transactionRepositorySuite) setupDb(createTokenEntity bool) []*type
 				Status: resultSuccess},
 			{AccountId: nodeAccountId, Amount: &types.HbarAmount{Value: 20}, Type: types.OperationTypeFee,
 				Status: resultSuccess},
+			{AccountId: firstAccountId, Amount: &types.HbarAmount{}, Type: types.OperationTypeCryptoTransfer,
+				Status: types.TransactionResults[28]},
 		},
 	}
 
@@ -1010,8 +1012,9 @@ func (suite *transactionRepositorySuite) setupDb(createTokenEntity bool) []*type
 		{Amount: 20, ConsensusTimestamp: consensusTimestamp, EntityId: nodeEntityId, PayerAccountId: firstEntityId},
 	}
 	nonFeeTransfers = []domain.NonFeeTransfer{
-		{Amount: -500, ConsensusTimestamp: consensusTimestamp, EntityId: firstEntityId, PayerAccountId: firstEntityId},
-		{Amount: 500, ConsensusTimestamp: consensusTimestamp, EntityId: newEntityId, PayerAccountId: firstEntityId},
+		{Amount: -500, ConsensusTimestamp: consensusTimestamp, EntityId: &firstEntityId, PayerAccountId: firstEntityId},
+		{Amount: -500, ConsensusTimestamp: consensusTimestamp, PayerAccountId: firstEntityId}, // with nil entity id
+		{Amount: 500, ConsensusTimestamp: consensusTimestamp, EntityId: &newEntityId, PayerAccountId: firstEntityId},
 	}
 	transactionHash = randstr.Bytes(6)
 	addTransaction(dbClient, consensusTimestamp, &newEntityId, &nodeEntityId, firstEntityId, 22, transactionHash,


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR ports the changes to `release/0.67`

- Add a 0-amount hbar transfer with the transaction status for any failed transaction
- Fix bug when reading non fee transfer with a null entity id

**Related issue(s)**:

Relates to #4673

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
