### PR TITLE
HIP-584: Adapt Mirror Archive Node to respect alias addresses

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessorFacadeImpl.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessorFacadeImpl.java
@@ -102,10 +102,10 @@ public class MirrorEvmTxProcessorFacadeImpl implements MirrorEvmTxProcessorFacad
                 (int) evmProperties.getExpirationCacheTime().toSeconds();
         final var store = new StoreImpl(databaseAccessors);
         final var mirrorEntityAccess = new MirrorEntityAccess(contractStateRepository, contractRepository, store);
-        final var tokenAccessor = new TokenAccessorImpl(evmProperties, store);
-        final var accountAccessor = new AccountAccessorImpl(mirrorEntityAccess, store);
-        final var codeCache = new AbstractCodeCache(expirationCacheTime, mirrorEntityAccess);
         final var mirrorEvmContractAliases = new MirrorEvmContractAliases(store);
+        final var tokenAccessor = new TokenAccessorImpl(evmProperties, store, mirrorEvmContractAliases);
+        final var accountAccessor = new AccountAccessorImpl(store, mirrorEntityAccess, mirrorEvmContractAliases);
+        final var codeCache = new AbstractCodeCache(expirationCacheTime, mirrorEntityAccess);
         final var mirrorOperationTracer = new MirrorOperationTracer(traceProperties, mirrorEvmContractAliases);
 
         final var worldState = new HederaEvmWorldState(

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/utils/EthSigsUtils.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/utils/EthSigsUtils.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.web3.evm.utils;
+
+import static org.hyperledger.besu.nativelib.secp256k1.LibSecp256k1.CONTEXT;
+import static org.hyperledger.besu.nativelib.secp256k1.LibSecp256k1.SECP256K1_EC_UNCOMPRESSED;
+
+import com.sun.jna.ptr.LongByReference;
+import java.nio.ByteBuffer;
+import org.bouncycastle.jcajce.provider.digest.Keccak;
+import org.hyperledger.besu.nativelib.secp256k1.LibSecp256k1;
+
+/**
+ * This utility class is a copy from hedera-services. It could be used to validate test scenarios using address with alias format.
+ * */
+public final class EthSigsUtils {
+
+    private EthSigsUtils() {}
+
+    public static byte[] recoverAddressFromPubKey(byte[] pubKeyBytes) {
+        LibSecp256k1.secp256k1_pubkey pubKey = new LibSecp256k1.secp256k1_pubkey();
+        var parseResult = LibSecp256k1.secp256k1_ec_pubkey_parse(CONTEXT, pubKey, pubKeyBytes, pubKeyBytes.length);
+        if (parseResult == 1) {
+            return recoverAddressFromPubKey(pubKey);
+        } else {
+            return new byte[0];
+        }
+    }
+
+    public static byte[] recoverAddressFromPubKey(LibSecp256k1.secp256k1_pubkey pubKey) {
+        final ByteBuffer recoveredFullKey = ByteBuffer.allocate(65);
+        final LongByReference fullKeySize = new LongByReference(recoveredFullKey.limit());
+        LibSecp256k1.secp256k1_ec_pubkey_serialize(
+                CONTEXT, recoveredFullKey, fullKeySize, pubKey, SECP256K1_EC_UNCOMPRESSED);
+
+        recoveredFullKey.get(); // read and discard - recoveryId is not part of the account hash
+        var preHash = new byte[64];
+        recoveredFullKey.get(preHash, 0, 64);
+        var keyHash = new Keccak.Digest256().digest(preHash);
+        var address = new byte[20];
+        System.arraycopy(keyHash, 12, address, 0, 20);
+        return address;
+    }
+}

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/utils/EntityIdUtils.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/utils/EntityIdUtils.java
@@ -17,6 +17,7 @@
 package com.hedera.services.utils;
 
 import static com.hedera.mirror.web3.evm.account.AccountAccessorImpl.EVM_ADDRESS_SIZE;
+import static com.hedera.node.app.service.evm.store.models.HederaEvmAccount.ECDSA_SECP256K1_ALIAS_SIZE;
 import static com.hedera.services.utils.BitPackUtils.numFromCode;
 import static java.lang.System.arraycopy;
 
@@ -128,6 +129,14 @@ public final class EntityIdUtils {
 
     public static TokenID tokenIdFromEvmAddress(final Address address) {
         return tokenIdFromEvmAddress(address.toArrayUnsafe());
+    }
+
+    public static boolean isOfEvmAddressSize(final ByteString alias) {
+        return alias.size() == EVM_ADDRESS_SIZE;
+    }
+
+    public static boolean isOfEcdsaAddressSize(final ByteString alias) {
+        return alias.size() == ECDSA_SECP256K1_ALIAS_SIZE;
     }
 
     public static long[] asDotDelimitedLongArray(String s) {

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/account/AccountAccessorImplTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/account/AccountAccessorImplTest.java
@@ -16,15 +16,11 @@
 
 package com.hedera.mirror.web3.evm.account;
 
-import static com.google.protobuf.ByteString.EMPTY;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Mockito.when;
 
-import com.google.protobuf.ByteString;
 import com.hedera.mirror.web3.evm.store.Store;
-import com.hedera.mirror.web3.evm.store.Store.OnMissing;
 import com.hedera.node.app.service.evm.store.contracts.HederaEvmEntityAccess;
-import com.hedera.services.store.models.Account;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,6 +38,7 @@ class AccountAccessorImplTest {
     private static final Address ALIAS_ADDRESS = Address.fromHexString(ALIAS_HEX);
     private static final Bytes BYTES = Bytes.fromHexString(HEX);
     private static final byte[] DATA = BYTES.toArrayUnsafe();
+    public AccountAccessorImpl accountAccessor;
 
     @Mock
     private HederaEvmEntityAccess mirrorEntityAccess;
@@ -50,13 +47,11 @@ class AccountAccessorImplTest {
     private Store store;
 
     @Mock
-    private Account account;
-
-    public AccountAccessorImpl accountAccessor;
+    private MirrorEvmContractAliases mirrorEvmContractAliases;
 
     @BeforeEach
     void setUp() {
-        accountAccessor = new AccountAccessorImpl(mirrorEntityAccess, store);
+        accountAccessor = new AccountAccessorImpl(store, mirrorEntityAccess, mirrorEvmContractAliases);
     }
 
     @Test
@@ -75,48 +70,36 @@ class AccountAccessorImplTest {
 
     @Test
     void canonicalAddress() {
-        when(store.getAccount(ADDRESS, OnMissing.DONT_THROW)).thenReturn(account);
         final var result = accountAccessor.canonicalAddress(ADDRESS);
         assertThat(result).isEqualTo(ADDRESS);
     }
 
     @Test
     void canonicalAliasAddress() {
-        when(store.getAccount(ALIAS_ADDRESS, OnMissing.DONT_THROW)).thenReturn(account);
         final var result = accountAccessor.canonicalAddress(ALIAS_ADDRESS);
         assertThat(result).isEqualTo(ALIAS_ADDRESS);
     }
 
     @Test
     void missingCanonicalAliasAddressResolvesToItself() {
-        when(store.getAccount(ALIAS_ADDRESS, OnMissing.DONT_THROW)).thenReturn(Account.getEmptyAccount());
         final var result = accountAccessor.canonicalAddress(ALIAS_ADDRESS);
         assertThat(result).isEqualTo(ALIAS_ADDRESS);
     }
 
     @Test
     void isExtantTrue() {
-        when(store.getAccount(ADDRESS, OnMissing.DONT_THROW)).thenReturn(Account.getEmptyAccount());
-        when(mirrorEntityAccess.isExtant(ADDRESS)).thenReturn(true);
-        when(mirrorEntityAccess.alias(ADDRESS)).thenReturn(EMPTY);
         final var result = accountAccessor.canonicalAddress(ADDRESS);
         assertThat(result).isEqualTo(ADDRESS);
     }
 
     @Test
     void alias() {
-        when(store.getAccount(ADDRESS, OnMissing.DONT_THROW)).thenReturn(Account.getEmptyAccount());
-        when(mirrorEntityAccess.isExtant(ADDRESS)).thenReturn(true);
-        when(mirrorEntityAccess.alias(ADDRESS)).thenReturn(ByteString.copyFrom(DATA));
         final var result = accountAccessor.canonicalAddress(ADDRESS);
         assertThat(result).isEqualTo(ADDRESS);
     }
 
     @Test
     void aliasDifferentFromEvmAddressSize() {
-        when(store.getAccount(ADDRESS, OnMissing.DONT_THROW)).thenReturn(Account.getEmptyAccount());
-        when(mirrorEntityAccess.isExtant(ADDRESS)).thenReturn(true);
-        when(mirrorEntityAccess.alias(ADDRESS)).thenReturn(ByteString.copyFrom(new byte[32]));
         final var result = accountAccessor.canonicalAddress(ADDRESS);
         assertThat(result).isEqualTo(ADDRESS);
     }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/token/TokenAccessorImplTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/token/TokenAccessorImplTest.java
@@ -39,6 +39,7 @@ import com.hedera.mirror.common.domain.token.TokenSupplyTypeEnum;
 import com.hedera.mirror.common.domain.token.TokenTypeEnum;
 import com.hedera.mirror.common.domain.transaction.CustomFee;
 import com.hedera.mirror.common.util.DomainUtils;
+import com.hedera.mirror.web3.evm.account.MirrorEvmContractAliases;
 import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
 import com.hedera.mirror.web3.evm.store.Store;
 import com.hedera.mirror.web3.evm.store.StoreImpl;
@@ -73,14 +74,16 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class TokenAccessorImplTest {
 
-    private final long serialNo = 0L;
     private static final String HEX_TOKEN = "0x00000000000000000000000000000000000004e4";
     private static final String HEX_ACCOUNT = "0x00000000000000000000000000000000000004e5";
     private static final Address TOKEN = Address.fromHexString(HEX_TOKEN);
-    private static final Address ACCOUNT = Address.fromHexString(HEX_ACCOUNT);
     private static final EntityId ENTITY = DomainUtils.fromEvmAddress(TOKEN.toArrayUnsafe());
     private static final Long ENTITY_ID =
             EntityIdEndec.encode(ENTITY.getShardNum(), ENTITY.getRealmNum(), ENTITY.getEntityNum());
+    private static final Address ACCOUNT = Address.fromHexString(HEX_ACCOUNT);
+    private final long serialNo = 0L;
+    private final DomainBuilder domainBuilder = new DomainBuilder();
+    public TokenAccessorImpl tokenAccessor;
 
     @Mock
     private EntityRepository entityRepository;
@@ -106,6 +109,9 @@ class TokenAccessorImplTest {
     @Mock
     private NftAllowanceRepository nftAllowanceRepository;
 
+    @Mock
+    private MirrorEvmContractAliases mirrorEvmContractAliases;
+
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private MirrorNodeEvmProperties properties;
 
@@ -116,11 +122,7 @@ class TokenAccessorImplTest {
     private Token token;
 
     private List<DatabaseAccessor<Object, ?>> accessors;
-
     private Store store;
-    private final DomainBuilder domainBuilder = new DomainBuilder();
-
-    public TokenAccessorImpl tokenAccessor;
 
     @BeforeEach
     void setUp() {
@@ -144,7 +146,7 @@ class TokenAccessorImplTest {
                         tokenDatabaseAccessor, accountDatabaseAccessor, tokenAccountRepository),
                 new UniqueTokenDatabaseAccessor(nftRepository));
         store = new StoreImpl(accessors);
-        tokenAccessor = new TokenAccessorImpl(properties, store);
+        tokenAccessor = new TokenAccessorImpl(properties, store, mirrorEvmContractAliases);
     }
 
     @Test
@@ -209,6 +211,7 @@ class TokenAccessorImplTest {
         when(token.getType()).thenReturn(null);
         when(token.getSupplyType()).thenReturn(null);
         when(entityRepository.findByIdAndDeletedIsFalse(any())).thenReturn(Optional.of(entity));
+        when(mirrorEvmContractAliases.resolveForEvm(any())).thenReturn(ACCOUNT);
         assertTrue(tokenAccessor.isFrozen(ACCOUNT, TOKEN));
     }
 
@@ -222,6 +225,7 @@ class TokenAccessorImplTest {
         when(token.getType()).thenReturn(null);
         when(token.getSupplyType()).thenReturn(null);
         when(entityRepository.findByIdAndDeletedIsFalse(any())).thenReturn(Optional.of(entity));
+        when(mirrorEvmContractAliases.resolveForEvm(any())).thenReturn(ACCOUNT);
         assertTrue(tokenAccessor.isKyc(ACCOUNT, TOKEN));
     }
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceERCTokenTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceERCTokenTest.java
@@ -78,13 +78,18 @@ class ContractCallServiceERCTokenTest extends ContractCallTestSetup {
         GET_APPROVED_EMPTY_SPENDER("getApproved", new Object[] {NFT_ADDRESS, 2L}, new Address[] {Address.ZERO}),
         IS_APPROVE_FOR_ALL(
                 "isApprovedForAll", new Address[] {NFT_ADDRESS, SENDER_ADDRESS, SPENDER_ADDRESS}, new Boolean[] {true}),
+        IS_APPROVE_FOR_ALL_WITH_ALIAS(
+                "isApprovedForAll", new Address[] {NFT_ADDRESS, SENDER_ALIAS, SPENDER_ALIAS}, new Boolean[] {true}),
         ALLOWANCE_OF(
                 "allowance", new Address[] {FUNGIBLE_TOKEN_ADDRESS, SENDER_ADDRESS, SPENDER_ADDRESS}, new Long[] {13L}),
+        ALLOWANCE_OF_WITH_ALIAS(
+                "allowance", new Address[] {FUNGIBLE_TOKEN_ADDRESS, SENDER_ALIAS, SPENDER_ALIAS}, new Long[] {13L}),
         GET_APPROVED("getApproved", new Object[] {NFT_ADDRESS, 1L}, new Address[] {SPENDER_ADDRESS}),
         ERC_DECIMALS("decimals", new Address[] {FUNGIBLE_TOKEN_ADDRESS}, new Integer[] {12}),
         TOTAL_SUPPLY("totalSupply", new Address[] {FUNGIBLE_TOKEN_ADDRESS}, new Long[] {12345L}),
         ERC_SYMBOL("symbol", new Address[] {FUNGIBLE_TOKEN_ADDRESS}, new String[] {"HBAR"}),
         BALANCE_OF("balanceOf", new Address[] {FUNGIBLE_TOKEN_ADDRESS, SENDER_ADDRESS}, new Long[] {12L}),
+        BALANCE_OF_WITH_ALIAS("balanceOf", new Address[] {FUNGIBLE_TOKEN_ADDRESS, SENDER_ALIAS}, new Long[] {12L}),
         ERC_NAME("name", new Address[] {FUNGIBLE_TOKEN_ADDRESS}, new String[] {"Hbars"}),
         OWNER_OF("getOwnerOf", new Object[] {NFT_ADDRESS, 1L}, new Address[] {OWNER_ADDRESS}),
         EMPTY_OWNER_OF("getOwnerOf", new Object[] {NFT_ADDRESS, 2L}, new Address[] {Address.ZERO});
@@ -97,8 +102,12 @@ class ContractCallServiceERCTokenTest extends ContractCallTestSetup {
     @RequiredArgsConstructor
     public enum ErcContractModificationFunctions {
         TRANSFER("transfer", new Object[] {FUNGIBLE_TOKEN_ADDRESS, SPENDER_ADDRESS, 2L}),
+        TRANSFER_WITH_ALIAS("transfer", new Object[] {FUNGIBLE_TOKEN_ADDRESS, SPENDER_ALIAS, 2L}),
         TRANSFER_FROM("transferFrom", new Object[] {FUNGIBLE_TOKEN_ADDRESS, SENDER_ADDRESS, SPENDER_ADDRESS, 2L}),
-        APPROVE("approve", new Object[] {FUNGIBLE_TOKEN_ADDRESS, SENDER_ADDRESS, 2L});
+        TRANSFER_FROM_WITH_ALIAS(
+                "transferFrom", new Object[] {FUNGIBLE_TOKEN_ADDRESS, SENDER_ALIAS, SPENDER_ALIAS, 2L}),
+        APPROVE("approve", new Object[] {FUNGIBLE_TOKEN_ADDRESS, SENDER_ADDRESS, 2L}),
+        APPROVE_WITH_ALIAS("approve", new Object[] {FUNGIBLE_TOKEN_ADDRESS, SENDER_ALIAS, 2L});
 
         private final String name;
         private final Object[] functionParameters;

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileTest.java
@@ -113,7 +113,7 @@ class ContractCallServicePrecompileTest extends ContractCallTestSetup {
                 assertThat((boolean) fixedFee[0].get(2)).isFalse();
                 assertThat((boolean) fixedFee[0].get(3)).isFalse();
                 assertThat((com.esaulpaugh.headlong.abi.Address) fixedFee[0].get(4))
-                        .isEqualTo(convertAddress(SENDER_ADDRESS));
+                        .isEqualTo(convertAddress(SENDER_ALIAS));
             }
             case FRACTIONAL_FEE -> {
                 assertThat((long) fractionalFee[0].get(0)).isEqualTo(100L);
@@ -122,7 +122,7 @@ class ContractCallServicePrecompileTest extends ContractCallTestSetup {
                 assertThat((long) fractionalFee[0].get(3)).isEqualTo(1000L);
                 assertThat((boolean) fractionalFee[0].get(4)).isTrue();
                 assertThat((com.esaulpaugh.headlong.abi.Address) fractionalFee[0].get(5))
-                        .isEqualTo(convertAddress(SENDER_ADDRESS));
+                        .isEqualTo(convertAddress(SENDER_ALIAS));
             }
             case ROYALTY_FEE -> {
                 assertThat((long) royaltyFee[0].get(0)).isEqualTo(20L);
@@ -132,7 +132,7 @@ class ContractCallServicePrecompileTest extends ContractCallTestSetup {
                         .isEqualTo(convertAddress(FUNGIBLE_TOKEN_ADDRESS));
                 assertThat((boolean) royaltyFee[0].get(4)).isFalse();
                 assertThat((com.esaulpaugh.headlong.abi.Address) royaltyFee[0].get(5))
-                        .isEqualTo(convertAddress(SENDER_ADDRESS));
+                        .isEqualTo(convertAddress(SENDER_ALIAS));
             }
         }
     }
@@ -241,10 +241,12 @@ class ContractCallServicePrecompileTest extends ContractCallTestSetup {
     @RequiredArgsConstructor
     enum ContractReadFunctions {
         IS_FROZEN("isTokenFrozen", new Address[] {FUNGIBLE_TOKEN_ADDRESS, SENDER_ADDRESS}, new Boolean[] {true}),
-        IS_FROZEN_ETH_ADDRESS(
-                "isTokenFrozen", new Address[] {FUNGIBLE_TOKEN_ADDRESS, ETH_ADDRESS}, new Boolean[] {true}),
+        IS_FROZEN_WITH_ALIAS(
+                "isTokenFrozen", new Address[] {FUNGIBLE_TOKEN_ADDRESS, SENDER_ALIAS}, new Boolean[] {true}),
         IS_KYC("isKycGranted", new Address[] {FUNGIBLE_TOKEN_ADDRESS, SENDER_ADDRESS}, new Boolean[] {true}),
+        IS_KYC_WITH_ALIAS("isKycGranted", new Address[] {FUNGIBLE_TOKEN_ADDRESS, SENDER_ALIAS}, new Boolean[] {true}),
         IS_KYC_FOR_NFT("isKycGranted", new Address[] {NFT_ADDRESS, SENDER_ADDRESS}, new Boolean[] {true}),
+        IS_KYC_FOR_NFT_WITH_ALIAS("isKycGranted", new Address[] {NFT_ADDRESS, SENDER_ALIAS}, new Boolean[] {true}),
         IS_TOKEN_PRECOMPILE("isTokenAddress", new Address[] {FUNGIBLE_TOKEN_ADDRESS}, new Boolean[] {true}),
         IS_TOKEN_PRECOMPILE_NFT("isTokenAddress", new Address[] {NFT_ADDRESS}, new Boolean[] {true}),
         GET_TOKEN_DEFAULT_KYC("getTokenDefaultKyc", new Address[] {FUNGIBLE_TOKEN_ADDRESS}, new Boolean[] {true}),
@@ -319,23 +321,36 @@ class ContractCallServicePrecompileTest extends ContractCallTestSetup {
     @RequiredArgsConstructor
     enum SupportedContractModificationFunctions {
         ASSOCIATE_TOKEN("associateTokenExternal", new Object[] {SPENDER_ADDRESS, FUNGIBLE_TOKEN_ADDRESS}),
+        ASSOCIATE_TOKEN_WITH_ALIAS("associateTokenExternal", new Object[] {SPENDER_ALIAS, FUNGIBLE_TOKEN_ADDRESS}),
         ASSOCIATE_TOKENS(
                 "associateTokensExternal", new Object[] {SPENDER_ADDRESS, new Address[] {FUNGIBLE_TOKEN_ADDRESS}}),
+        ASSOCIATE_TOKENS_WITH_ALIAS(
+                "associateTokensExternal", new Object[] {SPENDER_ALIAS, new Address[] {FUNGIBLE_TOKEN_ADDRESS}}),
         MINT_TOKEN("mintTokenExternal", new Object[] {NOT_FROZEN_FUNGIBLE_TOKEN_ADDRESS, 100L, new byte[0][0]}),
         MINT_NFT_TOKEN("mintTokenExternal", new Object[] {
             NFT_ADDRESS, 0L, new byte[][] {ByteString.copyFromUtf8("firstMeta").toByteArray()}
         }),
         DISSOCIATE_TOKEN("dissociateTokenExternal", new Object[] {SPENDER_ADDRESS, TREASURY_TOKEN_ADDRESS}),
+        DISSOCIATE_TOKEN_WITH_ALIAS("dissociateTokenExternal", new Object[] {SPENDER_ALIAS, TREASURY_TOKEN_ADDRESS}),
         DISSOCIATE_TOKENS(
                 "dissociateTokensExternal", new Object[] {SPENDER_ADDRESS, new Address[] {TREASURY_TOKEN_ADDRESS}}),
+        DISSOCIATE_TOKENS_WITH_ALIAS(
+                "dissociateTokensExternal", new Object[] {SPENDER_ALIAS, new Address[] {TREASURY_TOKEN_ADDRESS}}),
         BURN_TOKEN("burnTokenExternal", new Object[] {NOT_FROZEN_FUNGIBLE_TOKEN_ADDRESS, 1L, new long[0]}),
-        WIPE_TOKEN("wipeTokenAccountExternal", new Object[] {NOT_FROZEN_FUNGIBLE_TOKEN_ADDRESS, ETH_ADDRESS, 1L}),
+        WIPE_TOKEN("wipeTokenAccountExternal", new Object[] {NOT_FROZEN_FUNGIBLE_TOKEN_ADDRESS, SENDER_ALIAS, 1L}),
+        WIPE_TOKEN_WITH_ALIAS(
+                "wipeTokenAccountExternal", new Object[] {NOT_FROZEN_FUNGIBLE_TOKEN_ADDRESS, SENDER_ALIAS, 1L}),
         WIPE_NFT_TOKEN(
                 "wipeTokenAccountNFTExternal",
                 new Object[] {NFT_ADDRESS_WITH_DIFFERENT_OWNER_AND_TREASURY, SENDER_ADDRESS, new long[] {1}}),
+        WIPE_NFT_TOKEN_WITH_ALIAS(
+                "wipeTokenAccountNFTExternal",
+                new Object[] {NFT_ADDRESS_WITH_DIFFERENT_OWNER_AND_TREASURY, SENDER_ALIAS, new long[] {1}}),
         BURN_NFT_TOKEN("burnTokenExternal", new Object[] {NFT_ADDRESS, 0L, new long[] {1}}),
         REVOKE_TOKEN_KYC("revokeTokenKycExternal", new Object[] {FUNGIBLE_TOKEN_ADDRESS, SENDER_ADDRESS}),
+        REVOKE_TOKEN_KYC_WITH_ALIAS("revokeTokenKycExternal", new Object[] {FUNGIBLE_TOKEN_ADDRESS, SENDER_ALIAS}),
         GRANT_TOKEN_KYC("grantTokenKycExternal", new Object[] {FUNGIBLE_TOKEN_ADDRESS, SENDER_ADDRESS}),
+        GRANT_TOKEN_KYC_WITH_ALIAS("grantTokenKycExternal", new Object[] {FUNGIBLE_TOKEN_ADDRESS, SENDER_ALIAS}),
         DELETE_TOKEN("deleteTokenExternal", new Object[] {FUNGIBLE_TOKEN_ADDRESS});
 
         private final String name;


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
Currently when we try to invoke accounts with alias addresses from the in-memory store we don't find them, since we persist them using their long-zero form. This PR fixes the issue and now we first resolve the alias to a long-zero address and then we try to find it from the in-memory store. This issue is present since 0.84.0 release of mirror-node.
**Related issue(s)**:

Fixes #6451 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
