### PR TITLE
HIP-584: Fix mint NFT too high gas price

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/utils/BinaryGasEstimator.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/utils/BinaryGasEstimator.java
@@ -47,7 +47,7 @@ public class BinaryGasEstimator {
         // threshold.
         // This value might be adapted or removed in the future, when we have the support of more precompiles and adjust
         // the binary search algorithm accordingly.
-        long minimumThreshold = (long) (lo * 0.09);
+        long minimumThreshold = (long) (lo * 0.1);
         final long estimateIterationThreshold =
                 Math.max(minimumThreshold, properties.getEstimateGasIterationThreshold());
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/fees/calculation/utils/AccessorBasedUsages.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/fees/calculation/utils/AccessorBasedUsages.java
@@ -183,7 +183,7 @@ public class AccessorBasedUsages {
     private void estimateTokenMint(
             SigUsage sigUsage, TxnAccessor accessor, BaseTransactionMeta baseMeta, UsageAccumulator into, Store store) {
         final var tokenMintMeta = opUsageCtxHelper.metaForTokenMint(accessor, store);
-        tokenOpsUsage.tokenMintUsage(sigUsage, baseMeta, tokenMintMeta, into);
+        tokenOpsUsage.tokenMintUsage(sigUsage, baseMeta, tokenMintMeta, into, accessor.getSubType());
     }
 
     private void estimateTokenWipe(

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/fees/usage/state/UsageAccumulator.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/fees/usage/state/UsageAccumulator.java
@@ -273,4 +273,21 @@ public class UsageAccumulator {
     public int hashCode() {
         return HashCodeBuilder.reflectionHashCode(this);
     }
+
+    /**
+     * This is only called in when calculating TokenMintUsage for non-fungible unique tokens,
+     * because it only depends on the number of serials minted and doesn't need all other fields.
+     * Resets all the fields in the accumulator.
+     */
+    public void reset() {
+        numPayerKeys = 0;
+        bpt = 0;
+        bpr = 0;
+        sbpr = 0;
+        vpt = 0;
+        gas = 0;
+        rbs = 0;
+        sbs = 0;
+        networkRbs = 0;
+    }
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/fees/usage/token/TokenOpsUsage.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/fees/usage/token/TokenOpsUsage.java
@@ -33,6 +33,7 @@ import com.hedera.services.fees.usage.token.meta.TokenWipeMeta;
 import com.hedera.services.hapi.fees.usage.BaseTransactionMeta;
 import com.hedera.services.hapi.fees.usage.SigUsage;
 import com.hederahashgraph.api.proto.java.CustomFee;
+import com.hederahashgraph.api.proto.java.SubType;
 import java.util.List;
 
 /**
@@ -138,8 +139,13 @@ public final class TokenOpsUsage {
             final SigUsage sigUsage,
             final BaseTransactionMeta baseMeta,
             final TokenMintMeta tokenMintMeta,
-            final UsageAccumulator accumulator) {
-        accumulator.resetForTransaction(baseMeta, sigUsage);
+            final UsageAccumulator accumulator,
+            final SubType subType) {
+        if (SubType.TOKEN_NON_FUNGIBLE_UNIQUE.equals(subType)) {
+            accumulator.reset();
+        } else {
+            accumulator.resetForTransaction(baseMeta, sigUsage);
+        }
 
         accumulator.addBpt(tokenMintMeta.getBpt());
         accumulator.addRbs(tokenMintMeta.getRbs());

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/fees/usage/token/TokenOpsUsageUtils.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/fees/usage/token/TokenOpsUsageUtils.java
@@ -28,7 +28,6 @@ import static com.hederahashgraph.api.proto.java.SubType.TOKEN_NON_FUNGIBLE_UNIQ
 import static com.hederahashgraph.api.proto.java.SubType.TOKEN_NON_FUNGIBLE_UNIQUE_WITH_CUSTOM_FEES;
 import static com.hederahashgraph.api.proto.java.TokenType.NON_FUNGIBLE_UNIQUE;
 
-import com.google.protobuf.ByteString;
 import com.hedera.services.fees.usage.token.meta.TokenBurnMeta;
 import com.hedera.services.fees.usage.token.meta.TokenCreateMeta;
 import com.hedera.services.fees.usage.token.meta.TokenFreezeMeta;
@@ -95,18 +94,14 @@ public enum TokenOpsUsageUtils {
         long rbs = 0;
         int transferRecordRb = 0;
         if (subType == TOKEN_NON_FUNGIBLE_UNIQUE) {
-            var metadataBytes = 0;
-            for (final ByteString o : op.getMetadataList()) {
-                metadataBytes += o.size();
-            }
-            bpt = metadataBytes;
-            rbs = metadataBytes * expectedLifeTime;
-            transferRecordRb = TOKEN_ENTITY_SIZES.bytesUsedToRecordTokenTransfers(1, 0, op.getMetadataCount());
+            // bpt section in feeSchedules.json is manually modified to just use a constant price of $0.02
+            // for each nft metadata
+            bpt = op.getMetadataList().size();
         } else {
             bpt = AMOUNT_REPR_BYTES;
             transferRecordRb = TOKEN_ENTITY_SIZES.bytesUsedToRecordTokenTransfers(1, 1, 0);
+            bpt += BASIC_ENTITY_ID_SIZE;
         }
-        bpt += BASIC_ENTITY_ID_SIZE;
         return new TokenMintMeta(bpt, subType, transferRecordRb, rbs);
     }
 

--- a/hedera-mirror-web3/src/main/resources/canonical-prices.json
+++ b/hedera-mirror-web3/src/main/resources/canonical-prices.json
@@ -77,7 +77,7 @@
   },
   "TokenMint": {
     "TOKEN_FUNGIBLE_COMMON": 0.001,
-    "TOKEN_NON_FUNGIBLE_UNIQUE": 0.05
+    "TOKEN_NON_FUNGIBLE_UNIQUE": 0.02
   },
   "TokenBurn": {
     "TOKEN_FUNGIBLE_COMMON": 0.001,

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallTestSetup.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallTestSetup.java
@@ -69,6 +69,7 @@ import com.hederahashgraph.api.proto.java.FeeComponents;
 import com.hederahashgraph.api.proto.java.FeeData;
 import com.hederahashgraph.api.proto.java.FeeSchedule;
 import com.hederahashgraph.api.proto.java.Key;
+import com.hederahashgraph.api.proto.java.SubType;
 import com.hederahashgraph.api.proto.java.TimestampSeconds;
 import com.hederahashgraph.api.proto.java.TransactionFeeSchedule;
 import java.math.BigInteger;
@@ -88,16 +89,17 @@ import org.springframework.jdbc.core.JdbcTemplate;
 public class ContractCallTestSetup extends Web3IntegrationTest {
 
     protected static final long expiry = 1_234_567_890L;
+    // Exchange rates from local node.
     protected static final ExchangeRateSet exchangeRatesSet = ExchangeRateSet.newBuilder()
             .setCurrentRate(ExchangeRate.newBuilder()
-                    .setCentEquiv(1)
-                    .setHbarEquiv(12)
-                    .setExpirationTime(TimestampSeconds.newBuilder().setSeconds(expiry))
+                    .setCentEquiv(12)
+                    .setHbarEquiv(1)
+                    .setExpirationTime(TimestampSeconds.newBuilder().setSeconds(4_102_444_800L))
                     .build())
             .setNextRate(ExchangeRate.newBuilder()
-                    .setCentEquiv(2)
-                    .setHbarEquiv(31)
-                    .setExpirationTime(TimestampSeconds.newBuilder().setSeconds(2_234_567_890L))
+                    .setCentEquiv(15)
+                    .setHbarEquiv(1)
+                    .setExpirationTime(TimestampSeconds.newBuilder().setSeconds(4_102_444_800L))
                     .build())
             .build();
     protected static final EntityId FEE_SCHEDULE_ENTITY_ID = EntityId.of(0L, 0L, 111L);
@@ -215,8 +217,20 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
                     .addTransactionFeeSchedule(TransactionFeeSchedule.newBuilder()
                             .setHederaFunctionality(TokenMint)
                             .addFees(FeeData.newBuilder()
+                                    .setSubType(SubType.TOKEN_NON_FUNGIBLE_UNIQUE)
                                     .setServicedata(FeeComponents.newBuilder()
-                                            .setGas(852000)
+                                            .setMax(1000000000000000L)
+                                            .setMin(0)
+                                            .build())
+                                    .setNodedata(FeeComponents.newBuilder()
+                                            .setBpt(40000000000L)
+                                            .setMax(1000000000000000L)
+                                            .setMin(0)
+                                            .build())
+                                    .setNetworkdata(FeeComponents.newBuilder()
+                                            .setMax(1000000000000000L)
+                                            .setBpt(160000000000L)
+                                            .setMin(0)
                                             .build())))
                     .addTransactionFeeSchedule(TransactionFeeSchedule.newBuilder()
                             .setHederaFunctionality(TokenBurn)
@@ -276,8 +290,20 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
                     .addTransactionFeeSchedule(TransactionFeeSchedule.newBuilder()
                             .setHederaFunctionality(TokenMint)
                             .addFees(FeeData.newBuilder()
+                                    .setSubType(SubType.TOKEN_NON_FUNGIBLE_UNIQUE)
                                     .setServicedata(FeeComponents.newBuilder()
-                                            .setGas(852000)
+                                            .setMax(1000000000000000L)
+                                            .setMin(0)
+                                            .build())
+                                    .setNodedata(FeeComponents.newBuilder()
+                                            .setBpt(40000000000L)
+                                            .setMax(1000000000000000L)
+                                            .setMin(0)
+                                            .build())
+                                    .setNetworkdata(FeeComponents.newBuilder()
+                                            .setMax(1000000000000000L)
+                                            .setMin(0)
+                                            .setBpt(160000000000L)
                                             .build())))
                     .addTransactionFeeSchedule(TransactionFeeSchedule.newBuilder()
                             .setHederaFunctionality(CryptoTransfer)

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/fees/calculation/utils/AccessorBasedUsagesTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/fees/calculation/utils/AccessorBasedUsagesTest.java
@@ -196,7 +196,7 @@ class AccessorBasedUsagesTest {
 
         subject.assess(sigUsage, txnAccessor, accumulator, store, mirrorEvmContractAliases);
 
-        verify(tokenOpsUsage).tokenMintUsage(sigUsage, baseMeta, tokenMintMeta, accumulator);
+        verify(tokenOpsUsage).tokenMintUsage(sigUsage, baseMeta, tokenMintMeta, accumulator, txnAccessor.getSubType());
     }
 
     @Test

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/fees/calculation/utils/OpUsageCtxHelperTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/fees/calculation/utils/OpUsageCtxHelperTest.java
@@ -193,10 +193,10 @@ class OpUsageCtxHelperTest {
         final var tokenMintMeta = subject.metaForTokenMint(accessor, store);
 
         // then:
-        assertEquals(34, tokenMintMeta.getBpt());
+        assertEquals(1, tokenMintMeta.getBpt());
         assertEquals(TOKEN_NON_FUNGIBLE_UNIQUE, tokenMintMeta.getSubType());
-        assertEquals(12345670, tokenMintMeta.getRbs());
-        assertEquals(80, tokenMintMeta.getTransferRecordDb());
+        assertEquals(0, tokenMintMeta.getRbs());
+        assertEquals(0, tokenMintMeta.getTransferRecordDb());
     }
 
     private TokenMintTransactionBody getUniqueTokenMintOp() {

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/fees/usage/token/TokenOpsUsageUtilsTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/fees/usage/token/TokenOpsUsageUtilsTest.java
@@ -183,9 +183,9 @@ public class TokenOpsUsageUtilsTest {
         final TokenMintMeta tokenMintMeta =
                 TOKEN_OPS_USAGE_UTILS.tokenMintUsageFrom(txn, TOKEN_NON_FUNGIBLE_UNIQUE, 72000L);
 
-        assertEquals(1296000, tokenMintMeta.getRbs());
-        assertEquals(42, tokenMintMeta.getBpt());
-        assertEquals(136, tokenMintMeta.getTransferRecordDb());
+        assertEquals(0, tokenMintMeta.getRbs());
+        assertEquals(2, tokenMintMeta.getBpt());
+        assertEquals(0, tokenMintMeta.getTransferRecordDb());
     }
 
     @Test


### PR DESCRIPTION
**Description**:
Mint NFT had too high gas requirement after applying the latest fee schedules from the local node (needed for the acceptance tests). As a result an InvalidTransactionException was thrown.

Changes:
- The mint NFT pricing changes from services are applied here as well (PR: https://github.com/hashgraph/hedera-services/pull/7837).
- The fee schedules in the integration tests are updated with the latest fee schedules from the local node.

**Related issue(s)**:
Fixes https://github.com/hashgraph/hedera-mirror-node/issues/6769
