### PR TITLE
Rename RecordItemBuilder.record() to fix code smell

### DIFF
--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/RecordItem.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/RecordItem.java
@@ -197,13 +197,13 @@ public class RecordItem implements StreamItem {
             return buildInternal();
         }
 
-        public B record(TransactionRecord transactionRecord) {
+        public B transactionRecord(TransactionRecord transactionRecord) {
             this.transactionRecord = transactionRecord;
             this.recordBytes = transactionRecord.toByteArray();
             return (B) this;
         }
 
-        public B recordBytes(byte[] recordBytes) {
+        public B transactionRecordBytes(byte[] recordBytes) {
             try {
                 this.recordBytes = recordBytes;
                 this.transactionRecord = TransactionRecord.parseFrom(recordBytes);

--- a/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/transaction/RecordItemTest.java
+++ b/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/transaction/RecordItemTest.java
@@ -98,7 +98,7 @@ class RecordItemTest {
             parentRecord.getReceiptBuilder().setStatus(parentStatus);
             parent = RecordItem.builder()
                     .hapiVersion(DEFAULT_HAPI_VERSION)
-                    .record(parentRecord.build())
+                    .transactionRecord(parentRecord.build())
                     .transaction(Transaction.newBuilder().build())
                     .build();
         }
@@ -108,7 +108,7 @@ class RecordItemTest {
         RecordItem recordItem = RecordItem.builder()
                 .hapiVersion(DEFAULT_HAPI_VERSION)
                 .parent(parent)
-                .record(childRecord.build())
+                .transactionRecord(childRecord.build())
                 .transaction(Transaction.newBuilder().build())
                 .build();
         assertThat(recordItem.isSuccessful()).isEqualTo(expected);
@@ -138,7 +138,7 @@ class RecordItemTest {
                 .build();
         RecordItem recordItem = RecordItem.builder()
                 .hapiVersion(DEFAULT_HAPI_VERSION)
-                .record(TRANSACTION_RECORD)
+                .transactionRecord(TRANSACTION_RECORD)
                 .transaction(transaction)
                 .build();
         assertRecordItem(transaction, recordItem);
@@ -157,7 +157,7 @@ class RecordItemTest {
 
         RecordItem recordItem = RecordItem.builder()
                 .hapiVersion(DEFAULT_HAPI_VERSION)
-                .recordBytes(TRANSACTION_RECORD.toByteArray())
+                .transactionRecordBytes(TRANSACTION_RECORD.toByteArray())
                 .transactionBytes(transactionFromProto)
                 .build();
         assertRecordItem(expectedTransaction, recordItem);
@@ -171,7 +171,7 @@ class RecordItemTest {
                 .build();
         RecordItem recordItem = RecordItem.builder()
                 .hapiVersion(DEFAULT_HAPI_VERSION)
-                .record(TRANSACTION_RECORD)
+                .transactionRecord(TRANSACTION_RECORD)
                 .transaction(transaction)
                 .build();
         assertRecordItem(transaction, recordItem);
@@ -184,7 +184,7 @@ class RecordItemTest {
                 .build();
         RecordItem recordItem = RecordItem.builder()
                 .hapiVersion(DEFAULT_HAPI_VERSION)
-                .record(TRANSACTION_RECORD)
+                .transactionRecord(TRANSACTION_RECORD)
                 .transaction(transaction)
                 .build();
         assertRecordItem(transaction, recordItem);
@@ -199,7 +199,7 @@ class RecordItemTest {
                 .build();
         RecordItem recordItem = RecordItem.builder()
                 .hapiVersion(DEFAULT_HAPI_VERSION)
-                .record(transactionRecord)
+                .transactionRecord(transactionRecord)
                 .transaction(DEFAULT_TRANSACTION)
                 .build();
 
@@ -217,7 +217,7 @@ class RecordItemTest {
                 .build();
         RecordItem recordItem = RecordItem.builder()
                 .hapiVersion(DEFAULT_HAPI_VERSION)
-                .record(transactionRecord)
+                .transactionRecord(transactionRecord)
                 .transaction(DEFAULT_TRANSACTION)
                 .build();
 
@@ -239,7 +239,7 @@ class RecordItemTest {
 
         RecordItem previousRecordItem = RecordItem.builder()
                 .hapiVersion(DEFAULT_HAPI_VERSION)
-                .record(parentTransactionRecord)
+                .transactionRecord(parentTransactionRecord)
                 .transaction(transaction)
                 .build();
 
@@ -251,7 +251,7 @@ class RecordItemTest {
         RecordItem recordItem = RecordItem.builder()
                 .hapiVersion(DEFAULT_HAPI_VERSION)
                 .previous(previousRecordItem)
-                .record(transactionRecord)
+                .transactionRecord(transactionRecord)
                 .transaction(DEFAULT_TRANSACTION)
                 .build();
 
@@ -273,7 +273,7 @@ class RecordItemTest {
 
         RecordItem previousRecordItem = RecordItem.builder()
                 .hapiVersion(DEFAULT_HAPI_VERSION)
-                .record(parentTransactionRecord)
+                .transactionRecord(parentTransactionRecord)
                 .transaction(transaction)
                 .build();
 
@@ -286,7 +286,7 @@ class RecordItemTest {
         RecordItem recordItem = RecordItem.builder()
                 .hapiVersion(DEFAULT_HAPI_VERSION)
                 .previous(previousRecordItem)
-                .record(transactionRecord)
+                .transactionRecord(transactionRecord)
                 .transaction(DEFAULT_TRANSACTION)
                 .build();
 
@@ -308,7 +308,7 @@ class RecordItemTest {
 
         RecordItem previousRecordItem = RecordItem.builder()
                 .hapiVersion(DEFAULT_HAPI_VERSION)
-                .record(parentTransactionRecord)
+                .transactionRecord(parentTransactionRecord)
                 .transaction(transaction)
                 .build();
 
@@ -320,7 +320,7 @@ class RecordItemTest {
                 .build();
         RecordItem recordItem = RecordItem.builder()
                 .hapiVersion(DEFAULT_HAPI_VERSION)
-                .record(transactionRecord)
+                .transactionRecord(transactionRecord)
                 .previous(previousRecordItem)
                 .transaction(DEFAULT_TRANSACTION)
                 .build();
@@ -345,7 +345,7 @@ class RecordItemTest {
 
         RecordItem parentRecordItem = RecordItem.builder()
                 .hapiVersion(DEFAULT_HAPI_VERSION)
-                .record(parentTransactionRecord)
+                .transactionRecord(parentTransactionRecord)
                 .transaction(transaction)
                 .build();
 
@@ -358,7 +358,7 @@ class RecordItemTest {
         RecordItem siblingRecordItem = RecordItem.builder()
                 .hapiVersion(DEFAULT_HAPI_VERSION)
                 .parent(parentRecordItem)
-                .record(siblingTransactionRecord)
+                .transactionRecord(siblingTransactionRecord)
                 .transaction(DEFAULT_TRANSACTION)
                 .build();
 
@@ -371,7 +371,7 @@ class RecordItemTest {
         RecordItem recordItem = RecordItem.builder()
                 .hapiVersion(DEFAULT_HAPI_VERSION)
                 .previous(siblingRecordItem)
-                .record(transactionRecord)
+                .transactionRecord(transactionRecord)
                 .transaction(DEFAULT_TRANSACTION)
                 .build();
 
@@ -395,7 +395,7 @@ class RecordItemTest {
 
         RecordItem parentRecordItem = RecordItem.builder()
                 .hapiVersion(DEFAULT_HAPI_VERSION)
-                .record(parentTransactionRecord)
+                .transactionRecord(parentTransactionRecord)
                 .transaction(transaction)
                 .build();
 
@@ -407,7 +407,7 @@ class RecordItemTest {
                 .build();
         RecordItem siblingRecordItem = RecordItem.builder()
                 .hapiVersion(DEFAULT_HAPI_VERSION)
-                .record(siblingTransactionRecord)
+                .transactionRecord(siblingTransactionRecord)
                 .parent(parentRecordItem)
                 .transaction(DEFAULT_TRANSACTION)
                 .build();
@@ -421,7 +421,7 @@ class RecordItemTest {
         RecordItem recordItem = RecordItem.builder()
                 .hapiVersion(DEFAULT_HAPI_VERSION)
                 .previous(siblingRecordItem)
-                .record(transactionRecord)
+                .transactionRecord(transactionRecord)
                 .transaction(DEFAULT_TRANSACTION)
                 .build();
 
@@ -444,7 +444,7 @@ class RecordItemTest {
 
         RecordItem recordItem = RecordItem.builder()
                 .hapiVersion(DEFAULT_HAPI_VERSION)
-                .record(TRANSACTION_RECORD)
+                .transactionRecord(TRANSACTION_RECORD)
                 .transaction(transaction)
                 .build();
 
@@ -467,7 +467,7 @@ class RecordItemTest {
 
         RecordItem recordItem = RecordItem.builder()
                 .hapiVersion(DEFAULT_HAPI_VERSION)
-                .record(TRANSACTION_RECORD)
+                .transactionRecord(TRANSACTION_RECORD)
                 .transaction(transaction)
                 .build();
 
@@ -478,7 +478,7 @@ class RecordItemTest {
     private void testException(byte[] transactionBytes, byte[] recordBytes, String expectedMessage) {
         assertThatThrownBy(() -> RecordItem.builder()
                 .hapiVersion(DEFAULT_HAPI_VERSION)
-                .recordBytes(recordBytes)
+                .transactionRecordBytes(recordBytes)
                 .transactionBytes(transactionBytes)
                 .build()
                 .getTransactionBody())

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/ErrataMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/ErrataMigration.java
@@ -217,7 +217,7 @@ public class ErrataMigration extends RepeatableMigration implements BalanceStrea
                 byte[] transactionBytes = in.readLengthAndBytes(1, MAX_TRANSACTION_LENGTH, false, "transaction");
                 var transactionRecord = TransactionRecord.parseFrom(recordBytes);
                 var transaction = Transaction.parseFrom(transactionBytes);
-                var recordItem = RecordItem.builder().record(transactionRecord).transaction(transaction).build();
+                var recordItem = RecordItem.builder().transactionRecord(transactionRecord).transaction(transaction).build();
                 long timestamp = recordItem.getConsensusTimestamp();
 
                 if (transactionRepository.findById(timestamp).isEmpty() && dateRangeFilter.filter(timestamp)) {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/record/AbstractPreV5RecordFileReader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/record/AbstractPreV5RecordFileReader.java
@@ -124,7 +124,7 @@ public abstract class AbstractPreV5RecordFileReader implements RecordFileReader 
             RecordItem recordItem = RecordItem.builder()
                     .hapiVersion(recordFile.getHapiVersion())
                     .previous(lastRecordItem)
-                    .recordBytes(recordBytes)
+                    .transactionRecordBytes(recordBytes)
                     .transactionIndex(count)
                     .transactionBytes(transactionBytes)
                     .build();

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/record/ProtoRecordFileReader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/record/ProtoRecordFileReader.java
@@ -190,7 +190,7 @@ public class ProtoRecordFileReader implements RecordFileReader {
             var recordItem = RecordItem.builder()
                     .hapiVersion(hapiVersion)
                     .previous(previousItem)
-                    .recordBytes(recordStreamItem.getRecord().toByteArray())
+                    .transactionRecordBytes(recordStreamItem.getRecord().toByteArray())
                     .transactionBytes(recordStreamItem.getTransaction().toByteArray())
                     .transactionIndex(items.size())
                     .build();

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/record/RecordFileReaderImplV5.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/record/RecordFileReaderImplV5.java
@@ -115,7 +115,7 @@ public class RecordFileReaderImplV5 implements RecordFileReader {
             var recordItem = RecordItem.builder()
                     .hapiVersion(recordFile.getHapiVersion())
                     .previous(lastRecordItem)
-                    .recordBytes(recordStreamObject.recordBytes)
+                    .transactionRecordBytes(recordStreamObject.recordBytes)
                     .transactionIndex(count)
                     .transactionBytes(recordStreamObject.transactionBytes)
                     .build();

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/domain/RecordItemBuilder.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/domain/RecordItemBuilder.java
@@ -713,7 +713,7 @@ public class RecordItemBuilder {
             var sidecarRecords = this.sidecarRecords.stream().map(r -> r.build()).collect(Collectors.toList());
 
             return recordItemBuilder
-                    .recordBytes(record.toByteArray())
+                    .transactionRecordBytes(record.toByteArray())
                     .transactionBytes(transaction.toByteArray())
                     .sidecarRecords(sidecarRecords)
                     .build();

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileParserTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileParserTest.java
@@ -380,7 +380,7 @@ class RecordFileParserTest extends AbstractStreamFileParserTest<RecordFileParser
                 .setSignedTransactionBytes(signedTransaction.toByteString())
                 .build();
         return RecordItem.builder()
-                .record(transactionRecord)
+                .transactionRecord(transactionRecord)
                 .transactionBytes(transaction.toByteArray())
                 .build();
     }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerContractTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerContractTest.java
@@ -308,7 +308,7 @@ class EntityRecordItemListenerContractTest extends AbstractEntityRecordItemListe
         TransactionRecord record = getContractTransactionRecord(transactionBody, ContractTransactionType.UPDATE);
         ContractUpdateTransactionBody contractUpdateTransactionBody = transactionBody.getContractUpdateInstance();
 
-        var recordItem = RecordItem.builder().record(record).transaction(transaction).build();
+        var recordItem = RecordItem.builder().transactionRecord(record).transaction(transaction).build();
         parseRecordItemAndCommit(recordItem);
 
         assertAll(
@@ -344,7 +344,7 @@ class EntityRecordItemListenerContractTest extends AbstractEntityRecordItemListe
         TransactionRecord record = getContractTransactionRecord(transactionBody, ContractTransactionType.UPDATE);
         ContractUpdateTransactionBody contractUpdateTransactionBody = transactionBody.getContractUpdateInstance();
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(transaction).build());
 
         assertAll(
                 () -> assertEquals(1, transactionRepository.count()),
@@ -367,7 +367,7 @@ class EntityRecordItemListenerContractTest extends AbstractEntityRecordItemListe
         TransactionRecord record = getContractTransactionRecord(transactionBody, ContractTransactionType.UPDATE);
         ContractUpdateTransactionBody contractUpdateTransactionBody = transactionBody.getContractUpdateInstance();
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(transaction).build());
 
         assertAll(
                 () -> assertEquals(1, transactionRepository.count()),
@@ -388,7 +388,7 @@ class EntityRecordItemListenerContractTest extends AbstractEntityRecordItemListe
         TransactionBody transactionBody = getTransactionBody(transaction);
         TransactionRecord record = getContractTransactionRecord(transactionBody, ContractTransactionType.UPDATE);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(transaction).build());
 
         var dbTransaction = getDbTransaction(record.getConsensusTimestamp());
         assertAll(
@@ -408,7 +408,7 @@ class EntityRecordItemListenerContractTest extends AbstractEntityRecordItemListe
         TransactionRecord record = getContractTransactionRecord(transactionBody, ContractTransactionType.UPDATE);
         ContractUpdateTransactionBody contractUpdateTransactionBody = transactionBody.getContractUpdateInstance();
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(transaction).build());
 
         assertAll(
                 () -> assertEquals(1, transactionRepository.count()),
@@ -431,7 +431,7 @@ class EntityRecordItemListenerContractTest extends AbstractEntityRecordItemListe
         TransactionRecord record = getContractTransactionRecord(transactionBody,
                 ResponseCodeEnum.INSUFFICIENT_ACCOUNT_BALANCE,
                 ContractTransactionType.UPDATE);
-        RecordItem recordItem = RecordItem.builder().record(record).transaction(transaction).build();
+        RecordItem recordItem = RecordItem.builder().transactionRecord(record).transaction(transaction).build();
 
         parseRecordItemAndCommit(recordItem);
 
@@ -453,7 +453,7 @@ class EntityRecordItemListenerContractTest extends AbstractEntityRecordItemListe
         Transaction transaction = contractDeleteTransaction(setupResult.protoContractId, permanentRemoval);
         TransactionBody transactionBody = getTransactionBody(transaction);
         TransactionRecord record = getContractTransactionRecord(transactionBody, ContractTransactionType.DELETE);
-        RecordItem recordItem = RecordItem.builder().record(record).transaction(transaction).build();
+        RecordItem recordItem = RecordItem.builder().transactionRecord(record).transaction(transaction).build();
 
         parseRecordItemAndCommit(recordItem);
 
@@ -483,7 +483,7 @@ class EntityRecordItemListenerContractTest extends AbstractEntityRecordItemListe
         Transaction transaction = contractDeleteTransaction(setupResult.protoContractId, false);
         TransactionBody transactionBody = getTransactionBody(transaction);
         TransactionRecord record = getContractTransactionRecord(transactionBody, ContractTransactionType.DELETE);
-        RecordItem recordItem = RecordItem.builder().record(record).transaction(transaction).build();
+        RecordItem recordItem = RecordItem.builder().transactionRecord(record).transaction(transaction).build();
 
         parseRecordItemAndCommit(recordItem);
         Entity entity = getTransactionEntity(record.getConsensusTimestamp());
@@ -514,7 +514,7 @@ class EntityRecordItemListenerContractTest extends AbstractEntityRecordItemListe
         Transaction transaction = contractDeleteTransaction(setupResult.protoContractId, false);
         TransactionBody transactionBody = getTransactionBody(transaction);
         TransactionRecord record = getContractTransactionRecord(transactionBody, ContractTransactionType.DELETE);
-        RecordItem recordItem = RecordItem.builder().record(record).transaction(transaction).build();
+        RecordItem recordItem = RecordItem.builder().transactionRecord(record).transaction(transaction).build();
 
         parseRecordItemAndCommit(recordItem);
 
@@ -537,7 +537,7 @@ class EntityRecordItemListenerContractTest extends AbstractEntityRecordItemListe
                 ResponseCodeEnum.INSUFFICIENT_ACCOUNT_BALANCE,
                 ContractTransactionType.DELETE);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(transaction).build());
 
         assertAll(
                 () -> assertEquals(1, transactionRepository.count()),
@@ -641,7 +641,7 @@ class EntityRecordItemListenerContractTest extends AbstractEntityRecordItemListe
         TransactionBody transactionBody = getTransactionBody(transaction);
         TransactionRecord record = getContractTransactionRecord(transactionBody, ContractTransactionType.CALL);
         ContractCallTransactionBody contractCallTransactionBody = transactionBody.getContractCall();
-        RecordItem recordItem = RecordItem.builder().record(record).transaction(transaction).build();
+        RecordItem recordItem = RecordItem.builder().transactionRecord(record).transaction(transaction).build();
 
         parseRecordItemAndCommit(recordItem);
 
@@ -721,7 +721,7 @@ class EntityRecordItemListenerContractTest extends AbstractEntityRecordItemListe
                 ResponseCodeEnum.INSUFFICIENT_ACCOUNT_BALANCE, ContractTransactionType.CALL)
                 .toBuilder().clearContractCallResult().build();
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(transaction).build());
 
         assertAll(
                 () -> assertEquals(1, transactionRepository.count()),
@@ -739,7 +739,7 @@ class EntityRecordItemListenerContractTest extends AbstractEntityRecordItemListe
         TransactionBody transactionBody = getTransactionBody(transaction);
         TransactionRecord record = getContractTransactionRecord(transactionBody, ContractTransactionType.CALL);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(transaction).build());
 
         assertAll(
                 () -> assertEquals(1, transactionRepository.count()),

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerCryptoTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerCryptoTest.java
@@ -150,7 +150,7 @@ class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItemListene
         TransactionRecord record = transactionRecordSuccess(transactionBody, recordBuilder ->
                 groupCryptoTransfersByAccountId(recordBuilder, List.of(transfer1, transfer2)));
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(transaction).build());
 
         var accountEntityId = EntityId.of(accountId1);
         var consensusTimestamp = DomainUtils.timeStampInNanos(record.getConsensusTimestamp());
@@ -180,7 +180,7 @@ class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItemListene
         CryptoCreateTransactionBody cryptoCreateTransactionBody = transactionBody.getCryptoCreateAccount();
         TransactionRecord record = transactionRecordSuccess(transactionBody);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(transaction).build());
 
         var accountEntityId = EntityId.of(accountId1);
         var consensusTimestamp = DomainUtils.timeStampInNanos(record.getConsensusTimestamp());
@@ -210,7 +210,7 @@ class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItemListene
         recordBuilder.getReceiptBuilder().clearAccountID();
         TransactionRecord record = recordBuilder.build();
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(transaction).build());
 
         var dbTransaction = getDbTransaction(record.getConsensusTimestamp());
 
@@ -238,7 +238,7 @@ class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItemListene
                 groupCryptoTransfersByAccountId(recordBuilder, List.of(transfer1, transfer2))
         );
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(transaction).build());
 
         var dbTransaction = getDbTransaction(record.getConsensusTimestamp());
 
@@ -264,7 +264,7 @@ class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItemListene
                 transactionBody,
                 ResponseCodeEnum.SUCCESS.getNumber());
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(transaction).build());
 
         var accountEntityId = EntityId.of(accountId1);
         var consensusTimestamp = DomainUtils.timeStampInNanos(record.getConsensusTimestamp());
@@ -370,7 +370,7 @@ class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItemListene
         CryptoUpdateTransactionBody cryptoUpdateTransactionBody = transactionBody.getCryptoUpdateAccount();
         TransactionRecord record = transactionRecordSuccess(transactionBody);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(transaction).build());
         Entity dbAccountEntity = getTransactionEntity(record.getConsensusTimestamp());
 
         assertAll(
@@ -539,7 +539,7 @@ class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItemListene
                 .build();
         TransactionRecord record = transactionRecordSuccess(transactionBody);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(transaction).build());
 
         assertThat(transactionRepository.findById(DomainUtils.timestampInNanosMax(record.getConsensusTimestamp())))
                 .get()
@@ -565,7 +565,7 @@ class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItemListene
         TransactionRecord record = transactionRecordSuccess(transactionBody);
 
         // then: process the transaction without throwing NPE
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(transaction).build());
 
         assertThat(transactionRepository.count()).isEqualTo(1L);
         assertThat(entityRepository.findById(EntityId.of(accountId1).getId()))
@@ -598,7 +598,7 @@ class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItemListene
 
         var record = transactionRecordSuccess(transactionBody);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(updateTransaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(updateTransaction).build());
 
         var dbAccountEntity = getTransactionEntity(record.getConsensusTimestamp());
         var stakedAccountId = EntityId.of(transactionBody.getCryptoUpdateAccount().getStakedAccountId()).getId();
@@ -616,14 +616,14 @@ class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItemListene
     void cryptoUpdateFailedTransaction() {
         Transaction createTransaction = cryptoCreateTransaction();
         TransactionRecord createRecord = transactionRecordSuccess(getTransactionBody(createTransaction));
-        parseRecordItemAndCommit(RecordItem.builder().record(createRecord).transaction(createTransaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(createRecord).transaction(createTransaction).build());
 
         // now update
         Transaction transaction = cryptoUpdateTransaction(accountId1);
         TransactionBody transactionBody = getTransactionBody(transaction);
         TransactionRecord record = transactionRecord(transactionBody, ResponseCodeEnum.INSUFFICIENT_ACCOUNT_BALANCE);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(transaction).build());
 
         Entity dbAccountEntityBefore = getTransactionEntity(createRecord.getConsensusTimestamp());
         Entity dbAccountEntity = getTransactionEntity(record.getConsensusTimestamp());
@@ -766,7 +766,7 @@ class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItemListene
         TransactionBody transactionBody = getTransactionBody(transaction);
         TransactionRecord record = transactionRecordSuccess(transactionBody);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(transaction).build());
 
         Entity dbAccountEntity = getTransactionEntity(record.getConsensusTimestamp());
 
@@ -798,7 +798,7 @@ class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItemListene
                 ResponseCodeEnum.INSUFFICIENT_ACCOUNT_BALANCE.getNumber(),
                 recordBuilder -> groupCryptoTransfersByAccountId(recordBuilder, List.of()));
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(transaction).build());
 
         Entity dbAccountEntity = getTransactionEntity(record.getConsensusTimestamp());
 
@@ -820,7 +820,7 @@ class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItemListene
         CryptoAddLiveHashTransactionBody cryptoAddLiveHashTransactionBody = transactionBody.getCryptoAddLiveHash();
         TransactionRecord record = transactionRecordSuccess(transactionBody);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(transaction).build());
 
         var dbTransaction = getDbTransaction(record.getConsensusTimestamp());
         LiveHash dbLiveHash = liveHashRepository.findById(dbTransaction.getConsensusTimestamp()).get();
@@ -843,7 +843,7 @@ class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItemListene
         TransactionBody transactionBody = getTransactionBody(transaction);
         TransactionRecord record = transactionRecordSuccess(transactionBody);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(transaction).build());
 
         assertAll(
                 () -> assertEquals(1, transactionRepository.count()),
@@ -858,7 +858,7 @@ class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItemListene
     void cryptoDeleteLiveHash() {
         Transaction transactionAddLiveHash = cryptoAddLiveHashTransaction();
         var recordLiveHash = transactionRecordSuccess(getTransactionBody(transactionAddLiveHash));
-        var recordItem = RecordItem.builder().record(recordLiveHash).transaction(transactionAddLiveHash).build();
+        var recordItem = RecordItem.builder().transactionRecord(recordLiveHash).transaction(transactionAddLiveHash).build();
         parseRecordItemAndCommit(recordItem);
 
         // now delete the live hash
@@ -867,7 +867,7 @@ class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItemListene
         CryptoDeleteLiveHashTransactionBody deleteLiveHashTransactionBody = transactionBody.getCryptoDeleteLiveHash();
         TransactionRecord record = transactionRecordSuccess(transactionBody);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(transaction).build());
 
         assertAll(
                 () -> assertEquals(2, transactionRepository.count()),
@@ -886,7 +886,7 @@ class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItemListene
         TransactionBody transactionBody = getTransactionBody(transaction);
         TransactionRecord record = transactionRecordSuccess(transactionBody);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(transaction).build());
 
         assertAll(
                 () -> assertEquals(1, transactionRepository.count()),
@@ -904,7 +904,7 @@ class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItemListene
         TransactionBody transactionBody = getTransactionBody(transaction);
         TransactionRecord record = transactionRecordSuccess(transactionBody);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(transaction).build());
 
         assertAll(
                 () -> assertEquals(1, transactionRepository.count()),
@@ -923,7 +923,7 @@ class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItemListene
         TransactionBody transactionBody = getTransactionBody(transaction);
         TransactionRecord record = transactionRecord(transactionBody, ResponseCodeEnum.INVALID_ACCOUNT_ID);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(transaction).build());
 
         assertAll(
                 () -> assertEquals(1, transactionRepository.count()),
@@ -948,7 +948,7 @@ class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItemListene
             }
         }, transactionBody, ResponseCodeEnum.INVALID_ACCOUNT_ID.getNumber());
 
-        var recordItem = RecordItem.builder().record(record).transaction(transaction).build();
+        var recordItem = RecordItem.builder().transactionRecord(record).transaction(transaction).build();
         parseRecordItemAndCommit(recordItem);
 
         assertAll(
@@ -992,7 +992,7 @@ class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItemListene
             }
         }, transactionBody, ResponseCodeEnum.SUCCESS.getNumber());
 
-        var recordItem = RecordItem.builder().record(record).transaction(transaction).build();
+        var recordItem = RecordItem.builder().transactionRecord(record).transaction(transaction).build();
         parseRecordItemAndCommit(recordItem);
 
         assertAll(
@@ -1041,8 +1041,8 @@ class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItemListene
                 builder -> groupCryptoTransfersByAccountId(builder, List.of()));
 
         parseRecordItemsAndCommit(List.of(
-                RecordItem.builder().record(recordCreate).transaction(accountCreateTransaction).build(),
-                RecordItem.builder().record(recordTransfer).transaction(transaction).build()
+                RecordItem.builder().transactionRecord(recordCreate).transaction(accountCreateTransaction).build(),
+                RecordItem.builder().transactionRecord(recordTransfer).transaction(transaction).build()
         ));
 
         assertAll(
@@ -1073,7 +1073,7 @@ class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItemListene
                 .addAccountAmounts(transfer1));
         TransactionBody transactionBody = getTransactionBody(transaction);
         TransactionRecord transactionRecord = transactionRecordSuccess(transactionBody);
-        RecordItem recordItem = RecordItem.builder().record(transactionRecord).transaction(transaction).build();
+        RecordItem recordItem = RecordItem.builder().transactionRecord(transactionRecord).transaction(transaction).build();
         parseRecordItemAndCommit(recordItem);
 
         assertAll(
@@ -1121,7 +1121,7 @@ class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItemListene
                 Arrays.asList(account2.toEntityId(), null) : List.of(account2.toEntityId());
 
         // when
-        parseRecordItemAndCommit(RecordItem.builder().record(transactionRecord).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(transactionRecord).transaction(transaction).build());
 
         // then
         assertAll(
@@ -1156,7 +1156,7 @@ class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItemListene
                 transactionBody, ResponseCodeEnum.SUCCESS.getNumber());
 
         RecordItem recordItem = RecordItem.builder()
-                .record(transactionRecord)
+                .transactionRecord(transactionRecord)
                 .transaction(transaction)
                 .build();
 
@@ -1177,7 +1177,7 @@ class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItemListene
         TransactionBody transactionBody = getTransactionBody(transaction);
         TransactionRecord record = transactionRecord(transactionBody, unknownResult);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(transaction).build());
 
         assertThat(transactionRepository.findAll())
                 .hasSize(1)
@@ -1460,7 +1460,7 @@ class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItemListene
         Transaction createTransaction = cryptoCreateTransaction();
         TransactionBody createTransactionBody = getTransactionBody(createTransaction);
         TransactionRecord createRecord = transactionRecordSuccess(createTransactionBody);
-        parseRecordItemAndCommit(RecordItem.builder().record(createRecord).transaction(createTransaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(createRecord).transaction(createTransaction).build());
     }
 
     private CryptoCreateTransactionBody.Builder cryptoCreateAccountBuilderWithDefaults() {
@@ -1563,7 +1563,7 @@ class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItemListene
         TransactionRecord record = transactionRecordSuccess(transactionBody);
 
         // when
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(transaction).build());
 
         // then
         var dbTransaction = getDbTransaction(record.getConsensusTimestamp());

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerFileTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerFileTest.java
@@ -97,7 +97,7 @@ class EntityRecordItemListenerFileTest extends AbstractEntityRecordItemListenerT
         TransactionBody transactionBody = getTransactionBody(transaction);
         TransactionRecord record = transactionRecord(transactionBody);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(transaction).build());
 
         assertAll(
                 () -> assertRowCountOnSuccess(FILE_ID),
@@ -114,7 +114,7 @@ class EntityRecordItemListenerFileTest extends AbstractEntityRecordItemListenerT
         TransactionBody transactionBody = getTransactionBody(transaction);
         TransactionRecord record = transactionRecord(transactionBody);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(transaction).build());
 
         assertAll(
                 () -> assertRowCountOnSuccessNoData(FILE_ID),
@@ -130,7 +130,7 @@ class EntityRecordItemListenerFileTest extends AbstractEntityRecordItemListenerT
         FileID fileID = FileID.newBuilder().setShardNum(0).setRealmNum(0).setFileNum(10).build();
         TransactionRecord record = transactionRecord(transactionBody, fileID);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(transaction).build());
 
         assertAll(
                 () -> assertRowCountOnSuccess(fileID),
@@ -147,7 +147,7 @@ class EntityRecordItemListenerFileTest extends AbstractEntityRecordItemListenerT
         FileID fileID = FileID.newBuilder().setShardNum(0).setRealmNum(0).setFileNum(2000).build();
         TransactionRecord record = transactionRecord(transactionBody, fileID);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(transaction).build());
 
         assertAll(
                 () -> assertRowCountOnSuccessNoData(fileID),
@@ -168,7 +168,7 @@ class EntityRecordItemListenerFileTest extends AbstractEntityRecordItemListenerT
         TransactionBody transactionBody = getTransactionBody(transaction);
         TransactionRecord record = transactionRecord(transactionBody);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(transaction).build());
 
         var dbAccountEntity = getTransactionEntity(record.getConsensusTimestamp());
         assertEquals(expectedNanosTimestamp, dbAccountEntity.getExpirationTimestamp());
@@ -180,7 +180,7 @@ class EntityRecordItemListenerFileTest extends AbstractEntityRecordItemListenerT
         TransactionBody transactionBody = getTransactionBody(transaction);
         TransactionRecord record = transactionRecord(transactionBody);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(transaction).build());
 
         assertAll(
                 () -> assertRowCount(1, 3, 1),
@@ -199,7 +199,7 @@ class EntityRecordItemListenerFileTest extends AbstractEntityRecordItemListenerT
         entityProperties.getPersist().setFiles(true);
         entityProperties.getPersist().setSystemFiles(true);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(transaction).build());
 
         assertAll(
                 () -> assertRowCount(1, 3, 1),
@@ -215,14 +215,14 @@ class EntityRecordItemListenerFileTest extends AbstractEntityRecordItemListenerT
         TransactionBody createTransactionBody = getTransactionBody(fileCreateTransaction);
         TransactionRecord recordCreate = transactionRecord(createTransactionBody);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(recordCreate).transaction(fileCreateTransaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(recordCreate).transaction(fileCreateTransaction).build());
 
         // now update
         Transaction transaction = fileUpdateAllTransaction();
         TransactionBody transactionBody = getTransactionBody(transaction);
         TransactionRecord record = transactionRecord(transactionBody);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(transaction).build());
 
         assertAll(
                 () -> assertRowCountOnTwoFileTransactions(),
@@ -238,7 +238,7 @@ class EntityRecordItemListenerFileTest extends AbstractEntityRecordItemListenerT
         TransactionBody createTransactionBody = getTransactionBody(fileCreateTransaction);
         TransactionRecord recordCreate = transactionRecord(createTransactionBody);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(recordCreate).transaction(fileCreateTransaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(recordCreate).transaction(fileCreateTransaction).build());
 
         // now update
         Transaction transaction = fileUpdateAllTransaction();
@@ -246,7 +246,7 @@ class EntityRecordItemListenerFileTest extends AbstractEntityRecordItemListenerT
         TransactionRecord record = transactionRecord(transactionBody,
                 ResponseCodeEnum.INSUFFICIENT_PAYER_BALANCE);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(transaction).build());
 
         assertAll(
                 () -> assertEquals(2, transactionRepository.count())
@@ -278,8 +278,8 @@ class EntityRecordItemListenerFileTest extends AbstractEntityRecordItemListenerT
         FileAppendTransactionBody fileAppendTransactionBody = transactionBodyAppend.getFileAppend();
         TransactionRecord recordAppend = transactionRecord(transactionBodyAppend, ADDRESS_BOOK_FILEID);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(recordUpdate).transaction(transactionUpdate).build());
-        parseRecordItemAndCommit(RecordItem.builder().record(recordAppend).transaction(transactionAppend).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(recordUpdate).transaction(transactionUpdate).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(recordAppend).transaction(transactionAppend).build());
 
         // verify current address book is updated
         AddressBook newAddressBook = addressBookService.getCurrent();
@@ -315,7 +315,7 @@ class EntityRecordItemListenerFileTest extends AbstractEntityRecordItemListenerT
         Transaction transactionCreate = fileUpdateAllTransaction(ADDRESS_BOOK_FILEID, addressBookCreate);
         TransactionBody transactionBodyCreate = getTransactionBody(transactionCreate);
         TransactionRecord recordCreate = transactionRecord(transactionBodyCreate, ADDRESS_BOOK_FILEID);
-        parseRecordItemAndCommit(RecordItem.builder().record(recordCreate).transaction(transactionCreate).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(recordCreate).transaction(transactionCreate).build());
 
         assertAll(
                 () -> assertEquals(TEST_INITIAL_ADDRESS_BOOK_NODE_COUNT,
@@ -340,8 +340,8 @@ class EntityRecordItemListenerFileTest extends AbstractEntityRecordItemListenerT
         TransactionRecord recordAppend = transactionRecord(transactionBodyAppend, ADDRESS_BOOK_FILEID);
 
         parseRecordItemsAndCommit(List.of(
-                RecordItem.builder().record(recordUpdate).transaction(transactionUpdate).build(),
-                RecordItem.builder().record(recordAppend).transaction(transactionAppend).build()));
+                RecordItem.builder().transactionRecord(recordUpdate).transaction(transactionUpdate).build(),
+                RecordItem.builder().transactionRecord(recordAppend).transaction(transactionAppend).build()));
 
         // verify current address book is updated
         AddressBook newAddressBook = addressBookService.getCurrent();
@@ -365,7 +365,7 @@ class EntityRecordItemListenerFileTest extends AbstractEntityRecordItemListenerT
         TransactionBody transactionBody = getTransactionBody(transaction);
         TransactionRecord record = transactionRecord(transactionBody);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(transaction).build());
 
         assertAll(
                 () -> assertRowCountOnSuccess(FILE_ID),
@@ -382,14 +382,14 @@ class EntityRecordItemListenerFileTest extends AbstractEntityRecordItemListenerT
 
         TransactionRecord recordCreate = transactionRecord(createTransactionBody);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(recordCreate).transaction(fileCreateTransaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(recordCreate).transaction(fileCreateTransaction).build());
 
         // now update
         Transaction transaction = fileUpdateContentsTransaction();
         TransactionBody transactionBody = getTransactionBody(transaction);
         TransactionRecord record = transactionRecord(transactionBody);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(transaction).build());
 
         Entity actualFile = getTransactionEntity(record.getConsensusTimestamp());
 
@@ -412,7 +412,7 @@ class EntityRecordItemListenerFileTest extends AbstractEntityRecordItemListenerT
         TransactionBody transactionBody = getTransactionBody(transaction);
         TransactionRecord record = transactionRecord(transactionBody);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(transaction).build());
 
         Entity actualFile = getTransactionEntity(record.getConsensusTimestamp());
 
@@ -435,14 +435,14 @@ class EntityRecordItemListenerFileTest extends AbstractEntityRecordItemListenerT
         TransactionBody createTransactionBody = getTransactionBody(fileCreateTransaction);
         TransactionRecord recordCreate = transactionRecord(createTransactionBody);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(recordCreate).transaction(fileCreateTransaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(recordCreate).transaction(fileCreateTransaction).build());
 
         // now update
         Transaction transaction = fileUpdateExpiryTransaction();
         TransactionBody transactionBody = getTransactionBody(transaction);
         TransactionRecord record = transactionRecord(transactionBody);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(transaction).build());
 
         Entity actualFile = getTransactionEntity(record.getConsensusTimestamp());
 
@@ -466,7 +466,7 @@ class EntityRecordItemListenerFileTest extends AbstractEntityRecordItemListenerT
         TransactionBody transactionBody = getTransactionBody(transaction);
         TransactionRecord record = transactionRecord(transactionBody);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(transaction).build());
 
         Entity actualFile = getTransactionEntity(record.getConsensusTimestamp());
 
@@ -491,7 +491,7 @@ class EntityRecordItemListenerFileTest extends AbstractEntityRecordItemListenerT
         TransactionBody createTransactionBody = getTransactionBody(fileCreateTransaction);
         TransactionRecord recordCreate = transactionRecord(createTransactionBody);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(recordCreate).transaction(fileCreateTransaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(recordCreate).transaction(fileCreateTransaction).build());
 
         // now update
         Transaction transaction = fileUpdateKeysTransaction();
@@ -499,7 +499,7 @@ class EntityRecordItemListenerFileTest extends AbstractEntityRecordItemListenerT
         TransactionRecord record = transactionRecord(transactionBody);
         FileUpdateTransactionBody fileUpdateTransactionBody = transactionBody.getFileUpdate();
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(transaction).build());
 
         Entity dbFileEntity = getTransactionEntity(record.getConsensusTimestamp());
 
@@ -523,7 +523,7 @@ class EntityRecordItemListenerFileTest extends AbstractEntityRecordItemListenerT
         FileUpdateTransactionBody fileUpdateTransactionBody = transactionBody.getFileUpdate();
         TransactionRecord record = transactionRecord(transactionBody);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(transaction).build());
 
         Entity dbFileEntity = getTransactionEntity(record.getConsensusTimestamp());
 
@@ -551,7 +551,7 @@ class EntityRecordItemListenerFileTest extends AbstractEntityRecordItemListenerT
         entityProperties.getPersist().setFiles(true);
         entityProperties.getPersist().setSystemFiles(true);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(transaction).build());
 
         assertAll(
                 () -> assertRowCountOnSuccess(fileID),
@@ -572,7 +572,7 @@ class EntityRecordItemListenerFileTest extends AbstractEntityRecordItemListenerT
         entityProperties.getPersist().setFiles(true);
         entityProperties.getPersist().setSystemFiles(true);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(transaction).build());
 
         addressBookService.getCurrent();
         assertAll(
@@ -597,7 +597,7 @@ class EntityRecordItemListenerFileTest extends AbstractEntityRecordItemListenerT
         entityProperties.getPersist().setFiles(true);
         entityProperties.getPersist().setSystemFiles(true);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(transaction).build());
 
         // verify current address book is changed
         AddressBook currentAddressBook = addressBookService.getCurrent();
@@ -622,7 +622,7 @@ class EntityRecordItemListenerFileTest extends AbstractEntityRecordItemListenerT
         TransactionBody transactionBody = getTransactionBody(transaction);
         TransactionRecord record = transactionRecord(transactionBody, ResponseCodeEnum.FEE_SCHEDULE_FILE_PART_UPLOADED);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(transaction).build());
 
         assertAll(
                 () -> assertRowCountOnSuccess(fileId),
@@ -639,7 +639,7 @@ class EntityRecordItemListenerFileTest extends AbstractEntityRecordItemListenerT
         TransactionRecord record = transactionRecord(transactionBody,
                 ResponseCodeEnum.SUCCESS_BUT_MISSING_EXPECTED_OPERATION);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(transaction).build());
 
         assertAll(
                 () -> assertRowCountOnSuccess(fileId),
@@ -655,14 +655,14 @@ class EntityRecordItemListenerFileTest extends AbstractEntityRecordItemListenerT
         TransactionBody createTransactionBody = getTransactionBody(fileCreateTransaction);
         TransactionRecord recordCreate = transactionRecord(createTransactionBody);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(recordCreate).transaction(fileCreateTransaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(recordCreate).transaction(fileCreateTransaction).build());
 
         // now update
         Transaction transaction = fileDeleteTransaction();
         TransactionBody transactionBody = getTransactionBody(transaction);
         TransactionRecord record = transactionRecord(transactionBody);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(transaction).build());
 
         Entity dbFileEntity = getTransactionEntity(record.getConsensusTimestamp());
 
@@ -689,7 +689,7 @@ class EntityRecordItemListenerFileTest extends AbstractEntityRecordItemListenerT
         TransactionBody transactionBody = getTransactionBody(fileDeleteTransaction);
         TransactionRecord record = transactionRecord(transactionBody);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(fileDeleteTransaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(fileDeleteTransaction).build());
         Entity fileEntity = getTransactionEntity(record.getConsensusTimestamp());
 
         assertAll(
@@ -706,7 +706,7 @@ class EntityRecordItemListenerFileTest extends AbstractEntityRecordItemListenerT
         TransactionBody transactionBody = getTransactionBody(fileDeleteTransaction);
         TransactionRecord record = transactionRecord(transactionBody, ResponseCodeEnum.INSUFFICIENT_PAYER_BALANCE);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(fileDeleteTransaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(fileDeleteTransaction).build());
 
         assertAll(
                 () -> assertRowCountOnFailureNoData(),
@@ -720,7 +720,7 @@ class EntityRecordItemListenerFileTest extends AbstractEntityRecordItemListenerT
         TransactionBody transactionBody = getTransactionBody(systemDeleteTransaction);
         TransactionRecord record = transactionRecord(transactionBody);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(systemDeleteTransaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(systemDeleteTransaction).build());
         Entity fileEntity = getTransactionEntity(record.getConsensusTimestamp());
 
         assertAll(
@@ -736,7 +736,7 @@ class EntityRecordItemListenerFileTest extends AbstractEntityRecordItemListenerT
         TransactionBody transactionBody = getTransactionBody(systemUndeleteTransaction);
         TransactionRecord record = transactionRecord(transactionBody);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(systemUndeleteTransaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(systemUndeleteTransaction).build());
 
         assertAll(
                 () -> assertRowCountOnSuccessNoData(FILE_ID),
@@ -751,7 +751,7 @@ class EntityRecordItemListenerFileTest extends AbstractEntityRecordItemListenerT
         TransactionBody transactionBody = getTransactionBody(systemDeleteTransaction);
         TransactionRecord record = transactionRecord(transactionBody, ResponseCodeEnum.INSUFFICIENT_ACCOUNT_BALANCE);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(systemDeleteTransaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(systemDeleteTransaction).build());
 
         assertFailedFileTransaction(transactionBody, record);
     }
@@ -762,7 +762,7 @@ class EntityRecordItemListenerFileTest extends AbstractEntityRecordItemListenerT
         TransactionBody transactionBody = getTransactionBody(systemUndeleteTransaction);
         TransactionRecord record = transactionRecord(transactionBody, ResponseCodeEnum.INSUFFICIENT_ACCOUNT_BALANCE);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(systemUndeleteTransaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(systemUndeleteTransaction).build());
 
         assertFailedFileTransaction(transactionBody, record);
     }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerFreezeTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerFreezeTest.java
@@ -47,7 +47,7 @@ class EntityRecordItemListenerFreezeTest extends AbstractEntityRecordItemListene
         TransactionBody transactionBody = getTransactionBody(transaction);
         TransactionRecord record = transactionRecord(transactionBody);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(transaction).build());
 
         assertAll(
                 () -> assertRowCount(),
@@ -61,7 +61,7 @@ class EntityRecordItemListenerFreezeTest extends AbstractEntityRecordItemListene
         TransactionBody transactionBody = getTransactionBody(transaction);
         TransactionRecord record = transactionRecord(transactionBody, ResponseCodeEnum.INSUFFICIENT_ACCOUNT_BALANCE);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(transaction).build());
 
         assertAll(
                 () -> assertRowCount(),

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerNonFeeTransferTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerNonFeeTransferTest.java
@@ -248,7 +248,7 @@ class EntityRecordItemListenerNonFeeTransferTest extends AbstractEntityRecordIte
         var record = recordBuilder.setContractCallResult(contractCallResult).build();
 
         expectedTransactions.add(new TransactionContext(transaction, record));
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(transaction).build());
     }
 
     private Transaction contractCreate() {
@@ -272,7 +272,7 @@ class EntityRecordItemListenerNonFeeTransferTest extends AbstractEntityRecordIte
         var record = recordBuilder.setContractCreateResult(contractCreateResult).build();
 
         expectedTransactions.add(new TransactionContext(transaction, record));
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(transaction).build());
     }
 
     private Transaction cryptoCreate() {
@@ -296,7 +296,7 @@ class EntityRecordItemListenerNonFeeTransferTest extends AbstractEntityRecordIte
         var record = transactionRecordSuccess(transactionBody, transferList).build();
 
         expectedTransactions.add(new TransactionContext(transaction, record));
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(transaction).build());
     }
 
     private Transaction cryptoTransfer() {
@@ -324,7 +324,7 @@ class EntityRecordItemListenerNonFeeTransferTest extends AbstractEntityRecordIte
         var record = transactionRecord(transactionBody, rc, transferList).build();
 
         expectedTransactions.add(new TransactionContext(transaction, record));
-        parseRecordItemAndCommit(RecordItem.builder().record(record).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(record).transaction(transaction).build());
     }
 
     private void cryptoTransferWithTransferList(TransferList.Builder transferList) {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerScheduleTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerScheduleTest.java
@@ -442,7 +442,7 @@ class EntityRecordItemListenerScheduleTest extends AbstractEntityRecordItemListe
         var createTransactionRecord = createTransactionRecord(createdTimestamp, scheduleID, createTransactionBody,
                 SUCCESS, false);
 
-        var recordItem = RecordItem.builder().record(createTransactionRecord).transaction(createTransaction).build();
+        var recordItem = RecordItem.builder().transactionRecord(createTransactionRecord).transaction(createTransaction).build();
         parseRecordItemAndCommit(recordItem);
     }
 
@@ -451,7 +451,7 @@ class EntityRecordItemListenerScheduleTest extends AbstractEntityRecordItemListe
         var transactionBody = getTransactionBody(transaction);
         var transactionRecord = createTransactionRecord(timestamp, scheduleId, transactionBody, SUCCESS, false);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(transactionRecord).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(transactionRecord).transaction(transaction).build());
     }
 
     private void insertScheduleSign(long signTimestamp, SignatureMap signatureMap, ScheduleID scheduleID) {
@@ -460,7 +460,7 @@ class EntityRecordItemListenerScheduleTest extends AbstractEntityRecordItemListe
         var signTransactionRecord = createTransactionRecord(signTimestamp, scheduleID, signTransactionBody,
                 SUCCESS, false);
 
-        var recordItem = RecordItem.builder().transaction(signTransaction).record(signTransactionRecord).build();
+        var recordItem = RecordItem.builder().transaction(signTransaction).transactionRecord(signTransactionRecord).build();
         parseRecordItemAndCommit(recordItem);
     }
 
