### PR TITLE
Add GitHub Actions to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,11 @@
 
 version: 2
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
   - package-ecosystem: "gradle"
     directory: "/"
     schedule:

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Import GPG Key
         id: gpg_importer
-        uses: crazy-max/ghaction-import-gpg@v5.1.0
+        uses: crazy-max/ghaction-import-gpg@v5.2.0
         with:
           git_commit_gpgsign: true
           git_tag_gpgsign: true
@@ -161,7 +161,7 @@ jobs:
 
       - name: Import GPG Key
         id: gpg_importer
-        uses: crazy-max/ghaction-import-gpg@v5.1.0
+        uses: crazy-max/ghaction-import-gpg@v5.2.0
         with:
           git_commit_gpgsign: true
           git_tag_gpgsign: true

--- a/.github/workflows/charts.yml
+++ b/.github/workflows/charts.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install ct
-        uses: helm/chart-testing-action@v2.3.0
+        uses: helm/chart-testing-action@v2.3.1
 
       - name: Run lint
         run: ct lint --config .github/ct.yaml --all
@@ -42,14 +42,14 @@ jobs:
         run: curl --retry 3 -fsL https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
 
       - name: Create k3d cluster
-        run: k3d cluster create mirror --agents 1 --timeout 5m --registry-create registry:0.0.0.0:5001 --image rancher/k3s:v1.24.3-k3s1
+        run: k3d cluster create mirror --agents 1 --timeout 5m --registry-create registry:0.0.0.0:5001 --image rancher/k3s:v1.24.7-k3s1
         timeout-minutes: 3
 
       - name: Build images
         run: ./mvnw deploy -pl hedera-mirror-grpc,hedera-mirror-importer,hedera-mirror-rest,hedera-mirror-rosetta,hedera-mirror-web3 -Dmvn.golang.skip=true -Dskip.npm -DskipTests -Ddocker.push.repository=localhost:5001/mirrornode -Ddocker.tag.version=${IMAGE_TAG}
 
       - name: Install ct
-        uses: helm/chart-testing-action@v2.3.0
+        uses: helm/chart-testing-action@v2.3.1
 
       - name: Set GIT_BRANCH and GIT_REPO for pull request
         if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -14,12 +14,12 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v1
         with:
           credentials_json: '${{ secrets.GCR_KEY }}'
 
       - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v1
 
       - name: Configure Docker
         run: gcloud auth configure-docker gcr.io,marketplace.gcr.io

--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -18,12 +18,12 @@ jobs:
           java-version: 17
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v1
         with:
           credentials_json: '${{ secrets.GCR_KEY }}'
 
       - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v1
 
       - name: Configure Docker
         run: gcloud auth configure-docker gcr.io,marketplace.gcr.io

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -28,12 +28,12 @@ jobs:
           java-version: 17
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v1
         with:
           credentials_json: '${{ secrets.GCR_KEY }}'
 
       - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v1
 
       - name: Configure Docker
         run: gcloud auth configure-docker gcr.io,marketplace.gcr.io
@@ -66,7 +66,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Publish helm chart
-        uses: stefanprodan/helm-gh-pages@v1.5.0
+        uses: stefanprodan/helm-gh-pages@v1.7.0
         with:
           target_dir: charts
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rosetta-api.yml
+++ b/.github/workflows/rosetta-api.yml
@@ -94,7 +94,7 @@ jobs:
     timeout-minutes: 15
     env:
       OFFLINE_URL: http://localhost:5700
-      ROSETTA_CLI_VERSION: v0.8.0
+      ROSETTA_CLI_VERSION: v0.10.0
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -223,7 +223,7 @@ jobs:
     if: ${{ always() }}
     steps:
       - name: Delete Artifact
-        uses: geekyeggo/delete-artifact@v1
+        uses: geekyeggo/delete-artifact@v2
         with:
           name: ${{ env.IMAGE }}
           failOnError: false
