### PR TITLE
HIP-584: Copy AbstractAutoCreationLogic into hedera-mirror-web3

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/services/ledger/ids/EntityIdSource.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/ledger/ids/EntityIdSource.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.ledger.ids;
+
+import com.hederahashgraph.api.proto.java.AccountID;
+import com.hederahashgraph.api.proto.java.ContractID;
+import com.hederahashgraph.api.proto.java.FileID;
+import com.hederahashgraph.api.proto.java.ScheduleID;
+import com.hederahashgraph.api.proto.java.TokenID;
+import com.hederahashgraph.api.proto.java.TopicID;
+
+/** Defines a type able to create ids of various entities under various conditions. */
+public interface EntityIdSource {
+    /**
+     * Returns the {@link TopicID} to use for a new topic with the given sponsor.
+     *
+     * @param sponsor the sponsor of the new topic
+     * @return an appropriate id to use
+     */
+    TopicID newTopicId(AccountID sponsor);
+
+    /**
+     * Returns the {@link AccountID} to use for a new account
+     *
+     * @return an appropriate id to use
+     */
+    AccountID newAccountId();
+
+    /**
+     * Returns the new account number to use for a new account
+     *
+     * @return an appropriate id to use
+     */
+    long newAccountNumber();
+
+    /**
+     * Returns the {@link ContractID} to use for a new contract with the given account.
+     *
+     * @param newContractSponsor the account of the new contract
+     * @return an appropriate id to use
+     */
+    ContractID newContractId(AccountID newContractSponsor);
+
+    /**
+     * Returns the {@link FileID} to use for a new account with the given sponsor.
+     *
+     * @param newFileSponsor the sponsor of the new account.
+     * @return an appropriate id to use
+     */
+    FileID newFileId(AccountID newFileSponsor);
+
+    /**
+     * Returns the {@link TokenID} to use for a new token with the given sponsor.
+     *
+     * @param sponsor the sponsor of the new token.
+     * @return an appropriate id to use
+     */
+    TokenID newTokenId(AccountID sponsor);
+
+    /**
+     * Returns the {@link ScheduleID} to use for a new scheduled entity with the given sponsor.
+     *
+     * @param sponsor the sponsor of the new scheduled entity.
+     * @return an appropriate id to use
+     */
+    ScheduleID newScheduleId(AccountID sponsor);
+
+    /** Reclaims the last id issued. */
+    void reclaimLastId();
+
+    /** Reclaims the IDs issued during one logical {@code handleTransaction} operation. */
+    void reclaimProvisionalIds();
+
+    /**
+     * Resets the provisional ids created during one logical {@code handleTransaction} operation.
+     */
+    void resetProvisionalIds();
+}

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/txns/crypto/AbstractAutoCreationLogic.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/txns/crypto/AbstractAutoCreationLogic.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.txns.crypto;
+
+import static com.hedera.services.utils.EntityNum.fromAccountId;
+import static com.hedera.services.utils.MiscUtils.asFcKeyUnchecked;
+import static com.hedera.services.utils.MiscUtils.asPrimitiveKeyUnchecked;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.NOT_SUPPORTED;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
+
+import com.google.protobuf.ByteString;
+import com.hedera.mirror.web3.evm.store.StackedStateFrames;
+import com.hedera.node.app.service.evm.contracts.execution.EvmProperties;
+import com.hedera.services.fees.FeeCalculator;
+import com.hedera.services.jproto.JKey;
+import com.hedera.services.ledger.BalanceChange;
+import com.hedera.services.ledger.ids.EntityIdSource;
+import com.hedera.services.store.models.Account;
+import com.hedera.services.store.models.Id;
+import com.hederahashgraph.api.proto.java.AccountID;
+import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
+import com.hederahashgraph.api.proto.java.Timestamp;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.commons.lang3.tuple.Pair;
+
+public abstract class AbstractAutoCreationLogic {
+    private final StackedStateFrames<Object> stackedStateFrames;
+    protected final EntityIdSource ids;
+    protected final Map<ByteString, Set<Id>> tokenAliasMap = new HashMap<>();
+
+    protected final EvmProperties properties;
+    protected FeeCalculator feeCalculator;
+
+    protected AbstractAutoCreationLogic(
+            final EntityIdSource ids,
+            final StackedStateFrames<Object> stackedStateFrames,
+            final EvmProperties properties,
+            final FeeCalculator feeCalculator) {
+        this.ids = ids;
+        this.stackedStateFrames = stackedStateFrames;
+        this.properties = properties;
+        this.feeCalculator = feeCalculator;
+    }
+
+    public void setFeeCalculator(final FeeCalculator feeCalculator) {
+        this.feeCalculator = feeCalculator;
+    }
+
+    /**
+     * Clears any state related to provisionally created accounts and their pending child records.
+     */
+    public void reset() {
+        tokenAliasMap.clear();
+    }
+
+    public abstract boolean reclaimPendingAliases();
+
+    /**
+     * Provisionally auto-creates an account in the given accounts ledger for the triggering balance change.
+     *
+     * <p>Returns the amount deducted from the balance change as an auto-creation charge; or a
+     * failure code.
+     *
+     * <p><b>IMPORTANT:</b> If this change was to be part of a zero-sum balance change list, then
+     * after those changes are applied atomically, the returned fee must be given to the funding account!
+     *
+     * @param change  a triggering change with unique alias
+     * @param changes list of all changes need to construct tokenAliasMap
+     * @return the fee charged for the auto-creation if ok, a failure reason otherwise
+     */
+    public Pair<ResponseCodeEnum, Long> create(
+            final BalanceChange change, final List<BalanceChange> changes, final Timestamp timestamp) {
+        if (change.isForToken() && !properties.isLazyCreationEnabled()) {
+            return Pair.of(NOT_SUPPORTED, 0L);
+        }
+
+        final var alias = change.getNonEmptyAliasIfPresent();
+        if (alias == null) {
+            throw new IllegalStateException("Cannot auto-create an account from unaliased change " + change);
+        }
+        analyzeTokenTransferCreations(changes);
+        final var key = asPrimitiveKeyUnchecked(alias);
+        final JKey jKey = asFcKeyUnchecked(key);
+        var fee = autoCreationFeeFor(jKey, stackedStateFrames, timestamp);
+
+        final var newId = ids.newAccountId();
+        final var topFrame = stackedStateFrames.top();
+        final var accountAccessor = topFrame.getAccessor(Account.class);
+        final var account = new Account(
+                Id.fromGrpcAccount(newId),
+                0L,
+                0L,
+                false,
+                0L,
+                0L,
+                null,
+                0,
+                Collections.emptySortedMap(),
+                Collections.emptySortedMap(),
+                Collections.emptySortedSet(),
+                0,
+                0,
+                0);
+        accountAccessor.set(Id.fromGrpcAccount(newId).asEvmAddress(), account);
+        replaceAliasAndSetBalanceOnChange(change, newId);
+        trackAlias(alias, newId);
+        return Pair.of(OK, fee);
+    }
+
+    protected abstract void trackAlias(final ByteString alias, final AccountID newId);
+
+    private void replaceAliasAndSetBalanceOnChange(final BalanceChange change, final AccountID newAccountId) {
+        if (change.isForHbar()) {
+            change.setNewBalance(change.getAggregatedUnits());
+        }
+        change.replaceNonEmptyAliasWith(fromAccountId(newAccountId));
+    }
+
+    private long autoCreationFeeFor(
+            final JKey payerKey, final StackedStateFrames<Object> stackedStateFrames, Timestamp timestamp) {
+        final var fees = feeCalculator.computeFee(payerKey, stackedStateFrames, timestamp);
+        return fees.getServiceFee() + fees.getNetworkFee() + fees.getNodeFee();
+    }
+
+    private void analyzeTokenTransferCreations(final List<BalanceChange> changes) {
+        for (final var change : changes) {
+            if (change.isForHbar()) {
+                continue;
+            }
+            var alias = change.getNonEmptyAliasIfPresent();
+
+            if (alias != null) {
+                if (tokenAliasMap.containsKey(alias)) {
+                    final var oldSet = tokenAliasMap.get(alias);
+                    oldSet.add(change.getToken());
+                    tokenAliasMap.put(alias, oldSet);
+                } else {
+                    tokenAliasMap.put(alias, new HashSet<>(Arrays.asList(change.getToken())));
+                }
+            }
+        }
+    }
+}

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/utils/EntityIdUtils.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/utils/EntityIdUtils.java
@@ -22,6 +22,7 @@ import static java.lang.System.arraycopy;
 
 import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
