### PR TITLE
Fix sequenceNumber path parameter in OpenAPI

### DIFF
--- a/hedera-mirror-rest/api/v1/openapi.yml
+++ b/hedera-mirror-rest/api/v1/openapi.yml
@@ -916,7 +916,7 @@ paths:
             type: string
         - $ref: "#/components/parameters/limitQueryParam"
         - $ref: "#/components/parameters/orderQueryParamDesc"
-        - name: sequencenumber
+        - name: sequenceNumber
           in: query
           example: 2
           schema:
@@ -944,7 +944,7 @@ paths:
       operationId: getTopicMessageByIdAndSequenceNumber
       parameters:
         - $ref: "#/components/parameters/topicIdPathParam"
-        - name: sequencenumber
+        - name: sequenceNumber
           in: path
           required: true
           description: Topic message sequence number

--- a/hedera-mirror-rest/api/v1/openapi.yml
+++ b/hedera-mirror-rest/api/v1/openapi.yml
@@ -916,7 +916,7 @@ paths:
             type: string
         - $ref: "#/components/parameters/limitQueryParam"
         - $ref: "#/components/parameters/orderQueryParamDesc"
-        - name: sequenceNumber
+        - name: sequencenumber
           in: query
           example: 2
           schema:


### PR DESCRIPTION
**Description**:

Fixed typo `sequencenumber` for `sequenceNumber` in `openapi.yml`.

**Related issue(s)**:

**Notes for reviewer**:

**Before Fix:**
<img width="1681" alt="image" src="https://github.com/hashgraph/hedera-mirror-node/assets/123040664/eef0d6cf-6e5e-4629-8aff-ccee467decb9">
<img width="1668" alt="image" src="https://github.com/hashgraph/hedera-mirror-node/assets/123040664/326a0555-2e0d-4bef-8229-a3892c64c18c">

**After Fix:**
<img width="1655" alt="image" src="https://github.com/hashgraph/hedera-mirror-node/assets/123040664/d672b001-b614-4a42-b1c1-88047d846e48">



**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [] Tested (unit, integration, etc.)