@@ -244,7 +244,7 @@ jobs:
           rm -fr tmp
 
       - name: Run Gosec Security Scanner
-        uses: securego/gosec@v2.13.1
+        uses: securego/gosec@v2.14.0
         with:
           args: ./...
 

--- a/buildSrc/src/main/kotlin/javascript-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/javascript-conventions.gradle.kts
@@ -28,7 +28,7 @@ plugins {
 
 node {
     download.set(true)
-    version.set("18.12.0")
+    version.set("18.12.1")
 }
 
 val npmTest = tasks.register<NpmTask>("npmTest") {

--- a/charts/marketplace/gcp/release.sh
+++ b/charts/marketplace/gcp/release.sh
@@ -21,7 +21,7 @@ fi
 target_tag="${target_tag#v}" # Strip v prefix if present
 target_tag_minor="${target_tag%\.*}"
 bats_tag="1.8.2"
-postgresql_tag="14.5.0-debian-11-r34"
+postgresql_tag="14.6.0-debian-11-r2"
 registry="gcr.io/mirror-node-public/hedera-mirror-node"
 
 function retag() {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
   db:
-    image: postgres:14.2-alpine
+    image: postgres:14-alpine
     environment:
       PGDATA: /var/lib/postgresql/data
       POSTGRES_HOST_AUTH_METHOD: scram-sha-256
@@ -59,7 +59,7 @@ services:
       - ./application.yml:/usr/etc/hedera-mirror-monitor/application.yml
 
   redis:
-    image: redis:6.2.6-alpine
+    image: redis:6-alpine
     ports:
       - 6379:6379
     restart: unless-stopped

--- a/hedera-mirror-grpc/Dockerfile
+++ b/hedera-mirror-grpc/Dockerfile
@@ -1,9 +1,9 @@
-FROM eclipse-temurin:17.0.4.1_1-jre as builder
+FROM eclipse-temurin:17.0.5_8-jre-jammy as builder
 WORKDIR /app
 COPY target/ ./
 RUN java -Djarmode=layertools -jar *.jar extract
 
-FROM eclipse-temurin:17.0.4.1_1-jre
+FROM eclipse-temurin:17.0.5_8-jre-jammy
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80"
 EXPOSE 5600
 HEALTHCHECK --interval=10s --retries=3 --start-period=50s --timeout=2s CMD curl -f http://localhost:8081/actuator/health/liveness

--- a/hedera-mirror-grpc/src/test/resources/config/bootstrap.yml
+++ b/hedera-mirror-grpc/src/test/resources/config/bootstrap.yml
@@ -3,7 +3,7 @@ embedded:
     enabled: true
     docker-image: postgres:14-alpine
   redis:
-    docker-image: redis:6.2.3-alpine
+    docker-image: redis:6-alpine
 spring:
   flyway:
     baselineVersion: 0

--- a/hedera-mirror-importer/Dockerfile
+++ b/hedera-mirror-importer/Dockerfile
@@ -1,9 +1,9 @@
-FROM eclipse-temurin:17.0.4.1_1-jre as builder
+FROM eclipse-temurin:17.0.5_8-jre-jammy as builder
 WORKDIR /app
 COPY target/ ./
 RUN java -Djarmode=layertools -jar *.jar extract
 
-FROM eclipse-temurin:17.0.4.1_1-jre
+FROM eclipse-temurin:17.0.5_8-jre-jammy
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80"
 HEALTHCHECK --interval=30s --retries=3 --start-period=60s --timeout=2s CMD curl -f http://localhost:8080/actuator/health/liveness
 WORKDIR /app

--- a/hedera-mirror-importer/src/test/resources/config/bootstrap-pubsub.yml
+++ b/hedera-mirror-importer/src/test/resources/config/bootstrap-pubsub.yml
@@ -2,4 +2,3 @@ embedded:
   google:
     pubsub:
       enabled: true
-      docker-image: google/cloud-sdk:alpine

--- a/hedera-mirror-importer/src/test/resources/config/bootstrap-pubsub.yml
+++ b/hedera-mirror-importer/src/test/resources/config/bootstrap-pubsub.yml
@@ -2,4 +2,4 @@ embedded:
   google:
     pubsub:
       enabled: true
-      docker-image: google/cloud-sdk:290.0.1
+      docker-image: google/cloud-sdk:alpine

--- a/hedera-mirror-importer/src/test/resources/config/bootstrap.yml
+++ b/hedera-mirror-importer/src/test/resources/config/bootstrap.yml
@@ -11,4 +11,4 @@ embedded:
     password: mirror_node_pass
     user: mirror_node
   redis:
-    docker-image: redis:6.2.3-alpine
+    docker-image: redis:6-alpine

--- a/hedera-mirror-monitor/Dockerfile
+++ b/hedera-mirror-monitor/Dockerfile
@@ -1,9 +1,9 @@
-FROM eclipse-temurin:17.0.4.1_1-jre as builder
+FROM eclipse-temurin:17.0.5_8-jre-jammy as builder
 WORKDIR /app
 COPY target/*.jar ./
 RUN java -Djarmode=layertools -jar *.jar extract
 
-FROM eclipse-temurin:17.0.4.1_1-jre
+FROM eclipse-temurin:17.0.5_8-jre-jammy
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80"
 EXPOSE 8082
 HEALTHCHECK --interval=10s --retries=5 --start-period=60s --timeout=2s CMD curl -f http://localhost:8082/actuator/health/liveness

--- a/hedera-mirror-rest/Dockerfile
+++ b/hedera-mirror-rest/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.12.0-alpine3.16
+FROM node:18.12.1-alpine3.16
 LABEL maintainer="mirrornode@hedera.com"
 
 # Setup

--- a/hedera-mirror-rest/pom.xml
+++ b/hedera-mirror-rest/pom.xml
@@ -37,7 +37,7 @@
                             <goal>install-node-and-npm</goal>
                         </goals>
                         <configuration>
-                            <nodeVersion>v18.12.0</nodeVersion>
+                            <nodeVersion>v18.12.1</nodeVersion>
                         </configuration>
                         <phase>compile</phase>
                     </execution>

--- a/hedera-mirror-rosetta/Dockerfile
+++ b/hedera-mirror-rosetta/Dockerfile
@@ -6,7 +6,7 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 go build -ldflags="-w -s -X main.Version=${VERSION}" -o hedera-mirror-rosetta
 
-FROM alpine:3.16.2
+FROM alpine:3.16.3
 EXPOSE 5700
 HEALTHCHECK --interval=10s --retries=5 --start-period=30s --timeout=2s CMD wget -q -O- http://localhost:5700/health/liveness
 WORKDIR /app

--- a/hedera-mirror-web3/Dockerfile
+++ b/hedera-mirror-web3/Dockerfile
@@ -1,9 +1,9 @@
-FROM eclipse-temurin:17.0.4.1_1-jre as builder
+FROM eclipse-temurin:17.0.5_8-jre-jammy as builder
 WORKDIR /app
 COPY target/*.jar ./
 RUN java -Djarmode=layertools -jar *.jar extract
 
-FROM eclipse-temurin:17.0.4.1_1-jre
+FROM eclipse-temurin:17.0.5_8-jre-jammy
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80"
 EXPOSE 8545
 HEALTHCHECK --interval=10s --retries=3 --start-period=50s --timeout=2s CMD curl -f http://localhost:8545/actuator/health/liveness


### PR DESCRIPTION
**Description**:

* Add GitHub Actions to Dependabot so they stay up to date
* Bump GitHub Actions versions
* Bump JRE from `17.0.4.1_1-jre` to `17.0.5_8-jre-jammy`
* Bump Node.js from `v18.12.0` to `v18.12.1`
* Bump Rosetta CLI from `0.8.0` to `0.10.0`

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
