### PR TITLE
Fix multiple monitor API bugs

### DIFF
--- a/hedera-mirror-rest/monitoring/monitor_apis/account_tests.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/account_tests.js
@@ -32,6 +32,7 @@ import {
   DEFAULT_LIMIT,
   getAPIResponse,
   getUrl,
+  hasListItems,
   testRunner,
 } from './utils';
 
@@ -84,7 +85,7 @@ const getAccountsWithAccountCheck = async (server) => {
     type: 'credit',
     limit: 1,
   });
-  const singleAccount = await getAPIResponse(url, jsonRespKey);
+  const singleAccount = await getAPIResponse(url, jsonRespKey, hasListItems(jsonRespKey));
 
   result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
@@ -131,7 +132,7 @@ const getAccountsWithTimeAndLimitParams = async (server) => {
     timestamp: [`gt:${minusOne.toString()}`, `lt:${plusOne.toString()}`],
     limit: 1,
   });
-  accounts = await getAPIResponse(url, jsonRespKey);
+  accounts = await getAPIResponse(url, jsonRespKey, hasListItems(jsonRespKey));
 
   result = checkRunner.run(accounts);
   if (!result.passed) {
@@ -213,10 +214,10 @@ const getSingleAccountTokenRelationships = async (server) => {
   if (tokens.length === 0) {
     tokenResult.passed = true;
     tokenResult.message = 'No tokens were returned';
-    return {token_url, ...tokenResult};
+    return {url: token_url, ...tokenResult};
   }
   if (!tokenResult.passed) {
-    return {token_url, ...tokenResult};
+    return {url: token_url, ...tokenResult};
   }
 
   // get balances for a token and retrieve an  account id from it.
@@ -235,10 +236,10 @@ const getSingleAccountTokenRelationships = async (server) => {
   if (balances.length === 0) {
     balancesResult.passed = true;
     balancesResult.message = 'No balances were returned';
-    return {balances_url, ...balancesResult};
+    return {url: balances_url, ...balancesResult};
   }
   if (!balancesResult.passed) {
-    return {balances_url, ...balancesResult};
+    return {url: balances_url, ...balancesResult};
   }
   const accountId = balances[0].account;
 
@@ -246,7 +247,7 @@ const getSingleAccountTokenRelationships = async (server) => {
   const accountsTokenPath = `/accounts/${accountId}/tokens`;
   const accountsLimit = 1;
   let url = getUrl(server, accountsTokenPath, {limit: accountsLimit, order: 'asc'});
-  const tokenRelationships = await getAPIResponse(url, tokensJsonRespKey);
+  const tokenRelationships = await getAPIResponse(url, tokensJsonRespKey, hasListItems(jsonRespKey));
   let result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
     .withCheckSpec(checkRespObjDefined, {message: 'tokens is undefined '})

--- a/hedera-mirror-rest/monitoring/monitor_apis/account_tests.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/account_tests.js
@@ -32,7 +32,7 @@ import {
   DEFAULT_LIMIT,
   getAPIResponse,
   getUrl,
-  hasListItems,
+  hasEmptyList,
   testRunner,
 } from './utils';
 
@@ -85,7 +85,7 @@ const getAccountsWithAccountCheck = async (server) => {
     type: 'credit',
     limit: 1,
   });
-  const singleAccount = await getAPIResponse(url, jsonRespKey, hasListItems(jsonRespKey));
+  const singleAccount = await getAPIResponse(url, jsonRespKey, hasEmptyList(jsonRespKey));
 
   result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
@@ -132,7 +132,7 @@ const getAccountsWithTimeAndLimitParams = async (server) => {
     timestamp: [`gt:${minusOne.toString()}`, `lt:${plusOne.toString()}`],
     limit: 1,
   });
-  accounts = await getAPIResponse(url, jsonRespKey, hasListItems(jsonRespKey));
+  accounts = await getAPIResponse(url, jsonRespKey, hasEmptyList(jsonRespKey));
 
   result = checkRunner.run(accounts);
   if (!result.passed) {
@@ -247,7 +247,7 @@ const getSingleAccountTokenRelationships = async (server) => {
   const accountsTokenPath = `/accounts/${accountId}/tokens`;
   const accountsLimit = 1;
   let url = getUrl(server, accountsTokenPath, {limit: accountsLimit, order: 'asc'});
-  const tokenRelationships = await getAPIResponse(url, tokensJsonRespKey, hasListItems(jsonRespKey));
+  const tokenRelationships = await getAPIResponse(url, tokensJsonRespKey, hasEmptyList(tokensJsonRespKey));
   let result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
     .withCheckSpec(checkRespObjDefined, {message: 'tokens is undefined '})

--- a/hedera-mirror-rest/monitoring/monitor_apis/balance_tests.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/balance_tests.js
@@ -32,7 +32,7 @@ import {
   DEFAULT_LIMIT,
   getAPIResponse,
   getUrl,
-  hasListItems,
+  hasEmptyList,
   testRunner,
 } from './utils';
 
@@ -99,7 +99,7 @@ const getSingleBalanceById = async (server) => {
 
   const highestAccount = _.max(_.map(balances, (balance) => balance.account));
   url = getUrl(server, balancesPath, {'account.id': highestAccount});
-  const singleBalance = await getAPIResponse(url, jsonRespKey, hasListItems(jsonRespKey));
+  const singleBalance = await getAPIResponse(url, jsonRespKey, hasEmptyList(jsonRespKey));
 
   result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)

--- a/hedera-mirror-rest/monitoring/monitor_apis/balance_tests.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/balance_tests.js
@@ -22,17 +22,18 @@ import _ from 'lodash';
 import config from './config';
 
 import {
-  checkAPIResponseError,
-  checkRespObjDefined,
-  checkRespArrayLength,
   checkAccountId,
+  checkAPIResponseError,
   checkMandatoryParams,
   checkResourceFreshness,
+  checkRespArrayLength,
+  checkRespObjDefined,
+  CheckRunner,
   DEFAULT_LIMIT,
   getAPIResponse,
   getUrl,
+  hasListItems,
   testRunner,
-  CheckRunner,
 } from './utils';
 
 const balancesPath = '/balances';
@@ -98,7 +99,7 @@ const getSingleBalanceById = async (server) => {
 
   const highestAccount = _.max(_.map(balances, (balance) => balance.account));
   url = getUrl(server, balancesPath, {'account.id': highestAccount});
-  const singleBalance = await getAPIResponse(url, jsonRespKey);
+  const singleBalance = await getAPIResponse(url, jsonRespKey, hasListItems(jsonRespKey));
 
   result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)

--- a/hedera-mirror-rest/monitoring/monitor_apis/block_tests.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/block_tests.js
@@ -23,15 +23,15 @@ import config from './config';
 
 import {
   checkAPIResponseError,
-  checkRespObjDefined,
-  checkRespArrayLength,
   checkMandatoryParams,
   checkResourceFreshness,
+  checkRespArrayLength,
+  checkRespObjDefined,
+  CheckRunner,
   DEFAULT_LIMIT,
   getAPIResponse,
   getUrl,
   testRunner,
-  CheckRunner,
 } from './utils';
 
 const blocksPath = '/blocks';
@@ -73,7 +73,7 @@ const getSingleBlockById = async (server) => {
     })
     .run(blocks);
   if (!result.passed) {
-    return {blockUrl, ...result};
+    return {url, ...result};
   }
 
   const highestBlock = _.max(_.map(blocks, (block) => block.number));

--- a/hedera-mirror-rest/monitoring/monitor_apis/config/default.serverlist.json
+++ b/hedera-mirror-rest/monitoring/monitor_apis/config/default.serverlist.json
@@ -8,7 +8,7 @@
   ],
   "interval": 60,
   "retry": {
-    "maxAttempts": 2,
+    "maxAttempts": 4,
     "minBackoff": 1000
   },
   "shard": 0,
@@ -38,11 +38,7 @@
   },
   "stateproof": {
     "enabled": true,
-    "intervalMultiplier": 10,
-    "retry": {
-      "backoff": 10000,
-      "maxAttempts": 5
-    }
+    "intervalMultiplier": 10
   },
   "transaction": {
     "enabled": true,

--- a/hedera-mirror-rest/monitoring/monitor_apis/package-lock.json
+++ b/hedera-mirror-rest/monitoring/monitor_apis/package-lock.json
@@ -21,8 +21,7 @@
         "mathjs": "^11.5.0",
         "node-fetch": "^3.3.0",
         "parse-duration": "^1.0.2",
-        "pretty-ms": "^8.0.0",
-        "retry": "^0.13.1"
+        "pretty-ms": "^8.0.0"
       },
       "devDependencies": {
         "jest": "^29.4.1",
@@ -4145,14 +4144,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/retry": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/rfdc": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
@@ -7874,11 +7865,6 @@
       "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.0.tgz",
       "integrity": "sha512-6K/gDlqgQscOlg9fSRpWstA8sYe8rbELsSTNpx+3kTrsVCzvSl0zIvRErM7fdl9ERWDsKnrLnwB+Ne89918XOg==",
       "dev": true
-    },
-    "retry": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="
     },
     "rfdc": {
       "version": "1.3.0",

--- a/hedera-mirror-rest/monitoring/monitor_apis/package.json
+++ b/hedera-mirror-rest/monitoring/monitor_apis/package.json
@@ -28,8 +28,7 @@
     "mathjs": "^11.5.0",
     "node-fetch": "^3.3.0",
     "parse-duration": "^1.0.2",
-    "pretty-ms": "^8.0.0",
-    "retry": "^0.13.1"
+    "pretty-ms": "^8.0.0"
   },
   "devDependencies": {
     "jest": "^29.4.1",

--- a/hedera-mirror-rest/monitoring/monitor_apis/token_tests.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/token_tests.js
@@ -23,18 +23,19 @@ import config from './config';
 
 import {
   accountIdCompare,
+  checkAccountId,
   checkAPIResponseError,
   checkElementsOrder,
-  checkRespObjDefined,
-  checkRespArrayLength,
-  checkAccountId,
   checkMandatoryParams,
   checkResourceFreshness,
+  checkRespArrayLength,
+  checkRespObjDefined,
+  CheckRunner,
   DEFAULT_LIMIT,
   getAPIResponse,
   getUrl,
+  hasListItems,
   testRunner,
-  CheckRunner,
 } from './utils';
 
 const tokensPath = '/tokens';
@@ -384,7 +385,7 @@ const getTokenBalancesForAccount = async (server) => {
   }
 
   let url = getUrl(server, tokenBalancesPath(tokenId), {limit: 1});
-  let balances = await getAPIResponse(url, tokenBalancesJsonRespKey);
+  let balances = await getAPIResponse(url, tokenBalancesJsonRespKey, hasListItems(jsonRespKey));
 
   const checkRunner = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)

