### PR TITLE
Throw correct error when multiple contract type transactions are found

### DIFF
--- a/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/multiple-transactions-not-found.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/multiple-transactions-not-found.json
@@ -4,19 +4,22 @@
     "transactions": [
       {
         "consensus_timestamp": 167654000123456,
+        "nonce": 0,
         "payerAccountId": "8001",
-        "scheduled": true,
+        "scheduled": false,
         "transaction_hash": "519a008fabde4d",
-        "valid_start_timestamp": 167654000123400,
-        "type": 7
+        "type": 42,
+        "valid_start_timestamp": 167654000123400
       },
       {
         "consensus_timestamp": 167654000123459,
+        "nonce": 0,
         "payerAccountId": "8001",
-        "transaction_hash": "519a008fabde7d",
-        "valid_start_timestamp": 167654000123400,
         "result": 10,
-        "type": 8
+        "scheduled": true,
+        "transaction_hash": "519a008fabde7d",
+        "type": 14,
+        "valid_start_timestamp": 167654000123400
       }
     ]
   },

--- a/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/multiple-transactions-not-found.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/multiple-transactions-not-found.json
@@ -1,5 +1,5 @@
 {
-  "description": "Contract results api call for a transaction id with at most one transaction match invariance breached",
+  "description": "Contract results api call that results in multiple transactions",
   "setup": {
     "transactions": [
       {

--- a/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/multiple-transactions.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/multiple-transactions.json
@@ -30,6 +30,7 @@
         "consensus_timestamp": 167654000123456,
         "payerAccountId": "8001",
         "transaction_hash": "519a008fabde4d",
+        "type": 7,
         "valid_start_timestamp": 167654000123400
       },
       {
@@ -50,6 +51,7 @@
         "consensus_timestamp": 167654000123459,
         "payerAccountId": "8001",
         "transaction_hash": "519a008fabde7d",
+        "type": 8,
         "valid_start_timestamp": 167654000123400,
         "result": 10
       }

--- a/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/multiple-transactions.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/multiple-transactions.json
@@ -29,12 +29,14 @@
       {
         "consensus_timestamp": 167654000123456,
         "payerAccountId": "8001",
+        "scheduled": true,
         "transaction_hash": "519a008fabde4d",
         "valid_start_timestamp": 167654000123400
       },
       {
         "consensus_timestamp": 167654000123457,
         "payerAccountId": "8001",
+        "scheduled": true,
         "transaction_hash": "519a008fabde5d",
         "valid_start_timestamp": 167654000123400,
         "result": 11
@@ -42,6 +44,7 @@
       {
         "consensus_timestamp": 167654000123458,
         "payerAccountId": "8001",
+        "scheduled": true,
         "transaction_hash": "519a008fabde6d",
         "valid_start_timestamp": 167654000123400,
         "result": 11
@@ -49,6 +52,7 @@
       {
         "consensus_timestamp": 167654000123459,
         "payerAccountId": "8001",
+        "scheduled": true,
         "transaction_hash": "519a008fabde7d",
         "valid_start_timestamp": 167654000123400,
         "result": 10

--- a/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/multiple-transactions.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/multiple-transactions.json
@@ -29,14 +29,12 @@
       {
         "consensus_timestamp": 167654000123456,
         "payerAccountId": "8001",
-        "scheduled": true,
         "transaction_hash": "519a008fabde4d",
         "valid_start_timestamp": 167654000123400
       },
       {
         "consensus_timestamp": 167654000123457,
         "payerAccountId": "8001",
-        "scheduled": true,
         "transaction_hash": "519a008fabde5d",
         "valid_start_timestamp": 167654000123400,
         "result": 11
@@ -44,7 +42,6 @@
       {
         "consensus_timestamp": 167654000123458,
         "payerAccountId": "8001",
-        "scheduled": true,
         "transaction_hash": "519a008fabde6d",
         "valid_start_timestamp": 167654000123400,
         "result": 11
@@ -52,7 +49,6 @@
       {
         "consensus_timestamp": 167654000123459,
         "payerAccountId": "8001",
-        "scheduled": true,
         "transaction_hash": "519a008fabde7d",
         "valid_start_timestamp": 167654000123400,
         "result": 10

--- a/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/transaction-type-not-found.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/transaction-type-not-found.json
@@ -1,0 +1,37 @@
+{
+  "description": "Contract results api call for a transaction id with at most one transaction match invariance breached",
+  "setup": {
+    "transactions": [
+      {
+        "consensus_timestamp": 167654000123456,
+        "payerAccountId": "8001",
+        "scheduled": true,
+        "transaction_hash": "519a008fabde4d",
+        "valid_start_timestamp": 167654000123400,
+        "type": 7
+      },
+      {
+        "consensus_timestamp": 167654000123459,
+        "payerAccountId": "8001",
+        "transaction_hash": "519a008fabde7d",
+        "valid_start_timestamp": 167654000123400,
+        "result": 10,
+        "type": 8
+      }
+    ]
+  },
+  "urls": [
+    "/api/v1/contracts/results/0.0.8001-167654-000123400",
+    "/api/v1/contracts/results/0.0.8001-167654-000123400?nonce=0"
+  ],
+  "responseStatus": 404,
+  "responseJson": {
+    "_status": {
+      "messages": [
+        {
+          "message": "Not found"
+        }
+      ]
+    }
+  }
+}

--- a/hedera-mirror-rest/controllers/contractController.js
+++ b/hedera-mirror-rest/controllers/contractController.js
@@ -75,9 +75,10 @@ const contractWithBytecodeSelectFields = [
 ];
 const {default: defaultLimit} = getResponseLimit();
 
+const contractCallType = Number(TransactionType.getProtoId('CONTRACTCALL'));
+const contractCreateType = Number(TransactionType.getProtoId('CONTRACTCREATEINSTANCE'));
 const duplicateTransactionResult = TransactionResult.getProtoId('DUPLICATE_TRANSACTION');
 const wrongNonceTransactionResult = TransactionResult.getProtoId('WRONG_NONCE');
-const ethereumTransactionType = TransactionType.getProtoId('ETHEREUMTRANSACTION');
 
 const emptyBloomBuffer = Buffer.alloc(256);
 /**
@@ -1078,6 +1079,12 @@ class ContractController extends BaseController {
       if (transactions.length === 0) {
         throw new NotFoundError();
       } else if (transactions.length > 1) {
+        for (const transaction of transactions) {
+          if (transaction.type === contractCallType || transaction.type === contractCreateType) {
+            throw new NotFoundError();
+          }
+        }
+
         logger.error(
           'Transaction invariance breached: there should be at most one transaction with none-duplicate-transaction ' +
             'result for a specific (payer + valid start timestamp + nonce) combination'

--- a/hedera-mirror-rest/controllers/contractController.js
+++ b/hedera-mirror-rest/controllers/contractController.js
@@ -1081,9 +1081,7 @@ class ContractController extends BaseController {
         throw new NotFoundError();
       } else if (transactions.length > 1) {
         for (const transaction of transactions) {
-          const one = isUserInitiatedTransaction(transaction);
-          const two = !isContractTransaction(transaction);
-          if (isUserInitiatedTransaction(transaction) && !isContractTransaction(transaction)) {
+          if (!isContractTransaction(transaction)) {
             throw new NotFoundError();
           }
         }
@@ -1269,16 +1267,9 @@ const exportControllerMethods = (methods = []) => {
   }, {});
 };
 
-const isContractTransaction = (transaction) => {
-  return transaction.type === contractCallType || transaction.type === contractCreateType
-    || transaction.type === ethereumTransactionType ?
-    true : false;
-};
-
-const isUserInitiatedTransaction = (transaction) => {
-  return !transaction.scheduled && transaction.nonce === 0 ?
-    true : false;
-};
+const isContractTransaction = (transaction) =>
+  transaction.type === contractCallType || transaction.type === contractCreateType
+    || transaction.type === ethereumTransactionType;
 
 const contractController = exportControllerMethods([
   'getContractActions',

--- a/hedera-mirror-rest/controllers/contractController.js
+++ b/hedera-mirror-rest/controllers/contractController.js
@@ -77,6 +77,7 @@ const {default: defaultLimit} = getResponseLimit();
 
 const contractCallType = Number(TransactionType.getProtoId('CONTRACTCALL'));
 const contractCreateType = Number(TransactionType.getProtoId('CONTRACTCREATEINSTANCE'));
+const ethereumTransactionType = Number(TransactionType.getProtoId('ETHEREUMTRANSACTION'));
 const duplicateTransactionResult = TransactionResult.getProtoId('DUPLICATE_TRANSACTION');
 const wrongNonceTransactionResult = TransactionResult.getProtoId('WRONG_NONCE');
 
@@ -1080,7 +1081,9 @@ class ContractController extends BaseController {
         throw new NotFoundError();
       } else if (transactions.length > 1) {
         for (const transaction of transactions) {
-          if (transaction.type === contractCallType || transaction.type === contractCreateType) {
+          const one = isUserInitiatedTransaction(transaction);
+          const two = !isContractTransaction(transaction);
+          if (isUserInitiatedTransaction(transaction) && !isContractTransaction(transaction)) {
             throw new NotFoundError();
           }
         }
@@ -1264,6 +1267,17 @@ const exportControllerMethods = (methods = []) => {
 
     return exported;
   }, {});
+};
+
+const isContractTransaction = (transaction) => {
+  return transaction.type === contractCallType || transaction.type === contractCreateType
+    || transaction.type === ethereumTransactionType ?
+    true : false;
+};
+
+const isUserInitiatedTransaction = (transaction) => {
+  return !transaction.scheduled && transaction.nonce === 0 ?
+    true : false;
 };
 
 const contractController = exportControllerMethods([

--- a/hedera-mirror-rest/service/transactionService.js
+++ b/hedera-mirror-rest/service/transactionService.js
@@ -34,7 +34,7 @@ class TransactionService extends BaseService {
   }
 
   static transactionDetailsFromTransactionIdQuery = `
-    select ${Transaction.CONSENSUS_TIMESTAMP}
+    select ${Transaction.CONSENSUS_TIMESTAMP}, ${Transaction.TYPE}
     from ${Transaction.tableName}
     where ${Transaction.PAYER_ACCOUNT_ID} = $1 and ${Transaction.VALID_START_NS} = $2`;
 

--- a/hedera-mirror-rest/service/transactionService.js
+++ b/hedera-mirror-rest/service/transactionService.js
@@ -34,7 +34,7 @@ class TransactionService extends BaseService {
   }
 
   static transactionDetailsFromTransactionIdQuery = `
-    select ${Transaction.CONSENSUS_TIMESTAMP}, ${Transaction.TYPE}
+    select ${Transaction.CONSENSUS_TIMESTAMP}, ${Transaction.NONCE}, ${Transaction.SCHEDULED}, ${Transaction.TYPE}
     from ${Transaction.tableName}
     where ${Transaction.PAYER_ACCOUNT_ID} = $1 and ${Transaction.VALID_START_NS} = $2`;
 


### PR DESCRIPTION
Signed-off-by: Edwin Greene <edwin.greene@swirldslabs.com>

**Description**:
Instead of throwing a 500 error, throw the correct 404 error if more than one transaction is found for specific contract related transaction types.

**Related issue(s)**:

Fixes #4740 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
