### PR TITLE
Increase Jest timeout for s3ClientTest

### DIFF
--- a/hedera-mirror-rest/__tests__/s3client.test.js
+++ b/hedera-mirror-rest/__tests__/s3client.test.js
@@ -24,6 +24,7 @@ import querystring from 'querystring';
 import config from '../config';
 import {cloudProviders, defaultCloudProviderEndpoints} from '../constants';
 import s3client from '../s3client';
+import {jest} from "@jest/globals";
 
 const defaultValidStreamsConfig = {
   cloudProvider: cloudProviders.S3,
@@ -159,6 +160,7 @@ describe('createS3Client with valid config', () => {
     },
   ];
 
+  jest.setTimeout(60000);
   testSpecs.forEach((spec) => {
     test(spec.name, async () => {
       overrideStreamsConfig(spec.override);


### PR DESCRIPTION
Signed-off-by: Edwin Greene <edwin.greene@swirldslabs.com>

**Description**:
Increase the jest timeout for the flaky test.

**Related issue(s)**:

Fixes #5137 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
