### PR TITLE
Use @CustomLog instead of @Log4j2

### DIFF
--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/RecordItem.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/RecordItem.java
@@ -43,17 +43,17 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.CustomLog;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.Value;
 import lombok.experimental.NonFinal;
-import lombok.extern.log4j.Log4j2;
 import org.apache.commons.codec.binary.Hex;
 import org.springframework.data.util.Version;
 
 @Builder(buildMethodName = "buildInternal")
 @AllArgsConstructor(access = PRIVATE)
-@Log4j2
+@CustomLog
 @Value
 public class RecordItem implements StreamItem {
 

--- a/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/DomainBuilder.java
+++ b/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/DomainBuilder.java
@@ -120,9 +120,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 import lombok.Value;
-import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
@@ -131,7 +131,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.support.TransactionOperations;
 
 @Component
-@Log4j2
+@CustomLog
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
 @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
 public class DomainBuilder {

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/config/GrpcHealthIndicator.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/config/GrpcHealthIndicator.java
@@ -18,8 +18,8 @@ package com.hedera.mirror.grpc.config;
 
 import jakarta.inject.Named;
 import java.util.concurrent.atomic.AtomicReference;
+import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
 import net.devh.boot.grpc.server.event.GrpcServerShutdownEvent;
 import net.devh.boot.grpc.server.event.GrpcServerStartedEvent;
 import net.devh.boot.grpc.server.event.GrpcServerTerminatedEvent;
@@ -28,7 +28,7 @@ import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.boot.actuate.health.Status;
 import org.springframework.context.event.EventListener;
 
-@Log4j2
+@CustomLog
 @Named
 @RequiredArgsConstructor
 public class GrpcHealthIndicator implements HealthIndicator {

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/controller/ConsensusController.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/controller/ConsensusController.java
@@ -28,8 +28,8 @@ import com.hedera.mirror.grpc.service.TopicMessageService;
 import com.hedera.mirror.grpc.util.ProtoUtil;
 import com.hederahashgraph.api.proto.java.ConsensusMessageChunkInfo;
 import com.hederahashgraph.api.proto.java.TransactionID;
+import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
 import net.devh.boot.grpc.server.service.GrpcService;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -41,7 +41,7 @@ import reactor.core.publisher.Mono;
  * controller.
  */
 @GrpcService
-@Log4j2
+@CustomLog
 @RequiredArgsConstructor
 public class ConsensusController extends ReactorConsensusServiceGrpc.ConsensusServiceImplBase {
 

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/controller/NetworkController.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/controller/NetworkController.java
@@ -28,14 +28,14 @@ import com.hederahashgraph.api.proto.java.NodeAddress;
 import com.hederahashgraph.api.proto.java.ServiceEndpoint;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
 import net.devh.boot.grpc.server.service.GrpcService;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 @GrpcService
-@Log4j2
+@CustomLog
 @RequiredArgsConstructor
 public class NetworkController extends ReactorNetworkServiceGrpc.NetworkServiceImplBase {
 

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/CompositeTopicListener.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/CompositeTopicListener.java
@@ -24,13 +24,13 @@ import io.micrometer.core.instrument.Timer;
 import jakarta.annotation.PostConstruct;
 import jakarta.inject.Named;
 import java.util.concurrent.TimeUnit;
+import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
 import org.springframework.context.annotation.Primary;
 import reactor.core.publisher.Flux;
 
 @Named
-@Log4j2
+@CustomLog
 @Primary
 @RequiredArgsConstructor
 public class CompositeTopicListener implements TopicListener {

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/PollingTopicListener.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/PollingTopicListener.java
@@ -24,9 +24,9 @@ import jakarta.inject.Named;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import lombok.CustomLog;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
 import reactor.core.observability.micrometer.Micrometer;
 import reactor.core.publisher.Flux;
 import reactor.core.scheduler.Scheduler;
@@ -35,7 +35,7 @@ import reactor.retry.Jitter;
 import reactor.retry.Repeat;
 
 @Named
-@Log4j2
+@CustomLog
 @RequiredArgsConstructor
 public class PollingTopicListener implements TopicListener {
 

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/RedisTopicListener.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/RedisTopicListener.java
@@ -24,7 +24,7 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import lombok.extern.log4j.Log4j2;
+import lombok.CustomLog;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
 import org.springframework.data.redis.connection.ReactiveSubscription.Message;
@@ -39,7 +39,7 @@ import reactor.core.publisher.Mono;
 import reactor.util.retry.Retry;
 
 @Lazy
-@Log4j2
+@CustomLog
 @Named
 public class RedisTopicListener extends SharedTopicListener {
 

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/repository/TopicMessageRepositoryCustomImpl.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/repository/TopicMessageRepositoryCustomImpl.java
@@ -26,11 +26,11 @@ import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
 import java.util.stream.Stream;
+import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
 import org.hibernate.jpa.HibernateHints;
 
-@Log4j2
+@CustomLog
 @Named
 @RequiredArgsConstructor
 public class TopicMessageRepositoryCustomImpl implements TopicMessageRepositoryCustom {

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/retriever/PollingTopicMessageRetriever.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/retriever/PollingTopicMessageRetriever.java
@@ -26,8 +26,8 @@ import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import lombok.CustomLog;
 import lombok.Data;
-import lombok.extern.log4j.Log4j2;
 import reactor.core.observability.micrometer.Micrometer;
 import reactor.core.publisher.Flux;
 import reactor.core.scheduler.Scheduler;
@@ -37,7 +37,7 @@ import reactor.retry.Repeat;
 import reactor.util.retry.Retry;
 
 @Named
-@Log4j2
+@CustomLog
 public class PollingTopicMessageRetriever implements TopicMessageRetriever {
 
     private final ObservationRegistry observationRegistry;

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/service/NetworkServiceImpl.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/service/NetworkServiceImpl.java
@@ -32,9 +32,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 import lombok.Value;
-import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.transaction.support.TransactionOperations;
 import org.springframework.validation.annotation.Validated;
@@ -43,7 +43,7 @@ import reactor.core.scheduler.Schedulers;
 import reactor.retry.Jitter;
 import reactor.retry.Repeat;
 
-@Log4j2
+@CustomLog
 @Named
 @RequiredArgsConstructor
 @Validated

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/service/TopicMessageServiceImpl.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/service/TopicMessageServiceImpl.java
@@ -36,9 +36,9 @@ import java.time.Instant;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import lombok.CustomLog;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
 import org.springframework.validation.annotation.Validated;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -46,7 +46,7 @@ import reactor.core.publisher.SignalType;
 import reactor.retry.Repeat;
 
 @Named
-@Log4j2
+@CustomLog
 @RequiredArgsConstructor
 @Validated
 public class TopicMessageServiceImpl implements TopicMessageService {

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/util/ProtoUtil.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/util/ProtoUtil.java
@@ -28,13 +28,13 @@ import io.grpc.StatusRuntimeException;
 import jakarta.validation.ConstraintViolationException;
 import java.time.Instant;
 import java.util.concurrent.TimeoutException;
+import lombok.CustomLog;
 import lombok.experimental.UtilityClass;
-import lombok.extern.log4j.Log4j2;
 import org.springframework.dao.NonTransientDataAccessResourceException;
 import org.springframework.dao.TransientDataAccessException;
 import reactor.core.Exceptions;
 
-@Log4j2
+@CustomLog
 @UtilityClass
 public final class ProtoUtil {
 

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/controller/ConsensusControllerTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/controller/ConsensusControllerTest.java
@@ -40,8 +40,8 @@ import io.grpc.StatusRuntimeException;
 import jakarta.annotation.Resource;
 import java.time.Duration;
 import java.time.Instant;
+import lombok.CustomLog;
 import lombok.SneakyThrows;
-import lombok.extern.log4j.Log4j2;
 import net.devh.boot.grpc.client.inject.GrpcClient;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -51,7 +51,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
-@Log4j2
+@CustomLog
 class ConsensusControllerTest extends GrpcIntegrationTest {
 
     private static final Duration WAIT = Duration.ofSeconds(10L);

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/controller/NetworkControllerTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/controller/NetworkControllerTest.java
@@ -35,13 +35,13 @@ import io.grpc.StatusRuntimeException;
 import jakarta.annotation.Resource;
 import java.net.InetAddress;
 import java.time.Duration;
-import lombok.extern.log4j.Log4j2;
+import lombok.CustomLog;
 import net.devh.boot.grpc.client.inject.GrpcClient;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
-@Log4j2
+@CustomLog
 class NetworkControllerTest extends GrpcIntegrationTest {
 
     private static final Duration WAIT = Duration.ofSeconds(10L);

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/domain/ReactiveDomainBuilder.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/domain/ReactiveDomainBuilder.java
@@ -29,15 +29,15 @@ import jakarta.inject.Named;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
+import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
 import org.reactivestreams.Publisher;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Scope;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-@Log4j2
+@CustomLog
 @Named("grpcDomainBuilder")
 @RequiredArgsConstructor
 @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/listener/RedisTopicListenerTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/listener/RedisTopicListenerTest.java
@@ -18,11 +18,11 @@ package com.hedera.mirror.grpc.listener;
 
 import com.hedera.mirror.common.domain.topic.TopicMessage;
 import jakarta.annotation.Resource;
-import lombok.extern.log4j.Log4j2;
+import lombok.CustomLog;
 import org.springframework.data.redis.core.ReactiveRedisOperations;
 import reactor.core.publisher.Flux;
 
-@Log4j2
+@CustomLog
 @SuppressWarnings("java:S2187") // Ignore no tests in file warning
 class RedisTopicListenerTest extends AbstractSharedTopicListenerTest {
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/addressbook/AddressBookServiceImpl.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/addressbook/AddressBookServiceImpl.java
@@ -57,8 +57,8 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
+import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.cache.annotation.CacheConfig;
@@ -69,7 +69,7 @@ import org.springframework.core.io.Resource;
 import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.util.CollectionUtils;
 
-@Log4j2
+@CustomLog
 @Named
 @CacheConfig(cacheNames = CACHE_NAME, cacheManager = EXPIRE_AFTER_5M)
 @RequiredArgsConstructor

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/MetricsConfiguration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/MetricsConfiguration.java
@@ -28,15 +28,15 @@ import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.function.ToDoubleFunction;
 import javax.sql.DataSource;
+import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.jdbc.core.JdbcOperations;
 
-@Log4j2
+@CustomLog
 @Configuration
 @RequiredArgsConstructor
 class MetricsConfiguration {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/MetricsExecutionInterceptor.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/MetricsExecutionInterceptor.java
@@ -28,9 +28,9 @@ import java.time.Instant;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import lombok.CustomLog;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -42,7 +42,7 @@ import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 /**
  * Intercepts requests to the S3 API and records relevant metrics before continuing.
  */
-@Log4j2
+@CustomLog
 @Named
 @RequiredArgsConstructor
 public class MetricsExecutionInterceptor implements ExecutionInterceptor {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/MirrorDateRangePropertiesProcessor.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/MirrorDateRangePropertiesProcessor.java
@@ -37,11 +37,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 import lombok.Value;
-import lombok.extern.log4j.Log4j2;
 
-@Log4j2
+@CustomLog
 @Named
 @RequiredArgsConstructor
 public class MirrorDateRangePropertiesProcessor {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/MirrorImporterConfiguration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/MirrorImporterConfiguration.java
@@ -26,8 +26,8 @@ import com.hedera.mirror.importer.parser.batch.BatchUpserter;
 import com.hedera.mirror.importer.repository.upsert.DeletedTokenDissociateTransferUpsertQueryGenerator;
 import io.micrometer.core.instrument.MeterRegistry;
 import javax.sql.DataSource;
+import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnCloudPlatform;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -45,7 +45,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @Configuration
 @EnableAsync
 @EntityScan({"com.hedera.mirror.common.domain", "com.hedera.mirror.importer.repository.upsert"})
-@Log4j2
+@CustomLog
 @RequiredArgsConstructor
 @AutoConfigureBefore(FlywayAutoConfiguration.class) // Since this configuration creates FlywayConfigurationCustomizer
 public class MirrorImporterConfiguration {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/ContractResultServiceImpl.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/ContractResultServiceImpl.java
@@ -48,11 +48,11 @@ import jakarta.inject.Named;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import lombok.CustomLog;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
 
-@Log4j2
+@CustomLog
 @Named
 @RequiredArgsConstructor
 public class ContractResultServiceImpl implements ContractResultService {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/EntityIdServiceImpl.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/EntityIdServiceImpl.java
@@ -34,12 +34,12 @@ import jakarta.inject.Named;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.function.Function;
-import lombok.extern.log4j.Log4j2;
+import lombok.CustomLog;
 import org.apache.commons.codec.binary.Hex;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 
-@Log4j2
+@CustomLog
 @Named
 public class EntityIdServiceImpl implements EntityIdService {
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/balance/AccountBalancesDownloader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/balance/AccountBalancesDownloader.java
@@ -29,10 +29,10 @@ import com.hedera.mirror.importer.reader.balance.BalanceFileReader;
 import com.hedera.mirror.importer.reader.signature.SignatureFileReader;
 import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.inject.Named;
-import lombok.extern.log4j.Log4j2;
+import lombok.CustomLog;
 import org.springframework.scheduling.annotation.Scheduled;
 
-@Log4j2
+@CustomLog
 @Named
 public class AccountBalancesDownloader extends Downloader<AccountBalanceFile, AccountBalance> {
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/leader/LeaderAspect.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/leader/LeaderAspect.java
@@ -17,7 +17,7 @@
 package com.hedera.mirror.importer.leader;
 
 import java.util.concurrent.atomic.AtomicBoolean;
-import lombok.extern.log4j.Log4j2;
+import lombok.CustomLog;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
@@ -32,7 +32,7 @@ import org.springframework.integration.leader.event.OnRevokedEvent;
  * whether this pod is currently leader or not.
  */
 @Aspect
-@Log4j2
+@CustomLog
 @Order(1)
 public class LeaderAspect implements LeaderService {
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/batch/BatchInserter.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/batch/BatchInserter.java
@@ -39,7 +39,7 @@ import java.sql.SQLException;
 import java.util.Collection;
 import java.util.stream.Collectors;
 import javax.sql.DataSource;
-import lombok.extern.log4j.Log4j2;
+import lombok.CustomLog;
 import org.postgresql.PGConnection;
 import org.postgresql.copy.CopyIn;
 import org.postgresql.copy.PGCopyOutputStream;
@@ -48,7 +48,7 @@ import org.springframework.jdbc.datasource.DataSourceUtils;
 /**
  * Stateless writer to insert rows into PostgreSQL using COPY.
  */
-@Log4j2
+@CustomLog
 public class BatchInserter implements BatchPersister {
 
     protected final DataSource dataSource;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/CompositeEntityListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/CompositeEntityListener.java
@@ -50,11 +50,11 @@ import jakarta.inject.Named;
 import java.util.Collection;
 import java.util.List;
 import java.util.function.BiConsumer;
+import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
 import org.springframework.context.annotation.Primary;
 
-@Log4j2
+@CustomLog
 @Named
 @Primary
 @RequiredArgsConstructor

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/notify/NotifyingEntityListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/notify/NotifyingEntityListener.java
@@ -33,15 +33,15 @@ import jakarta.inject.Named;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
 import org.springframework.context.event.EventListener;
 import org.springframework.core.annotation.Order;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.PreparedStatementCallback;
 
 @ConditionOnEntityRecordParser
-@Log4j2
+@CustomLog
 @Named
 @Order(2)
 @RequiredArgsConstructor

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/redis/RedisEntityListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/redis/RedisEntityListener.java
@@ -37,15 +37,15 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicLong;
+import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
 import org.springframework.context.event.EventListener;
 import org.springframework.core.annotation.Order;
 import org.springframework.data.redis.core.RedisOperations;
 import org.springframework.data.redis.core.SessionCallback;
 
 @ConditionOnEntityRecordParser
-@Log4j2
+@CustomLog
 @Named
 @Order(1)
 @RequiredArgsConstructor

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/pubsub/PubSubRecordItemListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/pubsub/PubSubRecordItemListener.java
@@ -40,10 +40,10 @@ import com.hederahashgraph.api.proto.java.TransactionRecord;
 import jakarta.inject.Named;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
 
-@Log4j2
+@CustomLog
 @Named
 @RequiredArgsConstructor
 @ConditionalOnPubSubRecordParser

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/balance/CompositeBalanceFileReader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/balance/CompositeBalanceFileReader.java
@@ -20,11 +20,11 @@ import com.google.common.base.Stopwatch;
 import com.hedera.mirror.common.domain.balance.AccountBalanceFile;
 import com.hedera.mirror.importer.domain.StreamFileData;
 import jakarta.inject.Named;
+import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
 import org.springframework.context.annotation.Primary;
 
-@Log4j2
+@CustomLog
 @Named
 @Primary
 @RequiredArgsConstructor

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/balance/CsvBalanceFileReader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/balance/CsvBalanceFileReader.java
@@ -36,13 +36,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
+import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.StringUtils;
 import reactor.core.publisher.Flux;
 
-@Log4j2
+@CustomLog
 @RequiredArgsConstructor
 public abstract class CsvBalanceFileReader implements BalanceFileReader {
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/balance/ProtoBalanceFileReader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/balance/ProtoBalanceFileReader.java
@@ -35,13 +35,13 @@ import java.io.InputStream;
 import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
-import lombok.extern.log4j.Log4j2;
+import lombok.CustomLog;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.IOUtils;
 import org.springframework.util.Assert;
 import reactor.core.publisher.Flux;
 
-@Log4j2
+@CustomLog
 @Named
 public class ProtoBalanceFileReader implements BalanceFileReader {
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/event/EventFileReaderV3.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/event/EventFileReaderV3.java
@@ -27,10 +27,10 @@ import jakarta.inject.Named;
 import java.io.DataInputStream;
 import java.security.MessageDigest;
 import java.time.Instant;
-import lombok.extern.log4j.Log4j2;
+import lombok.CustomLog;
 import org.apache.commons.codec.binary.Hex;
 
-@Log4j2
+@CustomLog
 @Named
 public class EventFileReaderV3 implements EventFileReader {
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/record/CompositeRecordFileReader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/record/CompositeRecordFileReader.java
@@ -24,12 +24,12 @@ import com.hedera.mirror.importer.exception.StreamFileReaderException;
 import jakarta.inject.Named;
 import java.io.DataInputStream;
 import java.io.IOException;
+import lombok.CustomLog;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
 import org.springframework.context.annotation.Primary;
 
-@Log4j2
+@CustomLog
 @Named
 @Primary
 @RequiredArgsConstructor

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/record/ProtoRecordFileReader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/record/ProtoRecordFileReader.java
@@ -42,12 +42,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
-import lombok.extern.log4j.Log4j2;
+import lombok.CustomLog;
 import org.apache.commons.io.output.NullOutputStream;
 import org.springframework.data.util.Version;
 import reactor.core.publisher.Flux;
 
-@Log4j2
+@CustomLog
 @Named
 public class ProtoRecordFileReader implements RecordFileReader {
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/signature/CompositeSignatureFileReader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/signature/CompositeSignatureFileReader.java
@@ -22,11 +22,11 @@ import com.hedera.mirror.importer.exception.SignatureFileParsingException;
 import jakarta.inject.Named;
 import java.io.DataInputStream;
 import java.io.IOException;
+import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
 import org.springframework.context.annotation.Primary;
 
-@Log4j2
+@CustomLog
 @Named
 @Primary
 @RequiredArgsConstructor

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/EntityMetadataRegistry.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/EntityMetadataRegistry.java
@@ -42,15 +42,15 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import lombok.CustomLog;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.StringUtils;
 import org.hibernate.metamodel.model.domain.SingularPersistentAttribute;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.jdbc.core.JdbcOperations;
 
-@Log4j2
+@CustomLog
 @Named
 @RequiredArgsConstructor
 public class EntityMetadataRegistry {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/GenericUpsertQueryGenerator.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/GenericUpsertQueryGenerator.java
@@ -18,15 +18,15 @@ package com.hedera.mirror.importer.repository.upsert;
 
 import java.io.StringWriter;
 import java.text.MessageFormat;
+import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
 import org.apache.velocity.Template;
 import org.apache.velocity.VelocityContext;
 import org.apache.velocity.app.VelocityEngine;
 import org.apache.velocity.runtime.RuntimeConstants;
 import org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader;
 
-@Log4j2
+@CustomLog
 @RequiredArgsConstructor
 public class GenericUpsertQueryGenerator implements UpsertQueryGenerator {
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/UpsertQueryGeneratorFactory.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/UpsertQueryGeneratorFactory.java
@@ -20,10 +20,10 @@ import jakarta.inject.Named;
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
 
-@Log4j2
+@CustomLog
 @Named
 @RequiredArgsConstructor
 public class UpsertQueryGeneratorFactory {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/retention/RetentionJob.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/retention/RetentionJob.java
@@ -29,15 +29,15 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
+import lombok.CustomLog;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.ClassUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.transaction.support.TransactionOperations;
 
-@Log4j2
+@CustomLog
 @Named
 @RequiredArgsConstructor
 public class RetentionJob {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/util/ShutdownHelper.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/util/ShutdownHelper.java
@@ -17,7 +17,7 @@
 package com.hedera.mirror.importer.util;
 
 import jakarta.inject.Named;
-import lombok.extern.log4j.Log4j2;
+import lombok.CustomLog;
 
 /**
  * ShutdownHelper helps in shutting down the threads cleanly when JVM is doing down.
@@ -26,7 +26,7 @@ import lombok.extern.log4j.Log4j2;
  * threads will have fixed time (say 5 seconds), to stop gracefully. Therefore, long living and heavy lifting threads
  * should regularly probe for this flag.
  */
-@Log4j2
+@CustomLog
 @Named
 public class ShutdownHelper {
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/util/Utility.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/util/Utility.java
@@ -38,14 +38,14 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.util.Arrays;
+import lombok.CustomLog;
 import lombok.experimental.UtilityClass;
-import lombok.extern.log4j.Log4j2;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.lang3.StringUtils;
 import org.bouncycastle.jcajce.provider.digest.Keccak;
 import org.hyperledger.besu.nativelib.secp256k1.LibSecp256k1;
 
-@Log4j2
+@CustomLog
 @UtilityClass
 public class Utility {
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/FileCopier.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/FileCopier.java
@@ -25,14 +25,14 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.function.Function;
+import lombok.CustomLog;
 import lombok.NonNull;
 import lombok.Value;
-import lombok.extern.log4j.Log4j2;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.TrueFileFilter;
 import org.apache.commons.io.filefilter.WildcardFileFilter;
 
-@Log4j2
+@CustomLog
 @Value
 public class FileCopier {
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/performance/PerformanceIntegrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/performance/PerformanceIntegrationTest.java
@@ -31,7 +31,7 @@ import com.hedera.mirror.importer.repository.TransactionRepository;
 import java.sql.SQLException;
 import java.util.function.Consumer;
 import javax.sql.DataSource;
-import lombok.extern.log4j.Log4j2;
+import lombok.CustomLog;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -41,7 +41,7 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.OutputFrame;
 import org.testcontainers.containers.startupcheck.IndefiniteWaitOneShotStartupCheckStrategy;
 
-@Log4j2
+@CustomLog
 @SpringBootTest
 public abstract class PerformanceIntegrationTest {
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/performance/RestoreClientIntegrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/performance/RestoreClientIntegrationTest.java
@@ -16,7 +16,7 @@
 
 package com.hedera.mirror.importer.parser.performance;
 
-import lombok.extern.log4j.Log4j2;
+import lombok.CustomLog;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -25,7 +25,7 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-@Log4j2
+@CustomLog
 @Tag("largedbperf")
 @Testcontainers
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/config/LoggingFilter.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/config/LoggingFilter.java
@@ -20,7 +20,7 @@ import jakarta.inject.Named;
 import java.io.Serial;
 import java.net.InetSocketAddress;
 import java.net.URI;
-import lombok.extern.log4j.Log4j2;
+import lombok.CustomLog;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Level;
 import org.springframework.http.server.reactive.ServerHttpRequest;
@@ -31,7 +31,7 @@ import org.springframework.web.server.WebFilter;
 import org.springframework.web.server.WebFilterChain;
 import reactor.core.publisher.Mono;
 
-@Log4j2
+@CustomLog
 @Named
 public class LoggingFilter implements WebFilter {
 

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/config/MonitorConfiguration.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/config/MonitorConfiguration.java
@@ -27,8 +27,8 @@ import com.hedera.mirror.monitor.subscribe.SubscribeMetrics;
 import java.util.List;
 import java.util.concurrent.CompletionException;
 import java.util.function.Function;
+import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -37,7 +37,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Hooks;
 import reactor.core.scheduler.Schedulers;
 
-@Log4j2
+@CustomLog
 @Configuration
 @RequiredArgsConstructor
 class MonitorConfiguration {

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/converter/StringToInstantDeserializer.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/converter/StringToInstantDeserializer.java
@@ -21,10 +21,10 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import java.io.IOException;
 import java.time.Instant;
-import lombok.extern.log4j.Log4j2;
+import lombok.CustomLog;
 import org.apache.commons.lang3.StringUtils;
 
-@Log4j2
+@CustomLog
 public class StringToInstantDeserializer extends JsonDeserializer<Instant> {
 
     @Override

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/expression/ExpressionConverterImpl.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/expression/ExpressionConverterImpl.java
@@ -39,16 +39,16 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import lombok.CustomLog;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Value;
-import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.StringUtils;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 import reactor.util.retry.Retry;
 
-@Log4j2
+@CustomLog
 @Named
 @RequiredArgsConstructor
 public class ExpressionConverterImpl implements ExpressionConverter {

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/properties/ScenarioPropertiesAggregatorImpl.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/properties/ScenarioPropertiesAggregatorImpl.java
@@ -24,9 +24,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import lombok.extern.log4j.Log4j2;
+import lombok.CustomLog;
 
-@Log4j2
+@CustomLog
 @Named
 public class ScenarioPropertiesAggregatorImpl implements ScenarioPropertiesAggregator {
 

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishMetrics.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishMetrics.java
@@ -27,12 +27,12 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 import lombok.Value;
-import lombok.extern.log4j.Log4j2;
 import org.springframework.scheduling.annotation.Scheduled;
 
-@Log4j2
+@CustomLog
 @Named
 @RequiredArgsConstructor
 public class PublishMetrics {

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/TransactionPublisher.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/TransactionPublisher.java
@@ -33,12 +33,12 @@ import java.security.SecureRandom;
 import java.time.Instant;
 import java.util.Map;
 import java.util.stream.Collectors;
+import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-@Log4j2
+@CustomLog
 @Named
 @RequiredArgsConstructor
 public class TransactionPublisher implements AutoCloseable {

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/generator/CompositeTransactionGenerator.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/generator/CompositeTransactionGenerator.java
@@ -31,12 +31,12 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
-import lombok.extern.log4j.Log4j2;
+import lombok.CustomLog;
 import org.apache.commons.math3.distribution.EnumeratedDistribution;
 import org.apache.commons.math3.util.Pair;
 import reactor.core.publisher.Flux;
 
-@Log4j2
+@CustomLog
 @Named
 public class CompositeTransactionGenerator implements TransactionGenerator {
 

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/generator/ConfigurableTransactionGenerator.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/generator/ConfigurableTransactionGenerator.java
@@ -37,13 +37,13 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
+import lombok.CustomLog;
 import lombok.Getter;
-import lombok.extern.log4j.Log4j2;
 import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
 import org.springframework.util.Assert;
 import reactor.core.publisher.Flux;
 
-@Log4j2
+@CustomLog
 public class ConfigurableTransactionGenerator implements TransactionGenerator {
 
     private static final SecureRandom RANDOM = new SecureRandom();

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/account/AccountCreateTransactionSupplier.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/account/AccountCreateTransactionSupplier.java
@@ -23,11 +23,11 @@ import com.hedera.hashgraph.sdk.PublicKey;
 import com.hedera.mirror.monitor.publish.transaction.TransactionSupplier;
 import com.hedera.mirror.monitor.util.Utility;
 import jakarta.validation.constraints.Min;
+import lombok.CustomLog;
 import lombok.Data;
-import lombok.extern.log4j.Log4j2;
 
 @Data
-@Log4j2
+@CustomLog
 public class AccountCreateTransactionSupplier implements TransactionSupplier<AccountCreateTransaction> {
 
     @Min(1)

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/schedule/ScheduleCreateTransactionSupplier.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/schedule/ScheduleCreateTransactionSupplier.java
@@ -27,12 +27,12 @@ import com.hedera.mirror.monitor.publish.transaction.TransactionSupplier;
 import com.hedera.mirror.monitor.util.Utility;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import lombok.CustomLog;
 import lombok.Data;
 import lombok.Getter;
-import lombok.extern.log4j.Log4j2;
 
 @Data
-@Log4j2
+@CustomLog
 public class ScheduleCreateTransactionSupplier implements TransactionSupplier<ScheduleCreateTransaction>, AdminKeyable {
 
     private String adminKey;

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/SubscribeMetrics.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/SubscribeMetrics.java
@@ -27,11 +27,11 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
 import org.springframework.scheduling.annotation.Scheduled;
 
-@Log4j2
+@CustomLog
 @Named
 @RequiredArgsConstructor
 public class SubscribeMetrics {

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/controller/SubscriberController.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/controller/SubscriberController.java
@@ -24,8 +24,8 @@ import com.hedera.mirror.monitor.subscribe.Scenario;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -37,7 +37,7 @@ import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-@Log4j2
+@CustomLog
 @RequestMapping("/api/v1/subscriber")
 @RequiredArgsConstructor
 @RestController

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/grpc/GrpcClientSDK.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/grpc/GrpcClientSDK.java
@@ -29,13 +29,13 @@ import java.security.SecureRandom;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
-import lombok.extern.log4j.Log4j2;
+import lombok.CustomLog;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.Sinks;
 import reactor.core.scheduler.Schedulers;
 
-@Log4j2
+@CustomLog
 @Named
 class GrpcClientSDK implements GrpcClient {
 

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/grpc/GrpcSubscriber.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/grpc/GrpcSubscriber.java
@@ -28,13 +28,13 @@ import io.grpc.StatusRuntimeException;
 import jakarta.inject.Named;
 import java.util.ArrayList;
 import java.util.Collection;
+import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.StringUtils;
 import reactor.core.publisher.Flux;
 import reactor.util.retry.Retry;
 
-@Log4j2
+@CustomLog
 @Named
 @RequiredArgsConstructor
 @SuppressWarnings("unchecked")

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/rest/RestSubscriber.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/rest/RestSubscriber.java
@@ -29,8 +29,8 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Set;
+import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
@@ -40,7 +40,7 @@ import reactor.core.scheduler.Schedulers;
 import reactor.util.retry.Retry;
 import reactor.util.retry.RetryBackoffSpec;
 
-@Log4j2
+@CustomLog
 @Named
 @RequiredArgsConstructor
 @SuppressWarnings("unchecked")

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/util/Utility.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/util/Utility.java
@@ -41,12 +41,12 @@ import java.security.SecureRandom;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Random;
+import lombok.CustomLog;
 import lombok.experimental.UtilityClass;
-import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
 
-@Log4j2
+@CustomLog
 @UtilityClass
 public class Utility {
 

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/controller/SubscriberControllerTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/controller/SubscriberControllerTest.java
@@ -24,7 +24,7 @@ import com.hedera.mirror.monitor.config.LoggingFilter;
 import com.hedera.mirror.monitor.subscribe.MirrorSubscriber;
 import com.hedera.mirror.monitor.subscribe.TestScenario;
 import java.util.Arrays;
-import lombok.extern.log4j.Log4j2;
+import lombok.CustomLog;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -33,7 +33,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import reactor.core.publisher.Flux;
 
-@Log4j2
+@CustomLog
 @ExtendWith(MockitoExtension.class)
 class SubscriberControllerTest {
 

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/grpc/GrpcClientSDKTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/grpc/GrpcClientSDKTest.java
@@ -38,8 +38,8 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import lombok.CustomLog;
 import lombok.Data;
-import lombok.extern.log4j.Log4j2;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -47,7 +47,7 @@ import org.junit.jupiter.api.TestInfo;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
-@Log4j2
+@CustomLog
 class GrpcClientSDKTest {
 
     private static final Instant START_TIME = Instant.now();

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/MirrorNodeClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/MirrorNodeClient.java
@@ -48,8 +48,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import lombok.CustomLog;
 import lombok.NonNull;
-import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.StringUtils;
 import org.awaitility.Durations;
 import org.springframework.http.HttpStatus;
@@ -60,7 +60,7 @@ import reactor.core.publisher.Mono;
 import reactor.util.retry.Retry;
 import reactor.util.retry.RetryBackoffSpec;
 
-@Log4j2
+@CustomLog
 @Named
 public class MirrorNodeClient {
 

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/SubscriptionResponse.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/SubscriptionResponse.java
@@ -26,11 +26,11 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.CustomLog;
 import lombok.Data;
-import lombok.extern.log4j.Log4j2;
 
 @Data
-@Log4j2
+@CustomLog
 public class SubscriptionResponse {
     private SubscriptionHandle subscription;
     private List<MirrorHCSResponse> mirrorHCSResponses = new ArrayList<>();

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AbstractFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AbstractFeature.java
@@ -24,10 +24,10 @@ import com.hedera.mirror.test.e2e.acceptance.props.MirrorTransaction;
 import com.hedera.mirror.test.e2e.acceptance.response.MirrorTransactionsResponse;
 import com.hedera.mirror.test.e2e.acceptance.response.NetworkTransactionResponse;
 import java.util.List;
-import lombok.extern.log4j.Log4j2;
+import lombok.CustomLog;
 import org.springframework.http.HttpStatus;
 
-@Log4j2
+@CustomLog
 abstract class AbstractFeature {
     protected NetworkTransactionResponse networkTransactionResponse;
 


### PR DESCRIPTION
**Description**:

Use `@CustomLog` instead of `@Log4j2` so we can switch out logging libraries easier

**Related issue(s)**:

**Notes for reviewer**:

No other change besides a find and replace of the import and annotation.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
