### PR TITLE
Mark staking reward payout related operations as CRYPTOTRANSFER

### DIFF
--- a/hedera-mirror-rosetta/app/persistence/domain/staking_reward_transfer.go
+++ b/hedera-mirror-rosetta/app/persistence/domain/staking_reward_transfer.go
@@ -1,0 +1,34 @@
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+package domain
+
+const tableNameStakingRewardTransfer = "staking_reward_transfer"
+
+type StakingRewardTransfer struct {
+	AccountId          EntityId `json:"account_id"`
+	Amount             int64
+	ConsensusTimestamp int64    `json:"consensus_timestamp"`
+	PayerAccountId     EntityId `json:"payer_account_id"`
+}
+
+func (StakingRewardTransfer) TableName() string {
+	return tableNameStakingRewardTransfer
+}

--- a/hedera-mirror-rosetta/app/persistence/domain/staking_reward_transfer_test.go
+++ b/hedera-mirror-rosetta/app/persistence/domain/staking_reward_transfer_test.go
@@ -1,0 +1,31 @@
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+package domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStakingRewardTransferTableName(t *testing.T) {
+	assert.Equal(t, "staking_reward_transfer", StakingRewardTransfer{}.TableName())
+}

--- a/hedera-mirror-rosetta/app/persistence/transaction.go
+++ b/hedera-mirror-rosetta/app/persistence/transaction.go
@@ -464,7 +464,7 @@ func (tr *transactionRepository) constructTransaction(sameHashTransactions []*tr
 
 		transactionResult := types.TransactionResults[int32(transaction.Result)]
 		operations = tr.appendHbarTransferOperations(transactionResult, transactionType, nonFeeTransfers, operations)
-		// fee transfers and staking reward transfers are always successful regardless of the transaction result
+		// fee transfers are always successful regardless of the transaction result
 		operations = tr.appendHbarTransferOperations(success, types.OperationTypeFee, feeHbarTransfers, operations)
 		// staking reward transfers (both credit and debit) are always successful and marked as crypto transfer
 		operations = tr.appendHbarTransferOperations(success, types.OperationTypeCryptoTransfer,

--- a/hedera-mirror-rosetta/test/domain/staking_reward_transfer_builder.go
+++ b/hedera-mirror-rosetta/test/domain/staking_reward_transfer_builder.go
@@ -1,0 +1,62 @@
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+package domain
+
+import (
+	"github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/app/interfaces"
+	"github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta/app/persistence/domain"
+)
+
+type StakingRewardTransferBuilder struct {
+	dbClient              interfaces.DbClient
+	stakingRewardTransfer domain.StakingRewardTransfer
+}
+
+func (b *StakingRewardTransferBuilder) AccountId(accountId int64) *StakingRewardTransferBuilder {
+	b.stakingRewardTransfer.AccountId = domain.MustDecodeEntityId(accountId)
+	return b
+}
+
+func (b *StakingRewardTransferBuilder) Amount(amount int64) *StakingRewardTransferBuilder {
+	b.stakingRewardTransfer.Amount = amount
+	return b
+}
+
+func (b *StakingRewardTransferBuilder) ConsensusTimestamp(timestamp int64) *StakingRewardTransferBuilder {
+	b.stakingRewardTransfer.ConsensusTimestamp = timestamp
+	return b
+}
+
+func (b *StakingRewardTransferBuilder) PayerAccountId(payerAccountId int64) *StakingRewardTransferBuilder {
+	b.stakingRewardTransfer.PayerAccountId = domain.MustDecodeEntityId(payerAccountId)
+	return b
+}
+
+func (b *StakingRewardTransferBuilder) Persist() {
+	b.dbClient.GetDb().Create(&b.stakingRewardTransfer)
+}
+
+func NewStakingRewardTransferBuilder(dbClient interfaces.DbClient) *StakingRewardTransferBuilder {
+	return &StakingRewardTransferBuilder{
+		dbClient:              dbClient,
+		stakingRewardTransfer: domain.StakingRewardTransfer{PayerAccountId: defaultPayer},
+	}
+}


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR fixes the issue that staking reward payout related operations are marked as `FEE` operations

- categorize staking reward payout related operations and mark them as `CRYPTOTRANSFER`

**Related issue(s)**:

Fixes #5186 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
