### PR TITLE
Fix importer issue when generating EVM address (0.67)

### DIFF
--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/util/UtilityTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/util/UtilityTest.java
@@ -50,11 +50,14 @@ public class UtilityTest {
     void aliasToEvmAddress() {
         byte[] aliasEd25519 = Key.newBuilder().setEd25519(ByteString.copyFromUtf8("ab")).build().toByteArray();
         byte[] aliasEcdsa2 = Hex.decode("3a2102ff806fecbd31b4c377293cba8d2b78725965a4990e0ff1b1b29a1d2c61402310");
+        byte[] aliasUncompressedEcdsa = Hex.decode(
+                "3a374349514637575a4f55475132415336334d504757573633484750484b584b5442344f3643505a334b3437374133354b584257525a4e4941");
         byte[] evmAddress2 = Hex.decode("efa0d905af20199aa03aca71cfa5f7647f29f439");
         byte[] invalidBytes = new byte[] {'a', 'b'};
 
         assertThat(Utility.aliasToEvmAddress(ALIAS_ECDSA_SECP256K1)).isEqualTo(EVM_ADDRESS);
         assertThat(Utility.aliasToEvmAddress(aliasEcdsa2)).isEqualTo(evmAddress2);
+        assertThat(Utility.aliasToEvmAddress(aliasUncompressedEcdsa)).isNull();
         assertThat(Utility.aliasToEvmAddress(aliasEd25519)).isNull();
         assertThat(Utility.aliasToEvmAddress(null)).isNull();
         assertThat(Utility.aliasToEvmAddress(new byte[] {})).isNull();


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR ports the fix to `release/0.67`

- Only generate EVM address for 33-byte compressed ECDSA public key

**Related issue(s)**:

Relates to #4750

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
