### PR TITLE
Add fungible token transfers to errata migration

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/ErrataMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/ErrataMigration.java
@@ -31,6 +31,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
 import javax.inject.Named;
 import lombok.SneakyThrows;
 import org.springframework.beans.factory.annotation.Value;
@@ -42,6 +43,8 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
 import org.springframework.transaction.support.TransactionOperations;
 
 import com.hedera.mirror.common.domain.balance.AccountBalanceFile;
+import com.hedera.mirror.common.domain.entity.EntityId;
+import com.hedera.mirror.common.domain.token.TokenTransfer;
 import com.hedera.mirror.common.domain.transaction.RecordItem;
 import com.hedera.mirror.importer.MirrorProperties;
 import com.hedera.mirror.importer.config.MirrorDateRangePropertiesProcessor.DateRangeFilter;
@@ -51,6 +54,7 @@ import com.hedera.mirror.importer.parser.record.RecordStreamFileListener;
 import com.hedera.mirror.importer.parser.record.entity.EntityProperties;
 import com.hedera.mirror.importer.parser.record.entity.EntityRecordItemListener;
 import com.hedera.mirror.importer.reader.ValidatedDataInputStream;
+import com.hedera.mirror.importer.repository.TokenTransferRepository;
 import com.hedera.mirror.importer.repository.TransactionRepository;
 
 /**
@@ -72,6 +76,7 @@ public class ErrataMigration extends RepeatableMigration implements BalanceStrea
     private final NamedParameterJdbcOperations jdbcOperations;
     private final MirrorProperties mirrorProperties;
     private final RecordStreamFileListener recordStreamFileListener;
+    private final TokenTransferRepository tokenTransferRepository;
     private final TransactionOperations transactionOperations;
     private final TransactionRepository transactionRepository;
     private final Set<Long> timestamps = new HashSet<>();
@@ -84,6 +89,7 @@ public class ErrataMigration extends RepeatableMigration implements BalanceStrea
                            NamedParameterJdbcOperations jdbcOperations,
                            MirrorProperties mirrorProperties,
                            RecordStreamFileListener recordStreamFileListener,
+                           TokenTransferRepository tokenTransferRepository,
                            TransactionOperations transactionOperations,
                            TransactionRepository transactionRepository) {
         super(mirrorProperties.getMigration());
@@ -93,6 +99,7 @@ public class ErrataMigration extends RepeatableMigration implements BalanceStrea
         this.jdbcOperations = jdbcOperations;
         this.mirrorProperties = mirrorProperties;
         this.recordStreamFileListener = recordStreamFileListener;
+        this.tokenTransferRepository = tokenTransferRepository;
         this.transactionOperations = transactionOperations;
         this.transactionRepository = transactionRepository;
     }
@@ -217,14 +224,46 @@ public class ErrataMigration extends RepeatableMigration implements BalanceStrea
                 byte[] transactionBytes = in.readLengthAndBytes(1, MAX_TRANSACTION_LENGTH, false, "transaction");
                 var transactionRecord = TransactionRecord.parseFrom(recordBytes);
                 var transaction = Transaction.parseFrom(transactionBytes);
-                var recordItem = RecordItem.builder().transactionRecord(transactionRecord).transaction(transaction).build();
+                var recordItem = RecordItem.builder()
+                        .transactionRecord(transactionRecord)
+                        .transaction(transaction)
+                        .build();
                 long timestamp = recordItem.getConsensusTimestamp();
+                boolean inRange = dateRangeFilter.filter(timestamp);
+                var count = new AtomicLong(0L);
 
-                if (transactionRepository.findById(timestamp).isEmpty() && dateRangeFilter.filter(timestamp)) {
+                if (transactionRepository.findById(timestamp).isEmpty() && inRange) {
                     entityRecordItemListener.onItem(recordItem);
                     consensusTimestamps.add(timestamp);
+                    count.incrementAndGet();
                     log.info("Processed errata {} successfully", name);
-                } else {
+                } else if (inRange) {
+                    // We missed inserting the token transfers from the 2023-02 FAIL_INVALID transactions
+                    recordItem.getTransactionRecord().getTokenTransferListsList().forEach(t -> {
+                        var tokenId = EntityId.of(t.getToken());
+                        t.getTransfersList().forEach(aa -> {
+                            var accountId = EntityId.of(aa.getAccountID());
+                            var id = new TokenTransfer.Id(recordItem.getConsensusTimestamp(), tokenId, accountId);
+
+                            if (tokenTransferRepository.findById(id).isEmpty()) {
+                                TokenTransfer tokenTransfer = new TokenTransfer();
+                                tokenTransfer.setAmount(aa.getAmount());
+                                tokenTransfer.setId(id);
+                                tokenTransfer.setIsApproval(false);
+                                tokenTransfer.setPayerAccountId(recordItem.getPayerAccountId());
+                                tokenTransfer.setTokenDissociate(false);
+                                tokenTransferRepository.save(tokenTransfer);
+                                count.incrementAndGet();
+                            }
+                        });
+                    });
+
+                    if (count.get() > 0) {
+                        log.info("Processed errata {} successfully with {} missing token transfers", name, count);
+                    }
+                }
+
+                if (count.get() == 0) {
                     log.info("Skipped previously processed errata {}", name);
                 }
             } catch (IOException e) {

--- a/hedera-mirror-importer/src/main/resources/application.yml
+++ b/hedera-mirror-importer/src/main/resources/application.yml
@@ -17,11 +17,13 @@ hedera:
         blockNumberMigration:
           checksum: 4
         errataMigration:
-          checksum: 5
+          checksum: 6
         historicalAccountInfoMigration:
           checksum: 3
         initializeEntityBalanceMigration:
           checksum: 3
+        tokenAccountBalanceMigration:
+          checksum: 2
 
 logging:
   level:

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/TokenAccountBalanceMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/TokenAccountBalanceMigrationTest.java
@@ -52,10 +52,15 @@ import com.hedera.mirror.importer.repository.TokenTransferRepository;
 @Tag("migration")
 class TokenAccountBalanceMigrationTest extends IntegrationTest {
 
-    private AccountBalanceFile accountBalanceFile;
     private final AccountBalanceFileRepository accountBalanceFileRepository;
-
     private final RecordFileRepository recordFileRepository;
+    private final TokenAccountRepository tokenAccountRepository;
+    private final TokenAccountHistoryRepository tokenAccountHistoryRepository;
+    private final TokenBalanceRepository tokenBalanceRepository;
+    private final TokenAccountBalanceMigration tokenAccountBalanceMigration;
+    private final TokenTransferRepository tokenTransferRepository;
+
+    private AccountBalanceFile accountBalanceFile;
     private AtomicLong timestamp;
     private TokenAccount tokenAccount;
     private TokenAccount tokenAccount2;
@@ -63,15 +68,15 @@ class TokenAccountBalanceMigrationTest extends IntegrationTest {
     private TokenAccount deletedEntityTokenAccount4;
     private TokenAccount disassociatedTokenAccount5;
     private TokenBalance tokenBalance;
-    private final TokenAccountRepository tokenAccountRepository;
-    private final TokenAccountHistoryRepository tokenAccountHistoryRepository;
-    private final TokenBalanceRepository tokenBalanceRepository;
-    private final TokenAccountBalanceMigration tokenAccountBalanceMigration;
-    private final TokenTransferRepository tokenTransferRepository;
 
     @BeforeEach
     void beforeEach() {
         timestamp = new AtomicLong(0L);
+    }
+
+    @Test
+    void checksum() {
+        assertThat(tokenAccountBalanceMigration.getChecksum()).isEqualTo(2);
     }
 
     @Test

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerCryptoTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerCryptoTest.java
@@ -30,8 +30,6 @@ import com.google.protobuf.BoolValue;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Int32Value;
 import com.google.protobuf.StringValue;
-import com.hedera.mirror.common.domain.contract.Contract;
-import com.hedera.mirror.common.domain.entity.EntityType;
 import com.hederahashgraph.api.proto.java.AccountAmount;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ContractID;
@@ -49,6 +47,7 @@ import com.hederahashgraph.api.proto.java.ShardID;
 import com.hederahashgraph.api.proto.java.SignedTransaction;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TokenID;
+import com.hederahashgraph.api.proto.java.TokenTransferList;
 import com.hederahashgraph.api.proto.java.Transaction;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionRecord;
@@ -74,9 +73,11 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import com.hedera.mirror.common.domain.contract.Contract;
 import com.hedera.mirror.common.domain.entity.AbstractEntity;
 import com.hedera.mirror.common.domain.entity.Entity;
 import com.hedera.mirror.common.domain.entity.EntityId;
+import com.hedera.mirror.common.domain.entity.EntityType;
 import com.hedera.mirror.common.domain.token.Nft;
 import com.hedera.mirror.common.domain.token.NftId;
 import com.hedera.mirror.common.domain.transaction.CryptoTransfer;
@@ -95,6 +96,7 @@ import com.hedera.mirror.importer.repository.CryptoAllowanceRepository;
 import com.hedera.mirror.importer.repository.NftAllowanceRepository;
 import com.hedera.mirror.importer.repository.NftRepository;
 import com.hedera.mirror.importer.repository.TokenAllowanceRepository;
+import com.hedera.mirror.importer.repository.TokenTransferRepository;
 import com.hedera.mirror.importer.util.Utility;
 import com.hedera.mirror.importer.util.UtilityTest;
 
@@ -112,6 +114,7 @@ class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItemListene
     private final NftRepository nftRepository;
     private final RecordParserProperties parserProperties;
     private final TokenAllowanceRepository tokenAllowanceRepository;
+    private final TokenTransferRepository tokenTransferRepository;
 
     @BeforeEach
     void before() {
@@ -939,6 +942,9 @@ class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItemListene
         entityProperties.getPersist().setCryptoTransferAmounts(true);
         Transaction transaction = cryptoTransferTransaction();
         TransactionBody transactionBody = getTransactionBody(transaction);
+        var tokenId = EntityId.of(1020L, EntityType.TOKEN);
+        long amount = 100L;
+
         TransactionRecord record = buildTransactionRecord(r -> {
             r.setConsensusTimestamp(TestUtils.toTimestamp(1577836799000000000L - 1));
             for (int i = 0; i < additionalTransfers.length; i++) {
@@ -946,7 +952,12 @@ class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItemListene
                 var accountAmount = accountAmount(additionalTransfers[i], additionalTransferAmounts[i]);
                 r.getTransferListBuilder().addAccountAmounts(accountAmount);
             }
-        }, transactionBody, ResponseCodeEnum.INVALID_ACCOUNT_ID.getNumber());
+            r.addTokenTransferLists(TokenTransferList.newBuilder()
+                    .setToken(TokenID.newBuilder().setTokenNum(tokenId.getEntityNum()))
+                    .addTransfers(AccountAmount.newBuilder()
+                            .setAccountID(accountId1)
+                            .setAmount(amount)));
+        }, transactionBody, ResponseCodeEnum.FAIL_INVALID.getNumber());
 
         var recordItem = RecordItem.builder().transactionRecord(record).transaction(transaction).build();
         parseRecordItemAndCommit(recordItem);
@@ -956,6 +967,12 @@ class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItemListene
                 () -> assertEntities(),
                 () -> assertEquals(4, cryptoTransferRepository.count(), "Node, network fee & errata"),
                 () -> assertEquals(0, nonFeeTransferRepository.count()),
+                () -> assertThat(tokenTransferRepository.findAll())
+                        .hasSize(1)
+                        .first()
+                        .returns(tokenId, t -> t.getId().getTokenId())
+                        .returns(amount, t -> t.getAmount())
+                        .returns(EntityId.of(accountId1), t -> t.getId().getAccountId()),
                 () -> assertTransactionAndRecord(transactionBody, record),
                 () -> {
                     for (int i = 0; i < additionalTransfers.length; i++) {


### PR DESCRIPTION
**Description**:

* Add fungible token transfers to errata migration
* Change parser to persist data from the `TransactionRecord` for `FAIL_INVALID` transactions
* Rerun errata and token balance migrations

**Related issue(s)**:

Fixes #5472

**Notes for reviewer**:

Will cherry pick to 0.74 and 0.75

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
