### PR TITLE
Fix empty function_parameters in `/contracts/results/{id}` response

### DIFF
--- a/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/transactionid-or-hash-call-data-in-file.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/transactionid-or-hash-call-data-in-file.json
@@ -1,0 +1,182 @@
+{
+  "description": "Contract results api call using transactionId or an ethereum transaction hash with call data in file",
+  "setup": {
+    "entities": [
+      {
+        "num": 5001,
+        "evm_address": "0x25fe26adc577cc89172e6156c9e24f7b9751b762"
+      }
+    ],
+    "contractresults": [
+      {
+        "amount": 30,
+        "bloom": [5, 5],
+        "call_result": [6, 6],
+        "consensus_timestamp": "167654000123456",
+        "contract_id": 5001,
+        "created_contract_ids": [7001],
+        "error_message": "",
+        "function_parameters": [1, 2, 3, 4, 5, 6, 7, 8],
+        "function_result": [8, 8],
+        "gas_limit": 1000000,
+        "gas_used": 123,
+        "payer_account_id": 8001,
+        "sender_id": 8001,
+        "transaction_result": 22,
+        "transaction_hash": "4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6392",
+        "transaction_index": 1
+      }
+    ],
+    "contractlogs": [
+      {
+        "consensus_timestamp": "167654000123456",
+        "contract_id": 5001,
+        "index": 0,
+        "root_contract_id": 5001
+      },
+      {
+        "consensus_timestamp": "167654000123456",
+        "contract_id": 5002,
+        "index": 1,
+        "root_contract_id": 5001,
+        "topic2": null,
+        "topic3": null
+      },
+      {
+        "consensus_timestamp": "167654000123457",
+        "contract_id": 5001,
+        "index": 0
+      }
+    ],
+    "contractStateChanges": [
+      {
+        "consensus_timestamp": "167654000123456",
+        "contract_id": 5001,
+        "slot": [1, 1]
+      },
+      {
+        "consensus_timestamp": "167654000123456",
+        "contract_id": 5002,
+        "slot": [2, 2]
+      },
+      {
+        "consensus_timestamp": "167654000123456",
+        "contract_id": 5002,
+        "migration": true,
+        "slot": [3, 3]
+      }
+    ],
+    "recordFiles": [
+      {
+        "index": 17,
+        "gas_used": 50000000,
+        "consensus_start": 167654000123450,
+        "consensus_end": 167654000123460,
+        "hash": "6ceecd8bb224da491"
+      }
+    ],
+    "transactions": [
+      {
+        "consensus_timestamp": 167654000123456,
+        "payerAccountId": "8001",
+        "transaction_hash": "519a008fabde4d",
+        "type": 50,
+        "valid_start_timestamp": 167654000123400
+      }
+    ],
+    "ethereumtransactions": [
+      {
+        "call_data": "",
+        "call_data_id": 9120,
+        "consensus_timestamp": 167654000123456,
+        "hash": "4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6392",
+        "payer_account_id": "8001",
+        "value": "0x0077359400",
+        "_value_description": "2000000000 tinybars, in importer java BigInteger.toByteArray always adds extra 0x00"
+      }
+    ]
+  },
+  "urls": [
+    "/api/v1/contracts/results/0.0.8001-167654-000123400",
+    "/api/v1/contracts/results/0.0.8001-167654-000123400?nonce=0",
+    "/api/v1/contracts/results/0.0.8001-167654-000123400?nonce=1&nonce=0",
+    "/api/v1/contracts/results/4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6392",
+    "/api/v1/contracts/results/0x4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6392"
+  ],
+  "responseStatus": 200,
+  "responseJson": {
+    "access_list": "0x",
+    "amount": 2000000000,
+    "block_gas_used": 50000000,
+    "block_hash": "0x6ceecd8bb224da491",
+    "block_number": 17,
+    "bloom": "0x0505",
+    "call_result": "0x0606",
+    "chain_id": "0x",
+    "contract_id": "0.0.5001",
+    "created_contract_ids": ["0.0.7001"],
+    "error_message": null,
+    "address": "0x25fe26adc577cc89172e6156c9e24f7b9751b762",
+    "failed_initcode": null,
+    "from": "0x0000000000000000000000000000000000001f41",
+    "function_parameters": "0x0102030405060708",
+    "gas_limit": 1000000,
+    "gas_price": "0x4a817c80",
+    "gas_used": 123,
+    "hash": "0x4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6392",
+    "logs": [
+      {
+        "address": "0x25fe26adc577cc89172e6156c9e24f7b9751b762",
+        "bloom": "0x0123",
+        "contract_id": "0.0.5001",
+        "data": "0x0123",
+        "index": 0,
+        "topics": [
+          "0x97c1fc0a6ed5551bc831571325e9bdb365d06803100dc20648640ba24ce69750",
+          "0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925",
+          "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+          "0xe8d47b56e8cdfa95f871b19d4f50a857217c44a95502b0811a350fec1500dd67"
+        ]
+      },
+      {
+        "address": "0x000000000000000000000000000000000000138a",
+        "bloom": "0x0123",
+        "contract_id": "0.0.5002",
+        "data": "0x0123",
+        "index": 1,
+        "topics": [
+          "0x97c1fc0a6ed5551bc831571325e9bdb365d06803100dc20648640ba24ce69750",
+          "0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925"
+        ]
+      }
+    ],
+    "max_fee_per_gas": "0x",
+    "max_priority_fee_per_gas": "0x",
+    "nonce": 1,
+    "r": "0xd693b532a80fed6392b428604171fb32fdbf953728a3a7ecc7d4062b1652c042",
+    "result": "SUCCESS",
+    "s": "0x24e9c602ac800b983b035700a14b23f78a253ab762deab5dc27e3555a750b354",
+    "state_changes": [
+      {
+        "address": "0x25fe26adc577cc89172e6156c9e24f7b9751b762",
+        "contract_id": "0.0.5001",
+        "slot": "0x0000000000000000000000000000000000000000000000000000000000000101",
+        "value_read": "0x0000000000000000000000000000000000000000000000000000000000000101",
+        "value_written": "0x000000000000000000000000000000000000000000000000000000000000a1a1"
+      },
+      {
+        "address": "0x000000000000000000000000000000000000138a",
+        "contract_id": "0.0.5002",
+        "slot": "0x0000000000000000000000000000000000000000000000000000000000000202",
+        "value_read": "0x0000000000000000000000000000000000000000000000000000000000000101",
+        "value_written": "0x000000000000000000000000000000000000000000000000000000000000a1a1"
+      }
+    ],
+    "status": "0x1",
+    "timestamp": "167654.000123456",
+    "to": "0x0000000000000000000000000000000000001389",
+    "transaction_index": 1,
+    "type": 2,
+    "v": 1
+  }
+}

--- a/hedera-mirror-rest/viewmodel/contractResultDetailsViewModel.js
+++ b/hedera-mirror-rest/viewmodel/contractResultDetailsViewModel.js
@@ -105,7 +105,7 @@ class ContractResultDetailsViewModel extends ContractResultViewModel {
       this.type = ethTransaction.type;
       this.v = ethTransaction.recoveryId;
 
-      if (!_.isNil(ethTransaction.callData)) {
+      if (!_.isEmpty(ethTransaction.callData)) {
         this.function_parameters = utils.toHexStringNonQuantity(ethTransaction.callData);
       } else if (!contractResult.functionParameters.length && !_.isNil(fileData)) {
         this.function_parameters = utils.toHexStringNonQuantity(fileData.file_data);


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR fixes the empty function_parameters in certain `/contracts/results/{id}` response

- Do not override function_parameters if `ethTransaction.callData` is empty

**Related issue(s)**:

Fixes #5279 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
