### PR TITLE
Fix contract call acceptance tests ran via helm test

### DIFF
--- a/charts/hedera-mirror/values.yaml
+++ b/charts/hedera-mirror/values.yaml
@@ -376,7 +376,9 @@ test:
           acceptance:
             mirrorNodeAddress: "{{ .Release.Name }}-grpc:5600"
             rest:
-              baseUrl: "http://{{ .Release.Name }}-rest/api/v1"
+              baseUrl: "http://{{ .Release.Name }}-rest"
+            web3:
+              baseUrl: "http://{{ .Release.Name }}-web3"
   cucumberTags: "@acceptance"
   enabled: false
   git:

--- a/hedera-mirror-test/README.md
+++ b/hedera-mirror-test/README.md
@@ -57,7 +57,7 @@ under `hedera.mirror.test.acceptance` include:
 - `operatorKey` - Account private key to be used for signing transaction and client identification. Please do not check
   in.
 - `rest`
-  - `baseUrl` - The host URL to the mirror node. For example, https://testnet.mirrornode.hedera.com/api/v1
+  - `baseUrl` - The host URL to the mirror node. For example, https://testnet.mirrornode.hedera.com
   - `delay` - The time to wait in between failed REST API calls.
   - `maxAttempts` - The maximum number of attempts when calling a REST API endpoint and receiving a 404.
   - `maxBackoff` - The maximum backoff duration the mirror grpc subscriber will wait between attempts.
@@ -70,6 +70,8 @@ under `hedera.mirror.test.acceptance` include:
   - `maxAttempts` - The maximum number of times the sdk should try to submit a transaction to the network.
 - `startupTimeout` - How long the startup probe should wait for the network as a whole to be healthy before failing the
   tests
+- `web3`
+  - `baseUrl` - The endpoint associated with the web3 API.
 - `webclient`
   - `connectionTimeout` - The timeout duration to wait to establish a connection with the server
   - `readTimeout` - The timeout duration to wait for data to be read.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/Web3Properties.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/Web3Properties.java
@@ -1,0 +1,44 @@
+package com.hedera.mirror.test.e2e.acceptance.config;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import static com.hedera.mirror.test.e2e.acceptance.config.RestPollingProperties.URL_SUFFIX;
+
+import javax.inject.Named;
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@ConfigurationProperties(prefix = "hedera.mirror.test.acceptance.web3")
+@Data
+@Named
+@Validated
+public class Web3Properties {
+
+    private String baseUrl;
+
+    public String getBaseUrl() {
+        if (baseUrl != null && !baseUrl.endsWith(URL_SUFFIX)) {
+            return baseUrl + URL_SUFFIX;
+        }
+        return baseUrl;
+    }
+}

--- a/hedera-mirror-test/src/test/resources/application.yml
+++ b/hedera-mirror-test/src/test/resources/application.yml
@@ -4,7 +4,7 @@ hedera:
       acceptance:
         messageTimeout: 20s
         # grpc endpoint
-        mirrorNodeAddress: hcs.testnet.mirrornode.hedera.com:5600
+        mirrorNodeAddress: testnet.mirrornode.hedera.com:443
         network: testnet
         rest:
-          baseUrl: http://testnet.mirrornode.hedera.com/api/v1
+          baseUrl: https://testnet.mirrornode.hedera.com


### PR DESCRIPTION
**Description**:

* Add an optional `hedera.mirror.test.acceptance.web3.baseUrl` property
* Change acceptance tests to accept a `baseUrl` with or without `/api/v1` suffix
* Change default testnet URLs to use TLS
* Fix acceptance tests retrying negative test case

**Related issue(s)**:

Fixes #5334

**Notes for reviewer**:

Will cherry pick to `release/0.74`.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
