### PR TITLE
Update Acceptance Test Max Retry Polling

### DIFF
--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/RestPollingProperties.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/RestPollingProperties.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.test.e2e.acceptance.config;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -44,7 +44,7 @@ public class RestPollingProperties {
 
     @Min(1)
     @Max(60)
-    private int maxAttempts = 10;
+    private int maxAttempts = 20;
 
     @NotNull
     @DurationMin(millis = 500L)


### PR DESCRIPTION
Signed-off-by: Edwin Greene <edwin.greene@swirldslabs.com>

**Description**:
Update the maximum number of polling attempts so that the `verifyMirrorTokenUpdateFlow()` test has the time it needs to get the result from the network and correctly pass.

**Related issue(s)**:

Fixes #4848

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
