### PR TITLE
Acceptance tests for remaining allowances

### DIFF
--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorCryptoAllowance.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorCryptoAllowance.java
@@ -20,5 +20,6 @@ import lombok.Data;
 
 @Data
 public class MirrorCryptoAllowance extends MirrorTransferAllowance {
+    private long amount;
     private long amountGranted;
 }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AccountFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AccountFeature.java
@@ -224,11 +224,6 @@ public class AccountFeature extends AbstractFeature {
         verifyMirrorAPIApprovedCryptoAllowanceResponse(approvedAmount, transferAmount);
     }
 
-    @And("the mirror node REST API should confirm the approved allowance of {long} tℏ was again debited by {long} tℏ")
-    public void verifyMirrorAPICryptoAllowanceAmount2Response(long approvedAmount, long transferAmount) {
-        verifyMirrorAPIApprovedCryptoAllowanceResponse(approvedAmount, transferAmount + transferAmount);
-    }
-
     private void verifyMirrorAPIApprovedCryptoAllowanceResponse(long approvedAmount, long transferAmount) {
         verifyMirrorTransactionsResponse(mirrorClient, HttpStatus.OK.value());
 

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AccountFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AccountFeature.java
@@ -33,6 +33,7 @@ import com.hedera.mirror.test.e2e.acceptance.props.MirrorTransfer;
 import com.hedera.mirror.test.e2e.acceptance.response.MirrorTransactionsResponse;
 import io.cucumber.java.AfterAll;
 import io.cucumber.java.Before;
+import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
@@ -215,17 +216,33 @@ public class AccountFeature extends AbstractFeature {
 
     @Then("the mirror node REST API should confirm the approved {long} tℏ crypto allowance")
     public void verifyMirrorAPIApprovedCryptoAllowanceResponse(long approvedAmount) {
+        verifyMirrorAPIApprovedCryptoAllowanceResponse(approvedAmount, 0L);
+    }
+
+    @And("the mirror node REST API should confirm the approved allowance of {long} tℏ was debited by {long} tℏ")
+    public void verifyMirrorAPICryptoAllowanceAmountResponse(long approvedAmount, long transferAmount) {
+        verifyMirrorAPIApprovedCryptoAllowanceResponse(approvedAmount, transferAmount);
+    }
+
+    @And("the mirror node REST API should confirm the approved allowance of {long} tℏ was again debited by {long} tℏ")
+    public void verifyMirrorAPICryptoAllowanceAmount2Response(long approvedAmount, long transferAmount) {
+        verifyMirrorAPIApprovedCryptoAllowanceResponse(approvedAmount, transferAmount + transferAmount);
+    }
+
+    private void verifyMirrorAPIApprovedCryptoAllowanceResponse(long approvedAmount, long transferAmount) {
         verifyMirrorTransactionsResponse(mirrorClient, HttpStatus.OK.value());
 
         var owner = accountClient.getClient().getOperatorAccountId().toString();
         var spender = spenderAccountId.getAccountId().toString();
         var mirrorCryptoAllowanceResponse = mirrorClient.getAccountCryptoAllowanceBySpender(owner, spender);
+        var remainingAmount = approvedAmount - transferAmount;
 
         // verify valid set of allowance
         assertThat(mirrorCryptoAllowanceResponse.getAllowances())
                 .isNotEmpty()
                 .first()
                 .isNotNull()
+                .returns(remainingAmount, MirrorCryptoAllowance::getAmount)
                 .returns(approvedAmount, MirrorCryptoAllowance::getAmountGranted)
                 .returns(owner, MirrorCryptoAllowance::getOwner)
                 .returns(spender, MirrorCryptoAllowance::getSpender)
@@ -258,7 +275,7 @@ public class AccountFeature extends AbstractFeature {
 
     @Then("the mirror node REST API should confirm the crypto allowance deletion")
     public void verifyCryptoAllowanceDelete() {
-        verifyMirrorAPIApprovedCryptoAllowanceResponse(0);
+        verifyMirrorAPIApprovedCryptoAllowanceResponse(0L, 0L);
     }
 
     private void setCryptoAllowance(String accountName, long amount) {

--- a/hedera-mirror-test/src/test/resources/features/account/cryptoAllowance.feature
+++ b/hedera-mirror-test/src/test/resources/features/account/cryptoAllowance.feature
@@ -8,7 +8,7 @@ Feature: Account Crypto Allowance Coverage Feature
     When <spender> transfers <transferAmount> tℏ from the approved allowance to <recipient>
     Then the mirror node REST API should confirm the approved transfer of <transferAmount> tℏ
     And the mirror node REST API should confirm the approved allowance of <approvedAmount> tℏ was debited by <transferAmount> tℏ
-    When <spender> transfers <transferAmount> tℏ from the approved allowance to <recipient2>
+    When <spender> transfers <transferAmount> tℏ from the approved allowance to <recipient>
     Then the mirror node REST API should confirm the approved transfer of <transferAmount> tℏ
     And the mirror node REST API should confirm the approved allowance of <approvedAmount> tℏ was again debited by <transferAmount> tℏ
     When I approve <spender> to transfer up to <approvedAmount> tℏ
@@ -16,5 +16,5 @@ Feature: Account Crypto Allowance Coverage Feature
     When I delete the crypto allowance for <spender>
     Then the mirror node REST API should confirm the crypto allowance deletion
     Examples:
-      | spender | approvedAmount | recipient | recipient2 | transferAmount |
-      | "BOB"   | 100            | "ALICE"   | "CAROL"    | 1              |
+      | spender | approvedAmount | recipient | transferAmount |
+      | "BOB"   | 100            | "ALICE"   | 1              |

--- a/hedera-mirror-test/src/test/resources/features/account/cryptoAllowance.feature
+++ b/hedera-mirror-test/src/test/resources/features/account/cryptoAllowance.feature
@@ -7,8 +7,14 @@ Feature: Account Crypto Allowance Coverage Feature
     Then the mirror node REST API should confirm the approved <approvedAmount> tℏ crypto allowance
     When <spender> transfers <transferAmount> tℏ from the approved allowance to <recipient>
     Then the mirror node REST API should confirm the approved transfer of <transferAmount> tℏ
+    And the mirror node REST API should confirm the approved allowance of <approvedAmount> tℏ was debited by <transferAmount> tℏ
+    When <spender> transfers <transferAmount> tℏ from the approved allowance to <recipient2>
+    Then the mirror node REST API should confirm the approved transfer of <transferAmount> tℏ
+    And the mirror node REST API should confirm the approved allowance of <approvedAmount> tℏ was again debited by <transferAmount> tℏ
+    When I approve <spender> to transfer up to <approvedAmount> tℏ
+    Then the mirror node REST API should confirm the approved <approvedAmount> tℏ crypto allowance
     When I delete the crypto allowance for <spender>
     Then the mirror node REST API should confirm the crypto allowance deletion
     Examples:
-      | spender | approvedAmount | recipient | transferAmount |
-      | "BOB"   | 100            | "ALICE"   | 1              |
+      | spender | approvedAmount | recipient | recipient2 | transferAmount |
+      | "BOB"   | 100            | "ALICE"   | "CAROL"    | 1              |

--- a/hedera-mirror-test/src/test/resources/features/account/cryptoAllowance.feature
+++ b/hedera-mirror-test/src/test/resources/features/account/cryptoAllowance.feature
@@ -2,9 +2,14 @@
 Feature: Account Crypto Allowance Coverage Feature
 
   @critical @release @acceptance
-  Scenario Outline: Validate approval CryptoTransfer
+  Scenario Outline: Validate approval CryptoTransfer affect on CryptoAllowance amount
     Given I approve <spender> to transfer up to <approvedAmount> tℏ
     Then the mirror node REST API should confirm the approved <approvedAmount> tℏ crypto allowance
+    # This transfer by owner does not debit allowance amount
+    Given I send <transferAmount> tℏ to <recipient>
+    Then the mirror node REST API should return status 200 for the crypto transfer transaction
+    And the new balance should reflect cryptotransfer of <transferAmount>
+    But the mirror node REST API should confirm the approved <approvedAmount> tℏ crypto allowance
     When <spender> transfers <transferAmount> tℏ from the approved allowance to <recipient>
     Then the mirror node REST API should confirm the approved transfer of <transferAmount> tℏ
     And the mirror node REST API should confirm the approved allowance of <approvedAmount> tℏ was debited by <transferAmount> tℏ

--- a/hedera-mirror-test/src/test/resources/features/account/cryptoAllowance.feature
+++ b/hedera-mirror-test/src/test/resources/features/account/cryptoAllowance.feature
@@ -13,9 +13,6 @@ Feature: Account Crypto Allowance Coverage Feature
     When <spender> transfers <transferAmount> tℏ from the approved allowance to <recipient>
     Then the mirror node REST API should confirm the approved transfer of <transferAmount> tℏ
     And the mirror node REST API should confirm the approved allowance of <approvedAmount> tℏ was debited by <transferAmount> tℏ
-    When <spender> transfers <transferAmount> tℏ from the approved allowance to <recipient>
-    Then the mirror node REST API should confirm the approved transfer of <transferAmount> tℏ
-    And the mirror node REST API should confirm the approved allowance of <approvedAmount> tℏ was again debited by <transferAmount> tℏ
     When I approve <spender> to transfer up to <approvedAmount> tℏ
     Then the mirror node REST API should confirm the approved <approvedAmount> tℏ crypto allowance
     When I delete the crypto allowance for <spender>


### PR DESCRIPTION
**Description**:
Implement acceptance tests around the new functionality provided by #3576, namely crypto allowance definition and that approved crypto transfers are properly reflected in the allowance balances.

- Create allowance defining appropriate owner and spender IDs.
- Verify existence and expected configuration via mirror node rest api
- Perform crypto transfers, both approved utilizing the owner and spender as expected, as well as other scenarios that should not affect the allowance balances.

**Related issue(s)**:

This PR fixes the crypto allowance portion of #6553. The fungible token allowance tests will be addressed in a subsequent PR.

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
