### PR TITLE
Add testkube resources to common chart

### DIFF
--- a/charts/hedera-mirror-common/templates/k6-custom-executor.yaml
+++ b/charts/hedera-mirror-common/templates/k6-custom-executor.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.testkube.enabled -}}
+apiVersion: executor.testkube.io/v1
+kind: Executor
+metadata:
+  name: k6-custom-executor
+  namespace: {{ .Values.testkube.namespace }}
+spec:
+  command: ["k6", "run"]
+  executor_type: container
+  features:
+    - artifacts
+  image: loadimpact/k6:0.42.0
+  types:
+    - k6-custom/script
+{{- end }}

--- a/charts/hedera-mirror-common/templates/test-rest.yaml
+++ b/charts/hedera-mirror-common/templates/test-rest.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.testkube.enabled -}}
+apiVersion: tests.testkube.io/v3
+kind: Test
+metadata:
+  name: test-rest
+  namespace: {{ .Values.testkube.namespace }}
+spec:
+  content:
+    repository:
+      branch: {{ .Values.testkube.test.gitBranch }}
+      path: hedera-mirror-test/k6
+      type: git
+      uri: https://github.com/hashgraph/hedera-mirror-node
+    type: git-dir
+  executionRequest:
+    args:
+      - /data/repo/hedera-mirror-test/k6/src/rest/apis.js
+    artifactRequest:
+      storageClassName: standard
+      volumeMountPath: /share
+  type: k6-custom/script
+{{- end }}

--- a/charts/hedera-mirror-common/templates/test-suite-rest.yaml
+++ b/charts/hedera-mirror-common/templates/test-suite-rest.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.testkube.enabled -}}
+apiVersion: tests.testkube.io/v2
+kind: TestSuite
+metadata:
+  name: test-suite-rest
+  namespace: {{ .Values.testkube.namespace }}
+spec:
+  description: Mirrornode REST API performance test suite
+  executionRequest:
+    variables:
+      BASE_URL:
+        name: BASE_URL
+        type: basic
+        value: http://{{ .Values.testkube.test.target.release }}-rest.{{ .Values.testkube.test.target.namespace }}.svc.cluster.local
+      DEFAULT_DURATION:
+        name: DEFAULT_DURATION
+        type: basic
+        value: {{ .Values.testkube.test.duration }}
+      DEFAULT_VUS:
+        name: DEFAULT_VUS
+        type: basic
+        value: {{ quote .Values.testkube.test.vus }}
+      TEST_REPORTS_DIR:
+        name: TEST_REPORTS_DIR
+        type: basic
+        value: /share
+  steps:
+    - delay:
+        duration: 600000
+    - execute:
+        name: test-rest
+{{- end }}

--- a/charts/hedera-mirror-common/values.yaml
+++ b/charts/hedera-mirror-common/values.yaml
@@ -329,6 +329,17 @@ promtail:
   serviceMonitor:
     enabled: true
 
+testkube:
+  enabled: false
+  namespace: testkube
+  test:
+    duration: 600s
+    gitBranch: main
+    target:
+      namespace: ""
+      release: mirror
+    vus: 500
+
 traefik:
   affinity:
     podAntiAffinity:


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR adds testkube resources to `hedera-mirror-common` chart

- Add testkube executor, test, and test suite
- Add default values for testkube resources to values.yaml

**Related issue(s)**:

Relates to #3099 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
For a k8s cluster, to enable testkube, in the deploy branch, we need to

- Enable testkube helmrelease
- Set the common helmrelease to depend on the testkube helmrelease and set the testkube resource config accordingly

The testkube `test` and `testsuite` resources have to live in the same namespace `testkube` is installed unfortunately.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
