### PR TITLE
Disable helm release health check by default

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -339,7 +339,7 @@ monitor.
 Name                                                            | Default | Description
 ----------------------------------------------------------------|---------| ---------------------------------------
 `hedera.mirror.monitor.health.release.cacheExpiry`              | 30s     | The amount of time to cache cluster release health status
-`hedera.mirror.monitor.health.release.enabled`                  | true    | Whether to enable cluster release health check
+`hedera.mirror.monitor.health.release.enabled`                  | false   | Whether to enable cluster release health check
 `hedera.mirror.monitor.mirrorNode.grpc.host`                    | ""      | The hostname of the mirror node's gRPC API
 `hedera.mirror.monitor.mirrorNode.grpc.port`                    | 5600    | The port of the mirror node's gRPC API
 `hedera.mirror.monitor.mirrorNode.rest.host`                    | ""      | The hostname of the mirror node's REST API

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/health/ReleaseHealthProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/health/ReleaseHealthProperties.java
@@ -36,5 +36,5 @@ public class ReleaseHealthProperties {
     @NotNull
     private Duration cacheExpiry = Duration.ofSeconds(30);
 
-    private boolean enabled = true;
+    private boolean enabled = false;
 }

--- a/hedera-mirror-rest/api/v1/openapi.yml
+++ b/hedera-mirror-rest/api/v1/openapi.yml
@@ -31,6 +31,9 @@ paths:
       operationId: getAccountByIdOrAliasOrEvmAddress
       parameters:
         - $ref: '#/components/parameters/accountIdOrAliasOrEvmAddressPathParam'
+        - $ref: '#/components/parameters/limitQueryParam'
+        - $ref: '#/components/parameters/orderQueryParamDesc'
+        - $ref: '#/components/parameters/timestampQueryParam'
         - $ref: '#/components/parameters/transactionTypeQueryParam'
       responses:
         200:
@@ -90,11 +93,11 @@ paths:
       operationId: listNftByAccountId
       parameters:
         - $ref: '#/components/parameters/accountIdOrAliasOrEvmAddressPathParam'
-        - $ref: '#/components/parameters/tokenIdQueryParam'
-        - $ref: '#/components/parameters/serialNumberQueryParam'
-        - $ref: '#/components/parameters/spenderIdQueryParam'
         - $ref: '#/components/parameters/limitQueryParam'
         - $ref: '#/components/parameters/orderQueryParamDesc'
+        - $ref: '#/components/parameters/serialNumberQueryParam'
+        - $ref: '#/components/parameters/spenderIdQueryParam'
+        - $ref: '#/components/parameters/tokenIdQueryParam'
       responses:
         200:
           description: OK
@@ -140,9 +143,9 @@ paths:
       operationId: listTokenRelationshipByAccountId
       parameters:
         - $ref: '#/components/parameters/accountIdOrAliasOrEvmAddressPathParam'
-        - $ref: '#/components/parameters/tokenIdQueryParam'
         - $ref: '#/components/parameters/limitQueryParam'
         - $ref: '#/components/parameters/orderQueryParam'
+        - $ref: '#/components/parameters/tokenIdQueryParam'
       responses:
         200:
           description: OK
@@ -163,9 +166,9 @@ paths:
       operationId: listCryptoAllowancesByAccountId
       parameters:
         - $ref: '#/components/parameters/accountIdOrAliasOrEvmAddressPathParam'
-        - $ref: '#/components/parameters/spenderIdQueryParam'
         - $ref: '#/components/parameters/limitQueryParam'
         - $ref: '#/components/parameters/orderQueryParamDesc'
+        - $ref: '#/components/parameters/spenderIdQueryParam'
       responses:
         200:
           description: OK
@@ -212,10 +215,10 @@ paths:
       operationId: listTokenAllowancesByAccountId
       parameters:
         - $ref: '#/components/parameters/accountIdOrAliasOrEvmAddressPathParam'
