### PR TITLE
Fix acceptance tests on throttled networks

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/ContractResultServiceImpl.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/ContractResultServiceImpl.java
@@ -372,11 +372,14 @@ public class ContractResultServiceImpl implements ContractResultService {
         }
 
         sidecarContractMigration.migrate(contractBytecodes);
-        log.info(
-                "{} Sidecar records processed with {} migrations in {}",
-                sidecarRecords.size(),
-                migrationCount,
-                stopwatch);
+        if (migrationCount > 0) {
+            log.info(
+                    "{} Sidecar records processed with {} migrations in {}",
+                    sidecarRecords.size(),
+                    migrationCount,
+                    stopwatch);
+        }
+
         return failedInitcode;
     }
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListener.java
@@ -224,6 +224,7 @@ public class SqlEntityListener implements EntityListener, RecordStreamFileListen
         if (recordFile != null) {
             recordFileRepository.save(recordFile);
             sidecarFileRepository.saveAll(recordFile.getSidecars());
+            log.info("Processed {} sidecars", recordFile.getSidecars().size());
         }
     }
 

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/health/ReleaseHealthIndicator.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/health/ReleaseHealthIndicator.java
@@ -92,7 +92,8 @@ public class ReleaseHealthIndicator implements ReactiveHealthIndicator {
                 .filter(condition -> StringUtils.equals(condition.get("type"), "Ready"))
                 .findFirst()
                 .map(this::mapStatus)
-                .orElse(DOWN);
+                .orElse(DOWN)
+                .doOnNext(health -> log.info("Release status: {}", health));
     }
 
     private Mono<Health> mapStatus(Map<String, String> condition) {

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/health/ReleaseHealthIndicator.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/health/ReleaseHealthIndicator.java
@@ -93,7 +93,7 @@ public class ReleaseHealthIndicator implements ReactiveHealthIndicator {
                 .findFirst()
                 .map(this::mapStatus)
                 .orElse(DOWN)
-                .doOnNext(health -> log.info("Release status: {}", health));
+                .doOnNext(h -> log.info("Release status: {}", h));
     }
 
     private Mono<Health> mapStatus(Map<String, String> condition) {

--- a/hedera-mirror-test/README.md
+++ b/hedera-mirror-test/README.md
@@ -36,49 +36,43 @@ Tests can be compiled and run by running the following command from the root fol
 
 Configuration properties are set in the `application.yml` file located under `src/test/resources`. This component
 uses [Spring Boot](https://spring.io/projects/spring-boot) properties to configure the application. Available properties
-under `hedera.mirror.test.acceptance` include:
+include:
 
-- `backOffPeriod` - The number of milliseconds client should wait before retrying a retryable failure.
-- `createOperatorAccount` - Whether to create an operator account to run the acceptance tests
-- `emitBackgroundMessages` - Flag to set if background messages should be emitted. For operations use in non-production
-  `environments.
-- `feature`
-  - `maxContractFunctionGas` - The maximum amount of gas an account is willing to pay for a contract function call.
-- `maxRetries` - The number of times client should retry on supported failures.
-- `maxTinyBarTransactionFee` - The maximum transaction fee.
-- `messageTimeout` - The time to wait on messages representing transactions (default is 20 seconds).
-- `mirrorNodeAddress` - The mirror node grpc server endpoint including IP address and port. Refer to
-  public [documentation](https://docs.hedera.com/guides/mirrornet/hedera-mirror-node) for a list of available endpoints.
-- `network` - The desired Hedera network environment to point to. Options currently include `MAINNET`, `PREVIEWNET`,
-  `TESTNET` (default) and `OTHER`. Set to `OTHER` to point to a custom environment.
-- `nodes` - A map of custom nodes to be used by SDK. This is made up of an account ID (e.g. 0.0.1000) and host (e.g.
-  127.0.0.1) key-value pairs.
-- `operatorId` - Account ID on the network in 'x.y.z' format.
-- `operatorKey` - Account private key to be used for signing transaction and client identification. Please do not check
-  in.
-- `rest`
-  - `baseUrl` - The host URL to the mirror node. For example, https://testnet.mirrornode.hedera.com
-  - `delay` - The time to wait in between failed REST API calls.
-  - `maxAttempts` - The maximum number of attempts when calling a REST API endpoint and receiving a 404.
-  - `maxBackoff` - The maximum backoff duration the mirror grpc subscriber will wait between attempts.
-  - `minBackoff` - The minimum backoff duration the mirror grpc subscriber will wait between attempts.
-  - `retryableExceptions` - List of retryable exception class types
-- `retrieveAddressBook` - Whether to download the address book from the network and use those nodes over the default
-  nodes. Populating `hedera.mirror.test.acceptance.nodes` will take priority over this.
-- `sdk`
-  - `grpcDeadline` - The maximum amount of time to wait for a grpc call to complete.
-  - `maxAttempts` - The maximum number of times the sdk should try to submit a transaction to the network.
-- `startupTimeout` - How long the startup probe should wait for the network as a whole to be healthy before failing the
-  tests
-- `web3`
-  - `baseUrl` - The endpoint associated with the web3 API.
-- `webclient`
-  - `connectionTimeout` - The timeout duration to wait to establish a connection with the server
-  - `readTimeout` - The timeout duration to wait for data to be read.
-  - `wiretap` - Whether a wire logger configuration should be applied to connection calls.
-  - `writeTimeout` - The timeout duration to wait for data to be written.
+| Name                                                           | Default                                      | Description                                                                                               |
+| -------------------------------------------------------------- | -------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `hedera.mirror.test.acceptance.backOffPeriod`                  | 5s                                           | The amount of time the client will wait before retrying a retryable failure.                              |
+| `hedera.mirror.test.acceptance.createOperatorAccount`          | false                                        | Whether to create a separate operator account to run the acceptance tests.                                |
+| `hedera.mirror.test.acceptance.emitBackgroundMessages`         | false                                        | Whether background topic messages should be emitted.                                                      |
+| `hedera.mirror.test.acceptance.feature.maxContractFunctionGas` | 3000000                                      | The maximum amount of gas an account is willing to pay for a contract call.                               |
+| `hedera.mirror.test.acceptance.feature.sidecars`               | false                                        | Whether information in sidecars should be used to verify test scenarios.                                  |
+| `hedera.mirror.test.acceptance.maxNodes`                       | 10                                           | The maximum number of nodes to validate from the address book.                                            |
+| `hedera.mirror.test.acceptance.maxRetries`                     | 2                                            | The number of times client should retry mirror node on supported failures.                                |
+| `hedera.mirror.test.acceptance.maxTinyBarTransactionFee`       | 5000000000                                   | The maximum transaction fee the payer is willing to pay in tinybars.                                      |
+| `hedera.mirror.test.acceptance.messageTimeout`                 | 20s                                          | The maximum amount of time to wait to receive topic messages from the mirror node.                        |
+| `hedera.mirror.test.acceptance.mirrorNodeAddress`              | testnet.mirrornode.hedera.com:443            | The mirror node gRPC server endpoint including IP address and port.                                       |
+| `hedera.mirror.test.acceptance.network`                        | TESTNET                                      | Which Hedera network to use. Can be either `MAINNET`, `PREVIEWNET`, `TESTNET` or `OTHER`.                 |
+| `hedera.mirror.test.acceptance.nodes`                          | []                                           | A map of custom consensus node with the key being the account ID and the value its endpoint.              |
+| `hedera.mirror.test.acceptance.operatorBalance`                | 26000000000                                  | The amount of tinybars to fund the operator. Applicable only when `createOperatorAccount` is `true`.      |
+| `hedera.mirror.test.acceptance.operatorId`                     | 0.0.2                                        | Operator account ID used to pay for transactions.                                                         |
+| `hedera.mirror.test.acceptance.operatorKey`                    | Genesis key                                  | Operator ED25519 private key used to sign transactions in hex encoded DER format.                         |
+| `hedera.mirror.test.acceptance.rest.baseUrl`                   | https://testnet.mirrornode.hedera.com/api/v1 | The URL to the mirror node REST API.                                                                      |
+| `hedera.mirror.test.acceptance.rest.maxAttempts`               | 20                                           | The maximum number of attempts when calling a REST API endpoint and receiving a 404.                      |
+| `hedera.mirror.test.acceptance.rest.maxBackoff`                | 4s                                           | The maximum amount of time to wait between REST API attempts.                                             |
+| `hedera.mirror.test.acceptance.rest.minBackoff`                | 0.5s                                         | The minimum amount of time to wait between REST API attempts.                                             |
+| `hedera.mirror.test.acceptance.rest.retryableExceptions`       | [java.lang.Exception]                        | A list of exception classes that will be considered for retry.                                            |
+| `hedera.mirror.test.acceptance.retrieveAddressBook`            | true                                         | Whether to download the address book from the mirror node and use those nodes to publish transactions.    |
+| `hedera.mirror.test.acceptance.sdk.grpcDeadline`               | 10s                                          | The maximum amount of time to wait for a grpc call to complete.                                           |
+| `hedera.mirror.test.acceptance.sdk.maxAttempts`                | 100                                          | The maximum number of times the sdk should try to submit a transaction to the network.                    |
+| `hedera.mirror.test.acceptance.sdk.maxNodesPerTransaction`     | 2147483647                                   | The maximum number of nodes that a transaction can be submitted to.                                       |
+| `hedera.mirror.test.acceptance.startupTimeout`                 | 60m                                          | How long the startup probe should wait for the network as a whole to be healthy before failing the tests. |
+| `hedera.mirror.test.acceptance.web3.baseUrl`                   | Inherits `rest.baseUrl`                      | The endpoint associated with the web3 API.                                                                |
+| `hedera.mirror.test.acceptance.web3.enabled`                   | false                                        | Whether to invoke the web3 API.                                                                           |
+| `hedera.mirror.test.acceptance.webclient.connectionTimeout`    | 10s                                          | The timeout duration to wait to establish a connection with the server.                                   |
+| `hedera.mirror.test.acceptance.webclient.readTimeout`          | 10s                                          | The timeout duration to wait for data to be read.                                                         |
+| `hedera.mirror.test.acceptance.webclient.wiretap`              | false                                        | Whether a wire logger configuration should be applied to connection calls.                                |
+| `hedera.mirror.test.acceptance.webclient.writeTimeout`         | 10s                                          | The timeout duration to wait for data to be written.                                                      |
 
-(Recommended) Options can be set by creating your own configuration file with the above properties. This allows for
+Options can be set by creating your own configuration file with the above properties. This allows for
 multiple files per environment. The `spring.config.additional-location` property can be set to the folder containing
 the environment-specific `application.yml`:
 

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
@@ -39,7 +39,6 @@ public class AcceptanceTestProperties {
 
     private final FeatureProperties featureProperties;
     private final RestPollingProperties restPollingProperties;
-    private final SdkProperties sdkProperties;
     private final WebClientProperties webClientProperties;
 
     @NotNull
@@ -48,7 +47,6 @@ public class AcceptanceTestProperties {
     private boolean createOperatorAccount = false;
 
     private boolean emitBackgroundMessages = false;
-    private boolean contractTraceability = false;
 
     @Min(1)
     private int maxNodes = 10;
@@ -86,7 +84,7 @@ public class AcceptanceTestProperties {
 
     @DurationMin(seconds = 0L)
     @NotNull
-    private Duration startupTimeout = Duration.ofMinutes(30);
+    private Duration startupTimeout = Duration.ofMinutes(60);
 
     public enum HederaNetwork {
         MAINNET,

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/SdkProperties.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/SdkProperties.java
@@ -16,7 +16,6 @@
 
 package com.hedera.mirror.test.e2e.acceptance.config;
 
-import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import java.time.Duration;
@@ -32,11 +31,13 @@ import org.springframework.validation.annotation.Validated;
 @Validated
 public class SdkProperties {
 
-    @DurationMin(seconds = 5L)
+    @DurationMin(seconds = 1L)
     @NotNull
     private Duration grpcDeadline = Duration.ofSeconds(10L);
 
     @Min(1)
-    @Max(60)
-    private int maxAttempts = 10;
+    private int maxAttempts = 100;
+
+    @Min(1)
+    private int maxNodesPerTransaction = Integer.MAX_VALUE;
 }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/Web3Properties.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/Web3Properties.java
@@ -31,6 +31,8 @@ public class Web3Properties {
 
     private String baseUrl;
 
+    private boolean enabled = false;
+
     public String getBaseUrl() {
         if (baseUrl != null && !baseUrl.endsWith(URL_SUFFIX)) {
             return baseUrl + URL_SUFFIX;

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ContractFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ContractFeature.java
@@ -37,6 +37,7 @@ import com.hedera.mirror.test.e2e.acceptance.client.ContractClient.ExecuteContra
 import com.hedera.mirror.test.e2e.acceptance.client.FileClient;
 import com.hedera.mirror.test.e2e.acceptance.client.MirrorNodeClient;
 import com.hedera.mirror.test.e2e.acceptance.config.AcceptanceTestProperties;
+import com.hedera.mirror.test.e2e.acceptance.config.Web3Properties;
 import com.hedera.mirror.test.e2e.acceptance.props.CompiledSolidityArtifact;
 import com.hedera.mirror.test.e2e.acceptance.props.MirrorContractResult;
 import com.hedera.mirror.test.e2e.acceptance.props.MirrorTransaction;
@@ -81,6 +82,7 @@ public class ContractFeature extends AbstractFeature {
     private final FileClient fileClient;
     private final MirrorNodeClient mirrorClient;
     private final AcceptanceTestProperties acceptanceTestProperties;
+    private final Web3Properties web3Properties;
     private String create2ChildContractEvmAddress;
     private String create2ChildContractEntityId;
     private AccountId create2ChildContractAccountId;
@@ -170,7 +172,7 @@ public class ContractFeature extends AbstractFeature {
 
     @Then("I call the contract via the mirror node REST API")
     public void restContractCall() {
-        if (!acceptanceTestProperties.isContractTraceability()) {
+        if (!web3Properties.isEnabled()) {
             return;
         }
 


### PR DESCRIPTION
**Description**:

* Add a release health status log to verify health check is running
* Add a `hedera.mirror.test.acceptance.maxNodesPerTransaction=MAX_VALUE` property so SDK retries all nodes
* Change `hedera.mirror.test.acceptance.contractTraceability` to `hedera.mirror.test.acceptance.web3.enabled`
* Change SDK `maxAttempts` from 10 to 100 so entity creation is more likely to succeed on throttled networks
* Change `startupTimeout` to `60m` to provide more time for importer to catch up after long migrations
* Change the acceptance test README to use our standard table for properties
* Remove per transaction calls to `setGrpcDeadline()` in favor of a global client default
* Fix high rate of `Sidecar records processed` logs

**Related issue(s)**:

Fixes #6075

**Notes for reviewer**:

Tested against testnet multiple times without failure (before the NFT minting error was present).

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
