### PR TITLE
Remove entity deletion check in balance migrations…

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/InitializeEntityBalanceMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/InitializeEntityBalanceMigration.java
@@ -62,7 +62,7 @@ public class InitializeEntityBalanceMigration extends RepeatableMigration {
             update entity
             set balance = s.balance
             from state s
-            where account_id = id and deleted is not true and type in ('ACCOUNT', 'CONTRACT');
+            where account_id = id and type in ('ACCOUNT', 'CONTRACT');
             """;
 
     private final JdbcOperations jdbcOperations;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/TokenAccountBalanceMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/TokenAccountBalanceMigration.java
@@ -41,9 +41,6 @@ public class TokenAccountBalanceMigration extends RepeatableMigration {
                 order by consensus_timestamp desc
                 limit 1
             ),
-            entity as (
-                select id from entity where deleted = false
-            ),
             token_balance as (
                 select *
                 from token_balance
@@ -62,7 +59,6 @@ public class TokenAccountBalanceMigration extends RepeatableMigration {
                 end
             from token_balance
             left join token_transfer tt on tt.token_id = token_balance.token_id and tt.account_id = token_balance.account_id
-            join entity e on e.id = token_balance.account_id
             where t.account_id = token_balance.account_id and t.token_id = token_balance.token_id""";
 
     private final JdbcOperations jdbcOperations;

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/InitializeEntityBalanceMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/InitializeEntityBalanceMigrationTest.java
@@ -89,7 +89,6 @@ class InitializeEntityBalanceMigrationTest extends IntegrationTest {
         initializeEntityBalanceMigration.doMigrate();
 
         // then
-        accountDeleted.setBalance(20L);
         assertThat(entityRepository.findAll()).containsExactlyInAnyOrder(account, accountDeleted, contract, topic);
     }
 
@@ -109,7 +108,6 @@ class InitializeEntityBalanceMigrationTest extends IntegrationTest {
         initializeEntityBalanceMigration.doMigrate();
 
         // then
-        accountDeleted.setBalance(20L);
         assertThat(entityRepository.findAll()).containsExactlyInAnyOrder(account, accountDeleted, contract, topic);
     }
 
@@ -125,6 +123,7 @@ class InitializeEntityBalanceMigrationTest extends IntegrationTest {
 
         // then
         account.setBalance(0L);
+        accountDeleted.setBalance(0L);
         contract.setBalance(0L);
         assertThat(entityRepository.findAll()).containsExactlyInAnyOrder(account, accountDeleted, contract, topic);
     }
@@ -141,6 +140,7 @@ class InitializeEntityBalanceMigrationTest extends IntegrationTest {
 
         // then
         account.setBalance(0L);
+        accountDeleted.setBalance(0L);
         contract.setBalance(0L);
         assertThat(entityRepository.findAll()).containsExactlyInAnyOrder(account, accountDeleted, contract, topic);
     }
@@ -157,6 +157,7 @@ class InitializeEntityBalanceMigrationTest extends IntegrationTest {
 
         // then
         account.setBalance(0L);
+        accountDeleted.setBalance(0L);
         contract.setBalance(0L);
         assertThat(entityRepository.findAll()).containsExactlyInAnyOrder(account, accountDeleted, contract, topic);
     }
@@ -224,8 +225,9 @@ class InitializeEntityBalanceMigrationTest extends IntegrationTest {
         persistAccountBalance(750L, account.toEntityId(), accountBalanceTimestamp2);
         persistAccountBalance(450L, contract.toEntityId(), accountBalanceTimestamp2);
 
-        // Set expected balance
+        // Set expected balances
         account.setBalance(505L);
+        accountDeleted.setBalance(20L);
         contract.setBalance(25L);
     }
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/InitializeEntityBalanceMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/InitializeEntityBalanceMigrationTest.java
@@ -89,6 +89,7 @@ class InitializeEntityBalanceMigrationTest extends IntegrationTest {
         initializeEntityBalanceMigration.doMigrate();
 
         // then
+        accountDeleted.setBalance(20L);
         assertThat(entityRepository.findAll()).containsExactlyInAnyOrder(account, accountDeleted, contract, topic);
     }
 
@@ -108,6 +109,7 @@ class InitializeEntityBalanceMigrationTest extends IntegrationTest {
         initializeEntityBalanceMigration.doMigrate();
 
         // then
+        accountDeleted.setBalance(20L);
         assertThat(entityRepository.findAll()).containsExactlyInAnyOrder(account, accountDeleted, contract, topic);
     }
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/TokenAccountBalanceMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/TokenAccountBalanceMigrationTest.java
@@ -94,7 +94,6 @@ class TokenAccountBalanceMigrationTest extends IntegrationTest {
         tokenAccountBalanceMigration.doMigrate();
 
         // then
-        deletedEntityTokenAccount4.setBalance(1009875L);
         assertThat(tokenAccountRepository.findAll())
                 .containsExactlyInAnyOrder(tokenAccount, tokenAccount2, tokenAccount3, deletedEntityTokenAccount4,
                         disassociatedTokenAccount5);
@@ -127,7 +126,6 @@ class TokenAccountBalanceMigrationTest extends IntegrationTest {
         // then
         tokenAccount.setBalance(balanceUpdatedAfterBalanceFileConsensusTimestamp + secondBalanceUpdate +
                 tokenAccount.getBalance());
-        deletedEntityTokenAccount4.setBalance(1009875L);
         assertThat(tokenAccountRepository.findAll())
                 .containsExactlyInAnyOrder(tokenAccount, tokenAccount2, tokenAccount3, deletedEntityTokenAccount4,
                         disassociatedTokenAccount5);
@@ -144,6 +142,7 @@ class TokenAccountBalanceMigrationTest extends IntegrationTest {
         tokenAccountBalanceMigration.doMigrate();
 
         // then
+        deletedEntityTokenAccount4.setBalance(0L);
         tokenAccount.setBalance(0L);
         tokenAccount2.setBalance(0L);
         tokenAccount3.setBalance(0L);
@@ -165,6 +164,7 @@ class TokenAccountBalanceMigrationTest extends IntegrationTest {
         tokenAccount.setBalance(0L);
         tokenAccount2.setBalance(0L);
         tokenAccount3.setBalance(0L);
+        deletedEntityTokenAccount4.setBalance(0L);
         assertThat(tokenAccountRepository.findAll())
                 .containsExactlyInAnyOrder(tokenAccount, tokenAccount2, tokenAccount3, deletedEntityTokenAccount4,
                         disassociatedTokenAccount5);
@@ -183,6 +183,7 @@ class TokenAccountBalanceMigrationTest extends IntegrationTest {
         tokenAccount.setBalance(0L);
         tokenAccount2.setBalance(0L);
         tokenAccount3.setBalance(0L);
+        deletedEntityTokenAccount4.setBalance(0L);
         assertThat(tokenAccountRepository.findAll())
                 .containsExactlyInAnyOrder(tokenAccount, tokenAccount2, tokenAccount3, deletedEntityTokenAccount4,
                         disassociatedTokenAccount5);
@@ -336,7 +337,7 @@ class TokenAccountBalanceMigrationTest extends IntegrationTest {
         tokenAccount.setBalance(tokenBalance1Amount);
         tokenAccount2.setBalance(tokenBalance2Amount + tokenTransfer2Amount);
         tokenAccount3.setBalance(tokenBalance3Amount);
-        deletedEntityTokenAccount4.setBalance(0L);
+        deletedEntityTokenAccount4.setBalance(1009875L);
         disassociatedTokenAccount5.setBalance(0L);
 
         // Second record file

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/TokenAccountBalanceMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/TokenAccountBalanceMigrationTest.java
@@ -94,6 +94,7 @@ class TokenAccountBalanceMigrationTest extends IntegrationTest {
         tokenAccountBalanceMigration.doMigrate();
 
         // then
+        deletedEntityTokenAccount4.setBalance(1009875L);
         assertThat(tokenAccountRepository.findAll())
                 .containsExactlyInAnyOrder(tokenAccount, tokenAccount2, tokenAccount3, deletedEntityTokenAccount4,
                         disassociatedTokenAccount5);
@@ -126,6 +127,7 @@ class TokenAccountBalanceMigrationTest extends IntegrationTest {
         // then
         tokenAccount.setBalance(balanceUpdatedAfterBalanceFileConsensusTimestamp + secondBalanceUpdate +
                 tokenAccount.getBalance());
+        deletedEntityTokenAccount4.setBalance(1009875L);
         assertThat(tokenAccountRepository.findAll())
                 .containsExactlyInAnyOrder(tokenAccount, tokenAccount2, tokenAccount3, deletedEntityTokenAccount4,
                         disassociatedTokenAccount5);
@@ -198,6 +200,7 @@ class TokenAccountBalanceMigrationTest extends IntegrationTest {
         // then
         tokenAccount.setBalance(100L);
         tokenAccount2.setBalance(33L);
+        deletedEntityTokenAccount4.setBalance(999999L);
         assertThat(tokenAccountRepository.findAll())
                 .containsExactlyInAnyOrder(tokenAccount, tokenAccount2, tokenAccount3, deletedEntityTokenAccount4,
                         disassociatedTokenAccount5);


### PR DESCRIPTION
… (that is, `InitializeEntityBalanceMigration` and `TokenAccountBalanceMigration`)/

**Description**:
Remove the join/deleted check from both migrations, and (in the migration integration tests) adjust the expected balance on the deleted account.

**Related issue(s)**:

Fixes #5464 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
