### PR TITLE
Fix race condition in SyntheticCryptoTransferApprovalsMigrationTest

### DIFF
--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/converter/ObjectToStringSerializer.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/converter/ObjectToStringSerializer.java
@@ -48,6 +48,10 @@ public class ObjectToStringSerializer extends JsonSerializer<Object> {
         JsonConfiguration.INSTANCE.getObjectMapperWrapper().setObjectMapper(OBJECT_MAPPER);
     }
 
+    public static void init() {
+        // Called by other classes to ensure the static initializer runs
+    }
+
     @Override
     public void serialize(Object o, JsonGenerator gen, SerializerProvider serializers) throws IOException {
         var json = OBJECT_MAPPER.writeValueAsString(o);

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/util/DomainUtils.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/util/DomainUtils.java
@@ -21,6 +21,7 @@ import static com.hedera.mirror.common.domain.entity.EntityType.CONTRACT;
 import com.google.protobuf.ByteOutput;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.UnsafeByteOperations;
+import com.hedera.mirror.common.converter.ObjectToStringSerializer;
 import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.exception.InvalidEntityException;
 import com.hedera.mirror.common.exception.ProtobufException;
@@ -51,6 +52,11 @@ public class DomainUtils {
     public static final long NANOS_PER_SECOND = 1_000_000_000L;
     private static final char NULL_CHARACTER = (char) 0;
     private static final char NULL_REPLACEMENT = '�'; // Standard replacement character 0xFFFD
+
+    static {
+        // Ensure it's eagerly instantiated since it is used for the conversion of JSONB data into domain objects.
+        ObjectToStringSerializer.init();
+    }
 
     /**
      * Convert bytes to hex.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/accessor/CustomFeeDatabaseAccessor.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/accessor/CustomFeeDatabaseAccessor.java
@@ -20,14 +20,12 @@ import static com.hedera.mirror.web3.evm.utils.EvmTokenUtils.EMPTY_EVM_ADDRESS;
 import static com.hedera.mirror.web3.evm.utils.EvmTokenUtils.toAddress;
 import static java.util.Objects.requireNonNullElse;
 
-import com.hedera.mirror.common.converter.ObjectToStringSerializer;
 import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.web3.repository.CustomFeeRepository;
 import com.hedera.node.app.service.evm.store.contracts.precompile.codec.CustomFee;
 import com.hedera.node.app.service.evm.store.contracts.precompile.codec.FixedFee;
 import com.hedera.node.app.service.evm.store.contracts.precompile.codec.FractionalFee;
 import com.hedera.node.app.service.evm.store.contracts.precompile.codec.RoyaltyFee;
-import jakarta.annotation.PostConstruct;
 import jakarta.inject.Named;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -41,15 +39,7 @@ import org.springframework.util.CollectionUtils;
 @RequiredArgsConstructor
 public class CustomFeeDatabaseAccessor extends DatabaseAccessor<Object, List<CustomFee>> {
 
-    @PostConstruct
-    private void initConversion() {
-        // Ensure the ObjectToStringSerializer is instantiated.
-        // It is used for the conversion of Jsonb data into domain objects.
-        ObjectToStringSerializer.INSTANCE.toString();
-    }
-
     private final CustomFeeRepository customFeeRepository;
-
     private final EntityDatabaseAccessor entityDatabaseAccessor;
 
     @Override


### PR DESCRIPTION
**Description**:

Fix race condition in `SyntheticCryptoTransferApprovalsMigrationTest` by moving `ObjectToStringSerializer` initialization to common module

**Related issue(s)**:

**Notes for reviewer**:

https://github.com/hashgraph/hedera-mirror-node/actions/runs/5921211816/job/16053453981?pr=6687

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
