### PR TITLE
Add Snyk checks to CI

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [ main, release/** ]
   push:
-    branches: [ main, release/** ]
+    branches: [ main, release/**, snyk ]
     tags: [ v* ]
 
 jobs:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -90,7 +90,7 @@ jobs:
           arguments: snyk-test
 
       - name: Publish Snyk Results
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && always() }}
         run: |
           snyk-to-html -i snyk-test.json -o snyk-test.html --summary && \
           html-to-markdown snyk-test.html -o snyk && \
@@ -123,7 +123,7 @@ jobs:
           arguments: snyk-code
 
       - name: Publish Snyk Results
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && always() }}
         run: |
           snyk-to-html -i snyk-test.json -o snyk-test.html && \
           html-to-markdown snyk-test.html -o snyk && \

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [ main, release/** ]
   push:
-    branches: [main, release/**, snyk]
+    branches: [ main, release/** ]
     tags: [ v* ]
 
 jobs:
@@ -92,10 +92,9 @@ jobs:
       - name: Publish Snyk Results
         if: ${{ !cancelled() && always() }}
         run: |
-          snyk-to-html -i snyk-test.json -o snyk-test.html --summary && \
-          html-to-markdown snyk-test.html -o snyk && \
-          cat snyk/snyk-test.html.md >> $GITHUB_STEP_SUMMARY
-        working-directory: build/reports
+          snyk-to-html -i build/reports/snyk-test.json -o build/reports/snyk-test.html && \
+          html-to-markdown build/reports/snyk-test.html -o  build/reports/snyk && \
+          cat build/reports/snyk/snyk-test.html.md >> $GITHUB_STEP_SUMMARY
 
   snyk-code:
     if: github.event_name == 'push' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')
@@ -125,10 +124,9 @@ jobs:
       - name: Publish Snyk Results
         if: ${{ !cancelled() && always() }}
         run: |
-          snyk-to-html -i snyk-test.json -o snyk-test.html && \
-          html-to-markdown snyk-test.html -o snyk && \
-          cat snyk/snyk-test.html.md >> $GITHUB_STEP_SUMMARY
-        working-directory: build/reports
+          snyk-to-html -i build/reports/snyk-test.json -o build/reports/snyk-test.html && \
+          html-to-markdown build/reports/snyk-test.html -o  build/reports/snyk && \
+          cat build/reports/snyk/snyk-test.html.md >> $GITHUB_STEP_SUMMARY
 
   snyk-monitor:
     if: github.event_name == 'push' && github.ref_name == 'main'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [ main, release/** ]
   push:
-    branches: [ main, release/**, snyk ]
+    branches: [ main, release/** ]
     tags: [ v* ]
 
 jobs:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [ main, release/** ]
   push:
-    branches: [ main, release/** ]
+    branches: [main, release/**, snyk]
     tags: [ v* ]
 
 jobs:
@@ -79,7 +79,7 @@ jobs:
           java-version: 17
 
       - name: Setup Snyk
-        run: npm install -g snyk snyk-to-html @wcj/html-to-markdown-cli
+        run: npm install -g snyk-to-html @wcj/html-to-markdown-cli
 
       - name: Execute Gradle Snyk Test
         uses: gradle/gradle-build-action@v2
@@ -95,7 +95,7 @@ jobs:
           snyk-to-html -i snyk-test.json -o snyk-test.html --summary && \
           html-to-markdown snyk-test.html -o snyk && \
           cat snyk/snyk-test.html.md >> $GITHUB_STEP_SUMMARY
-        working-directory: reports
+        working-directory: build/reports
 
   snyk-code:
     if: github.event_name == 'push' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')
@@ -112,7 +112,7 @@ jobs:
           java-version: 17
 
       - name: Setup Snyk
-        run: npm install -g snyk snyk-to-html @wcj/html-to-markdown-cli
+        run: npm install -g snyk-to-html @wcj/html-to-markdown-cli
 
       - name: Execute Gradle Snyk Code Test
         uses: gradle/gradle-build-action@v2
@@ -128,7 +128,7 @@ jobs:
           snyk-to-html -i snyk-test.json -o snyk-test.html && \
           html-to-markdown snyk-test.html -o snyk && \
           cat snyk/snyk-test.html.md >> $GITHUB_STEP_SUMMARY
-        working-directory: reports
+        working-directory: build/reports
 
   snyk-monitor:
     if: github.event_name == 'push' && github.ref_name == 'main'
@@ -143,9 +143,6 @@ jobs:
         with:
           distribution: "temurin"
           java-version: 17
-
-      - name: Setup Snyk
-        run: npm install -g snyk snyk-to-html @wcj/html-to-markdown-cli
 
       - name: Execute Gradle Snyk Monitor
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -63,3 +63,94 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
           arguments: sonar -x test -Dsonar.projectKey=hedera-mirror-node
+
+  snyk:
+    if: github.event_name == 'push' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')
+    name: Snyk Open Source
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: 17
+
+      - name: Setup Snyk
+        run: npm install -g snyk snyk-to-html @wcj/html-to-markdown-cli
+
+      - name: Execute Gradle Snyk Test
+        uses: gradle/gradle-build-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          arguments: snyk-test
+
+      - name: Publish Snyk Results
+        if: ${{ !cancelled() }}
+        run: |
+          snyk-to-html -i snyk-test.json -o snyk-test.html --summary && \
+          html-to-markdown snyk-test.html -o snyk && \
+          cat snyk/snyk-test.html.md >> $GITHUB_STEP_SUMMARY
+        working-directory: reports
+
+  snyk-code:
+    if: github.event_name == 'push' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')
+    name: Snyk Code
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: 17
+
+      - name: Setup Snyk
+        run: npm install -g snyk snyk-to-html @wcj/html-to-markdown-cli
+
+      - name: Execute Gradle Snyk Code Test
+        uses: gradle/gradle-build-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          arguments: snyk-code
+
+      - name: Publish Snyk Results
+        if: ${{ !cancelled() }}
+        run: |
+          snyk-to-html -i snyk-test.json -o snyk-test.html && \
+          html-to-markdown snyk-test.html -o snyk && \
+          cat snyk/snyk-test.html.md >> $GITHUB_STEP_SUMMARY
+        working-directory: reports
+
+  snyk-monitor:
+    if: github.event_name == 'push' && github.ref_name == 'main'
+    name: Snyk Monitor
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: 17
+
+      - name: Setup Snyk
+        run: npm install -g snyk snyk-to-html @wcj/html-to-markdown-cli
+
+      - name: Execute Gradle Snyk Monitor
+        uses: gradle/gradle-build-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          arguments: snyk-monitor

--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,4 @@ release_notes.md
 .gradle
 build
 !gradle/wrapper/gradle-wrapper.jar
+snyk

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,7 @@ plugins {
     id("idea")
     id("java-platform")
     id("org.sonarqube")
+    id("snykcode-extension")
 }
 
 // Can't use typed variable syntax due to Dependabot limitations

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
     implementation("com.google.protobuf:protobuf-gradle-plugin:0.9.2")
     implementation("com.gorylenko.gradle-git-properties:gradle-git-properties:2.4.1")
     implementation("gradle.plugin.com.graphql-java-generator:graphql-gradle-plugin:1.18.10")
+    implementation("gradle.plugin.io.snyk.gradle.plugin:snyk:0.4")
     implementation("io.freefair.gradle:lombok-plugin:6.6.3")
     implementation("io.spring.gradle:dependency-management-plugin:1.1.0")
     implementation("org.apache.commons:commons-compress:1.22")
@@ -42,7 +43,6 @@ dependencies {
     implementation("org.owasp:dependency-check-gradle:8.1.2")
     implementation("org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:4.0.0.2929")
     implementation("org.springframework.boot:spring-boot-gradle-plugin:2.7.6")
-    implementation("gradle.plugin.io.snyk.gradle.plugin:snyk:0.4")
 }
 
 val gitHook = tasks.register<Exec>("gitHook") {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -42,6 +42,7 @@ dependencies {
     implementation("org.owasp:dependency-check-gradle:8.1.2")
     implementation("org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:4.0.0.2929")
     implementation("org.springframework.boot:spring-boot-gradle-plugin:2.7.6")
+    implementation("gradle.plugin.io.snyk.gradle.plugin:snyk:0.4")
 }
 
 val gitHook = tasks.register<Exec>("gitHook") {

--- a/buildSrc/src/main/kotlin/snykcode-extension.gradle.kts
+++ b/buildSrc/src/main/kotlin/snykcode-extension.gradle.kts
@@ -1,0 +1,39 @@
+plugins {
+    id("io.snyk.gradle.plugin.snykplugin")
+}
+abstract class SnykCodeTask : io.snyk.gradle.plugin.SnykTask() {
+    @TaskAction
+    fun doSnykTest() {
+        log.debug("Snyk Code Test Task")
+        authentication()
+        val output: io.snyk.gradle.plugin.Runner.Result = runSnykCommand("code test")
+        log.lifecycle(output.output)
+        if (output.exitcode > 0) {
+            throw GradleException("Snyk Code Test failed")
+        }
+    }
+}
+
+
+tasks.register<SnykCodeTask>("snyk-code"){
+    dependsOn("snyk-check-binary")
+    snyk {
+        setSeverity("high")
+        setArguments("--all-sub-projects --json-file-output=reports/snyk-test.json")
+    }
+}
+
+tasks.`snyk-monitor`{
+    doFirst{
+        snyk{
+            setArguments("--all-sub-projects")
+        }
+    }
+}
+
+tasks.`snyk-test`{
+    snyk {
+        setSeverity("high")
+        setArguments("--all-sub-projects --json-file-output=reports/snyk-test.json")
+    }
+}

--- a/buildSrc/src/main/kotlin/snykcode-extension.gradle.kts
+++ b/buildSrc/src/main/kotlin/snykcode-extension.gradle.kts
@@ -1,3 +1,23 @@
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
 plugins {
     id("io.snyk.gradle.plugin.snykplugin")
 }
@@ -19,7 +39,7 @@ tasks.register<SnykCodeTask>("snyk-code"){
     dependsOn("snyk-check-binary")
     snyk {
         setSeverity("high")
-        setArguments("--all-sub-projects --json-file-output=reports/snyk-test.json")
+        setArguments("--all-sub-projects --json-file-output=build/reports/snyk-test.json")
     }
 }
 
@@ -34,6 +54,6 @@ tasks.`snyk-monitor`{
 tasks.`snyk-test`{
     snyk {
         setSeverity("high")
-        setArguments("--all-sub-projects --json-file-output=reports/snyk-test.json")
+        setArguments("--all-sub-projects --json-file-output=build/reports/snyk-test.json")
     }
 }


### PR DESCRIPTION
**Description**:
This PR integrates and extends the Snyk gradle plugin to add Snyk scanning task to the gradle setup and integrate it in CI.
Snyk Open Source and Snyk Code scanning are implemented for pull requests and the monitored snapshot is updated on merge to main.

* Add gradle plugin
* Add jobs to the Security action



**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
