### PR TITLE
* add transaction_nonce integer not null column to contract_result table

### DIFF
--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/contract/ContractResult.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/contract/ContractResult.java
@@ -82,6 +82,8 @@ public class ContractResult implements Persistable<Long> {
 
     private Integer transactionIndex;
 
+    private Integer transactionNonce;
+
     private Integer transactionResult;
 
     @JsonIgnore

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/ContractResultServiceImpl.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/ContractResultServiceImpl.java
@@ -183,6 +183,7 @@ public class ContractResultServiceImpl implements ContractResultService {
         contractResult.setPayerAccountId(recordItem.getPayerAccountId());
         contractResult.setTransactionHash(transactionHash);
         contractResult.setTransactionIndex(transaction.getIndex());
+        contractResult.setTransactionNonce(transaction.getNonce());
         contractResult.setTransactionResult(transaction.getResult());
         transactionHandler.updateContractResult(contractResult, recordItem);
 

--- a/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.79.0__add_transaction_nonce_to_contract_result.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.79.0__add_transaction_nonce_to_contract_result.sql
@@ -1,0 +1,9 @@
+-- copy nonce from transaction to contract_result
+alter table if exists contract_result
+    add column if not exists transaction_nonce integer not null;
+
+update contract_result cr
+set transaction_nonce = t.nonce
+from transaction t
+where cr.consensus_timestamp = t.consensus_timestamp
+and cr.transaction_index = t.index;

--- a/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.0__create_tables.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.0__create_tables.sql
@@ -151,6 +151,7 @@ create table if not exists contract_result
     sender_id            bigint       null,
     transaction_hash     bytea        null,
     transaction_index    integer      null,
+    transaction_nonce    integer      not null,
     transaction_result   smallint     not null
 ) partition by range (consensus_timestamp);
 comment on table contract_result is 'Crypto contract execution results';

--- a/hedera-mirror-rest/__tests__/controllers/contractController.test.js
+++ b/hedera-mirror-rest/__tests__/controllers/contractController.test.js
@@ -429,7 +429,7 @@ describe('getLastNonceParamValue', () => {
 describe('extractContractResultsByIdQuery', () => {
   const defaultContractId = 1;
   const defaultExpected = {
-    conditions: [primaryContractFilter, 't.nonce = $2'],
+    conditions: [primaryContractFilter, 'cr.transaction_nonce = $2'],
     params: [defaultContractId, 0],
     order: constants.orderFilterValues.DESC,
     limit: defaultLimit,
@@ -502,7 +502,7 @@ describe('extractContractResultsByIdQuery', () => {
         conditions: [
           primaryContractFilter,
           'cr.payer_account_id > $2',
-          't.nonce = $3',
+          'cr.transaction_nonce = $3',
           'cr.payer_account_id in ($4,$5)',
         ],
         params: [defaultContractId, '1000', 0, '1001', '1002'],
@@ -535,7 +535,7 @@ describe('extractContractResultsByIdQuery', () => {
         conditions: [
           primaryContractFilter,
           'cr.consensus_timestamp > $2',
-          't.nonce = $3',
+          'cr.transaction_nonce = $3',
           'cr.consensus_timestamp in ($4,$5)',
         ],
         params: [defaultContractId, '1000', 0, '1001', '1002'],

--- a/hedera-mirror-rest/__tests__/integrationDomainOps.js
+++ b/hedera-mirror-rest/__tests__/integrationDomainOps.js
@@ -1016,6 +1016,7 @@ const contractResultDefaults = {
   payer_account_id: DEFAULT_PAYER_ACCOUNT_ID,
   transaction_hash: Buffer.from([...Array(32).keys()]),
   transaction_index: 1,
+  transaction_nonce: 0,
   transaction_result: 22,
 };
 

--- a/hedera-mirror-rest/__tests__/service/contractService.test.js
+++ b/hedera-mirror-rest/__tests__/service/contractService.test.js
@@ -52,6 +52,7 @@ describe('ContractService.getContractResultsByIdAndFiltersQuery tests', () => {
             cr.sender_id,
             cr.transaction_hash,
             cr.transaction_index,
+            cr.transaction_nonce,
             cr.transaction_result,
             coalesce(e.evm_address,'') as evm_address
         from contract_result cr
@@ -89,6 +90,7 @@ describe('ContractService.getContractResultsByIdAndFiltersQuery tests', () => {
         cr.sender_id,
         cr.transaction_hash,
         cr.transaction_index,
+        cr.transaction_nonce,
         cr.transaction_result,
         coalesce(e.evm_address,'') as evm_address
     from contract_result cr
@@ -101,7 +103,7 @@ describe('ContractService.getContractResultsByIdAndFiltersQuery tests', () => {
   });
 
   test('Verify transaction.nonce condition', async () => {
-    const additionalConditions = ['cr.contract_id = $1', 't.nonce = $2'];
+    const additionalConditions = ['cr.contract_id = $1', 'cr.transaction_nonce = $2'];
     const [query, params] = ContractService.getContractResultsByIdAndFiltersQuery(
       additionalConditions,
       [2, 10],
@@ -109,8 +111,7 @@ describe('ContractService.getContractResultsByIdAndFiltersQuery tests', () => {
       5
     );
     const expected = `
-    with entity as (select evm_address,id from entity),
-        t as (select consensus_timestamp, index, nonce from transaction where transaction.nonce = $2)
+    with entity as (select evm_address,id from entity)
     select
         cr.amount,
         cr.bloom,
@@ -127,12 +128,12 @@ describe('ContractService.getContractResultsByIdAndFiltersQuery tests', () => {
         cr.sender_id,
         cr.transaction_hash,
         cr.transaction_index,
+        cr.transaction_nonce,
         cr.transaction_result,
         coalesce(e.evm_address,'') as evm_address
     from contract_result cr
     left join entity e on e.id = cr.contract_id
-    join t on cr.consensus_timestamp = t.consensus_timestamp
-    where cr.contract_id = $1 and t.nonce = $2
+    where cr.contract_id = $1 and cr.transaction_nonce = $2
     order by cr.consensus_timestamp asc
     limit $3
     `;
@@ -141,7 +142,7 @@ describe('ContractService.getContractResultsByIdAndFiltersQuery tests', () => {
   });
 
   test('Verify transaction.index condition', async () => {
-    const additionalConditions = ['cr.contract_id = $1', 't.index = $2'];
+    const additionalConditions = ['cr.contract_id = $1', 'cr.transaction_index = $2'];
     const [query, params] = ContractService.getContractResultsByIdAndFiltersQuery(
       additionalConditions,
       [2, 10],
@@ -149,8 +150,7 @@ describe('ContractService.getContractResultsByIdAndFiltersQuery tests', () => {
       5
     );
     const expected = `
-    with  entity as (select evm_address,id from entity),
-        t as (select consensus_timestamp, index, nonce from transaction where transaction.index = $2)
+    with  entity as (select evm_address,id from entity)
     select
         cr.amount,
         cr.bloom,
@@ -167,12 +167,12 @@ describe('ContractService.getContractResultsByIdAndFiltersQuery tests', () => {
         cr.sender_id,
         cr.transaction_hash,
         cr.transaction_index,
+        cr.transaction_nonce,
         cr.transaction_result,
         coalesce(e.evm_address,'') as evm_address
     from contract_result cr
     left join entity e on e.id = cr.contract_id
-    join t on cr.consensus_timestamp = t.consensus_timestamp
-    where cr.contract_id = $1 and t.index = $2
+    where cr.contract_id = $1 and cr.transaction_index = $2
     order by cr.consensus_timestamp asc
     limit $3
     `;
@@ -472,6 +472,7 @@ describe('ContractService.getContractResultsByIdAndFilters tests', () => {
         consensus_timestamp: 1,
         function_parameters: '0x0D',
         amount: 10,
+        transaction_nonce: 1,
       },
     ]);
 
@@ -482,6 +483,7 @@ describe('ContractService.getContractResultsByIdAndFilters tests', () => {
         consensusTimestamp: 1,
         gasLimit: 1000,
         gasUsed: null,
+        transactionNonce: 1,
       },
     ];
 
@@ -497,6 +499,7 @@ describe('ContractService.getContractResultsByIdAndFilters tests', () => {
         function_parameters: '0x0D',
         amount: 10,
         payer_account_id: 123,
+        transaction_nonce: 2,
       },
       {
         contract_id: 2,
@@ -504,6 +507,7 @@ describe('ContractService.getContractResultsByIdAndFilters tests', () => {
         function_parameters: '0x0D',
         amount: 10,
         payer_account_id: 123,
+        transaction_nonce: 3,
       },
     ]);
 
@@ -515,6 +519,7 @@ describe('ContractService.getContractResultsByIdAndFilters tests', () => {
         gasLimit: 1000,
         gasUsed: null,
         payerAccountId: 123,
+        transactionNonce: 3,
       },
     ];
 
@@ -530,6 +535,7 @@ describe('ContractService.getContractResultsByIdAndFilters tests', () => {
         function_parameters: '0x0D',
         amount: 10,
         payer_account_id: 123,
+        transaction_nonce: 4,
       },
       {
         contract_id: 2,
@@ -537,6 +543,7 @@ describe('ContractService.getContractResultsByIdAndFilters tests', () => {
         function_parameters: '0x0D',
         amount: 10,
         payer_account_id: 123,
+        transaction_nonce: 5,
       },
       {
         contract_id: 3,
@@ -544,6 +551,7 @@ describe('ContractService.getContractResultsByIdAndFilters tests', () => {
         function_parameters: '0x0D',
         amount: 10,
         payer_account_id: 124,
+        transaction_nonce: 6,
       },
       {
         contract_id: 3,
@@ -551,6 +559,7 @@ describe('ContractService.getContractResultsByIdAndFilters tests', () => {
         function_parameters: '0x0D',
         amount: 10,
         payer_account_id: 124,
+        transaction_nonce: 7,
       },
       {
         contract_id: 3,
@@ -558,6 +567,7 @@ describe('ContractService.getContractResultsByIdAndFilters tests', () => {
         function_parameters: '0x0D',
         amount: 10,
         payer_account_id: 124,
+        transaction_nonce: 8,
       },
     ]);
 
@@ -566,11 +576,13 @@ describe('ContractService.getContractResultsByIdAndFilters tests', () => {
         contractId: 3,
         consensusTimestamp: 3,
         payerAccountId: 124,
+        transactionNonce: 6,
       },
       {
         contractId: 3,
         consensusTimestamp: 4,
         payerAccountId: 124,
+        transactionNonce: 7,
       },
     ];
 
@@ -683,6 +695,7 @@ describe('ContractService.getContractResultsByTimestamps tests', () => {
       function_parameters: '0x0D',
       amount: 10,
       payer_account_id: '5',
+      transaction_nonce: 9,
     },
     {
       contract_id: 3,
@@ -690,6 +703,7 @@ describe('ContractService.getContractResultsByTimestamps tests', () => {
       function_parameters: '0x0D',
       amount: 15,
       payer_account_id: '5',
+      transaction_nonce: 10,
     },
   ];
   const expected = [
@@ -703,6 +717,7 @@ describe('ContractService.getContractResultsByTimestamps tests', () => {
       gasLimit: 1000,
       gasUsed: null,
       payerAccountId: 5,
+      transactionNonce: 9,
     },
     {
       amount: 15,
@@ -714,6 +729,7 @@ describe('ContractService.getContractResultsByTimestamps tests', () => {
       gasLimit: 1000,
       gasUsed: null,
       payerAccountId: 5,
+      transactionNonce: 10,
     },
   ];
 
@@ -729,6 +745,7 @@ describe('ContractService.getContractResultsByTimestamps tests', () => {
         'gasLimit',
         'gasUsed',
         'payerAccountId',
+        'transactionNonce',
       ])
     );
   };
@@ -1181,6 +1198,7 @@ describe('ContractService.getContractResultsByHash tests', () => {
       transaction_result: successTransactionResult,
       transaction_index: 1,
       transaction_hash: ethereumTxHash,
+      transaction_nonce: 11,
       gasLimit: 1000,
     },
     {
@@ -1190,6 +1208,7 @@ describe('ContractService.getContractResultsByHash tests', () => {
       transaction_result: duplicateTransactionResult,
       transaction_index: 1,
       transaction_hash: ethereumTxHash,
+      transaction_nonce: 12,
       gasLimit: 1000,
     },
     {
@@ -1199,6 +1218,7 @@ describe('ContractService.getContractResultsByHash tests', () => {
       transaction_result: wrongNonceTransactionResult,
       transaction_index: 1,
       transaction_hash: ethereumTxHash,
+      transaction_nonce: 13,
       gasLimit: 1000,
     },
     {
@@ -1208,6 +1228,7 @@ describe('ContractService.getContractResultsByHash tests', () => {
       transaction_result: successTransactionResult,
       transaction_index: 1,
       transaction_hash: ethereumTxHash,
+      transaction_nonce: 14,
       gasLimit: 1000,
     },
     {
@@ -1215,6 +1236,7 @@ describe('ContractService.getContractResultsByHash tests', () => {
       payerAccountId: 10,
       type: contractCreateType,
       transaction_hash: '96ecf2e0cf1c8f7e2294ec731b2ad1aff95d9736f4ba15b5bbace1ad2766cc1c',
+      transaction_nonce: 15,
       gasLimit: 1000,
     },
   ];

--- a/hedera-mirror-rest/__tests__/specs/contracts/results/all-params.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/all-params.json
@@ -33,7 +33,8 @@
         "gas_limit": 1234556,
         "gas_used": 987,
         "payer_account_id": 6001,
-        "transaction_hash": "0x160502030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+        "transaction_hash": "0x160502030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_nonce": 0
       },
       {
         "amount": 30,
@@ -48,7 +49,8 @@
         "gas_limit": 987654,
         "gas_used": 123,
         "payer_account_id": 8001,
-        "transaction_hash": "0x170502030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+        "transaction_hash": "0x170502030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_nonce": 0
       }
     ],
     "transactions": [

--- a/hedera-mirror-rest/__tests__/specs/contracts/results/block-hash.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/block-hash.json
@@ -33,7 +33,8 @@
         "gas_limit": 1234556,
         "gas_used": 987,
         "payer_account_id": 6001,
-        "transaction_hash": "0x185602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+        "transaction_hash": "0x185602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_nonce": 0
       },
       {
         "amount": 30,
@@ -48,7 +49,8 @@
         "gas_limit": 987654,
         "gas_used": 123,
         "payer_account_id": 8001,
-        "transaction_hash": "0x164002030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+        "transaction_hash": "0x164002030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_nonce": 0
       }
     ],
     "transactions": [

--- a/hedera-mirror-rest/__tests__/specs/contracts/results/block-number.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/block-number.json
@@ -33,7 +33,8 @@
         "gas_limit": 1234556,
         "gas_used": 987,
         "payer_account_id": 6001,
-        "transaction_hash": "0x111102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+        "transaction_hash": "0x111102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_nonce": 0
       },
       {
         "amount": 30,
@@ -48,7 +49,8 @@
         "gas_limit": 987654,
         "gas_used": 123,
         "payer_account_id": 8001,
-        "transaction_hash": "0x222202030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+        "transaction_hash": "0x222202030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_nonce": 0
       },
       {
         "amount": 20,
@@ -63,7 +65,8 @@
         "gas_limit": 1234556,
         "gas_used": 987,
         "payer_account_id": 7001,
-        "transaction_hash": "0x333302030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+        "transaction_hash": "0x333302030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_nonce": 0
       },
       {
         "amount": 20,

--- a/hedera-mirror-rest/__tests__/specs/contracts/results/internal-false.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/internal-false.json
@@ -33,7 +33,8 @@
         "gas_limit": 1234556,
         "gas_used": 987,
         "payer_account_id": 6001,
-        "transaction_hash": "0x185602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+        "transaction_hash": "0x185602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_nonce": 0
       },
       {
         "amount": 30,
@@ -48,7 +49,8 @@
         "gas_limit": 987654,
         "gas_used": 123,
         "payer_account_id": 8001,
-        "transaction_hash": "0x985602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+        "transaction_hash": "0x985602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_nonce": 1
       }
     ],
     "transactions": [

--- a/hedera-mirror-rest/__tests__/specs/contracts/results/internal-true.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/internal-true.json
@@ -33,7 +33,8 @@
         "gas_limit": 1234556,
         "gas_used": 987,
         "payer_account_id": 6001,
-        "transaction_hash": "0x185602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+        "transaction_hash": "0x185602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_nonce": 0
       },
       {
         "amount": 30,
@@ -48,7 +49,8 @@
         "gas_limit": 987654,
         "gas_used": 123,
         "payer_account_id": 8001,
-        "transaction_hash": "0x985602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+        "transaction_hash": "0x985602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_nonce": 1
       },
       {
         "amount": 30,
@@ -63,7 +65,8 @@
         "gas_limit": 987654,
         "gas_used": 123,
         "payer_account_id": 8001,
-        "transaction_hash": "0x995602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+        "transaction_hash": "0x995602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_nonce": 2
       }
     ],
     "transactions": [

--- a/hedera-mirror-rest/__tests__/specs/contracts/results/limit.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/limit.json
@@ -33,7 +33,8 @@
         "gas_limit": 1234556,
         "gas_used": 987,
         "payer_account_id": 6001,
-        "transaction_hash": "0x185602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+        "transaction_hash": "0x185602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_nonce": 0
       },
       {
         "amount": 30,
@@ -48,7 +49,8 @@
         "gas_limit": 987654,
         "gas_used": 123,
         "payer_account_id": 8001,
-        "transaction_hash": "0x985602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+        "transaction_hash": "0x985602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_nonce": 0
       }
     ],
     "transactions": [

--- a/hedera-mirror-rest/__tests__/specs/contracts/results/no-params.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/no-params.json
@@ -33,7 +33,8 @@
         "gas_limit": 1234556,
         "gas_used": 987,
         "payer_account_id": 6001,
-        "transaction_hash": "0x185602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+        "transaction_hash": "0x185602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_nonce": 0
       },
       {
         "amount": 30,
@@ -48,7 +49,8 @@
         "gas_limit": 987654,
         "gas_used": 123,
         "payer_account_id": 8001,
-        "transaction_hash": "0x985602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+        "transaction_hash": "0x985602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_nonce": 0
       }
     ],
     "transactions": [

--- a/hedera-mirror-rest/__tests__/specs/contracts/results/order.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/order.json
@@ -33,7 +33,8 @@
         "gas_limit": 1234556,
         "gas_used": 987,
         "payer_account_id": 6001,
-        "transaction_hash": "0x185602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+        "transaction_hash": "0x185602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_nonce": 0
       },
       {
         "amount": 30,
@@ -48,7 +49,8 @@
         "gas_limit": 987654,
         "gas_used": 123,
         "payer_account_id": 8001,
-        "transaction_hash": "0x985602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+        "transaction_hash": "0x985602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_nonce": 0
       }
     ],
     "transactions": [

--- a/hedera-mirror-rest/__tests__/specs/contracts/results/timestamp.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/timestamp.json
@@ -33,7 +33,8 @@
         "gas_limit": 1234556,
         "gas_used": 987,
         "payer_account_id": 6001,
-        "transaction_hash": "0x185602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+        "transaction_hash": "0x185602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_nonce": 0
       },
       {
         "amount": 30,
@@ -48,7 +49,8 @@
         "gas_limit": 987654,
         "gas_used": 123,
         "payer_account_id": 8001,
-        "transaction_hash": "0x985602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+        "transaction_hash": "0x985602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_nonce": 0
       }
     ],
     "transactions": [

--- a/hedera-mirror-rest/__tests__/specs/contracts/results/transaction-index-isolated.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/transaction-index-isolated.json
@@ -32,7 +32,8 @@
         "function_result": [4, 4],
         "gas_limit": 1234556,
         "gas_used": 987,
-        "payer_account_id": 6001
+        "payer_account_id": 6001,
+        "transaction_nonce": 0
       },
       {
         "amount": 30,
@@ -46,7 +47,8 @@
         "function_result": [8, 8],
         "gas_limit": 987654,
         "gas_used": 123,
-        "payer_account_id": 8001
+        "payer_account_id": 8001,
+        "transaction_nonce": 0
       }
     ],
     "transactions": [

--- a/hedera-mirror-rest/__tests__/specs/contracts/results/transaction-index.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/transaction-index.json
@@ -33,7 +33,9 @@
         "gas_limit": 1234556,
         "gas_used": 987,
         "payer_account_id": 6001,
-        "transaction_hash": "0x181202030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+        "transaction_hash": "0x181202030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_index": 1,
+        "transaction_nonce": 0
       },
       {
         "amount": 30,
@@ -48,7 +50,9 @@
         "gas_limit": 987654,
         "gas_used": 123,
         "payer_account_id": 8001,
-        "transaction_hash": "0x981202030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+        "transaction_hash": "0x981202030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_index": 1,
+        "transaction_nonce": 0
       },
       {
         "amount": 35,
@@ -63,7 +67,9 @@
         "gas_limit": 987654,
         "gas_used": 123,
         "payer_account_id": 8001,
-        "transaction_hash": "0x985702030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+        "transaction_hash": "0x985702030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_index": 2,
+        "transaction_nonce": 0
       },
       {
         "amount": 30,
@@ -78,7 +84,9 @@
         "gas_limit": 987654,
         "gas_used": 123,
         "payer_account_id": 8001,
-        "transasction_hash": "0x995602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+        "transaction_hash": "0x995602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_index": 2,
+        "transaction_nonce": 0
       }
     ],
     "transactions": [

--- a/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/actions/all-params.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/actions/all-params.json
@@ -33,7 +33,8 @@
         "gas_limit": 1234556,
         "gas_used": 987,
         "payer_account_id": 5001,
-        "transaction_hash": "0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb98"
+        "transaction_hash": "0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb98",
+        "transaction_nonce": 0
       },
       {
         "amount": 30,
@@ -48,7 +49,8 @@
         "gas_limit": 987654,
         "gas_used": 123,
         "payer_account_id": 8001,
-        "transaction_hash": "0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb99"
+        "transaction_hash": "0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb99",
+        "transaction_nonce": 0
       }
     ],
     "transactions": [

--- a/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/actions/empty-result.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/actions/empty-result.json
@@ -33,7 +33,8 @@
         "gas_limit": 1234556,
         "gas_used": 987,
         "payer_account_id": 6001,
-        "transaction_hash": "0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb98"
+        "transaction_hash": "0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb98",
+        "transaction_nonce": 0
       },
       {
         "amount": 30,
@@ -48,7 +49,8 @@
         "gas_limit": 987654,
         "gas_used": 123,
         "payer_account_id": 8001,
-        "transaction_hash": "0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb99"
+        "transaction_hash": "0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb99",
+        "transaction_nonce": 0
       }
     ],
     "transactions": [

--- a/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/actions/index-filter.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/actions/index-filter.json
@@ -33,7 +33,8 @@
         "gas_limit": 1234556,
         "gas_used": 987,
         "payer_account_id": 5001,
-        "transaction_hash": "0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb98"
+        "transaction_hash": "0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb98",
+        "transaction_nonce": 0
       },
       {
         "amount": 30,
@@ -48,7 +49,8 @@
         "gas_limit": 987654,
         "gas_used": 123,
         "payer_account_id": 8001,
-        "transaction_hash": "0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb99"
+        "transaction_hash": "0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb99",
+        "transaction_nonce": 0
       }
     ],
     "transactions": [

--- a/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/actions/limit-and-order-desc.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/actions/limit-and-order-desc.json
@@ -33,7 +33,8 @@
         "gas_limit": 1234556,
         "gas_used": 987,
         "payer_account_id": 5001,
-        "transaction_hash": "0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb98"
+        "transaction_hash": "0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb98",
+        "transaction_nonce": 0
       },
       {
         "amount": 30,
@@ -48,7 +49,8 @@
         "gas_limit": 987654,
         "gas_used": 123,
         "payer_account_id": 8001,
-        "transaction_hash": "0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb99"
+        "transaction_hash": "0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb99",
+        "transaction_nonce": 0
       }
     ],
     "transactions": [

--- a/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/actions/limit.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/actions/limit.json
@@ -33,7 +33,8 @@
         "gas_limit": 1234556,
         "gas_used": 987,
         "payer_account_id": 5001,
-        "transaction_hash": "0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb98"
+        "transaction_hash": "0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb98",
+        "transaction_nonce": 0
       },
       {
         "amount": 30,
@@ -48,7 +49,8 @@
         "gas_limit": 987654,
         "gas_used": 123,
         "payer_account_id": 8001,
-        "transaction_hash": "0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb99"
+        "transaction_hash": "0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb99",
+        "transaction_nonce": 0
       }
     ],
     "transactions": [

--- a/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/actions/no-params.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/actions/no-params.json
@@ -33,7 +33,8 @@
         "gas_limit": 1234556,
         "gas_used": 987,
         "payer_account_id": 5001,
-        "transaction_hash": "0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb98"
+        "transaction_hash": "0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb98",
+        "transaction_nonce": 0
       },
       {
         "amount": 30,
@@ -48,7 +49,8 @@
         "gas_limit": 987654,
         "gas_used": 123,
         "payer_account_id": 8001,
-        "transaction_hash": "0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb99"
+        "transaction_hash": "0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb99",
+        "transaction_nonce": 0
       }
     ],
     "transactions": [

--- a/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/actions/order-asc.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/actions/order-asc.json
@@ -33,7 +33,8 @@
         "gas_limit": 1234556,
         "gas_used": 987,
         "payer_account_id": 5001,
-        "transaction_hash": "0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb98"
+        "transaction_hash": "0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb98",
+        "transaction_nonce": 0
       },
       {
         "amount": 30,
@@ -48,7 +49,8 @@
         "gas_limit": 987654,
         "gas_used": 123,
         "payer_account_id": 8001,
-        "transaction_hash": "0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb99"
+        "transaction_hash": "0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb99",
+        "transaction_nonce": 0
       }
     ],
     "transactions": [

--- a/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/actions/order-desc.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/actions/order-desc.json
@@ -33,7 +33,8 @@
         "gas_limit": 1234556,
         "gas_used": 987,
         "payer_account_id": 5001,
-        "transaction_hash": "0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb98"
+        "transaction_hash": "0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb98",
+        "transaction_nonce": 0
       },
       {
         "amount": 30,
@@ -48,7 +49,8 @@
         "gas_limit": 987654,
         "gas_used": 123,
         "payer_account_id": 8001,
-        "transaction_hash": "0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb99"
+        "transaction_hash": "0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb99",
+        "transaction_nonce": 0
       }
     ],
     "transactions": [

--- a/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/by-hash-no-eth-tx.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/by-hash-no-eth-tx.json
@@ -15,8 +15,9 @@
         "payer_account_id": 8001,
         "sender_id": 8001,
         "transaction_hash": "4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6392",
-        "transaction_result": 22,
-        "transaction_index": 1
+        "transaction_index": 1,
+        "transaction_nonce": 0,
+        "transaction_result": 22
       }
     ],
     "contractlogs": [

--- a/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/by-hash-nonce-is-ignored.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/by-hash-nonce-is-ignored.json
@@ -18,7 +18,8 @@
         "sender_id": 8001,
         "transaction_result": 22,
         "transaction_hash": "4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6392",
-        "transaction_index": 1
+        "transaction_index": 1,
+        "transaction_nonce": 0
       }
     ],
     "contractlogs": [

--- a/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/failed-contractcreate-eth-calldata.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/failed-contractcreate-eth-calldata.json
@@ -19,7 +19,8 @@
         "sender_id": 8001,
         "transaction_result": 33,
         "transaction_hash": "4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6392",
-        "transaction_index": 1
+        "transaction_index": 1,
+        "transaction_nonce": 0
       }
     ],
     "recordFiles": [

--- a/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/failed-contractcreate.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/failed-contractcreate.json
@@ -19,7 +19,8 @@
         "sender_id": 8001,
         "transaction_result": 33,
         "transaction_hash": "4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6392",
-        "transaction_index": 1
+        "transaction_index": 1,
+        "transaction_nonce": 0
       }
     ],
     "recordFiles": [

--- a/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/invalid-transactionid-or-hash.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/invalid-transactionid-or-hash.json
@@ -14,7 +14,8 @@
         "function_result": [8, 8],
         "gas_limit": 987654,
         "gas_used": 123,
-        "payer_account_id": 8001
+        "payer_account_id": 8001,
+        "transaction_nonce": 0
       }
     ],
     "recordFiles": [

--- a/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/missing-transaction.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/missing-transaction.json
@@ -17,7 +17,8 @@
         "payer_account_id": 8001,
         "transaction_result": 22,
         "transaction_hash": "4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6393",
-        "transaction_index": 1
+        "transaction_index": 1,
+        "transaction_nonce": 1
       }
     ],
     "recordFiles": [],

--- a/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/multiple-single-result.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/multiple-single-result.json
@@ -18,7 +18,8 @@
         "sender_id": 8001,
         "transaction_result": 22,
         "transaction_hash": "4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6392",
-        "transaction_index": 1
+        "transaction_index": 1,
+        "transaction_nonce": 0
       }
     ],
     "contractlogs": [

--- a/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/multiple-transactions.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/multiple-transactions.json
@@ -14,7 +14,8 @@
         "function_result": [8, 8],
         "gas_limit": 987654,
         "gas_used": 123,
-        "payer_account_id": 8001
+        "payer_account_id": 8001,
+        "transaction_nonce": 0
       }
     ],
     "recordFiles": [

--- a/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/no-evm-address.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/no-evm-address.json
@@ -18,7 +18,8 @@
         "sender_id": 8001,
         "transaction_result": 22,
         "transaction_hash": "4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6392",
-        "transaction_index": 1
+        "transaction_index": 1,
+        "transaction_nonce": 0
       }
     ],
     "contractlogs": [

--- a/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/non-eth-tx-result-not-found.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/non-eth-tx-result-not-found.json
@@ -6,7 +6,8 @@
         "amount": 30,
         "consensus_timestamp": "167654000123457",
         "contract_id": 5001,
-        "payer_account_id": 8001
+        "payer_account_id": 8001,
+        "transaction_nonce": 0
       }
     ],
     "recordFiles": [

--- a/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/result-partial-result.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/result-partial-result.json
@@ -11,7 +11,8 @@
         "sender_id": 8001,
         "transaction_result": 33,
         "transaction_hash": "4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6392",
-        "transaction_index": 1
+        "transaction_index": 1,
+        "transaction_nonce": 0
       }
     ],
     "recordFiles": [

--- a/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/transaction-hash-match-multiple-tx.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/transaction-hash-match-multiple-tx.json
@@ -18,7 +18,8 @@
         "sender_id": 8001,
         "transaction_result": 22,
         "transaction_hash": "4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6392",
-        "transaction_index": 1
+        "transaction_index": 1,
+        "transaction_nonce": 0
       },
       {
         "amount": 30,
@@ -36,7 +37,8 @@
         "sender_id": 8001,
         "transaction_result": 22,
         "transaction_hash": "4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6392",
-        "transaction_index": 1
+        "transaction_index": 1,
+        "transaction_nonce": 0
       },
       {
         "amount": 30,
@@ -54,7 +56,8 @@
         "sender_id": 8001,
         "transaction_result": 312,
         "transaction_hash": "4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6392",
-        "transaction_index": 1
+        "transaction_index": 1,
+        "transaction_nonce": 0
       }
     ],
     "recordFiles": [

--- a/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/transactionid-or-hash-call-data-in-file.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/transactionid-or-hash-call-data-in-file.json
@@ -24,7 +24,8 @@
         "sender_id": 8001,
         "transaction_result": 22,
         "transaction_hash": "4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6392",
-        "transaction_index": 1
+        "transaction_index": 1,
+        "transaction_nonce": 0
       }
     ],
     "contractlogs": [

--- a/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/transactionid-or-hash.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/transactionid-or-hash.json
@@ -24,7 +24,8 @@
         "sender_id": 8001,
         "transaction_result": 22,
         "transaction_hash": "4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6392",
-        "transaction_index": 1
+        "transaction_index": 1,
+        "transaction_nonce": 0
       }
     ],
     "contractlogs": [

--- a/hedera-mirror-rest/__tests__/specs/contracts/{id}/results/all-params-with-create2.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/{id}/results/all-params-with-create2.json
@@ -26,7 +26,8 @@
         "call_result": [2, 2],
         "consensus_timestamp": "187654000123456",
         "contract_id": 5001,
-        "gas_used": 101
+        "gas_used": 101,
+        "transaction_nonce": 0
       },
       {
         "amount": 30,
@@ -36,7 +37,8 @@
         "contract_id": 5001,
         "created_contract_ids": [7001],
         "payer_account_id": 8001,
-        "gas_used": 102
+        "gas_used": 102,
+        "transaction_nonce": 0
       },
       {
         "amount": 40,
@@ -47,7 +49,8 @@
         "created_contract_ids": [7002],
         "payer_account_id": 8001,
         "gas_used": 103,
-        "transaction_hash": "0x880102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+        "transaction_hash": "0x880102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_nonce": 0
       },
       {
         "amount": 50,
@@ -57,7 +60,8 @@
         "contract_id": 5001,
         "created_contract_ids": [7003],
         "payer_account_id": 8001,
-        "gas_used": 104
+        "gas_used": 104,
+        "transaction_nonce": 0
       }
     ],
     "transactions": [

--- a/hedera-mirror-rest/__tests__/specs/contracts/{id}/results/all-params.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/{id}/results/all-params.json
@@ -8,7 +8,9 @@
         "call_result": [2, 2],
         "consensus_timestamp": "187654000123456",
         "contract_id": 5001,
-        "gas_used": 101
+        "gas_used": 101,
+        "transaction_index": 1,
+        "transaction_nonce": 0
       },
       {
         "amount": 30,
@@ -18,7 +20,9 @@
         "contract_id": 5001,
         "created_contract_ids": [7001],
         "payer_account_id": 8001,
-        "gas_used": 102
+        "gas_used": 102,
+        "transaction_index": 2,
+        "transaction_nonce": 0
       },
       {
         "amount": 40,
@@ -28,7 +32,9 @@
         "contract_id": 5001,
         "created_contract_ids": [7002],
         "payer_account_id": 8001,
-        "gas_used": 103
+        "gas_used": 103,
+        "transaction_index": 3,
+        "transaction_nonce": 0
       },
       {
         "amount": 50,
@@ -38,7 +44,9 @@
         "contract_id": 5001,
         "created_contract_ids": [7003],
         "payer_account_id": 8001,
-        "gas_used": 104
+        "gas_used": 104,
+        "transaction_index": 4,
+        "transaction_nonce": 0
       }
     ],
     "transactions": [

--- a/hedera-mirror-rest/__tests__/specs/contracts/{id}/results/block-hash.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/{id}/results/block-hash.json
@@ -26,7 +26,8 @@
         "call_result": [2, 2],
         "consensus_timestamp": "187654000123456",
         "contract_id": 5001,
-        "gas_used": 100
+        "gas_used": 100,
+        "transaction_nonce": 0
       },
       {
         "amount": 30,
@@ -35,7 +36,8 @@
         "consensus_timestamp": "987654000123456",
         "contract_id": 5001,
         "created_contract_ids": [7001],
-        "gas_used": 10
+        "gas_used": 10,
+        "transaction_nonce": 0
       }
     ],
     "transactions": [

--- a/hedera-mirror-rest/__tests__/specs/contracts/{id}/results/block-number.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/{id}/results/block-number.json
@@ -26,7 +26,8 @@
         "call_result": [2, 2],
         "consensus_timestamp": "1676540001234390005",
         "contract_id": 5001,
-        "gas_used": 100
+        "gas_used": 100,
+        "transaction_nonce": 0
       },
       {
         "amount": 30,
@@ -35,7 +36,8 @@
         "consensus_timestamp": "1676540001234500005",
         "contract_id": 5001,
         "created_contract_ids": [7001],
-        "gas_used": 10
+        "gas_used": 10,
+        "transaction_nonce": 0
       }
     ],
     "transactions": [

--- a/hedera-mirror-rest/__tests__/specs/contracts/{id}/results/evm-address-path-param.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/{id}/results/evm-address-path-param.json
@@ -33,7 +33,8 @@
         "gas_limit": 1234556,
         "gas_used": 987,
         "payer_account_id": 6001,
-        "transaction_hash": "0x180102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+        "transaction_hash": "0x180102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_nonce": 0
       },
       {
         "amount": 30,
@@ -47,7 +48,8 @@
         "function_result": [8, 8],
         "gas_limit": 987654,
         "gas_used": 123,
-        "payer_account_id": 8001
+        "payer_account_id": 8001,
+        "transaction_nonce": 0
       }
     ],
     "transactions": [

--- a/hedera-mirror-rest/__tests__/specs/contracts/{id}/results/from-address.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/{id}/results/from-address.json
@@ -27,7 +27,8 @@
         "consensus_timestamp": "187654000123456",
         "contract_id": 5001,
         "payer_account_id": 8001,
-        "gas_used": 101
+        "gas_used": 101,
+        "transaction_nonce": 0
       },
       {
         "amount": 30,
@@ -37,7 +38,8 @@
         "contract_id": 5001,
         "created_contract_ids": [7001],
         "payer_account_id": 9001,
-        "gas_used": 102
+        "gas_used": 102,
+        "transaction_nonce": 0
       }
     ],
     "transactions": [

--- a/hedera-mirror-rest/__tests__/specs/contracts/{id}/results/from.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/{id}/results/from.json
@@ -27,7 +27,8 @@
         "consensus_timestamp": "187654000123456",
         "contract_id": 5001,
         "gas_used": 100,
-        "payer_account_id": 8001
+        "payer_account_id": 8001,
+        "transaction_nonce": 0
       },
       {
         "amount": 30,
@@ -37,7 +38,8 @@
         "contract_id": 5001,
         "created_contract_ids": [7001],
         "gas_used": 10,
-        "payer_account_id": 9001
+        "payer_account_id": 9001,
+        "transaction_nonce": 0
       }
     ],
     "transactions": [

--- a/hedera-mirror-rest/__tests__/specs/contracts/{id}/results/internal-false.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/{id}/results/internal-false.json
@@ -26,7 +26,8 @@
         "call_result": [2, 2],
         "consensus_timestamp": "187654000123456",
         "contract_id": 5001,
-        "gas_used": 100
+        "gas_used": 100,
+        "transaction_nonce": 0
       },
       {
         "amount": 30,
@@ -35,7 +36,8 @@
         "consensus_timestamp": "987654000123456",
         "contract_id": 5001,
         "created_contract_ids": [7001],
-        "gas_used": 10
+        "gas_used": 10,
+        "transaction_nonce": 1
       }
     ],
     "transactions": [

--- a/hedera-mirror-rest/__tests__/specs/contracts/{id}/results/internal-true.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/{id}/results/internal-true.json
@@ -33,7 +33,8 @@
         "gas_limit": 1234556,
         "gas_used": 987,
         "payer_account_id": 6001,
-        "transaction_hash": "0x180102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+        "transaction_hash": "0x180102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_nonce": 0
       },
       {
         "amount": 30,
@@ -48,7 +49,8 @@
         "gas_limit": 987654,
         "gas_used": 123,
         "payer_account_id": 8001,
-        "transaction_hash": "0x980102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+        "transaction_hash": "0x980102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_nonce": 1
       },
       {
         "amount": 30,
@@ -62,7 +64,8 @@
         "function_result": [8, 8],
         "gas_limit": 987654,
         "gas_used": 123,
-        "payer_account_id": 8001
+        "payer_account_id": 8001,
+        "transaction_nonce": 2
       }
     ],
     "transactions": [

--- a/hedera-mirror-rest/__tests__/specs/contracts/{id}/results/limit.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/{id}/results/limit.json
@@ -16,7 +16,8 @@
         "call_result": [2, 2],
         "consensus_timestamp": "187654000123456",
         "contract_id": 5001,
-        "gas_used": 101
+        "gas_used": 101,
+        "transaction_nonce": 0
       },
       {
         "amount": 30,
@@ -26,7 +27,8 @@
         "contract_id": 5001,
         "created_contract_ids": [7001],
         "gas_used": 102,
-        "transaction_hash": "0x120102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+        "transaction_hash": "0x120102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_nonce": 0
       },
       {
         "amount": 40,
@@ -35,7 +37,8 @@
         "consensus_timestamp": "987654000223456",
         "contract_id": 5001,
         "gas_used": 103,
-        "transaction_hash": "0x220102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+        "transaction_hash": "0x220102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_nonce": 0
       },
       {
         "amount": 50,
@@ -44,7 +47,8 @@
         "consensus_timestamp": "987654000323456",
         "contract_id": 5001,
         "gas_used": 104,
-        "transaction_hash": "0x320102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+        "transaction_hash": "0x320102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_nonce": 0
       },
       {
         "amount": 60,
@@ -54,7 +58,8 @@
         "contract_id": 5001,
         "created_contract_ids": [7005],
         "gas_used": 105,
-        "transaction_hash": "0x420102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+        "transaction_hash": "0x420102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_nonce": 0
       }
     ],
     "transactions": [

--- a/hedera-mirror-rest/__tests__/specs/contracts/{id}/results/order.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/{id}/results/order.json
@@ -9,7 +9,8 @@
         "consensus_timestamp": "187654000123456",
         "contract_id": 5001,
         "gas_used": 101,
-        "transaction_hash": "0x181202030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+        "transaction_hash": "0x181202030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_nonce": 0
       },
       {
         "amount": 30,
@@ -19,7 +20,8 @@
         "contract_id": 5001,
         "created_contract_ids": [7001],
         "gas_used": 102,
-        "transaction_hash": "0x981202030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+        "transaction_hash": "0x981202030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_nonce": 0
       }
     ],
     "transactions": [

--- a/hedera-mirror-rest/__tests__/specs/contracts/{id}/results/specific-id.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/{id}/results/specific-id.json
@@ -33,7 +33,8 @@
         "gas_limit": 1234556,
         "gas_used": 987,
         "payer_account_id": 6001,
-        "transaction_hash": "0x181202030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+        "transaction_hash": "0x181202030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_nonce": 0
       },
       {
         "amount": 30,
@@ -48,7 +49,8 @@
         "gas_limit": 9223372036854775807,
         "gas_used": 9223372036854775806,
         "payer_account_id": 8001,
-        "transaction_hash": "0x981202030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+        "transaction_hash": "0x981202030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_nonce": 0
       }
     ],
     "transactions": [

--- a/hedera-mirror-rest/__tests__/specs/contracts/{id}/results/timestamp.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/{id}/results/timestamp.json
@@ -27,7 +27,8 @@
         "consensus_timestamp": "187654000123456",
         "contract_id": 5001,
         "gas_used": 100,
-        "transaction_hash": "0x181202030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+        "transaction_hash": "0x181202030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_nonce": 0
       },
       {
         "amount": 30,
@@ -37,7 +38,8 @@
         "contract_id": 5001,
         "created_contract_ids": [7001],
         "gas_used": 10,
-        "transaction_hash": "0x981202030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+        "transaction_hash": "0x981202030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_nonce": 0
       }
     ],
     "transactions": [

--- a/hedera-mirror-rest/__tests__/specs/contracts/{id}/results/transaction-index.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/{id}/results/transaction-index.json
@@ -27,7 +27,9 @@
         "consensus_timestamp": "187654000123456",
         "contract_id": 5001,
         "gas_used": 100,
-        "transaction_hash": "0x181202030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+        "transaction_hash": "0x181202030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_index": 1,
+        "transaction_nonce": 0
       },
       {
         "amount": 30,
@@ -37,7 +39,9 @@
         "contract_id": 5001,
         "created_contract_ids": [7001],
         "gas_used": 10,
-        "transaction_hash": "0x981202030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+        "transaction_hash": "0x981202030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_index": 2,
+        "transaction_nonce": 0
       }
     ],
     "transactions": [

--- a/hedera-mirror-rest/__tests__/specs/contracts/{id}/results/{id}/empty-logs.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/{id}/results/{id}/empty-logs.json
@@ -35,7 +35,8 @@
         "payer_account_id": 8001,
         "transaction_hash": "96ecf2e0cf1c8f7e2294ec731b2ad1aff95d9736f4ba15b5bbace1ad2766cc1c",
         "transaction_result": 22,
-        "transaction_index": 1
+        "transaction_index": 1,
+        "transaction_nonce": 0
       }
     ],
     "contractlogs": [

--- a/hedera-mirror-rest/__tests__/specs/contracts/{id}/results/{id}/non-populated-eth-data.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/{id}/results/{id}/non-populated-eth-data.json
@@ -36,7 +36,8 @@
         "sender_id": 8001,
         "transaction_hash": "4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6392",
         "transaction_result": 22,
-        "transaction_index": 1
+        "transaction_index": 1,
+        "transaction_nonce": 1
       }
     ],
     "contractlogs": [

--- a/hedera-mirror-rest/__tests__/specs/contracts/{id}/results/{id}/populated-eth-data-func-params-from-filedata.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/{id}/results/{id}/populated-eth-data-func-params-from-filedata.json
@@ -36,7 +36,8 @@
         "function_parameters": [],
         "transaction_hash": "4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6392",
         "transaction_result": 22,
-        "transaction_index": 1
+        "transaction_index": 1,
+        "transaction_nonce": 1
       }
     ],
     "contractlogs": [

--- a/hedera-mirror-rest/__tests__/specs/contracts/{id}/results/{id}/populated-eth-data.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/{id}/results/{id}/populated-eth-data.json
@@ -36,7 +36,8 @@
         "sender_id": 8001,
         "transaction_hash": "4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6392",
         "transaction_result": 22,
-        "transaction_index": 1
+        "transaction_index": 1,
+        "transaction_nonce": 1
       }
     ],
     "contractlogs": [

--- a/hedera-mirror-rest/__tests__/specs/contracts/{id}/results/{id}/timestamp-no-state-change.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/{id}/results/{id}/timestamp-no-state-change.json
@@ -35,7 +35,8 @@
         "payer_account_id": 8001,
         "transaction_hash": "96ecf2e0cf1c8f7e2294ec731b2ad1aff95d9736f4ba15b5bbace1ad2766cc1c",
         "transaction_result": 22,
-        "transaction_index": 1
+        "transaction_index": 1,
+        "transaction_nonce": 0
       }
     ],
     "contractlogs": [

--- a/hedera-mirror-rest/__tests__/specs/contracts/{id}/results/{id}/timestamp-partial-result-match.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/{id}/results/{id}/timestamp-partial-result-match.json
@@ -27,7 +27,8 @@
         "payer_account_id": 8001,
         "transaction_hash": "96ecf2e0cf1c8f7e2294ec731b2ad1aff95d9736f4ba15b5bbace1ad2766cc1c",
         "transaction_result": 33,
-        "transaction_index": 1
+        "transaction_index": 1,
+        "transaction_nonce": 0
       }
     ],
     "contractlogs": [],

