### PR TITLE
Bump Eclipse Temurin JRE from 17.0.5_8 to 17.0.6_10

### DIFF
--- a/hedera-mirror-graphql/Dockerfile
+++ b/hedera-mirror-graphql/Dockerfile
@@ -1,9 +1,9 @@
-FROM eclipse-temurin:17.0.5_8-jre-jammy as builder
+FROM eclipse-temurin:17.0.6_10-jre-jammy as builder
 WORKDIR /app
 COPY build/libs/*.jar ./
 RUN java -Djarmode=layertools -jar *.jar extract
 
-FROM eclipse-temurin:17.0.5_8-jre-jammy
+FROM eclipse-temurin:17.0.6_10-jre-jammy
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80"
 EXPOSE 8083
 HEALTHCHECK --interval=10s --retries=3 --start-period=50s --timeout=2s CMD curl -f http://localhost:8083/actuator/health/liveness

--- a/hedera-mirror-grpc/Dockerfile
+++ b/hedera-mirror-grpc/Dockerfile
@@ -1,9 +1,9 @@
-FROM eclipse-temurin:17.0.5_8-jre-jammy as builder
+FROM eclipse-temurin:17.0.6_10-jre-jammy as builder
 WORKDIR /app
 COPY build/libs/*.jar ./
 RUN java -Djarmode=layertools -jar *.jar extract
 
-FROM eclipse-temurin:17.0.5_8-jre-jammy
+FROM eclipse-temurin:17.0.6_10-jre-jammy
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80"
 EXPOSE 5600
 HEALTHCHECK --interval=10s --retries=3 --start-period=50s --timeout=2s CMD curl -f http://localhost:8081/actuator/health/liveness

--- a/hedera-mirror-importer/Dockerfile
+++ b/hedera-mirror-importer/Dockerfile
@@ -1,9 +1,9 @@
-FROM eclipse-temurin:17.0.5_8-jre-jammy as builder
+FROM eclipse-temurin:17.0.6_10-jre-jammy as builder
 WORKDIR /app
 COPY build/libs/*.jar ./
 RUN java -Djarmode=layertools -jar *.jar extract
 
-FROM eclipse-temurin:17.0.5_8-jre-jammy
+FROM eclipse-temurin:17.0.6_10-jre-jammy
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80"
 HEALTHCHECK --interval=30s --retries=3 --start-period=60s --timeout=2s CMD curl -f http://localhost:8080/actuator/health/liveness
 WORKDIR /app

--- a/hedera-mirror-monitor/Dockerfile
+++ b/hedera-mirror-monitor/Dockerfile
@@ -1,9 +1,9 @@
-FROM eclipse-temurin:17.0.5_8-jre-jammy as builder
+FROM eclipse-temurin:17.0.6_10-jre-jammy as builder
 WORKDIR /app
 COPY build/libs/*.jar ./
 RUN java -Djarmode=layertools -jar *.jar extract
 
-FROM eclipse-temurin:17.0.5_8-jre-jammy
+FROM eclipse-temurin:17.0.6_10-jre-jammy
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80"
 EXPOSE 8082
 HEALTHCHECK --interval=10s --retries=5 --start-period=60s --timeout=2s CMD curl -f http://localhost:8082/actuator/health/liveness

--- a/hedera-mirror-web3/Dockerfile
+++ b/hedera-mirror-web3/Dockerfile
@@ -1,9 +1,9 @@
-FROM eclipse-temurin:17.0.5_8-jre-jammy as builder
+FROM eclipse-temurin:17.0.6_10-jre-jammy as builder
 WORKDIR /app
 COPY build/libs/*.jar ./
 RUN java -Djarmode=layertools -jar *.jar extract
 
-FROM eclipse-temurin:17.0.5_8-jre-jammy
+FROM eclipse-temurin:17.0.6_10-jre-jammy
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80"
 EXPOSE 8545
 HEALTHCHECK --interval=10s --retries=3 --start-period=50s --timeout=2s CMD curl -f http://localhost:8545/actuator/health/liveness


### PR DESCRIPTION
**Description**:
Bump Eclipse Temurin JRE from 17.0.5_8 to 17.0.6_10

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
