### PR TITLE
Add a property to control network supply format (0.69)

### DIFF
--- a/hedera-mirror-rest/__tests__/config.test.js
+++ b/hedera-mirror-rest/__tests__/config.test.js
@@ -395,6 +395,63 @@ describe('Override db pool config', () => {
   });
 });
 
+describe('Override network currencyFormat config', () => {
+  const loadConfigWithCustomNetworkCurrencyFormatConfig = async (customNetworkCurrencyFormatConfig) => {
+    const customConfig = {
+      hedera: {
+        mirror: {
+          rest: {
+            network: {
+              currencyFormat: customNetworkCurrencyFormatConfig,
+            },
+          },
+        },
+      },
+    };
+    fs.writeFileSync(path.join(tempDir, 'application.yml'), yaml.dump(customConfig));
+    process.env = {CONFIG_PATH: tempDir};
+    return loadConfig();
+  };
+
+  const testSpecs = [
+    {
+      name: 'unspecified value should be valid',
+      expectThrow: false,
+    },
+    {
+      name: 'override with currencyFormat BOTH',
+      override: 'BOTH',
+      expectThrow: false,
+    },
+    {
+      name: 'override with currencyFormat HBARS',
+      override: 'HBARS',
+      expectThrow: false,
+    },
+    {
+      name: 'override with currencyFormat TINYBARS',
+      override: 'TINYBARS',
+      expectThrow: false,
+    },
+    {
+      name: 'override with currencyFormat INVALID',
+      override: 'INVALID',
+      expectThrow: true,
+    },
+  ];
+
+  testSpecs.forEach((testSpec) => {
+    const {name, override, expectThrow} = testSpec;
+    test(name, async () => {
+      if (!expectThrow) {
+        await loadConfigWithCustomNetworkCurrencyFormatConfig(override);
+      } else {
+        await expect(loadConfigWithCustomNetworkCurrencyFormatConfig(override)).rejects.toThrow();
+      }
+    });
+  });
+});
+
 describe('getResponseLimit', () => {
   test('default', async () => {
     const func = (await import('../config')).getResponseLimit;

--- a/hedera-mirror-rest/__tests__/controllers/networkController.test.js
+++ b/hedera-mirror-rest/__tests__/controllers/networkController.test.js
@@ -300,3 +300,31 @@ describe('extractFileDataQuery', () => {
     });
   });
 });
+
+describe('convertToCurrencyFormat', () => {
+  it.each`
+    tinycoins                | currencyFormat | expected
+    ${'1234567890000'}       | ${'BOTH'}      | ${'12345.67890000'}
+    ${'1234567890000'}       | ${null}        | ${'12345.67890000'}
+    ${'0'}                   | ${'BOTH'}      | ${'0.00000000'}
+    ${'42'}                  | ${'BOTH'}      | ${'0.00000042'}
+    ${'987654321098765432'}  | ${'BOTH'}      | ${'9876543210.98765432'}
+    ${'5000000000000000000'} | ${null}        | ${'50000000000.00000000'}
+    ${'1234567890000'}       | ${'HBARS'}     | ${'12345'}
+    ${'0'}                   | ${'HBARS'}     | ${'0'}
+    ${'42'}                  | ${'HBARS'}     | ${'0'}
+    ${'987654321098765432'}  | ${'HBARS'}     | ${'9876543210'}
+    ${'5000000000000000000'} | ${'HBARS'}     | ${'50000000000'}
+    ${'1234567890123'}       | ${'TINYBARS'}  | ${'1234567890123'}
+    ${'0'}                   | ${'TINYBARS'}  | ${'0'}
+    ${'42'}                  | ${'TINYBARS'}  | ${'42'}
+    ${'987654321098765432'}  | ${'TINYBARS'}  | ${'987654321098765432'}
+    ${'5000000000000000000'} | ${'TINYBARS'}  | ${'5000000000000000000'}
+    ${''}                    | ${undefined}   | ${'0.00000000'}
+    ${undefined}             | ${undefined}   | ${'0.00000000'}
+    ${undefined}             | ${'HBARS'}     | ${'0'}
+    ${undefined}             | ${'TINYBARS'}  | ${'0'}
+  `('verifies "$currencyFormat" on $tinycoins expecting $expected', ({tinycoins, currencyFormat, expected}) => {
+    expect(networkCtrl.convertToCurrencyFormat(tinycoins, currencyFormat)).toEqual(expected);
+  });
+});