@@ -469,7 +469,7 @@ class EntityRecordItemListenerScheduleTest extends AbstractEntityRecordItemListe
         var transaction = scheduledTransaction();
         var transactionBody = getTransactionBody(transaction);
         var record = createTransactionRecord(signTimestamp, scheduleID, transactionBody, responseCodeEnum, true);
-        var recordItem = RecordItem.builder().record(record).transaction(transaction).build();
+        var recordItem = RecordItem.builder().transactionRecord(record).transaction(transaction).build();
         parseRecordItemAndCommit(recordItem);
     }
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerTokenTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerTokenTest.java
@@ -1883,7 +1883,7 @@ class EntityRecordItemListenerTokenTest extends AbstractEntityRecordItemListener
             customBuilder.accept(builder);
         }, transactionBody, ResponseCodeEnum.SUCCESS.getNumber());
 
-        return RecordItem.builder().record(transactionRecord).transaction(transaction).build();
+        return RecordItem.builder().transactionRecord(transactionRecord).transaction(transaction).build();
     }
 
     private void insertAndParseTransaction(long consensusTimestamp, Transaction transaction) {
@@ -2294,7 +2294,7 @@ class EntityRecordItemListenerTokenTest extends AbstractEntityRecordItemListener
                 builder -> builder.setConsensusTimestamp(TestUtils.toTimestamp(consensusTimestamp)),
                 transactionBody, ResponseCodeEnum.SUCCESS.getNumber());
 
