### PR TITLE
Fix various k6 test issues (0.79)

### DIFF
--- a/hedera-mirror-rest/__tests__/specs/network/nodes/max-limit.json
+++ b/hedera-mirror-rest/__tests__/specs/network/nodes/max-limit.json
@@ -1,15 +1,1027 @@
 {
   "description": "Network nodes API with limit greater than max",
-  "setup": {},
+  "setup": {
+    "addressbooks": [
+      {
+        "start_consensus_timestamp": 1,
+        "file_id": 101,
+        "node_count": 1
+      },
+      {
+        "start_consensus_timestamp": 2,
+        "file_id": 102,
+        "node_count": 1
+      },
+      {
+        "start_consensus_timestamp": 187654000123456,
+        "file_id": 101,
+        "node_count": 26
+      },
+      {
+        "start_consensus_timestamp": 187654000123457,
+        "file_id": 102,
+        "node_count": 26
+      }
+    ],
+    "addressbookentries": [
+      {
+        "consensus_timestamp": 1,
+        "memo": null,
+        "node_id": 0,
+        "node_account_id": 3
+      },
+      {
+        "consensus_timestamp": 2,
+        "memo": "0.0.3",
+        "node_id": 0,
+        "node_account_id": 3
+      },
+      {
+        "consensus_timestamp": 187654000123457,
+        "memo": null,
+        "node_id": 0,
+        "node_account_id": 3
+      },
+      {
+        "consensus_timestamp": 187654000123457,
+        "node_id": 1,
+        "node_account_id": 4
+      },
+      {
+        "consensus_timestamp": 187654000123457,
+        "node_id": 2,
+        "node_account_id": 5
+      },
+      {
+        "consensus_timestamp": 187654000123457,
+        "node_id": 3,
+        "node_account_id": 6
+      },
+      {
+        "consensus_timestamp": 187654000123457,
+        "node_id": 4,
+        "node_account_id": 7
+      },
+      {
+        "consensus_timestamp": 187654000123457,
+        "node_id": 5,
+        "node_account_id": 8
+      },
+      {
+        "consensus_timestamp": 187654000123457,
+        "node_id": 6,
+        "node_account_id": 9
+      },
+      {
+        "consensus_timestamp": 187654000123457,
+        "node_id": 7,
+        "node_account_id": 10
+      },
+      {
+        "consensus_timestamp": 187654000123457,
+        "node_id": 8,
+        "node_account_id": 11
+      },
+      {
+        "consensus_timestamp": 187654000123457,
+        "node_id": 9,
+        "node_account_id": 12
+      },
+      {
+        "consensus_timestamp": 187654000123457,
+        "node_id": 10,
+        "node_account_id": 13
+      },
+      {
+        "consensus_timestamp": 187654000123457,
+        "node_id": 11,
+        "node_account_id": 14
+      },
+      {
+        "consensus_timestamp": 187654000123457,
+        "node_id": 12,
+        "node_account_id": 15
+      },
+      {
+        "consensus_timestamp": 187654000123457,
+        "node_id": 13,
+        "node_account_id": 16
+      },
+      {
+        "consensus_timestamp": 187654000123457,
+        "node_id": 14,
+        "node_account_id": 17
+      },
+      {
+        "consensus_timestamp": 187654000123457,
+        "node_id": 15,
+        "node_account_id": 18
+      },
+      {
+        "consensus_timestamp": 187654000123457,
+        "node_id": 16,
+        "node_account_id": 19
+      },
+      {
+        "consensus_timestamp": 187654000123457,
+        "node_id": 17,
+        "node_account_id": 20
+      },
+      {
+        "consensus_timestamp": 187654000123457,
+        "node_id": 18,
+        "node_account_id": 21
+      },
+      {
+        "consensus_timestamp": 187654000123457,
+        "node_id": 19,
+        "node_account_id": 22
+      },
+      {
+        "consensus_timestamp": 187654000123457,
+        "node_id": 20,
+        "node_account_id": 23
+      },
+      {
+        "consensus_timestamp": 187654000123457,
+        "node_id": 21,
+        "node_account_id": 24
+      },
+      {
+        "consensus_timestamp": 187654000123457,
+        "node_id": 22,
+        "node_account_id": 25
+      },
+      {
+        "consensus_timestamp": 187654000123457,
+        "node_id": 23,
+        "node_account_id": 26
+      },
+      {
+        "consensus_timestamp": 187654000123457,
+        "node_id": 24,
+        "node_account_id": 27
+      },
+      {
+        "consensus_timestamp": 187654000123457,
+        "node_id": 25,
+        "node_account_id": 28
+      }
+    ],
+    "addressbookserviceendpoints": [
+      {
+        "consensus_timestamp": 1,
+        "ip_address_v4": "127.0.0.1",
+        "node_id": 0,
+        "port": 50211
+      },
+      {
+        "consensus_timestamp": 2,
+        "ip_address_v4": "128.0.0.1",
+        "node_id": 0,
+        "port": 50212
+      },
+      {
+        "consensus_timestamp": 187654000123457,
+        "ip_address_v4": "128.0.0.5",
+        "node_id": 0,
+        "port": 50215
+      },
+      {
+        "consensus_timestamp": 187654000123457,
+        "ip_address_v4": "128.0.0.6",
+        "node_id": 1,
+        "port": 50216
+      },
+      {
+        "consensus_timestamp": 187654000123457,
+        "ip_address_v4": "128.0.0.7",
+        "node_id": 2,
+        "port": 50216
+      },
+      {
+        "consensus_timestamp": 187654000123457,
+        "ip_address_v4": "128.0.0.8",
+        "node_id": 3,
+        "port": 50216
+      },
+      {
+        "consensus_timestamp": 187654000123457,
+        "ip_address_v4": "128.0.0.9",
+        "node_id": 4,
+        "port": 50216
+      },
+      {
+        "consensus_timestamp": 187654000123457,
+        "ip_address_v4": "128.0.0.10",
+        "node_id": 5,
+        "port": 50216
+      },
+      {
+        "consensus_timestamp": 187654000123457,
+        "ip_address_v4": "128.0.0.11",
+        "node_id": 6,
+        "port": 50216
+      },
+      {
+        "consensus_timestamp": 187654000123457,
+        "ip_address_v4": "128.0.0.12",
+        "node_id": 7,
+        "port": 50216
+      },
+      {
+        "consensus_timestamp": 187654000123457,
+        "ip_address_v4": "128.0.0.13",
+        "node_id": 8,
+        "port": 50216
+      },
+      {
+        "consensus_timestamp": 187654000123457,
+        "ip_address_v4": "128.0.0.14",
+        "node_id": 9,
+        "port": 50216
+      },
+      {
+        "consensus_timestamp": 187654000123457,
+        "ip_address_v4": "128.0.0.15",
+        "node_id": 10,
+        "port": 50216
+      },
+      {
+        "consensus_timestamp": 187654000123457,
+        "ip_address_v4": "128.0.0.16",
+        "node_id": 11,
+        "port": 50216
+      },
+      {
+        "consensus_timestamp": 187654000123457,
+        "ip_address_v4": "128.0.0.17",
+        "node_id": 12,
+        "port": 50216
+      },
+      {
+        "consensus_timestamp": 187654000123457,
+        "ip_address_v4": "128.0.0.18",
+        "node_id": 13,
+        "port": 50216
+      },
+      {
+        "consensus_timestamp": 187654000123457,
+        "ip_address_v4": "128.0.0.19",
+        "node_id": 14,
+        "port": 50216
+      },
+      {
+        "consensus_timestamp": 187654000123457,
+        "ip_address_v4": "128.0.0.20",
+        "node_id": 15,
+        "port": 50216
+      },
+      {
+        "consensus_timestamp": 187654000123457,
+        "ip_address_v4": "128.0.0.21",
+        "node_id": 16,
+        "port": 50216
+      },
+      {
+        "consensus_timestamp": 187654000123457,
+        "ip_address_v4": "128.0.0.22",
+        "node_id": 17,
+        "port": 50216
+      },
+      {
+        "consensus_timestamp": 187654000123457,
+        "ip_address_v4": "128.0.0.23",
+        "node_id": 18,
+        "port": 50216
+      },
+      {
+        "consensus_timestamp": 187654000123457,
+        "ip_address_v4": "128.0.0.24",
+        "node_id": 19,
+        "port": 50216
+      },
+      {
+        "consensus_timestamp": 187654000123457,
+        "ip_address_v4": "128.0.0.25",
+        "node_id": 20,
+        "port": 50216
+      },
+      {
+        "consensus_timestamp": 187654000123457,
+        "ip_address_v4": "128.0.0.26",
+        "node_id": 21,
+        "port": 50216
+      },
+      {
+        "consensus_timestamp": 187654000123457,
+        "ip_address_v4": "128.0.0.27",
+        "node_id": 22,
+        "port": 50216
+      },
+      {
+        "consensus_timestamp": 187654000123457,
+        "ip_address_v4": "128.0.0.28",
+        "node_id": 23,
+        "port": 50216
+      },
+      {
+        "consensus_timestamp": 187654000123457,
+        "ip_address_v4": "128.0.0.29",
+        "node_id": 24,
+        "port": 50216
+      },
+      {
+        "consensus_timestamp": 187654000123457,
+        "ip_address_v4": "128.0.0.30",
+        "node_id": 25,
+        "port": 50216
+      }
+    ],
+    "nodestakes": [
+      {
+        "consensus_timestamp": 187654000123456,
+        "epoch_day": 3,
+        "node_id": 0,
+        "reward_rate": 5,
+        "stake": 12,
+        "stake_not_rewarded": 8,
+        "stake_rewarded": 4
+      },
+      {
+        "consensus_timestamp": 1655164800000000005,
+        "epoch_day": 4,
+        "max_stake": 5000,
+        "min_stake": 10,
+        "node_id": 0,
+        "reward_rate": 6,
+        "stake": 13,
+        "stake_not_rewarded": 8,
+        "stake_rewarded": 5,
+        "staking_period": 1655164799999999999
+      }
+    ]
+  },
   "url": "/api/v1/network/nodes?limit=26",
-  "responseStatus": 400,
+  "responseStatus": 200,
   "responseJson": {
-    "_status": {
-      "messages": [
-        {
-          "message": "Max value of 25 is supported for limit"
+    "nodes": [
+      {
+        "description": "description",
+        "file_id": "0.0.102",
+        "max_stake": 5000,
+        "memo": null,
+        "min_stake": 10,
+        "node_account_id": "0.0.3",
+        "node_cert_hash": "0x01d173753810c0aae794ba72d5443c292e9ff962b01046220dd99f5816422696e0569c977e2f169e1e5688afc8f4aa16",
+        "node_id": 0,
+        "public_key": "0x4a5ad514f0957fa170a676210c9bdbddf3bc9519702cf915fa6767a40463b96f",
+        "reward_rate_start": 6,
+        "service_endpoints": [
+          {
+            "ip_address_v4": "128.0.0.5",
+            "port": 50215
+          }
+        ],
+        "stake": 13,
+        "stake_not_rewarded": 8,
+        "stake_rewarded": 5,
+        "staking_period": {
+          "from": "1655164800.000000000",
+          "to": "1655251200.000000000"
+        },
+        "timestamp": {
+          "from": "187654.000123457",
+          "to": null
         }
-      ]
+      },
+      {
+        "description": "description",
+        "file_id": "0.0.102",
+        "max_stake": null,
+        "memo": "0.0.3",
+        "min_stake": null,
+        "node_account_id": "0.0.4",
+        "node_cert_hash": "0x01d173753810c0aae794ba72d5443c292e9ff962b01046220dd99f5816422696e0569c977e2f169e1e5688afc8f4aa16",
+        "node_id": 1,
+        "public_key": "0x4a5ad514f0957fa170a676210c9bdbddf3bc9519702cf915fa6767a40463b96f",
+        "reward_rate_start": null,
+        "service_endpoints": [
+          {
+            "ip_address_v4": "128.0.0.6",
+            "port": 50216
+          }
+        ],
+        "stake": null,
+        "stake_not_rewarded": null,
+        "stake_rewarded": null,
+        "staking_period": null,
+        "timestamp": {
+          "from": "187654.000123457",
+          "to": null
+        }
+      },
+      {
+        "description": "description",
+        "file_id": "0.0.102",
+        "max_stake": null,
+        "memo": "0.0.3",
+        "min_stake": null,
+        "node_account_id": "0.0.5",
+        "node_cert_hash": "0x01d173753810c0aae794ba72d5443c292e9ff962b01046220dd99f5816422696e0569c977e2f169e1e5688afc8f4aa16",
+        "node_id": 2,
+        "public_key": "0x4a5ad514f0957fa170a676210c9bdbddf3bc9519702cf915fa6767a40463b96f",
+        "reward_rate_start": null,
+        "service_endpoints": [
+          {
+            "ip_address_v4": "128.0.0.7",
+            "port": 50216
+          }
+        ],
+        "stake": null,
+        "stake_not_rewarded": null,
+        "stake_rewarded": null,
+        "staking_period": null,
+        "timestamp": {
+          "from": "187654.000123457",
+          "to": null
+        }
+      },
+      {
+        "description": "description",
+        "file_id": "0.0.102",
+        "max_stake": null,
+        "memo": "0.0.3",
+        "min_stake": null,
+        "node_account_id": "0.0.6",
+        "node_cert_hash": "0x01d173753810c0aae794ba72d5443c292e9ff962b01046220dd99f5816422696e0569c977e2f169e1e5688afc8f4aa16",
+        "node_id": 3,
+        "public_key": "0x4a5ad514f0957fa170a676210c9bdbddf3bc9519702cf915fa6767a40463b96f",
+        "reward_rate_start": null,
+        "service_endpoints": [
+          {
+            "ip_address_v4": "128.0.0.8",
+            "port": 50216
+          }
+        ],
+        "stake": null,
+        "stake_not_rewarded": null,
+        "stake_rewarded": null,
+        "staking_period": null,
+        "timestamp": {
+          "from": "187654.000123457",
+          "to": null
+        }
+      },
+      {
+        "description": "description",
+        "file_id": "0.0.102",
+        "max_stake": null,
+        "memo": "0.0.3",
+        "min_stake": null,
+        "node_account_id": "0.0.7",
+        "node_cert_hash": "0x01d173753810c0aae794ba72d5443c292e9ff962b01046220dd99f5816422696e0569c977e2f169e1e5688afc8f4aa16",
+        "node_id": 4,
+        "public_key": "0x4a5ad514f0957fa170a676210c9bdbddf3bc9519702cf915fa6767a40463b96f",
+        "reward_rate_start": null,
+        "service_endpoints": [
+          {
+            "ip_address_v4": "128.0.0.9",
+            "port": 50216
+          }
+        ],
+        "stake": null,
+        "stake_not_rewarded": null,
+        "stake_rewarded": null,
+        "staking_period": null,
+        "timestamp": {
+          "from": "187654.000123457",
+          "to": null
+        }
+      },
+      {
+        "description": "description",
+        "file_id": "0.0.102",
+        "max_stake": null,
+        "memo": "0.0.3",
+        "min_stake": null,
+        "node_account_id": "0.0.8",
+        "node_cert_hash": "0x01d173753810c0aae794ba72d5443c292e9ff962b01046220dd99f5816422696e0569c977e2f169e1e5688afc8f4aa16",
+        "node_id": 5,
+        "public_key": "0x4a5ad514f0957fa170a676210c9bdbddf3bc9519702cf915fa6767a40463b96f",
+        "reward_rate_start": null,
+        "service_endpoints": [
+          {
+            "ip_address_v4": "128.0.0.10",
+            "port": 50216
+          }
+        ],
+        "stake": null,
+        "stake_not_rewarded": null,
+        "stake_rewarded": null,
+        "staking_period": null,
+        "timestamp": {
+          "from": "187654.000123457",
+          "to": null
+        }
+      },
+      {
+        "description": "description",
+        "file_id": "0.0.102",
+        "max_stake": null,
+        "memo": "0.0.3",
+        "min_stake": null,
+        "node_account_id": "0.0.9",
+        "node_cert_hash": "0x01d173753810c0aae794ba72d5443c292e9ff962b01046220dd99f5816422696e0569c977e2f169e1e5688afc8f4aa16",
+        "node_id": 6,
+        "public_key": "0x4a5ad514f0957fa170a676210c9bdbddf3bc9519702cf915fa6767a40463b96f",
+        "reward_rate_start": null,
+        "service_endpoints": [
+          {
+            "ip_address_v4": "128.0.0.11",
+            "port": 50216
+          }
+        ],
+        "stake": null,
+        "stake_not_rewarded": null,
+        "stake_rewarded": null,
+        "staking_period": null,
+        "timestamp": {
+          "from": "187654.000123457",
+          "to": null
+        }
+      },
+      {
+        "description": "description",
+        "file_id": "0.0.102",
+        "max_stake": null,
+        "memo": "0.0.3",
+        "min_stake": null,
+        "node_account_id": "0.0.10",
+        "node_cert_hash": "0x01d173753810c0aae794ba72d5443c292e9ff962b01046220dd99f5816422696e0569c977e2f169e1e5688afc8f4aa16",
+        "node_id": 7,
+        "public_key": "0x4a5ad514f0957fa170a676210c9bdbddf3bc9519702cf915fa6767a40463b96f",
+        "reward_rate_start": null,
+        "service_endpoints": [
+          {
+            "ip_address_v4": "128.0.0.12",
+            "port": 50216
+          }
+        ],
+        "stake": null,
+        "stake_not_rewarded": null,
+        "stake_rewarded": null,
+        "staking_period": null,
+        "timestamp": {
+          "from": "187654.000123457",
+          "to": null
+        }
+      },
+      {
+        "description": "description",
+        "file_id": "0.0.102",
+        "max_stake": null,
+        "memo": "0.0.3",
+        "min_stake": null,
+        "node_account_id": "0.0.11",
+        "node_cert_hash": "0x01d173753810c0aae794ba72d5443c292e9ff962b01046220dd99f5816422696e0569c977e2f169e1e5688afc8f4aa16",
+        "node_id": 8,
+        "public_key": "0x4a5ad514f0957fa170a676210c9bdbddf3bc9519702cf915fa6767a40463b96f",
+        "reward_rate_start": null,
+        "service_endpoints": [
+          {
+            "ip_address_v4": "128.0.0.13",
+            "port": 50216
+          }
+        ],
+        "stake": null,
+        "stake_not_rewarded": null,
+        "stake_rewarded": null,
+        "staking_period": null,
+        "timestamp": {
+          "from": "187654.000123457",
+          "to": null
+        }
+      },
+      {
+        "description": "description",
+        "file_id": "0.0.102",
+        "max_stake": null,
+        "memo": "0.0.3",
+        "min_stake": null,
+        "node_account_id": "0.0.12",
+        "node_cert_hash": "0x01d173753810c0aae794ba72d5443c292e9ff962b01046220dd99f5816422696e0569c977e2f169e1e5688afc8f4aa16",
+        "node_id": 9,
+        "public_key": "0x4a5ad514f0957fa170a676210c9bdbddf3bc9519702cf915fa6767a40463b96f",
+        "reward_rate_start": null,
+        "service_endpoints": [
+          {
+            "ip_address_v4": "128.0.0.14",
+            "port": 50216
+          }
+        ],
+        "stake": null,
+        "stake_not_rewarded": null,
+        "stake_rewarded": null,
+        "staking_period": null,
+        "timestamp": {
+          "from": "187654.000123457",
+          "to": null
+        }
+      },
+      {
+        "description": "description",
+        "file_id": "0.0.102",
+        "max_stake": null,
+        "memo": "0.0.3",
+        "min_stake": null,
+        "node_account_id": "0.0.13",
+        "node_cert_hash": "0x01d173753810c0aae794ba72d5443c292e9ff962b01046220dd99f5816422696e0569c977e2f169e1e5688afc8f4aa16",
+        "node_id": 10,
+        "public_key": "0x4a5ad514f0957fa170a676210c9bdbddf3bc9519702cf915fa6767a40463b96f",
+        "reward_rate_start": null,
+        "service_endpoints": [
+          {
+            "ip_address_v4": "128.0.0.15",
+            "port": 50216
+          }
+        ],
+        "stake": null,
+        "stake_not_rewarded": null,
+        "stake_rewarded": null,
+        "staking_period": null,
+        "timestamp": {
+          "from": "187654.000123457",
+          "to": null
+        }
+      },
+      {
+        "description": "description",
+        "file_id": "0.0.102",
+        "max_stake": null,
+        "memo": "0.0.3",
+        "min_stake": null,
+        "node_account_id": "0.0.14",
+        "node_cert_hash": "0x01d173753810c0aae794ba72d5443c292e9ff962b01046220dd99f5816422696e0569c977e2f169e1e5688afc8f4aa16",
+        "node_id": 11,
+        "public_key": "0x4a5ad514f0957fa170a676210c9bdbddf3bc9519702cf915fa6767a40463b96f",
+        "reward_rate_start": null,
+        "service_endpoints": [
+          {
+            "ip_address_v4": "128.0.0.16",
+            "port": 50216
+          }
+        ],
+        "stake": null,
+        "stake_not_rewarded": null,
+        "stake_rewarded": null,
+        "staking_period": null,
+        "timestamp": {
+          "from": "187654.000123457",
+          "to": null
+        }
+      },
+      {
+        "description": "description",
+        "file_id": "0.0.102",
+        "max_stake": null,
+        "memo": "0.0.3",
+        "min_stake": null,
+        "node_account_id": "0.0.15",
+        "node_cert_hash": "0x01d173753810c0aae794ba72d5443c292e9ff962b01046220dd99f5816422696e0569c977e2f169e1e5688afc8f4aa16",
+        "node_id": 12,
+        "public_key": "0x4a5ad514f0957fa170a676210c9bdbddf3bc9519702cf915fa6767a40463b96f",
+        "reward_rate_start": null,
+        "service_endpoints": [
+          {
+            "ip_address_v4": "128.0.0.17",
+            "port": 50216
+          }
+        ],
+        "stake": null,
+        "stake_not_rewarded": null,
+        "stake_rewarded": null,
+        "staking_period": null,
+        "timestamp": {
+          "from": "187654.000123457",
+          "to": null
+        }
+      },
+      {
+        "description": "description",
+        "file_id": "0.0.102",
+        "max_stake": null,
+        "memo": "0.0.3",
+        "min_stake": null,
+        "node_account_id": "0.0.16",
+        "node_cert_hash": "0x01d173753810c0aae794ba72d5443c292e9ff962b01046220dd99f5816422696e0569c977e2f169e1e5688afc8f4aa16",
+        "node_id": 13,
+        "public_key": "0x4a5ad514f0957fa170a676210c9bdbddf3bc9519702cf915fa6767a40463b96f",
+        "reward_rate_start": null,
+        "service_endpoints": [
+          {
+            "ip_address_v4": "128.0.0.18",
+            "port": 50216
+          }
+        ],
+        "stake": null,
+        "stake_not_rewarded": null,
+        "stake_rewarded": null,
+        "staking_period": null,
+        "timestamp": {
+          "from": "187654.000123457",
+          "to": null
+        }
+      },
+      {
+        "description": "description",
+        "file_id": "0.0.102",
+        "max_stake": null,
+        "memo": "0.0.3",
+        "min_stake": null,
+        "node_account_id": "0.0.17",
+        "node_cert_hash": "0x01d173753810c0aae794ba72d5443c292e9ff962b01046220dd99f5816422696e0569c977e2f169e1e5688afc8f4aa16",
+        "node_id": 14,
+        "public_key": "0x4a5ad514f0957fa170a676210c9bdbddf3bc9519702cf915fa6767a40463b96f",
+        "reward_rate_start": null,
+        "service_endpoints": [
+          {
+            "ip_address_v4": "128.0.0.19",
+            "port": 50216
+          }
+        ],
+        "stake": null,
+        "stake_not_rewarded": null,
+        "stake_rewarded": null,
+        "staking_period": null,
+        "timestamp": {
+          "from": "187654.000123457",
+          "to": null
+        }
+      },
+      {
+        "description": "description",
+        "file_id": "0.0.102",
+        "max_stake": null,
+        "memo": "0.0.3",
+        "min_stake": null,
+        "node_account_id": "0.0.18",
+        "node_cert_hash": "0x01d173753810c0aae794ba72d5443c292e9ff962b01046220dd99f5816422696e0569c977e2f169e1e5688afc8f4aa16",
+        "node_id": 15,
+        "public_key": "0x4a5ad514f0957fa170a676210c9bdbddf3bc9519702cf915fa6767a40463b96f",
+        "reward_rate_start": null,
+        "service_endpoints": [
+          {
+            "ip_address_v4": "128.0.0.20",
+            "port": 50216
+          }
+        ],
+        "stake": null,
+        "stake_not_rewarded": null,
+        "stake_rewarded": null,
+        "staking_period": null,
+        "timestamp": {
+          "from": "187654.000123457",
+          "to": null
+        }
+      },
+      {
+        "description": "description",
+        "file_id": "0.0.102",
+        "max_stake": null,
+        "memo": "0.0.3",
+        "min_stake": null,
+        "node_account_id": "0.0.19",
+        "node_cert_hash": "0x01d173753810c0aae794ba72d5443c292e9ff962b01046220dd99f5816422696e0569c977e2f169e1e5688afc8f4aa16",
+        "node_id": 16,
+        "public_key": "0x4a5ad514f0957fa170a676210c9bdbddf3bc9519702cf915fa6767a40463b96f",
+        "reward_rate_start": null,
+        "service_endpoints": [
+          {
+            "ip_address_v4": "128.0.0.21",
+            "port": 50216
+          }
+        ],
+        "stake": null,
+        "stake_not_rewarded": null,
+        "stake_rewarded": null,
+        "staking_period": null,
+        "timestamp": {
+          "from": "187654.000123457",
+          "to": null
+        }
+      },
+      {
+        "description": "description",
+        "file_id": "0.0.102",
+        "max_stake": null,
+        "memo": "0.0.3",
+        "min_stake": null,
+        "node_account_id": "0.0.20",
+        "node_cert_hash": "0x01d173753810c0aae794ba72d5443c292e9ff962b01046220dd99f5816422696e0569c977e2f169e1e5688afc8f4aa16",
+        "node_id": 17,
+        "public_key": "0x4a5ad514f0957fa170a676210c9bdbddf3bc9519702cf915fa6767a40463b96f",
+        "reward_rate_start": null,
+        "service_endpoints": [
+          {
+            "ip_address_v4": "128.0.0.22",
+            "port": 50216
+          }
+        ],
+        "stake": null,
+        "stake_not_rewarded": null,
+        "stake_rewarded": null,
+        "staking_period": null,
+        "timestamp": {
+          "from": "187654.000123457",
+          "to": null
+        }
+      },
+      {
+        "description": "description",
+        "file_id": "0.0.102",
+        "max_stake": null,
+        "memo": "0.0.3",
+        "min_stake": null,
+        "node_account_id": "0.0.21",
+        "node_cert_hash": "0x01d173753810c0aae794ba72d5443c292e9ff962b01046220dd99f5816422696e0569c977e2f169e1e5688afc8f4aa16",
+        "node_id": 18,
+        "public_key": "0x4a5ad514f0957fa170a676210c9bdbddf3bc9519702cf915fa6767a40463b96f",
+        "reward_rate_start": null,
+        "service_endpoints": [
+          {
+            "ip_address_v4": "128.0.0.23",
+            "port": 50216
+          }
+        ],
+        "stake": null,
+        "stake_not_rewarded": null,
+        "stake_rewarded": null,
+        "staking_period": null,
+        "timestamp": {
+          "from": "187654.000123457",
+          "to": null
+        }
+      },
+      {
+        "description": "description",
+        "file_id": "0.0.102",
+        "max_stake": null,
+        "memo": "0.0.3",
+        "min_stake": null,
+        "node_account_id": "0.0.22",
+        "node_cert_hash": "0x01d173753810c0aae794ba72d5443c292e9ff962b01046220dd99f5816422696e0569c977e2f169e1e5688afc8f4aa16",
+        "node_id": 19,
+        "public_key": "0x4a5ad514f0957fa170a676210c9bdbddf3bc9519702cf915fa6767a40463b96f",
+        "reward_rate_start": null,
+        "service_endpoints": [
+          {
+            "ip_address_v4": "128.0.0.24",
+            "port": 50216
+          }
+        ],
+        "stake": null,
+        "stake_not_rewarded": null,
+        "stake_rewarded": null,
+        "staking_period": null,
+        "timestamp": {
+          "from": "187654.000123457",
+          "to": null
+        }
+      },
+      {
+        "description": "description",
+        "file_id": "0.0.102",
+        "max_stake": null,
+        "memo": "0.0.3",
+        "min_stake": null,
+        "node_account_id": "0.0.23",
+        "node_cert_hash": "0x01d173753810c0aae794ba72d5443c292e9ff962b01046220dd99f5816422696e0569c977e2f169e1e5688afc8f4aa16",
+        "node_id": 20,
+        "public_key": "0x4a5ad514f0957fa170a676210c9bdbddf3bc9519702cf915fa6767a40463b96f",
+        "reward_rate_start": null,
+        "service_endpoints": [
+          {
+            "ip_address_v4": "128.0.0.25",
+            "port": 50216
+          }
+        ],
+        "stake": null,
+        "stake_not_rewarded": null,
+        "stake_rewarded": null,
+        "staking_period": null,
+        "timestamp": {
+          "from": "187654.000123457",
+          "to": null
+        }
+      },
+      {
+        "description": "description",
+        "file_id": "0.0.102",
+        "max_stake": null,
+        "memo": "0.0.3",
+        "min_stake": null,
+        "node_account_id": "0.0.24",
+        "node_cert_hash": "0x01d173753810c0aae794ba72d5443c292e9ff962b01046220dd99f5816422696e0569c977e2f169e1e5688afc8f4aa16",
+        "node_id": 21,
+        "public_key": "0x4a5ad514f0957fa170a676210c9bdbddf3bc9519702cf915fa6767a40463b96f",
+        "reward_rate_start": null,
+        "service_endpoints": [
+          {
+            "ip_address_v4": "128.0.0.26",
+            "port": 50216
+          }
+        ],
+        "stake": null,
+        "stake_not_rewarded": null,
+        "stake_rewarded": null,
+        "staking_period": null,
+        "timestamp": {
+          "from": "187654.000123457",
+          "to": null
+        }
+      },
+      {
+        "description": "description",
+        "file_id": "0.0.102",
+        "max_stake": null,
+        "memo": "0.0.3",
+        "min_stake": null,
+        "node_account_id": "0.0.25",
+        "node_cert_hash": "0x01d173753810c0aae794ba72d5443c292e9ff962b01046220dd99f5816422696e0569c977e2f169e1e5688afc8f4aa16",
+        "node_id": 22,
+        "public_key": "0x4a5ad514f0957fa170a676210c9bdbddf3bc9519702cf915fa6767a40463b96f",
+        "reward_rate_start": null,
+        "service_endpoints": [
+          {
+            "ip_address_v4": "128.0.0.27",
+            "port": 50216
+          }
+        ],
+        "stake": null,
+        "stake_not_rewarded": null,
+        "stake_rewarded": null,
+        "staking_period": null,
+        "timestamp": {
+          "from": "187654.000123457",
+          "to": null
+        }
+      },
+      {
+        "description": "description",
+        "file_id": "0.0.102",
+        "max_stake": null,
+        "memo": "0.0.3",
+        "min_stake": null,
+        "node_account_id": "0.0.26",
+        "node_cert_hash": "0x01d173753810c0aae794ba72d5443c292e9ff962b01046220dd99f5816422696e0569c977e2f169e1e5688afc8f4aa16",
+        "node_id": 23,
+        "public_key": "0x4a5ad514f0957fa170a676210c9bdbddf3bc9519702cf915fa6767a40463b96f",
+        "reward_rate_start": null,
+        "service_endpoints": [
+          {
+            "ip_address_v4": "128.0.0.28",
+            "port": 50216
+          }
+        ],
+        "stake": null,
+        "stake_not_rewarded": null,
+        "stake_rewarded": null,
+        "staking_period": null,
+        "timestamp": {
+          "from": "187654.000123457",
+          "to": null
+        }
+      },
+      {
+        "description": "description",
+        "file_id": "0.0.102",
+        "max_stake": null,
+        "memo": "0.0.3",
+        "min_stake": null,
+        "node_account_id": "0.0.27",
+        "node_cert_hash": "0x01d173753810c0aae794ba72d5443c292e9ff962b01046220dd99f5816422696e0569c977e2f169e1e5688afc8f4aa16",
+        "node_id": 24,
+        "public_key": "0x4a5ad514f0957fa170a676210c9bdbddf3bc9519702cf915fa6767a40463b96f",
+        "reward_rate_start": null,
+        "service_endpoints": [
+          {
+            "ip_address_v4": "128.0.0.29",
+            "port": 50216
+          }
+        ],
+        "stake": null,
+        "stake_not_rewarded": null,
+        "stake_rewarded": null,
+        "staking_period": null,
+        "timestamp": {
+          "from": "187654.000123457",
+          "to": null
+        }
+      }
+    ],
+    "links": {
+      "next": "/api/v1/network/nodes?limit=26&node.id=gt:24"
     }
   }
 }

--- a/hedera-mirror-rest/__tests__/specs/network/nodes/max-limit.json
+++ b/hedera-mirror-rest/__tests__/specs/network/nodes/max-limit.json
@@ -412,7 +412,7 @@
             "port": 50216
           }
         ],
