### PR TITLE
Force s3 client to use path style request url

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/CloudStorageConfiguration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/CloudStorageConfiguration.java
@@ -104,6 +104,7 @@ class CloudStorageConfiguration {
         return S3AsyncClient.builder()
                 .credentialsProvider(awsCredentialsProvider(sourceProperties))
                 .endpointOverride(sourceProperties.getUri())
+                .forcePathStyle(true)
                 .httpClient(httpClient)
                 .overrideConfiguration(c -> c.addExecutionInterceptor(metricsExecutionInterceptor))
                 .overrideConfiguration(overrideProject(sourceProperties))


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

- Force s3 client to use path style request URL

**Related issue(s)**:

Fixes #4902

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
The new AWS SDK we bumped up to in release v0.68.0 changed the default request URL style from path style `http://endpoint/bucket-name?p1=*&p2=*` to virtual host style `https://bucket-name.endpoint/?p1=*&p2=*`, this breaks local node since DNS resolution on `bucket-name.endpoint` will fail.

Tested against mainnet using s3 and testnet using gcp.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
