### PR TITLE
HIP-584: Add integration tests for read-only precompiles

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/services/jproto/JDelegatableContractIDKey.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/jproto/JDelegatableContractIDKey.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.jproto;
+
+import com.hederahashgraph.api.proto.java.ContractID;
+
+/** Maps to proto Key of type contractID. */
+public class JDelegatableContractIDKey extends JContractIDKey {
+    public JDelegatableContractIDKey(final ContractID contractID) {
+        super(contractID);
+    }
+
+    @Override
+    public JDelegatableContractIDKey getDelegatableContractIdKey() {
+        return this;
+    }
+
+    @Override
+    public boolean hasDelegatableContractId() {
+        return true;
+    }
+
+    @Override
+    public boolean hasContractID() {
+        return false;
+    }
+
+    @Override
+    public JContractIDKey getContractIDKey() {
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return "<JDelegatableContractId: " + getShardNum() + "." + getRealmNum() + "." + getContractID() + ">";
+    }
+}

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/jproto/JKey.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/jproto/JKey.java
@@ -130,6 +130,10 @@ public abstract class JKey {
             rv = Key.newBuilder()
                     .setContractID(jkey.getContractIDKey().getContractID())
                     .build();
+        } else if (jkey.hasDelegatableContractId()) {
+            rv = Key.newBuilder()
+                    .setDelegatableContractId(jkey.getDelegatableContractIdKey().getContractID())
+                    .build();
         } else {
             throw new DecoderException("Key type not implemented: key=" + jkey);
         }
@@ -154,6 +158,8 @@ public abstract class JKey {
             rv = new JECDSASecp256k1Key(pubKeyBytes);
         } else if (key.getContractID().getContractNum() != 0) {
             rv = new JContractIDKey(key.getContractID());
+        } else if (key.getDelegatableContractId().getContractNum() != 0) {
+            rv = new JDelegatableContractIDKey(key.getDelegatableContractId());
         } else {
             throw new org.apache.commons.codec.DecoderException("Key type not implemented: key=" + key);
         }
@@ -200,6 +206,10 @@ public abstract class JKey {
         return false;
     }
 
+    public boolean hasDelegatableContractId() {
+        return false;
+    }
+
     public JKeyList getKeyList() {
         return null;
     }
@@ -213,6 +223,10 @@ public abstract class JKey {
     }
 
     public JContractIDKey getContractIDKey() {
+        return null;
+    }
+
+    public JDelegatableContractIDKey getDelegatableContractIdKey() {
         return null;
     }
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileTest.java
@@ -34,12 +34,16 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.EnumSource.Mode;
 
 class ContractCallServicePrecompileTest extends ContractCallTestSetup {
     private static final String ERROR_MESSAGE = "Precompile not supported for non-static frames";
 
     @ParameterizedTest
-    @EnumSource(ContractReadFunctions.class)
+    @EnumSource(
+            value = ContractReadFunctions.class,
+            mode = Mode.EXCLUDE,
+            names = {"GET_CUSTOM_FEES_FOR_TOKEN"})
     void evmPrecompileReadOnlyTokenFunctionsTestEthCall(ContractReadFunctions contractFunc) {
         final var functionHash =
                 functionEncodeDecoder.functionHashFor(contractFunc.name, ABI_PATH, contractFunc.functionParameters);
@@ -139,21 +143,6 @@ class ContractCallServicePrecompileTest extends ContractCallTestSetup {
                         .isEqualTo(convertAddress(SENDER_ALIAS));
             }
         }
-    }
-
-    @ParameterizedTest
-    @EnumSource(FeeCase.class)
-    void customFeesEthEstimateGas(FeeCase feeCase) {
-        final var functionName = "getCustomFeesForToken";
-        final var functionHash = functionEncodeDecoder.functionHashFor(functionName, ABI_PATH, FUNGIBLE_TOKEN_ADDRESS);
-        final var serviceParameters = serviceParametersForExecution(functionHash, CONTRACT_ADDRESS, ETH_ESTIMATE_GAS, 0L);
-
-        final var expectedGasUsed = gasUsedAfterExecution(serviceParameters);
-
-        assertThat(longValueOf.applyAsLong(contractCallService.processCall(serviceParameters)))
-                .as("result must be within 5-20% bigger than the gas used from the first call")
-                .isGreaterThanOrEqualTo((long) (expectedGasUsed * 1.05)) // expectedGasUsed value increased by 5%
-                .isCloseTo(expectedGasUsed, Percentage.withPercentage(20)); // Maximum percentage
     }
 
     @ParameterizedTest
