### PR TITLE
Revert "Bump dependency-check-gradle from 7.4.1 to 7.4.3"

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -38,7 +38,7 @@ dependencies {
     implementation("org.apache.commons:commons-compress:1.22")
     implementation("org.gradle:test-retry-gradle-plugin:1.5.0")
     implementation("org.openapitools:openapi-generator-gradle-plugin:6.2.1")
-    implementation("org.owasp:dependency-check-gradle:7.4.3")
+    implementation("org.owasp:dependency-check-gradle:7.4.1")
     implementation("org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:3.5.0.2730")
     implementation("org.springframework.boot:spring-boot-gradle-plugin:2.7.6")
 }


### PR DESCRIPTION
Reverts hashgraph/hedera-mirror-node#5146 due to regression https://github.com/jeremylong/DependencyCheck/issues/5220