### PR TITLE
Fix allowance acceptance test failing in previewnet (0.87)

### DIFF
--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AccountFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AccountFeature.java
@@ -268,9 +268,14 @@ public class AccountFeature extends AbstractFeature {
         setCryptoAllowance(spender, 0);
     }
 
-    @Then("the mirror node REST API should confirm the crypto allowance deletion")
+    @Then("the mirror node REST API should confirm the crypto allowance no longer exists")
     public void verifyCryptoAllowanceDelete() {
-        verifyMirrorAPIApprovedCryptoAllowanceResponse(0L, 0L);
+        verifyMirrorTransactionsResponse(mirrorClient, HttpStatus.OK.value());
+
+        var owner = accountClient.getClient().getOperatorAccountId().toString();
+        var spender = spenderAccountId.getAccountId().toString();
+        var mirrorCryptoAllowanceResponse = mirrorClient.getAccountCryptoAllowanceBySpender(owner, spender);
+        assertThat(mirrorCryptoAllowanceResponse.getAllowances()).isEmpty();
     }
 
     private void setCryptoAllowance(String accountName, long amount) {

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TokenFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TokenFeature.java
@@ -131,6 +131,25 @@ public class TokenFeature extends AbstractFeature {
         verifyMirrorAPIApprovedTokenAllowanceResponse(tokenId, spenderAccountId, approvedAmount, 0);
     }
 
+    @Then("the mirror node REST API should confirm the approved allowance for {string} and {string} no longer exists")
+    @RetryAsserts
+    public void verifyTokenAllowanceDelete(String tokenName, String accountName) {
+        verifyMirrorTransactionsResponse(mirrorClient, HttpStatus.OK.value());
+
+        var owner = accountClient.getClient().getOperatorAccountId().toString();
+        var spender = accountClient
+                .getAccount(AccountClient.AccountNameEnum.valueOf(accountName))
+                .getAccountId()
+                .toString();
+        var token = tokenClient
+                .getToken(TokenClient.TokenNameEnum.valueOf(tokenName))
+                .tokenId()
+                .toString();
+
+        var mirrorTokenAllowanceResponse = mirrorClient.getAccountTokenAllowanceBySpender(owner, token, spender);
+        assertThat(mirrorTokenAllowanceResponse.getAllowances()).isEmpty();
+    }
+
     @Then("the mirror node REST API should confirm the debit of {long} from {string} allowance of {long} for {string}")
     @RetryAsserts
     public void verifyMirrorAPIApprovedDebitedTokenAllowanceResponse(

--- a/hedera-mirror-test/src/test/resources/features/account/cryptoAllowance.feature
+++ b/hedera-mirror-test/src/test/resources/features/account/cryptoAllowance.feature
@@ -16,7 +16,7 @@ Feature: Account Crypto Allowance Coverage Feature
     When I approve <spender> to transfer up to <approvedAmount> tℏ
     Then the mirror node REST API should confirm the approved <approvedAmount> tℏ crypto allowance
     When I delete the crypto allowance for <spender>
-    Then the mirror node REST API should confirm the crypto allowance deletion
+    Then the mirror node REST API should confirm the crypto allowance no longer exists
     Examples:
       | spender | approvedAmount | recipient | transferAmount |
       | "BOB"   | 100            | "ALICE"   | 1              |

--- a/hedera-mirror-test/src/test/resources/features/token/tokenAllowance.feature
+++ b/hedera-mirror-test/src/test/resources/features/token/tokenAllowance.feature
@@ -14,7 +14,7 @@ Feature: Account Crypto Allowance Coverage Feature
     Given I approve <spender> to transfer up to <approvedAmount> of token <tokenName>
     Then the mirror node REST API should confirm the approved allowance <approvedAmount> of <tokenName> for <spender>
     When I delete the allowance on token <tokenName> for <spender>
-    Then the mirror node REST API should confirm the approved allowance 0 of <tokenName> for <spender>
+    Then the mirror node REST API should confirm the approved allowance for <tokenName> and <spender> no longer exists
     Examples:
       | tokenName  | spender | recipient | approvedAmount | transferAmount |
       | "FUNGIBLE" | "BOB"   | "ALICE"   | 10000          | 100            |


### PR DESCRIPTION
Cherry pick into 0.87.

**Description**:

A recent change to the allowances REST API is not to return deleted crypto and fungible token allowances. Previously they were returned with zero `amount_granted` and `amount`. 

The crypto and fungible token allowance acceptance tests have been adjusted to reflect this. The change is to expect a 200 response from the API as usual, but then to assert that the allowances list is empty.

**Related issue(s)**:

Fixes #6708

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
