### PR TITLE
Bump Spring Boot from 3.1.0 to 3.1.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,6 @@ plugins {
 extra.apply {
     set("gson.version", "2.8.9") // Temporary until Apache jclouds supports gson 2.9
     set("mapStructVersion", "1.5.5.Final")
-    set("netty.version", "4.1.94.Final") // Temporary until Spring Boot includes this version
     set("protobufVersion", "3.23.2")
     set("reactorGrpcVersion", "1.2.4")
     set("snakeyaml.version", "2.0")

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -27,10 +27,6 @@ repositories {
     mavenCentral()
 }
 
-extra.apply {
-    set("springBootVersion", "3.1.0")
-}
-
 dependencies {
     val springBootVersion: String by rootProject.extra
     implementation("com.bmuschko:gradle-docker-plugin:9.3.1")
@@ -39,7 +35,7 @@ dependencies {
     implementation("com.github.node-gradle:gradle-node-plugin:5.0.0")
     implementation("com.google.protobuf:protobuf-gradle-plugin:0.9.3")
     implementation("com.gorylenko.gradle-git-properties:gradle-git-properties:2.4.1")
-    implementation("com.graphql-java-generator:graphql-gradle-plugin:2.0")
+    implementation("com.graphql-java-generator:graphql-gradle-plugin3:2.1b")
     implementation("gradle.plugin.io.snyk.gradle.plugin:snyk:0.4")
     implementation("io.freefair.gradle:lombok-plugin:8.0.1")
     implementation("io.spring.gradle:dependency-management-plugin:1.1.0")
@@ -48,10 +44,7 @@ dependencies {
     implementation("org.openapitools:openapi-generator-gradle-plugin:6.6.0")
     implementation("org.owasp:dependency-check-gradle:8.2.1")
     implementation("org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:4.2.1.3168")
-    implementation("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
-
-    // Temporary due to https://github.com/graphql-java-generator/graphql-gradle-plugin-project/issues/16
-    implementation("org.springframework.boot:spring-boot-starter-graphql:${springBootVersion}")
+    implementation("org.springframework.boot:spring-boot-gradle-plugin:3.1.1")
 
     // Temporary until openapi-generator updates to a swagger-parser that is compatible with SnakeYAML 2.0
     implementation("io.swagger.parser.v3:swagger-parser-v3:2.1.15")

--- a/hedera-mirror-graphql/build.gradle.kts
+++ b/hedera-mirror-graphql/build.gradle.kts
@@ -20,7 +20,7 @@ import com.graphql_java_generator.plugin.conf.PluginMode
 description = "Hedera Mirror Node GraphQL"
 
 plugins {
-    id("com.graphql-java-generator.graphql-gradle-plugin")
+    id("com.graphql-java-generator.graphql-gradle-plugin3")
     id("spring-conventions")
 }
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/balance/BalanceDownloaderProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/balance/BalanceDownloaderProperties.java
@@ -23,18 +23,20 @@ import com.hedera.mirror.importer.downloader.DownloaderProperties;
 import jakarta.validation.constraints.NotNull;
 import java.time.Duration;
 import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.annotation.Validated;
 
+@ConfigurationProperties("hedera.mirror.importer.downloader.balance")
 @Data
 @Component
+@RequiredArgsConstructor(onConstructor = @__(@Autowired))
 @Validated
-@ConfigurationProperties("hedera.mirror.importer.downloader.balance")
 public class BalanceDownloaderProperties implements DownloaderProperties {
 
     private final MirrorProperties mirrorProperties;
-
     private final CommonDownloaderProperties common;
 
     private boolean enabled = true;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/event/EventDownloaderProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/event/EventDownloaderProperties.java
@@ -23,18 +23,20 @@ import com.hedera.mirror.importer.downloader.DownloaderProperties;
 import jakarta.validation.constraints.NotNull;
 import java.time.Duration;
 import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.annotation.Validated;
 
+@ConfigurationProperties("hedera.mirror.importer.downloader.event")
 @Data
 @Component
+@RequiredArgsConstructor(onConstructor = @__(@Autowired))
 @Validated
-@ConfigurationProperties("hedera.mirror.importer.downloader.event")
 public class EventDownloaderProperties implements DownloaderProperties {
 
     private final MirrorProperties mirrorProperties;
-
     private final CommonDownloaderProperties common;
 
     private boolean enabled = false;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/record/RecordDownloaderProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/record/RecordDownloaderProperties.java
@@ -23,14 +23,15 @@ import com.hedera.mirror.importer.downloader.DownloaderProperties;
 import jakarta.validation.constraints.NotNull;
 import java.time.Duration;
 import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.stereotype.Component;
 import org.springframework.validation.annotation.Validated;
 
-@Data
-@Component
-@Validated
 @ConfigurationProperties("hedera.mirror.importer.downloader.record")
+@Data
+@RequiredArgsConstructor(onConstructor = @__(@Autowired))
+@Validated
 public class RecordDownloaderProperties implements DownloaderProperties {
 
     private final MirrorProperties mirrorProperties;


### PR DESCRIPTION
**Description**:

* Bump Spring Boot from 3.1.0 to 3.1.1
* Bump GraphQL Gradle Plugin from 2.0 to 2.1b for proper Spring Boot 3 support and remove hack
* Fix constructor binding failure for configuration properties
* Remove Netty version override in favor of Spring Boot updated version

**Related issue(s)**:


**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
