### PR TITLE
Change balance migrations to not use account balance file

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/TokenAccountBalanceMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/TokenAccountBalanceMigration.java
@@ -31,19 +31,19 @@ public class TokenAccountBalanceMigration extends TimeSensitiveBalanceMigration 
     private static final String UPDATE_TOKEN_ACCOUNT_SQL =
             """
              with timestamp_range as (
-                select consensus_timestamp as snapshot_timestamp,
-                    consensus_timestamp + time_offset as from_timestamp,
+                select
+                    consensus_timestamp as from_timestamp,
                     consensus_end as to_timestamp
-                from account_balance_file
-                join (select consensus_end from record_file order by consensus_end desc limit 1) last_record_file
-                  on consensus_timestamp + time_offset <= consensus_end
+                from token_balance
+                         join (select consensus_end from record_file order by consensus_end desc limit 1) last_record_file
+                              on consensus_timestamp <= consensus_end
                 order by consensus_timestamp desc
                 limit 1
             ),
             token_balance_latest as (
                 select *
                 from token_balance
-                join timestamp_range on snapshot_timestamp = consensus_timestamp
+                join timestamp_range on from_timestamp = consensus_timestamp
             ),
             token_transfer as (
                 select account_id, token_id, sum(amount) as amount

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/TokenAccountBalanceMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/TokenAccountBalanceMigration.java
@@ -34,7 +34,7 @@ public class TokenAccountBalanceMigration extends TimeSensitiveBalanceMigration 
                 select
                     consensus_timestamp as from_timestamp,
                     consensus_end as to_timestamp
-                from token_balance
+                from account_balance
                          join (select consensus_end from record_file order by consensus_end desc limit 1) last_record_file
                               on consensus_timestamp <= consensus_end
                 order by consensus_timestamp desc

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/AccountBalanceRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/AccountBalanceRepository.java
@@ -37,4 +37,9 @@ public interface AccountBalanceRepository
     @Override
     @Query(nativeQuery = true, value = "delete from account_balance where consensus_timestamp <= ?1")
     int prune(long consensusTimestamp);
+
+    @Override
+    @Query(nativeQuery = true, value = "delete from account_balance")
+    @Modifying
+    void deleteAll();
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/TokenBalanceRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/TokenBalanceRepository.java
@@ -27,4 +27,9 @@ public interface TokenBalanceRepository extends CrudRepository<TokenBalance, Tok
     @Override
     @Query(nativeQuery = true, value = "delete from token_balance where consensus_timestamp <= ?1")
     int prune(long consensusTimestamp);
+
+    @Override
+    @Query(nativeQuery = true, value = "delete from token_balance")
+    @Modifying
+    void deleteAll();
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/InitializeEntityBalanceMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/InitializeEntityBalanceMigrationTest.java
@@ -101,25 +101,6 @@ class InitializeEntityBalanceMigrationTest extends IntegrationTest {
     }
 
     @Test
-    void migrateWhenAccountBalanceFileHasOffset() {
-        // given
-        setup();
-        // The account balance file has a +5ns offset, so the crypto transfer to account at +2ns shouldn't be included
-        // in the account's balance change
-        // Note the delete then insert is a workaround for citus
-        accountBalanceFileRepository.deleteById(accountBalanceFile1.getConsensusTimestamp());
-        accountBalanceFile1.setTimeOffset(5);
-        accountBalanceFileRepository.save(accountBalanceFile1);
-        persistCryptoTransfer(300, account.getId(), null, accountBalanceFile1.getConsensusTimestamp() + 2L);
-
-        // when
-        migration.doMigrate();
-
-        // then
-        assertThat(entityRepository.findAll()).containsExactlyInAnyOrder(account, accountDeleted, contract, topic);
-    }
-
-    @Test
     void migrateWhenNoAccountBalance() {
         // given
         setup();

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/TokenAccountBalanceMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/TokenAccountBalanceMigrationTest.java
@@ -21,6 +21,7 @@ import static com.hedera.mirror.common.domain.entity.EntityType.TOKEN;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.Range;
+import com.hedera.mirror.common.domain.balance.AccountBalance;
 import com.hedera.mirror.common.domain.balance.AccountBalanceFile;
 import com.hedera.mirror.common.domain.balance.TokenBalance;
 import com.hedera.mirror.common.domain.entity.EntityId;
@@ -534,6 +535,12 @@ class TokenAccountBalanceMigrationTest extends IntegrationTest {
         tokenAccount3.setBalance(tokenBalance3Amount);
         deletedEntityTokenAccount4.setBalance(1009875L);
         disassociatedTokenAccount5.setBalance(0L);
+
+        // account balance is needed to generate timestamp filter efficiently
+        domainBuilder
+                .accountBalance()
+                .customize(a -> a.balance(0).id(new AccountBalance.Id(accountBalanceTimestamp, accountId1)))
+                .persist();
     }
 
     private long timestamp(Duration delta) {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/TokenAccountBalanceMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/TokenAccountBalanceMigrationTest.java
@@ -183,6 +183,7 @@ class TokenAccountBalanceMigrationTest extends IntegrationTest {
         // given
         setup();
         accountBalanceFileRepository.deleteAll();
+        tokenBalanceRepository.deleteAll();
 
         // when
         tokenAccountBalanceMigration.doMigrate();


### PR DESCRIPTION
**Description**:
* update balance init migrations to use account_balance and token_balance for timestamp range filter

**Related issue(s)**:

Fixes #6678 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