-        "stake": null,
+        "stake": 0,
         "stake_not_rewarded": null,
         "stake_rewarded": null,
         "staking_period": null,
@@ -438,7 +438,7 @@
             "port": 50216
           }
         ],
-        "stake": null,
+        "stake": 0,
         "stake_not_rewarded": null,
         "stake_rewarded": null,
         "staking_period": null,
@@ -464,7 +464,7 @@
             "port": 50216
           }
         ],
-        "stake": null,
+        "stake": 0,
         "stake_not_rewarded": null,
         "stake_rewarded": null,
         "staking_period": null,
@@ -490,7 +490,7 @@
             "port": 50216
           }
         ],
-        "stake": null,
+        "stake": 0,
         "stake_not_rewarded": null,
         "stake_rewarded": null,
         "staking_period": null,
@@ -516,7 +516,7 @@
             "port": 50216
           }
         ],
-        "stake": null,
+        "stake": 0,
         "stake_not_rewarded": null,
         "stake_rewarded": null,
         "staking_period": null,
@@ -542,7 +542,7 @@
             "port": 50216
           }
         ],
-        "stake": null,
+        "stake": 0,
         "stake_not_rewarded": null,
         "stake_rewarded": null,
         "staking_period": null,
@@ -568,7 +568,7 @@
             "port": 50216
           }
         ],
