### PR TITLE
Adjust insert-only table autovacuum settings

### DIFF
--- a/hedera-mirror-graphql/src/test/resources/application.yml
+++ b/hedera-mirror-graphql/src/test/resources/application.yml
@@ -20,7 +20,6 @@ spring:
     placeholders:
       api-password: mirror_api_pass
       api-user: mirror_api
-      autovacuumFreezeMaxAgeInsertOnly: 100000
       db-name: ${hedera.mirror.graphql.db.name}
       db-user: ${hedera.mirror.graphql.db.username}
       idPartitionSize: 1000000000000000

--- a/hedera-mirror-grpc/src/test/resources/config/application.yml
+++ b/hedera-mirror-grpc/src/test/resources/config/application.yml
@@ -43,7 +43,6 @@ spring:
     placeholders:
       api-password: mirror_api_pass
       api-user: mirror_api
-      autovacuumFreezeMaxAgeInsertOnly: 100000
       db-name: ${hedera.mirror.grpc.db.name}
       db-user: ${hedera.mirror.grpc.db.username}
       idPartitionSize: 1000000000000000

--- a/hedera-mirror-importer/src/main/resources/application.yml
+++ b/hedera-mirror-importer/src/main/resources/application.yml
@@ -112,7 +112,6 @@ spring:
     placeholders:
       api-password: ${hedera.mirror.importer.db.restPassword}
       api-user: ${hedera.mirror.importer.db.restUsername}
-      autovacuumFreezeMaxAgeInsertOnly: 100000
       db-name: ${hedera.mirror.importer.db.name}
       db-user: ${hedera.mirror.importer.db.username}
       idPartitionSize: 1000000

--- a/hedera-mirror-importer/src/main/resources/db/migration/v1/R__autovacuum_insert_only_tables.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v1/R__autovacuum_insert_only_tables.sql
@@ -1,25 +1,113 @@
 -------------------
 -- autovacuum insert-only tables more frequently to ensure most pages are visible for index-only scans
--- prior to postgresql 13, this can be achieved by configuring a more aggressive anti-wraparound autovacuum
 -------------------
 
+-- reset table storage parameters set prior to postgresql 13
+alter table if exists crypto_transfer reset (
+    autovacuum_freeze_max_age,
+    autovacuum_freeze_table_age,
+    autovacuum_freeze_min_age,
+    log_autovacuum_min_duration
+    );
+
+alter table if exists token_transfer reset (
+    autovacuum_freeze_max_age,
+    autovacuum_freeze_table_age,
+    autovacuum_freeze_min_age,
+    log_autovacuum_min_duration
+    );
+
+alter table if exists transaction reset (
+    autovacuum_freeze_max_age,
+    autovacuum_freeze_table_age,
+    autovacuum_freeze_min_age,
+    log_autovacuum_min_duration
+    );
+
+-- auto vacuum per each account balance snapshot if there are at least 10000 accounts' balance inserted
+alter table if exists account_balance set (
+  autovacuum_vacuum_insert_scale_factor = 0,
+  autovacuum_vacuum_insert_threshold = 10000
+  );
+
+-- auto vacuum daily with 15-minute interval account balance files
+alter table if exists account_balance_file set (
+  autovacuum_vacuum_insert_scale_factor = 0,
+  autovacuum_vacuum_insert_threshold = 96
+  );
+
+-- based on 12 contract actions per smart contract transaction
+alter table if exists contract_action set (
+  autovacuum_vacuum_insert_scale_factor = 0,
+  autovacuum_vacuum_insert_threshold = 2160000
+  );
+
+-- base on average of 3 contract logs per smart contract transaction
+alter table if exists contract_log set (
+  autovacuum_vacuum_insert_scale_factor = 0,
+  autovacuum_vacuum_insert_threshold = 540000
+  );
+
+-- max 300 smart contract transactions per second
+alter table if exists contract_result set (
+  autovacuum_vacuum_insert_scale_factor = 0,
+  autovacuum_vacuum_insert_threshold = 180000
+  );
+
+-- based on average of 10 state changes per smart contract transaction
+alter table if exists contract_state_change set (
+  autovacuum_vacuum_insert_scale_factor = 0,
+  autovacuum_vacuum_insert_threshold = 1800000
+  );
+
+-- autovacuum every 10 minutes at 10K TPS with average of 4 crypto transfers per transaction
 alter table if exists crypto_transfer set (
-    autovacuum_freeze_max_age = ${autovacuumFreezeMaxAgeInsertOnly},
-    autovacuum_freeze_table_age = ${autovacuumFreezeMaxAgeInsertOnly},
-    autovacuum_freeze_min_age = 0,
-    log_autovacuum_min_duration = 0
-    );
+  autovacuum_vacuum_insert_scale_factor = 0,
+  autovacuum_vacuum_insert_threshold = 24000000
+  );
 
