### PR TITLE
Revert min nodejs to v16.13.0 for hedera-mirror-rest (0.87)

### DIFF
--- a/hedera-mirror-rest/package-lock.json
+++ b/hedera-mirror-rest/package-lock.json
@@ -95,7 +95,7 @@
         "supertest": "^6.3.3"
       },
       "engines": {
-        "node": ">=18.12.0 < 19"
+        "node": ">=16.13.0 < 19"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/hedera-mirror-rest/package.json
+++ b/hedera-mirror-rest/package.json
@@ -6,7 +6,7 @@
   "main": "server.js",
   "private": true,
   "engines": {
-    "node": ">=18.12.0 < 19"
+    "node": ">=16.13.0 < 19"
   },
   "scripts": {
     "dev": "HEDERA_MIRROR_REST_LOG_LEVEL=trace nodemon --experimental-specifier-resolution=node server.js",


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR reverts the minimum nodejs version to v16 for hedera-mirror-rest in `release/0.87`

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