-        parseRecordItemAndCommit(RecordItem.builder().record(transactionRecord).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(transactionRecord).transaction(transaction).build());
     }
 
     private TokenTransferList tokenTransfer(TokenID tokenId, AccountID accountId, long amount) {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerTopicTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerTopicTest.java
@@ -83,7 +83,7 @@ class EntityRecordItemListenerTopicTest extends AbstractEntityRecordItemListener
         var transaction = createCreateTopicTransaction(adminKey, submitKey, memo, autoRenewAccountNum, autoRenewPeriod);
         var transactionRecord = createTransactionRecord(topicId, consensusTimestamp, responseCode);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(transactionRecord).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(transactionRecord).transaction(transaction).build());
 
         var entity = getTopicEntity(topicId);
 
@@ -105,7 +105,7 @@ class EntityRecordItemListenerTopicTest extends AbstractEntityRecordItemListener
         var transaction = createCreateTopicTransaction(null, null, "", null, null);
         var transactionRecord = createTransactionRecord(TOPIC_ID, null, null, 2, consensusTimestamp, responseCode);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(transactionRecord).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(transactionRecord).transaction(transaction).build());
 
         var entity = getTopicEntity(TOPIC_ID);
         assertTransactionInRepository(responseCode, consensusTimestamp, entity.getId());
