### PR TITLE
Bump Spring Boot from 3.1.1 to 3.1.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,7 +34,6 @@ extra.apply {
     set("protobufVersion", "3.23.4")
     set("reactorGrpcVersion", "1.2.4")
     set("snakeyaml.version", "2.0")
-    set("spring-security.version", "6.1.2")
     set("testcontainersSpringBootVersion", "3.0.0-RC8")
     set("vertxVersion", "4.4.4")
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -44,7 +44,7 @@ dependencies {
     implementation("org.openapitools:openapi-generator-gradle-plugin:6.6.0")
     implementation("org.owasp:dependency-check-gradle:8.3.1")
     implementation("org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:4.2.1.3168")
-    implementation("org.springframework.boot:spring-boot-gradle-plugin:3.1.1")
+    implementation("org.springframework.boot:spring-boot-gradle-plugin:3.1.2")
 
     // Temporary until openapi-generator updates to a swagger-parser that is compatible with SnakeYAML 2.0
     implementation("io.swagger.parser.v3:swagger-parser-v3:2.1.16")


### PR DESCRIPTION
**Description**:

* Bump Spring Boot from 3.1.1 to 3.1.2
* Remove Spring security override since Spring Boot contains 6.1.2

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
