### PR TITLE
Eth_call account operation with eth address fix

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccess.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccess.java
@@ -84,7 +84,12 @@ public class MirrorEntityAccess implements HederaEvmEntityAccess {
 
     @Override
     public boolean isExtant(final Address address) {
-        return entityRepository.findByIdAndDeletedIsFalse(fetchEntityId(address)).isPresent();
+        final var entityId = fetchEntityId(address);
+        if (entityId == 0) {
+            return false;
+        }
+
+        return entityRepository.findByIdAndDeletedIsFalse(entityId).isPresent();
     }
 
     @Override
@@ -100,8 +105,13 @@ public class MirrorEntityAccess implements HederaEvmEntityAccess {
 
     @Override
     public Bytes getStorage(final Address address, final Bytes key) {
-        final var storage = contractStateRepository.findStorage(fetchEntityId(address),
-                key.toArrayUnsafe());
+        final var entityId = fetchEntityId(address);
+        if (entityId == 0) {
+            return Bytes.EMPTY;
+        }
+
+        final var storage =
+                contractStateRepository.findStorage(entityId, key.toArrayUnsafe());
         return storage.map(Bytes::wrap).orElse(Bytes.EMPTY);
     }
 
@@ -133,7 +143,6 @@ public class MirrorEntityAccess implements HederaEvmEntityAccess {
                 entityIdFromEvmAddress(address) :
                 findEntity(address)
                         .map(AbstractEntity::getId).orElse(0L);
-
     }
 
     private Long entityIdFromEvmAddress(final Address address) {

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccess.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccess.java
@@ -84,7 +84,7 @@ public class MirrorEntityAccess implements HederaEvmEntityAccess {
 
     @Override
     public boolean isExtant(final Address address) {
-        return entityRepository.findByIdAndDeletedIsFalse(fetchEntityIdNum(address)).isPresent();
+        return entityRepository.findByIdAndDeletedIsFalse(fetchEntityId(address)).isPresent();
     }
 
     @Override
@@ -100,14 +100,14 @@ public class MirrorEntityAccess implements HederaEvmEntityAccess {
 
     @Override
     public Bytes getStorage(final Address address, final Bytes key) {
-        final var storage = contractStateRepository.findStorage(fetchEntityIdNum(address),
+        final var storage = contractStateRepository.findStorage(fetchEntityId(address),
                 key.toArrayUnsafe());
         return storage.map(Bytes::wrap).orElse(Bytes.EMPTY);
     }
 
     @Override
     public Bytes fetchCodeIfPresent(final Address address) {
-        final var entityId = fetchEntityIdNum(address);
+        final var entityId = fetchEntityId(address);
         if (entityId == 0) {
             return Bytes.EMPTY;
         }
@@ -126,14 +126,14 @@ public class MirrorEntityAccess implements HederaEvmEntityAccess {
         }
     }
 
-    private Long fetchEntityIdNum(final Address address) {
+    private Long fetchEntityId(final Address address) {
         final var addressBytes = address.toArrayUnsafe();
-        final var entityIdNum = isMirror(addressBytes) ?
+
+        return isMirror(addressBytes) ?
                 entityIdFromEvmAddress(address) :
                 findEntity(address)
                         .map(AbstractEntity::getId).orElse(0L);
 
-        return entityIdNum;
     }
 
     private Long entityIdFromEvmAddress(final Address address) {

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccess.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccess.java
@@ -84,7 +84,7 @@ public class MirrorEntityAccess implements HederaEvmEntityAccess {
 
     @Override
     public boolean isExtant(final Address address) {
-        final var entityId = fetchEntityId(address);
+        final var entityId = entityIdFromAddress(address);
         if (entityId == 0) {
             return false;
         }
@@ -105,7 +105,7 @@ public class MirrorEntityAccess implements HederaEvmEntityAccess {
 
     @Override
     public Bytes getStorage(final Address address, final Bytes key) {
-        final var entityId = fetchEntityId(address);
+        final var entityId = entityIdFromAddress(address);
         if (entityId == 0) {
             return Bytes.EMPTY;
         }
@@ -117,7 +117,7 @@ public class MirrorEntityAccess implements HederaEvmEntityAccess {
 
     @Override
     public Bytes fetchCodeIfPresent(final Address address) {
-        final var entityId = fetchEntityId(address);
+        final var entityId = entityIdFromAddress(address);
         if (entityId == 0) {
             return Bytes.EMPTY;
         }
@@ -129,24 +129,15 @@ public class MirrorEntityAccess implements HederaEvmEntityAccess {
     public Optional<Entity> findEntity(final Address address) {
         final var addressBytes = address.toArrayUnsafe();
         if (isMirror(addressBytes)) {
-            final var entityId = entityIdFromEvmAddress(address);
+            final var entityId = fromEvmAddress(addressBytes).getId();
             return entityRepository.findByIdAndDeletedIsFalse(entityId);
         } else {
             return entityRepository.findByEvmAddressAndDeletedIsFalse(addressBytes);
         }
     }
 
-    private Long fetchEntityId(final Address address) {
-        final var addressBytes = address.toArrayUnsafe();
-
-        return isMirror(addressBytes) ?
-                entityIdFromEvmAddress(address) :
-                findEntity(address)
-                        .map(AbstractEntity::getId).orElse(0L);
-    }
-
-    private Long entityIdFromEvmAddress(final Address address) {
-        final var id = fromEvmAddress(address.toArrayUnsafe());
-        return id.getId();
+    private Long entityIdFromAddress(final Address address) {
+        return findEntity(address)
+                .map(AbstractEntity::getId).orElse(0L);
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccessTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccessTest.java
@@ -51,6 +51,8 @@ class MirrorEntityAccessTest {
     private static final Bytes BYTES = Bytes.fromHexString(HEX);
     private static final byte[] DATA = BYTES.toArrayUnsafe();
     private static final Address ADDRESS = Address.fromHexString(HEX);
+    private static final Address NON_MIRROR_ADDRESS = Address.fromHexString("0x23f5e49569a835d7bf9aefd30e4f60cdd570f225");
+
     private static final EntityId ENTITY = DomainUtils.fromEvmAddress(ADDRESS.toArrayUnsafe());
     private static final Long ENTITY_ID = EntityIdEndec.encode(ENTITY.getShardNum(), ENTITY.getRealmNum(),
             ENTITY.getEntityNum());
@@ -186,6 +188,13 @@ class MirrorEntityAccessTest {
     }
 
     @Test
+    void isExtantForNonMirrorAddress() {
+        when(entityRepository.findByEvmAddressAndDeletedIsFalse(NON_MIRROR_ADDRESS.toArrayUnsafe())).thenReturn(Optional.of(entity));
+        final var result = mirrorEntityAccess.isExtant(NON_MIRROR_ADDRESS);
+        assertThat(result).isTrue();
+    }
+
+    @Test
     void isExtantForZeroAddress() {
         final var result = mirrorEntityAccess.isExtant(ZERO);
         assertThat(result).isFalse();
@@ -238,6 +247,13 @@ class MirrorEntityAccessTest {
     }
 
     @Test
+    void getStorageFailsForNonMirrorAddress() {
+        final var key = Bytes.fromHexString(NON_MIRROR_ADDRESS.toHexString());
+        final var result = UInt256.fromBytes(mirrorEntityAccess.getStorage(ZERO, key));
+        assertThat(result).isEqualTo(UInt256.fromHexString(ZERO.toHexString()));
+    }
+
+    @Test
     void getStorageFailsForZeroAddress() {
         final var result = UInt256.fromBytes(mirrorEntityAccess.getStorage(ZERO, BYTES));
         assertThat(result).isEqualTo(UInt256.fromHexString(ZERO.toHexString()));
@@ -252,11 +268,10 @@ class MirrorEntityAccessTest {
 
     @Test
     void fetchCodeIfPresentForNonMirrorEvm() {
-        final var address = Address.fromHexString("0x23f5e49569a835d7bf9aefd30e4f60cdd570f225");
-        when(mirrorEntityAccess.findEntity(address)).thenReturn(Optional.of(entity));
+        when(mirrorEntityAccess.findEntity(NON_MIRROR_ADDRESS)).thenReturn(Optional.of(entity));
         when(entity.getId()).thenReturn(ENTITY_ID);
         when(contractRepository.findRuntimeBytecode(ENTITY_ID)).thenReturn(Optional.of(DATA));
-        final var result = mirrorEntityAccess.fetchCodeIfPresent(address);
+        final var result = mirrorEntityAccess.fetchCodeIfPresent(NON_MIRROR_ADDRESS);
         assertThat(result).isEqualTo(BYTES);
     }
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccessTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccessTest.java
@@ -22,6 +22,7 @@ package com.hedera.mirror.web3.evm.store.contract;
 
 import static com.google.protobuf.ByteString.EMPTY;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.hyperledger.besu.datatypes.Address.ZERO;
 import static org.mockito.Mockito.when;
 
 import java.time.Instant;
@@ -185,6 +186,12 @@ class MirrorEntityAccessTest {
     }
 
     @Test
+    void isExtantForZeroAddress() {
+        final var result = mirrorEntityAccess.isExtant(ZERO);
+        assertThat(result).isFalse();
+    }
+
+    @Test
     void isTokenAccount() {
         when(entityRepository.findByIdAndDeletedIsFalse(ENTITY_ID)).thenReturn(Optional.of(entity));
         when(entity.getType()).thenReturn(EntityType.TOKEN);
@@ -228,6 +235,12 @@ class MirrorEntityAccessTest {
         when(contractStateRepository.findStorage(ENTITY_ID, BYTES.toArrayUnsafe())).thenReturn(Optional.of(DATA));
         final var result = UInt256.fromBytes(mirrorEntityAccess.getStorage(ADDRESS, BYTES));
         assertThat(result).isEqualTo(UInt256.fromHexString(HEX));
+    }
+
+    @Test
+    void getStorageFailsForZeroAddress() {
+        final var result = UInt256.fromBytes(mirrorEntityAccess.getStorage(ZERO, BYTES));
+        assertThat(result).isEqualTo(UInt256.fromHexString(ZERO.toHexString()));
     }
 
     @Test


### PR DESCRIPTION
The following PR addresses an ongoing eth_call issue, where various HederaEvmEntityAccess methods fail when called with non-mirror evm address . To fix it, the HederaEvmEntityAccess methods first check the address type, in case of a ethereum  one it queries the entity table and extract correct value from the returned record.