### PR TITLE
Remove maxAutomaticTokenAssociations field from acceptance tests

### DIFF
--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/ContractClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/ContractClient.java
@@ -52,7 +52,6 @@ public class ContractClient extends AbstractNetworkClient {
                 .setBytecodeFileId(fileId)
                 .setContractMemo(memo)
                 .setGas(gas)
-                .setMaxAutomaticTokenAssociations(1)
                 .setTransactionMemo(memo);
 
         if (contractFunctionParameters != null) {

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ContractFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ContractFeature.java
@@ -211,7 +211,6 @@ public class ContractFeature extends AbstractFeature {
         assertThat(mirrorContract.getCreatedTimestamp()).isNotBlank();
         assertThat(mirrorContract.isDeleted()).isEqualTo(isDeleted);
         assertThat(mirrorContract.getFileId()).isEqualTo(fileId.toString());
-        assertThat(mirrorContract.getMaxAutomaticTokenAssociations()).isPositive();
         assertThat(mirrorContract.getMemo()).isNotBlank();
         String address = mirrorContract.getEvmAddress();
         assertThat(address).isNotBlank().isNotEqualTo("0x").isNotEqualTo("0x0000000000000000000000000000000000000000");


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

After the following [PR](https://github.com/hashgraph/hedera-services/pull/4701) we shouldn't set explicitly `maxAutomaticTokenAssociations` field to a contract unless a special feature flag is enabled. This causes an acceptance test to fail, so this PR removes the explicit set of this field.

**Related issue(s)**:

Fixes #5310 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
