### PR TITLE
HIP-584: Add unsupported exception when accessing HTS precompile

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,7 +59,7 @@ dependencies {
         api("com.graphql-java-generator:graphql-java-client-dependencies:1.18.10")
         api("com.graphql-java:graphql-java-extended-scalars:20.0")
         api("com.graphql-java:graphql-java-extended-validation:20.0-validator-6.2.0.Final")
-        api("com.hedera.evm:hedera-evm:0.34.0")
+        api("com.hedera.evm:hedera-evm:0.36.0-SNAPSHOT")
         api("com.hedera.hashgraph:hedera-protobuf-java-api:0.35.0")
         api("com.hedera.hashgraph:sdk:2.21.0")
         api("com.ongres.scram:client:2.1")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,7 +59,7 @@ dependencies {
         api("com.graphql-java-generator:graphql-java-client-dependencies:1.18.10")
         api("com.graphql-java:graphql-java-extended-scalars:20.0")
         api("com.graphql-java:graphql-java-extended-validation:20.0-validator-6.2.0.Final")
-        api("com.hedera.evm:hedera-evm:0.36.0-SNAPSHOT")
+        api("com.hedera.evm:hedera-evm:0.36.0-alpha.3")
         api("com.hedera.hashgraph:hedera-protobuf-java-api:0.35.0")
         api("com.hedera.hashgraph:sdk:2.21.0")
         api("com.ongres.scram:client:2.1")

--- a/buildSrc/src/main/kotlin/java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-conventions.gradle.kts
@@ -18,6 +18,7 @@
  * ‍
  */
 
+import org.gradle.internal.impldep.org.junit.platform.launcher.TagFilter.excludeTags
 import org.springframework.boot.gradle.plugin.SpringBootPlugin
 
 plugins {
@@ -49,6 +50,16 @@ repositories {
     }
     maven {
         url = uri("https://us-maven.pkg.dev/swirlds-registry/maven-adhoc-commits")
+    }
+    exclusiveContent {
+        forRepository {
+            maven {
+                url = uri("https://oss.sonatype.org/content/groups/staging")
+            }
+        }
+        filter {
+            includeGroup("com.hedera.evm")
+        }
     }
 }
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/EvmOperationConstructionUtil.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/EvmOperationConstructionUtil.java
@@ -22,7 +22,14 @@ package com.hedera.mirror.web3.evm.contracts.execution;
 
 import static org.hyperledger.besu.evm.MainnetEVMs.registerParisOperations;
 
+import com.hedera.mirror.web3.evm.store.contracts.precompile.MirrorHTSPrecompiledContract;
+import com.hedera.node.app.service.evm.contracts.execution.HederaEvmMessageCallProcessor;
+import com.hedera.node.app.service.evm.store.contracts.precompile.EvmHTSPrecompiledContract;
+import com.hedera.node.app.service.evm.store.contracts.precompile.EvmInfrastructureFactory;
+import com.hedera.node.app.service.evm.store.contracts.precompile.codec.EvmEncodingFacade;
+
 import java.math.BigInteger;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -38,6 +45,7 @@ import org.hyperledger.besu.evm.gascalculator.LondonGasCalculator;
 import org.hyperledger.besu.evm.internal.EvmConfiguration;
 import org.hyperledger.besu.evm.operation.OperationRegistry;
 import org.hyperledger.besu.evm.precompile.PrecompileContractRegistry;
+import org.hyperledger.besu.evm.precompile.PrecompiledContract;
 import org.hyperledger.besu.evm.processor.ContractCreationProcessor;
 import org.hyperledger.besu.evm.processor.MessageCallProcessor;
 
@@ -77,8 +85,17 @@ public class EvmOperationConstructionUtil {
                 () -> new MessageCallProcessor(
                         evm, new PrecompileContractRegistry()),
                 EVM_VERSION_0_34,
-                () -> new MessageCallProcessor(
-                        evm, new PrecompileContractRegistry()));
+                () -> new HederaEvmMessageCallProcessor(
+                        evm, new PrecompileContractRegistry(), precompiles()));
+    }
+
+    private static Map<String, PrecompiledContract> precompiles() {
+        final Map<String, PrecompiledContract> hederaPrecompiles = new HashMap<>();
+        final var evmFactory = new EvmInfrastructureFactory(new EvmEncodingFacade());
+        hederaPrecompiles.put(EvmHTSPrecompiledContract.EVM_HTS_PRECOMPILED_CONTRACT_ADDRESS,
+                new MirrorHTSPrecompiledContract(evmFactory));
+
+        return hederaPrecompiles;
     }
 
     private static EVM constructEvm() {

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/EvmOperationConstructionUtil.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/EvmOperationConstructionUtil.java
@@ -22,12 +22,6 @@ package com.hedera.mirror.web3.evm.contracts.execution;
 
 import static org.hyperledger.besu.evm.MainnetEVMs.registerParisOperations;
 
-import com.hedera.mirror.web3.evm.store.contracts.precompile.MirrorHTSPrecompiledContract;
-import com.hedera.node.app.service.evm.contracts.execution.HederaEvmMessageCallProcessor;
-import com.hedera.node.app.service.evm.store.contracts.precompile.EvmHTSPrecompiledContract;
-import com.hedera.node.app.service.evm.store.contracts.precompile.EvmInfrastructureFactory;
-import com.hedera.node.app.service.evm.store.contracts.precompile.codec.EvmEncodingFacade;
-
 import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.List;
@@ -49,12 +43,17 @@ import org.hyperledger.besu.evm.precompile.PrecompiledContract;
 import org.hyperledger.besu.evm.processor.ContractCreationProcessor;
 import org.hyperledger.besu.evm.processor.MessageCallProcessor;
 
+import com.hedera.mirror.web3.evm.store.contract.precompile.MirrorHTSPrecompiledContract;
+import com.hedera.node.app.service.evm.contracts.execution.HederaEvmMessageCallProcessor;
 import com.hedera.node.app.service.evm.contracts.operations.HederaBalanceOperation;
 import com.hedera.node.app.service.evm.contracts.operations.HederaDelegateCallOperation;
 import com.hedera.node.app.service.evm.contracts.operations.HederaEvmSLoadOperation;
 import com.hedera.node.app.service.evm.contracts.operations.HederaExtCodeCopyOperation;
 import com.hedera.node.app.service.evm.contracts.operations.HederaExtCodeHashOperation;
 import com.hedera.node.app.service.evm.contracts.operations.HederaExtCodeSizeOperation;
+import com.hedera.node.app.service.evm.store.contracts.precompile.EvmHTSPrecompiledContract;
+import com.hedera.node.app.service.evm.store.contracts.precompile.EvmInfrastructureFactory;
+import com.hedera.node.app.service.evm.store.contracts.precompile.codec.EvmEncodingFacade;
 
 /**
  * This is a temporary utility class for creating all besu evm related fields needed by the

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessorFacadeImpl.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessorFacadeImpl.java
@@ -33,7 +33,7 @@ import com.hedera.mirror.web3.evm.account.AccountAccessorImpl;
 import com.hedera.mirror.web3.evm.account.MirrorEvmContractAliases;
 import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
 import com.hedera.mirror.web3.evm.properties.StaticBlockMetaSource;
-import com.hedera.mirror.web3.evm.store.contract.MirrorEntityAccess;
+import com.hedera.mirror.web3.evm.store.contracts.MirrorEntityAccess;
 import com.hedera.node.app.service.evm.contracts.execution.HederaEvmTransactionProcessingResult;
 import com.hedera.node.app.service.evm.contracts.execution.traceability.DefaultHederaTracer;
 import com.hedera.node.app.service.evm.store.contracts.AbstractCodeCache;
@@ -70,7 +70,7 @@ public class MirrorEvmTxProcessorFacadeImpl implements MirrorEvmTxProcessorFacad
         this.worldState =
                 new HederaEvmWorldState(
                         entityAccess, evmProperties,
-                        codeCache, accountAccessor);
+                        codeCache, accountAccessor, null);
     }
 
     @Override

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessorFacadeImpl.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessorFacadeImpl.java
@@ -33,7 +33,7 @@ import com.hedera.mirror.web3.evm.account.AccountAccessorImpl;
 import com.hedera.mirror.web3.evm.account.MirrorEvmContractAliases;
 import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
 import com.hedera.mirror.web3.evm.properties.StaticBlockMetaSource;
-import com.hedera.mirror.web3.evm.store.contracts.MirrorEntityAccess;
+import com.hedera.mirror.web3.evm.store.contract.MirrorEntityAccess;
 import com.hedera.node.app.service.evm.contracts.execution.HederaEvmTransactionProcessingResult;
 import com.hedera.node.app.service.evm.contracts.execution.traceability.DefaultHederaTracer;
 import com.hedera.node.app.service.evm.store.contracts.AbstractCodeCache;

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/properties/MirrorNodeEvmProperties.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/properties/MirrorNodeEvmProperties.java
@@ -43,7 +43,7 @@ import java.time.Duration;
 public class MirrorNodeEvmProperties implements EvmProperties {
     private boolean directTokenCall = true;
 
-    private boolean dynamicEvmVersion;
+    private boolean dynamicEvmVersion = true;
 
     @NotBlank
     private String evmVersion = EVM_VERSION;

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/contract/precompile/MirrorHTSPrecompiledContract.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/contract/precompile/MirrorHTSPrecompiledContract.java
@@ -1,5 +1,25 @@
 package com.hedera.mirror.web3.evm.store.contract.precompile;
 
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
 import com.hedera.node.app.service.evm.store.contracts.precompile.EvmHTSPrecompiledContract;
 import com.hedera.node.app.service.evm.store.contracts.precompile.EvmInfrastructureFactory;
 import com.hedera.node.app.service.evm.store.contracts.precompile.proxy.ViewGasCalculator;

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/contract/precompile/MirrorHTSPrecompiledContract.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/contract/precompile/MirrorHTSPrecompiledContract.java
@@ -1,0 +1,33 @@
+package com.hedera.mirror.web3.evm.store.contract.precompile;
+
+import com.hedera.node.app.service.evm.store.contracts.precompile.EvmHTSPrecompiledContract;
+import com.hedera.node.app.service.evm.store.contracts.precompile.EvmInfrastructureFactory;
+import com.hedera.node.app.service.evm.store.contracts.precompile.proxy.ViewGasCalculator;
+import com.hedera.node.app.service.evm.store.tokens.TokenAccessor;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.tuweni.bytes.Bytes;
+import org.hyperledger.besu.evm.frame.MessageFrame;
+
+public class MirrorHTSPrecompiledContract extends EvmHTSPrecompiledContract {
+
+    public MirrorHTSPrecompiledContract(
+            EvmInfrastructureFactory infrastructureFactory) {
+        super(infrastructureFactory);
+    }
+
+    @Override
+    public Pair<Long, Bytes> computeCosted(
+            final Bytes input,
+            final MessageFrame frame,
+            final ViewGasCalculator viewGasCalculator,
+            final TokenAccessor tokenAccessor) {
+
+        throw new UnsupportedOperationException("Precompile not supported");
+    }
+
+    @Override
+    public String getName() {
+        return "MirrorHTS";
+    }
+}

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/properties/MirrorNodeEvmPropertiesTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/properties/MirrorNodeEvmPropertiesTest.java
@@ -41,7 +41,7 @@ class MirrorNodeEvmPropertiesTest extends Web3IntegrationTest {
     @Test
     void correctPropertiesEvaluation() {
         assertThat(properties.evmVersion()).isEqualTo(EVM_VERSION);
-        assertThat(properties.dynamicEvmVersion()).isFalse();
+        assertThat(properties.dynamicEvmVersion()).isTrue();
         assertThat(properties.maxGasRefundPercentage()).isEqualTo(MAX_REFUND_PERCENT);
         assertThat(properties.fundingAccountAddress()).isEqualTo(FUNDING_ADDRESS);
         assertThat(properties.isRedirectTokenCallsEnabled()).isTrue();

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
@@ -139,6 +139,17 @@ class ContractCallServiceTest extends Web3IntegrationTest {
     }
 
     @Test
+    void precompileCallReverts() {
+        final var tokenNameCall = "0x6f0fccab00000000000000000000000000000000000000000000000000000000000004e4";
+        final var serviceParameters = serviceParameters(tokenNameCall, 0, ETH_CALL, false);
+
+        persistEntities(false);
+
+        assertThatThrownBy(() -> contractCallService.processCall(serviceParameters)).
+                isInstanceOf(UnsupportedOperationException.class).hasMessage("Precompile not supported");
+    }
+
+    @Test
     void testRevertDetailMessage() {
         final var revertFunctionSignature = "0xa26388bb";
         final var serviceParameters = serviceParameters(revertFunctionSignature, 0, ETH_CALL, true);


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

In order for the relay to determine whether it should redirect an `eth_call` to mirror-node or consensus-node, we should add 501 Unsupported HTTP response code when we try to call a precompile on mirror-node side.

This is a temporary solution, until we start supporting precompiles.

**Related issue(s)**: #5645

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
