### PR TITLE
Update chart dependencies

### DIFF
--- a/charts/hedera-mirror-common/Chart.yaml
+++ b/charts/hedera-mirror-common/Chart.yaml
@@ -3,25 +3,25 @@ appVersion: 0.76.0-SNAPSHOT
 dependencies:
   - name: loki
     condition: loki.enabled
-    version: 2.16.0
+    version: 4.6.1
     repository: https://grafana.github.io/helm-charts
   - condition: prometheus-adapter.enabled
     name: prometheus-adapter
     repository: https://prometheus-community.github.io/helm-charts
-    version: 3.4.0
+    version: 4.1.1
   - alias: prometheus
     condition: prometheus.enabled
     name: kube-prometheus-stack
     repository: https://prometheus-community.github.io/helm-charts
-    version: 39.11.0
+    version: 45.1.0
   - name: promtail
     condition: promtail.enabled
-    version: 6.3.0
+    version: 6.8.3
     repository: https://grafana.github.io/helm-charts
   - condition: traefik.enabled
     name: traefik
     repository: https://helm.traefik.io/traefik
-    version: 10.24.1
+    version: 21.1.0
 description: Hedera Mirror Node common components installed globally for use across namespaces
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067

--- a/charts/hedera-mirror-common/dashboards/kubernetes-cluster-monitoring-via-prometheus_rev2.json
+++ b/charts/hedera-mirror-common/dashboards/kubernetes-cluster-monitoring-via-prometheus_rev2.json
@@ -1548,7 +1548,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum (rate (container_network_receive_bytes_total{kubernetes_io_hostname=~\"^$Node$\",namespace=~\"$namespace\"}[$interval]))",
+          "expr": "sum(rate(container_network_receive_bytes_total{node=~\"^$Node$\"}[__rate_interval]))",
           "format": "time_series",
           "interval": "10s",
           "intervalFactor": 1,
@@ -1559,7 +1559,7 @@
         },
         {
           "exemplar": true,
-          "expr": "- sum (rate (container_network_transmit_bytes_total{kubernetes_io_hostname=~\"^$Node$\",namespace=~\"$namespace\"}[$interval]))",
+          "expr": "- sum(rate(container_network_transmit_bytes_total{node=~\"^$Node$\"}[__rate_interval]))",
           "format": "time_series",
           "interval": "10s",
           "intervalFactor": 1,
@@ -1670,22 +1670,22 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum (rate (container_network_receive_bytes_total{image!=\"\",kubernetes_io_hostname=~\"^$Node$\",namespace=~\"$namespace\"}[$interval])) by (pod)",
+          "expr": "sum(rate(container_network_receive_bytes_total{node=~\"^$Node$\"}[$__rate_interval]))",
           "format": "time_series",
           "interval": "10s",
           "intervalFactor": 1,
-          "legendFormat": "-> {{ pod }}",
+          "legendFormat": "Received",
           "metric": "network",
           "refId": "A",
           "step": 10
         },
         {
           "exemplar": true,
-          "expr": "- sum (rate (container_network_transmit_bytes_total{image!=\"\",kubernetes_io_hostname=~\"^$Node$\",namespace=~\"$namespace\"}[$interval])) by (pod)",
+          "expr": "- sum(rate(container_network_transmit_bytes_total{node=~\"^$Node$\"}[__rate_interval]))",
           "format": "time_series",
           "interval": "10s",
           "intervalFactor": 1,
-          "legendFormat": "<- {{ pod }}",
+          "legendFormat": "Sent",
           "metric": "network",
           "refId": "B",
           "step": 10

--- a/charts/hedera-mirror-common/templates/configmap-log-alerts.yaml
+++ b/charts/hedera-mirror-common/templates/configmap-log-alerts.yaml
@@ -1,0 +1,12 @@
+{{- if (gt (len .Values.loki.rules) 0) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels: {{ include "hedera-mirror-common.labels" . | nindent 4 }}
+  name: mirror-log-alerts
+  namespace: {{ include "hedera-mirror-common.namespace" . }}
+data:
+  rules.yaml: |-
+    groups:
+    {{- toYaml .Values.loki.rules | nindent 6 }}
+{{- end }}

--- a/charts/hedera-mirror-common/values.yaml
+++ b/charts/hedera-mirror-common/values.yaml
@@ -5,8 +5,41 @@ labels: {}
 
 loki:
   enabled: true
-  # TODO: Enhance Loki to support watching for PrometheusRules via the Kubernetes API so we can declare these within their chart
-  alerting_groups:
+  gateway:
+    enabled: false
+  loki:
+    auth_enabled: false
+    commonConfig:
+      replication_factor: 1
+    storage:
+      type: 'filesystem'
+    structuredConfig:
+      ruler:
+        alertmanager_url: http://{{ .Release.Name }}-prometheus-alertmanager:9093
+        enable_alertmanager_v2: true
+        enable_api: true
+        ring:
+          kvstore:
+            store: inmemory
+        rule_path: /tmp/scratch
+        storage:
+          type: local
+          local:
+            directory: /rules
+      table_manager:
+        retention_deletes_enabled: true
+        retention_period: 2184h
+  monitoring:
+    lokiCanary:
+      enabled: false
+    selfMonitoring:
+      enabled: false
+      grafanaAgent:
+        installOperator: false
+  persistence:
+    enableStatefulSetAutoDeletePVC: true
+    size: 100Gi
+  rules:
     - name: hedera-mirror-grpc
       rules:
         - alert: GrpcLogErrors
@@ -94,38 +127,27 @@ loki:
           for: 1m
           labels:
             severity: critical
-  config:
-    ruler:
-      alertmanager_url: http://{{ .Release.Name }}-prometheus-alertmanager:9093
-      enable_alertmanager_v2: true
-      enable_api: true
-      ring:
-        kvstore:
-          store: inmemory
-      rule_path: /tmp/scratch
-      storage:
-        type: local
-        local:
-          directory: /rules
-    table_manager:
-      retention_deletes_enabled: true
-      retention_period: 2184h
-  networkPolicy:
-    enabled: true
-  persistence:
-    enabled: true
-    size: 100Gi
-  rbac:
-    pspEnabled: false
-  resources:
-    limits:
-      cpu: 200m
-      memory: 256Mi
-    requests:
-      cpu: 50m
-      memory: 64Mi
   serviceMonitor:
     enabled: true
+  singleBinary:
+    extraVolumeMounts:
+      - mountPath: /rules
+        name: rules
+    extraVolumes:
+      - name: rules
+        configMap:
+          defaultMode: 420
+          name: mirror-log-alerts
+    replicas: 1
+    resources:
+      limits:
+        cpu: 200m
+        memory: 256Mi
+      requests:
+        cpu: 50m
+        memory: 64Mi
+  test:
+    enabled: false
 
 networkPolicy:
   enabled: false
@@ -361,7 +383,10 @@ traefik:
     access:
       enabled: true
       filters:
-        statuscodes: 300-599
+        statuscodes: 400-599
+  metrics:
+    prometheus:
+      addServicesLabels: true
   podDisruptionBudget:
     enabled: true
     minAvailable: 1

--- a/charts/hedera-mirror-grpc/templates/hpa.yaml
+++ b/charts/hedera-mirror-grpc/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.hpa.enabled -}}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   labels: {{ include "hedera-mirror-grpc.labels" . | nindent 4 }}

--- a/charts/hedera-mirror-rest/templates/hpa.yaml
+++ b/charts/hedera-mirror-rest/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.hpa.enabled -}}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   labels: {{ include "hedera-mirror-rest.labels" . | nindent 4 }}

--- a/charts/hedera-mirror-rosetta/templates/hpa.yaml
+++ b/charts/hedera-mirror-rosetta/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.hpa.enabled -}}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   labels: {{ include "hedera-mirror-rosetta.labels" . | nindent 4 }}

--- a/charts/hedera-mirror-web3/templates/hpa.yaml
+++ b/charts/hedera-mirror-web3/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.hpa.enabled -}}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   labels: {{ include "hedera-mirror-web3.labels" . | nindent 4 }}

