### PR TITLE
Fix getNodes API attempting to update stake

### DIFF
--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/config/GrpcConfiguration.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/config/GrpcConfiguration.java
@@ -25,13 +25,30 @@ import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import net.devh.boot.grpc.server.serverfactory.GrpcServerConfigurer;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionOperations;
+import org.springframework.transaction.support.TransactionTemplate;
 
 @Configuration
 @EntityScan({"com.hedera.mirror.common.domain"})
 class GrpcConfiguration {
+
+    @Bean
+    @Qualifier("readOnly")
+    TransactionOperations transactionOperationsReadOnly(PlatformTransactionManager transactionManager) {
+        var transactionTemplate = new TransactionTemplate(transactionManager);
+        transactionTemplate.setReadOnly(true);
+        return transactionTemplate;
+    }
+
+    @Bean
+    TransactionOperations transactionOperations(PlatformTransactionManager transactionManager) {
+        return new TransactionTemplate(transactionManager);
+    }
 
     @Bean
     GrpcServerConfigurer grpcServerConfigurer(GrpcProperties grpcProperties) {

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/service/NetworkServiceImpl.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/service/NetworkServiceImpl.java
@@ -35,6 +35,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import lombok.RequiredArgsConstructor;
 import lombok.Value;
 import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.transaction.support.TransactionOperations;
 import org.springframework.validation.annotation.Validated;
 import reactor.core.publisher.Flux;
@@ -57,6 +58,8 @@ public class NetworkServiceImpl implements NetworkService {
     private final AddressBookRepository addressBookRepository;
     private final AddressBookEntryRepository addressBookEntryRepository;
     private final NodeStakeRepository nodeStakeRepository;
+
+    @Qualifier("readOnly")
     private final TransactionOperations transactionOperations;
 
     @Override

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/service/NetworkServiceTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/service/NetworkServiceTest.java
@@ -214,6 +214,9 @@ class NetworkServiceTest extends GrpcIntegrationTest {
 
         var filter = AddressBookFilter.builder().fileId(addressBook.getFileId()).build();
         assertThat(getNodes(filter)).containsExactly(addressBookEntry1, addressBookEntry2, addressBookEntry3);
+        assertThat(addressBookEntryRepository.findAll())
+                .extracting(AddressBookEntry::getStake)
+                .doesNotContain(nodeStakeTableStake);
     }
 
     @Test


### PR DESCRIPTION
**Description**:

Fix getNodes API triggering an update statement due to changing a Hibernate managed bean within a transaction.

**Related issue(s)**:

Fixes #6525

**Notes for reviewer**:

Need to cherry pick to 0.85 and 0.84.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
