### PR TITLE
Importer Log and Alert Fixes

### DIFF
--- a/charts/hedera-mirror-common/values.yaml
+++ b/charts/hedera-mirror-common/values.yaml
@@ -92,11 +92,10 @@ loki:
             description: "{{ $labels.namespace }}/{{ $labels.pod }} requires a restart after logging {{ $value }} messages per second in a 1m period with the unrecoverable error '{{ $labels.message }}'"
             summary: Importer received an error that indicates a restart is required
           expr: >
-            sum(rate({component="importer"}
+            sum(count_over_time({component="importer"}
               | regexp `(?P<timestamp>\S+) (?P<level>\S+) (?P<thread>\S+) (?P<class>\S+) (?P<message>.+)`
               | message =~ ".*(Error starting watch service|Unable to fetch entity types|Unable to fetch transaction types|environment variable not set|Cannot load configuration from).*"
-            [1m])) by (namespace, pod, message) > 0.01
-          for: 1m
+            [1m])) by (namespace, pod, message) > 0
           labels:
             severity: critical
         - alert: ImporterRecoverableErrors
@@ -104,12 +103,11 @@ loki:
             description: "Recoverable Error Logs for {{ $labels.namespace }}/{{ $labels.pod }} have reached {{ $value }} error messages/s in a 1m period"
             summary: Recoverable Error found in logs
           expr: >
-            sum(rate({component="importer"}
+            sum(count_over_time({component="importer"}
               | regexp `(?P<timestamp>\S+) (?P<level>\S+) (?P<thread>\S+) (?P<class>\S+) (?P<message>.+)`
               | level = "ERROR"
               | message =~ ".*Recoverable error.*"
             [1m])) by (namespace, pod) > 0
-          for: 1m
           labels:
             severity: critical
     - name: hedera-mirror-rest

--- a/charts/hedera-mirror-common/values.yaml
+++ b/charts/hedera-mirror-common/values.yaml
@@ -87,17 +87,6 @@ loki:
           for: 5m
           labels:
             severity: critical
-        - alert: ImporterRequiresRestart
-          annotations:
-            description: "{{ $labels.namespace }}/{{ $labels.pod }} requires a restart after logging {{ $value }} messages per second in a 1m period with the unrecoverable error '{{ $labels.message }}'"
-            summary: Importer received an error that indicates a restart is required
-          expr: >
-            sum(count_over_time({component="importer"}
-              | regexp `(?P<timestamp>\S+) (?P<level>\S+) (?P<thread>\S+) (?P<class>\S+) (?P<message>.+)`
-              | message =~ ".*(Error starting watch service|Unable to fetch entity types|Unable to fetch transaction types|environment variable not set|Cannot load configuration from).*"
-            [1m])) by (namespace, pod, message) > 0
-          labels:
-            severity: critical
         - alert: ImporterRecoverableErrors
           annotations:
             description: "Recoverable Error Logs for {{ $labels.namespace }}/{{ $labels.pod }} have reached {{ $value }} error messages/s in a 1m period"

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/ContractResultServiceImpl.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/ContractResultServiceImpl.java
@@ -45,6 +45,7 @@ import com.hederahashgraph.api.proto.java.ContractID;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import javax.inject.Named;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -86,11 +87,17 @@ public class ContractResultServiceImpl implements ContractResultService {
         var transactionHandler = transactionHandlerFactory.get(TransactionType.of(transaction.getType()));
 
         // in pre-compile case transaction is not a contract type and entityId will be of a different type
-        var contractId = isContractCreateOrCall(transactionBody)
-                ? transaction.getEntityId()
-                : entityIdService.lookup(functionResult.getContractID()).orElse(EntityId.EMPTY);
-        if (EntityId.isEmpty(contractId)) {
-            contractId = EntityId.EMPTY;
+        var contractCallOrCreate = isContractCreateOrCall(transactionBody);
+        var contractId = (contractCallOrCreate
+                        ? Optional.ofNullable(transaction.getEntityId())
+                        : entityIdService.lookup(functionResult.getContractID()))
+                .orElse(EntityId.EMPTY);
+        var isRecoverableError = EntityId.isEmpty(contractId)
+                && ((contractCallOrCreate && !EntityId.isEmpty(transaction.getEntityId()))
+                        || (!contractCallOrCreate
+                                && functionResult.getContractID() != ContractID.getDefaultInstance()));
+
+        if (isRecoverableError) {
             log.error(
                     RECOVERABLE_ERROR + "Invalid contract id for contract result at {}",
                     recordItem.getConsensusTimestamp());

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/EntityIdServiceImpl.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/EntityIdServiceImpl.java
@@ -91,7 +91,6 @@ public class EntityIdServiceImpl implements EntityIdService {
             if (!EntityId.isEmpty(entityId)) {
                 return entityId;
             }
-            log.warn("Skipping entity ID {}", entityIdProto);
         }
         return EntityId.EMPTY;
     }


### PR DESCRIPTION
**Description**:

* Change importer restart required and recoverable error alerts to fire on single occurrence
* Remove logging empty entity id when looking up entity
* Only log recoverable error for empty contractId if lookup is not expected to be empty

**Related issue(s)**:

Fixes #5820

**Notes for reviewer**:
* Ran common chart in minikube and fired several different logs on scheduled. Asserted alerts appeared in alertmanager.
* Verified `ContractResultServiceImpl` by loading the record file for the [transaction](https://hashscan.io/testnet/transaction/1681491693.022293003) contained in #5820. 
* Removed logging of empty entity id in lookup service

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