@@ -274,27 +263,28 @@ class ContractCallServicePrecompileTest extends ContractCallTestSetup {
         GET_TOKEN_TYPE_FOR_NFT("getType", new Address[] {NFT_ADDRESS}, new Long[] {1L}),
         GET_TOKEN_DEFAULT_FREEZE("getTokenDefaultFreeze", new Address[] {FUNGIBLE_TOKEN_ADDRESS}, new Boolean[] {true}),
         GET_TOKEN_DEFAULT_FREEZE_FOR_NFT("getTokenDefaultFreeze", new Address[] {NFT_ADDRESS}, new Boolean[] {true}),
-        GET_TOKEN_ADMIN_KEY("getTokenKeyPublic", new Object[] {FUNGIBLE_TOKEN_ADDRESS, 1L}, new Object[] {
-            false, Address.ZERO, new byte[0], ECDSA_KEY, Address.ZERO
+        GET_TOKEN_ADMIN_KEY("getTokenKeyPublic", new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY, 1L}, new Object[] {
+            false, CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO
         }),
-        GET_TOKEN_FREEZE_KEY("getTokenKeyPublic", new Object[] {FUNGIBLE_TOKEN_ADDRESS, 4L}, new Object[] {
-            false, Address.ZERO, new byte[0], ECDSA_KEY, Address.ZERO
+        GET_TOKEN_FREEZE_KEY("getTokenKeyPublic", new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY, 4L}, new Object[] {
+            false, CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO
         }),
-        GET_TOKEN_WIPE_KEY("getTokenKeyPublic", new Object[] {FUNGIBLE_TOKEN_ADDRESS, 8L}, new Object[] {
-            false, Address.ZERO, new byte[0], ECDSA_KEY, Address.ZERO
+        GET_TOKEN_WIPE_KEY("getTokenKeyPublic", new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY, 8L}, new Object[] {
+            false, CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO
         }),
-        GET_TOKEN_SUPPLY_KEY("getTokenKeyPublic", new Object[] {FUNGIBLE_TOKEN_ADDRESS, 16L}, new Object[] {
-            false, Address.ZERO, new byte[0], ECDSA_KEY, Address.ZERO
+        GET_TOKEN_SUPPLY_KEY("getTokenKeyPublic", new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY, 16L}, new Object[] {
+            false, CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO
         }),
-        GET_TOKEN_KYC_KEY_FOR_NFT("getTokenKeyPublic", new Object[] {NFT_ADDRESS, 2L}, new Object[] {
-            false, Address.ZERO, new byte[0], ECDSA_KEY, Address.ZERO
+        GET_TOKEN_KYC_KEY_FOR_NFT("getTokenKeyPublic", new Object[] {NFT_ADDRESS_GET_KEY, 2L}, new Object[] {
+            false, CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO
         }),
-        GET_TOKEN_FEE_KEY_FOR_NFT("getTokenKeyPublic", new Object[] {NFT_ADDRESS, 32L}, new Object[] {
-            false, Address.ZERO, new byte[0], ECDSA_KEY, Address.ZERO
+        GET_TOKEN_FEE_KEY_FOR_NFT("getTokenKeyPublic", new Object[] {NFT_ADDRESS_GET_KEY, 32L}, new Object[] {
+            false, CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO
         }),
-        GET_TOKEN_PAUSE_KEY_FOR_NFT("getTokenKeyPublic", new Object[] {NFT_ADDRESS, 64L}, new Object[] {
-            false, Address.ZERO, new byte[0], ECDSA_KEY, Address.ZERO
-        });
+        GET_TOKEN_PAUSE_KEY_FOR_NFT("getTokenKeyPublic", new Object[] {NFT_ADDRESS_GET_KEY, 64L}, new Object[] {
+            false, CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO
+        }),
+        GET_CUSTOM_FEES_FOR_TOKEN("getCustomFeesForToken", new Object[] {FUNGIBLE_TOKEN_ADDRESS}, new Object[] {});
 
         private final String name;
         private final Object[] functionParameters;

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileTest.java
@@ -263,27 +263,118 @@ class ContractCallServicePrecompileTest extends ContractCallTestSetup {
         GET_TOKEN_TYPE_FOR_NFT("getType", new Address[] {NFT_ADDRESS}, new Long[] {1L}),
         GET_TOKEN_DEFAULT_FREEZE("getTokenDefaultFreeze", new Address[] {FUNGIBLE_TOKEN_ADDRESS}, new Boolean[] {true}),
         GET_TOKEN_DEFAULT_FREEZE_FOR_NFT("getTokenDefaultFreeze", new Address[] {NFT_ADDRESS}, new Boolean[] {true}),
-        GET_TOKEN_ADMIN_KEY("getTokenKeyPublic", new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY, 1L}, new Object[] {
-            false, CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO
-        }),
-        GET_TOKEN_FREEZE_KEY("getTokenKeyPublic", new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY, 4L}, new Object[] {
-            false, CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO
-        }),
-        GET_TOKEN_WIPE_KEY("getTokenKeyPublic", new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY, 8L}, new Object[] {
-            false, CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO
-        }),
-        GET_TOKEN_SUPPLY_KEY("getTokenKeyPublic", new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY, 16L}, new Object[] {
-            false, CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO
-        }),
-        GET_TOKEN_KYC_KEY_FOR_NFT("getTokenKeyPublic", new Object[] {NFT_ADDRESS_GET_KEY, 2L}, new Object[] {
-            false, CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO
-        }),
-        GET_TOKEN_FEE_KEY_FOR_NFT("getTokenKeyPublic", new Object[] {NFT_ADDRESS_GET_KEY, 32L}, new Object[] {
-            false, CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO
-        }),
-        GET_TOKEN_PAUSE_KEY_FOR_NFT("getTokenKeyPublic", new Object[] {NFT_ADDRESS_GET_KEY, 64L}, new Object[] {
-            false, CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO
-        }),
+        GET_TOKEN_ADMIN_KEY_WITH_CONTRACT_ADDRESS(
+                "getTokenKeyPublic",
+                new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_CONTRACT_ADDRESS, 1L},
+                new Object[] {false, CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
+        GET_TOKEN_FREEZE_KEY_WITH_CONTRACT_ADDRESS(
+                "getTokenKeyPublic",
+                new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_CONTRACT_ADDRESS, 4L},
+                new Object[] {false, CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
+        GET_TOKEN_WIPE_KEY_WITH_CONTRACT_ADDRESS(
+                "getTokenKeyPublic",
+                new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_CONTRACT_ADDRESS, 8L},
+                new Object[] {false, CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
+        GET_TOKEN_SUPPLY_KEY_WITH_CONTRACT_ADDRESS(
+                "getTokenKeyPublic",
+                new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_CONTRACT_ADDRESS, 16L},
+                new Object[] {false, CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
+        GET_TOKEN_ADMIN_KEY_WITH_ED25519_KEY(
+                "getTokenKeyPublic",
+                new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_ED25519_KEY, 1L},
+                new Object[] {false, Address.ZERO, ED25519_KEY, new byte[0], Address.ZERO}),
+        GET_TOKEN_FREEZE_KEY_WITH_ED25519_KEY(
+                "getTokenKeyPublic",
+                new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_ED25519_KEY, 4L},
+                new Object[] {false, Address.ZERO, ED25519_KEY, new byte[0], Address.ZERO}),
+        GET_TOKEN_WIPE_KEY_WITH_ED25519_KEY(
+                "getTokenKeyPublic",
+                new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_ED25519_KEY, 8L},
+                new Object[] {false, Address.ZERO, ED25519_KEY, new byte[0], Address.ZERO}),
+        GET_TOKEN_SUPPLY_KEY_WITH_ED25519_KEY(
+                "getTokenKeyPublic",
+                new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_ED25519_KEY, 16L},
+                new Object[] {false, Address.ZERO, ED25519_KEY, new byte[0], Address.ZERO}),
+        GET_TOKEN_ADMIN_KEY_WITH_ECDSA_KEY(
+                "getTokenKeyPublic",
+                new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_ECDSA_KEY, 1L},
+                new Object[] {false, Address.ZERO, new byte[0], ECDSA_KEY, Address.ZERO}),
+        GET_TOKEN_FREEZE_KEY_WITH_ECDSA_KEY(
+                "getTokenKeyPublic",
+                new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_ECDSA_KEY, 4L},
+                new Object[] {false, Address.ZERO, new byte[0], ECDSA_KEY, Address.ZERO}),
+        GET_TOKEN_WIPE_KEY_WITH_ECDSA_KEY(
+                "getTokenKeyPublic",
+                new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_ECDSA_KEY, 8L},
+                new Object[] {false, Address.ZERO, new byte[0], ECDSA_KEY, Address.ZERO}),
+        GET_TOKEN_SUPPLY_KEY_WITH_ECDSA_KEY(
+                "getTokenKeyPublic",
+                new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_ECDSA_KEY, 16L},
+                new Object[] {false, Address.ZERO, new byte[0], ECDSA_KEY, Address.ZERO}),
+        GET_TOKEN_ADMIN_KEY_WITH_DELEGATABLE_CONTRACT_ID(
+                "getTokenKeyPublic",
+                new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_DELEGATABLE_CONTRACT_ID, 1L},
+                new Object[] {false, Address.ZERO, new byte[0], new byte[0], CONTRACT_ADDRESS}),
+        GET_TOKEN_FREEZE_KEY_WITH_DELEGATABLE_CONTRACT_ID(
+                "getTokenKeyPublic",
+                new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_DELEGATABLE_CONTRACT_ID, 4L},
+                new Object[] {false, Address.ZERO, new byte[0], new byte[0], CONTRACT_ADDRESS}),
+        GET_TOKEN_WIPE_KEY_WITH_DELEGATABLE_CONTRACT_ID(
+                "getTokenKeyPublic",
+                new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_DELEGATABLE_CONTRACT_ID, 8L},
+                new Object[] {false, Address.ZERO, new byte[0], new byte[0], CONTRACT_ADDRESS}),
+        GET_TOKEN_SUPPLY_KEY_WITH_DELEGATABLE_CONTRACT_ID(
+                "getTokenKeyPublic",
+                new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_DELEGATABLE_CONTRACT_ID, 16L},
+                new Object[] {false, Address.ZERO, new byte[0], new byte[0], CONTRACT_ADDRESS}),
+        GET_TOKEN_KYC_KEY_FOR_NFT_WITH_CONTRACT_ADDRESS(
+                "getTokenKeyPublic",
+                new Object[] {NFT_ADDRESS_GET_KEY_WITH_CONTRACT_ADDRESS, 2L},
+                new Object[] {false, CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
+        GET_TOKEN_FEE_KEY_FOR_NFT_WITH_CONTRACT_ADDRESS(
+                "getTokenKeyPublic",
+                new Object[] {NFT_ADDRESS_GET_KEY_WITH_CONTRACT_ADDRESS, 32L},
+                new Object[] {false, CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
+        GET_TOKEN_PAUSE_KEY_FOR_NFT_WITH_CONTRACT_ADDRESS(
+                "getTokenKeyPublic",
+                new Object[] {NFT_ADDRESS_GET_KEY_WITH_CONTRACT_ADDRESS, 64L},
+                new Object[] {false, CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
+        GET_TOKEN_KYC_KEY_FOR_NFT_WITH_ED25519_KEY(
+                "getTokenKeyPublic",
+                new Object[] {NFT_ADDRESS_GET_KEY_WITH_ED25519_KEY, 2L},
+                new Object[] {false, Address.ZERO, ED25519_KEY, new byte[0], Address.ZERO}),
+        GET_TOKEN_FEE_KEY_FOR_NFT_WITH_ED25519_KEY(
+                "getTokenKeyPublic",
+                new Object[] {NFT_ADDRESS_GET_KEY_WITH_ED25519_KEY, 32L},
+                new Object[] {false, Address.ZERO, ED25519_KEY, new byte[0], Address.ZERO}),
+        GET_TOKEN_PAUSE_KEY_FOR_NFT_WITH_ED25519_KEY(
+                "getTokenKeyPublic",
+                new Object[] {NFT_ADDRESS_GET_KEY_WITH_ED25519_KEY, 64L},
+                new Object[] {false, Address.ZERO, ED25519_KEY, new byte[0], Address.ZERO}),
+        GET_TOKEN_KYC_KEY_FOR_NFT_WITH_ECDSA_KEY(
+                "getTokenKeyPublic",
+                new Object[] {NFT_ADDRESS_GET_KEY_WITH_ECDSA_KEY, 2L},
+                new Object[] {false, Address.ZERO, new byte[0], ECDSA_KEY, Address.ZERO}),
+        GET_TOKEN_FEE_KEY_FOR_NFT_WITH_ECDSA_KEY(
+                "getTokenKeyPublic",
+                new Object[] {NFT_ADDRESS_GET_KEY_WITH_ECDSA_KEY, 32L},
+                new Object[] {false, Address.ZERO, new byte[0], ECDSA_KEY, Address.ZERO}),
+        GET_TOKEN_PAUSE_KEY_FOR_NFT_WITH_ECDSA_KEY(
+                "getTokenKeyPublic",
+                new Object[] {NFT_ADDRESS_GET_KEY_WITH_ECDSA_KEY, 64L},
+                new Object[] {false, Address.ZERO, new byte[0], ECDSA_KEY, Address.ZERO}),
+        GET_TOKEN_KYC_KEY_FOR_NFT_WITH_DELEGATABLE_CONTRACT_ID(
+                "getTokenKeyPublic",
+                new Object[] {NFT_ADDRESS_GET_KEY_WITH_DELEGATABLE_CONTRACT_ID, 2L},
+                new Object[] {false, Address.ZERO, new byte[0], new byte[0], CONTRACT_ADDRESS}),
+        GET_TOKEN_FEE_KEY_FOR_NFT_WITH_DELEGATABLE_CONTRACT_ID(
+                "getTokenKeyPublic",
+                new Object[] {NFT_ADDRESS_GET_KEY_WITH_DELEGATABLE_CONTRACT_ID, 32L},
+                new Object[] {false, Address.ZERO, new byte[0], new byte[0], CONTRACT_ADDRESS}),
+        GET_TOKEN_PAUSE_KEY_FOR_NFT_WITH_DELEGATABLE_CONTRACT_ID(
+                "getTokenKeyPublic",
+                new Object[] {NFT_ADDRESS_GET_KEY_WITH_DELEGATABLE_CONTRACT_ID, 64L},
+                new Object[] {false, Address.ZERO, new byte[0], new byte[0], CONTRACT_ADDRESS}),
         GET_CUSTOM_FEES_FOR_TOKEN("getCustomFeesForToken", new Object[] {FUNGIBLE_TOKEN_ADDRESS}, new Object[] {});
 
         private final String name;

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallTestSetup.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallTestSetup.java
@@ -115,7 +115,7 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
     protected static final Address FROZEN_FUNGIBLE_TOKEN_ADDRESS = toAddress(EntityId.of(0, 0, 1050, TOKEN));
     protected static final Address TREASURY_TOKEN_ADDRESS = toAddress(EntityId.of(0, 0, 1049, TOKEN));
     protected static final Address FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_CONTRACT_ADDRESS =
-            toAddress(EntityId.of(0, 0, 1052, TOKEN));
+            toAddress(EntityId.of(0, 0, 1060, TOKEN));
     protected static final Address FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_ED25519_KEY =
             toAddress(EntityId.of(0, 0, 1054, TOKEN));
     protected static final Address FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_ECDSA_KEY =

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallTestSetup.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallTestSetup.java
@@ -114,18 +114,31 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
     protected static final Address NOT_FROZEN_FUNGIBLE_TOKEN_ADDRESS = toAddress(EntityId.of(0, 0, 1048, TOKEN));
     protected static final Address FROZEN_FUNGIBLE_TOKEN_ADDRESS = toAddress(EntityId.of(0, 0, 1050, TOKEN));
     protected static final Address TREASURY_TOKEN_ADDRESS = toAddress(EntityId.of(0, 0, 1049, TOKEN));
-    protected static final Address FUNGIBLE_TOKEN_ADDRESS_GET_KEY = toAddress(EntityId.of(0, 0, 1052, TOKEN));
+    protected static final Address FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_CONTRACT_ADDRESS =
+            toAddress(EntityId.of(0, 0, 1052, TOKEN));
+    protected static final Address FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_ED25519_KEY =
+            toAddress(EntityId.of(0, 0, 1054, TOKEN));
+    protected static final Address FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_ECDSA_KEY =
+            toAddress(EntityId.of(0, 0, 1055, TOKEN));
+    protected static final Address FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_DELEGATABLE_CONTRACT_ID =
+            toAddress(EntityId.of(0, 0, 1056, TOKEN));
     protected static final Address NFT_ADDRESS = toAddress(EntityId.of(0, 0, 1047, TOKEN));
     protected static final Address NFT_ADDRESS_WITH_DIFFERENT_OWNER_AND_TREASURY =
             toAddress(EntityId.of(0, 0, 1067, TOKEN));
     protected static final Address NFT_TRANSFER_ADDRESS = toAddress(EntityId.of(0, 0, 1051, TOKEN));
-    protected static final Address NFT_ADDRESS_GET_KEY = toAddress(EntityId.of(0, 0, 1053, TOKEN));
+    protected static final Address NFT_ADDRESS_GET_KEY_WITH_CONTRACT_ADDRESS =
+            toAddress(EntityId.of(0, 0, 1053, TOKEN));
+    protected static final Address NFT_ADDRESS_GET_KEY_WITH_ED25519_KEY = toAddress(EntityId.of(0, 0, 1057, TOKEN));
+    protected static final Address NFT_ADDRESS_GET_KEY_WITH_ECDSA_KEY = toAddress(EntityId.of(0, 0, 1058, TOKEN));
+    protected static final Address NFT_ADDRESS_GET_KEY_WITH_DELEGATABLE_CONTRACT_ID =
+            toAddress(EntityId.of(0, 0, 1059, TOKEN));
     protected static final Address MODIFICATION_CONTRACT_ADDRESS = toAddress(EntityId.of(0, 0, 1257, CONTRACT));
     protected static final byte[] KEY_PROTO = new byte[] {
         58, 33, -52, -44, -10, 81, 99, 100, 6, -8, -94, -87, -112, 42, 42, 96, 75, -31, -5, 72, 13, -70, 101, -111, -1,
         77, -103, 47, -118, 107, -58, -85, -63, 55, -57
     };
     protected static final byte[] ECDSA_KEY = Arrays.copyOfRange(KEY_PROTO, 2, KEY_PROTO.length);
+    protected static final byte[] ED25519_KEY = Arrays.copyOfRange(KEY_PROTO, 2, KEY_PROTO.length);
     protected static final Address ETH_ADDRESS = Address.fromHexString("0x23f5e49569a835d7bf9aefd30e4f60cdd570f225");
     protected static final Address ETH_ADDRESS2 = Address.fromHexString("0x23f5e49569a835d7bf9aefd30e4f60cdd570f226");
     protected static final Address EMPTY_ADDRESS = Address.wrap(Bytes.wrap(new byte[20]));
@@ -236,8 +249,18 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
                                     .build())))
             .build();
 
-    protected static Key key = Key.newBuilder()
+    protected static Key keyWithContractId = Key.newBuilder()
             .setContractID(contractIdFromEvmAddress(CONTRACT_ADDRESS.toArrayUnsafe()))
+            .build();
+
+    protected static Key keyWithEd25519 =
+            Key.newBuilder().setEd25519(ByteString.copyFrom(ED25519_KEY)).build();
+
+    protected static Key keyWithECDSASecp256K1 =
+            Key.newBuilder().setECDSASecp256K1(ByteString.copyFrom(ECDSA_KEY)).build();
+
+    protected static Key keyWithDelegatableContractId = Key.newBuilder()
+            .setDelegatableContractId(contractIdFromEvmAddress(CONTRACT_ADDRESS.toArrayUnsafe()))
             .build();
 
     @Autowired
@@ -357,8 +380,30 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
                 spenderEntityId, KEY_PROTO, FROZEN_FUNGIBLE_TOKEN_ADDRESS, 9999999999999L, TokenPauseStatusEnum.PAUSED);
         final var tokenTreasuryEntityId = fungibleTokenPersist(
                 treasuryEntityId, new byte[0], TREASURY_TOKEN_ADDRESS, 0L, TokenPauseStatusEnum.UNPAUSED);
-        final var tokenGetKeyEntityId = fungibleTokenPersist(
-                senderEntityId, key.toByteArray(), FUNGIBLE_TOKEN_ADDRESS_GET_KEY, 9999999999999L, TokenPauseStatusEnum.PAUSED);
+        final var tokenGetKeyContractAddressEntityId = fungibleTokenPersist(
+                senderEntityId,
+                keyWithContractId.toByteArray(),
+                FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_CONTRACT_ADDRESS,
+                9999999999999L,
+                TokenPauseStatusEnum.PAUSED);
+        final var tokenGetKeyEcdsaEntityId = fungibleTokenPersist(
+                senderEntityId,
+                keyWithECDSASecp256K1.toByteArray(),
+                FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_ECDSA_KEY,
+                9999999999999L,
+                TokenPauseStatusEnum.PAUSED);
+        final var tokenGetKeyEd25519EntityId = fungibleTokenPersist(
+                senderEntityId,
+                keyWithEd25519.toByteArray(),
+                FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_ED25519_KEY,
+                9999999999999L,
+                TokenPauseStatusEnum.PAUSED);
+        final var tokenGetKeyDelegatableContractIdEntityId = fungibleTokenPersist(
+                senderEntityId,
+                keyWithDelegatableContractId.toByteArray(),
+                FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_DELEGATABLE_CONTRACT_ID,
+                9999999999999L,
+                TokenPauseStatusEnum.PAUSED);
 
         final var nftEntityId = nftPersist(
                 NFT_ADDRESS, ownerEntityId, spenderEntityId, ownerEntityId, KEY_PROTO, TokenPauseStatusEnum.PAUSED);
@@ -377,11 +422,32 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
                 KEY_PROTO,
                 TokenPauseStatusEnum.UNPAUSED);
         final var nftEntityId4 = nftPersist(
-                NFT_ADDRESS_GET_KEY,
+                NFT_ADDRESS_GET_KEY_WITH_CONTRACT_ADDRESS,
                 ownerEntityId,
                 spenderEntityId,
                 ownerEntityId,
-                key.toByteArray(),
+                keyWithContractId.toByteArray(),
+                TokenPauseStatusEnum.PAUSED);
+        final var nftEntityId5 = nftPersist(
+                NFT_ADDRESS_GET_KEY_WITH_ED25519_KEY,
+                ownerEntityId,
+                spenderEntityId,
+                ownerEntityId,
+                keyWithEd25519.toByteArray(),
+                TokenPauseStatusEnum.PAUSED);
+        final var nftEntityId6 = nftPersist(
+                NFT_ADDRESS_GET_KEY_WITH_ECDSA_KEY,
+                ownerEntityId,
+                spenderEntityId,
+                ownerEntityId,
+                keyWithECDSASecp256K1.toByteArray(),
+                TokenPauseStatusEnum.PAUSED);
+        final var nftEntityId7 = nftPersist(
+                NFT_ADDRESS_GET_KEY_WITH_DELEGATABLE_CONTRACT_ID,
+                ownerEntityId,
+                spenderEntityId,
+                ownerEntityId,
+                keyWithDelegatableContractId.toByteArray(),
                 TokenPauseStatusEnum.PAUSED);
 
         final var ethAccount = ethAccountPersist(358L, ETH_ADDRESS);

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallTestSetup.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallTestSetup.java
@@ -24,6 +24,7 @@ import static com.hedera.mirror.common.util.DomainUtils.toEvmAddress;
 import static com.hedera.mirror.web3.evm.utils.EvmTokenUtils.toAddress;
 import static com.hedera.mirror.web3.service.model.CallServiceParameters.CallType.ETH_ESTIMATE_GAS;
 import static com.hedera.node.app.service.evm.utils.EthSigsUtils.recoverAddressFromPubKey;
+import static com.hedera.services.utils.EntityIdUtils.contractIdFromEvmAddress;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.ContractCall;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.CryptoTransfer;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.TokenAccountWipe;
@@ -62,6 +63,7 @@ import com.hederahashgraph.api.proto.java.ExchangeRateSet;
 import com.hederahashgraph.api.proto.java.FeeComponents;
 import com.hederahashgraph.api.proto.java.FeeData;
 import com.hederahashgraph.api.proto.java.FeeSchedule;
+import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.TimestampSeconds;
 import com.hederahashgraph.api.proto.java.TransactionFeeSchedule;
 import java.math.BigInteger;
@@ -112,10 +114,12 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
     protected static final Address NOT_FROZEN_FUNGIBLE_TOKEN_ADDRESS = toAddress(EntityId.of(0, 0, 1048, TOKEN));
     protected static final Address FROZEN_FUNGIBLE_TOKEN_ADDRESS = toAddress(EntityId.of(0, 0, 1050, TOKEN));
     protected static final Address TREASURY_TOKEN_ADDRESS = toAddress(EntityId.of(0, 0, 1049, TOKEN));
+    protected static final Address FUNGIBLE_TOKEN_ADDRESS_GET_KEY = toAddress(EntityId.of(0, 0, 1052, TOKEN));
     protected static final Address NFT_ADDRESS = toAddress(EntityId.of(0, 0, 1047, TOKEN));
     protected static final Address NFT_ADDRESS_WITH_DIFFERENT_OWNER_AND_TREASURY =
             toAddress(EntityId.of(0, 0, 1067, TOKEN));
     protected static final Address NFT_TRANSFER_ADDRESS = toAddress(EntityId.of(0, 0, 1051, TOKEN));
+    protected static final Address NFT_ADDRESS_GET_KEY = toAddress(EntityId.of(0, 0, 1053, TOKEN));
     protected static final Address MODIFICATION_CONTRACT_ADDRESS = toAddress(EntityId.of(0, 0, 1257, CONTRACT));
     protected static final byte[] KEY_PROTO = new byte[] {
         58, 33, -52, -44, -10, 81, 99, 100, 6, -8, -94, -87, -112, 42, 42, 96, 75, -31, -5, 72, 13, -70, 101, -111, -1,
@@ -230,6 +234,10 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
                                             .setGas(852000)
                                             .build())
                                     .build())))
