### PR TITLE
HIP-584: Add tests for eth_call with modification functions

### DIFF
--- a/hedera-mirror-test/src/test/resources/features/contract/call.feature
+++ b/hedera-mirror-test/src/test/resources/features/contract/call.feature
@@ -1,9 +1,10 @@
 @contractbase @fullsuite @acceptance @web3
 Feature: eth_call Contract Base Coverage Feature
-  
+
   Scenario Outline: Validate eth_call
     Given I successfully create ERC contract
     Given I successfully create Precompile contract
+    Given I successfully create EstimateGas contract
     Then I call function with IERC721Metadata token name
     Then I call function with IERC721Metadata token symbol
     Then I call function with IERC721Metadata token totalSupply
@@ -13,3 +14,8 @@ Feature: eth_call Contract Base Coverage Feature
     Then I call function with HederaTokenService isKyc token, account
     Then I call function with HederaTokenService getTokenDefaultFreezeStatus token
     Then I call function with HederaTokenService getTokenDefaultKycStatus token
+    Then I call function with update and I expect return of the updated value
+    Then I call function that makes N times state update
+    Then I call function with nested deploy using create function
+    Then I call function with nested deploy using create2 function
+    Then I call function with transfer that returns the balance


### PR DESCRIPTION
**Description**: 

Covers eth_call with modification functions based on the `EstimateGasContract.sol`. It covers the following tests:

* ETHCALL-054 Test state update once
* ETHCALL-055 Test state update N times
* ETHCALL-056 Test nested deploy using create function
* ETHCALL-057 Test nested deploy using create2 function
* ETHCALL-059 Test executing a transfer and returning the contract balance before and after

**Related issue(s)**:

Fixes #6108

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
