### PR TITLE
HIP-584: Copied PauseLogic and PausePrecompile

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/config/ServicesConfiguration.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/config/ServicesConfiguration.java
@@ -52,6 +52,7 @@ import com.hedera.services.store.contracts.precompile.impl.GrantKycPrecompile;
 import com.hedera.services.store.contracts.precompile.impl.MintPrecompile;
 import com.hedera.services.store.contracts.precompile.impl.MultiAssociatePrecompile;
 import com.hedera.services.store.contracts.precompile.impl.MultiDissociatePrecompile;
+import com.hedera.services.store.contracts.precompile.impl.PausePrecompile;
 import com.hedera.services.store.contracts.precompile.impl.RevokeKycPrecompile;
 import com.hedera.services.store.contracts.precompile.impl.TokenCreatePrecompile;
 import com.hedera.services.store.contracts.precompile.impl.WipeFungiblePrecompile;
@@ -64,6 +65,7 @@ import com.hedera.services.txn.token.DeleteLogic;
 import com.hedera.services.txn.token.DissociateLogic;
 import com.hedera.services.txn.token.GrantKycLogic;
 import com.hedera.services.txn.token.MintLogic;
+import com.hedera.services.txn.token.PauseLogic;
 import com.hedera.services.txn.token.RevokeKycLogic;
 import com.hedera.services.txn.token.WipeLogic;
 import com.hedera.services.txns.crypto.ApproveAllowanceLogic;
@@ -407,5 +409,18 @@ public class ServicesConfiguration {
             SyntheticTxnFactory syntheticTxnFactory,
             DeleteLogic deleteLogic) {
         return new DeleteTokenPrecompile(precompilePricingUtils, syntheticTxnFactory, deleteLogic);
+    }
+
+    @Bean
+    PauseLogic pauseLogic() {
+        return new PauseLogic();
+    }
+
+    @Bean
+    PausePrecompile pausePrecompile(
+            PrecompilePricingUtils precompilePricingUtils,
+            SyntheticTxnFactory syntheticTxnFactory,
+            PauseLogic pauseLogic) {
+        return new PausePrecompile(precompilePricingUtils, syntheticTxnFactory, pauseLogic);
     }
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/SyntheticTxnFactory.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/SyntheticTxnFactory.java
@@ -27,6 +27,7 @@ import com.hedera.services.store.contracts.precompile.codec.BurnWrapper;
 import com.hedera.services.store.contracts.precompile.codec.DeleteWrapper;
 import com.hedera.services.store.contracts.precompile.codec.Dissociation;
 import com.hedera.services.store.contracts.precompile.codec.MintWrapper;
+import com.hedera.services.store.contracts.precompile.codec.PauseWrapper;
 import com.hedera.services.store.contracts.precompile.codec.WipeWrapper;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.CryptoCreateTransactionBody;
@@ -39,6 +40,7 @@ import com.hederahashgraph.api.proto.java.TokenDissociateTransactionBody;
 import com.hederahashgraph.api.proto.java.TokenGrantKycTransactionBody;
 import com.hederahashgraph.api.proto.java.TokenID;
 import com.hederahashgraph.api.proto.java.TokenMintTransactionBody;
+import com.hederahashgraph.api.proto.java.TokenPauseTransactionBody;
 import com.hederahashgraph.api.proto.java.TokenRevokeKycTransactionBody;
 import com.hederahashgraph.api.proto.java.TokenWipeAccountTransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionBody;
