### PR TITLE
HIP-584: Disable allowance ERC precompile (0.78)

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/token/TokenAccessorImpl.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/token/TokenAccessorImpl.java
@@ -46,13 +46,9 @@ import org.hyperledger.besu.datatypes.Address;
 import org.springframework.util.CollectionUtils;
 
 import com.hedera.mirror.common.domain.entity.AbstractEntity;
-import com.hedera.mirror.common.domain.entity.AbstractNftAllowance;
-import com.hedera.mirror.common.domain.entity.AbstractTokenAllowance;
 import com.hedera.mirror.common.domain.entity.Entity;
 import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.entity.EntityType;
-import com.hedera.mirror.common.domain.entity.NftAllowance;
-import com.hedera.mirror.common.domain.entity.TokenAllowance;
 import com.hedera.mirror.common.domain.token.AbstractTokenAccount;
 import com.hedera.mirror.common.domain.token.Nft;
 import com.hedera.mirror.common.domain.token.NftId;

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/token/TokenAccessorImpl.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/token/TokenAccessorImpl.java
@@ -218,34 +218,17 @@ public class TokenAccessorImpl implements TokenAccessor {
 
     @Override
     public long staticAllowanceOf(final Address owner, final Address spender, final Address token) {
-        final var tokenAllowanceId = new AbstractTokenAllowance.Id();
-        tokenAllowanceId.setOwner(entityIdFromAccountAddress(owner));
-        tokenAllowanceId.setSpender(entityIdFromAccountAddress(spender));
-        tokenAllowanceId.setTokenId(entityIdNumFromEvmAddress(token));
-
-        return tokenAllowanceRepository.findById(tokenAllowanceId).map(TokenAllowance::getAmount).orElse(0L);
+        throw new UnsupportedOperationException("allowance(address owner, address spender) is not supported.");
     }
 
     @Override
     public Address staticApprovedSpenderOf(final Address nft, long serialNo) {
-        final var nftId = new NftId(serialNo, entityIdFromEvmAddress(nft));
-        final var spenderEntity = nftRepository.findById(nftId).map(Nft::getSpender);
-
-        if (spenderEntity.isEmpty()) {
-            return Address.ZERO;
-        }
-
-        return evmAddressFromId(spenderEntity.get());
+        throw new UnsupportedOperationException("getApproved(uint256 tokenId) is not supported.");
     }
 
     @Override
     public boolean staticIsOperator(final Address owner, final Address operator, final Address token) {
-        final var nftAllowanceId = new AbstractNftAllowance.Id();
-        nftAllowanceId.setOwner(entityIdFromAccountAddress(owner));
-        nftAllowanceId.setSpender(entityIdFromAccountAddress(operator));
-        nftAllowanceId.setTokenId(entityIdNumFromEvmAddress(token));
-
-        return nftAllowanceRepository.findById(nftAllowanceId).map(NftAllowance::isApprovedForAll).orElse(false);
+        throw new UnsupportedOperationException("isApprovedForAll(address owner, address operator) is not supported.");
     }
 
     @Override

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceERCTokenTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceERCTokenTest.java
@@ -81,15 +81,14 @@ class ContractCallServiceERCTokenTest extends Web3IntegrationTest {
         assertThat(contractCallService.processCall(serviceParameters)).isEqualTo(successfulResponse);
     }
 
-    @ParameterizedTest
-    @EnumSource(UnsupportedContractFunctions.class)
-    void unsupportedErcPrecompileOperationsTest(UnsupportedContractFunctions ercFunction) {
+    @Test
+    void unsupportedApprovePrecompileTest() {
         final var functionHash =
-                functionEncodeDecoder.functionHashFor(ercFunction.name, ABI_PATH, ercFunction.functionParameters);
+                functionEncodeDecoder.functionHashFor("allowance", ABI_PATH, new Address[] {FUNGIBLE_TOKEN_ADDRESS, SENDER_ADDRESS, RECEIVER_ADDRESS});
         final var serviceParameters = serviceParameters(functionHash);
 
         assertThatThrownBy(() -> contractCallService.processCall(serviceParameters)).
-                isInstanceOf(UnsupportedOperationException.class).hasMessage(ercFunction.expectedExceptionMessage);
+                isInstanceOf(UnsupportedOperationException.class).hasMessage("allowance(address owner, address spender) is not supported.");
     }
 
     @Test
@@ -102,6 +101,9 @@ class ContractCallServiceERCTokenTest extends Web3IntegrationTest {
 
     @RequiredArgsConstructor
     public enum ContractFunctions {
+        GET_APPROVED_EMPTY_SPENDER("getApproved",new Object[] {NFT_ADDRESS, 2L}, new Address[] {Address.ZERO}),
+        IS_APPROVE_FOR_ALL        ("isApprovedForAll", new Address[] {NFT_ADDRESS, SENDER_ADDRESS, RECEIVER_ADDRESS}, new Boolean[] {true}),
+        GET_APPROVED              ("getApproved",new Object[] {NFT_ADDRESS, 1L},new Address[] {RECEIVER_ADDRESS}),
         ERC_DECIMALS              ("decimals", new Address[] {FUNGIBLE_TOKEN_ADDRESS}, new Integer[] {12}),
         TOTAL_SUPPLY              ("totalSupply", new Address[] {FUNGIBLE_TOKEN_ADDRESS}, new Long[] {12345L}),
         ERC_SYMBOL                ("symbol", new Address[] {FUNGIBLE_TOKEN_ADDRESS}, new String[] {"HBAR"}),
@@ -113,18 +115,6 @@ class ContractCallServiceERCTokenTest extends Web3IntegrationTest {
         private final String name;
         private final Object[] functionParameters;
         private final Object[] expectedResultFields;
-    }
-
-    @RequiredArgsConstructor
-    public enum UnsupportedContractFunctions {
-        GET_APPROVED_EMPTY_SPENDER("getApproved",new Object[] {NFT_ADDRESS, 2L}, "getApproved(uint256 tokenId) is not supported."),
-        IS_APPROVE_FOR_ALL        ("isApprovedForAll", new Address[] {NFT_ADDRESS, SENDER_ADDRESS, RECEIVER_ADDRESS}, "isApprovedForAll(address owner, address operator) is not supported."),
-        ALLOWANCE_OF              ("allowance", new Address[] {FUNGIBLE_TOKEN_ADDRESS, SENDER_ADDRESS, RECEIVER_ADDRESS}, "allowance(address owner, address spender) is not supported."),
-        GET_APPROVED              ("getApproved",new Object[] {NFT_ADDRESS, 1L}, "getApproved(uint256 tokenId) is not supported.");
-
-        private final String name;
-        private final Object[] functionParameters;
-        private final String expectedExceptionMessage;
     }
 
     private CallServiceParameters serviceParameters(Bytes callData) {


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

This PR disables the `allowance(address token, address owner, address spender) external returns (int responseCode)` precompile by throwing `UnsupportedOperationException` if it is accessed. The reason is, there is some incorrect data in (fixed in 37 services release), connected to exporting child records for approve operations related to fungible tokens.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
