### PR TITLE
Increase REST API pod resources

### DIFF
--- a/charts/hedera-mirror-common/values.yaml
+++ b/charts/hedera-mirror-common/values.yaml
@@ -414,7 +414,7 @@ traefik:
   resources:
     limits:
       cpu: 850m
-      memory: 1250Mi
+      memory: 2000Mi
     requests:
       cpu: 250m
       memory: 150Mi

--- a/charts/hedera-mirror-rest/values.yaml
+++ b/charts/hedera-mirror-rest/values.yaml
@@ -60,14 +60,14 @@ hpa:
   behavior: {}
   enabled: true
   maxReplicas: 15
-  metrics:  # Using a custom metric exposed via the prometheus adapter.
-    - type: Pods
-      pods:
-        metric:
-          name: requests_per_second
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
         target:
-          type: AverageValue
-          averageValue: 300
+          type: Utilization
+          averageUtilization: 80
+
   minReplicas: 1
 
 image:
@@ -227,10 +227,10 @@ readinessProbe:
 
 resources:
   limits:
-    cpu: 750m
+    cpu: 1100m
     memory: 350Mi
   requests:
-    cpu: 300m
+    cpu: 700m
     memory: 64Mi
 
 revisionHistoryLimit: 3

--- a/charts/hedera-mirror/ci/citus-values.yaml
+++ b/charts/hedera-mirror/ci/citus-values.yaml
@@ -32,6 +32,9 @@ rest:
         ],
         "stateproof": { "enabled": false }
       }
+  resources:
+    requests:
+      cpu: 200m
 rosetta:
   test:
     enabled: false

--- a/charts/hedera-mirror/ci/default-values.yaml
+++ b/charts/hedera-mirror/ci/default-values.yaml
@@ -2,6 +2,12 @@
 graphql:
   test:
     defaultAccount: 111146
+importer:
+  # Ensure importer has time to start stream processing after startup
+  readinessProbe:
+    initialDelaySeconds: 20
+    periodSeconds: 15
+    successThreshold: 2
 monitor:
   enabled: false
 postgresql:
@@ -20,10 +26,6 @@ rest:
         ],
         "stateproof": { "enabled": false }
       }
-
-# Ensure importer has time to start stream processing after startup
-importer:
-  readinessProbe:
-    initialDelaySeconds: 20
-    periodSeconds: 15
-    successThreshold: 2
+  resources:
+    requests:
+      cpu: 200m

--- a/charts/hedera-mirror/values-prod.yaml
+++ b/charts/hedera-mirror/values-prod.yaml
@@ -88,7 +88,7 @@ rest:
     inhibitRules:
       enabled: true
   hpa:
-    minReplicas: 3
+    minReplicas: 2
   podDisruptionBudget:
     enabled: true
   priorityClassName: medium


### PR DESCRIPTION
**Description**:

Testing in the performance environments shows a marked improvement in overall throughput with the below chart adjustments:

* Increase Traefik memory
* Increase REST deployment limit to a little more than 1 CPU
* Revert autoscaling back to CPU based but with higher requests
* Reduce minimum replicas to 2 since resources have been raised

**Related issue(s)**:

Fixes #5857

**Notes for reviewer**:

Node.js is a single threaded process so to give it less than one CPU is inefficient at best and can cause instability at worst.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
