### PR TITLE
Bump Spring Boot from 2.7.9 to 2.7.10 (0.77)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,7 +35,6 @@ extra.apply {
     set("protobufVersion", "3.22.2")
     set("reactorGrpcVersion", "1.2.3")
     set("snakeyaml.version", "1.33") // Temporary fix for transient dependency security issue
-    set("spring-data-bom.version", "2021.2.10") // Temporary fix for security issue. Remove after Boot 2.7.10
     set("testcontainersSpringBootVersion", "2.3.2")
     set("vertxVersion", "4.4.0")
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -42,7 +42,7 @@ dependencies {
     implementation("org.openapitools:openapi-generator-gradle-plugin:6.4.0")
     implementation("org.owasp:dependency-check-gradle:8.1.2")
     implementation("org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:4.0.0.2929")
-    implementation("org.springframework.boot:spring-boot-gradle-plugin:2.7.9")
+    implementation("org.springframework.boot:spring-boot-gradle-plugin:2.7.10")
 }
 
 val gitHook = tasks.register<Exec>("gitHook") {


### PR DESCRIPTION
**Description**:

Cherry-pick of #5671 to `release/0.77`:

Bump Spring Boot from 2.7.9 to 2.7.10

**Related issue(s)**:


**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
