### PR TITLE
Fix NoClassDefFoundError in RecordFileParser

### DIFF
--- a/charts/hedera-mirror-importer/values.yaml
+++ b/charts/hedera-mirror-importer/values.yaml
@@ -156,7 +156,8 @@ networkPolicy:
 
 nodeSelector: {}
 
-podAnnotations: {}
+podAnnotations:
+  "cluster-autoscaler.kubernetes.io/safe-to-evict": "true"
 
 podDisruptionBudget:
   enabled: false
@@ -489,6 +490,8 @@ updateStrategy:
 volumeMounts:
   config:
     mountPath: /usr/etc/hedera
+  temp:
+    mountPath: /tmp
 
 # Volume mounts to add to the container. The key is the volume name and the value is the volume definition. Evaluated as a template.
 volumes:
@@ -496,3 +499,7 @@ volumes:
     secret:
       defaultMode: 420
       secretName: '{{ include "hedera-mirror-importer.fullname" . }}'
+  temp:
+    emptyDir:
+      medium: Memory
+      sizeLimit: 500Mi

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/AbstractStreamFileParser.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/AbstractStreamFileParser.java
@@ -108,15 +108,19 @@ public abstract class AbstractStreamFileParser<T extends StreamFile> implements 
         }
 
         var lastStreamFile = last.get();
+        var name = streamFile.getName();
+
         if (lastStreamFile.getConsensusEnd() >= streamFile.getConsensusStart()) {
-            log.warn("Skipping existing stream file {}", streamFile.getName());
+            log.warn("Skipping existing stream file {}", name);
             return false;
         }
 
+        var actualHash = streamFile.getPreviousHash();
+        var expectedHash = lastStreamFile.getHash();
+
         // Verify hash chain
