### PR TITLE
Add a Citus Helm chart

### DIFF
--- a/charts/hedera-mirror/Chart.yaml
+++ b/charts/hedera-mirror/Chart.yaml
@@ -1,6 +1,11 @@
 apiVersion: v2
 appVersion: "main"
 dependencies:
+  - alias: citus
+    condition: citus.enabled
+    name: postgresql
+    repository: https://charts.bitnami.com/bitnami
+    version: 12.1.2
   - alias: grpc
     condition: grpc.enabled
     name: hedera-mirror-grpc

--- a/charts/hedera-mirror/ci/citus-values.yaml
+++ b/charts/hedera-mirror/ci/citus-values.yaml
@@ -1,0 +1,6 @@
+citus:
+  enabled: true
+monitor:
+  enabled: false
+postgresql:
+  enabled: false

--- a/charts/hedera-mirror/ci/default-values.yaml
+++ b/charts/hedera-mirror/ci/default-values.yaml
@@ -1,7 +1,5 @@
 # CT generates release names that are too long for postgresql-ha, so we override it here
-db:
-  host: p
 monitor:
   enabled: false
 postgresql:
-  fullnameOverride: p-postgres
+  fullnameOverride: db

--- a/charts/hedera-mirror/templates/_helpers.tpl
+++ b/charts/hedera-mirror/templates/_helpers.tpl
@@ -8,6 +8,21 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Constructs the database host that should be used by all components.
+*/}}
+{{- define "hedera-mirror.db" -}}
+{{- if .Values.db.host -}}
+{{- tpl .Values.db.host . -}}
+{{- else if and .Values.postgresql.enabled (gt (.Values.postgresql.pgpool.replicaCount | int) 0) -}}
+{{- include "postgresql-ha.pgpool" .Subcharts.postgresql -}}
+{{- else if .Values.postgresql.enabled -}}
+{{- include "postgresql-ha.postgresql" .Subcharts.postgresql -}}
+{{- else if .Values.citus.enabled -}}
+{{- include "postgresql.primary.fullname" .Subcharts.citus -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.

--- a/charts/hedera-mirror/templates/configmap-init.yaml
+++ b/charts/hedera-mirror/templates/configmap-init.yaml
@@ -1,18 +1,20 @@
 apiVersion: v1
-kind: Secret
+kind: ConfigMap
 metadata:
   labels: {{- include "hedera-mirror.labels" . | nindent 4 }}
   name: {{ .Release.Name }}-init
   namespace: {{ include "hedera-mirror.namespace" . }}
-stringData:
-  init.sh: |-
+data:
+  001-init.sh: |-
     #!/bin/bash
     set -e
 
     PGHBACONF="/opt/bitnami/postgresql/conf/pg_hba.conf"
-    cp "${PGHBACONF}" "${PGHBACONF}.bak"
-    echo "local all all trust" > "${PGHBACONF}"
-    pg_ctl reload
+    if [[ -f "${PGHBACONF}" ]]; then
+      cp "${PGHBACONF}" "${PGHBACONF}.bak"
+      echo "local all all trust" > "${PGHBACONF}"
+      pg_ctl reload
+    fi
 
     psql -d "user=postgres connect_timeout=3" \
       --set ON_ERROR_STOP=1 \
@@ -74,5 +76,45 @@ stringData:
     alter database :dbName set search_path = :dbSchema, public;
     __SQL__
 
-    mv "${PGHBACONF}.bak" "${PGHBACONF}"
-    pg_ctl reload
+    if [[ -f "${PGHBACONF}.bak" ]]; then
+      mv "${PGHBACONF}.bak" "${PGHBACONF}"
+      pg_ctl reload
+    fi
+  {{- if .Values.citus.enabled }}
+  002-citus.sh: |
+    #!/bin/bash
+    set -e
+    name="{{ include "postgresql.primary.fullname" .Subcharts.citus }}"
+    coordinator="${name}-0.${name}-hl.{{ .Release.Namespace }}.svc.cluster.local"
+
+    # Setup coordinator
+    psql -v ON_ERROR_STOP=1 --username "${POSTGRES_USER}" --dbname "${POSTGRES_DB}" -p "${POSTGRESQL_PORT_NUMBER}" <<-EOSQL
+      create extension if not exists citus;
+      update pg_dist_node_metadata SET metadata=jsonb_insert(metadata, '{docker}', 'true');
+      insert into pg_dist_authinfo(nodeid, rolename, authinfo) values(1, '${POSTGRES_USER}', 'password=${POSTGRES_PASSWORD}');
+      select citus_set_coordinator_host('${coordinator}', ${POSTGRESQL_PORT_NUMBER});
+    EOSQL
+
+    # Setup workers
+    id=0
+    replicas={{.Values.citus.readReplicas.replicaCount}}
+    name="{{ include "postgresql.readReplica.fullname" .Subcharts.citus }}"
+    echo "Adding ${replicas} workers"
+
+    while [[ ${id} -lt ${replicas} ]]; do
+      nodeid=$((id + 2))
+      host="${name}-${id}.${name}-hl.{{ .Release.Namespace }}.svc.cluster.local"
+
+      until ( exec pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB" -h "${host}" -p "${POSTGRESQL_PORT_NUMBER}" ); do
+        echo "Waiting for worker ${id} to become ready"
+        sleep 1
+      done
+
+      psql -v ON_ERROR_STOP=1 --username "${POSTGRES_USER}" --dbname "${POSTGRES_DB}" -p "${POSTGRESQL_PORT_NUMBER}" <<-EOSQL
+        insert into pg_dist_authinfo(nodeid, rolename, authinfo) values(${nodeid}, '${POSTGRES_USER}', 'password=${POSTGRES_PASSWORD}');
+        select citus_add_node('${host}', ${POSTGRESQL_PORT_NUMBER});
+    EOSQL
+
+      ((id = id + 1))
+    done
+  {{- end }}

--- a/charts/hedera-mirror/templates/secret-passwords.yaml
+++ b/charts/hedera-mirror/templates/secret-passwords.yaml
@@ -23,7 +23,7 @@ stringData:
 
   HEDERA_MIRROR_GRPC_DB_PASSWORD: "{{ $grpcPassword }}"
   HEDERA_MIRROR_GRPC_DB_USERNAME: "{{ $grpcUsername }}"
-  HEDERA_MIRROR_IMPORTER_DB_HOST: "{{ tpl .Values.db.host . }}{{ if .Values.postgresql.enabled }}{{ ternary "-postgres-pgpool" "-postgres-postgresql" (gt (.Values.postgresql.pgpool.replicaCount | int) 0) }}{{ end }}"
+  HEDERA_MIRROR_IMPORTER_DB_HOST: {{ include "hedera-mirror.db" . | quote }}
   HEDERA_MIRROR_IMPORTER_DB_NAME: "{{ .Values.db.name }}"
   HEDERA_MIRROR_IMPORTER_DB_SCHEMA: "{{ .Values.db.schema }}"
   HEDERA_MIRROR_IMPORTER_DB_PASSWORD: "{{ $importerPassword }}"

--- a/charts/hedera-mirror/values-prod.yaml
+++ b/charts/hedera-mirror/values-prod.yaml
@@ -3,6 +3,10 @@ alertmanager:
   inhibitRules:
     enabled: true
 
+citus:
+  readReplicas:
+    replicaCount: 3
+
 global:
   middleware: true
 

--- a/charts/hedera-mirror/values.yaml
+++ b/charts/hedera-mirror/values.yaml
@@ -60,8 +60,52 @@ applicationResource:
   partnerName: ""
   solutionId: ""
 
+citus:
+  architecture: replication
+  enabled: false
+  image:
+    repository: citusdata/citus
+    tag: 11.1.4-pg14
+  nameOverride: citus
+  primary:
+    args: ["-c", "config_file=/bitnami/postgresql/conf/postgresql.conf"]
+    configuration: |
+      citus.node_conninfo = 'sslmode=prefer'
+      listen_addresses = '*'
+      log_timezone = 'Etc/UTC'
+      max_connections = 600
+      max_replication_slots = 5
+      max_wal_senders = 5
+      max_wal_size = 24GB
+      shared_preload_libraries = 'citus'
+      wal_level = logical
+    extraEnvVarsSecret: mirror-passwords
+    initdb:
+      scriptsConfigMap: "{{ .Release.Name }}-init"
+    name: coordinator
+  readReplicas:
+    args: ["-c", "config_file=/usr/local/etc/postgresql/override.conf"]
+    extendedConfiguration: |
+      citus.node_conninfo = 'sslmode=prefer'
+      listen_addresses = '*'
+      log_timezone = 'Etc/UTC'
+      max_connections = 600
+      max_replication_slots = 5
+      max_wal_senders = 5
+      max_wal_size = 24GB
+      shared_preload_libraries = 'citus'
+      wal_level = logical
+    extraVolumeMounts:
+      - name: config
+        mountPath: /usr/local/etc/postgresql
+    extraVolumes:
+      - name: config
+        configMap:
+          name: '{{ printf "%s-extended-configuration" (include "postgresql.readReplica.fullname" .) }}'
+    name: worker
+
 db:
-  host: "{{ .Release.Name }}"
+  host: ""  # Auto-generated from the database sub-charts
   name: mirror_node
   schema: public
   owner:
@@ -182,7 +226,7 @@ postgresql:
     extraEnvVarsSecret: mirror-passwords
     image:
       debug: true
-    initdbScriptsSecret: "{{ .Release.Name }}-init"
+    initdbScriptsCM: "{{ .Release.Name }}-init"
     password: ""  # Randomly generated if left blank
     podAntiAffinityPreset: soft
     replicaCount: 1

--- a/charts/marketplace/gcp/values.yaml
+++ b/charts/marketplace/gcp/values.yaml
@@ -6,8 +6,6 @@ applicationResource:
   version: ""
 
 global:
-  db:
-    host: RELEASE-NAME-postgres-postgresql
   useReleaseForNameLabel: true
 
 grpc:

--- a/hedera-mirror-importer/src/test/resources/db/scripts/init.sql
+++ b/hedera-mirror-importer/src/test/resources/db/scripts/init.sql
@@ -1,9 +1,20 @@
+-- Spring takes care of creating the database and owner in tests, but on a real database these commands should still be ran.
+-- create user mirror_node with login createrole password 'mirror_node_pass';
+-- grant mirror_node to postgres;
+-- create database mirror_node with owner mirror_node;
+
+-- Add extensions
+create extension if not exists pg_stat_statements;
+
 -- Create roles
 create role readonly;
 create role readwrite in role readonly;
 
--- Create user mirror_importer
+-- Create users
+create user mirror_grpc with login password 'mirror_grpc_pass' in role readonly;
 create user mirror_importer with login password 'mirror_importer_pass' in role readwrite;
+create user mirror_rosetta with login password 'mirror_rosetta_pass' in role readonly;
+create user mirror_web3 with login password 'mirror_web3_pass' in role readonly;
 
 -- Create schema
 create schema if not exists public authorization mirror_node;


### PR DESCRIPTION
**Description**:

* Add CitusDB to the helm chart gated behind a `citus.enabled=false` property
* Add a new Citus chart install test to CI
* Add Cloud SQL setup commands to `init.sql`
* Change `db.host` to not hardcode a default and dynamically choose the host from the corresponding enabled database sub-chart

**Related issue(s)**:

Fixes #2725

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
