### PR TITLE
Bump hedera-evm from 0.36.0-alpha.3 to 0.36.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,7 +58,7 @@ dependencies {
         api("com.graphql-java-generator:graphql-java-client-dependencies:1.18.11")
         api("com.graphql-java:graphql-java-extended-scalars:20.0")
         api("com.graphql-java:graphql-java-extended-validation:20.0-validator-6.2.0.Final")
-        api("com.hedera.evm:hedera-evm:0.36.0-alpha.3")
+        api("com.hedera.evm:hedera-evm:0.36.2")
         api("com.hedera.hashgraph:hedera-protobuf-java-api:0.36.1")
         api("com.hedera.hashgraph:sdk:2.22.0")
         api("com.ongres.scram:client:2.1")


### PR DESCRIPTION
**Description**:

Bump hedera-evm from 0.36.0-alpha.3 to 0.36.2

**Related issue(s)**:

**Notes for reviewer**:

Fixes the build due to alpha build being expired from Nexus.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