@@ -152,5 +154,11 @@ public class SyntheticTxnFactory {
         builder.setAccount(grantRevokeKycWrapper.account());
 
         return TransactionBody.newBuilder().setTokenGrantKyc(builder);
+    }
+
+    public TransactionBody.Builder createPause(final PauseWrapper pauseWrapper) {
+        final var builder = TokenPauseTransactionBody.newBuilder();
+        builder.setToken(pauseWrapper.token());
+        return TransactionBody.newBuilder().setTokenPause(builder);
     }
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/PauseWrapper.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/PauseWrapper.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.store.contracts.precompile.codec;
+
+import com.hederahashgraph.api.proto.java.TokenID;
+
+public record PauseWrapper(TokenID token) {}

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/PausePrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/PausePrecompile.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.store.contracts.precompile.impl;
+
+import static com.hedera.node.app.service.evm.store.contracts.precompile.codec.EvmDecodingFacade.decodeFunctionCall;
+import static com.hedera.node.app.service.evm.utils.ValidationUtils.validateTrue;
+import static com.hedera.services.hapi.utils.contracts.ParsingConstants.BYTES32;
+import static com.hedera.services.hapi.utils.contracts.ParsingConstants.INT;
+import static com.hedera.services.store.contracts.precompile.AbiConstants.ABI_ID_PAUSE_TOKEN;
+import static com.hedera.services.store.contracts.precompile.codec.DecodingFacade.convertAddressBytesToTokenID;
+import static com.hedera.services.store.contracts.precompile.utils.PrecompilePricingUtils.GasCostType.PAUSE;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
+
+import com.esaulpaugh.headlong.abi.ABIType;
+import com.esaulpaugh.headlong.abi.Function;
+import com.esaulpaugh.headlong.abi.Tuple;
+import com.esaulpaugh.headlong.abi.TypeFactory;
+import com.hedera.mirror.web3.evm.store.contract.HederaEvmStackedWorldStateUpdater;
+import com.hedera.services.store.contracts.precompile.Precompile;
+import com.hedera.services.store.contracts.precompile.SyntheticTxnFactory;
+import com.hedera.services.store.contracts.precompile.codec.BodyParams;
+import com.hedera.services.store.contracts.precompile.codec.EmptyRunResult;
+import com.hedera.services.store.contracts.precompile.codec.PauseWrapper;
+import com.hedera.services.store.contracts.precompile.codec.RunResult;
+import com.hedera.services.store.contracts.precompile.utils.PrecompilePricingUtils;
+import com.hedera.services.store.models.Id;
+import com.hedera.services.txn.token.PauseLogic;
+import com.hederahashgraph.api.proto.java.Timestamp;
+import com.hederahashgraph.api.proto.java.TransactionBody;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.UnaryOperator;
+import org.apache.tuweni.bytes.Bytes;
+import org.hyperledger.besu.evm.frame.MessageFrame;
+
+/**
+ * This class is a modified copy of PausePrecompile from hedera-services repo.
+ *
+ * Differences with the original:
+ *  1. Implements a modified {@link Precompile} interface
+ *  2. Removed class fields and adapted constructors in order to achieve stateless behaviour
+ *  3. Body method is modified to accept {@link BodyParams} argument in order to achieve stateless behaviour
+ *  4. Run method accepts Store argument in order to achieve stateless behaviour and returns {@link RunResult}
+ */
+public class PausePrecompile extends AbstractWritePrecompile {
+    private static final Function PAUSE_TOKEN_FUNCTION = new Function("pauseToken(address)", INT);
+    private static final Bytes PAUSE_TOKEN_SELECTOR = Bytes.wrap(PAUSE_TOKEN_FUNCTION.selector());
+    private static final ABIType<Tuple> PAUSE_TOKEN_DECODER = TypeFactory.create(BYTES32);
+    private final PauseLogic pauseLogic;
+
+    public PausePrecompile(
+            final PrecompilePricingUtils pricingUtils,
+            final SyntheticTxnFactory syntheticTxnFactory,
+            final PauseLogic pauseLogic) {
+        super(pricingUtils, syntheticTxnFactory);
+        this.pauseLogic = pauseLogic;
+    }
+
+    @Override
+    public TransactionBody.Builder body(
+            final Bytes input, final UnaryOperator<byte[]> aliasResolver, final BodyParams bodyParams) {
+        var pauseOp = decodePause(input);
+        return syntheticTxnFactory.createPause(pauseOp);
+    }
+
+    @Override
+    public long getMinimumFeeInTinybars(final Timestamp consensusTime, final TransactionBody transactionBody) {
+        Objects.requireNonNull(transactionBody, "`body` method should be called before `getMinimumFeeInTinybars`");
+        return pricingUtils.getMinimumPriceInTinybars(PAUSE, consensusTime);
+    }
+
+    @Override
+    public RunResult run(final MessageFrame frame, final TransactionBody transactionBody) {
+        Objects.requireNonNull(transactionBody, "`body` method should be called before `run`");
+
+        final var store = ((HederaEvmStackedWorldStateUpdater) frame.getWorldUpdater()).getStore();
+        final var tokenId = transactionBody.getTokenPause().getToken();
+        final var validity = pauseLogic.validateSyntax(transactionBody);
+        validateTrue(validity == OK, validity);
+
+        /* --- Execute the transaction --- */
+        pauseLogic.pause(Id.fromGrpcToken(tokenId), store);
+
+        return new EmptyRunResult();
+    }
+
+    @Override
+    public Set<Integer> getFunctionSelectors() {
+        return Set.of(ABI_ID_PAUSE_TOKEN);
+    }
+
+    public static PauseWrapper decodePause(final Bytes input) {
+        final Tuple decodedArguments = decodeFunctionCall(input, PAUSE_TOKEN_SELECTOR, PAUSE_TOKEN_DECODER);
+
+        final var tokenID = convertAddressBytesToTokenID(decodedArguments.get(0));
+
+        return new PauseWrapper(tokenID);
+    }
+}

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/txn/token/PauseLogic.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/txn/token/PauseLogic.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.txn.token;
+
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_ID;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
+
+import com.hedera.mirror.web3.evm.store.Store;
+import com.hedera.services.store.models.Id;
+import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
+import com.hederahashgraph.api.proto.java.TokenPauseTransactionBody;
+import com.hederahashgraph.api.proto.java.TransactionBody;
+
+/**
+ * Copied Logic type from hedera-services.
+ * <p>
+ * Differences with the original:
+ * 1. Use abstraction for the state by introducing {@link Store} interface
+ * 2. Used token.setPaused instead of token.changePauseStatus (like in services)
+ * 3. Used store.updateToken(token)
+ *    instead of tokenStore.commitToken(token) (like in services)
+ */
+public class PauseLogic {
+
+    public void pause(final Id targetTokenId, final Store store) {
+        /* --- Load the model objects --- */
+        var token = store.loadPossiblyPausedToken(targetTokenId.asEvmAddress());
+
+        /* --- Do the business logic --- */
+        var pausedToken = token.setPaused(true);
+
+        /* --- Persist the updated models --- */
+        store.updateToken(pausedToken);
+    }
+
+    public ResponseCodeEnum validateSyntax(final TransactionBody txnBody) {
+        TokenPauseTransactionBody op = txnBody.getTokenPause();
+
+        if (!op.hasToken()) {
+            return INVALID_TOKEN_ID;
+        }
+
+        return OK;
+    }
+}

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileTest.java
@@ -306,7 +306,6 @@ class ContractCallServicePrecompileTest extends ContractCallTestSetup {
                 "transferNFTsExternal", new Object[] {EMPTY_ADDRESS, new Address[0], new Address[0], new long[0]}),
         TRANSFER_TOKEN("transferTokenExternal", new Object[] {EMPTY_ADDRESS, EMPTY_ADDRESS, EMPTY_ADDRESS, 0L}),
         TRANSFER_NFT_TOKEN("transferNFTExternal", new Object[] {EMPTY_ADDRESS, EMPTY_ADDRESS, EMPTY_ADDRESS, 0L}),
