### PR TITLE
Fixing "No such account or token" issue for estimate gas

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/account/MirrorEvmContractAliases.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/account/MirrorEvmContractAliases.java
@@ -35,6 +35,11 @@ public class MirrorEvmContractAliases extends HederaEvmContractAliases {
 
     @Override
     public Address resolveForEvm(Address addressOrAlias) {
+        // returning the zero address in cases when estimating contract creations
+        if (addressOrAlias.equals(Address.ZERO)) {
+            return addressOrAlias;
+        }
+
         final var entityOptional = mirrorEntityAccess.findEntity(addressOrAlias);
 
         if (entityOptional.isEmpty()) {

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
@@ -91,7 +91,7 @@ class ContractCallServiceTest extends Web3IntegrationTest {
         // multiplySimpleNumbers()
         final var pureFuncHash = "8070450f";
         final var successfulReadResponse = "0x0000000000000000000000000000000000000000000000000000000000000004";
-        final var serviceParameters = serviceParameters(pureFuncHash, 0, ETH_CALL, true, ETH_CALL_CONTRACT_ADDRESS, 0);
+        final var serviceParameters = serviceParameters(pureFuncHash, 0, ETH_CALL, true, 0, ETH_CALL_CONTRACT_ADDRESS);
 
         persistEntities(false);
 
@@ -106,7 +106,21 @@ class ContractCallServiceTest extends Web3IntegrationTest {
         final var gasUsedBeforeExecution = getGasUsedBeforeExecution(ETH_ESTIMATE_GAS);
         final var expectedGasUsed = 22217L;
         final var serviceParameters =
-                serviceParameters(pureFuncHash, 0, ETH_ESTIMATE_GAS, true, ETH_CALL_CONTRACT_ADDRESS, 0);
+                serviceParameters(pureFuncHash, 0, ETH_ESTIMATE_GAS, true, 0, ETH_CALL_CONTRACT_ADDRESS);
+
+        persistEntities(false);
+
+        assertThat(contractCallService.processCall(serviceParameters)).isEqualTo(hexValueOf.apply(expectedGasUsed));
+
+        assertGasUsedIsPositive(gasUsedBeforeExecution, ETH_ESTIMATE_GAS);
+    }
+
+    @Test
+    void estimateGasWithoutReceiver() {
+        final var pureFuncHash = "8070450f";
+        final var gasUsedBeforeExecution = getGasUsedBeforeExecution(ETH_ESTIMATE_GAS);
+        final var expectedGasUsed = 21773L;
+        final var serviceParameters = serviceParameters(pureFuncHash, 0, ETH_ESTIMATE_GAS, true, 0, Address.ZERO);
 
         persistEntities(false);
 
@@ -124,7 +138,7 @@ class ContractCallServiceTest extends Web3IntegrationTest {
                 "0x6601c296000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000036b75720000000000000000000000000000000000000000000000000000000000";
         final var successfulReadResponse =
                 "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000047465737400000000000000000000000000000000000000000000000000000000";
-        final var serviceParameters = serviceParameters(viewFuncHash, 0, ETH_CALL, true, ETH_CALL_CONTRACT_ADDRESS, 0);
+        final var serviceParameters = serviceParameters(viewFuncHash, 0, ETH_CALL, true, 0, ETH_CALL_CONTRACT_ADDRESS);
 
         persistEntities(false);
 
@@ -139,7 +153,7 @@ class ContractCallServiceTest extends Web3IntegrationTest {
                 "0x6601c296000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000036b75720000000000000000000000000000000000000000000000000000000000";
         final var expectedGasUsed = 23175L;
         final var serviceParameters =
-                serviceParameters(viewFuncHash, 0, ETH_ESTIMATE_GAS, true, ETH_CALL_CONTRACT_ADDRESS, 0);
+                serviceParameters(viewFuncHash, 0, ETH_ESTIMATE_GAS, true, 0, ETH_CALL_CONTRACT_ADDRESS);
 
         persistEntities(false);
 
@@ -150,7 +164,7 @@ class ContractCallServiceTest extends Web3IntegrationTest {
     void transferFunds() {
         final var gasUsedBeforeExecution = getGasUsedBeforeExecution(ETH_CALL);
 
-        final var serviceParameters = serviceParameters("0x", 7L, ETH_CALL, true, ETH_CALL_CONTRACT_ADDRESS, 0);
+        final var serviceParameters = serviceParameters("0x", 7L, ETH_CALL, true, 0, RECEIVER_ADDRESS);
         persistEntities(true);
 
         assertThatCode(() -> contractCallService.processCall(serviceParameters)).doesNotThrowAnyException();
@@ -165,7 +179,7 @@ class ContractCallServiceTest extends Web3IntegrationTest {
         // getAccountBalance(address)
         final var balanceCall = "0x93423e9c00000000000000000000000000000000000000000000000000000000000003e6";
         final var expectedBalance = "0x0000000000000000000000000000000000000000000000000000000000004e20";
-        final var params = serviceParameters(balanceCall, 0, ETH_CALL, true, ETH_CALL_CONTRACT_ADDRESS, 0);
+        final var params = serviceParameters(balanceCall, 0, ETH_CALL, true, 0, ETH_CALL_CONTRACT_ADDRESS);
 
         persistEntities(false);
 
@@ -181,7 +195,7 @@ class ContractCallServiceTest extends Web3IntegrationTest {
         final var balanceCall = "0x93423e9c00000000000000000000000000000000000000000000000000000000000003e6";
         final var expectedGasUsed = 22738L;
         final var params =
-                serviceParameters(balanceCall, 0, ETH_ESTIMATE_GAS, true, ETH_CALL_CONTRACT_ADDRESS, 15_000_000L);
+                serviceParameters(balanceCall, 0, ETH_ESTIMATE_GAS, true, 15_000_000L, ETH_CALL_CONTRACT_ADDRESS);
 
         persistEntities(false);
 
@@ -195,7 +209,7 @@ class ContractCallServiceTest extends Web3IntegrationTest {
     void testRevertDetailMessage() {
         final var revertFunctionSignature = "0xa26388bb";
         final var serviceParameters =
-                serviceParameters(revertFunctionSignature, 0, ETH_CALL, true, ETH_CALL_CONTRACT_ADDRESS, 0);
+                serviceParameters(revertFunctionSignature, 0, ETH_CALL, true, 0, ETH_CALL_CONTRACT_ADDRESS);
 
         persistEntities(false);
 
@@ -212,7 +226,7 @@ class ContractCallServiceTest extends Web3IntegrationTest {
     @EnumSource(RevertFunctions.class)
     void testReverts(final RevertFunctions revertFunctions) {
         final var serviceParameters =
-                serviceParameters(revertFunctions.functionSignature, 0, ETH_CALL, true, REVERTER_CONTRACT_ADDRESS, 0);
+                serviceParameters(revertFunctions.functionSignature, 0, ETH_CALL, true, 0, REVERTER_CONTRACT_ADDRESS);
 
         persistEntities(false);
 
@@ -229,7 +243,7 @@ class ContractCallServiceTest extends Web3IntegrationTest {
 
         final var wrongFunctionSignature = "0x542ec32e";
         final var serviceParameters =
-                serviceParameters(wrongFunctionSignature, 0, ETH_CALL, true, ETH_CALL_CONTRACT_ADDRESS, 0);
+                serviceParameters(wrongFunctionSignature, 0, ETH_CALL, true, 0, ETH_CALL_CONTRACT_ADDRESS);
 
         persistEntities(false);
 
@@ -243,7 +257,7 @@ class ContractCallServiceTest extends Web3IntegrationTest {
 
     @Test
     void transferNegative() {
-        final var serviceParameters = serviceParameters("0x", -5L, ETH_CALL, true, ETH_CALL_CONTRACT_ADDRESS, 0);
+        final var serviceParameters = serviceParameters("0x", -5L, ETH_CALL, true, 0, RECEIVER_ADDRESS);
         persistEntities(true);
 
         assertThatThrownBy(() -> contractCallService.processCall(serviceParameters))
@@ -252,7 +266,7 @@ class ContractCallServiceTest extends Web3IntegrationTest {
 
     @Test
     void transferExceedsBalance() {
-        final var serviceParameters = serviceParameters("0x", 210000L, ETH_CALL, true, ETH_CALL_CONTRACT_ADDRESS, 0);
+        final var serviceParameters = serviceParameters("0x", 210000L, ETH_CALL, true, 0, RECEIVER_ADDRESS);
         persistEntities(true);
 
         assertThatThrownBy(() -> contractCallService.processCall(serviceParameters))
@@ -269,7 +283,7 @@ class ContractCallServiceTest extends Web3IntegrationTest {
 
         // transferHbarsToAddress(address)
         final var stateChangePayable = "0x80b9f03c00000000000000000000000000000000000000000000000000000000000004e6";
-        final var params = serviceParameters(stateChangePayable, 90L, ETH_CALL, true, ETH_CALL_CONTRACT_ADDRESS, 0);
+        final var params = serviceParameters(stateChangePayable, 90L, ETH_CALL, true, 0, ETH_CALL_CONTRACT_ADDRESS);
 
         persistEntities(false);
 
@@ -287,7 +301,7 @@ class ContractCallServiceTest extends Web3IntegrationTest {
         final var stateChangeHash =
                 "0x9ac27b62000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000033233320000000000000000000000000000000000000000000000000000000000";
         final var serviceParameters =
-                serviceParameters(stateChangeHash, 0, ETH_ESTIMATE_GAS, false, ETH_CALL_CONTRACT_ADDRESS, 0);
+                serviceParameters(stateChangeHash, 0, ETH_ESTIMATE_GAS, false, 0, ETH_CALL_CONTRACT_ADDRESS);
         final var expectedGasUsed = 29233L;
 
         persistEntities(false);
@@ -302,7 +316,7 @@ class ContractCallServiceTest extends Web3IntegrationTest {
         final var stateChangeHash =
                 "0x51fecdca000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000003e700000000000000000000000000000000000000000000000000000000000000046976616e00000000000000000000000000000000000000000000000000000000";
         final var serviceParameters =
-                serviceParameters(stateChangeHash, 0, ETH_CALL, false, ETH_CALL_CONTRACT_ADDRESS, 0);
+                serviceParameters(stateChangeHash, 0, ETH_CALL, false, 0, ETH_CALL_CONTRACT_ADDRESS);
 
         persistEntities(false);
 
@@ -315,7 +329,7 @@ class ContractCallServiceTest extends Web3IntegrationTest {
     void contractCreationWork() {
         final var deployHash =
                 "0xc32723ed000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000046976616e00000000000000000000000000000000000000000000000000000000";
-        final var serviceParameters = serviceParameters(deployHash, 0, ETH_CALL, false, ETH_CALL_CONTRACT_ADDRESS, 0);
+        final var serviceParameters = serviceParameters(deployHash, 0, ETH_CALL, false, 0, ETH_CALL_CONTRACT_ADDRESS);
 
         persistEntities(false);
 
@@ -332,7 +346,7 @@ class ContractCallServiceTest extends Web3IntegrationTest {
         final var stateChangeHash =
                 "0x9ac27b62000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000033233320000000000000000000000000000000000000000000000000000000000";
         final var serviceParameters =
-                serviceParameters(stateChangeHash, 0, ETH_CALL, true, ETH_CALL_CONTRACT_ADDRESS, 0);
+                serviceParameters(stateChangeHash, 0, ETH_CALL, true, 0, ETH_CALL_CONTRACT_ADDRESS);
 
         persistEntities(false);
 
@@ -347,7 +361,7 @@ class ContractCallServiceTest extends Web3IntegrationTest {
     void ercPrecompileCallRevertsForEstimateGas() {
         final var tokenNameCall = "0x6f0fccab00000000000000000000000000000000000000000000000000000000000003e4";
         final var serviceParameters =
-                serviceParameters(tokenNameCall, 0, ETH_ESTIMATE_GAS, false, ETH_CALL_CONTRACT_ADDRESS, 0L);
+                serviceParameters(tokenNameCall, 0, ETH_ESTIMATE_GAS, false, 0L, ETH_CALL_CONTRACT_ADDRESS);
 
         persistEntities(false);
 
@@ -360,7 +374,7 @@ class ContractCallServiceTest extends Web3IntegrationTest {
     void precompileCallRevertsForEstimateGas() {
         final var freezeTokenCall = "0x7c93c87e00000000000000000000000000000000000000000000000000000000000003e4";
         final var serviceParameters =
-                serviceParameters(freezeTokenCall, 0, ETH_ESTIMATE_GAS, false, ETH_CALL_CONTRACT_ADDRESS, 0L);
+                serviceParameters(freezeTokenCall, 0, ETH_ESTIMATE_GAS, false, 0L, ETH_CALL_CONTRACT_ADDRESS);
 
         persistEntities(false);
 
@@ -370,12 +384,12 @@ class ContractCallServiceTest extends Web3IntegrationTest {
     }
 
     private CallServiceParameters serviceParameters(
-            String callData, long value, CallType callType, boolean isStatic, Address contract, long estimatedGas) {
+            String callData, long value, CallType callType, boolean isStatic, long estimatedGas, Address receiver) {
         final var isGasEstimate = callType == ETH_ESTIMATE_GAS;
         final var gas = (isGasEstimate && estimatedGas > 0) ? estimatedGas : 120000L;
         final var sender = new HederaEvmAccount(SENDER_ADDRESS);
         final var data = Bytes.fromHexString(callData);
-        final var receiver = callData.equals("0x") ? RECEIVER_ADDRESS : contract;
+        //        final var receiver = callData.equals("0x") ? RECEIVER_ADDRESS : contract;
 
         return CallServiceParameters.builder()
                 .sender(sender)


### PR DESCRIPTION
 `No such contract or token 0x000000000000000000` is being returned when calling estimate_gas without providing receiver (i.e `to`) in `ContractCallRequest`. 

Fixes #5987

