### PR TITLE
Fix slow entity stake history migration

### DIFF
--- a/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.83.0.1__entity_stake_history.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.83.0.1__entity_stake_history.sql
@@ -31,8 +31,7 @@ alter table if exists entity_stake
 
 update entity_stake
 set timestamp_range =
-  int8range((select consensus_timestamp from node_stake where epoch_day = end_stake_period limit 1), null)
-from node_stake;
+  int8range((select consensus_timestamp from node_stake where epoch_day = end_stake_period limit 1), null);
 
 alter table if exists entity_stake
   alter column timestamp_range set not null;


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR fixes the slow entity stake history migration.

**Related issue(s)**:

Fixes #6501 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
The problem is the extra `from node_stake` in the update statement, that makes the statement to update 3m * 9k (the number of rows in table `node_stake`) rows instead of just 3m rows.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
