### PR TITLE
Fix contract entity initial nonce

### DIFF
--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/AbstractEntity.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/AbstractEntity.java
@@ -71,6 +71,12 @@ public abstract class AbstractEntity implements History {
 
     private Boolean deleted;
 
+    @UpsertColumn(
+            coalesce =
+                    """
+            case when coalesce(e_type, type) = ''ACCOUNT'' then coalesce({0}, e_{0}, {1})
+                 else coalesce({0}, e_{0})
+            end""")
     private Long ethereumNonce;
 
     @Column(updatable = false)

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/AbstractEntityRecordItemListenerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/AbstractEntityRecordItemListenerTest.java
@@ -427,7 +427,6 @@ public abstract class AbstractEntityRecordItemListenerTest extends IntegrationTe
         entity.setCreatedTimestamp(createdTimestamp);
         entity.setDeclineReward(false);
         entity.setDeleted(deleted);
-        entity.setEthereumNonce(0L);
         entity.setExpirationTimestamp(expiryTimeNs);
         entity.setMemo(memo);
         entity.setTimestampLower(modifiedTimestamp);
@@ -435,6 +434,11 @@ public abstract class AbstractEntityRecordItemListenerTest extends IntegrationTe
         entity.setSubmitKey(submitKeyBytes);
         entity.setStakedNodeId(-1L);
         entity.setStakePeriodStart(-1L);
+
+        if (entity.getType() == EntityType.ACCOUNT) {
+            entity.setEthereumNonce(0L);
+        }
+
         return entity;
     }
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerScheduleTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerScheduleTest.java
@@ -19,7 +19,7 @@ package com.hedera.mirror.importer.parser.record.entity;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.from;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.google.protobuf.ByteString;
 import com.google.protobuf.UnknownFieldSet;

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerTopicTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerTopicTest.java
@@ -20,7 +20,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_A
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.from;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.google.protobuf.ByteString;
 import com.google.protobuf.StringValue;
@@ -869,7 +869,6 @@ class EntityRecordItemListenerTopicTest extends AbstractEntityRecordItemListener
         }
 
         topic.setDeclineReward(false);
