### PR TITLE
Fix timezone in Java logs

### DIFF
--- a/charts/hedera-mirror-common/values.yaml
+++ b/charts/hedera-mirror-common/values.yaml
@@ -339,7 +339,9 @@ promtail:
       - url: http://{{ .Release.Name }}-loki:3100/loki/api/v1/push
     snippets:
       pipelineStages:
-        - docker: {}
+        - cri: {}
+        - multiline:
+            firstline: '^\d{4}-\d{2}-\d{2}T\d{1,2}:\d{2}:\d{2}\.\d+(Z|\+\d{4}) '
   enabled: true
   resources:
     limits:

--- a/charts/hedera-mirror-common/values.yaml
+++ b/charts/hedera-mirror-common/values.yaml
@@ -341,7 +341,7 @@ promtail:
       pipelineStages:
         - cri: {}
         - multiline:
-            firstline: '^\d{4}-\d{2}-\d{2}T\d{1,2}:\d{2}:\d{2}\.\d+(Z|\+\d{4}) '
+            firstline: '^\d{4}-\d{2}-\d{2}T\d{1,2}:\d{2}:\d{2}\.\d+(Z|[+-]\d{4}) '
   enabled: true
   resources:
     limits:

--- a/hedera-mirror-graphql/src/main/resources/log4j2.xml
+++ b/hedera-mirror-graphql/src/main/resources/log4j2.xml
@@ -1,17 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration shutdownHook="disable" status="WARN">
-    <Appenders>
-        <Console name="console" target="SYSTEM_OUT">
-            <PatternLayout>
-                <alwaysWriteExceptions>false</alwaysWriteExceptions>
-                <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}{GMT-6} %p %t %c{1.} %m %ex%n
-                </pattern>
-            </PatternLayout>
-        </Console>
-    </Appenders>
-    <Loggers>
-        <Root level="WARN">
-            <AppenderRef ref="console"/>
-        </Root>
-    </Loggers>
+  <Appenders>
+    <Console name="console" target="SYSTEM_OUT">
+      <PatternLayout>
+        <alwaysWriteExceptions>false</alwaysWriteExceptions>
+        <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}{UTC} %p %t %c{1.} %m %ex%n</pattern>
+      </PatternLayout>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Root level="WARN">
+      <AppenderRef ref="console"/>
+    </Root>
+  </Loggers>
 </Configuration>

--- a/hedera-mirror-graphql/src/test/resources/log4j2-test.xml
+++ b/hedera-mirror-graphql/src/test/resources/log4j2-test.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="WARN">
-    <Appenders>
-        <Console name="console" target="SYSTEM_OUT">
-            <PatternLayout>
-                <alwaysWriteExceptions>false</alwaysWriteExceptions>
-                <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}{GMT-6} %p %t %c{1.} %m %ex{short}%n</pattern>
-            </PatternLayout>
-        </Console>
-    </Appenders>
-    <Loggers>
-        <Root level="WARN">
-            <AppenderRef ref="console"/>
-        </Root>
-        <Logger name="com.hedera.mirror.graphql" level="INFO" additivity="false">
-            <AppenderRef ref="console"/>
-        </Logger>
-    </Loggers>
+  <Appenders>
+    <Console name="console" target="SYSTEM_OUT">
+      <PatternLayout>
+        <alwaysWriteExceptions>false</alwaysWriteExceptions>
+        <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}{UTC} %p %t %c{1.} %m %ex%n</pattern>
+      </PatternLayout>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Logger additivity="false" level="INFO" name="com.hedera.mirror.graphql">
+      <AppenderRef ref="console"/>
+    </Logger>
+    <Root level="WARN">
+      <AppenderRef ref="console"/>
+    </Root>
+  </Loggers>
 </Configuration>

