### PR TITLE
Add Rosetta to Gradle build

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     implementation("com.google.protobuf:protobuf-gradle-plugin:0.9.1")
     implementation("io.freefair.gradle:lombok-plugin:6.5.1")
     implementation("io.spring.gradle:dependency-management-plugin:1.1.0")
+    implementation("org.apache.commons:commons-compress:1.21")
     implementation("org.gradle:test-retry-gradle-plugin:1.4.1")
     implementation("org.openapitools:openapi-generator-gradle-plugin:6.2.0")
     implementation("org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:3.4.0.2513")

--- a/buildSrc/src/main/kotlin/plugin/go/Go.kt
+++ b/buildSrc/src/main/kotlin/plugin/go/Go.kt
@@ -17,15 +17,22 @@
  * limitations under the License.
  * ‍
  */
+package plugin.go
 
-description = "Hedera Mirror Node Rosetta API"
+import org.gradle.api.tasks.Exec
+import org.gradle.kotlin.dsl.getByName
 
-plugins {
-    id("docker-conventions")
-    id("go-conventions")
-}
+// Template task to execute the go CLI
+abstract class Go : Exec() {
 
-go {
-    pkg = "./app/..."
-    version = "1.18"
+    init {
+        dependsOn("setup")
+    }
+
+    override fun exec() {
+        logger.info("Executing go ${args}")
+        val go = project.extensions.getByName<GoExtension>("go")
+        executable(go.goBin.absolutePath)
+        super.exec()
+    }
 }

--- a/buildSrc/src/main/kotlin/plugin/go/GoExtension.kt
+++ b/buildSrc/src/main/kotlin/plugin/go/GoExtension.kt
@@ -18,14 +18,17 @@
  * ‍
  */
 
-description = "Hedera Mirror Node Rosetta API"
+package plugin.go
 
-plugins {
-    id("docker-conventions")
-    id("go-conventions")
-}
+import java.io.File
 
-go {
-    pkg = "./app/..."
-    version = "1.18"
+// Extension object to contain the Go plugin properties
+open class GoExtension {
+    var arch: String = ""
+    lateinit var cacheDir: File
+    lateinit var goRoot: File
+    lateinit var goBin: File
+    var os: String = ""
+    var pkg: String = ""
+    var version: String = ""
 }

--- a/buildSrc/src/main/kotlin/plugin/go/GoPlugin.kt
+++ b/buildSrc/src/main/kotlin/plugin/go/GoPlugin.kt
@@ -1,0 +1,67 @@
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+package plugin.go
+
+import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.create
+import org.gradle.kotlin.dsl.register
+
+// The Golang plugin that registers the extension and the setup task
+class GolangPlugin : Plugin<Project> {
+
+    override fun apply(project: Project) {
+        val go = project.extensions.create<GoExtension>("go")
+        go.arch = detectArchitecture()
+        go.cacheDir = project.rootDir.resolve(".gradle")
+        go.goRoot = go.cacheDir.resolve("go")
+        go.goBin = go.goRoot.resolve("bin").resolve("go")
+        go.os = detectOs()
+        project.tasks.register<GoSetup>("setup")
+    }
+
+    fun detectArchitecture(): String {
+        val env = System.getProperty("GOARCH", "")
+
+        if (env.isNotBlank()) {
+            return env
+        } else if (Os.isArch("aarch64")) {
+            return "arm64"
+        }
+
+        return "amd64"
+    }
+
+    fun detectOs(): String {
+        val env = System.getProperty("GOOS", "")
+
+        if (env.isNotBlank()) {
+            return env
+        } else if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+            return "windows"
+        } else if (Os.isFamily(Os.FAMILY_MAC)) {
+            return "darwin"
+        }
+
+        return "linux"
+    }
+}

--- a/buildSrc/src/main/kotlin/plugin/go/GoSetup.kt
+++ b/buildSrc/src/main/kotlin/plugin/go/GoSetup.kt
@@ -1,0 +1,76 @@
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+package plugin.go
+
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.TaskAction
+import org.gradle.kotlin.dsl.getByName
+import java.io.File
+import java.io.FileInputStream
+import java.net.URL
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.nio.file.StandardCopyOption
+import java.util.zip.GZIPInputStream
+
+// Downloads and decompresses the Go artifacts
+open class GoSetup : DefaultTask() {
+
+    @TaskAction
+    fun prepare() {
+        val go = project.extensions.getByName<GoExtension>("go")
+        go.goRoot.mkdirs()
+        val url =
+            URL("https://storage.googleapis.com/golang/go${go.version}.${go.os}-${go.arch}.tar.gz")
+        val filename = Paths.get(url.path).fileName
+        val targetFile = go.cacheDir.toPath().resolve(filename)
+
+        if (!targetFile.toFile().exists()) {
+            url.openStream().use {
+                logger.warn("Downloading: ${url}")
+                Files.copy(it, targetFile, StandardCopyOption.REPLACE_EXISTING)
+            }
+        }
+
+        if (!go.goBin.exists()) {
+            decompressTgz(targetFile.toFile(), go.cacheDir)
+        }
+    }
+
+    fun decompressTgz(source: File, destDir: File) {
+        TarArchiveInputStream(GZIPInputStream(FileInputStream(source))).use {
+            destDir.mkdirs()
+            var entry = it.nextEntry
+
+            while (entry != null) {
+                val file = destDir.resolve(entry.name)
+                if (entry.isDirectory) {
+                    file.mkdirs()
+                } else {
+                    Files.copy(it, file.toPath(), StandardCopyOption.REPLACE_EXISTING)
+                    file.setExecutable(true, true)
+                }
+                entry = it.nextEntry
+            }
+        }
+    }
+}


### PR DESCRIPTION
**Description**:

Add Rosetta to Gradle build

* Add a Golang plugin to `buildSrc`
* Add a `GoSetup` task to download Go binaries and unpack them
* Add a template `Go` task to run the Go CLI
* Add common Go tasks like build, test, etc. to Rosetta
* Add auto-detection of OS and architecture for Go binaries

**Related issue(s)**:

Fixes #4796

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
