### PR TITLE
Fix NoClassDefFoundError in RecordFileParser (0.69)

### DIFF
--- a/charts/hedera-mirror-importer/values.yaml
+++ b/charts/hedera-mirror-importer/values.yaml
@@ -156,7 +156,8 @@ networkPolicy:
 
 nodeSelector: {}
 
-podAnnotations: {}
+podAnnotations:
+  "cluster-autoscaler.kubernetes.io/safe-to-evict": "true"
 
 podDisruptionBudget:
   enabled: false
@@ -489,6 +490,8 @@ updateStrategy:
 volumeMounts:
   config:
     mountPath: /usr/etc/hedera
+  temp:
+    mountPath: /tmp
 
 # Volume mounts to add to the container. The key is the volume name and the value is the volume definition. Evaluated as a template.
 volumes:
@@ -496,3 +499,7 @@ volumes:
     secret:
       defaultMode: 420
       secretName: '{{ include "hedera-mirror-importer.fullname" . }}'
+  temp:
+    emptyDir:
+      medium: Memory
+      sizeLimit: 500Mi

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordFileParser.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordFileParser.java
@@ -111,6 +111,8 @@ public class RecordFileParser extends AbstractStreamFileParser<RecordFile> {
             delayExpression = "#{@recordParserProperties.getRetry().getMinBackoff().toMillis()}",
             maxDelayExpression = "#{@recordParserProperties.getRetry().getMaxBackoff().toMillis()}",
             multiplierExpression = "#{@recordParserProperties.getRetry().getMultiplier()}"),