-        "stake": null,
+        "stake": 0,
         "stake_not_rewarded": null,
         "stake_rewarded": null,
         "staking_period": null,
@@ -594,7 +594,7 @@
             "port": 50216
           }
         ],
-        "stake": null,
+        "stake": 0,
         "stake_not_rewarded": null,
         "stake_rewarded": null,
         "staking_period": null,
@@ -620,7 +620,7 @@
             "port": 50216
           }
         ],
-        "stake": null,
+        "stake": 0,
         "stake_not_rewarded": null,
         "stake_rewarded": null,
         "staking_period": null,
@@ -646,7 +646,7 @@
             "port": 50216
           }
         ],
-        "stake": null,
+        "stake": 0,
         "stake_not_rewarded": null,
         "stake_rewarded": null,
         "staking_period": null,
@@ -672,7 +672,7 @@
             "port": 50216
           }
         ],
-        "stake": null,
+        "stake": 0,
         "stake_not_rewarded": null,
         "stake_rewarded": null,
         "staking_period": null,
@@ -698,7 +698,7 @@
             "port": 50216
           }
         ],
-        "stake": null,
+        "stake": 0,
         "stake_not_rewarded": null,
         "stake_rewarded": null,
         "staking_period": null,
@@ -724,7 +724,7 @@
             "port": 50216
           }
         ],