--- a/hedera-mirror-rest/monitoring/monitor_apis/token_tests.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/token_tests.js
@@ -34,7 +34,7 @@ import {
   DEFAULT_LIMIT,
   getAPIResponse,
   getUrl,
-  hasListItems,
+  hasEmptyList,
   testRunner,
 } from './utils';
 
@@ -385,7 +385,7 @@ const getTokenBalancesForAccount = async (server) => {
   }
 
   let url = getUrl(server, tokenBalancesPath(tokenId), {limit: 1});
-  let balances = await getAPIResponse(url, tokenBalancesJsonRespKey, hasListItems(jsonRespKey));
+  let balances = await getAPIResponse(url, tokenBalancesJsonRespKey, hasEmptyList(tokenBalancesJsonRespKey));
 
   const checkRunner = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)

--- a/hedera-mirror-rest/monitoring/monitor_apis/transaction_tests.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/transaction_tests.js
@@ -34,7 +34,7 @@ import {
   DEFAULT_LIMIT,
   getAPIResponse,
   getUrl,
-  hasListItems,
+  hasEmptyList,
   testRunner,
 } from './utils';
 
@@ -125,7 +125,7 @@ const getTransactionsWithAccountCheck = async (server) => {
     type: 'credit',
     limit: 1,
   });
