### PR TITLE
Split Gradle build in CI

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -12,8 +12,11 @@ env:
   SPRING_CLOUD_KUBERNETES_ENABLED: "false"
 
 jobs:
-  build:
+  gradle:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        project: [ grpc, importer, monitor, rest, rosetta, web3 ]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -37,7 +40,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
-          arguments: build --scan
+          arguments: :${{matrix.project}}:build --scan
 
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v3


### PR DESCRIPTION
**Description**:

Split the Gradle build by project in CI to avoid errors and decrease execution time.

**Related issue(s)**:

Fixes #4928

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
