### PR TITLE
Rosetta resolve account with invalid alias to 0.0.X format

### DIFF
--- a/hedera-mirror-rosetta/app/persistence/account.go
+++ b/hedera-mirror-rosetta/app/persistence/account.go
@@ -23,6 +23,7 @@ package persistence
 import (
 	"context"
 	"database/sql"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -202,11 +203,13 @@ func (ar *accountRepository) GetAccountAlias(ctx context.Context, accountId type
 		return accountId, nil
 	}
 
-	if accountAlias, err := types.NewAccountIdFromEntity(entity); err == nil {
-		return accountAlias, nil
+	accountAlias, err := types.NewAccountIdFromEntity(entity)
+	if err != nil {
+		log.Warnf("Failed to create AccountId from alias '0x%s': %v", hex.EncodeToString(entity.Alias), err)
+		return accountId, nil
 	}
 
-	return zero, hErrors.ErrInternalServerError
+	return accountAlias, nil
 }
 
 func (ar *accountRepository) GetAccountId(ctx context.Context, accountId types.AccountId) (

--- a/hedera-mirror-rosetta/app/persistence/account_test.go
+++ b/hedera-mirror-rosetta/app/persistence/account_test.go
@@ -94,7 +94,7 @@ var (
 	account4Alias = hexutil.MustDecode("0x12205a081255a92b7c262bc2ea3ab7114b8a815345b3cc40f800b2b40914afecc44e")
 	account5Alias = randstr.Bytes(48)
 	// alias with invalid public key, the Key message is valid, but it's formed from an invalid 16-byte ED25519 pub key
-	account6Alias = hexutil.MustDecode("0x1210b7114b8a815345b3cc40f800b2b40914afecc44e")
+	account6Alias = hexutil.MustDecode("0x1210815345b3cc40f800b2b40914afecc44e")
 )
 
 // run the suite
@@ -763,6 +763,7 @@ func (suite *accountRepositoryWithAliasSuite) SetupSuite() {
 	suite.account3Alias = account3Alias
 	suite.account4Alias = account4Alias
 	suite.account5Alias = account5Alias
+	suite.account6Alias = account6Alias
 }
 
 func (suite *accountRepositoryWithAliasSuite) SetupTest() {

--- a/hedera-mirror-rosetta/app/persistence/account_test.go
+++ b/hedera-mirror-rosetta/app/persistence/account_test.go
@@ -44,6 +44,7 @@ const (
 	account3
 	account4
 	account5
+	account6
 )
 
 const (
@@ -72,6 +73,7 @@ const (
 	account3CreatedTimestamp = consensusTimestamp + 100
 	account4CreatedTimestamp = consensusTimestamp + 110
 	account5CreatedTimestamp = consensusTimestamp + 120
+	account6CreatedTimestamp = consensusTimestamp + 130
 )
 
 var (
@@ -91,6 +93,8 @@ var (
 	account3Alias = hexutil.MustDecode("0x3a2103d9a822b91df7850274273a338c152e7bcfa2036b24cd9e3b29d07efd949b387a")
 	account4Alias = hexutil.MustDecode("0x12205a081255a92b7c262bc2ea3ab7114b8a815345b3cc40f800b2b40914afecc44e")
 	account5Alias = randstr.Bytes(48)
+	// alias with invalid public key, the Key message is valid, but it's formed from an invalid 16-byte ED25519 pub key
+	account6Alias = hexutil.MustDecode("0x1210b7114b8a815345b3cc40f800b2b40914afecc44e")
 )
 
 // run the suite
@@ -107,6 +111,7 @@ type accountRepositorySuite struct {
 	account3Alias   []byte
 	account4Alias   []byte
 	account5Alias   []byte
+	account6Alias   []byte
 }
 
 func (suite *accountRepositorySuite) SetupSuite() {
@@ -337,6 +342,9 @@ func (suite *accountRepositorySuite) SetupTest() {
 		Persist()
 	tdomain.NewEntityBuilder(dbClient, account5, account5CreatedTimestamp, domain.EntityTypeAccount).
 		Alias(suite.account5Alias).
+		Persist()
+	tdomain.NewEntityBuilder(dbClient, account6, account6CreatedTimestamp, domain.EntityTypeAccount).
+		Alias(suite.account6Alias).
 		Persist()
 }
 
@@ -797,12 +805,26 @@ func (suite *accountRepositoryWithAliasSuite) TestGetAccountAlias() {
 	}
 }
 
-func (suite *accountRepositoryWithAliasSuite) TestGetAccountAliasThrowWhenInvalidAlias() {
-	accountId := types.NewAccountIdFromEntityId(domain.MustDecodeEntityId(account5))
+func (suite *accountRepositoryWithAliasSuite) TestGetAccountAliasWithInvalidAlias() {
+	tests := []struct {
+		encodedId int64
+		expected  string
+	}{
+		{encodedId: account5, expected: fmt.Sprintf("0.0.%d", account5)},
+		{encodedId: account6, expected: fmt.Sprintf("0.0.%d", account6)},
+	}
+
 	repo := NewAccountRepository(dbClient, "")
-	actual, err := repo.GetAccountAlias(defaultContext, accountId)
-	assert.NotNil(suite.T(), err)
-	assert.Equal(suite.T(), types.AccountId{}, actual)
+
+	for _, tt := range tests {
+		name := fmt.Sprintf("%d", tt.encodedId)
+		suite.T().Run(name, func(t *testing.T) {
+			accountId := types.NewAccountIdFromEntityId(domain.MustDecodeEntityId(tt.encodedId))
+			actual, err := repo.GetAccountAlias(defaultContext, accountId)
+			assert.Nil(t, err)
+			assert.Equal(t, tt.expected, actual.String())
+		})
+	}
 }
 
 func (suite *accountRepositoryWithAliasSuite) TestGetAccountId() {


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR fixes the issue `/block` returns 500 if there's account with invalid alias

- Resolve account with invalid alias to its `0.0.X` format address

**Related issue(s)**:

Fixes #4765 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
