### PR TITLE
HIP-584: Disable allowance ERC precompile

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -553,6 +553,7 @@ Name                                                        | Default           
 `hedera.mirror.web3.db.port`                                | 5432                                       | The port used to connect to the database
 `hedera.mirror.web3.db.sslMode`                             | DISABLE                                    | The ssl level of protection against eavesdropping, man-in-the-middle (MITM) and impersonation on the db connection. Accepts either DISABLE, ALLOW, PREFER, REQUIRE, VERIFY_CA or VERIFY_FULL.
 `hedera.mirror.web3.db.username`                            | mirror_web3                                | The username used to connect to the database
+`hedera.mirror.web3.evm.allowanceEnabled`                   | false                                      | Flag enabling ERC approve precompile
 `hedera.mirror.web3.evm.directTokenCall`                    | true                                       | Flag enabling contract like calls to tokens
 `hedera.mirror.web3.evm.dynamicEvmVersion`                  | false                                      | Flag indicating whether a dynamic evm version to be used
 `hedera.mirror.web3.evm.evmVersion`                         | v0.32                                      | The besu EVM version to be used as dynamic one

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/properties/MirrorNodeEvmProperties.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/properties/MirrorNodeEvmProperties.java
@@ -72,6 +72,9 @@ public class MirrorNodeEvmProperties implements EvmProperties {
     @NotNull
     private HederaNetwork network = HederaNetwork.TESTNET;
 
+    @Getter
+    private boolean isAllowanceEnabled = false;
+
     @Override
     public boolean isRedirectTokenCallsEnabled() {
         return directTokenCall;

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/properties/MirrorNodeEvmProperties.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/properties/MirrorNodeEvmProperties.java
@@ -44,6 +44,9 @@ import static com.swirlds.common.utility.CommonUtils.unhex;
 @Validated
 @ConfigurationProperties(prefix = "hedera.mirror.web3.evm")
 public class MirrorNodeEvmProperties implements EvmProperties {
+    @Getter
+    private boolean allowanceEnabled = false;
+    
     private boolean directTokenCall = true;
 
     private boolean dynamicEvmVersion = true;
@@ -71,9 +74,6 @@ public class MirrorNodeEvmProperties implements EvmProperties {
     @Getter
     @NotNull
     private HederaNetwork network = HederaNetwork.TESTNET;
-
-    @Getter
-    private boolean isAllowanceEnabled = false;
 
     @Override
     public boolean isRedirectTokenCallsEnabled() {

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/token/TokenAccessorImpl.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/token/TokenAccessorImpl.java
@@ -218,12 +218,16 @@ public class TokenAccessorImpl implements TokenAccessor {
 
     @Override
     public long staticAllowanceOf(final Address owner, final Address spender, final Address token) {
-        final var tokenAllowanceId = new AbstractTokenAllowance.Id();
-        tokenAllowanceId.setOwner(entityIdFromAccountAddress(owner));
-        tokenAllowanceId.setSpender(entityIdFromAccountAddress(spender));
-        tokenAllowanceId.setTokenId(entityIdNumFromEvmAddress(token));
+        if(properties.isAllowanceEnabled()) {
+            final var tokenAllowanceId = new AbstractTokenAllowance.Id();
+            tokenAllowanceId.setOwner(entityIdFromAccountAddress(owner));
+            tokenAllowanceId.setSpender(entityIdFromAccountAddress(spender));
+            tokenAllowanceId.setTokenId(entityIdNumFromEvmAddress(token));
 
-        return tokenAllowanceRepository.findById(tokenAllowanceId).map(TokenAllowance::getAmount).orElse(0L);
+            return tokenAllowanceRepository.findById(tokenAllowanceId).map(TokenAllowance::getAmount).orElse(0L);
+        } else {
+            throw new UnsupportedOperationException("allowance(address owner, address spender) is not supported.");
+        }
     }
 
     @Override

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/token/TokenAccessorImpl.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/token/TokenAccessorImpl.java
@@ -218,16 +218,16 @@ public class TokenAccessorImpl implements TokenAccessor {
 
     @Override
     public long staticAllowanceOf(final Address owner, final Address spender, final Address token) {
-        if(properties.isAllowanceEnabled()) {
-            final var tokenAllowanceId = new AbstractTokenAllowance.Id();
-            tokenAllowanceId.setOwner(entityIdFromAccountAddress(owner));
-            tokenAllowanceId.setSpender(entityIdFromAccountAddress(spender));
-            tokenAllowanceId.setTokenId(entityIdNumFromEvmAddress(token));
-
-            return tokenAllowanceRepository.findById(tokenAllowanceId).map(TokenAllowance::getAmount).orElse(0L);
-        } else {
+        if (!properties.isAllowanceEnabled()) {
             throw new UnsupportedOperationException("allowance(address owner, address spender) is not supported.");
         }
+
+        final var tokenAllowanceId = new AbstractTokenAllowance.Id();
+        tokenAllowanceId.setOwner(entityIdFromAccountAddress(owner));
+        tokenAllowanceId.setSpender(entityIdFromAccountAddress(spender));
+        tokenAllowanceId.setTokenId(entityIdNumFromEvmAddress(token));
+
+        return tokenAllowanceRepository.findById(tokenAllowanceId).map(TokenAllowance::getAmount).orElse(0L);
     }
 
     @Override

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceERCTokenTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceERCTokenTest.java
@@ -32,6 +32,8 @@ import static com.hedera.mirror.web3.service.model.CallServiceParameters.CallTyp
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
+import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
+
 import lombok.RequiredArgsConstructor;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
@@ -65,10 +67,13 @@ class ContractCallServiceERCTokenTest extends Web3IntegrationTest {
     private static final Address NFT_ADDRESS = toAddress(EntityId.of(0, 0, 1047, TOKEN));
     private final ContractCallService contractCallService;
     private final FunctionEncodeDecoder functionEncodeDecoder;
+    private final MirrorNodeEvmProperties properties;
 
     @ParameterizedTest
     @EnumSource(ContractFunctions.class)
     void ercPrecompileOperationsTest(ContractFunctions ercFunction) {
+        properties.setAllowanceEnabled(true);
+
         final var functionHash =
                 functionEncodeDecoder.functionHashFor(ercFunction.name, ABI_PATH, ercFunction.functionParameters);
         final var serviceParameters = serviceParameters(functionHash);
@@ -100,6 +105,7 @@ class ContractCallServiceERCTokenTest extends Web3IntegrationTest {
     public enum ContractFunctions {
         GET_APPROVED_EMPTY_SPENDER("getApproved",new Object[] {NFT_ADDRESS, 2L}, new Address[] {Address.ZERO}),
         IS_APPROVE_FOR_ALL        ("isApprovedForAll", new Address[] {NFT_ADDRESS, SENDER_ADDRESS, RECEIVER_ADDRESS}, new Boolean[] {true}),
+        ALLOWANCE_OF              ("allowance", new Address[] {FUNGIBLE_TOKEN_ADDRESS, SENDER_ADDRESS, RECEIVER_ADDRESS}, new Long[] {13L}),
         GET_APPROVED              ("getApproved",new Object[] {NFT_ADDRESS, 1L},new Address[] {RECEIVER_ADDRESS}),
         ERC_DECIMALS              ("decimals", new Address[] {FUNGIBLE_TOKEN_ADDRESS}, new Integer[] {12}),
         TOTAL_SUPPLY              ("totalSupply", new Address[] {FUNGIBLE_TOKEN_ADDRESS}, new Long[] {12345L}),


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

This PR disables the `allowance(address token, address owner, address spender) external returns (int responseCode)` precompile by throwing `UnsupportedOperationException` if it is accessed. The reason is, there is some incorrect data in (fixed in 37 services release), connected to exporting child records for approve operations related to fungible tokens.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
