### PR TITLE
Add a few missing rest endpoints to k6 tests

### DIFF
--- a/hedera-mirror-test/k6/README.md
+++ b/hedera-mirror-test/k6/README.md
@@ -22,7 +22,8 @@ To run a test suite, such as rest, use the following command.
 DEFAULT_DURATION=1s \
 DEFAULT_VUS=1 \
 BASE_URL=https://testnet.mirrornode.hedera.com \
-DEFAULT_LIMIT=100 k6 run src/rest/apis.js
+DEFAULT_LIMIT=100 \
+DEFAULT_START_ACCOUNT=0.0.34196600 k6 run src/rest/apis.js
 ```
 
 Another option is to have a parameters file named `parameters.env` with the content:
@@ -32,6 +33,7 @@ export DEFAULT_DURATION=1s
 export DEFAULT_VUS=1
 export BASE_URL=https://testnet.mirrornode.hedera.com
 export DEFAULT_LIMIT=100
+export DEFAULT_START_ACCOUNT=0.0.34196600
 ```
 
 And execute k6 after exporting the values for the env variables:

--- a/hedera-mirror-test/k6/src/lib/constants.js
+++ b/hedera-mirror-test/k6/src/lib/constants.js
@@ -20,6 +20,7 @@
 
 export const accountListName = "accounts";
 export const balanceListName = "balances";
+export const blockListName = "blocks";
 export const contractListName = "contracts";
 export const logListName = "logs";
 export const messageListName = "messages";

--- a/hedera-mirror-test/k6/src/lib/constants.js
+++ b/hedera-mirror-test/k6/src/lib/constants.js
@@ -19,6 +19,7 @@
  */
 
 export const accountListName = "accounts";
+export const allowanceListName = "allowances";
 export const balanceListName = "balances";
 export const blockListName = "blocks";
 export const contractListName = "contracts";

--- a/hedera-mirror-test/k6/src/lib/parameters.js
+++ b/hedera-mirror-test/k6/src/lib/parameters.js
@@ -159,7 +159,7 @@ export const computeBlockParameters = (configuration) =>
     };
     return getPropertiesForEntity(configuration, extractProperties, {
       entitiesKey: blockListName,
-      entityIdResponseKey: 'blocks',
+      queryParamMap: {limit: 1},
     });
 });
 

--- a/hedera-mirror-test/k6/src/lib/parameters.js
+++ b/hedera-mirror-test/k6/src/lib/parameters.js
@@ -22,6 +22,8 @@ import http from 'k6/http';
 
 import {
   accountListName,
+  allowanceListName,
+  balanceListName,
   blockListName,
   contractListName,
   messageListName,
@@ -78,7 +80,6 @@ const getPropertiesForEntity = (configuration, extractProperties, properties) =>
     if (entities.length === 0) {
       throw new Error('No ${entitiesKey} matching criteria found');
     }
-
     for (const entity of entities) {
       try {
         lastEntityId = entity[entityIdResponseKey];
@@ -148,6 +149,73 @@ export const computeAccountParameters = (configuration) =>
       entityIdResponseKey: 'account',
     });
   });
