### PR TITLE
Fix automated release workflow unable to install JDK 

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -78,13 +78,6 @@ jobs:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
-      - name: Install JDK
-        uses: actions/setup-java@v3
-        with:
-          cache: 'maven'
-          distribution: 'temurin'
-          java-version: 17
-
       - name: Create and Switch to Release Branch
         run: |
           if ! git ls-remote --exit-code --heads --quiet origin refs/heads/${RELEASE_BRANCH}; then
@@ -97,6 +90,13 @@ jobs:
           else
             git checkout ${RELEASE_BRANCH}
           fi
+
+      - name: Install JDK
+        uses: actions/setup-java@v3
+        with:
+          cache: 'maven'
+          distribution: 'temurin'
+          java-version: 17
 
       - name: Maven Release
         run: ./mvnw package -Drelease.version=$VERSION -Drelease.chartVersion=$CHART_VERSION -Ddocker.tag.version=$VERSION -N -P=release


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR fixes the issue in the automated release github workflow

- Install JDK after switching to the release branch with pom files

**Related issue(s)**:

Fixes #5116 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
The `setup-java` action in `Install JDK` step is configured with `cache: 'maven'` so it expects existence of `**/pom.xml` files. By changing the job to switching to the release branch which is supposed to still have the maven build system can fix it.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