--- a/hedera-mirror-grpc/src/main/resources/log4j2.xml
+++ b/hedera-mirror-grpc/src/main/resources/log4j2.xml
@@ -1,17 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration shutdownHook="disable" status="WARN">
-    <Appenders>
-        <Console name="console" target="SYSTEM_OUT">
-            <PatternLayout>
-                <alwaysWriteExceptions>false</alwaysWriteExceptions>
-                <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}{GMT-6} %p %t %c{1.} %m %ex{separator(\\n)}%n
-                </pattern>
-            </PatternLayout>
-        </Console>
-    </Appenders>
-    <Loggers>
-        <Root level="WARN">
-            <AppenderRef ref="console"/>
-        </Root>
-    </Loggers>
+  <Appenders>
+    <Console name="console" target="SYSTEM_OUT">
+      <PatternLayout>
+        <alwaysWriteExceptions>false</alwaysWriteExceptions>
+        <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}{UTC} %p %t %c{1.} %m %ex%n</pattern>
+      </PatternLayout>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Root level="WARN">
+      <AppenderRef ref="console"/>
+    </Root>
+  </Loggers>
 </Configuration>

--- a/hedera-mirror-grpc/src/test/resources/log4j2-test.xml
+++ b/hedera-mirror-grpc/src/test/resources/log4j2-test.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="WARN">
-    <Appenders>
-        <Console name="console" target="SYSTEM_OUT">
-            <PatternLayout>
-                <alwaysWriteExceptions>false</alwaysWriteExceptions>
-                <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}{GMT-6} %p %t %c{1.} %m %ex{short}%n</pattern>
-            </PatternLayout>
-        </Console>
-    </Appenders>
-    <Loggers>
-        <Root level="WARN">
-            <AppenderRef ref="console"/>
-        </Root>
-        <Logger name="com.hedera.mirror.grpc" level="INFO" additivity="false">
-            <AppenderRef ref="console"/>
-        </Logger>
-    </Loggers>
+  <Appenders>
+    <Console name="console" target="SYSTEM_OUT">
+      <PatternLayout>
+        <alwaysWriteExceptions>false</alwaysWriteExceptions>
+        <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}{UTC} %p %t %c{1.} %m %ex%n</pattern>
+      </PatternLayout>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Logger additivity="false" level="INFO" name="com.hedera.mirror.grpc">
+      <AppenderRef ref="console"/>
+    </Logger>
+    <Root level="WARN">
+      <AppenderRef ref="console"/>
+    </Root>
+  </Loggers>
 </Configuration>

--- a/hedera-mirror-importer/src/main/resources/log4j2.xml
+++ b/hedera-mirror-importer/src/main/resources/log4j2.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration shutdownHook="disable" status="WARN">
-    <Appenders>
-        <Console name="console" target="SYSTEM_OUT">
-            <PatternLayout>
-                <alwaysWriteExceptions>false</alwaysWriteExceptions>
-                <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}{GMT-6} %p %t %c{1.} %m %ex{separator(\\n)}%n</pattern>
-            </PatternLayout>
-        </Console>
-    </Appenders>
-    <Loggers>
-        <Root level="WARN">
-            <AppenderRef ref="console"/>
-        </Root>
-    </Loggers>
+  <Appenders>
+    <Console name="console" target="SYSTEM_OUT">
+      <PatternLayout>
+        <alwaysWriteExceptions>false</alwaysWriteExceptions>
+        <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}{UTC} %p %t %c{1.} %m %ex%n</pattern>
+      </PatternLayout>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Root level="WARN">
+      <AppenderRef ref="console"/>
+    </Root>
+  </Loggers>
 </Configuration>

