### PR TITLE
05755-Account model copy from services to mirror-node-web3 package

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/models/Account.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/models/Account.java
@@ -1,0 +1,181 @@
+package com.hedera.services.store.models;
+
+/*
+ * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import static com.hedera.node.app.service.evm.utils.ValidationUtils.validateFalse;
+import static com.hedera.node.app.service.evm.utils.ValidationUtils.validateTrue;
+import static com.hedera.services.utils.BitPackUtils.getAlreadyUsedAutomaticAssociationsFrom;
+import static com.hedera.services.utils.BitPackUtils.getMaxAutomaticAssociationsFrom;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FAIL_INVALID;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKENS_PER_ACCOUNT_LIMIT_EXCEEDED;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_ALREADY_ASSOCIATED_TO_ACCOUNT;
+
+import com.google.common.base.MoreObjects;
+import java.util.ArrayList;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import lombok.Builder;
+import lombok.Value;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.hyperledger.besu.datatypes.Address;
+
+import com.hedera.node.app.service.evm.store.models.HederaEvmAccount;
+import com.hedera.services.utils.EntityNum;
+
+@Value
+@Builder
+public class Account extends HederaEvmAccount {
+    Id id;
+    long expiry;
+    long balance;
+    boolean deleted = false;
+    boolean isSmartContract = false;
+    boolean isReceiverSigRequired = false;
+    long ownedNfts;
+    long autoRenewSecs;
+    String memo = "";
+    Id proxy;
+    Address accountAddress;
+    int autoAssociationMetadata;
+    TreeMap<EntityNum, Long> cryptoAllowances;
+    TreeMap<FcTokenAllowanceId, Long> fungibleTokenAllowances;
+    TreeSet<FcTokenAllowanceId> approveForAllNfts;
+    int numAssociations;
+    int numPositiveBalances;
+    int numTreasuryTitles;
+
+    public Account(Id id, long expiry, long balance, long ownedNfts, long autoRenewSecs,
+                   Id proxy, Address accountAddress, int autoAssociationMetadata,
+                   TreeMap<EntityNum, Long> cryptoAllowances, TreeMap<FcTokenAllowanceId, Long> fungibleTokenAllowances,
+                   TreeSet<FcTokenAllowanceId> approveForAllNfts, int numAssociations, int numPositiveBalances,
+                   int numTreasuryTitles) {
+        super(id.asEvmAddress());
+        this.id = id;
+        this.expiry = expiry;
+        this.balance = balance;
+        this.ownedNfts = ownedNfts;
+        this.autoRenewSecs = autoRenewSecs;
+        this.proxy = proxy;
+        this.accountAddress = accountAddress;
+        this.autoAssociationMetadata = autoAssociationMetadata;
+        this.cryptoAllowances = cryptoAllowances;
+        this.fungibleTokenAllowances = fungibleTokenAllowances;
+        this.approveForAllNfts = approveForAllNfts;
+        this.numAssociations = numAssociations;
+        this.numPositiveBalances = numPositiveBalances;
+        this.numTreasuryTitles = numTreasuryTitles;
+    }
+
+    public int getMaxAutomaticAssociations() {
+        return getMaxAutomaticAssociationsFrom(autoAssociationMetadata);
+    }
+
+    public int getAlreadyUsedAutomaticAssociations() {
+        return getAlreadyUsedAutomaticAssociationsFrom(autoAssociationMetadata);
+    }
+
+    /**
+     * Associated the given list of Tokens to this account.
+     *
+     * @param tokens                   List of tokens to be associated to the Account
+     * @param tokenStore               TypedTokenStore to validate if existing relationship with the tokens to be
+     *                                 associated with
+     * @param isAutomaticAssociation   whether these associations count against the max auto-associations limit
+     * @param shouldEnableRelationship whether the new relationships should be enabled unconditionally, no matter KYC
+     *                                 and freeze settings
+     * @param dynamicProperties        GlobalDynamicProperties to fetch the token associations limit and enforce it.
+     * @return the new token relationships formed by this association
+     */
+    public List<TokenRelationship> associateWith(
+            final List<Token> tokens,
+            final TypedTokenStore tokenStore,
+            final boolean isAutomaticAssociation,
+            final boolean shouldEnableRelationship,
+            final GlobalDynamicProperties dynamicProperties) {
+        final var proposedTotalAssociations = tokens.size() + numAssociations;
+        validateFalse(
+                exceedsTokenAssociationLimit(dynamicProperties, proposedTotalAssociations),
+                TOKENS_PER_ACCOUNT_LIMIT_EXCEEDED);
+        final List<TokenRelationship> newModelRels = new ArrayList<>();
+        for (final var token : tokens) {
+            validateFalse(tokenStore.hasAssociation(token, this), TOKEN_ALREADY_ASSOCIATED_TO_ACCOUNT);
+            if (isAutomaticAssociation) {
+                incrementUsedAutomaticAssociations();
+            }
+            final var newRel = shouldEnableRelationship
+                    ? token.newEnabledRelationship(this)
+                    : token.newRelationshipWith(this, false);
+            numAssociations++;
+            newModelRels.add(newRel);
+        }
+        return newModelRels;
+    }
+
+    public void dissociateUsing(final List<Dissociation> dissociations, final OptionValidator validator) {
+        for (final var dissociation : dissociations) {
+            validateTrue(id.equals(dissociation.dissociatingAccountId()), FAIL_INVALID);
+            dissociation.updateModelRelsSubjectTo(validator);
+            final var pastRel = dissociation.dissociatingAccountRel();
+            if (pastRel.isAutomaticAssociation()) {
+                decrementUsedAutomaticAssociations();
+            }
+            if (pastRel.getBalanceChange() != 0) {
+                numPositiveBalances--;
+            }
+            numAssociations--;
+        }
+    }
+
+    private boolean exceedsTokenAssociationLimit(MirrorNodeEvmProperties dynamicProperties, int totalAssociations) {
+        return dynamicProperties.areTokenAssociationsLimited()
+                && totalAssociations > dynamicProperties.maxTokensPerAccount();
+    }
+
+    /* NOTE: The object methods below are only overridden to improve
+    readability of unit tests; this model object is not used in hash-based
+    collections, so the performance of these methods doesn't matter. */
+
+    @Override
+    public boolean equals(Object obj) {
+        return EqualsBuilder.reflectionEquals(this, obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(Account.class)
+                .add("id", id)
+                .add("expiry", expiry)
+                .add("balance", balance)
+                .add("deleted", deleted)
+                .add("ownedNfts", ownedNfts)
+                .add("alreadyUsedAutoAssociations", getAlreadyUsedAutomaticAssociations())
+                .add("maxAutoAssociations", getMaxAutomaticAssociations())
+                .add("alias", getAlias().toStringUtf8())
+                .add("cryptoAllowances", cryptoAllowances)
+                .add("fungibleTokenAllowances", fungibleTokenAllowances)
+                .add("approveForAllNfts", approveForAllNfts)
+                .add("numAssociations", numAssociations)
+                .add("numPositiveBalances", numPositiveBalances)
+                .toString();
+    }
+}

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/models/FcTokenAllowanceId.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/models/FcTokenAllowanceId.java
@@ -1,0 +1,138 @@
+package com.hedera.services.store.models;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.google.common.base.MoreObjects;
+
+import com.hedera.services.utils.EntityNum;
+
+import com.hederahashgraph.api.proto.java.AccountID;
+import com.hederahashgraph.api.proto.java.TokenID;
+import com.swirlds.common.io.SelfSerializable;
+import com.swirlds.common.io.streams.SerializableDataInputStream;
+import com.swirlds.common.io.streams.SerializableDataOutputStream;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import org.apache.commons.lang3.builder.CompareToBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import java.io.IOException;
+
+/**
+ * Represents the key for {@code nftAllowances} and {@code fungibleTokenAllowances} maps in {@code
+ * MerkleAccountState}. It consists of the information about the token for which allowance is
+ * granted to and the spender who is granted the allowance.
+ *
+ * <p>Having allowance on a token will grant the spender to transfer fungible or non-fungible token
+ * units from the owner's account.
+ */
+public class FcTokenAllowanceId implements SelfSerializable, Comparable<FcTokenAllowanceId> {
+    static final int RELEASE_023X_VERSION = 1;
+    static final int CURRENT_VERSION = RELEASE_023X_VERSION;
+    static final long RUNTIME_CONSTRUCTABLE_ID = 0xf55baa544950f139L;
+
+    private EntityNum tokenNum;
+    private EntityNum spenderNum;
+
+    public FcTokenAllowanceId() {
+        /* RuntimeConstructable */
+    }
+
+    public FcTokenAllowanceId(final EntityNum tokenNum, final EntityNum spenderNum) {
+        this.tokenNum = tokenNum;
+        this.spenderNum = spenderNum;
+    }
+
+    public static FcTokenAllowanceId from(final TokenID tokenId, final AccountID accountId) {
+        return new FcTokenAllowanceId(EntityNum.fromTokenId(tokenId), EntityNum.fromAccountId(accountId));
+    }
+
+    @Override
+    public void deserialize(final SerializableDataInputStream din, final int i) throws IOException {
+        tokenNum = EntityNum.fromInt(din.readInt());
+        spenderNum = EntityNum.fromInt(din.readInt());
+    }
+
+    @Override
+    public void serialize(final SerializableDataOutputStream dos) throws IOException {
+        dos.writeInt(tokenNum.intValue());
+        dos.writeInt(spenderNum.intValue());
+    }
+
+    @Override
+    public long getClassId() {
+        return RUNTIME_CONSTRUCTABLE_ID;
+    }
+
+    @Override
+    public int getVersion() {
+        return CURRENT_VERSION;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || !obj.getClass().equals(FcTokenAllowanceId.class)) {
+            return false;
+        }
+
+        final var that = (FcTokenAllowanceId) obj;
+        return new EqualsBuilder()
+                .append(tokenNum, that.tokenNum)
+                .append(spenderNum, that.spenderNum)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder().append(tokenNum).append(spenderNum).toHashCode();
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .omitNullValues()
+                .add("tokenNum", tokenNum.longValue())
+                .add("spenderNum", spenderNum.longValue())
+                .toString();
+    }
+
+    public EntityNum getTokenNum() {
+        return tokenNum;
+    }
+
+    public EntityNum getSpenderNum() {
+        return spenderNum;
+    }
+
+    public static FcTokenAllowanceId from(final EntityNum tokenNum, final EntityNum spenderNum) {
+        return new FcTokenAllowanceId(tokenNum, spenderNum);
+    }
+
+    @Override
+    public int compareTo(@NonNull final FcTokenAllowanceId that) {
+        return new CompareToBuilder()
+                .append(tokenNum, that.tokenNum)
+                .append(spenderNum, that.spenderNum)
+                .toComparison();
+    }
+}

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/models/Id.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/models/Id.java
@@ -1,0 +1,96 @@
+package com.hedera.services.store.models;
+
+import static com.hedera.services.utils.BitPackUtils.perm64;
+
+import com.hedera.services.utils.EntityIdUtils;
+
+import com.hederahashgraph.api.proto.java.AccountID;
+import com.hederahashgraph.api.proto.java.ContractID;
+import com.hederahashgraph.api.proto.java.TokenID;
+import com.hederahashgraph.api.proto.java.TopicID;
+import java.util.Comparator;
+import org.apache.tuweni.bytes.Bytes;
+import org.hyperledger.besu.datatypes.Address;
+
+import com.hedera.services.utils.EntityNum;
+
+/** Represents the id of a Hedera entity (account, topic, token, contract, file, or schedule). */
+public record Id(long shard, long realm, long num) {
+    public static final Id DEFAULT = new Id(0, 0, 0);
+    public static final Comparator<Id> ID_COMPARATOR =
+            Comparator.comparingLong(Id::num).thenComparingLong(Id::shard).thenComparingLong(Id::realm);
+    public static final Id MISSING_ID = new Id(0, 0, 0);
+
+    public static Id fromGrpcAccount(final AccountID id) {
+        return new Id(id.getShardNum(), id.getRealmNum(), id.getAccountNum());
+    }
+
+    public static Id fromGrpcContract(final ContractID id) {
+        return new Id(id.getShardNum(), id.getRealmNum(), id.getContractNum());
+    }
+
+    public static Id fromGrpcToken(final TokenID id) {
+        return new Id(id.getShardNum(), id.getRealmNum(), id.getTokenNum());
+    }
+
+    public static Id fromGrpcTopic(final TopicID id) {
+        return new Id(id.getShardNum(), id.getRealmNum(), id.getTopicNum());
+    }
+
+    public EntityNum asEntityNum() {
+        return EntityNum.fromLong(num);
+    }
+
+    public AccountID asGrpcAccount() {
+        return AccountID.newBuilder()
+                .setShardNum(shard)
+                .setRealmNum(realm)
+                .setAccountNum(num)
+                .build();
+    }
+
+    public TokenID asGrpcToken() {
+        return TokenID.newBuilder()
+                .setShardNum(shard)
+                .setRealmNum(realm)
+                .setTokenNum(num)
+                .build();
+    }
+
+    public TopicID asGrpcTopic() {
+        return TopicID.newBuilder()
+                .setShardNum(shard)
+                .setRealmNum(realm)
+                .setTopicNum(num)
+                .build();
+    }
+
+    public ContractID asGrpcContract() {
+        return ContractID.newBuilder()
+                .setShardNum(shard)
+                .setRealmNum(realm)
+                .setContractNum(num)
+                .build();
+    }
+
+    @Override
+    public int hashCode() {
+        return (int) perm64(perm64(perm64(shard) ^ realm) ^ num);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%d.%d.%d", shard, realm, num);
+    }
+
+
+    /**
+     * Returns the EVM representation of the Account
+     *
+     * @return {@link Address} evm representation
+     */
+    public Address asEvmAddress() {
+        return Address.fromHexString(EntityIdUtils.asHexedEvmAddress(this));
+    }
+}
+

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/utils/BitPackUtils.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/utils/BitPackUtils.java
@@ -1,0 +1,213 @@
+package com.hedera.services.utils;
+
+import lombok.experimental.UtilityClass;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+@UtilityClass
+public class BitPackUtils {
+    private static final int MAX_AUTOMATIC_ASSOCIATIONS_MASK = (1 << 16) - 1;
+    private static final int ALREADY_USED_AUTOMATIC_ASSOCIATIONS_MASK = MAX_AUTOMATIC_ASSOCIATIONS_MASK << 16;
+
+    private static final long MASK_INT_AS_UNSIGNED_LONG = (1L << 32) - 1;
+    private static final long MASK_HI_ORDER_32 = MASK_INT_AS_UNSIGNED_LONG << 32;
+
+    public static final long MAX_NUM_ALLOWED = 0xFFFFFFFFL;
+
+    /**
+     * Returns a {@code long} whose high-order 32 bits "encode" an unsigned integer value, and whose
+     * low-order 32 bits are a signed integer. For use with the {@link
+     * BitPackUtils#unsignedHighOrder32From(long)} and {@link
+     * BitPackUtils#signedLowOrder32From(long)} helpers below. This format can represent timestamps
+     * through January 2106.
+     *
+     * @param seconds some number of seconds since the epoch
+     * @param nanos some number of nanos after the above second
+     * @return a "packed" version of these values
+     */
+    public static long packedTime(long seconds, int nanos) {
+        assertValid(seconds);
+        return seconds << 32 | (nanos & MASK_INT_AS_UNSIGNED_LONG);
+    }
+
+    /**
+     * Returns a {@code long} whose high-order and low-order 32 bits both "encode" an unsigned
+     * integer value. For use with the {@link BitPackUtils#unsignedHighOrder32From(long)} and {@link
+     * BitPackUtils#unsignedLowOrder32From(long)}.
+     *
+     * @param a some number in the range [0, MAX_NUM_ALLOWED]
+     * @param b some other number in the range [0, MAX_NUM_ALLOWED]
+     * @return a "packed" version of these values
+     * @throws IllegalArgumentException if either argument is less than 0 or greater than
+     *     4_294_967_295
+     */
+    public static long packedNums(long a, long b) {
+        assertValid(a);
+        assertValid(b);
+        return a << 32 | b;
+    }
+
+    /**
+     * Returns the high-order 32 bits of the given {@code long}, interpreted as an unsigned integer.
+     *
+     * @param l any long
+     * @return the high-order 32 bits as an unsigned integer
+     */
+    public static long unsignedHighOrder32From(long l) {
+        return (l & MASK_HI_ORDER_32) >>> 32;
+    }
+
+    /**
+     * Returns the low-order 32 bits of the given {@code long}, interpreted as an unsigned integer.
+     *
+     * @param l any long
+     * @return the low-order 32 bits as an unsigned integer
+     */
+    public static long unsignedLowOrder32From(long l) {
+        return l & MASK_INT_AS_UNSIGNED_LONG;
+    }
+
+    /**
+     * Returns the low-order 32 bits of the given {@code long} as a signed integer.
+     *
+     * @param packedTime any long
+     * @return the low-order 32 bits as a signed integer
+     */
+    public static int signedLowOrder32From(long packedTime) {
+        return (int) (packedTime & MASK_INT_AS_UNSIGNED_LONG);
+    }
+
+    /**
+     * Returns the positive long represented by the given integer code.
+     *
+     * @param code an int to interpret as unsigned
+     * @return the corresponding positive long
+     */
+    public static long numFromCode(int code) {
+        return code & MASK_INT_AS_UNSIGNED_LONG;
+    }
+
+    /**
+     * Returns the int representing the given positive long.
+     *
+     * @param num a positive long
+     * @return the corresponding integer code
+     */
+    public static int codeFromNum(long num) {
+        assertValid(num);
+        return (int) num;
+    }
+
+    /**
+     * Throws an exception if the given long is not a number in the allowed range.
+     *
+     * @param num the long to check
+     * @throws IllegalArgumentException if the argument is less than 0 or greater than 4_294_967_295
+     */
+    public static void assertValid(long num) {
+        if (num < 0 || num > MAX_NUM_ALLOWED) {
+            throw new IllegalArgumentException("Serial number " + num + " out of range!");
+        }
+    }
+
+    /**
+     * Returns a {@code int} whose higher-order 16 bits "encode" an unsigned int value which
+     * represent the already used AutomaticAssociations of an account and lower-order 16 bits
+     * "encode" an unsigned int value which represent the maximum allowed AutomaticAssociations for
+     * that account.
+     *
+     * @param maxAutoAssociations maximum allowed automatic associations of an account.
+     * @param alreadyUsedAutoAssociations already used automatic associations of an account.
+     * @return metadata of
+     */
+    public static int buildAutomaticAssociationMetaData(int maxAutoAssociations, int alreadyUsedAutoAssociations) {
+        return (alreadyUsedAutoAssociations << 16) | maxAutoAssociations;
+    }
+
+    /**
+     * Returns the lower-order 16 bits of a given {@code int}
+     *
+     * @param autoAssociationMetadata any int
+     * @return the low-order 16-bits
+     */
+    public static int getMaxAutomaticAssociationsFrom(int autoAssociationMetadata) {
+        return autoAssociationMetadata & MAX_AUTOMATIC_ASSOCIATIONS_MASK;
+    }
+
+    /**
+     * Returns the higher-order 16 bits of a given {@code int}
+     *
+     * @param autoAssociationMetadata any int
+     * @return the higher-order 16-bits
+     */
+    public static int getAlreadyUsedAutomaticAssociationsFrom(int autoAssociationMetadata) {
+        return (autoAssociationMetadata & ALREADY_USED_AUTOMATIC_ASSOCIATIONS_MASK) >>> 16;
+    }
+
+    /**
+     * Set the lower-order 16 bits of automatic association Metadata
+     *
+     * @param autoAssociationMetadata metadata of already used automatic associations and max
+     *     allowed automatic associations
+     * @param maxAutomaticAssociations new max allowed automatic associations to set
+     * @return metadata after changing the new max.
+     */
+    public static int setMaxAutomaticAssociationsTo(int autoAssociationMetadata, int maxAutomaticAssociations) {
+        return (autoAssociationMetadata & ALREADY_USED_AUTOMATIC_ASSOCIATIONS_MASK) | maxAutomaticAssociations;
+    }
+
+    /**
+     * Set the higher-order 16 bits of automatic association Metadata
+     *
+     * @param autoAssociationMetadata metadata of already used automatic associations and max
+     *     allowed automatic associations
+     * @param alreadyUsedAutoAssociations new already used automatic associations to set
+     * @return metadata after changing the already used associations count.
+     */
+    public static int setAlreadyUsedAutomaticAssociationsTo(
+            int autoAssociationMetadata, int alreadyUsedAutoAssociations) {
+        return (alreadyUsedAutoAssociations << 16) | getMaxAutomaticAssociationsFrom(autoAssociationMetadata);
+    }
+
+    /**
+     * Checks if the given long is not a number in the allowed range
+     *
+     * @param num given long number to check
+     * @return true if valid, else returns false
+     */
+    public static boolean isValidNum(long num) {
+        return num >= 0 && num <= MAX_NUM_ALLOWED;
+    }
+
+    public static long perm64(long x) {
+        // Shifts: {30, 27, 16, 20, 5, 18, 10, 24, 30}
+        x += x << 30;
+        x ^= x >>> 27;
+        x += x << 16;
+        x ^= x >>> 20;
+        x += x << 5;
+        x ^= x >>> 18;
+        x += x << 10;
+        x ^= x >>> 24;
+        x += x << 30;
+        return x;
+    }
+}

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/utils/EntityIdUtils.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/utils/EntityIdUtils.java
@@ -16,21 +16,24 @@
 package com.hedera.services.utils;
 
 import static com.hedera.mirror.web3.evm.account.AccountAccessorImpl.EVM_ADDRESS_SIZE;
