### PR TITLE
Add a dependency-check-gradle plugin

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        project: [ grpc, importer, monitor, rest, rosetta, web3 ]
+        project: [ grpc, importer, monitor, rest, 'rest:check-state-proof', 'rest:monitoring', rosetta, web3 ]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -40,7 +40,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
-          arguments: :${{matrix.project}}:build --scan
+          arguments: :${{matrix.project}}:build --scan ${{ secrets.GRADLE_ARGS }}
 
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v3

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -8,42 +8,6 @@ on:
     tags: [ v* ]
 
 jobs:
-  dependencies:
-    name: Dependency check
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Install JDK
-        uses: actions/setup-java@v3
-        with:
-          cache: 'maven'
-          distribution: 'temurin'
-          java-version: 17
-
-      - name: NPM cache
-        uses: actions/cache@v3
-        with:
-          key: ${{ runner.os }}-node-${{ hashFiles('./package-lock.json', './check-state-proof/package-lock.json', 'monitoring/monitor_apis/package-lock.json') }}
-          path: |
-            ~/.npm
-            .node-flywaydb
-          restore-keys: ${{ runner.os }}-node-
-
-      - name: Install REST dependencies
-        run: ./mvnw compile -pl hedera-mirror-rest
-
-      - name: Vulnerability check
-        run: ./mvnw dependency-check:aggregate
-
-      - name: Upload report
-        if: failure()
-        uses: actions/upload-artifact@v3
-        with:
-          name: dependency-check-report
-          path: target/dependency-check-report.html
-
   sonar:
     if: github.event_name == 'push' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')
     name: SonarCloud

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,10 +29,10 @@ plugins {
 // Can't use typed variable syntax due to Dependabot limitations
 extra.apply {
     set("gson.version", "2.8.9") // Temporary until Apache jclouds supports gson 2.9
+    set("postgresql.version", "42.5.1") // Temporary fix for transient dependency security issue
     set("protobufVersion", "3.21.9")
     set("reactorGrpcVersion", "1.2.3")
     set("snakeyaml.version", "1.33") // Temporary fix for transient dependency security issue
-    set("spring-security.version", "5.7.5") // Temporary fix for transient dependency security issue
     set("testcontainersSpringBootVersion", "2.2.11")
 }
 
@@ -79,7 +79,6 @@ dependencies {
         api("org.springdoc:springdoc-openapi-webflux-ui:1.6.13")
         api("org.springframework.cloud:spring-cloud-dependencies:2021.0.5")
         api("org.testcontainers:junit-jupiter:1.17.6")
-        api("org.web3j:core:5.0.0")
         api("software.amazon.awssdk:bom:2.18.3")
     }
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -38,8 +38,9 @@ dependencies {
     implementation("org.apache.commons:commons-compress:1.22")
     implementation("org.gradle:test-retry-gradle-plugin:1.4.1")
     implementation("org.openapitools:openapi-generator-gradle-plugin:6.2.0")
+    implementation("org.owasp:dependency-check-gradle:7.3.2")
     implementation("org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:3.5.0.2730")
-    implementation("org.springframework.boot:spring-boot-gradle-plugin:2.7.5")
+    implementation("org.springframework.boot:spring-boot-gradle-plugin:2.7.6")
 }
 
 val gitHook = tasks.register<Exec>("gitHook") {

--- a/buildSrc/src/main/kotlin/go-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/go-conventions.gradle.kts
@@ -22,9 +22,14 @@ import plugin.go.Go
 import plugin.go.GoExtension
 import plugin.go.GolangPlugin
 
+plugins {
+    id("common-conventions")
+    id("jacoco")
+}
+
 apply<GolangPlugin>()
 
-tasks.register<Go>("build") {
+val goBuild = tasks.register<Go>("goBuild") {
     val binary = buildDir.resolve(project.projectDir.name)
     val ldFlags = "-w -s -X main.Version=${project.version}"
     environment["CGO_ENABLED"] = "true"
@@ -32,7 +37,7 @@ tasks.register<Go>("build") {
     dependsOn("test")
 }
 
-tasks.register<Go>("clean") {
+val goClean = tasks.register<Go>("goClean") {
     args("clean")
     buildDir.deleteRecursively()
     projectDir.resolve("coverage.txt").delete()
@@ -54,11 +59,19 @@ tasks.register<Go>("generate") {
 
 tasks.register<Exec>("run") {
     commandLine(buildDir.resolve(project.projectDir.name))
-    dependsOn("build")
+    dependsOn(goBuild)
 }
 
 tasks.register<Go>("test") {
     val go = project.extensions.getByName<GoExtension>("go")
     args("test", "-coverpkg=${go.pkg}", "-coverprofile=coverage.txt", "-covermode=atomic", "-race", "-v", go.pkg)
     dependsOn("fix")
+}
+
+tasks.build {
+    dependsOn(goBuild)
+}
+
+tasks.clean {
+    dependsOn(goClean)
 }

--- a/buildSrc/src/main/kotlin/java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-conventions.gradle.kts
@@ -21,11 +21,11 @@
 import org.springframework.boot.gradle.plugin.SpringBootPlugin
 
 plugins {
+    id("common-conventions")
     id("io.freefair.lombok")
     id("io.spring.dependency-management")
     id("jacoco")
     id("org.gradle.test-retry")
-    id("spotless-conventions")
     `java-library`
 }
 
@@ -34,7 +34,6 @@ configurations.all {
 }
 
 repositories {
-    mavenCentral()
     maven {
         url = uri("https://oss.sonatype.org/content/repositories/snapshots")
     }

--- a/buildSrc/src/main/kotlin/javascript-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/javascript-conventions.gradle.kts
@@ -23,10 +23,11 @@ import org.gradle.internal.io.NullOutputStream
 
 plugins {
     id("com.github.node-gradle.node")
-    id("java-conventions")
+    id("common-conventions")
+    id("jacoco")
 }
 
-val npmTest = tasks.register<NpmTask>("npmTest") {
+val test = tasks.register<NpmTask>("test") {
     dependsOn(tasks.npmInstall)
     args.set(listOf("test"))
     execOverrides {
@@ -37,10 +38,10 @@ val npmTest = tasks.register<NpmTask>("npmTest") {
     }
 }
 
-tasks.named("assemble") {
+tasks.assemble {
     dependsOn(tasks.npmInstall)
 }
 
-tasks.named("build") {
-    dependsOn(npmTest)
+tasks.build {
+    dependsOn(test)
 }

--- a/buildSrc/src/main/resources/hooks/pre-commit
+++ b/buildSrc/src/main/resources/hooks/pre-commit
@@ -1,14 +1,13 @@
 #!/bin/sh
 set -e
 
-# Stash any unstaged changes
-git stash -q --keep-index --include-untracked
+rootDir=$(pwd)
+filesStr="$(git diff --name-only --cached --diff-filter=ACMRTUB HEAD)"
+files=($filesStr)
 
-echo "Running spotlessApply to format code..."
-./gradlew spotlessApply
+echo "Running Spotless to format ${#files[@]} changed files"
+#./gradlew spotlessApply
 
-# Add all files modified by Spotless
-git add .
-
-# Unstash the unstaged changes
-git stash pop -q
+#for file in ${files[@]}; do
+  #git add "${rootDir}/${file}"
+#done

--- a/buildSrc/src/main/resources/suppressions.xml
+++ b/buildSrc/src/main/resources/suppressions.xml
@@ -24,4 +24,8 @@
         <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-web@.*$</packageUrl>
         <cve>CVE-2016-1000027</cve>
     </suppress>
+    <suppress>
+        <notes>No snakeyaml release available with a fix yet</notes>
+        <cve>CVE-2022-1471</cve>
+    </suppress>
 </suppressions>

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 dockerRegistry=gcr.io/mirrornode
 dockerTag=latest
 group="com.hedera"
-version=0.70.0-SNAPSHOT
+version=0.71.0-SNAPSHOT
 # Gradle settings
 org.gradle.caching=true
 org.gradle.configureondemand=true

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/service/AddressBookProperties.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/service/AddressBookProperties.java
@@ -35,7 +35,7 @@ public class AddressBookProperties {
 
     @DurationMin(millis = 500L)
     @NotNull
-    private Duration cacheExpiry = Duration.ofSeconds(5);
+    private Duration cacheExpiry = Duration.ofSeconds(60);
 
     @Min(0)
     private long cacheSize = 50L;

--- a/hedera-mirror-importer/build.gradle.kts
+++ b/hedera-mirror-importer/build.gradle.kts
@@ -55,7 +55,6 @@ dependencies {
     implementation("org.springframework.cloud:spring-cloud-starter-bootstrap")
     implementation("org.springframework.cloud:spring-cloud-starter-kubernetes-fabric8-config")
     implementation("org.springframework.integration:spring-integration-core")
-    implementation("org.web3j:core")
     implementation("software.amazon.awssdk:netty-nio-client")
     implementation("software.amazon.awssdk:s3")
     implementation("software.amazon.awssdk:sts")

--- a/hedera-mirror-importer/pom.xml
+++ b/hedera-mirror-importer/pom.xml
@@ -210,11 +210,6 @@
             <artifactId>headlong</artifactId>
             <version>${headlong.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.web3j</groupId>
-            <artifactId>core</artifactId>
-            <version>${web3j.version}</version>
-        </dependency>
         <!-- Test -->
         <dependency>
             <groupId>com.github.vertical-blank</groupId>

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/domain/RecordItemBuilder.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/domain/RecordItemBuilder.java
@@ -102,7 +102,6 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Scope;
 import org.springframework.data.util.Version;
-import org.web3j.crypto.Hash;
 
 import com.hedera.mirror.common.domain.transaction.RecordFile;
 import com.hedera.mirror.common.domain.transaction.RecordItem;
@@ -414,7 +413,7 @@ public class RecordItemBuilder {
                 .setMaxGasAllowance(10_000L);
 
         var contractId = contractId();
-        var digestedHash = ByteString.copyFrom(Hash.sha3(transactionBytes));
+        var digestedHash = bytes(32);
         var functionResult = contractFunctionResult(contractId);
         var builder = new Builder<>(TransactionType.ETHEREUMTRANSACTION, transactionBody)
                 .record(r -> r.setContractCallResult(functionResult).setEthereumHash(digestedHash))

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerEthereumTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerEthereumTest.java
@@ -35,7 +35,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.web3j.crypto.Hash;
 
 import com.hedera.mirror.common.domain.entity.Entity;
 import com.hedera.mirror.common.domain.entity.EntityId;
@@ -139,7 +138,7 @@ class EntityRecordItemListenerEthereumTest extends AbstractEntityRecordItemListe
         var transactionBytes = Hex.decodeHex(transactionBytesString);
         return recordItemBuilder.ethereumTransaction(create)
                 .transactionBody(x -> x.setEthereumData(ByteString.copyFrom(transactionBytes)))
-                .record(x -> x.setEthereumHash(ByteString.copyFrom(Hash.sha3(transactionBytes))))
+                .record(x -> x.setEthereumHash(ByteString.copyFrom(domainBuilder.bytes(32))))
                 .build();
     }
 

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/rest/RestSubscriber.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/rest/RestSubscriber.java
@@ -33,6 +33,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 import reactor.util.retry.Retry;
 import reactor.util.retry.RetryBackoffSpec;
@@ -120,7 +121,8 @@ class RestSubscriber implements MirrorSubscriber {
                                 "/transactions/{transactionId}", toString(publishResponse.getTransactionId()))
                         .timeout(properties.getTimeout())
                         .retryWhen(retrySpec)
-                        .onErrorContinue((t, o) -> subscription.onError(t))
+                        .doOnError(t -> subscription.onError(t))
+                        .onErrorResume(e -> Mono.empty())
                         .doOnNext(subscription::onNext)
                         .map(transaction -> toResponse(subscription, publishResponse, transaction)))
                 .take(properties.getLimit(), true)

--- a/hedera-mirror-rest/check-state-proof/build.gradle.kts
+++ b/hedera-mirror-rest/check-state-proof/build.gradle.kts
@@ -23,3 +23,8 @@ description = "Hedera Mirror Node Check State Proof"
 plugins {
     id("javascript-conventions")
 }
+
+// This project imports code from the parent project
+tasks.npmInstall {
+    dependsOn(":rest:npmInstall")
+}

--- a/pom.xml
+++ b/pom.xml
@@ -50,13 +50,12 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.5</version>
+        <version>2.7.6</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
     <properties>
         <besu.version>22.10.0</besu.version>
-        <dependency-check.version>7.2.1</dependency-check.version>
         <disruptor.version>3.4.4</disruptor.version> <!-- Used for asynchronous logging -->
         <docker-maven-plugin.version>0.40.2</docker-maven-plugin.version>
         <docker.architecture>amd64</docker.architecture>
@@ -104,9 +103,6 @@
         <sonar.issue.ignore.multicriteria.e5.resourceKey>**/stateproof/*.sql
         </sonar.issue.ignore.multicriteria.e5.resourceKey>
         <sonar.issue.ignore.multicriteria.e5.ruleKey>plsql:S1192</sonar.issue.ignore.multicriteria.e5.ruleKey>
-        <!-- Temporary fix for transient dependency security issue -->
-        <spring-security.version>5.7.5</spring-security.version>
-        <web3j.version>4.9.2</web3j.version>
     </properties>
 
     <scm>
@@ -179,29 +175,6 @@
     <build>
         <pluginManagement>
             <plugins>
-                <plugin>
-                    <groupId>org.owasp</groupId>
-                    <artifactId>dependency-check-maven</artifactId>
-                    <version>${dependency-check.version}</version>
-                    <configuration>
-                        <enableExperimental>true</enableExperimental>
-                        <failBuildOnCVSS>8</failBuildOnCVSS>
-                        <scanSet>
-                            <fileSet>
-                                <directory>${maven.multiModuleProjectDirectory}/hedera-mirror-rest/check-state-proof
-                                </directory>
-                            </fileSet>
-                            <fileSet>
-                                <directory>${maven.multiModuleProjectDirectory}/hedera-mirror-rest/monitor_apis
-                                </directory>
-                            </fileSet>
-                        </scanSet>
-                        <suppressionFiles>
-                            <suppressionFile>${maven.multiModuleProjectDirectory}/suppressions.xml</suppressionFile>
-                        </suppressionFiles>
-                        <versionCheckEnabled>false</versionCheckEnabled>
-                    </configuration>
-                </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>


### PR DESCRIPTION
**Description**:

* Add `check-state-proof` and `monitoring` projects to CI
* Add dependency-check-gradle plugin
* Add `GRADLE_ARGS` secret to CI to dynamically pass args for debugging or working around issues
* Bump various dependencies to pass vulnerability checks
* Change gRPC address book cache to `60s`
* Fix `check-state-proof` build not depending upon `rest` project dependencies
* Fix flaky `RestSubscriberTest`
* Fix buggy spotless commit hook
* Remove `org.web3j` dependency since it was only used for a few tests and had vulnerabilities
* Replace separate Maven dependency check workflow with inline Gradle check
* Suppress `snakeyaml` vulnerability until there's an available release

**Related issue(s)**:

Fixes #4971

**Notes for reviewer**:

I've reworked the spotless commit hook to not use the stash as it was troublesome. It now detects which files were staged and only adds those after formatting. This can be further improved in a followup to not add partially staged files. However, I've disabled it for now to avoid formatting churn in PRs. After merge, I will do a giant formatting PR so the codebase is corrected at once.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
