### PR TITLE
HIP-584: Adapt Mirror Archive Node to respect alias addresses (0.85)

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessorFacadeImpl.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessorFacadeImpl.java
@@ -33,7 +33,6 @@ import com.hedera.mirror.web3.evm.store.contract.MirrorEntityAccess;
 import com.hedera.mirror.web3.evm.token.TokenAccessorImpl;
 import com.hedera.mirror.web3.repository.ContractRepository;
 import com.hedera.mirror.web3.repository.ContractStateRepository;
-import com.hedera.mirror.web3.repository.EntityRepository;
 import com.hedera.node.app.service.evm.contracts.execution.HederaEvmTransactionProcessingResult;
 import com.hedera.node.app.service.evm.store.contracts.AbstractCodeCache;
 import com.hedera.node.app.service.evm.store.models.HederaEvmAccount;
@@ -73,7 +72,6 @@ public class MirrorEvmTxProcessorFacadeImpl implements MirrorEvmTxProcessorFacad
             final EntityAddressSequencer entityAddressSequencer,
             final ContractRepository contractRepository,
             final ContractStateRepository contractStateRepository,
-            final EntityRepository entityRepository,
             final List<DatabaseAccessor<Object, ?>> databaseAccessors,
             final PrecompileMapper precompileMapper) {
         this.evmProperties = evmProperties;
@@ -101,11 +99,11 @@ public class MirrorEvmTxProcessorFacadeImpl implements MirrorEvmTxProcessorFacad
         final int expirationCacheTime =
                 (int) evmProperties.getExpirationCacheTime().toSeconds();
         final var store = new StoreImpl(databaseAccessors);
-        final var mirrorEntityAccess = new MirrorEntityAccess(contractStateRepository, contractRepository, store);
-        final var tokenAccessor = new TokenAccessorImpl(evmProperties, store);
-        final var accountAccessor = new AccountAccessorImpl(mirrorEntityAccess, store);
-        final var codeCache = new AbstractCodeCache(expirationCacheTime, mirrorEntityAccess);
         final var mirrorEvmContractAliases = new MirrorEvmContractAliases(store);
+        final var mirrorEntityAccess = new MirrorEntityAccess(contractStateRepository, contractRepository, store);
+        final var tokenAccessor = new TokenAccessorImpl(evmProperties, store, mirrorEvmContractAliases);
+        final var accountAccessor = new AccountAccessorImpl(store, mirrorEntityAccess, mirrorEvmContractAliases);
+        final var codeCache = new AbstractCodeCache(expirationCacheTime, mirrorEntityAccess);
         final var mirrorOperationTracer = new MirrorOperationTracer(traceProperties, mirrorEvmContractAliases);
 
         final var worldState = new HederaEvmWorldState(

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/StoreImpl.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/StoreImpl.java
@@ -108,6 +108,11 @@ public class StoreImpl implements Store {
     public void updateAccount(final Account updatedAccount) {
         final var accountAccessor = stackedStateFrames.top().getAccessor(Account.class);
         accountAccessor.set(updatedAccount.getAccountAddress(), updatedAccount);
+
+        final var canonicalAddress = updatedAccount.canonicalAddress();
+        if (canonicalAddress != null && !canonicalAddress.equals(updatedAccount.getAccountAddress())) {
+            accountAccessor.set(canonicalAddress, updatedAccount);
+        }
     }
 
     @Override
@@ -115,7 +120,17 @@ public class StoreImpl implements Store {
         final var topFrame = stackedStateFrames.top();
         final var accountAccessor = topFrame.getAccessor(com.hedera.services.store.models.Account.class);
         try {
+            final var account = accountAccessor.get(accountAddress);
+            if (account.isEmpty()) {
+                return;
+            }
+
             accountAccessor.delete(accountAddress);
+
+            final var canonicalAddress = account.get().canonicalAddress();
+            if (canonicalAddress != accountAddress) {
+                accountAccessor.delete(canonicalAddress);
+            }
         } catch (UpdatableCacheUsageException ex) {
             // ignore, value has been deleted
         }
@@ -124,7 +139,13 @@ public class StoreImpl implements Store {
     @Override
     public void updateTokenRelationship(final TokenRelationship updatedTokenRelationship) {
         final var tokenRelationshipAccessor = stackedStateFrames.top().getAccessor(TokenRelationship.class);
-        tokenRelationshipAccessor.set(keyFromRelationship(updatedTokenRelationship), updatedTokenRelationship);
+        final var tokenRelationshipKey = keyFromRelationship(updatedTokenRelationship);
+        tokenRelationshipAccessor.set(tokenRelationshipKey, updatedTokenRelationship);
+
+        final var tokenRelationshipKeyWithAlias = keyFromRelationshipWithAlias(updatedTokenRelationship);
+        if (tokenRelationshipKeyWithAlias != tokenRelationshipKey) {
+            tokenRelationshipAccessor.set(tokenRelationshipKeyWithAlias, updatedTokenRelationship);
+        }
     }
 
     @Override
@@ -190,6 +211,12 @@ public class StoreImpl implements Store {
     private TokenRelationshipKey keyFromRelationship(TokenRelationship tokenRelationship) {
         final var tokenAddress = tokenRelationship.getToken().getId().asEvmAddress();
         final var accountAddress = tokenRelationship.getAccount().getAccountAddress();
+        return new TokenRelationshipKey(tokenAddress, accountAddress);
+    }
+
+    private TokenRelationshipKey keyFromRelationshipWithAlias(TokenRelationship tokenRelationship) {
+        final var tokenAddress = tokenRelationship.getToken().getId().asEvmAddress();
+        final var accountAddress = tokenRelationship.getAccount().canonicalAddress();
         return new TokenRelationshipKey(tokenAddress, accountAddress);
     }
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/accessor/AccountDatabaseAccessor.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/accessor/AccountDatabaseAccessor.java
@@ -20,6 +20,7 @@ import static com.hedera.mirror.common.domain.entity.EntityType.*;
 import static com.hedera.services.utils.EntityIdUtils.idFromEntityId;
 import static com.hedera.services.utils.MiscUtils.asFcKeyUnchecked;
 
+import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.mirror.common.domain.entity.AbstractTokenAllowance;
 import com.hedera.mirror.common.domain.entity.CryptoAllowance;
@@ -65,6 +66,9 @@ public class AccountDatabaseAccessor extends DatabaseAccessor<Object, Account> {
     private Account accountFromEntity(Entity entity) {
         final var tokenAssociationsCounts = getNumberOfAllAndPositiveBalanceTokenAssociations(entity.getId());
         return new Account(
+                entity.getEvmAddress() != null && entity.getEvmAddress().length > 0
+                        ? ByteString.copyFrom(entity.getEvmAddress())
+                        : ByteString.EMPTY,
                 entity.getId(),
                 new Id(entity.getShard(), entity.getRealm(), entity.getNum()),
                 entity.getEffectiveExpiration(),

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/contract/HederaEvmStackedWorldStateUpdater.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/contract/HederaEvmStackedWorldStateUpdater.java
@@ -19,6 +19,7 @@ package com.hedera.mirror.web3.evm.store.contract;
 import static com.hedera.services.utils.EntityIdUtils.accountIdFromEvmAddress;
 import static com.hedera.services.utils.EntityIdUtils.asTypedEvmAddress;
 
+import com.google.protobuf.ByteString;
 import com.hedera.mirror.web3.evm.account.MirrorEvmContractAliases;
 import com.hedera.mirror.web3.evm.store.Store;
 import com.hedera.mirror.web3.evm.store.Store.OnMissing;
@@ -98,13 +99,13 @@ public class HederaEvmStackedWorldStateUpdater
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     public void trackLazilyCreatedAccount(final Address address) {
-        persistAccount(address, 0L, Wei.ZERO);
         final UpdateTrackingAccount newMutable = new UpdateTrackingAccount<>(address, null);
         track(newMutable);
     }
 
     private void persistAccount(Address address, long nonce, Wei balance) {
         final var accountModel = new com.hedera.services.store.models.Account(
+                ByteString.EMPTY,
                 0L,
                 Id.fromGrpcAccount(accountIdFromEvmAddress(address.toArrayUnsafe())),
                 0L,

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/token/TokenAccessorImpl.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/token/TokenAccessorImpl.java
@@ -22,6 +22,7 @@ import static com.hedera.mirror.web3.evm.utils.EvmTokenUtils.evmKey;
 import static com.hedera.services.utils.MiscUtils.asKeyUnchecked;
 
 import com.hedera.mirror.common.domain.entity.EntityId;
+import com.hedera.mirror.web3.evm.account.MirrorEvmContractAliases;
 import com.hedera.mirror.web3.evm.exception.ParsingException;
 import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
 import com.hedera.mirror.web3.evm.store.Store;
@@ -50,6 +51,7 @@ public class TokenAccessorImpl implements TokenAccessor {
 
     private final MirrorNodeEvmProperties properties;
     private final Store store;
+    private final MirrorEvmContractAliases aliases;
 
     @Override
     public Optional<EvmTokenInfo> evmInfoForToken(Address address) {
@@ -158,7 +160,9 @@ public class TokenAccessorImpl implements TokenAccessor {
     @Override
     public long staticAllowanceOf(final Address owner, final Address spender, final Address token) {
         final var tokenNum = EntityNum.fromEvmAddress(token);
-        final var spenderNum = EntityNum.fromEvmAddress(spender);
+
+        final var resolvedSpender = aliases.resolveForEvm(spender);
+        final var spenderNum = EntityNum.fromEvmAddress(resolvedSpender);
 
         final var fcTokenAllowanceId = new FcTokenAllowanceId(tokenNum, spenderNum);
 
@@ -184,7 +188,7 @@ public class TokenAccessorImpl implements TokenAccessor {
     @Override
     public boolean staticIsOperator(final Address owner, final Address operator, final Address token) {
         final var tokenNum = EntityNum.fromEvmAddress(token);
-        final var operatorNum = EntityNum.fromEvmAddress(operator);
+        final var operatorNum = EntityNum.fromEvmAddress(aliases.resolveForEvm(operator));
 
         final var fcTokenAllowanceId = new FcTokenAllowanceId(tokenNum, operatorNum);
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/DecodingFacade.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/DecodingFacade.java
@@ -16,6 +16,7 @@
 
 package com.hedera.services.store.contracts.precompile.codec;
 
+import static com.hedera.node.app.service.evm.accounts.HederaEvmContractAliases.isMirror;
 import static com.hedera.node.app.service.evm.store.contracts.utils.EvmParsingConstants.ARRAY_BRACKETS;
 import static com.hedera.node.app.service.evm.store.contracts.utils.EvmParsingConstants.EXPIRY;
 import static com.hedera.node.app.service.evm.store.contracts.utils.EvmParsingConstants.TOKEN_KEY;
@@ -26,6 +27,7 @@ import static com.hedera.services.utils.IdUtils.asContract;
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.UnsafeByteOperations;
+import com.hedera.services.hapi.utils.ByteStringUtils;
 import com.hedera.services.store.contracts.precompile.FungibleTokenTransfer;
 import com.hedera.services.store.contracts.precompile.HbarTransfer;
 import com.hedera.services.store.contracts.precompile.NftExchange;
@@ -215,6 +217,16 @@ public class DecodingFacade {
     public static AccountID convertLeftPaddedAddressToAccountId(
             final byte[] leftPaddedAddress, @NonNull final UnaryOperator<byte[]> aliasResolver) {
         final var addressOrAlias = Arrays.copyOfRange(leftPaddedAddress, ADDRESS_SKIP_BYTES_LENGTH, WORD_LENGTH);
-        return accountIdFromEvmAddress(aliasResolver.apply(addressOrAlias));
+        final var resolvedAddress = aliasResolver.apply(addressOrAlias);
+        // The input address was missing, so we return an AccountID with the
+        // missing address as alias; this means that any downstream code that
+        // relies on 0.0.X account numbers will get INVALID_ACCOUNT_ID, but
+        // the AccountID in any synthetic transaction body will have a valid
+        if (!isMirror(resolvedAddress)) {
+            return AccountID.newBuilder()
+                    .setAlias(ByteStringUtils.wrapUnsafely(addressOrAlias))
+                    .build();
+        }
+        return accountIdFromEvmAddress(resolvedAddress);
     }
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/models/Account.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/models/Account.java
@@ -23,6 +23,7 @@ import static com.hedera.services.utils.BitPackUtils.setAlreadyUsedAutomaticAsso
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.NO_REMAINING_AUTOMATIC_ASSOCIATIONS;
 
 import com.google.common.base.MoreObjects;
+import com.google.protobuf.ByteString;
 import com.hedera.node.app.service.evm.store.models.HederaEvmAccount;
 import com.hedera.services.jproto.JKey;
 import com.hedera.services.utils.EntityNum;
@@ -30,7 +31,6 @@ import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import lombok.Builder;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.hyperledger.besu.datatypes.Address;
@@ -70,9 +70,9 @@ public class Account extends HederaEvmAccount {
     private final boolean isSmartContract;
     private final JKey key;
 
-    @Builder(toBuilder = true)
     @SuppressWarnings("java:S107")
     public Account(
+            ByteString alias,
             Long entityId,
             Id id,
             long expiry,
@@ -92,6 +92,7 @@ public class Account extends HederaEvmAccount {
             boolean isSmartContract,
             JKey key) {
         super(id.asEvmAddress());
+        setAlias(alias);
         this.entityId = entityId;
         this.id = id;
         this.expiry = expiry;
@@ -119,6 +120,7 @@ public class Account extends HederaEvmAccount {
      */
     public Account(Long entityId, Id id, long balance) {
         this(
+                ByteString.EMPTY,
                 entityId,
                 id,
                 0L,
@@ -157,6 +159,7 @@ public class Account extends HederaEvmAccount {
      */
     private Account createNewAccountWithNewOwnedNfts(final Account oldAccount, final long ownedNfts) {
         return new Account(
+                oldAccount.alias,
                 oldAccount.entityId,
                 oldAccount.id,
                 oldAccount.expiry,
@@ -187,6 +190,7 @@ public class Account extends HederaEvmAccount {
      */
     private Account createNewAccountWithNumAssociations(final Account oldAccount, final int numAssociations) {
         return new Account(
+                oldAccount.alias,
                 oldAccount.entityId,
                 oldAccount.id,
                 oldAccount.expiry,
@@ -217,6 +221,7 @@ public class Account extends HederaEvmAccount {
      */
     private Account createNewAccountWithNewPositiveBalances(Account oldAccount, int newNumPositiveBalances) {
         return new Account(
+                oldAccount.alias,
                 oldAccount.entityId,
                 oldAccount.id,
                 oldAccount.expiry,
@@ -249,6 +254,7 @@ public class Account extends HederaEvmAccount {
     private Account createNewAccountWithNewAutoAssociationMetadata(
             Account oldAccount, int updatedAutoAssociationMetadata) {
         return new Account(
+                oldAccount.alias,
                 oldAccount.entityId,
                 oldAccount.id,
                 oldAccount.expiry,
@@ -279,6 +285,7 @@ public class Account extends HederaEvmAccount {
      */
     private Account createNewAccountWithNewIsSmartContract(Account oldAccount, boolean isSmartContract) {
         return new Account(
+                oldAccount.alias,
                 oldAccount.entityId,
                 oldAccount.id,
                 oldAccount.expiry,
@@ -309,6 +316,7 @@ public class Account extends HederaEvmAccount {
      */
     private Account createNewAccountWithNewExpiry(Account oldAccount, long expiry) {
         return new Account(
+                oldAccount.alias,
                 oldAccount.entityId,
                 oldAccount.id,
                 expiry,
@@ -339,6 +347,7 @@ public class Account extends HederaEvmAccount {
      */
     private Account createNewAccountWithNewBalance(Account oldAccount, long newBalance) {
         return new Account(
+                oldAccount.alias,
                 oldAccount.entityId,
                 oldAccount.id,
                 oldAccount.expiry,
@@ -370,6 +379,7 @@ public class Account extends HederaEvmAccount {
     private Account createNewAccountWithNewCryptoAllowances(
             Account oldAccount, SortedMap<EntityNum, Long> cryptoAllowances) {
         return new Account(
+                oldAccount.alias,
                 oldAccount.entityId,
                 oldAccount.id,
                 oldAccount.expiry,
@@ -401,6 +411,7 @@ public class Account extends HederaEvmAccount {
     private Account createNewAccountWithNewFungibleTokenAllowances(
             Account oldAccount, SortedMap<FcTokenAllowanceId, Long> fungibleTokenAllowances) {
         return new Account(
+                oldAccount.alias,
                 oldAccount.entityId,
                 oldAccount.id,
                 oldAccount.expiry,
@@ -433,6 +444,7 @@ public class Account extends HederaEvmAccount {
     private Account createNewAccountWithNewApproveForAllNfts(
             Account oldAccount, SortedSet<FcTokenAllowanceId> newApproveForAllNfts) {
         return new Account(
+                oldAccount.alias,
                 oldAccount.entityId,
                 oldAccount.id,
                 oldAccount.expiry,
@@ -459,6 +471,13 @@ public class Account extends HederaEvmAccount {
 
     public int getAlreadyUsedAutomaticAssociations() {
         return getAlreadyUsedAutomaticAssociationsFrom(autoAssociationMetadata);
+    }
+
+    public Account setAlreadyUsedAutomaticAssociations(int alreadyUsedCount) {
+        validateTrue(isValidAlreadyUsedCount(alreadyUsedCount), NO_REMAINING_AUTOMATIC_ASSOCIATIONS);
+        final var updatedAutoAssociationMetadata =
+                setAlreadyUsedAutomaticAssociationsTo(autoAssociationMetadata, alreadyUsedCount);
+        return createNewAccountWithNewAutoAssociationMetadata(this, updatedAutoAssociationMetadata);
     }
 
     public int getAutoAssociationMetadata() {
@@ -489,6 +508,10 @@ public class Account extends HederaEvmAccount {
         return balance;
     }
 
+    public Account setBalance(long balance) {
+        return createNewAccountWithNewBalance(this, balance);
+    }
+
     public boolean isDeleted() {
         return deleted;
     }
@@ -503,14 +526,6 @@ public class Account extends HederaEvmAccount {
 
     public Account setCryptoAllowance(SortedMap<EntityNum, Long> cryptoAllowances) {
         return createNewAccountWithNewCryptoAllowances(this, cryptoAllowances);
-    }
-
-    public Account setFungibleTokenAllowances(SortedMap<FcTokenAllowanceId, Long> fungibleTokenAllowances) {
-        return createNewAccountWithNewFungibleTokenAllowances(this, fungibleTokenAllowances);
-    }
-
-    public Account setApproveForAllNfts(SortedSet<FcTokenAllowanceId> approveForAllNfts) {
-        return createNewAccountWithNewApproveForAllNfts(this, approveForAllNfts);
     }
 
     public long getOwnedNfts() {
@@ -541,8 +556,16 @@ public class Account extends HederaEvmAccount {
         return fungibleTokenAllowances;
     }
 
+    public Account setFungibleTokenAllowances(SortedMap<FcTokenAllowanceId, Long> fungibleTokenAllowances) {
+        return createNewAccountWithNewFungibleTokenAllowances(this, fungibleTokenAllowances);
+    }
+
     public SortedSet<FcTokenAllowanceId> getApproveForAllNfts() {
         return approveForAllNfts;
+    }
+
+    public Account setApproveForAllNfts(SortedSet<FcTokenAllowanceId> approveForAllNfts) {
+        return createNewAccountWithNewApproveForAllNfts(this, approveForAllNfts);
     }
 
     public int getNumAssociations() {
@@ -561,28 +584,17 @@ public class Account extends HederaEvmAccount {
         return numPositiveBalances;
     }
 
-    public long getEthereumNonce() {
-        return ethereumNonce;
-    }
-
     public Account setNumPositiveBalances(int newNumPositiveBalances) {
         return createNewAccountWithNewPositiveBalances(this, newNumPositiveBalances);
     }
 
-    public Account setAlreadyUsedAutomaticAssociations(int alreadyUsedCount) {
-        validateTrue(isValidAlreadyUsedCount(alreadyUsedCount), NO_REMAINING_AUTOMATIC_ASSOCIATIONS);
-        final var updatedAutoAssociationMetadata =
-                setAlreadyUsedAutomaticAssociationsTo(autoAssociationMetadata, alreadyUsedCount);
-        return createNewAccountWithNewAutoAssociationMetadata(this, updatedAutoAssociationMetadata);
+    public long getEthereumNonce() {
+        return ethereumNonce;
     }
 
     public Account decrementUsedAutomaticAssociations() {
         var count = getAlreadyUsedAutomaticAssociations();
         return setAlreadyUsedAutomaticAssociations(--count);
-    }
-
-    public Account setBalance(long balance) {
-        return createNewAccountWithNewBalance(this, balance);
     }
 
     public JKey getKey() {

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/txns/crypto/AbstractAutoCreationLogic.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/txns/crypto/AbstractAutoCreationLogic.java
@@ -106,6 +106,7 @@ public abstract class AbstractAutoCreationLogic {
 
         final var newId = ids.getNewAccountId();
         final var account = new Account(
+                alias,
                 0L,
                 Id.fromGrpcAccount(newId),
                 0L,

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/utils/EntityIdUtils.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/utils/EntityIdUtils.java
@@ -17,10 +17,10 @@
 package com.hedera.services.utils;
 
 import static com.hedera.mirror.web3.evm.account.AccountAccessorImpl.EVM_ADDRESS_SIZE;
+import static com.hedera.node.app.service.evm.store.models.HederaEvmAccount.ECDSA_SECP256K1_ALIAS_SIZE;
 import static com.hedera.services.utils.BitPackUtils.numFromCode;
 import static java.lang.System.arraycopy;
 
-import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
 import com.google.protobuf.ByteString;
 import com.hedera.mirror.common.domain.entity.EntityId;
@@ -32,7 +32,6 @@ import com.hederahashgraph.api.proto.java.NftID;
 import com.hederahashgraph.api.proto.java.TokenID;
 import com.swirlds.common.utility.CommonUtils;
 import java.util.Arrays;
-import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 
@@ -45,37 +44,25 @@ public final class EntityIdUtils {
     }
 
     public static byte[] asEvmAddress(final ContractID id) {
-        if (id.getEvmAddress().size() == EVM_ADDRESS_SIZE) {
+        if (isOfEvmAddressSize(id.getEvmAddress())) {
             return id.getEvmAddress().toByteArray();
         } else {
-            return asEvmAddress((int) id.getShardNum(), id.getRealmNum(), id.getContractNum());
+            return asEvmAddress(id.getContractNum());
         }
     }
 
     public static byte[] asEvmAddress(final AccountID id) {
-        return asEvmAddress((int) id.getShardNum(), id.getRealmNum(), id.getAccountNum());
+        return asEvmAddress(id.getAccountNum());
     }
 
     public static byte[] asEvmAddress(final TokenID id) {
-        return asEvmAddress((int) id.getShardNum(), id.getRealmNum(), id.getTokenNum());
+        return asEvmAddress(id.getTokenNum());
     }
 
-    public static byte[] asEvmAddress(final int shard, final long realm, final long num) {
+    public static byte[] asEvmAddress(final long num) {
         final byte[] evmAddress = new byte[20];
-
-        arraycopy(Ints.toByteArray(shard), 0, evmAddress, 0, 4);
-        arraycopy(Longs.toByteArray(realm), 0, evmAddress, 4, 8);
         arraycopy(Longs.toByteArray(num), 0, evmAddress, 12, 8);
-
         return evmAddress;
-    }
-
-    public static long shardFromEvmAddress(final byte[] bytes) {
-        return Ints.fromByteArray(Arrays.copyOfRange(bytes, 0, 4));
-    }
-
-    public static long realmFromEvmAddress(final byte[] bytes) {
-        return Longs.fromByteArray(Arrays.copyOfRange(bytes, 4, 12));
     }
 
     public static long numFromEvmAddress(final byte[] bytes) {
@@ -87,25 +74,17 @@ public final class EntityIdUtils {
     }
 
     public static AccountID accountIdFromEvmAddress(final byte[] bytes) {
-        return AccountID.newBuilder()
-                .setShardNum(shardFromEvmAddress(bytes))
-                .setRealmNum(realmFromEvmAddress(bytes))
-                .setAccountNum(numFromEvmAddress(bytes))
-                .build();
+        return AccountID.newBuilder().setAccountNum(numFromEvmAddress(bytes)).build();
     }
 
     public static ContractID contractIdFromEvmAddress(final byte[] bytes) {
         return ContractID.newBuilder()
-                .setShardNum(Ints.fromByteArray(Arrays.copyOfRange(bytes, 0, 4)))
-                .setRealmNum(Longs.fromByteArray(Arrays.copyOfRange(bytes, 4, 12)))
                 .setContractNum(Longs.fromByteArray(Arrays.copyOfRange(bytes, 12, 20)))
                 .build();
     }
 
     public static TokenID tokenIdFromEvmAddress(final byte[] bytes) {
         return TokenID.newBuilder()
-                .setShardNum(Ints.fromByteArray(Arrays.copyOfRange(bytes, 0, 4)))
-                .setRealmNum(Longs.fromByteArray(Arrays.copyOfRange(bytes, 4, 12)))
                 .setTokenNum(Longs.fromByteArray(Arrays.copyOfRange(bytes, 12, 20)))
                 .build();
     }
@@ -130,9 +109,12 @@ public final class EntityIdUtils {
         return tokenIdFromEvmAddress(address.toArrayUnsafe());
     }
 
-    public static long[] asDotDelimitedLongArray(String s) {
-        String[] parts = s.split("[.]");
-        return Stream.of(parts).mapToLong(Long::valueOf).toArray();
+    public static boolean isOfEvmAddressSize(final ByteString alias) {
+        return alias.size() == EVM_ADDRESS_SIZE;
+    }
+
+    public static boolean isOfEcdsaPublicAddressSize(final ByteString alias) {
+        return alias.size() == ECDSA_SECP256K1_ALIAS_SIZE;
     }
 
     public static AccountID parseAccount(final String literal) {
@@ -188,8 +170,12 @@ public final class EntityIdUtils {
         return triple;
     }
 
+    public static String asHexedEvmAddress(final AccountID id) {
+        return CommonUtils.hex(asEvmAddress(id.getAccountNum()));
+    }
+
     public static String asHexedEvmAddress(final Id id) {
-        return CommonUtils.hex(asEvmAddress((int) id.shard(), id.realm(), id.num()));
+        return CommonUtils.hex(asEvmAddress(id.num()));
     }
 
     public static boolean isAlias(final AccountID idOrAlias) {

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/account/AccountAccessorImplTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/account/AccountAccessorImplTest.java
@@ -16,7 +16,7 @@
 
 package com.hedera.mirror.web3.evm.account;
 
-import static com.google.protobuf.ByteString.EMPTY;
+import static com.hedera.node.app.service.evm.utils.EthSigsUtils.recoverAddressFromPubKey;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Mockito.when;
 
@@ -26,6 +26,7 @@ import com.hedera.mirror.web3.evm.store.Store.OnMissing;
 import com.hedera.node.app.service.evm.store.contracts.HederaEvmEntityAccess;
 import com.hedera.services.store.models.Account;
 import org.apache.tuweni.bytes.Bytes;
+import org.bouncycastle.util.encoders.Hex;
 import org.hyperledger.besu.datatypes.Address;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -38,10 +39,15 @@ class AccountAccessorImplTest {
 
     private static final String HEX = "0x00000000000000000000000000000000000004e4";
     private static final String ALIAS_HEX = "0x67d8d32e9bf1a9968a5ff53b87d777aa8ebbee69";
+    private static final ByteString ECDSA_KEY =
+            ByteString.copyFrom(Hex.decode("3a2103af80b90d25145da28c583359beb47b21796b2fe1a23c1511e443e7a64dfdb27d"));
+    protected static final Address ECDSA_KEY_ALIAS_ADDRESS = Address.wrap(
+            Bytes.wrap(recoverAddressFromPubKey(ECDSA_KEY.substring(2).toByteArray())));
     private static final Address ADDRESS = Address.fromHexString(HEX);
     private static final Address ALIAS_ADDRESS = Address.fromHexString(ALIAS_HEX);
     private static final Bytes BYTES = Bytes.fromHexString(HEX);
     private static final byte[] DATA = BYTES.toArrayUnsafe();
+    public AccountAccessorImpl accountAccessor;
 
     @Mock
     private HederaEvmEntityAccess mirrorEntityAccess;
@@ -52,11 +58,12 @@ class AccountAccessorImplTest {
     @Mock
     private Account account;
 
-    public AccountAccessorImpl accountAccessor;
+    @Mock
+    private MirrorEvmContractAliases mirrorEvmContractAliases;
 
     @BeforeEach
     void setUp() {
-        accountAccessor = new AccountAccessorImpl(mirrorEntityAccess, store);
+        accountAccessor = new AccountAccessorImpl(store, mirrorEntityAccess, mirrorEvmContractAliases);
     }
 
     @Test
@@ -74,50 +81,26 @@ class AccountAccessorImplTest {
     }
 
     @Test
-    void canonicalAddress() {
+    void canonicalAddressForEvmAddress() {
+        when(mirrorEvmContractAliases.isMirror(ADDRESS)).thenReturn(true);
         when(store.getAccount(ADDRESS, OnMissing.DONT_THROW)).thenReturn(account);
+        when(account.canonicalAddress()).thenReturn(ALIAS_ADDRESS);
         final var result = accountAccessor.canonicalAddress(ADDRESS);
-        assertThat(result).isEqualTo(ADDRESS);
+        assertThat(result).isEqualTo(ALIAS_ADDRESS);
     }
 
     @Test
-    void canonicalAliasAddress() {
-        when(store.getAccount(ALIAS_ADDRESS, OnMissing.DONT_THROW)).thenReturn(account);
+    void canonicalAddressIsAlreadyResolved() {
         final var result = accountAccessor.canonicalAddress(ALIAS_ADDRESS);
         assertThat(result).isEqualTo(ALIAS_ADDRESS);
     }
 
     @Test
-    void missingCanonicalAliasAddressResolvesToItself() {
-        when(store.getAccount(ALIAS_ADDRESS, OnMissing.DONT_THROW)).thenReturn(Account.getEmptyAccount());
-        final var result = accountAccessor.canonicalAddress(ALIAS_ADDRESS);
-        assertThat(result).isEqualTo(ALIAS_ADDRESS);
-    }
-
-    @Test
-    void isExtantTrue() {
-        when(store.getAccount(ADDRESS, OnMissing.DONT_THROW)).thenReturn(Account.getEmptyAccount());
-        when(mirrorEntityAccess.isExtant(ADDRESS)).thenReturn(true);
-        when(mirrorEntityAccess.alias(ADDRESS)).thenReturn(EMPTY);
+    void canonicalAddressForRecoveredEcdsaKey() {
+        when(mirrorEvmContractAliases.isMirror(ADDRESS)).thenReturn(true);
+        when(store.getAccount(ADDRESS, OnMissing.DONT_THROW)).thenReturn(account);
+        when(account.canonicalAddress()).thenReturn(ECDSA_KEY_ALIAS_ADDRESS);
         final var result = accountAccessor.canonicalAddress(ADDRESS);
-        assertThat(result).isEqualTo(ADDRESS);
-    }
-
-    @Test
-    void alias() {
-        when(store.getAccount(ADDRESS, OnMissing.DONT_THROW)).thenReturn(Account.getEmptyAccount());
-        when(mirrorEntityAccess.isExtant(ADDRESS)).thenReturn(true);
-        when(mirrorEntityAccess.alias(ADDRESS)).thenReturn(ByteString.copyFrom(DATA));
-        final var result = accountAccessor.canonicalAddress(ADDRESS);
-        assertThat(result).isEqualTo(ADDRESS);
-    }
-
-    @Test
-    void aliasDifferentFromEvmAddressSize() {
-        when(store.getAccount(ADDRESS, OnMissing.DONT_THROW)).thenReturn(Account.getEmptyAccount());
-        when(mirrorEntityAccess.isExtant(ADDRESS)).thenReturn(true);
-        when(mirrorEntityAccess.alias(ADDRESS)).thenReturn(ByteString.copyFrom(new byte[32]));
-        final var result = accountAccessor.canonicalAddress(ADDRESS);
-        assertThat(result).isEqualTo(ADDRESS);
+        assertThat(result).isEqualTo(ECDSA_KEY_ALIAS_ADDRESS);
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/account/MirrorEvmContractAliasesTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/account/MirrorEvmContractAliasesTest.java
@@ -17,9 +17,7 @@
 package com.hedera.mirror.web3.evm.account;
 
 import static com.hedera.mirror.common.util.DomainUtils.toEvmAddress;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FAIL_INVALID;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -30,12 +28,10 @@ import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.entity.EntityType;
 import com.hedera.mirror.web3.evm.store.Store;
 import com.hedera.mirror.web3.evm.store.Store.OnMissing;
-import com.hedera.mirror.web3.exception.InvalidTransactionException;
 import com.hedera.node.app.service.evm.utils.EthSigsUtils;
 import com.hedera.services.jproto.JKey;
 import com.hedera.services.store.models.Account;
 import com.hedera.services.store.models.Id;
-import com.hedera.services.store.models.Token;
 import com.hederahashgraph.api.proto.java.Key;
 import org.apache.commons.codec.DecoderException;
 import org.apache.tuweni.bytes.Bytes;
@@ -63,9 +59,6 @@ class MirrorEvmContractAliasesTest {
 
     @Mock
     private Store store;
-
-    @Mock
-    private Token token;
 
     @Mock
     private Account account;
@@ -105,41 +98,11 @@ class MirrorEvmContractAliasesTest {
     }
 
     @Test
-    void resolveForEvmWhenAliasIsPresentAndIsPendingRemovalShouldReturnEntityEvmAddress() {
-        mirrorEvmContractAliases.aliases.put(ALIAS, ADDRESS);
-        mirrorEvmContractAliases.pendingRemovals.add(ALIAS);
-
-        when(store.getToken(ALIAS, OnMissing.DONT_THROW)).thenReturn(token);
-        when(token.getId()).thenReturn(id);
-
-        assertThat(mirrorEvmContractAliases.resolveForEvm(ALIAS)).isEqualTo(Bytes.wrap(toEvmAddress(entityId)));
-    }
-
-    @Test
     void resolveForEvmForAccountWhenAliasesNotPresentShouldReturnEntityEvmAddress() {
-        when(store.getToken(ALIAS, OnMissing.DONT_THROW)).thenReturn(Token.getEmptyToken());
-        when(store.getAccount(ALIAS, OnMissing.THROW)).thenReturn(account);
-        when(account.getAccountAddress()).thenReturn(Address.wrap(Bytes.wrap(toEvmAddress(entityId))));
+        when(store.getAccount(ALIAS, OnMissing.DONT_THROW)).thenReturn(account);
+        when(account.getId()).thenReturn(id);
 
         assertThat(mirrorEvmContractAliases.resolveForEvm(ALIAS)).isEqualTo(Bytes.wrap(toEvmAddress(entityId)));
-    }
-
-    @Test
-    void resolveForEvmForTokenWhenAliasesNotPresentShouldReturnEntityEvmAddress() {
-        when(store.getToken(ALIAS, OnMissing.DONT_THROW)).thenReturn(token);
-        when(token.getId()).thenReturn(id);
-
-        assertThat(mirrorEvmContractAliases.resolveForEvm(ALIAS)).isEqualTo(Bytes.wrap(toEvmAddress(entityId)));
-    }
-
-    @Test
-    void resolveForEvmWhenInvalidAddressShouldFail() {
-        when(store.getToken(ALIAS, OnMissing.DONT_THROW)).thenReturn(Token.getEmptyToken());
-        when(store.getAccount(ALIAS, OnMissing.THROW))
-                .thenThrow(new InvalidTransactionException(FAIL_INVALID, "Entity is missing", ""));
-
-        assertThatThrownBy(() -> mirrorEvmContractAliases.resolveForEvm(ALIAS))
-                .isInstanceOf(InvalidTransactionException.class);
     }
 
     @Test

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/StoreImplTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/StoreImplTest.java
@@ -29,6 +29,7 @@ import com.hedera.mirror.common.domain.token.AbstractNft;
 import com.hedera.mirror.common.domain.token.Nft;
 import com.hedera.mirror.common.domain.token.Token;
 import com.hedera.mirror.common.domain.token.TokenAccount;
+import com.hedera.mirror.web3.evm.account.MirrorEvmContractAliases;
 import com.hedera.mirror.web3.evm.store.Store.OnMissing;
 import com.hedera.mirror.web3.evm.store.accessor.AccountDatabaseAccessor;
 import com.hedera.mirror.web3.evm.store.accessor.CustomFeeDatabaseAccessor;
@@ -111,6 +112,9 @@ class StoreImplTest {
 
     @Mock
     private CustomFeeDatabaseAccessor customFeeDatabaseAccessor;
+
+    @Mock
+    private MirrorEvmContractAliases mirrorEvmContractAliases;
 
     @Mock
     private NftRepository nftRepository;

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/EntityAddressSequencerTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/EntityAddressSequencerTest.java
@@ -30,9 +30,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class EntityAddressSequencerTest {
     private static final long contractNum = 1_000_000_000L;
-    private static final long shardNum = 1L;
-    private static final long realmNum = 2L;
-    private static final Address sponsor = new Id(shardNum, realmNum, contractNum).asEvmAddress();
+    private static final Address sponsor = new Id(0, 0, contractNum).asEvmAddress();
 
     @InjectMocks
     private EntityAddressSequencer entityAddressSequencer;
@@ -40,8 +38,8 @@ class EntityAddressSequencerTest {
     @Test
     void getNewContractId() {
         assertThat(entityAddressSequencer.getNewContractId(sponsor))
-                .returns(shardNum, ContractID::getShardNum)
-                .returns(realmNum, ContractID::getRealmNum)
+                .returns(0L, ContractID::getShardNum)
+                .returns(0L, ContractID::getRealmNum)
                 .returns(contractNum, ContractID::getContractNum);
     }
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/HederaEvmStackedWorldStateUpdaterTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/HederaEvmStackedWorldStateUpdaterTest.java
@@ -232,8 +232,6 @@ class HederaEvmStackedWorldStateUpdaterTest {
         assertNotNull(lazyAccount);
         assertEquals(Wei.ZERO, lazyAccount.getBalance());
         assertFalse(subject.getDeletedAccounts().contains(Address.ALTBN128_MUL));
-        final var accountFromTopFrame = store.getAccount(Address.ALTBN128_MUL, OnMissing.DONT_THROW);
-        assertThat(accountFromTopFrame.getAccountAddress()).isEqualTo(Address.ALTBN128_MUL);
     }
 
     @Test

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/HederaEvmWorldStateTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/HederaEvmWorldStateTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import com.google.protobuf.ByteString;
 import com.hedera.mirror.web3.evm.account.MirrorEvmContractAliases;
 import com.hedera.mirror.web3.evm.store.Store;
 import com.hedera.mirror.web3.evm.store.Store.OnMissing;
@@ -192,6 +193,7 @@ class HederaEvmWorldStateTest {
         final var actualSubject = subject.updater();
 
         final var accountModel = new com.hedera.services.store.models.Account(
+                ByteString.EMPTY,
                 0L,
                 Id.fromGrpcAccount(accountIdFromEvmAddress(address.toArrayUnsafe())),
                 0L,

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/precompile/MirrorHTSPrecompiledContractTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/precompile/MirrorHTSPrecompiledContractTest.java
@@ -26,6 +26,7 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 
 import com.esaulpaugh.headlong.util.Integers;
+import com.hedera.mirror.web3.evm.account.MirrorEvmContractAliases;
 import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
 import com.hedera.mirror.web3.evm.store.Store;
 import com.hedera.mirror.web3.evm.store.StoreImpl;
@@ -93,6 +94,9 @@ class MirrorHTSPrecompiledContractTest {
 
     @Mock
     private HederaEvmWorldStateTokenAccount account;
+
+    @Mock
+    private MirrorEvmContractAliases mirrorEvmContractAliases;
 
     private MirrorHTSPrecompiledContract subject;
     private Deque<MessageFrame> messageFrameStack;

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/token/TokenAccessorImplTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/token/TokenAccessorImplTest.java
@@ -39,6 +39,7 @@ import com.hedera.mirror.common.domain.token.TokenSupplyTypeEnum;
 import com.hedera.mirror.common.domain.token.TokenTypeEnum;
 import com.hedera.mirror.common.domain.transaction.CustomFee;
 import com.hedera.mirror.common.util.DomainUtils;
+import com.hedera.mirror.web3.evm.account.MirrorEvmContractAliases;
 import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
 import com.hedera.mirror.web3.evm.store.Store;
 import com.hedera.mirror.web3.evm.store.StoreImpl;
@@ -73,14 +74,16 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class TokenAccessorImplTest {
 
-    private final long serialNo = 0L;
     private static final String HEX_TOKEN = "0x00000000000000000000000000000000000004e4";
     private static final String HEX_ACCOUNT = "0x00000000000000000000000000000000000004e5";
     private static final Address TOKEN = Address.fromHexString(HEX_TOKEN);
-    private static final Address ACCOUNT = Address.fromHexString(HEX_ACCOUNT);
     private static final EntityId ENTITY = DomainUtils.fromEvmAddress(TOKEN.toArrayUnsafe());
     private static final Long ENTITY_ID =
             EntityIdEndec.encode(ENTITY.getShardNum(), ENTITY.getRealmNum(), ENTITY.getEntityNum());
+    private static final Address ACCOUNT = Address.fromHexString(HEX_ACCOUNT);
+    private final long serialNo = 0L;
+    private final DomainBuilder domainBuilder = new DomainBuilder();
+    public TokenAccessorImpl tokenAccessor;
 
     @Mock
     private EntityRepository entityRepository;
@@ -106,6 +109,9 @@ class TokenAccessorImplTest {
     @Mock
     private NftAllowanceRepository nftAllowanceRepository;
 
+    @Mock
+    private MirrorEvmContractAliases mirrorEvmContractAliases;
+
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private MirrorNodeEvmProperties properties;
 
@@ -116,11 +122,7 @@ class TokenAccessorImplTest {
     private Token token;
 
     private List<DatabaseAccessor<Object, ?>> accessors;
-
     private Store store;
-    private final DomainBuilder domainBuilder = new DomainBuilder();
-
-    public TokenAccessorImpl tokenAccessor;
 
     @BeforeEach
     void setUp() {
@@ -144,7 +146,7 @@ class TokenAccessorImplTest {
                         tokenDatabaseAccessor, accountDatabaseAccessor, tokenAccountRepository),
                 new UniqueTokenDatabaseAccessor(nftRepository));
         store = new StoreImpl(accessors);
-        tokenAccessor = new TokenAccessorImpl(properties, store);
+        tokenAccessor = new TokenAccessorImpl(properties, store, mirrorEvmContractAliases);
     }
 
     @Test

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileTest.java
@@ -113,7 +113,7 @@ class ContractCallServicePrecompileTest extends ContractCallTestSetup {
                 assertThat((boolean) fixedFee[0].get(2)).isFalse();
                 assertThat((boolean) fixedFee[0].get(3)).isFalse();
                 assertThat((com.esaulpaugh.headlong.abi.Address) fixedFee[0].get(4))
-                        .isEqualTo(convertAddress(SENDER_ADDRESS));
+                        .isEqualTo(convertAddress(SENDER_ALIAS));
             }
             case FRACTIONAL_FEE -> {
                 assertThat((long) fractionalFee[0].get(0)).isEqualTo(100L);
@@ -122,7 +122,7 @@ class ContractCallServicePrecompileTest extends ContractCallTestSetup {
                 assertThat((long) fractionalFee[0].get(3)).isEqualTo(1000L);
                 assertThat((boolean) fractionalFee[0].get(4)).isTrue();
                 assertThat((com.esaulpaugh.headlong.abi.Address) fractionalFee[0].get(5))
-                        .isEqualTo(convertAddress(SENDER_ADDRESS));
+                        .isEqualTo(convertAddress(SENDER_ALIAS));
             }
             case ROYALTY_FEE -> {
                 assertThat((long) royaltyFee[0].get(0)).isEqualTo(20L);
@@ -132,7 +132,7 @@ class ContractCallServicePrecompileTest extends ContractCallTestSetup {
                         .isEqualTo(convertAddress(FUNGIBLE_TOKEN_ADDRESS));
                 assertThat((boolean) royaltyFee[0].get(4)).isFalse();
                 assertThat((com.esaulpaugh.headlong.abi.Address) royaltyFee[0].get(5))
-                        .isEqualTo(convertAddress(SENDER_ADDRESS));
+                        .isEqualTo(convertAddress(SENDER_ALIAS));
             }
         }
     }
@@ -242,7 +242,7 @@ class ContractCallServicePrecompileTest extends ContractCallTestSetup {
     enum ContractReadFunctions {
         IS_FROZEN("isTokenFrozen", new Address[] {FUNGIBLE_TOKEN_ADDRESS, SENDER_ADDRESS}, new Boolean[] {true}),
         IS_FROZEN_ETH_ADDRESS(
-                "isTokenFrozen", new Address[] {FUNGIBLE_TOKEN_ADDRESS, ETH_ADDRESS}, new Boolean[] {true}),
+                "isTokenFrozen", new Address[] {FUNGIBLE_TOKEN_ADDRESS, SENDER_ALIAS}, new Boolean[] {true}),
         IS_KYC("isKycGranted", new Address[] {FUNGIBLE_TOKEN_ADDRESS, SENDER_ADDRESS}, new Boolean[] {true}),
         IS_KYC_FOR_NFT("isKycGranted", new Address[] {NFT_ADDRESS, SENDER_ADDRESS}, new Boolean[] {true}),
         IS_TOKEN_PRECOMPILE("isTokenAddress", new Address[] {FUNGIBLE_TOKEN_ADDRESS}, new Boolean[] {true}),
@@ -332,7 +332,7 @@ class ContractCallServicePrecompileTest extends ContractCallTestSetup {
                 "dissociateTokensExternal", new Object[] {SPENDER_ADDRESS, new Address[] {TREASURY_TOKEN_ADDRESS}}),
         BURN_TOKEN("burnTokenExternal", new Object[] {NOT_FROZEN_FUNGIBLE_TOKEN_ADDRESS, 1L, new long[0]}),
         BURN_NFT_TOKEN("burnTokenExternal", new Object[] {NFT_ADDRESS, 0L, new long[] {1}}),
-        WIPE_TOKEN("wipeTokenAccountExternal", new Object[] {NOT_FROZEN_FUNGIBLE_TOKEN_ADDRESS, ETH_ADDRESS, 1L}),
+        WIPE_TOKEN("wipeTokenAccountExternal", new Object[] {NOT_FROZEN_FUNGIBLE_TOKEN_ADDRESS, SENDER_ALIAS, 1L}),
         WIPE_NFT_TOKEN(
                 "wipeTokenAccountNFTExternal",
                 new Object[] {NFT_ADDRESS_WITH_DIFFERENT_OWNER_AND_TREASURY, SENDER_ADDRESS, new long[] {1}}),

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
@@ -140,7 +140,8 @@ class ContractCallServiceTest extends ContractCallTestSetup {
         final var gasUsedBeforeExecution = getGasUsedBeforeExecution(ETH_CALL);
 
         // getAccountBalance(address)
-        final var balanceCall = "0x93423e9c00000000000000000000000000000000000000000000000000000000000002e6";
+        // Use alias address when applicable as EVM checks alias with highest priority
+        final var balanceCall = "0x93423e9c000000000000000000000000" + SENDER_ALIAS.toUnprefixedHexString();
         final var expectedBalance = "0x0000000000000000000000000000000000000000000000000000000000004e20";
         final var serviceParameters = serviceParametersForExecution(
                 Bytes.fromHexString(balanceCall), ETH_CALL_CONTRACT_ADDRESS, ETH_CALL, 0L);

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallTestSetup.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallTestSetup.java
@@ -23,6 +23,7 @@ import static com.hedera.mirror.common.util.DomainUtils.fromEvmAddress;
 import static com.hedera.mirror.common.util.DomainUtils.toEvmAddress;
 import static com.hedera.mirror.web3.evm.utils.EvmTokenUtils.toAddress;
 import static com.hedera.mirror.web3.service.model.CallServiceParameters.CallType.ETH_ESTIMATE_GAS;
+import static com.hedera.node.app.service.evm.utils.EthSigsUtils.recoverAddressFromPubKey;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.ContractCall;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.TokenAccountWipe;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.TokenAssociateToAccount;
@@ -30,6 +31,7 @@ import static com.hederahashgraph.api.proto.java.HederaFunctionality.TokenBurn;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.TokenMint;
 
 import com.google.common.collect.Range;
+import com.google.protobuf.ByteString;
 import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.entity.EntityType;
 import com.hedera.mirror.common.domain.token.TokenFreezeStatusEnum;
@@ -59,6 +61,7 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.function.ToLongFunction;
 import org.apache.tuweni.bytes.Bytes;
+import org.bouncycastle.util.encoders.Hex;
 import org.hyperledger.besu.datatypes.Address;
 import org.jetbrains.annotations.Nullable;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -83,8 +86,16 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
     protected static final EntityId EXCHANGE_RATE_ENTITY_ID = new EntityId(0L, 0L, 112L, EntityType.FILE);
     protected static final Address CONTRACT_ADDRESS = toAddress(EntityId.of(0, 0, 1256, CONTRACT));
     protected static final Address SENDER_ADDRESS = toAddress(EntityId.of(0, 0, 742, ACCOUNT));
+    protected static final ByteString SENDER_PUBLIC_KEY =
+            ByteString.copyFrom(Hex.decode("3a2103af80b90d25145da28c583359beb47b21796b2fe1a23c1511e443e7a64dfdb27d"));
+    protected static final Address SENDER_ALIAS = Address.wrap(
+            Bytes.wrap(recoverAddressFromPubKey(SENDER_PUBLIC_KEY.substring(2).toByteArray())));
     protected static final Address OWNER_ADDRESS = toAddress(EntityId.of(0, 0, 750, ACCOUNT));
     protected static final Address SPENDER_ADDRESS = toAddress(EntityId.of(0, 0, 741, ACCOUNT));
+    protected static final ByteString SPENDER_PUBLIC_KEY =
+            ByteString.fromHex("3a2102ff806fecbd31b4c377293cba8d2b78725965a4990e0ff1b1b29a1d2c61402310");
+    protected static final Address SPENDER_ALIAS = Address.wrap(
+            Bytes.wrap(recoverAddressFromPubKey(SPENDER_PUBLIC_KEY.substring(2).toByteArray())));
     protected static final Address TREASURY_ADDRESS = toAddress(EntityId.of(0, 0, 743, ACCOUNT));
     protected static final Address FUNGIBLE_TOKEN_ADDRESS = toAddress(EntityId.of(0, 0, 1046, TOKEN));
     protected static final Address NOT_FROZEN_FUNGIBLE_TOKEN_ADDRESS = toAddress(EntityId.of(0, 0, 1048, TOKEN));
@@ -297,6 +308,7 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
         tokenAccountPersist(ethAccount, notFrozenFungibleTokenEntityId, TokenFreezeStatusEnum.UNFROZEN);
         tokenAccountPersist(spenderEntityId, tokenTreasuryEntityId, TokenFreezeStatusEnum.UNFROZEN);
         tokenAccountPersist(ethAccount, tokenTreasuryEntityId, TokenFreezeStatusEnum.UNFROZEN);
+        tokenAccountPersist(senderEntityId, notFrozenFungibleTokenEntityId, TokenFreezeStatusEnum.UNFROZEN);
         tokenAccountPersist(ownerEntityId, nftEntityId, TokenFreezeStatusEnum.UNFROZEN);
         tokenAccountPersist(senderEntityId, nftEntityId, TokenFreezeStatusEnum.UNFROZEN);
         tokenAccountPersist(ownerEntityId, nftEntityId2, TokenFreezeStatusEnum.UNFROZEN);
@@ -417,7 +429,8 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
                 .entity()
                 .customize(e -> e.id(spenderEntityId.getId())
                         .num(spenderEntityId.getEntityNum())
-                        .evmAddress(spenderEvmAddress))
+                        .evmAddress(SPENDER_ALIAS.toArray())
+                        .alias(SPENDER_PUBLIC_KEY.toByteArray()))
                 .persist();
         return spenderEntityId;
     }
@@ -429,7 +442,8 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
                 .entity()
                 .customize(e -> e.id(ethAccount)
                         .num(ethAccount)
-                        .evmAddress(ETH_ADDRESS.toArrayUnsafe())
+                        .evmAddress(SPENDER_ALIAS.toArray())
+                        .alias(SPENDER_PUBLIC_KEY.toByteArray())
                         .balance(2000L))
                 .persist();
         return ethAccount;
@@ -443,8 +457,8 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
                 .entity()
                 .customize(e -> e.id(senderEntityId.getId())
                         .num(senderEntityId.getEntityNum())
-                        .evmAddress(null)
-                        .alias(toEvmAddress(senderEntityId))
+                        .evmAddress(SENDER_ALIAS.toArray())
+                        .alias(SENDER_PUBLIC_KEY.toByteArray())
                         .balance(20000L))
                 .persist();
         return senderEntityId;

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/impl/TransferPrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/impl/TransferPrecompileTest.java
@@ -55,6 +55,7 @@ import static org.mockito.Mockito.when;
 import com.esaulpaugh.headlong.util.Integers;
 import com.hedera.mirror.web3.evm.store.Store;
 import com.hedera.node.app.service.evm.accounts.HederaEvmContractAliases;
+import com.hedera.services.hapi.utils.ByteStringUtils;
 import com.hedera.services.store.contracts.precompile.FungibleTokenTransfer;
 import com.hedera.services.store.contracts.precompile.HbarTransfer;
 import com.hedera.services.store.contracts.precompile.NftExchange;
@@ -407,8 +408,8 @@ class TransferPrecompileTest {
         final var fungibleTransfers =
                 decodedInput.tokenTransferWrappers().get(0).fungibleTransfers();
 
-        final var nonLongZeroAlias =
-                wrapUnsafely(java.util.HexFormat.of().parseHex("0000000000000000001000000000000000000441"));
+        final var nonLongZeroAlias = ByteStringUtils.wrapUnsafely(
+                java.util.HexFormat.of().parseHex("0000000000000000001000000000000000000441"));
 
         assertEquals(2, fungibleTransfers.size());
         assertTrue(fungibleTransfers.get(0).getDenomination().getTokenNum() > 0);

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/models/AccountTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/models/AccountTest.java
@@ -17,7 +17,6 @@
 package com.hedera.services.store.models;
 
 import static com.swirlds.common.utility.CommonUtils.unhex;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.google.protobuf.ByteString;
@@ -42,6 +41,7 @@ class AccountTest {
     @BeforeEach
     void setUp() {
         subject = new Account(
+                ByteString.EMPTY,
                 0L,
                 subjectId,
                 defaultLongValue,
@@ -124,10 +124,5 @@ class AccountTest {
 
         // expect:
         assertEquals(desired, subject.toString());
-    }
-
-    @Test
-    void modificationBuilder() {
-        assertThat(subject.toBuilder().build()).isEqualTo(subject);
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/models/TokenRelationshipTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/models/TokenRelationshipTest.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.google.protobuf.ByteString;
 import com.hedera.node.app.service.evm.exceptions.InvalidTransactionException;
 import com.hedera.node.app.service.evm.store.tokens.TokenType;
 import com.hedera.services.jproto.JKey;
@@ -91,6 +92,7 @@ class TokenRelationshipTest {
                 Collections.emptyList());
 
         account = new Account(
+                ByteString.EMPTY,
                 0L,
                 accountId,
                 defaultLongValue,

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/models/TokenTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/models/TokenTest.java
@@ -54,6 +54,7 @@ class TokenTest {
     private final long defaultLongValue = 0;
     private final int defaultIntValue = 0;
     private Account treasuryAccount = new Account(
+            ByteString.EMPTY,
             0L,
             treasuryId,
             defaultLongValue,
@@ -73,6 +74,7 @@ class TokenTest {
             false,
             null);
     private Account nonTreasuryAccount = new Account(
+            ByteString.EMPTY,
             0L,
             nonTreasuryId,
             defaultLongValue,

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/txn/token/DissociateLogicTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/txn/token/DissociateLogicTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.protobuf.ByteString;
 import com.hedera.mirror.web3.evm.store.Store;
 import com.hedera.mirror.web3.evm.store.Store.OnMissing;
 import com.hedera.mirror.web3.evm.store.accessor.model.TokenRelationshipKey;
@@ -202,7 +203,25 @@ class DissociateLogicTest {
     @Test
     void verifyDecrementedAutoAssociations() {
         var newAccount = new Account(
-                0L, accountId, 9999999999L, 0L, false, 0L, 0L, null, 3, null, null, null, 3, 0, 0, 0, false, null);
+                ByteString.EMPTY,
+                0L,
+                accountId,
+                9999999999L,
+                0L,
+                false,
+                0L,
+                0L,
+                null,
+                3,
+                null,
+                null,
+                null,
+                3,
+                0,
+                0,
+                0,
+                false,
+                null);
         newAccount = newAccount.setAlreadyUsedAutomaticAssociations(3);
         spyAccount = spy(newAccount);
         tokenRelationship =
@@ -220,7 +239,25 @@ class DissociateLogicTest {
     @Test
     void verifyUpdagtedNumPositiveBalance() {
         var newAccount = new Account(
-                0L, accountId, 9999999999L, 0L, false, 0L, 0L, null, 3, null, null, null, 3, 3, 0, 0, false, null);
+                ByteString.EMPTY,
+                0L,
+                accountId,
+                9999999999L,
+                0L,
+                false,
+                0L,
+                0L,
+                null,
+                3,
+                null,
+                null,
+                null,
+                3,
+                3,
+                0,
+                0,
+                false,
+                null);
         newAccount = newAccount.setAlreadyUsedAutomaticAssociations(3);
         spyAccount = spy(newAccount);
         tokenRelationship =

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/txns/crypto/AutoCreationLogicTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/txns/crypto/AutoCreationLogicTest.java
@@ -69,6 +69,16 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class AutoCreationLogicTest {
 
+    public static final AccountID payer = asAccount("0.0.12345");
+    public static final TokenID token = asToken("0.0.23456");
+    private static final long initialTransfer = 16L;
+    private static final AccountID created = asAccount("0.0.1234");
+    private static final FeeObject fees = new FeeObject(1L, 2L, 3L);
+    private static final long totalFee = 6L;
+    private static final byte[] ECDSA_PUBLIC_KEY =
+            Hex.decode("3a21033a514176466fa815ed481ffad09110a2d344f6c9b78c1d14afc351c3a51be33d");
+    private final Timestamp at = Timestamp.newBuilder().setSeconds(1_234_567L).build();
+
     @Mock
     private EntityDatabaseAccessor entityDatabaseAccessor;
 
@@ -199,15 +209,4 @@ class AutoCreationLogicTest {
                         .build(),
                 payer);
     }
-
-    private static final long initialTransfer = 16L;
-    private final Timestamp at = Timestamp.newBuilder().setSeconds(1_234_567L).build();
-    private static final AccountID created = asAccount("0.0.1234");
-    public static final AccountID payer = asAccount("0.0.12345");
-    private static final FeeObject fees = new FeeObject(1L, 2L, 3L);
-    private static final long totalFee = 6L;
-
-    public static final TokenID token = asToken("0.0.23456");
-    private static final byte[] ECDSA_PUBLIC_KEY =
-            Hex.decode("3a21033a514176466fa815ed481ffad09110a2d344f6c9b78c1d14afc351c3a51be33d");
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/utils/EntityIdUtilsTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/utils/EntityIdUtilsTest.java
@@ -18,6 +18,8 @@ package com.hedera.services.utils;
 
 import static com.hedera.services.utils.EntityIdUtils.asEvmAddress;
 import static com.hedera.services.utils.EntityIdUtils.contractIdFromEvmAddress;
+import static com.hedera.services.utils.EntityIdUtils.isOfEcdsaPublicAddressSize;
+import static com.hedera.services.utils.EntityIdUtils.isOfEvmAddressSize;
 import static com.hedera.services.utils.EntityIdUtils.parseAccount;
 import static com.hedera.services.utils.EntityIdUtils.tokenIdFromEvmAddress;
 import static com.hedera.services.utils.IdUtils.asAccount;
@@ -35,6 +37,7 @@ import com.hedera.services.store.models.Id;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ContractID;
 import com.hederahashgraph.api.proto.java.TokenID;
+import com.swirlds.common.utility.CommonUtils;
 import org.bouncycastle.util.encoders.Hex;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -44,6 +47,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class EntityIdUtilsTest {
+
+    public static final ByteString ECDSA_PUBLIC_KEY =
+            ByteString.fromHex("3a2103af80b90d25145da28c583359beb47b21796b2fe1a23c1511e443e7a64dfdb27d");
+    public static final ByteString ECDSA_WRONG_PUBLIC_KEY =
+            ByteString.fromHex("3a2103af80b90d145da28c583359beb47b217511e443e7a64dfdb27d");
+    public static final ByteString EVM_ADDRESS = ByteString.fromHex("ebb9a1be370150759408cd7af48e9eda2b8ead57");
+    public static final ByteString WRONG_EVM_ADDRESS = ByteString.fromHex("ebb9a1be3701cd7af48e9eda2b8ead57");
 
     @Test
     void asSolidityAddressBytesWorksProperly() {
@@ -55,7 +65,7 @@ class EntityIdUtilsTest {
 
         final var result = asEvmAddress(id);
 
-        final var expectedBytes = new byte[] {0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 3};
+        final var expectedBytes = new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3};
 
         assertArrayEquals(expectedBytes, result);
     }
@@ -70,7 +80,7 @@ class EntityIdUtilsTest {
 
         final var result = asEvmAddress(id);
 
-        final var expectedBytes = new byte[] {0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 3};
+        final var expectedBytes = new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3};
 
         assertArrayEquals(expectedBytes, result);
     }
@@ -110,9 +120,9 @@ class EntityIdUtilsTest {
         };
         final var num = Longs.fromByteArray(numBytes);
         final byte[] expected = {
-            (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0xAB,
-            (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0xCD,
-            (byte) 0xFE, (byte) 0x00, (byte) 0x00, (byte) 0xFE,
+            (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00,
+            (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00,
+            (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00,
             (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0xDE,
             (byte) 0xBA, (byte) 0x00, (byte) 0x00, (byte) 0xBA
         };
@@ -124,22 +134,22 @@ class EntityIdUtilsTest {
                 .setEvmAddress(ByteString.copyFrom(create2AddressBytes))
                 .build();
 
-        final var actual = asEvmAddress(shard, realm, num);
+        final var actual = asEvmAddress(num);
         final var typedActual = EntityIdUtils.asTypedEvmAddress(equivAccount);
         final var typedToken = EntityIdUtils.asTypedEvmAddress(equivToken);
-        final var typedContract = EntityIdUtils.asTypedEvmAddress(equivContract);
-        final var anotherActual = asEvmAddress(equivContract);
-        final var create2Actual = asEvmAddress(create2Contract);
+        final var anotherActual = EntityIdUtils.asEvmAddress(equivContract);
+        final var create2Actual = EntityIdUtils.asEvmAddress(create2Contract);
+        final var actualHex = EntityIdUtils.asHexedEvmAddress(equivAccount);
 
         assertArrayEquals(expected, actual);
         assertArrayEquals(expected, anotherActual);
         assertArrayEquals(expected, typedActual.toArray());
         assertArrayEquals(expected, typedToken.toArray());
-        assertArrayEquals(expected, typedContract.toArray());
         assertArrayEquals(create2AddressBytes, create2Actual);
-        assertEquals(equivAccount, EntityIdUtils.accountIdFromEvmAddress(actual));
-        assertEquals(equivContract, contractIdFromEvmAddress(actual));
-        assertEquals(equivToken, tokenIdFromEvmAddress(actual));
+        assertEquals(CommonUtils.hex(expected), actualHex);
+        assertEquals(asAccount(String.format("%d.%d.%d", 0, 0, num)), EntityIdUtils.accountIdFromEvmAddress(actual));
+        assertEquals(asContract(String.format("%d.%d.%d", 0, 0, num)), contractIdFromEvmAddress(actual));
+        assertEquals(asToken(String.format("%d.%d.%d", 0, 0, num)), tokenIdFromEvmAddress(actual));
     }
 
     @ParameterizedTest
@@ -179,5 +189,35 @@ class EntityIdUtilsTest {
     @Test
     void idFromEntityIdNullHandling() {
         assertThat(EntityIdUtils.idFromEntityId(null)).isNull();
+    }
+
+    @Test
+    void isOfEvmAddressSizeWorks() {
+        assertThat(isOfEvmAddressSize(EVM_ADDRESS)).isTrue();
+        assertThat(isOfEvmAddressSize(WRONG_EVM_ADDRESS)).isFalse();
+    }
+
+    @Test
+    void isOfEcdsaPublicAddressSizeWorks() {
+        assertThat(isOfEcdsaPublicAddressSize(ECDSA_PUBLIC_KEY)).isTrue();
+        assertThat(isOfEcdsaPublicAddressSize(ECDSA_WRONG_PUBLIC_KEY)).isFalse();
+    }
+
+    @Test
+    void asSolidityAddressHexWorksProperly() {
+        final var id = new Id(1, 2, 3);
+
+        assertEquals("0000000000000000000000000000000000000003", EntityIdUtils.asHexedEvmAddress(id));
+    }
+
+    @Test
+    void asSolidityAddressHexWorksProperlyForAccount() {
+        final var accountId = AccountID.newBuilder()
+                .setShardNum(1)
+                .setRealmNum(2)
+                .setAccountNum(3)
+                .build();
+
+        assertEquals("0000000000000000000000000000000000000003", EntityIdUtils.asHexedEvmAddress(accountId));
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/utils/EntityNumTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/utils/EntityNumTest.java
@@ -84,6 +84,6 @@ class EntityNumTest {
         assertEquals(MISSING_NUM, EntityNum.fromAccountId(IdUtils.asAccount("1.0.123")));
         assertEquals(
                 new EntityNum(123),
-                EntityNum.fromEvmAddress(Address.wrap(Bytes.wrap(EntityIdUtils.asEvmAddress(0, 0, 123)))));
+                EntityNum.fromEvmAddress(Address.wrap(Bytes.wrap(EntityIdUtils.asEvmAddress(123)))));
     }
 }


### PR DESCRIPTION
**Description**:

Currently when we try to invoke accounts with alias addresses from the in-memory store we don't find them, since we persist them using their long-zero form. This PR fixes the issue and now we first resolve the alias to a long-zero address and then we try to find it from the in-memory store. This issue is present since 0.84.0 release of mirror-node.

Additionally this PR aligns encoding to long zero addresses to use only num values and ignore shard and realm, as is the current logic in hedera-services.

Removed persisting of account from trackLazilyCreatedAccount since we already persisted it in AutoCreationLogic.

(cherry picked from commit 05a09b458744caad066e7e007d3e5140ef11d283)

**Related issue(s)**:

Fixes #6541

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