--- a/hedera-mirror-rest/__tests__/specs/network/supply/q-circulating-BOTH.json
+++ b/hedera-mirror-rest/__tests__/specs/network/supply/q-circulating-BOTH.json
@@ -1,6 +1,11 @@
 {
-  "description": "Network supply API with q=circulating with currencyFormat defaulting to BOTH",
+  "description": "Network supply API with q=circulating with currencyFormat explicitly set to BOTH",
   "setup": {
+    "config": {
+      "network": {
+        "currencyFormat": "BOTH"
+      }
+    },
     "accounts": [
       {
         "balance": 10,

--- a/hedera-mirror-rest/__tests__/specs/network/supply/q-circulating-HBARS.json
+++ b/hedera-mirror-rest/__tests__/specs/network/supply/q-circulating-HBARS.json
@@ -1,6 +1,11 @@
 {
-  "description": "Network supply API with q=circulating with currencyFormat defaulting to BOTH",
+  "description": "Network supply API with q=circulating with currencyFormat explicitly set to HBARS",
   "setup": {
+    "config": {
+      "network": {
+        "currencyFormat": "HBARS"
+      }
+    },
     "accounts": [
       {
         "balance": 10,
@@ -37,5 +42,5 @@
   "url": "/api/v1/network/supply?q=circulating",
   "responseContentType": "text/plain; charset=utf-8",
   "responseStatus": 200,
-  "responseJson": "9999999999.99999949"
+  "responseJson": "9999999999"
 }

--- a/hedera-mirror-rest/__tests__/specs/network/supply/q-circulating-TINYBARS.json
+++ b/hedera-mirror-rest/__tests__/specs/network/supply/q-circulating-TINYBARS.json
@@ -1,6 +1,11 @@
 {
-  "description": "Network supply API with q=circulating with currencyFormat defaulting to BOTH",
+  "description": "Network supply API with q=circulating with currencyFormat explicitly set to TINYBARS",
   "setup": {
+    "config": {
+      "network": {
+        "currencyFormat": "TINYBARS"
+      }
+    },
     "accounts": [
       {
         "balance": 10,
@@ -37,5 +42,5 @@
   "url": "/api/v1/network/supply?q=circulating",
   "responseContentType": "text/plain; charset=utf-8",
   "responseStatus": 200,
-  "responseJson": "9999999999.99999949"
+  "responseJson": "999999999999999949"
 }

--- a/hedera-mirror-rest/__tests__/specs/network/supply/q-totalcoins-BOTH.json
+++ b/hedera-mirror-rest/__tests__/specs/network/supply/q-totalcoins-BOTH.json
@@ -1,6 +1,11 @@
 {
-  "description": "Network supply API with q=circulating with currencyFormat defaulting to BOTH",
+  "description": "Network supply API with q=totalcoins with currencyFormat explicitly set to BOTH",
   "setup": {
+    "config": {
+      "network": {
+        "currencyFormat": "BOTH"
+      }
+    },
     "accounts": [
       {
         "balance": 10,
@@ -34,8 +39,8 @@
       }
     ]
   },
-  "url": "/api/v1/network/supply?q=circulating",
+  "url": "/api/v1/network/supply?q=totalcoins",
   "responseContentType": "text/plain; charset=utf-8",
   "responseStatus": 200,
-  "responseJson": "9999999999.99999949"
+  "responseJson": "50000000000.00000000"
 }

--- a/hedera-mirror-rest/__tests__/specs/network/supply/q-totalcoins-HBARS.json
+++ b/hedera-mirror-rest/__tests__/specs/network/supply/q-totalcoins-HBARS.json
@@ -1,6 +1,11 @@
 {
-  "description": "Network supply API with q=circulating with currencyFormat defaulting to BOTH",
+  "description": "Network supply API with q=totalcoins with currencyFormat explicitly set to HBARS",
   "setup": {
+    "config": {
+      "network": {
+        "currencyFormat": "HBARS"
+      }
+    },
     "accounts": [
       {
         "balance": 10,
@@ -34,8 +39,8 @@
       }
     ]
   },
-  "url": "/api/v1/network/supply?q=circulating",
+  "url": "/api/v1/network/supply?q=totalcoins",
   "responseContentType": "text/plain; charset=utf-8",
   "responseStatus": 200,
-  "responseJson": "9999999999.99999949"
+  "responseJson": "50000000000"
 }

--- a/hedera-mirror-rest/__tests__/specs/network/supply/q-totalcoins-TINYBARS.json
+++ b/hedera-mirror-rest/__tests__/specs/network/supply/q-totalcoins-TINYBARS.json
@@ -1,6 +1,11 @@
 {
-  "description": "Network supply API with q=circulating with currencyFormat defaulting to BOTH",
+  "description": "Network supply API with q=totalcoins with currencyFormat explicitly set to TINYBARS",
   "setup": {
+    "config": {
+      "network": {
+        "currencyFormat": "TINYBARS"
+      }
+    },
     "accounts": [
       {
         "balance": 10,
@@ -34,8 +39,8 @@
       }
     ]
   },
-  "url": "/api/v1/network/supply?q=circulating",
+  "url": "/api/v1/network/supply?q=totalcoins",
   "responseContentType": "text/plain; charset=utf-8",
   "responseStatus": 200,
-  "responseJson": "9999999999.99999949"
+  "responseJson": "5000000000000000000"
 }

--- a/hedera-mirror-rest/__tests__/specs/network/supply/q-totalcoins.json
+++ b/hedera-mirror-rest/__tests__/specs/network/supply/q-totalcoins.json
@@ -1,5 +1,5 @@
 {
-  "description": "Network supply API with q=totalcoins",
+  "description": "Network supply API with q=totalcoins with currencyFormat defaulting to BOTH",
   "setup": {
     "accounts": [
       {
@@ -37,5 +37,5 @@
   "url": "/api/v1/network/supply?q=totalcoins",
   "responseContentType": "text/plain; charset=utf-8",
   "responseStatus": 200,
-  "responseJson": "5000000000000000000"
+  "responseJson": "50000000000.00000000"
 }

--- a/hedera-mirror-rest/config.js
+++ b/hedera-mirror-rest/config.js
@@ -173,6 +173,16 @@ const parseMaxTimestampRange = () => {
   conf.maxTimestampRangeNs = BigInt(ms) * 1000000n;
 };
 
+const parseNetworkConfig = () => {
+  const currencyFormat = getConfig().network.currencyFormat;
+  if (currencyFormat) {
+    const validValues = ['BOTH', 'HBARS', 'TINYBARS'];
+    if (!validValues.includes(currencyFormat)) {
+      throw new InvalidConfigError(`invalid currencyFormat ${currencyFormat}`);
+    }
+  }
+};
+
 if (!loaded) {
   const configName = process.env.CONFIG_NAME || defaultConfigName;
   // always load the default configuration
@@ -184,6 +194,7 @@ if (!loaded) {
   parseDbPoolConfig();
   parseStateProofStreamsConfig();
   parseMaxTimestampRange();
+  parseNetworkConfig();
   loaded = true;
   configureLogger(getConfig().log.level);
 }

--- a/hedera-mirror-rest/config/application.yml
+++ b/hedera-mirror-rest/config/application.yml
@@ -54,6 +54,8 @@ hedera:
             to: 0.0.349
           - from: 0.0.400
             to: 0.0.750
+        # valid values for currencyFormat are 'BOTH', 'HBARS', and 'TINYBARS'
+        currencyFormat: 'BOTH'
       openapi:
         specFileName: 'openapi'
         swaggerUIPath: 'docs'

--- a/hedera-mirror-rest/constants.js
+++ b/hedera-mirror-rest/constants.js
@@ -21,6 +21,7 @@
 const MAX_INT32 = 2147483647;
 
 const ONE_DAY_IN_NS = 86_400_000_000_000n;
+const DECIMALS_IN_HBARS = 8;
 
 // url query filer keys
 const filterKeys = {
@@ -116,6 +117,12 @@ const networkSupplyQuery = {
   TOTALCOINS: 'totalcoins',
 };
 
+const networkSupplyCurrencyFormatType = {
+  TINYBARS: 'TINYBARS', // output circulating or total coins in tinybars
+  HBARS: 'HBARS', // output circulating or total coins in hbars (rounded to nearest integer)
+  BOTH: 'BOTH', // default; output circulating or total coins in fractional hbars (with a decimal point between hbars and remaining tinybars)
+};
+
 const transactionResultFilter = {
   SUCCESS: 'success',
   FAIL: 'fail',
@@ -209,6 +216,7 @@ const queryParamOperatorPatterns = {
 };
 
 export {
+  DECIMALS_IN_HBARS,
   MAX_INT32,
   ONE_DAY_IN_NS,
   characterEncoding,
@@ -221,6 +229,7 @@ export {
   httpStatusCodes,
   keyTypes,
   networks,
+  networkSupplyCurrencyFormatType,
   networkSupplyQuery,
   orderFilterValues,
   queryParamOperators,


### PR DESCRIPTION
**Description**:

Cherry pick of #4974 to `release/0.69`.

* Add a property (hedera.mirror.rest.network.currencyFormat) to the config that determines the way to output total (or released) contains: as TINYBARS (current value), as HBARS (rounded to nearest hbar), or as BOTH (with a decimal point).

**Related issue(s)**:

Fixes #4944

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
