### PR TITLE
HIP-584: Add tests for eth_call functions with alias accounts

### DIFF
--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AccountClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AccountClient.java
@@ -167,15 +167,6 @@ public class AccountClient extends AbstractNetworkClient {
         return createCryptoAccount(Hbar.fromTinybars(initialBalance), false, null, null, keyType);
     }
 
-    public ExpandedAccountId createNewECDSAAccount(long initialBalance) {
-        PrivateKey newAccountPrivateKey = PrivateKey.generateECDSA();
-        AccountId newAccountId = newAccountPrivateKey.getPublicKey().toAccountId(0, 0);
-        sendCryptoTransfer(newAccountId, Hbar.fromTinybars(initialBalance));
-
-        MirrorAccountResponse accountInfo = sdkClient.getMirrorNodeClient().getAccountDetailsUsingAlias(newAccountId);
-        return new ExpandedAccountId(accountInfo.getAccount(), newAccountPrivateKey.toString());
-    }
-
     public ExpandedAccountId createNewAccount(long initialBalance, AccountNameEnum accountNameEnum) {
         // Get the keyType from the enum
         Key.KeyCase keyType = accountNameEnum.keyType;

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ERCContractFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ERCContractFeature.java
@@ -469,7 +469,6 @@ public class ERCContractFeature extends AbstractFeature {
                 .estimate(false)
                 .build();
         var getBalanceOfResponse = mirrorClient.contractsCall(contractCallGetBalanceOf);
-
         assertThat(getBalanceOfResponse.getResultAsNumber()).isEqualTo(500);
     }
 

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ERCContractFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ERCContractFeature.java
@@ -19,10 +19,22 @@ package com.hedera.mirror.test.e2e.acceptance.steps;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.hedera.hashgraph.sdk.*;
+import com.hedera.hashgraph.sdk.ContractId;
+import com.hedera.hashgraph.sdk.CustomFee;
+import com.hedera.hashgraph.sdk.FileId;
+import com.hedera.hashgraph.sdk.Hbar;
+import com.hedera.hashgraph.sdk.NftId;
+import com.hedera.hashgraph.sdk.TokenId;
+import com.hedera.hashgraph.sdk.TokenSupplyType;
+import com.hedera.hashgraph.sdk.TokenType;
+import com.hedera.hashgraph.sdk.TransactionReceipt;
 import com.hedera.hashgraph.sdk.proto.TokenFreezeStatus;
 import com.hedera.hashgraph.sdk.proto.TokenKycStatus;
-import com.hedera.mirror.test.e2e.acceptance.client.*;
+import com.hedera.mirror.test.e2e.acceptance.client.AccountClient;
+import com.hedera.mirror.test.e2e.acceptance.client.ContractClient;
+import com.hedera.mirror.test.e2e.acceptance.client.FileClient;
+import com.hedera.mirror.test.e2e.acceptance.client.MirrorNodeClient;
+import com.hedera.mirror.test.e2e.acceptance.client.TokenClient;
 import com.hedera.mirror.test.e2e.acceptance.props.CompiledSolidityArtifact;
 import com.hedera.mirror.test.e2e.acceptance.props.ContractCallRequest;
 import com.hedera.mirror.test.e2e.acceptance.props.ExpandedAccountId;
@@ -454,6 +466,7 @@ public class ERCContractFeature extends AbstractFeature {
                 .estimate(false)
                 .build();
         var getAllowanceResponse = mirrorClient.contractsCall(contractCallGetAllowance);
+
         assertThat(getAllowanceResponse.getResultAsNumber()).isEqualTo(1000);
     }
 
@@ -469,6 +482,7 @@ public class ERCContractFeature extends AbstractFeature {
                 .estimate(false)
                 .build();
         var getBalanceOfResponse = mirrorClient.contractsCall(contractCallGetBalanceOf);
+
         assertThat(getBalanceOfResponse.getResultAsNumber()).isEqualTo(500);
     }
 

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/PrecompileContractFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/PrecompileContractFeature.java
@@ -158,7 +158,7 @@ public class PrecompileContractFeature extends AbstractFeature {
 
     @Given("I create an ecdsa account and associate it to the tokens")
     public void createEcdsaAccountAndAssociateItToTokens() {
-        ecdsaEaId = accountClient.createNewECDSAAccount(1_000_000_000);
+        ecdsaEaId = accountClient.createNewAccount(1_000_000_000, AccountClient.AccountNameEnum.BOB);
         for (TokenId tokenId : tokenIds) {
             tokenClient.associate(ecdsaEaId, tokenId);
         }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/PrecompileContractFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/PrecompileContractFeature.java
@@ -158,7 +158,7 @@ public class PrecompileContractFeature extends AbstractFeature {
 
     @Given("I create an ecdsa account and associate it to the tokens")
     public void createEcdsaAccountAndAssociateItToTokens() {
-        ecdsaEaId = accountClient.createNewAccount(1_000_000_000, AccountClient.AccountNameEnum.BOB);
+        ecdsaEaId = accountClient.getAccount(AccountClient.AccountNameEnum.BOB);
         for (TokenId tokenId : tokenIds) {
             tokenClient.associate(ecdsaEaId, tokenId);
         }

--- a/hedera-mirror-test/src/test/resources/features/contract/erc.feature
+++ b/hedera-mirror-test/src/test/resources/features/contract/erc.feature
@@ -26,6 +26,10 @@ Feature: ERC Contract Base Coverage Feature
     When I approve <tokenAllowanceSpender> with <allowances>
     Then the mirror node REST API should return status 200 for the erc contract transaction
     And I call the erc contract via the mirror node REST API for token allowance with allowances
+    Then I call the erc contract via the mirror node REST API for token isApprovedForAll with response true with alias accounts
+    Then I call the erc contract via the mirror node REST API for token allowance with alias accounts
+    Then I call the erc contract via the mirror node REST API for token balance with alias account
+
     Examples:
       | supplyType | spenderName | approvedForAllSpenderName | tokenAllowanceSpender | allowances |
       | "INFINITE" | "BOB"       | "ALICE"                   | "ALICE"               | 2          |


### PR DESCRIPTION
**Description**:

This PR introduces tests to validate the interaction of eth_call with alias accounts, specifically focusing on the isApprovedForAll, allowance, and balanceOf functions. Be advised that these tests won't work until #6454 is merged.


**Related issue(s)**:

Fixes #6465

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
