### PR TITLE
Fix release related github workflows (0.71)

### DIFF
--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -87,9 +87,7 @@ jobs:
       - name: Gradle Release
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: release -Pversion=$VERSION
-        env:
-          VERSION: ${{ steps.version_parser.outputs.version }}
+          arguments: release -Pversion=${{ steps.version_parser.outputs.version }}
 
       - name: Create Release Notes
         if: ${{ steps.milestone.outputs.number != '' }}
@@ -169,7 +167,7 @@ jobs:
       - name: Gradle Release for Next Minor Snapshot
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: release -Pversion=$NEXT_VERSION_SNAPSHOT
+          arguments: release -Pversion=${{ env.NEXT_VERSION_SNAPSHOT }}
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -55,8 +55,7 @@ jobs:
       - name: Build and push images
         uses: docker/build-push-action@v3
         with:
-          build-args:
-            - VERSION=${{env.TAG}}
+          build-args: VERSION=${{env.TAG}}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           context: ${{env.MODULE}}


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR cherry-picks the fix to `release/0.71`

- Fix version in release automation workflow
- Fix docker build-args in release production workflow

**Related issue(s)**:

Fixes #5091 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
It turns out when triggered by tag, the release integration workflow file with the triggering tag is used, as a result, the workflow failed on tag 0.71.0-beta2. Will tag 0.71.0-beta3 afterwards

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
