### PR TITLE
Fix multiple monitor API bugs (0.74)

### DIFF
--- a/hedera-mirror-rest/monitoring/monitor_apis/account_tests.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/account_tests.js
@@ -32,6 +32,7 @@ import {
   DEFAULT_LIMIT,
   getAPIResponse,
   getUrl,
+  hasEmptyList,
   testRunner,
 } from './utils';
 
@@ -84,7 +85,7 @@ const getAccountsWithAccountCheck = async (server) => {
     type: 'credit',
     limit: 1,
   });
-  const singleAccount = await getAPIResponse(url, jsonRespKey);
+  const singleAccount = await getAPIResponse(url, jsonRespKey, hasEmptyList(jsonRespKey));
 
   result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
@@ -131,7 +132,7 @@ const getAccountsWithTimeAndLimitParams = async (server) => {
     timestamp: [`gt:${minusOne.toString()}`, `lt:${plusOne.toString()}`],
     limit: 1,
   });
-  accounts = await getAPIResponse(url, jsonRespKey);
+  accounts = await getAPIResponse(url, jsonRespKey, hasEmptyList(jsonRespKey));
 
   result = checkRunner.run(accounts);
   if (!result.passed) {
@@ -213,10 +214,10 @@ const getSingleAccountTokenRelationships = async (server) => {
   if (tokens.length === 0) {
     tokenResult.passed = true;
     tokenResult.message = 'No tokens were returned';
-    return {token_url, ...tokenResult};
+    return {url: token_url, ...tokenResult};
   }
   if (!tokenResult.passed) {
-    return {token_url, ...tokenResult};
+    return {url: token_url, ...tokenResult};
   }
 
   // get balances for a token and retrieve an  account id from it.
@@ -235,10 +236,10 @@ const getSingleAccountTokenRelationships = async (server) => {
   if (balances.length === 0) {
     balancesResult.passed = true;
     balancesResult.message = 'No balances were returned';
-    return {balances_url, ...balancesResult};
+    return {url: balances_url, ...balancesResult};
   }
   if (!balancesResult.passed) {
-    return {balances_url, ...balancesResult};
+    return {url: balances_url, ...balancesResult};
   }
   const accountId = balances[0].account;
 
@@ -246,7 +247,7 @@ const getSingleAccountTokenRelationships = async (server) => {
   const accountsTokenPath = `/accounts/${accountId}/tokens`;
   const accountsLimit = 1;
   let url = getUrl(server, accountsTokenPath, {limit: accountsLimit, order: 'asc'});
-  const tokenRelationships = await getAPIResponse(url, tokensJsonRespKey);
+  const tokenRelationships = await getAPIResponse(url, tokensJsonRespKey, hasEmptyList(tokensJsonRespKey));
   let result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
     .withCheckSpec(checkRespObjDefined, {message: 'tokens is undefined '})

--- a/hedera-mirror-rest/monitoring/monitor_apis/balance_tests.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/balance_tests.js
@@ -22,17 +22,18 @@ import _ from 'lodash';
 import config from './config';
 
 import {
-  checkAPIResponseError,
-  checkRespObjDefined,
-  checkRespArrayLength,
   checkAccountId,
+  checkAPIResponseError,
   checkMandatoryParams,
   checkResourceFreshness,
+  checkRespArrayLength,
+  checkRespObjDefined,
+  CheckRunner,
   DEFAULT_LIMIT,
   getAPIResponse,
   getUrl,
+  hasEmptyList,
   testRunner,
-  CheckRunner,
 } from './utils';
 
 const balancesPath = '/balances';
@@ -98,7 +99,7 @@ const getSingleBalanceById = async (server) => {
 
   const highestAccount = _.max(_.map(balances, (balance) => balance.account));
   url = getUrl(server, balancesPath, {'account.id': highestAccount});
-  const singleBalance = await getAPIResponse(url, jsonRespKey);
+  const singleBalance = await getAPIResponse(url, jsonRespKey, hasEmptyList(jsonRespKey));
 
   result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)

--- a/hedera-mirror-rest/monitoring/monitor_apis/block_tests.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/block_tests.js
@@ -23,15 +23,15 @@ import config from './config';
 
 import {
   checkAPIResponseError,
-  checkRespObjDefined,
-  checkRespArrayLength,
   checkMandatoryParams,
   checkResourceFreshness,
+  checkRespArrayLength,
+  checkRespObjDefined,
+  CheckRunner,
   DEFAULT_LIMIT,
   getAPIResponse,
   getUrl,
   testRunner,
-  CheckRunner,
 } from './utils';
 
 const blocksPath = '/blocks';
@@ -73,7 +73,7 @@ const getSingleBlockById = async (server) => {
     })
     .run(blocks);
   if (!result.passed) {
-    return {blockUrl, ...result};
+    return {url, ...result};
   }
 
   const highestBlock = _.max(_.map(blocks, (block) => block.number));

--- a/hedera-mirror-rest/monitoring/monitor_apis/config/default.serverlist.json
+++ b/hedera-mirror-rest/monitoring/monitor_apis/config/default.serverlist.json
@@ -8,7 +8,7 @@
   ],
   "interval": 60,
   "retry": {
-    "maxAttempts": 2,
+    "maxAttempts": 4,
     "minBackoff": 1000
   },
   "shard": 0,
@@ -38,11 +38,7 @@
   },
   "stateproof": {
     "enabled": true,
-    "intervalMultiplier": 10,
-    "retry": {
-      "backoff": 10000,
-      "maxAttempts": 5
-    }
+    "intervalMultiplier": 10
   },
   "transaction": {
     "enabled": true,

--- a/hedera-mirror-rest/monitoring/monitor_apis/package-lock.json
+++ b/hedera-mirror-rest/monitoring/monitor_apis/package-lock.json
@@ -21,8 +21,7 @@
         "mathjs": "^11.5.0",
         "node-fetch": "^3.3.0",
         "parse-duration": "^1.0.2",
-        "pretty-ms": "^8.0.0",
-        "retry": "^0.13.1"
+        "pretty-ms": "^8.0.0"
       },
       "devDependencies": {
         "jest": "^29.4.1",
@@ -4145,14 +4144,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/retry": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/rfdc": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
@@ -7874,11 +7865,6 @@
       "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.0.tgz",
       "integrity": "sha512-6K/gDlqgQscOlg9fSRpWstA8sYe8rbELsSTNpx+3kTrsVCzvSl0zIvRErM7fdl9ERWDsKnrLnwB+Ne89918XOg==",
       "dev": true
-    },
-    "retry": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="
     },
     "rfdc": {
       "version": "1.3.0",

--- a/hedera-mirror-rest/monitoring/monitor_apis/package.json
+++ b/hedera-mirror-rest/monitoring/monitor_apis/package.json
@@ -28,8 +28,7 @@
     "mathjs": "^11.5.0",
     "node-fetch": "^3.3.0",
     "parse-duration": "^1.0.2",
-    "pretty-ms": "^8.0.0",
-    "retry": "^0.13.1"
+    "pretty-ms": "^8.0.0"
   },
   "devDependencies": {
     "jest": "^29.4.1",

--- a/hedera-mirror-rest/monitoring/monitor_apis/token_tests.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/token_tests.js
@@ -23,18 +23,19 @@ import config from './config';
 
 import {
   accountIdCompare,
+  checkAccountId,
   checkAPIResponseError,
   checkElementsOrder,
-  checkRespObjDefined,
-  checkRespArrayLength,
-  checkAccountId,
   checkMandatoryParams,
   checkResourceFreshness,
+  checkRespArrayLength,
+  checkRespObjDefined,
+  CheckRunner,
   DEFAULT_LIMIT,
   getAPIResponse,
   getUrl,
+  hasEmptyList,
   testRunner,
-  CheckRunner,
 } from './utils';
 
 const tokensPath = '/tokens';
@@ -384,7 +385,7 @@ const getTokenBalancesForAccount = async (server) => {
   }
 
   let url = getUrl(server, tokenBalancesPath(tokenId), {limit: 1});
-  let balances = await getAPIResponse(url, tokenBalancesJsonRespKey);
+  let balances = await getAPIResponse(url, tokenBalancesJsonRespKey, hasEmptyList(tokenBalancesJsonRespKey));
 
   const checkRunner = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)