-        if (streamFile.getType().isChained() && !lastStreamFile.getHash().contentEquals(streamFile.getPreviousHash())) {
-            throw new HashMismatchException(streamFile.getName(), lastStreamFile.getHash(),
-                    streamFile.getPreviousHash(), getClass().getSimpleName());
+        if (streamFile.getType().isChained() && !expectedHash.contentEquals(actualHash)) {
+            throw new HashMismatchException(name, expectedHash, actualHash, getClass().getSimpleName());
         }
 
         return true;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/AbstractStreamFileParser.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/AbstractStreamFileParser.java
@@ -29,6 +29,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import com.hedera.mirror.common.domain.StreamFile;
+import com.hedera.mirror.importer.exception.HashMismatchException;
 import com.hedera.mirror.importer.repository.StreamFileRepository;
 
 public abstract class AbstractStreamFileParser<T extends StreamFile> implements StreamFileParser<T> {
@@ -83,7 +84,7 @@ public abstract class AbstractStreamFileParser<T extends StreamFile> implements 
                 success = true;
                 Instant consensusInstant = Instant.ofEpochSecond(0L, streamFile.getConsensusEnd());
                 parseLatencyMetric.record(Duration.between(consensusInstant, Instant.now()));
-            } catch (Exception e) {
+            } catch (Throwable e) {
                 log.error("Error parsing file {} after {}", streamFile.getName(), stopwatch, e);
                 throw e;
             } finally {
@@ -100,12 +101,24 @@ public abstract class AbstractStreamFileParser<T extends StreamFile> implements 
             return false;
         }
 
-        boolean exists = streamFileRepository.existsById(streamFile.getConsensusEnd());
+        var last = streamFileRepository.findLatest();
 
-        if (exists) {
-            log.warn("Skipping existing stream file {}", streamFile.getName());
+        if (last.isEmpty()) {
+            return true;
         }
 
-        return !exists;
+        var lastStreamFile = last.get();
+        if (lastStreamFile.getConsensusEnd() >= streamFile.getConsensusStart()) {
+            log.warn("Skipping existing stream file {}", streamFile.getName());
+            return false;
+        }
+
+        // Verify hash chain
+        if (streamFile.getType().isChained() && !lastStreamFile.getHash().contentEquals(streamFile.getPreviousHash())) {
+            throw new HashMismatchException(streamFile.getName(), lastStreamFile.getHash(),
+                    streamFile.getPreviousHash(), getClass().getSimpleName());
+        }
+
+        return true;
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordFileParser.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordFileParser.java
@@ -111,6 +111,8 @@ public class RecordFileParser extends AbstractStreamFileParser<RecordFile> {
             delayExpression = "#{@recordParserProperties.getRetry().getMinBackoff().toMillis()}",
             maxDelayExpression = "#{@recordParserProperties.getRetry().getMaxBackoff().toMillis()}",
             multiplierExpression = "#{@recordParserProperties.getRetry().getMultiplier()}"),
+            include = Throwable.class,
+            exclude = OutOfMemoryError.class,
             maxAttemptsExpression = "#{@recordParserProperties.getRetry().getMaxAttempts()}")
     @Transactional(timeoutString = "#{@recordParserProperties.getTransactionTimeout().toSeconds()}")
     public void parse(RecordFile recordFile) {
@@ -139,9 +141,9 @@ public class RecordFileParser extends AbstractStreamFileParser<RecordFile> {
                     .block();
 
             recordFile.finishLoad(count);
-            recordStreamFileListener.onEnd(recordFile);
             updateIndex(recordFile);
-        } catch (Exception ex) {
+            recordStreamFileListener.onEnd(recordFile);
+        } catch (Throwable ex) {
             recordStreamFileListener.onError();
             throw ex;
         }
@@ -168,7 +170,8 @@ public class RecordFileParser extends AbstractStreamFileParser<RecordFile> {
 
     // Correct v5 block numbers once we receive a v6 block with a canonical number
     private void updateIndex(RecordFile recordFile) {
-        var lastRecordFile = last.get();
+        var lastInMemory = last.get();
+        var lastRecordFile = lastInMemory;
         var recordFileRepository = (RecordFileRepository) streamFileRepository;
 
         if (lastRecordFile == null) {
@@ -185,6 +188,6 @@ public class RecordFileParser extends AbstractStreamFileParser<RecordFile> {
             }
         }
 
-        last.set(recordFile);
+        last.compareAndSet(lastInMemory, recordFile);
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/IntegrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/IntegrationTest.java
@@ -80,13 +80,16 @@ public abstract class IntegrationTest {
     @Resource
     private MirrorProperties mirrorProperties;
 
+    @Resource
+    protected IntegrationTestConfiguration.RetryRecorder retryRecorder;
+
     @BeforeEach
     void logTest(TestInfo testInfo) {
         reset();
         log.info("Executing: {}", testInfo.getDisplayName());
     }
 
-    protected<T> Collection<T> findEntity(Class<T> entityClass, String ids, String table) {
+    protected <T> Collection<T> findEntity(Class<T> entityClass, String ids, String table) {
         String sql = String.format("select * from %s order by %s, timestamp_range asc", table, ids);
         return jdbcOperations.query(sql, rowMapper(entityClass));
     }
@@ -95,7 +98,7 @@ public abstract class IntegrationTest {
         return findHistory(historyClass, "id");
     }
 
-    protected  <T> Collection<T> findHistory(Class<T> historyClass, String ids) {
+    protected <T> Collection<T> findHistory(Class<T> historyClass, String ids) {
         return findHistory(historyClass, ids, null);
     }
 
@@ -114,6 +117,7 @@ public abstract class IntegrationTest {
         cacheManagers.forEach(c -> c.getCacheNames().forEach(name -> c.getCache(name).clear()));
         mirrorDateRangePropertiesProcessor.clear();
         mirrorProperties.setStartDate(Instant.EPOCH);
+        retryRecorder.reset();
     }
 
     protected static <T> RowMapper<T> rowMapper(Class<T> entityClass) {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/AbstractStreamFileParserTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/AbstractStreamFileParserTest.java
@@ -28,6 +28,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.hedera.mirror.common.domain.StreamFile;
@@ -56,10 +58,14 @@ public abstract class AbstractStreamFileParserTest<T extends StreamFileParser> {
         parserProperties.setEnabled(true);
     }
 
-    @Test
-    void parse() {
+    @ValueSource(booleans = {true, false})
+    @ParameterizedTest
+    void parse(boolean startAndEndSame) {
         // given
         StreamFile streamFile = getStreamFile();
+        if (startAndEndSame) {
+            streamFile.setConsensusStart(streamFile.getConsensusStart());
+        }
 
         // when
         parser.parse(streamFile);
@@ -81,10 +87,14 @@ public abstract class AbstractStreamFileParserTest<T extends StreamFileParser> {
         assertParsed(streamFile, false, false);
     }
 
-    @Test
-    void alreadyExists() {
+    @ValueSource(booleans = {true, false})
+    @ParameterizedTest
+    void alreadyExists(boolean startAndEndSame) {
         // given
         StreamFile streamFile = getStreamFile();
+        if (startAndEndSame) {
+            streamFile.setConsensusStart(streamFile.getConsensusStart());
+        }
         when(getStreamFileRepository().findLatest()).thenReturn(Optional.of(streamFile));
 
         // when

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/AbstractStreamFileParserTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/AbstractStreamFileParserTest.java
@@ -23,6 +23,7 @@ package com.hedera.mirror.importer.parser;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
+import java.util.Optional;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -84,7 +85,7 @@ public abstract class AbstractStreamFileParserTest<T extends StreamFileParser> {
     void alreadyExists() {
         // given
         StreamFile streamFile = getStreamFile();
-        when(getStreamFileRepository().existsById(streamFile.getConsensusEnd())).thenReturn(true);
+        when(getStreamFileRepository().findLatest()).thenReturn(Optional.of(streamFile));
 
         // when
         parser.parse(streamFile);

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileParserIntegrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileParserIntegrationTest.java
@@ -23,29 +23,33 @@ package com.hedera.mirror.importer.parser.record;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.google.protobuf.ByteString;
 import java.io.File;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import reactor.core.publisher.Flux;
 
 import com.hedera.mirror.common.domain.transaction.RecordFile;
 import com.hedera.mirror.importer.IntegrationTest;
 import com.hedera.mirror.importer.domain.StreamFileData;
 import com.hedera.mirror.importer.exception.ParserException;
+import com.hedera.mirror.importer.parser.domain.RecordItemBuilder;
 import com.hedera.mirror.importer.reader.record.RecordFileReader;
 import com.hedera.mirror.importer.repository.CryptoTransferRepository;
 import com.hedera.mirror.importer.repository.EntityRepository;
 import com.hedera.mirror.importer.repository.RecordFileRepository;
 import com.hedera.mirror.importer.repository.TransactionRepository;
 
-@Disabled("Fails in CI")
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
 class RecordFileParserIntegrationTest extends IntegrationTest {
 
@@ -59,6 +63,10 @@ class RecordFileParserIntegrationTest extends IntegrationTest {
     private final Path recordFilePath1;
     @Value("classpath:data/recordstreams/v2/record0.0.3/2019-08-30T18_10_05.249678Z.rcd")
     private final Path recordFilePath2;
+    private final RecordItemBuilder recordItemBuilder;
+
+    @TempDir
+    private File tempDir;
 
     private RecordFileDescriptor recordFileDescriptor1;
     private RecordFileDescriptor recordFileDescriptor2;
@@ -67,8 +75,8 @@ class RecordFileParserIntegrationTest extends IntegrationTest {
     void before() {
         RecordFile recordFile1 = recordFile(recordFilePath1.toFile(), 0L);
         RecordFile recordFile2 = recordFile(recordFilePath2.toFile(), 1L);
-        recordFileDescriptor1 = new RecordFileDescriptor(93, 8, recordFile1);
-        recordFileDescriptor2 = new RecordFileDescriptor(75, 5, recordFile2);
+        recordFileDescriptor1 = new RecordFileDescriptor(83, 5, recordFile1);
+        recordFileDescriptor2 = new RecordFileDescriptor(65, 5, recordFile2);
     }
 
     @Test
@@ -96,10 +104,32 @@ class RecordFileParserIntegrationTest extends IntegrationTest {
         verifyFinalDatabaseState(recordFileDescriptor1);
 
         // when
-        Assertions.assertThrows(ParserException.class, () -> recordFileParser.parse(recordFile));
+        RecordFile recordFile2 = recordFileDescriptor2.getRecordFile();
+        recordFile2.setItems(recordFile.getItems()); // Re-processing same transactions should result in duplicate keys
+        Assertions.assertThrows(ParserException.class, () -> recordFileParser.parse(recordFile2));
 
         // then
         verifyFinalDatabaseState(recordFileDescriptor1);
+        assertThat(retryRecorder.getRetries(ParserException.class)).isEqualTo(2);
+    }
+
+    @Disabled("Works in IDE but not on CLI")
+    @Test
+    void retryErrors() {
+        // when
+        // Mark the JNA temp dir as read only to trigger a java.lang.Error when extracting the native binary from jar
+        System.setProperty("jna.tmpdir", tempDir.getAbsolutePath());
+        tempDir.setReadOnly();
+
+        var alias = ByteString.copyFrom(Base64.getDecoder().decode("OiEDHLsCqqW3ztVNnDETNQDusK5GVQGwK8mD+KusAtjhL/A="));
+        var recordItem = recordItemBuilder.cryptoCreate().record(b -> b.setAlias(alias)).build();
+        var recordFile = recordFileDescriptor1.getRecordFile();
+        recordFile.setItems(Flux.just(recordItem));
+        Assertions.assertThrows(NoClassDefFoundError.class, () -> recordFileParser.parse(recordFile));
+
+        // then
+        assertThat(recordFileRepository.count()).isZero();
+        assertThat(retryRecorder.getRetries(NoClassDefFoundError.class)).isEqualTo(1);
     }
 
     void verifyFinalDatabaseState(RecordFileDescriptor... recordFileDescriptors) {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileParserIntegrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileParserIntegrationTest.java
@@ -113,7 +113,6 @@ class RecordFileParserIntegrationTest extends IntegrationTest {
         assertThat(retryRecorder.getRetries(ParserException.class)).isEqualTo(2);
     }
 
-    @Disabled("Works in IDE but not on CLI")
     @Test
     void retryErrors() {
         // when

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileParserTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileParserTest.java
@@ -115,7 +115,7 @@ class RecordFileParserTest extends AbstractStreamFileParserTest<RecordFileParser
 
     @Override
     protected StreamFile getStreamFile() {
-        long id = ++count;
+        long id = ++count * 100;
         recordItem = cryptoTransferRecordItem(id);
         return getStreamFile(Flux.just(recordItem), id);
     }
@@ -398,7 +398,7 @@ class RecordFileParserTest extends AbstractStreamFileParserTest<RecordFileParser
         return domainBuilder
                 .recordFile()
                 .customize(recordFileBuilder -> recordFileBuilder.bytes(new byte[] {0, 1, 2})
-                        .consensusEnd(timestamp)
+                        .consensusEnd(timestamp+1)
                         .consensusStart(timestamp)
                         .gasUsed(0L)
                         .items(items)

--- a/hedera-mirror-importer/src/test/resources/config/application.yml
+++ b/hedera-mirror-importer/src/test/resources/config/application.yml
@@ -22,6 +22,8 @@ hedera:
           entity:
             redis:
               enabled: false
+          retry:
+            maxAttempts: 2
       network: TESTNET
       startDate: 1970-01-01T00:00:00Z
 
@@ -34,8 +36,6 @@ spring:
     password: ${embedded.redis.password}
     port: ${embedded.redis.port}
     username: "" # Redis 5 does not support authentication with a username and will fail if provided
-  retry:
-    enabled: false
   task:
     scheduling:
       enabled: false


### PR DESCRIPTION
**Description**:

* Add temporary volume to importer pod so it can load native libraries
* Fix loading current block as last block on startup
* Fix parser not retrying `java.lang.Error`
* Fix parser not validating hash chain

**Related issue(s)**:

Fixes #4978

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
