### PR TITLE
Suppress protobufjs false positive

### DIFF
--- a/buildSrc/src/main/resources/suppressions.xml
+++ b/buildSrc/src/main/resources/suppressions.xml
@@ -20,12 +20,7 @@
         <cpe>cpe:/a:grpc:grpc</cpe>
     </suppress>
     <suppress>
-        <notes>Issue is in spring-web and will only be fixed by Spring in their next major release.</notes>
-        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-web@.*$</packageUrl>
-        <cve>CVE-2016-1000027</cve>
-    </suppress>
-    <suppress>
-        <notes>No snakeyaml release available with a fix yet</notes>
-        <cve>CVE-2022-1471</cve>
+      <notes>Upgraded to protobufjs 7.2.4 with the fix, but it's still erroneously marked as vulnerable.</notes>
+      <cve>CVE-2023-36665</cve>
     </suppress>
 </suppressions>


### PR DESCRIPTION
**Description**:

Suppress `protobuf.js` false positive since we upgraded to the version in the CVE that has the fix but dependency check plugin still marks it as vulnerable.

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
