### PR TITLE
Fix alarms caused by premature close error in rest monitor

### DIFF
--- a/buildSrc/src/main/kotlin/common-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/common-conventions.gradle.kts
@@ -63,7 +63,7 @@ dependencyCheck {
 // Spotless uses Prettier and it requires Node.js
 node {
     download = true
-    version = "18.17.0"
+    version = "18.17.1"
     workDir = rootDir.resolve(".gradle").resolve("nodejs")
 }
 

--- a/hedera-mirror-rest/Dockerfile
+++ b/hedera-mirror-rest/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.17.0-bullseye-slim
+FROM node:18.17.1-bullseye-slim
 LABEL maintainer="mirrornode@hedera.com"
 
 # Setup

--- a/hedera-mirror-rest/monitoring/Dockerfile
+++ b/hedera-mirror-rest/monitoring/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.17.0-bullseye-slim
+FROM node:18.17.1-bullseye-slim
 LABEL maintainer="mirrornode@hedera.com"
 
 # Setup

--- a/hedera-mirror-rest/monitoring/monitor_apis/package-lock.json
+++ b/hedera-mirror-rest/monitoring/monitor_apis/package-lock.json
@@ -19,7 +19,6 @@
         "lodash": "^4.17.21",
         "log4js": "^6.9.1",
         "mathjs": "^11.9.1",
-        "node-fetch": "^3.3.2",
         "parse-duration": "^1.1.0",
         "pretty-ms": "^8.0.0"
       },
@@ -1753,14 +1752,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/date-format": {
       "version": "4.0.14",
       "resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.14.tgz",
@@ -2109,28 +2100,6 @@
         "bser": "2.1.1"
       }
     },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      }
-    },
     "node_modules/fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -2177,17 +2146,6 @@
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ=="
-    },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
-      }
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
@@ -3763,41 +3721,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
-      }
-    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -4967,14 +4890,6 @@
       "dev": true,
       "dependencies": {
         "makeerror": "1.0.12"
-      }
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
-      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/which": {

--- a/hedera-mirror-rest/monitoring/monitor_apis/package-lock.json
+++ b/hedera-mirror-rest/monitoring/monitor_apis/package-lock.json
@@ -29,7 +29,7 @@
         "nodemon": "^3.0.1"
       },
       "engines": {
-        "node": ">=16.13.0 < 19"
+        "node": ">=18.12.0 < 19"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/hedera-mirror-rest/monitoring/monitor_apis/package.json
+++ b/hedera-mirror-rest/monitoring/monitor_apis/package.json
@@ -6,7 +6,7 @@
   "main": "server.js",
   "private": true,
   "engines": {
-    "node": ">=16.13.0 < 19"
+    "node": ">=18.17.1 < 19"
   },
   "scripts": {
     "dev": "nodemon --experimental-specifier-resolution=node server.js",
@@ -26,7 +26,6 @@
     "lodash": "^4.17.21",
     "log4js": "^6.9.1",
     "mathjs": "^11.9.1",
-    "node-fetch": "^3.3.2",
     "parse-duration": "^1.1.0",
     "pretty-ms": "^8.0.0"
   },

--- a/hedera-mirror-rest/monitoring/monitor_apis/package.json
+++ b/hedera-mirror-rest/monitoring/monitor_apis/package.json
@@ -6,7 +6,7 @@
   "main": "server.js",
   "private": true,
   "engines": {
-    "node": ">=18.17.1 < 19"
+    "node": ">=18.12.0 < 19"
   },
   "scripts": {
     "dev": "nodemon --experimental-specifier-resolution=node server.js",

--- a/hedera-mirror-rest/monitoring/monitor_apis/utils.js
+++ b/hedera-mirror-rest/monitoring/monitor_apis/utils.js
@@ -19,7 +19,6 @@ import httpErrors from 'http-errors';
 import _ from 'lodash';
 import log4js from 'log4js';
 import * as math from 'mathjs';
-import fetch from 'node-fetch';
 import parseDuration from 'parse-duration';
 import prettyMilliseconds from 'pretty-ms';
 import querystring from 'querystring';

--- a/hedera-mirror-rest/package-lock.json
+++ b/hedera-mirror-rest/package-lock.json
@@ -95,7 +95,7 @@
         "supertest": "^6.3.3"
       },
       "engines": {
-        "node": ">=16.13.0 < 19"
+        "node": ">=18.12.0 < 19"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/hedera-mirror-rest/package.json
+++ b/hedera-mirror-rest/package.json
@@ -6,7 +6,7 @@
   "main": "server.js",
   "private": true,
   "engines": {
-    "node": ">=16.13.0 < 19"
+    "node": ">=18.12.0 < 19"
   },
   "scripts": {
     "dev": "HEDERA_MIRROR_REST_LOG_LEVEL=trace nodemon --experimental-specifier-resolution=node server.js",


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR fixes the alarms caused by premature close error in rest monitor.

- Switch to nodejs global fetch API
- Upgrade minimum nodejs engine version to v18 LTS
- Upgrade to nodejs v18.17.1 in Dockerfile and build system

**Related issue(s)**:

Fixes #6702 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
There are several issues w.r.t. premature close in [node-fetch](https://github.com/node-fetch/node-fetch/issues?q=is%3Aissue+is%3Aopen+premature+close). The most convincing findings in the tickets is node-fetch gets confused when underlying sockets get reused with chunked response and throws false positive premature close error.

This might be a regression in node-fetch v3.3.2 which removed the `Connection: close` request header so connections are tend to be `keep-alive` and increase the possibility of being reused over http requests. 

We need to upgrade to v18 since the global fetch API is developed in v17.

Note: tested overnight, for testnet, 0 premature close error v.s. 5 in testnet monitor in the same period.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
