### PR TITLE
Fix sidecar bytecode migration for partial mirror nodes (0.79)

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/CloudStorageConfiguration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/CloudStorageConfiguration.java
@@ -75,17 +75,19 @@ class CloudStorageConfiguration {
     }
 
     private AwsCredentialsProvider awsCredentialsProvider(StreamSourceProperties sourceProperties) {
+        var type = sourceProperties.getType();
+
         if (commonDownloaderProperties.isAnonymousCredentials()) {
-            log.info("Setting up S3 async client using anonymous credentials");
+            log.info("Setting up {} client using anonymous credentials", type);
             return AnonymousCredentialsProvider.create();
         } else if (sourceProperties.isStaticCredentials()) {
-            log.info("Setting up S3 async client using provided access/secret key");
+            log.info("Setting up {} client using provided access/secret key", type);
             var credentials = sourceProperties.getCredentials();
             return StaticCredentialsProvider.create(AwsBasicCredentials.create(credentials.getAccessKey(),
                     credentials.getSecretKey()));
         }
 
-        log.info("Setting up S3 async client using AWS Default Credentials Provider");
+        log.info("Setting up {} client using default credentials provider", type);
         return DefaultCredentialsProvider.create();
     }
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/SidecarContractMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/SidecarContractMigration.java
@@ -21,8 +21,13 @@ package com.hedera.mirror.importer.migration;
  */
 
 import com.google.common.base.Stopwatch;
-import com.google.common.collect.Iterables;
-import java.util.ArrayList;
+import com.hedera.mirror.common.domain.entity.EntityId;
+import com.hedera.mirror.common.util.DomainUtils;
+import com.hedera.mirror.importer.repository.EntityHistoryRepository;
+import com.hedera.mirror.importer.repository.EntityRepository;
+import com.hedera.services.stream.proto.ContractBytecode;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import javax.inject.Named;
 import lombok.CustomLog;
