### PR TITLE
Bump postgresql-repmgr image to 14.7.0-debian-11-r4

### DIFF
--- a/charts/hedera-mirror/values.yaml
+++ b/charts/hedera-mirror/values.yaml
@@ -249,6 +249,7 @@ postgresql:
     extraEnvVarsSecret: mirror-passwords
     image:
       debug: true
+      tag: 14.7.0-debian-11-r4
     initdbScriptsCM: "{{ .Release.Name }}-init"
     password: ""  # Randomly generated if left blank
     podAntiAffinityPreset: soft


### PR DESCRIPTION
**Description**:

Bump postgresql-repmgr image to 14.7.0-debian-11-r4

**Related issue(s)**:


**Notes for reviewer**:

Necessary for GCP Marketplace image scanning

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
