### PR TITLE
Bump Spring Boot from 2.7.10 to 2.7.11 (0.79)

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -42,7 +42,7 @@ dependencies {
     implementation("org.openapitools:openapi-generator-gradle-plugin:6.5.0")
     implementation("org.owasp:dependency-check-gradle:8.2.1")
     implementation("org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:4.0.0.2929")
-    implementation("org.springframework.boot:spring-boot-gradle-plugin:2.7.10")
+    implementation("org.springframework.boot:spring-boot-gradle-plugin:2.7.11")
 }
 
 val gitHook = tasks.register<Exec>("gitHook") {


### PR DESCRIPTION
**Description**:

Cherry pick of #5880 to `release/0.79`:

* Bump Spring Boot from 2.7.10 to 2.7.11

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
