### PR TITLE
default download ratio to 100%

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/CommonDownloaderProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/CommonDownloaderProperties.java
@@ -65,7 +65,7 @@ public class CommonDownloaderProperties {
 
     @Max(1)
     @Min(0)
-    private BigDecimal downloadRatio = null;
+    private BigDecimal downloadRatio = BigDecimal.ONE;
 
     private String endpointOverride;
 


### PR DESCRIPTION
**Description**:
default downloader download ratio to 1

**Related issue(s)**:

Fixes #6130 

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
