### PR TITLE
HIP-584: Fix flaky ERC acceptance tests behaviour (0.78)

### DIFF
--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ERCContractFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ERCContractFeature.java
@@ -318,7 +318,7 @@ public class ERCContractFeature extends AbstractFeature {
 
     @Then("the mirror node REST API should return status {int} for the mint transaction")
     public void verifyMirrorAPIResponses(int status) {
-        MirrorTransaction mirrorTransaction = verifyMirrorTransactionsResponse(mirrorClient, status);
+        verifyMirrorTransactionsResponse(mirrorClient, status);
     }
 
     @Then("I approve {string} for nft")

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ERCContractFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ERCContractFeature.java
@@ -318,9 +318,7 @@ public class ERCContractFeature extends AbstractFeature {
 
     @Then("the mirror node REST API should return status {int} for the mint transaction")
     public void verifyMirrorAPIResponses(int status) {
-        log.info("Verify mint transaction");
         MirrorTransaction mirrorTransaction = verifyMirrorTransactionsResponse(mirrorClient, status);
-        assertThat(mirrorTransaction.getEntityId()).isEqualTo(tokenIds.get(1).toString());
     }
 
     @Then("I approve {string} for nft")

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ERCContractFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ERCContractFeature.java
@@ -27,6 +27,9 @@ import static org.junit.jupiter.api.Assertions.*;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+
+import com.hedera.mirror.test.e2e.acceptance.props.MirrorTransaction;
+
 import io.cucumber.java.After;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
@@ -311,6 +314,13 @@ public class ERCContractFeature extends AbstractFeature {
         long serialNumber = receipt.serials.get(0);
         assertThat(serialNumber).isPositive();
         tokenSerialNumbers.get(tokenId).add(serialNumber);
+    }
+
+    @Then("the mirror node REST API should return status {int} for the mint transaction")
+    public void verifyMirrorAPIResponses(int status) {
+        log.info("Verify mint transaction");
+        MirrorTransaction mirrorTransaction = verifyMirrorTransactionsResponse(mirrorClient, status);
+        assertThat(mirrorTransaction.getEntityId()).isEqualTo(tokenIds.get(1).toString());
     }
 
     @Then("I approve {string} for nft")

--- a/hedera-mirror-test/src/test/resources/features/contract/erc.feature
+++ b/hedera-mirror-test/src/test/resources/features/contract/erc.feature
@@ -7,6 +7,7 @@ Feature: ERC Contract Base Coverage Feature
         Then I create a new token with freeze status 2 and kyc status 1
         Then I create a new nft with supplyType <supplyType>
         Then I mint a serial number
+        Then the mirror node REST API should return status <httpStatusCode> for the mint transaction
         And I call the erc contract via the mirror node REST API for token name
         And I call the erc contract via the mirror node REST API for token symbol
         And I call the erc contract via the mirror node REST API for token decimals
@@ -24,5 +25,5 @@ Feature: ERC Contract Base Coverage Feature
         Then I approve <tokenAllowanceSpender> with <allowances>
         And I call the erc contract via the mirror node REST API for token allowance with allowances
         Examples:
-            | supplyType | spenderName | approvedForAllSpenderName | tokenAllowanceSpender | allowances |
-            | "INFINITE" | "BOB"       | "ALICE"                   | "ALICE"               | 2          |
+            | supplyType | httpStatusCode | spenderName | approvedForAllSpenderName | tokenAllowanceSpender | allowances |
+            | "INFINITE" | 200            | "BOB"       | "ALICE"                   | "ALICE"               | 2          |

--- a/hedera-mirror-test/src/test/resources/features/contract/erc.feature
+++ b/hedera-mirror-test/src/test/resources/features/contract/erc.feature
@@ -7,7 +7,7 @@ Feature: ERC Contract Base Coverage Feature
         Then I create a new token with freeze status 2 and kyc status 1
         Then I create a new nft with supplyType <supplyType>
         Then I mint a serial number
-        Then the mirror node REST API should return status <httpStatusCode> for the mint transaction
+        Then the mirror node REST API should return status 200 for the mint transaction
         And I call the erc contract via the mirror node REST API for token name
         And I call the erc contract via the mirror node REST API for token symbol
         And I call the erc contract via the mirror node REST API for token decimals
@@ -25,5 +25,5 @@ Feature: ERC Contract Base Coverage Feature
         Then I approve <tokenAllowanceSpender> with <allowances>
         And I call the erc contract via the mirror node REST API for token allowance with allowances
         Examples:
-            | supplyType | httpStatusCode | spenderName | approvedForAllSpenderName | tokenAllowanceSpender | allowances |
-            | "INFINITE" | 200            | "BOB"       | "ALICE"                   | "ALICE"               | 2          |
+            | supplyType | spenderName | approvedForAllSpenderName | tokenAllowanceSpender | allowances |
+            | "INFINITE" | "BOB"       | "ALICE"                   | "ALICE"               | 2          |

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/controller/ContractController.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/controller/ContractController.java
@@ -159,8 +159,8 @@ class ContractController {
 
     @ExceptionHandler
     @ResponseStatus(NOT_FOUND)
-    private Mono<GenericErrorResponse> tokeOrContractMissingError(final EntityNotFoundException e) {
-        log.warn("Missing entity error: {}", e.getMessage());
+    private Mono<GenericErrorResponse> notFound(final EntityNotFoundException e) {
+        log.warn("Not found: {}", e.getMessage());
         return errorResponse(e.getMessage());
     }
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/controller/ContractController.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/controller/ContractController.java
@@ -26,9 +26,12 @@ import static com.hedera.mirror.web3.service.model.CallServiceParameters.CallTyp
 import static org.apache.tuweni.bytes.Bytes.EMPTY;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.NOT_IMPLEMENTED;
 import static org.springframework.http.HttpStatus.TOO_MANY_REQUESTS;
 import static org.springframework.http.HttpStatus.UNSUPPORTED_MEDIA_TYPE;
+
+import com.hedera.mirror.web3.exception.EntityNotFoundException;
 
 import io.github.bucket4j.Bucket;
 import javax.validation.Valid;
@@ -152,6 +155,13 @@ class ContractController {
     private Mono<GenericErrorResponse> invalidTxnBodyError(final ServerWebInputException e) {
         log.warn("Transaction body parsing error: {}", e.getMessage());
         return errorResponse(e.getReason(), e.getMostSpecificCause().getMessage(), StringUtils.EMPTY);
+    }
+
+    @ExceptionHandler
+    @ResponseStatus(NOT_FOUND)
+    private Mono<GenericErrorResponse> tokeOrContractMissingError(final EntityNotFoundException e) {
+        log.warn("Missing entity error: {}", e.getMessage());
+        return errorResponse(e.getMessage());
     }
 
     @ExceptionHandler

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/account/MirrorEvmContractAliases.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/account/MirrorEvmContractAliases.java
@@ -45,7 +45,7 @@ public class MirrorEvmContractAliases extends HederaEvmContractAliases {
         final var entityOptional = mirrorEntityAccess.findEntity(addressOrAlias);
 
         if (entityOptional.isEmpty()) {
-            throw new EntityNotFoundException("No such contract or token");
+            throw new EntityNotFoundException("No such contract or token: " + addressOrAlias);
         }
 
         final var entity = entityOptional.get();
@@ -58,7 +58,7 @@ public class MirrorEvmContractAliases extends HederaEvmContractAliases {
             final var bytes = Bytes.wrap(entity.getEvmAddress() != null ? entity.getEvmAddress() : toEvmAddress(entityId));
             return Address.wrap(bytes);
         } else {
-            throw new InvalidParametersException("No such contract or token");
+            throw new InvalidParametersException("Not a contract or token: " + addressOrAlias);
         }
     }
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/account/MirrorEvmContractAliases.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/account/MirrorEvmContractAliases.java
@@ -24,6 +24,7 @@ import static com.hedera.mirror.common.util.DomainUtils.toEvmAddress;
 
 import com.hedera.mirror.common.domain.entity.EntityType;
 
+import com.hedera.mirror.web3.exception.EntityNotFoundException;
 import com.hedera.mirror.web3.exception.InvalidParametersException;
 
 import javax.inject.Named;
@@ -44,7 +45,7 @@ public class MirrorEvmContractAliases extends HederaEvmContractAliases {
         final var entityOptional = mirrorEntityAccess.findEntity(addressOrAlias);
 
         if (entityOptional.isEmpty()) {
-            throw new InvalidParametersException("No such contract or token");
+            throw new EntityNotFoundException("No such contract or token");
         }
 
         final var entity = entityOptional.get();

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/exception/EntityNotFoundException.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/exception/EntityNotFoundException.java
@@ -21,10 +21,11 @@ package com.hedera.mirror.web3.exception;
  */
 
 import com.hedera.mirror.common.exception.MirrorNodeException;
+import com.hedera.mirror.web3.evm.exception.EvmException;
 
 import java.io.Serial;
 
-public class EntityNotFoundException extends MirrorNodeException {
+public class EntityNotFoundException extends EvmException {
 
     @Serial
     private static final long serialVersionUID = -3067964948484169965L;

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/exception/EntityNotFoundException.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/exception/EntityNotFoundException.java
@@ -24,6 +24,7 @@ import com.hedera.mirror.web3.evm.exception.EvmException;
 
 import java.io.Serial;
 
+@SuppressWarnings("java:S110")
 public class EntityNotFoundException extends EvmException {
 
     @Serial

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/exception/EntityNotFoundException.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/exception/EntityNotFoundException.java
@@ -1,0 +1,35 @@
+package com.hedera.mirror.web3.exception;
+
+/*-
+ * ‌
+ * Hedera Mirror Node
+ * ​
+ * Copyright (C) 2019 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import com.hedera.mirror.common.exception.MirrorNodeException;
+
+import java.io.Serial;
+
+public class EntityNotFoundException extends MirrorNodeException {
+
+    @Serial
+    private static final long serialVersionUID = -3067964948484169965L;
+
+    public EntityNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/exception/EntityNotFoundException.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/exception/EntityNotFoundException.java
@@ -20,7 +20,6 @@ package com.hedera.mirror.web3.exception;
  * ‍
  */
 
-import com.hedera.mirror.common.exception.MirrorNodeException;
 import com.hedera.mirror.web3.evm.exception.EvmException;
 
 import java.io.Serial;

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/controller/ContractControllerTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/controller/ContractControllerTest.java
@@ -26,11 +26,13 @@ import static org.mockito.BDDMockito.given;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_REVERT_EXECUTED;
 import static org.mockito.ArgumentMatchers.any;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.NOT_IMPLEMENTED;
 import static org.springframework.http.HttpStatus.OK;
 import static org.springframework.http.HttpStatus.TOO_MANY_REQUESTS;
 import static org.springframework.http.HttpStatus.UNSUPPORTED_MEDIA_TYPE;
 
+import com.hedera.mirror.web3.exception.EntityNotFoundException;
 import com.hedera.mirror.web3.exception.InvalidParametersException;
 import com.hedera.mirror.web3.exception.InvalidTransactionException;
 
@@ -140,6 +142,23 @@ class ContractControllerTest {
                 .expectStatus()
                 .isEqualTo(BAD_REQUEST)
                 .expectBody(GenericErrorResponse.class);
+    }
+
+    @Test
+    void callMissingTo() {
+        final var request = request();
+
+        given(service.processCall(any())).willThrow(new EntityNotFoundException("No such contract or token"));
+
+        webClient.post()
+                .uri(CALL_URI)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(BodyInserters.fromValue(request))
+                .exchange()
+                .expectStatus()
+                .isEqualTo(NOT_FOUND)
+                .expectBody(GenericErrorResponse.class)
+                .isEqualTo(new GenericErrorResponse("No such contract or token"));
     }
 
     @EmptySource

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/controller/ContractControllerTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/controller/ContractControllerTest.java
@@ -146,9 +146,10 @@ class ContractControllerTest {
 
     @Test
     void callMissingTo() {
+        final var exceptionMessage = "No such contract or token";
         final var request = request();
 
-        given(service.processCall(any())).willThrow(new EntityNotFoundException("No such contract or token"));
+        given(service.processCall(any())).willThrow(new EntityNotFoundException(exceptionMessage));
 
         webClient.post()
                 .uri(CALL_URI)
@@ -158,7 +159,7 @@ class ContractControllerTest {
                 .expectStatus()
                 .isEqualTo(NOT_FOUND)
                 .expectBody(GenericErrorResponse.class)
-                .isEqualTo(new GenericErrorResponse("No such contract or token"));
+                .isEqualTo(new GenericErrorResponse(exceptionMessage));
     }
 
     @EmptySource

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/account/MirrorEvmContractAliasesTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/account/MirrorEvmContractAliasesTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.when;
 
 import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.entity.EntityType;
+import com.hedera.mirror.web3.exception.EntityNotFoundException;
 import com.hedera.mirror.web3.exception.InvalidParametersException;
 
 import java.util.Optional;
@@ -97,13 +98,13 @@ class MirrorEvmContractAliasesTest {
         when(entity.getType()).thenReturn(EntityType.TOPIC);
         assertThatThrownBy(() -> mirrorEvmContractAliases.resolveForEvm(ADDRESS))
                 .isInstanceOf(InvalidParametersException.class)
-                .hasMessage("No such contract or token");
+                .hasMessage("Not a contract or token: 0x00000000000000000000000000000000000004e4");
     }
 
     @Test
     void resolveForEvmFail() {
         assertThatThrownBy(() -> mirrorEvmContractAliases.resolveForEvm(INVALID_ADDRESS))
-                .isInstanceOf(InvalidParametersException.class)
-                .hasMessage("No such contract or token");
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessage("No such contract or token: 0x00000000000000000000000000000000000004e5");
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/account/MirrorEvmContractAliasesTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/account/MirrorEvmContractAliasesTest.java
@@ -98,13 +98,13 @@ class MirrorEvmContractAliasesTest {
         when(entity.getType()).thenReturn(EntityType.TOPIC);
         assertThatThrownBy(() -> mirrorEvmContractAliases.resolveForEvm(ADDRESS))
                 .isInstanceOf(InvalidParametersException.class)
-                .hasMessage("Not a contract or token: 0x00000000000000000000000000000000000004e4");
+                .hasMessage("Not a contract or token: " + HEX);
     }
 
     @Test
     void resolveForEvmFail() {
         assertThatThrownBy(() -> mirrorEvmContractAliases.resolveForEvm(INVALID_ADDRESS))
                 .isInstanceOf(EntityNotFoundException.class)
-                .hasMessage("No such contract or token: 0x00000000000000000000000000000000000004e5");
+                .hasMessage("No such contract or token: " + HEX2);
     }
 }


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

This PR fixes flaky behaviour of ERC precompile acceptance tests. The flaky behaviour was introduced, since we don't await the last HAPI call was properly imported into the mirror-node and there were cases where the created tokens via HAPI were not processed and presented in the DB.

In addition, the exception handling logic was enhanced to catch exceptions triggered via missing entities in the DB and now we return 404 NOT FOUND instead of 400 BAD REQUEST.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
