### PR TITLE
Update README.md

### DIFF
--- a/docs/monitor/README.md
+++ b/docs/monitor/README.md
@@ -148,7 +148,7 @@ hedera:
         scenarios:
           nftMint:
             properties:
-              tokenType: NON_FUNGIBLE_UNIQUE
+              type: NON_FUNGIBLE_UNIQUE
               tokenId: ${nft.1}
               amount: 1
             type: TOKEN_MINT


### PR DESCRIPTION
**Description**:
This PR modifies the documentation in orfer to fix the NFT scenario.

**Related issue(s)**:

Fixes #5108 

**Notes for reviewer**:

The correct attribute is `type`, not `tokenType` (https://github.com/hashgraph/hedera-mirror-node/blob/e59c02d0506d1287914dd28a063d8fec2410f619/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/token/TokenMintTransactionSupplier.java#L56).

Using `tokenType` the field is ignored, and the scenario tries to mint a fungible token.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
