### PR TITLE
Add contract call route to web3 ingress

### DIFF
--- a/charts/hedera-mirror-web3/values.yaml
+++ b/charts/hedera-mirror-web3/values.yaml
@@ -79,6 +79,8 @@ ingress:
   hosts:
     - host: ""
       paths:
+        # the rest of /api/v1/contracts will still be handled by the REST API logic, except for this one address
+        - "/api/v1/contracts/call"
         - "/web3"
   tls:
     enabled: false

--- a/hedera-mirror-web3/postman.json
+++ b/hedera-mirror-web3/postman.json
@@ -228,6 +228,56 @@
                         }
                     },
                     "response": []
+                },
+                {
+                    "name": "Invalid request for contracts/call",
+                    "event": [
+                        {
+                            "listen": "test",
+                            "script": {
+                                "exec": [
+                                    "pm.test(\"Invalid request\", () => {",
+                                    "    var response = pm.response.json();",
+                                    "    pm.expect(pm.response.code).to.equal(200);",
+                                    "    pm.expect(response).to.not.have.key('result');",
+                                    "});",
+                                    ""
+                                ],
+                                "append_to_exec_above": [
+                                    "    pm.expect(response.message)",
+                                    "      .to.contain(\"Invalid request\")",
+                                    "      .and.contain(\"to field invalid hexadecimal string\")",
+                                    "      .and.contain(\"from field invalid hexadecimal string\")",
+                                    "      .and.contain(\"value field must be greater than or equal to 0\")",
+                                    "      .and.contain(\"gas field must be greater than or equal to 0\")",
+                                    "      .and.contain(\"gasPrice field must be greater than or equal to 0\");",
+                                    "});",
+                                    ""
+                                ],
+                                "type": "text/javascript"
+                            }
+                        }
+                    ],
+                    "request": {
+                        "method": "POST",
+                        "header": [],
+                        "body": {
+                            "mode": "raw",
+                            "raw": "{\"to\": \"0x\", \"from\": \"0x\", \"value\": -1, \"gas\": -1, \"gasPrice\": -1}",
+                            "options": {
+                                "raw": {
+                                    "language": "json"
+                                }
+                            }
+                        },
+                        "url": {
+                            "raw": "{{baseUrl}}/api/v1/contracts/call",
+                            "host": ["{{baseUrl}}"],
+                            "path": ["web3", "v1"],
+                            "proper_path": ["api", "v1", "contracts", "call"]
+                        }
+                    },
+                    "response": []
                 }
             ]
         },

--- a/hedera-mirror-web3/postman.json
+++ b/hedera-mirror-web3/postman.json
@@ -238,15 +238,10 @@
                                 "exec": [
                                     "pm.test(\"Invalid request\", () => {",
                                     "    var response = pm.response.json();",
-                                    "    pm.expect(pm.response.code).to.equal(200);",
+                                    "    pm.expect(pm.response.code).to.equal(400);",
                                     "    pm.expect(response).to.not.have.key('result');",
-                                    "});",
-                                    ""
-                                ],
-                                "append_to_exec_above": [
-                                    "    pm.expect(response.message)",
-                                    "      .to.contain(\"Invalid request\")",
-                                    "      .and.contain(\"to field invalid hexadecimal string\")",
+                                    "    pm.expect(response._status.messages[0].message)",
+                                    "      .to.contain(\"to field invalid hexadecimal string\")",
                                     "      .and.contain(\"from field invalid hexadecimal string\")",
                                     "      .and.contain(\"value field must be greater than or equal to 0\")",
                                     "      .and.contain(\"gas field must be greater than or equal to 0\")",
@@ -273,8 +268,7 @@
                         "url": {
                             "raw": "{{baseUrl}}/api/v1/contracts/call",
                             "host": ["{{baseUrl}}"],
-                            "path": ["web3", "v1"],
-                            "proper_path": ["api", "v1", "contracts", "call"]
+                            "path": ["api", "v1", "contracts", "call"]
                         }
                     },
                     "response": []


### PR DESCRIPTION
**Description**:
This PR modifies the web3 helm chart in order to specify /api/v1/contracts/call as an addition ingress for web3 ...
* One line addition to `charts/hedera-mirror-web3/values.yaml`
* Add *postman* test for the new endpoint

**Related issue(s)**:

Fixes #4977

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (Integration Kubernetes)
