### PR TITLE
Remove JUnit Test Report action from CI

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -46,13 +46,6 @@ jobs:
         uses: codecov/codecov-action@v3
         if: always() && matrix.schema == 'v1'
 
-      - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v3
-        if: always()
-        with:
-          report_paths: "**/build/test-results/test/TEST-*.xml"
-          require_tests: "false"
-
       - name: Upload artifact
         if: startsWith(github.ref, 'refs/tags/v') && matrix.project != 'common' && matrix.schema == 'v1'
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
**Description**:

Remove JUnit Test Report action from CI since:

* It is not used by anyone
* Doesn't account for automatic flaky test retries
* Marks entire PR as failing checks when everything is passing but a retry test
* Build scan shows similar info
* Bug that causes the report to sometimes gets uploaded to the [wrong](https://github.com/hashgraph/hedera-mirror-node/actions/runs/5892246438) workflow

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