-        PAUSE_TOKEN("pauseTokenExternal", new Object[] {EMPTY_ADDRESS}),
         UNPAUSE_TOKEN("unpauseTokenExternal", new Object[] {EMPTY_ADDRESS}),
         UPDATE_TOKEN_KEYS("updateTokenKeysExternal", new Object[] {EMPTY_ADDRESS, new Object[] {}}),
         UPDATE_TOKEN_EXPIRY("updateTokenExpiryInfoExternal", new Object[] {EMPTY_ADDRESS, new Object[] {}}),
@@ -336,7 +335,8 @@ class ContractCallServicePrecompileTest extends ContractCallTestSetup {
         BURN_NFT_TOKEN("burnTokenExternal", new Object[] {NFT_ADDRESS, 0L, new long[] {1}}),
         REVOKE_TOKEN_KYC("revokeTokenKycExternal", new Object[] {FUNGIBLE_TOKEN_ADDRESS, SENDER_ADDRESS}),
         GRANT_TOKEN_KYC("grantTokenKycExternal", new Object[] {FUNGIBLE_TOKEN_ADDRESS, SENDER_ADDRESS}),
-        DELETE_TOKEN("deleteTokenExternal", new Object[] {FUNGIBLE_TOKEN_ADDRESS});
+        DELETE_TOKEN("deleteTokenExternal", new Object[] {FUNGIBLE_TOKEN_ADDRESS}),
+        PAUSE_TOKEN("pauseTokenExternal", new Object[] {FUNGIBLE_TOKEN_ADDRESS});
 
         private final String name;
         private final Object[] functionParameters;

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/HTSTestsUtil.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/HTSTestsUtil.java
@@ -35,6 +35,7 @@ import com.hedera.services.store.contracts.precompile.codec.Association;
 import com.hedera.services.store.contracts.precompile.codec.BurnWrapper;
 import com.hedera.services.store.contracts.precompile.codec.Dissociation;
 import com.hedera.services.store.contracts.precompile.codec.MintWrapper;
+import com.hedera.services.store.contracts.precompile.codec.PauseWrapper;
 import com.hedera.services.store.contracts.precompile.codec.TokenExpiryWrapper;
 import com.hedera.services.store.contracts.precompile.codec.TokenKeyWrapper;
 import com.hedera.services.store.contracts.precompile.codec.WipeWrapper;
@@ -139,6 +140,7 @@ public class HTSTestsUtil {
             "0x0000000000000000000000000000000000000000000000000000000000000016000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000000");
     public static final Bytes fungibleSuccessResultWithLongMaxValueSupply = Bytes.fromHexString(
             "0x00000000000000000000000000000000000000000000000000000000000000160000000000000000000000000000000000000000000000007fffffffffffffff00000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000000");
+    public static final PauseWrapper fungiblePause = new PauseWrapper(fungible);
     public static final Bytes failInvalidResult = UInt256.valueOf(ResponseCodeEnum.FAIL_INVALID_VALUE);
     public static final Instant pendingChildConsTime = Instant.ofEpochSecond(1_234_567L, 890);
     public static final Address senderAddr = Address.ALTBN128_PAIRING;

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/PausePrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/PausePrecompileTest.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.store.contracts.precompile;
+
+import static com.hedera.services.store.contracts.precompile.AbiConstants.ABI_ID_PAUSE_TOKEN;
+import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.*;
+import static com.hedera.services.store.contracts.precompile.impl.PausePrecompile.decodePause;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.esaulpaugh.headlong.util.Integers;
+import com.hedera.mirror.web3.evm.account.MirrorEvmContractAliases;
+import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
+import com.hedera.mirror.web3.evm.store.Store;
+import com.hedera.mirror.web3.evm.store.contract.HederaEvmStackedWorldStateUpdater;
+import com.hedera.node.app.service.evm.store.contracts.precompile.EvmHTSPrecompiledContract;
+import com.hedera.node.app.service.evm.store.contracts.precompile.EvmInfrastructureFactory;
+import com.hedera.services.fees.FeeCalculator;
+import com.hedera.services.fees.HbarCentExchange;
+import com.hedera.services.fees.calculation.UsagePricesProvider;
+import com.hedera.services.fees.pricing.AssetsLoader;
+import com.hedera.services.hapi.utils.fees.FeeObject;
+import com.hedera.services.store.contracts.precompile.impl.PausePrecompile;
+import com.hedera.services.store.contracts.precompile.utils.PrecompilePricingUtils;
+import com.hedera.services.txn.token.PauseLogic;
+import com.hedera.services.utils.accessors.AccessorFactory;
+import com.hederahashgraph.api.proto.java.*;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.apache.tuweni.bytes.Bytes;
+import org.hyperledger.besu.datatypes.Wei;
+import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PausePrecompileTest {
+    private final Bytes pretendArguments = Bytes.of(Integers.toBytes(ABI_ID_PAUSE_TOKEN));
+
+    @InjectMocks
+    private MirrorNodeEvmProperties evmProperties;
+
+    @Mock
+    private MessageFrame frame;
+
+    @Mock
+    private PauseLogic pauseLogic;
+
+    @Mock
+    private SyntheticTxnFactory syntheticTxnFactory;
+
+    @Mock
+    private HederaEvmStackedWorldStateUpdater worldUpdater;
+
+    @Mock
+    private FeeCalculator feeCalculator;
+
+    @Mock
+    private FeeObject mockFeeObject;
+
+    @Mock
+    private UsagePricesProvider resourceCosts;
+
+    @Mock
+    private EvmInfrastructureFactory infrastructureFactory;
+
+    @Mock
+    private AssetsLoader assetLoader;
+
+    @Mock
+    private HbarCentExchange exchange;
+
+    @Mock
+    private ExchangeRate exchangeRate;
+
+    @Mock
+    private AccessorFactory accessorFactory;
+
+    @Mock
+    private EvmHTSPrecompiledContract evmHTSPrecompiledContract;
+
+    @Mock
+    private Store store;
+
+    private static final long TEST_SERVICE_FEE = 5_000_000;
+    private static final long TEST_NETWORK_FEE = 400_000;
+    private static final long TEST_NODE_FEE = 300_000;
+    private static final int CENTS_RATE = 12;
+    private static final int HBAR_RATE = 1;
+    private static final long EXPECTED_GAS_PRICE =
+            (TEST_SERVICE_FEE + TEST_NETWORK_FEE + TEST_NODE_FEE) / DEFAULT_GAS_PRICE * 6 / 5;
+    private static final Bytes FUNGIBLE_PAUSE_INPUT =
+            Bytes.fromHexString("0x7c41ad2c000000000000000000000000000000000000000000000000000000000000043d");
+    private static final Bytes NON_FUNGIBLE_PAUSE_INPUT =
+            Bytes.fromHexString("0x7c41ad2c0000000000000000000000000000000000000000000000000000000000000445");
+
+    private final TransactionBody.Builder transactionBody =
+            TransactionBody.newBuilder().setTokenPause(TokenPauseTransactionBody.newBuilder());
+
+    private HTSPrecompiledContract subject;
+    private MockedStatic<PausePrecompile> staticPausePrecompile;
+
+    @Mock
+    private MirrorEvmContractAliases contractAliases;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        final Map<HederaFunctionality, Map<SubType, BigDecimal>> canonicalPrices = new HashMap<>();
+        canonicalPrices.put(HederaFunctionality.TokenPause, Map.of(SubType.DEFAULT, BigDecimal.valueOf(0)));
+        given(assetLoader.loadCanonicalPrices()).willReturn(canonicalPrices);
+        final PrecompilePricingUtils precompilePricingUtils =
+                new PrecompilePricingUtils(assetLoader, exchange, feeCalculator, resourceCosts, accessorFactory);
+
+        syntheticTxnFactory = new SyntheticTxnFactory();
+        PausePrecompile pausePrecompile = new PausePrecompile(precompilePricingUtils, syntheticTxnFactory, pauseLogic);
+        PrecompileMapper precompileMapper = new PrecompileMapper(Set.of(pausePrecompile));
+        staticPausePrecompile = Mockito.mockStatic(PausePrecompile.class);
+
+        subject = new HTSPrecompiledContract(
+                infrastructureFactory, evmProperties, precompileMapper, evmHTSPrecompiledContract);
+    }
+
+    @AfterEach
+    void closeMocks() {
+        staticPausePrecompile.close();
+    }
+
+    @Test
+    void pauseHappyPathWorks() {
+        given(worldUpdater.permissivelyUnaliased(any()))
+                .willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
+        givenFungibleFrameContext();
+        givenPricingUtilsContext();
+        given(worldUpdater.getStore()).willReturn(store);
+        given(feeCalculator.estimatedGasPriceInTinybars(HederaFunctionality.ContractCall, timestamp))
+                .willReturn(1L);
+        given(feeCalculator.computeFee(any(), any(), any(), any(), any())).willReturn(mockFeeObject);
+        given(pauseLogic.validateSyntax(any())).willReturn(OK);
+
+        subject.prepareFields(frame);
+        subject.prepareComputation(pretendArguments, a -> a);
+        subject.getPrecompile().getGasRequirement(TEST_CONSENSUS_TIME, transactionBody, store, contractAliases);
+        final var result = subject.computeInternal(frame);
+
+        assertEquals(successResult, result);
+        verify(pauseLogic).pause(fungibleId, store);
+    }
+
+    @Test
+    void gasRequirementReturnsCorrectValueForPauseFungibleToken() {
+        // given
+        given(worldUpdater.permissivelyUnaliased(any()))
+                .willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
+        givenMinFrameContext();
+        givenPricingUtilsContext();
+        final Bytes input = Bytes.of(Integers.toBytes(ABI_ID_PAUSE_TOKEN));
+        staticPausePrecompile.when(() -> decodePause(pretendArguments)).thenReturn(fungiblePause);
+        given(feeCalculator.computeFee(any(), any(), any(), any(), any()))
+                .willReturn(new FeeObject(TEST_NODE_FEE, TEST_NETWORK_FEE, TEST_SERVICE_FEE));
+        given(feeCalculator.estimatedGasPriceInTinybars(any(), any())).willReturn(DEFAULT_GAS_PRICE);
+        given(worldUpdater.permissivelyUnaliased(any()))
+                .willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
+
+        subject.prepareFields(frame);
+        subject.prepareComputation(input, a -> a);
+        final long result =
+                subject.getPrecompile().getGasRequirement(TEST_CONSENSUS_TIME, transactionBody, store, contractAliases);
+
+        // then
+        assertEquals(EXPECTED_GAS_PRICE, result);
+    }
+
+    @Test
+    void decodeFungiblePauseInput() {
+        staticPausePrecompile.when(() -> decodePause(FUNGIBLE_PAUSE_INPUT)).thenCallRealMethod();
+        final var decodedInput = decodePause(FUNGIBLE_PAUSE_INPUT);
+
+        assertTrue(decodedInput.token().getTokenNum() > 0);
+    }
+
+    @Test
+    void decodeNonFungiblePauseInput() {
+        staticPausePrecompile.when(() -> decodePause(NON_FUNGIBLE_PAUSE_INPUT)).thenCallRealMethod();
+        final var decodedInput = decodePause(NON_FUNGIBLE_PAUSE_INPUT);
+
+        assertTrue(decodedInput.token().getTokenNum() > 0);
+    }
+
+    private void givenFungibleFrameContext() {
+        givenFrameContext();
+        staticPausePrecompile.when(() -> decodePause(pretendArguments)).thenReturn(fungiblePause);
+    }
+
+    private void givenFrameContext() {
+        given(frame.getSenderAddress()).willReturn(contractAddress);
+        given(frame.getWorldUpdater()).willReturn(worldUpdater);
+        given(frame.getRemainingGas()).willReturn(30000000L);
+        given(frame.getValue()).willReturn(Wei.ZERO);
+    }
+
+    private void givenPricingUtilsContext() {
+        given(exchange.rate(any())).willReturn(exchangeRate);
+        given(exchangeRate.getCentEquiv()).willReturn(CENTS_RATE);
+        given(exchangeRate.getHbarEquiv()).willReturn(HBAR_RATE);
+    }
+
+    private void givenMinFrameContext() {
+        given(frame.getSenderAddress()).willReturn(contractAddress);
+        given(frame.getWorldUpdater()).willReturn(worldUpdater);
+    }
+}

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/SyntheticTxnFactoryTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/SyntheticTxnFactoryTest.java
@@ -32,6 +32,7 @@ import com.hedera.services.jproto.JKey;
 import com.hedera.services.store.contracts.precompile.codec.BurnWrapper;
 import com.hedera.services.store.contracts.precompile.codec.Dissociation;
 import com.hedera.services.store.contracts.precompile.codec.MintWrapper;
