### PR TITLE
Update testnet bucket name for 2023-07 reset

### DIFF
--- a/docs/database/README.md
+++ b/docs/database/README.md
@@ -37,7 +37,7 @@ nodes connected to those environments will need to be reset to remain functional
    a new bucket, the importer start date can be set to 1970 to ensure no data is missed.
 
    ```properties
-   hedera.mirror.importer.downloader.bucketName=hedera-testnet-streams-2023-01
+   hedera.mirror.importer.downloader.bucketName=hedera-testnet-streams-2023-07
    hedera.mirror.importer.startDate=1970-01-01T00:00:00Z
    ```
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/MirrorProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/MirrorProperties.java
@@ -97,7 +97,7 @@ public class MirrorProperties {
                 MAINNET, "hedera-mainnet-streams",
                 // OTHER has no default bucket
                 PREVIEWNET, "hedera-preview-testnet-streams",
-                TESTNET, "hedera-testnet-streams-2023-01");
+                TESTNET, "hedera-testnet-streams-2023-07");
 
         private HederaNetwork() {}
 

--- a/hedera-mirror-rest/constants.js
+++ b/hedera-mirror-rest/constants.js
@@ -153,7 +153,7 @@ const networks = {
 const defaultBucketNames = {
   [networks.DEMO]: 'hedera-demo-streams',
   [networks.MAINNET]: 'hedera-mainnet-streams',
-  [networks.TESTNET]: 'hedera-testnet-streams-2023-01',
+  [networks.TESTNET]: 'hedera-testnet-streams-2023-07',
   [networks.PREVIEWNET]: 'hedera-preview-testnet-streams',
   [networks.OTHER]: null,
 };


### PR DESCRIPTION
**Description**:

Update testnet bucket name for 2023-07 reset

**Related issue(s)**:

Fixes #6496

**Notes for reviewer**:

Will also cherry-pick to `release/0.85`.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
