### PR TITLE
Fix HTS NFT Synthetic events logs (#5861) (0.79)

### DIFF
--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/RecordItem.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/RecordItem.java
@@ -28,8 +28,10 @@ import com.hederahashgraph.api.proto.java.SignedTransaction;
 import com.hederahashgraph.api.proto.java.Transaction;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionRecord;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import lombok.AccessLevel;
@@ -185,6 +187,17 @@ public class RecordItem implements StreamItem {
         }
 
         return dataCase.getNumber();
+    }
+
+    /**
+     * Check whether ethereum transaction exist in the record item and returns it hash, if not return 32-byte representation of the transaction hash
+     *
+     * @return 32-byte transaction hash of this record item
+     */
+    public byte[] getTransactionHash() {
+        return Optional.ofNullable(getEthereumTransaction())
+                .map(EthereumTransaction::getHash)
+                .orElseGet(() -> Arrays.copyOfRange(DomainUtils.toBytes(getTransactionRecord().getTransactionHash()), 0, 32));
     }
 
     private record TransactionBodyAndSignatureMap(TransactionBody transactionBody, SignatureMap signatureMap) {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/ContractResultServiceImpl.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/ContractResultServiceImpl.java
@@ -167,9 +167,7 @@ public class ContractResultServiceImpl implements ContractResultService {
         }
 
         // Normalize the two distinct hashes into one 32 byte hash
-        var transactionHash = Optional.ofNullable(recordItem.getEthereumTransaction())
-                .map(EthereumTransaction::getHash)
-                .orElseGet(() -> Arrays.copyOfRange(transaction.getTransactionHash(), 0, 32));
+        var transactionHash = recordItem.getTransactionHash();
 
         ContractResult contractResult = new ContractResult();
         contractResult.setConsensusTimestamp(recordItem.getConsensusTimestamp());

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractlog/AbstractSyntheticContractLog.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractlog/AbstractSyntheticContractLog.java
@@ -32,14 +32,16 @@ public abstract class AbstractSyntheticContractLog implements SyntheticContractL
     private final byte[] topic0;
     private final byte[] topic1;
     private final byte[] topic2;
+    private final byte[] topic3;
     private final byte[] data;
 
-    AbstractSyntheticContractLog(RecordItem recordItem, EntityId tokenId, byte[] topic0, byte[] topic1, byte[] topic2, byte[] data) {
+    AbstractSyntheticContractLog(RecordItem recordItem, EntityId tokenId, byte[] topic0, byte[] topic1, byte[] topic2, byte[] topic3, byte[] data) {
         this.recordItem = recordItem;
         this.entityId = tokenId;
         this.topic0 = topic0;
         this.topic1 = topic1;
         this.topic2 = topic2;
+        this.topic3 = topic3;
         this.data = data;
     }
     static final byte[] TRANSFER_SIGNATURE = Bytes.fromHexString("ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef").toArray();

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractlog/ApproveAllowanceContractLog.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractlog/ApproveAllowanceContractLog.java
@@ -24,8 +24,7 @@ import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.transaction.RecordItem;
 
 public class ApproveAllowanceContractLog extends AbstractSyntheticContractLog {
-
     public ApproveAllowanceContractLog(RecordItem recordItem, EntityId tokenId, EntityId ownerId, EntityId spenderId, long amount) {
-        super(recordItem, tokenId, APPROVE_SIGNATURE, entityIdToBytes(ownerId), entityIdToBytes(spenderId), longToBytes(amount));
+        super(recordItem, tokenId, APPROVE_SIGNATURE, entityIdToBytes(ownerId), entityIdToBytes(spenderId), null, longToBytes(amount));
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractlog/ApproveAllowanceIndexedContractLog.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractlog/ApproveAllowanceIndexedContractLog.java
@@ -23,8 +23,8 @@ package com.hedera.mirror.importer.parser.contractlog;
 import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.transaction.RecordItem;
 
-public class TransferContractLog extends AbstractSyntheticContractLog {
-    public TransferContractLog(RecordItem recordItem, EntityId tokenId, EntityId senderId, EntityId receiverId, long amount) {
-        super(recordItem ,tokenId, TRANSFER_SIGNATURE, entityIdToBytes(senderId), entityIdToBytes(receiverId), null, longToBytes(amount));
+public class ApproveAllowanceIndexedContractLog extends AbstractSyntheticContractLog {
+    public ApproveAllowanceIndexedContractLog(RecordItem recordItem, EntityId tokenId, EntityId ownerId, EntityId spenderId, long amount) {
+        super(recordItem, tokenId, APPROVE_SIGNATURE, entityIdToBytes(ownerId), entityIdToBytes(spenderId), longToBytes(amount), null);
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractlog/ApproveForAllAllowanceContractLog.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractlog/ApproveForAllAllowanceContractLog.java
@@ -25,6 +25,6 @@ import com.hedera.mirror.common.domain.transaction.RecordItem;
 
 public class ApproveForAllAllowanceContractLog extends AbstractSyntheticContractLog {
     public ApproveForAllAllowanceContractLog(RecordItem recordItem, EntityId tokenId, EntityId ownerId, EntityId spenderId, boolean approved) {
-        super(recordItem, tokenId, APPROVE_FOR_ALL_SIGNATURE, entityIdToBytes(ownerId), entityIdToBytes(spenderId), booleanToBytes(approved));
+        super(recordItem, tokenId, APPROVE_FOR_ALL_SIGNATURE, entityIdToBytes(ownerId), entityIdToBytes(spenderId), null, booleanToBytes(approved));
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractlog/SyntheticContractLog.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractlog/SyntheticContractLog.java
@@ -29,5 +29,6 @@ public interface SyntheticContractLog {
     byte[] getTopic0();
     byte[] getTopic1();
     byte[] getTopic2();
+    byte[] getTopic3();
     byte[] getData();
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractlog/SyntheticContractLogServiceImpl.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractlog/SyntheticContractLogServiceImpl.java
@@ -36,10 +36,9 @@ import org.apache.tuweni.bytes.Bytes;
 @Named
 @RequiredArgsConstructor
 public class SyntheticContractLogServiceImpl implements SyntheticContractLogService {
-
     private final EntityListener entityListener;
     private final EntityProperties entityProperties;
-    private final byte[] emptyBloom = Bytes.of(0).toArray();
+    private final byte[] empty = Bytes.of(0).toArray();
     @Override
     public void create(SyntheticContractLog log) {
         if (isContract(log.getRecordItem()) || !entityProperties.getPersist().isSyntheticContractLogs()) {
@@ -51,16 +50,19 @@ public class SyntheticContractLogServiceImpl implements SyntheticContractLogServ
 
         ContractLog contractLog = new ContractLog();
 
-        contractLog.setBloom(emptyBloom);
+        contractLog.setBloom(empty);
         contractLog.setConsensusTimestamp(consensusTimestamp);
         contractLog.setContractId(log.getEntityId());
-        contractLog.setData(log.getData());
+        contractLog.setData(log.getData() != null ? log.getData() : empty);
         contractLog.setIndex(logIndex);
         contractLog.setRootContractId(log.getEntityId());
         contractLog.setPayerAccountId(log.getRecordItem().getPayerAccountId());
         contractLog.setTopic0(log.getTopic0());
         contractLog.setTopic1(log.getTopic1());
         contractLog.setTopic2(log.getTopic2());
+        contractLog.setTopic3(log.getTopic3());
+        contractLog.setTransactionIndex(log.getRecordItem().getTransactionIndex());
+        contractLog.setTransactionHash(log.getRecordItem().getTransactionHash());
         entityListener.onContractLog(contractLog);
     }
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractlog/TransferIndexedContractLog.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractlog/TransferIndexedContractLog.java
@@ -23,8 +23,8 @@ package com.hedera.mirror.importer.parser.contractlog;
 import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.transaction.RecordItem;
 
-public class TransferContractLog extends AbstractSyntheticContractLog {
-    public TransferContractLog(RecordItem recordItem, EntityId tokenId, EntityId senderId, EntityId receiverId, long amount) {
-        super(recordItem ,tokenId, TRANSFER_SIGNATURE, entityIdToBytes(senderId), entityIdToBytes(receiverId), null, longToBytes(amount));
+public class TransferIndexedContractLog extends AbstractSyntheticContractLog {
+    public TransferIndexedContractLog(RecordItem recordItem, EntityId tokenId, EntityId senderId, EntityId receiverId, long amount) {
+        super(recordItem ,tokenId, TRANSFER_SIGNATURE, entityIdToBytes(senderId), entityIdToBytes(receiverId), longToBytes(amount), null);
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListener.java
@@ -29,6 +29,8 @@ import com.google.protobuf.UnknownFieldSet;
 import com.hedera.mirror.importer.parser.contractlog.SyntheticContractLogService;
 import com.hedera.mirror.importer.parser.contractlog.TransferContractLog;
 
+import com.hedera.mirror.importer.parser.contractlog.TransferIndexedContractLog;
+
 import com.hederahashgraph.api.proto.java.AccountAmount;
 import com.hederahashgraph.api.proto.java.NftTransfer;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
@@ -352,7 +354,7 @@ public class EntityRecordItemListener implements RecordItemListener {
         boolean isDeletedTokenDissociate = isTokenDissociate && tokenTransferCount == 1;
 
         boolean isWipeOrBurn = recordItem.getTransactionType() == TransactionType.TOKENBURN.getProtoId() || recordItem.getTransactionType() == TransactionType.TOKENWIPE.getProtoId();
-        boolean isMint = recordItem.getTransactionType() == TransactionType.TOKENMINT.getProtoId();
+        boolean isMint = recordItem.getTransactionType() == TransactionType.TOKENMINT.getProtoId() || recordItem.getTransactionType() == TransactionType.TOKENCREATION.getProtoId();
         boolean isSingleTransfer = tokenTransferCount == 2;
 
         for (int i = 0; i < tokenTransferCount; i++) {
@@ -482,7 +484,7 @@ public class EntityRecordItemListener implements RecordItemListener {
                 transferNftOwnership(consensusTimestamp, serialNumber, entityTokenId, receiverId);
             }
             syntheticContractLogService
-                    .create(new TransferContractLog(recordItem, entityTokenId, senderId, receiverId, serialNumber));
+                    .create(new TransferIndexedContractLog(recordItem, entityTokenId, senderId, receiverId, serialNumber));
         }
     }
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoApproveAllowanceTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoApproveAllowanceTransactionHandler.java
@@ -22,6 +22,7 @@ package com.hedera.mirror.importer.parser.record.transactionhandler;
 
 import static com.hedera.mirror.importer.util.Utility.RECOVERABLE_ERROR;
 
+import com.hedera.mirror.importer.parser.contractlog.ApproveAllowanceIndexedContractLog;
 import com.hedera.mirror.importer.parser.contractlog.SyntheticContractLogService;
 
 import com.hedera.mirror.importer.parser.contractlog.ApproveAllowanceContractLog;
@@ -148,7 +149,7 @@ class CryptoApproveAllowanceTransactionHandler implements TransactionHandler {
                 if (nftSerialAllowanceState.putIfAbsent(nft.getId(), nft) == null) {
                     entityListener.onNft(nft);
                     if (!hasApprovedForAll) {
-                        syntheticContractLogService.create(new ApproveAllowanceContractLog(recordItem, tokenId, ownerAccountId, spender, serialNumber));
+                        syntheticContractLogService.create(new ApproveAllowanceIndexedContractLog(recordItem, tokenId, ownerAccountId, spender, serialNumber));
                     }
                 }
             }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoDeleteAllowanceTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoDeleteAllowanceTransactionHandler.java
@@ -22,8 +22,8 @@ package com.hedera.mirror.importer.parser.record.transactionhandler;
 
 import javax.inject.Named;
 
+import com.hedera.mirror.importer.parser.contractlog.ApproveAllowanceIndexedContractLog;
 import com.hedera.mirror.importer.parser.contractlog.SyntheticContractLogService;
-import com.hedera.mirror.importer.parser.contractlog.ApproveAllowanceContractLog;
 
 import lombok.RequiredArgsConstructor;
 
@@ -67,7 +67,7 @@ class CryptoDeleteAllowanceTransactionHandler implements TransactionHandler {
                 var nft = new Nft(serialNumber, tokenId);
                 nft.setModifiedTimestamp(recordItem.getConsensusTimestamp());
                 entityListener.onNft(nft);
-                syntheticContractLogService.create(new ApproveAllowanceContractLog(recordItem, tokenId, ownerId, EntityId.EMPTY, serialNumber));
+                syntheticContractLogService.create(new ApproveAllowanceIndexedContractLog(recordItem, tokenId, ownerId, EntityId.EMPTY, serialNumber));
             }
         }
     }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/ContractResultServiceImplIntegrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/ContractResultServiceImplIntegrationTest.java
@@ -618,6 +618,7 @@ class ContractResultServiceImplIntegrationTest extends IntegrationTest {
         var entityId = EntityId.of(recordItem.getTransactionRecord().getReceipt().getContractID());
         transaction = domainBuilder.transaction()
                 .customize(t -> t.entityId(entityId).type(recordItem.getTransactionType()))
+                .customize(t -> t.transactionHash(DomainUtils.toBytes(recordItem.getTransactionRecord().getTransactionHash())))
                 .get();
 
         transactionTemplate.executeWithoutResult(status -> {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/contractlog/SyntheticContractLogServiceImplTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/contractlog/SyntheticContractLogServiceImplTest.java
@@ -72,6 +72,13 @@ class SyntheticContractLogServiceImplTest {
     }
 
     @Test
+    @DisplayName("Should be able to create valid synthetic contract log with indexed value")
+    void createValidIndexed() {
+        syntheticContractLogService.create(new TransferIndexedContractLog(recordItem, entityTokenId, senderId, receiverId, amount));
+        verify(entityListener, times(1)).onContractLog(any());
+    }
+
+    @Test
     @DisplayName("Should not create synthetic contract log with contract")
     void createWithContract() {
         recordItem = recordItemBuilder.contractCall().build();

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerTokenTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerTokenTest.java
@@ -1272,7 +1272,7 @@ class EntityRecordItemListenerTokenTest extends AbstractEntityRecordItemListener
                 .returns(TRANSFER_SIGNATURE, from(ContractLog::getTopic0))
                 .returns(Bytes.ofUnsignedLong(PAYER2.getAccountNum()).toArray(), from(ContractLog::getTopic1))
                 .returns(Bytes.ofUnsignedLong(0).toArray(), from(ContractLog::getTopic2))
-                .returns(Bytes.ofUnsignedLong(SERIAL_NUMBER_1).toArray(), from(ContractLog::getData));
+                .returns(Bytes.ofUnsignedLong(SERIAL_NUMBER_1).toArray(), from(ContractLog::getTopic3));
     }
 
     @Test
@@ -1415,7 +1415,7 @@ class EntityRecordItemListenerTokenTest extends AbstractEntityRecordItemListener
                 .returns(TRANSFER_SIGNATURE, from(ContractLog::getTopic0))
                 .returns(Bytes.ofUnsignedLong(0).toArray(), from(ContractLog::getTopic1))
                 .returns(Bytes.ofUnsignedLong(PAYER2.getAccountNum()).toArray(), from(ContractLog::getTopic2))
-                .returns(Bytes.ofUnsignedLong(SERIAL_NUMBER_1).toArray(), from(ContractLog::getData));
+                .returns(Bytes.ofUnsignedLong(SERIAL_NUMBER_1).toArray(), from(ContractLog::getTopic3));
     }
 
     @Test
@@ -1627,7 +1627,7 @@ class EntityRecordItemListenerTokenTest extends AbstractEntityRecordItemListener
                 .returns(TRANSFER_SIGNATURE, from(ContractLog::getTopic0))
                 .returns(Bytes.ofUnsignedLong(PAYER.getAccountNum()).toArray(), from(ContractLog::getTopic1))
                 .returns(Bytes.ofUnsignedLong(RECEIVER.getAccountNum()).toArray(), from(ContractLog::getTopic2))
-                .returns(Bytes.ofUnsignedLong(SERIAL_NUMBER_1).toArray(), from(ContractLog::getData));
+                .returns(Bytes.ofUnsignedLong(SERIAL_NUMBER_1).toArray(), from(ContractLog::getTopic3));
     }
 
     @ParameterizedTest
@@ -1927,7 +1927,7 @@ class EntityRecordItemListenerTokenTest extends AbstractEntityRecordItemListener
                 .returns(TRANSFER_SIGNATURE, from(ContractLog::getTopic0))
                 .returns(Bytes.ofUnsignedLong(PAYER2.getAccountNum()).toArray(), from(ContractLog::getTopic1))
                 .returns(Bytes.ofUnsignedLong(0).toArray(), from(ContractLog::getTopic2))
-                .returns(Bytes.ofUnsignedLong(SERIAL_NUMBER_1).toArray(), from(ContractLog::getData));
+                .returns(Bytes.ofUnsignedLong(SERIAL_NUMBER_1).toArray(), from(ContractLog::getTopic3));
     }
 
     @Test


### PR DESCRIPTION
This PR adds/fixes indexed event logs for HTS NFTs for synthetic events via HAPI tx. Also adds TOKENCREATION to isMint, because this basically is mint and it's expected from people coming from ethereum.

Transfer and Approval for ERC721 has three parameters indexed. That means that data field is empty and topic1,2,3 are the values from those parameters.

**Description**:
Cherry-pick of https://github.com/hashgraph/hedera-mirror-node/pull/5861 to release/0.79:

Fix HTS NFT Synthetic events logs

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
