### PR TITLE
Improve alias to EVM address conversion (0.67)

### DIFF
--- a/hedera-mirror-importer/pom.xml
+++ b/hedera-mirror-importer/pom.xml
@@ -18,10 +18,12 @@
 
     <properties>
         <awaitility.version>4.2.0</awaitility.version>
+        <besu-secp256k1.version>0.6.1</besu-secp256k1.version>
         <bouncycastle.version>1.71</bouncycastle.version>
         <commons-beanutils.version>1.9.4</commons-beanutils.version>
         <commons-compress.version>1.21</commons-compress.version>
         <commons-io.version>2.11.0</commons-io.version>
+        <jna.version>5.12.1</jna.version>
         <s3proxy.version>2.0.0</s3proxy.version>
         <sql-formatter.version>2.0.3</sql-formatter.version>
         <testcontainers.version>1.17.5</testcontainers.version>
@@ -87,6 +89,11 @@
             <version>${javax.version}</version>
         </dependency>
         <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna</artifactId>
+            <version>${jna.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
             <version>${commons-compress.version}</version>
@@ -99,6 +106,11 @@
         <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hyperledger.besu</groupId>
+            <artifactId>secp256k1</artifactId>
+            <version>${besu-secp256k1.version}</version>
         </dependency>
         <dependency>
             <groupId>org.msgpack</groupId>

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/util/Utility.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/util/Utility.java
@@ -20,6 +20,9 @@ package com.hedera.mirror.importer.util;
  * ‍
  */
 
+import static org.hyperledger.besu.nativelib.secp256k1.LibSecp256k1.CONTEXT;
+import static org.hyperledger.besu.nativelib.secp256k1.LibSecp256k1.SECP256K1_EC_UNCOMPRESSED;
+
 import com.google.common.base.CaseFormat;
 import com.google.common.collect.Iterables;
 import com.google.protobuf.ByteString;
@@ -30,6 +33,8 @@ import com.hederahashgraph.api.proto.java.ContractLoginfo;
 import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TransactionID;
+import com.sun.jna.ptr.LongByReference;
+import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -42,9 +47,7 @@ import lombok.extern.log4j.Log4j2;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.lang3.StringUtils;
 import org.bouncycastle.jcajce.provider.digest.Keccak;
-import org.bouncycastle.math.ec.ECCurve;
-import org.bouncycastle.math.ec.ECPoint;
-import org.bouncycastle.math.ec.custom.sec.SecP256K1Curve;
+import org.hyperledger.besu.nativelib.secp256k1.LibSecp256k1;
 
 import com.hedera.mirror.common.util.DomainUtils;
 import com.hedera.mirror.importer.exception.ParserException;
@@ -56,7 +59,6 @@ public class Utility {
     public static final Instant MAX_INSTANT_LONG = Instant.ofEpochSecond(0, Long.MAX_VALUE);
 
     private static final int ECDSA_SECP256K1_COMPRESSED_KEY_LENGTH = 33;
-    private static final ECCurve SECP256K1_CURVE = new SecP256K1Curve();
 
     /**
      * Converts an ECDSA secp256k1 alias to a 20 byte EVM address by taking the keccak hash of it. Logic copied from
@@ -71,25 +73,18 @@ public class Utility {
                 return null;
             }
 
+            byte[] evmAddress = null;
             var key = Key.parseFrom(alias);
-
-            if (key.getKeyCase() == Key.KeyCase.ECDSA_SECP256K1) {
-                var rawCompressedKey = DomainUtils.toBytes(key.getECDSASecp256K1());
-                if (rawCompressedKey.length != ECDSA_SECP256K1_COMPRESSED_KEY_LENGTH) {
-                    log.warn("Skipping generating evm address for non-compressed {}-byte ECDSA key",
-                            rawCompressedKey.length);
-                    return null;
+            if (key.getKeyCase() == Key.KeyCase.ECDSA_SECP256K1 &&
+                    key.getECDSASecp256K1().size() == ECDSA_SECP256K1_COMPRESSED_KEY_LENGTH) {
+                byte[] rawCompressedKey = DomainUtils.toBytes(key.getECDSASecp256K1());
+                evmAddress = recoverAddressFromPubKey(rawCompressedKey);
+                if (evmAddress == null) {
+                    log.warn("Unable to recover EVM address from {}", Hex.encodeHexString(rawCompressedKey));
                 }
-
-                ECPoint ecPoint = SECP256K1_CURVE.decodePoint(rawCompressedKey);
-                byte[] uncompressedKeyDer = ecPoint.getEncoded(false);
-                byte[] uncompressedKeyRaw = new byte[64];
-                System.arraycopy(uncompressedKeyDer, 1, uncompressedKeyRaw, 0, 64);
-                byte[] hashedKey = new Keccak.Digest256().digest(uncompressedKeyRaw);
-                return Arrays.copyOfRange(hashedKey, 12, 32);
             }
 
-            return null;
+            return evmAddress;
         } catch (Exception e) {
             var aliasHex = Hex.encodeHexString(alias);
             throw new ParserException("Unable to decode alias to EVM address: " + aliasHex, e);
@@ -184,5 +179,32 @@ public class Utility {
             return text;
         }
         return CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, text);
+    }
+
+    // This method is copied from hedera-services EthTxSigs::recoverAddressFromPubKey and should be kept in sync
+    private static byte[] recoverAddressFromPubKey(byte[] pubKeyBytes) {
+        LibSecp256k1.secp256k1_pubkey pubKey = new LibSecp256k1.secp256k1_pubkey();
+        var parseResult = LibSecp256k1.secp256k1_ec_pubkey_parse(CONTEXT, pubKey, pubKeyBytes, pubKeyBytes.length);
+        if (parseResult == 1) {
+            return recoverAddressFromPubKey(pubKey);
+        } else {
+            return null;
+        }
+    }
+
+    // This method is copied from hedera-services EthTxSigs::recoverAddressFromPubKey and should be kept in sync
+    private static byte[] recoverAddressFromPubKey(LibSecp256k1.secp256k1_pubkey pubKey) {
+        final ByteBuffer recoveredFullKey = ByteBuffer.allocate(65);
+        final LongByReference fullKeySize = new LongByReference(recoveredFullKey.limit());
+        LibSecp256k1.secp256k1_ec_pubkey_serialize(CONTEXT, recoveredFullKey, fullKeySize, pubKey,
+                SECP256K1_EC_UNCOMPRESSED);
+
+        recoveredFullKey.get(); // read and discard - recoveryId is not part of the account hash
+        var preHash = new byte[64];
+        recoveredFullKey.get(preHash, 0, 64);
+        var keyHash = new Keccak.Digest256().digest(preHash);
+        var address = new byte[20];
+        System.arraycopy(keyHash, 12, address, 0, 20);
+        return address;
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/util/UtilityTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/util/UtilityTest.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
+import com.hedera.mirror.importer.TestUtils;
 import com.hedera.mirror.importer.exception.ParserException;
 
 public class UtilityTest {
@@ -50,6 +51,10 @@ public class UtilityTest {
     void aliasToEvmAddress() {
         byte[] aliasEd25519 = Key.newBuilder().setEd25519(ByteString.copyFromUtf8("ab")).build().toByteArray();
         byte[] aliasEcdsa2 = Hex.decode("3a2102ff806fecbd31b4c377293cba8d2b78725965a4990e0ff1b1b29a1d2c61402310");
+        byte[] aliasInvalidEcdsa = Key.newBuilder()
+                .setECDSASecp256K1(ByteString.copyFrom(TestUtils.generateRandomByteArray(33)))
+                .build()
+                .toByteArray();
         byte[] aliasUncompressedEcdsa = Hex.decode(
                 "3a374349514637575a4f55475132415336334d504757573633484750484b584b5442344f3643505a334b3437374133354b584257525a4e4941");
         byte[] evmAddress2 = Hex.decode("efa0d905af20199aa03aca71cfa5f7647f29f439");
@@ -57,6 +62,7 @@ public class UtilityTest {
 
         assertThat(Utility.aliasToEvmAddress(ALIAS_ECDSA_SECP256K1)).isEqualTo(EVM_ADDRESS);
         assertThat(Utility.aliasToEvmAddress(aliasEcdsa2)).isEqualTo(evmAddress2);
+        assertThat(Utility.aliasToEvmAddress(aliasInvalidEcdsa)).isNull();
         assertThat(Utility.aliasToEvmAddress(aliasUncompressedEcdsa)).isNull();
         assertThat(Utility.aliasToEvmAddress(aliasEd25519)).isNull();
         assertThat(Utility.aliasToEvmAddress(null)).isNull();


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR ports the changes to `release/0.67`

- use the same logic in services to recover EVM address from proper ECDSASecp256k1 public key

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