--- a/hedera-mirror-rest/monitoring/monitor_apis/transaction_tests.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/transaction_tests.js
@@ -34,6 +34,7 @@ import {
   DEFAULT_LIMIT,
   getAPIResponse,
   getUrl,
+  hasEmptyList,
   testRunner,
 } from './utils';
 
@@ -124,7 +125,7 @@ const getTransactionsWithAccountCheck = async (server) => {
     type: 'credit',
     limit: 1,
   });
-  const accTransactions = await getAPIResponse(url, jsonRespKey);
+  const accTransactions = await getAPIResponse(url, jsonRespKey, hasEmptyList(jsonRespKey));
 
   result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
@@ -238,7 +239,7 @@ const getTransactionsWithTimeAndLimitParams = async (server) => {
     timestamp: [`gt:${minusOne.toString()}`, `lt:${plusOne.toString()}`],
     limit: 1,
   });
-  transactions = await getAPIResponse(url, jsonRespKey);
+  transactions = await getAPIResponse(url, jsonRespKey, hasEmptyList(jsonRespKey));
 
   result = checkRunner.run(transactions);
   if (!result.passed) {


### PR DESCRIPTION
**Description**:

* Fix race condition in environments with multiple clusters by retrying 404
* Fix race condition in environments with multiple clusters by retrying successful calls with empty lists
* Fix TypeError: Cannot read properties of undefined (reading 'localeCompare') in dashboard
* Fix ReferenceError: blockUrl is not defined
* Increase retry maxAttempts from 2 to 4
* Remove adhoc stateproof retry in favor of centralized 404 retry

**Related issue(s)**:

Fixes #5316

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
