### PR TITLE
Handle null hapiVersion in blocks API

### DIFF
--- a/hedera-mirror-rest/__tests__/specs/blocks/null-hapi-version.json
+++ b/hedera-mirror-rest/__tests__/specs/blocks/null-hapi-version.json
@@ -1,0 +1,57 @@
+{
+  "description": "Get first block with hapi version all nulls",
+  "setup": {
+    "recordFiles": [
+      {
+        "index": 16,
+        "count": 3,
+        "hapi_version_major": null,
+        "hapi_version_minor": null,
+        "hapi_version_patch": null,
+        "name": "2022-04-27T12_09_24.499938763Z.rcd",
+        "prev_hash": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+        "consensus_start": "1676540001234390000",
+        "consensus_end": "1676540001234490000",
+        "hash": "fbd921184e229e2051280d827ba3b31599117af7eafba65dc0e5a998b70c48c0492bf793a150769b1b4fb2c9b7cb4c1c"
+      },
+      {
+        "index": 17,
+        "count": 5,
+        "hapi_version_major": null,
+        "hapi_version_minor": null,
+        "hapi_version_patch": null,
+        "name": "2022-04-27T12_24_30.768994443Z.rcd",
+        "prev_hash": "fbd921184e229e2051280d827ba3b31599117af7eafba65dc0e5a998b70c48c0492bf793a150769b1b4fb2c9b7cb4c1c",
+        "consensus_start": "1676540001234500000",
+        "consensus_end": "1676540001234600000",
+        "hash": "b0162e8a244dc05fbd6f321445b14dddf0e94b00eb169b58ff77b1b5206c12782457f7f1a2ae8cea890f378542ac7216"
+      }
+    ]
+  },
+  "urls": [
+    "/api/v1/blocks?order=asc&limit=1"
+  ],
+  "responseStatus": 200,
+  "responseJson": {
+    "blocks": [
+      {
+        "count": 3,
+        "gas_used": 0,
+        "hapi_version": null,
+        "hash": "0xfbd921184e229e2051280d827ba3b31599117af7eafba65dc0e5a998b70c48c0492bf793a150769b1b4fb2c9b7cb4c1c",
+        "logs_bloom": "0x",
+        "name": "2022-04-27T12_09_24.499938763Z.rcd",
+        "number": 16,
+        "previous_hash": "0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+        "size": 6,
+        "timestamp": {
+          "from": "1676540001.234390000",
+          "to": "1676540001.234490000"
+        }
+      }
+    ],
+    "links": {
+      "next": "/api/v1/blocks?order=asc&limit=1&block.number=gt:16"
+    }
+  }
+}

--- a/hedera-mirror-rest/api/v1/openapi.yml
+++ b/hedera-mirror-rest/api/v1/openapi.yml
@@ -2815,6 +2815,7 @@ components:
           nullable: true
         hapi_version:
           type: string
+          nullable: true
         hash:
           type: string
         logs_bloom:

--- a/hedera-mirror-rest/model/recordFile.js
+++ b/hedera-mirror-rest/model/recordFile.js
@@ -62,7 +62,8 @@ class RecordFile {
   }
 
   getFullHapiVersion() {
-    return `${this.hapiVersionMajor}.${this.hapiVersionMinor}.${this.hapiVersionPatch}`;
+    return `${this.hapiVersionMajor}` == `null` ? null
+        : `${this.hapiVersionMajor}.${this.hapiVersionMinor}.${this.hapiVersionPatch}`;
   }
 }
 

--- a/hedera-mirror-rest/model/recordFile.js
+++ b/hedera-mirror-rest/model/recordFile.js
@@ -62,7 +62,7 @@ class RecordFile {
   }
 
   getFullHapiVersion() {
-    return `${this.hapiVersionMajor}` == `null` ? null
+    return hapiVersionMajor === null || hapiVersionMinor === null || hapiVersionPatch === null ? null
         : `${this.hapiVersionMajor}.${this.hapiVersionMinor}.${this.hapiVersionPatch}`;
   }
 }

--- a/hedera-mirror-rest/model/recordFile.js
+++ b/hedera-mirror-rest/model/recordFile.js
@@ -62,7 +62,7 @@ class RecordFile {
   }
 
   getFullHapiVersion() {
-    return hapiVersionMajor === null || hapiVersionMinor === null || hapiVersionPatch === null ? null
+    return (this.hapiVersionMajor === null || this.hapiVersionMinor === null || this.hapiVersionPatch === null) ? null
         : `${this.hapiVersionMajor}.${this.hapiVersionMinor}.${this.hapiVersionPatch}`;
   }
 }


### PR DESCRIPTION
**Description**:

* Fix `recordFile.getFullVersion` to return `null` instead of `null.null.null`
* New spec file to test that it works

**Related issue(s)**:

Fixes #6069 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit)