-        "stake": null,
+        "stake": 0,
         "stake_not_rewarded": null,
         "stake_rewarded": null,
         "staking_period": null,
@@ -750,7 +750,7 @@
             "port": 50216
           }
         ],
-        "stake": null,
+        "stake": 0,
         "stake_not_rewarded": null,
         "stake_rewarded": null,
         "staking_period": null,
@@ -776,7 +776,7 @@
             "port": 50216
           }
         ],
-        "stake": null,
+        "stake": 0,
         "stake_not_rewarded": null,
         "stake_rewarded": null,
         "staking_period": null,
@@ -802,7 +802,7 @@
             "port": 50216
           }
         ],
-        "stake": null,
+        "stake": 0,
         "stake_not_rewarded": null,
         "stake_rewarded": null,
         "staking_period": null,
@@ -828,7 +828,7 @@
             "port": 50216
           }
         ],
-        "stake": null,
+        "stake": 0,
         "stake_not_rewarded": null,
         "stake_rewarded": null,
         "staking_period": null,
@@ -854,7 +854,7 @@
             "port": 50216
           }
         ],
-        "stake": null,
+        "stake": 0,
         "stake_not_rewarded": null,
         "stake_rewarded": null,
         "staking_period": null,
@@ -880,7 +880,7 @@
             "port": 50216
           }
         ],
