### PR TITLE
Fix slow token account upsert

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/TokenAccountUpsertQueryGenerator.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/TokenAccountUpsertQueryGenerator.java
@@ -18,10 +18,8 @@ package com.hedera.mirror.importer.repository.upsert;
 
 import jakarta.inject.Named;
 import java.text.MessageFormat;
-import lombok.Value;
 
 @Named
-@Value
 public class TokenAccountUpsertQueryGenerator implements UpsertQueryGenerator {
 
     @Override

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/TokenAccountUpsertQueryGenerator.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/TokenAccountUpsertQueryGenerator.java
@@ -61,14 +61,6 @@ public class TokenAccountUpsertQueryGenerator implements UpsertQueryGenerator {
                     left join current e on e.account_id = t.account_id
                     and e.token_id = t.token_id
                 ),
-                token as (
-                  select
-                    token_id,
-                    freeze_key,
-                    freeze_default,
-                    kyc_key
-                  from token
-                ),
                 existing_history as (
                   insert into
                     token_account_history (


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR fixes the slow `token_account` upsert

**Related issue(s)**:

Fixes #6152 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

explain (analyze, costs, timing, buffers, summary):

- before
```
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Insert on token_account  (cost=284882.41..307823.50 rows=0 width=0) (actual time=1914.613..1914.624 rows=0 loops=1)
   Conflict Resolution: UPDATE
   Conflict Arbiter Indexes: token_account_pkey
   Tuples Inserted: 0
   Conflicting Tuples: 1
   Buffers: shared hit=41366, temp written=6163
```

- after
```
                                                                                        QUERY PLAN
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Insert on token_account  (cost=2230.52..2259.42 rows=0 width=0) (actual time=0.115..0.118 rows=0 loops=1)
   Conflict Resolution: UPDATE
   Conflict Arbiter Indexes: token_account_pkey
   Tuples Inserted: 0
   Conflicting Tuples: 1
   Buffers: shared hit=16
```

Note the difference in actual time and the `Buffers` part. The slow upsert has `temp written=6163`.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