-        - $ref: '#/components/parameters/spenderIdQueryParam'
-        - $ref: '#/components/parameters/tokenIdQueryParam'
         - $ref: '#/components/parameters/limitQueryParam'
         - $ref: '#/components/parameters/orderQueryParam'
+        - $ref: '#/components/parameters/spenderIdQueryParam'
+        - $ref: '#/components/parameters/tokenIdQueryParam'
       responses:
         200:
           description: OK
@@ -237,10 +240,10 @@ paths:
       parameters:
         - $ref: '#/components/parameters/accountIdQueryParam'
         - $ref: '#/components/parameters/accountBalanceQueryParam'
-        - $ref: '#/components/parameters/orderQueryParamDesc'
         - $ref: '#/components/parameters/accountPublicKeyQueryParam'
-        - $ref: '#/components/parameters/timestampQueryParam'
         - $ref: '#/components/parameters/limitQueryParam'
+        - $ref: '#/components/parameters/orderQueryParamDesc'
+        - $ref: '#/components/parameters/timestampQueryParam'
       responses:
         200:
           description: OK
@@ -259,9 +262,9 @@ paths:
       operationId: listBlocks
       parameters:
         - $ref: '#/components/parameters/blockNumberQueryParam'
-        - $ref: '#/components/parameters/timestampQueryParam'
-        - $ref: '#/components/parameters/orderQueryParamDesc'
         - $ref: '#/components/parameters/limitQueryParam'
+        - $ref: '#/components/parameters/orderQueryParamDesc'
+        - $ref: '#/components/parameters/timestampQueryParam'
       responses:
         200:
           description: OK
@@ -341,14 +344,14 @@ paths:
       operationId: listContractResults
       parameters:
         - $ref: '#/components/parameters/contractIdOrAddressPathParam'
+        - $ref: '#/components/parameters/blockHashQueryParam'
+        - $ref: '#/components/parameters/contractsBlockNumberQueryParam'
         - $ref: '#/components/parameters/fromQueryParam'
+        - $ref: '#/components/parameters/internalQueryParam'
         - $ref: '#/components/parameters/limitQueryParam'
         - $ref: '#/components/parameters/orderQueryParamDesc'
         - $ref: '#/components/parameters/timestampQueryParam'
-        - $ref: '#/components/parameters/contractsBlockNumberQueryParam'
-        - $ref: '#/components/parameters/blockHashQueryParam'
         - $ref: '#/components/parameters/transactionIndexQueryParam'
-        - $ref: '#/components/parameters/internalQueryParam'
       responses:
         200:
           description: OK
@@ -367,9 +370,9 @@ paths:
       operationId: listContractState
       parameters:
         - $ref: '#/components/parameters/contractIdOrAddressPathParam'
-        - $ref: '#/components/parameters/slotQueryParam'
-        - $ref: '#/components/parameters/orderQueryParam'
         - $ref: '#/components/parameters/limitQueryParam'
+        - $ref: '#/components/parameters/orderQueryParam'
+        - $ref: '#/components/parameters/slotQueryParam'
       responses:
         200:
           description: OK
@@ -397,13 +400,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ContractResultResponse'
+                $ref: '#/components/schemas/ContractResultDetails'
         206:
           description: Partial Content
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ContractResultResponse'
+                $ref: '#/components/schemas/ContractResultDetails'
         400:
           $ref: '#/components/responses/InvalidParameterError'
         404:
@@ -417,13 +420,13 @@ paths:
       operationId: listAllContractsResults
       parameters:
         - $ref: '#/components/parameters/fromQueryParam'
+        - $ref: '#/components/parameters/blockHashQueryParam'
+        - $ref: '#/components/parameters/contractsBlockNumberQueryParam'
+        - $ref: '#/components/parameters/internalQueryParam'
         - $ref: '#/components/parameters/limitQueryParam'
         - $ref: '#/components/parameters/orderQueryParamDesc'
         - $ref: '#/components/parameters/timestampQueryParam'
