### PR TITLE
Fix multi-node citus extension config

### DIFF
--- a/charts/hedera-mirror/templates/configmap-init.yaml
+++ b/charts/hedera-mirror/templates/configmap-init.yaml
@@ -92,9 +92,6 @@ data:
       # Setup coordinator
       psql -v ON_ERROR_STOP=1 --username "${POSTGRES_USER}" --dbname "${POSTGRES_DB}" -p "${POSTGRESQL_PORT_NUMBER}" <<-EOSQL
         select citus_set_coordinator_host('${coordinator}', ${POSTGRESQL_PORT_NUMBER});
-
-        \c ${HEDERA_MIRROR_IMPORTER_DB_NAME}
-        select citus_set_coordinator_host('${coordinator}', ${POSTGRESQL_PORT_NUMBER});
     EOSQL
 
       # Add workers

--- a/charts/hedera-mirror/templates/configmap-init.yaml
+++ b/charts/hedera-mirror/templates/configmap-init.yaml
@@ -84,44 +84,64 @@ data:
   002-citus.sh: |
     #!/bin/bash
     set -e
-    name="{{ include "postgresql.primary.fullname" .Subcharts.citus }}"
-    coordinator="${name}-0.${name}-hl.{{ .Release.Namespace }}.svc.cluster.local"
 
