### PR TITLE
Fix HTS NFT Synthetic events logs

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractlog/AbstractSyntheticContractLog.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractlog/AbstractSyntheticContractLog.java
@@ -32,14 +32,16 @@ public abstract class AbstractSyntheticContractLog implements SyntheticContractL
     private final byte[] topic0;
     private final byte[] topic1;
     private final byte[] topic2;
+    private final byte[] topic3;
     private final byte[] data;
 
-    AbstractSyntheticContractLog(RecordItem recordItem, EntityId tokenId, byte[] topic0, byte[] topic1, byte[] topic2, byte[] data) {
+    AbstractSyntheticContractLog(RecordItem recordItem, EntityId tokenId, byte[] topic0, byte[] topic1, byte[] topic2, byte[] topic3, byte[] data) {
         this.recordItem = recordItem;
         this.entityId = tokenId;
         this.topic0 = topic0;
         this.topic1 = topic1;
         this.topic2 = topic2;
+        this.topic3 = topic3;
         this.data = data;
     }
     static final byte[] TRANSFER_SIGNATURE = Bytes.fromHexString("ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef").toArray();

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractlog/ApproveAllowanceContractLog.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractlog/ApproveAllowanceContractLog.java
@@ -25,7 +25,9 @@ import com.hedera.mirror.common.domain.transaction.RecordItem;
 
 public class ApproveAllowanceContractLog extends AbstractSyntheticContractLog {
 
-    public ApproveAllowanceContractLog(RecordItem recordItem, EntityId tokenId, EntityId ownerId, EntityId spenderId, long amount) {
-        super(recordItem, tokenId, APPROVE_SIGNATURE, entityIdToBytes(ownerId), entityIdToBytes(spenderId), longToBytes(amount));
+    public ApproveAllowanceContractLog(RecordItem recordItem, EntityId tokenId, EntityId ownerId, EntityId spenderId, long amount, boolean indexed) {
+        super(recordItem, tokenId, APPROVE_SIGNATURE, entityIdToBytes(ownerId),
+                entityIdToBytes(spenderId), indexed ? longToBytes(amount) : null,
+                indexed ? null : longToBytes(amount));
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractlog/ApproveForAllAllowanceContractLog.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractlog/ApproveForAllAllowanceContractLog.java
@@ -25,6 +25,6 @@ import com.hedera.mirror.common.domain.transaction.RecordItem;
 
 public class ApproveForAllAllowanceContractLog extends AbstractSyntheticContractLog {
     public ApproveForAllAllowanceContractLog(RecordItem recordItem, EntityId tokenId, EntityId ownerId, EntityId spenderId, boolean approved) {
-        super(recordItem, tokenId, APPROVE_FOR_ALL_SIGNATURE, entityIdToBytes(ownerId), entityIdToBytes(spenderId), booleanToBytes(approved));
+        super(recordItem, tokenId, APPROVE_FOR_ALL_SIGNATURE, entityIdToBytes(ownerId), entityIdToBytes(spenderId), null, booleanToBytes(approved));
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractlog/SyntheticContractLog.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractlog/SyntheticContractLog.java
@@ -29,5 +29,6 @@ public interface SyntheticContractLog {
     byte[] getTopic0();
     byte[] getTopic1();
     byte[] getTopic2();
+    byte[] getTopic3();
     byte[] getData();
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractlog/SyntheticContractLogServiceImpl.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractlog/SyntheticContractLogServiceImpl.java
@@ -39,7 +39,7 @@ public class SyntheticContractLogServiceImpl implements SyntheticContractLogServ
 
     private final EntityListener entityListener;
     private final EntityProperties entityProperties;
-    private final byte[] emptyBloom = Bytes.of(0).toArray();
+    private final byte[] empty = Bytes.of(0).toArray();
     @Override
     public void create(SyntheticContractLog log) {
         if (isContract(log.getRecordItem()) || !entityProperties.getPersist().isSyntheticContractLogs()) {
@@ -51,16 +51,19 @@ public class SyntheticContractLogServiceImpl implements SyntheticContractLogServ
 
         ContractLog contractLog = new ContractLog();
 
-        contractLog.setBloom(emptyBloom);
+        contractLog.setBloom(empty);
         contractLog.setConsensusTimestamp(consensusTimestamp);
         contractLog.setContractId(log.getEntityId());
-        contractLog.setData(log.getData());
+        contractLog.setData(empty);
+        if (log.getData() != null) contractLog.setData(log.getData());
         contractLog.setIndex(logIndex);
         contractLog.setRootContractId(log.getEntityId());
         contractLog.setPayerAccountId(log.getRecordItem().getPayerAccountId());
         contractLog.setTopic0(log.getTopic0());
         contractLog.setTopic1(log.getTopic1());
         contractLog.setTopic2(log.getTopic2());
+        if (log.getTopic3() != null) contractLog.setTopic3(log.getTopic3());
+        contractLog.setTransactionIndex(log.getRecordItem().getTransactionIndex());
         entityListener.onContractLog(contractLog);
     }
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractlog/TransferContractLog.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractlog/TransferContractLog.java
@@ -24,7 +24,9 @@ import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.transaction.RecordItem;
 
 public class TransferContractLog extends AbstractSyntheticContractLog {
-    public TransferContractLog(RecordItem recordItem, EntityId tokenId, EntityId senderId, EntityId receiverId, long amount) {
-        super(recordItem ,tokenId, TRANSFER_SIGNATURE, entityIdToBytes(senderId), entityIdToBytes(receiverId), longToBytes(amount));
+    public TransferContractLog(RecordItem recordItem, EntityId tokenId, EntityId senderId, EntityId receiverId, long amount, boolean indexed) {
+        super(recordItem ,tokenId, TRANSFER_SIGNATURE, entityIdToBytes(senderId),
+                entityIdToBytes(receiverId), indexed ? longToBytes(amount) : null,
+                indexed ? null : longToBytes(amount));
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListener.java
@@ -352,7 +352,7 @@ public class EntityRecordItemListener implements RecordItemListener {
         boolean isDeletedTokenDissociate = isTokenDissociate && tokenTransferCount == 1;
 
         boolean isWipeOrBurn = recordItem.getTransactionType() == TransactionType.TOKENBURN.getProtoId() || recordItem.getTransactionType() == TransactionType.TOKENWIPE.getProtoId();
-        boolean isMint = recordItem.getTransactionType() == TransactionType.TOKENMINT.getProtoId();
+        boolean isMint = recordItem.getTransactionType() == TransactionType.TOKENMINT.getProtoId() || recordItem.getTransactionType() == TransactionType.TOKENCREATION.getProtoId();
         boolean isSingleTransfer = tokenTransferCount == 2;
 
         for (int i = 0; i < tokenTransferCount; i++) {
@@ -391,7 +391,7 @@ public class EntityRecordItemListener implements RecordItemListener {
             EntityId senderId = amount < 0 ? accountId : EntityId.EMPTY;
             EntityId receiverId = amount > 0 ? accountId : EntityId.EMPTY;
             syntheticContractLogService.create(new TransferContractLog(recordItem, tokenId, senderId, receiverId,
-                    Math.abs(amount)));
+                    Math.abs(amount), false));
         }
     }
 
@@ -399,7 +399,7 @@ public class EntityRecordItemListener implements RecordItemListener {
                                    boolean isSingleTransfer, int i, EntityId accountId, long amount) {
         if (isSingleTransfer && amount > 0) {
             EntityId senderId = i == 0 ? EntityId.of(tokenTransfers.get(1).getAccountID()) : EntityId.of(tokenTransfers.get(0).getAccountID());
-            syntheticContractLogService.create(new TransferContractLog(recordItem, tokenId, senderId, accountId, amount));
+            syntheticContractLogService.create(new TransferContractLog(recordItem, tokenId, senderId, accountId, amount, false));
         }
     }
 
@@ -482,7 +482,7 @@ public class EntityRecordItemListener implements RecordItemListener {
                 transferNftOwnership(consensusTimestamp, serialNumber, entityTokenId, receiverId);
             }
             syntheticContractLogService
-                    .create(new TransferContractLog(recordItem, entityTokenId, senderId, receiverId, serialNumber));
+                    .create(new TransferContractLog(recordItem, entityTokenId, senderId, receiverId, serialNumber, true));
         }
     }
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoApproveAllowanceTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoApproveAllowanceTransactionHandler.java
@@ -148,7 +148,7 @@ class CryptoApproveAllowanceTransactionHandler implements TransactionHandler {
                 if (nftSerialAllowanceState.putIfAbsent(nft.getId(), nft) == null) {
                     entityListener.onNft(nft);
                     if (!hasApprovedForAll) {
-                        syntheticContractLogService.create(new ApproveAllowanceContractLog(recordItem, tokenId, ownerAccountId, spender, serialNumber));
+                        syntheticContractLogService.create(new ApproveAllowanceContractLog(recordItem, tokenId, ownerAccountId, spender, serialNumber, true));
                     }
                 }
             }
@@ -207,7 +207,7 @@ class CryptoApproveAllowanceTransactionHandler implements TransactionHandler {
 
             if (tokenAllowanceState.putIfAbsent(tokenAllowance.getId(), tokenAllowance) == null) {
                 entityListener.onTokenAllowance(tokenAllowance);
-                syntheticContractLogService.create(new ApproveAllowanceContractLog(recordItem, tokenId, ownerAccountId, spenderId, tokenApproval.getAmount()));
+                syntheticContractLogService.create(new ApproveAllowanceContractLog(recordItem, tokenId, ownerAccountId, spenderId, tokenApproval.getAmount(), false));
             }
         }
     }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoDeleteAllowanceTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoDeleteAllowanceTransactionHandler.java
@@ -67,7 +67,7 @@ class CryptoDeleteAllowanceTransactionHandler implements TransactionHandler {
                 var nft = new Nft(serialNumber, tokenId);
                 nft.setModifiedTimestamp(recordItem.getConsensusTimestamp());
                 entityListener.onNft(nft);
-                syntheticContractLogService.create(new ApproveAllowanceContractLog(recordItem, tokenId, ownerId, EntityId.EMPTY, serialNumber));
+                syntheticContractLogService.create(new ApproveAllowanceContractLog(recordItem, tokenId, ownerId, EntityId.EMPTY, serialNumber, false));
             }
         }
     }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/contractlog/SyntheticContractLogServiceImplTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/contractlog/SyntheticContractLogServiceImplTest.java
@@ -67,7 +67,14 @@ class SyntheticContractLogServiceImplTest {
     @Test
     @DisplayName("Should be able to create valid synthetic contract log")
     void createValid() {
-        syntheticContractLogService.create(new TransferContractLog(recordItem, entityTokenId, senderId, receiverId, amount));
+        syntheticContractLogService.create(new TransferContractLog(recordItem, entityTokenId, senderId, receiverId, amount, false));
+        verify(entityListener, times(1)).onContractLog(any());
+    }
+
+    @Test
+    @DisplayName("Should be able to create valid synthetic contract log with indexed value")
+    void createValidIndexed() {
+        syntheticContractLogService.create(new TransferContractLog(recordItem, entityTokenId, senderId, receiverId, amount, true));
         verify(entityListener, times(1)).onContractLog(any());
     }
 
@@ -75,7 +82,7 @@ class SyntheticContractLogServiceImplTest {
     @DisplayName("Should not create synthetic contract log with contract")
     void createWithContract() {
         recordItem = recordItemBuilder.contractCall().build();
-        syntheticContractLogService.create(new TransferContractLog(recordItem, entityTokenId, senderId, receiverId, amount));
+        syntheticContractLogService.create(new TransferContractLog(recordItem, entityTokenId, senderId, receiverId, amount, false));
         verify(entityListener, times(0)).onContractLog(any());
     }
 
@@ -83,7 +90,7 @@ class SyntheticContractLogServiceImplTest {
     @DisplayName("Should not create synthetic contract log with entity property turned off")
     void createTurnedOff() {
         entityProperties.getPersist().setSyntheticContractLogs(false);
-        syntheticContractLogService.create(new TransferContractLog(recordItem, entityTokenId, senderId, receiverId, amount));
+        syntheticContractLogService.create(new TransferContractLog(recordItem, entityTokenId, senderId, receiverId, amount, false));
         verify(entityListener, times(0)).onContractLog(any());
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerTokenTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerTokenTest.java
@@ -1272,7 +1272,7 @@ class EntityRecordItemListenerTokenTest extends AbstractEntityRecordItemListener
                 .returns(TRANSFER_SIGNATURE, from(ContractLog::getTopic0))
                 .returns(Bytes.ofUnsignedLong(PAYER2.getAccountNum()).toArray(), from(ContractLog::getTopic1))
                 .returns(Bytes.ofUnsignedLong(0).toArray(), from(ContractLog::getTopic2))
-                .returns(Bytes.ofUnsignedLong(SERIAL_NUMBER_1).toArray(), from(ContractLog::getData));
+                .returns(Bytes.ofUnsignedLong(SERIAL_NUMBER_1).toArray(), from(ContractLog::getTopic3));
     }
 
     @Test
@@ -1415,7 +1415,7 @@ class EntityRecordItemListenerTokenTest extends AbstractEntityRecordItemListener
                 .returns(TRANSFER_SIGNATURE, from(ContractLog::getTopic0))
                 .returns(Bytes.ofUnsignedLong(0).toArray(), from(ContractLog::getTopic1))
                 .returns(Bytes.ofUnsignedLong(PAYER2.getAccountNum()).toArray(), from(ContractLog::getTopic2))
-                .returns(Bytes.ofUnsignedLong(SERIAL_NUMBER_1).toArray(), from(ContractLog::getData));
+                .returns(Bytes.ofUnsignedLong(SERIAL_NUMBER_1).toArray(), from(ContractLog::getTopic3));
     }
 
     @Test
@@ -1627,7 +1627,7 @@ class EntityRecordItemListenerTokenTest extends AbstractEntityRecordItemListener
                 .returns(TRANSFER_SIGNATURE, from(ContractLog::getTopic0))
                 .returns(Bytes.ofUnsignedLong(PAYER.getAccountNum()).toArray(), from(ContractLog::getTopic1))
                 .returns(Bytes.ofUnsignedLong(RECEIVER.getAccountNum()).toArray(), from(ContractLog::getTopic2))
-                .returns(Bytes.ofUnsignedLong(SERIAL_NUMBER_1).toArray(), from(ContractLog::getData));
+                .returns(Bytes.ofUnsignedLong(SERIAL_NUMBER_1).toArray(), from(ContractLog::getTopic3));
     }
 
     @ParameterizedTest
@@ -1927,7 +1927,7 @@ class EntityRecordItemListenerTokenTest extends AbstractEntityRecordItemListener
                 .returns(TRANSFER_SIGNATURE, from(ContractLog::getTopic0))
                 .returns(Bytes.ofUnsignedLong(PAYER2.getAccountNum()).toArray(), from(ContractLog::getTopic1))
                 .returns(Bytes.ofUnsignedLong(0).toArray(), from(ContractLog::getTopic2))
-                .returns(Bytes.ofUnsignedLong(SERIAL_NUMBER_1).toArray(), from(ContractLog::getData));
+                .returns(Bytes.ofUnsignedLong(SERIAL_NUMBER_1).toArray(), from(ContractLog::getTopic3));
     }
 
     @Test


### PR DESCRIPTION
**Description**:
This PR adds/fixes indexed event logs for HTS NFTs for synthetic events via HAPI tx. Also adds TOKENCREATION to isMint, because this basically is mint and it's expected from people coming from ethereum.

**Related issue(s)**:

Fixes #5860 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