-        - $ref: '#/components/parameters/contractsBlockNumberQueryParam'
-        - $ref: '#/components/parameters/blockHashQueryParam'
         - $ref: '#/components/parameters/transactionIndexQueryParam'
-        - $ref: '#/components/parameters/internalQueryParam'
       responses:
         200:
           description: OK
@@ -449,13 +452,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ContractResultResponse'
+                $ref: '#/components/schemas/ContractResultDetails'
         206:
           description: Partial Content
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ContractResultResponse'
+                $ref: '#/components/schemas/ContractResultDetails'
         400:
           $ref: '#/components/responses/InvalidParameterError'
         404:
@@ -621,8 +624,8 @@ paths:
       description: Returns the estimated gas in tinybars per each transaction type. Default order is ASC. Currently only `ContractCall`, `ContractCreate` and `EthereumTransaction` transaction types are supported.
       operationId: getNetworkFees
       parameters:
-        - $ref: '#/components/parameters/timestampQueryParam'
         - $ref: '#/components/parameters/orderQueryParam'
+        - $ref: '#/components/parameters/timestampQueryParam'
       responses:
         200:
           description: OK
@@ -645,8 +648,8 @@ paths:
       operationId: getNetworkNodes
       parameters:
         - $ref: '#/components/parameters/fileIdQueryParam'
-        - $ref: '#/components/parameters/nodeIdQueryParam'
         - $ref: '#/components/parameters/limitQueryParam'
+        - $ref: '#/components/parameters/nodeIdQueryParam'
         - $ref: '#/components/parameters/orderQueryParam'
       responses:
         200:
@@ -825,6 +828,13 @@ paths:
       operationId: listTopicMessagesById
       parameters:
         - $ref: '#/components/parameters/topicIdPathParam'
+        - name: encoding
+          in: query
+          example: base64
+          schema:
+            type: string
+        - $ref: '#/components/parameters/limitQueryParam'
+        - $ref: '#/components/parameters/orderQueryParamDesc'
         - name: sequencenumber
           in: query
           example: 2
@@ -833,13 +843,6 @@ paths:
             minimum: 0
             type: integer
         - $ref: '#/components/parameters/timestampQueryParam'
-        - name: encoding
-          in: query
-          example: base64
-          schema:
-            type: string
-        - $ref: '#/components/parameters/limitQueryParam'
-        - $ref: '#/components/parameters/orderQueryParamDesc'
       responses:
         200:
           description: OK
@@ -908,12 +911,12 @@ paths:
       description: Returns a list of tokens on the network.
       operationId: listTokens
       parameters:
+        - $ref: '#/components/parameters/accountIdQueryParam'
+        - $ref: '#/components/parameters/limitQueryParam'
+        - $ref: '#/components/parameters/orderQueryParam'
         - $ref: '#/components/parameters/publicKeyQueryParam'
         - $ref: '#/components/parameters/tokenIdQueryParam'
         - $ref: '#/components/parameters/tokenTypeQueryParam'
-        - $ref: '#/components/parameters/limitQueryParam'
-        - $ref: '#/components/parameters/accountIdQueryParam'
-        - $ref: '#/components/parameters/orderQueryParam'
       responses:
         200:
           description: OK
@@ -1061,12 +1064,12 @@ paths:
       operationId: listTokenBalancesById
       parameters:
         - $ref: '#/components/parameters/tokenIdPathParam'
-        - $ref: '#/components/parameters/accountIdQueryParam'
         - $ref: '#/components/parameters/accountBalanceQueryParam'
-        - $ref: '#/components/parameters/orderQueryParam'
+        - $ref: '#/components/parameters/accountIdQueryParam'
         - $ref: '#/components/parameters/accountPublicKeyQueryParam'
-        - $ref: '#/components/parameters/timestampQueryParam'
         - $ref: '#/components/parameters/limitQueryParam'
