### PR TITLE
Add Builder.default to data model fields to reduce build warnings

### DIFF
--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/addressbook/AddressBookEntry.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/addressbook/AddressBookEntry.java
@@ -84,6 +84,7 @@ public class AddressBookEntry implements Persistable<AddressBookEntry.Id> {
     @Transient
     private final PublicKey publicKeyObject = parsePublicKey();
 
+    @Builder.Default
     @EqualsAndHashCode.Exclude
     @JoinColumn(name = "consensusTimestamp", referencedColumnName = "consensusTimestamp")
     @JoinColumn(name = "nodeId", referencedColumnName = "nodeId")

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/balance/AccountBalance.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/balance/AccountBalance.java
@@ -56,6 +56,7 @@ public class AccountBalance implements Persistable<AccountBalance.Id>, StreamIte
 
     private long balance;
 
+    @Builder.Default
     @EqualsAndHashCode.Exclude
     @JsonIgnore
     @OneToMany(cascade = {CascadeType.ALL}, orphanRemoval = true)

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/balance/AccountBalanceFile.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/balance/AccountBalanceFile.java
@@ -53,6 +53,7 @@ public class AccountBalanceFile implements StreamFile<AccountBalance> {
     @ToString.Exclude
     private String fileHash;
 
+    @Builder.Default
     @EqualsAndHashCode.Exclude
     @ToString.Exclude
     @Transient

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/contract/ContractResult.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/contract/ContractResult.java
@@ -27,6 +27,7 @@ import java.util.List;
 import javax.persistence.Convert;
 import javax.persistence.Entity;
 import javax.persistence.Id;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
@@ -57,6 +58,7 @@ public class ContractResult implements Persistable<Long> {
 
     private long contractId;
 
+    @Builder.Default
     @Type(type = "com.vladmihalcea.hibernate.type.array.ListArrayType")
     @JsonSerialize(using = LongListToStringSerializer.class)
     private List<Long> createdContractIds = Collections.emptyList();

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/event/EventFile.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/event/EventFile.java
@@ -63,6 +63,7 @@ public class EventFile implements StreamFile<EventItem> {
     @ToString.Exclude
     private String hash;
 
+    @Builder.Default
     @EqualsAndHashCode.Exclude
     @ToString.Exclude
     @Transient

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/AssessedCustomFee.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/AssessedCustomFee.java
@@ -57,6 +57,7 @@ public class AssessedCustomFee implements Persistable<AssessedCustomFee.Id> {
 
     private long amount;
 
+    @Builder.Default
     @Type(type = "com.vladmihalcea.hibernate.type.array.ListArrayType")
     @JsonSerialize(using = LongListToStringSerializer.class)
     private List<Long> effectivePayerAccountIds = Collections.emptyList();

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/RecordFile.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/RecordFile.java
@@ -76,6 +76,7 @@ public class RecordFile implements StreamFile<RecordItem> {
     @ToString.Exclude
     private String fileHash;
 
+    @Builder.Default
     private long gasUsed = 0L;
 
     @EqualsAndHashCode.Exclude
@@ -94,6 +95,7 @@ public class RecordFile implements StreamFile<RecordItem> {
 
     private Long index;
 
+    @Builder.Default
     @EqualsAndHashCode.Exclude
     @ToString.Exclude
     @Transient

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/SidecarFile.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/SidecarFile.java
@@ -86,6 +86,7 @@ public class SidecarFile implements Persistable<SidecarFile.Id> {
 
     private Integer size;
 
+    @Builder.Default
     @Type(type = "com.vladmihalcea.hibernate.type.array.ListArrayType")
     @JsonSerialize(using = LongListToStringSerializer.class)
     private List<Integer> types = Collections.emptyList();

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamFileSignature.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamFileSignature.java
@@ -58,6 +58,8 @@ public class StreamFileSignature implements Comparable<StreamFileSignature> {
     @EqualsAndHashCode.Include
     private ConsensusNode node;
     private SignatureType signatureType;
+
+    @Builder.Default
     private SignatureStatus status = SignatureStatus.DOWNLOADED;
     private StreamType streamType;
     private byte version;


### PR DESCRIPTION
**Description**:
This PR adds @Builder.default to the data model fields with default initialization to reduce build warnings.
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
