### PR TITLE
Fix HTS allowance when transferring using Ethereum Tools (0.87)

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListener.java
@@ -519,9 +519,17 @@ public class EntityRecordItemListener implements RecordItemListener {
         }
 
         var tokenTransfers = recordItem.getTransactionBody().getCryptoTransfer().getTokenTransfersList();
+        long spenderId = payerAccountId.getId();
+        if (!tokenTransfers.isEmpty() && recordItem.getTransactionRecord().hasContractCallResult()) {
+            spenderId = EntityId.of(recordItem
+                            .getTransactionRecord()
+                            .getContractCallResult()
+                            .getSenderId())
+                    .getId();
+        }
+        long transferSpenderId = spenderId;
         tokenTransfers.forEach(tokenTransfer -> {
             var tokenId = EntityId.of(tokenTransfer.getToken());
-
             tokenTransfer.getTransfersList().forEach(accountAmount -> {
                 // Emit allowance amount representing approved transfer debit
                 if (accountAmount.getIsApproval() && accountAmount.getAmount() < 0) {
@@ -529,7 +537,7 @@ public class EntityRecordItemListener implements RecordItemListener {
                             .amount(accountAmount.getAmount())
                             .owner(EntityId.of(accountAmount.getAccountID()).getId())
                             .payerAccountId(payerAccountId)
-                            .spender(payerAccountId.getId())
+                            .spender(transferSpenderId)
                             .tokenId(tokenId.getId())
                             .build();
 


### PR DESCRIPTION
**Description**:
Cherry-pick #6722 to `release/0.87`

This PR fixes HTS allowance for tokens used by ethereum tools by applying ERC20 interface, this happens specifically when transferring with transferFrom method.

**Related issue(s)**:

Fixes #6721 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
