### PR TITLE
Fix Synthetic Token Allowance Owner Migration

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/SyntheticTokenAllowanceOwnerMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/SyntheticTokenAllowanceOwnerMigration.java
@@ -27,9 +27,10 @@ import org.springframework.jdbc.core.JdbcTemplate;
 @Named
 public class SyntheticTokenAllowanceOwnerMigration extends RepeatableMigration {
 
-    private static final String UPDATE_TOKEN_ALLOWANCE_OWNER_SQL = """
+    private static final String UPDATE_TOKEN_ALLOWANCE_OWNER_SQL =
+            """
             begin;
-            
+
             create temp table token_allowance_temp (
               amount            bigint not null,
               created_timestamp bigint not null,
@@ -39,7 +40,7 @@ public class SyntheticTokenAllowanceOwnerMigration extends RepeatableMigration {
               token_id          bigint not null,
               primary key (owner, spender, token_id, created_timestamp)
             ) on commit drop;
-            
+
             with affected as (
               select ta.*, cr.consensus_timestamp, cr.sender_id
               from (
@@ -76,7 +77,7 @@ public class SyntheticTokenAllowanceOwnerMigration extends RepeatableMigration {
             select amount, created_timestamp, owner, payer_account_id, spender, token_id from delete_token_allowance
             union all
             select amount, created_timestamp, owner, payer_account_id, spender, token_id from delete_token_allowance_history;
-            
+
             with correct_timestamp_range as (
               select
                 amount,
@@ -98,7 +99,7 @@ public class SyntheticTokenAllowanceOwnerMigration extends RepeatableMigration {
             )
             insert into token_allowance (amount, owner, payer_account_id, spender, timestamp_range, token_id)
             select * from correct_timestamp_range where upper(timestamp_range) is null;
-            
+
             commit;
             """;
 

--- a/hedera-mirror-importer/src/main/resources/application.yml
+++ b/hedera-mirror-importer/src/main/resources/application.yml
@@ -24,6 +24,8 @@ hedera:
           checksum: 3
         initializeEntityBalanceMigration:
           checksum: 3
+        syntheticTokenAllowanceOwnerMigration:
+          checksum: 2
         tokenAccountBalanceMigration:
           checksum: 3
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/SyntheticTokenAllowanceOwnerMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/SyntheticTokenAllowanceOwnerMigrationTest.java
@@ -154,8 +154,7 @@ class SyntheticTokenAllowanceOwnerMigrationTest extends IntegrationTest {
                         .consensusTimestamp(newTokenAllowance.getTimestampLower()))
                 .persist();
 
-        // A token allowance that has no contract result, but has primary key values that will end up matching those of
-        // a migrated token allowance.
+        // The collision token allowances
         var ownerAccountId = 3491438L;
         var spender = 3491439L;
         var tokenId = 3491444L;
@@ -168,20 +167,17 @@ class SyntheticTokenAllowanceOwnerMigrationTest extends IntegrationTest {
                         .tokenId(tokenId))
                 .persist();
 
-        // A token allowance that has a contract result, once migrated it will have the same primary key fields as the
-        // above token allowance.
         var ownerPreMigration = 1322L;
         var contractResultConsensus = 1676546391434923004L;
         domainBuilder
                 .tokenAllowance()
                 .customize(t -> t.owner(ownerPreMigration)
-                        .payerAccountId(EntityId.of(1322L, CONTRACT))
+                        .payerAccountId(EntityId.of(ownerPreMigration, CONTRACT))
                         .spender(spender)
                         .timestampRange(Range.atLeast(contractResultConsensus))
                         .tokenId(tokenId))
                 .persist();
 
-        // The contract result for the above token allowance
         domainBuilder
                 .contractResult()
                 .customize(c -> c.senderId(EntityId.of(ownerAccountId, CONTRACT))

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/SyntheticTokenAllowanceOwnerMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/SyntheticTokenAllowanceOwnerMigrationTest.java
@@ -42,7 +42,7 @@ class SyntheticTokenAllowanceOwnerMigrationTest extends IntegrationTest {
 
     @Test
     void checksum() {
-        assertThat(migration.getChecksum()).isEqualTo(1);
+        assertThat(migration.getChecksum()).isEqualTo(2);
     }
 
     @Test

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/SyntheticTokenAllowanceOwnerMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/SyntheticTokenAllowanceOwnerMigrationTest.java
@@ -78,6 +78,41 @@ class SyntheticTokenAllowanceOwnerMigrationTest extends IntegrationTest {
                         .consensusTimestamp(newTokenAllowance.getTimestampLower()))
                 .persist();
 
+        // A token allowance that has no contract result, but has primary key values that will end up matching those of
+        // a migrated token allowance.
+        var ownerAccountId = 38L;
+        var spender = 39L;
+        var tokenId = 44L;
+        var tokenAllowancePreMigration = domainBuilder
+                .tokenAllowance()
+                .customize(t -> t.owner(ownerAccountId)
+                        .payerAccountId(EntityId.of(ownerAccountId, CONTRACT))
+                        .spender(spender)
+                        .timestampRange(Range.atLeast(1676546171829734003L))
+                        .tokenId(tokenId))
+                .persist();
+
+        // A token allowance that has a contract result, once migrated it will have the same primary key fields as the
+        // above token allowance.
+        var ownerPreMigration = 1322L;
+        var contractResultConsensus = 1676546391434923004L;
+        var collidedTokenAllowance = domainBuilder
+                .tokenAllowance()
+                .customize(t -> t.owner(ownerPreMigration)
+                        .payerAccountId(EntityId.of(ownerPreMigration, CONTRACT))
+                        .spender(spender)
+                        .timestampRange(Range.atLeast(contractResultConsensus))
+                        .tokenId(tokenId))
+                .persist();
+
+        // The contract result for the collided token allowance
+        domainBuilder
+                .contractResult()
+                .customize(c -> c.senderId(EntityId.of(ownerAccountId, CONTRACT))
+                        .payerAccountId(EntityId.of(ownerPreMigration, CONTRACT))
+                        .consensusTimestamp(contractResultConsensus))
+                .persist();
+
         // when
         migration.doMigrate();
 
@@ -88,6 +123,8 @@ class SyntheticTokenAllowanceOwnerMigrationTest extends IntegrationTest {
         expected.add(unaffectedTokenAllowancePair.getLeft());
         expected.add(correctTokenAllowancePair.getLeft());
         expected.add(newTokenAllowance);
+        collidedTokenAllowance.setOwner(ownerAccountId);
+        expected.add(collidedTokenAllowance);
         assertThat(tokenAllowanceRepository.findAll()).containsExactlyInAnyOrderElementsOf(expected);
 
         // The history of the token allowance should also be updated with the corrected owner
@@ -96,6 +133,8 @@ class SyntheticTokenAllowanceOwnerMigrationTest extends IntegrationTest {
         expectedHistory.forEach(t -> t.setOwner(contractResultSenderId.getId()));
         expectedHistory.addAll(unaffectedTokenAllowancePair.getRight());
         expectedHistory.addAll(correctTokenAllowancePair.getRight());
+        tokenAllowancePreMigration.setTimestampUpper(contractResultConsensus);
+        expectedHistory.add(tokenAllowancePreMigration);
         assertThat(findHistory(TokenAllowance.class, idColumns)).containsExactlyInAnyOrderElementsOf(expectedHistory);
     }
 
@@ -113,6 +152,41 @@ class SyntheticTokenAllowanceOwnerMigrationTest extends IntegrationTest {
                 .contractResult()
                 .customize(c -> c.senderId(new EntityId(0L, 0L, newTokenAllowance.getOwner(), CONTRACT))
                         .consensusTimestamp(newTokenAllowance.getTimestampLower()))
+                .persist();
+
+        // A token allowance that has no contract result, but has primary key values that will end up matching those of
+        // a migrated token allowance.
+        var ownerAccountId = 3491438L;
+        var spender = 3491439L;
+        var tokenId = 3491444L;
+        domainBuilder
+                .tokenAllowance()
+                .customize(t -> t.owner(ownerAccountId)
+                        .payerAccountId(EntityId.of(ownerAccountId, CONTRACT))
+                        .spender(spender)
+                        .timestampRange(Range.atLeast(1676546171829734003L))
+                        .tokenId(tokenId))
+                .persist();
+
+        // A token allowance that has a contract result, once migrated it will have the same primary key fields as the
+        // above token allowance.
+        var ownerPreMigration = 1322L;
+        var contractResultConsensus = 1676546391434923004L;
+        domainBuilder
+                .tokenAllowance()
+                .customize(t -> t.owner(ownerPreMigration)
+                        .payerAccountId(EntityId.of(1322L, CONTRACT))
+                        .spender(spender)
+                        .timestampRange(Range.atLeast(contractResultConsensus))
+                        .tokenId(tokenId))
+                .persist();
+
+        // The contract result for the above token allowance
+        domainBuilder
+                .contractResult()
+                .customize(c -> c.senderId(EntityId.of(ownerAccountId, CONTRACT))
+                        .payerAccountId(EntityId.of(ownerPreMigration, CONTRACT))
+                        .consensusTimestamp(contractResultConsensus))
                 .persist();
 
         migration.doMigrate();


### PR DESCRIPTION
**Description**:
The migration now takes into account the possibility that the migrated token allowance could collide with an existing primary key. Token allowances that do not have contract results, yet would have the same primary key as a migrated token allowance, are now included in the token allowance history. 

**Related issue(s)**:

Fixes #5944 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
