### PR TITLE
Fix flaky Flyway setup in REST tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,5 @@ build
 # Security
 .dccache
 snyk
+
+hedera-mirror-rest/report.html*


### PR DESCRIPTION
**Description**:

* Add a report file to `.gitignore`
* Bump Flyway version in REST API to match importer
* Fix flaky Flyway setup in REST tests by retrying `flyway migrate`
* Fix not breaking out of the retry loop upon success

**Related issue(s)**:

Fixes #6083

**Notes for reviewer**:

We did `flyway info` in a retry loop but not the actual `flyway migrate`. We mistakenly assumed that the second invocation would not download the Flyway artifacts again unnecessarily. So we remove the info command and run the migrate in a retry loop.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