@@ -127,7 +127,7 @@ class EntityRecordItemListenerTopicTest extends AbstractEntityRecordItemListener
         var transaction = createCreateTopicTransaction(null, null, "", autoRenewAccountId, null);
         var transactionRecord = createTransactionRecord(TOPIC_ID, null, null, 1, consensusTimestamp, responseCode);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(transactionRecord).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(transactionRecord).transaction(transaction).build());
 
         var entity = getTopicEntity(TOPIC_ID);
 
@@ -151,7 +151,7 @@ class EntityRecordItemListenerTopicTest extends AbstractEntityRecordItemListener
         var transactionRecord = createTransactionRecord(TopicID.newBuilder().setTopicNum(topicId)
                 .build(), null, null, 1, consensusTimestamp, responseCode);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(transactionRecord).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(transactionRecord).transaction(transaction).build());
 
         assertEquals(0L, entityRepository.count());
         assertEquals(0L, transactionRepository.count());
@@ -164,7 +164,7 @@ class EntityRecordItemListenerTopicTest extends AbstractEntityRecordItemListener
         var transaction = createCreateTopicTransaction(null, null, "memo", null, null);
         var transactionRecord = createTransactionRecord(null, consensusTimestamp, responseCode);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(transactionRecord).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(transactionRecord).transaction(transaction).build());
 
         assertTransactionInRepository(responseCode, consensusTimestamp, null);
         assertEquals(0L, entityRepository.count());
