### PR TITLE
Bump hedera-protobuf-java-api version to 0.40.0 (0.84)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,7 +58,7 @@ dependencies {
         api("com.graphql-java:graphql-java-extended-scalars:20.2")
         api("com.graphql-java:graphql-java-extended-validation:20.0")
         api("com.hedera.evm:hedera-evm:0.39.0")
-        api("com.hedera.hashgraph:hedera-protobuf-java-api:0.40.0-SNAPSHOT")
+        api("com.hedera.hashgraph:hedera-protobuf-java-api:0.40.0")
         api("com.hedera.hashgraph:sdk:2.25.0")
         api("com.ongres.scram:client:2.1")
         api("com.playtika.testcontainers:embedded-google-pubsub:$testcontainersSpringBootVersion")


### PR DESCRIPTION
Description:
Cherry pick.
Update hedera-protobuf version to 0.40.0

Related issue(s):

Notes for reviewer:

Checklist

 Documented (Code comments, README, etc.)
 Tested (unit, integration, etc.)