### PR TITLE
Rosetta rework transaction valid until timestamp (0.76)

### DIFF
--- a/.github/workflows/rosetta.yml
+++ b/.github/workflows/rosetta.yml
@@ -72,16 +72,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 2  # retrieve the preceding commit so changed-files action can diff and get the changes
-
-      - name: Get Changed Files
-        id: changed-files-module
-        uses: tj-actions/changed-files@v34
-        with:
-          files: |
-            .github/workflows/rosetta-api.yml
-            hedera-mirror-rosetta
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -165,7 +155,6 @@ jobs:
           exit $code
 
       - name: Run Rosetta BDD Tests
-        if: steps.changed-files-module.outputs.any_changed == 'true'
         working-directory: ./hedera-mirror-rosetta/test/bdd-client
         run: |
           export GOROOT=$GOROOT_1_18_X64


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR ports the changes to `release/0.76`:

- remove `valid_until` metadata from the response of /construction/parse
- set `valid_until_nanos` metadata in /construction/metadata
- set transaction valid start based on `valid_until_nanos` metadata in /construction/payload
- remove changed file detection in github workflow to always run bdd test

**Related issue(s)**:

Relates to #5275 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