@@ -198,7 +198,7 @@ class EntityRecordItemListenerTopicTest extends AbstractEntityRecordItemListener
         expected.setDeleted(false);
         expected.setTimestampLower(updateTimestamp);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(transactionRecord).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(transactionRecord).transaction(transaction).build());
 
         assertTransactionInRepository(SUCCESS, updateTimestamp, topic.getId());
         assertEntity(expected);
@@ -223,7 +223,7 @@ class EntityRecordItemListenerTopicTest extends AbstractEntityRecordItemListener
                 updatedAdminKey, updatedSubmitKey, "updated-memo", null, 30L);
         var transactionRecord = createTransactionRecord(topicId, consensusTimestamp, responseCode);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(transactionRecord).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(transactionRecord).transaction(transaction).build());
         var entity = getTopicEntity(topicId);
         assertTransactionInRepository(responseCode, consensusTimestamp, entity.getId());
         assertEquals(1L, entityRepository.count());
@@ -244,7 +244,7 @@ class EntityRecordItemListenerTopicTest extends AbstractEntityRecordItemListener
                 autoRenewAccount.getId(), 30L);
         var transactionRecord = createTransactionRecord(TOPIC_ID, consensusTimestamp, responseCode);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(transactionRecord).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(transactionRecord).transaction(transaction).build());
         var entity = getTopicEntity(TOPIC_ID);
         assertTransactionInRepository(responseCode, consensusTimestamp, entity.getId());
         assertEquals(1L, entityRepository.count());
