### PR TITLE
Filter transaction hash by transaction type (0.77)

### DIFF
--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/Transaction.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/Transaction.java
@@ -115,4 +115,12 @@ public class Transaction implements Persistable<Long> {
     public boolean isNew() {
         return true; // Since we never update and use a natural ID, avoid Hibernate querying before insert
     }
+
+    public TransactionHash toTransactionHash() {
+        return TransactionHash.builder()
+                .consensusTimestamp(consensusTimestamp)
+                .hash(transactionHash)
+                .payerAccountId(payerAccountId.getId())
+                .build();
+    }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/BackfillTransactionHashMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/BackfillTransactionHashMigration.java
@@ -20,12 +20,15 @@ package com.hedera.mirror.importer.migration;
  * ‍
  */
 
+import static java.util.stream.Collectors.joining;
+
 import com.google.common.base.Stopwatch;
 import java.io.IOException;
 import javax.inject.Named;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.jdbc.core.JdbcTemplate;
 
+import com.hedera.mirror.common.domain.transaction.TransactionType;
 import com.hedera.mirror.importer.MirrorProperties;
 import com.hedera.mirror.importer.config.Owner;
 import com.hedera.mirror.importer.parser.record.entity.EntityProperties;
@@ -39,7 +42,7 @@ public class BackfillTransactionHashMigration extends RepeatableMigration {
             insert into transaction_hash (consensus_timestamp, hash, payer_account_id)
             select consensus_timestamp, transaction_hash, payer_account_id
             from transaction
-            where consensus_timestamp >= ?;
+            where consensus_timestamp >= ? %1$s;
             commit;
             """;
 
@@ -60,7 +63,8 @@ public class BackfillTransactionHashMigration extends RepeatableMigration {
 
     @Override
     protected void doMigrate() throws IOException {
-        if (!entityProperties.getPersist().isTransactionHash()) {
+        var persist = entityProperties.getPersist();
+        if (!persist.isTransactionHash()) {
             log.info("Skipping migration since transaction hash persistence is disabled");
             return;
         }
@@ -72,7 +76,14 @@ public class BackfillTransactionHashMigration extends RepeatableMigration {
         }
 
         var stopwatch = Stopwatch.createStarted();
-        jdbcTemplate.update(BACKFILL_TRANSACTION_HASH_SQL, startTimestamp);
+        var transactionHashTypes = persist.getTransactionHashTypes();
+        String transactionTypesCondition = transactionHashTypes.isEmpty() ? "" :
+                String.format("and type in (%s)", transactionHashTypes.stream()
+                        .map(TransactionType::getProtoId)
+                        .map(Object::toString)
+                        .collect(joining(",")));
+        String sql = String.format(BACKFILL_TRANSACTION_HASH_SQL, transactionTypesCondition);
+        jdbcTemplate.update(sql, startTimestamp);
         log.info("Backfilled transaction hash for transactions at or after {} in {}", startTimestamp, stopwatch);
     }
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityProperties.java
@@ -20,6 +20,7 @@ package com.hedera.mirror.importer.parser.record.entity;
  * ‍
  */
 
+import static com.hedera.mirror.common.domain.transaction.TransactionType.CONSENSUSSUBMITMESSAGE;
 import static com.hedera.mirror.common.domain.transaction.TransactionType.SCHEDULECREATE;
 import static com.hedera.mirror.common.domain.transaction.TransactionType.SCHEDULESIGN;
 
@@ -39,7 +40,7 @@ public class EntityProperties {
     private PersistProperties persist = new PersistProperties();
 
     @Data
-    public class PersistProperties {
+    public static class PersistProperties {
 
         private boolean claims = false;
 
@@ -70,10 +71,23 @@ public class EntityProperties {
         private boolean transactionHash = false;
 
         /**
+         * A set of transaction types to persist transaction hash for. If empty and transactionHash is true, transaction
+         * hash of all transaction types will be persisted
+         */
+        @NotNull
+        private Set<TransactionType> transactionHashTypes = EnumSet.complementOf(EnumSet.of(CONSENSUSSUBMITMESSAGE));
+
+        /**
          * If configured the mirror node will store the raw transaction bytes on the transaction table
          */
         private boolean transactionBytes = false;
 
+        @NotNull
         private Set<TransactionType> transactionSignatures = EnumSet.of(SCHEDULECREATE, SCHEDULESIGN);
+
+        public boolean shouldPersistTransactionHash(TransactionType transactionType) {
+            return transactionHash &&
+                    (transactionHashTypes.isEmpty() || transactionHashTypes.contains(transactionType));
+        }
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListener.java
@@ -74,6 +74,7 @@ import com.hedera.mirror.common.domain.transaction.StakingRewardTransfer;
 import com.hedera.mirror.common.domain.transaction.Transaction;
 import com.hedera.mirror.common.domain.transaction.TransactionHash;
 import com.hedera.mirror.common.domain.transaction.TransactionSignature;
+import com.hedera.mirror.common.domain.transaction.TransactionType;
 import com.hedera.mirror.importer.domain.EntityIdService;
 import com.hedera.mirror.importer.exception.ImporterException;
 import com.hedera.mirror.importer.exception.ParserException;
@@ -485,12 +486,8 @@ public class SqlEntityListener implements EntityListener, RecordStreamFileListen
     public void onTransaction(Transaction transaction) throws ImporterException {
         transactions.add(transaction);
 
-        if (entityProperties.getPersist().isTransactionHash()) {
-            transactionHashes.add(TransactionHash.builder()
-                    .consensusTimestamp(transaction.getConsensusTimestamp())
-                    .hash(transaction.getTransactionHash())
-                    .payerAccountId(transaction.getPayerAccountId().getId())
-                    .build());
+        if (entityProperties.getPersist().shouldPersistTransactionHash(TransactionType.of(transaction.getType()))) {
+            transactionHashes.add(transaction.toTransactionHash());
         }
 
         if (transactions.size() == sqlProperties.getBatchSize()) {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/BackfillTransactionHashMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/BackfillTransactionHashMigrationTest.java
@@ -23,10 +23,12 @@ package com.hedera.mirror.importer.migration;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
-import java.util.Map;
+import java.util.EnumSet;
+import java.util.Set;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -35,7 +37,8 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 
-import com.hedera.mirror.common.domain.transaction.TransactionHash;
+import com.hedera.mirror.common.domain.transaction.Transaction;
+import com.hedera.mirror.common.domain.transaction.TransactionType;
 import com.hedera.mirror.importer.EnabledIfV1;
 import com.hedera.mirror.importer.IntegrationTest;
 import com.hedera.mirror.importer.MirrorProperties;
@@ -56,16 +59,23 @@ class BackfillTransactionHashMigrationTest extends IntegrationTest {
     private final MirrorProperties mirrorProperties;
     private final TransactionHashRepository transactionHashRepository;
 
+    private Set<TransactionType> defaultTransactionHashTypes;
     private BackfillTransactionHashMigration migration;
     private MigrationProperties migrationProperties;
 
     @BeforeEach
     void setup() {
+        defaultTransactionHashTypes = entityProperties.getPersist().getTransactionHashTypes();
         entityProperties.getPersist().setTransactionHash(true);
         migrationProperties = new MigrationProperties();
         migrationProperties.getParams().put("startTimestamp", Long.valueOf(DEFAULT_START_TIMESTAMP).toString());
         mirrorProperties.getMigration().put(MIGRATION_NAME, migrationProperties);
         migration = new BackfillTransactionHashMigration(entityProperties, jdbcTemplate, mirrorProperties);
+    }
+
+    @AfterEach
+    void teardown() {
+        entityProperties.getPersist().setTransactionHashTypes(defaultTransactionHashTypes);
     }
 
     @Test
@@ -84,11 +94,7 @@ class BackfillTransactionHashMigrationTest extends IntegrationTest {
                         domainBuilder.transaction().customize(t -> t.consensusTimestamp(DEFAULT_START_TIMESTAMP + 1)).persist()
                 )
                 .filter(t -> persistTransactionHash)
-                .map(t -> TransactionHash.builder()
-                        .consensusTimestamp(t.getConsensusTimestamp())
-                        .hash(t.getTransactionHash())
-                        .payerAccountId(t.getPayerAccountId().getId())
-                        .build())
+                .map(Transaction::toTransactionHash)
                 .toList();
         entityProperties.getPersist().setTransactionHash(persistTransactionHash);
 
@@ -97,6 +103,61 @@ class BackfillTransactionHashMigrationTest extends IntegrationTest {
 
         // then
         assertThat(transactionHashRepository.findAll()).containsExactlyInAnyOrderElementsOf(expectedTransactionHashes);
+    }
+
+    @Test
+    void migrateWhenTransactionHashTypesEmpty() {
+        // given
+        entityProperties.getPersist().setTransactionHashTypes(Collections.emptySet());
+        var expected = Stream.of(
+                domainBuilder.transaction().customize(t -> t.consensusTimestamp(DEFAULT_START_TIMESTAMP)).persist(),
+                domainBuilder.transaction().customize(t -> t.consensusTimestamp(DEFAULT_START_TIMESTAMP + 1)
+                        .type(TransactionType.CONSENSUSSUBMITMESSAGE.getProtoId())).persist()
+                )
+                .map(Transaction::toTransactionHash)
+                .toList();
+
+        // when
+        runMigration();
+
+        // then
+        assertThat(transactionHashRepository.findAll()).containsExactlyInAnyOrderElementsOf(expected);
+    }
+
+    @Test
+    void migrateWhenSomeTransactionTypesExcluded() {
+        // given
+        var cryptoTransfer = domainBuilder.transaction().customize(t -> t.consensusTimestamp(DEFAULT_START_TIMESTAMP))
+                .persist();
+        domainBuilder.transaction().customize(t -> t.consensusTimestamp(DEFAULT_START_TIMESTAMP + 1)
+                        .type(TransactionType.CONSENSUSSUBMITMESSAGE.getProtoId()))
+                .persist();
+        var expected = cryptoTransfer.toTransactionHash();
+
+        // when
+        runMigration();
+
+        // then
+        assertThat(transactionHashRepository.findAll()).containsExactly(expected);
+    }
+
+    @Test
+    void migrateWhenTransactionTypesCustomized() {
+        // given
+        entityProperties.getPersist().setTransactionHashTypes(EnumSet.complementOf(
+                EnumSet.of(TransactionType.CRYPTOTRANSFER)));
+        domainBuilder.transaction().customize(t -> t.consensusTimestamp(DEFAULT_START_TIMESTAMP)).persist();
+        var consensusSubmitMessage = domainBuilder.transaction()
+                .customize(t -> t.consensusTimestamp(DEFAULT_START_TIMESTAMP + 1)
+                        .type(TransactionType.CONSENSUSSUBMITMESSAGE.getProtoId()))
+                .persist();
+        var expected = consensusSubmitMessage.toTransactionHash();
+
+        // when
+        runMigration();
+
+        // then
+        assertThat(transactionHashRepository.findAll()).containsExactly(expected);
     }
 
     @Test
@@ -121,11 +182,7 @@ class BackfillTransactionHashMigrationTest extends IntegrationTest {
         var transaction = domainBuilder.transaction()
                 .customize(t -> t.consensusTimestamp(DEFAULT_START_TIMESTAMP))
                 .persist();
-        var expected = TransactionHash.builder()
-                .consensusTimestamp(transaction.getConsensusTimestamp())
-                .hash(transaction.getTransactionHash())
-                .payerAccountId(transaction.getPayerAccountId().getId())
-                .build();
+        var expected = transaction.toTransactionHash();
 
         // when
         runMigration();
@@ -141,11 +198,7 @@ class BackfillTransactionHashMigrationTest extends IntegrationTest {
         var transaction = domainBuilder.transaction()
                 .customize(t -> t.consensusTimestamp(DEFAULT_START_TIMESTAMP))
                 .persist();
-        var expected = TransactionHash.builder()
-                .consensusTimestamp(transaction.getConsensusTimestamp())
-                .hash(transaction.getTransactionHash())
-                .payerAccountId(transaction.getPayerAccountId().getId())
-                .build();
+        var expected = transaction.toTransactionHash();
 
         // when
         runMigration();

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/PersistPropertiesTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/PersistPropertiesTest.java
@@ -1,0 +1,63 @@
+package com.hedera.mirror.importer.parser.record.entity;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import com.hedera.mirror.common.domain.transaction.TransactionType;
+
+class PersistPropertiesTest {
+
+    @ParameterizedTest
+    @CsvSource(textBlock = """
+            true, CRYPTOTRANSFER, true,
+            true, CONSENSUSSUBMITMESSAGE, false,
+            false, CRYPTOTRANSFER, false,
+            false, CONSENSUSSUBMITMESSAGE, false,
+            """)
+    void shouldPersistTransactionHash(boolean transactionHash, TransactionType transactionType, boolean expected) {
+        var persistProperties = new EntityProperties.PersistProperties();
+        persistProperties.setTransactionHash(transactionHash);
+        persistProperties.setTransactionHashTypes(Set.of(transactionType));
+        assertThat(persistProperties.shouldPersistTransactionHash(TransactionType.CRYPTOTRANSFER)).isEqualTo(expected);
+        assertThat(persistProperties.shouldPersistTransactionHash(TransactionType.CONTRACTCALL)).isFalse();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldPersistTransactionHashWhenEmptyFilter(boolean transactionHash) {
+        var persistProperties = new EntityProperties.PersistProperties();
+        persistProperties.setTransactionHash(transactionHash);
+        persistProperties.setTransactionHashTypes(Collections.emptySet());
+        assertThat(persistProperties.shouldPersistTransactionHash(TransactionType.CRYPTOTRANSFER))
+                .isEqualTo(transactionHash);
+        assertThat(persistProperties.shouldPersistTransactionHash(TransactionType.CONTRACTCALL))
+                .isEqualTo(transactionHash);
+    }
+}

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListenerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListenerTest.java
@@ -29,21 +29,23 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.google.common.collect.Range;
 import com.google.protobuf.ByteString;
-import com.hedera.mirror.common.domain.token.NftTransferId;
-import com.hederahashgraph.api.proto.java.EntityID;
 import com.hederahashgraph.api.proto.java.Key;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import org.apache.commons.codec.binary.Hex;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.support.TransactionTemplate;
@@ -65,6 +67,7 @@ import com.hedera.mirror.common.domain.schedule.Schedule;
 import com.hedera.mirror.common.domain.token.Nft;
 import com.hedera.mirror.common.domain.token.NftId;
 import com.hedera.mirror.common.domain.token.NftTransfer;
+import com.hedera.mirror.common.domain.token.NftTransferId;
 import com.hedera.mirror.common.domain.token.Token;
 import com.hedera.mirror.common.domain.token.TokenAccount;
 import com.hedera.mirror.common.domain.token.TokenFreezeStatusEnum;
@@ -80,6 +83,7 @@ import com.hedera.mirror.common.domain.transaction.RecordFile;
 import com.hedera.mirror.common.domain.transaction.Transaction;
 import com.hedera.mirror.common.domain.transaction.TransactionHash;
 import com.hedera.mirror.common.domain.transaction.TransactionSignature;
+import com.hedera.mirror.common.domain.transaction.TransactionType;
 import com.hedera.mirror.common.util.DomainUtils;
 import com.hedera.mirror.importer.IntegrationTest;
 import com.hedera.mirror.importer.TestUtils;
@@ -161,15 +165,25 @@ class SqlEntityListenerTest extends IntegrationTest {
     private final TransactionSignatureRepository transactionSignatureRepository;
     private final TransactionTemplate transactionTemplate;
 
+    private Set<TransactionType> defaultTransactionHashTypes;
+
     private static Key keyFromString(String key) {
         return Key.newBuilder().setEd25519(ByteString.copyFromUtf8(key)).build();
     }
 
     @BeforeEach
     void beforeEach() {
+        defaultTransactionHashTypes = entityProperties.getPersist().getTransactionHashTypes();
+
+        entityProperties.getPersist().setTransactionHash(false);
         entityProperties.getPersist().setTrackBalance(true);
         sqlProperties.setBatchSize(20_000);
         sqlEntityListener.onStart();
+    }
+
+    @AfterEach
+    void afterEach() {
+        entityProperties.getPersist().setTransactionHashTypes(defaultTransactionHashTypes);
     }
 
     @Test
@@ -892,11 +906,7 @@ class SqlEntityListenerTest extends IntegrationTest {
         var thirdTransaction = domainBuilder.transaction().get();
         var expectedTransactionHashes = Stream.of(firstTransaction, secondTransaction, thirdTransaction)
                 .filter(t -> persistTransactionHash)
-                .map(transaction -> TransactionHash.builder()
-                        .consensusTimestamp(transaction.getConsensusTimestamp())
-                        .hash(transaction.getTransactionHash())
-                        .payerAccountId(transaction.getPayerAccountId().getId())
-                        .build())
+                .map(Transaction::toTransactionHash)
                 .toList();
 
         // when
@@ -927,6 +937,54 @@ class SqlEntityListenerTest extends IntegrationTest {
                 .extracting(Transaction::getIndex)
                 .isEqualTo(2);
 
+        assertThat(transactionHashRepository.findAll()).containsExactlyInAnyOrderElementsOf(expectedTransactionHashes);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = TransactionType.class, names = {"CRYPTOTRANSFER", "CONSENSUSSUBMITMESSAGE"})
+    void onTransactionHashByTransactionType(TransactionType includedTransactionType) {
+        // given
+        entityProperties.getPersist().setTransactionHash(true);
+        entityProperties.getPersist().setTransactionHashTypes(Set.of(includedTransactionType));
+        var consensusSubmitMessage = domainBuilder.transaction()
+                .customize(t -> t.type(TransactionType.CONSENSUSSUBMITMESSAGE.getProtoId())).get();
+        var cryptoTransfer = domainBuilder.transaction().get();
+        var expectedTransactionHashes = Stream.of(consensusSubmitMessage, cryptoTransfer)
+                .filter(t -> t.getType() == includedTransactionType.getProtoId())
+                .map(Transaction::toTransactionHash)
+                .toList();
+
+        // when
+        sqlEntityListener.onTransaction(cryptoTransfer);
+        sqlEntityListener.onTransaction(consensusSubmitMessage);
+        completeFileAndCommit();
+
+        // then
+        assertThat(transactionRepository.findAll())
+                .containsExactlyInAnyOrder(consensusSubmitMessage, cryptoTransfer);
+        assertThat(transactionHashRepository.findAll()).containsExactlyInAnyOrderElementsOf(expectedTransactionHashes);
+    }
+
+    @Test
+    void onTransactionHashWhenFilterEmpty() {
+        // given
+        entityProperties.getPersist().setTransactionHash(true);
+        entityProperties.getPersist().setTransactionHashTypes(Collections.emptySet());
+        var consensusSubmitMessage = domainBuilder.transaction()
+                .customize(t -> t.type(TransactionType.CONSENSUSSUBMITMESSAGE.getProtoId())).get();
+        var cryptoTransfer = domainBuilder.transaction().get();
+        var expectedTransactionHashes = Stream.of(consensusSubmitMessage, cryptoTransfer)
+                .map(Transaction::toTransactionHash)
+                .toList();
+
+        // when
+        sqlEntityListener.onTransaction(cryptoTransfer);
+        sqlEntityListener.onTransaction(consensusSubmitMessage);
+        completeFileAndCommit();
+
+        // then
+        assertThat(transactionRepository.findAll())
+                .containsExactlyInAnyOrder(consensusSubmitMessage, cryptoTransfer);
         assertThat(transactionHashRepository.findAll()).containsExactlyInAnyOrderElementsOf(expectedTransactionHashes);
     }
 


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR ports the change to `release/0.77`.

- Add a persist property `transactionHashTypes` and default to exclude `CONSENSUSSUBMITMESSAGE`
- Persist transaction hash of transaction types in the persist property
- Update `BackfillTransactionHashMigration` to filter by transaction type

**Related issue(s)**:

Relates to #5714

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
