### PR TITLE
Verify token creation on mirror node during acceptance tests

### DIFF
--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TokenClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TokenClient.java
@@ -91,11 +91,7 @@ public class TokenClient extends AbstractNetworkClient {
         return -1;
     }
 
-    public TokenId getToken(TokenNameEnum tokenNameEnum) {
-        return getTokenAndResponse(tokenNameEnum).tokenId();
-    }
-
-    public TokenResponse getTokenAndResponse(TokenNameEnum tokenNameEnum) {
+    public TokenResponse getToken(TokenNameEnum tokenNameEnum) {
         AtomicReference<NetworkTransactionResponse> responseRef = new AtomicReference<>();
         // Create token only if it does not currently exist
         var tokenId = tokenMap.computeIfAbsent(tokenNameEnum, x -> {

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/CallFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/CallFeature.java
@@ -136,7 +136,7 @@ public class CallFeature extends AbstractFeature {
     @Then("I call function with IERC721Metadata token {string} name")
     public void ierc721MetadataTokenName(String tokenName) {
         var tokenNameEnum = TokenClient.TokenNameEnum.valueOf(tokenName);
-        var tokenId = tokenClient.getToken(tokenNameEnum);
+        var tokenId = tokenClient.getToken(tokenNameEnum).tokenId();
         var contractCallRequestBody = ContractCallRequest.builder()
                 .data(ContractMethods.IERC721_TOKEN_NAME_SELECTOR.getSelector()
                         + to32BytesString(tokenId.toSolidityAddress()))
@@ -155,7 +155,7 @@ public class CallFeature extends AbstractFeature {
     @Then("I call function with IERC721Metadata token {string} symbol")
     public void ierc721MetadataTokenSymbol(String tokenName) {
         var tokenNameEnum = TokenClient.TokenNameEnum.valueOf(tokenName);
-        var tokenId = tokenClient.getToken(tokenNameEnum);
+        var tokenId = tokenClient.getToken(tokenNameEnum).tokenId();
         var contractCallRequestBody = ContractCallRequest.builder()
                 .data(ContractMethods.IERC721_TOKEN_SYMBOL_SELECTOR.getSelector()
                         + to32BytesString(tokenId.toSolidityAddress()))
@@ -172,7 +172,9 @@ public class CallFeature extends AbstractFeature {
     @RetryAsserts
     @Then("I call function with IERC721Metadata token {string} totalSupply")
     public void ierc721MetadataTokenTotalSupply(String tokenName) {
-        var tokenId = tokenClient.getToken(TokenClient.TokenNameEnum.valueOf(tokenName));
+        var tokenId = tokenClient
+                .getToken(TokenClient.TokenNameEnum.valueOf(tokenName))
+                .tokenId();
         var contractCallRequestBody = ContractCallRequest.builder()
                 .data(ContractMethods.IERC721_TOKEN_TOTAL_SUPPLY_SELECTOR.getSelector()
                         + to32BytesString(tokenId.toSolidityAddress()))
@@ -189,7 +191,9 @@ public class CallFeature extends AbstractFeature {
     @RetryAsserts
     @Then("I call function with IERC721 token {string} balanceOf owner")
     public void ierc721MetadataTokenBalanceOf(String tokenName) {
-        var tokenId = tokenClient.getToken(TokenClient.TokenNameEnum.valueOf(tokenName));
+        var tokenId = tokenClient
+                .getToken(TokenClient.TokenNameEnum.valueOf(tokenName))
+                .tokenId();
         var contractCallRequestBody = ContractCallRequest.builder()
                 .data(ContractMethods.IERC721_TOKEN_BALANCE_OF_SELECTOR.getSelector()
                         + to32BytesString(tokenId.toSolidityAddress())
@@ -207,7 +211,9 @@ public class CallFeature extends AbstractFeature {
     @RetryAsserts
     @Then("I call function with HederaTokenService isToken token {string}")
     public void htsIsToken(String tokenName) {
-        var tokenId = tokenClient.getToken(TokenClient.TokenNameEnum.valueOf(tokenName));
+        var tokenId = tokenClient
+                .getToken(TokenClient.TokenNameEnum.valueOf(tokenName))
+                .tokenId();
         var contractCallRequestBody = ContractCallRequest.builder()
                 .data(ContractMethods.HTS_IS_TOKEN_SELECTOR.getSelector()
                         + to32BytesString(tokenId.toSolidityAddress()))
@@ -225,7 +231,9 @@ public class CallFeature extends AbstractFeature {
     @RetryAsserts
     @Then("I call function with HederaTokenService isFrozen token {string}, account")
     public void htsIsFrozen(String tokenName) {
-        var tokenId = tokenClient.getToken(TokenClient.TokenNameEnum.valueOf(tokenName));
+        var tokenId = tokenClient
+                .getToken(TokenClient.TokenNameEnum.valueOf(tokenName))
+                .tokenId();
         var contractCallRequestBody = ContractCallRequest.builder()
                 .data(ContractMethods.HTS_IS_FROZEN_SELECTOR.getSelector()
                         + to32BytesString(tokenId.toSolidityAddress())
@@ -243,7 +251,9 @@ public class CallFeature extends AbstractFeature {
     @RetryAsserts
     @Then("I call function with HederaTokenService isKyc token {string}, account")
     public void htsIsKyc(String tokenName) {
-        var tokenId = tokenClient.getToken(TokenClient.TokenNameEnum.valueOf(tokenName));
+        var tokenId = tokenClient
+                .getToken(TokenClient.TokenNameEnum.valueOf(tokenName))
+                .tokenId();
         var contractCallRequestBody = ContractCallRequest.builder()
                 .data(ContractMethods.HTS_IS_KYC_SELECTOR.getSelector()
                         + to32BytesString(tokenId.toSolidityAddress())
@@ -261,7 +271,9 @@ public class CallFeature extends AbstractFeature {
     @RetryAsserts
     @Then("I call function with HederaTokenService getTokenDefaultFreezeStatus token {string}")
     public void htsGetTokenDefaultFreezeStatus(String tokenName) {
-        var tokenId = tokenClient.getToken(TokenClient.TokenNameEnum.valueOf(tokenName));
+        var tokenId = tokenClient
+                .getToken(TokenClient.TokenNameEnum.valueOf(tokenName))
+                .tokenId();
         var contractCallRequestBody = ContractCallRequest.builder()
                 .data(ContractMethods.HTS_GET_DEFAULT_FREEZE_STATUS_SELECTOR.getSelector()
                         + to32BytesString(tokenId.toSolidityAddress()))
@@ -278,7 +290,9 @@ public class CallFeature extends AbstractFeature {
     @RetryAsserts
     @Then("I call function with HederaTokenService getTokenDefaultKycStatus token {string}")
     public void htsGetTokenDefaultKycStatus(String tokenName) {
-        var tokenId = tokenClient.getToken(TokenClient.TokenNameEnum.valueOf(tokenName));
+        var tokenId = tokenClient
+                .getToken(TokenClient.TokenNameEnum.valueOf(tokenName))
+                .tokenId();
         var contractCallRequestBody = ContractCallRequest.builder()
                 .data(ContractMethods.HTS_GET_TOKEN_DEFAULT_KYC_STATUS_SELECTOR.getSelector()
                         + to32BytesString(tokenId.toSolidityAddress()))

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/CallFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/CallFeature.java
@@ -131,10 +131,18 @@ public class CallFeature extends AbstractFeature {
         receiverAccountId = accountClient.getAccount(AccountNameEnum.BOB);
     }
 
-    @Given("I ensure token {string} has been created")
+    @Given("I create or reuse token {string}")
     public void createNamedToken(String tokenName) {
-        // If just now created, then ensure transaction has been seen by mirror node and receipt was available
-        tokenClient.getToken(TokenClient.TokenNameEnum.valueOf(tokenName));
+        var tokenAndResponse = tokenClient.getTokenAndResponse(TokenClient.TokenNameEnum.valueOf(tokenName));
+        this.networkTransactionResponse = tokenAndResponse.response();
+    }
+
+    @RetryAsserts
+    @Then("the mirror node REST API should return status {int} for the token creation transaction")
+    public void conditionallyVerifyMirrorAPIResponses(int status) {
+        if (this.networkTransactionResponse != null) {
+            verifyMirrorTransactionsResponse(mirrorClient, status);
+        }
     }
 
     // ETHCALL-017

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/CallFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/CallFeature.java
@@ -131,20 +131,6 @@ public class CallFeature extends AbstractFeature {
         receiverAccountId = accountClient.getAccount(AccountNameEnum.BOB);
     }
 
-    @Given("I create or reuse token {string}")
-    public void createNamedToken(String tokenName) {
-        var tokenAndResponse = tokenClient.getTokenAndResponse(TokenClient.TokenNameEnum.valueOf(tokenName));
-        this.networkTransactionResponse = tokenAndResponse.response();
-    }
-
-    @RetryAsserts
-    @Then("the mirror node REST API should return status {int} for the token creation transaction")
-    public void conditionallyVerifyMirrorAPIResponses(int status) {
-        if (this.networkTransactionResponse != null) {
-            verifyMirrorTransactionsResponse(mirrorClient, status);
-        }
-    }
-
     // ETHCALL-017
     @RetryAsserts
     @Then("I call function with IERC721Metadata token {string} name")

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TokenFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TokenFeature.java
@@ -89,6 +89,15 @@ public class TokenFeature extends AbstractFeature {
     private final Map<TokenId, List<Long>> tokenSerialNumbers = new HashMap<>();
     private final List<TokenId> tokenIds = new ArrayList<>();
 
+    @Given("I ensure token {string} has been created")
+    public void createNamedToken(String tokenName) {
+        var tokenAndResponse = tokenClient.getTokenAndResponse(TokenClient.TokenNameEnum.valueOf(tokenName));
+        if (tokenAndResponse.response() != null) {
+            this.networkTransactionResponse = tokenAndResponse.response();
+            verifyMirrorTransactionsResponse(mirrorClient, 200);
+        }
+    }
+
     @Given("I associate account {string} with token {string}")
     public void associateToken(String accountName, String tokenName) {
         var accountId = accountClient.getAccount(AccountClient.AccountNameEnum.valueOf(accountName));

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TokenFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TokenFeature.java
@@ -91,7 +91,7 @@ public class TokenFeature extends AbstractFeature {
 
     @Given("I ensure token {string} has been created")
     public void createNamedToken(String tokenName) {
-        var tokenAndResponse = tokenClient.getTokenAndResponse(TokenClient.TokenNameEnum.valueOf(tokenName));
+        var tokenAndResponse = tokenClient.getToken(TokenClient.TokenNameEnum.valueOf(tokenName));
         if (tokenAndResponse.response() != null) {
             this.networkTransactionResponse = tokenAndResponse.response();
             verifyMirrorTransactionsResponse(mirrorClient, 200);
@@ -101,7 +101,9 @@ public class TokenFeature extends AbstractFeature {
     @Given("I associate account {string} with token {string}")
     public void associateToken(String accountName, String tokenName) {
         var accountId = accountClient.getAccount(AccountClient.AccountNameEnum.valueOf(accountName));
-        var tokenId = tokenClient.getToken(TokenClient.TokenNameEnum.valueOf(tokenName));
+        var tokenId = tokenClient
+                .getToken(TokenClient.TokenNameEnum.valueOf(tokenName))
+                .tokenId();
         associateWithToken(accountId, tokenId);
     }
 
@@ -110,7 +112,9 @@ public class TokenFeature extends AbstractFeature {
         var spenderAccountId = accountClient
                 .getAccount(AccountClient.AccountNameEnum.valueOf(accountName))
                 .getAccountId();
-        var tokenId = tokenClient.getToken(TokenClient.TokenNameEnum.valueOf(tokenName));
+        var tokenId = tokenClient
+                .getToken(TokenClient.TokenNameEnum.valueOf(tokenName))
+                .tokenId();
         networkTransactionResponse = accountClient.approveToken(tokenId, spenderAccountId, amount);
         assertNotNull(networkTransactionResponse.getTransactionId());
         assertNotNull(networkTransactionResponse.getReceipt());
@@ -120,7 +124,9 @@ public class TokenFeature extends AbstractFeature {
     @RetryAsserts
     public void verifyMirrorAPIApprovedTokenAllowanceResponse(
             long approvedAmount, String tokenName, String accountName) {
-        var tokenId = tokenClient.getToken(TokenClient.TokenNameEnum.valueOf(tokenName));
+        var tokenId = tokenClient
+                .getToken(TokenClient.TokenNameEnum.valueOf(tokenName))
+                .tokenId();
         var spenderAccountId = accountClient.getAccount(AccountClient.AccountNameEnum.valueOf(accountName));
         verifyMirrorAPIApprovedTokenAllowanceResponse(tokenId, spenderAccountId, approvedAmount, 0);
     }
@@ -129,14 +135,18 @@ public class TokenFeature extends AbstractFeature {
     @RetryAsserts
     public void verifyMirrorAPIApprovedDebitedTokenAllowanceResponse(
             long debitAmount, String tokenName, long approvedAmount, String accountName) {
-        var tokenId = tokenClient.getToken(TokenClient.TokenNameEnum.valueOf(tokenName));
+        var tokenId = tokenClient
+                .getToken(TokenClient.TokenNameEnum.valueOf(tokenName))
+                .tokenId();
         var spenderAccountId = accountClient.getAccount(AccountClient.AccountNameEnum.valueOf(accountName));
         verifyMirrorAPIApprovedTokenAllowanceResponse(tokenId, spenderAccountId, approvedAmount, debitAmount);
     }
 
     @Then("I transfer {long} of token {string} to {string}")
     public void transferTokensToRecipient(long amount, String tokenName, String accountName) {
-        var tokenId = tokenClient.getToken(TokenClient.TokenNameEnum.valueOf(tokenName));
+        var tokenId = tokenClient
+                .getToken(TokenClient.TokenNameEnum.valueOf(tokenName))
+                .tokenId();
         var recipientAccountId = accountClient
                 .getAccount(AccountClient.AccountNameEnum.valueOf(accountName))
                 .getAccountId();
@@ -152,7 +162,9 @@ public class TokenFeature extends AbstractFeature {
     public void transferFromAllowance(
             String spenderAccountName, long amount, String tokenName, String recipientAccountName) {
 
-        var tokenId = tokenClient.getToken(TokenClient.TokenNameEnum.valueOf(tokenName));
+        var tokenId = tokenClient
+                .getToken(TokenClient.TokenNameEnum.valueOf(tokenName))
+                .tokenId();
         var spenderAccountId = accountClient.getAccount(AccountClient.AccountNameEnum.valueOf(spenderAccountName));
         var recipientAccountId = accountClient
                 .getAccount(AccountClient.AccountNameEnum.valueOf(recipientAccountName))
@@ -185,6 +197,7 @@ public class TokenFeature extends AbstractFeature {
         // verify valid set of transactions
         var tokenId = tokenClient
                 .getToken(TokenClient.TokenNameEnum.valueOf(tokenName))
+                .tokenId()
                 .toString();
         var owner = accountClient.getClient().getOperatorAccountId().toString();
         var transactions = mirrorTransactionsResponse.getTransactions();
@@ -199,7 +212,9 @@ public class TokenFeature extends AbstractFeature {
 
     @Given("I delete the allowance on token {string} for {string}")
     public void setFungibleTokenAllowance(String tokenName, String spenderAccountName) {
-        var tokenId = tokenClient.getToken(TokenClient.TokenNameEnum.valueOf(tokenName));
+        var tokenId = tokenClient
+                .getToken(TokenClient.TokenNameEnum.valueOf(tokenName))
+                .tokenId();
         var spenderAccountId = accountClient.getAccount(AccountClient.AccountNameEnum.valueOf(spenderAccountName));
         networkTransactionResponse = accountClient.approveToken(tokenId, spenderAccountId.getAccountId(), 0L);
         assertNotNull(networkTransactionResponse.getTransactionId());

--- a/hedera-mirror-test/src/test/resources/features/contract/call.feature
+++ b/hedera-mirror-test/src/test/resources/features/contract/call.feature
@@ -2,8 +2,10 @@
 Feature: eth_call Contract Base Coverage Feature
 
   Scenario Outline: Validate eth_call
-    Given I ensure token "NFT" has been created
-    Given I ensure token "FUNGIBLE" has been created
+    Given I create or reuse token "FUNGIBLE"
+    Then the mirror node REST API should return status 200 for the token creation transaction
+    And I create or reuse token "NFT"
+    Then the mirror node REST API should return status 200 for the token creation transaction
     Given I successfully create ERC contract
     Given I successfully create Precompile contract
     Given I successfully create EstimateGas contract

--- a/hedera-mirror-test/src/test/resources/features/contract/call.feature
+++ b/hedera-mirror-test/src/test/resources/features/contract/call.feature
@@ -2,10 +2,8 @@
 Feature: eth_call Contract Base Coverage Feature
 
   Scenario Outline: Validate eth_call
-    Given I create or reuse token "FUNGIBLE"
-    Then the mirror node REST API should return status 200 for the token creation transaction
-    And I create or reuse token "NFT"
-    Then the mirror node REST API should return status 200 for the token creation transaction
+    Given I ensure token "NFT" has been created
+    And I ensure token "FUNGIBLE" has been created
     Given I successfully create ERC contract
     Given I successfully create Precompile contract
     Given I successfully create EstimateGas contract

--- a/hedera-mirror-test/src/test/resources/features/token/tokenAllowance.feature
+++ b/hedera-mirror-test/src/test/resources/features/token/tokenAllowance.feature
@@ -3,7 +3,8 @@ Feature: Account Crypto Allowance Coverage Feature
 
   @critical @release @acceptance
   Scenario Outline: Validate approval TokenTransfer affect on TokenAllowance amount
-    Given I associate account <recipient> with token <tokenName>
+    Given I ensure token <tokenName> has been created
+    And I associate account <recipient> with token <tokenName>
     Then the mirror node REST API should return the transaction
     Given I approve <spender> to transfer up to <approvedAmount> of token <tokenName>
     Then the mirror node REST API should confirm the approved allowance <approvedAmount> of <tokenName> for <spender>


### PR DESCRIPTION
**Description**:
After known named token creation, make the `NetworkTransactionResponse` produced in `TokenClient` available to `TokenFeature` so that it can just invoke `verifyMirrorTransactionsResponse()` in its superclass to verify the transaction with the mirror node REST API.

Eliminate `getToken()` convenience method and rename token and response method as it and update dependent code accordingly.

**Related issue(s)**:

Fixes #6648

**Notes for reviewer**:
`TokenClient` stores the token in a map and may or may not create the token on the network when called vs simply returning the existing token with that name. Therefore, a transaction may or may not be executed, and thus looking for it via the REST API may or may not be applicable.

`CallFeature` is separate from `TokenService` so some information needs to be communicated beyond just the token ID so that `TokenService` knows whether or not a transaction was executed, and if so, when to actually verify its status.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