+        - $ref: '#/components/parameters/orderQueryParam'
+        - $ref: '#/components/parameters/timestampQueryParam'
       responses:
         200:
           description: OK
@@ -1266,15 +1269,10 @@ components:
           $ref: '#/components/schemas/Contracts'
         links:
           $ref: '#/components/schemas/Links'
-    ContractResultResponse:
-      type: object
-      properties:
-        contracts:
-          $ref: '#/components/schemas/ContractResultDetails'
     ContractResultsResponse:
       type: object
       properties:
-        contracts:
+        results:
           $ref: '#/components/schemas/ContractResults'
         links:
           $ref: '#/components/schemas/Links'
@@ -1682,7 +1680,8 @@ components:
     AccountBalanceTransactions:
       allOf:
         - $ref: '#/components/schemas/AccountInfo'
-        - required:
+        - type: object
+          required:
             - transactions
             - links
           properties:

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AbstractNetworkClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AbstractNetworkClient.java
@@ -132,9 +132,18 @@ public abstract class AbstractNetworkClient {
     }
 
     public TransactionReceipt getTransactionReceipt(TransactionId transactionId) {
-        // TransactionReceiptQuery is free
         var query = new TransactionReceiptQuery().setTransactionId(transactionId);
-        return executeQuery(() -> query);
+        var receipt = executeQuery(() -> query);
+
+        if (log.isDebugEnabled()) {
+            log.debug("Transaction receipt: {}", receipt);
+        }
+
+        if (receipt.status != Status.SUCCESS) {
+            throw new NetworkException("Transaction was unsuccessful: " + receipt);
+        }
+
+        return receipt;
     }
 
     @SneakyThrows

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
@@ -56,7 +56,7 @@ public class AcceptanceTestProperties {
     @Max(5)
     private int maxRetries = 2;
 
-    private long maxTinyBarTransactionFee = Hbar.from(40).toTinybars();
+    private long maxTinyBarTransactionFee = Hbar.from(50).toTinybars();
 
     @NotNull
     private Duration messageTimeout = Duration.ofSeconds(20);
@@ -69,7 +69,7 @@ public class AcceptanceTestProperties {
 
     private Set<NodeProperties> nodes = new LinkedHashSet<>();
 
-    private long operatorBalance = Hbar.from(200).toTinybars();
+    private long operatorBalance = Hbar.from(260).toTinybars();
 
     @NotBlank
     private String operatorId = "0.0.2";

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/response/NetworkTransactionResponse.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/response/NetworkTransactionResponse.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.test.e2e.acceptance.response;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,21 +20,17 @@ package com.hedera.mirror.test.e2e.acceptance.response;
  * ‍
  */
 
-import lombok.Data;
+import lombok.Value;
 import org.apache.commons.lang3.StringUtils;
 
 import com.hedera.hashgraph.sdk.TransactionId;
 import com.hedera.hashgraph.sdk.TransactionReceipt;
 
-@Data
+@Value
 public class NetworkTransactionResponse {
+
     private final TransactionId transactionId;
     private final TransactionReceipt receipt;
-
-    public String getTransactionIdString() {
-        return transactionId.accountId.toString() + "-" + transactionId.validStart
-                .getEpochSecond() + "-" + getPaddedNanos();
-    }
 
     // interim function until mirror node supports checksum
     public String getTransactionIdStringNoCheckSum() {


### PR DESCRIPTION
**Description**:

* Add missing query parameters to `/api/v1/accounts/{id}`
* Disable helm release health check by default
* Fix field in list contract results in OpenAPI named `contracts` instead of `results`
* Fix extra nesting in get contract result in OpenAPI
* Fix acceptance tests not printing error on receipt query
* Fix insufficient fee and balance on staging by increasing max fee and operator balance
* Sort REST API query parameters in OpenAPI

**Related issue(s)**:

Fixes #5167

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
