### PR TITLE
Revert bump spring-framework to 5.3.26

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,7 +36,6 @@ extra.apply {
     set("reactorGrpcVersion", "1.2.3")
     set("snakeyaml.version", "1.33") // Temporary fix for transient dependency security issue
     set("spring-data-bom.version", "2021.2.10") // Temporary fix for security issue. Remove after Boot 2.7.10
-    set("spring-framework.version", "5.3.26") // Temporary fix for security issue. Remove after Boot 2.7.10
     set("testcontainersSpringBootVersion", "2.3.2")
     set("vertxVersion", "4.4.0")
 }


### PR DESCRIPTION
**Description**:

Revert bump spring-framework to 5.3.26

**Related issue(s)**:

Fixes #5639

**Notes for reviewer**:

Upgrading Spring Framework requires other dependent libraries to also be upgraded otherwise we get the NoSuchMethodError. Safer to wait for 2.7.10 and maybe cherry pick to the release branch before GA.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