-  const accTransactions = await getAPIResponse(url, jsonRespKey, hasListItems(jsonRespKey));
+  const accTransactions = await getAPIResponse(url, jsonRespKey, hasEmptyList(jsonRespKey));
 
   result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
@@ -239,7 +239,7 @@ const getTransactionsWithTimeAndLimitParams = async (server) => {
     timestamp: [`gt:${minusOne.toString()}`, `lt:${plusOne.toString()}`],
     limit: 1,
   });
-  transactions = await getAPIResponse(url, jsonRespKey, hasListItems(jsonRespKey));
+  transactions = await getAPIResponse(url, jsonRespKey, hasEmptyList(jsonRespKey));
 
   result = checkRunner.run(transactions);
   if (!result.passed) {

--- a/hedera-mirror-rest/monitoring/monitor_apis/transaction_tests.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/transaction_tests.js
@@ -34,6 +34,7 @@ import {
   DEFAULT_LIMIT,
   getAPIResponse,
   getUrl,
+  hasListItems,
   testRunner,
 } from './utils';
 
@@ -124,7 +125,7 @@ const getTransactionsWithAccountCheck = async (server) => {
     type: 'credit',
     limit: 1,
   });
-  const accTransactions = await getAPIResponse(url, jsonRespKey);
+  const accTransactions = await getAPIResponse(url, jsonRespKey, hasListItems(jsonRespKey));
 
   result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
