### PR TITLE
Fix nft balance and state tracking with nested nft transfer

### DIFF
--- a/.github/workflows/charts.yml
+++ b/.github/workflows/charts.yml
@@ -2,7 +2,7 @@ name: Charts
 
 on:
   pull_request:
-    branches: [ main, release/** ]
+    branches: [ main, release/**, 4099-nested-nft-transfers ]
   push:
     branches: [ main, release/** ]
     tags: [ v* ]

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -2,7 +2,7 @@ name: "Gradle"
 
 on:
   pull_request:
-    branches: [ main, release/** ]
+    branches: [ main, release/**, 4099-nested-nft-transfers ]
   push:
     branches: [ main, release/** ]
     tags: [ v* ]

--- a/.github/workflows/rosetta.yml
+++ b/.github/workflows/rosetta.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: "0 1 * * *" # Daily at 1:00 AM
   pull_request:
-    branches: [ main, release/** ]
+    branches: [ main, release/**, 4099-nested-nft-transfers ]
     paths: [ hedera-mirror-rosetta/** ]
   push:
     branches: [ main, release/** ]

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -2,7 +2,7 @@ name: Security
 
 on:
   pull_request:
-    branches: [ main, release/** ]
+    branches: [ main, release/**, 4099-nested-nft-transfers ]
   push:
     branches: [ main, release/** ]
     tags: [ v* ]

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/converter/AbstractEntityIdDeserializer.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/converter/AbstractEntityIdDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,17 +19,19 @@ package com.hedera.mirror.common.converter;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.hedera.mirror.common.domain.entity.EntityId;
+import com.hedera.mirror.common.domain.entity.EntityType;
 import java.io.IOException;
+import lombok.RequiredArgsConstructor;
 
-public class StringToObjectDeserializer extends JsonDeserializer<Object> {
-    private static final ObjectMapper OBJECT_MAPPER =
-            new ObjectMapper().setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+@RequiredArgsConstructor
+abstract class AbstractEntityIdDeserializer extends JsonDeserializer<EntityId> {
+
+    private final EntityType entityType;
 
     @Override
-    public Object deserialize(JsonParser parser, DeserializationContext context) throws IOException {
-        var jsonObject = OBJECT_MAPPER.readValue(parser, Object.class);
-        return jsonObject;
+    public EntityId deserialize(JsonParser jsonParser, DeserializationContext context) throws IOException {
+        Long value = jsonParser.readValueAs(Long.class);
+        return value != null ? EntityId.of(value, entityType) : null;
     }
 }

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/converter/AccountIdDeserializer.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/converter/AccountIdDeserializer.java
@@ -16,18 +16,11 @@
 
 package com.hedera.mirror.common.converter;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.hedera.mirror.common.domain.entity.EntityId;
-import com.hedera.mirror.common.domain.entity.EntityIdEndec;
 import com.hedera.mirror.common.domain.entity.EntityType;
-import java.io.IOException;
 
-public class AccountIdDeserializer extends JsonDeserializer<EntityId> {
-    @Override
-    public EntityId deserialize(JsonParser jsonParser, DeserializationContext context) throws IOException {
-        Long value = jsonParser.readValueAs(Long.class);
-        return value != null ? EntityIdEndec.decode(value, EntityType.ACCOUNT) : null;
+public class AccountIdDeserializer extends AbstractEntityIdDeserializer {
+
+    public AccountIdDeserializer() {
+        super(EntityType.ACCOUNT);
     }
 }

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/converter/ContractIdConverter.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/converter/ContractIdConverter.java
@@ -17,9 +17,10 @@
 package com.hedera.mirror.common.converter;
 
 import com.hedera.mirror.common.domain.entity.EntityType;
+import jakarta.persistence.Converter;
 import org.springframework.boot.context.properties.ConfigurationPropertiesBinding;
 
-@jakarta.persistence.Converter
+@Converter
 @ConfigurationPropertiesBinding
 public class ContractIdConverter extends AbstractEntityIdConverter {
 

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/converter/FileIdConverter.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/converter/FileIdConverter.java
@@ -17,9 +17,10 @@
 package com.hedera.mirror.common.converter;
 
 import com.hedera.mirror.common.domain.entity.EntityType;
+import jakarta.persistence.Converter;
 import org.springframework.boot.context.properties.ConfigurationPropertiesBinding;
 
-@jakarta.persistence.Converter
+@Converter
 @ConfigurationPropertiesBinding
 public class FileIdConverter extends AbstractEntityIdConverter {
 

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/converter/ScheduleIdConverter.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/converter/ScheduleIdConverter.java
@@ -17,9 +17,10 @@
 package com.hedera.mirror.common.converter;
 
 import com.hedera.mirror.common.domain.entity.EntityType;
+import jakarta.persistence.Converter;
 import org.springframework.boot.context.properties.ConfigurationPropertiesBinding;
 
-@jakarta.persistence.Converter
+@Converter
 @ConfigurationPropertiesBinding
 public class ScheduleIdConverter extends AbstractEntityIdConverter {
 

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/converter/TokenIdConverter.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/converter/TokenIdConverter.java
@@ -17,9 +17,10 @@
 package com.hedera.mirror.common.converter;
 
 import com.hedera.mirror.common.domain.entity.EntityType;
+import jakarta.persistence.Converter;
 import org.springframework.boot.context.properties.ConfigurationPropertiesBinding;
 
-@jakarta.persistence.Converter
+@Converter
 @ConfigurationPropertiesBinding
 public class TokenIdConverter extends AbstractEntityIdConverter {
 

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/converter/TokenIdDeserializer.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/converter/TokenIdDeserializer.java
@@ -16,18 +16,11 @@
 
 package com.hedera.mirror.common.converter;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.hedera.mirror.common.domain.entity.EntityId;
-import com.hedera.mirror.common.domain.entity.EntityIdEndec;
 import com.hedera.mirror.common.domain.entity.EntityType;
-import java.io.IOException;
 
-public class TokenIdDeserializer extends JsonDeserializer<EntityId> {
-    @Override
-    public EntityId deserialize(JsonParser jsonParser, DeserializationContext context) throws IOException {
-        Long value = jsonParser.readValueAs(Long.class);
-        return value != null ? EntityIdEndec.decode(value, EntityType.TOKEN) : null;
+public class TokenIdDeserializer extends AbstractEntityIdDeserializer {
+
+    public TokenIdDeserializer() {
+        super(EntityType.TOKEN);
     }
 }

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/converter/TopicIdConverter.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/converter/TopicIdConverter.java
@@ -17,9 +17,10 @@
 package com.hedera.mirror.common.converter;
 
 import com.hedera.mirror.common.domain.entity.EntityType;
+import jakarta.persistence.Converter;
 import org.springframework.boot.context.properties.ConfigurationPropertiesBinding;
 
-@jakarta.persistence.Converter
+@Converter
 @ConfigurationPropertiesBinding
 public class TopicIdConverter extends AbstractEntityIdConverter {
 

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/converter/TopicIdDeserializer.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/converter/TopicIdDeserializer.java
@@ -16,18 +16,11 @@
 
 package com.hedera.mirror.common.converter;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.hedera.mirror.common.domain.entity.EntityId;
-import com.hedera.mirror.common.domain.entity.EntityIdEndec;
 import com.hedera.mirror.common.domain.entity.EntityType;
-import java.io.IOException;
 
-public class TopicIdDeserializer extends JsonDeserializer<EntityId> {
-    @Override
-    public EntityId deserialize(JsonParser jsonParser, DeserializationContext context) throws IOException {
-        Long value = jsonParser.readValueAs(Long.class);
-        return value != null ? EntityIdEndec.decode(value, EntityType.TOPIC) : null;
+public class TopicIdDeserializer extends AbstractEntityIdDeserializer {
+
+    public TopicIdDeserializer() {
+        super(EntityType.TOPIC);
     }
 }

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/NftTransfer.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/NftTransfer.java
@@ -20,15 +20,10 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-
-import com.hedera.mirror.common.converter.AccountIdConverter;
 import com.hedera.mirror.common.converter.AccountIdDeserializer;
 import com.hedera.mirror.common.converter.EntityIdSerializer;
-import com.hedera.mirror.common.converter.TokenIdConverter;
 import com.hedera.mirror.common.converter.TokenIdDeserializer;
 import com.hedera.mirror.common.domain.entity.EntityId;
-
-import jakarta.persistence.Convert;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -45,19 +40,16 @@ public class NftTransfer {
 
     private Boolean isApproval;
 
-    @Convert(converter = AccountIdConverter.class)
     @JsonDeserialize(using = AccountIdDeserializer.class)
     @JsonSerialize(using = EntityIdSerializer.class)
     private EntityId receiverAccountId;
 
-    @Convert(converter = AccountIdConverter.class)
     @JsonDeserialize(using = AccountIdDeserializer.class)
     @JsonSerialize(using = EntityIdSerializer.class)
     private EntityId senderAccountId;
 
     private Long serialNumber;
 
-    @Convert(converter = TokenIdConverter.class)
     @JsonDeserialize(using = TokenIdDeserializer.class)
     @JsonSerialize(using = EntityIdSerializer.class)
     private EntityId tokenId;

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/Transaction.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/Transaction.java
@@ -31,12 +31,14 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.NonNull;
 import lombok.ToString;
 import org.hibernate.annotations.Type;
 import org.springframework.data.domain.Persistable;
@@ -70,8 +72,9 @@ public class Transaction implements Persistable<Long> {
 
     private Long maxFee;
 
-    @Type(JsonBinaryType.class)
     @JsonSerialize(using = ObjectToStringSerializer.class)
+    @ToString.Exclude
+    @Type(JsonBinaryType.class)
     private List<NftTransfer> nftTransfer;
 
     @Convert(converter = AccountIdConverter.class)
@@ -101,6 +104,14 @@ public class Transaction implements Persistable<Long> {
     private Long validDurationSeconds;
 
     private Long validStartNs;
+
+    public void addNftTransfer(@NonNull NftTransfer nftTransfer) {
+        if (this.nftTransfer == null) {
+            this.nftTransfer = new ArrayList<>();
+        }
+
+        this.nftTransfer.add(nftTransfer);
+    }
 
     @JsonIgnore
     @Override

--- a/hedera-mirror-common/src/test/java/com/hedera/mirror/common/converter/AbstractEntityIdDeserializerTest.java
+++ b/hedera-mirror-common/src/test/java/com/hedera/mirror/common/converter/AbstractEntityIdDeserializerTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.common.converter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hedera.mirror.common.domain.entity.EntityId;
+import com.hedera.mirror.common.domain.entity.EntityType;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@RequiredArgsConstructor
+abstract class AbstractEntityIdDeserializerTest {
+
+    @Mock
+    private JsonParser jsonParser;
+
+    private final AbstractEntityIdDeserializer deserializer;
+    private final EntityType entityType;
+
+    @Test
+    void deserialize() throws IOException {
+        doReturn(98L).when(jsonParser).readValueAs(Long.class);
+        var actual = deserializer.deserialize(jsonParser, context());
+        assertThat(actual).isEqualTo(EntityId.of(98L, entityType));
+    }
+
+    @Test
+    void deserializeNull() throws IOException {
+        doReturn(null).when(jsonParser).readValueAs(Long.class);
+        assertThat(deserializer.deserialize(jsonParser, context())).isNull();
+    }
+
+    private DeserializationContext context() {
+        return new ObjectMapper().getDeserializationContext();
+    }
+}

--- a/hedera-mirror-common/src/test/java/com/hedera/mirror/common/converter/AccountIdDeserializerTest.java
+++ b/hedera-mirror-common/src/test/java/com/hedera/mirror/common/converter/AccountIdDeserializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,14 +17,10 @@
 package com.hedera.mirror.common.converter;
 
 import com.hedera.mirror.common.domain.entity.EntityType;
-import jakarta.persistence.Converter;
-import org.springframework.boot.context.properties.ConfigurationPropertiesBinding;
 
-@Converter
-@ConfigurationPropertiesBinding
-public class UnknownIdConverter extends AbstractEntityIdConverter {
+class AccountIdDeserializerTest extends AbstractEntityIdDeserializerTest {
 
-    public UnknownIdConverter() {
-        super(EntityType.UNKNOWN);
+    public AccountIdDeserializerTest() {
+        super(new AccountIdDeserializer(), EntityType.ACCOUNT);
     }
 }

--- a/hedera-mirror-common/src/test/java/com/hedera/mirror/common/converter/ObjectToStringSerializerTest.java
+++ b/hedera-mirror-common/src/test/java/com/hedera/mirror/common/converter/ObjectToStringSerializerTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.common.converter;
+
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import java.io.IOException;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ObjectToStringSerializerTest {
+
+    private static final ObjectToStringSerializer serializer = new ObjectToStringSerializer();
+
+    @Mock
+    private JsonGenerator jsonGenerator;
+
+    @Test
+    void serialize() throws IOException {
+        serializer.serialize(Entity.builder().id(1).type("unknown").build(), jsonGenerator, null);
+        verify(jsonGenerator).writeString("{\"id\":1,\"type\":\"unknown\"}");
+    }
+
+    @Test
+    void serializeList() throws IOException {
+        var entities = List.of(
+                Entity.builder().id(1).type("unknown").build(),
+                Entity.builder().id(2).type(null).build());
+        serializer.serialize(entities, jsonGenerator, null);
+        verify(jsonGenerator).writeString("[{\"id\":1,\"type\":\"unknown\"},{\"id\":2,\"type\":null}]");
+    }
+
+    @Test
+    void serializeNull() throws IOException {
+        serializer.serialize(null, jsonGenerator, null);
+        verify(jsonGenerator).writeString("null");
+    }
+
+    @AllArgsConstructor
+    @Builder
+    @Data
+    private static class Entity {
+        private long id;
+        private String type;
+    }
+}

--- a/hedera-mirror-common/src/test/java/com/hedera/mirror/common/converter/TokenIdDeserializerTest.java
+++ b/hedera-mirror-common/src/test/java/com/hedera/mirror/common/converter/TokenIdDeserializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,14 +17,10 @@
 package com.hedera.mirror.common.converter;
 
 import com.hedera.mirror.common.domain.entity.EntityType;
-import jakarta.persistence.Converter;
-import org.springframework.boot.context.properties.ConfigurationPropertiesBinding;
 
-@Converter
-@ConfigurationPropertiesBinding
-public class UnknownIdConverter extends AbstractEntityIdConverter {
+class TokenIdDeserializerTest extends AbstractEntityIdDeserializerTest {
 
-    public UnknownIdConverter() {
-        super(EntityType.UNKNOWN);
+    public TokenIdDeserializerTest() {
+        super(new TokenIdDeserializer(), EntityType.TOKEN);
     }
 }

--- a/hedera-mirror-common/src/test/java/com/hedera/mirror/common/converter/TopicIdDeserializerTest.java
+++ b/hedera-mirror-common/src/test/java/com/hedera/mirror/common/converter/TopicIdDeserializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,14 +17,10 @@
 package com.hedera.mirror.common.converter;
 
 import com.hedera.mirror.common.domain.entity.EntityType;
-import jakarta.persistence.Converter;
-import org.springframework.boot.context.properties.ConfigurationPropertiesBinding;
 
-@Converter
-@ConfigurationPropertiesBinding
-public class UnknownIdConverter extends AbstractEntityIdConverter {
+class TopicIdDeserializerTest extends AbstractEntityIdDeserializerTest {
 
-    public UnknownIdConverter() {
-        super(EntityType.UNKNOWN);
+    public TopicIdDeserializerTest() {
+        super(new TopicIdDeserializer(), EntityType.TOPIC);
     }
 }

--- a/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/DomainBuilder.java
+++ b/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/DomainBuilder.java
@@ -576,9 +576,10 @@ public class DomainBuilder {
 
     public DomainWrapper<NftTransfer, NftTransfer.NftTransferBuilder> nftTransfer() {
         var builder = NftTransfer.builder()
+                .isApproval(false)
                 .receiverAccountId(entityId(ACCOUNT))
                 .senderAccountId(entityId(ACCOUNT))
-                .serialNumber(id())
+                .serialNumber(1L)
                 .tokenId(entityId(TOKEN));
 
         return new DomainWrapperImpl<>(builder, builder::build);

--- a/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/transaction/TransactionTest.java
+++ b/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/transaction/TransactionTest.java
@@ -20,46 +20,118 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.hedera.mirror.common.domain.DomainBuilder;
 import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.entity.EntityType;
 import com.hedera.mirror.common.domain.token.NftTransfer;
-import java.util.Arrays;
 import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
 
 class TransactionTest {
 
-    // Test serialization to JSON to verify contract with PostgreSQL listen/notify
+    private static final ObjectMapper OBJECT_MAPPER =
+            new ObjectMapper().setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+    private static final String EXPECTED_JSON_TEMPLATE =
+            """
+            {
+              "consensus_timestamp": 1684791152000000000,
+              "charged_tx_fee": 1,
+              "entity_id": 2,
+              "errata": "INSERT",
+              "index":4,
+              "initial_balance": 5,
+              "memo": "BgcI",
+              "max_fee": 9,
+              "nft_transfer": %s,
+              "node_account_id": 3,
+              "nonce": 19,
+              "parent_consensus_timestamp": 20,
+              "payer_account_id": 21,
+              "result": 22,
+              "scheduled": false,
+              "transaction_bytes": "FxgZ",
+              "transaction_hash": "Ghsc",
+              "type": 29,
+              "valid_duration_seconds": 30,
+              "valid_start_ns": 31
+            }
+            """;
+    private static final String EXPECTED_NFT_TRANSFER_VALUE =
+            """
+        "[{\\"is_approval\\":false,\\"receiver_account_id\\":10,\\"sender_account_id\\":11,\\"serial_number\\":12,\\"token_id\\":13},{\\"is_approval\\":true,\\"receiver_account_id\\":14,\\"sender_account_id\\":15,\\"serial_number\\":16,\\"token_id\\":17}]"
+        """;
+
+    @Test
+    void addNftTransfer() {
+        var transaction = Transaction.builder().build();
+        assertThat(transaction.getNftTransfer()).isNull();
+
+        var domainBuilder = new DomainBuilder();
+        var nftTransfer1 = domainBuilder.nftTransfer().get();
+        transaction.addNftTransfer(nftTransfer1);
+        assertThat(transaction.getNftTransfer()).containsExactly(nftTransfer1);
+
+        var nftTransfer2 = domainBuilder.nftTransfer().get();
+        transaction.addNftTransfer(nftTransfer2);
+        assertThat(transaction.getNftTransfer()).containsExactly(nftTransfer1, nftTransfer2);
+    }
+
     @Test
     void toJson() throws Exception {
-        Transaction transaction = new Transaction();
+        // given
+        var transaction = getTransaction();
+        var nftTransfer1 = new NftTransfer();
+        nftTransfer1.setIsApproval(false);
+        nftTransfer1.setReceiverAccountId(EntityId.of(10L, EntityType.ACCOUNT));
+        nftTransfer1.setSenderAccountId(EntityId.of(11L, EntityType.ACCOUNT));
+        nftTransfer1.setSerialNumber(12L);
+        nftTransfer1.setTokenId(EntityId.of(13L, EntityType.TOKEN));
+        transaction.addNftTransfer(nftTransfer1);
+
+        NftTransfer nftTransfer2 = new NftTransfer();
+        nftTransfer2.setIsApproval(true);
+        nftTransfer2.setReceiverAccountId(EntityId.of(14L, EntityType.ACCOUNT));
+        nftTransfer2.setSenderAccountId(EntityId.of(15L, EntityType.ACCOUNT));
+        nftTransfer2.setSerialNumber(16L);
+        nftTransfer2.setTokenId(EntityId.of(17L, EntityType.TOKEN));
+        transaction.addNftTransfer(nftTransfer2);
+
+        // when
+        String actual = OBJECT_MAPPER.writeValueAsString(transaction);
+
+        // then
+        String expected = String.format(EXPECTED_JSON_TEMPLATE, EXPECTED_NFT_TRANSFER_VALUE);
+        JSONAssert.assertEquals(expected, actual, JSONCompareMode.STRICT);
+    }
+
+    @Test
+    void toJsonNullNftTransfer() throws Exception {
+        // given
+        var transaction = getTransaction();
+
+        // when
+        String actual = OBJECT_MAPPER.writeValueAsString(transaction);
+
+        // then
+        String expected = String.format(EXPECTED_JSON_TEMPLATE, "null");
+        JSONAssert.assertEquals(expected, actual, JSONCompareMode.STRICT);
+    }
+
+    private Transaction getTransaction() {
+        var transaction = new Transaction();
         transaction.setConsensusTimestamp(1684791152000000000L);
         transaction.setChargedTxFee(1L);
-        transaction.setEntityId(EntityId.of("0.0.2", EntityType.ACCOUNT));
+        transaction.setEntityId(EntityId.of(2L, EntityType.ACCOUNT));
         transaction.setErrata(ErrataType.INSERT);
         transaction.setIndex(4);
         transaction.setInitialBalance(5L);
         transaction.setMemo(new byte[] {6, 7, 8});
         transaction.setMaxFee(9L);
-
-        NftTransfer nftTransfer1 = new NftTransfer();
-        nftTransfer1.setIsApproval(false);
-        nftTransfer1.setReceiverAccountId(EntityId.of("0.0.10", EntityType.ACCOUNT));
-        nftTransfer1.setSenderAccountId(EntityId.of("0.0.11", EntityType.ACCOUNT));
-        nftTransfer1.setSerialNumber(12L);
-        nftTransfer1.setTokenId(EntityId.of("0.0.13", EntityType.TOKEN));
-
-        NftTransfer nftTransfer2 = new NftTransfer();
-        nftTransfer2.setIsApproval(true);
-        nftTransfer2.setReceiverAccountId(EntityId.of("0.0.14", EntityType.ACCOUNT));
-        nftTransfer2.setSenderAccountId(EntityId.of("0.0.15", EntityType.ACCOUNT));
-        nftTransfer2.setSerialNumber(16L);
-        nftTransfer2.setTokenId(EntityId.of("0.0.17", EntityType.TOKEN));
-
-        transaction.setNftTransfer(Arrays.asList(nftTransfer1, nftTransfer2));
-        transaction.setNodeAccountId(EntityId.of(0, 1, 18, EntityType.ACCOUNT));
+        transaction.setNodeAccountId(EntityId.of(3L, EntityType.ACCOUNT));
         transaction.setNonce(19);
         transaction.setParentConsensusTimestamp(20L);
-        transaction.setPayerAccountId(EntityId.of("0.0.21", EntityType.ACCOUNT));
+        transaction.setPayerAccountId(EntityId.of(21L, EntityType.ACCOUNT));
         transaction.setResult(22);
         transaction.setScheduled(false);
         transaction.setTransactionBytes(new byte[] {23, 24, 25});
@@ -67,39 +139,6 @@ class TransactionTest {
         transaction.setType(29);
         transaction.setValidDurationSeconds(30L);
         transaction.setValidStartNs(31L);
-
-        ObjectMapper objectMapper = new ObjectMapper().setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
-        String json = objectMapper.writeValueAsString(transaction);
-        assertThat(json)
-                .isEqualTo("{" + "\"consensus_timestamp\":1684791152000000000,"
-                        + "\"charged_tx_fee\":1,"
-                        + "\"entity_id\":2,"
-                        + "\"errata\":\"INSERT\","
-                        + "\"index\":4,"
-                        + "\"initial_balance\":5,"
-                        + "\"memo\":\"BgcI\","
-                        + "\"max_fee\":9,"
-                        + "\"nft_transfer\":\"["
-                        + "{\\\"is_approval\\\":false,"
-                        + "\\\"receiver_account_id\\\":10,"
-                        + "\\\"sender_account_id\\\":11,"
-                        + "\\\"serial_number\\\":12,"
-                        + "\\\"token_id\\\":13},"
-                        + "{\\\"is_approval\\\":true,"
-                        + "\\\"receiver_account_id\\\":14,"
-                        + "\\\"sender_account_id\\\":15,"
-                        + "\\\"serial_number\\\":16,"
-                        + "\\\"token_id\\\":17}]\","
-                        + "\"node_account_id\":4294967314,"
-                        + "\"nonce\":19,"
-                        + "\"parent_consensus_timestamp\":20,"
-                        + "\"payer_account_id\":21,"
-                        + "\"result\":22,"
-                        + "\"scheduled\":false,"
-                        + "\"transaction_bytes\":\"FxgZ\","
-                        + "\"transaction_hash\":\"Ghsc\","
-                        + "\"type\":29,"
-                        + "\"valid_duration_seconds\":30,"
-                        + "\"valid_start_ns\":31}");
+        return transaction;
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListener.java
@@ -371,14 +371,14 @@ public class EntityRecordItemListener implements RecordItemListener {
         }
     }
 
-    private boolean isApprovalNftTransfer(NftTransfer nftTransfer, TokenID nftId, TransactionBody body) {
+    private boolean isApprovalNftTransfer(NftTransfer nftTransfer, TokenID tokenId, TransactionBody body) {
         if (!body.hasCryptoTransfer()) {
             return false;
         }
 
         var tokenTransfersList = body.getCryptoTransfer().getTokenTransfersList();
         for (var transferList : tokenTransfersList) {
-            if (!transferList.getToken().equals(nftId)) {
+            if (!transferList.getToken().equals(tokenId)) {
                 continue;
             }
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListener.java
@@ -82,6 +82,7 @@ import org.springframework.beans.factory.BeanCreationNotAllowedException;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.core.annotation.Order;
+import org.springframework.util.CollectionUtils;
 
 @Log4j2
 @Named
@@ -856,7 +857,7 @@ public class SqlEntityListener implements EntityListener, RecordStreamFileListen
 
     private void onNftTransferList(Transaction transaction) {
         var nftTransferList = transaction.getNftTransfer();
-        if (nftTransferList == null || nftTransferList.isEmpty()) {
+        if (CollectionUtils.isEmpty(nftTransferList)) {
             return;
         }
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/NftRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/NftRepository.java
@@ -45,31 +45,20 @@ public interface NftRepository extends CrudRepository<Nft, NftId> {
                     """
             with nft_updated as (
               update nft
-                set account_id = ?3,
-                    modified_timestamp = ?4
-              where token_id = ?1 and account_id = ?2
+                set account_id = :newTreasury,
+                    modified_timestamp = :consensusTimestamp
+              where token_id = :tokenId and account_id = :previousTreasury
               returning serial_number
             ), updated_count as (
               select count(*) from nft_updated
-            ), update_balance as (
-              update token_account
-                set balance = case when account_id = ?2 then 0
-                                   else coalesce(balance, 0) + updated_count.count
-                              end
-              from updated_count
-              where account_id in (?2, ?3) and token_id = ?1
             )
-            insert into nft_transfer (token_id, sender_account_id, receiver_account_id, consensus_timestamp,
-             payer_account_id, serial_number, is_approval)
-            select ?1, ?2, ?3, ?4, ?5, nft_updated.serial_number, ?6
-            from nft_updated
+            update token_account
+              set balance = case when account_id = :previousTreasury then 0
+                                 else coalesce(balance, 0) + updated_count.count
+                            end
+            from updated_count
+            where account_id in (:newTreasury, :previousTreasury) and token_id = :tokenId
             """,
             nativeQuery = true)
-    void updateTreasury(
-            long tokenId,
-            long previousTreasury,
-            long newTreasury,
-            long consensusTimestamp,
-            long payerAccountId,
-            boolean isApproval);
+    void updateTreasury(long consensusTimestamp, long newTreasury, long previousTreasury, long tokenId);
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/DeletedTokenDissociateTransferUpsertQueryGenerator.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/DeletedTokenDissociateTransferUpsertQueryGenerator.java
@@ -24,23 +24,39 @@ public class DeletedTokenDissociateTransferUpsertQueryGenerator implements Upser
 
     private static final String TEMP_TABLE_NAME = "token_dissociate_transfer";
 
-    private static final String INSERT_SQL = "with dissociated_nft as ("
-            + "  update nft set deleted = true, modified_timestamp = tdt.consensus_timestamp"
-            + "  from "
-            + TEMP_TABLE_NAME + " tdt"
-            + "  where nft.token_id = tdt.token_id and nft.account_id = tdt.account_id and nft.deleted is false"
-            + "  returning nft.token_id, nft.serial_number, nft.account_id, nft.modified_timestamp, tdt"
-            + ".payer_account_id"
-            + "), updated_nft as ("
-            + "  insert into nft_transfer (consensus_timestamp, sender_account_id, serial_number, token_id,"
-            + "payer_account_id, is_approval)"
-            + "  select modified_timestamp, account_id, serial_number, token_id, payer_account_id, false"
-            + "  from dissociated_nft"
-            + "  returning token_id"
-            + ") "
-            + "insert into "
-            + FINAL_TABLE_NAME + " " + "select * from "
-            + TEMP_TABLE_NAME + " tdt " + "where tdt.token_id not in (select distinct token_id from updated_nft)";
+    private static final String INSERT_SQL = MessageFormat.format(
+            """
+            with dissociated_nft as (
+              update nft set deleted = true, modified_timestamp = tdt.consensus_timestamp
+              from {0} tdt
+              where nft.token_id = tdt.token_id and nft.account_id = tdt.account_id and nft.deleted is false
+              returning nft.token_id
+            ), nft_token as (
+              select distinct token_id from dissociated_nft
+            ), nft_transfer as (
+              select consensus_timestamp, jsonb_agg(jsonb_build_object(
+                ''is_approval'', false,
+                ''receiver_account_id'', null,
+                ''sender_account_id'', tdt.account_id,
+                ''serial_number'', tdt.amount,
+                ''token_id'', tdt.token_id
+              )) as transfer
+              from {0} tdt
+              join nft_token on nft_token.token_id = tdt.token_id
+              group by tdt.consensus_timestamp
+            ), update_transaction as (
+              update transaction t
+              set nft_transfer = transfer
+              from nft_transfer nt
+              where nt.consensus_timestamp = t.consensus_timestamp
+            )
+            insert into {1}
+            select tdt.*
+            from {0} tdt
+            left join nft_token nt on nt.token_id = tdt.token_id
+            where nt.token_id is null
+            """,
+            TEMP_TABLE_NAME, FINAL_TABLE_NAME);
 
     @Override
     public String getCreateTempIndexQuery() {
@@ -50,8 +66,8 @@ public class DeletedTokenDissociateTransferUpsertQueryGenerator implements Upser
 
     @Override
     public String getCreateTempTableQuery() {
-        return String.format(
-                "create temporary table if not exists %s on commit drop as table %s limit 0",
+        return MessageFormat.format(
+                "create temporary table if not exists {0} on commit drop as table {1} limit 0",
                 TEMP_TABLE_NAME, FINAL_TABLE_NAME);
     }
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/SupportDeletedTokenDissociateMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/SupportDeletedTokenDissociateMigrationTest.java
@@ -22,6 +22,7 @@ import static com.hedera.mirror.common.domain.token.TokenTypeEnum.FUNGIBLE_COMMO
 import static com.hedera.mirror.common.domain.token.TokenTypeEnum.NON_FUNGIBLE_UNIQUE;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.hedera.mirror.common.converter.AccountIdConverter;
 import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.entity.EntityIdEndec;
 import com.hedera.mirror.common.domain.entity.EntityType;
@@ -45,7 +46,6 @@ import java.io.File;
 import java.sql.Types;
 import java.util.Collection;
 import java.util.List;
-import java.util.function.Function;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -479,14 +479,13 @@ class SupportDeletedTokenDissociateMigrationTest extends IntegrationTest {
     }
 
     private void persistNftTransfer(MigrationNftTransfer nftTransfer) {
-        Function<EntityId, Long> converter = (entityId) -> EntityId.isEmpty(entityId) ? null : entityId.getId();
         jdbcOperations.update(
                 "insert into nft_transfer (consensus_timestamp, receiver_account_id, sender_account_id, "
                         + "serial_number, token_id)"
                         + " values (?,?,?,?,?)",
                 nftTransfer.getConsensusTimestamp(),
-                converter.apply(nftTransfer.getReceiverAccountId()),
-                converter.apply(nftTransfer.getSenderAccountId()),
+                AccountIdConverter.INSTANCE.convertToDatabaseColumn(nftTransfer.getReceiverAccountId()),
+                AccountIdConverter.INSTANCE.convertToDatabaseColumn(nftTransfer.getSenderAccountId()),
                 nftTransfer.getSerialNumber(),
                 nftTransfer.getTokenId());
     }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/SupportDeletedTokenDissociateMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/SupportDeletedTokenDissociateMigrationTest.java
@@ -197,9 +197,9 @@ class SupportDeletedTokenDissociateMigrationTest extends IntegrationTest {
         assertThat(findAllNftTransfers())
                 .usingRecursiveFieldByFieldElementComparatorIgnoringFields("id", "payerAccountId", "senderAccountId")
                 .containsExactlyInAnyOrder(
-                        nftTransfer(account1Nft1DissociateTimestamp, EntityId.EMPTY, account1, 2L, nftId1),
-                        nftTransfer(account1Nft2DissociateTimestamp, EntityId.EMPTY, account1, 2L, nftId2),
-                        nftTransfer(account2Nft1DissociateTimestamp, EntityId.EMPTY, account2, 4L, nftId1));
+                        nftTransfer(account1Nft1DissociateTimestamp, null, account1, 2L, nftId1),
+                        nftTransfer(account1Nft2DissociateTimestamp, null, account1, 2L, nftId2),
+                        nftTransfer(account2Nft1DissociateTimestamp, null, account2, 4L, nftId1));
         assertThat(findAllTokenAccounts()).containsExactlyInAnyOrderElementsOf(tokenAccounts);
         assertThat(findAllTokens())
                 .usingRecursiveFieldByFieldElementComparatorIgnoringFields(
@@ -518,13 +518,8 @@ class SupportDeletedTokenDissociateMigrationTest extends IntegrationTest {
     }
 
     private List<MigrationNftTransfer> findAllNftTransfers() {
-        return jdbcOperations.query("select * from nft_transfer", (rs, rowNum) -> MigrationNftTransfer.builder()
-                .consensusTimestamp(rs.getLong("consensus_timestamp"))
-                .receiverAccountId(EntityId.of(rs.getLong("receiver_account_id"), ACCOUNT))
-                .senderAccountId(EntityId.of(rs.getLong("sender_account_id"), ACCOUNT))
-                .serialNumber(rs.getLong("serial_number"))
-                .tokenId(rs.getLong("token_id"))
-                .build());
+        return jdbcOperations.query(
+                "select * from nft_transfer", IntegrationTest.rowMapper(MigrationNftTransfer.class));
     }
 
     // Use a custom class for entity table since its columns have changed from the current domain object

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/TransferTransactionPayerMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/TransferTransactionPayerMigrationTest.java
@@ -48,6 +48,7 @@ import java.sql.PreparedStatement;
 import java.util.Arrays;
 import java.util.List;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
@@ -96,6 +97,7 @@ class TransferTransactionPayerMigrationTest extends IntegrationTest {
         assertThat(entityRepository.count()).isZero();
         assertThat(transactionRepository.count()).isZero();
         assertThat(cryptoTransferRepository.count()).isZero();
+        assertThat(findNftTransfers()).isEmpty();
         assertThat(nonFeeTransferRepository.count()).isZero();
         assertThat(tokenTransferRepository.count()).isZero();
     }
@@ -327,6 +329,12 @@ class TransferTransactionPayerMigrationTest extends IntegrationTest {
                                 .entityId(receiverId))
                         .get()));
 
+        persistNftTransfers(List.of(
+                // nft transfer
+                nftTransfer(transfer3.getConsensusTimestamp(), receiverId, senderId, 1L, tokenId),
+                // all transfers
+                nftTransfer(transfer5.getConsensusTimestamp(), receiverId, senderId, 2L, tokenId)));
+
         persistTokenTransfers(List.of(
                 // token transfer
                 new TokenTransfer(transfer4.getConsensusTimestamp(), -receivedAmount, tokenId, senderId),
@@ -375,6 +383,11 @@ class TransferTransactionPayerMigrationTest extends IntegrationTest {
                 new SharedTransfer(
                         treasuryPaymentAmount, transfer5.getConsensusTimestamp(), PAYER_ID, treasuryId, null));
 
+        List<SharedTransfer> expectedNftTransfers = List.of(
+                // nft transfer
+                new SharedTransfer(1L, transfer3.getConsensusTimestamp(), PAYER_ID, receiverId, senderId),
+                new SharedTransfer(2L, transfer5.getConsensusTimestamp(), PAYER_ID, receiverId, senderId));
+
         List<SharedTransfer> expectedNonFeeTransfers = List.of(
                 // assessed custom fee only transfer
                 new SharedTransfer(senderPaymentAmount, transfer1.getConsensusTimestamp(), PAYER_ID, null, senderId),
@@ -405,6 +418,8 @@ class TransferTransactionPayerMigrationTest extends IntegrationTest {
 
         assertThat(findCryptoTransfers()).containsExactlyInAnyOrderElementsOf(expectedCryptoTransfers);
 
+        assertThat(findNftTransfers()).containsExactlyInAnyOrderElementsOf(expectedNftTransfers);
+
         assertThat(findNonFeeTransfersAsSharedTransfers()).containsExactlyInAnyOrderElementsOf(expectedNonFeeTransfers);
 
         assertThat(findTokenTransfers()).containsExactlyInAnyOrderElementsOf(expectedTokenTransfers);
@@ -425,6 +440,19 @@ class TransferTransactionPayerMigrationTest extends IntegrationTest {
 
     private void migrate() throws Exception {
         jdbcOperations.update(FileUtils.readFileToString(migrationSql, "UTF-8"));
+    }
+
+    private MigrationNftTransfer nftTransfer(
+            long consensusTimestamp, EntityId receiver, EntityId sender, long serialNumber, EntityId tokenId) {
+        Long receiverAccountId = EntityId.isEmpty(receiver) ? null : receiver.getId();
+        Long senderAccountId = EntityId.isEmpty(sender) ? null : sender.getId();
+        return MigrationNftTransfer.builder()
+                .consensusTimestamp(consensusTimestamp)
+                .receiverAccountId(receiverAccountId)
+                .senderAccountId(senderAccountId)
+                .serialNumber(serialNumber)
+                .tokenId(tokenId.getId())
+                .build();
     }
 
     private void persistAssessedCustomFees(List<AssessedCustomFee> assessedCustomFees) throws IOException {
@@ -449,6 +477,22 @@ class TransferTransactionPayerMigrationTest extends IntegrationTest {
                     cryptoTransfer.getAmount(),
                     cryptoTransfer.getConsensusTimestamp(),
                     cryptoTransfer.getEntityId());
+        }
+    }
+
+    private void persistNftTransfers(List<MigrationNftTransfer> nftTransfers) {
+        for (var nftTransfer : nftTransfers) {
+            jdbcOperations.update(
+                    """
+                            insert into nft_transfer (consensus_timestamp, receiver_account_id, sender_account_id,
+                            serial_number, token_id)
+                            values (?,?,?,?,?)
+                            """,
+                    nftTransfer.getConsensusTimestamp(),
+                    nftTransfer.getReceiverAccountId(),
+                    nftTransfer.getSenderAccountId(),
+                    nftTransfer.getSerialNumber(),
+                    nftTransfer.getTokenId());
         }
     }
 
@@ -505,6 +549,18 @@ class TransferTransactionPayerMigrationTest extends IntegrationTest {
                     EntityIdEndec.decode(rs.getLong("payer_account_id"), EntityType.ACCOUNT),
                     receiver,
                     sender);
+            return sharedTransfer;
+        });
+    }
+
+    private List<SharedTransfer> findNftTransfers() {
+        return jdbcOperations.query("select * from nft_transfer", (rs, rowNum) -> {
+            SharedTransfer sharedTransfer = new SharedTransfer(
+                    rs.getLong("serial_number"),
+                    rs.getLong("consensus_timestamp"),
+                    EntityIdEndec.decode(rs.getLong("payer_account_id"), EntityType.ACCOUNT),
+                    EntityIdEndec.decode(rs.getLong("receiver_account_id"), EntityType.ACCOUNT),
+                    EntityIdEndec.decode(rs.getLong("sender_account_id"), EntityType.ACCOUNT));
             return sharedTransfer;
         });
     }
@@ -597,20 +653,20 @@ class TransferTransactionPayerMigrationTest extends IntegrationTest {
         return longs == null ? "" : "{" + StringUtils.join(longs, ",") + "}";
     }
 
-    // custom class with shared attributes for all transfer classes prior to migration
+    @AllArgsConstructor
+    @Builder
     @Data
     @NoArgsConstructor
-    @AllArgsConstructor
-    private class SharedTransfer {
-        private long amount;
-        private long consensusTimeStamp;
-        private EntityId payerAccountId;
-        private EntityId receiver;
-        private EntityId sender;
+    private static class MigrationNftTransfer {
+        long consensusTimestamp;
+        Long receiverAccountId;
+        Long senderAccountId;
+        long serialNumber;
+        long tokenId;
     }
 
     @Data
-    private class MigrationTransaction {
+    private static class MigrationTransaction {
         private Long consensusTimestamp;
         private Long entityId;
         private Long nodeAccountId;
@@ -618,5 +674,17 @@ class TransferTransactionPayerMigrationTest extends IntegrationTest {
         private Integer result;
         private Integer type;
         private Long validStartNs;
+    }
+
+    // custom class with shared attributes for all transfer classes prior to migration
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    private static class SharedTransfer {
+        private long amount;
+        private long consensusTimeStamp;
+        private EntityId payerAccountId;
+        private EntityId receiver;
+        private EntityId sender;
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/TransferTransactionPayerMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/TransferTransactionPayerMigrationTest.java
@@ -558,9 +558,9 @@ class TransferTransactionPayerMigrationTest extends IntegrationTest {
             SharedTransfer sharedTransfer = new SharedTransfer(
                     rs.getLong("serial_number"),
                     rs.getLong("consensus_timestamp"),
-                    EntityIdEndec.decode(rs.getLong("payer_account_id"), EntityType.ACCOUNT),
-                    EntityIdEndec.decode(rs.getLong("receiver_account_id"), EntityType.ACCOUNT),
-                    EntityIdEndec.decode(rs.getLong("sender_account_id"), EntityType.ACCOUNT));
+                    EntityId.of(rs.getLong("payer_account_id"), EntityType.ACCOUNT),
+                    EntityId.of(rs.getLong("receiver_account_id"), EntityType.ACCOUNT),
+                    EntityId.of(rs.getLong("sender_account_id"), EntityType.ACCOUNT));
             return sharedTransfer;
         });
     }


### PR DESCRIPTION
**Description**:

This PR fixes nft balance and state tracking after nft transfer is nested in transaction

- Add back nft account balance tracking to SqlEntityListener
- Add back nft state and balance tracking for nft treasury change
- Fix token dissociate of deleted token SQL
- Fix nft transfer assertion in test cases
- Fix incorrect flow in several `EntityRecordItemListenerTokenTest` test cases
- Fix some migration tests 

**Related issue(s)**:

Fixes #6008 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
This PR also enable workflow runs on PR targeting the epic branch, should revert the changes when merging to main

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
