### PR TITLE
Optimize contract by ID for Citus

### DIFF
--- a/hedera-mirror-rest/__tests__/controllers/contractController.test.js
+++ b/hedera-mirror-rest/__tests__/controllers/contractController.test.js
@@ -26,7 +26,6 @@ import contracts from '../../controllers/contractController';
 import {assertSqlQueryEqual} from '../testutils';
 import * as utils from '../../utils';
 import {Entity} from '../../model';
-import {FileDataService} from '../../service';
 import Bound from '../../controllers/bound';
 import {ContractBytecodeViewModel, ContractViewModel} from '../../viewmodel';
 
@@ -272,9 +271,6 @@ describe('formatContractRow', () => {
 });
 
 describe('getContractByIdOrAddressQuery', () => {
-  const mainQuery = `select ce.*, coalesce(encode(ce.initcode, 'hex')::bytea, cf.bytecode) as bytecode
-                     from contract_entity ce,
-                          contract_file cf`;
 
   const queryForTable = ({table, extraConditions, columnName}) => {
     return `select ${contracts.contractWithBytecodeSelectFields}
@@ -285,6 +281,25 @@ describe('getContractByIdOrAddressQuery', () => {
               and ${(extraConditions && extraConditions.join(' and ') + ' and ') || ''} e.${columnName} = $3`;
   };
 
+  const fileQueryForTable = ({table, timestampParams, fileIdParam}) => {
+    return `select string_agg(
+                     f.file_data, ''
+            order by f.consensus_timestamp
+                     ) bytecode
+            from ${table} f
+            where
+              f.entity_id = ${fileIdParam}
+              and f.consensus_timestamp >= (
+              select f.consensus_timestamp
+              from file_data f
+              where f.entity_id = ${fileIdParam}
+                and f.consensus_timestamp <= ${timestampParams}
+                and (f.transaction_type = 17 or ( f.transaction_type = 19 and length(f.file_data) <> 0 ))
+              order by f.consensus_timestamp desc
+              limit 1
+              ) and f.consensus_timestamp <= ${timestampParams}`;
+  };
+
   const timestampConditions = ['c.timestamp_range && $1', 'c.timestamp_range && $2'];
 
   const specs = [
@@ -292,11 +307,14 @@ describe('getContractByIdOrAddressQuery', () => {
       name: 'latest',
       isCreate2Test: false,
       input: {timestampConditions: [], timestampParams: [1234, 5678], contractIdParam: '0.0.2'},
+      timestampParams: 12345678,
+      fileIdParam: '0.0.2',
       expectedParams: [1234, 5678, 2],
       expectedQuery: (columnName) => `
-        with contract_entity as (${queryForTable({table: 'entity', columnName})}),
-             contract_file as (${FileDataService.getContractInitCodeFiledataQuery()})
-          ${mainQuery}`,
+        select ce.* from (${queryForTable({table: 'entity', columnName})}) as ce`,
+      expectedFileQuery: (timestampParams, fileIdParam) => `
+       ${fileQueryForTable({table: 'file_data', timestampParams, fileIdParam})}
+       `,
     },
     {
       name: 'historical',
@@ -306,13 +324,15 @@ describe('getContractByIdOrAddressQuery', () => {
         timestampParams: [5678, 1234],
         contractIdParam: '70f2b2914a2a4b783faefb75f459a580616fcb5e',
       },
+      timestampParams: 12345678,
+      fileIdParam: '70f2b2914a2a4b783faefb75f459a580616fcb5e',
       expectedParams: [
         5678,
         1234,
         Buffer.from([112, 242, 178, 145, 74, 42, 75, 120, 63, 174, 251, 117, 244, 89, 165, 128, 97, 111, 203, 94]),
       ],
       expectedQuery: (columnName) => `
-        with contract_entity as (${queryForTable({table: 'entity', extraConditions: timestampConditions, columnName})}
+        select ce.* from (${queryForTable({table: 'entity', extraConditions: timestampConditions, columnName})}
             union
                                 ${queryForTable({
                                   table: 'entity_history',
@@ -320,9 +340,10 @@ describe('getContractByIdOrAddressQuery', () => {
                                   columnName,
                                 })}
                                 order by timestamp_range desc
-                                limit 1),
-             contract_file as (${FileDataService.getContractInitCodeFiledataQuery()})
-          ${mainQuery}`,
+                                limit 1) as ce`,
+      expectedFileQuery: (timestampParams, fileIdParam) => `
+       ${fileQueryForTable({table: 'file_data', timestampParams, fileIdParam})}
+       `,
     },
     {
       name: 'latest',
@@ -332,23 +353,28 @@ describe('getContractByIdOrAddressQuery', () => {
         timestampParams: [1234, 5678],
         contractIdParam: '70f2b2914a2a4b783faefb75f459a580616fcb5e',
       },
+      timestampParams: 12345678,
+      fileIdParam: '70f2b2914a2616fcb5e2a4b783faefb75f45',
       expectedParams: [
         1234,
         5678,
         Buffer.from([112, 242, 178, 145, 74, 42, 75, 120, 63, 174, 251, 117, 244, 89, 165, 128, 97, 111, 203, 94]),
       ],
       expectedQuery: (columnName) => `
-        with contract_entity as (${queryForTable({table: 'entity', columnName})}),
-             contract_file as (${FileDataService.getContractInitCodeFiledataQuery()})
-          ${mainQuery}`,
+        select ce.* from (${queryForTable({table: 'entity', columnName})}) as ce`,
+      expectedFileQuery: (timestampParams, fileIdParam) => `
+       ${fileQueryForTable({table: 'file_data', timestampParams, fileIdParam})}
+       `,
     },
     {
       name: 'historical',
       isCreate2Test: false,
       input: {timestampConditions, timestampParams: [5678, 1234], contractIdParam: '0.0.1'},
+      timestampParams: 12345678,
+      fileIdParam: '0.0.5',
       expectedParams: [5678, 1234, 1],
       expectedQuery: (columnName) => `
-        with contract_entity as (${queryForTable({table: 'entity', extraConditions: timestampConditions, columnName})}
+        select ce.* from (${queryForTable({table: 'entity', extraConditions: timestampConditions, columnName})}
             union
                                 ${queryForTable({
                                   table: 'entity_history',
@@ -356,39 +382,52 @@ describe('getContractByIdOrAddressQuery', () => {
                                   columnName,
                                 })}
                                 order by timestamp_range desc
-                                limit 1),
-             contract_file as (${FileDataService.getContractInitCodeFiledataQuery()})
-          ${mainQuery}`,
+                                limit 1) as ce`,
+      expectedFileQuery: (timestampParams, fileIdParam) => `
+       ${fileQueryForTable({table: 'file_data', timestampParams, fileIdParam})}
+       `,
     },
     {
       name: 'latest',
       isCreate2Test: false,
       input: {timestampConditions: [], timestampParams: [1234, 5678], contractIdParam: '0.0.924569'},
+      timestampParams: 12345678,
+      fileIdParam: '0.0.924136',
       expectedParams: [1234, 5678, 924569],
       expectedQuery: (columnName) => `
-        with contract_entity as (${queryForTable({table: 'entity', columnName})}),
-             contract_file as (${FileDataService.getContractInitCodeFiledataQuery()})
-          ${mainQuery}`,
+        select ce.* from (${queryForTable({table: 'entity', columnName})})
+        as ce`,
+      expectedFileQuery: (timestampParams, fileIdParam) => `
+       ${fileQueryForTable({table: 'file_data', timestampParams, fileIdParam})}
+       `,
     },
     {
       name: 'latest',
       isCreate2Test: false,
       input: {timestampConditions: [], timestampParams: [1234, 5678], contractIdParam: '1.1.924569'},
+      timestampParams: 12345678,
+      fileIdParam: '1.1.924136',
       expectedParams: [1234, 5678, 281479272602521],
       expectedQuery: (columnName) => `
-        with contract_entity as (${queryForTable({table: 'entity', columnName})}),
-             contract_file as (${FileDataService.getContractInitCodeFiledataQuery()})
-          ${mainQuery}`,
+        select ce.* from (${queryForTable({table: 'entity', columnName})})
+        as ce`,
+      expectedFileQuery: (timestampParams, fileIdParam) => `
+       ${fileQueryForTable({table: 'file_data', timestampParams, fileIdParam})}
+       `,
     },
   ];
 
   specs.forEach((spec) => {
     test(`${spec.name}`, () => {
-      const actualContract = contracts.getContractByIdOrAddressQuery(spec.input);
-      const actualQuery = actualContract.query;
+      const actualContractDetails = contracts.getContractByIdOrAddressQuery(spec.input);
+      const actualQuery = actualContractDetails.query;
       const expectedQuery = spec.expectedQuery(spec.isCreate2Test ? Entity.EVM_ADDRESS : Entity.ID);
       assertSqlQueryEqual(actualQuery, expectedQuery);
-      expect(actualContract.params).toEqual(spec.expectedParams);
+      expect(actualContractDetails.params).toEqual(spec.expectedParams);
+      const actualFileBytecode = contracts.getFileBytecodeQuery(spec.timestampParams, spec.fileIdParam);
+      const actualFileQuery = actualFileBytecode.query;
+      const expectedFileQuery = spec.expectedFileQuery(spec.timestampParams, spec.fileIdParam);
+      assertSqlQueryEqual(actualFileQuery, expectedFileQuery);
     });
   });
 });

--- a/hedera-mirror-rest/__tests__/specs/contracts/{id}/contract-empty-bytecode.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/{id}/contract-empty-bytecode.json
@@ -1,0 +1,57 @@
+{
+  "description": "Contracts api calls with contract with bytecode 0x and no file_id",
+  "setup": {
+    "contracts": [
+      {
+        "created_timestamp": "987654000123456",
+        "evm_address": "62cf9068fed962cf9068fed962cf9068fed9dddd",
+        "runtime_bytecode": [54, 48, 56, 48, 54, 48, 52, 48],
+        "key": [1, 1, 1],
+        "num": "8001",
+        "timestamp_range": "[987654000123456, 997654000123456]"
+      },
+      {
+        "created_timestamp": "987654000123456",
+        "evm_address": "62cf9068fed962cf9aaabbb962cf9068fed9dddd",
+        "runtime_bytecode": [54, 48, 56, 48, 54, 48, 52, 48],
+        "key": [1, 1, 1],
+        "num": "8001",
+        "timestamp_range": "[997654000123457,)"
+      }
+    ]
+  },
+  "urls": [
+    "/api/v1/contracts/0.0.8001",
+    "/api/v1/contracts/0.8001",
+    "/api/v1/contracts/8001",
+    "/api/v1/contracts/62cf9068fed962cf9aaabbb962cf9068fed9dddd",
+    "/api/v1/contracts/0.62cf9068fed962cf9aaabbb962cf9068fed9dddd",
+    "/api/v1/contracts/0.0.62cf9068fed962cf9aaabbb962cf9068fed9dddd"
+  ],
+  "responseStatus": 200,
+  "responseJson": {
+    "admin_key": {
+      "_type": "ProtobufEncoded",
+      "key": "010101"
+    },
+    "auto_renew_account": null,
+    "auto_renew_period": null,
+    "bytecode": "0x",
+    "contract_id": "0.0.8001",
+    "created_timestamp": "987654.000123456",
+    "deleted": false,
+    "evm_address": "0x62cf9068fed962cf9aaabbb962cf9068fed9dddd",
+    "expiration_timestamp": null,
+    "file_id": null,
+    "max_automatic_token_associations": 0,
+    "memo": "contract memo",
+    "obtainer_id": null,
+    "permanent_removal": null,
+    "proxy_account_id": null,
+    "runtime_bytecode": "0x3630383036303430",
+    "timestamp": {
+      "from": "997654.000123457",
+      "to": null
+    }
+  }
+}

--- a/hedera-mirror-rest/controllers/contractController.js
+++ b/hedera-mirror-rest/controllers/contractController.js
@@ -748,11 +748,11 @@ class ContractController extends BaseController {
     if(contract.file_id !== null) {
       const {query, params} = FileDataService.getFileData(contract.file_id, contract.created_timestamp);
       if (logger.isTraceEnabled()) {
-        logger.trace(`getFileBytecode query: ${query}, params: ${params}`);
+        logger.trace(`getFileData query: ${query}, params: ${params}`);
       }
       const {rows} = await pool.queryQuietly(query, params);
       if (rows.length === 1) {
-        contract.bytecode = rows[0].bytecode;
+        contract.bytecode = rows[0].data;
       }
     } else {
       contract.bytecode = contract.initcode.toString('hex');

--- a/hedera-mirror-rest/controllers/contractController.js
+++ b/hedera-mirror-rest/controllers/contractController.js
@@ -745,7 +745,7 @@ class ContractController extends BaseController {
       throw new NotFoundError();
     }
     const contract = rows[0];
-    if(_.first(rows).file_id !== null) {
+    if(contract.file_id !== null) {
       const {query, params} = FileDataService.getFileData(contract.file_id, contract.created_timestamp);
       if (logger.isTraceEnabled()) {
         logger.trace(`getFileBytecode query: ${query}, params: ${params}`);

--- a/hedera-mirror-rest/controllers/contractController.js
+++ b/hedera-mirror-rest/controllers/contractController.js
@@ -755,7 +755,7 @@ class ContractController extends BaseController {
         contract.bytecode = rows[0].data;
       }
     } else {
-      contract.bytecode = contract.initcode.toString('hex');
+      contract.bytecode = contract.initcode?.toString('hex');
     }
     res.locals[responseDataLabel] = formatContractRow(contract, ContractBytecodeViewModel);
   };

--- a/hedera-mirror-rest/controllers/contractController.js
+++ b/hedera-mirror-rest/controllers/contractController.js
@@ -33,6 +33,7 @@ import {
   ContractResult,
   ContractState,
   Entity,
+  FileData,
   RecordFile,
   Transaction,
   TransactionResult,
@@ -288,21 +289,24 @@ const getFileBytecodeQuery = (timestampParam, fileIdParam) => {
     query: [
       `select
          string_agg(
-           f.file_data, ''
-           order by f.consensus_timestamp
+           ${FileData.getFullName(FileData.FILE_DATA)}, ''
+           order by ${FileData.getFullName(FileData.CONSENSUS_TIMESTAMP)}
            ) bytecode
-        from file_data f
+        from ${FileData.tableName} ${FileData.tableAlias}
         where
-        f.entity_id = ${fileIdParam}
-        and f.consensus_timestamp >= (
-        select f.consensus_timestamp
-        from file_data f
-        where f.entity_id = ${fileIdParam}
-        and f.consensus_timestamp <= ${timestampParam}
-        and (f.transaction_type = 17 or ( f.transaction_type = 19 and length(f.file_data) <> 0 ))
-        order by f.consensus_timestamp desc
+         ${FileData.getFullName(FileData.ENTITY_ID)} = ${fileIdParam}
+        and ${FileData.getFullName(FileData.CONSENSUS_TIMESTAMP)} >= (
+        select ${FileData.getFullName(FileData.CONSENSUS_TIMESTAMP)}
+        from ${FileData.tableName} ${FileData.tableAlias}
+        where ${FileData.getFullName(FileData.ENTITY_ID)} = ${fileIdParam}
+        and ${FileData.getFullName(FileData.CONSENSUS_TIMESTAMP)} <= ${timestampParam}
+        and (${FileData.getFullName(FileData.TRANSACTION_TYPE)} = 17
+             or ( ${FileData.getFullName(FileData.TRANSACTION_TYPE)} = 19
+                  and
+                  length(${FileData.getFullName(FileData.FILE_DATA)}) <> 0 ))
+        order by ${FileData.getFullName(FileData.CONSENSUS_TIMESTAMP)} desc
         limit 1
-        ) and f.consensus_timestamp <= ${timestampParam}`,
+        ) and ${FileData.getFullName(FileData.CONSENSUS_TIMESTAMP)} <= ${timestampParam}`,
     ].join('\n'),
   };
 };

--- a/hedera-mirror-rest/controllers/contractController.js
+++ b/hedera-mirror-rest/controllers/contractController.js
@@ -280,7 +280,8 @@ const getContractByIdOrAddressContractEntityQuery = ({timestampConditions, times
 /**
  * Gets the sql query for a specific file, with parameters from getContractByIdOrAddressContractEntityQuery
  * @param timestampConditions
- * @return {query: string, params: any[]}
+ * @param fileIdParam
+ * @return {query: string}
  */
 const getFileBytecodeQuery = (timestampParam, fileIdParam) => {
 
@@ -796,7 +797,9 @@ class ContractController extends BaseController {
       }
       contractRows[0].bytecode = rows[0].bytecode;
     } else {
-      contractRows[0].bytecode = encode(contractRows[0].initcode, 'hex');
+      contractRows[0].bytecode = Array.from(contractRows[0].initcode, function(byte) {
+        return ('0' + (byte & 0xFF).toString(16)).slice(-2);
+      }).join('');
     }
     res.locals[responseDataLabel] = formatContractRow(contractRows[0], ContractBytecodeViewModel);
   };
@@ -1393,6 +1396,7 @@ if (utils.isTestEnv()) {
       formatContractRow,
       getContractByIdOrAddressQuery: getContractByIdOrAddressContractEntityQuery,
       getContractsQuery,
+      getFileBytecodeQuery,
       getLastNonceParamValue,
       validateContractIdAndConsensusTimestampParam,
       validateContractIdParam,

--- a/hedera-mirror-rest/controllers/contractController.js
+++ b/hedera-mirror-rest/controllers/contractController.js
@@ -745,15 +745,8 @@ class ContractController extends BaseController {
       throw new NotFoundError();
     }
     const contract = rows[0];
-    if(contract.file_id !== null) {
-      const {query, params} = FileDataService.getFileData(contract.file_id, contract.created_timestamp);
-      if (logger.isTraceEnabled()) {
-        logger.trace(`getFileData query: ${query}, params: ${params}`);
-      }
-      const {rows} = await pool.queryQuietly(query, params);
-      if (rows.length === 1) {
-        contract.bytecode = rows[0].data;
-      }
+    if (contract.file_id !== null) {
+      contract.bytecode = await FileDataService.getFileData(contract.file_id, contract.created_timestamp);
     } else {
       contract.bytecode = contract.initcode?.toString('hex');
     }

--- a/hedera-mirror-rest/service/fileDataService.js
+++ b/hedera-mirror-rest/service/fileDataService.js
@@ -75,7 +75,7 @@ class FileDataService extends BaseService {
          string_agg(
            ${FileData.getFullName(FileData.FILE_DATA)}, ''
            order by ${FileData.getFullName(FileData.CONSENSUS_TIMESTAMP)}
-           ) bytecode
+           ) data
         from ${FileData.tableName} ${FileData.tableAlias}
         where
          ${FileData.getFullName(FileData.ENTITY_ID)} = $1

--- a/hedera-mirror-rest/service/fileDataService.js
+++ b/hedera-mirror-rest/service/fileDataService.js
@@ -95,7 +95,6 @@ class FileDataService extends BaseService {
     };
   };
 
-
   getLatestFileContentsQuery = (innerWhere = '') => {
     const outerWhere = innerWhere.replace('and ', `and ${FileData.tableAlias}.`);
     return FileDataService.latestFileContentsQuery

--- a/hedera-mirror-rest/service/fileDataService.js
+++ b/hedera-mirror-rest/service/fileDataService.js
@@ -60,18 +60,7 @@ class FileDataService extends BaseService {
   }
     group by ${FileData.getFullName(FileData.ENTITY_ID)}`;
 
-  /**
-   * The function returns the query and params to get the active file content for the fileId at the provided consensus timestamp.
-   * @param fileId
-   * @param timestamp
-   * @return {query: string, params: any[]}
-   */
-  getFileData = (fileId, timestamp) => {
-    const params = [fileId, timestamp];
-
-    return {
-      query:
-        `select
+  static getFileDataQuery = `select
          string_agg(
            ${FileData.FILE_DATA}, ''
            order by ${FileData.CONSENSUS_TIMESTAMP}
@@ -90,7 +79,18 @@ class FileDataService extends BaseService {
                   length(${FileData.FILE_DATA}) <> 0 ))
         order by ${FileData.CONSENSUS_TIMESTAMP} desc
         limit 1
-        ) and ${FileData.CONSENSUS_TIMESTAMP} <= $2`,
+        ) and ${FileData.CONSENSUS_TIMESTAMP} <= $2`;
+
+  /**
+   * The function returns the query and params to get the active file content for the fileId at the provided consensus timestamp.
+   * @param fileId
+   * @param timestamp
+   * @return {query: string, params: any[]}
+   */
+  getFileData = (fileId, timestamp) => {
+    const params = [fileId, timestamp];
+    return {
+      query: FileDataService.getFileDataQuery,
       params,
     };
   };

--- a/hedera-mirror-rest/service/fileDataService.js
+++ b/hedera-mirror-rest/service/fileDataService.js
@@ -82,17 +82,16 @@ class FileDataService extends BaseService {
         ) and ${FileData.CONSENSUS_TIMESTAMP} <= $2`;
 
   /**
-   * The function returns the query and params to get the active file content for the fileId at the provided consensus timestamp.
+   * The function returns the data for the fileId at the provided consensus timestamp.
    * @param fileId
    * @param timestamp
-   * @return {query: string, params: any[]}
+   * @return {data: string}
    */
-  getFileData = (fileId, timestamp) => {
+  getFileData = async (fileId, timestamp) => {
     const params = [fileId, timestamp];
-    return {
-      query: FileDataService.getFileDataQuery,
-      params,
-    };
+    const query = FileDataService.getFileDataQuery;
+    const row = await super.getSingleRow(query, params, 'getFileData');
+    return _.isNil(row) ? null : row.data;
   };
 
   getLatestFileContentsQuery = (innerWhere = '') => {

--- a/hedera-mirror-rest/service/fileDataService.js
+++ b/hedera-mirror-rest/service/fileDataService.js
@@ -73,24 +73,24 @@ class FileDataService extends BaseService {
       query: [
         `select
          string_agg(
-           ${FileData.getFullName(FileData.FILE_DATA)}, ''
-           order by ${FileData.getFullName(FileData.CONSENSUS_TIMESTAMP)}
+           f.file_data, ''
+           order by f.consensus_timestamp
            ) data
-        from ${FileData.tableName} ${FileData.tableAlias}
+        from file_data f
         where
-         ${FileData.getFullName(FileData.ENTITY_ID)} = $1
-        and ${FileData.getFullName(FileData.CONSENSUS_TIMESTAMP)} >= (
-        select ${FileData.getFullName(FileData.CONSENSUS_TIMESTAMP)}
-        from ${FileData.tableName} ${FileData.tableAlias}
-        where ${FileData.getFullName(FileData.ENTITY_ID)} = $1
-        and ${FileData.getFullName(FileData.CONSENSUS_TIMESTAMP)} <= $2
-        and (${FileData.getFullName(FileData.TRANSACTION_TYPE)} = 17
-             or ( ${FileData.getFullName(FileData.TRANSACTION_TYPE)} = 19
+           f.entity_id = $1
+        and f.consensus_timestamp >= (
+        select f.consensus_timestamp
+        from file_data f
+        where f.entity_id = $1
+        and f.consensus_timestamp <= $2
+        and (f.transaction_type = 17
+             or ( f.transaction_type = 19
                   and
-                  length(${FileData.getFullName(FileData.FILE_DATA)}) <> 0 ))
-        order by ${FileData.getFullName(FileData.CONSENSUS_TIMESTAMP)} desc
+                  length(f.file_data) <> 0 ))
+        order by f.consensus_timestamp desc
         limit 1
-        ) and ${FileData.getFullName(FileData.CONSENSUS_TIMESTAMP)} <= $2`,
+        ) and f.consensus_timestamp <= $2`,
       ].join('\n'),
       params,
     };

--- a/hedera-mirror-rest/service/fileDataService.js
+++ b/hedera-mirror-rest/service/fileDataService.js
@@ -70,28 +70,27 @@ class FileDataService extends BaseService {
     const params = [fileId, timestamp];
 
     return {
-      query: [
+      query:
         `select
          string_agg(
-           f.file_data, ''
-           order by f.consensus_timestamp
+           ${FileData.FILE_DATA}, ''
+           order by ${FileData.CONSENSUS_TIMESTAMP}
            ) data
-        from file_data f
+        from ${FileData.tableName}
         where
-           f.entity_id = $1
-        and f.consensus_timestamp >= (
-        select f.consensus_timestamp
-        from file_data f
-        where f.entity_id = $1
-        and f.consensus_timestamp <= $2
-        and (f.transaction_type = 17
-             or ( f.transaction_type = 19
+           ${FileData.ENTITY_ID} = $1
+        and ${FileData.CONSENSUS_TIMESTAMP} >= (
+        select ${FileData.CONSENSUS_TIMESTAMP}
+        from ${FileData.tableName}
+        where ${FileData.ENTITY_ID} = $1
+        and ${FileData.CONSENSUS_TIMESTAMP} <= $2
+        and (${FileData.TRANSACTION_TYPE} = 17
+             or ( ${FileData.TRANSACTION_TYPE} = 19
                   and
-                  length(f.file_data) <> 0 ))
-        order by f.consensus_timestamp desc
+                  length(${FileData.FILE_DATA}) <> 0 ))
+        order by ${FileData.CONSENSUS_TIMESTAMP} desc
         limit 1
-        ) and f.consensus_timestamp <= $2`,
-      ].join('\n'),
+        ) and ${FileData.CONSENSUS_TIMESTAMP} <= $2`,
       params,
     };
   };


### PR DESCRIPTION
**Description**:
Citus (V2) optimize get contract by id query.

This PR modifies:
- Splits the original contract by ID to separately query the contracts and the file data table.


**Related issue(s)**:

Fixes #5231

**Notes for reviewer**:

This PR splits the original query to remove existing CTEs and query the contracts table. Then get the results from the first query and further query the file_data table.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
