### PR TITLE
Cache and utilize StreamFilename path and incorporate node ID based path access in LocalStreamFileProvider

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamFileData.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamFileData.java
@@ -56,8 +56,7 @@ public class StreamFileData {
         try {
             byte[] bytes = FileUtils.readFileToByteArray(file);
             var lastModified = Instant.ofEpochMilli(file.lastModified());
-            // TODO invoke new constructor with name and path
-            return new StreamFileData(new StreamFilename(file.getName()), bytes, lastModified);
+            return new StreamFileData(new StreamFilename(file.getPath()), bytes, lastModified);
         } catch (InvalidStreamFileException e) {
             throw e;
         } catch (Exception e) {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamFileData.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamFileData.java
@@ -23,8 +23,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.time.Instant;
-import java.util.function.Supplier;
 import lombok.CustomLog;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -53,11 +53,11 @@ public class StreamFileData {
 
     private final Instant lastModified;
 
-    private static StreamFileData readStreamFileData(File file, Supplier<StreamFilename> streamFilenameSupplier) {
+    private static StreamFileData readStreamFileData(File file, StreamFilename streamFilename) {
         try {
             byte[] bytes = FileUtils.readFileToByteArray(file);
             var lastModified = Instant.ofEpochMilli(file.lastModified());
-            return new StreamFileData(streamFilenameSupplier.get(), bytes, lastModified);
+            return new StreamFileData(streamFilename, bytes, lastModified);
         } catch (InvalidStreamFileException e) {
             throw e;
         } catch (Exception e) {
@@ -66,11 +66,12 @@ public class StreamFileData {
     }
 
     public static StreamFileData from(@NonNull File file) {
-        return readStreamFileData(file, () -> StreamFilename.from(file.getPath()));
+        return readStreamFileData(file, StreamFilename.from(file.getPath()));
     }
 
-    public static StreamFileData from(@NonNull StreamFilename streamFilename) {
-        return readStreamFileData(new File(streamFilename.getFilePath()), () -> streamFilename);
+    public static StreamFileData from(@NonNull Path basePath, @NonNull StreamFilename streamFilename) {
+        var streamFile = new File(basePath.toFile(), streamFilename.getFilePath());
+        return readStreamFileData(streamFile, streamFilename);
     }
 
     // Used for testing String based files like CSVs

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamFileData.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamFileData.java
@@ -66,7 +66,7 @@ public class StreamFileData {
     }
 
     public static StreamFileData from(@NonNull File file) {
-        return readStreamFileData(file, () -> StreamFilename.of(file.getPath()));
+        return readStreamFileData(file, () -> StreamFilename.from(file.getPath()));
     }
 
     public static StreamFileData from(@NonNull StreamFilename streamFilename) {
@@ -76,12 +76,12 @@ public class StreamFileData {
     // Used for testing String based files like CSVs
     public static StreamFileData from(@NonNull String filename, @NonNull String contents) {
         return new StreamFileData(
-                StreamFilename.of(filename), contents.getBytes(StandardCharsets.UTF_8), Instant.now());
+                StreamFilename.from(filename), contents.getBytes(StandardCharsets.UTF_8), Instant.now());
     }
 
     // Used for testing with raw bytes
     public static StreamFileData from(@NonNull String filename, byte[] bytes) {
-        return new StreamFileData(StreamFilename.of(filename), bytes, Instant.now());
+        return new StreamFileData(StreamFilename.from(filename), bytes, Instant.now());
     }
 
     public InputStream getInputStream() {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamFileData.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamFileData.java
@@ -56,6 +56,7 @@ public class StreamFileData {
         try {
             byte[] bytes = FileUtils.readFileToByteArray(file);
             var lastModified = Instant.ofEpochMilli(file.lastModified());
+            // TODO invoke new constructor with name and path
             return new StreamFileData(new StreamFilename(file.getName()), bytes, lastModified);
         } catch (InvalidStreamFileException e) {
             throw e;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamFileData.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamFileData.java
@@ -93,6 +93,10 @@ public class StreamFileData {
         return streamFilename.getFilename();
     }
 
+    public String getFilePath() {
+        return streamFilename.getFilePath();
+    }
+
     @Override
     public String toString() {
         return streamFilename.toString();

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamFileData.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamFileData.java
@@ -66,7 +66,7 @@ public class StreamFileData {
     }
 
     public static StreamFileData from(@NonNull File file) {
-        return readStreamFileData(file, StreamFilename.from(file.getPath()));
+        return readStreamFileData(file, StreamFilename.from(file.getPath(), File.separator));
     }
 
     public static StreamFileData from(@NonNull Path basePath, @NonNull StreamFilename streamFilename) {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamFileSignature.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamFileSignature.java
@@ -75,7 +75,7 @@ public class StreamFileSignature implements Comparable<StreamFileSignature> {
             dataFilename += COMPRESSED_EXTENSION;
         }
 
-        return StreamFilename.of(filename, dataFilename);
+        return StreamFilename.from(filename, dataFilename);
     }
 
     public String getFileHashAsHex() {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamFileSignature.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamFileSignature.java
@@ -75,7 +75,7 @@ public class StreamFileSignature implements Comparable<StreamFileSignature> {
             dataFilename += COMPRESSED_EXTENSION;
         }
 
-        return new StreamFilename(dataFilename, filename.getPath());
+        return StreamFilename.of(filename, dataFilename);
     }
 
     public String getFileHashAsHex() {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamFileSignature.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamFileSignature.java
@@ -75,7 +75,7 @@ public class StreamFileSignature implements Comparable<StreamFileSignature> {
             dataFilename += COMPRESSED_EXTENSION;
         }
 
-        return new StreamFilename(dataFilename);
+        return new StreamFilename(dataFilename, filename.getPath());
     }
 
     public String getFileHashAsHex() {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamFileSignature.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamFileSignature.java
@@ -78,6 +78,10 @@ public class StreamFileSignature implements Comparable<StreamFileSignature> {
         return StreamFilename.from(filename, dataFilename);
     }
 
+    public String getFilePath() {
+        return filename.getFilePath();
+    }
+
     public String getFileHashAsHex() {
         return DomainUtils.bytesToHex(fileHash);
     }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamFileSignature.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamFileSignature.java
@@ -78,10 +78,6 @@ public class StreamFileSignature implements Comparable<StreamFileSignature> {
         return StreamFilename.from(filename, dataFilename);
     }
 
-    public String getFilePath() {
-        return filename.getFilePath();
-    }
-
     public String getFileHashAsHex() {
         return DomainUtils.bytesToHex(fileHash);
     }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamFilename.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamFilename.java
@@ -48,7 +48,7 @@ public class StreamFilename implements Comparable<StreamFilename> {
     public static final Comparator<StreamFilename> EXTENSION_COMPARATOR =
             Comparator.comparing(StreamFilename::getExtension);
     public static final StreamFilename EPOCH;
-    public static final String SIDECAR_FOLDER = "sidecar/";
+    public static final String SIDECAR_FOLDER = "sidecar";
 
     private static final Comparator<StreamFilename> COMPARATOR = Comparator.comparing(StreamFilename::getFilename);
     private static final char COMPATIBLE_TIME_SEPARATOR = '_';
@@ -197,6 +197,7 @@ public class StreamFilename implements Comparable<StreamFilename> {
         }
         if (this.fileType == SIDECAR) {
             builder.append(SIDECAR_FOLDER);
+            builder.append(this.pathSeparator);
         }
         builder.append(this.filename);
         return builder.toString();

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamFilename.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamFilename.java
@@ -114,20 +114,6 @@ public class StreamFilename implements Comparable<StreamFilename> {
         this.instant = extractInstant(filename, this.fullExtension, this.sidecarId, this.streamType.getSuffix());
     }
 
-    public String getFilePath() {
-
-        var builder = new StringBuilder();
-        if (!StringUtils.isEmpty(this.path)) {
-            builder.append(this.path);
-            builder.append(pathSeparator);
-        }
-        if (this.fileType == SIDECAR) {
-            builder.append(SIDECAR_FOLDER);
-        }
-        builder.append(this.filename);
-        return builder.toString();
-    }
-
     public static String getFilename(StreamType streamType, FileType fileType, Instant instant) {
 
         String timestamp = instant.toString().replace(STANDARD_TIME_SEPARATOR, COMPATIBLE_TIME_SEPARATOR);
@@ -200,6 +186,20 @@ public class StreamFilename implements Comparable<StreamFilename> {
         } catch (DateTimeParseException ex) {
             throw new InvalidStreamFileException("Invalid datetime string in filename " + filename, ex);
         }
+    }
+
+    public String getFilePath() {
+
+        var builder = new StringBuilder();
+        if (!StringUtils.isEmpty(this.path)) {
+            builder.append(this.path);
+            builder.append(this.pathSeparator);
+        }
+        if (this.fileType == SIDECAR) {
+            builder.append(SIDECAR_FOLDER);
+        }
+        builder.append(this.filename);
+        return builder.toString();
     }
 
     @Override

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamFilename.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamFilename.java
@@ -74,8 +74,11 @@ public class StreamFilename implements Comparable<StreamFilename> {
     private final String compressor;
     private final StreamType.Extension extension;
     private final String filename;
-    private final String path;
     private final String pathSeparator;
+
+    // Relative path to directory containing filename, utilizing pathSeparator
+    private final String path;
+    // The computed file system or bucket relative path for this stream file
     private final String filePath;
 
     @EqualsAndHashCode.Include
@@ -106,7 +109,6 @@ public class StreamFilename implements Comparable<StreamFilename> {
         this.filenameWithoutCompressor = isCompressed() ? removeExtension(this.filename) : this.filename;
         this.instant = extractInstant(filename, this.fullExtension, this.sidecarId, this.streamType.getSuffix());
 
-        // The immutable full path for this file
         var builder = new StringBuilder();
         if (!StringUtils.isEmpty(this.path)) {
             builder.append(this.path);

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamFilename.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamFilename.java
@@ -68,7 +68,7 @@ public class StreamFilename implements Comparable<StreamFilename> {
             streamTypeExtensionMap.put(type, Collections.unmodifiableMap(extensions));
         }
         STREAM_TYPE_EXTENSION_MAP = Collections.unmodifiableMap(streamTypeExtensionMap);
-        EPOCH = of("1970-01-01T00_00_00Z.rcd");
+        EPOCH = from("1970-01-01T00_00_00Z.rcd");
     }
 
     private final String compressor;
@@ -120,23 +120,23 @@ public class StreamFilename implements Comparable<StreamFilename> {
         this.filePath = builder.toString();
     }
 
-    public static StreamFilename of(String filePath) {
-        return of(filePath, File.separator);
+    public static StreamFilename from(String filePath) {
+        return from(filePath, File.separator);
     }
 
-    public static StreamFilename of(@NonNull String filePath, @NonNull String pathSeparator) {
+    public static StreamFilename from(@NonNull String filePath, @NonNull String pathSeparator) {
         var lastSeparatorIndex = filePath.lastIndexOf(pathSeparator);
         var filename = lastSeparatorIndex < 0 ? filePath : filePath.substring(lastSeparatorIndex + 1);
         var path = lastSeparatorIndex < 0 ? null : filePath.substring(0, lastSeparatorIndex);
 
-        return of(path, filename, pathSeparator);
+        return from(path, filename, pathSeparator);
     }
 
-    public static StreamFilename of(@NonNull StreamFilename base, String filename) {
-        return of(base.getPath(), filename, base.getPathSeparator());
+    public static StreamFilename from(@NonNull StreamFilename base, String filename) {
+        return from(base.getPath(), filename, base.getPathSeparator());
     }
 
-    public static StreamFilename of(String path, @NonNull String filename, @NonNull String pathSeparator) {
+    public static StreamFilename from(String path, @NonNull String filename, @NonNull String pathSeparator) {
         return new StreamFilename(path, filename, pathSeparator);
     }
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamFilename.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamFilename.java
@@ -23,8 +23,8 @@ import static org.apache.commons.io.FilenameUtils.removeExtension;
 
 import com.google.common.base.Splitter;
 import com.hedera.mirror.common.domain.StreamType;
+import com.hedera.mirror.importer.downloader.provider.S3StreamFileProvider;
 import com.hedera.mirror.importer.exception.InvalidStreamFileException;
-import java.io.File;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.Collections;
@@ -123,7 +123,7 @@ public class StreamFilename implements Comparable<StreamFilename> {
     }
 
     public static StreamFilename from(String filePath) {
-        return from(filePath, File.separator);
+        return from(filePath, S3StreamFileProvider.SEPARATOR);
     }
 
     public static StreamFilename from(@NonNull String filePath, @NonNull String pathSeparator) {
@@ -143,7 +143,6 @@ public class StreamFilename implements Comparable<StreamFilename> {
     }
 
     public static String getFilename(StreamType streamType, FileType fileType, Instant instant) {
-
         String timestamp = instant.toString().replace(STANDARD_TIME_SEPARATOR, COMPATIBLE_TIME_SEPARATOR);
         String suffix = streamType.getSuffix();
         String extension;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/Downloader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/Downloader.java
@@ -46,7 +46,6 @@ import com.hedera.mirror.importer.util.Utility;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
-import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -381,15 +380,15 @@ public abstract class Downloader<T extends StreamFile<I>, I extends StreamItem> 
 
                 if (downloaderProperties.isWriteFiles()) {
                     Utility.archiveFile(
-                            streamFile.getName(),
+                            streamFileData.getStreamFilename(),
                             streamFile.getBytes(),
-                            downloaderProperties.getNodeStreamPath(nodeId));
+                            downloaderProperties.getStreamPath());
                 }
 
                 if (downloaderProperties.isWriteSignatures()) {
+                    var destination = downloaderProperties.getStreamPath();
                     signatures.forEach(s -> {
-                        Path destination = downloaderProperties.getNodeStreamPath(nodeId);
-                        Utility.archiveFile(s.getFilename().getFilename(), s.getBytes(), destination);
+                        Utility.archiveFile(s.getFilename(), s.getBytes(), destination);
                     });
                 }
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/Downloader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/Downloader.java
@@ -293,7 +293,7 @@ public abstract class Downloader<T extends StreamFile<I>, I extends StreamItem> 
                     return streamFile;
                 })
                 .map(StreamFile::getName)
-                .map(StreamFilename::of)
+                .map(StreamFilename::from)
                 .orElse(StreamFilename.EPOCH);
     }
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/Downloader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/Downloader.java
@@ -387,9 +387,7 @@ public abstract class Downloader<T extends StreamFile<I>, I extends StreamItem> 
 
                 if (downloaderProperties.isWriteSignatures()) {
                     var destination = downloaderProperties.getStreamPath();
-                    signatures.forEach(s -> {
-                        Utility.archiveFile(s.getFilename(), s.getBytes(), destination);
-                    });
+                    signatures.forEach(s -> Utility.archiveFile(s.getFilename(), s.getBytes(), destination));
                 }
 
                 if (!downloaderProperties.isPersistBytes()) {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/Downloader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/Downloader.java
@@ -293,7 +293,7 @@ public abstract class Downloader<T extends StreamFile<I>, I extends StreamItem> 
                     return streamFile;
                 })
                 .map(StreamFile::getName)
-                .map(StreamFilename::new)
+                .map(StreamFilename::of)
                 .orElse(StreamFilename.EPOCH);
     }
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/Downloader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/Downloader.java
@@ -380,12 +380,13 @@ public abstract class Downloader<T extends StreamFile<I>, I extends StreamItem> 
 
                 if (downloaderProperties.isWriteFiles()) {
                     Utility.archiveFile(
-                            streamFileData.getFilePath(), streamFile.getBytes(), downloaderProperties.getStreamPath());
+                            streamFileData.getFilePath(), streamFile.getBytes(), mirrorProperties.getDataPath());
                 }
 
                 if (downloaderProperties.isWriteSignatures()) {
-                    var destination = downloaderProperties.getStreamPath();
-                    signatures.forEach(s -> Utility.archiveFile(s.getFilePath(), s.getBytes(), destination));
+                    var destination = mirrorProperties.getDataPath();
+                    signatures.forEach(
+                            s -> Utility.archiveFile(s.getFilename().getFilePath(), s.getBytes(), destination));
                 }
 
                 if (!downloaderProperties.isPersistBytes()) {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/Downloader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/Downloader.java
@@ -380,14 +380,12 @@ public abstract class Downloader<T extends StreamFile<I>, I extends StreamItem> 
 
                 if (downloaderProperties.isWriteFiles()) {
                     Utility.archiveFile(
-                            streamFileData.getStreamFilename(),
-                            streamFile.getBytes(),
-                            downloaderProperties.getStreamPath());
+                            streamFileData.getFilePath(), streamFile.getBytes(), downloaderProperties.getStreamPath());
                 }
 
                 if (downloaderProperties.isWriteSignatures()) {
                     var destination = downloaderProperties.getStreamPath();
-                    signatures.forEach(s -> Utility.archiveFile(s.getFilename(), s.getBytes(), destination));
+                    signatures.forEach(s -> Utility.archiveFile(s.getFilePath(), s.getBytes(), destination));
                 }
 
                 if (!downloaderProperties.isPersistBytes()) {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/DownloaderProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/DownloaderProperties.java
@@ -29,10 +29,6 @@ public interface DownloaderProperties {
 
     MirrorProperties getMirrorProperties();
 
-    default Path getNodeStreamPath(long nodeId) {
-        return getStreamPath().resolve(getStreamType().getNodePrefix() + nodeId);
-    }
-
     Path getStreamPath();
 
     StreamType getStreamType();

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/DownloaderProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/DownloaderProperties.java
@@ -29,7 +29,9 @@ public interface DownloaderProperties {
 
     MirrorProperties getMirrorProperties();
 
-    Path getStreamPath();
+    default Path getStreamPath() {
+        return getMirrorProperties().getDataPath();
+    }
 
     StreamType getStreamType();
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/DownloaderProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/DownloaderProperties.java
@@ -18,7 +18,6 @@ package com.hedera.mirror.importer.downloader;
 
 import com.hedera.mirror.common.domain.StreamType;
 import com.hedera.mirror.importer.MirrorProperties;
-import java.nio.file.Path;
 import java.time.Duration;
 
 public interface DownloaderProperties {
@@ -28,10 +27,6 @@ public interface DownloaderProperties {
     Duration getFrequency();
 
     MirrorProperties getMirrorProperties();
-
-    default Path getStreamPath() {
-        return getMirrorProperties().getDataPath();
-    }
 
     StreamType getStreamType();
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/balance/BalanceDownloaderProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/balance/BalanceDownloaderProperties.java
@@ -21,7 +21,6 @@ import com.hedera.mirror.importer.MirrorProperties;
 import com.hedera.mirror.importer.downloader.CommonDownloaderProperties;
 import com.hedera.mirror.importer.downloader.DownloaderProperties;
 import jakarta.validation.constraints.NotNull;
-import java.nio.file.Path;
 import java.time.Duration;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -48,11 +47,6 @@ public class BalanceDownloaderProperties implements DownloaderProperties {
     private boolean writeFiles = false;
 
     private boolean writeSignatures = false;
-
-    @Override
-    public Path getStreamPath() {
-        return mirrorProperties.getDataPath();
-    }
 
     @Override
     public StreamType getStreamType() {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/balance/BalanceDownloaderProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/balance/BalanceDownloaderProperties.java
@@ -51,7 +51,7 @@ public class BalanceDownloaderProperties implements DownloaderProperties {
 
     @Override
     public Path getStreamPath() {
-        return mirrorProperties.getDataPath().resolve(getStreamType().getPath());
+        return mirrorProperties.getDataPath();
     }
 
     @Override

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/event/EventDownloaderProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/event/EventDownloaderProperties.java
@@ -21,7 +21,6 @@ import com.hedera.mirror.importer.MirrorProperties;
 import com.hedera.mirror.importer.downloader.CommonDownloaderProperties;
 import com.hedera.mirror.importer.downloader.DownloaderProperties;
 import jakarta.validation.constraints.NotNull;
-import java.nio.file.Path;
 import java.time.Duration;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -48,11 +47,6 @@ public class EventDownloaderProperties implements DownloaderProperties {
     private boolean writeFiles = false;
 
     private boolean writeSignatures = false;
-
-    @Override
-    public Path getStreamPath() {
-        return mirrorProperties.getDataPath();
-    }
 
     @Override
     public StreamType getStreamType() {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/event/EventDownloaderProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/event/EventDownloaderProperties.java
@@ -51,7 +51,7 @@ public class EventDownloaderProperties implements DownloaderProperties {
 
     @Override
     public Path getStreamPath() {
-        return mirrorProperties.getDataPath().resolve(getStreamType().getPath());
+        return mirrorProperties.getDataPath();
     }
 
     @Override

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/LocalStreamFileProvider.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/LocalStreamFileProvider.java
@@ -42,8 +42,8 @@ public class LocalStreamFileProvider implements StreamFileProvider {
 
     @Override
     public Mono<StreamFileData> get(ConsensusNode node, StreamFilename streamFilename) {
-        return Mono.fromSupplier(() -> getDirectory(node, streamFilename))
-                .map(dir -> dir.toPath().resolve(streamFilename.getFilename()).toFile())
+        return Mono.fromSupplier(() -> streamFilename.getFilePath())
+                .map(File::new)
                 .map(StreamFileData::from)
                 .timeout(commonDownloaderProperties.getTimeout())
                 .onErrorMap(FileOperationException.class, TransientProviderException::new);

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/LocalStreamFileProvider.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/LocalStreamFileProvider.java
@@ -17,7 +17,7 @@
 package com.hedera.mirror.importer.downloader.provider;
 
 import static com.hedera.mirror.common.domain.StreamType.SIGNATURE_SUFFIX;
-import static com.hedera.mirror.importer.downloader.provider.S3StreamFileProvider.SIDECAR_FOLDER;
+import static com.hedera.mirror.importer.domain.StreamFilename.SIDECAR_FOLDER;
 
 import com.hedera.mirror.importer.addressbook.ConsensusNode;
 import com.hedera.mirror.importer.domain.StreamFileData;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/LocalStreamFileProvider.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/LocalStreamFileProvider.java
@@ -42,8 +42,7 @@ public class LocalStreamFileProvider implements StreamFileProvider {
 
     @Override
     public Mono<StreamFileData> get(ConsensusNode node, StreamFilename streamFilename) {
-        return Mono.fromSupplier(() -> streamFilename.getFilePath())
-                .map(File::new)
+        return Mono.fromSupplier(() -> streamFilename)
                 .map(StreamFileData::from)
                 .timeout(commonDownloaderProperties.getTimeout())
                 .onErrorMap(FileOperationException.class, TransientProviderException::new);

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/LocalStreamFileProvider.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/LocalStreamFileProvider.java
@@ -85,7 +85,7 @@ public class LocalStreamFileProvider implements StreamFileProvider {
                 .sort()
                 .take(batchSize)
                 .map(file -> StreamFilename.from(prefixPathRef.get().toString(), file.getName(), File.separator))
-                .flatMapSequential(streamFilename -> get(node, streamFilename))
+                .map(streamFilename -> StreamFileData.from(basePath, streamFilename))
                 .doOnSubscribe(s -> log.debug("Searching for the next {} files after {}", batchSize, startAfter));
     }
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/LocalStreamFileProvider.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/LocalStreamFileProvider.java
@@ -94,8 +94,8 @@ public class LocalStreamFileProvider implements StreamFileProvider {
                     commonDownloaderProperties.getMirrorProperties().getNetwork(),
                     String.valueOf(
                             commonDownloaderProperties.getMirrorProperties().getShard()),
-                    streamType.getNodePrefix(),
-                    node.getNodeAccountId().toString());
+                    String.valueOf(node.getNodeId()),
+                    streamType.getNodeIdBasedSuffix());
         };
     }
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/S3StreamFileProvider.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/S3StreamFileProvider.java
@@ -49,7 +49,7 @@ public final class S3StreamFileProvider implements StreamFileProvider {
 
     static final String SEPARATOR = "/";
     private static final String TEMPLATE_ACCOUNT_ID_PREFIX = "%s/%s%s/";
-    private final String TEMPLATE_NODE_ID_PREFIX = "%s/%d/%d/%s/";
+    private static final String TEMPLATE_NODE_ID_PREFIX = "%s/%d/%d/%s/";
     private final CommonDownloaderProperties commonDownloaderProperties;
     private final Map<PathKey, PathResult> paths = new ConcurrentHashMap<>();
     private final S3AsyncClient s3Client;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/S3StreamFileProvider.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/S3StreamFileProvider.java
@@ -133,7 +133,7 @@ public final class S3StreamFileProvider implements StreamFileProvider {
         var key = s3Object.key();
 
         try {
-            return new StreamFilename(key, SEPARATOR);
+            return StreamFilename.of(key, SEPARATOR);
         } catch (Exception e) {
             log.warn("Unable to parse stream filename for {}", key, e);
             return EPOCH; // Reactor doesn't allow null return values for map(), so use a sentinel that we filter later

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/S3StreamFileProvider.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/S3StreamFileProvider.java
@@ -47,9 +47,9 @@ import software.amazon.awssdk.services.s3.model.S3Object;
 @RequiredArgsConstructor
 public final class S3StreamFileProvider implements StreamFileProvider {
 
-    public static final String SEPARATOR = "/";
+    static final String SEPARATOR = "/";
     private static final String TEMPLATE_ACCOUNT_ID_PREFIX = "%s/%s%s/";
-    private static final String TEMPLATE_NODE_ID_PREFIX = "%s/%d/%d/%s/";
+    private final String TEMPLATE_NODE_ID_PREFIX = "%s/%d/%d/%s/";
     private final CommonDownloaderProperties commonDownloaderProperties;
     private final Map<PathKey, PathResult> paths = new ConcurrentHashMap<>();
     private final S3AsyncClient s3Client;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/S3StreamFileProvider.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/S3StreamFileProvider.java
@@ -133,7 +133,7 @@ public final class S3StreamFileProvider implements StreamFileProvider {
         var key = s3Object.key();
 
         try {
-            return StreamFilename.of(key, SEPARATOR);
+            return StreamFilename.from(key, SEPARATOR);
         } catch (Exception e) {
             log.warn("Unable to parse stream filename for {}", key, e);
             return EPOCH; // Reactor doesn't allow null return values for map(), so use a sentinel that we filter later

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/S3StreamFileProvider.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/S3StreamFileProvider.java
@@ -47,7 +47,7 @@ import software.amazon.awssdk.services.s3.model.S3Object;
 @RequiredArgsConstructor
 public final class S3StreamFileProvider implements StreamFileProvider {
 
-    static final String SEPARATOR = "/";
+    public static final String SEPARATOR = "/";
     private static final String TEMPLATE_ACCOUNT_ID_PREFIX = "%s/%s%s/";
     private static final String TEMPLATE_NODE_ID_PREFIX = "%s/%d/%d/%s/";
     private final CommonDownloaderProperties commonDownloaderProperties;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/record/RecordDownloaderProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/record/RecordDownloaderProperties.java
@@ -51,7 +51,7 @@ public class RecordDownloaderProperties implements DownloaderProperties {
 
     @Override
     public Path getStreamPath() {
-        return mirrorProperties.getDataPath().resolve(getStreamType().getPath());
+        return mirrorProperties.getDataPath();
     }
 
     @Override

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/record/RecordDownloaderProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/record/RecordDownloaderProperties.java
@@ -21,7 +21,6 @@ import com.hedera.mirror.importer.MirrorProperties;
 import com.hedera.mirror.importer.downloader.CommonDownloaderProperties;
 import com.hedera.mirror.importer.downloader.DownloaderProperties;
 import jakarta.validation.constraints.NotNull;
-import java.nio.file.Path;
 import java.time.Duration;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -48,11 +47,6 @@ public class RecordDownloaderProperties implements DownloaderProperties {
     private boolean writeFiles = false;
 
     private boolean writeSignatures = false;
-
-    @Override
-    public Path getStreamPath() {
-        return mirrorProperties.getDataPath();
-    }
 
     @Override
     public StreamType getStreamType() {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/record/RecordFileDownloader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/record/RecordFileDownloader.java
@@ -137,7 +137,7 @@ public class RecordFileDownloader extends Downloader<RecordFile, RecordItem> {
     }
 
     private Mono<SidecarFile> getSidecar(ConsensusNode node, StreamFilename recordFilename, SidecarFile sidecar) {
-        var sidecarFilename = StreamFilename.of(recordFilename, sidecar.getName());
+        var sidecarFilename = StreamFilename.from(recordFilename, sidecar.getName());
         return streamFileProvider.get(node, sidecarFilename).map(streamFileData -> {
             sidecarFileReader.read(sidecar, streamFileData);
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/record/RecordFileDownloader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/record/RecordFileDownloader.java
@@ -137,7 +137,7 @@ public class RecordFileDownloader extends Downloader<RecordFile, RecordItem> {
     }
 
     private Mono<SidecarFile> getSidecar(ConsensusNode node, StreamFilename recordFilename, SidecarFile sidecar) {
-        var sidecarFilename = new StreamFilename(sidecar.getName(), recordFilename.getPath());
+        var sidecarFilename = StreamFilename.of(recordFilename, sidecar.getName());
         return streamFileProvider.get(node, sidecarFilename).map(streamFileData -> {
             sidecarFileReader.read(sidecar, streamFileData);
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/util/Utility.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/util/Utility.java
@@ -25,6 +25,7 @@ import com.google.protobuf.ByteString;
 import com.google.protobuf.GeneratedMessageV3;
 import com.google.protobuf.TextFormat;
 import com.hedera.mirror.common.util.DomainUtils;
+import com.hedera.mirror.importer.domain.StreamFilename;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ContractLoginfo;
 import com.hederahashgraph.api.proto.java.Key;
@@ -117,8 +118,8 @@ public class Utility {
         return TextFormat.shortDebugString(message);
     }
 
-    public static void archiveFile(String filename, byte[] contents, Path destinationRoot) {
-        Path destination = destinationRoot.resolve(filename);
+    public static void archiveFile(StreamFilename streamFilename, byte[] contents, Path destinationRoot) {
+        Path destination = destinationRoot.resolve(streamFilename.getFilePath());
 
         try {
             destination.getParent().toFile().mkdirs();

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/util/Utility.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/util/Utility.java
@@ -25,7 +25,6 @@ import com.google.protobuf.ByteString;
 import com.google.protobuf.GeneratedMessageV3;
 import com.google.protobuf.TextFormat;
 import com.hedera.mirror.common.util.DomainUtils;
-import com.hedera.mirror.importer.domain.StreamFilename;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ContractLoginfo;
 import com.hederahashgraph.api.proto.java.Key;
@@ -118,8 +117,8 @@ public class Utility {
         return TextFormat.shortDebugString(message);
     }
 
-    public static void archiveFile(StreamFilename streamFilename, byte[] contents, Path destinationRoot) {
-        Path destination = destinationRoot.resolve(streamFilename.getFilePath());
+    public static void archiveFile(String filename, byte[] contents, Path destinationRoot) {
+        Path destination = destinationRoot.resolve(filename);
 
         try {
             destination.getParent().toFile().mkdirs();

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/TestUtils.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/TestUtils.java
@@ -258,4 +258,24 @@ public class TestUtils {
                         String.valueOf(node.getNodeId()),
                         streamType.getNodeIdBasedSuffix());
     }
+
+    public static String accountIdStreamFileProviderPath(ConsensusNode node, StreamType streamType, String fileName) {
+        return "%s/%s%s/%s"
+                .formatted(
+                        streamType.getPath(),
+                        streamType.getNodePrefix(),
+                        node.getNodeAccountId().toString(),
+                        fileName);
+    }
+
+    public static String nodeIdStreamFileProviderPath(
+            ConsensusNode node, StreamType streamType, String fileName, String network) {
+        return "%s/%d/%d/%s/%s"
+                .formatted(
+                        network,
+                        node.getNodeAccountId().getShardNum(),
+                        node.getNodeId(),
+                        streamType.getNodeIdBasedSuffix(),
+                        fileName);
+    }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/StreamFileSignatureTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/StreamFileSignatureTest.java
@@ -33,7 +33,7 @@ class StreamFileSignatureTest {
     })
     void getDataFilename(String filename, byte version, String expected) {
         var streamFileSignature = new StreamFileSignature();
-        streamFileSignature.setFilename(StreamFilename.of(filename));
+        streamFileSignature.setFilename(StreamFilename.from(filename));
         streamFileSignature.setVersion(version);
         assertThat(streamFileSignature.getDataFilename().getFilename()).isEqualTo(expected);
     }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/StreamFileSignatureTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/StreamFileSignatureTest.java
@@ -33,7 +33,7 @@ class StreamFileSignatureTest {
     })
     void getDataFilename(String filename, byte version, String expected) {
         var streamFileSignature = new StreamFileSignature();
-        streamFileSignature.setFilename(new StreamFilename(filename));
+        streamFileSignature.setFilename(StreamFilename.of(filename));
         streamFileSignature.setVersion(version);
         assertThat(streamFileSignature.getDataFilename().getFilename()).isEqualTo(expected);
     }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/StreamFilenameTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/StreamFilenameTest.java
@@ -176,8 +176,8 @@ class StreamFilenameTest {
     @ParameterizedTest
     @CsvSource({
         "2020-06-03T16_45_00.100200345Z.rcd.gz, , /, 2020-06-03T16_45_00.100200345Z.rcd.gz",
-        "2020-06-03T16_45_00.100200345Z.rcd.gz, /some/path, /, /some/path/2020-06-03T16_45_00.100200345Z.rcd.gz",
-        "2020-06-03T16_45_00.100200345Z.rcd.gz, c:\\some\\path, \\, c:\\some\\path\\2020-06-03T16_45_00.100200345Z.rcd.gz",
+        "2020-06-03T16_45_00.100200345Z.rcd.gz, some/path, /, some/path/2020-06-03T16_45_00.100200345Z.rcd.gz",
+        "2020-06-03T16_45_00.100200345Z.rcd.gz, some\\path, \\, some\\path\\2020-06-03T16_45_00.100200345Z.rcd.gz",
         "2020-06-03T16_45_00.100200345Z.evts_sig, eventsStreams/events_0.0.9, /, eventsStreams/events_0.0.9/2020-06-03T16_45_00.100200345Z.evts_sig",
         "2020-06-03T16_45_00.100200345Z_02.rcd.gz, mainnet/0/3/record, /, mainnet/0/3/record/sidecar/2020-06-03T16_45_00.100200345Z_02.rcd.gz"
     })
@@ -198,7 +198,7 @@ class StreamFilenameTest {
 
     @ParameterizedTest
     @CsvSource({
-        "2020-06-03T16_45_00.100200345Z.evts_sig, /some/path, /, 2020-06-03T16_45_00.100200345Z.evts",
+        "2020-06-03T16_45_00.100200345Z.evts_sig, some/path, /, 2020-06-03T16_45_00.100200345Z.evts",
         "2020-06-03T16_45_00.100200345Z_Balances.csv_sig, , \\, 2020-06-03T16_45_00.100200345Z_Balances.csv",
         "2020-06-03T16_45_00.100200345Z.rcd_sig, mainnet/0/9/record, /, 2020-06-03T16_45_00.100200345Z.rcd"
     })

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/StreamFilenameTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/StreamFilenameTest.java
@@ -59,7 +59,7 @@ class StreamFilenameTest {
             String fullExtension,
             Instant instant,
             StreamType streamType) {
-        StreamFilename streamFilename = StreamFilename.of(filename);
+        StreamFilename streamFilename = StreamFilename.from(filename);
         String[] fields = {
             "filename",
             "compressor",
@@ -82,7 +82,7 @@ class StreamFilenameTest {
         "2020-06-03T16_45_00.123Z_02.rcd.gz, 02",
     })
     void newStreamFileFromSidecarRecordFilename(String filename, String expectedSidecarId) {
-        StreamFilename streamFilename = StreamFilename.of(filename);
+        StreamFilename streamFilename = StreamFilename.from(filename);
         assertThat(streamFilename)
                 .returns(SIDECAR, StreamFilename::getFileType)
                 .returns(expectedSidecarId, StreamFilename::getSidecarId);
@@ -98,7 +98,7 @@ class StreamFilenameTest {
                 "2020-06-03T16_45_00"
             })
     void newStreamFileFromInvalidFilename(String filename) {
-        assertThrows(InvalidStreamFileException.class, () -> StreamFilename.of(filename));
+        assertThrows(InvalidStreamFileException.class, () -> StreamFilename.from(filename));
     }
 
     @ParameterizedTest(name = "Get filename from streamType {0}, fileType {1}, and instant {2}")
@@ -135,7 +135,7 @@ class StreamFilenameTest {
         "2020-06-03T16_45_00.1Z.rcd, 2020-06-03T16_45_00.1Z_"
     })
     void getFilenameAfter(String filename, String expected) {
-        StreamFilename streamFilename = StreamFilename.of(filename);
+        StreamFilename streamFilename = StreamFilename.from(filename);
         assertThat(streamFilename.getFilenameAfter()).isEqualTo(expected);
     }
 
@@ -145,14 +145,14 @@ class StreamFilenameTest {
         "2020-06-03T16_45_00.100200345Z_02.rcd.gz, 3, 2020-06-03T16_45_00.100200345Z_03.rcd.gz",
     })
     void getSidecarFilename(String filename, int id, String expected) {
-        StreamFilename streamFilename = StreamFilename.of(filename);
+        StreamFilename streamFilename = StreamFilename.from(filename);
         assertThat(streamFilename.getSidecarFilename(id)).isEqualTo(expected);
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"2020-06-03T16_45_00.1Z_Balances.csv", "2020-06-03T16_45_00.100200345Z.rcd_sig"})
     void getSidecarFilenameThrows(String filename) {
-        StreamFilename streamFilename = StreamFilename.of(filename);
+        StreamFilename streamFilename = StreamFilename.from(filename);
         assertThrows(IllegalArgumentException.class, () -> streamFilename.getSidecarFilename(1));
     }
 
@@ -170,7 +170,7 @@ class StreamFilenameTest {
         "2020-06-03T16_45_00.100200345Z_02.rcd.gz, true"
     })
     void isCompressed(String filename, boolean compressed) {
-        assertThat(StreamFilename.of(filename).isCompressed()).isEqualTo(compressed);
+        assertThat(StreamFilename.from(filename).isCompressed()).isEqualTo(compressed);
     }
 
     @ParameterizedTest
@@ -182,14 +182,14 @@ class StreamFilenameTest {
         "2020-06-03T16_45_00.100200345Z_02.rcd.gz, mainnet/0/3/record, /, mainnet/0/3/record/sidecar/2020-06-03T16_45_00.100200345Z_02.rcd.gz"
     })
     void getPathProperties(String filename, String path, String pathSeparator, String expectedFilePath) {
-        StreamFilename streamFilename = StreamFilename.of(path, filename, pathSeparator);
+        StreamFilename streamFilename = StreamFilename.from(path, filename, pathSeparator);
         assertThat(streamFilename.getFilename()).isEqualTo(filename);
         assertThat(streamFilename.getPath()).isEqualTo(path);
         assertThat(streamFilename.getPathSeparator()).isEqualTo(pathSeparator);
         assertThat(streamFilename.getFilePath()).isEqualTo(expectedFilePath);
 
         if (!expectedFilePath.contains("sidecar")) {
-            StreamFilename streamFilenameFromPath = StreamFilename.of(expectedFilePath, pathSeparator);
+            StreamFilename streamFilenameFromPath = StreamFilename.from(expectedFilePath, pathSeparator);
             assertThat(streamFilenameFromPath.getFilename()).isEqualTo(filename);
             assertThat(streamFilenameFromPath.getPath()).isEqualTo(path);
             assertThat(streamFilenameFromPath.getPathSeparator()).isEqualTo(pathSeparator);
@@ -203,8 +203,8 @@ class StreamFilenameTest {
         "2020-06-03T16_45_00.100200345Z.rcd_sig, mainnet/0/9/record, /, 2020-06-03T16_45_00.100200345Z.rcd"
     })
     void getDataFilename(String sigFilename, String path, String pathSeparator, String dataFilename) {
-        StreamFilename sigStreamFilename = StreamFilename.of(path, sigFilename, pathSeparator);
-        StreamFilename dataStreamFilename = StreamFilename.of(sigStreamFilename, dataFilename);
+        StreamFilename sigStreamFilename = StreamFilename.from(path, sigFilename, pathSeparator);
+        StreamFilename dataStreamFilename = StreamFilename.from(sigStreamFilename, dataFilename);
 
         assertThat(dataStreamFilename.getFilename()).isEqualTo(dataFilename);
         assertThat(dataStreamFilename.getPath()).isEqualTo(sigStreamFilename.getPath());
@@ -215,11 +215,11 @@ class StreamFilenameTest {
     // Exercise lombok @NonNull for code coverage
     @Test
     void ensureNonNull() {
-        assertThrows(NullPointerException.class, () -> StreamFilename.of(null));
-        assertThrows(NullPointerException.class, () -> StreamFilename.of((String) null, "/"));
-        assertThrows(NullPointerException.class, () -> StreamFilename.of("somePath", null));
-        assertThrows(NullPointerException.class, () -> StreamFilename.of((StreamFilename) null, "someFilename"));
-        assertThrows(NullPointerException.class, () -> StreamFilename.of("somePath", null, "\\"));
-        assertThrows(NullPointerException.class, () -> StreamFilename.of("somePath", "someFilename", null));
+        assertThrows(NullPointerException.class, () -> StreamFilename.from(null));
+        assertThrows(NullPointerException.class, () -> StreamFilename.from((String) null, "/"));
+        assertThrows(NullPointerException.class, () -> StreamFilename.from("somePath", null));
+        assertThrows(NullPointerException.class, () -> StreamFilename.from((StreamFilename) null, "someFilename"));
+        assertThrows(NullPointerException.class, () -> StreamFilename.from("somePath", null, "\\"));
+        assertThrows(NullPointerException.class, () -> StreamFilename.from("somePath", "someFilename", null));
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/StreamFilenameTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/StreamFilenameTest.java
@@ -188,7 +188,7 @@ class StreamFilenameTest {
         assertThat(streamFilename.getPathSeparator()).isEqualTo(pathSeparator);
         assertThat(streamFilename.getFilePath()).isEqualTo(expectedFilePath);
 
-        if (!expectedFilePath.contains("sidecar")) {
+        if (streamFilename.getFileType() != SIDECAR) {
             StreamFilename streamFilenameFromPath = StreamFilename.from(expectedFilePath, pathSeparator);
             assertThat(streamFilenameFromPath.getFilename()).isEqualTo(filename);
             assertThat(streamFilenameFromPath.getPath()).isEqualTo(path);

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/AbstractDownloaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/AbstractDownloaderTest.java
@@ -307,7 +307,7 @@ public abstract class AbstractDownloaderTest<T extends StreamFile<?>> {
         downloader.download();
 
         verifyForSuccess();
-        assertThat(downloaderProperties.getStreamPath()).doesNotExist();
+        assertThat(downloaderProperties.getStreamPath()).isEmptyDirectory();
     }
 
     @Test
@@ -485,7 +485,7 @@ public abstract class AbstractDownloaderTest<T extends StreamFile<?>> {
         downloader.download();
 
         verifyForSuccess();
-        assertThat(downloaderProperties.getStreamPath()).doesNotExist();
+        assertThat(downloaderProperties.getStreamPath()).isEmptyDirectory();
     }
 
     @Test
@@ -616,7 +616,7 @@ public abstract class AbstractDownloaderTest<T extends StreamFile<?>> {
         downloader.download();
 
         verifyForSuccess();
-        assertThat(downloaderProperties.getStreamPath()).doesNotExist();
+        assertThat(downloaderProperties.getStreamPath()).isEmptyDirectory();
     }
 
     @SneakyThrows

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/AbstractDownloaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/AbstractDownloaderTest.java
@@ -647,7 +647,7 @@ public abstract class AbstractDownloaderTest<T extends StreamFile<?>> {
     }
 
     private String getSigFilename(String dataFilename) {
-        var streamFilename = StreamFilename.of(dataFilename);
+        var streamFilename = StreamFilename.from(dataFilename);
         var dataExtension = streamFilename.getExtension().getName();
         // take into account that data files may be compressed so the filename has an additional compression suffix,
         // while signature files won't be compressed.
@@ -730,8 +730,8 @@ public abstract class AbstractDownloaderTest<T extends StreamFile<?>> {
         file1 = files.get(0);
         file2 = files.get(1);
 
-        file1Instant = StreamFilename.of(file1).getInstant();
-        file2Instant = StreamFilename.of(file2).getInstant();
+        file1Instant = StreamFilename.from(file1).getInstant();
+        file2Instant = StreamFilename.from(file2).getInstant();
         instantFilenamePairs = List.of(Pair.of(file1Instant, file1), Pair.of(file2Instant, file2));
     }
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/AbstractDownloaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/AbstractDownloaderTest.java
@@ -647,7 +647,7 @@ public abstract class AbstractDownloaderTest<T extends StreamFile<?>> {
     }
 
     private String getSigFilename(String dataFilename) {
-        var streamFilename = new StreamFilename(dataFilename);
+        var streamFilename = StreamFilename.of(dataFilename);
         var dataExtension = streamFilename.getExtension().getName();
         // take into account that data files may be compressed so the filename has an additional compression suffix,
         // while signature files won't be compressed.
@@ -730,8 +730,8 @@ public abstract class AbstractDownloaderTest<T extends StreamFile<?>> {
         file1 = files.get(0);
         file2 = files.get(1);
 
-        file1Instant = new StreamFilename(file1).getInstant();
-        file2Instant = new StreamFilename(file2).getInstant();
+        file1Instant = StreamFilename.of(file1).getInstant();
+        file2Instant = StreamFilename.of(file2).getInstant();
         instantFilenamePairs = List.of(Pair.of(file1Instant, file1), Pair.of(file2Instant, file2));
     }
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/AbstractDownloaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/AbstractDownloaderTest.java
@@ -88,7 +88,6 @@ import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
-import org.junit.jupiter.params.provider.EnumSource.Mode;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -297,11 +296,12 @@ public abstract class AbstractDownloaderTest<T extends StreamFile<?>> {
     }
 
     @ParameterizedTest(name = "Download and verify files with path type: {0}")
-    @EnumSource(value = PathType.class, mode = Mode.EXCLUDE, names = "AUTO")
+    @EnumSource(PathType.class)
     void download(PathType pathType) {
         mirrorProperties.setStartBlockNumber(null);
         commonDownloaderProperties.setPathType(pathType);
 
+        commonDownloaderProperties.setPathRefreshInterval(Duration.ZERO);
         if (pathType == PathType.ACCOUNT_ID) {
             fileCopier.copy();
         } else {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/AbstractDownloaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/AbstractDownloaderTest.java
@@ -315,7 +315,7 @@ public abstract class AbstractDownloaderTest<T extends StreamFile<?>> {
         downloader.download();
 
         verifyForSuccess();
-        assertThat(downloaderProperties.getStreamPath()).isEmptyDirectory();
+        assertThat(mirrorProperties.getDataPath()).isEmptyDirectory();
     }
 
     @Test
@@ -428,7 +428,7 @@ public abstract class AbstractDownloaderTest<T extends StreamFile<?>> {
         preparePathType(pathType);
         expectLastStreamFile(Instant.EPOCH);
         downloader.download();
-        assertThat(Files.walk(downloaderProperties.getStreamPath()))
+        assertThat(Files.walk(mirrorProperties.getDataPath()))
                 .filteredOn(p -> !p.toFile().isDirectory())
                 .hasSizeGreaterThan(0)
                 .allMatch(this::isStreamFile);
@@ -441,7 +441,7 @@ public abstract class AbstractDownloaderTest<T extends StreamFile<?>> {
         preparePathType(pathType);
         expectLastStreamFile(Instant.EPOCH);
         downloader.download();
-        assertThat(Files.walk(downloaderProperties.getStreamPath()))
+        assertThat(Files.walk(mirrorProperties.getDataPath()))
                 .filteredOn(p -> !p.toFile().isDirectory())
                 .hasSizeGreaterThan(0)
                 .allMatch(this::isSigFile);
@@ -493,7 +493,7 @@ public abstract class AbstractDownloaderTest<T extends StreamFile<?>> {
         downloader.download();
 
         verifyForSuccess();
-        assertThat(downloaderProperties.getStreamPath()).isEmptyDirectory();
+        assertThat(mirrorProperties.getDataPath()).isEmptyDirectory();
     }
 
     @Test
@@ -624,7 +624,7 @@ public abstract class AbstractDownloaderTest<T extends StreamFile<?>> {
         downloader.download();
 
         verifyForSuccess();
-        assertThat(downloaderProperties.getStreamPath()).isEmptyDirectory();
+        assertThat(mirrorProperties.getDataPath()).isEmptyDirectory();
     }
 
     @SneakyThrows

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/AbstractDownloaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/AbstractDownloaderTest.java
@@ -297,12 +297,17 @@ public abstract class AbstractDownloaderTest<T extends StreamFile<?>> {
     }
 
     @ParameterizedTest(name = "Download and verify files with path type: {0}")
-    @EnumSource(value = PathType.class, mode = Mode.EXCLUDE, names = "NODE_ID")
+    @EnumSource(value = PathType.class, mode = Mode.EXCLUDE, names = "AUTO")
     void download(PathType pathType) {
         mirrorProperties.setStartBlockNumber(null);
         commonDownloaderProperties.setPathType(pathType);
 
-        fileCopier.copy();
+        if (pathType == PathType.ACCOUNT_ID) {
+            fileCopier.copy();
+        } else {
+            fileCopier.copyAsNodeIdStructure(Path::getParent, mirrorProperties.getNetwork());
+        }
+
         expectLastStreamFile(Instant.EPOCH);
         downloader.download();
 
@@ -701,7 +706,7 @@ public abstract class AbstractDownloaderTest<T extends StreamFile<?>> {
                     }
                 })
                 .allMatch(s -> downloaderProperties.isPersistBytes() ^ (s.getBytes() == null))
-                .allSatisfy(t -> extraAssert.accept(t));
+                .allSatisfy(extraAssert::accept);
 
         if (!files.isEmpty()) {
             var lastFilename = files.get(files.size() - 1);
@@ -716,14 +721,11 @@ public abstract class AbstractDownloaderTest<T extends StreamFile<?>> {
     }
 
     private Instant chooseFileInstant(String choice) {
-        switch (choice) {
-            case "file1":
-                return file1Instant;
-            case "file2":
-                return file2Instant;
-            default:
-                throw new RuntimeException("Invalid choice " + choice);
-        }
+        return switch (choice) {
+            case "file1" -> file1Instant;
+            case "file2" -> file2Instant;
+            default -> throw new RuntimeException("Invalid choice " + choice);
+        };
     }
 
     protected void setTestFilesAndInstants(List<String> files) {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/AbstractDownloaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/AbstractDownloaderTest.java
@@ -295,18 +295,21 @@ public abstract class AbstractDownloaderTest<T extends StreamFile<?>> {
                 .until(() -> AbstractLifeCycle.STARTED.equals(s3Proxy.getState()));
     }
 
-    @ParameterizedTest(name = "Download and verify files with path type: {0}")
-    @EnumSource(PathType.class)
-    void download(PathType pathType) {
-        mirrorProperties.setStartBlockNumber(null);
+    private void preparePathType(PathType pathType) {
         commonDownloaderProperties.setPathType(pathType);
-
         commonDownloaderProperties.setPathRefreshInterval(Duration.ZERO);
         if (pathType == PathType.ACCOUNT_ID) {
             fileCopier.copy();
         } else {
             fileCopier.copyAsNodeIdStructure(Path::getParent, mirrorProperties.getNetwork());
         }
+    }
+
+    @ParameterizedTest(name = "Download and verify files with path type: {0}")
+    @EnumSource(PathType.class)
+    void download(PathType pathType) {
+        mirrorProperties.setStartBlockNumber(null);
+        preparePathType(pathType);
 
         expectLastStreamFile(Instant.EPOCH);
         downloader.download();
@@ -418,11 +421,11 @@ public abstract class AbstractDownloaderTest<T extends StreamFile<?>> {
         verifyUnsuccessful();
     }
 
-    @Test
-    @DisplayName("Write stream files")
-    void writeFiles() throws Exception {
+    @ParameterizedTest(name = "Write stream files with path type: {0}")
+    @EnumSource(PathType.class)
+    void writeFiles(PathType pathType) throws Exception {
         downloaderProperties.setWriteFiles(true);
-        fileCopier.copy();
+        preparePathType(pathType);
         expectLastStreamFile(Instant.EPOCH);
         downloader.download();
         assertThat(Files.walk(downloaderProperties.getStreamPath()))
@@ -431,11 +434,11 @@ public abstract class AbstractDownloaderTest<T extends StreamFile<?>> {
                 .allMatch(this::isStreamFile);
     }
 
-    @Test
-    @DisplayName("Write signature files")
-    void writeSignatureFiles() throws Exception {
+    @ParameterizedTest(name = "Write signature files with path type: {0}")
+    @EnumSource(PathType.class)
+    void writeSignatureFiles(PathType pathType) throws Exception {
         downloaderProperties.setWriteSignatures(true);
-        fileCopier.copy();
+        preparePathType(pathType);
         expectLastStreamFile(Instant.EPOCH);
         downloader.download();
         assertThat(Files.walk(downloaderProperties.getStreamPath()))

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/DownloaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/DownloaderTest.java
@@ -39,7 +39,7 @@ class DownloaderTest {
     void streamFileSignatureMultiMapExpectNoDuplicate() {
         // given
         when(downloader.getStreamFileSignatureMultiMap()).thenCallRealMethod();
-        var signatureFilename = StreamFilename.of("2022-01-01T00_00_00Z.rcd_sig");
+        var signatureFilename = StreamFilename.from("2022-01-01T00_00_00Z.rcd_sig");
         var multimap = downloader.getStreamFileSignatureMultiMap();
         var streamFileSignature = streamFileSignature(1L, signatureFilename);
         multimap.put(signatureFilename, streamFileSignature);

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/DownloaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/DownloaderTest.java
@@ -39,7 +39,7 @@ class DownloaderTest {
     void streamFileSignatureMultiMapExpectNoDuplicate() {
         // given
         when(downloader.getStreamFileSignatureMultiMap()).thenCallRealMethod();
-        var signatureFilename = new StreamFilename("2022-01-01T00_00_00Z.rcd_sig");
+        var signatureFilename = StreamFilename.of("2022-01-01T00_00_00Z.rcd_sig");
         var multimap = downloader.getStreamFileSignatureMultiMap();
         var streamFileSignature = streamFileSignature(1L, signatureFilename);
         multimap.put(signatureFilename, streamFileSignature);

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/balance/AccountBalancesDownloaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/balance/AccountBalancesDownloaderTest.java
@@ -108,6 +108,6 @@ class AccountBalancesDownloaderTest extends AbstractDownloaderTest<AccountBalanc
         downloader.download();
 
         verifyForSuccess();
-        assertThat(downloaderProperties.getStreamPath()).doesNotExist();
+        assertThat(downloaderProperties.getStreamPath()).isEmptyDirectory();
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/balance/AccountBalancesDownloaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/balance/AccountBalancesDownloaderTest.java
@@ -108,6 +108,6 @@ class AccountBalancesDownloaderTest extends AbstractDownloaderTest<AccountBalanc
         downloader.download();
 
         verifyForSuccess();
-        assertThat(downloaderProperties.getStreamPath()).isEmptyDirectory();
+        assertThat(mirrorProperties.getDataPath()).isEmptyDirectory();
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/AbstractStreamFileProviderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/AbstractStreamFileProviderTest.java
@@ -245,12 +245,12 @@ abstract class AbstractStreamFileProviderTest {
         try {
             var streamFilename =
                     StreamFilename.from(resolveProviderRelativePath(node, filename), getProviderPathSeparator());
-            var filePath = fileCopier
+            var repoDataPath = fileCopier
                     .getFrom()
                     .resolve(nodePath(node))
                     .resolve(streamFilename.getFileType() == SIDECAR ? SIDECAR_FOLDER : "")
                     .resolve(filename);
-            var bytes = FileUtils.readFileToByteArray(filePath.toFile());
+            var bytes = FileUtils.readFileToByteArray(repoDataPath.toFile());
             return new StreamFileData(streamFilename, bytes, Instant.now());
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/AbstractStreamFileProviderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/AbstractStreamFileProviderTest.java
@@ -17,7 +17,7 @@
 package com.hedera.mirror.importer.downloader.provider;
 
 import static com.hedera.mirror.importer.domain.StreamFilename.FileType.SIDECAR;
-import static com.hedera.mirror.importer.downloader.provider.S3StreamFileProvider.SIDECAR_FOLDER;
+import static com.hedera.mirror.importer.domain.StreamFilename.SIDECAR_FOLDER;
 
 import com.hedera.mirror.common.domain.StreamType;
 import com.hedera.mirror.importer.FileCopier;

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/AbstractStreamFileProviderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/AbstractStreamFileProviderTest.java
@@ -187,7 +187,7 @@ abstract class AbstractStreamFileProviderTest {
 
     protected final void listAfter(FileCopier fileCopier, ConsensusNode node) {
         fileCopier.copy();
-        var lastFilename = StreamFilename.of("2022-07-13T08_46_08.041986003Z.rcd_sig");
+        var lastFilename = StreamFilename.from("2022-07-13T08_46_08.041986003Z.rcd_sig");
         var data = streamFileData(node, "2022-07-13T08_46_11.304284003Z.rcd_sig");
         StepVerifier.withVirtualTime(() -> streamFileProvider.list(node, lastFilename))
                 .thenAwait(Duration.ofSeconds(10L))
@@ -198,7 +198,7 @@ abstract class AbstractStreamFileProviderTest {
 
     protected final void listNotFound(FileCopier fileCopier, ConsensusNode node) {
         fileCopier.copy();
-        var lastFilename = StreamFilename.of("2100-01-01T01_01_01.000000001Z.rcd_sig");
+        var lastFilename = StreamFilename.from("2100-01-01T01_01_01.000000001Z.rcd_sig");
         StepVerifier.withVirtualTime(() -> streamFileProvider.list(node, lastFilename))
                 .thenAwait(Duration.ofSeconds(10L))
                 .expectNextCount(0)
@@ -244,7 +244,7 @@ abstract class AbstractStreamFileProviderTest {
     protected StreamFileData streamFileData(ConsensusNode node, FileCopier fileCopier, String filename) {
         try {
             var streamFilename =
-                    StreamFilename.of(resolveProviderRelativePath(node, filename), getProviderPathSeparator());
+                    StreamFilename.from(resolveProviderRelativePath(node, filename), getProviderPathSeparator());
             var filePath = fileCopier
                     .getFrom()
                     .resolve(nodePath(node))

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/AbstractStreamFileProviderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/AbstractStreamFileProviderTest.java
@@ -187,7 +187,7 @@ abstract class AbstractStreamFileProviderTest {
 
     protected final void listAfter(FileCopier fileCopier, ConsensusNode node) {
         fileCopier.copy();
-        var lastFilename = new StreamFilename("2022-07-13T08_46_08.041986003Z.rcd_sig");
+        var lastFilename = StreamFilename.of("2022-07-13T08_46_08.041986003Z.rcd_sig");
         var data = streamFileData(node, "2022-07-13T08_46_11.304284003Z.rcd_sig");
         StepVerifier.withVirtualTime(() -> streamFileProvider.list(node, lastFilename))
                 .thenAwait(Duration.ofSeconds(10L))
@@ -198,7 +198,7 @@ abstract class AbstractStreamFileProviderTest {
 
     protected final void listNotFound(FileCopier fileCopier, ConsensusNode node) {
         fileCopier.copy();
-        var lastFilename = new StreamFilename("2100-01-01T01_01_01.000000001Z.rcd_sig");
+        var lastFilename = StreamFilename.of("2100-01-01T01_01_01.000000001Z.rcd_sig");
         StepVerifier.withVirtualTime(() -> streamFileProvider.list(node, lastFilename))
                 .thenAwait(Duration.ofSeconds(10L))
                 .expectNextCount(0)
@@ -244,7 +244,7 @@ abstract class AbstractStreamFileProviderTest {
     protected StreamFileData streamFileData(ConsensusNode node, FileCopier fileCopier, String filename) {
         try {
             var streamFilename =
-                    new StreamFilename(resolveProviderRelativePath(node, filename), getProviderPathSeparator());
+                    StreamFilename.of(resolveProviderRelativePath(node, filename), getProviderPathSeparator());
             var filePath = fileCopier
                     .getFrom()
                     .resolve(nodePath(node))

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/AbstractStreamFileProviderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/AbstractStreamFileProviderTest.java
@@ -42,6 +42,8 @@ abstract class AbstractStreamFileProviderTest {
     @TempDir
     protected Path dataPath;
 
+    protected Path bucketRootPath;
+
     protected FileCopier fileCopier;
     protected CommonDownloaderProperties properties;
     protected StreamFileProvider streamFileProvider;
@@ -53,9 +55,14 @@ abstract class AbstractStreamFileProviderTest {
         properties = new CommonDownloaderProperties(mirrorProperties);
         customizeProperties(properties);
         fileCopier = createFileCopier(dataPath);
+        bucketRootPath = dataPath.resolve(properties.getBucketName());
     }
 
     protected abstract FileCopier createFileCopier(Path dataPath);
+
+    protected abstract String getProviderPathSeparator();
+
+    protected abstract String resolveProviderRelativePath(ConsensusNode node, String fileName);
 
     protected FileCopier getFileCopier(ConsensusNode node) {
         return fileCopier;
@@ -236,7 +243,8 @@ abstract class AbstractStreamFileProviderTest {
 
     protected StreamFileData streamFileData(ConsensusNode node, FileCopier fileCopier, String filename) {
         try {
-            var streamFilename = new StreamFilename(filename);
+            var streamFilename =
+                    new StreamFilename(resolveProviderRelativePath(node, filename), getProviderPathSeparator());
             var filePath = fileCopier
                     .getFrom()
                     .resolve(nodePath(node))

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/AutoS3StreamFileProviderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/AutoS3StreamFileProviderTest.java
@@ -85,6 +85,18 @@ class AutoS3StreamFileProviderTest extends S3StreamFileProviderTest {
         return TestUtils.nodePath(node, nodeInfo.pathType, StreamType.RECORD);
     }
 
+    @Override
+    protected String resolveProviderRelativePath(ConsensusNode node, String fileName) {
+        var nodeInfo = getNodeInfo(node);
+        return nodeInfo.pathType == PathType.ACCOUNT_ID
+                ? TestUtils.accountIdStreamFileProviderPath(node, StreamType.RECORD, fileName)
+                : TestUtils.nodeIdStreamFileProviderPath(
+                        node,
+                        StreamType.RECORD,
+                        fileName,
+                        properties.getMirrorProperties().getNetwork());
+    }
+
     @Test
     void nodeAccountIdToNodeIdListTransition() throws Exception {
         var node = node("0.0.3");

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/LocalStreamFileProviderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/LocalStreamFileProviderTest.java
@@ -68,7 +68,7 @@ class LocalStreamFileProviderTest extends AbstractStreamFileProviderTest {
         var accountId = "0.0.3";
         var node = node(accountId);
         getFileCopier(node).copy();
-        var lastFilename = new StreamFilename(Instant.now().toString().replace(':', '_') + ".rcd.gz");
+        var lastFilename = StreamFilename.of(Instant.now().toString().replace(':', '_') + ".rcd.gz");
         StepVerifier.withVirtualTime(() -> streamFileProvider.list(node, lastFilename))
                 .thenAwait(Duration.ofSeconds(10))
                 .expectNextCount(0)

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/LocalStreamFileProviderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/LocalStreamFileProviderTest.java
@@ -41,7 +41,13 @@ class LocalStreamFileProviderTest extends AbstractStreamFileProviderTest {
 
     @Override
     protected String resolveProviderRelativePath(ConsensusNode node, String fileName) {
-        return null;
+        return fileCopier
+                .getTo()
+                .resolve(Path.of(
+                        StreamType.RECORD.getNodePrefix()
+                                + node.getNodeAccountId().toString(),
+                        fileName))
+                .toString();
     }
 
     @BeforeEach

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/LocalStreamFileProviderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/LocalStreamFileProviderTest.java
@@ -21,7 +21,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.hedera.mirror.common.domain.StreamType;
 import com.hedera.mirror.importer.FileCopier;
 import com.hedera.mirror.importer.TestUtils;
+import com.hedera.mirror.importer.addressbook.ConsensusNode;
 import com.hedera.mirror.importer.domain.StreamFilename;
+import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -31,6 +33,16 @@ import org.junit.jupiter.api.Test;
 import reactor.test.StepVerifier;
 
 class LocalStreamFileProviderTest extends AbstractStreamFileProviderTest {
+
+    @Override
+    protected String getProviderPathSeparator() {
+        return File.separator;
+    }
+
+    @Override
+    protected String resolveProviderRelativePath(ConsensusNode node, String fileName) {
+        return null;
+    }
 
     @BeforeEach
     void setup() throws Exception {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/LocalStreamFileProviderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/LocalStreamFileProviderTest.java
@@ -41,12 +41,10 @@ class LocalStreamFileProviderTest extends AbstractStreamFileProviderTest {
 
     @Override
     protected String resolveProviderRelativePath(ConsensusNode node, String fileName) {
-        return fileCopier
-                .getTo()
-                .resolve(Path.of(
-                        StreamType.RECORD.getNodePrefix()
-                                + node.getNodeAccountId().toString(),
-                        fileName))
+        return Path.of(
+                        StreamType.RECORD.getPath(),
+                        StreamType.RECORD.getNodePrefix() + node.getNodeAccountId(),
+                        fileName)
                 .toString();
     }
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/LocalStreamFileProviderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/LocalStreamFileProviderTest.java
@@ -68,7 +68,7 @@ class LocalStreamFileProviderTest extends AbstractStreamFileProviderTest {
         var accountId = "0.0.3";
         var node = node(accountId);
         getFileCopier(node).copy();
-        var lastFilename = StreamFilename.of(Instant.now().toString().replace(':', '_') + ".rcd.gz");
+        var lastFilename = StreamFilename.from(Instant.now().toString().replace(':', '_') + ".rcd.gz");
         StepVerifier.withVirtualTime(() -> streamFileProvider.list(node, lastFilename))
                 .thenAwait(Duration.ofSeconds(10))
                 .expectNextCount(0)

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/LocalStreamFileProviderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/LocalStreamFileProviderTest.java
@@ -23,6 +23,7 @@ import com.hedera.mirror.importer.FileCopier;
 import com.hedera.mirror.importer.TestUtils;
 import com.hedera.mirror.importer.addressbook.ConsensusNode;
 import com.hedera.mirror.importer.domain.StreamFilename;
+import com.hedera.mirror.importer.downloader.CommonDownloaderProperties.PathType;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -30,6 +31,8 @@ import java.time.Duration;
 import java.time.Instant;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import reactor.test.StepVerifier;
 
 class LocalStreamFileProviderTest extends AbstractStreamFileProviderTest {
@@ -77,5 +80,29 @@ class LocalStreamFileProviderTest extends AbstractStreamFileProviderTest {
                         .filter(p -> !p.toString().contains("sidecar"))
                         .noneMatch(p -> p.toFile().isFile()))
                 .isTrue();
+    }
+
+    @ParameterizedTest
+    @EnumSource(PathType.class)
+    void listAllPathTypes(PathType pathType) {
+        properties.setPathType(pathType);
+
+        if (pathType == PathType.ACCOUNT_ID) {
+            fileCopier.copy();
+        } else {
+            fileCopier.copyAsNodeIdStructure(
+                    Path::getParent, properties.getMirrorProperties().getNetwork());
+        }
+
+        var accountId = "0.0.3";
+        var node = node(accountId);
+        var data1 = streamFileData(node, "2022-07-13T08_46_08.041986003Z.rcd_sig");
+        var data2 = streamFileData(node, "2022-07-13T08_46_11.304284003Z.rcd_sig");
+        StepVerifier.withVirtualTime(() -> streamFileProvider.list(node, StreamFilename.EPOCH))
+                .thenAwait(Duration.ofSeconds(10L))
+                .expectNext(data1)
+                .expectNext(data2)
+                .expectComplete()
+                .verify(Duration.ofSeconds(10L));
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/NodeIdS3StreamProviderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/NodeIdS3StreamProviderTest.java
@@ -51,4 +51,13 @@ public class NodeIdS3StreamProviderTest extends S3StreamFileProviderTest {
     protected Path nodePath(ConsensusNode node) {
         return TestUtils.nodePath(node, PathType.NODE_ID, StreamType.RECORD);
     }
+
+    @Override
+    protected String resolveProviderRelativePath(ConsensusNode node, String fileName) {
+        return TestUtils.nodeIdStreamFileProviderPath(
+                node,
+                StreamType.RECORD,
+                fileName,
+                properties.getMirrorProperties().getNetwork());
+    }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/S3StreamFileProviderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/S3StreamFileProviderTest.java
@@ -51,7 +51,7 @@ class S3StreamFileProviderTest extends AbstractStreamFileProviderTest {
 
     @Override
     protected String resolveProviderRelativePath(ConsensusNode node, String fileName) {
-        return "%s/%s/%s".formatted(StreamType.RECORD.getPath(), nodePath(node).toString(), fileName);
+        return TestUtils.accountIdStreamFileProviderPath(node, StreamType.RECORD, fileName);
     }
 
     @BeforeEach

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/S3StreamFileProviderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/S3StreamFileProviderTest.java
@@ -22,6 +22,7 @@ import static software.amazon.awssdk.core.client.config.SdkAdvancedAsyncClientOp
 import com.hedera.mirror.common.domain.StreamType;
 import com.hedera.mirror.importer.FileCopier;
 import com.hedera.mirror.importer.TestUtils;
+import com.hedera.mirror.importer.addressbook.ConsensusNode;
 import java.net.URI;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -42,6 +43,16 @@ class S3StreamFileProviderTest extends AbstractStreamFileProviderTest {
     private static final int S3_PROXY_PORT = 8001;
 
     private S3Proxy s3Proxy;
+
+    @Override
+    protected String getProviderPathSeparator() {
+        return S3StreamFileProvider.SEPARATOR;
+    }
+
+    @Override
+    protected String resolveProviderRelativePath(ConsensusNode node, String fileName) {
+        return "%s/%s/%s".formatted(StreamType.RECORD.getPath(), nodePath(node).toString(), fileName);
+    }
 
     @BeforeEach
     void setup() throws Exception {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/record/ProtoRecordFileDownloaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/record/ProtoRecordFileDownloaderTest.java
@@ -72,7 +72,7 @@ class ProtoRecordFileDownloaderTest extends AbstractRecordFileDownloaderTest {
         downloader.download();
 
         super.verifyStreamFiles(List.of(file1, file2), s -> {});
-        assertThat(downloaderProperties.getStreamPath()).doesNotExist();
+        assertThat(downloaderProperties.getStreamPath()).isEmptyDirectory();
     }
 
     @Test
@@ -98,7 +98,7 @@ class ProtoRecordFileDownloaderTest extends AbstractRecordFileDownloaderTest {
                     .block();
             assertThat(transactionSidecarRecords).isEmpty();
         });
-        assertThat(downloaderProperties.getStreamPath()).doesNotExist();
+        assertThat(downloaderProperties.getStreamPath()).isEmptyDirectory();
     }
 
     @Test
@@ -122,7 +122,7 @@ class ProtoRecordFileDownloaderTest extends AbstractRecordFileDownloaderTest {
                 assertThat(sidecarTypes).isEmpty();
             }
         });
-        assertThat(downloaderProperties.getStreamPath()).doesNotExist();
+        assertThat(downloaderProperties.getStreamPath()).isEmptyDirectory();
     }
 
     @Test
@@ -133,7 +133,7 @@ class ProtoRecordFileDownloaderTest extends AbstractRecordFileDownloaderTest {
         downloader.download();
 
         verifyForSuccess(List.of(file1));
-        assertThat(downloaderProperties.getStreamPath()).doesNotExist();
+        assertThat(downloaderProperties.getStreamPath()).isEmptyDirectory();
     }
 
     @Test
@@ -156,7 +156,7 @@ class ProtoRecordFileDownloaderTest extends AbstractRecordFileDownloaderTest {
             downloader.download();
 
             verifyForSuccess(List.of(file1));
-            assertThat(downloaderProperties.getStreamPath()).doesNotExist();
+            assertThat(downloaderProperties.getStreamPath()).isEmptyDirectory();
         }
     }
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/record/ProtoRecordFileDownloaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/record/ProtoRecordFileDownloaderTest.java
@@ -72,7 +72,7 @@ class ProtoRecordFileDownloaderTest extends AbstractRecordFileDownloaderTest {
         downloader.download();
 
         super.verifyStreamFiles(List.of(file1, file2), s -> {});
-        assertThat(downloaderProperties.getStreamPath()).isEmptyDirectory();
+        assertThat(mirrorProperties.getDataPath()).isEmptyDirectory();
     }
 
     @Test
@@ -98,7 +98,7 @@ class ProtoRecordFileDownloaderTest extends AbstractRecordFileDownloaderTest {
                     .block();
             assertThat(transactionSidecarRecords).isEmpty();
         });
-        assertThat(downloaderProperties.getStreamPath()).isEmptyDirectory();
+        assertThat(mirrorProperties.getDataPath()).isEmptyDirectory();
     }
 
     @Test
@@ -122,7 +122,7 @@ class ProtoRecordFileDownloaderTest extends AbstractRecordFileDownloaderTest {
                 assertThat(sidecarTypes).isEmpty();
             }
         });
-        assertThat(downloaderProperties.getStreamPath()).isEmptyDirectory();
+        assertThat(mirrorProperties.getDataPath()).isEmptyDirectory();
     }
 
     @Test
@@ -133,7 +133,7 @@ class ProtoRecordFileDownloaderTest extends AbstractRecordFileDownloaderTest {
         downloader.download();
 
         verifyForSuccess(List.of(file1));
-        assertThat(downloaderProperties.getStreamPath()).isEmptyDirectory();
+        assertThat(mirrorProperties.getDataPath()).isEmptyDirectory();
     }
 
     @Test
@@ -156,7 +156,7 @@ class ProtoRecordFileDownloaderTest extends AbstractRecordFileDownloaderTest {
             downloader.download();
 
             verifyForSuccess(List.of(file1));
-            assertThat(downloaderProperties.getStreamPath()).isEmptyDirectory();
+            assertThat(mirrorProperties.getDataPath()).isEmptyDirectory();
         }
     }
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/balance/CsvBalanceFileReaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/balance/CsvBalanceFileReaderTest.java
@@ -89,7 +89,7 @@ abstract class CsvBalanceFileReaderTest {
 
     @BeforeEach
     void setup() throws IOException {
-        Instant instant = StreamFilename.of(balanceFile.getName()).getInstant();
+        Instant instant = StreamFilename.from(balanceFile.getName()).getInstant();
         consensusTimestamp = DomainUtils.convertToNanosMax(instant);
         testFile = tempDir.resolve(balanceFile.getName()).toFile();
         assertThat(testFile.createNewFile()).isTrue();

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/balance/CsvBalanceFileReaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/balance/CsvBalanceFileReaderTest.java
@@ -18,7 +18,7 @@ package com.hedera.mirror.importer.reader.balance;
 
 import static com.hedera.mirror.common.domain.DigestAlgorithm.SHA_384;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.collect.Collections2;
 import com.hedera.mirror.common.domain.balance.AccountBalance;
@@ -89,7 +89,7 @@ abstract class CsvBalanceFileReaderTest {
 
     @BeforeEach
     void setup() throws IOException {
-        Instant instant = new StreamFilename(balanceFile.getName()).getInstant();
+        Instant instant = StreamFilename.of(balanceFile.getName()).getInstant();
         consensusTimestamp = DomainUtils.convertToNanosMax(instant);
         testFile = tempDir.resolve(balanceFile.getName()).toFile();
         assertThat(testFile.createNewFile()).isTrue();


### PR DESCRIPTION
**Description**:

Currently we are creating the bucket download path based on the `PathType` enum for download and then recreating it to write back to. We should be able to cache this path to avoid having to recreate it for every node. Also, `LocalStreamFileProvider` requires the ability to list and get stream files from the local file system using either the legacy node account ID and now the new node ID based bucket structures.

* In `StreamFilename` add a string path to store the path while downloading and then writing it back.
* Modify `LocalStreamFileProvider` to read from the new path where consensus node writes it.
* Change signature and stream file to write back to disk using the same structure, converting paths appropriately.
* For `LocalStreamFileProvder` `list()` operation, access file system hierarchy according to configured `PathType`.
* In addition, implement a simplified `AUTO` mode by just checking the `ACCOUNT_ID` directory, and if no files a present, go to the `NODE_ID` directory. No need for a refresh interval or map to store state etc. as in `S3StreamFileProvider`.

**Related issue(s)**:

Fixes #5759 
Fixes #6079

**Notes for reviewer**:
Note that I am still looking for getting more coverage using account ID, node ID and AUTO testing. So, I will be working on this a bit further during review.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