@@ -42,7 +47,12 @@ public class SidecarContractMigration {
 
     private static final int BATCH_SIZE = 100;
     private static final int IN_CLAUSE_LIMIT = 32767;
-    private static final String UPDATE_RUNTIME_BYTECODE_SQL = "update contract set runtime_bytecode = ? where id = ?";
+    private static final String UPDATE_RUNTIME_BYTECODE_SQL =
+            """
+            insert into contract (id, runtime_bytecode)
+            values (?, ?)
+            on conflict (id)
+            do update set runtime_bytecode = excluded.runtime_bytecode""";
 
     private final EntityHistoryRepository entityHistoryRepository;
     private final EntityRepository entityRepository;
@@ -53,28 +63,35 @@ public class SidecarContractMigration {
             return;
         }
 
+        var contractIds = new HashSet<Long>();
         var stopwatch = Stopwatch.createStarted();
-        var sidecarMigrationContractIds = new ArrayList<Long>();
-        for (var contractBytecode : contractBytecodes) {
-            long entityId = EntityId.of(contractBytecode.getContractId()).getId();
-            sidecarMigrationContractIds.add(entityId);
-        }
 
         jdbcOperations.batchUpdate(
-                UPDATE_RUNTIME_BYTECODE_SQL,
-                contractBytecodes,
-                BATCH_SIZE,
-                (ps, contractBytecode) -> {
-                    ps.setBytes(1, DomainUtils.toBytes(contractBytecode.getRuntimeBytecode()));
-                    ps.setLong(2, EntityId.of(contractBytecode.getContractId()).getId());
+                UPDATE_RUNTIME_BYTECODE_SQL, contractBytecodes, BATCH_SIZE, (ps, contractBytecode) -> {
+                    ps.setLong(1, EntityId.of(contractBytecode.getContractId()).getId());
+                    ps.setBytes(2, DomainUtils.toBytes(contractBytecode.getRuntimeBytecode()));
                 });
 
-        int count = 0;
-        var partitions = Iterables.partition(sidecarMigrationContractIds, IN_CLAUSE_LIMIT);
-        for (var partition : partitions) {
-            count += entityRepository.updateContractType(partition);
-            entityHistoryRepository.updateContractType(partition);
+        // We only need to update entity history's type since ContractUpdateTransactionHandler will upsert the entity
+        // with the correct type
+        for (var contractBytecode : contractBytecodes) {
+            long entityId = EntityId.of(contractBytecode.getContractId()).getId();
+            contractIds.add(entityId);
+
+            if (contractIds.size() >= IN_CLAUSE_LIMIT) {
+                updateContractType(contractIds);
+            }
         }
-        log.info("Migrated {} sidecar contract entities in {}", count, stopwatch);
+
+        updateContractType(contractIds);
+        log.info("Migrated {} sidecar contract entities in {}", contractBytecodes.size(), stopwatch);
+    }
+
+    private void updateContractType(Collection<Long> contractIds) {
+        if (!contractIds.isEmpty()) {
+            entityRepository.updateContractType(contractIds);
+            entityHistoryRepository.updateContractType(contractIds);
+            contractIds.clear();
+        }
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/IntegrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/IntegrationTest.java
@@ -32,8 +32,12 @@ import javax.annotation.Resource;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.postgresql.jdbc.PgArray;
 import org.postgresql.util.PGobject;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -51,21 +55,15 @@ import com.hedera.mirror.common.domain.transaction.NonFeeTransfer;
 import com.hedera.mirror.importer.config.IntegrationTestConfiguration;
 import com.hedera.mirror.importer.config.MirrorDateRangePropertiesProcessor;
 
+@ExtendWith(SoftAssertionsExtension.class)
 @SpringBootTest
 @Import(IntegrationTestConfiguration.class)
 public abstract class IntegrationTest {
 
     private static final RowMapper<NonFeeTransfer> NON_FEE_TRANSFER_ROW_MAPPER = rowMapper(NonFeeTransfer.class);
-
     private static final String SELECT_NON_FEE_TRANSFERS_QUERY = "select * from non_fee_transfer";
 
     protected final Logger log = LogManager.getLogger(getClass());
-
-    @Resource
-    private Collection<CacheManager> cacheManagers;
-
-    @Resource
-    private String cleanupSql;
 
     @Resource
     protected DomainBuilder domainBuilder;
@@ -74,13 +72,41 @@ public abstract class IntegrationTest {
     protected JdbcOperations jdbcOperations;
 
     @Resource
+    protected IntegrationTestConfiguration.RetryRecorder retryRecorder;
+
+    @InjectSoftAssertions
+    protected SoftAssertions softly;
+
+    @Resource
+    private Collection<CacheManager> cacheManagers;
+
+    @Resource
+    private String cleanupSql;
+
+    @Resource
     private MirrorDateRangePropertiesProcessor mirrorDateRangePropertiesProcessor;
 
     @Resource
     private MirrorProperties mirrorProperties;
 
-    @Resource
-    protected IntegrationTestConfiguration.RetryRecorder retryRecorder;
+    protected static <T> RowMapper<T> rowMapper(Class<T> entityClass) {
+        DefaultConversionService defaultConversionService = new DefaultConversionService();
+        defaultConversionService.addConverter(
+                PGobject.class, Range.class, source -> PostgreSQLGuavaRangeType.longRange(source.getValue()));
+        defaultConversionService.addConverter(
+                Long.class, EntityId.class, AccountIdConverter.INSTANCE::convertToEntityAttribute);
+        defaultConversionService.addConverter(PgArray.class, List.class, array -> {
+            try {
+                return Arrays.asList((Object[]) array.getArray());
+            } catch (SQLException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        DataClassRowMapper<T> dataClassRowMapper = new DataClassRowMapper<>(entityClass);
+        dataClassRowMapper.setConversionService(defaultConversionService);
+        return dataClassRowMapper;
+    }
 
     @BeforeEach
     void logTest(TestInfo testInfo) {
@@ -119,25 +145,5 @@ public abstract class IntegrationTest {
         mirrorProperties.setStartDate(Instant.EPOCH);
         jdbcOperations.execute(cleanupSql);
         retryRecorder.reset();
-    }
-
-    protected static <T> RowMapper<T> rowMapper(Class<T> entityClass) {
-        DefaultConversionService defaultConversionService = new DefaultConversionService();
-        defaultConversionService.addConverter(PGobject.class, Range.class,
-                source -> PostgreSQLGuavaRangeType.longRange(source.getValue()));
-        defaultConversionService.addConverter(Long.class, EntityId.class,
-                AccountIdConverter.INSTANCE::convertToEntityAttribute);
-        defaultConversionService.addConverter(PgArray.class, List.class,
-                array -> {
-                    try {
-                        return Arrays.asList((Object[]) array.getArray());
-                    } catch (SQLException e) {
-                        throw new RuntimeException(e);
-                    }
-                });
-
-        DataClassRowMapper<T> dataClassRowMapper = new DataClassRowMapper<>(entityClass);
-        dataClassRowMapper.setConversionService(defaultConversionService);
-        return dataClassRowMapper;
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/SidecarContractMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/SidecarContractMigrationTest.java
@@ -21,21 +21,11 @@ package com.hedera.mirror.importer.migration;
  */
 
 import static com.hedera.mirror.common.domain.entity.EntityType.CONTRACT;
+import static com.hedera.mirror.common.util.DomainUtils.fromBytes;
+import static com.hedera.mirror.importer.TestUtils.toContractId;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.protobuf.ByteString;
-import com.hederahashgraph.api.proto.java.ContractID;
-import com.vladmihalcea.hibernate.type.range.guava.PostgreSQLGuavaRangeType;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import lombok.RequiredArgsConstructor;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.jdbc.core.JdbcTemplate;
-
 import com.hedera.mirror.common.domain.contract.Contract;
 import com.hedera.mirror.common.domain.entity.Entity;
 import com.hedera.mirror.common.domain.entity.EntityHistory;
@@ -45,9 +35,18 @@ import com.hedera.mirror.importer.repository.ContractRepository;
 import com.hedera.mirror.importer.repository.EntityHistoryRepository;
 import com.hedera.mirror.importer.repository.EntityRepository;
 import com.hedera.services.stream.proto.ContractBytecode;
+import com.hederahashgraph.api.proto.java.ContractID;
+import com.vladmihalcea.hibernate.type.range.guava.PostgreSQLGuavaRangeType;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
 
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
-@Tag("migration")
 class SidecarContractMigrationTest extends IntegrationTest {
 
     private final ContractRepository contractRepository;
@@ -73,6 +72,30 @@ class SidecarContractMigrationTest extends IntegrationTest {
     }
 
     @Test
+    void migrateWhenMissingContract() {
+        // given
+        var runtimeBytecode = new byte[] {0, 1, 2, 3};
+        var contract = domainBuilder
+                .entity()
+                .customize(e -> e.evmAddress(null).type(CONTRACT))
+                .persist();
+        var contractBytecode = ContractBytecode.newBuilder()
+                .setContractId(toContractId(contract))
+                .setRuntimeBytecode(fromBytes(runtimeBytecode))
+                .build();
+
+        // when
+        sidecarContractMigration.migrate(List.of(contractBytecode));
+
+        // then
+        assertThat(contractRepository.findAll())
+                .hasSize(1)
+                .first()
+                .returns(runtimeBytecode, Contract::getRuntimeBytecode)
+                .returns(contract.getId(), Contract::getId);
+    }
+
+    @Test
     void migrateEntityTypeToContract() {
         // given
         var entities = new ArrayList<Entity>();
@@ -80,16 +103,20 @@ class SidecarContractMigrationTest extends IntegrationTest {
         var contractBytecodesMap = new HashMap<Long, ContractBytecode>();
         var contractBytecodeBuilder = ContractBytecode.newBuilder();
         var contractIdBuilder = ContractID.newBuilder();
+
         for (int i = 0; i < 66000; i++) {
             var entity = domainBuilder.entity().get();
             var entityId = entity.getId();
 
             entities.add(entity);
-            contracts.add(domainBuilder.contract().customize(c -> c.id(entityId)).get());
-            contractBytecodesMap.put(entityId, contractBytecodeBuilder
-                    .setContractId(contractIdBuilder.setContractNum(entityId))
-                    .setRuntimeBytecode(ByteString.copyFrom(domainBuilder.bytes(256)))
-                    .build());
+            contracts.add(
+                    domainBuilder.contract().customize(c -> c.id(entityId)).get());
+            contractBytecodesMap.put(
+                    entityId,
+                    contractBytecodeBuilder
+                            .setContractId(contractIdBuilder.setContractNum(entityId))
+                            .setRuntimeBytecode(fromBytes(domainBuilder.bytes(4)))
+                            .build());
         }
 
         persistEntities(entities);
@@ -116,52 +143,45 @@ class SidecarContractMigrationTest extends IntegrationTest {
         assertThat(contractBytecodesMap).isEmpty();
     }
 
+    // These persist methods are not functionally necessary but greatly speed up bulk insertion.
     private void persistEntities(List<Entity> entities) {
         jdbcTemplate.batchUpdate(
-                "insert into entity (decline_reward, id, memo, num, realm, shard, timestamp_range, type) " +
-                        "values (?, ?, ?, ?, ?, ?, ?::int8range, ?::entity_type)",
+                "insert into entity (id, num, realm, shard, timestamp_range, type) "
+                        + "values (?, ?, ?, ?, ?::int8range, ?::entity_type)",
                 entities,
                 entities.size(),
                 (ps, entity) -> {
-                    ps.setBoolean(1, entity.getDeclineReward());
-                    ps.setLong(2, entity.getId());
-                    ps.setString(3, entity.getMemo());
-                    ps.setLong(4, entity.getNum());
-                    ps.setLong(5, entity.getRealm());
-                    ps.setLong(6, entity.getShard());
-                    ps.setString(7, PostgreSQLGuavaRangeType.INSTANCE.asString(entity.getTimestampRange()));
-                    ps.setString(8, entity.getType().toString());
-                }
-        );
+                    ps.setLong(1, entity.getId());
+                    ps.setLong(2, entity.getNum());
+                    ps.setLong(3, entity.getRealm());
+                    ps.setLong(4, entity.getShard());
+                    ps.setString(5, PostgreSQLGuavaRangeType.INSTANCE.asString(entity.getTimestampRange()));
+                    ps.setString(6, entity.getType().toString());
+                });
 
         jdbcTemplate.batchUpdate(
-                "insert into entity_history (decline_reward, id, memo, num, realm, shard, timestamp_range, type) " +
-                        "values (?, ?, ?, ?, ?, ?, ?::int8range, ?::entity_type)",
+                "insert into entity_history (id, num, realm, shard, timestamp_range, type) "
+                        + "values (?, ?, ?, ?, ?::int8range, ?::entity_type)",
                 entities,
                 entities.size(),
                 (ps, entity) -> {
-                    ps.setBoolean(1, entity.getDeclineReward());
-                    ps.setLong(2, entity.getId());
-                    ps.setString(3, entity.getMemo());
-                    ps.setLong(4, entity.getNum());
-                    ps.setLong(5, entity.getRealm());
-                    ps.setLong(6, entity.getShard());
-                    ps.setString(7, PostgreSQLGuavaRangeType.INSTANCE.asString(entity.getTimestampRange()));
-                    ps.setString(8, entity.getType().toString());
-                }
-        );
+                    ps.setLong(1, entity.getId());
+                    ps.setLong(2, entity.getNum());
+                    ps.setLong(3, entity.getRealm());
+                    ps.setLong(4, entity.getShard());
+                    ps.setString(5, PostgreSQLGuavaRangeType.INSTANCE.asString(entity.getTimestampRange()));
+                    ps.setString(6, entity.getType().toString());
+                });
     }
 
     private void persistContracts(List<Contract> contracts) {
         jdbcTemplate.batchUpdate(
-                "insert into contract (file_id, id, runtime_bytecode) values (?, ?, ?)",
+                "insert into contract (id, runtime_bytecode) values (?, ?)",
                 contracts,
                 contracts.size(),
                 (ps, contract) -> {
-                    ps.setLong(1, contract.getFileId().getId());
-                    ps.setLong(2, contract.getId());
-                    ps.setBytes(3, contract.getRuntimeBytecode());
-                }
-        );
+                    ps.setLong(1, contract.getId());
+                    ps.setBytes(2, contract.getRuntimeBytecode());
+                });
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/domain/RecordItemBuilder.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/domain/RecordItemBuilder.java
@@ -917,7 +917,17 @@ public class RecordItemBuilder {
 
             Transaction transaction = transaction().build();
             TransactionRecord record = transactionRecord.build();
-            var sidecarRecords = this.sidecarRecords.stream().map(r -> r.build()).collect(Collectors.toList());
+            var contractId = record.getReceipt().getContractID();
+
+            var sidecarRecords = this.sidecarRecords.stream()
+                    .map(r -> {
+                        if (r.hasBytecode() && !contractId.equals(ContractID.getDefaultInstance())) {
+                            r.getBytecodeBuilder().setContractId(contractId);
+                        }
+                        return r.setConsensusTimestamp(record.getConsensusTimestamp())
+                                .build();
+                    })
+                    .collect(Collectors.toList());
 
             return recordItemBuilder
                     .transactionRecordBytes(record.toByteArray())

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/AbstractEntityRecordItemListenerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/AbstractEntityRecordItemListenerTest.java
@@ -72,6 +72,7 @@ import com.hedera.mirror.importer.parser.record.RecordStreamFileListener;
 import com.hedera.mirror.importer.repository.ContractRepository;
 import com.hedera.mirror.importer.repository.ContractResultRepository;
 import com.hedera.mirror.importer.repository.CryptoTransferRepository;
+import com.hedera.mirror.importer.repository.EntityHistoryRepository;
 import com.hedera.mirror.importer.repository.EntityRepository;
 import com.hedera.mirror.importer.repository.LiveHashRepository;
 import com.hedera.mirror.importer.repository.NonFeeTransferRepository;
@@ -119,6 +120,9 @@ public abstract class AbstractEntityRecordItemListenerTest extends IntegrationTe
 
     @Resource
     protected EntityRepository entityRepository;
+
+    @Resource
+    protected EntityHistoryRepository entityHistoryRepository;
 
     @Resource
     protected LiveHashRepository liveHashRepository;


### PR DESCRIPTION
**Description**:

Cherry-pick of #5915 to `release/0.79`:

Change sidecar migration to upsert contract


**Related issue(s)**:

Fixes #5914

**Notes for reviewer**:


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
