### PR TITLE
HIP-584: Remove InvalidTransactionException dependency from services code

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/Precompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/Precompile.java
@@ -21,8 +21,8 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_FEE_SU
 import static org.hyperledger.besu.evm.frame.MessageFrame.State.REVERT;
 
 import com.hedera.mirror.web3.evm.store.Store;
-import com.hedera.mirror.web3.exception.InvalidTransactionException;
 import com.hedera.node.app.service.evm.accounts.HederaEvmContractAliases;
+import com.hedera.node.app.service.evm.exceptions.InvalidTransactionException;
 import com.hedera.services.store.contracts.precompile.codec.BodyParams;
 import com.hedera.services.store.contracts.precompile.codec.EncodingFacade;
 import com.hedera.services.store.contracts.precompile.codec.RunResult;
@@ -68,7 +68,7 @@ public interface Precompile {
             final String INVALID_TRANSFER_MSG = "Transfer of Value to Hedera Precompile";
             frame.setRevertReason(Bytes.of(INVALID_TRANSFER_MSG.getBytes(StandardCharsets.UTF_8)));
             frame.setState(REVERT);
-            throw new InvalidTransactionException(INVALID_FEE_SUBMITTED, "", "");
+            throw new InvalidTransactionException(INVALID_FEE_SUBMITTED, true);
         }
     }
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/AllowancePrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/AllowancePrecompile.java
@@ -64,7 +64,7 @@ public class AllowancePrecompile extends AbstractReadOnlyPrecompile {
 
     @Override
     public RunResult run(MessageFrame frame, TransactionBody transactionBody) {
-        final var updater = ((HederaEvmStackedWorldStateUpdater) frame.getWorldUpdater());
+        final var updater = (HederaEvmStackedWorldStateUpdater) frame.getWorldUpdater();
         final var inputData = frame.getInputData();
         final var wrapper = decodeTokenAllowance(inputData);
         final var allowances = updater.tokenAccessor()

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/ApprovePrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/ApprovePrecompile.java
@@ -173,7 +173,7 @@ public class ApprovePrecompile extends AbstractWritePrecompile {
     @Override
     public RunResult run(final MessageFrame frame, TransactionBody transactionBody) {
         Objects.requireNonNull(transactionBody, "`body` method should be called before `run`");
-        final var updater = ((HederaEvmStackedWorldStateUpdater) frame.getWorldUpdater());
+        final var updater = (HederaEvmStackedWorldStateUpdater) frame.getWorldUpdater();
         final var store = updater.getStore();
         final var senderAddress = unalias(frame.getSenderAddress(), updater);
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/GetApprovedPrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/GetApprovedPrecompile.java
@@ -66,7 +66,7 @@ public class GetApprovedPrecompile extends AbstractReadOnlyPrecompile {
 
     @Override
     public RunResult run(MessageFrame frame, TransactionBody transactionBody) {
-        final var updater = ((HederaEvmStackedWorldStateUpdater) frame.getWorldUpdater());
+        final var updater = (HederaEvmStackedWorldStateUpdater) frame.getWorldUpdater();
         final var inputData = frame.getInputData();
         final var wrapper = decodeGetApproved(inputData);
         final var spender =

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/IsApprovedForAllPrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/IsApprovedForAllPrecompile.java
@@ -64,7 +64,7 @@ public class IsApprovedForAllPrecompile extends AbstractReadOnlyPrecompile {
 
     @Override
     public RunResult run(MessageFrame frame, TransactionBody transactionBody) {
-        final var updater = ((HederaEvmStackedWorldStateUpdater) frame.getWorldUpdater());
+        final var updater = (HederaEvmStackedWorldStateUpdater) frame.getWorldUpdater();
         final var inputData = frame.getInputData();
         final var wrapper = decodeIsApprovedForAll(inputData);
         final var allowances = updater.tokenAccessor()

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/SetApprovalForAllPrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/SetApprovalForAllPrecompile.java
@@ -115,7 +115,7 @@ public class SetApprovalForAllPrecompile extends AbstractWritePrecompile {
     public RunResult run(final MessageFrame frame, TransactionBody transactionBody) {
         Objects.requireNonNull(transactionBody, "`body` method should be called before `run`");
 
-        final var updater = ((HederaEvmStackedWorldStateUpdater) frame.getWorldUpdater());
+        final var updater = (HederaEvmStackedWorldStateUpdater) frame.getWorldUpdater();
         final var store = updater.getStore();
         final var senderAddress = unalias(frame.getSenderAddress(), updater);
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/TokenCreatePrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/TokenCreatePrecompile.java
@@ -269,8 +269,8 @@ public class TokenCreatePrecompile extends AbstractWritePrecompile {
 
     @Override
     public RunResult run(MessageFrame frame, TransactionBody transactionBody) {
-        final var store = ((HederaEvmStackedWorldStateUpdater) frame.getWorldUpdater()).getStore();
-        final var updater = ((HederaEvmStackedWorldStateUpdater) frame.getWorldUpdater());
+        final var updater = (HederaEvmStackedWorldStateUpdater) frame.getWorldUpdater();
+        final var store = updater.getStore();
         final var tokenCreateOp = transactionBody.getTokenCreation();
         final var senderAddress = unalias(frame.getSenderAddress(), updater);
         Objects.requireNonNull(tokenCreateOp, "`body` method should be called before `run`");
@@ -310,8 +310,8 @@ public class TokenCreatePrecompile extends AbstractWritePrecompile {
 
     @Override
     public void handleSentHbars(final MessageFrame frame, final TransactionBody.Builder transactionBody) {
-        final var store = ((HederaEvmStackedWorldStateUpdater) frame.getWorldUpdater()).getStore();
-        final var updater = ((HederaEvmStackedWorldStateUpdater) frame.getWorldUpdater());
+        final var updater = (HederaEvmStackedWorldStateUpdater) frame.getWorldUpdater();
+        final var store = updater.getStore();
         final var senderAddress = unalias(frame.getSenderAddress(), updater);
         final var aliases =
                 (MirrorEvmContractAliases) ((HederaEvmStackedWorldStateUpdater) frame.getWorldUpdater()).aliases();

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/TransferPrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/TransferPrecompile.java
@@ -54,7 +54,7 @@ import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
 import com.hedera.mirror.web3.evm.store.Store;
 import com.hedera.mirror.web3.evm.store.contract.EntityAddressSequencer;
 import com.hedera.mirror.web3.evm.store.contract.HederaEvmStackedWorldStateUpdater;
-import com.hedera.mirror.web3.exception.InvalidTransactionException;
+import com.hedera.node.app.service.evm.exceptions.InvalidTransactionException;
 import com.hedera.services.ledger.BalanceChange;
 import com.hedera.services.ledger.TransferLogic;
 import com.hedera.services.store.contracts.precompile.CryptoTransferWrapper;
@@ -96,7 +96,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.evm.frame.MessageFrame;
@@ -197,7 +196,7 @@ public class TransferPrecompile extends AbstractWritePrecompile {
         final var hederaTokenStore = initializeHederaTokenStore(store);
         final var impliedValidity = extrapolateValidityDetailsFromSyntheticTxn(transactionBody);
         if (impliedValidity != OK) {
-            throw new InvalidTransactionException(impliedValidity, StringUtils.EMPTY, StringUtils.EMPTY);
+            throw new InvalidTransactionException(impliedValidity, true);
         }
 
         final var impliedTransfers = extrapolateImpliedTransferDetailsFromSyntheticTxn(transactionBody);

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/StoreImplTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/StoreImplTest.java
@@ -322,15 +322,10 @@ class StoreImplTest {
         when(accountModel.getType()).thenReturn(EntityType.ACCOUNT);
         when(tokenAccountRepository.countByAccountIdAndAssociatedGroupedByBalanceIsPositive(12L))
                 .thenReturn(associationsCount);
-        var result = subject.hasApprovedForAll(
-                Address.ZERO,
-                EntityIdUtils.accountIdFromEvmAddress(ACCOUNT_ADDRESS),
-                EntityIdUtils.tokenIdFromEvmAddress(TOKEN_ADDRESS));
-        assertEquals(false, result);
-        result = subject.hasApprovedForAll(
-                ACCOUNT_ADDRESS,
-                EntityIdUtils.accountIdFromEvmAddress(ACCOUNT_ADDRESS),
-                EntityIdUtils.tokenIdFromEvmAddress(TOKEN_ADDRESS));
-        assertEquals(false, result);
+        var accountId = EntityIdUtils.accountIdFromEvmAddress(ACCOUNT_ADDRESS);
+        var tokenId = EntityIdUtils.tokenIdFromEvmAddress(TOKEN_ADDRESS);
+        assertThat(subject.hasApprovedForAll(Address.ZERO, accountId, tokenId)).isFalse();
+        assertThat(subject.hasApprovedForAll(ACCOUNT_ADDRESS, accountId, tokenId))
+                .isFalse();
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/precompile/MirrorHTSPrecompiledContractTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/precompile/MirrorHTSPrecompiledContractTest.java
@@ -237,7 +237,7 @@ class MirrorHTSPrecompiledContractTest {
         final var precompileResult =
                 subject.computeCosted(MOCK_PRECOMPILE_FUNCTION_HASH, messageFrame, gasCalculator, tokenAccessor);
 
-        final var expectedResult = Pair.of(0L, EncodingFacade.resultFrom(ResponseCodeEnum.FAIL_INVALID));
+        final var expectedResult = Pair.of(0L, EncodingFacade.resultFrom(ResponseCodeEnum.INVALID_FEE_SUBMITTED));
         assertThat(expectedResult).isEqualTo(precompileResult);
     }
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/TransferPrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/TransferPrecompileTest.java
@@ -86,6 +86,7 @@ import com.hedera.services.txns.validation.ContextOptionValidator;
 import com.hedera.services.utils.EntityIdUtils;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.CryptoTransferTransactionBody;
+import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import java.util.List;
 import java.util.Optional;
@@ -262,7 +263,7 @@ class TransferPrecompileTest {
                 .getGasRequirement(TEST_CONSENSUS_TIME, transactionBodyBuilder, store, hederaEvmContractAliases);
         final var result = subject.computeInternal(frame);
 
-        Assertions.assertEquals(HTSTestsUtil.failResult, result);
+        Assertions.assertEquals(UInt256.valueOf(ResponseCodeEnum.ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS_VALUE), result);
     }
 
     @Test


### PR DESCRIPTION
**Description**:  

As mentioned https://github.com/hashgraph/hedera-mirror-node/pull/6613#discussion_r1302237683 , services code should not have dependencies on web3 code, with the exception of the properties and Store classes. For this reason we need to replace InvalidTransactionException from web3 with InvalidTransactionException from services in the precompiles.
This change in the type of exception also makes HtsPrecompiledContract to not catch the exception properly and the flow goes into the generic catch(Exception e) block. This can cause confusion for the end user because the mirror node sends wrong error message as result.
This PR also covers some refactoring discussed [here](https://github.com/hashgraph/hedera-mirror-node/pull/6720#discussion_r1304636813)

**Related issue(s)**:

Fixes #6766

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
