### PR TITLE
Optimize get schedule by id query for citus

### DIFF
--- a/hedera-mirror-rest/__tests__/schedules.test.js
+++ b/hedera-mirror-rest/__tests__/schedules.test.js
@@ -118,7 +118,18 @@ describe('schedule formatScheduleRow tests', () => {
       description: 'input with undefined signatures',
       input: {
         ...defaultInput,
-        signatures: null,
+        signatures: undefined,
+      },
+      expected: {
+        ...defaultExpected,
+        signatures: [],
+      },
+    },
+    {
+      description: 'input with null signature object',
+      input: {
+        ...defaultInput,
+        signatures: [{consensus_timestamp: null, public_key_prefix: null, signature: null, type: null}],
       },
       expected: {
         ...defaultExpected,

--- a/hedera-mirror-test/k6/src/rest/test/index.js
+++ b/hedera-mirror-test/k6/src/rest/test/index.js
@@ -48,7 +48,7 @@ import * as contractsResults from './contractsResult.js';
 import * as contractsResultsId from './contractsResultsId.js';
 import * as contractsResultsIdActions from './contractsResultsIdActions.js';
 import * as contractsResultsLogs from './contractsResultsLogs.js';
-import * as networkExchangerate from './networkExchangerate.js';
+import * as networkExchangeRate from './networkExchangeRate.js';
 import * as networkFees from './networkFees.js';
 import * as networkNodes from './networkNodes.js';
 import * as networkStake from './networkStake.js';
@@ -105,7 +105,7 @@ const tests = {
   contractsResultsId,
   contractsResultsIdActions,
   contractsResultsLogs,
-  networkExchangerate,
+  networkExchangeRate,
   networkFees,
   networkNodes,
   networkStake,

--- a/hedera-mirror-test/k6/src/rest/test/networkExchangeRate.js
+++ b/hedera-mirror-test/k6/src/rest/test/networkExchangeRate.js
@@ -18,17 +18,17 @@
  * ‍
  */
 
-import http from "k6/http";
+import http from 'k6/http';
 
 import {TestScenarioBuilder} from '../../lib/common.js';
 import {urlPrefix} from '../../lib/constants.js';
-import {isSuccess} from "./common.js";
-import {setupTestParameters} from "./bootstrapEnvParameters.js";
+import {isSuccess} from './common.js';
+import {setupTestParameters} from './bootstrapEnvParameters.js';
 
 const urlTag = '/network/exchangerate';
 
 const {options, run} = new TestScenarioBuilder()
-  .name('networkExchangerate') // use unique scenario name among all tests
+  .name('networkExchangeRate') // use unique scenario name among all tests
   .tags({url: urlTag})
   .request((testParameters) => {
     const url = `${testParameters['BASE_URL']}${urlPrefix}${urlTag}`;


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR optimizes get schedule by id query for citus db

- Rewrite the get schedule by id query so citus only push down to a single shard
- Fix file name case issue in k6 test suite

**Related issue(s)**:

Fixes #5236 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
With the optimization, the RPS is ~3800/s and the average request duration is ~230ms. However the same query, when used for listing schedules, causes performance degradation with citus. For v1, both listing schedules and getting schedule by id show no noticeable performance change. 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
