### PR TITLE
Improve k6 rest test suite for automated regression test 

### DIFF
--- a/hedera-mirror-test/k6/src/lib/common.js
+++ b/hedera-mirror-test/k6/src/lib/common.js
@@ -41,7 +41,7 @@ const scenarioCommon = {
   gracefulStop: __ENV.DEFAULT_GRACEFUL_STOP || '5s',
 };
 
-const scenarioDefaults = Object.assign({}, scenarioCommon,{
+const scenarioDefaults = Object.assign({}, scenarioCommon, {
   duration: __ENV.DEFAULT_DURATION,
   executor: 'constant-vus',
   vus: __ENV.DEFAULT_VUS,
@@ -83,7 +83,7 @@ function getScenarioTimes(scenario) {
       duration: scenario.duration,
       gracefulStop: scenario.gracefulStop,
       startTime: scenario.startTime,
-    }
+    };
   } else if (executor === 'ramping-vus') {
     validateTime('gracefulRampDown', scenario.gracefulRampDown);
     let duration = parseInt(scenario.gracefulRampDown);
@@ -178,31 +178,33 @@ function getScenario(metricKey) {
 
 function defaultMetrics() {
   return {
-    "checks": {
-      "values": {
-        "rate": 0
+    checks: {
+      values: {
+        rate: 0,
       },
     },
-    "http_req_duration": {
-      "values": {
-        "avg": 0
-      }
-    },
-    "http_reqs": {
-      "values": {
-        "count": 0
+    http_req_duration: {
+      values: {
+        avg: 0,
       },
     },
-    "scenario_duration": {
-      "values": {
-        "value": 0
-      }
-    }
+    http_reqs: {
+      values: {
+        count: 0,
+      },
+    },
+    scenario_duration: {
+      values: {
+        value: 0,
+      },
+    },
   };
 }
 
 function markdownReport(data, includeUrlColumn, scenarios) {
-  const header = `| Scenario ${includeUrlColumn && '| URL'} | VUS | Pass% | RPS | Pass RPS | Avg. Req Duration | Comment |
+  const header = `| Scenario ${
+    includeUrlColumn && '| URL'
+  } | VUS | Pass% | RPS | Pass RPS | Avg. Req Duration | Comment |
 |----------${includeUrlColumn && '|----------'}|-----|-------|-----|----------|-------------------|---------|`;
 
   // collect the metrics
@@ -243,11 +245,13 @@ function markdownReport(data, includeUrlColumn, scenarios) {
       const passPercentage = (scenarioMetric['checks'].values.rate * 100.0).toFixed(2);
       const httpReqs = scenarioMetric['http_reqs'].values.count;
       const duration = scenarioMetric['scenario_duration'].values.value; // in ms
-      const rps = ((httpReqs * 1.0 / duration) * 1000).toFixed(2);
-      const passRps = (rps * passPercentage / 100.0).toFixed(2);
+      const rps = (((httpReqs * 1.0) / duration) * 1000).toFixed(2);
+      const passRps = ((rps * passPercentage) / 100.0).toFixed(2);
       const httpReqDuration = scenarioMetric['http_req_duration'].values.avg.toFixed(2);
 
-      markdown += `| ${scenario} ${includeUrlColumn && '| ' + scenarioUrls[scenario]} | ${__ENV.DEFAULT_VUS} | ${passPercentage} | ${rps}/s | ${passRps}/s | ${httpReqDuration}ms | |\n`;
+      markdown += `| ${scenario} ${includeUrlColumn && '| ' + scenarioUrls[scenario]} | ${
+        __ENV.DEFAULT_VUS
+      } | ${passPercentage} | ${rps}/s | ${passRps}/s | ${httpReqDuration}ms | |\n`;
     } catch (err) {
       console.error(`Unable to render report for scenario ${scenario}`);
     }
@@ -272,32 +276,32 @@ function TestScenarioBuilder() {
         check(response, that._checks);
       },
     };
-  }
+  };
 
   this.check = function (name, func) {
     this._checks[name] = func;
     return this;
-  }
+  };
 
   this.name = function (name) {
     this._name = name;
     return this;
-  }
+  };
 
   this.request = function (func) {
     this._request = func;
     return this;
-  }
+  };
 
   this.scenario = function (scenario) {
     this._scenario = scenario;
     return this;
-  }
+  };
 
   this.tags = function (tags) {
     this._tags = tags;
     return this;
-  }
+  };
 
   return this;
 }

--- a/hedera-mirror-test/k6/src/lib/common.js
+++ b/hedera-mirror-test/k6/src/lib/common.js
@@ -18,9 +18,9 @@
  * ‍
  */
 
-import {check} from "k6";
+import {check} from 'k6';
 import {Gauge} from 'k6/metrics';
-import {setDefaultValuesForEnvParameters} from "./parameters.js";
+import {setDefaultValuesForEnvParameters} from './parameters.js';
 
 setDefaultValuesForEnvParameters();
 
@@ -36,13 +36,16 @@ const options = {
   noVUConnectionReuse: true,
 };
 
-const scenario = {
-  duration: __ENV.DEFAULT_DURATION,
+const scenarioCommon = {
   exec: 'run',
-  executor: 'constant-vus',
-  gracefulStop: (__ENV.DEFAULT_GRACEFUL_STOP != null && __ENV.DEFAULT_GRACEFUL_STOP) || '5s',
-  vus: __ENV.DEFAULT_VUS,
+  gracefulStop: __ENV.DEFAULT_GRACEFUL_STOP || '5s',
 };
+
+const scenarioDefaults = Object.assign({}, scenarioCommon,{
+  duration: __ENV.DEFAULT_DURATION,
+  executor: 'constant-vus',
+  vus: __ENV.DEFAULT_VUS,
+});
 
 function getMetricNameWithTags(name, ...tags) {
   return tags.length === 0 ? name : `${name}{${tags}}`;
@@ -50,28 +53,54 @@ function getMetricNameWithTags(name, ...tags) {
 
 const timeRegex = /^[0-9]+s$/;
 
+function validateTime(name, value) {
+  if (!timeRegex.test(value)) {
+    throw new Error(`Invalid ${name} ${value}`);
+  }
+}
+
 function getNextStartTime(startTime, duration, gracefulStop) {
-  if (!timeRegex.test(startTime)) {
-    throw new Error(`Invalid startTime ${startTime}`);
-  }
-
-  if (!timeRegex.test(duration)) {
-    throw new Error(`Invalid duration ${duration}`);
-  }
-
-  if (!timeRegex.test(gracefulStop)) {
-    throw new Error(`Invalid gracefulStop ${gracefulStop}`);
-  }
+  validateTime('startTime', startTime);
+  validateTime('duration', duration);
+  validateTime('gracefulStop', gracefulStop);
 
   return `${parseInt(startTime) + parseInt(duration) + parseInt(gracefulStop)}s`;
 }
 
-function getOptionsWithScenario(name, tags = {}) {
+function getOptionsWithScenario(name, scenario, tags = {}) {
+  const sourceScenario = scenario ? Object.assign({}, scenario, scenarioCommon) : scenarioDefaults;
   return Object.assign({}, options, {
     scenarios: {
-      [name]: Object.assign({}, scenario, {tags}),
+      [name]: Object.assign({}, sourceScenario, {tags}),
     },
   });
+}
+
+function getScenarioTimes(scenario) {
+  const executor = scenario.executor;
+  if (executor === 'constant-vus') {
+    return {
+      duration: scenario.duration,
+      gracefulStop: scenario.gracefulStop,
+      startTime: scenario.startTime,
+    }
+  } else if (executor === 'ramping-vus') {
+    validateTime('gracefulRampDown', scenario.gracefulRampDown);
+    let duration = parseInt(scenario.gracefulRampDown);
+    for (const stage of scenario.stages) {
+      const stageDuration = stage.duration;
+      validateTime('stage duration', stageDuration);
+      duration += parseInt(stageDuration);
+    }
+
+    return {
+      duration: `${duration}s`,
+      gracefulStop: scenario.gracefulStop,
+      startTime: scenario.startTime,
+    };
+  } else {
+    throw new Error(`Unsupported k6 executor ${executor}`);
+  }
 }
 
 function getSequentialTestScenarios(tests) {
@@ -82,7 +111,25 @@ function getSequentialTestScenarios(tests) {
   const funcs = {};
   const scenarios = {};
   const thresholds = {};
-  for (const testName of Object.keys(tests).sort()) {
+
+  const constantVusTests = [];
+  const rampingVusTests = [];
+
+  for (const [name, test] of Object.entries(tests)) {
+    const executor = Object.values(test.options.scenarios)[0].executor;
+    if (executor === 'constant-vus') {
+      constantVusTests.push(name);
+      constantVusTests[name] = test;
+    } else if (executor === 'ramping-vus') {
+      rampingVusTests.push(name);
+    } else {
+      throw new Error(`Unsupported k6 executor ${executor} in test ${name}`);
+    }
+  }
+  constantVusTests.sort();
+  rampingVusTests.sort();
+
+  for (const testName of rampingVusTests.concat(constantVusTests)) {
     const testModule = tests[testName];
     const testScenarios = testModule.options.scenarios;
     const testThresholds = testModule.options.thresholds;
@@ -93,9 +140,11 @@ function getSequentialTestScenarios(tests) {
 
       // update the scenario's startTime, so scenarios run in sequence
       scenario.startTime = getNextStartTime(startTime, duration, gracefulStop);
-      startTime = scenario.startTime;
-      duration = scenario.duration;
-      gracefulStop = scenario.gracefulStop;
+
+      const times = getScenarioTimes(scenario);
+      duration = times.duration;
+      gracefulStop = times.gracefulStop;
+      startTime = times.startTime;
 
       // thresholds
       const tag = `scenario:${scenarioName}`;
@@ -113,7 +162,7 @@ function getSequentialTestScenarios(tests) {
 
   const testOptions = Object.assign({}, options, {scenarios, thresholds});
 
-  return {funcs, options: testOptions, scenarioDurationGauge: new Gauge(SCENARIO_DURATION_METRIC_NAME)};
+  return {funcs, options: testOptions, scenarioDurationGauge: new Gauge(SCENARIO_DURATION_METRIC_NAME), scenarios};
 }
 
 const checksRegex = /^checks{.*scenario:.*}$/;
@@ -152,10 +201,9 @@ function defaultMetrics() {
   };
 }
 
-function markdownReport(data, isFirstColumnUrl, scenarios) {
-  const firstColumnName = isFirstColumnUrl ? 'URL' : 'Scenario';
-  const header = `| ${firstColumnName} | VUS | Pass% | RPS | Pass RPS | Avg. Req Duration | Comment |
-|----------|-----|-------|-----|----------|-------------------|---------|`;
+function markdownReport(data, includeUrlColumn, scenarios) {
+  const header = `| Scenario ${includeUrlColumn && '| URL'} | VUS | Pass% | RPS | Pass RPS | Avg. Req Duration | Comment |
+|----------${includeUrlColumn && '|----------'}|-----|-------|-----|----------|-------------------|---------|`;
 
   // collect the metrics
   const {metrics} = data;
@@ -181,7 +229,7 @@ function markdownReport(data, isFirstColumnUrl, scenarios) {
   }
 
   const scenarioUrls = {};
-  if (isFirstColumnUrl) {
+  if (includeUrlColumn) {
     for (const [name, scenario] of Object.entries(scenarios)) {
       scenarioUrls[name] = scenario.tags.url;
     }
@@ -199,8 +247,7 @@ function markdownReport(data, isFirstColumnUrl, scenarios) {
       const passRps = (rps * passPercentage / 100.0).toFixed(2);
       const httpReqDuration = scenarioMetric['http_req_duration'].values.avg.toFixed(2);
 
-      const firstColumn = isFirstColumnUrl ? scenarioUrls[scenario] : scenario;
-      markdown += `| ${firstColumn} | ${__ENV.DEFAULT_VUS} | ${passPercentage} | ${rps}/s | ${passRps}/s | ${httpReqDuration}ms | |\n`;
+      markdown += `| ${scenario} ${includeUrlColumn && '| ' + scenarioUrls[scenario]} | ${__ENV.DEFAULT_VUS} | ${passPercentage} | ${rps}/s | ${passRps}/s | ${httpReqDuration}ms | |\n`;
     } catch (err) {
       console.error(`Unable to render report for scenario ${scenario}`);
     }
@@ -213,12 +260,13 @@ function TestScenarioBuilder() {
   this._checks = {};
   this._name = null;
   this._request = null;
+  this._scenario = null;
   this._tags = {};
 
   this.build = function () {
     const that = this;
     return {
-      options: getOptionsWithScenario(that._name, that._tags),
+      options: getOptionsWithScenario(that._name, this._scenario, that._tags),
       run: function (testParameters) {
         const response = that._request(testParameters);
         check(response, that._checks);
@@ -238,6 +286,11 @@ function TestScenarioBuilder() {
 
   this.request = function (func) {
     this._request = func;
+    return this;
+  }
+
+  this.scenario = function (scenario) {
+    this._scenario = scenario;
     return this;
   }
 

--- a/hedera-mirror-test/k6/src/lib/parameters.js
+++ b/hedera-mirror-test/k6/src/lib/parameters.js
@@ -22,12 +22,14 @@ import http from 'k6/http';
 
 import {
   accountListName,
-  contractListName, messageListName,
-  nftListName,
+  contractListName,
+  messageListName,
   scheduleListName,
   tokenListName,
-  transactionListName
-} from "./constants.js";
+  transactionListName,
+} from './constants.js';
+
+const last = (arr) => arr[arr.length - 1];
 
 const getValidResponse = (requestUrl, requestBody, httpVerbMethod) => {
   const response = httpVerbMethod(requestUrl, JSON.stringify(requestBody));
@@ -35,18 +37,64 @@ const getValidResponse = (requestUrl, requestBody, httpVerbMethod) => {
     throw new Error(`${response.status} received when requesting ${requestUrl}`);
   }
   return JSON.parse(response.body);
-}
+};
 
-const getFirstEntity = (entityPath, key) => {
-  const body = getValidResponse(entityPath, null, http.get);
-  if (!body.hasOwnProperty(key)) {
-    throw new Error(`Missing ${key} property in ${entityPath} response`);
+const getEntities = (listEntityPath, key) => {
+  const body = getValidResponse(listEntityPath, null, http.get);
+  const entities = body[key];
+  if (entities == null) {
+    throw new Error(`Missing ${key} property in ${listEntityPath} response`);
   }
-  const entity = body[key];
-  if (entity.length === 0) {
-    throw new Error(`No ${key} were found in the response for request at ${entityPath}`);
+
+  return entities;
+};
+
+const getFirstEntity = (listEntityPath, key) => {
+  const entities = getEntities(listEntityPath, key);
+  if (entities.length === 0) {
+    throw new Error(`No ${key} were found in the response for request at ${listEntityPath}`);
   }
-  return entity[0];
+  return entities[0];
+};
+
+const getPropertiesForEntity = (configuration, extractProperties, properties) => {
+  const {baseApiUrl} = configuration;
+  const {entitiesKey, subResourcePath} = properties;
+  const queryParamMap = Object.assign({limit: 100, order: 'desc'}, properties.queryParamMap || {});
+  const queryParams = Object.entries(queryParamMap)
+    .map(([key, val]) => `${key}=${val}`)
+    .join('&');
+  const defaultEntitiesQuery = `${baseApiUrl}/${entitiesKey}?${queryParams}`;
+  const entityIdPaginationKey = `${entitiesKey.substring(0, entitiesKey.length - 1)}.id`;
+  const entityIdResponseKey = properties.entityIdResponseKey || entityIdPaginationKey.replace('.', '_');
+  const subResourceKey = subResourcePath && last(subResourcePath.split('/'));
+
+  let lastEntityId = '';
+
+  while (true) {
+    const query = `${defaultEntitiesQuery}${lastEntityId && entityIdPaginationKey + '=lt:' + lastEntityId}`;
+    const entities = getEntities(query, entitiesKey);
+    if (entities.length === 0) {
+      throw new Error('No ${entitiesKey} matching criteria found');
+    }
+
+    for (const entity of entities) {
+      try {
+        lastEntityId = entity[entityIdResponseKey];
+        const args = [entity];
+
+        if (subResourcePath) {
+          const query = `${baseApiUrl}/${entitiesKey}/${lastEntityId}/${subResourcePath}?limit=1&order=desc`;
+          const subResource = getFirstEntity(query, subResourceKey);
+          args.push(subResource);
+        }
+
+        return extractProperties(...args);
+      } catch (err) {
+        // Ignore the error and continue to the next entity
+      }
+    }
+  }
 };
 
 const copyEnvParamsFromEnvMap = (propertyList) => {
@@ -61,9 +109,9 @@ const copyEnvParamsFromEnvMap = (propertyList) => {
   }
   return {
     allPropertiesFound,
-    envProperties
+    envProperties,
   };
-}
+};
 
 const computeProperties = (propertyList, fallback) => {
   const copyResult = copyEnvParamsFromEnvMap(propertyList);
@@ -71,178 +119,161 @@ const computeProperties = (propertyList, fallback) => {
     return copyResult.envProperties;
   }
   return Object.assign(copyResult.envProperties, fallback());
-}
+};
 
 export const computeAccountParameters = (configuration) =>
-  computeProperties(
-    ['DEFAULT_ACCOUNT_ID', 'DEFAULT_ACCOUNT_BALANCE', 'DEFAULT_PUBLIC_KEY'],
-    () => {
-      const accountPath = `${configuration.baseApiUrl}/accounts?balance=true&limit=1&order=desc`;
-      const firstAccount = getFirstEntity(accountPath, accountListName);
-      return {
-        DEFAULT_ACCOUNT_ID: firstAccount.account,
-        DEFAULT_ACCOUNT_BALANCE: firstAccount.balance.balance || 0,
-        DEFAULT_PUBLIC_KEY: firstAccount.key.key
-      };
-    });
+  computeProperties(['DEFAULT_ACCOUNT_ID', 'DEFAULT_ACCOUNT_BALANCE', 'DEFAULT_PUBLIC_KEY'], () => {
+    const extractProperties = (account) => {
+      const {
+        balance: {balance},
+        key,
+      } = account;
+      if (key === null) {
+        throw new Error('The account has no key');
+      }
 
-export const computeContractParameters = (configuration) =>
-  computeProperties(
-    ['DEFAULT_CONTRACT_ID', 'DEFAULT_CONTRACT_TIMESTAMP'],
-    () => {
-      const contractPath = `${configuration.baseApiUrl}/contracts?limit=1&order=desc`;
-      const firstContract = getFirstEntity(contractPath, contractListName)
+      if (balance === 0) {
+        throw new Error('The account has a zero balance');
+      }
+
       return {
-        DEFAULT_CONTRACT_ID: firstContract.contract_id,
-        DEFAULT_CONTRACT_TIMESTAMP: firstContract.created_timestamp
+        DEFAULT_ACCOUNT_BALANCE: balance,
+        DEFAULT_ACCOUNT_ID: account.account,
+        DEFAULT_PUBLIC_KEY: key.key,
       };
-    }
+    };
+    return getPropertiesForEntity(configuration, extractProperties, {
+      entitiesKey: accountListName,
+      entityIdResponseKey: 'account',
+    });
+  });
+
+export const computeContractParameters = (configuration) => {
+  const extractProperties = (contract, log) => ({
+    DEFAULT_CONTRACT_ID: contract.contract_id,
+    DEFAULT_CONTRACT_TIMESTAMP: log.timestamp,
+  });
+  return computeProperties(['DEFAULT_CONTRACT_ID', 'DEFAULT_CONTRACT_TIMESTAMP'], () =>
+    getPropertiesForEntity(configuration, extractProperties, {
+      entitiesKey: contractListName,
+      subResourcePath: 'results/logs',
+    })
   );
+};
 
 export const computeNftParameters = (configuration) => {
-  const tokenProperties = computeProperties(
-    ['DEFAULT_NFT_ID'],
-    () => {
-      const tokenPath = `${configuration.baseApiUrl}/tokens?type=NON_FUNGIBLE_UNIQUE&limit=1&order=desc`;
-      const firstNftFromTokenList = getFirstEntity(tokenPath, tokenListName);
-      return {DEFAULT_NFT_ID: firstNftFromTokenList.token_id};
-    }
+  const extractProperties = (token, nft) => ({DEFAULT_NFT_ID: token.token_id, DEFAULT_NFT_SERIAL: nft.serial_number});
+  return computeProperties(['DEFAULT_NFT_ID', 'DEFAULT_NFT_SERIAL'], () =>
+    getPropertiesForEntity(configuration, extractProperties, {
+      entitiesKey: tokenListName,
+      queryParamMap: {type: 'NON_FUNGIBLE_UNIQUE'},
+      subResourcePath: 'nfts',
+    })
   );
-
-  const nftProperties = computeProperties(
-    ['DEFAULT_NFT_SERIAL'],
-    () => {
-      const nftPath = `${configuration.baseApiUrl}/tokens/${tokenProperties.DEFAULT_NFT_ID}/nfts?limit=1&order=desc`;
-      const firstNft = getFirstEntity(nftPath, nftListName);
-      return {DEFAULT_NFT_SERIAL: firstNft.serial_number};
-    }
-  );
-
-  return Object.assign(tokenProperties, nftProperties)
 };
 
 export const computeScheduleParameters = (configuration) =>
-  computeProperties(
-    ['DEFAULT_SCHEDULE_ACCOUNT_ID', 'DEFAULT_SCHEDULE_ID'],
-    () => {
-      const schedulePath = `${configuration.baseApiUrl}/schedules?limit=1&order=desc`;
-      const firstSchedule = getFirstEntity(schedulePath, scheduleListName);
-      return {
-        DEFAULT_SCHEDULE_ACCOUNT_ID: firstSchedule.creator_account_id,
-        DEFAULT_SCHEDULE_ID: firstSchedule.schedule_id
-      };
-    }
-  );
+  computeProperties(['DEFAULT_SCHEDULE_ACCOUNT_ID', 'DEFAULT_SCHEDULE_ID'], () => {
+    const extractProperties = (schedule) => ({
+      DEFAULT_SCHEDULE_ACCOUNT_ID: schedule.creator_account_id,
+      DEFAULT_SCHEDULE_ID: schedule.schedule_id,
+    });
+    return getPropertiesForEntity(configuration, extractProperties, {
+      entitiesKey: scheduleListName,
+      queryParamMap: {limit: 1},
+    });
+  });
 
 export const computeFungibleTokenParameters = (configuration) =>
-  computeProperties(
-    ['DEFAULT_TOKEN_ID'],
-    () => {
-      const tokenPath = `${configuration.baseApiUrl}/tokens?type=FUNGIBLE_COMMON&limit=1&order=desc`;
-      const firstToken = getFirstEntity(tokenPath, tokenListName);
-      return {
-        DEFAULT_TOKEN_ID: firstToken.token_id,
-      };
-    }
-  );
+  computeProperties(['DEFAULT_TOKEN_ID'], () => {
+    const extractProperties = (token) => ({DEFAULT_TOKEN_ID: token.token_id});
+    return getPropertiesForEntity(configuration, extractProperties, {
+      entitiesKey: tokenListName,
+      queryParamMap: {type: 'FUNGIBLE_COMMON', limit: 1},
+    });
+  });
 
 export const computeTransactionParameters = (configuration) =>
-  computeProperties(
-    ['DEFAULT_TRANSACTION_ID'],
-    () => {
-      const tokenPath = `${configuration.baseApiUrl}/transactions?limit=1&transactiontype=cryptotransfer&order=desc`;
-      const firstTransaction = getFirstEntity(tokenPath, transactionListName)
-      return {
-        DEFAULT_TRANSACTION_ID: firstTransaction.transaction_id
-      };
-    }
-  );
+  computeProperties(['DEFAULT_TRANSACTION_ID'], () => {
+    const extractProperties = (transaction) => ({DEFAULT_TRANSACTION_ID: transaction.transaction_id});
+    return getPropertiesForEntity(configuration, extractProperties, {
+      entitiesKey: transactionListName,
+      queryParamMap: {limit: 1, transactiontype: 'cryptotransfer'},
+    });
+  });
 
 export const computeTopicInfo = (configuration) => {
-  const transactionProperties = computeProperties(
-    ['DEFAULT_TOPIC_ID'],
-    () => {
-      const transactionPath = `${configuration.baseApiUrl}/transactions?transactiontype=CONSENSUSSUBMITMESSAGE&result=success&limit=1&order=desc`;
-      const DEFAULT_TOPIC_ID = getFirstEntity(transactionPath, transactionListName).entity_id;
-      return {DEFAULT_TOPIC_ID};
-    }
-  );
+  const transactionProperties = computeProperties(['DEFAULT_TOPIC_ID'], () => {
+    const extractProperties = (transaction) => ({DEFAULT_TOPIC_ID: transaction.entity_id});
+    return getPropertiesForEntity(configuration, extractProperties, {
+      entitiesKey: transactionListName,
+      queryParamMap: {limit: 1, result: 'success', transactiontype: 'CONSENSUSSUBMITMESSAGE'},
+    });
+  });
 
-  const topicProperties = computeProperties(
-    ['DEFAULT_TOPIC_SEQUENCE', 'DEFAULT_TOPIC_TIMESTAMP'],
-    () => {
-      const topicMessagePath = `${configuration.baseApiUrl}/topics/${transactionProperties.DEFAULT_TOPIC_ID}/messages`;
-      const firstTopicMessage = getFirstEntity(topicMessagePath, messageListName);
-      return {
-        DEFAULT_TOPIC_SEQUENCE: firstTopicMessage.sequence_number,
-        DEFAULT_TOPIC_TIMESTAMP: firstTopicMessage.consensus_timestamp
-      };
-    }
-  );
+  const topicProperties = computeProperties(['DEFAULT_TOPIC_SEQUENCE', 'DEFAULT_TOPIC_TIMESTAMP'], () => {
+    const topicMessagePath = `${configuration.baseApiUrl}/topics/${transactionProperties.DEFAULT_TOPIC_ID}/messages`;
+    const firstTopicMessage = getFirstEntity(topicMessagePath, messageListName);
+    return {
+      DEFAULT_TOPIC_SEQUENCE: firstTopicMessage.sequence_number,
+      DEFAULT_TOPIC_TIMESTAMP: firstTopicMessage.consensus_timestamp,
+    };
+  });
 
   return Object.assign(transactionProperties, topicProperties);
 };
 
 export const computeBlockFromNetwork = (rosettaApiUrl, network) =>
-  computeProperties(
-    ['DEFAULT_BLOCK_INDEX', 'DEFAULT_BLOCK_HASH'],
-    () => {
-      const requestUrl = `${rosettaApiUrl}/rosetta/network/status`;
-      const requestBody = {
-        "network_identifier": {
-          "blockchain": "Hedera",
-          "network": network,
-          "sub_network_identifier": {
-            "network": "shard 0 realm 0"
-          }
+  computeProperties(['DEFAULT_BLOCK_INDEX', 'DEFAULT_BLOCK_HASH'], () => {
+    const requestUrl = `${rosettaApiUrl}/rosetta/network/status`;
+    const requestBody = {
+      network_identifier: {
+        blockchain: 'Hedera',
+        network: network,
+        sub_network_identifier: {
+          network: 'shard 0 realm 0',
         },
-        "metadata": {}
-      };
-      const response = getValidResponse(requestUrl, requestBody, http.post);
-      return {
-        DEFAULT_BLOCK_INDEX: parseInt(response.current_block_identifier.index),
-        DEFAULT_BLOCK_HASH: response.current_block_identifier.hash
-      };
-    }
-  );
+      },
+      metadata: {},
+    };
+    const response = getValidResponse(requestUrl, requestBody, http.post);
+    return {
+      DEFAULT_BLOCK_INDEX: parseInt(response.current_block_identifier.index),
+      DEFAULT_BLOCK_HASH: response.current_block_identifier.hash,
+    };
+  });
 
 export const computeTransactionFromBlock = (rosettaApiUrl, networkIdentifier, blockIdentifier) =>
-  computeProperties(
-    ['DEFAULT_TRANSACTION_HASH'],
-    () => {
-      const requestUrl = `${rosettaApiUrl}/rosetta/block`;
-      const requestBody = {
-        network_identifier: networkIdentifier,
-        block_identifier: blockIdentifier
-      };
-      const response = getValidResponse(requestUrl, requestBody, http.post);
-      const transactions = response.block.transactions;
-      if (!transactions || transactions.length === 0) {
-        throw new Error(`It was not possible to find a transaction with the block identifier: ${JSON.stringify(blockIdentifier)}`);
-      }
-      return {
-        DEFAULT_TRANSACTION_HASH: transactions[0].transaction_identifier.hash
-      };
+  computeProperties(['DEFAULT_TRANSACTION_HASH'], () => {
+    const requestUrl = `${rosettaApiUrl}/rosetta/block`;
+    const requestBody = {
+      network_identifier: networkIdentifier,
+      block_identifier: blockIdentifier,
+    };
+    const response = getValidResponse(requestUrl, requestBody, http.post);
+    const transactions = response.block.transactions;
+    if (!transactions || transactions.length === 0) {
+      throw new Error(
+        `It was not possible to find a transaction with the block identifier: ${JSON.stringify(blockIdentifier)}`
+      );
     }
-  );
-
+    return {
+      DEFAULT_TRANSACTION_HASH: transactions[0].transaction_identifier.hash,
+    };
+  });
 
 export const computeNetworkInfo = (rosettaApiUrl) =>
-  computeProperties(
-    ['DEFAULT_NETWORK'],
-    () => {
-      const requestUrl = `${rosettaApiUrl}/rosetta/network/list`;
-      const response = getValidResponse(requestUrl, {"metadata": {}}, http.post);
-      const networks = response.network_identifiers;
-      if (networks.length === 0) {
-        throw new Error(`It was not possible to find a network at ${rosettaApiUrl}`);
-      }
-      return {
-        DEFAULT_NETWORK: networks[0].network
-      };
+  computeProperties(['DEFAULT_NETWORK'], () => {
+    const requestUrl = `${rosettaApiUrl}/rosetta/network/list`;
+    const response = getValidResponse(requestUrl, {metadata: {}}, http.post);
+    const networks = response.network_identifiers;
+    if (networks.length === 0) {
+      throw new Error(`It was not possible to find a network at ${rosettaApiUrl}`);
     }
-  );
-
+    return {
+      DEFAULT_NETWORK: networks[0].network,
+    };
+  });
 
 export const setDefaultValuesForEnvParameters = () => {
   __ENV['BASE_URL'] = __ENV['BASE_URL'] || 'http://localhost';
@@ -251,4 +282,4 @@ export const setDefaultValuesForEnvParameters = () => {
   __ENV['DEFAULT_LIMIT'] = __ENV['DEFAULT_LIMIT'] || 100;
   __ENV['DEFAULT_PASS_RATE'] = __ENV['DEFAULT_PASS_RATE'] || 0.95;
   __ENV['DEFAULT_MAX_DURATION'] = __ENV['DEFAULT_MAX_DURATION'] || 500;
-}
+};

--- a/hedera-mirror-test/k6/src/rest/apis.js
+++ b/hedera-mirror-test/k6/src/rest/apis.js
@@ -27,8 +27,8 @@ import {setupTestParameters} from './test/bootstrapEnvParameters.js';
 
 function handleSummary(data) {
   return {
-    'stdout': textSummary(data, {indent: ' ', enableColors: true}),
-    'report.md': markdownReport(data, true, scenarios)
+    stdout: textSummary(data, {indent: ' ', enableColors: true}),
+    'report.md': markdownReport(data, true, scenarios),
   };
 }
 

--- a/hedera-mirror-test/k6/src/rest/apis.js
+++ b/hedera-mirror-test/k6/src/rest/apis.js
@@ -19,16 +19,16 @@
  */
 
 import exec from 'k6/execution';
-import {textSummary} from 'https://jslib.k6.io/k6-summary/0.0.1/index.js';
+import {textSummary} from 'https://jslib.k6.io/k6-summary/0.0.2/index.js';
 
 import {markdownReport} from '../lib/common.js';
-import {funcs, options, scenarioDurationGauge} from './test/index.js';
-import {setupTestParameters} from "./test/bootstrapEnvParameters.js";
+import {funcs, options, scenarioDurationGauge, scenarios} from './test/index.js';
+import {setupTestParameters} from './test/bootstrapEnvParameters.js';
 
 function handleSummary(data) {
   return {
     'stdout': textSummary(data, {indent: ' ', enableColors: true}),
-    'report.md': markdownReport(data, true, options.scenarios)
+    'report.md': markdownReport(data, true, scenarios)
   };
 }
 

--- a/hedera-mirror-test/k6/src/rest/test/contractsIdResults.js
+++ b/hedera-mirror-test/k6/src/rest/test/contractsIdResults.js
@@ -18,12 +18,12 @@
  * ‍
  */
 
-import http from "k6/http";
+import http from 'k6/http';
 
 import {TestScenarioBuilder} from '../../lib/common.js';
 import {resultListName, urlPrefix} from '../../lib/constants.js';
-import {isValidListResponse} from "./common.js";
-import {setupTestParameters} from "./bootstrapEnvParameters.js";
+import {isValidListResponse} from './common.js';
+import {setupTestParameters} from './bootstrapEnvParameters.js';
 
 const urlTag = '/contracts/{id}/results';
 
@@ -31,7 +31,7 @@ const {options, run} = new TestScenarioBuilder()
   .name('contractsIdResults') // use unique scenario name among all tests
   .tags({url: urlTag})
   .request((testParameters) => {
-    const url = `${testParameters['BASE_URL']}${urlPrefix}/contracts/${testParameters['DEFAULT_CONTRACT_ID']}/results`;
+    const url = `${testParameters['BASE_URL']}${urlPrefix}/contracts/${testParameters['DEFAULT_CONTRACT_ID']}/results?internal=true`;
     return http.get(url);
   })
   .check('Contracts id results OK', (r) => isValidListResponse(r, resultListName))

--- a/hedera-mirror-test/k6/src/rest/test/index.js
+++ b/hedera-mirror-test/k6/src/rest/test/index.js
@@ -40,6 +40,7 @@ import * as contractsIdResultsLogs from './contractsIdResultsLogs.js';
 import * as contractsIdResultsTimestamp from './contractsIdResultsTimestamp.js';
 import * as networkStake from './networkStake.js';
 import * as networkSupply from './networkSupply.js';
+import * as rampUp from './rampUp.js';
 import * as schedules from './schedules.js';
 import * as schedulesAccount from './schedulesAccount.js';
 import * as schedulesId from './schedulesId.js';
@@ -83,6 +84,7 @@ const tests = {
   contractsIdResultsTimestamp,
   networkStake,
   networkSupply,
+  rampUp,
   schedules,
   schedulesAccount,
   schedulesId,
@@ -106,6 +108,6 @@ const tests = {
   transactionsTransactionTypeAscending
 };
 
-const {funcs, options, scenarioDurationGauge} = getSequentialTestScenarios(tests);
+const {funcs, options, scenarioDurationGauge, scenarios} = getSequentialTestScenarios(tests);
 
-export {funcs, options, scenarioDurationGauge};
+export {funcs, options, scenarioDurationGauge, scenarios};

--- a/hedera-mirror-test/k6/src/rest/test/index.js
+++ b/hedera-mirror-test/k6/src/rest/test/index.js
@@ -59,7 +59,6 @@ import * as topicsIdMessagesSequenceQueryParam from './topicsIdMessagesSequenceQ
 import * as topicsMessagesTimestamp from './topicsMessagesTimestamp.js';
 import * as transactions from './transactions.js';
 import * as transactionsAccountId from './transactionsAccountId.js';
-import * as transactionsCryptoCreateAccountDebit from './transactionsCryptoCreateAccountDebit.js';
 import * as transactionsId from './transactionsId.js';
 import * as transactionsTransactionTypeAscending from './transactionsTransactionTypeAscending.js';
 
@@ -103,9 +102,8 @@ const tests = {
   topicsMessagesTimestamp,
   transactions,
   transactionsAccountId,
-  transactionsCryptoCreateAccountDebit,
   transactionsId,
-  transactionsTransactionTypeAscending
+  transactionsTransactionTypeAscending,
 };
 
 const {funcs, options, scenarioDurationGauge, scenarios} = getSequentialTestScenarios(tests);

--- a/hedera-mirror-test/k6/src/rest/test/rampUp.js
+++ b/hedera-mirror-test/k6/src/rest/test/rampUp.js
@@ -33,10 +33,12 @@ const {options, run} = new TestScenarioBuilder()
   .scenario({
     executor: 'ramping-vus',
     startVUs: 0,
-    stages: [{
-      duration: __ENV.DEFAULT_RAMPUP_DURATION || __ENV.DEFAULT_DURATION,
-      target: __ENV.DEFAULT_RAMPUP_VUS || __ENV.DEFAULT_VUS,
-    }],
+    stages: [
+      {
+        duration: __ENV.DEFAULT_RAMPUP_DURATION || __ENV.DEFAULT_DURATION,
+        target: __ENV.DEFAULT_RAMPUP_VUS || __ENV.DEFAULT_VUS,
+      },
+    ],
     gracefulRampDown: '0s',
   })
   .request((testParameters) => {

--- a/hedera-mirror-test/k6/src/rest/test/rampUp.js
+++ b/hedera-mirror-test/k6/src/rest/test/rampUp.js
@@ -1,0 +1,51 @@
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import http from 'k6/http';
+
+import {TestScenarioBuilder} from '../../lib/common.js';
+import {accountListName, urlPrefix} from '../../lib/constants.js';
+import {isValidListResponse} from './common.js';
+import {setupTestParameters} from './bootstrapEnvParameters.js';
+
+const urlTag = '/accounts';
+
+const {options, run} = new TestScenarioBuilder()
+  .name('rampUp') // use unique scenario name among all tests
+  .tags({url: urlTag})
+  .scenario({
+    executor: 'ramping-vus',
+    startVUs: 0,
+    stages: [{
+      duration: __ENV.DEFAULT_RAMPUP_DURATION || __ENV.DEFAULT_DURATION,
+      target: __ENV.DEFAULT_RAMPUP_VUS || __ENV.DEFAULT_VUS,
+    }],
+    gracefulRampDown: '0s',
+  })
+  .request((testParameters) => {
+    const url = `${testParameters['BASE_URL']}${urlPrefix}${urlTag}?limit=${testParameters['DEFAULT_LIMIT']}`;
+    return http.get(url);
+  })
+  .check('Accounts OK', (r) => isValidListResponse(r, accountListName))
+  .build();
+
+export {options, run};
+
+export const setup = setupTestParameters;

--- a/hedera-mirror-test/k6/src/rosetta/apis.js
+++ b/hedera-mirror-test/k6/src/rosetta/apis.js
@@ -27,7 +27,7 @@ import {setupTestParameters} from './test/bootstrapEnvParameters.js';
 
 function handleSummary(data) {
   return {
-    'stdout': textSummary(data, {indent: ' ', enableColors: true}),
+    stdout: textSummary(data, {indent: ' ', enableColors: true}),
     'report.md': markdownReport(data, true, scenarios),
   };
 }

--- a/hedera-mirror-test/k6/src/rosetta/apis.js
+++ b/hedera-mirror-test/k6/src/rosetta/apis.js
@@ -19,16 +19,16 @@
  */
 
 import exec from 'k6/execution';
-import {textSummary} from 'https://jslib.k6.io/k6-summary/0.0.1/index.js';
+import {textSummary} from 'https://jslib.k6.io/k6-summary/0.0.2/index.js';
 
-import {markdownReport} from "../lib/common.js";
-import {funcs, options, scenarioDurationGauge} from './test/index.js';
-import {setupTestParameters} from "./test/bootstrapEnvParameters.js";
+import {markdownReport} from '../lib/common.js';
+import {funcs, options, scenarioDurationGauge, scenarios} from './test/index.js';
+import {setupTestParameters} from './test/bootstrapEnvParameters.js';
 
 function handleSummary(data) {
   return {
     'stdout': textSummary(data, {indent: ' ', enableColors: true}),
-    'report.md': markdownReport(data, true, options.scenarios),
+    'report.md': markdownReport(data, true, scenarios),
   };
 }
 

--- a/hedera-mirror-test/k6/src/rosetta/test/index.js
+++ b/hedera-mirror-test/k6/src/rosetta/test/index.js
@@ -48,6 +48,6 @@ const tests = {
   networkStatus,
 };
 
-const {funcs, options, scenarioDurationGauge} = getSequentialTestScenarios(tests);
+const {funcs, options, scenarioDurationGauge, scenarios} = getSequentialTestScenarios(tests);
 
-export {funcs, options, scenarioDurationGauge};
+export {funcs, options, scenarioDurationGauge, scenarios};

--- a/hedera-mirror-test/k6/src/web3/apis.js
+++ b/hedera-mirror-test/k6/src/web3/apis.js
@@ -19,15 +19,15 @@
  */
 
 import exec from 'k6/execution';
-import {textSummary} from 'https://jslib.k6.io/k6-summary/0.0.1/index.js';
+import {textSummary} from 'https://jslib.k6.io/k6-summary/0.0.2/index.js';
 
-import {markdownReport} from "../lib/common.js";
-import {funcs, options, scenarioDurationGauge} from './test/index.js';
+import {markdownReport} from '../lib/common.js';
+import {funcs, options, scenarioDurationGauge, scenarios} from './test/index.js';
 
 function handleSummary(data) {
   return {
     'stdout': textSummary(data, {indent: ' ', enableColors: true}),
-    'report.md': markdownReport(data, false, options.scenarios),
+    'report.md': markdownReport(data, false, scenarios),
   };
 }
 

--- a/hedera-mirror-test/k6/src/web3/apis.js
+++ b/hedera-mirror-test/k6/src/web3/apis.js
@@ -26,7 +26,7 @@ import {funcs, options, scenarioDurationGauge, scenarios} from './test/index.js'
 
 function handleSummary(data) {
   return {
-    'stdout': textSummary(data, {indent: ' ', enableColors: true}),
+    stdout: textSummary(data, {indent: ' ', enableColors: true}),
     'report.md': markdownReport(data, false, scenarios),
   };
 }

--- a/hedera-mirror-test/k6/src/web3/test/index.js
+++ b/hedera-mirror-test/k6/src/web3/test/index.js
@@ -26,6 +26,6 @@ import * as ethBlockNumber from './ethBlockNumber.js';
 // add test modules here
 const tests = {ethBlockNumber};
 
-const {funcs, options, scenarioDurationGauge} = getSequentialTestScenarios(tests);
+const {funcs, options, scenarioDurationGauge, scenarios} = getSequentialTestScenarios(tests);
 
-export {funcs, options, scenarioDurationGauge};
+export {funcs, options, scenarioDurationGauge, scenarios};


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR improves the k6 rest test suite to be ready for automated performance regression test

- Add a `rampUp` test scenario for rest
- Extended the library to run `ramping-vus` scenarios first
- Fix newer k6 alters `options.scenarios` which cause markdownReport to fail
- Fix rest test param discovery for various types of entities
- Bump up `k6-summary`

**Related issue(s)**:

Relates to #3099

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
