### PR TITLE
Update fungible token migration to no longer use account balance file

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/FixFungibleTokenTotalSupplyMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/FixFungibleTokenTotalSupplyMigration.java
@@ -33,8 +33,9 @@ public class FixFungibleTokenTotalSupplyMigration extends RepeatableMigration {
             """
             with snapshot_timestamp as (
               select max(consensus_timestamp) as timestamp
-              from account_balance_file
+              from account_balance
               where consensus_timestamp <= (select max(consensus_end) from record_file)
+               and account_id = 2
             ), token_balance_sum as (
               select token_id, sum(balance) amount
               from token_balance
@@ -58,7 +59,7 @@ public class FixFungibleTokenTotalSupplyMigration extends RepeatableMigration {
             update token t
             set total_supply = amount
             from final f
-            where t.token_id = f.token_id
+            where t.token_id = f.token_id;
             """;
 
     private final JdbcTemplate jdbcTemplate;

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/FixFungibleTokenTotalSupplyMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/FixFungibleTokenTotalSupplyMigrationTest.java
@@ -20,6 +20,7 @@ import static com.hedera.mirror.common.domain.entity.EntityType.TOKEN;
 import static com.hedera.mirror.common.domain.token.TokenTypeEnum.NON_FUNGIBLE_UNIQUE;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.hedera.mirror.common.domain.balance.AccountBalance.Id;
 import com.hedera.mirror.common.domain.balance.TokenBalance;
 import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.token.TokenTransfer;
@@ -54,6 +55,8 @@ class FixFungibleTokenTotalSupplyMigrationTest extends IntegrationTest {
     void migrate() {
         // given
         long lastTimestamp = domainBuilder.timestamp();
+        var treasuryAccount =
+                domainBuilder.entity().customize(a -> a.num(2L)).persist().toEntityId();
         var account = domainBuilder.entity().persist().toEntityId();
         long token1DissociateAmount = 500;
         var treasury = domainBuilder.entity().persist().toEntityId();
@@ -96,9 +99,14 @@ class FixFungibleTokenTotalSupplyMigrationTest extends IntegrationTest {
                         .consensusEnd(lastTimestamp))
                 .persist();
         var accountBalanceTimestamp = plus(lastTimestamp, Duration.ofMinutes(-5));
+        // treasury account balance
         domainBuilder
-                .accountBalanceFile()
-                .customize(abf -> abf.consensusTimestamp(accountBalanceTimestamp))
+                .accountBalance()
+                .customize(ab -> ab.id(new Id(accountBalanceTimestamp, treasuryAccount)))
+                .persist();
+        domainBuilder
+                .accountBalance()
+                .customize(ab -> ab.id(new Id(accountBalanceTimestamp, account)))
                 .persist();
         // token1 balance distribution
         domainBuilder


### PR DESCRIPTION
**Description**:
Fungible token total supply migration now references the account balance table instead of the account balance file. 

**Related issue(s)**:

Fixes #6679 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
