### PR TITLE
Disable git pre-commit hook

### DIFF
--- a/buildSrc/src/main/resources/hooks/pre-commit
+++ b/buildSrc/src/main/resources/hooks/pre-commit
@@ -3,9 +3,9 @@ set -e
 
 rootDir=$(pwd)
 filesStr="$(git diff --name-only --cached --diff-filter=ACMRTUB HEAD)"
-files=($filesStr)
+#files=($filesStr)
 
-echo "Running Spotless to format ${#files[@]} changed files"
+#echo "Running Spotless to format ${#files[@]} changed files"
 #./gradlew spotlessApply
 
 #for file in ${files[@]}; do


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR disables the part in our git pre-commit hook which causes failure in github workflow step.

**Related issue(s)**:

Fixes #5093 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
This is not a permanent fix,  just a workaround so we can avoid the error in our Create PR job's Create Pull Request step. The pre-commit hook is already effectively disabled so the changes don't have side effect.

Will cherry-pick it to release/0.71 since it's the pre-commit in the release branch the release automation job uses. 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
