### PR TITLE
HIP-584: Properly set hex error `data` field in JSON Error response

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/controller/ContractController.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/controller/ContractController.java
@@ -30,13 +30,8 @@ import static org.springframework.http.HttpStatus.NOT_IMPLEMENTED;
 import static org.springframework.http.HttpStatus.TOO_MANY_REQUESTS;
 import static org.springframework.http.HttpStatus.UNSUPPORTED_MEDIA_TYPE;
 
-import com.hedera.mirror.web3.exception.InvalidParametersException;
-
-import javax.validation.Valid;
-
-import com.hedera.mirror.web3.exception.RateLimitException;
-
 import io.github.bucket4j.Bucket;
+import javax.validation.Valid;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
@@ -49,12 +44,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.support.WebExchangeBindException;
-import org.springframework.web.reactive.function.UnsupportedMediaTypeException;
 import org.springframework.web.server.ServerWebInputException;
 import org.springframework.web.server.UnsupportedMediaTypeStatusException;
 import reactor.core.publisher.Mono;
 
+import com.hedera.mirror.web3.exception.InvalidParametersException;
 import com.hedera.mirror.web3.exception.InvalidTransactionException;
+import com.hedera.mirror.web3.exception.RateLimitException;
 import com.hedera.mirror.web3.service.ContractCallService;
 import com.hedera.mirror.web3.service.model.CallServiceParameters;
 import com.hedera.mirror.web3.viewmodel.ContractCallRequest;
@@ -148,7 +144,7 @@ class ContractController {
     @ResponseStatus(BAD_REQUEST)
     private Mono<GenericErrorResponse> invalidTxnError(final InvalidTransactionException e) {
         log.warn("Transaction error: {}", e.getMessage());
-        return errorResponse(e.getMessage(), e.getDetail(), StringUtils.EMPTY);
+        return errorResponse(e.getMessage(), e.getDetail(), e.getData());
     }
 
     @ExceptionHandler

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/exception/InvalidTransactionException.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/exception/InvalidTransactionException.java
@@ -56,4 +56,8 @@ public class InvalidTransactionException extends EvmException {
     public String getDetail() {
         return detail;
     }
+
+    public String getData() {
+        return data;
+    }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/controller/ContractControllerTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/controller/ContractControllerTest.java
@@ -217,11 +217,12 @@ class ContractControllerTest {
     @Test
     void callRevertMethodAndExpectDetailMessage() {
         final var detailedErrorMessage = "Custom revert message";
+        final var hexDataErrorMessage = "0x08c379a000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000015437573746f6d20726576657274206d6573736167650000000000000000000000";
         final var request = request();
         request.setData("0xa26388bb");
 
         given(service.processCall(any())).willThrow(new InvalidTransactionException(CONTRACT_REVERT_EXECUTED, detailedErrorMessage,
-                StringUtils.EMPTY));
+                hexDataErrorMessage));
 
         webClient.post()
                 .uri(CALL_URI)
@@ -231,7 +232,7 @@ class ContractControllerTest {
                 .expectStatus()
                 .isEqualTo(BAD_REQUEST)
                 .expectBody(GenericErrorResponse.class)
-                .isEqualTo(new GenericErrorResponse(CONTRACT_REVERT_EXECUTED.name(), detailedErrorMessage, StringUtils.EMPTY));
+                .isEqualTo(new GenericErrorResponse(CONTRACT_REVERT_EXECUTED.name(), detailedErrorMessage, hexDataErrorMessage));
     }
 
     @Test

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
@@ -146,7 +146,9 @@ class ContractCallServiceTest extends Web3IntegrationTest {
         persistEntities(false);
 
         assertThatThrownBy(() -> contractCallService.processCall(serviceParameters)).
-                isInstanceOf(InvalidTransactionException.class).hasMessage(CONTRACT_REVERT_EXECUTED.name()).hasFieldOrPropertyWithValue("data", "0x08c379a000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000015437573746f6d20726576657274206d6573736167650000000000000000000000");
+                isInstanceOf(InvalidTransactionException.class).hasMessage(CONTRACT_REVERT_EXECUTED.name())
+                .hasFieldOrPropertyWithValue("detail", "Custom revert message")
+                .hasFieldOrPropertyWithValue("data", "0x08c379a000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000015437573746f6d20726576657274206d6573736167650000000000000000000000");
     }
 
     @Test


### PR DESCRIPTION
**Description**

This PR fixes an issue related to data field in the error JSON response is not being set even though the exception object is holding this data.

**Related issue(s)**:

Fixes #5620

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