+            .build();
+
+    protected static Key key = Key.newBuilder()
+            .setContractID(contractIdFromEvmAddress(CONTRACT_ADDRESS.toArrayUnsafe()))
             .build();
 
     @Autowired
@@ -349,6 +357,8 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
                 spenderEntityId, KEY_PROTO, FROZEN_FUNGIBLE_TOKEN_ADDRESS, 9999999999999L, TokenPauseStatusEnum.PAUSED);
         final var tokenTreasuryEntityId = fungibleTokenPersist(
                 treasuryEntityId, new byte[0], TREASURY_TOKEN_ADDRESS, 0L, TokenPauseStatusEnum.UNPAUSED);
+        final var tokenGetKeyEntityId = fungibleTokenPersist(
+                senderEntityId, key.toByteArray(), FUNGIBLE_TOKEN_ADDRESS_GET_KEY, 9999999999999L, TokenPauseStatusEnum.PAUSED);
 
         final var nftEntityId = nftPersist(
                 NFT_ADDRESS, ownerEntityId, spenderEntityId, ownerEntityId, KEY_PROTO, TokenPauseStatusEnum.PAUSED);
@@ -366,6 +376,13 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
                 ownerEntityId,
                 KEY_PROTO,
                 TokenPauseStatusEnum.UNPAUSED);
+        final var nftEntityId4 = nftPersist(
+                NFT_ADDRESS_GET_KEY,
+                ownerEntityId,
+                spenderEntityId,
+                ownerEntityId,
+                key.toByteArray(),
+                TokenPauseStatusEnum.PAUSED);
 
         final var ethAccount = ethAccountPersist(358L, ETH_ADDRESS);
 


### PR DESCRIPTION
**Description**:

This PR adds integration tests for eth estimate gas for the read-only precompiles defined in ContractCallServicePrecompileTest$ContractReadFunctions and for custom fees.

Since ContractCallServicePrecompileTest#evmPrecompileReadOnlyTokenFunctionsTest and ContractCallServicePrecompileTest#evmPrecompileReadOnlyTokenFunctionsTestWithNonStaticFrame were exactly the same (and the frame is always non-static) the latter one was changed to support eth estimate gas.

**Related issue(s)**:

Fixes https://github.com/hashgraph/hedera-mirror-node/issues/6463
Fixes https://github.com/hashgraph/hedera-mirror-node/issues/6461
Fixes https://github.com/hashgraph/hedera-mirror-node/issues/6460