+
+export const computeAccountWithNftsParameters = (configuration) =>
+  computeProperties(['DEFAULT_ACCOUNT_ID_NFTS'], () => {
+    const tokensPath = `${configuration.baseApiUrl}/tokens?type=NON_FUNGIBLE_UNIQUE&limit=100&order=asc`;
+    const tokensResult = getEntities(tokensPath, tokenListName);
+    for (const entity of tokensResult) {
+      const tokensBalancePath = `${configuration.baseApiUrl}/tokens/${entity.token_id}/balances`;
+      const tokensBalanceEntity = getEntities(tokensBalancePath, balanceListName);
+      if(tokensBalanceEntity.length === undefined) continue;
+      for (const balanceEntity of tokensBalanceEntity) {
+        if (balanceEntity.balance >= 20) {
+          return {
+            DEFAULT_ACCOUNT_ID_NFTS: tokensBalanceEntity.account
+          };
+        }
+      }
+    }
+    throw new Error(
+      `It was not possible to find an account with with significant number of nfts.`
+    );
+  });
+
+export const computeAccountWithTokenAllowanceParameters = (configuration) => //29631749
+  computeProperties(['DEFAULT_ACCOUNT_ID_TOKEN_ALLOWANCE'], () => {
+    const accountsPath = `${configuration.baseApiUrl}/accounts?account.id=gt%3A${configuration.startAccountId}&balance=false&order=asc&limit=100`;
+    const accountsResult = getEntities(accountsPath, accountListName);
+    for (const entity of accountsResult) {
+      const tokensAllowancePath = `${configuration.baseApiUrl}/accounts/${entity.account}/allowances/tokens`;
+      let tokensAllowanceEntities;
+      try {
+        tokensAllowanceEntities = getEntities(tokensAllowancePath, allowanceListName);
+      } catch (err) {
+        //Continuing to avoid errors due to accounts not having allowance tokens.
+        continue;
+      }
+      if(tokensAllowanceEntities.length === undefined) continue;
+      if (tokensAllowanceEntities.length >= 25) {
+          return {
+            DEFAULT_ACCOUNT_ID_TOKEN_ALLOWANCE: entity.account
+          };
+      }
+    }
+    throw new Error(
+      `It was not possible to find an account with with significant number of allowance tokens.`
+    );
+  });
+
+export const computeAccountWithTokenParameters = (configuration) =>
+  computeProperties(['DEFAULT_ACCOUNT_ID_TOKEN'], () => {
+    const accountsPath = `${configuration.baseApiUrl}/accounts`;
+    const accountsResult = getEntities(accountsPath, accountListName);
+    for (const entity of accountsResult) {
+      const tokensPath = `${configuration.baseApiUrl}/accounts/${entity.account}/tokens`;
+      const tokensEntities = getEntities(tokensPath, tokenListName);
+      if (tokensEntities.length === undefined) continue;
+      if (tokensEntities.length >= 25) {
+        return {
+          DEFAULT_ACCOUNT_ID_TOKEN: entity.account
+        };
+      }
+    }
+    throw new Error(
+      `It was not possible to find an account with with significant number of tokens.`
+    );
+  });
+
+
 
 export const computeBlockParameters = (configuration) =>
   computeProperties(['DEFAULT_BLOCK_NUMBER', 'DEFAULT_BLOCK_HASH'], () => {

--- a/hedera-mirror-test/k6/src/lib/parameters.js
+++ b/hedera-mirror-test/k6/src/lib/parameters.js
@@ -161,7 +161,7 @@ export const computeAccountWithNftsParameters = (configuration) =>
       for (const balanceEntity of tokensBalanceEntity) {
         if (balanceEntity.balance >= 20) {
           return {
-            DEFAULT_ACCOUNT_ID_NFTS: tokensBalanceEntity.account
+            DEFAULT_ACCOUNT_ID_NFTS: balanceEntity.account
           };
         }
       }

--- a/hedera-mirror-test/k6/src/lib/parameters.js
+++ b/hedera-mirror-test/k6/src/lib/parameters.js
@@ -22,6 +22,7 @@ import http from 'k6/http';
 
 import {
   accountListName,
+  blockListName,
   contractListName,
   messageListName,
   scheduleListName,
@@ -147,6 +148,20 @@ export const computeAccountParameters = (configuration) =>
       entityIdResponseKey: 'account',
     });
   });
