### PR TITLE
Bump up hedera-sdk-java to 2.19.0 for hedera-mirror-test

### DIFF
--- a/hedera-mirror-test/pom.xml
+++ b/hedera-mirror-test/pom.xml
@@ -18,7 +18,7 @@
     <properties>
         <cucumber.version>7.9.0</cucumber.version>
         <cucumber-reporting.version>7.3.0</cucumber-reporting.version>
-        <hedera-sdk.version>2.18.0</hedera-sdk.version>
+        <hedera-sdk.version>2.19.0</hedera-sdk.version>
         <junit-platform.version>1.9.1</junit-platform.version>
         <skipTests>true</skipTests>
     </properties>


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
Revert the changes to downgrade to hedera-sdk-java 2.18.0 for hedera-mirror-test. We need 2.19.0 for hedera-mirror-rest since it has the executor fix in `Client.java`

**Related issue(s)**:

Relates to #5062 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
