### PR TITLE
Update to Node.js 18.12 LTS and Go 1.19

### DIFF
--- a/buildSrc/src/main/kotlin/javascript-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/javascript-conventions.gradle.kts
@@ -28,7 +28,7 @@ plugins {
 
 node {
     download.set(true)
-    version.set("16.17.1")
+    version.set("18.12.0")
 }
 
 val npmTest = tasks.register<NpmTask>("npmTest") {

--- a/charts/hedera-mirror-rest/values.yaml
+++ b/charts/hedera-mirror-rest/values.yaml
@@ -232,7 +232,7 @@ test:
   image:
     pullPolicy: IfNotPresent
     repository: bats/bats
-    tag: 1.7.0
+    tag: 1.8.2
 
 tolerations: []
 

--- a/charts/marketplace/gcp/release.sh
+++ b/charts/marketplace/gcp/release.sh
@@ -20,8 +20,8 @@ fi
 
 target_tag="${target_tag#v}" # Strip v prefix if present
 target_tag_minor="${target_tag%\.*}"
-bats_tag="1.7.0"
-postgresql_tag="14.4.0-debian-11-r9"
+bats_tag="1.8.2"
+postgresql_tag="14.5.0-debian-11-r34"
 registry="gcr.io/mirror-node-public/hedera-mirror-node"
 
 function retag() {

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -84,7 +84,7 @@ npm test
 #### Prerequisites
 
 ``
-Go 1.18+
+Go 1.19+
 ``
 
 To start the Rosetta API ensure you have the necessary [configuration](configuration.md#rosetta-api) populated and run:

--- a/hedera-mirror-rest/Dockerfile
+++ b/hedera-mirror-rest/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.18.0-alpine3.16
+FROM node:18.12.0-alpine3.16
 LABEL maintainer="mirrornode@hedera.com"
 
 # Setup

--- a/hedera-mirror-rest/monitoring/monitor_apis/package-lock.json
+++ b/hedera-mirror-rest/monitoring/monitor_apis/package-lock.json
@@ -28,7 +28,7 @@
         "nodemon": "^2.0.20"
       },
       "engines": {
-        "node": ">=16.13.0 < 17"
+        "node": ">=16.13.0 < 19"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/hedera-mirror-rest/monitoring/monitor_apis/package.json
+++ b/hedera-mirror-rest/monitoring/monitor_apis/package.json
@@ -6,7 +6,7 @@
   "main": "server.js",
   "private": true,
   "engines": {
-    "node": ">=16.13.0 < 17"
+    "node": ">=16.13.0 < 19"
   },
   "scripts": {
     "dev": "nodemon --experimental-specifier-resolution=node server.js",

--- a/hedera-mirror-rest/package-lock.json
+++ b/hedera-mirror-rest/package-lock.json
@@ -102,7 +102,7 @@
         "testcontainers": "^8.16.0"
       },
       "engines": {
-        "node": ">=16.13.0 < 17"
+        "node": ">=16.13.0 < 19"
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {

--- a/hedera-mirror-rest/package.json
+++ b/hedera-mirror-rest/package.json
@@ -6,7 +6,7 @@
   "main": "server.js",
   "private": true,
   "engines": {
-    "node": ">=16.13.0 < 17"
+    "node": ">=16.13.0 < 19"
   },
   "scripts": {
     "dev": "HEDERA_MIRROR_REST_LOG_LEVEL=trace nodemon --experimental-specifier-resolution=node server.js",

--- a/hedera-mirror-rest/pom.xml
+++ b/hedera-mirror-rest/pom.xml
@@ -37,7 +37,7 @@
                             <goal>install-node-and-npm</goal>
                         </goals>
                         <configuration>
-                            <nodeVersion>v16.18.0</nodeVersion>
+                            <nodeVersion>v18.12.0</nodeVersion>
                         </configuration>
                         <phase>compile</phase>
                     </execution>

--- a/hedera-mirror-rosetta/Dockerfile
+++ b/hedera-mirror-rosetta/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18.8-alpine3.16 as build
+FROM golang:1.19.3-alpine3.16 as build
 ARG VERSION=development
 WORKDIR /app
 COPY go.* ./

--- a/hedera-mirror-rosetta/build.gradle.kts
+++ b/hedera-mirror-rosetta/build.gradle.kts
@@ -27,5 +27,5 @@ plugins {
 
 go {
     pkg = "./app/..."
-    version = "1.18"
+    version = "1.19"
 }

--- a/hedera-mirror-rosetta/container/Dockerfile
+++ b/hedera-mirror-rosetta/container/Dockerfile
@@ -2,7 +2,7 @@
 # Importer, Rosetta and PostgreSQL into one image
 # and run the services using supervisord
 
-FROM ubuntu:20.04 as builder
+FROM ubuntu:22.04 as builder
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y gcc git openjdk-17-jdk-headless wget
 # GIT_REF can be a branch, a tag, or a 40-charater git commit hash
@@ -25,7 +25,7 @@ RUN mkdir importer rosetta scripts \
 # --------------------------- Runner Container --------------------------- #
 # ######################################################################## #
 
-FROM ubuntu:20.04 as runner
+FROM ubuntu:22.04 as runner
 
 # ---------------------- Install Deps & PostgreSQL ------------------------ #
 # Add the PostgreSQL PGP key to verify their Debian packages.

--- a/hedera-mirror-rosetta/go.mod
+++ b/hedera-mirror-rosetta/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta
 
-go 1.18
+go 1.19
 
 require (
 	github.com/Code-Hex/go-generics-cache v1.2.1

--- a/hedera-mirror-rosetta/pom.xml
+++ b/hedera-mirror-rosetta/pom.xml
@@ -38,7 +38,7 @@
                 <version>2.3.10</version>
                 <configuration>
                     <goPath>${go.dir}/path</goPath>
-                    <goVersion>1.18</goVersion>
+                    <goVersion>1.19</goVersion>
                     <hideBanner>true</hideBanner>
                     <storeFolder>${go.dir}/store</storeFolder>
                     <useEnvVars>true</useEnvVars>


### PR DESCRIPTION
**Description**:

* Update BATS versions
* Update Go to 1.19
* Update Node.js to 18.12
* Update postgresql-repmgr in Marketplace
* Update Rosetta to 22.04 LTS

**Related issue(s)**:

Fixes #4818

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
