### PR TITLE
Rosetta resolve account with invalid alias to 0.0.X format (0.67)

### DIFF
--- a/hedera-mirror-rosetta/app/persistence/account.go
+++ b/hedera-mirror-rosetta/app/persistence/account.go
@@ -23,6 +23,7 @@ package persistence
 import (
 	"context"
 	"database/sql"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -202,11 +203,13 @@ func (ar *accountRepository) GetAccountAlias(ctx context.Context, accountId type
 		return accountId, nil
 	}
 
-	if accountAlias, err := types.NewAccountIdFromEntity(entity); err == nil {
-		return accountAlias, nil
+	accountAlias, err := types.NewAccountIdFromEntity(entity)
+	if err != nil {
+		log.Warnf("Failed to create AccountId from alias '0x%s': %v", hex.EncodeToString(entity.Alias), err)
+		return accountId, nil
 	}
 
-	return zero, hErrors.ErrInternalServerError
+	return accountAlias, nil
 }
 
 func (ar *accountRepository) GetAccountId(ctx context.Context, accountId types.AccountId) (


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR ports the fix to `release/0.67`

- Resolve account with invalid alias to its 0.0.X format address

**Related issue(s)**:

Relates to #4765

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