+import com.google.protobuf.ByteString;
 import com.hedera.services.store.models.Id;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ContractID;
@@ -217,5 +218,9 @@ public final class EntityIdUtils {
 
     public static boolean isAlias(final AccountID idOrAlias) {
         return idOrAlias.getAccountNum() == 0 && !idOrAlias.getAlias().isEmpty();
+    }
+
+    public static boolean isOfEvmAddressSize(final ByteString alias) {
+        return alias.size() == EVM_ADDRESS_SIZE;
     }
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/utils/MiscUtils.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/utils/MiscUtils.java
@@ -16,6 +16,8 @@
 
 package com.hedera.services.utils;
 
+import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.services.jproto.JKey;
 import com.hederahashgraph.api.proto.java.Key;
 import java.util.Optional;
@@ -39,6 +41,14 @@ public final class MiscUtils {
         x ^= x >>> 24;
         x += x << 30;
         return x;
+    }
+
+    public static Key asPrimitiveKeyUnchecked(final ByteString alias) {
+        try {
+            return Key.parseFrom(alias);
+        } catch (final InvalidProtocolBufferException internal) {
+            throw new IllegalStateException(internal);
+        }
     }
 
     public static JKey asFcKeyUnchecked(final Key key) {


### PR DESCRIPTION
**Description**:

We need to have AbstractAutoCreationLogic in web3 module, so that we can execute lazy account creation, when needed.

**Related issue(s)**:

Fixes #6076

**Notes for reviewer**:


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
