### PR TITLE
Fix migration SQL performance issue

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/MergeDuplicateBlocksMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/MergeDuplicateBlocksMigration.java
@@ -50,17 +50,11 @@ class MergeDuplicateBlocksMigration extends RepeatableMigration {
               from block1
               where block2.consensus_end = 1675962001984524003 and block1.index = block2.index
               returning block2.*
-            ),
-            transaction_index as (
-              select row_number() over (order by t.consensus_timestamp asc) - 1 as new_index, t.consensus_timestamp
-              from transaction t, merged_block b
-              where t.consensus_timestamp >= b.consensus_start and t.consensus_timestamp <= b.consensus_end
-              order by consensus_timestamp asc
             )
             update transaction t
-            set index = ti.new_index
-            from transaction_index ti
-            where t.consensus_timestamp = ti.consensus_timestamp;
+            set index = t.index + block1.count
+            from block1
+            where consensus_timestamp > 1675962000231859003 and consensus_timestamp <= 1675962001984524003;
             """;
 
     private final JdbcTemplate jdbcTemplate;

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/MergeDuplicateBlocksMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/MergeDuplicateBlocksMigrationTest.java
@@ -121,7 +121,7 @@ class MergeDuplicateBlocksMigrationTest extends IntegrationTest {
 
     private RecordFile block(long timestamp) {
         return domainBuilder.recordFile()
-                .customize(r -> r.consensusEnd(timestamp).consensusStart(timestamp - 1).index(NUMBER)
+                .customize(r -> r.consensusEnd(timestamp).consensusStart(timestamp - 1).count(2L).index(NUMBER)
                         .hapiVersionMinor((int) domainBuilder.id()))
                 .persist();
     }


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR optimizes the migration SQL

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

ran on mainnet-staging db

```
mirror_node=> begin;
BEGIN
Time: 2.210 ms
mirror_node=*>             with block1 as (
mirror_node(*>               delete from record_file
mirror_node(*>               where consensus_end = 1675962000231859003 and index = 44029066
mirror_node(*>               returning *
mirror_node(*>             ),
mirror_node-*>             merged_block as (
mirror_node(*>               update record_file block2 set
mirror_node(*>               consensus_start = block1.consensus_start,
mirror_node(*>               count = block1.count + block2.count,
mirror_node(*>               gas_used = block1.gas_used + block2.gas_used,
mirror_node(*>               load_start = block1.load_start,
mirror_node(*>               name = block1.name,
mirror_node(*>               prev_hash = block1.prev_hash,
mirror_node(*>               sidecar_count = block1.sidecar_count + block2.sidecar_count,
mirror_node(*>               size = block1.size + block2.size
mirror_node(*>               from block1
mirror_node(*>               where block2.consensus_end = 1675962001984524003 and block1.index = block2.index
mirror_node(*>               returning block2.*
mirror_node(*>             )
mirror_node-*>             update transaction t
mirror_node-*>             set index = t.index + block1.count
mirror_node-*>             from block1
mirror_node-*>             where consensus_timestamp > 1675962000231859003 and consensus_timestamp <= 1675962001984524003;
UPDATE 578
Time: 47.345 ms
mirror_node=*> rollback;
ROLLBACK
```

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
