### PR TITLE
Fix gRPC Topic Message serialization

### DIFF
--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/config/RedisConfiguration.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/config/RedisConfiguration.java
@@ -17,7 +17,6 @@
 package com.hedera.mirror.grpc.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.hedera.mirror.common.converter.EntityIdDeserializer;
 import com.hedera.mirror.common.converter.EntityIdSerializer;
@@ -50,8 +49,7 @@ class RedisConfiguration {
         module.addDeserializer(EntityId.class, EntityIdDeserializer.INSTANCE);
         module.addSerializer(EntityIdSerializer.INSTANCE);
 
-        var objectMapper = new ObjectMapper(new MessagePackFactory())
-                .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+        var objectMapper = new ObjectMapper(new MessagePackFactory());
         objectMapper.registerModule(module);
         return new Jackson2JsonRedisSerializer<>(objectMapper, TopicMessage.class);
     }


### PR DESCRIPTION
**Description**:

Fixes a regression caused by #6256. Changes msgpack serialization from snake case back to camel case to match importer. 

**Related issue(s)**:

**Notes for reviewer**:

Tested in integration

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