+-- adjust when there are higher number of ethereum transactions per second
+alter table if exists ethereum_transaction set (autovacuum_vacuum_insert_scale_factor = 0.1);
+
+-- autovacuum every 60 minutes with 2s interval record files
+alter table if exists record_file set (
+  autovacuum_vacuum_insert_scale_factor = 0,
+  autovacuum_vacuum_insert_threshold = 1800
+  );
+
+-- normally there is just one sidecar record per each record file
+alter table if exists sidecar_file set (
+  autovacuum_vacuum_insert_scale_factor = 0,
+  autovacuum_vacuum_insert_threshold = 1800
+  );
+
+-- threshold set based on recent stats so the table has about 2 to 3 automatic vacuums per day, adjust if there's more
+-- daily pending reward claim
+alter table if exists staking_reward_transfer set (
+  autovacuum_vacuum_insert_scale_factor = 0,
+  autovacuum_vacuum_insert_threshold = 4000
+  );
+
+-- autovacuum per each token balance snapshot if there are at least 10000 account token balance inserted
+alter table if exists token_balance set (
+  autovacuum_vacuum_insert_scale_factor = 0,
+  autovacuum_vacuum_insert_threshold = 10000
+  );
+
+-- autovacuum every 10 minutes at 10K TPS crypto transaction transaction with two token transfer rows per transaction
 alter table if exists token_transfer set (
-    autovacuum_freeze_max_age = ${autovacuumFreezeMaxAgeInsertOnly},
-    autovacuum_freeze_table_age = ${autovacuumFreezeMaxAgeInsertOnly},
-    autovacuum_freeze_min_age = 0,
-    log_autovacuum_min_duration = 0
-    );
+  autovacuum_vacuum_insert_scale_factor = 0,
+  autovacuum_vacuum_insert_threshold = 12000000
+  );
 
+-- autovacuum every 10 minutes at 10K TPS consensus submit message transactions
+alter table if exists topic_message set (
+  autovacuum_vacuum_insert_scale_factor = 0,
+  autovacuum_vacuum_insert_threshold = 6000000
+  );
+
+-- autovacuum every 10 minutes at 10K TPS
 alter table if exists transaction set (
-    autovacuum_freeze_max_age = ${autovacuumFreezeMaxAgeInsertOnly},
-    autovacuum_freeze_table_age = ${autovacuumFreezeMaxAgeInsertOnly},
-    autovacuum_freeze_min_age = 0,
-    log_autovacuum_min_duration = 0
-    );
+  autovacuum_vacuum_insert_scale_factor = 0,
+  autovacuum_vacuum_insert_threshold = 6000000
+  );

--- a/hedera-mirror-importer/src/main/resources/db/migration/v1/R__autovacuum_insert_only_tables.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v1/R__autovacuum_insert_only_tables.sql
@@ -36,13 +36,13 @@ alter table if exists account_balance_file set (
   autovacuum_vacuum_insert_threshold = 96
   );
 
--- based on 12 contract actions per smart contract transaction
+-- based on 12 contract actions per smart contract transaction and max 300 TPS
 alter table if exists contract_action set (
   autovacuum_vacuum_insert_scale_factor = 0,
   autovacuum_vacuum_insert_threshold = 2160000
   );
 