+            include = Throwable.class,
+            exclude = OutOfMemoryError.class,
             maxAttemptsExpression = "#{@recordParserProperties.getRetry().getMaxAttempts()}")
     @Transactional(timeoutString = "#{@recordParserProperties.getTransactionTimeout().toSeconds()}")
     public void parse(RecordFile recordFile) {
@@ -139,9 +141,9 @@ public class RecordFileParser extends AbstractStreamFileParser<RecordFile> {
                     .block();
 
             recordFile.finishLoad(count);
-            recordStreamFileListener.onEnd(recordFile);
             updateIndex(recordFile);
-        } catch (Exception ex) {
+            recordStreamFileListener.onEnd(recordFile);
+        } catch (Throwable ex) {
             recordStreamFileListener.onError();
             throw ex;
         }
@@ -168,7 +170,8 @@ public class RecordFileParser extends AbstractStreamFileParser<RecordFile> {
 
     // Correct v5 block numbers once we receive a v6 block with a canonical number
     private void updateIndex(RecordFile recordFile) {
-        var lastRecordFile = last.get();
+        var lastInMemory = last.get();
+        var lastRecordFile = lastInMemory;
         var recordFileRepository = (RecordFileRepository) streamFileRepository;
 
         if (lastRecordFile == null) {
@@ -185,6 +188,6 @@ public class RecordFileParser extends AbstractStreamFileParser<RecordFile> {
             }
         }
 
-        last.set(recordFile);
+        last.compareAndSet(lastInMemory, recordFile);
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/IntegrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/IntegrationTest.java
@@ -80,13 +80,16 @@ public abstract class IntegrationTest {
     @Resource
     private MirrorProperties mirrorProperties;
 
+    @Resource
+    protected IntegrationTestConfiguration.RetryRecorder retryRecorder;
+
     @BeforeEach
     void logTest(TestInfo testInfo) {
         reset();
         log.info("Executing: {}", testInfo.getDisplayName());
     }
 
-    protected<T> Collection<T> findEntity(Class<T> entityClass, String ids, String table) {
+    protected <T> Collection<T> findEntity(Class<T> entityClass, String ids, String table) {
         String sql = String.format("select * from %s order by %s, timestamp_range asc", table, ids);
         return jdbcOperations.query(sql, rowMapper(entityClass));
     }
@@ -95,7 +98,7 @@ public abstract class IntegrationTest {
         return findHistory(historyClass, "id");
     }
 
-    protected  <T> Collection<T> findHistory(Class<T> historyClass, String ids) {
+    protected <T> Collection<T> findHistory(Class<T> historyClass, String ids) {
         return findHistory(historyClass, ids, null);
     }
 
@@ -114,6 +117,7 @@ public abstract class IntegrationTest {
         cacheManagers.forEach(c -> c.getCacheNames().forEach(name -> c.getCache(name).clear()));
         mirrorDateRangePropertiesProcessor.clear();
         mirrorProperties.setStartDate(Instant.EPOCH);
+        retryRecorder.reset();
     }
 
     protected static <T> RowMapper<T> rowMapper(Class<T> entityClass) {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/AbstractStreamFileParserTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/AbstractStreamFileParserTest.java
@@ -23,10 +23,13 @@ package com.hedera.mirror.importer.parser;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
+import java.util.Optional;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.hedera.mirror.common.domain.StreamFile;
@@ -55,10 +58,14 @@ public abstract class AbstractStreamFileParserTest<T extends StreamFileParser> {
         parserProperties.setEnabled(true);
     }
 
-    @Test
-    void parse() {
+    @ValueSource(booleans = {true, false})
+    @ParameterizedTest
+    void parse(boolean startAndEndSame) {
         // given
         StreamFile streamFile = getStreamFile();
+        if (startAndEndSame) {
+            streamFile.setConsensusStart(streamFile.getConsensusStart());
+        }
 
         // when
         parser.parse(streamFile);
@@ -80,11 +87,15 @@ public abstract class AbstractStreamFileParserTest<T extends StreamFileParser> {
         assertParsed(streamFile, false, false);
     }
 
-    @Test
-    void alreadyExists() {
+    @ValueSource(booleans = {true, false})
+    @ParameterizedTest
+    void alreadyExists(boolean startAndEndSame) {
         // given
         StreamFile streamFile = getStreamFile();
-        when(getStreamFileRepository().existsById(streamFile.getConsensusEnd())).thenReturn(true);
+        if (startAndEndSame) {
+            streamFile.setConsensusStart(streamFile.getConsensusStart());
+        }
+        when(getStreamFileRepository().findLatest()).thenReturn(Optional.of(streamFile));
 
         // when
         parser.parse(streamFile);

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileParserTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileParserTest.java
@@ -20,6 +20,7 @@ package com.hedera.mirror.importer.parser.record;
  * ‍
  */
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -56,6 +57,7 @@ import com.hedera.mirror.common.domain.transaction.RecordFile;
 import com.hedera.mirror.common.domain.transaction.RecordItem;
 import com.hedera.mirror.importer.config.MirrorDateRangePropertiesProcessor;
 import com.hedera.mirror.importer.config.MirrorDateRangePropertiesProcessor.DateRangeFilter;
+import com.hedera.mirror.importer.exception.HashMismatchException;
 import com.hedera.mirror.importer.exception.ParserSQLException;
 import com.hedera.mirror.importer.parser.AbstractStreamFileParserTest;
 import com.hedera.mirror.importer.parser.domain.RecordItemBuilder;
@@ -113,7 +115,7 @@ class RecordFileParserTest extends AbstractStreamFileParserTest<RecordFileParser
 
     @Override
     protected StreamFile getStreamFile() {
-        long id = ++count;
+        long id = ++count * 100;
         recordItem = cryptoTransferRecordItem(id);
         return getStreamFile(Flux.just(recordItem), id);
     }
@@ -235,6 +237,7 @@ class RecordFileParserTest extends AbstractStreamFileParserTest<RecordFileParser
         var streamFile2 = (RecordFile) getStreamFile();
         streamFile1.setIndex(streamFile2.getIndex() - offset);
         streamFile1.setVersion(5);
+        streamFile2.setPreviousHash(streamFile1.getHash());
 
         // when
         parser.parse(streamFile1);
@@ -247,6 +250,35 @@ class RecordFileParserTest extends AbstractStreamFileParserTest<RecordFileParser
     }
 
     @Test
+    void hashMismatch() {
+        // given
+        var streamFile1 = (RecordFile) getStreamFile();
+        var streamFile2 = (RecordFile) getStreamFile();
+        streamFile1.setIndex(streamFile2.getIndex() - 2);
+        streamFile1.setVersion(5);
+        when(recordFileRepository.findLatest()).thenReturn(Optional.of(streamFile1));
+
+        // when
+        assertThatThrownBy(() -> parser.parse(streamFile2)).isInstanceOf(HashMismatchException.class);
+    }
+
+    @Test
+    void noExistingRecordFile() {
+        // given
+        int offset = 2;
+        var streamFile = (RecordFile) getStreamFile();
+        streamFile.setIndex(3L);
+        streamFile.setVersion(5);
+        when(recordFileRepository.findLatest()).thenReturn(Optional.empty());
+
+        // when
+        parser.parse(streamFile);
+
+        // then
+        assertParsed(streamFile, true, false);
+    }
+
+    @Test
     void blockNumberMigrationOnStartup() {
         // given
         int offset = 2;
@@ -254,6 +286,7 @@ class RecordFileParserTest extends AbstractStreamFileParserTest<RecordFileParser
         var streamFile2 = (RecordFile) getStreamFile();
         streamFile1.setIndex(streamFile2.getIndex() - offset);
         streamFile1.setVersion(5);
+        streamFile2.setPreviousHash(streamFile1.getHash());
         when(recordFileRepository.findLatest()).thenReturn(Optional.of(streamFile1));
 
         // when
@@ -272,6 +305,7 @@ class RecordFileParserTest extends AbstractStreamFileParserTest<RecordFileParser
         streamFile1.setIndex(streamFile2.getIndex() - 2);
         streamFile1.setVersion(5);
         streamFile2.setVersion(5);
+        streamFile2.setPreviousHash(streamFile1.getHash());
 
         // when
         parser.parse(streamFile1);
@@ -289,6 +323,7 @@ class RecordFileParserTest extends AbstractStreamFileParserTest<RecordFileParser
         var streamFile1 = (RecordFile) getStreamFile();
         var streamFile2 = (RecordFile) getStreamFile();
         streamFile1.setIndex(streamFile2.getIndex() - 1);
+        streamFile2.setPreviousHash(streamFile1.getHash());
 
         // when
         parser.parse(streamFile1);
@@ -363,7 +398,7 @@ class RecordFileParserTest extends AbstractStreamFileParserTest<RecordFileParser
         return domainBuilder
                 .recordFile()
                 .customize(recordFileBuilder -> recordFileBuilder.bytes(new byte[] {0, 1, 2})
-                        .consensusEnd(timestamp)
+                        .consensusEnd(timestamp+1)
                         .consensusStart(timestamp)
                         .gasUsed(0L)
                         .items(items)

--- a/hedera-mirror-importer/src/test/resources/config/application.yml
+++ b/hedera-mirror-importer/src/test/resources/config/application.yml
@@ -22,6 +22,8 @@ hedera:
           entity:
             redis:
               enabled: false
+          retry:
+            maxAttempts: 2
       network: TESTNET
       startDate: 1970-01-01T00:00:00Z
 
@@ -34,8 +36,6 @@ spring:
     password: ${embedded.redis.password}
     port: ${embedded.redis.port}
     username: "" # Redis 5 does not support authentication with a username and will fail if provided
-  retry:
-    enabled: false
   task:
     scheduling:
       enabled: false


### PR DESCRIPTION
**Description**:

Cherry pick of #4979 to `release/0.69`
* Add temporary volume to importer pod so it can load native libraries
* Fix loading current block as last block on startup
* Fix parser not retrying java.lang.Error
* Fix parser not validating hash chain

**Related issue(s)**:

Fixes #4978

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