@@ -307,7 +307,7 @@ class EntityRecordItemListenerTopicTest extends AbstractEntityRecordItemListener
                 updatedAutoRenewPeriod);
         var transactionRecord = createTransactionRecord(topicId, consensusTimestamp, responseCode);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(transactionRecord).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(transactionRecord).transaction(transaction).build());
 
         if (updatedAutoRenewAccountNum != null) {
             topic.setAutoRenewAccountId(updatedAutoRenewAccountNum);
@@ -337,7 +337,7 @@ class EntityRecordItemListenerTopicTest extends AbstractEntityRecordItemListener
         var transaction = createDeleteTopicTransaction(TOPIC_ID);
         var transactionRecord = createTransactionRecord(TOPIC_ID, consensusTimestamp, responseCode);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(transactionRecord).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(transactionRecord).transaction(transaction).build());
 
         var entity = getTopicEntity(TOPIC_ID);
         assertTransactionInRepository(SUCCESS, consensusTimestamp, entity.getId());
@@ -359,7 +359,7 @@ class EntityRecordItemListenerTopicTest extends AbstractEntityRecordItemListener
         var transaction = createDeleteTopicTransaction(TOPIC_ID);
         var transactionRecord = createTransactionRecord(TOPIC_ID, consensusTimestamp, responseCode);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(transactionRecord).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(transactionRecord).transaction(transaction).build());
 
         var entity = getTopicEntity(TOPIC_ID);
         assertTransactionInRepository(responseCode, consensusTimestamp, entity.getId());