-    # Setup coordinator
+    function setup_coordinator() {
+      name="{{ include "postgresql.primary.fullname" .Subcharts.citus }}"
+      coordinator="${name}-0.${name}-hl.{{ .Release.Namespace }}.svc.cluster.local"
+
+      # Setup coordinator
+      psql -v ON_ERROR_STOP=1 --username "${POSTGRES_USER}" --dbname "${POSTGRES_DB}" -p "${POSTGRESQL_PORT_NUMBER}" <<-EOSQL
+        select citus_set_coordinator_host('${coordinator}', ${POSTGRESQL_PORT_NUMBER});
+
+        \c ${HEDERA_MIRROR_IMPORTER_DB_NAME}
+        select citus_set_coordinator_host('${coordinator}', ${POSTGRESQL_PORT_NUMBER});
+    EOSQL
+
+      # Add workers
+      id=0
+      replicas={{.Values.citus.readReplicas.replicaCount}}
+      name="{{ include "postgresql.readReplica.fullname" .Subcharts.citus }}"
+      echo "Adding ${replicas} workers"
+
+      while [[ ${id} -lt ${replicas} ]]; do
+        host="${name}-${id}.${name}-hl.{{ .Release.Namespace }}.svc.cluster.local"
+
+        until ( exec pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB" -h "${host}" -p "${POSTGRESQL_PORT_NUMBER}" ); do
+          echo "Waiting for worker ${id} to become ready"
+          sleep 1
+        done
+
+        psql -v ON_ERROR_STOP=1 --username "${POSTGRES_USER}" --dbname "${POSTGRES_DB}" -p "${POSTGRESQL_PORT_NUMBER}" <<-EOSQL
+          select citus_add_node('${host}', ${POSTGRESQL_PORT_NUMBER});
+
+          \c ${HEDERA_MIRROR_IMPORTER_DB_NAME}
+          select citus_add_node('${host}', ${POSTGRESQL_PORT_NUMBER});
+    EOSQL
+
+        ((id = id + 1))
+      done
+    }
+
+    # Common setup for coordinator and workers
     psql -v ON_ERROR_STOP=1 --username "${POSTGRES_USER}" --dbname "${POSTGRES_DB}" -p "${POSTGRESQL_PORT_NUMBER}" <<-EOSQL
       create extension if not exists citus;
       update pg_dist_node_metadata SET metadata=jsonb_insert(metadata, '{docker}', 'true');
-      insert into pg_dist_authinfo(nodeid, rolename, authinfo) values(1, '${POSTGRES_USER}', 'password=${POSTGRES_PASSWORD}');
-      select citus_set_coordinator_host('${coordinator}', ${POSTGRESQL_PORT_NUMBER});
+      insert into pg_dist_authinfo(nodeid, rolename, authinfo) values(0, '${POSTGRES_USER}', 'password=${POSTGRES_PASSWORD}');
 
       \c ${HEDERA_MIRROR_IMPORTER_DB_NAME}
       create extension if not exists citus;
       create user ${HEDERA_MIRROR_IMPORTER_DB_RESTUSERNAME} with login password '${HEDERA_MIRROR_IMPORTER_DB_RESTPASSWORD}' in role readonly;
+      insert into pg_dist_authinfo(nodeid, rolename, authinfo) values
+        (0, '${POSTGRES_USER}', 'password=${POSTGRES_PASSWORD}'),
+        (0, '${HEDERA_MIRROR_GRPC_DB_USERNAME}', 'password=${HEDERA_MIRROR_GRPC_DB_PASSWORD}'),
+        (0, '${HEDERA_MIRROR_IMPORTER_DB_USERNAME}', 'password=${HEDERA_MIRROR_IMPORTER_DB_PASSWORD}'),
+        (0, '${HEDERA_MIRROR_IMPORTER_DB_OWNER}', 'password=${HEDERA_MIRROR_IMPORTER_DB_OWNERPASSWORD}'),
+        (0, '${HEDERA_MIRROR_IMPORTER_DB_RESTUSERNAME}', 'password=${HEDERA_MIRROR_IMPORTER_DB_RESTPASSWORD}'),
+        (0, '${HEDERA_MIRROR_ROSETTA_DB_USERNAME}', 'password=${HEDERA_MIRROR_ROSETTA_DB_PASSWORD}'),
+        (0, '${HEDERA_MIRROR_WEB3_DB_USERNAME}', 'password=${HEDERA_MIRROR_WEB3_DB_PASSWORD}');
     EOSQL
 
-    # Setup workers
-    id=0
-    replicas={{.Values.citus.readReplicas.replicaCount}}
-    name="{{ include "postgresql.readReplica.fullname" .Subcharts.citus }}"
-    echo "Adding ${replicas} workers"
-
-    while [[ ${id} -lt ${replicas} ]]; do
-      nodeid=$((id + 2))
-      host="${name}-${id}.${name}-hl.{{ .Release.Namespace }}.svc.cluster.local"
-
-      until ( exec pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB" -h "${host}" -p "${POSTGRESQL_PORT_NUMBER}" ); do
-        echo "Waiting for worker ${id} to become ready"
-        sleep 1
-      done
-
-      psql -v ON_ERROR_STOP=1 --username "${POSTGRES_USER}" --dbname "${POSTGRES_DB}" -p "${POSTGRESQL_PORT_NUMBER}" <<-EOSQL
-        insert into pg_dist_authinfo(nodeid, rolename, authinfo) values(${nodeid}, '${POSTGRES_USER}', 'password=${POSTGRES_PASSWORD}');
-        select citus_add_node('${host}', ${POSTGRESQL_PORT_NUMBER});
-
-        \c ${HEDERA_MIRROR_IMPORTER_DB_NAME}
-        create extension if not exists citus;
-    EOSQL
-
-      ((id = id + 1))
-    done
+    if [[ "${POSTGRES_REPLICATION_MODE}" = "master" ]]; then
+      setup_coordinator
+    fi
   {{- end }}

--- a/charts/hedera-mirror/values.yaml
+++ b/charts/hedera-mirror/values.yaml
@@ -95,13 +95,19 @@ citus:
       max_wal_size = 24GB
       shared_preload_libraries = 'citus'
       wal_level = logical
+    extraEnvVarsSecret: mirror-passwords
     extraVolumeMounts:
       - name: config
         mountPath: /usr/local/etc/postgresql
+      - name: custom-init-scripts
+        mountPath: /docker-entrypoint-initdb.d/
     extraVolumes:
       - name: config
         configMap:
           name: '{{ printf "%s-extended-configuration" (include "postgresql.readReplica.fullname" .) }}'
+      - name: custom-init-scripts
+        configMap:
+          name: "{{ .Release.Name }}-init"
     name: worker
 
 db:


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR fixes the citus extension config issue in multi-node deployment

- create `mirror_node` database and roles in worker nodes
- create and configure citus extension in `mirror_node` database
- use special nodeid `0` to config role auth info for inter-node communication

**Related issue(s)**:

Fixes #4972 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
Tested with a 3-node deployment, verified

- distributed table is propagated to worker nodes
- data written to the distributed table is saved to the corresponding shards on the worker nodes

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