-        "stake": null,
+        "stake": 0,
         "stake_not_rewarded": null,
         "stake_rewarded": null,
         "staking_period": null,
@@ -906,7 +906,7 @@
             "port": 50216
           }
         ],
-        "stake": null,
+        "stake": 0,
         "stake_not_rewarded": null,
         "stake_rewarded": null,
         "staking_period": null,
@@ -932,7 +932,7 @@
             "port": 50216
           }
         ],
-        "stake": null,
+        "stake": 0,
         "stake_not_rewarded": null,
         "stake_rewarded": null,
         "staking_period": null,
@@ -958,7 +958,7 @@
             "port": 50216
           }
         ],
-        "stake": null,
+        "stake": 0,
         "stake_not_rewarded": null,
         "stake_rewarded": null,
         "staking_period": null,
@@ -984,7 +984,7 @@
             "port": 50216
           }
         ],
-        "stake": null,
+        "stake": 0,
         "stake_not_rewarded": null,
         "stake_rewarded": null,
         "staking_period": null,
@@ -1010,7 +1010,7 @@
             "port": 50216
           }
         ],
-        "stake": null,
+        "stake": 0,
         "stake_not_rewarded": null,
         "stake_rewarded": null,
         "staking_period": null,

--- a/hedera-mirror-rest/controllers/networkController.js
+++ b/hedera-mirror-rest/controllers/networkController.js
@@ -31,7 +31,6 @@ import {
   responseContentType,
   responseDataLabel,
 } from '../constants';
