### PR TITLE
Fix cluster health check

### DIFF
--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/ClusterHealthIndicator.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/ClusterHealthIndicator.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.monitor;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -72,6 +72,6 @@ public class ClusterHealthIndicator implements ReactiveHealthIndicator {
                 .reduce(0.0, (cur, next) -> cur + next)
                 .filter(sum -> sum > 0)
                 .flatMap(n -> UP)
-                .switchIfEmpty(DOWN);
+                .switchIfEmpty(UNKNOWN);
     }
 }

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/ClusterHealthIndicatorTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/ClusterHealthIndicatorTest.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.monitor;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -70,7 +70,7 @@ class ClusterHealthIndicatorTest {
     void subscribingInactive() {
         when(transactionGenerator.scenarios()).thenReturn(Flux.just(publishScenario(1.0)));
         when(mirrorSubscriber.getSubscriptions()).thenReturn(Flux.just(subscribeScenario(0.0)));
-        assertThat(clusterHealthIndicator.health().block()).extracting(Health::getStatus).isEqualTo(Status.DOWN);
+        assertThat(clusterHealthIndicator.health().block()).extracting(Health::getStatus).isEqualTo(Status.UNKNOWN);
     }
 
     @Test


### PR DESCRIPTION
**Description**:

* Fix cluster health check by return `UNKNOWN` when subscription is inactive

**Related issue(s)**:

Fixes #4752

**Notes for reviewer**:

`UNKNOWN` is still mapped to `200` by Spring like `UP`, but provides some indication there's trouble

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