--- base on average of 3 contract logs per smart contract transaction
+-- base on average of 3 contract logs per smart contract transaction and max 300 TPS
 alter table if exists contract_log set (
   autovacuum_vacuum_insert_scale_factor = 0,
   autovacuum_vacuum_insert_threshold = 540000
@@ -54,7 +54,7 @@ alter table if exists contract_result set (
   autovacuum_vacuum_insert_threshold = 180000
   );
 
--- based on average of 10 state changes per smart contract transaction
+-- based on average of 10 state changes per smart contract transaction and max 300 TPS
 alter table if exists contract_state_change set (
   autovacuum_vacuum_insert_scale_factor = 0,
   autovacuum_vacuum_insert_threshold = 1800000
@@ -66,7 +66,7 @@ alter table if exists crypto_transfer set (
   autovacuum_vacuum_insert_threshold = 24000000
   );
 
--- adjust when there are higher number of ethereum transactions per second
+-- adjust when ethereum transaction TPS becomes higher
 alter table if exists ethereum_transaction set (autovacuum_vacuum_insert_scale_factor = 0.1);
 
 -- autovacuum every 60 minutes with 2s interval record files
@@ -75,14 +75,15 @@ alter table if exists record_file set (
   autovacuum_vacuum_insert_threshold = 1800
   );
 
--- normally there is just one sidecar record per each record file
+-- autovacuum every 60 minutes with 2s interval record files. Note normally there is just one sidecar record
+-- per each record file
 alter table if exists sidecar_file set (
   autovacuum_vacuum_insert_scale_factor = 0,
   autovacuum_vacuum_insert_threshold = 1800
   );
 
 -- threshold set based on recent stats so the table has about 2 to 3 automatic vacuums per day, adjust if there's more
--- daily pending reward claim
+-- daily staking reward claims
 alter table if exists staking_reward_transfer set (
   autovacuum_vacuum_insert_scale_factor = 0,
   autovacuum_vacuum_insert_threshold = 4000
@@ -94,7 +95,7 @@ alter table if exists token_balance set (
   autovacuum_vacuum_insert_threshold = 10000
   );
 
--- autovacuum every 10 minutes at 10K TPS crypto transaction transaction with two token transfer rows per transaction
+-- autovacuum every 10 minutes at 10K TPS crypto transfer transactions with two token transfer rows per transaction
 alter table if exists token_transfer set (
   autovacuum_vacuum_insert_scale_factor = 0,
   autovacuum_vacuum_insert_threshold = 12000000

--- a/hedera-mirror-rest-java/src/test/resources/application.yml
+++ b/hedera-mirror-rest-java/src/test/resources/application.yml
@@ -19,7 +19,6 @@ spring:
     placeholders:
       api-password: mirror_api_pass
       api-user: mirror_api
-      autovacuumFreezeMaxAgeInsertOnly: 100000
       db-name: ${hedera.mirror.restJava.db.name}
       db-user: ${hedera.mirror.restJava.db.username}
       idPartitionSize: 1000000000000000

--- a/hedera-mirror-rest/__tests__/integrationDbOps.js
+++ b/hedera-mirror-rest/__tests__/integrationDbOps.js
@@ -111,7 +111,6 @@ const flywayMigrate = async () => {
       "password": "${dbConnectionParams.password}",
       "placeholders.api-password": "${defaultDbConfig.password}",
       "placeholders.api-user": "${apiUsername}",
-      "placeholders.autovacuumFreezeMaxAgeInsertOnly": 100000,
       "placeholders.db-name": "${dbName}",
       "placeholders.db-user": "${dbConnectionParams.user}",
       "placeholders.idPartitionSize": 1000000000000000,

--- a/hedera-mirror-rosetta/test/db/db.go
+++ b/hedera-mirror-rosetta/test/db/db.go
@@ -247,10 +247,9 @@ func runFlywayMigration(pool *dockertest.Pool, network *dockertest.Network, para
 	}
 
 	args := map[string]string{
-		"password":                  params.password,
-		"placeholders.api-password": "mirror_api",
-		"placeholders.api-user":     "mirror_api_password",
-		"placeholders.autovacuumFreezeMaxAgeInsertOnly": "100000",
+		"password":                                      params.password,
+		"placeholders.api-password":                     "mirror_api",
+		"placeholders.api-user":                         "mirror_api_password",
 		"placeholders.idPartitionSize":                  "1000000000000000",
 		"placeholders.maxEntityId":                      "5000000",
 		"placeholders.maxEntityIdRatio":                 "2.0",

--- a/hedera-mirror-web3/src/test/resources/application.yml
+++ b/hedera-mirror-web3/src/test/resources/application.yml
@@ -20,7 +20,6 @@ spring:
     placeholders:
       api-password: mirror_api_pass
       api-user: mirror_api
-      autovacuumFreezeMaxAgeInsertOnly: 100000
       db-name: ${hedera.mirror.web3.db.name}
       db-user: ${hedera.mirror.web3.db.username}
       idPartitionSize: 1000000000000000


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR adjusts insert-only table autovacuum settings based on new insert-only table storage parameters since pg 13 and database stats with sustained 10K tps traffic.

**Related issue(s)**:

Fixes #6622 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

Tested with `itemzed_transfers` turned on, can check other charts in grafana under cluster `preprod`, namespace `pg-2pc`, from `2023-08-26 02:30:00` to `2023-08-26 18:50:00`. 

![Screenshot 2023-08-28 at 11 20 56 AM](https://github.com/hashgraph/hedera-mirror-node/assets/59580070/f864b26c-ab8f-4aca-9d5b-53cf6fd5600e)


the formula to run an autovacuum on the insert-only table is the difference  >= autovacuum_vacuum_insert_threshold + autovacuum_vacuum_insert_scale_factor * reltuples.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
