### PR TITLE
Add synthetic token allowance migration

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/SyntheticTokenAllowanceOwnerMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/SyntheticTokenAllowanceOwnerMigration.java
@@ -1,0 +1,115 @@
+package com.hedera.mirror.importer.migration;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.google.common.base.Stopwatch;
+import com.google.common.collect.Range;
+import com.vladmihalcea.hibernate.type.range.guava.PostgreSQLGuavaRangeType;
+import javax.inject.Named;
+import org.flywaydb.core.api.MigrationVersion;
+import org.postgresql.util.PGobject;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.core.convert.support.DefaultConversionService;
+import org.springframework.jdbc.core.DataClassRowMapper;
+import org.springframework.jdbc.core.JdbcOperations;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import com.hedera.mirror.common.converter.AccountIdConverter;
+import com.hedera.mirror.common.domain.entity.EntityId;
+import com.hedera.mirror.common.domain.entity.TokenAllowance;
+import com.hedera.mirror.importer.MirrorProperties;
+import com.hedera.mirror.importer.parser.record.entity.sql.SqlEntityListener;
+
+@Named
+public class SyntheticTokenAllowanceOwnerMigration extends RepeatableMigration {
+
+    private static final String UPDATE_TOKEN_ALLOWANCE_OWNER_SQL = """
+            with affected as (
+              select ta.*, cr.consensus_timestamp, cr.sender_id
+              from (
+                select * from token_allowance
+                union all
+                select * from token_allowance_history
+              ) ta
+              join contract_result cr on cr.consensus_timestamp = lower(ta.timestamp_range)
+            ), delete_token_allowance as (
+              delete from token_allowance ta
+              using affected a
+              where ta.owner = a.owner and ta.spender = a.spender and ta.token_id = a.token_id
+            ), delete_token_allowance_history as (
+              delete from token_allowance_history ta
+              using affected a
+              where ta.owner = a.owner and ta.spender = a.spender and ta.token_id = a.token_id and ta.timestamp_range = a.timestamp_range
+            )
+            select amount, sender_id as owner, payer_account_id, spender, int8range(consensus_timestamp, null) timestamp_range, token_id
+            from affected
+            order by consensus_timestamp;
+            """;
+
+    private static DataClassRowMapper<TokenAllowance> resultRowMapper = new DataClassRowMapper<>(TokenAllowance.class);
+    private final JdbcOperations jdbcOperations;
+    private final SqlEntityListener sqlEntityListener;
+    private final TransactionTemplate transactionTemplate;
+
+    @Lazy
+    public SyntheticTokenAllowanceOwnerMigration(JdbcOperations jdbcOperations,
+                                                 MirrorProperties mirrorProperties,
+                                                 SqlEntityListener sqlEntityListener,
+                                                 TransactionTemplate transactionTemplate) {
+        super(mirrorProperties.getMigration());
+        this.jdbcOperations = jdbcOperations;
+        this.sqlEntityListener = sqlEntityListener;
+        this.transactionTemplate = transactionTemplate;
+
+        var defaultConversionService = new DefaultConversionService();
+        defaultConversionService.addConverter(PGobject.class, Range.class,
+                source -> PostgreSQLGuavaRangeType.longRange(source.getValue()));
+        defaultConversionService.addConverter(Long.class, EntityId.class,
+                AccountIdConverter.INSTANCE::convertToEntityAttribute);
+        resultRowMapper.setConversionService(defaultConversionService);
+    }
+
+    @Override
+    public String getDescription() {
+        return "Updates the owner for synthetic token allowances to the corresponding contract result sender";
+    }
+
+    @Override
+    protected MigrationVersion getMinimumVersion() {
+        // The version where token_allowance and token_allowance_history were added
+        return MigrationVersion.fromVersion("1.54.3");
+    }
+
+    @Override
+    protected void doMigrate() {
+        var stopwatch = Stopwatch.createStarted();
+        var tokenAllowances = jdbcOperations.query(UPDATE_TOKEN_ALLOWANCE_OWNER_SQL, resultRowMapper);
+        if (!tokenAllowances.isEmpty()) {
+            sqlEntityListener.onStart();
+            for (var tokenAllowance : tokenAllowances) {
+                sqlEntityListener.onTokenAllowance(tokenAllowance);
+            }
+            transactionTemplate.executeWithoutResult(status -> sqlEntityListener.onEnd(null));
+        }
+
+        log.info("Updated {} crypto approve allowance owners in {}", tokenAllowances.size(), stopwatch);
+    }
+}

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/SyntheticTokenAllowanceOwnerMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/SyntheticTokenAllowanceOwnerMigration.java
@@ -94,8 +94,8 @@ public class SyntheticTokenAllowanceOwnerMigration extends RepeatableMigration {
 
     @Override
     protected MigrationVersion getMinimumVersion() {
-        // The version where token_allowance and token_allowance_history were added
-        return MigrationVersion.fromVersion("1.54.3");
+        // The version where contract_result sender_id was added
+        return MigrationVersion.fromVersion("1.58.4");
     }
 
     @Override

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/SyntheticTokenAllowanceOwnerMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/SyntheticTokenAllowanceOwnerMigrationTest.java
@@ -23,43 +23,27 @@ package com.hedera.mirror.importer.migration;
 import static com.hedera.mirror.common.domain.entity.EntityType.CONTRACT;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.google.common.collect.Range;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.tuple.Pair;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.transaction.support.TransactionTemplate;
 
 import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.entity.TokenAllowance;
 import com.hedera.mirror.importer.IntegrationTest;
-import com.hedera.mirror.importer.TestUtils;
-import com.hedera.mirror.importer.config.Owner;
-import com.hedera.mirror.importer.parser.record.entity.sql.SqlEntityListener;
-import com.hedera.mirror.importer.repository.TokenAllowanceHistoryRepository;
 import com.hedera.mirror.importer.repository.TokenAllowanceRepository;
 
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
 @Tag("migration")
 class SyntheticTokenAllowanceOwnerMigrationTest extends IntegrationTest {
 
-    private final @Owner JdbcTemplate jdbcTemplate;
-    private final SqlEntityListener sqlEntityListener;
     private final SyntheticTokenAllowanceOwnerMigration migration;
-    private final TokenAllowanceHistoryRepository tokenAllowanceHistoryRepository;
     private final TokenAllowanceRepository tokenAllowanceRepository;
-    private final TransactionTemplate transactionTemplate;
-
     private final String idColumns = "payer_account_id, spender, token_id";
-
-    @AfterEach
-    void teardown() {
-        jdbcTemplate.execute("truncate token_allowance, token_allowance_history, contract_result;");
-    }
 
     @Test
     void checksum() {
@@ -70,107 +54,127 @@ class SyntheticTokenAllowanceOwnerMigrationTest extends IntegrationTest {
     void empty() {
         migration.doMigrate();
         assertThat(tokenAllowanceRepository.findAll()).isEmpty();
-        assertThat(tokenAllowanceHistoryRepository.findAll()).isEmpty();
+        assertThat(findHistory(TokenAllowance.class, idColumns)).isEmpty();
     }
 
     @Test
     void migrate() {
         // given
+        // Token allowance and token allowance history entries that have the incorrect owner
         var contractResultSenderId = EntityId.of("0.0.2001", CONTRACT);
         long incorrectOwnerAccountId = 1001L;
-        // A token allowance and historical token allowances that all have corresponding Contract Results.
-        // The token allowances are saved with an incorrect owner
-        var affectedTokenAllowancePair = generateTokenAllowance(contractResultSenderId, incorrectOwnerAccountId);
+        var incorrectTokenAllowancePair = generateTokenAllowance(contractResultSenderId, incorrectOwnerAccountId);
 
         // A token allowance can occur through HAPI and absent a corresponding Contract Result.
         // This token allowance and it's history should be unaffected by the migration
         var unaffectedTokenAllowancePair = generateTokenAllowance(null, null);
 
-        // Before migration verify that the token allowances have the incorrect owner
-        assertThat(tokenAllowanceRepository.findAll()).filteredOn(t -> t.getOwner() == incorrectOwnerAccountId)
-                .containsExactlyInAnyOrderElementsOf(affectedTokenAllowancePair.getLeft());
-        assertThat(findHistory(TokenAllowance.class, idColumns)).filteredOn(t -> t.getOwner() == incorrectOwnerAccountId)
-                .containsExactlyInAnyOrderElementsOf(affectedTokenAllowancePair.getRight());
+        // This problem has already been fixed. So there are token allowances with the correct owner.
+        // This token allowance and it's history should be unaffected by the migration
+        var correctContractResultSenderId = EntityId.of("0.0.3001", CONTRACT);
+        var correctTokenAllowancePair = generateTokenAllowance(correctContractResultSenderId,
+                correctContractResultSenderId.getId());
+
+        // A token allowance that has no history and the correct owner, it should not be affected by the migration.
+        var newTokenAllowance = domainBuilder.tokenAllowance().persist();
 
         // when
         migration.doMigrate();
 
         // then
-        var expected = new ArrayList<>(affectedTokenAllowancePair.getLeft());
+        var expected = new ArrayList<>(List.of(incorrectTokenAllowancePair.getLeft()));
         // The owner should be set to the contract result sender id
         expected.forEach(t -> t.setOwner(contractResultSenderId.getId()));
-        expected.addAll(unaffectedTokenAllowancePair.getLeft());
+        expected.add(unaffectedTokenAllowancePair.getLeft());
+        expected.add(correctTokenAllowancePair.getLeft());
+        expected.add(newTokenAllowance);
         assertThat(tokenAllowanceRepository.findAll()).containsExactlyInAnyOrderElementsOf(expected);
 
         // The history of the token allowance should also be updated with the corrected owner
-        var expectedHistory = new ArrayList<>(affectedTokenAllowancePair.getRight());
+        var expectedHistory = new ArrayList<>(incorrectTokenAllowancePair.getRight());
         // The owner should be set to the contract result sender id
         expectedHistory.forEach(t -> t.setOwner(contractResultSenderId.getId()));
         expectedHistory.addAll(unaffectedTokenAllowancePair.getRight());
+        expectedHistory.addAll(correctTokenAllowancePair.getRight());
         assertThat(findHistory(TokenAllowance.class, idColumns)).containsExactlyInAnyOrderElementsOf(expectedHistory);
     }
 
     @Test
-    void migrateWithCorrectOwner() {
+    void repeatableMigration() {
         // given
-        // A token allowance with history that has corresponding Contract Results.
         var contractResultSenderId = EntityId.of("0.0.2001", CONTRACT);
-        // The token allowances already have the correct owner
-        var tokenAllowancePair = generateTokenAllowance(contractResultSenderId, contractResultSenderId.getId());
+        long incorrectOwnerAccountId = 1001L;
+        generateTokenAllowance(contractResultSenderId, incorrectOwnerAccountId);
+        generateTokenAllowance(null, null);
+        var correctContractResultSenderId = EntityId.of("0.0.3001", CONTRACT);
+        generateTokenAllowance(correctContractResultSenderId, correctContractResultSenderId.getId());
+        domainBuilder.tokenAllowance().persist();
+
+        migration.doMigrate();
+        var firstPassTokenAllowances = tokenAllowanceRepository.findAll();
+        var firstPassHistory = findHistory(TokenAllowance.class, idColumns);
 
         // when
         migration.doMigrate();
+        var secondPassTokenAllowances = tokenAllowanceRepository.findAll();
+        var secondPassHistory = findHistory(TokenAllowance.class, idColumns);
 
         // then
-        // The token allowances should be unaffected by the migration
-        assertThat(tokenAllowanceRepository.findAll()).containsExactlyInAnyOrderElementsOf(tokenAllowancePair.getLeft());
-        assertThat(findHistory(TokenAllowance.class, idColumns)).containsExactlyInAnyOrderElementsOf(tokenAllowancePair.getRight());
+        assertThat(firstPassTokenAllowances).containsExactlyInAnyOrderElementsOf(secondPassTokenAllowances);
+        assertThat(firstPassHistory).containsExactlyInAnyOrderElementsOf(secondPassHistory);
     }
 
     /**
-     * Creates a token allowance and updates it twice to populate token_allowance and token_allowance_history
+     * Creates a token allowance and two historical token allowances to populate token_allowance and
+     * token_allowance_history
      *
      * @param contractResultSenderId
      * @param ownerAccountId
      * @return the current token allowance and the historical token allowances
      */
-    private Pair<List<TokenAllowance>, List<TokenAllowance>> generateTokenAllowance(EntityId contractResultSenderId,
-                                                                                    Long ownerAccountId) {
+    private Pair<TokenAllowance, List<TokenAllowance>> generateTokenAllowance(EntityId contractResultSenderId,
+                                                                              Long ownerAccountId) {
         var builder = domainBuilder.tokenAllowance();
         if (contractResultSenderId != null) {
-            builder = builder.customize(t -> t.owner(ownerAccountId));
+            builder.customize(t -> t.owner(ownerAccountId));
+        }
+        var currentTokenAllowance = builder.persist();
+        var range = currentTokenAllowance.getTimestampRange();
+        var rangeUpdate1 = Range.closedOpen(range.lowerEndpoint() - 2, range.lowerEndpoint() - 1);
+        var rangeUpdate2 = Range.closedOpen(range.lowerEndpoint() - 1, range.lowerEndpoint());
+
+        var update1 = builder.customize(t -> t
+                .amount(999L)
+                .timestampRange(rangeUpdate1)
+        ).get();
+        var update2 = builder.customize(t -> t
+                .amount(0)
+                .timestampRange(rangeUpdate2)
+        ).get();
+        saveHistory(update1);
+        saveHistory(update2);
+
+        if (contractResultSenderId != null) {
+            var contractResult = domainBuilder.contractResult();
+            for (var tokenAllowance : List.of(currentTokenAllowance, update1, update2)) {
+                contractResult.customize(c -> c
+                        .senderId(contractResultSenderId)
+                        .consensusTimestamp(tokenAllowance.getTimestampLower())
+                ).persist();
+            }
         }
 
-        var createTokenAllowance = builder.get();
-        var tokenAllowanceUpdate1 = builder.customize(c -> c.amount(999L)).get();
-        tokenAllowanceUpdate1.setTimestampLower(createTokenAllowance.getTimestampLower() + 1);
-        var tokenAllowanceUpdate2 = builder.customize(c -> c.amount(55L)).get();
-        tokenAllowanceUpdate2.setTimestampLower(createTokenAllowance.getTimestampLower() + 2);
-
-        // Save the token allowance and its updates to populate token_allowance and token_allowance_history
-        saveTokenAllowance(createTokenAllowance, contractResultSenderId);
-        saveTokenAllowance(tokenAllowanceUpdate1, contractResultSenderId);
-        saveTokenAllowance(tokenAllowanceUpdate2, contractResultSenderId);
-
-        var expectedCreate = TestUtils.clone(createTokenAllowance);
-        var expectedUpdate1 = TestUtils.merge(createTokenAllowance, tokenAllowanceUpdate1);
-        var expectedUpdate2 = TestUtils.merge(expectedUpdate1, tokenAllowanceUpdate2);
-        expectedCreate.setTimestampUpper(tokenAllowanceUpdate1.getTimestampLower());
-        expectedUpdate1.setTimestampUpper(tokenAllowanceUpdate2.getTimestampLower());
-
-        var tokenAllowanceExpected = List.of(expectedUpdate2);
-        var tokenAllowanceHistoryExpected = List.of(expectedCreate, expectedUpdate1);
-        return Pair.of(tokenAllowanceExpected, tokenAllowanceHistoryExpected);
+        return Pair.of(currentTokenAllowance, List.of(update1, update2));
     }
 
-    private void saveTokenAllowance(TokenAllowance tokenAllowance, EntityId contractResultSenderId) {
-        sqlEntityListener.onTokenAllowance(tokenAllowance);
-        transactionTemplate.executeWithoutResult(status -> sqlEntityListener.onEnd(null));
-        if (contractResultSenderId != null) {
-            domainBuilder.contractResult()
-                    .customize(c -> c.senderId(contractResultSenderId)
-                            .consensusTimestamp(tokenAllowance.getTimestampLower()))
-                    .persist();
-        }
+    private void saveHistory(TokenAllowance tokenAllowance) {
+        domainBuilder.tokenAllowanceHistory().customize(c -> c
+                .amount(tokenAllowance.getAmount())
+                .owner(tokenAllowance.getOwner())
+                .payerAccountId(tokenAllowance.getPayerAccountId())
+                .spender(tokenAllowance.getSpender())
+                .timestampRange(tokenAllowance.getTimestampRange())
+                .tokenId(tokenAllowance.getTokenId())
+        ).persist();
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/SyntheticTokenAllowanceOwnerMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/SyntheticTokenAllowanceOwnerMigrationTest.java
@@ -1,0 +1,176 @@
+package com.hedera.mirror.importer.migration;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import static com.hedera.mirror.common.domain.entity.EntityType.CONTRACT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import com.hedera.mirror.common.domain.entity.EntityId;
+import com.hedera.mirror.common.domain.entity.TokenAllowance;
+import com.hedera.mirror.importer.IntegrationTest;
+import com.hedera.mirror.importer.TestUtils;
+import com.hedera.mirror.importer.config.Owner;
+import com.hedera.mirror.importer.parser.record.entity.sql.SqlEntityListener;
+import com.hedera.mirror.importer.repository.TokenAllowanceHistoryRepository;
+import com.hedera.mirror.importer.repository.TokenAllowanceRepository;
+
+@RequiredArgsConstructor(onConstructor = @__(@Autowired))
+@Tag("migration")
+class SyntheticTokenAllowanceOwnerMigrationTest extends IntegrationTest {
+
+    private final @Owner JdbcTemplate jdbcTemplate;
+    private final SqlEntityListener sqlEntityListener;
+    private final SyntheticTokenAllowanceOwnerMigration migration;
+    private final TokenAllowanceHistoryRepository tokenAllowanceHistoryRepository;
+    private final TokenAllowanceRepository tokenAllowanceRepository;
+    private final TransactionTemplate transactionTemplate;
+
+    private final String idColumns = "payer_account_id, spender, token_id";
+
+    @AfterEach
+    void teardown() {
+        jdbcTemplate.execute("truncate token_allowance, token_allowance_history, contract_result;");
+    }
+
+    @Test
+    void checksum() {
+        assertThat(migration.getChecksum()).isEqualTo(1);
+    }
+
+    @Test
+    void empty() {
+        migration.doMigrate();
+        assertThat(tokenAllowanceRepository.findAll()).isEmpty();
+        assertThat(tokenAllowanceHistoryRepository.findAll()).isEmpty();
+    }
+
+    @Test
+    void migrate() {
+        // given
+        var contractResultSenderId = EntityId.of("0.0.2001", CONTRACT);
+        long incorrectOwnerAccountId = 1001L;
+        // A token allowance and historical token allowances that all have corresponding Contract Results.
+        // The token allowances are saved with an incorrect owner
+        var affectedTokenAllowancePair = generateTokenAllowance(contractResultSenderId, incorrectOwnerAccountId);
+
+        // A token allowance can occur through HAPI and absent a corresponding Contract Result.
+        // This token allowance and it's history should be unaffected by the migration
+        var unaffectedTokenAllowancePair = generateTokenAllowance(null, null);
+
+        // Before migration verify that the token allowances have the incorrect owner
+        assertThat(tokenAllowanceRepository.findAll()).filteredOn(t -> t.getOwner() == incorrectOwnerAccountId)
+                .containsExactlyInAnyOrderElementsOf(affectedTokenAllowancePair.getLeft());
+        assertThat(findHistory(TokenAllowance.class, idColumns)).filteredOn(t -> t.getOwner() == incorrectOwnerAccountId)
+                .containsExactlyInAnyOrderElementsOf(affectedTokenAllowancePair.getRight());
+
+        // when
+        migration.doMigrate();
+
+        // then
+        var expected = new ArrayList<>(affectedTokenAllowancePair.getLeft());
+        // The owner should be set to the contract result sender id
+        expected.forEach(t -> t.setOwner(contractResultSenderId.getId()));
+        expected.addAll(unaffectedTokenAllowancePair.getLeft());
+        assertThat(tokenAllowanceRepository.findAll()).containsExactlyInAnyOrderElementsOf(expected);
+
+        // The history of the token allowance should also be updated with the corrected owner
+        var expectedHistory = new ArrayList<>(affectedTokenAllowancePair.getRight());
+        // The owner should be set to the contract result sender id
+        expectedHistory.forEach(t -> t.setOwner(contractResultSenderId.getId()));
+        expectedHistory.addAll(unaffectedTokenAllowancePair.getRight());
+        assertThat(findHistory(TokenAllowance.class, idColumns)).containsExactlyInAnyOrderElementsOf(expectedHistory);
+    }
+
+    @Test
+    void migrateWithCorrectOwner() {
+        // given
+        // A token allowance with history that has corresponding Contract Results.
+        var contractResultSenderId = EntityId.of("0.0.2001", CONTRACT);
+        // The token allowances already have the correct owner
+        var tokenAllowancePair = generateTokenAllowance(contractResultSenderId, contractResultSenderId.getId());
+
+        // when
+        migration.doMigrate();
+
+        // then
+        // The token allowances should be unaffected by the migration
+        assertThat(tokenAllowanceRepository.findAll()).containsExactlyInAnyOrderElementsOf(tokenAllowancePair.getLeft());
+        assertThat(findHistory(TokenAllowance.class, idColumns)).containsExactlyInAnyOrderElementsOf(tokenAllowancePair.getRight());
+    }
+
+    /**
+     * Creates a token allowance and updates it twice to populate token_allowance and token_allowance_history
+     *
+     * @param contractResultSenderId
+     * @param ownerAccountId
+     * @return the current token allowance and the historical token allowances
+     */
+    private Pair<List<TokenAllowance>, List<TokenAllowance>> generateTokenAllowance(EntityId contractResultSenderId,
+                                                                                    Long ownerAccountId) {
+        var builder = domainBuilder.tokenAllowance();
+        if (contractResultSenderId != null) {
+            builder = builder.customize(t -> t.owner(ownerAccountId));
+        }
+
+        var createTokenAllowance = builder.get();
+        var tokenAllowanceUpdate1 = builder.customize(c -> c.amount(999L)).get();
+        tokenAllowanceUpdate1.setTimestampLower(createTokenAllowance.getTimestampLower() + 1);
+        var tokenAllowanceUpdate2 = builder.customize(c -> c.amount(55L)).get();
+        tokenAllowanceUpdate2.setTimestampLower(createTokenAllowance.getTimestampLower() + 2);
+
+        // Save the token allowance and its updates to populate token_allowance and token_allowance_history
+        saveTokenAllowance(createTokenAllowance, contractResultSenderId);
+        saveTokenAllowance(tokenAllowanceUpdate1, contractResultSenderId);
+        saveTokenAllowance(tokenAllowanceUpdate2, contractResultSenderId);
+
+        var expectedCreate = TestUtils.clone(createTokenAllowance);
+        var expectedUpdate1 = TestUtils.merge(createTokenAllowance, tokenAllowanceUpdate1);
+        var expectedUpdate2 = TestUtils.merge(expectedUpdate1, tokenAllowanceUpdate2);
+        expectedCreate.setTimestampUpper(tokenAllowanceUpdate1.getTimestampLower());
+        expectedUpdate1.setTimestampUpper(tokenAllowanceUpdate2.getTimestampLower());
+
+        var tokenAllowanceExpected = List.of(expectedUpdate2);
+        var tokenAllowanceHistoryExpected = List.of(expectedCreate, expectedUpdate1);
+        return Pair.of(tokenAllowanceExpected, tokenAllowanceHistoryExpected);
+    }
+
+    private void saveTokenAllowance(TokenAllowance tokenAllowance, EntityId contractResultSenderId) {
+        sqlEntityListener.onTokenAllowance(tokenAllowance);
+        transactionTemplate.executeWithoutResult(status -> sqlEntityListener.onEnd(null));
+        if (contractResultSenderId != null) {
+            domainBuilder.contractResult()
+                    .customize(c -> c.senderId(contractResultSenderId)
+                            .consensusTimestamp(tokenAllowance.getTimestampLower()))
+                    .persist();
+        }
+    }
+}

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/SyntheticTokenAllowanceOwnerMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/SyntheticTokenAllowanceOwnerMigrationTest.java
@@ -77,6 +77,10 @@ class SyntheticTokenAllowanceOwnerMigrationTest extends IntegrationTest {
 
         // A token allowance that has no history and the correct owner, it should not be affected by the migration.
         var newTokenAllowance = domainBuilder.tokenAllowance().persist();
+        domainBuilder.contractResult().customize(c -> c
+                .senderId(new EntityId(0L, 0L, newTokenAllowance.getOwner(), CONTRACT))
+                .consensusTimestamp(newTokenAllowance.getTimestampLower())
+        ).persist();
 
         // when
         migration.doMigrate();
@@ -108,7 +112,11 @@ class SyntheticTokenAllowanceOwnerMigrationTest extends IntegrationTest {
         generateTokenAllowance(null, null);
         var correctContractResultSenderId = EntityId.of("0.0.3001", CONTRACT);
         generateTokenAllowance(correctContractResultSenderId, correctContractResultSenderId.getId());
-        domainBuilder.tokenAllowance().persist();
+        var newTokenAllowance = domainBuilder.tokenAllowance().persist();
+        domainBuilder.contractResult().customize(c -> c
+                .senderId(new EntityId(0L, 0L, newTokenAllowance.getOwner(), CONTRACT))
+                .consensusTimestamp(newTokenAllowance.getTimestampLower())
+        ).persist();
 
         migration.doMigrate();
         var firstPassTokenAllowances = tokenAllowanceRepository.findAll();


### PR DESCRIPTION
**Description**:
Add a migration to update the owners of synthetic token allowances to the correct contract result spender id.

**Related issue(s)**:

Fixes #5715  

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
