### PR TITLE
Filter transaction hash by transaction type

### DIFF
--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/Transaction.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/Transaction.java
@@ -115,4 +115,12 @@ public class Transaction implements Persistable<Long> {
     public boolean isNew() {
         return true; // Since we never update and use a natural ID, avoid Hibernate querying before insert
     }
+
+    public TransactionHash toTransactionHash() {
+        return TransactionHash.builder()
+                .consensusTimestamp(consensusTimestamp)
+                .hash(transactionHash)
+                .payerAccountId(payerAccountId.getId())
+                .build();
+    }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/BackfillTransactionHashMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/BackfillTransactionHashMigration.java
@@ -78,7 +78,7 @@ public class BackfillTransactionHashMigration extends RepeatableMigration {
         var stopwatch = Stopwatch.createStarted();
         var transactionHashTypes = persist.getTransactionHashTypes();
         String transactionTypesCondition = transactionHashTypes.isEmpty() ? "" :
-                String.format("and type in(%s)", transactionHashTypes.stream()
+                String.format("and type in (%s)", transactionHashTypes.stream()
                         .map(TransactionType::getProtoId)
                         .map(Object::toString)
                         .collect(joining(",")));

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityProperties.java
@@ -70,6 +70,10 @@ public class EntityProperties {
 
         private boolean transactionHash = false;
 
+        /**
+         * A set of transaction types to persist transaction hash for. If empty and transactionHash is true, transaction
+         * hash of all transaction types will be persisted
+         */
         @NotNull
         private Set<TransactionType> transactionHashTypes = EnumSet.complementOf(EnumSet.of(CONSENSUSSUBMITMESSAGE));
 
@@ -82,7 +86,8 @@ public class EntityProperties {
         private Set<TransactionType> transactionSignatures = EnumSet.of(SCHEDULECREATE, SCHEDULESIGN);
 
         public boolean shouldPersistTransactionHash(TransactionType transactionType) {
-            return transactionHash && transactionHashTypes.contains(transactionType);
+            return transactionHash &&
+                    (transactionHashTypes.isEmpty() || transactionHashTypes.contains(transactionType));
         }
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityProperties.java
@@ -20,6 +20,7 @@ package com.hedera.mirror.importer.parser.record.entity;
  * ‍
  */
 
+import static com.hedera.mirror.common.domain.transaction.TransactionType.CONSENSUSSUBMITMESSAGE;
 import static com.hedera.mirror.common.domain.transaction.TransactionType.SCHEDULECREATE;
 import static com.hedera.mirror.common.domain.transaction.TransactionType.SCHEDULESIGN;
 
@@ -39,7 +40,7 @@ public class EntityProperties {
     private PersistProperties persist = new PersistProperties();
 
     @Data
-    public class PersistProperties {
+    public static class PersistProperties {
 
         private boolean claims = false;
 
@@ -69,11 +70,19 @@ public class EntityProperties {
 
         private boolean transactionHash = false;
 
+        @NotNull
+        private Set<TransactionType> transactionHashTypes = EnumSet.complementOf(EnumSet.of(CONSENSUSSUBMITMESSAGE));
+
         /**
          * If configured the mirror node will store the raw transaction bytes on the transaction table
          */
         private boolean transactionBytes = false;
 
+        @NotNull
         private Set<TransactionType> transactionSignatures = EnumSet.of(SCHEDULECREATE, SCHEDULESIGN);
+
+        public boolean shouldPersistTransactionHash(TransactionType transactionType) {
+            return transactionHash && transactionHashTypes.contains(transactionType);
+        }
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListener.java
@@ -74,6 +74,7 @@ import com.hedera.mirror.common.domain.transaction.StakingRewardTransfer;
 import com.hedera.mirror.common.domain.transaction.Transaction;
 import com.hedera.mirror.common.domain.transaction.TransactionHash;
 import com.hedera.mirror.common.domain.transaction.TransactionSignature;
+import com.hedera.mirror.common.domain.transaction.TransactionType;
 import com.hedera.mirror.importer.domain.EntityIdService;
 import com.hedera.mirror.importer.exception.ImporterException;
 import com.hedera.mirror.importer.exception.ParserException;
@@ -485,7 +486,7 @@ public class SqlEntityListener implements EntityListener, RecordStreamFileListen
     public void onTransaction(Transaction transaction) throws ImporterException {
         transactions.add(transaction);
 
-        if (entityProperties.getPersist().isTransactionHash()) {
+        if (entityProperties.getPersist().shouldPersistTransactionHash(TransactionType.of(transaction.getType()))) {
             transactionHashes.add(TransactionHash.builder()
                     .consensusTimestamp(transaction.getConsensusTimestamp())
                     .hash(transaction.getTransactionHash())

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListener.java
@@ -487,11 +487,7 @@ public class SqlEntityListener implements EntityListener, RecordStreamFileListen
         transactions.add(transaction);
 
         if (entityProperties.getPersist().shouldPersistTransactionHash(TransactionType.of(transaction.getType()))) {
-            transactionHashes.add(TransactionHash.builder()
-                    .consensusTimestamp(transaction.getConsensusTimestamp())
-                    .hash(transaction.getTransactionHash())
-                    .payerAccountId(transaction.getPayerAccountId().getId())
-                    .build());
+            transactionHashes.add(transaction.toTransactionHash());
         }
 
         if (transactions.size() == sqlProperties.getBatchSize()) {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/TestUtils.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/TestUtils.java
@@ -45,6 +45,8 @@ import java.util.function.Supplier;
 import lombok.experimental.UtilityClass;
 import org.apache.commons.beanutils.BeanUtilsBean;
 
+import com.hedera.mirror.common.domain.transaction.Transaction;
+import com.hedera.mirror.common.domain.transaction.TransactionHash;
 import com.hedera.mirror.importer.util.Utility;
 
 @UtilityClass
@@ -150,10 +152,8 @@ public class TestUtils {
                 .setAccountNum(Long.parseLong(parts[2])).build();
     }
 
-    public TransactionID toTransactionId(String transactionId) {
-        var parts = transactionId.split("-");
-        return TransactionID.newBuilder().setAccountID(toAccountId(parts[0]))
-                .setTransactionValidStart(toTimestamp(Long.valueOf(parts[1]))).build();
+    public byte[] toByteArray(Key key) {
+        return (null == key) ? null : key.toByteArray();
     }
 
     public Timestamp toTimestamp(Long nanosecondsSinceEpoch) {
@@ -167,8 +167,18 @@ public class TestUtils {
         return Timestamp.newBuilder().setSeconds(seconds).setNanos((int) nanoseconds).build();
     }
 
-    public byte[] toByteArray(Key key) {
-        return (null == key) ? null : key.toByteArray();
+    public TransactionHash toTransactionHash(Transaction transaction) {
+        return TransactionHash.builder()
+                .consensusTimestamp(transaction.getConsensusTimestamp())
+                .hash(transaction.getTransactionHash())
+                .payerAccountId(transaction.getPayerAccountId().getId())
+                .build();
+    }
+
+    public TransactionID toTransactionId(String transactionId) {
+        var parts = transactionId.split("-");
+        return TransactionID.newBuilder().setAccountID(toAccountId(parts[0]))
+                .setTransactionValidStart(toTimestamp(Long.valueOf(parts[1]))).build();
     }
 
     public byte[] generateRandomByteArray(int size) {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/TestUtils.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/TestUtils.java
@@ -45,8 +45,6 @@ import java.util.function.Supplier;
 import lombok.experimental.UtilityClass;
 import org.apache.commons.beanutils.BeanUtilsBean;
 
-import com.hedera.mirror.common.domain.transaction.Transaction;
-import com.hedera.mirror.common.domain.transaction.TransactionHash;
 import com.hedera.mirror.importer.util.Utility;
 
 @UtilityClass
@@ -152,8 +150,10 @@ public class TestUtils {
                 .setAccountNum(Long.parseLong(parts[2])).build();
     }
 
-    public byte[] toByteArray(Key key) {
-        return (null == key) ? null : key.toByteArray();
+    public TransactionID toTransactionId(String transactionId) {
+        var parts = transactionId.split("-");
+        return TransactionID.newBuilder().setAccountID(toAccountId(parts[0]))
+                .setTransactionValidStart(toTimestamp(Long.valueOf(parts[1]))).build();
     }
 
     public Timestamp toTimestamp(Long nanosecondsSinceEpoch) {
@@ -167,18 +167,8 @@ public class TestUtils {
         return Timestamp.newBuilder().setSeconds(seconds).setNanos((int) nanoseconds).build();
     }
 
-    public TransactionHash toTransactionHash(Transaction transaction) {
-        return TransactionHash.builder()
-                .consensusTimestamp(transaction.getConsensusTimestamp())
-                .hash(transaction.getTransactionHash())
-                .payerAccountId(transaction.getPayerAccountId().getId())
-                .build();
-    }
-
-    public TransactionID toTransactionId(String transactionId) {
-        var parts = transactionId.split("-");
-        return TransactionID.newBuilder().setAccountID(toAccountId(parts[0]))
-                .setTransactionValidStart(toTimestamp(Long.valueOf(parts[1]))).build();
+    public byte[] toByteArray(Key key) {
+        return (null == key) ? null : key.toByteArray();
     }
 
     public byte[] generateRandomByteArray(int size) {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/BackfillTransactionHashMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/BackfillTransactionHashMigrationTest.java
@@ -37,11 +37,11 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 
+import com.hedera.mirror.common.domain.transaction.Transaction;
 import com.hedera.mirror.common.domain.transaction.TransactionType;
 import com.hedera.mirror.importer.EnabledIfV1;
 import com.hedera.mirror.importer.IntegrationTest;
 import com.hedera.mirror.importer.MirrorProperties;
-import com.hedera.mirror.importer.TestUtils;
 import com.hedera.mirror.importer.config.Owner;
 import com.hedera.mirror.importer.parser.record.entity.EntityProperties;
 import com.hedera.mirror.importer.repository.TransactionHashRepository;
@@ -94,7 +94,7 @@ class BackfillTransactionHashMigrationTest extends IntegrationTest {
                         domainBuilder.transaction().customize(t -> t.consensusTimestamp(DEFAULT_START_TIMESTAMP + 1)).persist()
                 )
                 .filter(t -> persistTransactionHash)
-                .map(TestUtils::toTransactionHash)
+                .map(Transaction::toTransactionHash)
                 .toList();
         entityProperties.getPersist().setTransactionHash(persistTransactionHash);
 
@@ -114,7 +114,7 @@ class BackfillTransactionHashMigrationTest extends IntegrationTest {
                 domainBuilder.transaction().customize(t -> t.consensusTimestamp(DEFAULT_START_TIMESTAMP + 1)
                         .type(TransactionType.CONSENSUSSUBMITMESSAGE.getProtoId())).persist()
                 )
-                .map(TestUtils::toTransactionHash)
+                .map(Transaction::toTransactionHash)
                 .toList();
 
         // when
@@ -132,7 +132,7 @@ class BackfillTransactionHashMigrationTest extends IntegrationTest {
         domainBuilder.transaction().customize(t -> t.consensusTimestamp(DEFAULT_START_TIMESTAMP + 1)
                         .type(TransactionType.CONSENSUSSUBMITMESSAGE.getProtoId()))
                 .persist();
-        var expected = TestUtils.toTransactionHash(cryptoTransfer);
+        var expected = cryptoTransfer.toTransactionHash();
 
         // when
         runMigration();
@@ -151,7 +151,7 @@ class BackfillTransactionHashMigrationTest extends IntegrationTest {
                 .customize(t -> t.consensusTimestamp(DEFAULT_START_TIMESTAMP + 1)
                         .type(TransactionType.CONSENSUSSUBMITMESSAGE.getProtoId()))
                 .persist();
-        var expected = TestUtils.toTransactionHash(consensusSubmitMessage);
+        var expected = consensusSubmitMessage.toTransactionHash();
 
         // when
         runMigration();
@@ -182,7 +182,7 @@ class BackfillTransactionHashMigrationTest extends IntegrationTest {
         var transaction = domainBuilder.transaction()
                 .customize(t -> t.consensusTimestamp(DEFAULT_START_TIMESTAMP))
                 .persist();
-        var expected = TestUtils.toTransactionHash(transaction);
+        var expected = transaction.toTransactionHash();
 
         // when
         runMigration();
@@ -198,7 +198,7 @@ class BackfillTransactionHashMigrationTest extends IntegrationTest {
         var transaction = domainBuilder.transaction()
                 .customize(t -> t.consensusTimestamp(DEFAULT_START_TIMESTAMP))
                 .persist();
-        var expected = TestUtils.toTransactionHash(transaction);
+        var expected = transaction.toTransactionHash();
 
         // when
         runMigration();

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/PersistPropertiesTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/PersistPropertiesTest.java
@@ -23,9 +23,12 @@ package com.hedera.mirror.importer.parser.record.entity;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Collections;
 import java.util.Set;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import com.hedera.mirror.common.domain.transaction.TransactionType;
 
@@ -44,5 +47,17 @@ class PersistPropertiesTest {
         persistProperties.setTransactionHashTypes(Set.of(transactionType));
         assertThat(persistProperties.shouldPersistTransactionHash(TransactionType.CRYPTOTRANSFER)).isEqualTo(expected);
         assertThat(persistProperties.shouldPersistTransactionHash(TransactionType.CONTRACTCALL)).isFalse();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldPersistTransactionHashWhenEmptyFilter(boolean transactionHash) {
+        var persistProperties = new EntityProperties.PersistProperties();
+        persistProperties.setTransactionHash(transactionHash);
+        persistProperties.setTransactionHashTypes(Collections.emptySet());
+        assertThat(persistProperties.shouldPersistTransactionHash(TransactionType.CRYPTOTRANSFER))
+                .isEqualTo(transactionHash);
+        assertThat(persistProperties.shouldPersistTransactionHash(TransactionType.CONTRACTCALL))
+                .isEqualTo(transactionHash);
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/PersistPropertiesTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/PersistPropertiesTest.java
@@ -1,0 +1,48 @@
+package com.hedera.mirror.importer.parser.record.entity;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import com.hedera.mirror.common.domain.transaction.TransactionType;
+
+class PersistPropertiesTest {
+
+    @ParameterizedTest
+    @CsvSource(textBlock = """
+            true, CRYPTOTRANSFER, true,
+            true, CONSENSUSSUBMITMESSAGE, false,
+            false, CRYPTOTRANSFER, false,
+            false, CONSENSUSSUBMITMESSAGE, false,
+            """)
+    void shouldPersistTransactionHash(boolean transactionHash, TransactionType transactionType, boolean expected) {
+        var persistProperties = new EntityProperties.PersistProperties();
+        persistProperties.setTransactionHash(transactionHash);
+        persistProperties.setTransactionHashTypes(Set.of(transactionType));
+        assertThat(persistProperties.shouldPersistTransactionHash(TransactionType.CRYPTOTRANSFER)).isEqualTo(expected);
+        assertThat(persistProperties.shouldPersistTransactionHash(TransactionType.CONTRACTCALL)).isFalse();
+    }
+}

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListenerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListenerTest.java
@@ -906,7 +906,7 @@ class SqlEntityListenerTest extends IntegrationTest {
         var thirdTransaction = domainBuilder.transaction().get();
         var expectedTransactionHashes = Stream.of(firstTransaction, secondTransaction, thirdTransaction)
                 .filter(t -> persistTransactionHash)
-                .map(TestUtils::toTransactionHash)
+                .map(Transaction::toTransactionHash)
                 .toList();
 
         // when
@@ -951,7 +951,7 @@ class SqlEntityListenerTest extends IntegrationTest {
         var cryptoTransfer = domainBuilder.transaction().get();
         var expectedTransactionHashes = Stream.of(consensusSubmitMessage, cryptoTransfer)
                 .filter(t -> t.getType() == includedTransactionType.getProtoId())
-                .map(TestUtils::toTransactionHash)
+                .map(Transaction::toTransactionHash)
                 .toList();
 
         // when
@@ -974,7 +974,7 @@ class SqlEntityListenerTest extends IntegrationTest {
                 .customize(t -> t.type(TransactionType.CONSENSUSSUBMITMESSAGE.getProtoId())).get();
         var cryptoTransfer = domainBuilder.transaction().get();
         var expectedTransactionHashes = Stream.of(consensusSubmitMessage, cryptoTransfer)
-                .map(TestUtils::toTransactionHash)
+                .map(Transaction::toTransactionHash)
                 .toList();
 
         // when


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR add a feature to filter transaction hash by transaction type

- Add a persist property `transactionHashTypes` and default to exclude `CONSENSUSSUBMITMESSAGE`
- Persist transaction hash of transaction types in the persist property
- Update `BackfillTransactionHashMigration` to filter by transaction type

**Related issue(s)**:

Fixes #5714 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

Intentionally left the new property out of configuration.md

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
