### PR TITLE
Update the posgresql-repmgr version

### DIFF
--- a/charts/marketplace/gcp/release.sh
+++ b/charts/marketplace/gcp/release.sh
@@ -21,7 +21,7 @@ fi
 target_tag="${target_tag#v}" # Strip v prefix if present
 target_tag_minor="${target_tag%\.*}"
 bats_tag="1.8.2"
-postgresql_tag="14.6.0-debian-11-r2"
+postgresql_tag="14.6.0-debian-11-r20"
 registry="gcr.io/mirror-node-public/hedera-mirror-node"
 
 function retag() {


### PR DESCRIPTION
**Description**:
The current postgresql-repmgr version has vulnerabilities as reported by the gcp marketplace .Hence, upgrading the postgresql version.

This PR upgrades:
* postgresql version.

**Related issue(s)**:

Fixes #5200

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
