### PR TITLE
Misc fixes

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/account/AccountAccessorImpl.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/account/AccountAccessorImpl.java
@@ -20,7 +20,13 @@ package com.hedera.mirror.web3.evm.account;
  * ‍
  */
 
+import static com.hedera.mirror.common.util.DomainUtils.fromBytes;
+import static com.hedera.node.app.service.evm.accounts.HederaEvmContractAliases.isMirror;
+
 import com.google.protobuf.ByteString;
+
+import com.hedera.mirror.web3.repository.EntityRepository;
+
 import javax.inject.Named;
 import lombok.RequiredArgsConstructor;
 import org.apache.tuweni.bytes.Bytes;
@@ -34,9 +40,17 @@ import com.hedera.node.app.service.evm.accounts.AccountAccessor;
 public class AccountAccessorImpl implements AccountAccessor {
     public static final int EVM_ADDRESS_SIZE = 20;
     private final MirrorEntityAccess mirrorEntityAccess;
+    private final EntityRepository entityRepository;
 
     @Override
     public Address canonicalAddress(Address addressOrAlias) {
+        if(!isMirror(addressOrAlias.toArray())) {
+            final var entityFoundByAlias = entityRepository.findByEvmAddressAndDeletedIsFalse(addressOrAlias.toArray());
+            if(entityFoundByAlias.isPresent()) {
+                return addressOrAlias;
+            }
+        }
+
         return getAddressOrAlias(addressOrAlias);
     }
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/account/AccountAccessorImpl.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/account/AccountAccessorImpl.java
@@ -37,9 +37,6 @@ public class AccountAccessorImpl implements AccountAccessor {
 
     @Override
     public Address canonicalAddress(Address addressOrAlias) {
-        if (mirrorEntityAccess.isUsable(addressOrAlias)) {
-            return addressOrAlias;
-        }
         return getAddressOrAlias(addressOrAlias);
     }
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/account/AccountAccessorImpl.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/account/AccountAccessorImpl.java
@@ -20,19 +20,16 @@ package com.hedera.mirror.web3.evm.account;
  * ‍
  */
 
-import static com.hedera.mirror.common.util.DomainUtils.fromBytes;
 import static com.hedera.node.app.service.evm.accounts.HederaEvmContractAliases.isMirror;
 
 import com.google.protobuf.ByteString;
-
-import com.hedera.mirror.web3.repository.EntityRepository;
-
 import javax.inject.Named;
 import lombok.RequiredArgsConstructor;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 
 import com.hedera.mirror.web3.evm.store.contract.MirrorEntityAccess;
+import com.hedera.mirror.web3.repository.EntityRepository;
 import com.hedera.node.app.service.evm.accounts.AccountAccessor;
 
 @Named

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/account/AccountAccessorImpl.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/account/AccountAccessorImpl.java
@@ -41,8 +41,9 @@ public class AccountAccessorImpl implements AccountAccessor {
 
     @Override
     public Address canonicalAddress(Address addressOrAlias) {
-        if(!isMirror(addressOrAlias.toArray())) {
-            final var entityFoundByAlias = entityRepository.findByEvmAddressAndDeletedIsFalse(addressOrAlias.toArray());
+        final var addressBytes = addressOrAlias.toArrayUnsafe();
+        if(!isMirror(addressBytes)) {
+            final var entityFoundByAlias = entityRepository.findByEvmAddressAndDeletedIsFalse(addressBytes);
             if(entityFoundByAlias.isPresent()) {
                 return addressOrAlias;
             }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/EvmOperationConstructionUtil.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/EvmOperationConstructionUtil.java
@@ -57,6 +57,7 @@ import com.hedera.node.app.service.evm.contracts.operations.HederaExtCodeSizeOpe
 public class EvmOperationConstructionUtil {
     private static final String EVM_VERSION_0_30 = "v0.30";
     private static final String EVM_VERSION_0_34 = "v0.34";
+    public static final String EVM_VERSION = EVM_VERSION_0_34;
     static final GasCalculator gasCalculator = new LondonGasCalculator();
     private static final EVM evm = constructEvm();
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/EvmOperationConstructionUtil.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/EvmOperationConstructionUtil.java
@@ -56,7 +56,7 @@ import com.hedera.node.app.service.evm.contracts.operations.HederaExtCodeSizeOpe
 @UtilityClass
 public class EvmOperationConstructionUtil {
     private static final String EVM_VERSION_0_30 = "v0.30";
-    private static final String EVM_VERSION_0_32 = "v0.32";
+    private static final String EVM_VERSION_0_34 = "v0.34";
     static final GasCalculator gasCalculator = new LondonGasCalculator();
     private static final EVM evm = constructEvm();
 
@@ -65,7 +65,7 @@ public class EvmOperationConstructionUtil {
                 EVM_VERSION_0_30,
                 () -> new ContractCreationProcessor(
                         gasCalculator, evm, true, List.of(), 1),
-                EVM_VERSION_0_32,
+                EVM_VERSION_0_34,
                 () -> new ContractCreationProcessor(
                         gasCalculator, evm, true, List.of(), 1));
     }
@@ -75,7 +75,7 @@ public class EvmOperationConstructionUtil {
                 EVM_VERSION_0_30,
                 () -> new MessageCallProcessor(
                         evm, new PrecompileContractRegistry()),
-                EVM_VERSION_0_32,
+                EVM_VERSION_0_34,
                 () -> new MessageCallProcessor(
                         evm, new PrecompileContractRegistry()));
     }
@@ -84,14 +84,14 @@ public class EvmOperationConstructionUtil {
         var operationRegistry = new OperationRegistry();
         BiPredicate<Address, MessageFrame> validator = (Address x, MessageFrame y) -> true;
 
-         Set.of(new HederaBalanceOperation(gasCalculator, validator),
+        registerParisOperations(operationRegistry, gasCalculator, BigInteger.ZERO);
+        Set.of(new HederaBalanceOperation(gasCalculator, validator),
                 new HederaDelegateCallOperation(gasCalculator, validator),
                 new HederaExtCodeCopyOperation(gasCalculator, validator),
                 new HederaExtCodeHashOperation(gasCalculator, validator),
                 new HederaExtCodeSizeOperation(gasCalculator, validator),
                 new HederaEvmSLoadOperation(gasCalculator)).forEach(operationRegistry::put);
-        registerParisOperations(operationRegistry, gasCalculator, BigInteger.ZERO);
 
-        return new EVM(operationRegistry, gasCalculator, EvmConfiguration.DEFAULT, EvmSpecVersion.LONDON);
+        return new EVM(operationRegistry, gasCalculator, EvmConfiguration.DEFAULT, EvmSpecVersion.PARIS);
     }
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/properties/MirrorNodeEvmProperties.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/properties/MirrorNodeEvmProperties.java
@@ -44,7 +44,7 @@ public class MirrorNodeEvmProperties implements EvmProperties {
     private boolean dynamicEvmVersion;
 
     @NotBlank
-    private String evmVersion = "v0.32";
+    private String evmVersion = "v0.34";
 
     @NotBlank
     private String fundingAccount = "0x0000000000000000000000000000000000000062";

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/properties/MirrorNodeEvmProperties.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/properties/MirrorNodeEvmProperties.java
@@ -20,6 +20,8 @@ package com.hedera.mirror.web3.evm.properties;
  * ‍
  */
 
+import static com.hedera.mirror.web3.evm.contracts.execution.EvmOperationConstructionUtil.EVM_VERSION;
+
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
@@ -44,7 +46,7 @@ public class MirrorNodeEvmProperties implements EvmProperties {
     private boolean dynamicEvmVersion;
 
     @NotBlank
-    private String evmVersion = "v0.34";
+    private String evmVersion = EVM_VERSION;
 
     @NotBlank
     private String fundingAccount = "0x0000000000000000000000000000000000000062";

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccess.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccess.java
@@ -72,12 +72,8 @@ public class MirrorEntityAccess implements HederaEvmEntityAccess {
             return false;
         }
 
-        if (createdTimestamp != null && autoRenewPeriod != null &&
-                (createdTimestamp + autoRenewPeriod) <= currentTime) {
-            return false;
-        }
-
-        return true;
+        return createdTimestamp == null || autoRenewPeriod == null ||
+                (createdTimestamp + autoRenewPeriod) > currentTime;
     }
 
     @Override

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccess.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccess.java
@@ -55,24 +55,26 @@ public class MirrorEntityAccess implements HederaEvmEntityAccess {
 
         if (optionalEntity.isEmpty()) {
             return false;
-        } else {
-            final var entity = optionalEntity.get();
+        }
 
-            final var balance = entity.getBalance();
-            if(balance != null && balance > 0) {
-                return true;
-            }
+        final var entity = optionalEntity.get();
+        final var balance = entity.getBalance();
+        if (balance != null && balance > 0) {
+            return true;
+        }
 
-            final var expirationTimestamp = entity.getExpirationTimestamp();
-            final var createdTimestamp = entity.getCreatedTimestamp();
-            final var autoRenewPeriod = entity.getAutoRenewPeriod();
+        final var expirationTimestamp = entity.getExpirationTimestamp();
+        final var createdTimestamp = entity.getCreatedTimestamp();
+        final var autoRenewPeriod = entity.getAutoRenewPeriod();
+        final var currentTime = Instant.now().getEpochSecond();
 
-            final var currentTime = Instant.now().getEpochSecond();
-            if((expirationTimestamp != null && expirationTimestamp <= currentTime) ||
-                    (createdTimestamp != null && autoRenewPeriod != null &&
-                            (createdTimestamp + autoRenewPeriod) <= currentTime)) {
-                return false;
-            }
+        if (expirationTimestamp != null && expirationTimestamp <= currentTime) {
+            return false;
+        }
+
+        if (createdTimestamp != null && autoRenewPeriod != null &&
+                (createdTimestamp + autoRenewPeriod) <= currentTime) {
+            return false;
         }
 
         return true;
@@ -81,17 +83,7 @@ public class MirrorEntityAccess implements HederaEvmEntityAccess {
     @Override
     public long getBalance(final Address address) {
         final var entity = findEntity(address);
-
-        if(entity.isPresent()) {
-            final var balance = entity.get().getBalance();
-            if(balance != null && balance > 0) {
-                return balance;
-            } else {
-                return 0L;
-            }
-        }
-
-        return 0L;
+        return entity.map(Entity::getBalance).orElse(0L);
     }
 
     @Override

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccess.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccess.java
@@ -48,9 +48,11 @@ public class MirrorEntityAccess implements HederaEvmEntityAccess {
     private final ContractRepository contractRepository;
     private final ContractStateRepository contractStateRepository;
 
+    //In the corresponding services implementation, we check whether the account is expired. We don't have this concept
+    //in mirror-node side, so we should always return true.
     @Override
     public boolean isUsable(final Address address) {
-        return findEntity(address).filter(e -> e.getBalance() > 0).isPresent();
+        return true;
     }
 
     @Override

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/account/AccountAccessorImplTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/account/AccountAccessorImplTest.java
@@ -74,14 +74,20 @@ class AccountAccessorImplTest {
     }
 
     @Test
-    void canonicalAddressIsUsable() {
+    void canonicalAddress() {
         final var result = accountAccessor.canonicalAddress(ADDRESS);
         assertThat(result).isEqualTo(ADDRESS);
     }
 
     @Test
-    void canonicalAliasAddressIsUsable() {
+    void canonicalAliasAddress() {
         when(entityRepository.findByEvmAddressAndDeletedIsFalse(ALIAS_ADDRESS.toArray())).thenReturn(Optional.of(account));
+        final var result = accountAccessor.canonicalAddress(ALIAS_ADDRESS);
+        assertThat(result).isEqualTo(ALIAS_ADDRESS);
+    }
+
+    @Test
+    void missingCanonicalAliasAddressResolvesToItself() {
         final var result = accountAccessor.canonicalAddress(ALIAS_ADDRESS);
         assertThat(result).isEqualTo(ALIAS_ADDRESS);
     }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/account/AccountAccessorImplTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/account/AccountAccessorImplTest.java
@@ -65,14 +65,12 @@ class AccountAccessorImplTest {
 
     @Test
     void canonicalAddressIsUsableTrue() {
-        when(mirrorEntityAccess.isUsable(ADDRESS)).thenReturn(true);
         final var result = accountAccessor.canonicalAddress(ADDRESS);
         assertThat(result).isEqualTo(ADDRESS);
     }
 
     @Test
     void canonicalAddressIsUsableFalse() {
-        when(mirrorEntityAccess.isUsable(ADDRESS)).thenReturn(false);
         final var result = accountAccessor.canonicalAddress(ADDRESS);
         assertThat(result).isEqualTo(ADDRESS);
     }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/account/AccountAccessorImplTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/account/AccountAccessorImplTest.java
@@ -65,12 +65,14 @@ class AccountAccessorImplTest {
 
     @Test
     void canonicalAddressIsUsableTrue() {
+        when(mirrorEntityAccess.isUsable(ADDRESS)).thenReturn(true);
         final var result = accountAccessor.canonicalAddress(ADDRESS);
         assertThat(result).isEqualTo(ADDRESS);
     }
 
     @Test
     void canonicalAddressIsUsableFalse() {
+        when(mirrorEntityAccess.isUsable(ADDRESS)).thenReturn(false);
         final var result = accountAccessor.canonicalAddress(ADDRESS);
         assertThat(result).isEqualTo(ADDRESS);
     }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/account/AccountAccessorImplTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/account/AccountAccessorImplTest.java
@@ -26,8 +26,12 @@ import static org.mockito.Mockito.when;
 
 import com.google.protobuf.ByteString;
 
+import com.hedera.mirror.common.domain.entity.Entity;
 import com.hedera.mirror.web3.evm.store.contract.MirrorEntityAccess;
 
+import com.hedera.mirror.web3.repository.EntityRepository;
+
+import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 import org.junit.jupiter.api.Test;
@@ -40,12 +44,18 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class AccountAccessorImplTest {
 
     private static final String HEX = "0x00000000000000000000000000000000000004e4";
+    private static final String ALIAS_HEX = "0x67d8d32e9bf1a9968a5ff53b87d777aa8ebbee69";
     private static final Address ADDRESS = Address.fromHexString(HEX);
+    private static final Address ALIAS_ADDRESS = Address.fromHexString(ALIAS_HEX);
     private static final Bytes BYTES = Bytes.fromHexString(HEX);
     private static final byte[] DATA = BYTES.toArrayUnsafe();
 
     @Mock
     private MirrorEntityAccess mirrorEntityAccess;
+    @Mock
+    private EntityRepository entityRepository;
+    @Mock
+    private Entity account;
     @InjectMocks
     public AccountAccessorImpl accountAccessor;
 
@@ -64,15 +74,16 @@ class AccountAccessorImplTest {
     }
 
     @Test
-    void canonicalAddressIsUsableTrue() {
+    void canonicalAddressIsUsable() {
         final var result = accountAccessor.canonicalAddress(ADDRESS);
         assertThat(result).isEqualTo(ADDRESS);
     }
 
     @Test
-    void canonicalAddressIsUsableFalse() {
-        final var result = accountAccessor.canonicalAddress(ADDRESS);
-        assertThat(result).isEqualTo(ADDRESS);
+    void canonicalAliasAddressIsUsable() {
+        when(entityRepository.findByEvmAddressAndDeletedIsFalse(ALIAS_ADDRESS.toArray())).thenReturn(Optional.of(account));
+        final var result = accountAccessor.canonicalAddress(ALIAS_ADDRESS);
+        assertThat(result).isEqualTo(ALIAS_ADDRESS);
     }
 
     @Test

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/properties/MirrorNodeEvmPropertiesTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/properties/MirrorNodeEvmPropertiesTest.java
@@ -31,7 +31,7 @@ import com.hedera.mirror.web3.Web3IntegrationTest;
 
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
 class MirrorNodeEvmPropertiesTest extends Web3IntegrationTest {
-    private static final String EVM_VERSION = "v0.32";
+    private static final String EVM_VERSION = "v0.34";
     private static final int MAX_REFUND_PERCENT = 20;
     private static final Address FUNDING_ADDRESS =
             Address.fromHexString("0x0000000000000000000000000000000000000062");

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccessTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccessTest.java
@@ -100,6 +100,16 @@ class MirrorEntityAccessTest {
     }
 
     @Test
+    void isNotUsableWithExpiredTimestampAndNullBalance() {
+        final long expiredTimestamp = Instant.MIN.getEpochSecond();
+        when(entityRepository.findByIdAndDeletedIsFalse(ENTITY_ID)).thenReturn(Optional.of(entity));
+        when(entity.getExpirationTimestamp()).thenReturn(expiredTimestamp);
+        when(entity.getBalance()).thenReturn(null);
+        final var result = mirrorEntityAccess.isUsable(ADDRESS);
+        assertThat(result).isFalse();
+    }
+
+    @Test
     void isUsableWithNotExpiredTimestamp() {
         final long expiredTimestamp = Instant.MAX.getEpochSecond();
         when(entityRepository.findByIdAndDeletedIsFalse(ENTITY_ID)).thenReturn(Optional.of(entity));
@@ -136,6 +146,17 @@ class MirrorEntityAccessTest {
         when(entity.getCreatedTimestamp()).thenReturn(Instant.now().getEpochSecond());
         when(entity.getAutoRenewPeriod()).thenReturn(null);
         when(entity.getExpirationTimestamp()).thenReturn(null);
+        final var result = mirrorEntityAccess.isUsable(ADDRESS);
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void isUsableWithEmptyExpiryAndAutoRenewAndCreatedTimestampPeriod() {
+        when(entityRepository.findByIdAndDeletedIsFalse(ENTITY_ID)).thenReturn(Optional.of(entity));
+        when(entity.getCreatedTimestamp()).thenReturn(Instant.now().getEpochSecond());
+        when(entity.getAutoRenewPeriod()).thenReturn(null);
+        when(entity.getExpirationTimestamp()).thenReturn(null);
+        when(entity.getCreatedTimestamp()).thenReturn(null);
         final var result = mirrorEntityAccess.isUsable(ADDRESS);
         assertThat(result).isTrue();
     }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccessTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccessTest.java
@@ -24,6 +24,7 @@ import static com.google.protobuf.ByteString.EMPTY;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Mockito.when;
 
+import java.time.Instant;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
@@ -64,11 +65,78 @@ class MirrorEntityAccessTest {
     @InjectMocks
     private MirrorEntityAccess mirrorEntityAccess;
 
-    //We hard-code isUsable to always return true, due to this method logic not applicable to mirror-node state
     @Test
-    void isUsableWithWrongAliasReturnsTrue() {
+    void isUsableWithPositiveBalance() {
+        final long balance = 23L;
+        when(entityRepository.findByIdAndDeletedIsFalse(ENTITY_ID)).thenReturn(Optional.of(entity));
+        when(entity.getBalance()).thenReturn(balance);
+        final var result = mirrorEntityAccess.isUsable(ADDRESS);
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void isNotUsableWithNegativeBalance() {
+        final long balance = -1L;
+        when(entityRepository.findByIdAndDeletedIsFalse(ENTITY_ID)).thenReturn(Optional.of(entity));
+        when(entity.getBalance()).thenReturn(balance);
+        final var result = mirrorEntityAccess.isUsable(ADDRESS);
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void isNotUsableWithWrongAlias() {
         final var address = Address.fromHexString("0x3232134567785444e");
         final var result = mirrorEntityAccess.isUsable(address);
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void isNotUsableWithExpiredTimestamp() {
+        final long expiredTimestamp = Instant.MIN.getEpochSecond();
+        when(entityRepository.findByIdAndDeletedIsFalse(ENTITY_ID)).thenReturn(Optional.of(entity));
+        when(entity.getExpirationTimestamp()).thenReturn(expiredTimestamp);
+        final var result = mirrorEntityAccess.isUsable(ADDRESS);
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void isUsableWithNotExpiredTimestamp() {
+        final long expiredTimestamp = Instant.MAX.getEpochSecond();
+        when(entityRepository.findByIdAndDeletedIsFalse(ENTITY_ID)).thenReturn(Optional.of(entity));
+        when(entity.getExpirationTimestamp()).thenReturn(expiredTimestamp);
+        when(entity.getCreatedTimestamp()).thenReturn(Instant.now().getEpochSecond());
+        when(entity.getAutoRenewPeriod()).thenReturn(Instant.MAX.getEpochSecond());
+        final var result = mirrorEntityAccess.isUsable(ADDRESS);
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void isNotUsableWithExpiredAutoRenewTimestamp() {
+        final long autoRenewPeriod = Instant.MAX.getEpochSecond();
+        when(entityRepository.findByIdAndDeletedIsFalse(ENTITY_ID)).thenReturn(Optional.of(entity));
+        when(entity.getCreatedTimestamp()).thenReturn(Instant.now().getEpochSecond() - 1000L);
+        when(entity.getAutoRenewPeriod()).thenReturn(autoRenewPeriod);
+        final var result = mirrorEntityAccess.isUsable(ADDRESS);
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void isUsableWithNotExpiredAutoRenewTimestamp() {
+        when(entityRepository.findByIdAndDeletedIsFalse(ENTITY_ID)).thenReturn(Optional.of(entity));
+        when(entity.getCreatedTimestamp()).thenReturn(Instant.now().getEpochSecond());
+        when(entity.getAutoRenewPeriod()).thenReturn(Instant.MAX.getEpochSecond());
+        when(entity.getExpirationTimestamp()).thenReturn(Instant.MAX.getEpochSecond());
+        final var result = mirrorEntityAccess.isUsable(ADDRESS);
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void isUsableWithEmptyExpiryAndAutoRenewPeriod() {
+        when(entityRepository.findByIdAndDeletedIsFalse(ENTITY_ID)).thenReturn(Optional.of(entity));
+        when(entity.getCreatedTimestamp()).thenReturn(Instant.now().getEpochSecond());
+        when(entity.getAutoRenewPeriod()).thenReturn(null);
+        when(entity.getExpirationTimestamp()).thenReturn(null);
+        final var result = mirrorEntityAccess.isUsable(ADDRESS);
         assertThat(result).isTrue();
     }
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccessTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccessTest.java
@@ -64,8 +64,9 @@ class MirrorEntityAccessTest {
     @InjectMocks
     private MirrorEntityAccess mirrorEntityAccess;
 
+    //We hard-code isUsable to always return true, due to this method logic not applicable to mirror-node state
     @Test
-    void isUsableWithPositiveBalance() {
+    void isUsableWithPositiveBalanceReturnsTrue() {
         final long balance = 23L;
         when(entityRepository.findByIdAndDeletedIsFalse(ENTITY_ID)).thenReturn(Optional.of(entity));
         when(entity.getBalance()).thenReturn(balance);
@@ -73,20 +74,22 @@ class MirrorEntityAccessTest {
         assertThat(result).isTrue();
     }
 
+    //We hard-code isUsable to always return true, due to this method logic not applicable to mirror-node state
     @Test
-    void isUsableWithNegativeBalance() {
+    void isUsableWithNegativeBalanceReturnsTrue() {
         final long balance = -1L;
         when(entityRepository.findByIdAndDeletedIsFalse(ENTITY_ID)).thenReturn(Optional.of(entity));
         when(entity.getBalance()).thenReturn(balance);
         final var result = mirrorEntityAccess.isUsable(ADDRESS);
-        assertThat(result).isFalse();
+        assertThat(result).isTrue();
     }
 
+    //We hard-code isUsable to always return true, due to this method logic not applicable to mirror-node state
     @Test
-    void isUsableWithAliasNegative() {
+    void isUsableWithWrongAliasReturnsTrue() {
         final var address = Address.fromHexString("0x3232134567785444e");
         final var result = mirrorEntityAccess.isUsable(address);
-        assertThat(result).isFalse();
+        assertThat(result).isTrue();
     }
 
     @Test

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccessTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccessTest.java
@@ -66,26 +66,6 @@ class MirrorEntityAccessTest {
 
     //We hard-code isUsable to always return true, due to this method logic not applicable to mirror-node state
     @Test
-    void isUsableWithPositiveBalanceReturnsTrue() {
-        final long balance = 23L;
-        when(entityRepository.findByIdAndDeletedIsFalse(ENTITY_ID)).thenReturn(Optional.of(entity));
-        when(entity.getBalance()).thenReturn(balance);
-        final var result = mirrorEntityAccess.isUsable(ADDRESS);
-        assertThat(result).isTrue();
-    }
-
-    //We hard-code isUsable to always return true, due to this method logic not applicable to mirror-node state
-    @Test
-    void isUsableWithNegativeBalanceReturnsTrue() {
-        final long balance = -1L;
-        when(entityRepository.findByIdAndDeletedIsFalse(ENTITY_ID)).thenReturn(Optional.of(entity));
-        when(entity.getBalance()).thenReturn(balance);
-        final var result = mirrorEntityAccess.isUsable(ADDRESS);
-        assertThat(result).isTrue();
-    }
-
-    //We hard-code isUsable to always return true, due to this method logic not applicable to mirror-node state
-    @Test
     void isUsableWithWrongAliasReturnsTrue() {
         final var address = Address.fromHexString("0x3232134567785444e");
         final var result = mirrorEntityAccess.isUsable(address);


### PR DESCRIPTION
**Description**:

Several issues were identified in the custom EVM related logic in web3 module. This PR fixes:

* Fix order of binding custom op codes - currently the custom op codes were not taken into account and the Besu internal implementations were used instead
* Change EVM version from `0.32` to `0.34`
* Fix `MirrorEntityAccess.isUsable` implementation. In the corresponding services implementation we check whether a given account is expired. We don't keep this information on mirror-node side, so we should always return `true`.
* Remove unnecessary logic for `canonicalAddress`. This logic is applicable for services where we keep a store for aliases.

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
