### PR TITLE
Install missing wget in rest and rosetta Dockerfile

### DIFF
--- a/hedera-mirror-rest/Dockerfile
+++ b/hedera-mirror-rest/Dockerfile
@@ -12,6 +12,7 @@ COPY . ./
 # Install OS updates, required packages, and dependencies
 RUN apt-get update && \
     apt-get upgrade -y && \
+    apt-get install -y wget && \
     apt-get install -y build-essential python3 && \
     npm ci --only=production && \
     npm cache clean --force --loglevel=error && \

--- a/hedera-mirror-rosetta/Dockerfile
+++ b/hedera-mirror-rosetta/Dockerfile
@@ -11,7 +11,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 EXPOSE 5700
 HEALTHCHECK --interval=10s --retries=5 --start-period=30s --timeout=2s CMD wget -q -O- http://localhost:5700/health/liveness
 WORKDIR /app
-RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/* # install OS updates
+RUN apt-get update && apt-get upgrade -y && apt-get install -y wget && rm -rf /var/lib/apt/lists/* # install OS updates
 USER 1000:1000
 COPY --from=build /app/hedera-mirror-rosetta .
 


### PR DESCRIPTION
**Description**:
This PR fixes adds the missing wget binary to the images to fix the failing health checks

* change to docker files

**Related issue(s)**:

Fixes #5120 

**Notes for reviewer**:


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
