### PR TITLE
Eliminate the need for a boolean "ethereum" parameter from…

### DIFF
--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/ContractResultServiceImplIntegrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/ContractResultServiceImplIntegrationTest.java
@@ -175,8 +175,8 @@ class ContractResultServiceImplIntegrationTest extends IntegrationTest {
 
         process(recordItem);
 
-        assertContractResult(recordItem, true);
-        assertContractLogs(recordItem, true);
+        assertContractResult(recordItem);
+        assertContractLogs(recordItem);
         assertContractActions(recordItem);
         assertContractStateChanges(recordItem);
         assertThat(contractRepository.count()).isZero();
@@ -459,19 +459,12 @@ class ContractResultServiceImplIntegrationTest extends IntegrationTest {
 
     @SuppressWarnings("deprecation")
     private void assertContractResult(RecordItem recordItem) {
-        assertContractResult(recordItem, false);
-    }
-
-    @SuppressWarnings("deprecation")
-    private void assertContractResult(RecordItem recordItem, boolean ethereum) {
         var functionResult = getFunctionResult(recordItem);
         var createdIds = functionResult.getCreatedContractIDsList().stream()
                 .map(x -> EntityId.of(x).getId())
                 .collect(Collectors.toList());
         var failedInitcode = getFailedInitcode(recordItem);
-        var hash = ethereum
-                ? recordItem.getEthereumTransaction().getHash()
-                : Arrays.copyOfRange(transaction.getTransactionHash(), 0, 32);
+        var hash = getTransactionHash(recordItem);
 
         assertThat(contractResultRepository.findAll())
                 .hasSize(1)
@@ -554,16 +547,16 @@ class ContractResultServiceImplIntegrationTest extends IntegrationTest {
                 .containsAll(expected);
     }
 
-    private void assertContractLogs(RecordItem recordItem) {
-        assertContractLogs(recordItem, false);
+    private byte[] getTransactionHash(RecordItem recordItem) {
+        return recordItem.getEthereumTransaction() == null
+                ? Arrays.copyOfRange(transaction.getTransactionHash(), 0, 32)
+                : recordItem.getEthereumTransaction().getHash();
     }
 
-    private void assertContractLogs(RecordItem recordItem, boolean ethereum) {
+    private void assertContractLogs(RecordItem recordItem) {
         var contractFunctionResult = getFunctionResult(recordItem);
         var listAssert = assertThat(contractLogRepository.findAll()).hasSize(contractFunctionResult.getLogInfoCount());
-        var transactionHash = ethereum
-                ? recordItem.getEthereumTransaction().getHash()
-                : Arrays.copyOfRange(transaction.getTransactionHash(), 0, 32);
+        var transactionHash = getTransactionHash(recordItem);
         Integer transactionIndex = transaction.getIndex();
 
         if (contractFunctionResult.getLogInfoCount() > 0) {


### PR DESCRIPTION
…assertContractLogs() and assertContractResult().
Instead, added a helper routine to extract the proper transaction hash (from either type of transaction).

**Description**:
This PR modifies ContractResultServiceImplIntegrationTest.java in order to eliminate the two-parameter versions of
`assertContractLogs()` and `assertContractResult()` .
* Remove two-parameter version of each method.
* Instead, call a new helper method that determines which hash (transactionHash or ethereumTransactionHash) is needed, based on the passed-in transaction.

**Related issue(s)**:

Fixes #5471 

**Notes for reviewer**:
Very small change, fully covered by existing methods.
**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
