### PR TITLE
Use token balance for accounts by id API with timestamp parameter

### DIFF
--- a/hedera-mirror-rest/__tests__/specs/accounts/{id}/no-params.json
+++ b/hedera-mirror-rest/__tests__/specs/accounts/{id}/no-params.json
@@ -32,6 +32,38 @@
         "num": 98
       }
     ],
+    "balances": [
+      {
+        "timestamp": "1234567890000000004",
+        "id": 8,
+        "balance": 555,
+        "tokens": [
+          {
+            "token_num": 99998,
+            "balance": 71
+          },
+          {
+            "token_num": 99999,
+            "balance": 72
+          }
+        ]
+      },
+      {
+        "timestamp": "1234567880000000004",
+        "id": 7,
+        "balance": 444,
+        "tokens": [
+          {
+            "token_num": 99998,
+            "balance": 61
+          },
+          {
+            "token_num": 99999,
+            "balance": 62
+          }
+        ]
+      }
+    ],
     "entityStakes": [
       {
         "decline_reward_start": false,

--- a/hedera-mirror-rest/__tests__/specs/accounts/{id}/timestamp-lte.json
+++ b/hedera-mirror-rest/__tests__/specs/accounts/{id}/timestamp-lte.json
@@ -37,13 +37,32 @@
       {
         "timestamp": "1234567890000000004",
         "id": 8,
-        "balance": 555
+        "balance": 555,
+        "tokens": [
+          {
+            "token_num": 99998,
+            "balance": 71
+          },
+          {
+            "token_num": 99999,
+            "balance": 72
+          }
+        ]
       },
-
       {
         "timestamp": "1234567880000000004",
         "id": 8,
-        "balance": 444
+        "balance": 444,
+        "tokens": [
+          {
+            "token_num": 99998,
+            "balance": 61
+          },
+          {
+            "token_num": 99999,
+            "balance": 62
+          }
+        ]
       }
     ],
     "recordFiles": [
@@ -263,8 +282,12 @@
       "balance": 555,
       "tokens": [
         {
+          "token_id": "0.0.99998",
+          "balance": 71
+        },
+        {
           "token_id": "0.0.99999",
-          "balance": 88
+          "balance": 72
         }
       ]
     },

--- a/hedera-mirror-rest/__tests__/specs/accounts/{id}/timestamp-noaccountbalance.json
+++ b/hedera-mirror-rest/__tests__/specs/accounts/{id}/timestamp-noaccountbalance.json
@@ -37,12 +37,21 @@
       {
         "timestamp": "1234567890000000010",
         "id": 8,
-        "balance": 555
+        "balance": 555,
+        "tokens": [
+          {
+            "token_num": 99998,
+            "balance": 71
+          },
+          {
+            "token_num": 99999,
+            "balance": 72
+          }
+        ]
       },
-
       {
         "timestamp": "1234567890000000009",
-        "id": 8,
+        "id": 7,
         "balance": 444
       }
     ],
@@ -261,12 +270,7 @@
     "balance": {
       "timestamp": "1234567890.000000007",
       "balance": 30,
-      "tokens": [
-        {
-          "token_id": "0.0.99999",
-          "balance": 88
-        }
-      ]
+      "tokens": []
     },
     "account": "0.0.8",
     "alias": "KGNABD5L3ZGSRVUCSPDR7TONZSRY3D5OMEBKQMVTD2AC6JL72HMQ",

--- a/hedera-mirror-rest/__tests__/specs/accounts/{id}/timestamp.json
+++ b/hedera-mirror-rest/__tests__/specs/accounts/{id}/timestamp.json
@@ -33,6 +33,43 @@
         "num": 98
       }
     ],
+    "balances": [
+      {
+        "timestamp": "1234567890300000010",
+        "id": 7,
+        "balance": 80,
+        "tokens": [
+          {
+            "token_num": 99998,
+            "balance": 7
+          },
+          {
+            "token_num": 99999,
+            "balance": 77
+          }
+        ]
+      },
+      {
+        "timestamp": "1234567890300000010",
+        "id": 8,
+        "balance": 80,
+        "tokens": [
+          {
+            "token_num": 99998,
+            "balance": 98
+          },
+          {
+            "token_num": 99999,
+            "balance": 88
+          }
+        ]
+      },
+      {
+        "timestamp": 2200,
+        "id": 9,
+        "balance": 999
+      }
+    ],
     "recordFiles": [
       {
         "consensus_start": 2000,
@@ -246,12 +283,16 @@
       }
     ],
     "balance": {
-      "timestamp": "0.000002345",
+      "timestamp": "1234567890.300000010",
       "balance": 80,
       "tokens": [
         {
           "token_id": "0.0.99998",
-          "balance": 8
+          "balance": 98
+        },
+        {
+          "token_id": "0.0.99999",
+          "balance": 88
         }
       ]
     },

--- a/hedera-mirror-rest/accounts.js
+++ b/hedera-mirror-rest/accounts.js
@@ -397,7 +397,6 @@ const getOneAccount = async (req, res) => {
     let tokenBalanceTsQuery = `consensus_timestamp ${opsMap.eq} $${++paramCount}`;
     tokenBalanceQuery.query += ` and ${tokenBalanceTsQuery} `;
 
-    console.log('Token balance query: ' + tokenBalanceTsQuery);
     const [entityTsQuery, entityTsParams] = utils.buildTimestampRangeQuery(
       tsRange,
       Entity.getFullName(Entity.TIMESTAMP_RANGE),

--- a/hedera-mirror-rest/accounts.js
+++ b/hedera-mirror-rest/accounts.js
@@ -160,7 +160,7 @@ const getEntityBalanceQuery = (
     );
   } else {
     queries.push(
-      `with latest_token_balance as (select account_id, balance, token_id, created_timestamp as consensus_timestamp
+      `with latest_token_balance as (select account_id, balance, token_id
                                      from token_account
                                      where associated is true)`
     );


### PR DESCRIPTION
**Description**:

Accounts by id endpoint will now use balance values from the token balance table when timestamp provided 

This PR modifies 
* token balances query in the /accounts/{id} api with timestamp parameter
* In case of no parameter use still uses token_account table

**Related issue(s)**:

Fixes #6304

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
