### PR TITLE
Reduce Citus default shard count to 16

### DIFF
--- a/charts/hedera-mirror/values.yaml
+++ b/charts/hedera-mirror/values.yaml
@@ -68,7 +68,11 @@ citus:
     tag: 11.2.0-pg14
   nameOverride: citus
   primary:
-    args: ["-c", "config_file=/bitnami/postgresql/conf/postgresql.conf"]
+    args:
+    - "-c"
+    - "config_file=/bitnami/postgresql/conf/postgresql.conf"
+    - "-c"
+    - "hba_file=/bitnami/postgresql/conf/pg_hba.conf"
     configuration: |
       checkpoint_timeout = 1800
       citus.executor_slow_start_interval = 100ms
@@ -92,6 +96,15 @@ citus:
     initdb:
       scriptsConfigMap: "{{ .Release.Name }}-init"
     name: coordinator
+    pgHbaConfiguration: |
+      local   all             all                                     trust
+      host    all             all             127.0.0.1/32            trust
+      host    all             all             ::1/128                 trust
+      local   replication     all                                     trust
+      host    replication     all             127.0.0.1/32            trust
+      host    replication     all             ::1/128                 trust
+      host    replication     all             all                     scram-sha-256
+      host    all             all             all                     scram-sha-256
     startupProbe:
       enabled: true
       failureThreshold: 60

--- a/docs/database.md
+++ b/docs/database.md
@@ -201,6 +201,16 @@ transactions in the balance and record streams. These issues should only appear 
   
 ## Database migration from V1 to V2
 
+[Citus](https://github.com/citusdata/citus) is the database engine to use with the V2 schema.
+
+The following table is the recommended configuration for a production Citus cluster. Note the storage size is an
+estimation for all mainnet data since OA till 04/2023.
+
+| Node Type   | Count | vCPU | Memory | Disk Storage |
+|-------------|-------|------|--------|--------------|
+| Coordinator | 3     | 4    | 26 GB  | 256 GB       |
+| Worker      | 3     | 4    | 26 GB  | 5 TB         |
+
 Following are the prerequisites and steps for migrating V1 data to V2.
 
 1. Create a Citus cluster with enough resources (Disk, CPU and memory).
@@ -214,11 +224,3 @@ Following are the prerequisites and steps for migrating V1 data to V2.
 6. Run the [migration.sh](/hedera-mirror-importer/src/main/resources/db/scripts/v2/migration.sh) script.
 7. Stop the [Importer](/docs/importer/README.md) process.
 8. Update the Importer to point to the new Citus DB and start it.
-
-The recommended configuration for a production Citus cluster. Note the storage size depends on the amount of data to
-ingest and keep.
-
-| Node Type   | Count | vCPU | Memory | Disk Storage |
-|-------------|-------|------|--------|--------------|
-| Coordinator | 1     | 4    | 26 GB  | 64 GB        |
-| Worker      | 3     | 4    | 26 GB  | 512 GB       |

--- a/docs/database.md
+++ b/docs/database.md
@@ -199,15 +199,26 @@ transactions in the balance and record streams. These issues should only appear 
 * Solution: Fixed in Hedera Services [v0.34.2](https://github.com/hashgraph/hedera-services/releases/tag/v0.34.2) on
   February 17, 2023. Fixed in Mirror Node in v0.74.3 by a migration that adds the missing transactions.
   
-### Database migration from V1 to V2
+## Database migration from V1 to V2
 
 Following are the prerequisites and steps for migrating V1 data to V2.
-1. Create a citus cluster with enough resources(Disk, CPU and memory).
-2. Populate correct values for OLD_DB config in the [migration.config](/hedera-mirror-importer/src/main/resources/db/scripts/v2/migration.config) to point to the existing database instance.
+
+1. Create a Citus cluster with enough resources (Disk, CPU and memory).
+2. Populate correct values for OLD_DB config in the 
+   [migration.config](/hedera-mirror-importer/src/main/resources/db/scripts/v2/migration.config) to point to the 
+   existing database instance.
 3. Populate correct values for NEW_DB config in the migration.config to point to the new citus DB.
-4. Get the correct version of [flyway](https://flywaydb.org/documentation/usage/commandline/) based on your OS and update it in the FLYWAY_URL field in the migration.config file. The default is set to the macosx version.
+4. Get the correct version of [flyway](https://flywaydb.org/documentation/usage/commandline/) based on your OS and
+   update it in the FLYWAY_URL field in the migration.config file. The default is set to the macosx version.
 5. Update the flyway.url field in the flyway.conf file to point to the citus db location.
 6. Run the [migration.sh](/hedera-mirror-importer/src/main/resources/db/scripts/v2/migration.sh) script.
 7. Stop the [Importer](/docs/importer/README.md) process.
-8. Update the Importer to point to the new citus DB and start it.
+8. Update the Importer to point to the new Citus DB and start it.
 
+The recommended configuration for a production Citus cluster. Note the storage size depends on the amount of data to
+ingest and keep.
+
+| Node Type   | Count | vCPU | Memory | Disk Storage |
+|-------------|-------|------|--------|--------------|
+| Coordinator | 1     | 4    | 26 GB  | 64 GB        |
+| Worker      | 3     | 4    | 26 GB  | 512 GB       |

--- a/hedera-mirror-importer/src/main/resources/application.yml
+++ b/hedera-mirror-importer/src/main/resources/application.yml
@@ -112,7 +112,7 @@ spring:
       partitionIdInterval: "'1000000'"
       partitionStartDate: "'3 years'"
       schema: ${hedera.mirror.importer.db.schema}
-      shardCount: 32
+      shardCount: 16
     user: ${hedera.mirror.importer.db.owner}
   jpa:
     properties:


### PR DESCRIPTION
**Description**:

* Document recommended Citus cluster configuration
* Reduce Citus default shard count to 16
* Update Citus coordinator config to allow replication

**Related issue(s)**:

Fixes #5622 

**Notes for reviewer**:

Per the discussion in scrum, the PR reduces the Citus default shard count to 16. The test result with 3 coordinators can be found in #5622.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