+
+export const computeBlockParameters = (configuration) =>
+  computeProperties(['DEFAULT_BLOCK_NUMBER', 'DEFAULT_BLOCK_HASH'], () => {
+    const extractProperties = (block) => {
+      return {
+        DEFAULT_BLOCK_NUMBER: block.number,
+        DEFAULT_BLOCK_HASH: block.hash,
+      };
+    };
+    return getPropertiesForEntity(configuration, extractProperties, {
+      entitiesKey: blockListName,
+      entityIdResponseKey: 'blocks',
+    });
+});
 
 export const computeContractParameters = (configuration) => {
   const extractProperties = (contract, log) => ({

--- a/hedera-mirror-test/k6/src/rest/test/accountsNfts.js
+++ b/hedera-mirror-test/k6/src/rest/test/accountsNfts.js
@@ -21,8 +21,8 @@
 import http from "k6/http";
 
 import {TestScenarioBuilder} from '../../lib/common.js';
-import {resultListName, urlPrefix} from '../../lib/constants.js';
-import {isSuccess} from "./common.js";
+import {nftListName, urlPrefix} from '../../lib/constants.js';
+import {isValidListResponse} from "./common.js";
 import {setupTestParameters} from "./bootstrapEnvParameters.js";
 
 const urlTag = '/accounts/{id}/nfts';
@@ -31,10 +31,10 @@ const {options, run} = new TestScenarioBuilder()
   .name('accountNftsResults') // use unique scenario name among all tests
   .tags({url: urlTag})
   .request((testParameters) => {
-    const url = `${testParameters['BASE_URL']}${urlPrefix}/accounts/${testParameters['DEFAULT_ACCOUNT_ID_NFTS']}/nfts`;
+    const url = `${testParameters['BASE_URL']}${urlPrefix}/accounts/${testParameters['DEFAULT_ACCOUNT_ID_NFTS']}/nfts?limit=${testParameters['DEFAULT_LIMIT']}`;
     return http.get(url);
   })
-  .check('Account nfts results OK', (r) => isSuccess(r, resultListName))
+  .check('Account nfts results OK', (r) => isValidListResponse(r, nftListName))
   .build();
 
 export {options, run};

--- a/hedera-mirror-test/k6/src/rest/test/accountsNfts.js
+++ b/hedera-mirror-test/k6/src/rest/test/accountsNfts.js
@@ -31,7 +31,7 @@ const {options, run} = new TestScenarioBuilder()
   .name('accountNftsResults') // use unique scenario name among all tests
   .tags({url: urlTag})
   .request((testParameters) => {
-    const url = `${testParameters['BASE_URL']}${urlPrefix}/accounts/${testParameters['DEFAULT_ACCOUNT_ID']}/nfts`;
+    const url = `${testParameters['BASE_URL']}${urlPrefix}/accounts/${testParameters['DEFAULT_ACCOUNT_ID_NFTS']}/nfts`;
     return http.get(url);
   })
   .check('Account nfts results OK', (r) => isSuccess(r, resultListName))

--- a/hedera-mirror-test/k6/src/rest/test/accountsNfts.js
+++ b/hedera-mirror-test/k6/src/rest/test/accountsNfts.js
@@ -1,0 +1,42 @@
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import http from "k6/http";
+
+import {TestScenarioBuilder} from '../../lib/common.js';
+import {resultListName, urlPrefix} from '../../lib/constants.js';
+import {isSuccess} from "./common.js";
+import {setupTestParameters} from "./bootstrapEnvParameters.js";
+
+const urlTag = '/accounts/{id}/nfts';
+
+const {options, run} = new TestScenarioBuilder()
+  .name('accountNftsResults') // use unique scenario name among all tests
+  .tags({url: urlTag})
+  .request((testParameters) => {
+    const url = `${testParameters['BASE_URL']}${urlPrefix}/accounts/${testParameters['DEFAULT_ACCOUNT_ID']}/nfts`;
+    return http.get(url);
+  })
+  .check('Account nfts results OK', (r) => isSuccess(r, resultListName))
+  .build();
+
+export {options, run};
+
+export const setup = setupTestParameters;

--- a/hedera-mirror-test/k6/src/rest/test/accountsTokenAllowance.js
+++ b/hedera-mirror-test/k6/src/rest/test/accountsTokenAllowance.js
@@ -31,7 +31,7 @@ const {options, run} = new TestScenarioBuilder()
   .name('accountTokenAllowancesResults') // use unique scenario name among all tests
   .tags({url: urlTag})
   .request((testParameters) => {
-    const url = `${testParameters['BASE_URL']}${urlPrefix}/accounts/${testParameters['DEFAULT_ACCOUNT_ID']}/allowances/tokens`;
+    const url = `${testParameters['BASE_URL']}${urlPrefix}/accounts/${testParameters['DEFAULT_ACCOUNT_ID_TOKEN_ALLOWANCE']}/allowances/tokens`;
     return http.get(url);
   })
   .check('Account token allowances results OK', (r) => isSuccess(r, resultListName))

--- a/hedera-mirror-test/k6/src/rest/test/accountsTokenAllowance.js
+++ b/hedera-mirror-test/k6/src/rest/test/accountsTokenAllowance.js
@@ -21,8 +21,8 @@
 import http from "k6/http";
 
 import {TestScenarioBuilder} from '../../lib/common.js';
-import {resultListName, urlPrefix} from '../../lib/constants.js';
-import {isSuccess} from "./common.js";
+import {allowanceListName, urlPrefix} from '../../lib/constants.js';
+import {isValidListResponse} from "./common.js";
 import {setupTestParameters} from "./bootstrapEnvParameters.js";
 
 const urlTag = '/accounts/{id}/allowances/tokens';
@@ -31,10 +31,10 @@ const {options, run} = new TestScenarioBuilder()
   .name('accountTokenAllowancesResults') // use unique scenario name among all tests
   .tags({url: urlTag})
   .request((testParameters) => {
-    const url = `${testParameters['BASE_URL']}${urlPrefix}/accounts/${testParameters['DEFAULT_ACCOUNT_ID_TOKEN_ALLOWANCE']}/allowances/tokens`;
+    const url = `${testParameters['BASE_URL']}${urlPrefix}/accounts/${testParameters['DEFAULT_ACCOUNT_ID_TOKEN_ALLOWANCE']}/allowances/tokens?limit=${testParameters['DEFAULT_LIMIT']}`;
     return http.get(url);
   })
-  .check('Account token allowances results OK', (r) => isSuccess(r, resultListName))
+  .check('Account token allowances results OK', (r) => isValidListResponse(r, allowanceListName))
   .build();
 
 export {options, run};

--- a/hedera-mirror-test/k6/src/rest/test/accountsTokenAllowance.js
+++ b/hedera-mirror-test/k6/src/rest/test/accountsTokenAllowance.js
@@ -1,0 +1,42 @@
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import http from "k6/http";
+
+import {TestScenarioBuilder} from '../../lib/common.js';
+import {resultListName, urlPrefix} from '../../lib/constants.js';
+import {isSuccess} from "./common.js";
+import {setupTestParameters} from "./bootstrapEnvParameters.js";
+
+const urlTag = '/accounts/{id}/allowances/tokens';
+
+const {options, run} = new TestScenarioBuilder()
+  .name('accountTokenAllowancesResults') // use unique scenario name among all tests
+  .tags({url: urlTag})
+  .request((testParameters) => {
+    const url = `${testParameters['BASE_URL']}${urlPrefix}/accounts/${testParameters['DEFAULT_ACCOUNT_ID']}/allowances/tokens`;
+    return http.get(url);
+  })
+  .check('Account token allowances results OK', (r) => isSuccess(r, resultListName))
+  .build();
+
+export {options, run};
+
+export const setup = setupTestParameters;

--- a/hedera-mirror-test/k6/src/rest/test/accountsTokens.js
+++ b/hedera-mirror-test/k6/src/rest/test/accountsTokens.js
@@ -31,7 +31,7 @@ const {options, run} = new TestScenarioBuilder()
   .name('accountTokensResults') // use unique scenario name among all tests
   .tags({url: urlTag})
   .request((testParameters) => {
-    const url = `${testParameters['BASE_URL']}${urlPrefix}/accounts/${testParameters['DEFAULT_ACCOUNT_ID']}/tokens`;
+    const url = `${testParameters['BASE_URL']}${urlPrefix}/accounts/${testParameters['DEFAULT_ACCOUNT_ID_TOKEN']}/tokens`;
     return http.get(url);
   })
   .check('Account tokens results OK', (r) => isSuccess(r, resultListName))

--- a/hedera-mirror-test/k6/src/rest/test/accountsTokens.js
+++ b/hedera-mirror-test/k6/src/rest/test/accountsTokens.js
@@ -21,8 +21,8 @@
 import http from "k6/http";
 
 import {TestScenarioBuilder} from '../../lib/common.js';
-import {resultListName, urlPrefix} from '../../lib/constants.js';
-import {isSuccess} from "./common.js";
+import {tokenListName, urlPrefix} from '../../lib/constants.js';
+import {isValidListResponse} from "./common.js";
 import {setupTestParameters} from "./bootstrapEnvParameters.js";
 
 const urlTag = '/accounts/{id}/tokens';
@@ -31,10 +31,10 @@ const {options, run} = new TestScenarioBuilder()
   .name('accountTokensResults') // use unique scenario name among all tests
   .tags({url: urlTag})
   .request((testParameters) => {
-    const url = `${testParameters['BASE_URL']}${urlPrefix}/accounts/${testParameters['DEFAULT_ACCOUNT_ID_TOKEN']}/tokens`;
+    const url = `${testParameters['BASE_URL']}${urlPrefix}/accounts/${testParameters['DEFAULT_ACCOUNT_ID_TOKEN']}/tokens?limit=${testParameters['DEFAULT_LIMIT']}`;
     return http.get(url);
   })
-  .check('Account tokens results OK', (r) => isSuccess(r, resultListName))
+  .check('Account tokens results OK', (r) => isValidListResponse(r, tokenListName))
   .build();
 
 export {options, run};

--- a/hedera-mirror-test/k6/src/rest/test/accountsTokens.js
+++ b/hedera-mirror-test/k6/src/rest/test/accountsTokens.js
@@ -1,0 +1,42 @@
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import http from "k6/http";
+
+import {TestScenarioBuilder} from '../../lib/common.js';
+import {resultListName, urlPrefix} from '../../lib/constants.js';
+import {isSuccess} from "./common.js";
+import {setupTestParameters} from "./bootstrapEnvParameters.js";
+
+const urlTag = '/accounts/{id}/tokens';
+
+const {options, run} = new TestScenarioBuilder()
+  .name('accountTokensResults') // use unique scenario name among all tests
+  .tags({url: urlTag})
+  .request((testParameters) => {
+    const url = `${testParameters['BASE_URL']}${urlPrefix}/accounts/${testParameters['DEFAULT_ACCOUNT_ID']}/tokens`;
+    return http.get(url);
+  })
+  .check('Account tokens results OK', (r) => isSuccess(r, resultListName))
+  .build();
+
+export {options, run};
+
+export const setup = setupTestParameters;

--- a/hedera-mirror-test/k6/src/rest/test/blocks.js
+++ b/hedera-mirror-test/k6/src/rest/test/blocks.js
@@ -1,0 +1,42 @@
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import http from "k6/http";
+
+import {TestScenarioBuilder} from '../../lib/common.js';
+import {blockListName, urlPrefix} from '../../lib/constants.js';
+import {isValidListResponse} from "./common.js";
+import {setupTestParameters} from "./bootstrapEnvParameters.js";
+
+const urlTag = '/blocks';
+
+const {options, run} = new TestScenarioBuilder()
+  .name('blocks') // use unique scenario name among all tests
+  .tags({url: urlTag})
+  .request((testParameters) => {
+    const url = `${testParameters['BASE_URL']}${urlPrefix}${urlTag}?limit=${testParameters['DEFAULT_LIMIT']}`;
+    return http.get(url);
+  })
+  .check('Blocks OK', (r) => isValidListResponse(r, blockListName))
+  .build();
+
+export {options, run};
+
+export const setup = setupTestParameters;

--- a/hedera-mirror-test/k6/src/rest/test/blocksHash.js
+++ b/hedera-mirror-test/k6/src/rest/test/blocksHash.js
@@ -25,16 +25,16 @@ import {blockListName, urlPrefix} from '../../lib/constants.js';
 import {isSuccess, isValidListResponse} from "./common.js";
 import {setupTestParameters} from "./bootstrapEnvParameters.js";
 
-const urlTag = '/blocks/{number}';
+const urlTag = '/blocks/{hash}';
 
 const {options, run} = new TestScenarioBuilder()
-  .name('blockNumber') // use unique scenario name among all tests
+  .name('blockHash') // use unique scenario name among all tests
   .tags({url: urlTag})
   .request((testParameters) => {
-    const url = `${testParameters['BASE_URL']}${urlPrefix}/blocks/${testParameters['DEFAULT_BLOCK_NUMBER']}`;
+    const url = `${testParameters['BASE_URL']}${urlPrefix}/blocks/${testParameters['DEFAULT_BLOCK_HASH']}`;
     return http.get(url);
   })
-  .check('Blocks number OK', isSuccess)
+  .check('Blocks hash OK', isSuccess)
   .build();
 
 export {options, run};

--- a/hedera-mirror-test/k6/src/rest/test/blocksHash.js
+++ b/hedera-mirror-test/k6/src/rest/test/blocksHash.js
@@ -22,7 +22,7 @@ import http from "k6/http";
 
 import {TestScenarioBuilder} from '../../lib/common.js';
 import {blockListName, urlPrefix} from '../../lib/constants.js';
-import {isSuccess, isValidListResponse} from "./common.js";
+import {isSuccess} from "./common.js";
 import {setupTestParameters} from "./bootstrapEnvParameters.js";
 
 const urlTag = '/blocks/{hash}';

--- a/hedera-mirror-test/k6/src/rest/test/blocksNumber.js
+++ b/hedera-mirror-test/k6/src/rest/test/blocksNumber.js
@@ -1,0 +1,42 @@
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import http from "k6/http";
+
+import {TestScenarioBuilder} from '../../lib/common.js';
+import {blockListName, urlPrefix} from '../../lib/constants.js';
+import {isSuccess, isValidListResponse} from "./common.js";
+import {setupTestParameters} from "./bootstrapEnvParameters.js";
+
+const urlTag = '/blocks/{hashOrNumber}';
+
+const {options, run} = new TestScenarioBuilder()
+  .name('blockNumber') // use unique scenario name among all tests
+  .tags({url: urlTag})
+  .request((testParameters) => {
+    const url = `${testParameters['BASE_URL']}${urlPrefix}/blocks/${testParameters['DEFAULT_BLOCK_HASH']}`;
+    return http.get(url);
+  })
+  .check('Blocks hash OK', isSuccess)
+  .build();
+
+export {options, run};
+
+export const setup = setupTestParameters;

--- a/hedera-mirror-test/k6/src/rest/test/blocksNumber.js
+++ b/hedera-mirror-test/k6/src/rest/test/blocksNumber.js
@@ -22,7 +22,7 @@ import http from "k6/http";
 
 import {TestScenarioBuilder} from '../../lib/common.js';
 import {blockListName, urlPrefix} from '../../lib/constants.js';
-import {isSuccess, isValidListResponse} from "./common.js";
+import {isSuccess} from "./common.js";
 import {setupTestParameters} from "./bootstrapEnvParameters.js";
 
 const urlTag = '/blocks/{number}';

--- a/hedera-mirror-test/k6/src/rest/test/blocksNumber.js
+++ b/hedera-mirror-test/k6/src/rest/test/blocksNumber.js
@@ -25,7 +25,7 @@ import {blockListName, urlPrefix} from '../../lib/constants.js';
 import {isSuccess, isValidListResponse} from "./common.js";
 import {setupTestParameters} from "./bootstrapEnvParameters.js";
 
-const urlTag = '/blocks/{hashOrNumber}';
+const urlTag = '/blocks/{hash}';
 
 const {options, run} = new TestScenarioBuilder()
   .name('blockNumber') // use unique scenario name among all tests

--- a/hedera-mirror-test/k6/src/rest/test/bootstrapEnvParameters.js
+++ b/hedera-mirror-test/k6/src/rest/test/bootstrapEnvParameters.js
@@ -20,6 +20,7 @@
 
 import {
   computeAccountParameters,
+  computeBlockParameters,
   computeContractParameters,
   computeFungibleTokenParameters,
   computeNftParameters,
@@ -31,6 +32,7 @@ import {
 const computeTestParameters = (configuration) =>
   Object.assign({},
     computeAccountParameters(configuration),
+    computeBlockParameters(configuration),
     computeContractParameters(configuration),
     computeNftParameters(configuration),
     computeScheduleParameters(configuration),

--- a/hedera-mirror-test/k6/src/rest/test/bootstrapEnvParameters.js
+++ b/hedera-mirror-test/k6/src/rest/test/bootstrapEnvParameters.js
@@ -20,11 +20,15 @@
 
 import {
   computeAccountParameters,
+  computeAccountWithNftsParameters,
+  computeAccountWithTokenAllowanceParameters,
+  computeAccountWithTokenParameters,
   computeBlockParameters,
   computeContractParameters,
   computeFungibleTokenParameters,
   computeNftParameters,
-  computeScheduleParameters, computeTopicInfo,
+  computeScheduleParameters,
+  computeTopicInfo,
   computeTransactionParameters,
   setDefaultValuesForEnvParameters,
 } from "../../lib/parameters.js";
@@ -32,6 +36,9 @@ import {
 const computeTestParameters = (configuration) =>
   Object.assign({},
     computeAccountParameters(configuration),
+    computeAccountWithNftsParameters(configuration),
+    computeAccountWithTokenAllowanceParameters(configuration),
+    computeAccountWithTokenParameters(configuration),
     computeBlockParameters(configuration),
     computeContractParameters(configuration),
     computeNftParameters(configuration),
@@ -44,7 +51,8 @@ const computeTestParameters = (configuration) =>
 const setupTestParameters = () => {
   setDefaultValuesForEnvParameters();
   const baseApiUrl = __ENV['BASE_URL'];
-  const testParametersMap = computeTestParameters({baseApiUrl: `${baseApiUrl}/api/v1`});
+  const startAccountId = __ENV['DEFAULT_START_ACCOUNT'];
+  const testParametersMap = computeTestParameters({baseApiUrl: `${baseApiUrl}/api/v1`, startAccountId: `${startAccountId}`});
   return Object.assign(testParametersMap, {
     BASE_URL: baseApiUrl,
     DEFAULT_LIMIT: __ENV.DEFAULT_LIMIT

--- a/hedera-mirror-test/k6/src/rest/test/contractsResult.js
+++ b/hedera-mirror-test/k6/src/rest/test/contractsResult.js
@@ -1,0 +1,42 @@
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import http from 'k6/http';
+
+import {TestScenarioBuilder} from '../../lib/common.js';
+import {resultListName, urlPrefix} from '../../lib/constants.js';
+import {isValidListResponse} from './common.js';
+import {setupTestParameters} from './bootstrapEnvParameters.js';
+
+const urlTag = '/contracts/results';
+
+const {options, run} = new TestScenarioBuilder()
+  .name('contractsResults') // use unique scenario name among all tests
+  .tags({url: urlTag})
+  .request((testParameters) => {
+    const url = `${testParameters['BASE_URL']}${urlPrefix}/contracts/${testParameters['DEFAULT_CONTRACT_ID']}/results`;
+    return http.get(url);
+  })
+  .check('Contracts id state OK', (r) => isValidListResponse(r, resultListName))
+  .build();
+
+export {options, run};
+
+export const setup = setupTestParameters;

--- a/hedera-mirror-test/k6/src/rest/test/contractsResult.js
+++ b/hedera-mirror-test/k6/src/rest/test/contractsResult.js
@@ -31,7 +31,7 @@ const {options, run} = new TestScenarioBuilder()
   .name('contractsResults') // use unique scenario name among all tests
   .tags({url: urlTag})
   .request((testParameters) => {
-    const url = `${testParameters['BASE_URL']}${urlPrefix}/contracts/${testParameters['DEFAULT_CONTRACT_ID']}/results`;
+    const url = `${testParameters['BASE_URL']}${urlPrefix}/contracts/${testParameters['DEFAULT_CONTRACT_ID']}/results?limit=${testParameters['DEFAULT_LIMIT']}`;
     return http.get(url);
   })
   .check('Contracts id state OK', (r) => isValidListResponse(r, resultListName))

--- a/hedera-mirror-test/k6/src/rest/test/index.js
+++ b/hedera-mirror-test/k6/src/rest/test/index.js
@@ -31,13 +31,19 @@ import * as accountsCryptoAllowance from './accountsCryptoAllowance.js';
 import * as accountsCryptoAllowanceSpender from './accountsCryptoAllowanceSpender.js';
 import * as accountsId from './accountsId.js';
 import * as accountsIdNe from './accountsIdNe.js';
+import * as accountsNfts from './accountsNfts.js';
+import * as accountsTokens from './accountsTokens.js';
+import * as accountsTokenAllowance from './accountsTokenAllowance.js';
 import * as balances from './balances.js';
 import * as balancesAccount from './balancesAccount.js';
+import * as blocks from './blocks.js';
+import * as blocksNumber from './blocksNumber.js';
 import * as contracts from './contracts.js';
 import * as contractsId from './contractsId.js';
 import * as contractsIdResults from './contractsIdResults.js';
 import * as contractsIdResultsLogs from './contractsIdResultsLogs.js';
 import * as contractsIdResultsTimestamp from './contractsIdResultsTimestamp.js';
+import * as contractsResults from './contractsResult.js';
 import * as networkStake from './networkStake.js';
 import * as networkSupply from './networkSupply.js';
 import * as rampUp from './rampUp.js';
@@ -74,13 +80,19 @@ const tests = {
   accountsCryptoAllowanceSpender,
   accountsId,
   accountsIdNe,
+  accountsNfts,
+  accountsTokens,
+  accountsTokenAllowance,
   balances,
   balancesAccount,
+  blocks,
+  blocksNumber,
   contracts,
   contractsId,
   contractsIdResults,
   contractsIdResultsLogs,
   contractsIdResultsTimestamp,
+  contractsResults,
   networkStake,
   networkSupply,
   rampUp,


### PR DESCRIPTION

**Description**:
Adding the following missing rest endpoints to k6 performance tests.

/accounts/{id}/allowances/tokens
/accounts/{id}/nfts
/accounts/{id}/tokens
/blocks
/blocks/{id}
/contracts/result

**Related issue(s)**:

Fixes #4961

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
