### PR TITLE
HIP-584: Disable support for precompiles when eth_estimateGas is used

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/EvmOperationConstructionUtil.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/EvmOperationConstructionUtil.java
@@ -19,6 +19,7 @@ package com.hedera.mirror.web3.evm.contracts.execution;
 import static com.hedera.node.app.service.evm.store.contracts.precompile.EvmHTSPrecompiledContract.EVM_HTS_PRECOMPILED_CONTRACT_ADDRESS;
 import static org.hyperledger.besu.evm.MainnetEVMs.registerParisOperations;
 
+import com.hedera.mirror.web3.evm.store.contract.precompile.MirrorHTSPrecompiledContract;
 import com.hedera.node.app.service.evm.contracts.execution.HederaEvmMessageCallProcessor;
 import com.hedera.node.app.service.evm.contracts.operations.HederaBalanceOperation;
 import com.hedera.node.app.service.evm.contracts.operations.HederaDelegateCallOperation;
@@ -26,7 +27,6 @@ import com.hedera.node.app.service.evm.contracts.operations.HederaEvmSLoadOperat
 import com.hedera.node.app.service.evm.contracts.operations.HederaExtCodeCopyOperation;
 import com.hedera.node.app.service.evm.contracts.operations.HederaExtCodeHashOperation;
 import com.hedera.node.app.service.evm.contracts.operations.HederaExtCodeSizeOperation;
-import com.hedera.node.app.service.evm.store.contracts.precompile.EvmHTSPrecompiledContract;
 import com.hedera.node.app.service.evm.store.contracts.precompile.EvmInfrastructureFactory;
 import com.hedera.node.app.service.evm.store.contracts.precompile.codec.EvmEncodingFacade;
 import java.math.BigInteger;
@@ -82,7 +82,7 @@ public class EvmOperationConstructionUtil {
     private static Map<String, PrecompiledContract> precompiles() {
         final Map<String, PrecompiledContract> hederaPrecompiles = new HashMap<>();
         final var evmFactory = new EvmInfrastructureFactory(new EvmEncodingFacade());
-        hederaPrecompiles.put(EVM_HTS_PRECOMPILED_CONTRACT_ADDRESS, new EvmHTSPrecompiledContract(evmFactory));
+        hederaPrecompiles.put(EVM_HTS_PRECOMPILED_CONTRACT_ADDRESS, new MirrorHTSPrecompiledContract(evmFactory));
 
         return hederaPrecompiles;
     }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/contract/precompile/MirrorHTSPrecompiledContract.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/contract/precompile/MirrorHTSPrecompiledContract.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.web3.evm.store.contract.precompile;
+
+import com.hedera.node.app.service.evm.store.contracts.precompile.EvmHTSPrecompiledContract;
+import com.hedera.node.app.service.evm.store.contracts.precompile.EvmInfrastructureFactory;
+import com.hedera.node.app.service.evm.store.contracts.precompile.proxy.ViewGasCalculator;
+import com.hedera.node.app.service.evm.store.tokens.TokenAccessor;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.tuweni.bytes.Bytes;
+import org.hyperledger.besu.evm.frame.MessageFrame;
+
+public class MirrorHTSPrecompiledContract extends EvmHTSPrecompiledContract {
+
+    public MirrorHTSPrecompiledContract(EvmInfrastructureFactory infrastructureFactory) {
+        super(infrastructureFactory);
+    }
+
+    @Override
+    public Pair<Long, Bytes> computeCosted(
+            final Bytes input,
+            final MessageFrame frame,
+            final ViewGasCalculator viewGasCalculator,
+            final TokenAccessor tokenAccessor) {
+        // We need to check if a precompile call was made with preceding non-static frame. This would mean there might
+        // be an operation
+        // which modifies state. Currently we do not support speculative writes, so we should throw na error.
+        if (frameContainsNonStaticFrameInStack(frame)) {
+            throw new UnsupportedOperationException("Precompile not supported for non-static frames");
+        }
+
+        return super.computeCosted(input, frame, viewGasCalculator, tokenAccessor);
+    }
+
+    @Override
+    public String getName() {
+        return "MirrorHTS";
+    }
+
+    private boolean frameContainsNonStaticFrameInStack(final MessageFrame messageFrame) {
+        if (!messageFrame.isStatic()) {
+            return true;
+        }
+
+        for (final var frame : messageFrame.getMessageFrameStack()) {
+            if (!frame.isStatic()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
@@ -259,6 +259,19 @@ class ContractCallServiceTest extends Web3IntegrationTest {
         assertGasUsedIsPositive(gasUsedBeforeExecution, ETH_ESTIMATE_GAS);
     }
 
+    @Test
+    void precompileCallRevertsForEstimateGas() {
+        final var tokenNameCall = "0x6f0fccab00000000000000000000000000000000000000000000000000000000000003e4";
+        final var serviceParameters =
+                serviceParameters(tokenNameCall, 0, ETH_ESTIMATE_GAS, false, ETH_CALL_CONTRACT_ADDRESS);
+
+        persistEntities(false);
+
+        assertThatThrownBy(() -> contractCallService.processCall(serviceParameters))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessage("Precompile not supported for non-static frames");
+    }
+
     private CallServiceParameters serviceParameters(
             String callData, long value, CallType callType, boolean isStatic, Address contract) {
         final var sender = new HederaEvmAccount(SENDER_ADDRESS);


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
Since we don't have speculative writes support during transaction simulations yet, we don't support precompile calls for `eth_estimateGas`. Thus, we need to throw a meaningful error, so that the `json-rpc relay` could redirect those calls to existing logic.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