--- a/charts/hedera-mirror/Chart.yaml
+++ b/charts/hedera-mirror/Chart.yaml
@@ -5,7 +5,7 @@ dependencies:
     condition: citus.enabled
     name: postgresql
     repository: https://charts.bitnami.com/bitnami
-    version: 12.1.2
+    version: 12.1.4
   - alias: grpc
     condition: grpc.enabled
     name: hedera-mirror-grpc
@@ -27,11 +27,11 @@ dependencies:
     condition: postgresql.enabled
     name: postgresql-ha
     repository: https://charts.bitnami.com/bitnami
-    version: 9.4.11
+    version: 11.1.1
   - condition: redis.enabled
     name: redis
     repository: https://charts.bitnami.com/bitnami
-    version: 17.3.7
+    version: 17.7.3
   - alias: rest
     condition: rest.enabled
     name: hedera-mirror-rest

--- a/charts/hedera-mirror/templates/alertmanagerconfig.yaml
+++ b/charts/hedera-mirror/templates/alertmanagerconfig.yaml
@@ -2,8 +2,8 @@
 apiVersion: monitoring.coreos.com/v1alpha1
 kind: AlertmanagerConfig
 metadata:
-  name: {{ include "hedera-mirror.fullname" . }}
   labels: {{ include "hedera-mirror.labels" . | nindent 4 }}
