### PR TITLE
Revert spring-cloud-gcp-dependencies version bump

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,7 +48,7 @@ dependencies {
         api("com.esaulpaugh:headlong:9.1.1")
         api("com.github.meanbeanlib:meanbean:3.0.0-M9")
         api("com.github.vertical-blank:sql-formatter:2.0.3")
-        api("com.google.cloud:spring-cloud-gcp-dependencies:3.4.3")
+        api("com.google.cloud:spring-cloud-gcp-dependencies:3.4.4")
         api("com.google.guava:guava:31.1-jre")
         api("com.google.protobuf:protobuf-java:$protobufVersion")
         api("com.graphql-java-generator:graphql-java-client-dependencies:1.18.9")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,7 +48,7 @@ dependencies {
         api("com.esaulpaugh:headlong:9.1.1")
         api("com.github.meanbeanlib:meanbean:3.0.0-M9")
         api("com.github.vertical-blank:sql-formatter:2.0.3")
-        api("com.google.cloud:spring-cloud-gcp-dependencies:4.1.0")
+        api("com.google.cloud:spring-cloud-gcp-dependencies:3.4.3")
         api("com.google.guava:guava:31.1-jre")
         api("com.google.protobuf:protobuf-java:$protobufVersion")
         api("com.graphql-java-generator:graphql-java-client-dependencies:1.18.9")


### PR DESCRIPTION
Signed-off-by: Edwin Greene <edwin.greene@swirldslabs.com>

**Description**:
Version `4.1.0` of `spring-cloud-gcp-dependencies` is not supported.

**Related issue(s)**:

Fixes #5418 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
