### PR TITLE
Add runtime_bytecode to OpenAPI

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,7 +13,7 @@ trim_trailing_whitespace = true
 
 # IntelliJ specific
 ij_continuation_indent_size = 8
-ij_visual_guides = 100, 120
+ij_visual_guides = 120, 120
 
 [*.{js, json, md, yaml, yml}]
 indent_size = 2
@@ -240,7 +240,6 @@ ij_java_while_brace_force = always
 ij_java_wrap_comments = true
 # ij_java_wrap_first_method_in_call_chain = false
 ij_java_wrap_long_lines = true
-max_line_length = 100
 
 [*.js]
 ij_continuation_indent_size = 2

--- a/.github/workflows/rosetta.yml
+++ b/.github/workflows/rosetta.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   image:
-    if: github.event_name == 'push' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')
+    if: github.event_name == 'push' || github.event_name == 'schedule' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/hedera-mirror-rest/api/v1/openapi.yml
+++ b/hedera-mirror-rest/api/v1/openapi.yml
@@ -1251,8 +1251,14 @@ components:
               type: string
               nullable: true
               format: binary
-              description: The contract bytecode in hex
+              description: The contract bytecode in hex during deployment
               example: "0x01021a1fdc9b"
+            runtime_bytecode:
+              type: string
+              nullable: true
+              format: binary
+              description: The contract bytecode in hex after deployment
+              example: "0x0302fa1ad39c"
     ContractsResponse:
       type: object
       properties:


### PR DESCRIPTION
**Description**:

* Add `runtime_bytecode` to OpenAPI
* Fix Rosetta nightly workflow
* Revert max line length back to 120

**Related issue(s)**:

Fixes #5061

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
