### PR TITLE
Ensure OS packages are kept up to date

### DIFF
--- a/charts/hedera-mirror/values.yaml
+++ b/charts/hedera-mirror/values.yaml
@@ -276,7 +276,7 @@ postgresql:
     extraEnvVarsSecret: mirror-passwords
     image:
       debug: true
-      tag: 14.7.0-debian-11-r1
+      tag: 14.7.0-debian-11-r5
     initdbScriptsCM: "{{ .Release.Name }}-init"
     password: ""  # Randomly generated if left blank
     podAntiAffinityPreset: soft

--- a/charts/marketplace/gcp/release.sh
+++ b/charts/marketplace/gcp/release.sh
@@ -20,8 +20,8 @@ fi
 
 target_tag="${target_tag#v}" # Strip v prefix if present
 target_tag_minor="${target_tag%\.*}"
-bats_tag="1.8.2"
-postgresql_tag="14.6.0-debian-11-r20"
+bats_tag="1.9.0"
+postgresql_tag="14.7.0-debian-11-r5"
 registry="gcr.io/mirror-node-public/hedera-mirror-node"
 
 function retag() {

--- a/hedera-mirror-graphql/Dockerfile
+++ b/hedera-mirror-graphql/Dockerfile
@@ -16,7 +16,7 @@ RUN true  # Workaround https://github.com/moby/moby/issues/37965
 COPY --chown=1000:1000 --from=builder /app/spring-boot-loader/ ./
 COPY --chown=1000:1000 --from=builder /app/application/ ./
 RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*    # install OS updates
 USER 1000:1000
 

--- a/hedera-mirror-grpc/Dockerfile
+++ b/hedera-mirror-grpc/Dockerfile
@@ -16,7 +16,7 @@ RUN true  # Workaround https://github.com/moby/moby/issues/37965
 COPY --chown=1000:1000 --from=builder /app/spring-boot-loader/ ./
 COPY --chown=1000:1000 --from=builder /app/application/ ./
 RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*    # install OS updates
 USER 1000:1000
 

--- a/hedera-mirror-importer/Dockerfile
+++ b/hedera-mirror-importer/Dockerfile
@@ -15,7 +15,7 @@ RUN true  # Workaround https://github.com/moby/moby/issues/37965
 COPY --chown=1000:1000 --from=builder /app/spring-boot-loader/ ./
 COPY --chown=1000:1000 --from=builder /app/application/ ./
 RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*    # install OS updates
 USER 1000:1000
 

--- a/hedera-mirror-importer/src/main/resources/db/scripts/v2/docker/debian/Dockerfile
+++ b/hedera-mirror-importer/src/main/resources/db/scripts/v2/docker/debian/Dockerfile
@@ -3,6 +3,7 @@ ARG PG_CRON_DB='mirror_node'
 
 # install pg cron and partman
 RUN apt-get update \
+    && apt-get upgrade -y --no-install-recommends \
     && apt-get install -y postgresql-14-cron postgresql-14-partman \
     && rm -rf /var/lib/apt/lists/*
 

--- a/hedera-mirror-monitor/Dockerfile
+++ b/hedera-mirror-monitor/Dockerfile
@@ -16,7 +16,7 @@ RUN true  # Workaround https://github.com/moby/moby/issues/37965
 COPY --chown=1000:1000 --from=builder /app/spring-boot-loader/ ./
 COPY --chown=1000:1000 --from=builder /app/application/ ./
 RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*    # install OS updates
 USER 1000:1000
 

--- a/hedera-mirror-rest/Dockerfile
+++ b/hedera-mirror-rest/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.12.1-bullseye-slim
+FROM node:18.14.2-bullseye-slim
 LABEL maintainer="mirrornode@hedera.com"
 
 # Setup
@@ -11,9 +11,8 @@ COPY . ./
 
 # Install OS updates, required packages, and dependencies
 RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y wget && \
-    apt-get install -y build-essential python3 && \
+    apt-get upgrade -y --no-install-recommends && \
+    apt-get install -y wget build-essential python3 && \
     npm ci --only=production && \
     npm cache clean --force --loglevel=error && \
     chown -R node:node . && \

--- a/hedera-mirror-rest/monitoring/Dockerfile
+++ b/hedera-mirror-rest/monitoring/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.12.1-bullseye-slim
+FROM node:18.14.2-bullseye-slim
 LABEL maintainer="mirrornode@hedera.com"
 
 # Setup
@@ -13,7 +13,7 @@ COPY . ./
 # Install OS updates, required packages, and dependencies
 RUN cd monitor_apis && \
     apt-get update && \
-    apt-get upgrade -y && \
+    apt-get upgrade -y --no-install-recommends && \
     apt-get install -y wget && \
     npm install pm2 -g && \
     npm ci --only=production && \

--- a/hedera-mirror-rosetta/container/Dockerfile
+++ b/hedera-mirror-rosetta/container/Dockerfile
@@ -5,7 +5,7 @@
 FROM ubuntu:22.04 as builder
 ENV LANG=C.UTF-8
 ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get install -y gcc git openjdk-17-jdk-headless wget
+RUN apt-get update -y --no-install-recommends && apt-get install -y gcc git openjdk-17-jdk-headless wget
 # GIT_REF can be a branch, a tag, or a 40-charater git commit hash
 ARG GIT_REF=main
 ARG REPO_URL=https://github.com/hashgraph/hedera-mirror-node
@@ -38,7 +38,7 @@ RUN apt-get update \
     && apt-get install -y ca-certificates curl gnupg lsb-release \
     && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8 \
     && echo "deb https://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
-    && apt-get update \
+    && apt-get update -y --no-install-recommends \
     && apt-get install -y postgresql-${PG_VERSION} postgresql-client-${PG_VERSION} supervisor openjdk-17-jre-headless \
     && rm -rf /var/lib/apt/lists/*
 

--- a/hedera-mirror-web3/Dockerfile
+++ b/hedera-mirror-web3/Dockerfile
@@ -16,7 +16,7 @@ RUN true  # Workaround https://github.com/moby/moby/issues/37965
 COPY --chown=1000:1000 --from=builder /app/spring-boot-loader/ ./
 COPY --chown=1000:1000 --from=builder /app/application/ ./
 RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*    # install OS updates
 USER 1000:1000
 


### PR DESCRIPTION
**Description**:

* Bump node 18.12.1-bullseye-slim to 18.14.2-bullseye-slim
* Bump postgresql-repmgr from 14.7.0-debian-11-r1 to 14.7.0-debian-11-r5
* Fix OS packages not being updated

**Related issue(s)**:

Fixes #5509

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
