### PR TITLE
Disable topic message query hint in certain scenario

### DIFF
--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/repository/TopicMessageRepositoryCustomImpl.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/repository/TopicMessageRepositoryCustomImpl.java
@@ -75,7 +75,11 @@ public class TopicMessageRepositoryCustomImpl implements TopicMessageRepositoryC
             typedQuery.setMaxResults((int) filter.getLimit());
         }
 
-        entityManager.createNativeQuery(TOPIC_MESSAGES_BY_ID_QUERY_HINT).executeUpdate();
+        if (filter.getLimit() != 1) {
+            // only apply the hint when limit is not 1
+            entityManager.createNativeQuery(TOPIC_MESSAGES_BY_ID_QUERY_HINT).executeUpdate();
+        }
+
         return typedQuery.getResultList().stream(); // getResultStream()'s cursor doesn't work with reactive streams
     }
 }

--- a/hedera-mirror-rest/topicmessage.js
+++ b/hedera-mirror-rest/topicmessage.js
@@ -137,9 +137,11 @@ const getTopicMessages = async (req, res) => {
   };
 
   // get results and return formatted response
-  // set random_page_cost to 0 to make the cost estimation of using the index on (topic_id, consensus_timestamp)
-  // lower than that of the primary key so pg planner will choose the better index when querying topic messages by id
-  const messages = await getMessages(query, params, constants.zeroRandomPageCostQueryHint);
+  // if limit is not 1, set random_page_cost to 0 to make the cost estimation of using the index on
+  // (topic_id, consensus_timestamp) lower than that of the primary key so pg planner will choose the better index
+  // when querying topic messages by id
+  const queryHint = limit !== 1 ? constants.zeroRandomPageCostQueryHint : undefined;
+  const messages = await getMessages(query, params, queryHint);
   topicMessagesResponse.messages = messages.map((m) => new TopicMessageViewModel(m, messageEncoding));
 
   // populate next
@@ -245,7 +247,7 @@ const acceptedTopicsParameters = new Set([
   constants.filterKeys.LIMIT,
   constants.filterKeys.ORDER,
   constants.filterKeys.SEQUENCE_NUMBER,
-  constants.filterKeys.TIMESTAMP
+  constants.filterKeys.TIMESTAMP,
 ]);
 
 if (utils.isTestEnv()) {


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR skips the query hint for topic message query when limit is 1.

**Related issue(s)**:

Fixes #5315 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
