### PR TITLE
Skip web3 acceptance tests for environments with disabled sidecars

### DIFF
--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
@@ -52,6 +52,7 @@ public class AcceptanceTestProperties {
     private boolean createOperatorAccount = true;
 
     private boolean emitBackgroundMessages = false;
+    private boolean contractTraceability = false;
 
     @Max(5)
     private int maxRetries = 2;

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ContractFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ContractFeature.java
@@ -30,6 +30,9 @@ import static org.junit.jupiter.api.Assertions.*;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+
+import com.hedera.mirror.test.e2e.acceptance.config.AcceptanceTestProperties;
+
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import java.io.IOException;
@@ -76,6 +79,7 @@ public class ContractFeature extends AbstractFeature {
     private final ContractClient contractClient;
     private final FileClient fileClient;
     private final MirrorNodeClient mirrorClient;
+    private final AcceptanceTestProperties acceptanceTestProperties;
 
     @Value("classpath:solidity/artifacts/contracts/Parent.sol/Parent.json")
     private Path parentContract;
@@ -144,6 +148,10 @@ public class ContractFeature extends AbstractFeature {
 
     @Then("I call the contract via the mirror node REST API")
     public void restContractCall() {
+        if(!acceptanceTestProperties.isContractTraceability()) {
+            return;
+        }
+
         var from = contractClient.getClientAddress();
         var to = contractId.toSolidityAddress();
 


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

Since SideCar support is not enabled on all environments, we should add a mechanism for skipping acceptance web3 tests that rely on calling smart contracts and use their runtime bytecode.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