-import entityId from '../entityId';
 import {InvalidArgumentError, NotFoundError} from '../errors';
 import {AddressBookEntry, FileData} from '../model';
 import {FileDataService, NetworkNodeService} from '../service';
@@ -95,10 +94,7 @@ class NetworkController extends BaseController {
           break;
         case filterKeys.LIMIT:
           // response per address book node can be large so a reduced limit is enforced
-          if (filter.value > networkNodesMaxSize) {
-            throw new InvalidArgumentError(`Max value of ${networkNodesMaxSize} is supported for ${filterKeys.LIMIT}`);
-          }
-          limit = filter.value;
+          limit = filter.value <= networkNodesMaxSize ? filter.value : networkNodesMaxSize;
           break;
         case filterKeys.ORDER:
           order = filter.value;

--- a/hedera-mirror-test/k6/src/rest/test/accountsBalanceGte0Pubkey.js
+++ b/hedera-mirror-test/k6/src/rest/test/accountsBalanceGte0Pubkey.js
@@ -26,10 +26,10 @@ import {accountListName} from '../libex/constants.js';
 const urlTag = '/accounts?account.balance=gt:0&account.publickey={publicKey}';
 
 const {options, run, setup} = new RestTestScenarioBuilder()
-  .name('accountsBalanceGt0Pubkey') // use unique scenario name among all tests
+  .name('accountsBalanceGte0Pubkey') // use unique scenario name among all tests
   .tags({url: urlTag})
   .request((testParameters) => {
-    const url = `${testParameters['BASE_URL_PREFIX']}/accounts?account.balance=gt:0&account.publickey=${testParameters['DEFAULT_PUBLIC_KEY']}`;
+    const url = `${testParameters['BASE_URL_PREFIX']}/accounts?account.balance=gte:0&account.publickey=${testParameters['DEFAULT_PUBLIC_KEY']}`;
     return http.get(url);
   })
   .requiredParameters('DEFAULT_PUBLIC_KEY')

--- a/hedera-mirror-test/k6/src/rest/test/contractsIdResults.js
+++ b/hedera-mirror-test/k6/src/rest/test/contractsIdResults.js
@@ -29,7 +29,7 @@ const {options, run, setup} = new RestTestScenarioBuilder()
   .name('contractsIdResults') // use unique scenario name among all tests
   .tags({url: urlTag})
   .request((testParameters) => {
-    const url = `${testParameters['BASE_URL_PREFIX']}/contracts/${testParameters['DEFAULT_CONTRACT_ID']}/results?internal=true`;
+    const url = `${testParameters['BASE_URL_PREFIX']}/contracts/${testParameters['DEFAULT_CONTRACT_ID']}/results?limit=${testParameters['DEFAULT_LIMIT']}`;
     return http.get(url);
   })
   .requiredParameters('DEFAULT_CONTRACT_ID')

--- a/hedera-mirror-test/k6/src/rest/test/contractsIdResultsLogs.js
+++ b/hedera-mirror-test/k6/src/rest/test/contractsIdResultsLogs.js
@@ -29,7 +29,7 @@ const {options, run, setup} = new RestTestScenarioBuilder()
   .name('contractsIdResultsLogs') // use unique scenario name among all tests
   .tags({url: urlTag})
   .request((testParameters) => {
-    const url = `${testParameters['BASE_URL_PREFIX']}/contracts/${testParameters['DEFAULT_CONTRACT_ID']}/results/logs`;
+    const url = `${testParameters['BASE_URL_PREFIX']}/contracts/${testParameters['DEFAULT_CONTRACT_ID']}/results/logs?limit=${testParameters['DEFAULT_LIMIT']}`;
     return http.get(url);
   })
   .requiredParameters('DEFAULT_CONTRACT_ID')

--- a/hedera-mirror-test/k6/src/rest/test/contractsResult.js
+++ b/hedera-mirror-test/k6/src/rest/test/contractsResult.js
@@ -29,7 +29,7 @@ const {options, run, setup} = new RestTestScenarioBuilder()
   .name('contractsResults') // use unique scenario name among all tests
   .tags({url: urlTag})
   .request((testParameters) => {
-    const url = `${testParameters['BASE_URL_PREFIX']}/contracts/${testParameters['DEFAULT_CONTRACT_ID']}/results?limit=${testParameters['DEFAULT_LIMIT']}`;
+    const url = `${testParameters['BASE_URL_PREFIX']}/contracts/results?limit=${testParameters['DEFAULT_LIMIT']}`;
     return http.get(url);
   })
   .requiredParameters('DEFAULT_CONTRACT_ID')

--- a/hedera-mirror-test/k6/src/rest/test/contractsResultsId.js
+++ b/hedera-mirror-test/k6/src/rest/test/contractsResultsId.js
@@ -28,7 +28,7 @@ const {options, run, setup} = new RestTestScenarioBuilder()
   .name('contractsResultsId') // use unique scenario name among all tests
   .tags({url: urlTag})
   .request((testParameters) => {
-    const url = `${testParameters['BASE_URL_PREFIX']}/contracts/results/${testParameters['DEFAULT_CONTRACT_RESULT_HASH']}?limit=${testParameters['DEFAULT_LIMIT']}`;
+    const url = `${testParameters['BASE_URL_PREFIX']}/contracts/results/${testParameters['DEFAULT_CONTRACT_RESULT_HASH']}`;
     return http.get(url);
   })
   .requiredParameters('DEFAULT_CONTRACT_RESULT_HASH')

--- a/hedera-mirror-test/k6/src/rest/test/index.js
+++ b/hedera-mirror-test/k6/src/rest/test/index.js
@@ -25,7 +25,7 @@ import * as accounts from './accounts.js';
 import * as accountsBalanceFalse from './accountsBalanceFalse.js';
 import * as accountsBalanceFalsePubkey from './accountsBalanceFalsePubkey.js';
 import * as accountsBalanceGt0 from './accountsBalanceGt0.js';
-import * as accountsBalanceGt0Pubkey from './accountsBalanceGt0Pubkey.js';
+import * as accountsBalanceGt0Pubkey from './accountsBalanceGte0Pubkey.js';
 import * as accountsBalanceNe from './accountsBalanceNe.js';
 import * as accountsCryptoAllowance from './accountsCryptoAllowance.js';
 import * as accountsCryptoAllowanceSpender from './accountsCryptoAllowanceSpender.js';


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR ports the fix to `release/0.79`

- Fix /network/nodes endpoint return 400 if limit is more than 25
- Change accountsBalanceGt0Pubkey balance query to account.balance=gte:0
- Add limit=? to contractsIdResults and contractsIdResultsLogs
- Fix contractsResult url
- Remove limit=? from contractsResults

**Related issue(s)**:

Relates to #5935 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
cherry-pick it so when 0.79.1 is deployed to mainnet staging, we can get valid performance result for those endpoints

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
