### PR TITLE
Containerize monitor dashboard

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        module: [ graphql, grpc, importer, monitor, rest, rosetta, web3 ]
+        module: [ graphql, grpc, importer, monitor, rest, rest-monitor, rosetta, web3 ]
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -8,7 +8,7 @@ jobs:
   image:
     strategy:
       matrix:
-        module: [ graphql, grpc, importer, monitor, rest, rosetta, web3 ]
+        module: [ graphql, grpc, importer, monitor, rest, rest-monitor, rosetta, web3 ]
     env:
       MODULE: hedera-mirror-${{ matrix.module }}
       IMAGE: gcr.io/mirrornode/hedera-mirror-${{ matrix.module }}

--- a/buildSrc/src/main/kotlin/docker-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/docker-conventions.gradle.kts
@@ -29,9 +29,11 @@ val latest = "latest"
 
 // Get the Docker images to tag by splitting dockerTag property and adding the project version
 fun dockerImages(): Collection<String> {
+    val dockerImageName =
+        if (project.extra.has("dockerImageName")) project.extra.get("dockerImageName") else projectDir.name
     val dockerRegistry: String by project
     val dockerTag: String by project
-    val dockerImage = "${dockerRegistry}/${projectDir.name}:"
+    val dockerImage = "${dockerRegistry}/${dockerImageName}:"
     val customTags = dockerTag.split(',').map { dockerImage.plus(it) }
     val versionTag = dockerImage.plus(project.version)
     val tags = customTags.plus(versionTag).toMutableSet()

--- a/buildSrc/src/main/kotlin/javascript-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/javascript-conventions.gradle.kts
@@ -40,6 +40,11 @@ tasks.register<NpmTask>("package") {
     }
 }
 
+tasks.register<NpmTask>("start") {
+    dependsOn(tasks.npmInstall)
+    args.set(listOf("start"))
+}
+
 val test = tasks.register<NpmTask>("test") {
     dependsOn(tasks.npmInstall)
     args.set(listOf("test"))

--- a/charts/hedera-mirror-rest/templates/_helpers.tpl
+++ b/charts/hedera-mirror-rest/templates/_helpers.tpl
@@ -28,15 +28,30 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Common labels
 */}}
-{{- define "hedera-mirror-rest.labels" -}}
-{{ include "hedera-mirror-rest.selectorLabels" . }}
+{{- define "hedera-mirror-rest.commonLabels" -}}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: hedera-mirror-node
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 helm.sh/chart: {{ include "hedera-mirror-rest.chart" . }}
+{{- end -}}
+
+{{/*
+Labels
+*/}}
+{{- define "hedera-mirror-rest.labels" -}}
+{{ include "hedera-mirror-rest.selectorLabels" . }}
+{{ include "hedera-mirror-rest.commonLabels" . }}
 {{- if .Values.labels }}
 {{ toYaml .Values.labels }}
 {{- end }}
+{{- end -}}
+
+{{/*
+Monitor labels
+*/}}
+{{- define "hedera-mirror-rest-monitor.labels" -}}
+{{ include "hedera-mirror-rest-monitor.selectorLabels" . }}
+{{ include "hedera-mirror-rest.commonLabels" . }}
 {{- end -}}
 
 {{/*
@@ -63,6 +78,15 @@ Selector labels
 {{- define "hedera-mirror-rest.selectorLabels" -}}
 app.kubernetes.io/component: rest
 app.kubernetes.io/name: {{ include "hedera-mirror-rest.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Monitor selector labels
+*/}}
+{{- define "hedera-mirror-rest-monitor.selectorLabels" -}}
+app.kubernetes.io/component: rest-monitor
+app.kubernetes.io/name: {{ include "hedera-mirror-rest.name" . }}-monitor
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 

