### PR TITLE
Add support for EVM address to balances endpoint

### DIFF
--- a/hedera-mirror-rest/__tests__/accountAlias.test.js
+++ b/hedera-mirror-rest/__tests__/accountAlias.test.js
@@ -65,6 +65,24 @@ describe('AccountAlias', () => {
     });
   });
 
+  describe('isValid', () => {
+    const shardRealmInputs = _.flattenDeep([
+      {alias: '', noShardRealm: false, expected: false},
+      {alias: undefined, noShardRealm: false, expected: false},
+      {alias: null, noShardRealm: false, expected: false},
+      {alias: '99999.99999.AABBCC22', noShardRealm: false, expected: true},
+      {alias: '99999.99999.AABBCC22', noShardRealm: true, expected: false},
+      {alias: 'AABBCC22', noShardRealm: true, expected: true},
+      {alias: 'AABBCC22', noShardRealm: false, expected: true},
+    ]);
+
+    shardRealmInputs.forEach((input) => {
+      test(`${input}`, () => {
+        expect(AccountAlias.isValid(input.alias, input.noShardRealm)).toBe(input.expected);
+      });
+    });
+  });
+
   describe('toString', () => {
     test('only alias', () => {
       const accountAlias = new AccountAlias(null, null, 'AABBCC22');

--- a/hedera-mirror-rest/__tests__/balances.test.js
+++ b/hedera-mirror-rest/__tests__/balances.test.js
@@ -314,9 +314,9 @@ describe('Balances tests', () => {
 
   // Negative testing
   testutils.testBadParams(request, server, api, 'timestamp', testutils.badParamsList());
-  testutils.testBadParams(request, server, api, 'account.id', testutils.badParamsList());
   testutils.testBadParams(request, server, api, 'account.balance', testutils.badParamsList());
   testutils.testBadParams(request, server, api, 'account.publickey', testutils.badParamsList());
+  testutils.testBadParams(request, server, api, 'idOrAliasOrEvmAddress'.toLowerCase(), testutils.badParamsList());
   testutils.testBadParams(request, server, api, 'limit', testutils.badParamsList());
   testutils.testBadParams(request, server, api, 'order', testutils.badParamsList());
 });

--- a/hedera-mirror-rest/__tests__/balances.test.js
+++ b/hedera-mirror-rest/__tests__/balances.test.js
@@ -314,9 +314,9 @@ describe('Balances tests', () => {
 
   // Negative testing
   testutils.testBadParams(request, server, api, 'timestamp', testutils.badParamsList());
+  testutils.testBadParams(request, server, api, 'account.id', testutils.badParamsList());
   testutils.testBadParams(request, server, api, 'account.balance', testutils.badParamsList());
   testutils.testBadParams(request, server, api, 'account.publickey', testutils.badParamsList());
-  testutils.testBadParams(request, server, api, 'idOrAliasOrEvmAddress'.toLowerCase(), testutils.badParamsList());
   testutils.testBadParams(request, server, api, 'limit', testutils.badParamsList());
   testutils.testBadParams(request, server, api, 'order', testutils.badParamsList());
 });

--- a/hedera-mirror-rest/__tests__/specs/balances/invalid-param-values.json
+++ b/hedera-mirror-rest/__tests__/specs/balances/invalid-param-values.json
@@ -58,7 +58,7 @@
         "_status": {
           "messages": [
             {
-              "message": "Invalid operator. Ethereum accounts only support equals operator."
+              "message": "Invalid operator. Evm address only supports equals operator."
             }
           ]
         }
@@ -75,7 +75,7 @@
         "_status": {
           "messages": [
             {
-              "message": "Only one ethereum address is allowed."
+              "message": "Only one evm address is allowed."
             }
           ]
         }

--- a/hedera-mirror-rest/__tests__/specs/balances/invalid-param-values.json
+++ b/hedera-mirror-rest/__tests__/specs/balances/invalid-param-values.json
@@ -27,9 +27,6 @@
         "_status": {
           "messages": [
             {
-              "message": "Invalid parameter: account.id"
-            },
-            {
               "message": "Invalid parameter: account.balance"
             },
             {
@@ -43,6 +40,9 @@
             },
             {
               "message": "Unknown query parameter: token.id"
+            },
+            {
+              "message": "Invalid parameter: idOrAliasOrEvmAddress"
             }
           ]
         }
@@ -60,7 +60,7 @@
         "_status": {
           "messages": [
             {
-              "message": "Invalid operator. Evm address or alias only supports equals operator."
+              "message": "Invalid parameter: idOrAliasOrEvmAddress"
             }
           ]
         }

--- a/hedera-mirror-rest/__tests__/specs/balances/invalid-param-values.json
+++ b/hedera-mirror-rest/__tests__/specs/balances/invalid-param-values.json
@@ -27,6 +27,9 @@
         "_status": {
           "messages": [
             {
+              "message": "Invalid parameter: account.id"
+            },
+            {
               "message": "Invalid parameter: account.balance"
             },
             {
@@ -40,9 +43,6 @@
             },
             {
               "message": "Unknown query parameter: token.id"
-            },
-            {
-              "message": "Invalid parameter: idOrAliasOrEvmAddress"
             }
           ]
         }
@@ -51,8 +51,9 @@
     {
       "urls": [
         "/api/v1/balances?account.id=gte:ac384c53f03855fa1b3616052f8ba32c6c2a2fec",
-        "/api/v1/balances?account.id=lt:ac384c53f03855fa1b3616052f8ba32c6c2a2fff",
+        "/api/v1/balances?account.id=lt:0xac384c53f03855fa1b3616052f8ba32c6c2a2fff",
         "/api/v1/balances?account.id=lte:0.0.ac384c53f03855fa1b3616052f8ba32c6c2a2fff",
+        "/api/v1/balances?account.id=gte:0x0000000000000000000000000000000000000320",
         "/api/v1/balances?account.id=lte:KGNABD5L3ZGSRVUCSPDR7TONZSRY3D5OMEBKQMVTD2AC6JL72HMQ"
       ],
       "responseStatus": 400,
@@ -60,7 +61,7 @@
         "_status": {
           "messages": [
             {
-              "message": "Invalid parameter: idOrAliasOrEvmAddress"
+              "message": "Invalid operator. Evm address or alias only supports equals operator."
             }
           ]
         }
@@ -71,6 +72,7 @@
         "/api/v1/balances?account.id=ac384c53f03855fa1b3616052f8ba32c6c2a2fec&account.id=ac384c53f03855fa1b3616052f8ba32c6c2a2fff",
         "/api/v1/balances?account.id=0xac384c53f03855fa1b3616052f8ba32c6c2a2fec&account.id=ac384c53f03855fa1b3616052f8ba32c6c2a2fff",
         "/api/v1/balances?account.id=ac384c53f03855fa1b3616052f8ba32c6c2a2fec&account.id=0.0.ac384c53f03855fa1b3616052f8ba32c6c2a2fff",
+        "/api/v1/balances?account.id=0xac384c53f03855fa1b3616052f8ba32c6c2a2fec&account.id=0x0000000000000000000000000000000000000009",
         "/api/v1/balances?account.id=KGNABD5L3ZGSRVUCSPDR7TONZSRY3D5OMEBKQMVTD2AC6JL72HMQ&account.id=0.0.ac384c53f03855fa1b3616052f8ba32c6c2a2fff"
       ],
       "responseStatus": 400,

--- a/hedera-mirror-rest/__tests__/specs/balances/invalid-param-values.json
+++ b/hedera-mirror-rest/__tests__/specs/balances/invalid-param-values.json
@@ -1,33 +1,85 @@
 {
   "description": "Balance api invalid account id format",
-  "setup": {},
-  "urls": [
-    "/api/v1/balances?account.id=lte:0.1.2.3&account.balance=gt:-2&account.publickey=-2&timestamp=-1.2&order=any&token.id=0.0.45678",
-    "/api/v1/balances?account.id=lte:0.1.2.3&account.balance=gt:9223372036854775808&account.publickey=-2&timestamp=-1.2&order=any,&token.id=0.0.45678"
-  ],
-  "responseStatus": 400,
-  "responseJson": {
-    "_status": {
-      "messages": [
-        {
-          "message": "Invalid parameter: account.id"
-        },
-        {
-          "message": "Invalid parameter: account.balance"
-        },
-        {
-          "message": "Invalid parameter: account.publickey"
-        },
-        {
-          "message": "Invalid parameter: timestamp"
-        },
-        {
-          "message": "Invalid parameter: order"
-        },
-        {
-          "message": "Unknown query parameter: token.id"
+  "setup": {
+    "accounts": [
+      {
+        "evm_address": "ac384c53f03855fa1b3616052f8ba32c6c2a2fec",
+        "num": 7
+      },
+      {
+        "num": 8
+      },
+      {
+        "evm_address": "ac384c53f03855fa1b3616052f8ba32c6c2a2fff",
+        "num": 9
+      }
+    ]
+  },
+  "tests": [
+    {
+      "urls": [
+        "/api/v1/balances?account.id=lte:0.1.2.3&account.balance=gt:-2&account.publickey=-2&timestamp=-1.2&order=any&token.id=0.0.45678",
+        "/api/v1/balances?account.id=lte:0.1.2.3&account.balance=gt:9223372036854775808&account.publickey=-2&timestamp=-1.2&order=any,&token.id=0.0.45678"
+      ],
+      "responseStatus": 400,
+      "responseJson": {
+        "_status": {
+          "messages": [
+            {
+              "message": "Invalid parameter: account.id"
+            },
+            {
+              "message": "Invalid parameter: account.balance"
+            },
+            {
+              "message": "Invalid parameter: account.publickey"
+            },
+            {
+              "message": "Invalid parameter: timestamp"
+            },
+            {
+              "message": "Invalid parameter: order"
+            },
+            {
+              "message": "Unknown query parameter: token.id"
+            }
+          ]
         }
-      ]
+      }
+    },
+    {
+      "urls": [
+        "/api/v1/balances?account.id=gte:ac384c53f03855fa1b3616052f8ba32c6c2a2fec",
+        "/api/v1/balances?account.id=lt:ac384c53f03855fa1b3616052f8ba32c6c2a2fff",
+        "/api/v1/balances?account.id=lte:0.0.ac384c53f03855fa1b3616052f8ba32c6c2a2fff"
+      ],
+      "responseStatus": 400,
+      "responseJson": {
+        "_status": {
+          "messages": [
+            {
+              "message": "Invalid operator. Ethereum accounts only support equals operator."
+            }
+          ]
+        }
+      }
+    },
+    {
+      "urls": [
+        "/api/v1/balances?account.id=ac384c53f03855fa1b3616052f8ba32c6c2a2fec&account.id=ac384c53f03855fa1b3616052f8ba32c6c2a2fff",
+        "/api/v1/balances?account.id=0xac384c53f03855fa1b3616052f8ba32c6c2a2fec&account.id=ac384c53f03855fa1b3616052f8ba32c6c2a2fff",
+        "/api/v1/balances?account.id=ac384c53f03855fa1b3616052f8ba32c6c2a2fec&account.id=0.0.ac384c53f03855fa1b3616052f8ba32c6c2a2fff"
+      ],
+      "responseStatus": 400,
+      "responseJson": {
+        "_status": {
+          "messages": [
+            {
+              "message": "Only one ethereum address is allowed."
+            }
+          ]
+        }
+      }
     }
-  }
+  ]
 }

--- a/hedera-mirror-rest/__tests__/specs/balances/invalid-param-values.json
+++ b/hedera-mirror-rest/__tests__/specs/balances/invalid-param-values.json
@@ -19,16 +19,13 @@
   "tests": [
     {
       "urls": [
-        "/api/v1/balances?account.id=lte:0.1.2.3&account.balance=gt:-2&account.publickey=-2&timestamp=-1.2&order=any&token.id=0.0.45678",
-        "/api/v1/balances?account.id=lte:0.1.2.3&account.balance=gt:9223372036854775808&account.publickey=-2&timestamp=-1.2&order=any,&token.id=0.0.45678"
+        "/api/v1/balances?account.balance=gt:-2&account.publickey=-2&timestamp=-1.2&order=any&token.id=0.0.45678",
+        "/api/v1/balances?account.balance=gt:9223372036854775808&account.publickey=-2&timestamp=-1.2&order=any,&token.id=0.0.45678"
       ],
       "responseStatus": 400,
       "responseJson": {
         "_status": {
           "messages": [
-            {
-              "message": "Invalid parameter: account.id"
-            },
             {
               "message": "Invalid parameter: account.balance"
             },
@@ -52,8 +49,7 @@
       "urls": [
         "/api/v1/balances?account.id=gte:ac384c53f03855fa1b3616052f8ba32c6c2a2fec",
         "/api/v1/balances?account.id=lt:0xac384c53f03855fa1b3616052f8ba32c6c2a2fff",
-        "/api/v1/balances?account.id=lte:0.0.ac384c53f03855fa1b3616052f8ba32c6c2a2fff",
-        "/api/v1/balances?account.id=gte:0x0000000000000000000000000000000000000320",
+        "/api/v1/balances?account.id=gte:0x0000000000000000000000000000000000000008",
         "/api/v1/balances?account.id=lte:KGNABD5L3ZGSRVUCSPDR7TONZSRY3D5OMEBKQMVTD2AC6JL72HMQ"
       ],
       "responseStatus": 400,
@@ -61,7 +57,8 @@
         "_status": {
           "messages": [
             {
-              "message": "Invalid operator. Evm address or alias only supports equals operator."
+              "message": "Invalid parameter: account.id",
+              "detail": "EVM address or alias only supports equals operator"
             }
           ]
         }
@@ -71,16 +68,33 @@
       "urls": [
         "/api/v1/balances?account.id=ac384c53f03855fa1b3616052f8ba32c6c2a2fec&account.id=ac384c53f03855fa1b3616052f8ba32c6c2a2fff",
         "/api/v1/balances?account.id=0xac384c53f03855fa1b3616052f8ba32c6c2a2fec&account.id=ac384c53f03855fa1b3616052f8ba32c6c2a2fff",
-        "/api/v1/balances?account.id=ac384c53f03855fa1b3616052f8ba32c6c2a2fec&account.id=0.0.ac384c53f03855fa1b3616052f8ba32c6c2a2fff",
         "/api/v1/balances?account.id=0xac384c53f03855fa1b3616052f8ba32c6c2a2fec&account.id=0x0000000000000000000000000000000000000009",
-        "/api/v1/balances?account.id=KGNABD5L3ZGSRVUCSPDR7TONZSRY3D5OMEBKQMVTD2AC6JL72HMQ&account.id=0.0.ac384c53f03855fa1b3616052f8ba32c6c2a2fff"
+        "/api/v1/balances?account.id=KGNABD5L3ZGSRVUCSPDR7TONZSRY3D5OMEBKQMVTD2AC6JL72HMQ&account.id=ac384c53f03855fa1b3616052f8ba32c6c2a2fff"
       ],
       "responseStatus": 400,
       "responseJson": {
         "_status": {
           "messages": [
             {
-              "message": "Only one evm address or alias is allowed."
+              "message": "Invalid parameter: account.id",
+              "detail": "Only one EVM address or alias is allowed."
+            }
+          ]
+        }
+      }
+    },
+    {
+      "urls": [
+        "/api/v1/balances?account.id=account.id=lte:0.1.2.3",
+        "/api/v1/balances?account.id=0.0.ac384c53f03855fa1b3616052f8ba32c6c2a2fec",
+        "/api/v1/balances?account.id=0.0.KGNABD5L3ZGSRVUCSPDR7TONZSRY3D5OMEBKQMVTD2AC6JL72HMQ"
+      ],
+      "responseStatus": 400,
+      "responseJson": {
+        "_status": {
+          "messages": [
+            {
+              "message": "Invalid parameter: account.id"
             }
           ]
         }

--- a/hedera-mirror-rest/__tests__/specs/balances/invalid-param-values.json
+++ b/hedera-mirror-rest/__tests__/specs/balances/invalid-param-values.json
@@ -3,6 +3,7 @@
   "setup": {
     "accounts": [
       {
+        "alias": "KGNABD5L3ZGSRVUCSPDR7TONZSRY3D5OMEBKQMVTD2AC6JL72HMQ",
         "evm_address": "ac384c53f03855fa1b3616052f8ba32c6c2a2fec",
         "num": 7
       },
@@ -51,14 +52,15 @@
       "urls": [
         "/api/v1/balances?account.id=gte:ac384c53f03855fa1b3616052f8ba32c6c2a2fec",
         "/api/v1/balances?account.id=lt:ac384c53f03855fa1b3616052f8ba32c6c2a2fff",
-        "/api/v1/balances?account.id=lte:0.0.ac384c53f03855fa1b3616052f8ba32c6c2a2fff"
+        "/api/v1/balances?account.id=lte:0.0.ac384c53f03855fa1b3616052f8ba32c6c2a2fff",
+        "/api/v1/balances?account.id=lte:KGNABD5L3ZGSRVUCSPDR7TONZSRY3D5OMEBKQMVTD2AC6JL72HMQ"
       ],
       "responseStatus": 400,
       "responseJson": {
         "_status": {
           "messages": [
             {
-              "message": "Invalid operator. Evm address only supports equals operator."
+              "message": "Invalid operator. Evm address or alias only supports equals operator."
             }
           ]
         }
@@ -68,14 +70,15 @@
       "urls": [
         "/api/v1/balances?account.id=ac384c53f03855fa1b3616052f8ba32c6c2a2fec&account.id=ac384c53f03855fa1b3616052f8ba32c6c2a2fff",
         "/api/v1/balances?account.id=0xac384c53f03855fa1b3616052f8ba32c6c2a2fec&account.id=ac384c53f03855fa1b3616052f8ba32c6c2a2fff",
-        "/api/v1/balances?account.id=ac384c53f03855fa1b3616052f8ba32c6c2a2fec&account.id=0.0.ac384c53f03855fa1b3616052f8ba32c6c2a2fff"
+        "/api/v1/balances?account.id=ac384c53f03855fa1b3616052f8ba32c6c2a2fec&account.id=0.0.ac384c53f03855fa1b3616052f8ba32c6c2a2fff",
+        "/api/v1/balances?account.id=KGNABD5L3ZGSRVUCSPDR7TONZSRY3D5OMEBKQMVTD2AC6JL72HMQ&account.id=0.0.ac384c53f03855fa1b3616052f8ba32c6c2a2fff"
       ],
       "responseStatus": 400,
       "responseJson": {
         "_status": {
           "messages": [
             {
-              "message": "Only one evm address is allowed."
+              "message": "Only one evm address or alias is allowed."
             }
           ]
         }

--- a/hedera-mirror-rest/__tests__/specs/balances/multiple-ids.json
+++ b/hedera-mirror-rest/__tests__/specs/balances/multiple-ids.json
@@ -9,6 +9,7 @@
         "num": 8
       },
       {
+        "alias": "KGNABD5L3ZGSRVUCSPDR7TONZSRY3D5OMEBKQMVTD2AC6JL72HMQ",
         "evm_address": "ac384c53f03855fa1b3616052f8ba32c6c2a2fff",
         "num": 9
       }
@@ -45,7 +46,8 @@
   },
   "urls": [
     "/api/v1/balances?account.id=0.0.7&account.id=0.0.9&timestamp=0.0010023",
-    "/api/v1/balances?account.id=0.0.7&account.id=ac384c53f03855fa1b3616052f8ba32c6c2a2fff&timestamp=0.0010023"
+    "/api/v1/balances?account.id=0.0.7&account.id=ac384c53f03855fa1b3616052f8ba32c6c2a2fff&timestamp=0.0010023",
+    "/api/v1/balances?account.id=0.0.7&account.id=KGNABD5L3ZGSRVUCSPDR7TONZSRY3D5OMEBKQMVTD2AC6JL72HMQ&timestamp=0.0010023"
   ],
   "responseStatus": 200,
   "responseJson": {

--- a/hedera-mirror-rest/__tests__/specs/balances/multiple-ids.json
+++ b/hedera-mirror-rest/__tests__/specs/balances/multiple-ids.json
@@ -9,6 +9,7 @@
         "num": 8
       },
       {
+        "evm_address": "ac384c53f03855fa1b3616052f8ba32c6c2a2fff",
         "num": 9
       }
     ],
@@ -42,7 +43,10 @@
     "transactions": [],
     "cryptotransfers": []
   },
-  "url": "/api/v1/balances?account.id=0.0.7&account.id=0.0.9&timestamp=0.0010023",
+  "urls": [
+    "/api/v1/balances?account.id=0.0.7&account.id=0.0.9&timestamp=0.0010023",
+    "/api/v1/balances?account.id=0.0.7&account.id=ac384c53f03855fa1b3616052f8ba32c6c2a2fff&timestamp=0.0010023"
+  ],
   "responseStatus": 200,
   "responseJson": {
     "timestamp": "0.000002345",

--- a/hedera-mirror-rest/__tests__/specs/balances/specific-id.json
+++ b/hedera-mirror-rest/__tests__/specs/balances/specific-id.json
@@ -7,9 +7,10 @@
         "num": 7
       },
       {
+        "alias": "KGNABD5L3ZGSRVUCSPDR7TONZSRY3D5OMEBKQMVTD2AC6JL72HMQ",
+        "evm_address": "ac384c53f03855fa1b3616052f8ba32c6c2a2fec",
         "balance": 8,
-        "num": 8,
-        "evm_address": "ac384c53f03855fa1b3616052f8ba32c6c2a2fec"
+        "num": 8
       },
       {
         "balance": 9,
@@ -80,7 +81,10 @@
         "/api/v1/balances?account.id=8&timestamp=10",
         "/api/v1/balances?account.id=ac384c53f03855fa1b3616052f8ba32c6c2a2fec&timestamp=10",
         "/api/v1/balances?account.id=0xac384c53f03855fa1b3616052f8ba32c6c2a2fec&timestamp=10",
-        "/api/v1/balances?account.id=0.0.ac384c53f03855fa1b3616052f8ba32c6c2a2fec&timestamp=10"
+        "/api/v1/balances?account.id=0.0.ac384c53f03855fa1b3616052f8ba32c6c2a2fec&timestamp=10",
+        "/api/v1/balances?account.id=KGNABD5L3ZGSRVUCSPDR7TONZSRY3D5OMEBKQMVTD2AC6JL72HMQ&timestamp=10",
+        "/api/v1/balances?account.id=0.KGNABD5L3ZGSRVUCSPDR7TONZSRY3D5OMEBKQMVTD2AC6JL72HMQ&timestamp=10",
+        "/api/v1/balances?account.id=0.0.KGNABD5L3ZGSRVUCSPDR7TONZSRY3D5OMEBKQMVTD2AC6JL72HMQ&timestamp=10"
       ],
       "responseStatus": 200,
       "responseJson": {
@@ -113,7 +117,10 @@
         "/api/v1/balances?account.id=8",
         "/api/v1/balances?account.id=ac384c53f03855fa1b3616052f8ba32c6c2a2fec",
         "/api/v1/balances?account.id=0xac384c53f03855fa1b3616052f8ba32c6c2a2fec",
-        "/api/v1/balances?account.id=0.0.ac384c53f03855fa1b3616052f8ba32c6c2a2fec"
+        "/api/v1/balances?account.id=0.0.ac384c53f03855fa1b3616052f8ba32c6c2a2fec",
+        "/api/v1/balances?account.id=KGNABD5L3ZGSRVUCSPDR7TONZSRY3D5OMEBKQMVTD2AC6JL72HMQ",
+        "/api/v1/balances?account.id=0.KGNABD5L3ZGSRVUCSPDR7TONZSRY3D5OMEBKQMVTD2AC6JL72HMQ",
+        "/api/v1/balances?account.id=0.0.KGNABD5L3ZGSRVUCSPDR7TONZSRY3D5OMEBKQMVTD2AC6JL72HMQ"
       ],
       "responseStatus": 200,
       "responseJson": {

--- a/hedera-mirror-rest/__tests__/specs/balances/specific-id.json
+++ b/hedera-mirror-rest/__tests__/specs/balances/specific-id.json
@@ -81,11 +81,8 @@
         "/api/v1/balances?account.id=8&timestamp=10",
         "/api/v1/balances?account.id=ac384c53f03855fa1b3616052f8ba32c6c2a2fec&timestamp=10",
         "/api/v1/balances?account.id=0xac384c53f03855fa1b3616052f8ba32c6c2a2fec&timestamp=10",
-        "/api/v1/balances?account.id=0.0.ac384c53f03855fa1b3616052f8ba32c6c2a2fec&timestamp=10",
         "/api/v1/balances?account.id=0x0000000000000000000000000000000000000008&timestamp=10",
-        "/api/v1/balances?account.id=KGNABD5L3ZGSRVUCSPDR7TONZSRY3D5OMEBKQMVTD2AC6JL72HMQ&timestamp=10",
-        "/api/v1/balances?account.id=0.KGNABD5L3ZGSRVUCSPDR7TONZSRY3D5OMEBKQMVTD2AC6JL72HMQ&timestamp=10",
-        "/api/v1/balances?account.id=0.0.KGNABD5L3ZGSRVUCSPDR7TONZSRY3D5OMEBKQMVTD2AC6JL72HMQ&timestamp=10"
+        "/api/v1/balances?account.id=KGNABD5L3ZGSRVUCSPDR7TONZSRY3D5OMEBKQMVTD2AC6JL72HMQ&timestamp=10"
       ],
       "responseStatus": 200,
       "responseJson": {
@@ -118,13 +115,9 @@
         "/api/v1/balances?account.id=8",
         "/api/v1/balances?account.id=ac384c53f03855fa1b3616052f8ba32c6c2a2fec",
         "/api/v1/balances?account.id=0xac384c53f03855fa1b3616052f8ba32c6c2a2fec",
-        "/api/v1/balances?account.id=0.0.ac384c53f03855fa1b3616052f8ba32c6c2a2fec",
         "/api/v1/balances?account.id=0000000000000000000000000000000000000008",
         "/api/v1/balances?account.id=0x0000000000000000000000000000000000000008",
-        "/api/v1/balances?account.id=0.0.0000000000000000000000000000000000000008",
-        "/api/v1/balances?account.id=KGNABD5L3ZGSRVUCSPDR7TONZSRY3D5OMEBKQMVTD2AC6JL72HMQ",
-        "/api/v1/balances?account.id=0.KGNABD5L3ZGSRVUCSPDR7TONZSRY3D5OMEBKQMVTD2AC6JL72HMQ",
-        "/api/v1/balances?account.id=0.0.KGNABD5L3ZGSRVUCSPDR7TONZSRY3D5OMEBKQMVTD2AC6JL72HMQ"
+        "/api/v1/balances?account.id=KGNABD5L3ZGSRVUCSPDR7TONZSRY3D5OMEBKQMVTD2AC6JL72HMQ"
       ],
       "responseStatus": 200,
       "responseJson": {

--- a/hedera-mirror-rest/__tests__/specs/balances/specific-id.json
+++ b/hedera-mirror-rest/__tests__/specs/balances/specific-id.json
@@ -8,7 +8,8 @@
       },
       {
         "balance": 8,
-        "num": 8
+        "num": 8,
+        "evm_address": "ac384c53f03855fa1b3616052f8ba32c6c2a2fec"
       },
       {
         "balance": 9,
@@ -76,7 +77,10 @@
       "urls": [
         "/api/v1/balances?account.id=0.0.8&timestamp=10",
         "/api/v1/balances?account.id=0.8&timestamp=10",
-        "/api/v1/balances?account.id=8&timestamp=10"
+        "/api/v1/balances?account.id=8&timestamp=10",
+        "/api/v1/balances?account.id=ac384c53f03855fa1b3616052f8ba32c6c2a2fec&timestamp=10",
+        "/api/v1/balances?account.id=0xac384c53f03855fa1b3616052f8ba32c6c2a2fec&timestamp=10",
+        "/api/v1/balances?account.id=0.0.ac384c53f03855fa1b3616052f8ba32c6c2a2fec&timestamp=10"
       ],
       "responseStatus": 200,
       "responseJson": {
@@ -106,7 +110,10 @@
       "urls": [
         "/api/v1/balances?account.id=0.0.8",
         "/api/v1/balances?account.id=0.8",
-        "/api/v1/balances?account.id=8"
+        "/api/v1/balances?account.id=8",
+        "/api/v1/balances?account.id=ac384c53f03855fa1b3616052f8ba32c6c2a2fec",
+        "/api/v1/balances?account.id=0xac384c53f03855fa1b3616052f8ba32c6c2a2fec",
+        "/api/v1/balances?account.id=0.0.ac384c53f03855fa1b3616052f8ba32c6c2a2fec"
       ],
       "responseStatus": 200,
       "responseJson": {

--- a/hedera-mirror-rest/__tests__/specs/balances/specific-id.json
+++ b/hedera-mirror-rest/__tests__/specs/balances/specific-id.json
@@ -82,6 +82,7 @@
         "/api/v1/balances?account.id=ac384c53f03855fa1b3616052f8ba32c6c2a2fec&timestamp=10",
         "/api/v1/balances?account.id=0xac384c53f03855fa1b3616052f8ba32c6c2a2fec&timestamp=10",
         "/api/v1/balances?account.id=0.0.ac384c53f03855fa1b3616052f8ba32c6c2a2fec&timestamp=10",
+        "/api/v1/balances?account.id=0x0000000000000000000000000000000000000008&timestamp=10",
         "/api/v1/balances?account.id=KGNABD5L3ZGSRVUCSPDR7TONZSRY3D5OMEBKQMVTD2AC6JL72HMQ&timestamp=10",
         "/api/v1/balances?account.id=0.KGNABD5L3ZGSRVUCSPDR7TONZSRY3D5OMEBKQMVTD2AC6JL72HMQ&timestamp=10",
         "/api/v1/balances?account.id=0.0.KGNABD5L3ZGSRVUCSPDR7TONZSRY3D5OMEBKQMVTD2AC6JL72HMQ&timestamp=10"
@@ -118,6 +119,9 @@
         "/api/v1/balances?account.id=ac384c53f03855fa1b3616052f8ba32c6c2a2fec",
         "/api/v1/balances?account.id=0xac384c53f03855fa1b3616052f8ba32c6c2a2fec",
         "/api/v1/balances?account.id=0.0.ac384c53f03855fa1b3616052f8ba32c6c2a2fec",
+        "/api/v1/balances?account.id=0000000000000000000000000000000000000008",
+        "/api/v1/balances?account.id=0x0000000000000000000000000000000000000008",
+        "/api/v1/balances?account.id=0.0.0000000000000000000000000000000000000008",
         "/api/v1/balances?account.id=KGNABD5L3ZGSRVUCSPDR7TONZSRY3D5OMEBKQMVTD2AC6JL72HMQ",
         "/api/v1/balances?account.id=0.KGNABD5L3ZGSRVUCSPDR7TONZSRY3D5OMEBKQMVTD2AC6JL72HMQ",
         "/api/v1/balances?account.id=0.0.KGNABD5L3ZGSRVUCSPDR7TONZSRY3D5OMEBKQMVTD2AC6JL72HMQ"

--- a/hedera-mirror-rest/accountAlias.js
+++ b/hedera-mirror-rest/accountAlias.js
@@ -16,7 +16,6 @@
 
 import base32 from './base32';
 import {InvalidArgumentError} from './errors';
-import _ from 'lodash';
 
 // limit the alias to the base32 alphabet excluding padding, other checks will be done in base32.decode. We need
 // the check here because base32.decode allows lower case letters, padding, and auto corrects some typos.
@@ -56,9 +55,6 @@ class AccountAlias {
    * @return {boolean}
    */
   static isValid(accountAlias, noShardRealm = false) {
-    if (_.isEmpty(accountAlias)) {
-      return false;
-    }
     const regex = noShardRealm ? noShardRealmAccountAliasRegex : accountAliasRegex;
     return typeof accountAlias === 'string' && regex.test(accountAlias);
   }

--- a/hedera-mirror-rest/accountAlias.js
+++ b/hedera-mirror-rest/accountAlias.js
@@ -16,10 +16,12 @@
 
 import base32 from './base32';
 import {InvalidArgumentError} from './errors';
+import _ from 'lodash';
 
 // limit the alias to the base32 alphabet excluding padding, other checks will be done in base32.decode. We need
 // the check here because base32.decode allows lower case letters, padding, and auto corrects some typos.
 const accountAliasRegex = /^(\d{1,5}\.){0,2}[A-Z2-7]+$/;
+const noShardRealmAccountAliasRegex = /^[A-Z2-7]+$/;
 
 class AccountAlias {
   /**
@@ -50,10 +52,15 @@ class AccountAlias {
   /**
    * Checks if the accountAlias string is valid
    * @param {string} accountAlias
+   * @param {boolean} noShardRealm If shard realm is allowed as a part of the alias.
    * @return {boolean}
    */
-  static isValid(accountAlias) {
-    return typeof accountAlias === 'string' && accountAliasRegex.test(accountAlias);
+  static isValid(accountAlias, noShardRealm = false) {
+    if (_.isEmpty(accountAlias)) {
+      return false;
+    }
+    const regex = noShardRealm ? noShardRealmAccountAliasRegex : accountAliasRegex;
+    return typeof accountAlias === 'string' && regex.test(accountAlias);
   }
 
   /**

--- a/hedera-mirror-rest/api/v1/openapi.yml
+++ b/hedera-mirror-rest/api/v1/openapi.yml
@@ -1751,6 +1751,11 @@ components:
               $ref: "#/components/schemas/Transactions"
             links:
               $ref: "#/components/schemas/Links"
+    AccountIdOrAliasOrEvmAddress:
+      oneOf:
+        - $ref: "#/components/schemas/Alias"
+        - $ref: "#/components/schemas/EntityId"
+        - $ref: "#/components/schemas/EvmAddress"
     Alias:
       description: RFC4648 no-padding base32 encoded account alias
       type: string
@@ -3623,7 +3628,7 @@ components:
         evmAddressWithShardAndRealm:
           value: 0.0.ac384c53f03855fa1b3616052f8ba32c6c2a2fec
       schema:
-        pattern: ^(\d{1,10}\.){0,2}(\d{1,10}|(0x)?[A-Fa-f0-9]{40}|(?:[A-Z2-7]{8})*(?:[A-Z2-7]{2}|[A-Z2-7]{4,5}|[A-Z2-7]{7,8}))$
+        $ref: "#/components/schemas/AccountIdOrAliasOrEvmAddress"
         type: string
     accountIdOrAliasOrEvmAddressQueryParam:
       name: account.id
@@ -3650,7 +3655,7 @@ components:
         evmAddressWithShardAndRealm:
           value: 0.0.ac384c53f03855fa1b3616052f8ba32c6c2a2fec
       schema:
-        pattern: ^(\d{1,10}\.){0,2}(\d{1,10}|(0x)?[A-Fa-f0-9]{40}|(?:[A-Z2-7]{8})*(?:[A-Z2-7]{2}|[A-Z2-7]{4,5}|[A-Z2-7]{7,8}))$
+        $ref: "#/components/schemas/AccountIdOrAliasOrEvmAddress"
         type: string
     accountBalanceQueryParam:
       name: account.balance

--- a/hedera-mirror-rest/api/v1/openapi.yml
+++ b/hedera-mirror-rest/api/v1/openapi.yml
@@ -3634,7 +3634,6 @@ components:
       name: account.id
       in: query
       description: Account alias or account id or evm address
-      required: true
       examples:
         aliasOnly:
           value: HIQQEXWKW53RKN4W6XXC4Q232SYNZ3SZANVZZSUME5B5PRGXL663UAQA

--- a/hedera-mirror-rest/api/v1/openapi.yml
+++ b/hedera-mirror-rest/api/v1/openapi.yml
@@ -1751,11 +1751,6 @@ components:
               $ref: "#/components/schemas/Transactions"
             links:
               $ref: "#/components/schemas/Links"
-    AccountIdOrAliasOrEvmAddress:
-      oneOf:
-        - $ref: "#/components/schemas/Alias"
-        - $ref: "#/components/schemas/EntityId"
-        - $ref: "#/components/schemas/EvmAddress"
     Alias:
       description: RFC4648 no-padding base32 encoded account alias
       type: string
@@ -3628,19 +3623,15 @@ components:
         evmAddressWithShardAndRealm:
           value: 0.0.ac384c53f03855fa1b3616052f8ba32c6c2a2fec
       schema:
-        $ref: "#/components/schemas/AccountIdOrAliasOrEvmAddress"
+        pattern: ^(\d{1,10}\.){0,2}(\d{1,10}|(0x)?[A-Fa-f0-9]{40}|(?:[A-Z2-7]{8})*(?:[A-Z2-7]{2}|[A-Z2-7]{4,5}|[A-Z2-7]{7,8}))$
         type: string
     accountIdOrAliasOrEvmAddressQueryParam:
       name: account.id
       in: query
-      description: Account alias or account id or evm address
+      description: Account id or account alias with no shard realm or evm address with no shard realm
       examples:
         aliasOnly:
           value: HIQQEXWKW53RKN4W6XXC4Q232SYNZ3SZANVZZSUME5B5PRGXL663UAQA
-        realmAlias:
-          value: 0.HIQQEXWKW53RKN4W6XXC4Q232SYNZ3SZANVZZSUME5B5PRGXL663UAQA
-        shardRealmAlias:
-          value: 0.1.HIQQEXWKW53RKN4W6XXC4Q232SYNZ3SZANVZZSUME5B5PRGXL663UAQA
         accountNumOnly:
           value: 8
         realmAccountNum:
@@ -3651,10 +3642,8 @@ components:
           value: ac384c53f03855fa1b3616052f8ba32c6c2a2fec
         evmAddressWithPrefix:
           value: 0xac384c53f03855fa1b3616052f8ba32c6c2a2fec
-        evmAddressWithShardAndRealm:
-          value: 0.0.ac384c53f03855fa1b3616052f8ba32c6c2a2fec
       schema:
-        $ref: "#/components/schemas/AccountIdOrAliasOrEvmAddress"
+        pattern: ^(\d{1,10}\.){0,2}(\d{1,10}|(0x)?[A-Fa-f0-9]{40}|(?:[A-Z2-7]{8})*(?:[A-Z2-7]{2}|[A-Z2-7]{4,5}|[A-Z2-7]{7,8}))$
         type: string
     accountBalanceQueryParam:
       name: account.balance

--- a/hedera-mirror-rest/api/v1/openapi.yml
+++ b/hedera-mirror-rest/api/v1/openapi.yml
@@ -238,7 +238,7 @@ paths:
       description: Returns a timestamped list of account balances on the network, limited to at most 50 token balances per account as outlined in HIP-367. This includes both HBAR and token balances for accounts.
       operationId: listAccountBalances
       parameters:
-        - $ref: "#/components/parameters/accountIdQueryParam"
+        - $ref: "#/components/parameters/accountIdOrAliasOrEvmAddressQueryParam"
         - $ref: "#/components/parameters/accountBalanceQueryParam"
         - $ref: "#/components/parameters/accountPublicKeyQueryParam"
         - $ref: "#/components/parameters/limitQueryParam"
@@ -3601,6 +3601,33 @@ components:
     accountIdOrAliasOrEvmAddressPathParam:
       name: idOrAliasOrEvmAddress
       in: path
+      description: Account alias or account id or evm address
+      required: true
+      examples:
+        aliasOnly:
+          value: HIQQEXWKW53RKN4W6XXC4Q232SYNZ3SZANVZZSUME5B5PRGXL663UAQA
+        realmAlias:
+          value: 0.HIQQEXWKW53RKN4W6XXC4Q232SYNZ3SZANVZZSUME5B5PRGXL663UAQA
+        shardRealmAlias:
+          value: 0.1.HIQQEXWKW53RKN4W6XXC4Q232SYNZ3SZANVZZSUME5B5PRGXL663UAQA
+        accountNumOnly:
+          value: 8
+        realmAccountNum:
+          value: 0.8
+        shardRealmAccountNum:
+          value: 0.0.8
+        evmAddress:
+          value: ac384c53f03855fa1b3616052f8ba32c6c2a2fec
+        evmAddressWithPrefix:
+          value: 0xac384c53f03855fa1b3616052f8ba32c6c2a2fec
+        evmAddressWithShardAndRealm:
+          value: 0.0.ac384c53f03855fa1b3616052f8ba32c6c2a2fec
+      schema:
+        pattern: ^(\d{1,10}\.){0,2}(\d{1,10}|(0x)?[A-Fa-f0-9]{40}|(?:[A-Z2-7]{8})*(?:[A-Z2-7]{2}|[A-Z2-7]{4,5}|[A-Z2-7]{7,8}))$
+        type: string
+    accountIdOrAliasOrEvmAddressQueryParam:
+      name: account.id
+      in: query
       description: Account alias or account id or evm address
       required: true
       examples:

--- a/hedera-mirror-rest/balances.js
+++ b/hedera-mirror-rest/balances.js
@@ -204,11 +204,8 @@ const parseAccountIdQueryParam = (query, columnName) => {
       return EntityId.parse(value).getEncodedId();
     },
     (op, value) => {
-      if (evmAddressCount === 1) {
-        if (op !== utils.opsMap.eq) {
-          throw new InvalidArgumentError(`Invalid operator. Evm address only supports equals operator.`);
-        }
-        return [`${columnName}${op}?`, value];
+      if (evmAddressCount > 0 && op !== utils.opsMap.eq) {
+        throw new InvalidArgumentError(`Invalid operator. Evm address only supports equals operator.`);
       }
 
       return Array.isArray(value)

--- a/hedera-mirror-rest/balances.js
+++ b/hedera-mirror-rest/balances.js
@@ -190,23 +190,23 @@ const getTokenAccountBalanceSubQuery = (order) => {
 };
 
 const parseAccountIdQueryParam = (query, columnName) => {
-  let ethereumAddressCount = 0;
+  let evmAddressCount = 0;
   return utils.parseParams(
     query[constants.filterKeys.ACCOUNT_ID],
     (value) => {
       if (EntityId.isValidEvmAddress(value)) {
-        if (++ethereumAddressCount === 1) {
+        if (++evmAddressCount === 1) {
           return EntityService.getEncodedId(value);
         }
-        throw new InvalidArgumentError(`Only one ethereum address is allowed.`);
+        throw new InvalidArgumentError(`Only one evm address is allowed.`);
       }
 
       return EntityId.parse(value).getEncodedId();
     },
     (op, value) => {
-      if (ethereumAddressCount === 1) {
+      if (evmAddressCount === 1) {
         if (op !== utils.opsMap.eq) {
-          throw new InvalidArgumentError(`Invalid operator. Ethereum accounts only support equals operator.`);
+          throw new InvalidArgumentError(`Invalid operator. Evm address only supports equals operator.`);
         }
         return [`${columnName}${op}?`, value];
       }

--- a/hedera-mirror-rest/balances.js
+++ b/hedera-mirror-rest/balances.js
@@ -214,43 +214,9 @@ const parseAccountIdQueryParam = (query, columnName) => {
 };
 
 const balanceFilterValidator = (param, op, val) => {
-  let ret = false;
-
-  if (op === undefined || val === undefined) {
-    return ret;
-  }
-
-  // Validate operator
-  if (!utils.isValidOperatorQuery(op)) {
-    return ret;
-  }
-
-  // Validate the value
-  switch (param) {
-    case constants.filterKeys.ACCOUNT_BALANCE:
-      ret = utils.isPositiveLong(val, true);
-      break;
-    case constants.filterKeys.ACCOUNT_ID:
-      ret = EntityId.isValidEntityId(val) || AccountAlias.isValid(val);
-      break;
-    case constants.filterKeys.ACCOUNT_PUBLICKEY:
-      ret = utils.isValidPublicKeyQuery(val);
-      break;
-    case constants.filterKeys.LIMIT:
-      ret = utils.isPositiveLong(val);
-      break;
-    case constants.filterKeys.ORDER:
-      // Acceptable words: asc or desc
-      ret = utils.isValidValueIgnoreCase(val, Object.values(constants.orderFilterValues));
-      break;
-    case constants.filterKeys.TIMESTAMP:
-      ret = utils.isValidTimestampParam(val);
-      break;
-    default:
-      ret = false;
-  }
-
-  return ret;
+  return param === constants.filterKeys.ACCOUNT_ID
+    ? utils.validateOpAndValue(op, val) && (EntityId.isValidEntityId(val) || AccountAlias.isValid(val))
+    : utils.filterValidityChecks(param, op, val);
 };
 
 const acceptedBalancesParameters = new Set([

--- a/hedera-mirror-rest/balances.js
+++ b/hedera-mirror-rest/balances.js
@@ -190,22 +190,18 @@ const getTokenAccountBalanceSubQuery = (order) => {
 };
 
 const parseAccountIdQueryParam = (query, columnName) => {
-  let evmAddressCount = 0;
+  let evmAliasAddressCount = 0;
   return utils.parseParams(
     query[constants.filterKeys.ACCOUNT_ID],
     (value) => {
-      if (EntityId.isValidEvmAddress(value)) {
-        if (++evmAddressCount === 1) {
-          return EntityService.getEncodedId(value);
-        }
-        throw new InvalidArgumentError(`Only one evm address is allowed.`);
+      if (!EntityId.isValidEntityId(value, false) && ++evmAliasAddressCount > 1) {
+        throw new InvalidArgumentError(`Only one evm address or alias is allowed.`);
       }
-
-      return EntityId.parse(value).getEncodedId();
+      return EntityService.getEncodedId(value);
     },
     (op, value) => {
-      if (evmAddressCount > 0 && op !== utils.opsMap.eq) {
-        throw new InvalidArgumentError(`Invalid operator. Evm address only supports equals operator.`);
+      if (evmAliasAddressCount > 0 && op !== utils.opsMap.eq) {
+        throw new InvalidArgumentError(`Invalid operator. Evm address or alias only supports equals operator.`);
       }
 
       return Array.isArray(value)

--- a/hedera-mirror-rest/middleware/httpErrorHandler.js
+++ b/hedera-mirror-rest/middleware/httpErrorHandler.js
@@ -63,7 +63,7 @@ const errorMessageFormat = (errorMessages) => {
   return {
     _status: {
       messages: errorMessages.map((m) => {
-        return {message: m};
+        return m.detail ? {message: m.message, detail: m.detail} : {message: m};
       }),
     },
   };

--- a/hedera-mirror-rest/utils.js
+++ b/hedera-mirror-rest/utils.js
@@ -226,18 +226,22 @@ const basicOperators = Object.values(constants.queryParamOperators).filter(
   (o) => o !== constants.queryParamOperators.ne
 );
 
+/**
+ * Returns false if the op or val is undefined or if the op is an invalid operator
+ * @param op
+ * @param val
+ * @returns {boolean}
+ */
+const validateOpAndValue = (op, val) => {
+  return !(op === undefined || val === undefined || !isValidOperatorQuery(op));
+};
+
 const filterValidityChecks = (param, op, val) => {
-  let ret = false;
-
-  if (op === undefined || val === undefined) {
-    return ret;
+  if (!validateOpAndValue(op, val)) {
+    return false;
   }
 
-  // Validate operator
-  if (!isValidOperatorQuery(op)) {
-    return ret;
-  }
-
+  let ret;
   // Validate the value
   switch (param) {
     case constants.filterKeys.ACCOUNT_BALANCE:
@@ -1565,6 +1569,7 @@ export {
   toHexStringQuantity,
   validateAndParseFilters,
   validateFilters,
+  validateOpAndValue,
   validateReq,
   stripHexPrefix,
   toUint256,

--- a/hedera-mirror-rest/utils.js
+++ b/hedera-mirror-rest/utils.js
@@ -24,6 +24,7 @@ import pg from 'pg';
 import pgRange from 'pg-range';
 import util from 'util';
 
+import AccountAlias from './accountAlias.js';
 import * as constants from './constants';
 import EntityId from './entityId';
 import config from './config';
@@ -244,7 +245,7 @@ const filterValidityChecks = (param, op, val) => {
       ret = isPositiveLong(val, true);
       break;
     case constants.filterKeys.ACCOUNT_ID:
-      ret = EntityId.isValidEntityId(val);
+      ret = EntityId.isValidEntityId(val) || AccountAlias.isValid(val);
       break;
     case constants.filterKeys.ACCOUNT_PUBLICKEY:
       ret = isValidPublicKeyQuery(val);

--- a/hedera-mirror-rest/utils.js
+++ b/hedera-mirror-rest/utils.js
@@ -245,7 +245,7 @@ const filterValidityChecks = (param, op, val) => {
       ret = isPositiveLong(val, true);
       break;
     case constants.filterKeys.ACCOUNT_ID:
-      ret = EntityId.isValidEntityId(val) || AccountAlias.isValid(val);
+      ret = EntityId.isValidEntityId(val);
       break;
     case constants.filterKeys.ACCOUNT_PUBLICKEY:
       ret = isValidPublicKeyQuery(val);
@@ -281,6 +281,12 @@ const filterValidityChecks = (param, op, val) => {
       break;
     case constants.filterKeys.FROM:
       ret = EntityId.isValidEntityId(val, true, constants.EvmAddressType.NO_SHARD_REALM);
+      break;
+    case constants.filterKeys.ID_OR_ALIAS_OR_EVM_ADDRESS:
+      ret = EntityId.isValidEntityId(val, false);
+      if (!ret) {
+        ret = (EntityId.isValidEvmAddress(val) || AccountAlias.isValid(val)) && op === constants.queryParamOperators.eq;
+      }
       break;
     case constants.filterKeys.INDEX:
       ret = isNumeric(val) && val >= 0;


### PR DESCRIPTION
**Description**:
The balances endpoint now supports a single account.id value in the form of an evm address or an alias.

**Related issue(s)**:

Fixes #5863

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
