### PR TITLE
Fix EntityRecordItemListenerFileTest failure

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/MergeDuplicateBlocksMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/MergeDuplicateBlocksMigration.java
@@ -23,6 +23,7 @@ package com.hedera.mirror.importer.migration;
 import javax.inject.Named;
 import java.io.IOException;
 
+import com.google.common.base.Stopwatch;
 import com.hedera.mirror.importer.MirrorProperties;
 import com.hedera.mirror.importer.config.Owner;
 import org.springframework.context.annotation.Lazy;
@@ -74,7 +75,9 @@ class MergeDuplicateBlocksMigration extends RepeatableMigration {
             return;
         }
 
-        jdbcTemplate.update(SQL);
+        var stopwatch = Stopwatch.createStarted();
+        int count = jdbcTemplate.update(SQL);
+        log.info("Successfully merged the blocks and fixed {} transaction indexes in {}", count, stopwatch);
     }
 
     @Override

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/IntegrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/IntegrationTest.java
@@ -115,6 +115,7 @@ public abstract class IntegrationTest {
     protected void reset() {
         cacheManagers.forEach(c -> c.getCacheNames().forEach(name -> c.getCache(name).clear()));
         mirrorDateRangePropertiesProcessor.clear();
+        mirrorProperties.setNetwork(MirrorProperties.HederaNetwork.TESTNET);
         mirrorProperties.setStartDate(Instant.EPOCH);
         jdbcOperations.execute(cleanupSql);
         retryRecorder.reset();


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR fixes `EntityRecordItemListenerFileTest` failure:

- reset network to `TESTNET` in integration test
- add verbose success log to MergeDuplicateBlocksMigration 

**Related issue(s)**:

Fixes #5400 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
The regression is caused by MergeDuplicateBlocksMigrationTest setting network to mainnet so the address book related EntityRecordItemListenerFileTest cases started to load the mainnet bootstrap adressbook instead of testnet's.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