-        topic.setEthereumNonce(0L);
         topic.setMemo(memo);
         topic.setType(EntityType.TOPIC);
         topic.setStakedNodeId(-1L);

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/GenericUpsertQueryGeneratorTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/GenericUpsertQueryGeneratorTest.java
@@ -72,286 +72,292 @@ class GenericUpsertQueryGeneratorTest extends IntegrationTest {
     void getUpsertQueryHistory() {
         var sql =
                 """
-                with current as (
-                  select e.*
-                  from entity e
-                  join entity_temp t on e.id = t.id
-                  where upper(t.timestamp_range) is null
-                ),
-                existing as (
-                  select
-                    e.alias as e_alias,
-                    e.auto_renew_account_id as e_auto_renew_account_id,
-                    e.auto_renew_period as e_auto_renew_period,
-                    e.balance as e_balance,
-                    e.created_timestamp as e_created_timestamp,
-                    e.decline_reward as e_decline_reward,
-                    e.deleted as e_deleted,
-                    e.ethereum_nonce as e_ethereum_nonce,
-                    e.evm_address as e_evm_address,
-                    e.expiration_timestamp as e_expiration_timestamp,
-                    e.id as e_id,
-                    e.key as e_key,
-                    e.max_automatic_token_associations as e_max_automatic_token_associations,
-                    e.memo as e_memo,
-                    e.num as e_num,
-                    e.obtainer_id as e_obtainer_id,
-                    e.permanent_removal as e_permanent_removal,
-                    e.proxy_account_id as e_proxy_account_id,
-                    e.public_key as e_public_key,
-                    e.realm as e_realm,
-                    e.receiver_sig_required as e_receiver_sig_required,
-                    e.shard as e_shard,
-                    e.stake_period_start as e_stake_period_start,
-                    e.staked_account_id as e_staked_account_id,
-                    e.staked_node_id as e_staked_node_id,
-                    e.submit_key as e_submit_key,
-                    e.timestamp_range as e_timestamp_range,
-                    e.type as e_type,
-                    t.*
-                  from entity_temp t
-                  left join current e on e.id = t.id
-                ),
-                existing_history as (
-                  insert into
-                    entity_history (
-                      alias,
-                      auto_renew_account_id,
-                      auto_renew_period,
-                      balance,
-                      created_timestamp,
-                      decline_reward,
-                      deleted,
-                      ethereum_nonce,
-                      evm_address,
-                      expiration_timestamp,
-                      id,
-                      key,
-                      max_automatic_token_associations,
-                      memo,
-                      num,
-                      obtainer_id,
-                      permanent_removal,
-                      proxy_account_id,
-                      public_key,
-                      realm,
-                      receiver_sig_required,
-                      shard,
-                      stake_period_start,
-                      staked_account_id,
-                      staked_node_id,
-                      submit_key,
-                      timestamp_range,
-                      type
-                    )
-                  select
-                    distinct on (id) e_alias,
-                    e_auto_renew_account_id,
-                    e_auto_renew_period,
-                    e_balance,
-                    e_created_timestamp,
-                    e_decline_reward,
-                    e_deleted,
-                    e_ethereum_nonce,
-                    e_evm_address,
-                    e_expiration_timestamp,
-                    e_id,
-                    e_key,
-                    e_max_automatic_token_associations,
-                    e_memo,
-                    e_num,
-                    e_obtainer_id,
-                    e_permanent_removal,
-                    e_proxy_account_id,
-                    e_public_key,
-                    e_realm,
-                    e_receiver_sig_required,
-                    e_shard,
-                    e_stake_period_start,
-                    e_staked_account_id,
-                    e_staked_node_id,
-                    e_submit_key,
-                    int8range(lower(e_timestamp_range), lower(timestamp_range)) as timestamp_range,
-                    e_type
-                  from
-                    existing
-                  where
-                    e_timestamp_range is not null
-                    and timestamp_range is not null
-                  order by
-                    id,
-                    timestamp_range asc
-                ),
-                temp_history as (
-                  insert into
-                    entity_history (
-                      alias,
-                      auto_renew_account_id,
-                      auto_renew_period,
-                      balance,
-                      created_timestamp,
-                      decline_reward,
-                      deleted,
-                      ethereum_nonce,
-                      evm_address,
-                      expiration_timestamp,
-                      id,
-                      key,
-                      max_automatic_token_associations,
-                      memo,
-                      num,
-                      obtainer_id,
-                      permanent_removal,
-                      proxy_account_id,
-                      public_key,
-                      realm,
-                      receiver_sig_required,
-                      shard,
-                      stake_period_start,
-                      staked_account_id,
-                      staked_node_id,
-                      submit_key,
-                      timestamp_range,
-                      type
-                    )
-                  select
-                    distinct coalesce(alias, e_alias, null),
-                    coalesce(auto_renew_account_id, e_auto_renew_account_id, null),
-                    coalesce(auto_renew_period, e_auto_renew_period, null),
-                    case
-                      when coalesce(e_type, type) in ('ACCOUNT', 'CONTRACT')
-                      then coalesce(e_balance, 0) + coalesce(balance, 0)
-                      else null
-                    end,
-                    coalesce(created_timestamp, e_created_timestamp, null),
-                    coalesce(decline_reward, e_decline_reward, false),
-                    coalesce(deleted, e_deleted, null),
-                    coalesce(ethereum_nonce, e_ethereum_nonce, 0),
-                    coalesce(evm_address, e_evm_address, null),
-                    coalesce(expiration_timestamp, e_expiration_timestamp, null),
-                    coalesce(id, e_id, null),
-                    coalesce(key, e_key, null),
-                    coalesce(max_automatic_token_associations, e_max_automatic_token_associations, null),
-                    coalesce(memo, e_memo, ''),
-                    coalesce(num, e_num, null),
-                    coalesce(obtainer_id, e_obtainer_id, null),
-                    coalesce(permanent_removal, e_permanent_removal, null),
-                    coalesce(proxy_account_id, e_proxy_account_id, null),
-                    coalesce(public_key, e_public_key, null),
-                    coalesce(realm, e_realm, null),
-                    coalesce(receiver_sig_required, e_receiver_sig_required, null),
-                    coalesce(shard, e_shard, null),
-                    coalesce(stake_period_start, e_stake_period_start, '-1'),
-                    coalesce(staked_account_id, e_staked_account_id, null),
-                    coalesce(staked_node_id, e_staked_node_id, '-1'),
-                    coalesce(submit_key, e_submit_key, null),
-                    coalesce(timestamp_range, e_timestamp_range, null),
-                    coalesce(type, e_type, null)
-                  from
-                    existing
-                  where
-                    timestamp_range is not null
-                    and upper(timestamp_range) is not null
-                )
-                insert into
-                  entity (
-                    alias,
-                    auto_renew_account_id,
-                    auto_renew_period,
-                    balance,
-                    created_timestamp,
-                    decline_reward,
-                    deleted,
-                    ethereum_nonce,
-                    evm_address,
-                    expiration_timestamp,
-                    id,
-                    key,
-                    max_automatic_token_associations,
-                    memo,
-                    num,
-                    obtainer_id,
-                    permanent_removal,
-                    proxy_account_id,
-                    public_key,
-                    realm,
-                    receiver_sig_required,
-                    shard,
-                    stake_period_start,
-                    staked_account_id,
-                    staked_node_id,
-                    submit_key,
-                    timestamp_range,
-                    type
-                  )
-                select
-                  coalesce(alias, e_alias, null),
-                  coalesce(auto_renew_account_id, e_auto_renew_account_id, null),
-                  coalesce(auto_renew_period, e_auto_renew_period, null),
-                  case
-                    when coalesce(e_type, type) in ('ACCOUNT', 'CONTRACT')
-                    then coalesce(e_balance, 0) + coalesce(balance, 0)
-                    else null
-                  end,
-                  coalesce(created_timestamp, e_created_timestamp, null),
-                  coalesce(decline_reward, e_decline_reward, false),
-                  coalesce(deleted, e_deleted, null),
-                  coalesce(ethereum_nonce, e_ethereum_nonce, 0),
-                  coalesce(evm_address, e_evm_address, null),
-                  coalesce(expiration_timestamp, e_expiration_timestamp, null),
-                  coalesce(id, e_id, null),
-                  coalesce(key, e_key, null),
-                  coalesce(max_automatic_token_associations, e_max_automatic_token_associations, null),
-                  coalesce(memo, e_memo, ''),
-                  coalesce(num, e_num, null),
-                  coalesce(obtainer_id, e_obtainer_id, null),
-                  coalesce(permanent_removal, e_permanent_removal, null),
-                  coalesce(proxy_account_id, e_proxy_account_id, null),
-                  coalesce(public_key, e_public_key, null),
-                  coalesce(realm, e_realm, null),
-                  coalesce(receiver_sig_required, e_receiver_sig_required, null),
-                  coalesce(shard, e_shard, null),
-                  coalesce(stake_period_start, e_stake_period_start, '-1'),
-                  coalesce(staked_account_id, e_staked_account_id, null),
-                  coalesce(staked_node_id, e_staked_node_id, '-1'),
-                  coalesce(submit_key, e_submit_key, null),
-                  coalesce(timestamp_range, e_timestamp_range, null),
-                  coalesce(type, e_type, null)
-                from
-                  existing
-                where
-                  (
-                    e_timestamp_range is not null
-                    and timestamp_range is null
-                  )
-                  or (
-                    timestamp_range is not null
-                    and upper(timestamp_range) is null
-                  )
-                on conflict (id) do update
-                set
-                  auto_renew_account_id = excluded.auto_renew_account_id,
-                  auto_renew_period = excluded.auto_renew_period,
-                  balance = excluded.balance,
-                  decline_reward = excluded.decline_reward,
-                  deleted = excluded.deleted,
-                  ethereum_nonce = excluded.ethereum_nonce,
-                  expiration_timestamp = excluded.expiration_timestamp,
-                  key = excluded.key,
-                  max_automatic_token_associations = excluded.max_automatic_token_associations,
-                  memo = excluded.memo,
-                  obtainer_id = excluded.obtainer_id,
-                  permanent_removal = excluded.permanent_removal,
-                  proxy_account_id = excluded.proxy_account_id,
-                  public_key = excluded.public_key,
-                  receiver_sig_required = excluded.receiver_sig_required,
-                  stake_period_start = excluded.stake_period_start,
-                  staked_account_id = excluded.staked_account_id,
-                  staked_node_id = excluded.staked_node_id,
-                  submit_key = excluded.submit_key,
-                  timestamp_range = excluded.timestamp_range,
-                  type = excluded.type
-                """;
+                        with current as (
+                          select e.*
+                          from entity e
+                          join entity_temp t on e.id = t.id
+                          where upper(t.timestamp_range) is null
+                        ),
+                        existing as (
+                          select
+                            e.alias as e_alias,
+                            e.auto_renew_account_id as e_auto_renew_account_id,
+                            e.auto_renew_period as e_auto_renew_period,
+                            e.balance as e_balance,
+                            e.created_timestamp as e_created_timestamp,
+                            e.decline_reward as e_decline_reward,
+                            e.deleted as e_deleted,
+                            e.ethereum_nonce as e_ethereum_nonce,
+                            e.evm_address as e_evm_address,
+                            e.expiration_timestamp as e_expiration_timestamp,
+                            e.id as e_id,
+                            e.key as e_key,
+                            e.max_automatic_token_associations as e_max_automatic_token_associations,
+                            e.memo as e_memo,
+                            e.num as e_num,
+                            e.obtainer_id as e_obtainer_id,
+                            e.permanent_removal as e_permanent_removal,
+                            e.proxy_account_id as e_proxy_account_id,
+                            e.public_key as e_public_key,
+                            e.realm as e_realm,
+                            e.receiver_sig_required as e_receiver_sig_required,
+                            e.shard as e_shard,
+                            e.stake_period_start as e_stake_period_start,
+                            e.staked_account_id as e_staked_account_id,
+                            e.staked_node_id as e_staked_node_id,
+                            e.submit_key as e_submit_key,
+                            e.timestamp_range as e_timestamp_range,
+                            e.type as e_type,
+                            t.*
+                          from entity_temp t
+                          left join current e on e.id = t.id
+                        ),
+                        existing_history as (
+                          insert into
+                            entity_history (
+                              alias,
+                              auto_renew_account_id,
+                              auto_renew_period,
+                              balance,
+                              created_timestamp,
+                              decline_reward,
+                              deleted,
+                              ethereum_nonce,
+                              evm_address,
+                              expiration_timestamp,
+                              id,
+                              key,
+                              max_automatic_token_associations,
+                              memo,
+                              num,
+                              obtainer_id,
+                              permanent_removal,
+                              proxy_account_id,
+                              public_key,
+                              realm,
+                              receiver_sig_required,
+                              shard,
+                              stake_period_start,
+                              staked_account_id,
+                              staked_node_id,
+                              submit_key,
+                              timestamp_range,
+                              type
+                            )
+                          select
+                            distinct on (id) e_alias,
+                            e_auto_renew_account_id,
+                            e_auto_renew_period,
+                            e_balance,
+                            e_created_timestamp,
+                            e_decline_reward,
+                            e_deleted,
+                            e_ethereum_nonce,
+                            e_evm_address,
+                            e_expiration_timestamp,
+                            e_id,
+                            e_key,
+                            e_max_automatic_token_associations,
+                            e_memo,
+                            e_num,
+                            e_obtainer_id,
+                            e_permanent_removal,
+                            e_proxy_account_id,
+                            e_public_key,
+                            e_realm,
+                            e_receiver_sig_required,
+                            e_shard,
+                            e_stake_period_start,
+                            e_staked_account_id,
+                            e_staked_node_id,
+                            e_submit_key,
+                            int8range(lower(e_timestamp_range), lower(timestamp_range)) as timestamp_range,
+                            e_type
+                          from
+                            existing
+                          where
+                            e_timestamp_range is not null
+                            and timestamp_range is not null
+                          order by
+                            id,
+                            timestamp_range asc
+                        ),
+                        temp_history as (
+                          insert into
+                            entity_history (
+                              alias,
+                              auto_renew_account_id,
+                              auto_renew_period,
+                              balance,
+                              created_timestamp,
+                              decline_reward,
+                              deleted,
+                              ethereum_nonce,
+                              evm_address,
+                              expiration_timestamp,
+                              id,
+                              key,
+                              max_automatic_token_associations,
+                              memo,
+                              num,
+                              obtainer_id,
+                              permanent_removal,
+                              proxy_account_id,
+                              public_key,
+                              realm,
+                              receiver_sig_required,
+                              shard,
+                              stake_period_start,
+                              staked_account_id,
+                              staked_node_id,
+                              submit_key,
+                              timestamp_range,
+                              type
+                            )
+                          select
+                            distinct coalesce(alias, e_alias, null),
+                            coalesce(auto_renew_account_id, e_auto_renew_account_id, null),
+                            coalesce(auto_renew_period, e_auto_renew_period, null),
+                            case
+                              when coalesce(e_type, type) in ('ACCOUNT', 'CONTRACT')
+                              then coalesce(e_balance, 0) + coalesce(balance, 0)
+                              else null
+                            end,
+                            coalesce(created_timestamp, e_created_timestamp, null),
+                            coalesce(decline_reward, e_decline_reward, false),
+                            coalesce(deleted, e_deleted, null),
+                            case
+                              when coalesce(e_type, type) = 'ACCOUNT' then coalesce(ethereum_nonce, e_ethereum_nonce, 0)
+                              else coalesce(ethereum_nonce, e_ethereum_nonce)
+                            end,
+                            coalesce(evm_address, e_evm_address, null),
+                            coalesce(expiration_timestamp, e_expiration_timestamp, null),
+                            coalesce(id, e_id, null),
+                            coalesce(key, e_key, null),
+                            coalesce(max_automatic_token_associations, e_max_automatic_token_associations, null),
+                            coalesce(memo, e_memo, ''),
+                            coalesce(num, e_num, null),
+                            coalesce(obtainer_id, e_obtainer_id, null),
+                            coalesce(permanent_removal, e_permanent_removal, null),
+                            coalesce(proxy_account_id, e_proxy_account_id, null),
+                            coalesce(public_key, e_public_key, null),
+                            coalesce(realm, e_realm, null),
+                            coalesce(receiver_sig_required, e_receiver_sig_required, null),
+                            coalesce(shard, e_shard, null),
+                            coalesce(stake_period_start, e_stake_period_start, '-1'),
+                            coalesce(staked_account_id, e_staked_account_id, null),
+                            coalesce(staked_node_id, e_staked_node_id, '-1'),
+                            coalesce(submit_key, e_submit_key, null),
+                            coalesce(timestamp_range, e_timestamp_range, null),
+                            coalesce(type, e_type, null)
+                          from
+                            existing
+                          where
+                            timestamp_range is not null
+                            and upper(timestamp_range) is not null
+                        )
+                        insert into
+                          entity (
+                            alias,
+                            auto_renew_account_id,
+                            auto_renew_period,
+                            balance,
+                            created_timestamp,
+                            decline_reward,
+                            deleted,
+                            ethereum_nonce,
+                            evm_address,
+                            expiration_timestamp,
+                            id,
+                            key,
+                            max_automatic_token_associations,
+                            memo,
+                            num,
+                            obtainer_id,
+                            permanent_removal,
+                            proxy_account_id,
+                            public_key,
+                            realm,
+                            receiver_sig_required,
+                            shard,
+                            stake_period_start,
+                            staked_account_id,
+                            staked_node_id,
+                            submit_key,
+                            timestamp_range,
+                            type
+                          )
+                        select
+                          coalesce(alias, e_alias, null),
+                          coalesce(auto_renew_account_id, e_auto_renew_account_id, null),
+                          coalesce(auto_renew_period, e_auto_renew_period, null),
+                          case
+                            when coalesce(e_type, type) in ('ACCOUNT', 'CONTRACT')
+                            then coalesce(e_balance, 0) + coalesce(balance, 0)
+                            else null
+                          end,
+                          coalesce(created_timestamp, e_created_timestamp, null),
+                          coalesce(decline_reward, e_decline_reward, false),
+                          coalesce(deleted, e_deleted, null),
+                          case
+                            when coalesce(e_type, type) = 'ACCOUNT' then coalesce(ethereum_nonce, e_ethereum_nonce, 0)
+                            else coalesce(ethereum_nonce, e_ethereum_nonce)
+                          end,
+                          coalesce(evm_address, e_evm_address, null),
+                          coalesce(expiration_timestamp, e_expiration_timestamp, null),
+                          coalesce(id, e_id, null),
+                          coalesce(key, e_key, null),
+                          coalesce(max_automatic_token_associations, e_max_automatic_token_associations, null),
+                          coalesce(memo, e_memo, ''),
+                          coalesce(num, e_num, null),
+                          coalesce(obtainer_id, e_obtainer_id, null),
+                          coalesce(permanent_removal, e_permanent_removal, null),
+                          coalesce(proxy_account_id, e_proxy_account_id, null),
+                          coalesce(public_key, e_public_key, null),
+                          coalesce(realm, e_realm, null),
+                          coalesce(receiver_sig_required, e_receiver_sig_required, null),
+                          coalesce(shard, e_shard, null),
+                          coalesce(stake_period_start, e_stake_period_start, '-1'),
+                          coalesce(staked_account_id, e_staked_account_id, null),
+                          coalesce(staked_node_id, e_staked_node_id, '-1'),
+                          coalesce(submit_key, e_submit_key, null),
+                          coalesce(timestamp_range, e_timestamp_range, null),
+                          coalesce(type, e_type, null)
+                        from
+                          existing
+                        where
+                          (
+                            e_timestamp_range is not null
+                            and timestamp_range is null
+                          )
+                          or (
+                            timestamp_range is not null
+                            and upper(timestamp_range) is null
+                          )
+                        on conflict (id) do update
+                        set
+                          auto_renew_account_id = excluded.auto_renew_account_id,
+                          auto_renew_period = excluded.auto_renew_period,
+                          balance = excluded.balance,
+                          decline_reward = excluded.decline_reward,
+                          deleted = excluded.deleted,
+                          ethereum_nonce = excluded.ethereum_nonce,
+                          expiration_timestamp = excluded.expiration_timestamp,
+                          key = excluded.key,
+                          max_automatic_token_associations = excluded.max_automatic_token_associations,
+                          memo = excluded.memo,
+                          obtainer_id = excluded.obtainer_id,
+                          permanent_removal = excluded.permanent_removal,
+                          proxy_account_id = excluded.proxy_account_id,
+                          public_key = excluded.public_key,
+                          receiver_sig_required = excluded.receiver_sig_required,
+                          stake_period_start = excluded.stake_period_start,
+                          staked_account_id = excluded.staked_account_id,
+                          staked_node_id = excluded.staked_node_id,
+                          submit_key = excluded.submit_key,
+                          timestamp_range = excluded.timestamp_range,
+                          type = excluded.type
+                        """;
 
         var generator = factory.get(Entity.class);
         assertThat(generator).isInstanceOf(GenericUpsertQueryGenerator.class);


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR fixes the contract entity initial nonce

- Don't set entity.ethereum_nonce to the default value `0` for entities other than `ACCOUNT`

**Related issue(s)**:

Relates to #6120 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

We need the fix so before contract nonce info in services goes alive in networks, mirrornode doesn't set new contract's nonce to 0.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
