### PR TITLE
Add AccountStakingRewardsTransfer to Monitor dashboard

### DIFF
--- a/hedera-mirror-rest/monitoring/monitor_apis/account_tests.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/account_tests.js
@@ -267,7 +267,7 @@ const getSingleAccountTokenRelationships = async (server) => {
 };
 
 const getAccountStakingRewards = async (server) => {
-  const stakingRewardsPath = (tokenId) => `${accountsPath}/${stakingRewardAccountId}/rewards`;
+  const stakingRewardsPath = `${accountsPath}/${stakingRewardAccountId}/rewards`;
   const rewardsJsonRespKey = 'rewards';
   let url = getUrl(server, stakingRewardsPath, {limit: resourceLimit});
   const rewardMandatoryParams = ['account_id', 'amount', 'timestamp'];

--- a/hedera-mirror-rest/monitoring/monitor_apis/config/default.serverlist.json
+++ b/hedera-mirror-rest/monitoring/monitor_apis/config/default.serverlist.json
@@ -17,6 +17,7 @@
     "enabled": true,
     "intervalMultiplier": 1,
     "limit": 10,
+    "stakingRewardAccountId": null,
     "tokenRelationshipEnabled": true
   },
   "balance": {


### PR DESCRIPTION
**Description**:
* Add account staking rewards API to monitor dashboard
* Add `account.stakingRewardAccountId` property to control which account id is used for the above test

**Related issue(s)**:

Fixes #4853

**Notes for reviewer**:
You will need to set the property `account.stakingRewardAccountId` to specify the accountId to use; unless you have a local database with a "staking_reward_transfer` table specified, expect a 404 HTTP result (and a red test circle).  Or just wait until testnet (or your network of choice) has [PR 4852](https://github.com/hashgraph/hedera-mirror-node/pull/4852) (Milestone 0.70.0) deployed to it.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (api monitoring)
