### PR TITLE
Revert to hedera-sdk-java 2.18.0 to workaround regression

### DIFF
--- a/hedera-mirror-monitor/build.gradle.kts
+++ b/hedera-mirror-monitor/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
     implementation(platform("org.springframework.cloud:spring-cloud-dependencies"))
     implementation("com.fasterxml.jackson.core:jackson-databind")
     implementation("com.google.guava:guava")
-    implementation("com.hedera.hashgraph:sdk")
+    implementation("com.hedera.hashgraph:sdk:2.18.0") // Workaround hedera-sdk-java#1278
     implementation("io.github.mweirauch:micrometer-jvm-extras")
     implementation("io.grpc:grpc-netty")
     implementation("io.grpc:grpc-stub")


### PR DESCRIPTION
**Description**:

Revert to hedera-sdk-java `2.18.0` to workaround regression

**Related issue(s)**:

Fixes #5062

**Notes for reviewer**:

Issue caused by SDK no longer notifying error handler for cancellations caused by non-user initiated events like `RST_STREAM`. Upstream ticket to address regression: https://github.com/hashgraph/hedera-sdk-java/issues/1278

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
