### PR TITLE
Enabling contact byte code search with non-mirror evm address 

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccess.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccess.java
@@ -88,6 +88,9 @@ public class MirrorEntityAccess implements HederaEvmEntityAccess {
         final var entityId = isMirror(addressBytes) ?
                 entityIdFromEvmAddress(address) :
                 findEntity(address).map(AbstractEntity::getId).orElse(0L);
+        if (entityId == 0) {
+            return Bytes.EMPTY;
+        }
 
         final var runtimeCode = contractRepository.findRuntimeBytecode(entityId);
         return runtimeCode.map(Bytes::wrap).orElse(Bytes.EMPTY);

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccess.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccess.java
@@ -28,6 +28,9 @@ import static com.hedera.node.app.service.evm.accounts.HederaEvmContractAliases.
 import com.google.protobuf.ByteString;
 import java.util.Optional;
 import javax.inject.Named;
+
+import com.hedera.mirror.common.domain.entity.AbstractEntity;
+
 import lombok.RequiredArgsConstructor;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
@@ -81,7 +84,12 @@ public class MirrorEntityAccess implements HederaEvmEntityAccess {
 
     @Override
     public Bytes fetchCodeIfPresent(Address address) {
-        final var runtimeCode = contractRepository.findRuntimeBytecode(entityIdFromEvmAddress(address));
+        final var addressBytes = address.toArrayUnsafe();
+        Long entityId = isMirror(addressBytes) ?
+                entityIdFromEvmAddress(address) :
+                findEntity(address).map(AbstractEntity::getId).orElse(0L);
+
+        final var runtimeCode = contractRepository.findRuntimeBytecode(entityId);
         return runtimeCode.map(Bytes::wrap).orElse(Bytes.EMPTY);
     }
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccess.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccess.java
@@ -49,43 +49,43 @@ public class MirrorEntityAccess implements HederaEvmEntityAccess {
     private final ContractStateRepository contractStateRepository;
 
     @Override
-    public boolean isUsable(Address address) {
+    public boolean isUsable(final Address address) {
         return findEntity(address).filter(e -> e.getBalance() > 0).isPresent();
     }
 
     @Override
-    public long getBalance(Address address) {
+    public long getBalance(final Address address) {
         final var entity = findEntity(address);
         return entity.map(Entity::getBalance).orElse(0L);
     }
 
     @Override
-    public boolean isExtant(Address address) {
+    public boolean isExtant(final Address address) {
         return entityRepository.existsById(entityIdFromEvmAddress(address));
     }
 
     @Override
-    public boolean isTokenAccount(Address address) {
+    public boolean isTokenAccount(final Address address) {
         return findEntity(address).filter(e -> e.getType() == TOKEN).isPresent();
     }
 
     @Override
-    public ByteString alias(Address address) {
+    public ByteString alias(final Address address) {
         final var entity = findEntity(address);
         return entity.map(value -> fromBytes(value.getAlias())).orElse(ByteString.EMPTY);
     }
 
     @Override
-    public Bytes getStorage(Address address, Bytes key) {
+    public Bytes getStorage(final Address address, final Bytes key) {
         final var storage = contractStateRepository.findStorage(entityIdFromEvmAddress(address),
                 key.toArrayUnsafe());
         return storage.map(Bytes::wrap).orElse(Bytes.EMPTY);
     }
 
     @Override
-    public Bytes fetchCodeIfPresent(Address address) {
+    public Bytes fetchCodeIfPresent(final Address address) {
         final var addressBytes = address.toArrayUnsafe();
-        Long entityId = isMirror(addressBytes) ?
+        final var entityId = isMirror(addressBytes) ?
                 entityIdFromEvmAddress(address) :
                 findEntity(address).map(AbstractEntity::getId).orElse(0L);
 
@@ -93,7 +93,7 @@ public class MirrorEntityAccess implements HederaEvmEntityAccess {
         return runtimeCode.map(Bytes::wrap).orElse(Bytes.EMPTY);
     }
 
-    public Optional<Entity> findEntity(Address address) {
+    public Optional<Entity> findEntity(final Address address) {
         final var addressBytes = address.toArrayUnsafe();
         if (isMirror(addressBytes)) {
             final var entityId = entityIdFromEvmAddress(address);
@@ -103,7 +103,7 @@ public class MirrorEntityAccess implements HederaEvmEntityAccess {
         }
     }
 
-    private Long entityIdFromEvmAddress(Address address) {
+    private Long entityIdFromEvmAddress(final Address address) {
         final var id = fromEvmAddress(address.toArrayUnsafe());
         return id.getId();
     }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccessTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccessTest.java
@@ -166,6 +166,16 @@ class MirrorEntityAccessTest {
     }
 
     @Test
+    void fetchCodeIfPresentForNonMirrorEvm() {
+        final var address = Address.fromHexString("0x23f5e49569a835d7bf9aefd30e4f60cdd570f225");
+        when(mirrorEntityAccess.findEntity(address)).thenReturn(Optional.of(entity));
+        when(entity.getId()).thenReturn(ENTITY_ID);
+        when(contractRepository.findRuntimeBytecode(ENTITY_ID)).thenReturn(Optional.of(DATA));
+        final var result = mirrorEntityAccess.fetchCodeIfPresent(address);
+        assertThat(result).isEqualTo(BYTES);
+    }
+
+    @Test
     void fetchCodeIfPresentReturnsEmpy() {
         when(contractRepository.findRuntimeBytecode(ENTITY_ID)).thenReturn(Optional.empty());
         final var result = mirrorEntityAccess.fetchCodeIfPresent(ADDRESS);


### PR DESCRIPTION
The following PR addresses an ongoing eth_call issue, where a Contract's byte code isn't returned when queried with non-mirror evm address . To fix that, now fetchCodeIfPresent() method first checks the address, in case of a non-mirror one it queries the entity table and extract correct value from the returned record.