### PR TITLE
Add search for account by alias or EVM address to GraphQL API

### DIFF
--- a/charts/hedera-mirror-graphql/postman.json
+++ b/charts/hedera-mirror-graphql/postman.json
@@ -1,165 +1,284 @@
 {
-  "info": {
-    "_postman_id": "553483ca-fd77-4ccd-93e0-4628bc1c6a8f",
-    "name": "GraphQL API",
-    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "_exporter_id": "24928384"
-  },
-  "item": [
-    {
-      "name": "Negative Tests",
-      "item": [
-        {
-          "name": "Get Account Non Existing field",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test(\"Non Existing Field\", () => {",
-                  "    pm.expect(pm.response.code).to.equal(200);",
-                  "",
-                  "    var response = pm.response.json();",
-                  "",
-                  "    pm.expect(response.errors.length).to.equal(1);",
-                  "    pm.expect(response.errors[0].message).to.equal(\"Validation error of type FieldUndefined: Field 'alais' in type 'Account' is undefined @ 'account/alais'\");",
-                  "});"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [],
-            "body": {
-              "mode": "graphql",
-              "graphql": {
-                "query": "{\n  account(input: {\n    entityId: {\n    shard: 0, realm: 0, num: {{default_account}}}}) {\n    alais\n    autoRenewPeriod\n    autoRenewAccount {\n        alias\n        deleted\n        entityId {\n            shard\n            realm\n            num\n        }\n        createdTimestamp\n    }\n    \n  }\n}",
-                "variables": ""
-              }
-            },
-            "url": {
-              "raw": "{{baseUrl}}/graphql/alpha",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": ["graphql", "alpha"]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "By Alias (Unimplemented)",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "pm.test(\"By Id (Unimplemented)\", () => {",
-                  "    pm.expect(pm.response.code).to.equal(200);",
-                  "",
-                  "    var response = pm.response.json();",
-                  "    var account = response.data.account;",
-                  "",
-                  "    pm.expect(account).to.equal(null);",
-                  "    pm.expect(response.errors.length).to.equal(1);",
-                  "    pm.expect(response.errors[0].message).to.equal(\"Not implemented\");",
-                  "});"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [],
-            "body": {
-              "mode": "graphql",
-              "graphql": {
-                "query": "{\n  account(input: \n    {alias: \"AZ234567\"}) {\n    alias\n    autoRenewPeriod\n    autoRenewAccount {\n        alias\n        deleted\n        entityId {\n            shard\n            realm\n            num\n        }\n        createdTimestamp\n    }\n    \n  }\n}",
-                "variables": ""
-              }
-            },
-            "url": {
-              "raw": "{{baseUrl}}/graphql/alpha",
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": ["graphql", "alpha"]
-            }
-          },
-          "response": []
-        }
-      ]
-    },
-    {
-      "name": "Get Account",
-      "event": [
-        {
-          "listen": "test",
-          "script": {
-            "exec": [
-              "pm.test(\"Get By Entity Id (All Fields)\", () => {",
-              "    pm.expect(pm.response.code).to.equal(200);",
-              "",
-              "var response = pm.response.json();",
-              "var account = response.data.account;",
-              "",
-              "pm.expect(account).to.include.keys(",
-              "    'type', 'autoRenewAccount', ",
-              "    'autoRenewPeriod', 'balance', ",
-              "    'createdTimestamp', 'declineReward',",
-              "    'deleted', 'entityId',",
-              "    'expirationTimestamp', 'id',",
-              "    'key', 'maxAutomaticTokenAssociations',",
-              "    'memo', 'nonce',",
-              "    'obtainer', 'pendingReward',",
-              "    'receiverSigRequired', 'stakedAccount',",
-              "    'stakePeriodStart', 'timestamp',",
-              "    'type'",
-              "    );",
-              "pm.expect(account.entityId).to.have.keys('shard', 'realm', 'num');",
-              "pm.expect(account.timestamp).to.have.keys('from', 'to');",
-              "",
-              "pm.expect(account.type).to.equal('ACCOUNT');",
-              "pm.expect(account.entityId.num).to.equal(parseInt(pm.environment.get(\"default_account\")));",
-              "",
-              "});"
-            ],
-            "type": "text/javascript"
-          }
-        }
-      ],
-      "request": {
-        "method": "POST",
-        "header": [],
-        "body": {
-          "mode": "graphql",
-          "graphql": {
-            "query": "{\n  account(input: {\n    entityId: {\n    shard: 0, realm: 0, num: {{default_account}}}}) {\n    alias\n    autoRenewAccount {\n        entityId {\n            shard\n            realm\n            num\n        }\n    }\n    autoRenewPeriod\n    balance\n    createdTimestamp\n    declineReward\n    deleted\n    entityId {\n            shard\n            realm\n            num\n        }\n    expirationTimestamp\n    id\n    key\n    maxAutomaticTokenAssociations\n    memo\n    nonce\n    obtainer {\n        entityId {\n                shard\n                realm\n                num\n        }\n    }\n    pendingReward\n    receiverSigRequired\n    stakedAccount {\n        entityId {\n            shard\n            realm\n            num\n        }\n    }\n    stakePeriodStart\n    timestamp {\n        from\n        to\n    }\n    type\n  }\n}",
-            "variables": ""
-          }
-        },
-        "url": {
-          "raw": "{{baseUrl}}/graphql/alpha",
-          "host": [
-            "{{baseUrl}}"
-          ],
-          "path": ["graphql", "alpha"]
-        }
-      },
-      "response": []
-    }
-  ],
-  "variable": [
-    {
-      "key": "default_account",
-      "value": "98"
-    },
-    {
-      "key": "baseUrl",
-      "value": "http://localhost:8083/graphql/alpha"
-    }
-  ]
+	"info": {
+		"_postman_id": "ffa7bc3c-1aaa-4872-a8e0-6df6ab6acf42",
+		"name": "GraphQL API",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Negative Tests",
+			"item": [
+				{
+					"name": "Get Account Non Existing field",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Non Existing Field\", () => {",
+									"    pm.expect(pm.response.code).to.equal(200);",
+									"",
+									"    var response = pm.response.json();",
+									"",
+									"    pm.expect(response.errors.length).to.equal(1);",
+									"    pm.expect(response.errors[0].message).to.equal(\"Validation error of type FieldUndefined: Field 'alais' in type 'Account' is undefined @ 'account/alais'\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "graphql",
+							"graphql": {
+								"query": "{\n  account(input: {\n    entityId: {\n    shard: 0, realm: 0, num: {{default_account}}}}) {\n    alais\n    autoRenewPeriod\n    autoRenewAccount {\n        alias\n        deleted\n        entityId {\n            shard\n            realm\n            num\n        }\n        createdTimestamp\n    }\n    \n  }\n}",
+								"variables": ""
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/graphql/alpha",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"graphql",
+								"alpha"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Get Account",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Get By Entity Id (All Fields)\", () => {",
+							"    pm.expect(pm.response.code).to.equal(200);",
+							"",
+							"    var response = pm.response.json();",
+							"    var account = response.data.account;",
+							"",
+							"    pm.expect(account).to.include.keys(",
+							"        'type', 'autoRenewAccount',",
+							"        'autoRenewPeriod', 'balance',",
+							"        'createdTimestamp', 'declineReward',",
+							"        'deleted', 'entityId',",
+							"        'expirationTimestamp', 'id',",
+							"        'key', 'maxAutomaticTokenAssociations',",
+							"        'memo', 'nonce',",
+							"        'obtainer', 'pendingReward',",
+							"        'receiverSigRequired', 'stakedAccount',",
+							"        'stakePeriodStart', 'timestamp',",
+							"        'type'",
+							"    );",
+							"    pm.expect(account.entityId).to.have.keys('shard', 'realm', 'num');",
+							"    pm.expect(account.timestamp).to.have.keys('from', 'to');",
+							"",
+							"    pm.expect(account.type).to.equal('ACCOUNT');",
+							"    pm.expect(account.entityId.num).to.equal(parseInt(pm.variables.get(\"default_account\") || pm.environment.get(\"default_account\")));",
+							"",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "{\n  account(input: {\n    entityId: {\n    shard: 0, realm: 0, num: {{default_account}}}}) {\n    alias\n    autoRenewAccount {\n        entityId {\n            shard\n            realm\n            num\n        }\n    }\n    autoRenewPeriod\n    balance\n    createdTimestamp\n    declineReward\n    deleted\n    entityId {\n            shard\n            realm\n            num\n        }\n    expirationTimestamp\n    id\n    key\n    maxAutomaticTokenAssociations\n    memo\n    nonce\n    obtainer {\n        entityId {\n                shard\n                realm\n                num\n        }\n    }\n    pendingReward\n    receiverSigRequired\n    stakedAccount {\n        entityId {\n            shard\n            realm\n            num\n        }\n    }\n    stakePeriodStart\n    timestamp {\n        from\n        to\n    }\n    type\n  }\n}",
+						"variables": ""
+					}
+				},
+				"url": {
+					"raw": "{{baseUrl}}/graphql/alpha",
+					"host": [
+						"{{baseUrl}}"
+					],
+					"path": [
+						"graphql",
+						"alpha"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Account By EvmAddress",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"const default_evm_address = pm.variables.get(\"default_evm_address\") || pm.environment.get(\"default_evm_address\")",
+							"",
+							"if (default_evm_address) {",
+							"    pm.test(\"Get By Entity EvmAddress (All Fields)\", () => {",
+							"        pm.expect(pm.response.code).to.equal(200);",
+							"",
+							"        var response = pm.response.json();",
+							"        var account = response.data.account;",
+							"",
+							"        pm.expect(account).to.include.keys(",
+							"            'type', 'autoRenewAccount',",
+							"            'autoRenewPeriod', 'balance',",
+							"            'createdTimestamp', 'declineReward',",
+							"            'deleted', 'entityId',",
+							"            'expirationTimestamp', 'id',",
+							"            'key', 'maxAutomaticTokenAssociations',",
+							"            'memo', 'nonce',",
+							"            'obtainer', 'pendingReward',",
+							"            'receiverSigRequired', 'stakedAccount',",
+							"            'stakePeriodStart', 'timestamp',",
+							"            'type'",
+							"        );",
+							"        pm.expect(account.entityId).to.have.keys('shard', 'realm', 'num');",
+							"        pm.expect(account.timestamp).to.have.keys('from', 'to');",
+							"",
+							"        pm.expect(account.type).to.equal('ACCOUNT');",
+							"        pm.expect(account.entityId.num).to.equal(parseInt(pm.variables.get(\"default_account\") || pm.environment.get(\"default_account\")));",
+							"",
+							"    });",
+							"}"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "{\n  account(input: {evmAddress: \"{{default_evm_address}}\"}) {\n    alias\n    autoRenewAccount {\n        entityId {\n            shard\n            realm\n            num\n        }\n    }\n    autoRenewPeriod\n    balance\n    createdTimestamp\n    declineReward\n    deleted\n    entityId {\n            shard\n            realm\n            num\n        }\n    expirationTimestamp\n    id\n    key\n    maxAutomaticTokenAssociations\n    memo\n    nonce\n    obtainer {\n        entityId {\n                shard\n                realm\n                num\n        }\n    }\n    pendingReward\n    receiverSigRequired\n    stakedAccount {\n        entityId {\n            shard\n            realm\n            num\n        }\n    }\n    stakePeriodStart\n    timestamp {\n        from\n        to\n    }\n    type\n  }\n}",
+						"variables": ""
+					}
+				},
+				"url": {
+					"raw": "{{baseUrl}}/graphql/alpha",
+					"host": [
+						"{{baseUrl}}"
+					],
+					"path": [
+						"graphql",
+						"alpha"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Account By Alias",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"const default_alias = pm.variables.get(\"default_alias\") || pm.environment.get(\"default_alias\")",
+							"if (default_alias) {",
+							"    pm.test(\"Get By Alias (All Fields)\", () => {",
+							"        pm.expect(pm.response.code).to.equal(200);",
+							"",
+							"        var response = pm.response.json();",
+							"        var account = response.data.account;",
+							"",
+							"        pm.expect(account).to.include.keys(",
+							"            'type', 'autoRenewAccount',",
+							"            'autoRenewPeriod', 'balance',",
+							"            'createdTimestamp', 'declineReward',",
+							"            'deleted', 'entityId',",
+							"            'expirationTimestamp', 'id',",
+							"            'key', 'maxAutomaticTokenAssociations',",
+							"            'memo', 'nonce',",
+							"            'obtainer', 'pendingReward',",
+							"            'receiverSigRequired', 'stakedAccount',",
+							"            'stakePeriodStart', 'timestamp',",
+							"            'type'",
+							"        );",
+							"        pm.expect(account.entityId).to.have.keys('shard', 'realm', 'num');",
+							"        pm.expect(account.timestamp).to.have.keys('from', 'to');",
+							"",
+							"        pm.expect(account.type).to.equal('ACCOUNT');",
+							"        pm.expect(account.entityId.num).to.equal(parseInt(pm.variables.get(\"default_account\") || pm.environment.get(\"default_account\")));",
+							"    });",
+							"}"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "{\n  account(input: {alias: \"{{default_alias}}\"}) {\n    alias\n    autoRenewAccount {\n        entityId {\n            shard\n            realm\n            num\n        }\n    }\n    autoRenewPeriod\n    balance\n    createdTimestamp\n    declineReward\n    deleted\n    entityId {\n            shard\n            realm\n            num\n        }\n    expirationTimestamp\n    id\n    key\n    maxAutomaticTokenAssociations\n    memo\n    nonce\n    obtainer {\n        entityId {\n                shard\n                realm\n                num\n        }\n    }\n    pendingReward\n    receiverSigRequired\n    stakedAccount {\n        entityId {\n            shard\n            realm\n            num\n        }\n    }\n    stakePeriodStart\n    timestamp {\n        from\n        to\n    }\n    type\n  }\n}",
+						"variables": ""
+					}
+				},
+				"url": {
+					"raw": "{{baseUrl}}/graphql/alpha",
+					"host": [
+						"{{baseUrl}}"
+					],
+					"path": [
+						"graphql",
+						"alpha"
+					]
+				}
+			},
+			"response": []
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"variable": [
+		{
+			"key": "default_account",
+			"value": "98"
+		},
+		{
+			"key": "baseUrl",
+			"value": "http://localhost:8083"
+		},
+		{
+			"key": "default_evm_address",
+			"value": ""
+		},
+		{
+			"key": "default_alias",
+			"value": ""
+		}
+	]
 }

--- a/hedera-mirror-graphql/src/main/java/com/hedera/mirror/graphql/controller/AccountController.java
+++ b/hedera-mirror-graphql/src/main/java/com/hedera/mirror/graphql/controller/AccountController.java
@@ -25,6 +25,7 @@ import static com.hedera.mirror.graphql.util.GraphQlUtils.toEntityId;
 import static com.hedera.mirror.graphql.util.GraphQlUtils.validateOneOf;
 
 import javax.validation.Valid;
+
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 import org.springframework.graphql.data.method.annotation.Argument;
@@ -59,6 +60,16 @@ class AccountController {
 
         if (entityId != null) {
             return Mono.justOrEmpty(entityService.getByIdAndType(toEntityId(entityId), EntityType.ACCOUNT)
+                    .map(accountMapper::map));
+        }
+
+        if (alias != null) {
+            return Mono.justOrEmpty(entityService.getByAliasAndType(alias, EntityType.ACCOUNT)
+                    .map(accountMapper::map));
+        }
+
+        if (evmAddress != null) {
+            return Mono.justOrEmpty(entityService.getByEvmAddressAndType(evmAddress, EntityType.ACCOUNT)
                     .map(accountMapper::map));
         }
 

--- a/hedera-mirror-graphql/src/main/java/com/hedera/mirror/graphql/repository/EntityRepository.java
+++ b/hedera-mirror-graphql/src/main/java/com/hedera/mirror/graphql/repository/EntityRepository.java
@@ -25,7 +25,15 @@ import org.springframework.graphql.data.GraphQlRepository;
 
 import com.hedera.mirror.common.domain.entity.Entity;
 
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+
 @GraphQlRepository
 public interface EntityRepository extends CrudRepository<Entity, Long> {
+    @Query(value = "select * from entity where alias = ?1 and deleted is not true", nativeQuery = true)
+    Optional<Entity> findByAlias(byte[] alias);
 
+    @Query(value = "select * from entity where evm_address = ?1 and deleted is not true", nativeQuery = true)
+    Optional<Entity> findByEvmAddress(byte[] evmAddress);
 }

--- a/hedera-mirror-graphql/src/main/java/com/hedera/mirror/graphql/service/EntityService.java
+++ b/hedera-mirror-graphql/src/main/java/com/hedera/mirror/graphql/service/EntityService.java
@@ -29,4 +29,8 @@ import com.hedera.mirror.common.domain.entity.EntityType;
 public interface EntityService {
 
     Optional<Entity> getByIdAndType(EntityId entityId, EntityType type);
+
+    Optional<Entity> getByAliasAndType(String alias, EntityType type);
+
+    Optional<Entity> getByEvmAddressAndType(String evmAddress, EntityType type);
 }

--- a/hedera-mirror-graphql/src/main/java/com/hedera/mirror/graphql/util/GraphQlUtils.java
+++ b/hedera-mirror-graphql/src/main/java/com/hedera/mirror/graphql/util/GraphQlUtils.java
@@ -21,10 +21,12 @@ package com.hedera.mirror.graphql.util;
  */
 
 import com.google.common.base.Splitter;
+
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
 import java.util.function.Function;
+
 import lombok.experimental.UtilityClass;
 
 import com.hedera.mirror.common.domain.entity.EntityId;
@@ -32,10 +34,16 @@ import com.hedera.mirror.common.domain.entity.EntityType;
 import com.hedera.mirror.graphql.viewmodel.HbarUnit;
 import com.hedera.mirror.graphql.viewmodel.Node;
 
+import org.apache.commons.codec.DecoderException;
+import org.apache.commons.codec.binary.Base32;
+import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.lang3.StringUtils;
+
 @UtilityClass
 public class GraphQlUtils {
 
     private static final Splitter SPLITTER = Splitter.on(':');
+    private static final String HEX_PREFIX = "0x";
 
     public static Long convertCurrency(HbarUnit unit, Long tinybars) {
         if (tinybars == null) {
@@ -92,6 +100,25 @@ public class GraphQlUtils {
         if (nonNull != 1) {
             throw new IllegalArgumentException("Must provide exactly one input value but " + nonNull + " have been " +
                     "provided");
+        }
+    }
+
+    public static byte[] decodeBase32(String base32) {
+        if (base32 == null) {
+            return null;
+        }
+        return new Base32().decode(base32);
+    }
+
+    public static byte[] decodeEvmAddress(String evmAddress) {
+        if (evmAddress == null) {
+            return null;
+        }
+        evmAddress = StringUtils.removeStart(evmAddress, HEX_PREFIX);
+        try {
+            return Hex.decodeHex(evmAddress);
+        } catch (DecoderException e) {
+            throw new IllegalArgumentException("Unable to decode evmAddress: " + evmAddress);
         }
     }
 }

--- a/hedera-mirror-graphql/src/test/java/com/hedera/mirror/graphql/controller/AccountControllerTest.java
+++ b/hedera-mirror-graphql/src/test/java/com/hedera/mirror/graphql/controller/AccountControllerTest.java
@@ -35,6 +35,9 @@ import com.hedera.mirror.graphql.GraphqlIntegrationTest;
 import com.hedera.mirror.graphql.mapper.AccountMapper;
 import com.hedera.mirror.graphql.viewmodel.Account;
 
+import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.codec.binary.Base32;
+
 @AutoConfigureHttpGraphQlTester
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
 class AccountControllerTest extends GraphqlIntegrationTest {
@@ -47,7 +50,6 @@ class AccountControllerTest extends GraphqlIntegrationTest {
               query { account(input: {}) { id }}                                                         | Must provide exactly one input value
               query { account(input: {alias: ""}) { id }}                                                | alias must match
               query { account(input: {alias: "abcZ"}) { id }}                                            | alias must match
-              query { account(input: {alias: "CIQ"}) { id }}                                             | Not implemented
               query { account(input: {entityId: {num: -1}}) { id }}                                      | num must be greater than or equal to 0
               query { account(input: {entityId: {realm: -1, num: 1}}) { id }}                            | realm must be greater than or equal to 0
               query { account(input: {entityId: {shard: -1, num: 1}}) { id }}                            | shard must be greater than or equal to 0
@@ -55,7 +57,6 @@ class AccountControllerTest extends GraphqlIntegrationTest {
               query { account(input: {evmAddress: ""}) { id }}                                           | evmAddress must match
               query { account(input: {evmAddress: "abc"}) { id }}                                        | evmAddress must match
               query { account(input: {evmAddress: "01234567890123456789012345678901234567890"}) { id }}  | evmAddress must match
-              query { account(input: {evmAddress: "0x0123456789012345678901234567890123456789"}) { id }} | Not implemented
               query { account(input: {id: ""}) { id }}                                                   | id must match
               query { account(input: {id: "*"}) { id }}                                                  | id must match
               query { account(input: {id: "azAZ0123456789+/="}) { id }}                                  | Not implemented
@@ -74,9 +75,14 @@ class AccountControllerTest extends GraphqlIntegrationTest {
                 );
     }
 
-    @Test
-    void missing() {
-        tester.document("query { account(input: {entityId: {num: 999}}) { id }}")
+    @CsvSource(textBlock = """
+            query { account(input: {entityId: {num: 999}}) { id }}
+            query { account(input: {evmAddress: \"9999999999999999999999999999999999999999\"}) { id }}
+            query { account(input: {alias: \"ABCDEFGHIJKLMNOPQABCDEFGHIJKLMNOPQ\"}) { id }}
+            """)
+    @ParameterizedTest
+    void missing(String query) {
+        tester.document(query)
                 .execute()
                 .errors()
                 .verify()
@@ -112,6 +118,94 @@ class AccountControllerTest extends GraphqlIntegrationTest {
                         }
                         """)
                 .variable("id", entity.getNum())
+                .execute()
+                .errors()
+                .verify()
+                .path("account")
+                .hasValue()
+                .entity(Account.class)
+                .satisfies(a -> assertThat(a).usingRecursiveComparison().isEqualTo(accountMapper.map(entity)));
+    }
+
+    @CsvSource(delimiter = '|', textBlock = """
+            false | false
+            false | true
+            true  | false
+            true  | true
+            """)
+    @ParameterizedTest
+    void successByEvmAddress(boolean prefix, boolean uppercase) {
+        var entity = domainBuilder.entity().persist();
+        var evmAddress = Hex.encodeHexString(entity.getEvmAddress());
+        if (uppercase) {
+            evmAddress = evmAddress.toUpperCase();
+        }
+        if (prefix) {
+            evmAddress = "0x" + evmAddress;
+        }
+        tester.document("""
+                        query Account($evmAddress: String!) {
+                          account(input: { evmAddress: $evmAddress }) {
+                            alias
+                            autoRenewPeriod
+                            balance
+                            createdTimestamp
+                            declineReward
+                            deleted
+                            entityId { shard, realm, num }
+                            expirationTimestamp
+                            id
+                            key
+                            maxAutomaticTokenAssociations
+                            memo
+                            nonce
+                            pendingReward
+                            receiverSigRequired
+                            stakePeriodStart
+                            timestamp {from, to}
+                            type
+                          }
+                        }
+                        """)
+                .variable("evmAddress", evmAddress)
+                .execute()
+                .errors()
+                .verify()
+                .path("account")
+                .hasValue()
+                .entity(Account.class)
+                .satisfies(a -> assertThat(a).usingRecursiveComparison().isEqualTo(accountMapper.map(entity)));
+    }
+
+    @Test
+    void successByAlias() {
+        var entity = domainBuilder.entity().persist();
+        var alias = new Base32().encodeAsString(entity.getAlias());
+        tester.document("""
+                        query Account($alias: String!) {
+                          account(input: { alias: $alias }) {
+                            alias
+                            autoRenewPeriod
+                            balance
+                            createdTimestamp
+                            declineReward
+                            deleted
+                            entityId { shard, realm, num }
+                            expirationTimestamp
+                            id
+                            key
+                            maxAutomaticTokenAssociations
+                            memo
+                            nonce
+                            pendingReward
+                            receiverSigRequired
+                            stakePeriodStart
+                            timestamp {from, to}
+                            type
+                          }
+                        }
+                        """)
+                .variable("alias", alias)
                 .execute()
                 .errors()
                 .verify()

--- a/hedera-mirror-graphql/src/test/java/com/hedera/mirror/graphql/repository/EntityRepositoryTest.java
+++ b/hedera-mirror-graphql/src/test/java/com/hedera/mirror/graphql/repository/EntityRepositoryTest.java
@@ -38,4 +38,16 @@ class EntityRepositoryTest extends GraphqlIntegrationTest {
         var entity = domainBuilder.entity().persist();
         assertThat(entityRepository.findById(entity.getId())).get().isEqualTo(entity);
     }
+
+    @Test
+    void findByAlias() {
+        var entity = domainBuilder.entity().persist();
+        assertThat(entityRepository.findByAlias(entity.getAlias())).get().isEqualTo(entity);
+    }
+
+    @Test
+    void findByEvmAddress() {
+        var entity = domainBuilder.entity().persist();
+        assertThat(entityRepository.findByEvmAddress(entity.getEvmAddress())).get().isEqualTo(entity);
+    }
 }

--- a/hedera-mirror-graphql/src/test/java/com/hedera/mirror/graphql/service/EntityServiceTest.java
+++ b/hedera-mirror-graphql/src/test/java/com/hedera/mirror/graphql/service/EntityServiceTest.java
@@ -23,7 +23,13 @@ package com.hedera.mirror.graphql.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
+import java.nio.ByteBuffer;
 import java.util.Optional;
+
+import org.apache.commons.codec.DecoderException;
+import org.apache.commons.codec.binary.Base32;
+import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -38,6 +44,8 @@ import com.hedera.mirror.graphql.repository.EntityRepository;
 class EntityServiceTest {
 
     private final DomainBuilder domainBuilder = new DomainBuilder();
+    private final Base32 base32 = new Base32();
+    private final int EVM_ADDRESS_BYTE_LENGTH = 20;
 
     @Mock
     private EntityRepository entityRepository;
@@ -52,6 +60,28 @@ class EntityServiceTest {
     }
 
     @Test
+    void getByAliasAndTypeMissing() {
+        var entity = domainBuilder.entity().get();
+        assertThat(entityService.getByAliasAndType(base32.encodeAsString(entity.getAlias()), entity.getType())).isEmpty();
+    }
+
+    @Test
+    void getByEvmAddressAndTypeMissing() {
+        var entity = domainBuilder.entity().get();
+        assertThat(entityService.getByEvmAddressAndType(Hex.encodeHexString(entity.getEvmAddress()), entity.getType()))
+                .isEmpty();
+    }
+
+    @Test
+    void getByIdAsEvmAddressAndTypeMissing() {
+        var entity = domainBuilder.entity().get();
+        ByteBuffer evmBuffer = ByteBuffer.allocate(EVM_ADDRESS_BYTE_LENGTH);
+        evmBuffer.putLong(EVM_ADDRESS_BYTE_LENGTH - Long.BYTES, entity.getId());
+        assertThat(entityService.getByEvmAddressAndType(Hex.encodeHexString(evmBuffer), entity.getType()))
+                .isEmpty();
+    }
+
+    @Test
     void getByIdAndTypeMismatch() {
         var entity = domainBuilder.entity().get();
         when(entityRepository.findById(entity.getId())).thenReturn(Optional.of(entity));
@@ -59,9 +89,79 @@ class EntityServiceTest {
     }
 
     @Test
+    void getByAliasAndTypeMismatch() {
+        var entity = domainBuilder.entity().get();
+        when(entityRepository.findByAlias(entity.getAlias())).thenReturn(Optional.of(entity));
+        assertThat(entityService.getByAliasAndType(base32.encodeAsString(entity.getAlias()), EntityType.CONTRACT)).isEmpty();
+    }
+
+    @Test
+    void getByEvmAddressAndTypeMismatch() {
+        var entity = domainBuilder.entity().get();
+        when(entityRepository.findByEvmAddress(entity.getEvmAddress())).thenReturn(Optional.of(entity));
+        assertThat(entityService.getByEvmAddressAndType(Hex.encodeHexString(entity.getEvmAddress()),
+                EntityType.CONTRACT)).isEmpty();
+    }
+
+    @Test
+    void getByIdAsEvmAddressAndTypeMismatch() {
+
+        var entity = domainBuilder.entity().get();
+        ByteBuffer evmBuffer = ByteBuffer.allocate(EVM_ADDRESS_BYTE_LENGTH);
+        evmBuffer.putLong(EVM_ADDRESS_BYTE_LENGTH - Long.BYTES, entity.getId());
+        when(entityRepository.findById(entity.getId())).thenReturn(Optional.of(entity));
+        assertThat(entityService.getByEvmAddressAndType(Hex.encodeHexString(evmBuffer),
+                EntityType.CONTRACT)).isEmpty();
+    }
+
+    @Test
     void getByIdAndTypeFound() {
         var entity = domainBuilder.entity().get();
         when(entityRepository.findById(entity.getId())).thenReturn(Optional.of(entity));
         assertThat(entityService.getByIdAndType(entity.toEntityId(), entity.getType())).get().isEqualTo(entity);
+    }
+
+    @Test
+    void getByAliasAndTypeFound() {
+        var entity = domainBuilder.entity().get();
+        when(entityRepository.findByAlias(entity.getAlias())).thenReturn(Optional.of(entity));
+        assertThat(entityService.getByAliasAndType(base32.encodeAsString(entity.getAlias()), entity.getType())).get()
+                .isEqualTo(entity);
+    }
+
+    @Test
+    void getByEvmAddressAndTypeFound() {
+        var entity = domainBuilder.entity().get();
+        when(entityRepository.findByEvmAddress(entity.getEvmAddress())).thenReturn(Optional.of(entity));
+        assertThat(entityService.getByEvmAddressAndType(Hex.encodeHexString(entity.getEvmAddress()),
+                entity.getType())).get()
+                .isEqualTo(entity);
+    }
+
+    @Test
+    void getByEvmAddressLookAlikeEntityAndTypeFound() {
+        var entity = domainBuilder.entity().get();
+        int integerStringLength = Integer.BYTES * 2;
+        String padZero = StringUtils.repeat('0', integerStringLength);
+        String evmAddress = padZero + Hex.encodeHexString(entity.getEvmAddress()).substring(integerStringLength);
+        try {
+            when(entityRepository.findByEvmAddress(Hex.decodeHex(evmAddress))).thenReturn(Optional.of(entity));
+        } catch (DecoderException e) {
+            throw new RuntimeException(e);
+        }
+        assertThat(entityService.getByEvmAddressAndType(evmAddress,
+                entity.getType())).get()
+                .isEqualTo(entity);
+    }
+
+    @Test
+    void getByIdAsEvmAddressAndTypeFound() {
+        var entity = domainBuilder.entity().get();
+        ByteBuffer evmBuffer = ByteBuffer.allocate(EVM_ADDRESS_BYTE_LENGTH);
+        evmBuffer.putLong(EVM_ADDRESS_BYTE_LENGTH - Long.BYTES, entity.getId());
+        when(entityRepository.findById(entity.getId())).thenReturn(Optional.of(entity));
+        assertThat(entityService.getByEvmAddressAndType(Hex.encodeHexString(evmBuffer),
+                entity.getType())).get()
+                .isEqualTo(entity);
     }
 }


### PR DESCRIPTION
**Description**:

- Added support for `account(id: {alias})` and `account(id: {evmAddress})` lookup. Executes the same entity lookup as `/api/v1/accounts/{idOrAliasOrEvmAddress}` does.
- Added unit/integration tests for the above
- Added a query to postman

**Related issue(s)**:

Fixes #5318 

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
