### PR TITLE
Remove uniqueness of `unique` indices in both v1 and v2 migrations.

### DIFF
--- a/hedera-mirror-importer/src/main/resources/db/migration/v1/R__entity_state_start.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v1/R__entity_state_start.sql
@@ -74,7 +74,8 @@ from entity_state
      balance_timestamp bt
 where bt.consensus_timestamp is not null;
 
-create unique index if not exists entity_state_start__id on entity_state_start (id);
+drop index if exists entity_state_start__id;
+create index if not exists entity_state_start__id on entity_state_start (id);
 create index if not exists entity_state_start__staked_account_id
   on entity_state_start (staked_account_id) where staked_account_id <> 0;
 

--- a/hedera-mirror-importer/src/main/resources/db/migration/v1/R__entity_state_start.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v1/R__entity_state_start.sql
@@ -74,7 +74,6 @@ from entity_state
      balance_timestamp bt
 where bt.consensus_timestamp is not null;
 
-drop index if exists entity_state_start__id;
 create index if not exists entity_state_start__id on entity_state_start (id);
 create index if not exists entity_state_start__staked_account_id
   on entity_state_start (staked_account_id) where staked_account_id <> 0;

--- a/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.77.0__make_indexes_not_unique.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.77.0__make_indexes_not_unique.sql
@@ -1,0 +1,21 @@
+-- replace the 5 "create unique index" currently-existing indices with non-"unique" versions of the same index.
+
+drop index if exists account_balance_file__name;
+create index if not exists account_balance_file__name on account_balance_file(name);
+
+drop index if exists entity_state_start__id;
+create index if not exists entity_state_start__id on entity_state_start (id);
+
+drop index if exists nft_transfer__token_id_serial_num_timestamp;
+create index if not exists nft_transfer__token_id_serial_num_timestamp
+  on nft_transfer(token_id desc, serial_number desc, consensus_timestamp desc);
+
+drop index if exists record_file__hash;
+create index if not exists record_file__hash on record_file (hash collate "C");
+
+drop index if exists transaction_signature__timestamp_public_key_prefix;
+create index if not exists transaction_signature__timestamp_public_key_prefix
+    on schedule_signature (consensus_timestamp desc, public_key_prefix);
+
+-- one last unique index -- topic_message__topic_id_seqnum -- still remains, but it would be very expensive to rebuild
+-- (with 4 billion rows as of March 1, 2023).

--- a/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.77.0__make_indexes_not_unique.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.77.0__make_indexes_not_unique.sql
@@ -1,10 +1,7 @@
--- replace the 5 "create unique index" currently-existing indices with non-"unique" versions of the same index.
+-- replace the "unique" currently-existing indices with non-"unique" versions of the same index.
 
 drop index if exists account_balance_file__name;
 create index if not exists account_balance_file__name on account_balance_file(name);
-
-drop index if exists entity_state_start__id;
-create index if not exists entity_state_start__id on entity_state_start (id);
 
 drop index if exists nft_transfer__token_id_serial_num_timestamp;
 create index if not exists nft_transfer__token_id_serial_num_timestamp

--- a/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.77.0__make_indexes_not_unique.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.77.0__make_indexes_not_unique.sql
@@ -15,7 +15,7 @@ create index if not exists record_file__hash on record_file (hash collate "C");
 
 drop index if exists transaction_signature__timestamp_public_key_prefix;
 create index if not exists transaction_signature__timestamp_public_key_prefix
-    on schedule_signature (consensus_timestamp desc, public_key_prefix);
+    on transaction_signature (consensus_timestamp desc, public_key_prefix);
 
 -- one last unique index -- topic_message__topic_id_seqnum -- still remains, but it would be very expensive to rebuild
 -- (with 4 billion rows as of March 1, 2023).

--- a/hedera-mirror-importer/src/main/resources/db/migration/v2/R__entity_state_start.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v2/R__entity_state_start.sql
@@ -76,7 +76,8 @@ where bt.consensus_timestamp is not null;
 
 comment on materialized view entity_state_start is 'Network entity state at start of staking period';
 
-create unique index if not exists entity_state_start__id on entity_state_start (id);
+drop index if exists entity_state_start__id;
+create index if not exists entity_state_start__id on entity_state_start (id);
 create index if not exists entity_state_start__staked_account_id
   on entity_state_start (staked_account_id) where staked_account_id <> 0;
 

--- a/hedera-mirror-importer/src/main/resources/db/migration/v2/R__entity_state_start.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v2/R__entity_state_start.sql
@@ -76,7 +76,6 @@ where bt.consensus_timestamp is not null;
 
 comment on materialized view entity_state_start is 'Network entity state at start of staking period';
 
-drop index if exists entity_state_start__id;
 create index if not exists entity_state_start__id on entity_state_start (id);
 create index if not exists entity_state_start__staked_account_id
   on entity_state_start (staked_account_id) where staked_account_id <> 0;

--- a/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.3__index_init.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.3__index_init.sql
@@ -150,7 +150,7 @@ create index if not exists nft_allowance_history__timestamp_range on nft_allowan
 -- nft_transfer
 create index if not exists nft_transfer__timestamp on nft_transfer (consensus_timestamp desc);
 create index if not exists nft_transfer__token_id_serial_num_timestamp
-    on nft_transfer (token_id desc, serial_number desc, consensus_timestamp desc, payer_account_id);
+    on nft_transfer (token_id desc, serial_number desc, consensus_timestamp desc);
 
 alter table if exists node_stake
     add constraint node_stake__pk primary key (consensus_timestamp, node_id);
@@ -226,7 +226,7 @@ alter table if exists topic_message
 create index if not exists topic_message__topic_id_timestamp
     on topic_message (topic_id, consensus_timestamp);
 create index if not exists topic_message__topic_id_seqnum
-    on topic_message (topic_id, sequence_number, consensus_timestamp);
+    on topic_message (topic_id, sequence_number);
 
 -- transaction
 alter table if exists transaction

--- a/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.3__index_init.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.3__index_init.sql
@@ -149,7 +149,7 @@ create index if not exists nft_allowance_history__timestamp_range on nft_allowan
 
 -- nft_transfer
 create index if not exists nft_transfer__timestamp on nft_transfer (consensus_timestamp desc);
-create unique index if not exists nft_transfer__token_id_serial_num_timestamp
+create index if not exists nft_transfer__token_id_serial_num_timestamp
     on nft_transfer (token_id desc, serial_number desc, consensus_timestamp desc, payer_account_id);
 
 alter table if exists node_stake
@@ -225,7 +225,7 @@ alter table if exists topic_message
     add constraint topic_message__pk primary key (consensus_timestamp, topic_id);
 create index if not exists topic_message__topic_id_timestamp
     on topic_message (topic_id, consensus_timestamp);
-create unique index if not exists topic_message__topic_id_seqnum
+create index if not exists topic_message__topic_id_seqnum
     on topic_message (topic_id, sequence_number, consensus_timestamp);
 
 -- transaction


### PR DESCRIPTION
**Description**:
This PR modifies the (mirror node) index definitions of v1 and v2 migrations. 

* Delete 5 v1 indices, and recreate them without the "unique" tag.
* Delete the word "unique" from 2 v2 index definitions. 

**Related issue(s)**:

Fixes #5405

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