@@ -238,7 +239,7 @@ const getTransactionsWithTimeAndLimitParams = async (server) => {
     timestamp: [`gt:${minusOne.toString()}`, `lt:${plusOne.toString()}`],
     limit: 1,
   });
-  transactions = await getAPIResponse(url, jsonRespKey);
+  transactions = await getAPIResponse(url, jsonRespKey, hasListItems(jsonRespKey));
 
   result = checkRunner.run(transactions);
   if (!result.passed) {

--- a/hedera-mirror-rest/monitoring/monitor_apis/utils.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/utils.js
@@ -98,7 +98,7 @@ const fetchWithRetry = async (url, opts = {}, retryPredicate) => {
       }
 
       const json = await response.json();
-      if (!retryPredicate || !retryPredicate(json)) {
+      if (!retryPredicate(json)) {
         return json;
       }
     }
@@ -111,6 +111,8 @@ const fetchWithRetry = async (url, opts = {}, retryPredicate) => {
   throw new Error(`Retries exhausted with ${statusCode} status code`);
 };
 
+const noRetry = () => false;
+
 /**
  * Make an http request to mirror-node api
  * Host info is prepended to if only path is provided
@@ -119,7 +121,7 @@ const fetchWithRetry = async (url, opts = {}, retryPredicate) => {
  * @param {Function} retryPredicate An optional predicate that returns true if a successful request should be retried.
  * @return {Object} JSON object representing api response or error
  */
-const getAPIResponse = async (url, key = undefined, retryPredicate = undefined) => {
+const getAPIResponse = async (url, key = undefined, retryPredicate = noRetry) => {
   const controller = new AbortController();
   const timeout = setTimeout(
     () => {
@@ -173,7 +175,7 @@ class ServerTestResult {
  * @param jsonRespKey The field within the JSON response that contains the list to check.
  * @returns function A retry predicate
  */
-const hasListItems = (jsonRespKey) => (res) => !res.hasOwnProperty(jsonRespKey) || res[jsonRespKey].length < 1;
+const hasEmptyList = (jsonRespKey) => (res) => !res.hasOwnProperty(jsonRespKey) || res[jsonRespKey].length < 1;
 
 /**
  * Creates a function to run specific tests with the provided server address, classs result, and resource
@@ -458,6 +460,6 @@ export {
   checkRespObjDefined,
   getAPIResponse,
   getUrl,
-  hasListItems,
+  hasEmptyList,
   testRunner,
 };

--- a/hedera-mirror-rest/monitoring/monitor_apis/utils.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/utils.js
@@ -80,17 +80,27 @@ const getBackoff = (retryAfter, xRetryIn) => {
  *
  * @param url
  * @param opts
+ * @param {Function} retryPredicate An optional predicate that returns true if a successful request should be retried.
  * @returns {Promise<Response>}
  */
-const fetchWithRetry = async (url, opts = {}) => {
+const fetchWithRetry = async (url, opts = {}, retryPredicate) => {
   let statusCode = 200;
 
   for (let attempt = 1; attempt <= config.retry.maxAttempts + 1; attempt++) {
     const response = await fetch(url, opts);
     statusCode = response.status;
 
-    if (statusCode !== 429 && statusCode < 500) {
-      return response;
+    // Most 404s are due to race conditions with requests that span multiple clusters.
+    if (statusCode !== 404 && statusCode !== 429 && statusCode < 500) {
+      if (!response.ok) {
+        const message = `GET ${url} failed with ${response.statusText} (${response.status})`;
+        throw httpErrors(message);
+      }
+
+      const json = await response.json();
+      if (!retryPredicate || !retryPredicate(json)) {
+        return json;
+      }
     }
 
     const backoffMillis = getBackoff(response.headers.get('retry-after'), response.headers.get('x-retry-in'));
@@ -106,9 +116,10 @@ const fetchWithRetry = async (url, opts = {}) => {
  * Host info is prepended to if only path is provided
  * @param {*} url rest-api endpoint
  * @param {String} key JSON key of the object to return
+ * @param {Function} retryPredicate An optional predicate that returns true if a successful request should be retried.
  * @return {Object} JSON object representing api response or error
  */
-const getAPIResponse = async (url, key = undefined) => {
+const getAPIResponse = async (url, key = undefined, retryPredicate = undefined) => {
   const controller = new AbortController();
   const timeout = setTimeout(
     () => {
@@ -118,13 +129,8 @@ const getAPIResponse = async (url, key = undefined) => {
   );
 
   try {
-    const response = await fetchWithRetry(url, {signal: controller.signal});
-    if (!response.ok) {
-      const message = `GET ${url} failed with ${response.statusText} (${response.status})`;
-      return httpErrors(message);
-    }
+    const json = await fetchWithRetry(url, {signal: controller.signal}, retryPredicate);
 
-    const json = await response.json();
     return key ? json[key] : json;
   } catch (error) {
     return Error(`${error}`);
@@ -160,6 +166,14 @@ class ServerTestResult {
     this.result.endTime = Date.now();
   }
 }
+
+/**
+ * Builds a retry predicate that checks if the JSON response contains a non-empty list.
+ *
+ * @param jsonRespKey The field within the JSON response that contains the list to check.
+ * @returns function A retry predicate
+ */
+const hasListItems = (jsonRespKey) => (res) => !res.hasOwnProperty(jsonRespKey) || res[jsonRespKey].length < 1;
 
 /**
  * Creates a function to run specific tests with the provided server address, classs result, and resource
@@ -444,5 +458,6 @@ export {
   checkRespObjDefined,
   getAPIResponse,
   getUrl,
+  hasListItems,
   testRunner,
 };


### PR DESCRIPTION
**Description**:

* Fix race condition in environments with multiple clusters by retrying 404
* Fix race condition in environments with multiple clusters by retrying successful calls with empty lists
* Fix `TypeError: Cannot read properties of undefined (reading 'localeCompare')` in dashboard
* Fix `ReferenceError: blockUrl is not defined`
* Increase retry maxAttempts from 2 to 4
* Remove adhoc stateproof retry in favor of centralized 404 retry

**Related issue(s)**:

Fixes #5316

**Notes for reviewer**:

Will cherry pick to `release/0.74`.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