+import static com.hedera.services.utils.BitPackUtils.numFromCode;
 import static java.lang.System.arraycopy;
 
 import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
+
+import com.hedera.services.store.models.Id;
+
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ContractID;
 import com.hederahashgraph.api.proto.java.TokenID;
 import java.util.Arrays;
 import java.util.stream.Stream;
+import com.swirlds.common.utility.CommonUtils;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 
 public final class EntityIdUtils {
-
-    private static final long MASK_INT_AS_UNSIGNED_LONG = (1L << 32) - 1;
     private static final String CANNOT_PARSE_PREFIX = "Cannot parse '";
 
     private EntityIdUtils() {
@@ -208,7 +211,7 @@ public final class EntityIdUtils {
         return triple;
     }
 
-    public static long numFromCode(int code) {
-        return code & MASK_INT_AS_UNSIGNED_LONG;
+    public static String asHexedEvmAddress(final Id id) {
+        return CommonUtils.hex(asEvmAddress((int) id.shard(), id.realm(), id.num()));
     }
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/utils/EntityNum.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/utils/EntityNum.java
@@ -1,0 +1,194 @@
+package com.hedera.services.utils;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import static com.hedera.services.utils.BitPackUtils.codeFromNum;
+import static com.hedera.services.utils.BitPackUtils.isValidNum;
+import static com.hedera.services.utils.BitPackUtils.numFromCode;
+import static com.hedera.services.utils.BitPackUtils.perm64;
+import static com.hedera.services.utils.EntityIdUtils.numFromEvmAddress;
+
+import com.hedera.services.store.models.Id;
+
+import com.hederahashgraph.api.proto.java.AccountID;
+import com.hederahashgraph.api.proto.java.ContractID;
+import com.hederahashgraph.api.proto.java.ScheduleID;
+import com.hederahashgraph.api.proto.java.TokenID;
+import com.hederahashgraph.api.proto.java.TopicID;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import org.hyperledger.besu.datatypes.Address;
+
+
+/**
+ * An integer whose {@code hashCode()} implementation vastly reduces the risk of hash collisions in
+ * structured data using this type, when compared to the {@code java.lang.Integer} boxed type.
+ */
+public class EntityNum implements Comparable<EntityNum> {
+    public static final EntityNum MISSING_NUM = new EntityNum(0);
+
+    private final int value;
+
+    public EntityNum(final int value) {
+        this.value = value;
+    }
+
+    public static EntityNum fromInt(final int i) {
+        return new EntityNum(i);
+    }
+
+    public static EntityNum fromLong(final long l) {
+        if (!isValidNum(l)) {
+            return MISSING_NUM;
+        }
+        final var value = codeFromNum(l);
+        return new EntityNum(value);
+    }
+
+    public static EntityNum fromModel(final Id id) {
+        if (!areValidNums(id.shard(), id.realm())) {
+            return MISSING_NUM;
+        }
+        return fromLong(id.num());
+    }
+
+    public static EntityNum fromAccountId(final AccountID grpc) {
+        if (!areValidNums(grpc.getShardNum(), grpc.getRealmNum())) {
+            return MISSING_NUM;
+        }
+        return fromLong(grpc.getAccountNum());
+    }
+
+    public static EntityNum fromEvmAddress(final Address address) {
+        final var bytes = address.toArrayUnsafe();
+        return fromLong(numFromEvmAddress(bytes));
+    }
+
+    public static EntityNum fromMirror(final byte[] evmAddress) {
+        return EntityNum.fromLong(numFromEvmAddress(evmAddress));
+    }
+
+    public static EntityNum fromTokenId(final TokenID grpc) {
+        if (!areValidNums(grpc.getShardNum(), grpc.getRealmNum())) {
+            return MISSING_NUM;
+        }
+        return fromLong(grpc.getTokenNum());
+    }
+
+    public static EntityNum fromTopicId(final TopicID grpc) {
+        if (!areValidNums(grpc.getShardNum(), grpc.getRealmNum())) {
+            return MISSING_NUM;
+        }
+        return fromLong(grpc.getTopicNum());
+    }
+
+    public static EntityNum fromContractId(final ContractID grpc) {
+        if (!areValidNums(grpc.getShardNum(), grpc.getRealmNum())) {
+            return MISSING_NUM;
+        }
+        return fromLong(grpc.getContractNum());
+    }
+
+    public static EntityNum fromScheduleId(final ScheduleID grpc) {
+        if (!areValidNums(grpc.getShardNum(), grpc.getRealmNum())) {
+            return MISSING_NUM;
+        }
+        return fromLong(grpc.getScheduleNum());
+    }
+
+    public int intValue() {
+        return value;
+    }
+
+    public long longValue() {
+        return numFromCode(value);
+    }
+
+//    public AccountID toGrpcAccountId() {
+//        return STATIC_PROPERTIES.scopedAccountWith(numFromCode(value));
+//    }
+//
+//    public EntityId toEntityId() {
+//        return STATIC_PROPERTIES.scopedEntityIdWith(numFromCode(value));
+//    }
+//
+//    public Id toId() {
+//        return STATIC_PROPERTIES.scopedIdWith(numFromCode(value));
+//    }
+//
+//    public ContractID toGrpcContractID() {
+//        return STATIC_PROPERTIES.scopedContractIdWith(numFromCode(value));
+//    }
+//
+//    public TokenID toGrpcTokenId() {
+//        return STATIC_PROPERTIES.scopedTokenWith(numFromCode(value));
+//    }
+//
+//    public ScheduleID toGrpcScheduleId() {
+//        return STATIC_PROPERTIES.scopedScheduleWith(numFromCode(value));
+//    }
+//
+//    public String toIdString() {
+//        return STATIC_PROPERTIES.scopedIdLiteralWith(numFromCode(value));
+//    }
+//
+//    public Address toEvmAddress() {
+//        return Address.wrap(Bytes.wrap(toRawEvmAddress()));
+//    }
+//
+//    public byte[] toRawEvmAddress() {
+//        return asEvmAddress(numFromCode(value));
+//    }
+
+    @Override
+    public int hashCode() {
+        return (int) perm64(value);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || EntityNum.class != o.getClass()) {
+            return false;
+        }
+
+        final var that = (EntityNum) o;
+
+        return this.value == that.value;
+    }
+
+    static boolean areValidNums(final long shard, final long realm) {
+        return isValidNum(shard) && isValidNum(realm);
+    }
+
+
+
+    @Override
+    public String toString() {
+        return "EntityNum{" + "value=" + value + '}';
+    }
+
+    @Override
+    public int compareTo(@NonNull final EntityNum that) {
+        return Integer.compare(this.value, that.value);
+    }
+}

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/models/AccountTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/models/AccountTest.java
@@ -1,0 +1,480 @@
+package com.hedera.services.store.models;
+
+/*
+ * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.google.protobuf.ByteString;
+
+import com.hedera.node.app.service.evm.exceptions.InvalidTransactionException;
+
+import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
+import org.apache.tuweni.bytes.Bytes;
+import org.bouncycastle.util.encoders.Hex;
+import org.hyperledger.besu.datatypes.Address;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import java.util.List;
+
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FAIL_INVALID;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.NO_REMAINING_AUTOMATIC_ASSOCIATIONS;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKENS_PER_ACCOUNT_LIMIT_EXCEEDED;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_ALREADY_ASSOCIATED_TO_ACCOUNT;
+import static com.swirlds.common.utility.CommonUtils.unhex;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class AccountTest {
+    private static final byte[] mockCreate2Addr = unhex("aaaaaaaaaaaaaaaaaaaaaaaa9abcdefabcdefbbb");
+    private final long miscAccountNum = 12345;
+    private final long treasuryNum = 11111;
+    private final long firstAssocTokenNum = 666;
+    private final long secondAssocTokenNum = 777;
+    private final long thirdAssocTokenNum = 555;
+    private final Id subjectId = new Id(0, 0, miscAccountNum);
+    private final Id treasuryId = new Id(0, 0, treasuryNum);
+    private final long ownedNfts = 5;
+    private final int numAssociations = 3;
+    private final int numPositiveBalances = 2;
+    private final int alreadyUsedAutoAssociations = 123;
+    private final int maxAutoAssociations = 1234;
+    private final int autoAssociationMetadata =
+            buildAutomaticAssociationMetaData(maxAutoAssociations, alreadyUsedAutoAssociations);
+    private final TokenRelationship firstRel = new TokenRelationship(null, null);
+    private final TokenRelationship secondRel = new TokenRelationship(null, null);
+    private final Token firstToken = new Token(new Id(0, 0, firstAssocTokenNum));
+    private final Token secondToken = new Token(new Id(0, 0, secondAssocTokenNum));
+    private final Token thirdToken = new Token(new Id(0, 0, thirdAssocTokenNum));
+    private final Account treasuryAccount = new Account(treasuryId);
+
+    private Account subject;
+    private OptionValidator validator;
+    private TypedTokenStore tokenStore;
+    private GlobalDynamicProperties dynamicProperties;
+
+    @BeforeEach
+    void setUp() {
+        subject = Account.builder()
+                .autoAssociationMetadata(autoAssociationMetadata)
+                .ownedNfts(ownedNfts)
+                .numAssociations(numAssociations)
+                .numPositiveBalances(numPositiveBalances)
+                .build();
+        firstToken.setTreasury(treasuryAccount);
+        secondToken.setTreasury(treasuryAccount);
+        thirdToken.setTreasury(treasuryAccount);
+
+        validator = mock(ContextOptionValidator.class);
+        tokenStore = mock(TypedTokenStore.class);
+        dynamicProperties = mock(GlobalDynamicProperties.class);
+    }
+
+    @Test
+    void cannotSetNegativeCounters() {
+        subject.setNumPositiveBalances(-1);
+        subject.setNumAssociations(-2);
+
+        assertEquals(0, subject.getNumPositiveBalances());
+        assertEquals(0, subject.getNumAssociations());
+    }
+
+    @Test
+    void canManipulateTreasuryTitles() {
+        subject.setNumTreasuryTitles(3);
+        assertEquals(3, subject.getNumTreasuryTitles());
+        subject.incrementNumTreasuryTitles();
+        assertEquals(4, subject.getNumTreasuryTitles());
+        subject.decrementNumTreasuryTitles();
+        assertEquals(3, subject.getNumTreasuryTitles());
+
+        subject.setNumTreasuryTitles(0);
+        assertFailsWith(() -> subject.decrementNumTreasuryTitles(), FAIL_INVALID);
+    }
+
+    @Test
+    void canonicalAddressIsMirrorWithEmptyAlias() {
+        assertEquals(EntityNum.fromModel(subjectId).toEvmAddress(), subject.canonicalAddress());
+    }
+
+    @Test
+    void canonicalAddressIs20ByteAliasIfPresent() {
+        subject.setAlias(ByteString.copyFrom(mockCreate2Addr));
+        assertEquals(Address.wrap(Bytes.wrap(mockCreate2Addr)), subject.canonicalAddress());
+    }
+
+    @Test
+    void canonicalAddressIsEVMAddressIfCorrectAlias() {
+        // default truffle address #0
+        subject.setAlias(ByteString.copyFrom(
+                Hex.decode("3a2103af80b90d25145da28c583359beb47b21796b2fe1a23c1511e443e7a64dfdb27d")));
+        assertEquals(
+                Address.wrap(Bytes.fromHexString("627306090abaB3A6e1400e9345bC60c78a8BEf57")),
+                subject.canonicalAddress());
+    }
+
+    @Test
+    void invalidCanonicalAddresses() {
+        Address untranslatedAddress = Address.wrap(Bytes.fromHexString("0000000000000000000000000000000000003039"));
+
+        // bogus alias
+        subject.setAlias(ByteString.copyFromUtf8("This alias is invalid"));
+        assertEquals(untranslatedAddress, subject.canonicalAddress());
+
+        // incorrect starting bytes for ECDSA
+        subject.setAlias(ByteString.copyFrom(
+                Hex.decode("ffff03af80b90d25145da28c583359beb47b21796b2fe1a23c1511e443e7a64dfdb27d")));
+        assertEquals(untranslatedAddress, subject.canonicalAddress());
+
+        // incorrect ECDSA key
+        subject.setAlias(ByteString.copyFrom(
+                Hex.decode("3a21ffaf80b90d25145da28c583359beb47b21796b2fe1a23c1511e443e7a64dfdb27d")));
+        assertEquals(untranslatedAddress, subject.canonicalAddress());
+    }
+
+    @Test
+    void objectContractWorks() {
+        final var TEST_KEY = TOKEN_ADMIN_KT.asJKeyUnchecked();
+        final var TEST_LONG_VALUE = 1L;
+        final var TEST_BOOLEAN_VALUE = true;
+
+        subject.setExpiry(TEST_LONG_VALUE);
+        assertEquals(TEST_LONG_VALUE, subject.getExpiry());
+
+        subject.setDeleted(TEST_BOOLEAN_VALUE);
+        assertTrue(subject.isDeleted());
+
+        subject.setSmartContract(TEST_BOOLEAN_VALUE);
+        assertTrue(subject.isSmartContract());
+
+        subject.setReceiverSigRequired(TEST_BOOLEAN_VALUE);
+        assertTrue(subject.isReceiverSigRequired());
+
+        subject.initBalance(TEST_LONG_VALUE);
+        assertEquals(TEST_LONG_VALUE, subject.getBalance());
+
+        subject.setAutoRenewSecs(TEST_LONG_VALUE);
+        assertEquals(TEST_LONG_VALUE, subject.getAutoRenewSecs());
+
+        subject.setKey(TEST_KEY);
+        assertEquals(TEST_KEY, subject.getKey());
+
+        subject.setMemo("Test memo");
+        assertEquals("Test memo", subject.getMemo());
+
+        subject.setProxy(Id.DEFAULT);
+        assertEquals(Id.DEFAULT, subject.getProxy());
+
+        assertTrue(subject.getMutableCryptoAllowances().isEmpty());
+        assertTrue(subject.getMutableFungibleTokenAllowances().isEmpty());
+        assertTrue(subject.getMutableApprovedForAllNfts().isEmpty());
+    }
+
+    @Test
+    void toStringAsExpected() {
+        final var desired = "Account{id=0.0.12345, expiry=0, balance=0, deleted=false, ownedNfts=5,"
+                + " alreadyUsedAutoAssociations=123, maxAutoAssociations=1234, alias=,"
+                + " cryptoAllowances=null, fungibleTokenAllowances=null,"
+                + " approveForAllNfts=null, numAssociations=3, numPositiveBalances=2, "
+                + "ethereumNonce=0}";
+
+        // expect:
+        assertEquals(desired, subject.toString());
+    }
+
+    @Test
+    void dissociationOnLastAssociatedTokenWorks() {
+        // setup:
+        final var alreadyAssocTokenId = new Id(0, 0, firstAssocTokenNum);
+        final var dissociationRel = mock(Dissociation.class);
+        final var tokenRel = mock(TokenRelationship.class);
+
+        given(dissociationRel.dissociatingAccountId()).willReturn(subjectId);
+        given(dissociationRel.dissociatedTokenId()).willReturn(alreadyAssocTokenId);
+        given(dissociationRel.dissociatingAccountRel()).willReturn(tokenRel);
+        given(dissociationRel.dissociatingToken()).willReturn(firstToken);
+        given(tokenRel.isAutomaticAssociation()).willReturn(true);
+        given(tokenRel.getBalanceChange()).willReturn(-1L);
+        given(tokenStore.loadPossiblyDeletedOrAutoRemovedToken(any())).willReturn(secondToken);
+        given(tokenStore.loadTokenRelationship(any(), any())).willReturn(secondRel);
+
+        // when:
+        subject.dissociateUsing(List.of(dissociationRel), validator);
+
+        // then:
+        verify(dissociationRel).updateModelRelsSubjectTo(validator);
+        assertEquals(numPositiveBalances - 1, subject.getNumPositiveBalances());
+        assertEquals(numAssociations - 1, subject.getNumAssociations());
+        assertEquals(alreadyUsedAutoAssociations - 1, subject.getAlreadyUsedAutomaticAssociations());
+    }
+
+    @Test
+    void dissociationWorks() {
+        // setup:
+        final var alreadyAssocTokenId = new Id(0, 0, secondAssocTokenNum);
+        final var dissociationRel = mock(Dissociation.class);
+        final var tokenRel = mock(TokenRelationship.class);
+
+        given(dissociationRel.dissociatingAccountId()).willReturn(subjectId);
+        given(dissociationRel.dissociatedTokenId()).willReturn(alreadyAssocTokenId);
+        given(dissociationRel.dissociatingAccountRel()).willReturn(tokenRel);
+        given(dissociationRel.dissociatingToken()).willReturn(secondToken);
+        given(tokenRel.isAutomaticAssociation()).willReturn(true);
+        given(tokenStore.loadPossiblyDeletedOrAutoRemovedToken(any())).willReturn(firstToken);
+        given(tokenStore.loadTokenRelationship(any(), any()))
+                .willReturn(secondRel)
+                .willReturn(firstRel);
+
+        // when:
+        subject.dissociateUsing(List.of(dissociationRel), validator);
+
+        // then:
+        verify(dissociationRel).updateModelRelsSubjectTo(validator);
+        assertEquals(numAssociations - 1, subject.getNumAssociations());
+        assertEquals(numPositiveBalances, subject.getNumPositiveBalances());
+        assertEquals(alreadyUsedAutoAssociations - 1, subject.getAlreadyUsedAutomaticAssociations());
+    }
+
+    @Test
+    void dissociatingWorksWithNonZeroBalance() {
+        // setup:
+        final var alreadyAssocTokenId = new Id(0, 0, secondAssocTokenNum);
+        final var dissociationRel = mock(Dissociation.class);
+        final var tokenRel = mock(TokenRelationship.class);
+
+        given(dissociationRel.dissociatingAccountId()).willReturn(subjectId);
+        given(dissociationRel.dissociatedTokenId()).willReturn(alreadyAssocTokenId);
+        given(dissociationRel.dissociatingAccountRel()).willReturn(tokenRel);
+        given(dissociationRel.dissociatingToken()).willReturn(secondToken);
+        given(tokenRel.isAutomaticAssociation()).willReturn(true);
+        given(tokenRel.getBalance()).willReturn(100L);
+        given(tokenStore.loadPossiblyDeletedOrAutoRemovedToken(any())).willReturn(firstToken);
+        given(tokenStore.loadTokenRelationship(any(), any()))
+                .willReturn(secondRel)
+                .willReturn(firstRel);
+
+        // when:
+        subject.dissociateUsing(List.of(dissociationRel), validator);
+
+        // then:
+        verify(dissociationRel).updateModelRelsSubjectTo(validator);
+        assertEquals(numAssociations - 1, subject.getNumAssociations());
+        assertEquals(numPositiveBalances, subject.getNumPositiveBalances());
+        assertEquals(alreadyUsedAutoAssociations - 1, subject.getAlreadyUsedAutomaticAssociations());
+    }
+
+    @Test
+    void treasuryDissociationWorks() {
+        // setup:
+        final var alreadyAssocTokenId = new Id(0, 0, secondAssocTokenNum);
+        final var dissociationRel = mock(Dissociation.class);
+        final var tokenRel = mock(TokenRelationship.class);
+        secondToken.setTreasury(subject);
+
+        given(dissociationRel.dissociatingAccountId()).willReturn(subjectId);
+        given(dissociationRel.dissociatedTokenId()).willReturn(alreadyAssocTokenId);
+        given(dissociationRel.dissociatingAccountRel()).willReturn(tokenRel);
+        given(dissociationRel.dissociatedTokenTreasuryRel()).willReturn(tokenRel);
+        given(dissociationRel.dissociatingToken()).willReturn(secondToken);
+        given(tokenRel.isAutomaticAssociation()).willReturn(true);
+        given(tokenStore.loadPossiblyDeletedOrAutoRemovedToken(any())).willReturn(firstToken);
+        given(tokenStore.loadTokenRelationship(any(), any()))
+                .willReturn(secondRel)
+                .willReturn(firstRel);
+
+        // when:
+        subject.dissociateUsing(List.of(dissociationRel), validator);
+
+        // then:
+        verify(dissociationRel).updateModelRelsSubjectTo(validator);
+        assertEquals(numAssociations - 1, subject.getNumAssociations());
+        assertEquals(numPositiveBalances, subject.getNumPositiveBalances());
+        assertEquals(alreadyUsedAutoAssociations - 1, subject.getAlreadyUsedAutomaticAssociations());
+    }
+
+    @Test
+    void dissociatingOnlyAssociationWorks() {
+        // setup:
+        final var alreadyAssocTokenId = new Id(0, 0, thirdAssocTokenNum);
+        final var dissociationRel = mock(Dissociation.class);
+        final var tokenRel = mock(TokenRelationship.class);
+
+        given(dissociationRel.dissociatingAccountId()).willReturn(subjectId);
+        given(dissociationRel.dissociatedTokenId()).willReturn(alreadyAssocTokenId);
+        given(dissociationRel.dissociatingAccountRel()).willReturn(tokenRel);
+        given(dissociationRel.dissociatingToken()).willReturn(thirdToken);
+        given(tokenRel.isAutomaticAssociation()).willReturn(true);
+        given(tokenStore.loadPossiblyDeletedOrAutoRemovedToken(any())).willReturn(thirdToken);
+        subject.setNumAssociations(1);
+
+        // when:
+        subject.dissociateUsing(List.of(dissociationRel), validator);
+
+        // then:
+        verify(dissociationRel).updateModelRelsSubjectTo(validator);
+        assertEquals(alreadyUsedAutoAssociations - 1, subject.getAlreadyUsedAutomaticAssociations());
+    }
+
+    @Test
+    void dissociationFailsInvalidIfRelDoesntReferToUs() {
+        // setup:
+        final var notOurId = new Id(0, 0, 666);
+        final var dissociationRel = mock(Dissociation.class);
+
+        given(dissociationRel.dissociatingAccountId()).willReturn(notOurId);
+
+        // expect:
+        assertFailsWith(() -> subject.dissociateUsing(List.of(dissociationRel), validator), FAIL_INVALID);
+    }
+
+    @Test
+    void failsOnAssociatingWithAlreadyRelatedToken() {
+        // setup:
+        final var alreadyAssocToken = new Token(new Id(0, 0, 666));
+        given(tokenStore.hasAssociation(alreadyAssocToken, subject)).willReturn(true);
+
+        // expect:
+        assertFailsWith(
+                () -> subject.associateWith(List.of(alreadyAssocToken), tokenStore, false, false, dynamicProperties),
+                TOKEN_ALREADY_ASSOCIATED_TO_ACCOUNT);
+    }
+
+    @Test
+    void failsOnCrossingAssociationLimit() {
+        // setup:
+        final var alreadyAssocToken = new Token(new Id(0, 0, 666));
+        given(tokenStore.hasAssociation(alreadyAssocToken, subject)).willReturn(false);
+        given(dynamicProperties.areTokenAssociationsLimited()).willReturn(true);
+        given(dynamicProperties.maxTokensPerAccount()).willReturn(numAssociations);
+
+        // expect:
+        assertFailsWith(
+                () -> subject.associateWith(List.of(alreadyAssocToken), tokenStore, false, false, dynamicProperties),
+                TOKENS_PER_ACCOUNT_LIMIT_EXCEEDED);
+    }
+
+    @Test
+    void canAssociateWithNewToken() {
+        // setup:
+        final var firstNewToken = new Token(new Id(0, 0, 888));
+        final var secondNewToken = new Token(new Id(0, 0, 999));
+        subject.setAutoAssociationMetadata(autoAssociationMetadata);
+        given(dynamicProperties.areTokenAssociationsLimited()).willReturn(true);
+        given(dynamicProperties.maxTokensPerAccount()).willReturn(numAssociations + 2);
+
+        // when:
+        subject.associateWith(List.of(firstNewToken, secondNewToken), tokenStore, true, true, dynamicProperties);
+
+        // expect:
+        assertEquals(numAssociations + 2, subject.getNumAssociations());
+    }
+
+    @Test
+    void accountEqualsCheck() {
+        // setup:
+        var account = new Account(subjectId);
+        account.setNumAssociations(numAssociations);
+        account.setNumPositiveBalances(numPositiveBalances);
+        account.setExpiry(1000L);
+        account.initBalance(100L);
+        account.setOwnedNfts(1L);
+        account.incrementOwnedNfts();
+        account.setMaxAutomaticAssociations(123);
+        account.setAlreadyUsedAutomaticAssociations(12);
+        account.setSmartContract(false);
+
+        subject.setExpiry(1000L);
+        subject.initBalance(100L);
+        subject.setOwnedNfts(1L);
+        subject.incrementOwnedNfts();
+        subject.setAutoAssociationMetadata(account.getAutoAssociationMetadata());
+        subject.setSmartContract(false);
+
+        // when:
+        var actualResult = subject.equals(account);
+
+        // expect:
+        assertEquals(account.getOwnedNfts(), subject.getOwnedNfts());
+        // and:
+        assertEquals(account.getId(), subject.getId());
+        // and:
+        assertEquals(account.getMaxAutomaticAssociations(), subject.getMaxAutomaticAssociations());
+        assertEquals(account.getAlreadyUsedAutomaticAssociations(), subject.getAlreadyUsedAutomaticAssociations());
+        assertEquals(subject.isSmartContract(), account.isSmartContract());
+        assertTrue(actualResult);
+    }
+
+    @Test
+    void accountHashCodeCheck() {
+        // setup:
+        subject.setOwnedNfts(0);
+        var otherSubject = new Account(subjectId);
+        otherSubject.incrementOwnedNfts();
+        otherSubject.setNumAssociations(numAssociations);
+        otherSubject.setNumPositiveBalances(numPositiveBalances);
+
+        subject.incrementOwnedNfts();
+        otherSubject.setAutoAssociationMetadata(autoAssociationMetadata);
+        // when:
+        var actualResult = subject.hashCode();
+
+        // expect:
+        assertEquals(otherSubject.hashCode(), actualResult);
+    }
+
+    @Test
+    void cannotAutomaticallyAssociateIfLimitReaches() {
+        final var firstNewToken = new Token(new Id(0, 0, 888));
+        subject.setMaxAutomaticAssociations(maxAutoAssociations);
+        subject.setAlreadyUsedAutomaticAssociations(maxAutoAssociations);
+
+        assertFailsWith(
+                () -> subject.associateWith(List.of(firstNewToken), tokenStore, true, true, dynamicProperties),
+                NO_REMAINING_AUTOMATIC_ASSOCIATIONS);
+    }
+
+    @Test
+    void incrementsTheAlreadyUsedAutoAssociationAsExpected() {
+        final var firstNewToken = new Token(new Id(0, 0, 888));
+        subject.setMaxAutomaticAssociations(maxAutoAssociations);
+        subject.setAlreadyUsedAutomaticAssociations(maxAutoAssociations - 1);
+
+        subject.associateWith(List.of(firstNewToken), tokenStore, true, false, dynamicProperties);
+
+        assertEquals(maxAutoAssociations, subject.getAlreadyUsedAutomaticAssociations());
+    }
+
+    @Test
+    void invalidValuesToAlreadyUsedAutoAssociationsFailAsExpected() {
+        assertFailsWith(
+                () -> subject.setAlreadyUsedAutomaticAssociations(maxAutoAssociations + 1),
+                NO_REMAINING_AUTOMATIC_ASSOCIATIONS);
+
+        subject.setAlreadyUsedAutomaticAssociations(maxAutoAssociations);
+
+        assertFailsWith(() -> subject.incrementUsedAutomaticAssociations(), NO_REMAINING_AUTOMATIC_ASSOCIATIONS);
+
+        subject.setAlreadyUsedAutomaticAssociations(0);
+
+        assertFailsWith(() -> subject.decrementUsedAutomaticAssociations(), NO_REMAINING_AUTOMATIC_ASSOCIATIONS);
+    }
+
+    private void assertFailsWith(Runnable something, ResponseCodeEnum status) {
+        var ex = assertThrows(InvalidTransactionException.class, something::run);
+        assertEquals(status, ex.getResponseCode());
+    }
+}

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/models/FcTokenAllowanceIdTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/models/FcTokenAllowanceIdTest.java
@@ -1,0 +1,119 @@
+package com.hedera.services.store.models;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+
+import com.hedera.services.utils.EntityNum;
+
+import com.swirlds.common.io.streams.SerializableDataInputStream;
+import com.swirlds.common.io.streams.SerializableDataOutputStream;
+import java.io.IOException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class FcTokenAllowanceIdTest {
+    private EntityNum tokenNum = EntityNum.fromLong(1L);
+    private EntityNum spenderNum = EntityNum.fromLong(2L);
+
+    private FcTokenAllowanceId subject;
+
+    @BeforeEach
+    void setup() {
+        subject = FcTokenAllowanceId.from(tokenNum, spenderNum);
+    }
+
+    @Test
+    void objectContractWorks() {
+        final var one = subject;
+        final var two = FcTokenAllowanceId.from(EntityNum.fromLong(3L), EntityNum.fromLong(4L));
+        final var three = FcTokenAllowanceId.from(EntityNum.fromLong(1L), EntityNum.fromLong(2L));
+        final var four = FcTokenAllowanceId.from(tokenNum.toGrpcTokenId(), spenderNum.toGrpcAccountId());
+
+        assertNotEquals(null, one);
+        assertNotEquals(new Object(), one);
+        assertNotEquals(two, one);
+        assertEquals(one, three);
+        assertEquals(three, four);
+
+        assertEquals(one.hashCode(), three.hashCode());
+        assertNotEquals(one.hashCode(), two.hashCode());
+    }
+
+    @Test
+    void toStringWorks() {
+        assertEquals(
+                "FcTokenAllowanceId{tokenNum=" + tokenNum.longValue() + ", spenderNum=" + spenderNum.longValue() + "}",
+                subject.toString());
+    }
+
+    @Test
+    void gettersWork() {
+        assertEquals(1L, subject.getTokenNum().longValue());
+        assertEquals(2L, subject.getSpenderNum().longValue());
+    }
+
+    @Test
+    void deserializeWorks() throws IOException {
+        final var in = mock(SerializableDataInputStream.class);
+        final var newSubject = new FcTokenAllowanceId();
+        given(in.readInt()).willReturn(tokenNum.intValue()).willReturn(spenderNum.intValue());
+
+        newSubject.deserialize(in, FcTokenAllowanceId.CURRENT_VERSION);
+
+        assertEquals(subject, newSubject);
+    }
+
+    @Test
+    void serializeWorks() throws IOException {
+        final var out = mock(SerializableDataOutputStream.class);
+        final var inOrder = inOrder(out);
+
+        subject.serialize(out);
+
+        inOrder.verify(out).writeInt(tokenNum.intValue());
+        inOrder.verify(out).writeInt(spenderNum.intValue());
+    }
+
+    @Test
+    void serializableDetWorks() {
+        assertEquals(FcTokenAllowanceId.RELEASE_023X_VERSION, subject.getVersion());
+        assertEquals(FcTokenAllowanceId.RUNTIME_CONSTRUCTABLE_ID, subject.getClassId());
+    }
+
+    @Test
+    void orderingPrioritizesTokenNumThenSpender() {
+        final var base = new FcTokenAllowanceId(tokenNum, spenderNum);
+        final var sameButDiff = base;
+        assertEquals(0, base.compareTo(sameButDiff));
+        final var largerNum = new FcTokenAllowanceId(
+                EntityNum.fromInt(tokenNum.intValue() + 1), EntityNum.fromInt(spenderNum.intValue() - 1));
+        assertEquals(-1, base.compareTo(largerNum));
+        final var smallerKey = new FcTokenAllowanceId(
+                EntityNum.fromInt(tokenNum.intValue() - 1), EntityNum.fromInt(spenderNum.intValue() - 1));
+        assertEquals(+1, base.compareTo(smallerKey));
+    }
+}
+

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/models/IdTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/models/IdTest.java
@@ -1,0 +1,114 @@
+package com.hedera.services.store.models;
+
+/*
+ * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import static com.hedera.services.utils.EntityIdUtils.asAccount;
+import static com.hedera.services.utils.EntityIdUtils.asToken;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.hederahashgraph.api.proto.java.ContractID;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.tuweni.bytes.Bytes;
+import org.hyperledger.besu.datatypes.Address;
+import org.junit.jupiter.api.Test;
+
+import com.hedera.services.utils.EntityIdUtils;
+
+class IdTest {
+    @Test
+    void hashCodeDiscriminates() {
+        final var aId = new Id(1, 2, 3);
+        final var bId = new Id(0, 2, 3);
+        final var cId = new Id(1, 0, 3);
+        final var dId = new Id(1, 2, 0);
+        final var eId = new Id(1, 2, 3);
+
+        assertNotEquals(bId.hashCode(), aId.hashCode());
+        assertNotEquals(cId.hashCode(), aId.hashCode());
+        assertNotEquals(dId.hashCode(), aId.hashCode());
+        assertEquals(eId.hashCode(), aId.hashCode());
+    }
+
+    @Test
+    void equalsDiscriminates() {
+        final var aId = new Id(1, 2, 3);
+        final var bId = new Id(0, 2, 3);
+        final var cId = new Id(1, 0, 3);
+        final var dId = new Id(1, 2, 0);
+        final var eId = new Id(1, 2, 3);
+
+        assertNotEquals(bId, aId);
+        assertNotEquals(cId, aId);
+        assertNotEquals(dId, aId);
+        assertEquals(eId, aId);
+        assertNotEquals(aId, new Object());
+        assertEquals(aId, aId);
+    }
+
+    @Test
+    void conversionsWork() {
+        final var id = new Id(1, 2, 3);
+        final var grpcAccount = asAccount("1.2.3");
+        final var grpcToken = asToken("1.2.3");
+        final var contractId = ContractID.newBuilder()
+                .setShardNum(1)
+                .setRealmNum(2)
+                .setContractNum(3)
+                .build();
+        final var address = Address.wrap(Bytes.wrap(EntityIdUtils.asEvmAddress(contractId)));
+
+        assertEquals(grpcAccount, id.asGrpcAccount());
+        assertEquals(grpcToken, id.asGrpcToken());
+        assertEquals(contractId, id.asGrpcContract());
+        assertEquals(address, id.asEvmAddress());
+        assertEquals(id, Id.fromGrpcAccount(grpcAccount));
+        assertEquals(id, Id.fromGrpcToken(grpcToken));
+        assertEquals(id, Id.fromGrpcContract(contractId));
+    }
+
+    @Test
+    void gettersWork() {
+        final var id = new Id(11, 22, 33);
+
+        assertEquals(11, id.shard());
+        assertEquals(22, id.realm());
+        assertEquals(33, id.num());
+    }
+
+    @Test
+    void toStringWorks() {
+        final var id = new Id(4, 5, 6);
+
+        assertEquals("4.5.6", id.toString());
+    }
+
+    @Test
+    void comparatorWorks() {
+        final var a = new Id(0, 0, 1);
+        final var b = new Id(1, 0, 0);
+        final var c = new Id(0, 1, 0);
+        final var l = new ArrayList<Id>();
+
+        l.add(a);
+        l.add(b);
+        l.add(c);
+        l.sort(Id.ID_COMPARATOR);
+
+        assertEquals(List.of(c, b, a), l);
+    }
+}

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/utils/EntityNumTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/utils/EntityNumTest.java
@@ -1,0 +1,118 @@
+package com.hedera.services.utils;
+
+import com.hedera.mirror.common.domain.entity.EntityId;
+
+import com.hedera.services.store.models.Id;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.hyperledger.besu.datatypes.Address;
+import org.junit.jupiter.api.Test;
+
+import static com.hedera.services.utils.EntityNum.MISSING_NUM;
+import static org.junit.jupiter.api.Assertions.*;
+
+class EntityNumTest {
+    @Test
+    void overridesJavaLangImpl() {
+        final var v = 1_234_567;
+
+        final var subject = new EntityNum(v);
+
+        assertNotEquals(v, subject.hashCode());
+    }
+
+    @Test
+    void equalsWorks() {
+        final var a = new EntityNum(1);
+        final var b = new EntityNum(2);
+        final var c = a;
+
+        assertNotEquals(a, b);
+        assertNotEquals(null, a);
+        assertNotEquals(new Object(), a);
+        assertEquals(a, c);
+    }
+
+    @Test
+    void returnsMissingNumForUnusableNum() {
+        assertEquals(MISSING_NUM, EntityNum.fromLong(Long.MAX_VALUE));
+    }
+
+    @Test
+    void factoriesWorkForValidShardRealm() {
+        final var expected = EntityNum.fromInt(123);
+
+        assertEquals(expected, EntityNum.fromLong(123L));
+        assertEquals(expected, EntityNum.fromAccountId(EntityIdUtils.asAccount("0.0.123")));
+        assertEquals(expected, EntityNum.fromTokenId(EntityIdUtils.asToken("0.0.123")));
+        assertEquals(expected, EntityNum.fromContractId(EntityIdUtils.asContract("0.0.123")));
+        assertEquals(expected, EntityNum.fromModel(new Id(0, 0, 123)));
+        assertEquals(expected, EntityNum.fromEvmAddress(Address.wrap(Bytes.wrap(EntityIdUtils.asEvmAddress(0,0,123)))));
+    }
+
+    @Test
+    void factoriesWorkForInvalidShard() {
+        assertEquals(MISSING_NUM, EntityNum.fromAccountId(EntityIdUtils.asAccount("1.0.123")));
+        assertEquals(MISSING_NUM, EntityNum.fromTokenId(EntityIdUtils.asToken("1.0.123")));
+        assertEquals(MISSING_NUM, EntityNum.fromContractId(EntityIdUtils.asContract("1.0.123")));
+        assertEquals(MISSING_NUM, EntityNum.fromModel(new Id(1, 0, 123)));
+        assertEquals(
+                new EntityNum(123),
+                EntityNum.fromEvmAddress(Address.wrap(Bytes.wrap(EntityIdUtils.asEvmAddress(0,0,123)))));
+    }
+
+    @Test
+    void factoriesWorkForInvalidRealm() {
+        assertEquals(MISSING_NUM, EntityNum.fromAccountId(EntityIdUtils.asAccount("0.1.123")));
+        assertEquals(MISSING_NUM, EntityNum.fromTokenId(EntityIdUtils.asToken("0.1.123")));
+        assertEquals(MISSING_NUM, EntityNum.fromContractId(EntityIdUtils.asContract("0.1.123")));
+        assertEquals(MISSING_NUM, EntityNum.fromModel(new Id(0, 1, 123)));
+        assertEquals(new EntityNum(123),
+                EntityNum.fromEvmAddress(Address.wrap(Bytes.wrap(EntityIdUtils.asEvmAddress(0,0,123)))));
+    }
+
+    @Test
+    void viewsWork() {
+        final var subject = EntityNum.fromInt(123);
+
+        assertEquals(123, subject.toGrpcAccountId().getAccountNum());
+        assertEquals(123, subject.toGrpcTokenId().getTokenNum());
+        assertEquals(123, subject.toGrpcScheduleId().getScheduleNum());
+        assertEquals(new EntityId(0, 0, 123), subject.toEntityId());
+        assertTrue(subject.toIdString().endsWith(".123"));
+    }
+
+    @Test
+    void viewsWorkEvenForNegativeNumCodes() {
+        final long realNum = (long) Integer.MAX_VALUE + 10;
+
+        final var subject = EntityNum.fromLong(realNum);
+
+        assertEquals(realNum, subject.toGrpcAccountId().getAccountNum());
+        assertEquals(realNum, subject.toGrpcTokenId().getTokenNum());
+        assertEquals(realNum, subject.toGrpcScheduleId().getScheduleNum());
+        assertTrue(subject.toIdString().endsWith("." + realNum));
+    }
+
+    @Test
+    void canGetLongValue() {
+        final long realNum = (long) Integer.MAX_VALUE + 10;
+
+        final var subject = EntityNum.fromLong(realNum);
+
+        assertEquals(realNum, subject.longValue());
+    }
+
+    @Test
+    void orderingSortsByValue() {
+        int value = 100;
+
+        final var base = new EntityNum(value);
+        final var sameButDiff = EntityNum.fromInt(value);
+        assertEquals(0, base.compareTo(sameButDiff));
+        final var largerNum = new EntityNum(value + 1);
+        assertEquals(-1, base.compareTo(largerNum));
+        final var smallerNum = new EntityNum(value - 1);
+        assertEquals(+1, base.compareTo(smallerNum));
+    }
+}


### PR DESCRIPTION
We need to copy the Account store model into mirror-node, so that we use it as a value in the Stacked State Frame design. This would also mean the model should be immutable. It will both hold data for the Account and also perform some business logic internally.

**Related issue(s)**:
Fixes #5755 
