### PR TITLE
HIP-584: Aliases are not resolved in web3 (0.87)

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/config/ServicesConfiguration.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/config/ServicesConfiguration.java
@@ -400,8 +400,9 @@ public class ServicesConfiguration {
     }
 
     @Bean
-    CreateLogic createLogic(final MirrorNodeEvmProperties mirrorNodeEvmProperties) {
-        return new CreateLogic(mirrorNodeEvmProperties);
+    CreateLogic createLogic(
+            final MirrorNodeEvmProperties mirrorNodeEvmProperties, final AssociateLogic associateLogic) {
+        return new CreateLogic(mirrorNodeEvmProperties, associateLogic);
     }
 
     @Bean

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/StoreImpl.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/StoreImpl.java
@@ -173,6 +173,9 @@ public class StoreImpl implements Store {
 
     @Override
     public boolean hasApprovedForAll(Address ownerAddress, AccountID operatorId, TokenID tokenId) {
+        if (Address.ZERO.equals(ownerAddress)) {
+            return false;
+        }
         final Set<FcTokenAllowanceId> approvedForAll =
                 getAccount(ownerAddress, OnMissing.THROW).getApproveForAllNfts();
         return approvedForAll.contains(FcTokenAllowanceId.from(tokenId, operatorId));

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/AbstractWritePrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/AbstractWritePrecompile.java
@@ -17,12 +17,22 @@
 package com.hedera.services.store.contracts.precompile.impl;
 
 import com.hedera.mirror.web3.evm.store.Store;
+import com.hedera.mirror.web3.evm.store.contract.HederaEvmStackedWorldStateUpdater;
 import com.hedera.node.app.service.evm.accounts.HederaEvmContractAliases;
 import com.hedera.services.store.contracts.precompile.Precompile;
 import com.hedera.services.store.contracts.precompile.SyntheticTxnFactory;
 import com.hedera.services.store.contracts.precompile.utils.PrecompilePricingUtils;
 import com.hederahashgraph.api.proto.java.TransactionBody;
+import org.apache.tuweni.bytes.Bytes;
+import org.hyperledger.besu.datatypes.Address;
 
+/**
+ * This class is a modified copy of AllowancePrecompile from hedera-services repo.
+ *
+ * Differences with the original:
+ *  1. Implements a modified {@link Precompile} interface
+ *  2. Added util method to unalias given address
+ */
 public abstract class AbstractWritePrecompile implements Precompile {
     protected static final String FAILURE_MESSAGE = "Invalid full prefix for %s precompile!";
     protected final PrecompilePricingUtils pricingUtils;
@@ -42,5 +52,9 @@ public abstract class AbstractWritePrecompile implements Precompile {
             final HederaEvmContractAliases mirrorEvmContractAliases) {
         return pricingUtils.computeGasRequirement(
                 blockTimestamp, this, transactionBody, store, mirrorEvmContractAliases);
+    }
+
+    protected Address unalias(Address addressOrAlias, HederaEvmStackedWorldStateUpdater updater) {
+        return Address.wrap(Bytes.wrap(updater.permissivelyUnaliased(addressOrAlias.toArray())));
     }
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/ApprovePrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/ApprovePrecompile.java
@@ -34,7 +34,6 @@ import static com.hedera.services.store.contracts.precompile.utils.PrecompilePri
 import static com.hedera.services.utils.EntityIdUtils.accountIdFromEvmAddress;
 import static com.hedera.services.utils.EntityIdUtils.asTypedEvmAddress;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FAIL_INVALID;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_NFT_SERIAL_NUMBER;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SENDER_DOES_NOT_OWN_NFT_SERIAL_NO;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
@@ -133,13 +132,13 @@ public class ApprovePrecompile extends AbstractWritePrecompile {
     public Builder body(final Bytes input, final UnaryOperator<byte[]> aliasResolver, final BodyParams bodyParams) {
         Address tokenAddress;
         Address senderAddress;
-        Id ownerId;
+        Id nftOwnerId;
         boolean isFungible;
         Builder transactionBody;
 
         if (bodyParams instanceof ApproveParams approveParams) {
             isFungible = approveParams.isFungible();
-            ownerId = approveParams.ownerId();
+            nftOwnerId = approveParams.ownerId();
             tokenAddress = approveParams.tokenAddress();
             senderAddress = approveParams.senderAddress();
         } else {
@@ -157,7 +156,7 @@ public class ApprovePrecompile extends AbstractWritePrecompile {
         if (approveOp.isFungible()) {
             transactionBody = syntheticTxnFactory.createFungibleApproval(approveOp, operatorId);
         } else {
-            final var nominalOwnerId = ownerId != null ? ownerId : Id.DEFAULT;
+            final var nominalOwnerId = nftOwnerId != null ? nftOwnerId : Id.DEFAULT;
             // Per the ERC-721 spec, "The zero address indicates there is no approved address"; so
             // translate this approveAllowance into a deleteAllowance
             if (isNftApprovalRevocation(approveOp)) {
@@ -176,12 +175,12 @@ public class ApprovePrecompile extends AbstractWritePrecompile {
         Objects.requireNonNull(transactionBody, "`body` method should be called before `run`");
         final var updater = ((HederaEvmStackedWorldStateUpdater) frame.getWorldUpdater());
         final var store = updater.getStore();
-        final var senderAddress = frame.getSenderAddress();
+        final var senderAddress = unalias(frame.getSenderAddress(), updater);
 
         // fields needed to be extracted from transactionBody
         boolean isFungible;
-        Id ownerId;
-        Id operatorId = Id.fromGrpcAccount(EntityIdUtils.accountIdFromEvmAddress(frame.getSenderAddress()));
+        Id nftOwnerId = Id.DEFAULT;
+        Id operatorId = Id.fromGrpcAccount(EntityIdUtils.accountIdFromEvmAddress(senderAddress));
         Address spender = Address.ZERO;
         TokenID tokenId;
         long amount = 0;
@@ -197,40 +196,34 @@ public class ApprovePrecompile extends AbstractWritePrecompile {
         // extract needed fields from the transactionBody
         if (isNftApprovalRevocation) { // when revoking nft allowance
             final var deleteNftAllowanceBody = deleteAllowanceBody.getNftAllowances(0);
-            ownerId = Id.fromGrpcAccount(deleteNftAllowanceBody.getOwner());
+            nftOwnerId = Id.fromGrpcAccount(deleteNftAllowanceBody.getOwner());
             tokenId = deleteNftAllowanceBody.getTokenId();
             serialNumber = deleteNftAllowanceBody.getSerialNumbers(0);
 
         } else if (isFungible) { // when setting allowance for fungible token
             final var tokenAllowances = approveAllowanceBody.getTokenAllowances(0);
-            ownerId = Id.fromGrpcAccount(tokenAllowances.getOwner());
             spender = EntityIdUtils.asTypedEvmAddress(tokenAllowances.getSpender());
             tokenId = tokenAllowances.getTokenId();
             amount = tokenAllowances.getAmount();
         } else { // when setting allowance for non-fungible token
             final var nftAllowances = approveAllowanceBody.getNftAllowances(0);
-            ownerId = nftAllowances
+            nftOwnerId = nftAllowances
                             .getDelegatingSpender()
                             .getDefaultInstanceForType()
                             .equals(nftAllowances.getDelegatingSpender())
-                    ? Id.fromGrpcAccount(nftAllowances.getDelegatingSpender())
-                    : Id.fromGrpcAccount(nftAllowances.getOwner());
+                    ? Id.fromGrpcAccount(nftAllowances.getOwner())
+                    : Id.fromGrpcAccount(nftAllowances.getDelegatingSpender());
             spender = EntityIdUtils.asTypedEvmAddress(nftAllowances.getSpender());
             tokenId = nftAllowances.getTokenId();
             serialNumber = nftAllowances.getSerialNumbers(0);
         }
 
-        validateTrueOrRevert(
-                isFungible
-                        || !Id.fromGrpcAccount(accountIdFromEvmAddress(senderAddress))
-                                .equals(ownerId),
-                INVALID_TOKEN_NFT_SERIAL_NUMBER);
         Objects.requireNonNull(operatorId);
         //  Per the ERC-721 spec, "Throws unless `msg.sender` is the current NFT owner, or
         //  an authorized operator of the current owner"
         if (!isFungible) {
-            final var isApproved = operatorId.equals(ownerId)
-                    || store.hasApprovedForAll(ownerId.asEvmAddress(), operatorId.asGrpcAccount(), tokenId);
+            final var isApproved = operatorId.equals(nftOwnerId)
+                    || store.hasApprovedForAll(nftOwnerId.asEvmAddress(), operatorId.asGrpcAccount(), tokenId);
             validateTrueOrRevert(isApproved, SENDER_DOES_NOT_OWN_NFT_SERIAL_NO);
         }
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/SetApprovalForAllPrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/SetApprovalForAllPrecompile.java
@@ -117,9 +117,10 @@ public class SetApprovalForAllPrecompile extends AbstractWritePrecompile {
 
         final var updater = ((HederaEvmStackedWorldStateUpdater) frame.getWorldUpdater());
         final var store = updater.getStore();
+        final var senderAddress = unalias(frame.getSenderAddress(), updater);
 
         /* --- Build the necessary infrastructure to execute the transaction --- */
-        final var payerAccount = store.getAccount(frame.getSenderAddress(), OnMissing.THROW);
+        final var payerAccount = store.getAccount(senderAddress, OnMissing.THROW);
 
         final var status = approveAllowanceChecks.allowancesValidation(
                 transactionBody.getCryptoApproveAllowance().getCryptoAllowancesList(),
@@ -137,13 +138,12 @@ public class SetApprovalForAllPrecompile extends AbstractWritePrecompile {
                 transactionBody.getCryptoApproveAllowance().getCryptoAllowancesList(),
                 transactionBody.getCryptoApproveAllowance().getTokenAllowancesList(),
                 transactionBody.getCryptoApproveAllowance().getNftAllowancesList(),
-                EntityIdUtils.accountIdFromEvmAddress(frame.getSenderAddress()));
+                EntityIdUtils.accountIdFromEvmAddress(senderAddress));
         final var nftAllowances = transactionBody.getCryptoApproveAllowance().getNftAllowances(0);
         final var tokenAddress = asTypedEvmAddress(nftAllowances.getTokenId());
         final var spenderAddress = asTypedEvmAddress(nftAllowances.getSpender());
         final var approved = nftAllowances.getApprovedForAll();
-        frame.addLog(
-                getLogForSetApprovalForAll(tokenAddress, frame.getSenderAddress(), spenderAddress, approved, updater));
+        frame.addLog(getLogForSetApprovalForAll(tokenAddress, senderAddress, spenderAddress, approved, updater));
         return new EmptyRunResult();
     }
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/models/Account.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/models/Account.java
@@ -239,7 +239,7 @@ public class Account extends HederaEvmAccount {
                 oldAccount.numTreasuryTitles,
                 oldAccount.ethereumNonce,
                 oldAccount.isSmartContract,
-                key);
+                oldAccount.key);
     }
 
     /**
@@ -428,7 +428,7 @@ public class Account extends HederaEvmAccount {
                 oldAccount.numTreasuryTitles,
                 oldAccount.ethereumNonce,
                 oldAccount.isSmartContract,
-                key);
+                oldAccount.key);
     }
 
     /**

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/txn/token/CreateLogic.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/txn/token/CreateLogic.java
@@ -56,9 +56,11 @@ import org.hyperledger.besu.datatypes.Address;
 public class CreateLogic {
 
     private final MirrorNodeEvmProperties dynamicProperties;
+    private final AssociateLogic associateLogic;
 
-    public CreateLogic(final MirrorNodeEvmProperties dynamicProperties) {
+    public CreateLogic(final MirrorNodeEvmProperties dynamicProperties, final AssociateLogic associateLogic) {
         this.dynamicProperties = dynamicProperties;
+        this.associateLogic = associateLogic;
     }
 
     public void create(
@@ -122,7 +124,6 @@ public class CreateLogic {
 
     private List<TokenRelationship> getNewRelationships(
             final Token provisionalToken, final Store store, final TokenCreateTransactionBody op) {
-        final var associateLogic = new AssociateLogic(dynamicProperties);
         final var newRels = listFrom(provisionalToken, store, associateLogic);
         if (op.getInitialSupply() > 0) {
             // Treasury relationship is always first

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/StoreImplTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/StoreImplTest.java
@@ -54,6 +54,7 @@ import com.hedera.services.store.models.Id;
 import com.hedera.services.store.models.NftId;
 import com.hedera.services.store.models.TokenRelationship;
 import com.hedera.services.store.models.UniqueToken;
+import com.hedera.services.utils.EntityIdUtils;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -311,5 +312,25 @@ class StoreImplTest {
         final var token = new com.hedera.services.store.models.Token(TOKEN_ID);
         assertThatThrownBy(() -> subject.loadUniqueTokens(token, serials))
                 .isInstanceOf(InvalidTransactionException.class);
+    }
+
+    @Test
+    void hasApprovedForAll() {
+        when(entityDatabaseAccessor.get(ACCOUNT_ADDRESS)).thenReturn(Optional.of(accountModel));
+        when(accountModel.getId()).thenReturn(12L);
+        when(accountModel.getNum()).thenReturn(12L);
+        when(accountModel.getType()).thenReturn(EntityType.ACCOUNT);
+        when(tokenAccountRepository.countByAccountIdAndAssociatedGroupedByBalanceIsPositive(12L))
+                .thenReturn(associationsCount);
+        var result = subject.hasApprovedForAll(
+                Address.ZERO,
+                EntityIdUtils.accountIdFromEvmAddress(ACCOUNT_ADDRESS),
+                EntityIdUtils.tokenIdFromEvmAddress(TOKEN_ADDRESS));
+        assertEquals(false, result);
+        result = subject.hasApprovedForAll(
+                ACCOUNT_ADDRESS,
+                EntityIdUtils.accountIdFromEvmAddress(ACCOUNT_ADDRESS),
+                EntityIdUtils.tokenIdFromEvmAddress(TOKEN_ADDRESS));
+        assertEquals(false, result);
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallDynamicCallsTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallDynamicCallsTest.java
@@ -30,12 +30,12 @@ import org.junit.jupiter.params.provider.EnumSource;
 class ContractCallDynamicCallsTest extends ContractCallTestSetup {
 
     @ParameterizedTest
-    @EnumSource(NestedCallsContractFunctions.class)
-    void nestedCallsTest(NestedCallsContractFunctions contractFunctions) {
+    @EnumSource(DynamicCallsContractFunctions.class)
+    void dynamicCallsTestWithAliasSender(DynamicCallsContractFunctions contractFunctions) {
         final var functionHash = functionEncodeDecoder.functionHashFor(
                 contractFunctions.name, DYNAMIC_ETH_CALLS_ABI_PATH, contractFunctions.functionParameters);
         final var serviceParameters =
-                serviceParametersForExecution(functionHash, DYNAMIC_ETH_CALLS_CONTRACT_ADDRESS, ETH_CALL, 0L);
+                serviceParametersForExecution(functionHash, DYNAMIC_ETH_CALLS_CONTRACT_ALIAS, ETH_CALL, 0L);
         if (contractFunctions.expectedErrorMessage != null) {
             assertThatThrownBy(() -> contractCallService.processCall(serviceParameters))
                     .isInstanceOf(InvalidTransactionException.class)
@@ -49,7 +49,7 @@ class ContractCallDynamicCallsTest extends ContractCallTestSetup {
     }
 
     @RequiredArgsConstructor
-    enum NestedCallsContractFunctions {
+    enum DynamicCallsContractFunctions {
         MINT_FUNGIBLE_TOKEN(
                 "mintTokenGetTotalSupplyAndBalanceOfTreasury",
                 new Object[] {NOT_FROZEN_FUNGIBLE_TOKEN_ADDRESS, 100L, new byte[0][0], TREASURY_ADDRESS},
@@ -75,15 +75,7 @@ class ContractCallDynamicCallsTest extends ContractCallTestSetup {
                 "wipeTokenGetTotalSupplyAndBalanceOfTreasury",
                 new Object[] {NOT_FROZEN_FUNGIBLE_TOKEN_ADDRESS, 10L, new long[0], SENDER_ALIAS},
                 null),
-        WIPE_FUNGIBLE_TOKEN_WITH_ALIAS(
-                "wipeTokenGetTotalSupplyAndBalanceOfTreasury",
-                new Object[] {NOT_FROZEN_FUNGIBLE_TOKEN_ADDRESS, 10L, new long[0], SENDER_ALIAS},
-                null),
         WIPE_NFT(
-                "wipeTokenGetTotalSupplyAndBalanceOfTreasury",
-                new Object[] {NFT_ADDRESS_WITH_DIFFERENT_OWNER_AND_TREASURY, 0L, new long[] {1L}, SENDER_ALIAS},
-                null),
-        WIPE_NFT_ALIAS(
                 "wipeTokenGetTotalSupplyAndBalanceOfTreasury",
                 new Object[] {NFT_ADDRESS_WITH_DIFFERENT_OWNER_AND_TREASURY, 0L, new long[] {1L}, SENDER_ALIAS},
                 null),
@@ -101,7 +93,7 @@ class ContractCallDynamicCallsTest extends ContractCallTestSetup {
                 new Object[] {
                     TREASURY_TOKEN_ADDRESS,
                     NOT_ASSOCIATED_SPENDER_ALIAS,
-                    DYNAMIC_ETH_CALLS_CONTRACT_ADDRESS,
+                    DYNAMIC_ETH_CALLS_CONTRACT_ALIAS,
                     BigInteger.ONE,
                     BigInteger.ZERO
                 },
@@ -117,10 +109,6 @@ class ContractCallDynamicCallsTest extends ContractCallTestSetup {
                 new Object[] {FUNGIBLE_TOKEN_ADDRESS, OWNER_ADDRESS, BigInteger.ONE, BigInteger.ZERO},
                 null),
         APPROVE_NFT_GET_ALLOWANCE(
-                "approveTokenGetAllowance",
-                new Object[] {NFT_ADDRESS, SPENDER_ALIAS, BigInteger.ZERO, BigInteger.ONE},
-                null),
-        APPROVE_NFT_GET_ALLOWANCE_WITH_ALIAS(
                 "approveTokenGetAllowance",
                 new Object[] {NFT_ADDRESS, SPENDER_ALIAS, BigInteger.ZERO, BigInteger.ONE},
                 null),

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileTest.java
@@ -425,36 +425,23 @@ class ContractCallServicePrecompileTest extends ContractCallTestSetup {
         APPROVE_NFT("approveNFTExternal", new Object[] {NFT_ADDRESS, TREASURY_ADDRESS, 1L}),
         SET_APPROVAL_FOR_ALL("setApprovalForAllExternal", new Object[] {NFT_ADDRESS, TREASURY_ADDRESS, true}),
         ASSOCIATE_TOKEN("associateTokenExternal", new Object[] {SPENDER_ALIAS, FUNGIBLE_TOKEN_ADDRESS}),
-        ASSOCIATE_TOKEN_WITH_ALIAS("associateTokenExternal", new Object[] {SPENDER_ALIAS, FUNGIBLE_TOKEN_ADDRESS}),
         ASSOCIATE_TOKENS(
-                "associateTokensExternal", new Object[] {SPENDER_ALIAS, new Address[] {FUNGIBLE_TOKEN_ADDRESS}}),
-        ASSOCIATE_TOKENS_WITH_ALIAS(
                 "associateTokensExternal", new Object[] {SPENDER_ALIAS, new Address[] {FUNGIBLE_TOKEN_ADDRESS}}),
         MINT_TOKEN("mintTokenExternal", new Object[] {NOT_FROZEN_FUNGIBLE_TOKEN_ADDRESS, 100L, new byte[0][0]}),
         MINT_NFT_TOKEN("mintTokenExternal", new Object[] {
             NFT_ADDRESS, 0L, new byte[][] {ByteString.copyFromUtf8("firstMeta").toByteArray()}
         }),
         DISSOCIATE_TOKEN("dissociateTokenExternal", new Object[] {SPENDER_ALIAS, TREASURY_TOKEN_ADDRESS}),
-        DISSOCIATE_TOKEN_WITH_ALIAS("dissociateTokenExternal", new Object[] {SPENDER_ALIAS, TREASURY_TOKEN_ADDRESS}),
         DISSOCIATE_TOKENS(
-                "dissociateTokensExternal", new Object[] {SPENDER_ALIAS, new Address[] {TREASURY_TOKEN_ADDRESS}}),
-        DISSOCIATE_TOKENS_WITH_ALIAS(
                 "dissociateTokensExternal", new Object[] {SPENDER_ALIAS, new Address[] {TREASURY_TOKEN_ADDRESS}}),
         BURN_TOKEN("burnTokenExternal", new Object[] {NOT_FROZEN_FUNGIBLE_TOKEN_ADDRESS, 1L, new long[0]}),
         WIPE_TOKEN("wipeTokenAccountExternal", new Object[] {NOT_FROZEN_FUNGIBLE_TOKEN_ADDRESS, SENDER_ALIAS, 1L}),
-        WIPE_TOKEN_WITH_ALIAS(
-                "wipeTokenAccountExternal", new Object[] {NOT_FROZEN_FUNGIBLE_TOKEN_ADDRESS, SENDER_ALIAS, 1L}),
         WIPE_NFT_TOKEN(
-                "wipeTokenAccountNFTExternal",
-                new Object[] {NFT_ADDRESS_WITH_DIFFERENT_OWNER_AND_TREASURY, SENDER_ALIAS, new long[] {1}}),
-        WIPE_NFT_TOKEN_WITH_ALIAS(
                 "wipeTokenAccountNFTExternal",
                 new Object[] {NFT_ADDRESS_WITH_DIFFERENT_OWNER_AND_TREASURY, SENDER_ALIAS, new long[] {1}}),
         BURN_NFT_TOKEN("burnTokenExternal", new Object[] {NFT_ADDRESS, 0L, new long[] {1}}),
         REVOKE_TOKEN_KYC("revokeTokenKycExternal", new Object[] {FUNGIBLE_TOKEN_ADDRESS, SENDER_ALIAS}),
-        REVOKE_TOKEN_KYC_WITH_ALIAS("revokeTokenKycExternal", new Object[] {FUNGIBLE_TOKEN_ADDRESS, SENDER_ALIAS}),
         GRANT_TOKEN_KYC("grantTokenKycExternal", new Object[] {FUNGIBLE_TOKEN_ADDRESS, SENDER_ALIAS}),
-        GRANT_TOKEN_KYC_WITH_ALIAS("grantTokenKycExternal", new Object[] {FUNGIBLE_TOKEN_ADDRESS, SENDER_ALIAS}),
         DELETE_TOKEN("deleteTokenExternal", new Object[] {FUNGIBLE_TOKEN_ADDRESS}),
         FREEZE_TOKEN("freezeTokenExternal", new Object[] {NOT_FROZEN_FUNGIBLE_TOKEN_ADDRESS, SPENDER_ALIAS}),
         UNFREEZE_TOKEN("unfreezeTokenExternal", new Object[] {FROZEN_FUNGIBLE_TOKEN_ADDRESS, SPENDER_ALIAS}),
@@ -470,7 +457,7 @@ class ContractCallServicePrecompileTest extends ContractCallTestSetup {
                 new Object[] {NON_FUNGIBLE_TOKEN, FIXED_FEE_WRAPPER, ROYALTY_FEE_WRAPPER}),
         TRANSFER_TOKEN(
                 "transferTokenExternal", new Object[] {TREASURY_TOKEN_ADDRESS, SPENDER_ALIAS, RECEIVER_ADDRESS, 1L}),
-        TRANSFER_TOKEN_WITH_ALIAS(
+        TRANSFER_TOKEN_WITH(
                 "transferTokenExternal", new Object[] {TREASURY_TOKEN_ADDRESS, SPENDER_ALIAS, SENDER_ALIAS, 1L}),
         TRANSFER_TOKENS("transferTokensExternal", new Object[] {
             TREASURY_TOKEN_ADDRESS, new Address[] {OWNER_ADDRESS, SPENDER_ALIAS}, new long[] {1L, -1L}
@@ -485,19 +472,10 @@ class ContractCallServicePrecompileTest extends ContractCallTestSetup {
         TRANSFER_NFT_TOKENS("transferNFTsExternal", new Object[] {
             NFT_TRANSFER_ADDRESS, new Address[] {OWNER_ADDRESS}, new Address[] {SPENDER_ALIAS}, new long[] {1}
         }),
-        TRANSFER_NFT_TOKENS_WITH_ALIAS("transferNFTsExternal", new Object[] {
-            NFT_TRANSFER_ADDRESS, new Address[] {OWNER_ADDRESS}, new Address[] {SPENDER_ALIAS}, new long[] {1}
-        }),
         TRANSFER_NFT_TOKEN(
                 "transferNFTExternal", new Object[] {NFT_TRANSFER_ADDRESS, OWNER_ADDRESS, SPENDER_ALIAS, 1L}),
-        TRANSFER_NFT_TOKEN_WITH_ALIAS(
-                "transferNFTExternal", new Object[] {NFT_TRANSFER_ADDRESS, OWNER_ADDRESS, SPENDER_ALIAS, 1L}),
         TRANSFER_FROM("transferFromExternal", new Object[] {TREASURY_TOKEN_ADDRESS, SENDER_ALIAS, SPENDER_ALIAS, 1L}),
-        TRANSFER_FROM_WITH_ALIAS(
-                "transferFromExternal", new Object[] {TREASURY_TOKEN_ADDRESS, SENDER_ALIAS, SPENDER_ALIAS, 1L}),
         TRANSFER_FROM_NFT(
-                "transferFromNFTExternal", new Object[] {NFT_TRANSFER_ADDRESS, OWNER_ADDRESS, SPENDER_ALIAS, 1L}),
-        TRANSFER_FROM_NFT_WITH_ALIAS(
                 "transferFromNFTExternal", new Object[] {NFT_TRANSFER_ADDRESS, OWNER_ADDRESS, SPENDER_ALIAS, 1L}),
         UPDATE_TOKEN_INFO("updateTokenInfoExternal", new Object[] {UNPAUSED_FUNGIBLE_TOKEN_ADDRESS, FUNGIBLE_TOKEN2}),
         UPDATE_TOKEN_EXPIRY(

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallTestSetup.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallTestSetup.java
@@ -54,6 +54,7 @@ import com.hedera.mirror.web3.service.model.CallServiceParameters;
 import com.hedera.mirror.web3.service.model.CallServiceParameters.CallType;
 import com.hedera.mirror.web3.utils.FunctionEncodeDecoder;
 import com.hedera.node.app.service.evm.store.models.HederaEvmAccount;
+import com.hedera.services.hapi.utils.ByteStringUtils;
 import com.hedera.services.store.contracts.precompile.TokenCreateWrapper;
 import com.hedera.services.store.contracts.precompile.TokenCreateWrapper.FixedFeeWrapper;
 import com.hedera.services.store.contracts.precompile.TokenCreateWrapper.FractionalFeeWrapper;
@@ -105,6 +106,8 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
     protected static final EntityId EXCHANGE_RATE_ENTITY_ID = new EntityId(0L, 0L, 112L, EntityType.FILE);
     protected static final Address CONTRACT_ADDRESS = toAddress(EntityId.of(0, 0, 1256, CONTRACT));
     protected static final Address DYNAMIC_ETH_CALLS_CONTRACT_ADDRESS = toAddress(EntityId.of(0, 0, 1255, CONTRACT));
+    protected static final Address DYNAMIC_ETH_CALLS_CONTRACT_ALIAS =
+            Address.fromHexString("0x742d35Cc6634C0532925a3b844Bc454e4438f44e");
     protected static final Address SENDER_ADDRESS = toAddress(EntityId.of(0, 0, 742, ACCOUNT));
     protected static final ByteString SENDER_PUBLIC_KEY =
             ByteString.copyFrom(Hex.decode("3a2103af80b90d25145da28c583359beb47b21796b2fe1a23c1511e443e7a64dfdb27d"));
@@ -1190,7 +1193,9 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
                 .entity()
                 .customize(e -> e.id(contractEntityId.getId())
                         .num(contractEntityId.getEntityNum())
-                        .evmAddress(contractEvmAddress)
+                        .evmAddress(DYNAMIC_ETH_CALLS_CONTRACT_ALIAS.toArray())
+                        .alias(ByteStringUtils.wrapUnsafely(SENDER_ALIAS.toArrayUnsafe())
+                                .toByteArray())
                         .type(CONTRACT)
                         .balance(1500L))
                 .persist();
@@ -1413,7 +1418,7 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
                         0b1111111,
                         new KeyValueWrapper(
                                 false,
-                                contractIdFromEvmAddress(DYNAMIC_ETH_CALLS_CONTRACT_ADDRESS.toArrayUnsafe()),
+                                contractIdFromEvmAddress(NESTED_ETH_CALLS_CONTRACT_ADDRESS.toArrayUnsafe()),
                                 new byte[] {},
                                 new byte[] {},
                                 null))),
@@ -1452,7 +1457,7 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
                         0b1111111,
                         new KeyValueWrapper(
                                 false,
-                                contractIdFromEvmAddress(DYNAMIC_ETH_CALLS_CONTRACT_ADDRESS.toArrayUnsafe()),
+                                contractIdFromEvmAddress(NESTED_ETH_CALLS_CONTRACT_ADDRESS.toArrayUnsafe()),
                                 new byte[] {},
                                 new byte[] {},
                                 null))),

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/txn/token/CreateLogicTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/txn/token/CreateLogicTest.java
@@ -99,7 +99,7 @@ class CreateLogicTest {
 
     @BeforeEach
     void setup() {
-        createLogic = new CreateLogic(evmProperties);
+        createLogic = new CreateLogic(evmProperties, new AssociateLogic(evmProperties));
         staticMock = Mockito.mockStatic(Id.class);
         staticToken = Mockito.mockStatic(Token.class);
     }


### PR DESCRIPTION
**Description**:
Cherry-pick #6720 

During precompile execution when using alias addresses we convert them to long zero addresses. All of the precompiles should work with long zero addresses, but there are some places (usage of `frame.getSender`) where the addresses are not resolved to long zero, which breaks functionalities like approve, transfer, etc .

This PR also addresses some bugs regarding `ApprovePrecompile` and `CreateLogic`

- [x] ApprovePrecompile has unnecessary check that reverts the transaction incorrectly
- [x] ApprovePrecompile does not set the `nftOwnerId` correctly
- [x] Added check for zero address in `StoreImpl` in case the owner of NFT is the zero address
- [x] `AssociateLogic` is not used as bean from Spring context

**Related issue(s)**:

Fixes #6707 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
