### PR TITLE
Update OS packages in image

### DIFF
--- a/buildSrc/src/main/kotlin/docker-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/docker-conventions.gradle.kts
@@ -35,6 +35,7 @@ val dockerBuild = tasks.register<DockerBuildImage>("dockerBuild") {
     images.add("$dockerRegistry/${project.name}:$dockerTag")
     images.add("$dockerRegistry/${project.name}:${project.version}")
     inputDir.set(file("$projectDir"))
+    pull.set(true)
 }
 
 tasks.register<DockerPushImage>("dockerPush") {

--- a/charts/hedera-mirror/Chart.yaml
+++ b/charts/hedera-mirror/Chart.yaml
@@ -22,11 +22,11 @@ dependencies:
     condition: postgresql.enabled
     name: postgresql-ha
     repository: https://charts.bitnami.com/bitnami
-    version: 9.4.1
+    version: 9.4.11
   - condition: redis.enabled
     name: redis
     repository: https://charts.bitnami.com/bitnami
-    version: 17.1.3
+    version: 17.3.7
   - alias: rest
     condition: rest.enabled
     name: hedera-mirror-rest

--- a/hedera-mirror-grpc/Dockerfile
+++ b/hedera-mirror-grpc/Dockerfile
@@ -7,14 +7,17 @@ FROM eclipse-temurin:17.0.4.1_1-jre
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80"
 EXPOSE 5600
 HEALTHCHECK --interval=10s --retries=3 --start-period=50s --timeout=2s CMD curl -f http://localhost:8081/actuator/health/liveness
-USER 1000:1000
 WORKDIR /app
 
 # Copy artifacts
-COPY --from=builder /app/dependencies/ ./
-COPY --from=builder /app/snapshot-dependencies/ ./
+COPY --chown=1000:1000 --from=builder /app/dependencies/ ./
+COPY --chown=1000:1000 --from=builder /app/snapshot-dependencies/ ./
 RUN true  # Workaround https://github.com/moby/moby/issues/37965
-COPY --from=builder /app/spring-boot-loader/ ./
-COPY --from=builder /app/application/ ./
+COPY --chown=1000:1000 --from=builder /app/spring-boot-loader/ ./
+COPY --chown=1000:1000 --from=builder /app/application/ ./
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*    # install OS updates
+USER 1000:1000
 
 ENTRYPOINT ["java", "org.springframework.boot.loader.JarLauncher"]

--- a/hedera-mirror-importer/Dockerfile
+++ b/hedera-mirror-importer/Dockerfile
@@ -6,14 +6,18 @@ RUN java -Djarmode=layertools -jar *.jar extract
 FROM eclipse-temurin:17.0.4.1_1-jre
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80"
 HEALTHCHECK --interval=30s --retries=3 --start-period=60s --timeout=2s CMD curl -f http://localhost:8080/actuator/health/liveness
-USER 1000:1000
 WORKDIR /app
 
 # Copy artifacts
-COPY --from=builder /app/dependencies/ ./
-COPY --from=builder /app/snapshot-dependencies/ ./
+COPY --chown=1000:1000 --from=builder /app/dependencies/ ./
+COPY --chown=1000:1000 --from=builder /app/snapshot-dependencies/ ./
 RUN true  # Workaround https://github.com/moby/moby/issues/37965
-COPY --from=builder /app/spring-boot-loader/ ./
-COPY --from=builder /app/application/ ./
+COPY --chown=1000:1000 --from=builder /app/spring-boot-loader/ ./
+# install OS updates
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+COPY --chown=1000:1000 --from=builder /app/application/ ./
+USER 1000:1000
 
 ENTRYPOINT ["java", "org.springframework.boot.loader.JarLauncher"]

--- a/hedera-mirror-importer/Dockerfile
+++ b/hedera-mirror-importer/Dockerfile
@@ -13,11 +13,10 @@ COPY --chown=1000:1000 --from=builder /app/dependencies/ ./
 COPY --chown=1000:1000 --from=builder /app/snapshot-dependencies/ ./
 RUN true  # Workaround https://github.com/moby/moby/issues/37965
 COPY --chown=1000:1000 --from=builder /app/spring-boot-loader/ ./
-# install OS updates
+COPY --chown=1000:1000 --from=builder /app/application/ ./
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/*
-COPY --chown=1000:1000 --from=builder /app/application/ ./
+    && rm -rf /var/lib/apt/lists/*    # install OS updates
 USER 1000:1000
 
 ENTRYPOINT ["java", "org.springframework.boot.loader.JarLauncher"]

--- a/hedera-mirror-monitor/Dockerfile
+++ b/hedera-mirror-monitor/Dockerfile
@@ -17,7 +17,7 @@ COPY --chown=1000:1000 --from=builder /app/spring-boot-loader/ ./
 COPY --chown=1000:1000 --from=builder /app/application/ ./
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/* # install OS updates
+    && rm -rf /var/lib/apt/lists/*    # install OS updates
 USER 1000:1000
 
 ENTRYPOINT ["java", "org.springframework.boot.loader.JarLauncher"]

--- a/hedera-mirror-monitor/Dockerfile
+++ b/hedera-mirror-monitor/Dockerfile
@@ -7,14 +7,17 @@ FROM eclipse-temurin:17.0.4.1_1-jre
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80"
 EXPOSE 8082
 HEALTHCHECK --interval=10s --retries=5 --start-period=60s --timeout=2s CMD curl -f http://localhost:8082/actuator/health/liveness
-USER 1000:1000
 WORKDIR /app
 
 # Copy artifacts
-COPY --from=builder /app/dependencies/ ./
-COPY --from=builder /app/snapshot-dependencies/ ./
+COPY --chown=1000:1000 --from=builder /app/dependencies/ ./
+COPY --chown=1000:1000 --from=builder /app/snapshot-dependencies/ ./
 RUN true  # Workaround https://github.com/moby/moby/issues/37965
-COPY --from=builder /app/spring-boot-loader/ ./
-COPY --from=builder /app/application/ ./
+COPY --chown=1000:1000 --from=builder /app/spring-boot-loader/ ./
+COPY --chown=1000:1000 --from=builder /app/application/ ./
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/* # install OS updates
+USER 1000:1000
 
 ENTRYPOINT ["java", "org.springframework.boot.loader.JarLauncher"]

--- a/hedera-mirror-rest/Dockerfile
+++ b/hedera-mirror-rest/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.14.2-alpine3.15
+FROM node:16.18.0-alpine3.16
 LABEL maintainer="mirrornode@hedera.com"
 
 # Setup
@@ -8,6 +8,7 @@ HEALTHCHECK --interval=10s --retries=3 --start-period=25s --timeout=2s CMD wget 
 WORKDIR /home/node/app/
 RUN chown -R node:node .
 COPY --chown=node:node . ./
+RUN apk update && apk upgrade && rm -rf /var/cache/apk/*    # install OS updates
 USER node
 
 # Build

--- a/hedera-mirror-rest/pom.xml
+++ b/hedera-mirror-rest/pom.xml
@@ -37,7 +37,7 @@
                             <goal>install-node-and-npm</goal>
                         </goals>
                         <configuration>
-                            <nodeVersion>v16.13.0</nodeVersion>
+                            <nodeVersion>v16.18.0</nodeVersion>
                         </configuration>
                         <phase>compile</phase>
                     </execution>

--- a/hedera-mirror-rosetta/Dockerfile
+++ b/hedera-mirror-rosetta/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18.0-alpine as build
+FROM golang:1.18.8-alpine3.16 as build
 ARG VERSION=development
 WORKDIR /app
 COPY go.* ./
@@ -6,10 +6,12 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 go build -ldflags="-w -s -X main.Version=${VERSION}" -o hedera-mirror-rosetta
 
-FROM alpine:3.15.4
+FROM alpine:3.16.2
 EXPOSE 5700
 HEALTHCHECK --interval=10s --retries=5 --start-period=30s --timeout=2s CMD wget -q -O- http://localhost:5700/health/liveness
-USER 1000:1000
 WORKDIR /app
+RUN apk update && apk upgrade && rm -rf /var/cache/apk/*     # install OS updates
+USER 1000:1000
 COPY --from=build /app/hedera-mirror-rosetta .
+
 CMD ["./hedera-mirror-rosetta"]

--- a/hedera-mirror-web3/Dockerfile
+++ b/hedera-mirror-web3/Dockerfile
@@ -17,7 +17,7 @@ COPY --chown=1000:1000 --from=builder /app/spring-boot-loader/ ./
 COPY --chown=1000:1000 --from=builder /app/application/ ./
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/* # install OS updates
+    && rm -rf /var/lib/apt/lists/*    # install OS updates
 USER 1000:1000
 
 ENTRYPOINT ["java", "org.springframework.boot.loader.JarLauncher"]

--- a/hedera-mirror-web3/Dockerfile
+++ b/hedera-mirror-web3/Dockerfile
@@ -7,14 +7,17 @@ FROM eclipse-temurin:17.0.4.1_1-jre
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80"
 EXPOSE 8545
 HEALTHCHECK --interval=10s --retries=3 --start-period=50s --timeout=2s CMD curl -f http://localhost:8545/actuator/health/liveness
-USER 1000:1000
 WORKDIR /app
 
 # Copy artifacts
-COPY --from=builder /app/dependencies/ ./
-COPY --from=builder /app/snapshot-dependencies/ ./
+COPY --chown=1000:1000 --from=builder /app/dependencies/ ./
+COPY --chown=1000:1000 --from=builder /app/snapshot-dependencies/ ./
 RUN true  # Workaround https://github.com/moby/moby/issues/37965
-COPY --from=builder /app/spring-boot-loader/ ./
-COPY --from=builder /app/application/ ./
+COPY --chown=1000:1000 --from=builder /app/spring-boot-loader/ ./
+COPY --chown=1000:1000 --from=builder /app/application/ ./
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/* # install OS updates
+USER 1000:1000
 
 ENTRYPOINT ["java", "org.springframework.boot.loader.JarLauncher"]

--- a/pom.xml
+++ b/pom.xml
@@ -359,6 +359,7 @@
                         </execution>
                     </executions>
                     <configuration>
+                        <imagePullPolicy>Always</imagePullPolicy>
                         <images>
                             <image>
                                 <build>


### PR DESCRIPTION
**Description**:

* Update base image for all mirror node components
* Update postgresql chart and postgres-repmgr image
* Update all OS packages so they at least are up to date as of each tag
* Change Docker plugins to always pull base image

**Related issue(s)**:

Fixes #4806

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)

The various changes were tested locally, but not with unit tests/integration tests.