@@ -379,7 +379,7 @@ class EntityRecordItemListenerTopicTest extends AbstractEntityRecordItemListener
         var transaction = createDeleteTopicTransaction(TOPIC_ID);
         var transactionRecord = createTransactionRecord(TOPIC_ID, consensusTimestamp, responseCode);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(transactionRecord).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(transactionRecord).transaction(transaction).build());
 
         var entity = getTopicEntity(TOPIC_ID);
         assertTransactionInRepository(responseCode, consensusTimestamp, entity.getId());
@@ -412,7 +412,7 @@ class EntityRecordItemListenerTopicTest extends AbstractEntityRecordItemListener
         var transactionRecord = createTransactionRecord(topicId, sequenceNumber, runningHash
                 .getBytes(), runningHashVersion, consensusTimestamp, responseCode);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(transactionRecord).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(transactionRecord).transaction(transaction).build());
 
         assertTransactionInRepository(responseCode, consensusTimestamp, topicId.getTopicNum());
         assertEquals(0L, entityRepository.count());
@@ -443,7 +443,7 @@ class EntityRecordItemListenerTopicTest extends AbstractEntityRecordItemListener
         var transactionRecord = createTransactionRecord(TOPIC_ID, sequenceNumber, runningHash
                 .getBytes(), runningHashVersion, consensusTimestamp, responseCode);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(transactionRecord).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(transactionRecord).transaction(transaction).build());
 
         assertTransactionInRepository(responseCode, consensusTimestamp, TOPIC_ID.getTopicNum());
         assertEquals(0L, entityRepository.count());
@@ -477,7 +477,7 @@ class EntityRecordItemListenerTopicTest extends AbstractEntityRecordItemListener
                 .getBytes(), runningHashVersion, consensusTimestamp, responseCode);
 
         // when
-        parseRecordItemAndCommit(RecordItem.builder().record(transactionRecord).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(transactionRecord).transaction(transaction).build());
 
         // then
         assertEquals(0L, entityRepository.count());
@@ -511,7 +511,7 @@ class EntityRecordItemListenerTopicTest extends AbstractEntityRecordItemListener
                 .getBytes(), runningHashVersion, consensusTimestamp, responseCode);
 
         // when
-        parseRecordItemAndCommit(RecordItem.builder().record(transactionRecord).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(transactionRecord).transaction(transaction).build());
 
         // then
         // if the transaction is filtered out, nothing in it should affect the state
@@ -534,7 +534,7 @@ class EntityRecordItemListenerTopicTest extends AbstractEntityRecordItemListener
                 .getBytes(), 2, id, SUCCESS);
 
         // when
-        parseRecordItemAndCommit(RecordItem.builder().record(transactionRecord).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(transactionRecord).transaction(transaction).build());
 
         // then
         assertEquals(0L, entityRepository.count());
@@ -566,7 +566,7 @@ class EntityRecordItemListenerTopicTest extends AbstractEntityRecordItemListener
         var transactionRecord = createTransactionRecord(TOPIC_ID, sequenceNumber, runningHash.getBytes(),
                 runningHashVersion, consensusTimestamp, responseCode);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(transactionRecord).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(transactionRecord).transaction(transaction).build());
 
         assertTransactionInRepository(responseCode, consensusTimestamp, TOPIC_ID.getTopicNum());
         assertEquals(0, entityRepository.count());