--- a/hedera-mirror-importer/src/test/resources/log4j2-test.xml
+++ b/hedera-mirror-importer/src/test/resources/log4j2-test.xml
@@ -1,21 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="WARN">
-    <Appenders>
-<!--        The follow param here allowed OutputCaptureExtension.java to function correctly-->
-<!--        See https://github.com/spring-projects/spring-boot/issues/32562-->
-        <Console name="console" target="SYSTEM_OUT" follow="true">
-            <PatternLayout>
-                <alwaysWriteExceptions>false</alwaysWriteExceptions>
-                <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}{GMT-6} %p %t %c{1.} %m %ex{short}%n</pattern>
-            </PatternLayout>
-        </Console>
-    </Appenders>
-    <Loggers>
-        <Root level="WARN">
-            <AppenderRef ref="console"/>
-        </Root>
-        <Logger name="com.hedera.mirror.importer" level="INFO" additivity="false">
-            <AppenderRef ref="console"/>
-        </Logger>
-    </Loggers>
+  <Appenders>
+    <Console follow="true" name="console" target="SYSTEM_OUT">
+      <PatternLayout>
+        <alwaysWriteExceptions>false</alwaysWriteExceptions>
+        <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}{UTC} %p %t %c{1.} %m %ex%n</pattern>
+      </PatternLayout>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Logger additivity="false" level="INFO" name="com.hedera.mirror.importer">
+      <AppenderRef ref="console"/>
+    </Logger>
+    <Root level="WARN">
+      <AppenderRef ref="console"/>
+    </Root>
+  </Loggers>
 </Configuration>

--- a/hedera-mirror-monitor/src/main/resources/log4j2.xml
+++ b/hedera-mirror-monitor/src/main/resources/log4j2.xml
@@ -1,17 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration shutdownHook="disable" status="WARN">
-    <Appenders>
-        <Console name="console" target="SYSTEM_OUT">
-            <PatternLayout>
-                <alwaysWriteExceptions>false</alwaysWriteExceptions>
-                <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}{GMT-6} %p %t %c{1.} %m %ex{separator(\\n)}%n
-                </pattern>
-            </PatternLayout>
-        </Console>
-    </Appenders>
-    <Loggers>
-        <Root level="WARN">
-            <AppenderRef ref="console"/>
-        </Root>
-    </Loggers>
+  <Appenders>
+    <Console name="console" target="SYSTEM_OUT">
+      <PatternLayout>
+        <alwaysWriteExceptions>false</alwaysWriteExceptions>
+        <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}{UTC} %p %t %c{1.} %m %ex%n</pattern>
+      </PatternLayout>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Root level="WARN">
+      <AppenderRef ref="console"/>
+    </Root>
+  </Loggers>
 </Configuration>

--- a/hedera-mirror-monitor/src/test/resources/log4j2-test.xml
+++ b/hedera-mirror-monitor/src/test/resources/log4j2-test.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="WARN">
-    <Appenders>
-        <Console name="console" target="SYSTEM_OUT">
-            <PatternLayout>
-                <alwaysWriteExceptions>false</alwaysWriteExceptions>
-                <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}{GMT-6} %p %t %c{1.} %m %ex{short}%n</pattern>
-            </PatternLayout>
-        </Console>
-    </Appenders>
-    <Loggers>
-        <Root level="WARN">
-            <AppenderRef ref="console"/>
-        </Root>
-        <Logger name="com.hedera.mirror.monitor" level="INFO" additivity="false">
-            <AppenderRef ref="console"/>
-        </Logger>
-    </Loggers>
+  <Appenders>
+    <Console name="console" target="SYSTEM_OUT">
+      <PatternLayout>
+        <alwaysWriteExceptions>false</alwaysWriteExceptions>
+        <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}{UTC} %p %t %c{1.} %m %ex%n</pattern>
+      </PatternLayout>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Logger additivity="false" level="INFO" name="com.hedera.mirror.monitor">
+      <AppenderRef ref="console"/>
+    </Logger>
+    <Root level="WARN">
+      <AppenderRef ref="console"/>
+    </Root>
+  </Loggers>
 </Configuration>

