### PR TITLE
Bump snakeyaml from 1.33 to 2.0 (0.82)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,6 +33,7 @@ extra.apply {
     set("mapStructVersion", "1.5.5.Final")
     set("protobufVersion", "3.23.2")
     set("reactorGrpcVersion", "1.2.4")
+    set("snakeyaml.version", "2.0")
     set("testcontainersSpringBootVersion", "3.0.0-RC7")
     set("vertxVersion", "4.4.2")
 }


### PR DESCRIPTION
**Description**:

Cherry picks #6193 to `release/0.82`:

* Bump snakeyaml from 1.33 to 2.0

**Related issue(s)**:


**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