@@ -599,7 +599,7 @@ class EntityRecordItemListenerTopicTest extends AbstractEntityRecordItemListener
         var transactionRecord = createTransactionRecord(TOPIC_ID, sequenceNumber, runningHash
                 .getBytes(), runningHashVersion, consensusTimestamp, responseCode);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(transactionRecord).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(transactionRecord).transaction(transaction).build());
 
         assertTransactionInRepository(responseCode, consensusTimestamp, TOPIC_ID.getTopicNum());
         assertEquals(0, entityRepository.count());
@@ -648,7 +648,7 @@ class EntityRecordItemListenerTopicTest extends AbstractEntityRecordItemListener
         var transactionRecord = createTransactionRecord(TOPIC_ID, sequenceNumber, runningHash
                 .getBytes(), runningHashVersion, consensusTimestamp, responseCode);
 
-        parseRecordItemAndCommit(RecordItem.builder().record(transactionRecord).transaction(transaction).build());
+        parseRecordItemAndCommit(RecordItem.builder().transactionRecord(transactionRecord).transaction(transaction).build());
 
         assertTransactionInRepository(responseCode, consensusTimestamp, TOPIC_ID.getTopicNum());
         assertEquals(0L, entityRepository.count());

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerUtilTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerUtilTest.java
@@ -99,7 +99,7 @@ class EntityRecordItemListenerUtilTest extends AbstractEntityRecordItemListenerT
 
         var recordItem = RecordItem.builder()
                 .hapiVersion(new Version(0, 30, 0))
-                .record(TransactionRecord.newBuilder().build())
+                .transactionRecord(TransactionRecord.newBuilder().build())
                 .transaction(transaction)
                 .build();
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/TransactionSignatureTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/TransactionSignatureTest.java
@@ -229,7 +229,7 @@ class TransactionSignatureTest {
                 .setConsensusTimestamp(Utility.instantToTimestamp(Instant.ofEpochSecond(0, CONSENSUS_TIMESTAMP)))
                 .setReceipt(TransactionReceipt.newBuilder().setStatus(responseCode).build())
                 .build();
-        return RecordItem.builder().record(transactionRecord).transaction(transaction).build();
+        return RecordItem.builder().transactionRecord(transactionRecord).transaction(transaction).build();
     }
 
     private TransactionBody getTransactionBody(TransactionType transactionType) {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/performance/EntityRecordItemListenerPerformanceCryptoTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/performance/EntityRecordItemListenerPerformanceCryptoTest.java
@@ -105,7 +105,7 @@ class EntityRecordItemListenerPerformanceCryptoTest extends AbstractEntityRecord
                 createTransactionBody,
                 ResponseCodeEnum.SUCCESS.getNumber(),
                 accountNum);
-        return RecordItem.builder().record(createRecord).transaction(createTransaction).build();
+        return RecordItem.builder().transactionRecord(createRecord).transaction(createTransaction).build();
     }
 
     private RecordItem getUpdateAccountRecordItem(int accountNum) throws Exception {
@@ -116,7 +116,7 @@ class EntityRecordItemListenerPerformanceCryptoTest extends AbstractEntityRecord
                 updateTransactionBody,
                 ResponseCodeEnum.SUCCESS.getNumber(),
                 accountNum);
-        return RecordItem.builder().record(createRecord).transaction(updateTransaction).build();
+        return RecordItem.builder().transactionRecord(createRecord).transaction(updateTransaction).build();
     }
 
     private Transaction cryptoCreateTransaction() {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/pubsub/PubSubRecordItemListenerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/pubsub/PubSubRecordItemListenerTest.java
@@ -161,7 +161,7 @@ class PubSubRecordItemListenerTest {
         Transaction transaction = buildTransaction(builder -> builder.setConsensusSubmitMessage(submitMessage));
         // when
         doReturn(topicIdEntity).when(transactionHandler).getEntity(any());
-        pubSubRecordItemListener.onItem(RecordItem.builder().record(DEFAULT_RECORD).transaction(transaction).build());
+        pubSubRecordItemListener.onItem(RecordItem.builder().transactionRecord(DEFAULT_RECORD).transaction(transaction).build());
 
         // then
         var pubSubMessage = assertPubSubMessage(buildPubSubTransaction(transaction), 1);
@@ -182,7 +182,7 @@ class PubSubRecordItemListenerTest {
         Transaction transaction = buildTransaction(builder -> builder.setConsensusSubmitMessage(submitMessage));
         // when
         doReturn(null).when(transactionHandler).getEntity(any());
-        pubSubRecordItemListener.onItem(RecordItem.builder().record(DEFAULT_RECORD).transaction(transaction).build());
+        pubSubRecordItemListener.onItem(RecordItem.builder().transactionRecord(DEFAULT_RECORD).transaction(transaction).build());
 
         // then
         var pubSubMessage = assertPubSubMessage(buildPubSubTransaction(transaction), 1);
@@ -203,7 +203,7 @@ class PubSubRecordItemListenerTest {
                         .build())
                 .build();
         Transaction transaction = buildTransaction(builder -> builder.setCryptoTransfer(cryptoTransfer));
-        var recordItem = RecordItem.builder().record(DEFAULT_RECORD).transaction(transaction).build();
+        var recordItem = RecordItem.builder().transactionRecord(DEFAULT_RECORD).transaction(transaction).build();
         when(nonFeeTransferExtractionStrategy.extractNonFeeTransfers(recordItem.getTransactionBody(),
                 recordItem.getTransactionRecord())).thenReturn(cryptoTransfer.getTransfers().getAccountAmountsList());
 
@@ -223,7 +223,7 @@ class PubSubRecordItemListenerTest {
                 .setTransfers(TransferList.newBuilder().build())
                 .build();
         Transaction transaction = buildTransaction(builder -> builder.setCryptoTransfer(cryptoTransfer));
-        RecordItem recordItem = RecordItem.builder().record(DEFAULT_RECORD)
+        RecordItem recordItem = RecordItem.builder().transactionRecord(DEFAULT_RECORD)
                 .transaction(transaction).build();
 
         // when
@@ -251,7 +251,7 @@ class PubSubRecordItemListenerTest {
                 .thenThrow(MessageTimeoutException.class)
                 .thenThrow(MessageTimeoutException.class)
                 .thenReturn(true);
-        pubSubRecordItemListener.onItem(RecordItem.builder().record(DEFAULT_RECORD).transaction(transaction).build());
+        pubSubRecordItemListener.onItem(RecordItem.builder().transactionRecord(DEFAULT_RECORD).transaction(transaction).build());
 
         // then
         var pubSubMessage = assertPubSubMessage(buildPubSubTransaction(transaction), 3);
@@ -273,7 +273,7 @@ class PubSubRecordItemListenerTest {
         // when
         EntityId entityId = EntityId.of(ADDRESS_BOOK_FILE_ID);
         doReturn(entityId).when(transactionHandler).getEntity(any());
-        pubSubRecordItemListener.onItem(RecordItem.builder().record(DEFAULT_RECORD).transaction(transaction).build());
+        pubSubRecordItemListener.onItem(RecordItem.builder().transactionRecord(DEFAULT_RECORD).transaction(transaction).build());
 
         // then
         FileData fileData = new FileData(100L, fileContents, entityId, TransactionType.FILEAPPEND
@@ -293,7 +293,7 @@ class PubSubRecordItemListenerTest {
 
         // when
         doReturn(EntityId.of(ADDRESS_BOOK_FILE_ID)).when(transactionHandler).getEntity(any());
-        pubSubRecordItemListener.onItem(RecordItem.builder().record(DEFAULT_RECORD).transaction(transaction).build());
+        pubSubRecordItemListener.onItem(RecordItem.builder().transactionRecord(DEFAULT_RECORD).transaction(transaction).build());
 
         // then
         FileData fileData = new FileData(100L, fileContents, EntityId

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/AbstractTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/AbstractTransactionHandlerTest.java
@@ -244,7 +244,7 @@ abstract class AbstractTransactionHandlerTest {
                                         .setSigMap(getDefaultSigMap())
                                         .build().toByteString())
                                 .build())
-                .record(transactionRecord)
+                .transactionRecord(transactionRecord)
                 .build();
         assertThat(transactionHandler.getEntity(recordItem)).isEqualTo(expectedEntity);
     }
@@ -532,7 +532,7 @@ abstract class AbstractTransactionHandlerTest {
                 )
                 .build();
 
-        return RecordItem.builder().record(record).transaction(transaction).build();
+        return RecordItem.builder().transactionRecord(record).transaction(transaction).build();
     }
 
     private boolean isCrudTransactionHandler(TransactionHandler transactionHandler) {


### PR DESCRIPTION
**Description**:

Rename `RecordItemBuilder.record()` and `RecordItemBuilder.recordBytes()` to fix a code smell about reserved `record` keyword

**Related issue(s)**:

**Notes for reviewer**:

No other changes in this PR besides a rename

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
