### PR TITLE
Fix crypto allowance acceptance test

### DIFF
--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AccountFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AccountFeature.java
@@ -150,14 +150,14 @@ public class AccountFeature extends AbstractFeature {
         setCryptoAllowance(accountName, amount);
     }
 
-    @When("{string} transfers {long} tℏ from their approved balance to {string}")
-    public void transferFromAllowance(String senderAccountName, long amount, String receiverAccountName) {
-        senderAccountId = accountClient.getAccount(AccountClient.AccountNameEnum.valueOf(senderAccountName));
+    @When("I transfer {long} tℏ from {string}'s approved balance to {string}")
+    public void transferFromAllowance(long amount, String senderAccountName, String receiverAccountName) {
+        ExpandedAccountId ownerExpandedId = accountClient.getSdkClient().getExpandedOperatorAccountId();
         receiverAccountId = accountClient
                 .getAccount(AccountClient.AccountNameEnum.valueOf(receiverAccountName))
                 .getAccountId();
         networkTransactionResponse =
-                accountClient.sendApprovedCryptoTransfer(senderAccountId, receiverAccountId, Hbar.fromTinybars(amount));
+                accountClient.sendApprovedCryptoTransfer(ownerExpandedId, receiverAccountId, Hbar.fromTinybars(amount));
         assertNotNull(networkTransactionResponse.getTransactionId());
         assertNotNull(networkTransactionResponse.getReceipt());
     }

--- a/hedera-mirror-test/src/test/resources/features/account/cryptoAllowance.feature
+++ b/hedera-mirror-test/src/test/resources/features/account/cryptoAllowance.feature
@@ -5,7 +5,7 @@ Feature: Account Crypto Allowance Coverage Feature
     Scenario Outline: Validate approval CryptoTransfer
         Given I approve <senderName> to transfer up to <approvedAmount> tℏ
         Then the mirror node REST API should confirm the approved <approvedAmount> tℏ crypto transfer allowance
-        When <senderName> transfers <transferAmount> tℏ from their approved balance to <recipientName>
+        When I transfer <transferAmount> tℏ from <senderName>'s approved balance to <recipientName>
         Then the mirror node REST API should return status <httpStatusCode> for the crypto transfer transaction
         When I delete the crypto allowance for <senderName>
         Then the mirror node REST API should confirm the crypto allowance deletion


### PR DESCRIPTION
…_history and crypto_allowance appear to be correct,

but the query on crypto_transfer only shows the first 3 rows, and not the two with amount -/+2500.

**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #3489 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