--- a/hedera-mirror-rest/__tests__/specs/contracts/{id}/results/{id}/timestamp-result-not-found.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/{id}/results/{id}/timestamp-result-not-found.json
@@ -17,7 +17,8 @@
         "payer_account_id": 8001,
         "transaction_hash": "96ecf2e0cf1c8f7e2294ec731b2ad1aff95d9736f4ba15b5bbace1ad2766cc1c",
         "transaction_result": 22,
-        "transaction_index": 1
+        "transaction_index": 1,
+        "transaction_nonce": 0
       }
     ],
     "contracts": [

--- a/hedera-mirror-rest/__tests__/specs/contracts/{id}/results/{id}/timestamp.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/{id}/results/{id}/timestamp.json
@@ -35,7 +35,8 @@
         "payer_account_id": 8001,
         "transaction_hash": "96ecf2e0cf1c8f7e2294ec731b2ad1aff95d9736f4ba15b5bbace1ad2766cc1c",
         "transaction_result": 22,
-        "transaction_index": 1
+        "transaction_index": 1,
+        "transaction_nonce": 0
       }
     ],
     "contractlogs": [

--- a/hedera-mirror-rest/controllers/contractController.js
+++ b/hedera-mirror-rest/controllers/contractController.js
@@ -462,7 +462,7 @@ class ContractController extends BaseController {
     const contractResultTimestampFullName = ContractResult.getFullName(ContractResult.CONSENSUS_TIMESTAMP);
     const contractResultTimestampInValues = [];
 
-    const transactionIndexFullName = Transaction.getFullName(Transaction.INDEX);
+    const transactionIndexFullName = ContractResult.getFullName(ContractResult.TRANSACTION_INDEX);
     const transactionIndexInValues = [];
 
     let blockFilter;
@@ -536,7 +536,7 @@ class ContractController extends BaseController {
 
     if (!internal) {
       params.push(0);
-      conditions.push(`${Transaction.getFullName(Transaction.NONCE)} = $${params.length}`);
+      conditions.push(`${ContractResult.getFullName(ContractResult.TRANSACTION_NONCE)} = $${params.length}`);
     }
 
     if (blockFilter) {

--- a/hedera-mirror-rest/model/contractResult.js
+++ b/hedera-mirror-rest/model/contractResult.js
@@ -46,6 +46,7 @@ class ContractResult {
   static SENDER_ID = 'sender_id';
   static TRANSACTION_HASH = 'transaction_hash';
   static TRANSACTION_INDEX = 'transaction_index';
+  static TRANSACTION_NONCE = 'transaction_nonce';
   static TRANSACTION_RESULT = 'transaction_result';
 
   /**


### PR DESCRIPTION

**Description**:
Replace the "join transaction" on the contract_result queries (which are not efficient due to the distribution column on that table not having a constraint on the distribution column).

* add transaction_nonce integer not null column to contract_result table
* add private Integer transactionNonce to ContractResult domain class
* persist contractResult.transactionNonce in parser
* update /api/v1/contracts/{id}/results endpoint handler to not join transaction table
* add a db migration to backfill contract_result.transaction_nonce
* add a "transaction_nonce" value to all hedera-mirror-rest tests involving 1 or more "contractresult" element(s).

**Related issue(s)**:

Fixes #5934 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