+import com.hedera.services.store.contracts.precompile.codec.PauseWrapper;
 import com.hedera.services.store.contracts.precompile.codec.WipeWrapper;
 import com.hedera.services.utils.EntityNum;
 import com.hedera.services.utils.IdUtils;
@@ -245,6 +246,15 @@ class SyntheticTxnFactoryTest {
         assertEquals(nonFungible, txnBody.getTokenWipe().getToken());
         assertEquals(a, txnBody.getTokenWipe().getAccount());
         assertEquals(targetSerialNos, txnBody.getTokenWipe().getSerialNumbersList());
+    }
+
+    @Test
+    void createsExpectedPause() {
+        final var pauseWrapper = new PauseWrapper(fungible);
+        final var result = subject.createPause(pauseWrapper);
+        final var txnBody = result.build();
+
+        assertEquals(fungible, txnBody.getTokenPause().getToken());
     }
 
     private static final long serialNo = 100;

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/txn/token/PauseLogicTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/txn/token/PauseLogicTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.txn.token;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.hedera.mirror.web3.evm.store.Store;
+import com.hedera.services.store.models.Id;
+import com.hedera.services.store.models.Token;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PauseLogicTest {
+    private final Id id = new Id(1, 2, 3);
+
+    @Mock
+    private Token token;
+
+    @Mock
+    private Token pausedToken;
+
+    @Mock
+    private Store store;
+
+    private PauseLogic subject;
+
+    @BeforeEach
+    void setup() {
+        subject = new PauseLogic();
+    }
+
+    @Test
+    void followsHappyPathForPausing() {
+        // given:
+        given(token.getId()).willReturn(id);
+        given(store.loadPossiblyPausedToken(id.asEvmAddress())).willReturn(token);
+        given(token.setPaused(true)).willReturn(pausedToken);
+
+        // when:
+        subject.pause(token.getId(), store);
+
+        // then:
+        verify(token).setPaused(true);
+        verify(store).updateToken(pausedToken);
+    }
+}


### PR DESCRIPTION
**Description**:
Changes in this PR:
- Copied PauseLogic from hedera-services (there are a couple of differences with the original described below):
  - Used token.setPaused instead of token.changePauseStatus (like in services)
  - Used store.updateToken(token) instead of tokenStore.commitToken(token) (like in services)
- Created PauseLogicTest and added unit tests
- Added new bean PauseLogic in Services Configuration
- Copied PausePrecompile from hedera-services (there are a couple of differences with the original described below):
  - Removed class fields and adapted constructors in order to achieve stateless behaviour
  - Added pauseLogic in constructor
  - Added javadoc for the differences
- Created PausePrecompileTest and added unit tests
- Added new bean pausePrecompile in ServicesConfiguration
- Added integration PAUSE_TOKEN test in ContractCallServicePrecompileTest

**Related issue(s)**:
Fixes https://github.com/hashgraph/hedera-mirror-node/issues/6324
Fixes https://github.com/hashgraph/hedera-mirror-node/issues/6326
