### PR TITLE
Bump snakeyaml from 1.33 to 2.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,10 +30,10 @@ plugins {
 extra.apply {
     set("gson.version", "2.8.9") // Temporary until Apache jclouds supports gson 2.9
     set("mapStructVersion", "1.5.3.Final")
-    set("postgresql.version", "42.5.1") // Temporary fix for transient dependency security issue
+    set("postgresql.version", "42.5.4") // Temporary fix for transient dependency security issue
     set("protobufVersion", "3.22.2")
     set("reactorGrpcVersion", "1.2.3")
-    set("snakeyaml.version", "1.33") // Temporary fix for transient dependency security issue
+    set("snakeyaml.version", "2.0") // Temporary fix for transient dependency security issue
     set("testcontainersSpringBootVersion", "2.3.2")
 }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -41,7 +41,7 @@ dependencies {
     implementation("org.openapitools:openapi-generator-gradle-plugin:6.4.0")
     implementation("org.owasp:dependency-check-gradle:8.1.2")
     implementation("org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:4.0.0.2929")
-    implementation("org.springframework.boot:spring-boot-gradle-plugin:2.7.6")
+    implementation("org.springframework.boot:spring-boot-gradle-plugin:2.7.9")
 }
 
 val gitHook = tasks.register<Exec>("gitHook") {


### PR DESCRIPTION
**Description**:

* Bump postgresql from 42.5.1 to 42.5.4
* Bump snakeyaml from 1.33 to 2.0 for [CVE-2022-1471](https://github.com/advisories/GHSA-mjmj-j48q-9wg2)
* Bump Spring Boot from 2.7.6 to 2.7.9

**Related issue(s)**:

**Notes for reviewer**:

Will cherry-pick to 0.76

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
