### PR TITLE
HIP-584: Copy JKey from services

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/services/jproto/JKey.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/jproto/JKey.java
@@ -18,14 +18,14 @@ package com.hedera.services.jproto;
 /**
  * Maps to proto Key.
  */
-public abstract class JKey {
+public interface JKey {
 
-    public abstract boolean isEmpty();
+    boolean isEmpty();
 
     /**
      * Expected to return {@code false} if the key is empty
      *
      * @return whether the key is valid
      */
-    public abstract boolean isValid();
+    boolean isValid();
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/jproto/JKey.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/jproto/JKey.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hedera.services.jproto;
+
+/**
+ * Maps to proto Key.
+ */
+public abstract class JKey {
+
+    public abstract boolean isEmpty();
+
+    /**
+     * Expected to return {@code false} if the key is empty
+     *
+     * @return whether the key is valid
+     */
+    public abstract boolean isValid();
+}


### PR DESCRIPTION
**Description**:

In order to copy the models like Token we need to have an implementation for JKey.

**Related issue(s)**:

Fixes #5868

**Notes for reviewer**:  

This change is as minimalistic as possible, in order to avoid copying unneeded logic.
Later we might need to add more logic into `JKey`.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
