### PR TITLE
Remove rosetta balance offset post services 0.30 (0.66)

### DIFF
--- a/hedera-mirror-rosetta/app/persistence/account.go
+++ b/hedera-mirror-rosetta/app/persistence/account.go
@@ -33,7 +33,6 @@ import (
 	hErrors "github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/app/errors"
 	"github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/app/interfaces"
 	"github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/app/persistence/domain"
-	"github.com/jackc/pgtype"
 	log "github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 )
@@ -100,7 +99,8 @@ const (
                                       from account_balance_file,
                                         lateral (
                                           select
-                                            case when consensus_timestamp >= @first_fixed_offset_timestamp then 53
+                                            case when consensus_timestamp <@ @fixed_offset_timestamp_range ::int8range
+                                                   then 53
                                                  else 0
                                             end value
                                         ) fixed_offset
@@ -172,14 +172,14 @@ type tokenAssociation struct {
 // accountRepository struct that has connection to the Database
 type accountRepository struct {
 	dbClient                        interfaces.DbClient
-	firstFixedOffsetTimestampSqlArg sql.NamedArg
+	fixedOffsetTimestampRangeSqlArg sql.NamedArg
 }
 
 // NewAccountRepository creates an instance of a accountRepository struct
 func NewAccountRepository(dbClient interfaces.DbClient, network string) interfaces.AccountRepository {
 	return &accountRepository{
 		dbClient:                        dbClient,
-		firstFixedOffsetTimestampSqlArg: getFirstAccountBalanceFileFixedOffsetTimestampSqlNamedArg(network),
+		fixedOffsetTimestampRangeSqlArg: getAccountBalanceFileFixedOffsetTimestampRangeSqlNamedArg(network),
 	}
 }
 
@@ -370,7 +370,7 @@ func (ar *accountRepository) getLatestBalanceSnapshot(ctx context.Context, accou
 		latestBalanceBeforeConsensus,
 		sql.Named("account_id", accountId),
 		sql.Named("timestamp", timestamp),
-		ar.firstFixedOffsetTimestampSqlArg,
+		ar.fixedOffsetTimestampRangeSqlArg,
 	).First(cb).Error; err != nil {
 		log.Errorf(
 			databaseErrorFormat,
@@ -419,7 +419,7 @@ func (ar *accountRepository) getBalanceChange(ctx context.Context, accountId, co
 		sql.Named("start", consensusStart),
 		sql.Named("end", consensusEnd),
 		sql.Named("end_range", getInclusiveInt8Range(consensusEnd, consensusEnd)),
-		ar.firstFixedOffsetTimestampSqlArg,
+		ar.fixedOffsetTimestampRangeSqlArg,
 	).First(change).Error; err != nil {
 		log.Errorf(
 			databaseErrorFormat,
@@ -471,7 +471,7 @@ func (ar *accountRepository) getNftBalance(
 		sql.Named("account_id", accountId),
 		sql.Named("start", consensusStart),
 		sql.Named("end", consensusEnd),
-		ar.firstFixedOffsetTimestampSqlArg,
+		ar.fixedOffsetTimestampRangeSqlArg,
 	).Scan(&nftTransfers).Error; err != nil {
 		log.Errorf(
 			databaseErrorFormat,
@@ -549,14 +549,4 @@ func getUpdatedTokenAmounts(
 	}
 
 	return amounts
-}
-
-func getInclusiveInt8Range(lower, upper int64) pgtype.Int8range {
-	return pgtype.Int8range{
-		Lower:     pgtype.Int8{Int: lower, Status: pgtype.Present},
-		Upper:     pgtype.Int8{Int: upper, Status: pgtype.Present},
-		LowerType: pgtype.Inclusive,
-		UpperType: pgtype.Inclusive,
-		Status:    pgtype.Present,
-	}
 }

--- a/hedera-mirror-rosetta/app/persistence/block.go
+++ b/hedera-mirror-rosetta/app/persistence/block.go
@@ -128,7 +128,7 @@ func (rb *recordBlock) ToBlock(genesisBlock recordBlock) *types.Block {
 // blockRepository struct that has connection to the Database
 type blockRepository struct {
 	dbClient                        interfaces.DbClient
-	firstFixedOffsetTimestampSqlArg sql.NamedArg
+	fixedOffsetTimestampRangeSqlArg sql.NamedArg
 	genesisBlock                    recordBlock
 	once                            sync.Once
 }
@@ -137,7 +137,7 @@ type blockRepository struct {
 func NewBlockRepository(dbClient interfaces.DbClient, network string) interfaces.BlockRepository {
 	return &blockRepository{
 		dbClient:                        dbClient,
-		firstFixedOffsetTimestampSqlArg: getFirstAccountBalanceFileFixedOffsetTimestampSqlNamedArg(network),
+		fixedOffsetTimestampRangeSqlArg: getAccountBalanceFileFixedOffsetTimestampRangeSqlNamedArg(network),
 		genesisBlock:                    recordBlock{ConsensusStart: genesisConsensusStartUnset},
 	}
 }
@@ -259,7 +259,7 @@ func (br *blockRepository) initGenesisRecordFile(ctx context.Context) *rTypes.Er
 	defer cancel()
 
 	var rb recordBlock
-	if err := db.Raw(selectGenesis, br.firstFixedOffsetTimestampSqlArg).First(&rb).Error; err != nil {
+	if err := db.Raw(selectGenesis, br.fixedOffsetTimestampRangeSqlArg).First(&rb).Error; err != nil {
 		return handleDatabaseError(err, hErrors.ErrNodeIsStarting)
 	}
 

--- a/hedera-mirror-rosetta/app/persistence/common.go
+++ b/hedera-mirror-rosetta/app/persistence/common.go
@@ -20,15 +20,19 @@
 
 package persistence
 
-import "database/sql"
+import (
+	"database/sql"
+
+	"github.com/jackc/pgtype"
+)
 
 const (
-	firstFixedOffsetTimestampSqlArgName = "first_fixed_offset_timestamp"
+	fixedOffsetTimestampRangeSqlArgName = "fixed_offset_timestamp_range"
 	genesisTimestampQuery               = `select consensus_timestamp + time_offset + fixed_offset.value as timestamp
                              from account_balance_file,
                                lateral (
                                  select
-                                   case when consensus_timestamp >= @first_fixed_offset_timestamp then 53
+                                   case when consensus_timestamp <@ @fixed_offset_timestamp_range ::int8range then 53
                                         else 0
                                    end value
                                ) fixed_offset
@@ -39,17 +43,27 @@ const (
 	testnet             = "testnet"
 )
 
-var firstAccountBalanceFileFixedOffsetTimestamps = map[string]int64{
-	mainnet: 1658420100626004000,
-	testnet: 1656693000269913000,
+var nullTimestampRangeSqlNamedArg = sql.Named(fixedOffsetTimestampRangeSqlArgName, pgtype.Int8range{Status: pgtype.Null})
+var accountBalanceFileFixedOffsetTimestampRanges = map[string]pgtype.Int8range{
+	// the lower is the first 0.27 account balance file, and the upper is the last 0.29 account balance file
+	mainnet: getInclusiveInt8Range(1658420100626004000, 1666368000880378770),
+	testnet: getInclusiveInt8Range(1656693000269913000, 1665072000124462000),
 }
 
-func getFirstAccountBalanceFileFixedOffsetTimestampSqlNamedArg(network string) sql.NamedArg {
-	nullInt64 := sql.NullInt64{}
-	if timestamp, ok := firstAccountBalanceFileFixedOffsetTimestamps[network]; ok {
-		nullInt64.Int64 = timestamp
-		nullInt64.Valid = true
+func getAccountBalanceFileFixedOffsetTimestampRangeSqlNamedArg(network string) sql.NamedArg {
+	if timestampRange, ok := accountBalanceFileFixedOffsetTimestampRanges[network]; ok {
+		return sql.Named(fixedOffsetTimestampRangeSqlArgName, timestampRange)
 	}
 
-	return sql.Named(firstFixedOffsetTimestampSqlArgName, nullInt64)
+	return nullTimestampRangeSqlNamedArg
+}
+
+func getInclusiveInt8Range(lower, upper int64) pgtype.Int8range {
+	return pgtype.Int8range{
+		Lower:     pgtype.Int8{Int: lower, Status: pgtype.Present},
+		Upper:     pgtype.Int8{Int: upper, Status: pgtype.Present},
+		LowerType: pgtype.Inclusive,
+		UpperType: pgtype.Inclusive,
+		Status:    pgtype.Present,
+	}
 }

--- a/hedera-mirror-rosetta/app/persistence/common_test.go
+++ b/hedera-mirror-rosetta/app/persistence/common_test.go
@@ -24,35 +24,48 @@ import (
 	"database/sql"
 	"testing"
 
+	"github.com/jackc/pgtype"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetFirstAccountBalanceFileFixedOffsetTimestampSqlNamedArg(t *testing.T) {
+func TestGetAccountBalanceFileFixedOffsetTimestampRangeSqlNamedArg(t *testing.T) {
 	tests := []struct {
 		network  string
 		expected sql.NamedArg
 	}{
 		{
-			network:  "mainnet",
-			expected: sql.Named(firstFixedOffsetTimestampSqlArgName, sql.NullInt64{Int64: 1658420100626004000, Valid: true}),
+			network: "mainnet",
+			expected: sql.Named(fixedOffsetTimestampRangeSqlArgName, pgtype.Int8range{
+				Lower:     pgtype.Int8{Int: 1658420100626004000, Status: pgtype.Present},
+				Upper:     pgtype.Int8{Int: 1666368000880378770, Status: pgtype.Present},
+				LowerType: pgtype.Inclusive,
+				UpperType: pgtype.Inclusive,
+				Status:    pgtype.Present,
+			}),
 		},
 		{
-			network:  "testnet",
-			expected: sql.Named(firstFixedOffsetTimestampSqlArgName, sql.NullInt64{Int64: 1656693000269913000, Valid: true}),
+			network: "testnet",
+			expected: sql.Named(fixedOffsetTimestampRangeSqlArgName, pgtype.Int8range{
+				Lower:     pgtype.Int8{Int: 1656693000269913000, Status: pgtype.Present},
+				Upper:     pgtype.Int8{Int: 1665072000124462000, Status: pgtype.Present},
+				LowerType: pgtype.Inclusive,
+				UpperType: pgtype.Inclusive,
+				Status:    pgtype.Present,
+			}),
 		},
 		{
 			network:  "",
-			expected: sql.Named(firstFixedOffsetTimestampSqlArgName, sql.NullInt64{}),
+			expected: sql.Named(fixedOffsetTimestampRangeSqlArgName, pgtype.Int8range{Status: pgtype.Null}),
 		},
 		{
 			network:  "demo",
-			expected: sql.Named(firstFixedOffsetTimestampSqlArgName, sql.NullInt64{}),
+			expected: sql.Named(fixedOffsetTimestampRangeSqlArgName, pgtype.Int8range{Status: pgtype.Null}),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.network, func(t *testing.T) {
-			actual := getFirstAccountBalanceFileFixedOffsetTimestampSqlNamedArg(tt.network)
+			actual := getAccountBalanceFileFixedOffsetTimestampRangeSqlNamedArg(tt.network)
 			assert.Equal(t, tt.expected, actual)
 		})
 	}

--- a/hedera-mirror-rosetta/app/persistence/transaction_test.go
+++ b/hedera-mirror-rosetta/app/persistence/transaction_test.go
@@ -354,7 +354,7 @@ func (suite *transactionRepositorySuite) TestFindBetweenHavingDisappearingTokenT
 }
 
 func (suite *transactionRepositorySuite) TestFindBetweenHavingDisappearingTokenTransferForMainnetWithFixedOffset() {
-	timestamp := firstAccountBalanceFileFixedOffsetTimestamps[mainnet]
+	timestamp := accountBalanceFileFixedOffsetTimestampRanges[mainnet].Lower.Int
 	suite.testFindBetweenHavingDisappearingTokenTransfer(timestamp, mainnet, true)
 }
 


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR ports the changes to `release/0.66`

- only apply the fixed balance offset for applicable account balance files

**Related issue(s)**:

Relates to #4660

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
