### PR TITLE
Changing the type for expiry_timestamp back to a number  (#5083)

### DIFF
--- a/hedera-mirror-rest/__tests__/specs/tokens/{id}/custom-fees.json
+++ b/hedera-mirror-rest/__tests__/specs/tokens/{id}/custom-fees.json
@@ -17,6 +17,7 @@
         "num": 1135,
         "type": "TOKEN",
         "memo": "token.0.0.1135",
+        "expiration_timestamp": "1234567890000010001",
         "deleted": false
       },
       {
@@ -128,7 +129,7 @@
     "created_timestamp": "1234567890.000000002",
     "decimals": "1000",
     "deleted": false,
-    "expiry_timestamp": null,
+    "expiry_timestamp": 1234567890000010001,
     "fee_schedule_key": {
       "_type": "ProtobufEncoded",
       "key": "7b2231222c2232222c2233227d"

--- a/hedera-mirror-rest/__tests__/specs/tokens/{id}/no-params.json
+++ b/hedera-mirror-rest/__tests__/specs/tokens/{id}/no-params.json
@@ -71,7 +71,7 @@
     "created_timestamp": "1234567890.000000002",
     "decimals": "1000",
     "deleted": null,
-    "expiry_timestamp": "1241567889.000000002",
+    "expiry_timestamp": 1241567889000000002,
     "fee_schedule_key": null,
     "freeze_default": false,
     "freeze_key": null,

--- a/hedera-mirror-rest/__tests__/tokens.test.js
+++ b/hedera-mirror-rest/__tests__/tokens.test.js
@@ -792,7 +792,7 @@ describe('token formatTokenInfoRow tests', () => {
     created_timestamp: '0.000000010',
     decimals: '10',
     deleted: true,
-    expiry_timestamp: '1594431063.696143000',
+    expiry_timestamp: 1594431063696143000,
     fee_schedule_key: {
       _type: 'ProtobufEncoded',
       key: '060606',

--- a/hedera-mirror-rest/__tests__/utils.test.js
+++ b/hedera-mirror-rest/__tests__/utils.test.js
@@ -1815,26 +1815,26 @@ describe('calculateExpiryTimestamp', () => {
   const autoRenewPeriodMax = 8_000_001; // ~92.5626 days as seconds
   const autoRenewPeriodMin = 6_999_999; // ~81.01 days as seconds
   test.each([
-    ['', '', '', '0.000000000'],
+    ['', '', '', ''],
     [null, null, null, null],
-    [undefined, undefined, undefined, null],
-    [undefined, undefined, 123, '0.000000123'],
-    [undefined, 1, 10, '0.000000010'],
-    [1, undefined, 10, '0.000000010'],
-    [1, 1, 10000000001, '10.000000001'],
-    [undefined, 1, undefined, null],
-    [1, undefined, undefined, null],
-    [1500, 987654111123456, undefined, '989154.111123456'],
+    [undefined, undefined, undefined, undefined],
+    [undefined, undefined, 123, 123],
+    [undefined, 1, 10, 10],
+    [1, undefined, 10, 10],
+    [1, 1, 10000000001, 10000000001],
+    [undefined, 1, undefined, undefined],
+    [1, undefined, undefined, undefined],
+    [1500, 987654111123456n, undefined, 989154111123456n],
     // Friday, February 13, 2009 11:31:30 PM GMT + 92.5626 days (8000001 seconds) -> Sunday, May 17, 2009 1:44:51 PM
-    [autoRenewPeriodMax, 1234567890000000003n, undefined, '1242567891.000000003'],
+    [autoRenewPeriodMax, 1234567890000000003n, undefined, 1242567891000000003n],
     // Monday, November 21, 2022 8:58:21 PM GMT + 81.01 days (6999999 seconds) -> Friday, February 10, 2023 9:25:00 PM
-    [autoRenewPeriodMin, 1669064301000000001n, undefined, '1676064300.000000001'],
+    [autoRenewPeriodMin, 1669064301000000001n, undefined, 1676064300000000001n],
   ])('%s expect %s', (autoRenewPeriod, createdTimestamp, expirationTimestamp, expected) => {
     expect(utils.calculateExpiryTimestamp(autoRenewPeriod, createdTimestamp, expirationTimestamp)).toEqual(expected);
     if (!_.isNil(autoRenewPeriod) && !_.isNil(createdTimestamp) && _.isNil(expirationTimestamp)) {
       const createdTimestampDate = utils.nsToSecNs(Number(createdTimestamp));
       const createdDate = new Date(Number(createdTimestampDate));
-      const expiryDate = new Date(Number(expected));
+      const expiryDate = new Date(Number(utils.nsToSecNs(expected)));
       const difference = expiryDate.getTime() - createdDate.getTime();
       expect(difference).toEqual(autoRenewPeriod);
     }

--- a/hedera-mirror-rest/accounts.js
+++ b/hedera-mirror-rest/accounts.js
@@ -60,11 +60,11 @@ const processRow = (row) => {
     deleted: row.deleted,
     ethereum_nonce: row.ethereum_nonce,
     evm_address: evmAddress,
-    expiry_timestamp: utils.calculateExpiryTimestamp(
+    expiry_timestamp: utils.nsToSecNs(utils.calculateExpiryTimestamp(
       row.auto_renew_period,
       row.created_timestamp,
       row.expiration_timestamp
-    ),
+    )),
     key: utils.encodeKey(row.key),
     max_automatic_token_associations: row.max_automatic_token_associations,
     memo: row.memo,

--- a/hedera-mirror-rest/api/v1/openapi.yml
+++ b/hedera-mirror-rest/api/v1/openapi.yml
@@ -2914,7 +2914,10 @@ components:
           example: true
           nullable: true
         expiry_timestamp:
-          $ref: '#/components/schemas/TimestampNullable'
+          example: 1234567890100000
+          format: int64
+          nullable: true
+          type: integer
         fee_schedule_key:
           $ref: '#/components/schemas/Key'
         freeze_default:

--- a/hedera-mirror-rest/utils.js
+++ b/hedera-mirror-rest/utils.js
@@ -1101,12 +1101,12 @@ const buildComparatorFilter = (name, filter) => {
  * @param {int} autoRenewPeriod: seconds format
  * @param {BigInt} createdTimestamp: nnnnnnnnnnnnnnnnnnn format
  * @param {BigInt} expirationTimestamp: nnnnnnnnnnnnnnnnnnn format
- * @returns {String} seconds.nnnnnnnnn format
+ * @returns {BigInt} nnnnnnnnnnnnnnnnnnn format
  */
 const calculateExpiryTimestamp = (autoRenewPeriod, createdTimestamp, expirationTimestamp) => {
   return _.isNil(expirationTimestamp) && !_.isNil(createdTimestamp) && !_.isNil(autoRenewPeriod)
-    ? nsToSecNs(BigInt(createdTimestamp) + BigInt(autoRenewPeriod) * constants.AUTO_RENEW_PERIOD_MULTIPLE)
-    : nsToSecNs(expirationTimestamp);
+    ? (BigInt(createdTimestamp) + BigInt(autoRenewPeriod) * constants.AUTO_RENEW_PERIOD_MULTIPLE)
+    : (expirationTimestamp);
 };
 
 /**

--- a/hedera-mirror-rest/viewmodel/contractViewModel.js
+++ b/hedera-mirror-rest/viewmodel/contractViewModel.js
@@ -41,11 +41,11 @@ class ContractViewModel {
     this.deleted = entity.deleted;
     this.evm_address =
       entity.evmAddress !== null ? utils.toHexString(entity.evmAddress, true) : contractId.toEvmAddress();
-    this.expiration_timestamp = utils.calculateExpiryTimestamp(
+    this.expiration_timestamp = utils.nsToSecNs(utils.calculateExpiryTimestamp(
       entity.autoRenewPeriod,
       entity.createdTimestamp,
       entity.expirationTimestamp
-    );
+    ));
     this.file_id = EntityId.parse(contract.fileId, {isNullable: true}).toString();
     this.max_automatic_token_associations = entity.maxAutomaticTokenAssociations;
     this.memo = entity.memo;


### PR DESCRIPTION
Description:

Fixing accidental changes from the PR #4914
Fixing a bug that the actual type in the response mismatches what's defined in our our openapi spec prior to 0.70.0.

This PR:
*Changes the type expiry_timestamp back to a number *Fixes the openapi spec to change the return type to a number for expiry_timestamp.

Related issue(s):
Fixes #5080

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
