### PR TITLE
Improve list transactions REST API performance

### DIFF
--- a/hedera-mirror-rest/__tests__/transactions.test.js
+++ b/hedera-mirror-rest/__tests__/transactions.test.js
@@ -780,6 +780,7 @@ describe('extractSqlFromTransactionsByIdOrHashRequest', () => {
         from crypto_transfer ctr
             join tlist
         on ctr.consensus_timestamp = tlist.consensus_timestamp
+        and ctr.payer_account_id = tlist.payer_account_id
         group by ctr.consensus_timestamp
             ), t_list as (
         select jsonb_agg(jsonb_build_object(
@@ -792,6 +793,7 @@ describe('extractSqlFromTransactionsByIdOrHashRequest', () => {
         from token_transfer tk_tr
             join tlist
         on tk_tr.consensus_timestamp = tlist.consensus_timestamp
+        and tk_tr.payer_account_id = tlist.payer_account_id
         group by tk_tr.consensus_timestamp
             ), nft_list as (
         select jsonb_agg(jsonb_build_object(

--- a/hedera-mirror-rest/transactions.js
+++ b/hedera-mirror-rest/transactions.js
@@ -130,6 +130,7 @@ const getSelectClauseWithTransfers = (includeExtraInfo, innerQuery, order = 'des
       select ${cryptoTransferJsonAgg} as ctr_list, ${CryptoTransfer.getFullName(CryptoTransfer.CONSENSUS_TIMESTAMP)}
       from ${CryptoTransfer.tableName} ${CryptoTransfer.tableAlias}
       join tlist on ${CryptoTransfer.getFullName(CryptoTransfer.CONSENSUS_TIMESTAMP)} = tlist.consensus_timestamp
+      and ${CryptoTransfer.getFullName(CryptoTransfer.PAYER_ACCOUNT_ID)} = tlist.payer_account_id
       group by ${CryptoTransfer.getFullName(CryptoTransfer.CONSENSUS_TIMESTAMP)}
   )`;
 
@@ -137,6 +138,7 @@ const getSelectClauseWithTransfers = (includeExtraInfo, innerQuery, order = 'des
     select ${tokenTransferJsonAgg} as ttr_list, ${TokenTransfer.getFullName(TokenTransfer.CONSENSUS_TIMESTAMP)}
     from ${TokenTransfer.tableName} ${TokenTransfer.tableAlias}
     join tlist on ${TokenTransfer.getFullName(TokenTransfer.CONSENSUS_TIMESTAMP)} = tlist.consensus_timestamp
+    and ${TokenTransfer.getFullName(TokenTransfer.PAYER_ACCOUNT_ID)} = tlist.payer_account_id
     group by ${TokenTransfer.getFullName(TokenTransfer.CONSENSUS_TIMESTAMP)}
   )`;
 


### PR DESCRIPTION
and "and tk_tr.payer_account_id = tlist.payer_account_id" to the ON clauses of the 2 relevant JOIN lines of the query.

**Description**
This PR modifies the query done by the "list transactions" API method in order to speed up the runtime by 90%.

**Related issue(s)**:

Fixes #5225

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