--- a/hedera-mirror-test/src/test/resources/log4j2.xml
+++ b/hedera-mirror-test/src/test/resources/log4j2.xml
@@ -1,20 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="WARN">
-    <Appenders>
-        <Console name="console" target="SYSTEM_OUT">
-            <PatternLayout>
-                <alwaysWriteExceptions>false</alwaysWriteExceptions>
-                <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}{GMT-6} %level{length=1} %-15.15t %c{1.} %m %ex%n
-                </pattern>
-            </PatternLayout>
-        </Console>
-    </Appenders>
-    <Loggers>
-        <Logger name="com.hedera.mirror.test" level="info" additivity="false">
-            <AppenderRef ref="console"/>
-        </Logger>
-        <Root level="warn">
-            <AppenderRef ref="console"/>
-        </Root>
-    </Loggers>
+  <Appenders>
+    <Console name="console" target="SYSTEM_OUT">
+      <PatternLayout>
+        <alwaysWriteExceptions>false</alwaysWriteExceptions>
+        <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}{UTC} %p %t %c{1.} %m %ex%n</pattern>
+      </PatternLayout>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Logger additivity="false" level="info" name="com.hedera.mirror.test">
+      <AppenderRef ref="console"/>
+    </Logger>
+    <Root level="warn">
+      <AppenderRef ref="console"/>
+    </Root>
+  </Loggers>
 </Configuration>

--- a/hedera-mirror-web3/src/main/resources/log4j2.xml
+++ b/hedera-mirror-web3/src/main/resources/log4j2.xml
@@ -1,17 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration shutdownHook="disable" status="WARN">
-    <Appenders>
-        <Console name="console" target="SYSTEM_OUT">
-            <PatternLayout>
-                <alwaysWriteExceptions>false</alwaysWriteExceptions>
-                <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}{GMT-6} %p %t %c{1.} %m %ex{separator(\\n)}%n
-                </pattern>
-            </PatternLayout>
-        </Console>
-    </Appenders>
-    <Loggers>
-        <Root level="WARN">
-            <AppenderRef ref="console"/>
-        </Root>
-    </Loggers>
+  <Appenders>
+    <Console name="console" target="SYSTEM_OUT">
+      <PatternLayout>
+        <alwaysWriteExceptions>false</alwaysWriteExceptions>
+        <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}{UTC} %p %t %c{1.} %m %ex%n</pattern>
+      </PatternLayout>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Root level="WARN">
+      <AppenderRef ref="console"/>
+    </Root>
+  </Loggers>
 </Configuration>

--- a/hedera-mirror-web3/src/test/resources/log4j2-test.xml
+++ b/hedera-mirror-web3/src/test/resources/log4j2-test.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="WARN">
-    <Appenders>
-        <Console name="console" target="SYSTEM_OUT" follow="true">
-            <PatternLayout>
-                <alwaysWriteExceptions>false</alwaysWriteExceptions>
-                <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}{GMT-6} %p %t %c{1.} %m %ex{short}%n</pattern>
-            </PatternLayout>
-        </Console>
-    </Appenders>
-    <Loggers>
-        <Root level="WARN">
-            <AppenderRef ref="console"/>
-        </Root>
-        <Logger name="com.hedera.mirror.web3" level="INFO" additivity="false">
-            <AppenderRef ref="console"/>
-        </Logger>
-    </Loggers>
+  <Appenders>
+    <Console follow="true" name="console" target="SYSTEM_OUT">
+      <PatternLayout>
+        <alwaysWriteExceptions>false</alwaysWriteExceptions>
+        <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}{UTC} %p %t %c{1.} %m %ex%n</pattern>
+      </PatternLayout>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Logger additivity="false" level="INFO" name="com.hedera.mirror.web3">
+      <AppenderRef ref="console"/>
+    </Logger>
+    <Root level="WARN">
+      <AppenderRef ref="console"/>
+    </Root>
+  </Loggers>
 </Configuration>


### PR DESCRIPTION
**Description**:

* Fix Java logs not showing timezone as UTC
* Fix [multiline](https://grafana.com/docs/loki/latest/clients/promtail/stages/multiline) logs in promtail and remove newline deletion hack in `log4j2.xml`
* Fix promtail still using docker log format despite switching to containerd awhile ago

**Related issue(s)**:

Fixes #6624

**Notes for reviewer**:

Ignore whitespace when reviewing `log4j2.xml`.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
