### PR TITLE
Extend `contracts/{id}/state` endpoint to support older states

### DIFF
--- a/hedera-mirror-rest/__tests__/viewmodel/contractStateViewModel.test.js
+++ b/hedera-mirror-rest/__tests__/viewmodel/contractStateViewModel.test.js
@@ -27,6 +27,14 @@ describe('ContractStateViewModel', () => {
     slot: Buffer.from([0x1]),
     value: Buffer.from([0x1]),
   };
+
+  const defaultTimestampContractState = {
+    contractId: 1500,
+    consensusTimestamp: 1651770056616171000,
+    slot: Buffer.from([0x1]),
+    valueWritten: Buffer.from([0x1]),
+  };
+
   const defaultExpected = {
     contract_id: '0.0.1500',
     timestamp: '1651770056.616171000',
@@ -38,4 +46,9 @@ describe('ContractStateViewModel', () => {
   test('default', () => {
     expect(new ContractStateViewModel(defaultContractState)).toEqual(defaultExpected);
   });
+
+  test('with timestamp', () => {
+    expect(new ContractStateViewModel(defaultTimestampContractState)).toEqual(defaultExpected);
+  })
+
 });

--- a/hedera-mirror-rest/api/v1/openapi.yml
+++ b/hedera-mirror-rest/api/v1/openapi.yml
@@ -365,14 +365,15 @@ paths:
         - contracts
   /api/v1/contracts/{contractIdOrAddress}/state:
     get:
-      summary: The contract current state from a contract on the network
-      description: Returns a list of all contract's slots.
+      summary: The contract state from a contract on the network
+      description: Returns a list of all contract's slots. If no timestamp is provided, returns the current state.
       operationId: listContractState
       parameters:
         - $ref: '#/components/parameters/contractIdOrAddressPathParam'
+        - $ref: '#/components/parameters/stateTimestampQueryParam'
+        - $ref: '#/components/parameters/slotQueryParam'
         - $ref: '#/components/parameters/limitQueryParam'
         - $ref: '#/components/parameters/orderQueryParam'
-        - $ref: '#/components/parameters/slotQueryParam'
       responses:
         200:
           description: OK
@@ -4027,6 +4028,15 @@ components:
       in: path
       description: The timestamp at which the associated transaction reached consensus
       required: true
+      example: 1234567890.000000700
+      schema:
+        type: string
+        pattern: ^\d{1,10}(.\d{1,9})?$
+    stateTimestampQueryParam:
+      name: timestamp
+      in: query
+      description: The timestamp at which the contract state is
+      required: false
       example: 1234567890.000000700
       schema:
         type: string

--- a/hedera-mirror-rest/controllers/contractController.js
+++ b/hedera-mirror-rest/controllers/contractController.js
@@ -32,6 +32,7 @@ import {
   ContractLog,
   ContractResult,
   ContractState,
+  ContractStateChange,
   Entity,
   RecordFile,
   Transaction,
@@ -430,7 +431,6 @@ const getAndValidateContractIdAndConsensusTimestampPathParams = async (req) => {
 const extractContractIdAndFiltersFromValidatedRequest = (req, acceptedParameters) => {
   // extract filters from query param
   const contractId = getAndValidateContractIdRequestPathParam(req);
-
   const filters = utils.buildAndValidateFilters(req.query, acceptedParameters, contractResultsFilterValidityChecks);
 
   return {
@@ -887,6 +887,7 @@ class ContractController extends BaseController {
   async extractContractStateByIdQuery(filters, contractId) {
     let limit = defaultLimit;
     let order = orderFilterValues.ASC;
+    let timestamp = false;
     const conditions = [this.getFilterWhereCondition(ContractState.CONTRACT_ID, {operator: '=', value: contractId})];
     const slotInValues = [];
 
@@ -898,8 +899,22 @@ class ContractController extends BaseController {
         case filterKeys.ORDER:
           order = filter.value;
           break;
+        case filterKeys.TIMESTAMP:
+          conditions.push(
+            this.getFilterWhereCondition(ContractStateChange.CONSENSUS_TIMESTAMP, {
+              operator: '<=',
+              value: filter.value
+            })
+          )
+          timestamp = true;
+          break;
         case filterKeys.SLOT:
-          const slot = Buffer.from(utils.stripHexPrefix(filter.value).padStart(64, 0), 'hex');
+          let slot = Buffer.from(utils.stripHexPrefix(filter.value).padStart(64, 0), 'hex');
+          //we need this additional conversion, because there is inconsistency between colums slot in table contract_state and contract_state_change.
+          if (timestamp) {
+            const formatedSlot = utils.stripHexPrefix(filter.value).replace(/^0+(?=\d)0/, '0');
+            slot = Buffer.from(formatedSlot === '0' ? '' : formatedSlot, 'hex');
+          }
           if (filter.operator === utils.opsMap.eq) {
             slotInValues.push(slot);
           } else {
@@ -924,6 +939,7 @@ class ContractController extends BaseController {
       conditions,
       order,
       limit,
+      timestamp
     };
   }
 
@@ -935,10 +951,9 @@ class ContractController extends BaseController {
    */
   getContractStateById = async (req, res) => {
     const {contractId: contractIdParam, filters} = extractContractIdAndFiltersFromValidatedRequest(req, acceptedContractStateParameters);
-
     const contractId = await ContractService.computeContractIdFromString(contractIdParam);
-    const {conditions, order, limit} = await this.extractContractStateByIdQuery(filters, contractId);
-    const rows = await ContractService.getContractStateByIdAndFilters(conditions, order, limit);
+    const {conditions, order, limit, timestamp} = await this.extractContractStateByIdQuery(filters, contractId);
+    const rows = await ContractService.getContractStateByIdAndFilters(conditions, order, limit, timestamp);
     const state = rows.map((row) => new ContractStateViewModel(row));
 
     let nextLink = null;
@@ -1295,7 +1310,8 @@ const acceptedSingleContractResultsParameters = new Set([
 const acceptedContractStateParameters = new Set([
   filterKeys.LIMIT,
   filterKeys.ORDER,
-  filterKeys.SLOT
+  filterKeys.SLOT,
+  filterKeys.TIMESTAMP
 ]);
 
 /**

--- a/hedera-mirror-rest/viewmodel/contractStateViewModel.js
+++ b/hedera-mirror-rest/viewmodel/contractStateViewModel.js
@@ -37,9 +37,13 @@ class ContractStateViewModel {
       ? toHexString(contractState.evmAddress, true)
       : contractId.toEvmAddress();
     this.contract_id = contractId.toString();
-    this.timestamp = nsToSecNs(contractState.modifiedTimestamp);
+    this.timestamp = contractState.modifiedTimestamp 
+      ? nsToSecNs(contractState.modifiedTimestamp) 
+      : nsToSecNs(contractState.consensusTimestamp);
     this.slot = toUint256(contractState.slot);
-    this.value = toUint256(contractState.value);
+    this.value = contractState.value
+      ? toUint256(contractState.value)
+      : toUint256(contractState.valueWritten);
   }
 }
 


### PR DESCRIPTION
**Description**:
With this PR we extend current functionality of the `contracts/{id}/state` to support older contract states.
For this we need to query table `contract_state_change`. This will unlock full functionality for forking with the json-rpc-relay.

**Related issue(s)**:

Fixes #5516 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
