### PR TITLE
HIP-584: Enhance JSON error response with `data` field that contains hex error

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/controller/ContractController.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/controller/ContractController.java
@@ -39,6 +39,7 @@ import com.hedera.mirror.web3.exception.RateLimitException;
 import io.github.bucket4j.Bucket;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -147,21 +148,21 @@ class ContractController {
     @ResponseStatus(BAD_REQUEST)
     private Mono<GenericErrorResponse> invalidTxnError(final InvalidTransactionException e) {
         log.warn("Transaction error: {}", e.getMessage());
-        return errorResponse(e.getMessage(), e.getDetail());
+        return errorResponse(e.getMessage(), e.getDetail(), StringUtils.EMPTY);
     }
 
     @ExceptionHandler
     @ResponseStatus(BAD_REQUEST)
     private Mono<GenericErrorResponse> invalidTxnBodyError(final ServerWebInputException e) {
         log.warn("Transaction body parsing error: {}", e.getMessage());
-        return errorResponse(e.getReason(), e.getMostSpecificCause().getMessage());
+        return errorResponse(e.getReason(), e.getMostSpecificCause().getMessage(), StringUtils.EMPTY);
     }
 
     @ExceptionHandler
     @ResponseStatus(UNSUPPORTED_MEDIA_TYPE)
     private Mono<GenericErrorResponse> unsupportedMediaTypeError(final UnsupportedMediaTypeStatusException e) {
         log.warn("Unsupported media type error: {}", e.getMessage());
-        return errorResponse(e.getStatus().getReasonPhrase(), e.getReason());
+        return errorResponse(e.getStatus().getReasonPhrase(), e.getReason(), StringUtils.EMPTY);
     }
 
     @ExceptionHandler()
@@ -175,7 +176,7 @@ class ContractController {
         return Mono.just(new GenericErrorResponse(errorMessage));
     }
 
-    private Mono<GenericErrorResponse> errorResponse(final String errorMessage, final String detailedErrorMessage) {
-        return Mono.just(new GenericErrorResponse(errorMessage, detailedErrorMessage));
+    private Mono<GenericErrorResponse> errorResponse(final String errorMessage, final String detailedErrorMessage, final String hexErrorMessage) {
+        return Mono.just(new GenericErrorResponse(errorMessage, detailedErrorMessage, hexErrorMessage));
     }
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessor.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessor.java
@@ -107,7 +107,7 @@ public class MirrorEvmTxProcessor extends HederaEvmTxProcessor {
         final var code = codeCache.getIfPresent(aliasManager.resolveForEvm(to));
 
         if (code == null) {
-            throw new InvalidTransactionException(ResponseCodeEnum.INVALID_TRANSACTION, StringUtils.EMPTY);
+            throw new InvalidTransactionException(ResponseCodeEnum.INVALID_TRANSACTION, StringUtils.EMPTY, StringUtils.EMPTY);
         }
 
         return baseInitialFrame

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/exception/ResponseCodeUtil.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/exception/ResponseCodeUtil.java
@@ -56,7 +56,7 @@ public class ResponseCodeUtil {
                             toMap(
                                     status ->
                                             new BytesKey(
-                                                    new InvalidTransactionException(status, StringUtils.EMPTY)
+                                                    new InvalidTransactionException(status, StringUtils.EMPTY, StringUtils.EMPTY)
                                                             .messageBytes()
                                                             .toArrayUnsafe()),
                                     status -> status));

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/exception/InvalidTransactionException.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/exception/InvalidTransactionException.java
@@ -34,15 +34,18 @@ public class InvalidTransactionException extends EvmException {
     private static final long serialVersionUID = 2244739157125796266L;
 
     private final String detail;
+    private final String data;
 
-    public InvalidTransactionException(final ResponseCodeEnum responseCode, final String detail) {
+    public InvalidTransactionException(final ResponseCodeEnum responseCode, final String detail, final String hexData) {
         super(responseCode.name());
         this.detail = detail;
+        this.data = hexData;
     }
 
-    public InvalidTransactionException(String message, final String detail) {
+    public InvalidTransactionException(final String message, final String detail, final String hexData) {
         super(message);
         this.detail = detail;
+        this.data = hexData;
     }
 
     public Bytes messageBytes() {

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/ContractCallService.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/ContractCallService.java
@@ -83,12 +83,12 @@ public class ContractCallService {
                 onComplete(CallType.ERROR, txnResult);
 
                 var revertReason = txnResult.getRevertReason().orElse(Bytes.EMPTY);
-                throw new InvalidTransactionException(getStatusOrDefault(txnResult), decodeEvmRevertReasonBytesToReadableMessage(revertReason));
+                throw new InvalidTransactionException(getStatusOrDefault(txnResult), decodeEvmRevertReasonBytesToReadableMessage(revertReason), revertReason.toHexString());
             } else {
                 onComplete(body.getCallType(), txnResult);
             }
         } catch (IllegalStateException | IllegalArgumentException e) {
-            throw new InvalidTransactionException(e.getMessage(), StringUtils.EMPTY);
+            throw new InvalidTransactionException(e.getMessage(), StringUtils.EMPTY, StringUtils.EMPTY);
         }
         return txnResult;
     }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/viewmodel/GenericErrorResponse.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/viewmodel/GenericErrorResponse.java
@@ -37,21 +37,22 @@ public class GenericErrorResponse {
     List<ErrorMessage> messages = new ArrayList<>();
 
     public GenericErrorResponse(String message) {
-        messages.add(new ErrorMessage(message, StringUtils.EMPTY));
+        messages.add(new ErrorMessage(message, StringUtils.EMPTY, StringUtils.EMPTY));
     }
 
-    public GenericErrorResponse(String message, String detailedMessage) {
-        final var errorMessage = new ErrorMessage(message, detailedMessage);
+    public GenericErrorResponse(String message, String detailedMessage, String data) {
+        final var errorMessage = new ErrorMessage(message, detailedMessage, data);
         messages.add(errorMessage);
     }
 
     public GenericErrorResponse(List<String> errorMessages) {
-        errorMessages.forEach(m -> messages.add(new ErrorMessage(m, StringUtils.EMPTY)));
+        errorMessages.forEach(m -> messages.add(new ErrorMessage(m, StringUtils.EMPTY, StringUtils.EMPTY)));
     }
 
     @Value
     public static class ErrorMessage {
         private String message;
         private String detail;
+        private String data;
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/controller/ContractControllerTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/controller/ContractControllerTest.java
@@ -36,6 +36,7 @@ import com.hedera.mirror.web3.exception.InvalidTransactionException;
 
 import io.github.bucket4j.Bucket;
 import javax.annotation.Resource;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -195,7 +196,7 @@ class ContractControllerTest {
                 .isEqualTo(BAD_REQUEST)
                 .expectBody(GenericErrorResponse.class)
                 .isEqualTo(new GenericErrorResponse("Failed to read HTTP message", "Unexpected character ('f' (code 102)): was expecting double-quote to start field name\n"
-                        + " at [Source: (org.springframework.core.io.buffer.DefaultDataBuffer$DefaultDataBufferInputStream); line: 1, column: 3]"));
+                        + " at [Source: (org.springframework.core.io.buffer.DefaultDataBuffer$DefaultDataBufferInputStream); line: 1, column: 3]", StringUtils.EMPTY));
     }
 
     @Test
@@ -210,7 +211,7 @@ class ContractControllerTest {
                 .expectStatus()
                 .isEqualTo(UNSUPPORTED_MEDIA_TYPE)
                 .expectBody(GenericErrorResponse.class)
-                .isEqualTo(new GenericErrorResponse("Unsupported Media Type", "Content type 'text/plain' not supported for bodyType=com.hedera.mirror.web3.viewmodel.ContractCallRequest"));
+                .isEqualTo(new GenericErrorResponse("Unsupported Media Type", "Content type 'text/plain' not supported for bodyType=com.hedera.mirror.web3.viewmodel.ContractCallRequest", StringUtils.EMPTY));
     }
 
     @Test
@@ -219,7 +220,8 @@ class ContractControllerTest {
         final var request = request();
         request.setData("0xa26388bb");
 
-        given(service.processCall(any())).willThrow(new InvalidTransactionException(CONTRACT_REVERT_EXECUTED, detailedErrorMessage));
+        given(service.processCall(any())).willThrow(new InvalidTransactionException(CONTRACT_REVERT_EXECUTED, detailedErrorMessage,
+                StringUtils.EMPTY));
 
         webClient.post()
                 .uri(CALL_URI)
@@ -229,7 +231,7 @@ class ContractControllerTest {
                 .expectStatus()
                 .isEqualTo(BAD_REQUEST)
                 .expectBody(GenericErrorResponse.class)
-                .isEqualTo(new GenericErrorResponse(CONTRACT_REVERT_EXECUTED.name(), detailedErrorMessage));
+                .isEqualTo(new GenericErrorResponse(CONTRACT_REVERT_EXECUTED.name(), detailedErrorMessage, StringUtils.EMPTY));
     }
 
     @Test

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
@@ -146,7 +146,7 @@ class ContractCallServiceTest extends Web3IntegrationTest {
         persistEntities(false);
 
         assertThatThrownBy(() -> contractCallService.processCall(serviceParameters)).
-                isInstanceOf(InvalidTransactionException.class).hasMessage(CONTRACT_REVERT_EXECUTED.name());
+                isInstanceOf(InvalidTransactionException.class).hasMessage(CONTRACT_REVERT_EXECUTED.name()).hasFieldOrPropertyWithValue("data", "0x08c379a000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000015437573746f6d20726576657274206d6573736167650000000000000000000000");
     }
 
     @Test
@@ -159,7 +159,7 @@ class ContractCallServiceTest extends Web3IntegrationTest {
         persistEntities(false);
 
         assertThatThrownBy(() -> contractCallService.processCall(serviceParameters)).isInstanceOf(InvalidTransactionException.class)
-                .hasMessage("CONTRACT_REVERT_EXECUTED");
+                .hasMessage("CONTRACT_REVERT_EXECUTED").hasFieldOrPropertyWithValue("data", "0x");
 
         assertGasUsedIsPositive(gasUsedBeforeExecution, ERROR);
     }
@@ -197,7 +197,8 @@ class ContractCallServiceTest extends Web3IntegrationTest {
 
         assertThatThrownBy(() -> contractCallService.processCall(params)).
                 isInstanceOf(InvalidTransactionException.class)
-                .hasMessage(LOCAL_CALL_MODIFICATION_EXCEPTION.toString());
+                .hasMessage(LOCAL_CALL_MODIFICATION_EXCEPTION.toString())
+                .hasFieldOrPropertyWithValue("data", "0x");
 
         assertGasUsedIsPositive(gasUsedBeforeExecution, ERROR);
     }
@@ -214,7 +215,7 @@ class ContractCallServiceTest extends Web3IntegrationTest {
         persistEntities(false);
 
         assertThatThrownBy(() -> contractCallService.processCall(serviceParameters)).
-                isInstanceOf(InvalidTransactionException.class);
+                isInstanceOf(InvalidTransactionException.class).hasFieldOrPropertyWithValue("data", "0x");
 
         assertGasUsedIsPositive(gasUsedBeforeExecution, ERROR);
     }


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

Add a new field called `data` in the JSON Error response in the web3 module. It contains directly the hex revert reason message that comes from the EVM in the case of an error.

**Related issue(s)**:

Fixes #5620 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
