### PR TITLE
Add acceptance test for auto account creation

### DIFF
--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AbstractNetworkClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AbstractNetworkClient.java
@@ -23,11 +23,6 @@ package com.hedera.mirror.test.e2e.acceptance.client;
 import java.time.Instant;
 import java.util.function.Supplier;
 
-import com.hedera.hashgraph.sdk.AccountId;
-import com.hedera.hashgraph.sdk.AccountInfo;
-
-import com.hedera.hashgraph.sdk.AccountInfoQuery;
-
 import lombok.Data;
 import lombok.SneakyThrows;
 import org.apache.commons.lang3.StringUtils;
@@ -173,11 +168,6 @@ public abstract class AbstractNetworkClient {
         var balance = executeQuery(() -> query).hbars;
         log.info("{} balance is {}", accountId, balance);
         return balance.toTinybars();
-    }
-
-    public AccountInfo getAccountInfo(AccountId accountId) {
-        var query = new AccountInfoQuery().setAccountId(accountId);
-        return executeQuery(() -> query);
     }
 
     protected String getMemo(String message) {

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AbstractNetworkClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AbstractNetworkClient.java
@@ -22,6 +22,12 @@ package com.hedera.mirror.test.e2e.acceptance.client;
 
 import java.time.Instant;
 import java.util.function.Supplier;
+
+import com.hedera.hashgraph.sdk.AccountId;
+import com.hedera.hashgraph.sdk.AccountInfo;
+
+import com.hedera.hashgraph.sdk.AccountInfoQuery;
+
 import lombok.Data;
 import lombok.SneakyThrows;
 import org.apache.commons.lang3.StringUtils;
@@ -167,6 +173,11 @@ public abstract class AbstractNetworkClient {
         var balance = executeQuery(() -> query).hbars;
         log.info("{} balance is {}", accountId, balance);
         return balance.toTinybars();
+    }
+
+    public AccountInfo getAccountInfo(AccountId accountId) {
+        var query = new AccountInfoQuery().setAccountId(accountId);
+        return executeQuery(() -> query);
     }
 
     protected String getMemo(String message) {

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/MirrorNodeClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/MirrorNodeClient.java
@@ -4,7 +4,7 @@ package com.hedera.mirror.test.e2e.acceptance.client;
  * ‌
  * Hedera Mirror Node
  * ​
- * Copyright (C) 2019 - 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2019 - 2023 Hedera Hashgraph, LLC
  * ​
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,14 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import javax.inject.Named;
+
+import com.hedera.hashgraph.sdk.AccountId;
+
+import com.hedera.mirror.test.e2e.acceptance.response.MirrorAccountResponse;
+
+import com.hedera.mirror.test.e2e.acceptance.util.TestUtil;
+
+import lombok.NonNull;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.MediaType;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -210,6 +218,10 @@ public class MirrorNodeClient {
                 MirrorTokenRelationshipResponse.class, accountId, tokenId);
     }
 
+    public MirrorAccountResponse getAccountDetailsUsingAlias(@NonNull AccountId accountId) {
+        log.debug("Retrieving account details for accountId '{}'", accountId);
+        return callRestEndpoint("/accounts/{accountId}", MirrorAccountResponse.class, TestUtil.getAliasFromPublicKey(accountId.aliasKey));
+    }
 
     public void unSubscribeFromTopic(SubscriptionHandle subscription) {
         subscription.unsubscribe();

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorAccountBalance.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorAccountBalance.java
@@ -9,9 +9,9 @@ package com.hedera.mirror.test.e2e.acceptance.props;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,6 +24,6 @@ import lombok.Data;
 
 @Data
 public class MirrorAccountBalance {
-    private String account;
-    private long balance;
+    private String timestamp;
+    private Long balance;
 }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/response/MirrorAccountResponse.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/response/MirrorAccountResponse.java
@@ -4,14 +4,14 @@ package com.hedera.mirror.test.e2e.acceptance.response;
  * ‌
  * Hedera Mirror Node
  * ​
- * Copyright (C) 2019 - 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2019 - 2023 Hedera Hashgraph, LLC
  * ​
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,12 +20,21 @@ package com.hedera.mirror.test.e2e.acceptance.response;
  * ‍
  */
 
-import java.util.List;
-import lombok.Data;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.hedera.mirror.test.e2e.acceptance.props.MirrorAccountBalance;
 
+import com.hedera.mirror.test.e2e.acceptance.props.MirrorTransaction;
+
+import lombok.Data;
+import java.util.List;
+
 @Data
-public class MirrorTokenBalancesResponse {
-    List<MirrorAccountBalance> balances;
+public class MirrorAccountResponse {
+    private String account;
+    private String createdTimestamp;
+    @JsonProperty("balance")
+    private MirrorAccountBalance balanceInfo;
+    private List<MirrorTransaction> transactions;
+    private String memo;
 }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AccountFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AccountFeature.java
@@ -187,7 +187,7 @@ public class AccountFeature extends AbstractFeature {
                 .isEqualTo(networkTransactionResponse.getValidStartString());
         assertThat(mirrorTransaction.getName()).isEqualTo("CRYPTOTRANSFER");
 
-        assertThat(mirrorTransaction.getTransfers().size()).isGreaterThanOrEqualTo(3); // network, node and transfer
+        assertThat(mirrorTransaction.getTransfers()).hasSizeGreaterThanOrEqualTo(3); // network, node and transfer
 
         //verify transfer credit and debits balance out
         long transferSum = 0;

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AccountFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AccountFeature.java
@@ -81,9 +81,9 @@ public class AccountFeature extends AbstractFeature {
         assertNotNull(networkTransactionResponse.getReceipt());
     }
 
-    @Given("I send {long} tℏ to {string} alias not present in the network")
-    public void createAccountOnTransferForEDAlias(long amount, String keyType) {
-        senderAccountId = accountClient.getAccount(AccountClient.AccountNameEnum.CAROL);
+    @Given("I send {long} tℏ from {string} to {string} alias not present in the network")
+    public void createAccountOnTransferForEDAlias(long amount, String senderAccount, String keyType) {
+        senderAccountId = accountClient.getAccount(AccountClient.AccountNameEnum.valueOf(senderAccount));
         startingBalance = accountClient.getBalance(senderAccountId);
 
         var recipientPrivateKey =  "ed".equalsIgnoreCase(keyType) ? PrivateKey.generateED25519() : PrivateKey.generateECDSA();

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/util/TestUtil.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/util/TestUtil.java
@@ -1,0 +1,55 @@
+package com.hedera.mirror.test.e2e.acceptance.util;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.google.common.io.BaseEncoding;
+
+import com.google.protobuf.ByteString;
+
+import com.hedera.hashgraph.sdk.PublicKey;
+
+import com.hedera.hashgraph.sdk.proto.Key;
+
+import lombok.NonNull;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class TestUtil {
+    private static final BaseEncoding BASE32_ENCODER = BaseEncoding.base32().omitPadding();
+
+    public static String getAliasFromPublicKey(@NonNull PublicKey key) {
+        if (key.isECDSA()) {
+            return BASE32_ENCODER
+                    .encode(Key.newBuilder()
+                            .setECDSASecp256K1(ByteString.copyFrom(key.toBytesRaw()))
+                            .build()
+                            .toByteArray());
+        } else if (key.isED25519()) {
+            return BASE32_ENCODER
+                    .encode(Key.newBuilder()
+                            .setEd25519(ByteString.copyFrom(key.toBytesRaw()))
+                            .build()
+                            .toByteArray());
+        }
+
+        throw new IllegalStateException("Unsupported key type");
+    }
+}

--- a/hedera-mirror-test/src/test/resources/features/account/account.feature
+++ b/hedera-mirror-test/src/test/resources/features/account/account.feature
@@ -20,10 +20,10 @@ Feature: Account Coverage Feature
 
     @release @acceptance @cryptotransfer @createcryptoaccount
         Scenario Outline: Create crypto account when transferring to alias
-        Given I send <amount> tℏ to <keyType> alias not present in the network
+        Given I send <amount> tℏ from <senderAccount> to <keyType> alias not present in the network
         Then the transfer auto creates a new account
         And the balance of the new account should reflect the transferred <amount>
         Examples:
-            | amount | keyType |
-            | 1      | "ED"    |
-            | 1      | "ECDSA" |
+            | amount | senderAccount | keyType |
+            | 1      | "ALICE"       | "ED"    |
+            | 1      | "ALICE"       | "ECDSA" |

--- a/hedera-mirror-test/src/test/resources/features/account/account.feature
+++ b/hedera-mirror-test/src/test/resources/features/account/account.feature
@@ -20,10 +20,9 @@ Feature: Account Coverage Feature
 
     @release @acceptance @cryptotransfer @createcryptoaccount
         Scenario Outline: Create crypto account when transferring to alias
-        Given I send <amount> tℏ from <senderAccount> to <keyType> alias not present in the network
-        Then the transfer auto creates a new account
-        And the balance of the new account should reflect the transferred <amount>
+        Given I send <amount> tℏ to <keyType> alias not present in the network
+        Then the transfer auto creates a new account with balance of transferred amount <amount> tℏ
         Examples:
-            | amount | senderAccount | keyType |
-            | 1      | "ALICE"       | "ED"    |
-            | 1      | "ALICE"       | "ECDSA" |
+            | amount | keyType  |
+            | 1      | "ED25519"    |
+            | 1      | "ECDSA" |

--- a/hedera-mirror-test/src/test/resources/features/account/account.feature
+++ b/hedera-mirror-test/src/test/resources/features/account/account.feature
@@ -17,3 +17,13 @@ Feature: Account Coverage Feature
         Examples:
             | amount | accountName | httpStatusCode |
             | 1      | "ALICE"     | 200            |
+
+    @release @acceptance @cryptotransfer @createcryptoaccount
+        Scenario Outline: Create crypto account when transferring to alias
+        Given I send <amount> tℏ to <keyType> alias not present in the network
+        Then the transfer auto creates a new account
+        And the balance of the new account should reflect the transferred <amount>
+        Examples:
+            | amount | keyType |
+            | 1      | "ED"    |
+            | 1      | "ECDSA" |


### PR DESCRIPTION
Signed-off-by: Jesse Nelson <jesse@swirldslabs.com>

**Description**:
Add acceptance test for auto account creation

* Add acceptance test to ensure account is created when a transfer is sent to ED alias
* Add acceptance test to ensure account is created when a transfer is sent to ECDSA alias

**Related issue(s)**:

Fixes #4983 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
