### PR TITLE
Bump Node.js from 18.16.0 to 18.17.0

### DIFF
--- a/buildSrc/src/main/kotlin/common-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/common-conventions.gradle.kts
@@ -63,7 +63,7 @@ dependencyCheck {
 // Spotless uses Prettier and it requires Node.js
 node {
     download = true
-    version = "18.16.0"
+    version = "18.17.0"
     workDir = rootDir.resolve(".gradle").resolve("nodejs")
 }
 

--- a/hedera-mirror-rest/Dockerfile
+++ b/hedera-mirror-rest/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.16.0-bullseye-slim
+FROM node:18.17.0-bullseye-slim
 LABEL maintainer="mirrornode@hedera.com"
 
 # Setup

--- a/hedera-mirror-rest/monitoring/Dockerfile
+++ b/hedera-mirror-rest/monitoring/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.16.0-bullseye-slim
+FROM node:18.17.0-bullseye-slim
 LABEL maintainer="mirrornode@hedera.com"
 
 # Setup


### PR DESCRIPTION
**Description**:

Bump Node.js from 18.16.0 to 18.17.0

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