--- a/charts/hedera-mirror-rest/templates/monitor/deployment.yaml
+++ b/charts/hedera-mirror-rest/templates/monitor/deployment.yaml
@@ -1,0 +1,74 @@
+{{- if .Values.monitor.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: {{ toYaml .Values.annotations | nindent 4 }}
+  labels: {{ include "hedera-mirror-rest-monitor.labels" . | nindent 4 }}
+  name: {{ include "hedera-mirror-rest.fullname" . }}-monitor
+  namespace: {{ include "hedera-mirror-rest.namespace" . }}
+spec:
+  replicas: {{ .Values.monitor.replicas }}
+  selector:
+    matchLabels: {{ include "hedera-mirror-rest-monitor.selectorLabels" . | nindent 6 }}
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/secret: {{ include (print $.Template.BasePath "/monitor/secret.yaml") . | sha256sum }}
+      labels: {{ include "hedera-mirror-rest-monitor.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: rest-monitor
+          env:
+            - name: CONFIG_PATH
+              value: "/config"
+          {{ $image := mergeOverwrite .Values.monitor.image .Values.global.image -}}
+          image: "{{ $image.registry }}/{{ $image.repository }}:{{ $image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ $image.pullPolicy }}
+          livenessProbe:
+            httpGet:
+              path: /health/liveness
+              port: api
+            initialDelaySeconds: 10
+            timeoutSeconds: 2
+          ports:
+            - containerPort: 3000
+              name: api
+              protocol: TCP
+            - containerPort: 8080
+              name: ui
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /health/readiness
+              port: api
+            initialDelaySeconds: 10
+            timeoutSeconds: 2
+          resources: {{ toYaml .Values.monitor.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ ALL ]
+            readOnlyRootFilesystem: false
+          volumeMounts:
+            - name: config
+              mountPath: /config
+            - name: pm2
+              mountPath: /home/node/.pm2
+      securityContext:
+        fsGroup: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: {{ include "hedera-mirror-rest.serviceAccountName" . }}
+      volumes:
+        - name: config
+          secret:
+            secretName: {{ include "hedera-mirror-rest.fullname" . }}-monitor
+        - name: pm2
+          emptyDir:
+            medium: Memory
+{{- end }}

--- a/charts/hedera-mirror-rest/templates/monitor/secret.yaml
+++ b/charts/hedera-mirror-rest/templates/monitor/secret.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.monitor.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  labels: {{ include "hedera-mirror-rest-monitor.labels" . | nindent 4 }}
+  name: {{ include "hedera-mirror-rest.fullname" . }}-monitor
+  namespace: {{ include "hedera-mirror-rest.namespace" . }}
+type: Opaque
+stringData:
+  serverlist.json: |
+    {{- tpl .Values.monitor.config $ | fromYaml | toJson | nindent 4 }}
+{{- end }}

--- a/charts/hedera-mirror-rest/templates/monitor/service.yaml
+++ b/charts/hedera-mirror-rest/templates/monitor/service.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.monitor.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {{ toYaml .Values.service.annotations | nindent 4 }}
+  labels: {{ include "hedera-mirror-rest-monitor.labels" . | nindent 4 }}
+  name: {{ include "hedera-mirror-rest.fullname" . }}-monitor
+  namespace: {{ include "hedera-mirror-rest.namespace" . }}
+spec:
+  ports:
+    - name: api
+      port: 3000
+      protocol: TCP
+      targetPort: api
+    - name: ui
+      port: 80
+      protocol: TCP
+      targetPort: ui
+  selector: {{ include "hedera-mirror-rest-monitor.selectorLabels" . | nindent 4 }}
+  type: {{ .Values.monitor.service.type }}
+{{- end }}

--- a/charts/hedera-mirror-rest/templates/monitor/tests/pod.yaml
+++ b/charts/hedera-mirror-rest/templates/monitor/tests/pod.yaml
@@ -1,0 +1,23 @@
+{{- if (and .Values.monitor.enabled .Values.monitor.test.enabled) -}}
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    helm.sh/hook: test-success
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+  labels: {{- include "hedera-mirror-rest-monitor.labels" . | nindent 4 }}
+  name: {{ include "hedera-mirror-rest.fullname" . }}-monitor-test
+  namespace: {{ include "hedera-mirror-rest.namespace" . }}
+spec:
+  containers:
+    - name: test
+      image: "{{ .Values.monitor.test.image.repository }}:{{ .Values.monitor.test.image.tag }}"
+      imagePullPolicy: {{ .Values.monitor.test.image.pullPolicy }}
+      args:
+        - wget
+        - --no-check-certificate
+        - -O-
+        - http://{{ include "hedera-mirror-rest.fullname" . }}-monitor:3000/api/v1/status
+  terminationGracePeriodSeconds: 1
+  restartPolicy: Never
+{{- end -}}

--- a/charts/hedera-mirror-rest/values.yaml
+++ b/charts/hedera-mirror-rest/values.yaml
@@ -105,6 +105,38 @@ middleware:
       attempts: 10
       initialInterval: 100ms
 
+monitor:
+  config: |-
+    {
+      "servers": [
+        {
+          "baseUrl": "http://{{ .Release.Name }}-rest:{{ .Values.service.port }}",
+          "name": "kubernetes"
+        }
+      ]
+    }
+  enabled: true
+  image:
+    pullPolicy: IfNotPresent
+    registry: gcr.io
+    repository: mirrornode/hedera-mirror-rest-monitor
+    tag: ""  # Defaults to the chart's app version
+  resources:
+    limits:
+      cpu: 250m
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 64Mi
+  service:
+    type: ClusterIP
+  test:
+    enabled: true
+    image:
+      pullPolicy: IfNotPresent
+      repository: busybox
+      tag: latest
+
 nodeSelector: {}
 
 podAnnotations: {}

--- a/charts/hedera-mirror/ci/citus-values.yaml
+++ b/charts/hedera-mirror/ci/citus-values.yaml
@@ -9,6 +9,20 @@ monitor:
   enabled: false
 postgresql:
   enabled: false
+rest:
+  monitor:
+    config: |-
+      {
+        "freshness": false,
+        "network": { "enabled": false },
+        "servers": [
+          {
+            "baseUrl": "http://{{ .Release.Name }}-rest:{{ .Values.service.port }}",
+            "name": "kubernetes"
+          }
+        ],
+        "stateproof": { "enabled": false }
+      }
 rosetta:
   test:
     enabled: false

--- a/charts/hedera-mirror/ci/default-values.yaml
+++ b/charts/hedera-mirror/ci/default-values.yaml
@@ -3,3 +3,17 @@ monitor:
   enabled: false
 postgresql:
   fullnameOverride: db
+rest:
+  monitor:
+    config: |-
+      {
+        "freshness": false,
+        "network": { "enabled": false },
+        "servers": [
+          {
+            "baseUrl": "http://{{ .Release.Name }}-rest:{{ .Values.service.port }}",
+            "name": "kubernetes"
+          }
+        ],
+        "stateproof": { "enabled": false }
+      }

--- a/hedera-mirror-rest/accounts.js
+++ b/hedera-mirror-rest/accounts.js
@@ -313,7 +313,7 @@ const getOneAccount = async (req, res) => {
   // Execute query & get a promise
   const entityPromise = pool.queryQuietly(pgEntityQuery, entityParams);
 
-  const [creditDebitQuery] = utils.parseCreditDebitParams(parsedQueryParams, 'ctl.amount');
+  const creditDebitQuery = ''; // type=credit|debit is not supported
   const accountQuery = 'ctl.entity_id = ?';
   const accountParams = [encodedId];
   const transactionTypeQuery = utils.parseTransactionTypeParam(parsedQueryParams);

--- a/hedera-mirror-rest/api/v1/openapi.yml
+++ b/hedera-mirror-rest/api/v1/openapi.yml
@@ -1941,7 +1941,7 @@ components:
         contract_id:
           $ref: '#/components/schemas/EntityId'
         created_contract_ids:
-          description: The network's released supply of hbars in tinybars
+          description: The list of smart contracts that were created by the function call.
           items:
             $ref: '#/components/schemas/EntityId'
           nullable: true
@@ -2994,13 +2994,13 @@ components:
       properties:
         automatic_association:
           type: boolean
-          description: Specifies if the relationship is implicitly/explicity (true/false) associated.
+          description: Specifies if the relationship is implicitly/explicitly associated.
           example: true
           nullable: false
         balance:
           format: int64
           type: integer
-          description: For FUNGIBLE_COMMON the balance that the Account holds in the smallest denomination.NON_FUNGIBLE_UNIQUE - the number of NFTs held by the account.
+          description: For FUNGIBLE_COMMON, the balance that the account holds in the smallest denomination. For NON_FUNGIBLE_UNIQUE, the number of NFTs held by the account.
           example: 5
           nullable: false
         created_timestamp:

--- a/hedera-mirror-rest/monitoring/Dockerfile
+++ b/hedera-mirror-rest/monitoring/Dockerfile
@@ -1,0 +1,26 @@
+FROM node:18.12.1-bullseye-slim
+LABEL maintainer="mirrornode@hedera.com"
+
+# Setup
+ENV DEBIAN_FRONTEND=noninteractive
+ENV NODE_ENV production
+EXPOSE 3000
+EXPOSE 8080
+HEALTHCHECK --interval=10s --retries=3 --start-period=25s --timeout=2s CMD wget -q -O- http://localhost:3000/health/liveness
+WORKDIR /home/node/app/
+COPY . ./
+
+# Install OS updates, required packages, and dependencies
+RUN cd monitor_apis && \
+    apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y wget && \
+    npm install pm2 -g && \
+    npm ci --only=production && \
+    npm cache clean --force --loglevel=error && \
+    chown -R node:node . && \
+    rm -rf /var/lib/apt/lists/*
+USER node
+
+# Run
+ENTRYPOINT ["pm2-runtime", "pm2.json"]

--- a/hedera-mirror-rest/monitoring/README.md
+++ b/hedera-mirror-rest/monitoring/README.md
@@ -11,7 +11,7 @@ It then checks the responses using a few simple checks for those APIs.
 The results of these checks are exposed as a set of REST APIs by this monitoring service as follows:
 
 | API                 | HTTP return code | Description                                                                                                                                          |
-| ------------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+|---------------------|------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
 | /api/v1/status      | 200 (OK)         | Provides a list of results of all tests run on all servers                                                                                           |
 | /api/v1/status/{id} | 200 (OK)         | If all tests pass for a server, then it returns the results                                                                                          |
 |                     | 4xx              | If any tests fail for a server, or if the server is not running, then it returns a 4xx error code to make it easy to integrate with alerting systems |
@@ -83,3 +83,11 @@ pm2 serve . 3001 // Serve the dashboard html pages on another port
 ```
 
 Using your browser, connect to `http://<host>:<port>/index.html`
+
+## Docker
+
+Create a custom `serverlist.json` in the current working directory. Then execute:
+
+```shell
+docker run -it --rm -e CONFIG_PATH=/config -v "${PWD}/serverlist.json:/config/serverlist.json" -p 8080:8080 -p 3000:3000 gcr.io/mirrornode/hedera-mirror-dashboard
+```

--- a/hedera-mirror-rest/monitoring/build.gradle.kts
+++ b/hedera-mirror-rest/monitoring/build.gradle.kts
@@ -21,8 +21,11 @@
 description = "Hedera Mirror Node Monitor API"
 
 plugins {
+    id("docker-conventions")
     id("javascript-conventions")
 }
+
+project.extra.set("dockerImageName", "hedera-mirror-rest-monitor")
 
 node {
     nodeProjectDir.set(projectDir.resolve("monitor_apis"))

--- a/hedera-mirror-rest/monitoring/monitor_apis/config.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/config.js
@@ -45,6 +45,10 @@ const REQUIRED_FIELDS = [
 
 const load = (configFile) => {
   try {
+    if (!configFile) {
+      return {};
+    }
+
     const data = JSON.parse(fs.readFileSync(configFile).toString('utf-8'));
     logger.info(`Loaded configuration source: ${configFile}`);
     return data;
@@ -62,6 +66,11 @@ if (!loaded) {
   config = load(path.join(moduleDirname, 'config', 'default.serverlist.json'));
   const customConfig = load(path.join(moduleDirname, 'config', 'serverlist.json'));
   extend(true, config, customConfig);
+
+  if (process.env.CONFIG_PATH) {
+    const customPathConfig = load(path.join(process.env.CONFIG_PATH, 'serverlist.json'));
+    extend(true, config, customPathConfig);
+  }
 
   for (const field of REQUIRED_FIELDS) {
     if (!_.has(config, field)) {

--- a/hedera-mirror-rest/monitoring/monitor_apis/config/default.serverlist.json
+++ b/hedera-mirror-rest/monitoring/monitor_apis/config/default.serverlist.json
@@ -6,6 +6,7 @@
       "name": "local"
     }
   ],
+  "freshness": true,
   "interval": 60,
   "retry": {
     "maxAttempts": 4,

--- a/hedera-mirror-rest/monitoring/monitor_apis/server.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/server.js
@@ -48,10 +48,24 @@ app.use(compression());
 app.use(cors());
 
 const apiPrefix = '/api/v1';
+const healthDown = '{"status": "DOWN"}';
+const healthUp = '{"status": "UP"}';
 
 common.initResults();
 
 // routes
+app.get('/health/liveness', (req, res) => res.status(200).send(healthUp));
+app.get('/health/readiness', (req, res) => {
+  const status = common.getStatus();
+  const total = status.results.map((r) => r.results.testResults ? 1 : 0).reduce((r, i) => r + i);
+
+  if (total > 0) {
+    res.status(200).send(healthUp);
+  } else {
+    res.status(503).send(healthDown);
+  }
+});
+
 app.get(`${apiPrefix}/status`, (req, res) => {
   const status = common.getStatus();
   const passed = status.results.map((r) => r.results.numPassedTests).reduce((r, i) => r + i);

--- a/hedera-mirror-rest/monitoring/monitor_apis/utils.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/utils.js
@@ -31,6 +31,7 @@ import config from './config';
 
 const apiPrefix = '/api/v1';
 const DEFAULT_LIMIT = 10;
+const {freshness} = config;
 const logger = log4js.getLogger();
 
 /**
@@ -357,7 +358,7 @@ const checkResourceFreshness = async (
   query = {limit: 1, order: 'desc'}
 ) => {
   const {freshnessThreshold} = config[resource];
-  if (freshnessThreshold === 0) {
+  if (!freshness || freshnessThreshold === 0) {
     return {skipped: true};
   }
 


### PR DESCRIPTION
**Description**:

* Add a `CONFIG_PATH` environment variable to monitor API to allow arbitrary config paths 
* Add a `dockerImageName` Gradle property to override image name
* Add a `freshness=true` property to monitor API that skips all freshness checks
* Add a `gcr.io/mirrornode/hedera-mirror-rest-monitor` image
* Add a `start` Gradle task to JavaScript projects
* Add liveness and readiness probes to monitor API
* Add the monitor API and helm test to the Helm deployment
* Fix monitor API accounts check using unknown parameters `timestamp` and `type`
* Remove unsupported `/api/v1/accounts/{id}?type=credit` query parameter

**Related issue(s)**:

Fixes #5303

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