+  name: {{ include "hedera-mirror.fullname" . }}
   namespace: {{ include "hedera-mirror.namespace" . }}
 spec:
   inhibitRules:

--- a/charts/hedera-mirror/templates/secret-passwords.yaml
+++ b/charts/hedera-mirror/templates/secret-passwords.yaml
@@ -41,6 +41,6 @@ stringData:
   admin-password: {{ coalesce .Values.postgresql.pgpool.adminPassword (get $passwords "admin-password" | default "" | b64dec) (randAlphaNum 40) | quote }}
   PGPOOL_POSTGRES_CUSTOM_PASSWORDS: "{{ $grpcPassword }},{{ $importerPassword }},{{ $ownerPassword }},{{ $restPassword }},{{ $rosettaPassword }},{{ $web3Password }}"
   PGPOOL_POSTGRES_CUSTOM_USERS: "{{ $grpcUsername }},{{ $importerUsername }},{{ $ownerUsername }},{{ $restUsername }},{{ $rosettaUsername }},{{ $web3Username }}"
-  postgresql-password: {{ coalesce .Values.postgresql.postgresql.password (get $passwords "postgresql-password" | default "" | b64dec) (randAlphaNum 40) | quote }}
+  password: {{ coalesce .Values.postgresql.postgresql.password (get $passwords "password" | default "" | b64dec) (randAlphaNum 40) | quote }}
   repmgr-password: {{ coalesce .Values.postgresql.postgresql.repmgrPassword (get $passwords "repmgr-password" | default "" | b64dec) (randAlphaNum 40) | quote }}
   {{ end -}}

--- a/charts/hedera-mirror/templates/secret-redis.yaml
+++ b/charts/hedera-mirror/templates/secret-redis.yaml
@@ -1,4 +1,4 @@
-{{- $name := "mirror-redis" -}}  # redis chart doesn't support template names
+{{- $name := printf "%s-redis" .Release.Name }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/hedera-mirror/values.yaml
+++ b/charts/hedera-mirror/values.yaml
@@ -171,12 +171,12 @@ grpc:
     SPRING_REDIS_HOST:
       valueFrom:
         secretKeyRef:
-          name: mirror-redis
+          name: "{{ .Release.Name }}-redis"
           key: SPRING_REDIS_HOST
     SPRING_REDIS_PASSWORD:
       valueFrom:
         secretKeyRef:
-          name: mirror-redis
+          name: "{{ .Release.Name }}-redis"
           key: SPRING_REDIS_PASSWORD
 
 importer:
@@ -188,7 +188,7 @@ importer:
     - secretRef:
         name: mirror-passwords
     - secretRef:
-        name: mirror-redis
+        name: "{{ .Release.Name }}-redis"
 
 labels: {}
 
@@ -305,6 +305,8 @@ redis:
     masterSet: mirror
     persistence:
       enabled: true
+    readinessProbe:
+      timeoutSeconds: 4
     resources:
       limits:
         cpu: 150m

--- a/charts/hedera-mirror/values.yaml
+++ b/charts/hedera-mirror/values.yaml
@@ -249,6 +249,7 @@ postgresql:
     extraEnvVarsSecret: mirror-passwords
     image:
       debug: true
+      tag: 14.7.0-debian-11-r1
     initdbScriptsCM: "{{ .Release.Name }}-init"
     password: ""  # Randomly generated if left blank
     podAntiAffinityPreset: soft
@@ -267,7 +268,7 @@ postgresql:
 
 redis:
   auth:
-    existingSecret: mirror-redis
+    existingSecret: "{{ .Release.Name }}-redis"
     existingSecretPasswordKey: SPRING_REDIS_PASSWORD
     password: ""  # Randomly generated if left blank
   enabled: true


### PR DESCRIPTION
**Description**:

* Change redis secret to be templated since that chart now supports it
* Fix network dashboard after breaking changes in underlying metrics
* Fix deprecated `autoscaling/v2beta2` warnings
* Update chart dependencies

**Related issue(s)**:

Fixes #5407

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
