### PR TITLE
Reverting changes to enable workflows on nft transfer epic branch.

### DIFF
--- a/.github/workflows/charts.yml
+++ b/.github/workflows/charts.yml
@@ -2,7 +2,7 @@ name: Charts
 
 on:
   pull_request:
-    branches: [ main, release/**, 4099-nested-nft-transfers ]
+    branches: [ main, release/** ]
   push:
     branches: [ main, release/** ]
     tags: [ v* ]

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -2,7 +2,7 @@ name: "Gradle"
 
 on:
   pull_request:
-    branches: [ main, release/**, 4099-nested-nft-transfers ]
+    branches: [ main, release/** ]
   push:
     branches: [ main, release/** ]
     tags: [ v* ]

--- a/.github/workflows/rosetta.yml
+++ b/.github/workflows/rosetta.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: "0 1 * * *" # Daily at 1:00 AM
   pull_request:
-    branches: [ main, release/**, 4099-nested-nft-transfers ]
+    branches: [ main, release/** ]
     paths: [ hedera-mirror-rosetta/** ]
   push:
     branches: [ main, release/** ]

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -2,7 +2,7 @@ name: Security
 
 on:
   pull_request:
-    branches: [ main, release/**, 4099-nested-nft-transfers ]
+    branches: [ main, release/** ]
   push:
     branches: [ main, release/** ]
     tags: [ v* ]


### PR DESCRIPTION
**Description**:

Reverting changes to enable workflows on the nft transfer epic branch.

This PR 
* Removes the build run on 4099-nested-nft-transfers

**Related issue(s)**:

Fixes #6126 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
