### PR TITLE
Remove rosetta balance offset post services 0.30

### DIFF
--- a/hedera-mirror-rosetta/app/persistence/block.go
+++ b/hedera-mirror-rosetta/app/persistence/block.go
@@ -128,7 +128,7 @@ func (rb *recordBlock) ToBlock(genesisBlock recordBlock) *types.Block {
 // blockRepository struct that has connection to the Database
 type blockRepository struct {
 	dbClient                        interfaces.DbClient
-	firstFixedOffsetTimestampSqlArg sql.NamedArg
+	fixedOffsetTimestampRangeSqlArg sql.NamedArg
 	genesisBlock                    recordBlock
 	once                            sync.Once
 }
@@ -137,7 +137,7 @@ type blockRepository struct {
 func NewBlockRepository(dbClient interfaces.DbClient, network string) interfaces.BlockRepository {
 	return &blockRepository{
 		dbClient:                        dbClient,
-		firstFixedOffsetTimestampSqlArg: getFirstAccountBalanceFileFixedOffsetTimestampSqlNamedArg(network),
+		fixedOffsetTimestampRangeSqlArg: getAccountBalanceFileFixedOffsetTimestampRangeSqlNamedArg(network),
 		genesisBlock:                    recordBlock{ConsensusStart: genesisConsensusStartUnset},
 	}
 }
@@ -259,7 +259,7 @@ func (br *blockRepository) initGenesisRecordFile(ctx context.Context) *rTypes.Er
 	defer cancel()
 
 	var rb recordBlock
-	if err := db.Raw(selectGenesis, br.firstFixedOffsetTimestampSqlArg).First(&rb).Error; err != nil {
+	if err := db.Raw(selectGenesis, br.fixedOffsetTimestampRangeSqlArg).First(&rb).Error; err != nil {
 		return handleDatabaseError(err, hErrors.ErrNodeIsStarting)
 	}
 

--- a/hedera-mirror-rosetta/app/persistence/common.go
+++ b/hedera-mirror-rosetta/app/persistence/common.go
@@ -44,13 +44,14 @@ const (
 )
 
 var nullTimestampRangeSqlNamedArg = sql.Named(fixedOffsetTimestampRangeSqlArgName, pgtype.Int8range{Status: pgtype.Null})
-var firstAccountBalanceFileFixedOffsetTimestamps = map[string]pgtype.Int8range{
+var accountBalanceFileFixedOffsetTimestampRanges = map[string]pgtype.Int8range{
+	// the lower is the first 0.27 account balance file, and the upper is the last 0.29 account balance file
 	mainnet: getInclusiveInt8Range(1658420100626004000, 1666368000880378770),
 	testnet: getInclusiveInt8Range(1656693000269913000, 1665072000124462000),
 }
 
 func getAccountBalanceFileFixedOffsetTimestampRangeSqlNamedArg(network string) sql.NamedArg {
-	if timestampRange, ok := firstAccountBalanceFileFixedOffsetTimestamps[network]; ok {
+	if timestampRange, ok := accountBalanceFileFixedOffsetTimestampRanges[network]; ok {
 		return sql.Named(fixedOffsetTimestampRangeSqlArgName, timestampRange)
 	}
 

--- a/hedera-mirror-rosetta/app/persistence/common_test.go
+++ b/hedera-mirror-rosetta/app/persistence/common_test.go
@@ -24,35 +24,48 @@ import (
 	"database/sql"
 	"testing"
 
+	"github.com/jackc/pgtype"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetFirstAccountBalanceFileFixedOffsetTimestampSqlNamedArg(t *testing.T) {
+func TestGetAccountBalanceFileFixedOffsetTimestampRangeSqlNamedArg(t *testing.T) {
 	tests := []struct {
 		network  string
 		expected sql.NamedArg
 	}{
 		{
-			network:  "mainnet",
-			expected: sql.Named(firstFixedOffsetTimestampSqlArgName, sql.NullInt64{Int64: 1658420100626004000, Valid: true}),
+			network: "mainnet",
+			expected: sql.Named(fixedOffsetTimestampRangeSqlArgName, pgtype.Int8range{
+				Lower:     pgtype.Int8{Int: 1658420100626004000, Status: pgtype.Present},
+				Upper:     pgtype.Int8{Int: 1666368000880378770, Status: pgtype.Present},
+				LowerType: pgtype.Inclusive,
+				UpperType: pgtype.Inclusive,
+				Status:    pgtype.Present,
+			}),
 		},
 		{
-			network:  "testnet",
-			expected: sql.Named(firstFixedOffsetTimestampSqlArgName, sql.NullInt64{Int64: 1656693000269913000, Valid: true}),
+			network: "testnet",
+			expected: sql.Named(fixedOffsetTimestampRangeSqlArgName, pgtype.Int8range{
+				Lower:     pgtype.Int8{Int: 1656693000269913000, Status: pgtype.Present},
+				Upper:     pgtype.Int8{Int: 1665072000124462000, Status: pgtype.Present},
+				LowerType: pgtype.Inclusive,
+				UpperType: pgtype.Inclusive,
+				Status:    pgtype.Present,
+			}),
 		},
 		{
 			network:  "",
-			expected: sql.Named(firstFixedOffsetTimestampSqlArgName, sql.NullInt64{}),
+			expected: sql.Named(fixedOffsetTimestampRangeSqlArgName, pgtype.Int8range{Status: pgtype.Null}),
 		},
 		{
 			network:  "demo",
-			expected: sql.Named(firstFixedOffsetTimestampSqlArgName, sql.NullInt64{}),
+			expected: sql.Named(fixedOffsetTimestampRangeSqlArgName, pgtype.Int8range{Status: pgtype.Null}),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.network, func(t *testing.T) {
-			actual := getFirstAccountBalanceFileFixedOffsetTimestampSqlNamedArg(tt.network)
+			actual := getAccountBalanceFileFixedOffsetTimestampRangeSqlNamedArg(tt.network)
 			assert.Equal(t, tt.expected, actual)
 		})
 	}

--- a/hedera-mirror-rosetta/app/persistence/transaction_test.go
+++ b/hedera-mirror-rosetta/app/persistence/transaction_test.go
@@ -354,7 +354,7 @@ func (suite *transactionRepositorySuite) TestFindBetweenHavingDisappearingTokenT
 }
 
 func (suite *transactionRepositorySuite) TestFindBetweenHavingDisappearingTokenTransferForMainnetWithFixedOffset() {
-	timestamp := firstAccountBalanceFileFixedOffsetTimestamps[mainnet]
+	timestamp := firstAccountBalanceFileFixedOffsetTimestamps[mainnet].Lower.Int
 	suite.testFindBetweenHavingDisappearingTokenTransfer(timestamp, mainnet, true)
 }
 

--- a/hedera-mirror-rosetta/app/persistence/transaction_test.go
+++ b/hedera-mirror-rosetta/app/persistence/transaction_test.go
@@ -354,7 +354,7 @@ func (suite *transactionRepositorySuite) TestFindBetweenHavingDisappearingTokenT
 }
 
 func (suite *transactionRepositorySuite) TestFindBetweenHavingDisappearingTokenTransferForMainnetWithFixedOffset() {
-	timestamp := firstAccountBalanceFileFixedOffsetTimestamps[mainnet].Lower.Int
+	timestamp := accountBalanceFileFixedOffsetTimestampRanges[mainnet].Lower.Int
 	suite.testFindBetweenHavingDisappearingTokenTransfer(timestamp, mainnet, true)
 }
 


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

This PR limits the rosetta balance offset workaround to the matching HAPI versions

- only apply the fixed balance offset for applicable account balance files 

**Related issue(s)**:

Relates to #4660 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
