### PR TITLE
Fast Historical Sync PoC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,4 @@ snyk
 **/secret.*
 
 hedera-mirror-rest/report.html*
+/historical-downloads/

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/MirrorProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/MirrorProperties.java
@@ -45,7 +45,7 @@ public class MirrorProperties {
     private Path dataPath = Paths.get(".", "data");
 
     @NotNull
-    private Path downloadPath = Paths.get(".", "historical-downloads");
+    private Path downloadPath = Paths.get("..", "..", "historical-downloads");
 
     @NotNull
     private Instant endDate = Utility.MAX_INSTANT_LONG;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/MirrorProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/MirrorProperties.java
@@ -45,6 +45,9 @@ public class MirrorProperties {
     private Path dataPath = Paths.get(".", "data");
 
     @NotNull
+    private Path downloadPath = Paths.get(".", "historical-downloads");
+
+    @NotNull
     private Instant endDate = Utility.MAX_INSTANT_LONG;
 
     private boolean importHistoricalAccountInfo = true;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/CacheConfiguration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/CacheConfiguration.java
@@ -62,7 +62,7 @@ public class CacheConfiguration {
     @Bean(CACHE_MANAGER_STREAM_DOWNLOADER)
     CacheManager cacheManagerStreamDownloder() {
         var caffeineCacheManager = new CaffeineCacheManager();
-        caffeineCacheManager.setCacheSpecification("maximumSize=5000,expireAfterWrite=1m");
+        caffeineCacheManager.setCacheSpecification("maximumSize=100000,expireAfterWrite=1m");
         return caffeineCacheManager;
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/CacheConfiguration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/CacheConfiguration.java
@@ -35,6 +35,7 @@ public class CacheConfiguration {
     public static final String EXPIRE_AFTER_5M = "cacheManagerExpireAfter5m";
     public static final String CACHE_MANAGER_ALIAS = "cacheManagerAlias";
     public static final String CACHE_MANAGER_TABLE_TIME_PARTITION = "cacheManagerTableTimePartition";
+    public static final String CACHE_MANAGER_STREAM_DOWNLOADER = "cacheManagerStreamDownloder";
 
     @Bean(EXPIRE_AFTER_5M)
     @Primary
@@ -55,6 +56,13 @@ public class CacheConfiguration {
     CacheManager cacheManagerTableTimePartition() {
         var caffeineCacheManager = new CaffeineCacheManager();
         caffeineCacheManager.setCacheSpecification("maximumSize=50,expireAfterWrite=1d");
+        return caffeineCacheManager;
+    }
+
+    @Bean(CACHE_MANAGER_STREAM_DOWNLOADER)
+    CacheManager cacheManagerStreamDownloder() {
+        var caffeineCacheManager = new CaffeineCacheManager();
+        caffeineCacheManager.setCacheSpecification("maximumSize=5000,expireAfterWrite=1m");
         return caffeineCacheManager;
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/CloudStorageConfiguration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/CloudStorageConfiguration.java
@@ -91,6 +91,8 @@ class CloudStorageConfiguration {
         var httpClient = NettyNioAsyncHttpClient.builder()
                 .connectionTimeout(sourceProperties.getConnectionTimeout())
                 .maxConcurrency(sourceProperties.getMaxConcurrency())
+                .maxPendingConnectionAcquires(500)
+                .connectionAcquisitionTimeout(Duration.ofSeconds(10))
                 .connectionMaxIdleTime(Duration.ofSeconds(5)) // https://github.com/aws/aws-sdk-java-v2/issues/1122
                 .build();
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/StreamSourceProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/StreamSourceProperties.java
@@ -33,12 +33,12 @@ public class StreamSourceProperties {
 
     @DurationMin(seconds = 1)
     @NotNull
-    private Duration connectionTimeout = Duration.ofSeconds(5L);
+    private Duration connectionTimeout = Duration.ofSeconds(10L);
 
     private SourceCredentials credentials;
 
     @Min(0)
-    private int maxConcurrency = 1000; // aws sdk default = 50
+    private int maxConcurrency = 2000; // aws sdk default = 50
 
     private String projectId;
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/historical/HistoricalDownloader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/historical/HistoricalDownloader.java
@@ -16,6 +16,9 @@
 
 package com.hedera.mirror.importer.downloader.historical;
 
+import static com.hedera.mirror.importer.config.CacheConfiguration.CACHE_MANAGER_STREAM_DOWNLOADER;
+import static java.util.stream.Collectors.groupingBy;
+
 import com.google.common.base.Stopwatch;
 import com.hedera.mirror.common.domain.StreamType;
 import com.hedera.mirror.importer.addressbook.ConsensusNode;
@@ -23,7 +26,6 @@ import com.hedera.mirror.importer.addressbook.ConsensusNodeService;
 import com.hedera.mirror.importer.domain.StreamFilename;
 import com.hedera.mirror.importer.downloader.DownloaderProperties;
 import com.hedera.mirror.importer.downloader.provider.StreamFileProvider;
-import com.hedera.mirror.importer.downloader.provider.StreamFileProvider.GetObjectResponseWithKey;
 import com.hedera.mirror.importer.exception.FileOperationException;
 import com.hedera.mirror.importer.leader.Leader;
 import jakarta.inject.Named;
@@ -31,23 +33,18 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.nio.file.Path;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 import lombok.CustomLog;
-import lombok.Value;
 import org.apache.commons.io.FileUtils;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.scheduling.annotation.Scheduled;
 import software.amazon.awssdk.services.s3.model.S3Object;
 
@@ -56,6 +53,7 @@ import software.amazon.awssdk.services.s3.model.S3Object;
 public class HistoricalDownloader {
 
     public static final String SEPARATOR = "/";
+    private static final String TEMPLATE_ACCOUNT_ID_PREFIX = "%s/%s%s/";
 
     private final ConsensusNodeService consensusNodeService;
     private final Path downloadPath;
@@ -63,34 +61,31 @@ public class HistoricalDownloader {
     private final ExecutorService executorService = Executors.newFixedThreadPool(100);
     private final StreamFileProvider streamFileProvider;
     private final StreamType streamType;
-    private final ConcurrentMap<String, FileSpecificInfo> downloadsInfoMap = new ConcurrentSkipListMap<>();
-    private final AtomicReference<ConsensusNodeInfo> nodeInfoRef = new AtomicReference<>();
+    private final Cache dataDownloadsCache;
     private final int downloadConcurrency = 3; // Debug, make a property
 
     public HistoricalDownloader(
             ConsensusNodeService consensusNodeService,
             HistoricalDownloaderProperties downloaderProperties,
-            StreamFileProvider streamFileProvider) {
+            StreamFileProvider streamFileProvider,
+            @Named(CACHE_MANAGER_STREAM_DOWNLOADER) CacheManager cacheManager) {
 
         this.consensusNodeService = consensusNodeService;
+        this.dataDownloadsCache = cacheManager.getCache("dataDownloads");
         this.downloaderProperties = downloaderProperties;
         this.streamFileProvider = streamFileProvider;
         this.streamType = downloaderProperties.getStreamType();
         this.downloadPath = downloaderProperties.getMirrorProperties().getDownloadPath();
     }
 
+    private static String getPrefix(ConsensusNode node, StreamType streamType) {
+        var nodeAccount = node.getNodeAccountId().toString();
+        return TEMPLATE_ACCOUNT_ID_PREFIX.formatted(streamType.getPath(), streamType.getNodePrefix(), nodeAccount);
+    }
+
     private static String s3Basename(String s3Key) {
         var lastSeparatorIndex = s3Key.lastIndexOf(SEPARATOR);
-        return lastSeparatorIndex < 0 ? s3Key : s3Key.substring(lastSeparatorIndex + 1);
-    }
-
-    private static String s3Prefix(String s3Key) {
-        var lastSeparatorIndex = s3Key.lastIndexOf(SEPARATOR);
-        return lastSeparatorIndex < 0 ? null : s3Key.substring(0, lastSeparatorIndex + 1);
-    }
-
-    private static boolean isSignatureFileObject(S3Object s3Object) {
-        return isSignatureFileName(s3Object.key());
+        return lastSeparatorIndex < 0 ? s3Key : s3Key.substring(lastSeparatorIndex + 1); // keep trailing /
     }
 
     private static boolean isSignatureFileName(String filename) {
@@ -101,13 +96,13 @@ public class HistoricalDownloader {
     // Run once
     @Scheduled(initialDelay = 1000 * 5, fixedDelay = Long.MAX_VALUE)
     public void downloadAll() {
-        var stopwatch = Stopwatch.createStarted();
-        log.info("Starting download from epoc for stream type {}", streamType);
         downloadAll(StreamFilename.EPOCH);
-        log.info("Total download time {}", stopwatch);
     }
 
     public void downloadAll(StreamFilename startFilename) {
+
+        var methodStopwatch = Stopwatch.createStarted();
+        log.info("Starting download from {}} for stream type {}", startFilename, streamType);
 
         /* NOTE: For first part (6413), the address book will not change while downloading since the data files
          * are not being imported.
@@ -124,198 +119,92 @@ public class HistoricalDownloader {
          * each invocation of downloadNextBatch(), which is pretty frequent, but certainly not each signature
          * file listed. Maybe utilize an epoch minute or hour cache key or something?
          */
-        var nodeInfo = partialCollection(consensusNodeService.getNodes());
-        //        var nodeInfo = partialCollection(List.of(consensusNodeService.getNodes().iterator().next()));
-        nodeInfoRef.set(nodeInfo);
+        var nodes = partialCollection(consensusNodeService.getNodes());
+        //        var nodes = partialCollection(List.of(consensusNodeService.getNodes().iterator().next()));
 
-        List<CompletableFuture<Long>> downloaders = new ArrayList<>(nodeInfo.nextIndex);
-        for (int nodeIdx = 0; nodeIdx < nodeInfo.nextIndex; nodeIdx++) {
-            var node = nodeInfo.nodes().get(nodeIdx);
+        List<CompletableFuture<Long>> nodeDownloaders = new ArrayList<>(nodes.size());
 
-            downloaders.add(CompletableFuture.supplyAsync(
+        for (var node : nodes) {
+            nodeDownloaders.add(CompletableFuture.supplyAsync(
                     () -> {
-                        log.info("Downloading signatures for node {}", node);
-
+                        log.info("Downloading files for node {}", node);
                         var stopwatch = Stopwatch.createStarted();
-                        AtomicReference<S3Object> previousDataFileObjectRef = new AtomicReference<>();
 
-                        /*
-                         * The node specific directory hierarchy within the S3 bucket contains both the signature and
-                         * stream data files. A common timestamp forms the first part of the pair of signature and
-                         * data files. In the listing of objects returned from S3, the data file precedes the
-                         * signature file.
-                         *
-                         * 2019-10-11T13_32_41.443132Z.rcd
-                         * 2019-10-11T13_32_41.443132Z.rcd_sig
-                         *  ...
-                         * 2023-05-11T00_00_00.296936002Z.rcd.gz
-                         * 2023-05-11T00_00_00.296936002Z.rcd_sig
-                         *  ...
-                         * 2019-10-11T15_30_00.026419Z_Balances.csv
-                         * 2019-10-11T15_30_00.026419Z_Balances.csv_sig
-                         *
-                         * The signature file protobufs are not processed, so version and compressor information
-                         * is not explicitly known. So, the file preceding a signature file is the assumed to be
-                         * the related data file. It is possible that a consensus node, due to some malfunction
-                         * perhaps, failed to upload the data file. In that case the mapped FileSpecificInfo will
-                         * contain a null reference which will get set later for another consensus node that
-                         * did provide the data file.
-                         *
-                         * NOTE: Need to integrate with sidecar files.
-                         */
+                        var prefix = getPrefix(node, streamType);
+                        var filesDownloadDir = downloadPath.resolve(prefix).toFile();
+                        try {
+                            FileUtils.forceMkdir(filesDownloadDir);
+                        } catch (IOException e) {
+                            throw new FileOperationException(
+                                    "Unable to create local directory %s".formatted(filesDownloadDir), e);
+                        }
+
                         try {
                             var count = streamFileProvider
                                     .listAllPaginated(node, startFilename)
                                     .log()
-                                    .doOnNext(s3Object -> {
-                                        if (isSignatureFileObject(s3Object)) {
-                                            setupForSignatureDownload(
-                                                    s3Object, previousDataFileObjectRef.getAndSet(null));
-                                        } else {
-                                            previousDataFileObjectRef.set(s3Object);
-                                        }
-                                    })
-                                    .filter(HistoricalDownloader::isSignatureFileObject)
-                                    .flatMap(
-                                            s3Object -> streamFileProvider.get(s3Object, downloadPath),
-                                            downloadConcurrency)
-                                    .doOnNext(this::objectDownloadCompleted)
+                                    .filter(this::isDownloadProspect)
+                                    .flatMap(streamFileProvider::getAsFile, downloadConcurrency)
                                     .count()
                                     .block();
 
-                            log.info("Downloaded {} signatures for node: {} in {}", count, node, stopwatch);
+                            log.info("Downloaded {} files for node: {} in {}", count, node, stopwatch);
                             return count;
                         } catch (Exception e) {
-                            log.error("Error downloading signature files for node: {} after {}", node, stopwatch, e);
+                            log.error("Error downloading files for node: {} after {}", node, stopwatch, e);
                             throw e; // Complete exceptionally for now
                         }
                     },
                     executorService));
         }
 
-        var toComplete = downloaders.toArray(CompletableFuture[]::new);
+        var toComplete = nodeDownloaders.toArray(CompletableFuture[]::new);
         CompletableFuture.allOf(toComplete).join();
-        // And do what with the returned counts? Sum -> total sig files downloaded
+
+        Map<Boolean, List<CompletableFuture<Long>>> completionsMap =
+                nodeDownloaders.stream().collect(groupingBy(CompletableFuture::isCompletedExceptionally));
+
+        var completedExceptionally = completionsMap.get(Boolean.TRUE);
+        var completedSuccessfully = completionsMap.get(Boolean.FALSE);
+
+        if (completedSuccessfully == null) {
+            log.warn("All node downloaders completed exceptionally. Some files may have been downloaded.");
+        } else {
+            var totalFilesDownload = completedSuccessfully.stream()
+                    .mapToLong(future -> future.getNow(0L))
+                    .sum();
+            log.info("Total download time {}, total number of files {}", methodStopwatch, totalFilesDownload);
+        }
+
+        if (completedExceptionally != null) {
+            log.warn(
+                    "{} downloader(s) terminated exceptionally, and file count may be greater than reported",
+                    completedExceptionally.size());
+        }
 
         executorService.shutdownNow();
     }
 
-    @Scheduled(initialDelay = 20000, fixedDelay = 10000)
-    public void manageDownloads() {
-        log.trace("manageDownloads - taking a look!");
-        var stopwatch = Stopwatch.createStarted();
-
-        long downloadsCompleted = 0L;
-        long downloadsStarted = 0L;
-
-        var now = Instant.now().getEpochSecond();
-        var shouldBeDoneTime = now - 60L;
-
-        var entryIterator = downloadsInfoMap.entrySet().iterator();
-        while (entryIterator.hasNext()) {
-            var entry = entryIterator.next();
-            var filename = entry.getKey();
-            var fileInfo = entry.getValue();
-
-            /*
-             * If a sufficient number of signature files have been successfully download, it is time to
-             * kick of the download of the stream data file.
-             */
-            if (fileInfo.isConsensusReached()) {
-                if (isSignatureFileName(filename)) {
-                    var signatureFileS3Key =
-                            fileInfo.getCompletions().iterator().next().s3Key();
-                    var dataFileS3Key = s3Prefix(signatureFileS3Key)
-                            + fileInfo.getDataFileBaseNameRef().get();
-                    log.info(
-                            "Sufficient signature files downloaded for {}, starting data download {}",
-                            filename,
-                            dataFileS3Key);
-                    streamFileProvider.get(dataFileS3Key, downloadPath, this::objectDownloadCompletedConsumer);
-                    downloadsStarted++;
-                } else {
-                    log.debug("Data file downloaded for {}", filename);
-                }
-
-                fileInfo.getCompletions().clear();
-                entryIterator.remove();
-                downloadsCompleted++;
-                continue;
-            }
-
-            /*
-             * Consensus has not yet been reached in terms of the number of files (nodes) downloaded. If we
-             * "should" be done by now, then perhaps one or more of the 1/3 stake of nodes does not have the
-             * file and did not request to download it, or encountered an error.
-             */
-            if (fileInfo.startTime < shouldBeDoneTime) {
-                // It's not just count, but stake...  TBD
-                var completions = fileInfo.getCompletions();
-                var completionsCount = completions.size();
-                var requiredCompletionsCount = fileInfo.consensusNodeInfo.nextIndex;
-
-                log.debug(
-                        "File {} has only {} of {} completions", filename, completionsCount, requiredCompletionsCount);
-                // TODO take action - download additional consensus file(s), or for data file, try another
-                // node prefix.
-            }
-        }
-
-        log.info(
-                "This cycle - downloads completed: {}, data downloads started: {}, in: {}",
-                downloadsCompleted,
-                downloadsStarted,
-                stopwatch);
-    }
-
-    private void setupForSignatureDownload(S3Object signatureFileObject, S3Object dataFileObject) {
-        var signatureFileKey = signatureFileObject.key();
-        var fileDownloadDir = downloadPath.resolve(signatureFileKey).getParent().toFile();
-        try {
-            FileUtils.forceMkdir(fileDownloadDir);
-        } catch (IOException e) {
-            throw new FileOperationException("Unable to create local directory %s".formatted(fileDownloadDir), e);
-        }
-
-        var fileInfo = this.downloadsInfoMap.computeIfAbsent(
-                s3Basename(signatureFileKey), key -> new FileSpecificInfo(this.nodeInfoRef.get(), dataFileObject));
-
-        if (dataFileObject != null) {
-            fileInfo.getDataFileBaseNameRef().compareAndSet(null, s3Basename(dataFileObject.key()));
-        }
-    }
-
-    private GetObjectResponseWithKey objectDownloadCompleted(GetObjectResponseWithKey responseWithKey) {
-        var s3Key = responseWithKey.s3Key();
-
-        var downloadInfo = this.downloadsInfoMap.get(s3Basename(s3Key));
-        if (downloadInfo != null) { // Consensus not yet reached
-            downloadInfo.getCompletions().add(responseWithKey);
-        }
-
-        log.debug("Download completed for {}", s3Key);
-        return responseWithKey;
-    }
-
-    private void objectDownloadCompletedConsumer(GetObjectResponseWithKey responseWithKey) {
-        objectDownloadCompleted(responseWithKey);
+    private boolean isDownloadProspect(S3Object s3Object) {
+        var s3Basename = s3Basename(s3Object.key());
+        return isSignatureFileName(s3Basename) || dataDownloadsCache.putIfAbsent(s3Basename, s3Basename) == null;
     }
 
     /**
-     * Returns a randomly-selected (and randomly-ordered) collection of ConsensusNode elements from the input, where the
+     * Returns a randomly-selected (and randomly-ordered) collection of CondensusNode elements from the input, where the
      * total stake is just enough to meet/exceed the CommonDownloader "downloadRatio" property.
      *
      * @param allNodes the entire set of ConsensusNodes
      * @return a randomly-ordered subcollection
      */
-    private ConsensusNodeInfo partialCollection(Collection<ConsensusNode> allNodes) {
+    private Collection<ConsensusNode> partialCollection(Collection<ConsensusNode> allNodes) {
         var downloadRatio = downloaderProperties.getCommon().getDownloadRatio();
         // no need to randomize (just return entire list) if # of nodes is 0 or 1 or downloadRatio == 1
-        var nodes = new ArrayList<>(allNodes);
         if (allNodes.size() <= 1 || downloadRatio.compareTo(BigDecimal.ONE) == 0) {
-            return new ConsensusNodeInfo(Collections.unmodifiableList(nodes), allNodes.size());
+            return allNodes;
         }
 
+        var nodes = new ArrayList<>(allNodes);
         // shuffle nodes into a random order
         Collections.shuffle(nodes);
 
@@ -337,31 +226,6 @@ public class HistoricalDownloader {
                 allNodes.size(),
                 aggregateStake,
                 totalStake);
-
-        return new ConsensusNodeInfo(Collections.unmodifiableList(nodes), lastEntry);
-    }
-
-    private record ConsensusNodeInfo(List<ConsensusNode> nodes, int nextIndex) {}
-
-    @Value
-    private static class FileSpecificInfo {
-        Set<GetObjectResponseWithKey> completions;
-        ConsensusNodeInfo consensusNodeInfo;
-        AtomicReference<String> dataFileBaseNameRef;
-        AtomicInteger nextNodeIndex;
-        long startTime;
-
-        FileSpecificInfo(ConsensusNodeInfo consensusNodeInfo, S3Object dataFileObject) {
-            this.consensusNodeInfo = consensusNodeInfo;
-            this.dataFileBaseNameRef =
-                    new AtomicReference<>(dataFileObject == null ? null : s3Basename(dataFileObject.key()));
-            this.startTime = Instant.now().getEpochSecond();
-            this.nextNodeIndex = new AtomicInteger(consensusNodeInfo.nextIndex());
-            this.completions = ConcurrentHashMap.newKeySet(consensusNodeInfo.nextIndex());
-        }
-
-        boolean isConsensusReached() {
-            return completions.size() >= consensusNodeInfo.nextIndex;
-        }
+        return nodes.subList(0, lastEntry);
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/historical/HistoricalDownloader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/historical/HistoricalDownloader.java
@@ -101,6 +101,9 @@ public class HistoricalDownloader {
     }
 
     public void downloadAll(StreamFilename startFilename) {
+        if (!downloaderProperties.isEnabled()) {
+            return;
+        }
 
         var methodStopwatch = Stopwatch.createStarted();
         log.info("Starting download from {} for stream type {}", startFilename, streamType);
@@ -155,7 +158,10 @@ public class HistoricalDownloader {
                                     .doOnNext(response -> {
                                         var fileCount = fileCounter.incrementAndGet();
                                         if (fileCount % 1000 == 0) {
-                                            log.info("Node {} cumulative total of {} files", nodeInfo, fileCount);
+                                            log.info(
+                                                    "Node {} downloaded cumulative total of {} files",
+                                                    nodeInfo,
+                                                    fileCount);
                                         }
                                     })
                                     .count()

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/historical/HistoricalDownloader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/historical/HistoricalDownloader.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.importer.downloader.historical;
+
+import com.google.common.base.Stopwatch;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.MultimapBuilder;
+import com.hedera.mirror.common.domain.StreamType;
+import com.hedera.mirror.importer.addressbook.ConsensusNode;
+import com.hedera.mirror.importer.addressbook.ConsensusNodeService;
+import com.hedera.mirror.importer.domain.StreamFilename;
+import com.hedera.mirror.importer.downloader.DownloaderProperties;
+import com.hedera.mirror.importer.downloader.provider.StreamFileProvider;
+import com.hedera.mirror.importer.leader.Leader;
+import jakarta.inject.Named;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import lombok.CustomLog;
+import org.springframework.scheduling.annotation.Scheduled;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+
+@Named
+@CustomLog
+public class HistoricalDownloader {
+
+    public static final String SEPARATOR = "/";
+
+    private final ConsensusNodeService consensusNodeService;
+    private final Path downloadPath;
+    private final DownloaderProperties downloaderProperties;
+    private final ExecutorService executorService = Executors.newFixedThreadPool(100);
+    private final StreamFileProvider streamFileProvider;
+    private final StreamType streamType;
+    private final Multimap<String, GetObjectResponse> downloadsMap =
+            MultimapBuilder.linkedHashKeys().hashSetValues().build();
+    private final int downloadConcurrency = 3;
+
+    public HistoricalDownloader(
+            ConsensusNodeService consensusNodeService,
+            HistoricalDownloaderProperties downloaderProperties,
+            StreamFileProvider streamFileProvider) {
+
+        this.consensusNodeService = consensusNodeService;
+        this.downloaderProperties = downloaderProperties;
+        this.streamFileProvider = streamFileProvider;
+        this.streamType = downloaderProperties.getStreamType();
+        this.downloadPath = downloaderProperties.getMirrorProperties().getDownloadPath();
+    }
+
+    @Leader
+    // Run once
+    @Scheduled(initialDelay = 1000 * 5, fixedDelay = Long.MAX_VALUE)
+    public void downloadAll() {
+        log.info("Starting download from epoc for stream type {}", streamType);
+        downloadAll(StreamFilename.EPOCH);
+    }
+
+    public void downloadAll(StreamFilename startFilename) {
+
+        /* NOTE: For part (6413), the address book will not change while downloading since the data files
+         * are not being imported.
+         *
+         * NOTE: AddressBookServiceImpl.getNodes() is @Cacheable. When an address book update is detected
+         * (update to file ID 102), AddressBookServiceImpl.update() evicts all cache entries.  Not sure if
+         * there is any eviction policy that affects things in between.
+         *
+         * Starting with the initial address book (network specific genesis classpath resource or property), the address
+         * book changes over time as file update transactions are processed. It seems that as the address book
+         * changes, the number of signature/stream files being downloaded should change so that sufficient
+         * numbers are present in the file system for when the Downloader processes them later.
+         *
+         * Currently, the various stream file type downloaders do choose random nodes and calculate 1/3 state for
+         * each invocation of downloadNextBatch(), which is pretty frequent, but certainly not each signature
+         * file listed. Maybe utilize an epoch minute or hour cache key or something?
+         */
+        var nodeInfo = partialCollection(
+                List.of(consensusNodeService.getNodes().iterator().next())); // TODO Single node for initial debug
+        Set<CompletableFuture<Long>> downloaders = new HashSet<>(nodeInfo.nextIndex);
+        for (int nodeIdx = 0; nodeIdx < nodeInfo.nextIndex; nodeIdx++) {
+            var node = nodeInfo.nodes().get(nodeIdx);
+
+            downloaders.add(CompletableFuture.supplyAsync(
+                    () -> {
+                        var stopwatch = Stopwatch.createStarted();
+
+                        try {
+                            var count = streamFileProvider
+                                    .listAllPaginated(node, startFilename)
+                                    .filter(s3Object -> s3Object.key().endsWith("_sig"))
+                                    .flatMap(
+                                            s3Object -> streamFileProvider.get(s3Object, downloadPath),
+                                            downloadConcurrency)
+                                    .doOnNext(responseWithKey -> {
+                                        var response = responseWithKey.getObjectResponse();
+                                        var s3Basename = s3Basename(responseWithKey.s3Key());
+                                        downloadsMap.put(s3Basename, response);
+                                        log.debug(
+                                                "Download completed for node: {}, filename: {}, size: {}",
+                                                node,
+                                                s3Basename,
+                                                response.contentLength());
+                                    })
+                                    .count()
+                                    .block();
+
+                            log.info("Downloaded {} signatures for node: {} in {}", count, node, stopwatch);
+                            return count;
+                        } catch (Exception e) {
+                            log.error("Error downloading signature files for node: {} after {}", node, stopwatch, e);
+                            throw e; // Complete exceptionally
+                        }
+                    },
+                    executorService));
+        }
+
+        var toComplete = downloaders.toArray(CompletableFuture[]::new);
+        CompletableFuture.allOf(toComplete);
+
+        // Initial early address book downloaders are launched and doing their thing.
+        // Need to launch download of stream data file from single node, retrying a different node if not found
+        // Now need to monitor the multimap and remote keys that have been successfully downloaded
+        // as well as attempt additional file downloads where the number of key values is less
+        // than consensus.
+        // Also, as the address book grows, the number needed to reach 1/3 stake also increases and download
+        // tasks need to be added to harvest those signature files.
+
+        try {
+            Thread.sleep(600000L);
+        } catch (InterruptedException e) {
+            log.info("Sleep interrupted");
+            Thread.currentThread().interrupt();
+        }
+        executorService.shutdownNow();
+    }
+
+    /**
+     * Returns a randomly-selected (and randomly-ordered) collection of ConsensusNode elements from the
+     * input, where the total stake is just enough to meet/exceed the CommonDownloader "downloadRatio" property.
+     *
+     * @param allNodes the entire set of ConsensusNodes
+     * @return a randomly-ordered subcollection
+     */
+    private ConsensusNodeInfo partialCollection(Collection<ConsensusNode> allNodes) {
+        var downloadRatio = downloaderProperties.getCommon().getDownloadRatio();
+        // no need to randomize (just return entire list) if # of nodes is 0 or 1 or downloadRatio == 1
+        var nodes = new ArrayList<>(allNodes);
+        if (allNodes.size() <= 1 || downloadRatio.compareTo(BigDecimal.ONE) == 0) {
+            return new ConsensusNodeInfo(Collections.unmodifiableList(nodes), allNodes.size());
+        }
+
+        // shuffle nodes into a random order
+        Collections.shuffle(nodes);
+
+        long totalStake = nodes.get(0).getTotalStake();
+        // only keep "just enough" nodes to reach/exceed downloadRatio
+        long neededStake = BigDecimal.valueOf(totalStake)
+                .multiply(downloadRatio)
+                .setScale(0, RoundingMode.CEILING)
+                .longValue();
+        long aggregateStake = 0; // sum of the stake of all nodes evaluated so far
+        int lastEntry = 0;
+        while (aggregateStake < neededStake) {
+            aggregateStake += nodes.get(lastEntry++).getStake();
+        }
+
+        log.debug(
+                "partialCollection: Kept {} of {} nodes, for stake of {} / {}",
+                lastEntry,
+                allNodes.size(),
+                aggregateStake,
+                totalStake);
+
+        return new ConsensusNodeInfo(Collections.unmodifiableList(nodes), lastEntry);
+    }
+
+    public record ConsensusNodeInfo(List<ConsensusNode> nodes, int nextIndex) {}
+
+    private static String s3Basename(String s3Key) {
+        var lastSeparatorIndex = s3Key.lastIndexOf(SEPARATOR);
+        return lastSeparatorIndex < 0 ? s3Key : s3Key.substring(lastSeparatorIndex + 1);
+    }
+}

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/historical/HistoricalDownloader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/historical/HistoricalDownloader.java
@@ -62,7 +62,6 @@ public class HistoricalDownloader {
     private final StreamFileProvider streamFileProvider;
     private final StreamType streamType;
     private final Cache dataDownloadsCache;
-    private final int downloadConcurrency = 5; // Debug, make a property
 
     public HistoricalDownloader(
             ConsensusNodeService consensusNodeService,
@@ -105,13 +104,14 @@ public class HistoricalDownloader {
         }
 
         var stopAtPrefix = downloaderProperties.getStopAtPrefix();
-        var methodStopwatch = Stopwatch.createStarted();
-
+        var downloadConcurrency = downloaderProperties.getDownloadConcurrency();
         log.info(
-                "Starting download from {} {} for stream type {}",
+                "Starting download from {} {}for stream type {}",
                 startFilename,
-                stopAtPrefix != null ? "until prefix %s".formatted(stopAtPrefix) : "",
+                stopAtPrefix != null ? "until prefix %s ".formatted(stopAtPrefix) : "",
                 streamType);
+
+        var methodStopwatch = Stopwatch.createStarted();
 
         /* NOTE: For first part (6413), the address book will not change while downloading since the data files
          * are not being imported.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/historical/HistoricalDownloaderProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/historical/HistoricalDownloaderProperties.java
@@ -41,6 +41,8 @@ public class HistoricalDownloaderProperties implements DownloaderProperties {
 
     private boolean enabled = true;
 
+    private String stopAtPrefix = null;
+
     private Duration frequency = null;
 
     private boolean persistBytes = false;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/historical/HistoricalDownloaderProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/historical/HistoricalDownloaderProperties.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.importer.downloader.historical;
+
+import com.hedera.mirror.common.domain.StreamType;
+import com.hedera.mirror.importer.MirrorProperties;
+import com.hedera.mirror.importer.downloader.CommonDownloaderProperties;
+import com.hedera.mirror.importer.downloader.DownloaderProperties;
+import java.time.Duration;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+@Component("historicalDownloaderProperties")
+@ConfigurationProperties("hedera.mirror.importer.downloader.historical")
+@Data
+@RequiredArgsConstructor(onConstructor = @__(@Autowired))
+@Validated
+public class HistoricalDownloaderProperties implements DownloaderProperties {
+
+    private final MirrorProperties mirrorProperties;
+
+    private final CommonDownloaderProperties common;
+
+    private boolean enabled = true;
+
+    private Duration frequency = null;
+
+    private boolean persistBytes = false;
+
+    private boolean writeFiles = false;
+
+    private boolean writeSignatures = false;
+
+    @Override
+    public StreamType getStreamType() {
+        return StreamType.RECORD;
+    }
+}

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/historical/HistoricalDownloaderProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/historical/HistoricalDownloaderProperties.java
@@ -43,6 +43,9 @@ public class HistoricalDownloaderProperties implements DownloaderProperties {
 
     private String stopAtPrefix = null;
 
+    // Limit of concurrent file downloads in progress per downloader task
+    private int downloadConcurrency = 5;
+
     private Duration frequency = null;
 
     private boolean persistBytes = false;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/historical/HistoricalDownloaderProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/historical/HistoricalDownloaderProperties.java
@@ -43,8 +43,8 @@ public class HistoricalDownloaderProperties implements DownloaderProperties {
 
     private String stopAtPrefix = null;
 
-    // Limit of concurrent file downloads in progress per downloader task
-    private int downloadConcurrency = 5;
+    // Limit of per node concurrent file downloads in progress per downloader task
+    private int downloadConcurrency = 20;
 
     private Duration frequency = null;
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/CompositeStreamFileProvider.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/CompositeStreamFileProvider.java
@@ -27,8 +27,10 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
 import lombok.CustomLog;
 import lombok.Value;
 import org.springframework.context.annotation.Primary;
@@ -71,6 +73,13 @@ final class CompositeStreamFileProvider implements StreamFileProvider {
         return Mono.fromSupplier(() -> getProvider(index))
                 .flatMap(p -> p.get(s3Object, downloadBase))
                 .retryWhen(Retry.from(s -> s.map(r -> shouldRetry(r, index))));
+    }
+
+    @Override
+    public CompletableFuture<GetObjectResponseWithKey> get(
+            String s3Key, Path downloadBase, Consumer<GetObjectResponseWithKey> completionHandler) {
+        var index = new AtomicInteger(0);
+        return getProvider(index).get(s3Key, downloadBase, completionHandler);
     }
 
     @Override

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/CompositeStreamFileProvider.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/CompositeStreamFileProvider.java
@@ -23,6 +23,7 @@ import com.hedera.mirror.importer.domain.StreamFilename;
 import com.hedera.mirror.importer.downloader.CommonDownloaderProperties;
 import com.hedera.mirror.importer.downloader.StreamSourceProperties;
 import jakarta.inject.Named;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -35,6 +36,7 @@ import reactor.core.Exceptions;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.util.retry.Retry;
+import software.amazon.awssdk.services.s3.model.S3Object;
 
 @CustomLog
 @Named
@@ -68,6 +70,22 @@ final class CompositeStreamFileProvider implements StreamFileProvider {
         var index = new AtomicInteger(0);
         return Mono.fromSupplier(() -> getProvider(index))
                 .flatMapMany(p -> p.list(consensusNode, lastFilename))
+                .retryWhen(Retry.from(s -> s.map(r -> shouldRetry(r, index))));
+    }
+
+    @Override
+    public Flux<S3Object> listAllPaginated(ConsensusNode node, StreamFilename lastFilename) {
+        var index = new AtomicInteger(0);
+        return Mono.fromSupplier(() -> getProvider(index))
+                .flatMapMany(p -> p.listAllPaginated(node, lastFilename))
+                .retryWhen(Retry.from(s -> s.map(r -> shouldRetry(r, index))));
+    }
+
+    @Override
+    public Mono<GetObjectResponseWithKey> get(S3Object s3Object, Path downloadBase) {
+        var index = new AtomicInteger(0);
+        return Mono.fromSupplier(() -> getProvider(index))
+                .flatMap(p -> p.get(s3Object, downloadBase))
                 .retryWhen(Retry.from(s -> s.map(r -> shouldRetry(r, index))));
     }
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/S3StreamFileProvider.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/S3StreamFileProvider.java
@@ -94,7 +94,6 @@ public final class S3StreamFileProvider implements StreamFileProvider {
                         downloadPath, FileTransformerConfiguration.defaultCreateOrReplaceExisting()));
 
         return Mono.fromFuture(responseFuture)
-                .timeout(commonDownloaderProperties.getTimeout())
                 .onErrorMap(NoSuchKeyException.class, TransientProviderException::new)
                 .doOnSuccess(r ->
                         log.debug("Finished downloading {} to {}, size {}", s3Key, downloadBase, r.contentLength()));
@@ -154,12 +153,11 @@ public final class S3StreamFileProvider implements StreamFileProvider {
         var nodeInfo = "%s (%s)".formatted(node, node.getNodeAccountId());
         var pageCounter = new AtomicLong(0L);
         return Flux.from(s3Client.listObjectsV2Paginator(listRequest))
-                .timeout(commonDownloaderProperties.getTimeout())
                 .doOnNext(r -> {
                     var pageCount = pageCounter.incrementAndGet();
                     if (!r.contents().isEmpty()) {
                         log.info(
-                                "Node {} loaded page {} of {} S3 objects, starting with: {}",
+                                "Node {} loaded page {} containing {} S3 objects, starting with: {}",
                                 nodeInfo,
                                 pageCount,
                                 r.contents().size(),

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/S3StreamFileProvider.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/S3StreamFileProvider.java
@@ -124,6 +124,11 @@ public final class S3StreamFileProvider implements StreamFileProvider {
                     if (exception != null) { // Will get retried using different node prefix
                         log.debug("Failed to download key {}, msg: {}", s3Key, exception.getMessage());
                     } else {
+                        log.debug(
+                                "Finished downloading {} to {}, size {}",
+                                s3Key,
+                                downloadBase,
+                                responseWithKey.getObjectResponse().contentLength());
                         completionHandler.accept(responseWithKey);
                     }
                 });

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/S3StreamFileProvider.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/S3StreamFileProvider.java
@@ -25,6 +25,7 @@ import com.hedera.mirror.importer.domain.StreamFileData;
 import com.hedera.mirror.importer.domain.StreamFilename;
 import com.hedera.mirror.importer.downloader.CommonDownloaderProperties;
 import com.hedera.mirror.importer.downloader.CommonDownloaderProperties.PathType;
+import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -34,6 +35,7 @@ import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import software.amazon.awssdk.core.FileTransformerConfiguration;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
@@ -109,9 +111,69 @@ public final class S3StreamFileProvider implements StreamFileProvider {
                 .switchIfEmpty(Flux.defer(() -> pathResult.fallback() ? list(node, lastFilename) : Flux.empty()));
     }
 
+    @Override
+    public Flux<S3Object> listAllPaginated(ConsensusNode node, StreamFilename lastFilename) {
+        var prefix = getAccountIdPrefix(node, lastFilename.getStreamType());
+        var startAfter = prefix + lastFilename.getFilenameAfter();
+        var bucketName = commonDownloaderProperties.getBucketName();
+
+        var listRequest = ListObjectsV2Request.builder()
+                .bucket(bucketName)
+                .prefix(prefix)
+                .startAfter(startAfter)
+                .delimiter(SEPARATOR)
+                .requestPayer(RequestPayer.REQUESTER)
+                .build();
+
+        return Flux.from(s3Client.listObjectsV2Paginator(listRequest))
+                .timeout(commonDownloaderProperties.getTimeout())
+                .doOnNext(r -> {
+                    if (log.isDebugEnabled()) {
+                        var contents = r.contents();
+                        if (contents.isEmpty()) {
+                            log.debug("Next batch of s3 objects is empty");
+                        } else {
+                            log.debug(
+                                    "Next batch of {} s3 objects, starting with: {}",
+                                    contents.size(),
+                                    contents.get(0).key());
+                        }
+                    }
+                })
+                .flatMapIterable(ListObjectsV2Response::contents)
+                .doOnSubscribe(s -> log.debug("Listing files from bucket {} after {}", bucketName, startAfter));
+    }
+
+    @Override
+    public Mono<GetObjectResponseWithKey> get(S3Object s3Object, Path downloadBase) {
+        var s3Key = s3Object.key();
+        log.debug("Starting download of {} to {}", s3Key, downloadBase);
+
+        var request = GetObjectRequest.builder()
+                .bucket(commonDownloaderProperties.getBucketName())
+                .key(s3Key)
+                .requestPayer(RequestPayer.REQUESTER)
+                .build();
+
+        var downloadPath = downloadBase.resolve(s3Key);
+        var responseFuture = s3Client.getObject(
+                        request,
+                        AsyncResponseTransformer.toFile(
+                                downloadPath, FileTransformerConfiguration.defaultCreateOrReplaceExisting()))
+                .thenApply(response -> new GetObjectResponseWithKey(response, s3Key));
+
+        return Mono.fromFuture(responseFuture)
+                .timeout(commonDownloaderProperties.getTimeout())
+                .onErrorMap(NoSuchKeyException.class, TransientProviderException::new)
+                .doOnSuccess(s -> log.debug("Finished downloading {} to {}", s3Key, downloadBase));
+    }
+
     private String getAccountIdPrefix(PathKey key) {
-        var streamType = key.type();
-        var nodeAccount = key.node().getNodeAccountId().toString();
+        return getAccountIdPrefix(key.node(), key.type());
+    }
+
+    private String getAccountIdPrefix(ConsensusNode node, StreamType streamType) {
+        var nodeAccount = node.getNodeAccountId().toString();
         return TEMPLATE_ACCOUNT_ID_PREFIX.formatted(streamType.getPath(), streamType.getNodePrefix(), nodeAccount);
     }
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/StreamFileProvider.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/StreamFileProvider.java
@@ -61,6 +61,7 @@ public interface StreamFileProvider {
         return Flux.empty();
     }
 
+    // For 4613 PoC
     default CompletableFuture<GetObjectResponseWithKey> get(
             String s3Key, Path downloadBase, Consumer<GetObjectResponseWithKey> completionHandler) {
         return null;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/StreamFileProvider.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/StreamFileProvider.java
@@ -20,6 +20,8 @@ import com.hedera.mirror.importer.addressbook.ConsensusNode;
 import com.hedera.mirror.importer.domain.StreamFileData;
 import com.hedera.mirror.importer.domain.StreamFilename;
 import java.nio.file.Path;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
@@ -57,6 +59,11 @@ public interface StreamFileProvider {
     // For 4613 PoC
     default Flux<S3Object> listAllPaginated(ConsensusNode node, StreamFilename lastFilename) {
         return Flux.empty();
+    }
+
+    default CompletableFuture<GetObjectResponseWithKey> get(
+            String s3Key, Path downloadBase, Consumer<GetObjectResponseWithKey> completionHandler) {
+        return null;
     }
 
     record GetObjectResponseWithKey(GetObjectResponse getObjectResponse, String s3Key) {}

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/StreamFileProvider.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/StreamFileProvider.java
@@ -19,8 +19,11 @@ package com.hedera.mirror.importer.downloader.provider;
 import com.hedera.mirror.importer.addressbook.ConsensusNode;
 import com.hedera.mirror.importer.domain.StreamFileData;
 import com.hedera.mirror.importer.domain.StreamFilename;
+import java.nio.file.Path;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.S3Object;
 
 /**
  * A stream file provider abstracts away the source of stream files provided by consensus nodes.
@@ -45,4 +48,16 @@ public interface StreamFileProvider {
      * @return The data associated with one or more stream files, wrapped in a Flux
      */
     Flux<StreamFileData> list(ConsensusNode node, StreamFilename lastFilename);
+
+    // For 4613 PoC
+    default Flux<S3Object> listAllPaginated(ConsensusNode node, StreamFilename lastFilename) {
+        return Flux.empty();
+    }
+
+    // For 4613 PoC
+    default Mono<GetObjectResponseWithKey> get(S3Object s3Object, Path downloadBase) {
+        return Mono.empty();
+    }
+
+    record GetObjectResponseWithKey(GetObjectResponse getObjectResponse, String s3Key) {}
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/StreamFileProvider.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/StreamFileProvider.java
@@ -19,9 +19,6 @@ package com.hedera.mirror.importer.downloader.provider;
 import com.hedera.mirror.importer.addressbook.ConsensusNode;
 import com.hedera.mirror.importer.domain.StreamFileData;
 import com.hedera.mirror.importer.domain.StreamFilename;
-import java.nio.file.Path;
-import java.util.concurrent.CompletableFuture;
-import java.util.function.Consumer;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
@@ -42,7 +39,7 @@ public interface StreamFileProvider {
     Mono<StreamFileData> get(ConsensusNode node, StreamFilename streamFilename);
 
     // For 4613 PoC
-    default Mono<GetObjectResponseWithKey> get(S3Object s3Object, Path downloadBase) {
+    default Mono<GetObjectResponse> getAsFile(S3Object s3Object) {
         return Mono.empty();
     }
 
@@ -59,12 +56,6 @@ public interface StreamFileProvider {
     // For 4613 PoC
     default Flux<S3Object> listAllPaginated(ConsensusNode node, StreamFilename lastFilename) {
         return Flux.empty();
-    }
-
-    // For 4613 PoC
-    default CompletableFuture<GetObjectResponseWithKey> get(
-            String s3Key, Path downloadBase, Consumer<GetObjectResponseWithKey> completionHandler) {
-        return null;
     }
 
     record GetObjectResponseWithKey(GetObjectResponse getObjectResponse, String s3Key) {}

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/StreamFileProvider.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/StreamFileProvider.java
@@ -39,6 +39,11 @@ public interface StreamFileProvider {
      */
     Mono<StreamFileData> get(ConsensusNode node, StreamFilename streamFilename);
 
+    // For 4613 PoC
+    default Mono<GetObjectResponseWithKey> get(S3Object s3Object, Path downloadBase) {
+        return Mono.empty();
+    }
+
     /**
      * Lists and downloads signature files for a particular node upon subscription. Uses the provided lastFilename to
      * search for files lexicographically and chronologically after the last confirmed stream file.
@@ -52,11 +57,6 @@ public interface StreamFileProvider {
     // For 4613 PoC
     default Flux<S3Object> listAllPaginated(ConsensusNode node, StreamFilename lastFilename) {
         return Flux.empty();
-    }
-
-    // For 4613 PoC
-    default Mono<GetObjectResponseWithKey> get(S3Object s3Object, Path downloadBase) {
-        return Mono.empty();
     }
 
     record GetObjectResponseWithKey(GetObjectResponse getObjectResponse, String s3Key) {}

--- a/hedera-mirror-importer/src/main/resources/application.yml
+++ b/hedera-mirror-importer/src/main/resources/application.yml
@@ -9,7 +9,8 @@ hedera:
           enabled: false
         historical:
           enabled: true
-          #stopAtPrefix: 2019-10-11T16_38
+          downloadConcurrency: 100
+          stopAtPrefix: 2023-08-04T
         record:
           enabled: false
       db:

--- a/hedera-mirror-importer/src/main/resources/application.yml
+++ b/hedera-mirror-importer/src/main/resources/application.yml
@@ -43,6 +43,8 @@ logging:
   level:
     root: warn
     com.hedera.mirror.importer: info
+    com.hedera.mirror.importer.downloader.historical: info
+    com.hedera.mirror.importer.downloader.provider.S3StreamFileProvider: info
     org.flywaydb.core.internal.command.DbMigrate: info
     org.springframework.cloud.kubernetes.fabric8.config: error
     #org.hibernate.type.descriptor.sql.BasicBinder: trace

--- a/hedera-mirror-importer/src/main/resources/application.yml
+++ b/hedera-mirror-importer/src/main/resources/application.yml
@@ -1,7 +1,8 @@
 hedera:
   mirror:
     importer:
-      downloader: # TODO Remove this
+      downloader:
+        downloadRatio: 0.34
         balance:
           enabled: false
         event:

--- a/hedera-mirror-importer/src/main/resources/application.yml
+++ b/hedera-mirror-importer/src/main/resources/application.yml
@@ -1,6 +1,15 @@
 hedera:
   mirror:
     importer:
+      downloader: # TODO Remove this
+        balance:
+          enabled: false
+        event:
+          enabled: false
+        historical:
+          enabled: true
+        record:
+          enabled: false
       db:
         connectionInitSql: set temp_buffers='256MB'; set timezone TO 'UTC';
         host: 127.0.0.1

--- a/hedera-mirror-importer/src/main/resources/application.yml
+++ b/hedera-mirror-importer/src/main/resources/application.yml
@@ -9,6 +9,7 @@ hedera:
           enabled: false
         historical:
           enabled: true
+          #stopAtPrefix: 2019-10-11T16_38
         record:
           enabled: false
       db:


### PR DESCRIPTION
# Description:

Fast Historical Sync, Proof of Concept.

**This PR will not leave Draft status, nor be merged into main.** It serves only to make the PoC accessible and to report some results produced by running the code. There are a few bullet items in the associated ticket that are not required at this point to just get a rough idea of performance and whether this approach should be pursued more fully.

Unless your local database already contains an address book, only the classpath genesis address book is available to the PoC. There is no code present to refresh the nodes/stake while downloading when the address book changes. More importantly, since the record files are only being downloaded and not parsed etc., the address book will not change anyway.

## Performance Results
When run using `testnet`, and the classpath genesis address book (7 nodes), stake is not associated with any node, so when 1/3 of stake is calculated, all nodes are considered equal with a stake of 1. So, that means 1/3 of stake is achieved with `n=3` of the 7 nodes.

For a given consensus timestamp, this PoC downloads `n` signature files. Then, for only one of the nodes, the data/record file is also downloaded. For the `testnet` scenario, this is 3 roughly 1000 byte signature files, and 1 varying (4-10KB and larger) data file. For `mainnet` the number of nodes has grown from 13 to 29 over the years. While this PoC would only consider the classpath genesis address book of 13 nodes, a full implementation must accommodate the growth of the address book and adjust its calculation of 1/3 stake as the address book changes over time.

Let's say that today, for `mainnet`, 1/3 of stake is `n=10` of 29 nodes. Thus, 10 signature files and one data file must be downloaded. The current upload rate for any given node is a signature file and data file every two seconds, or 43,200 signature files per day and 43,200 data files per day. 

So to keep pace,  the PoC must download per day:
`testnet`:  3 * 43200 + 43200 = 172,800
`mainnet`: 10 * 43200 + 43200 = 475,200

Of course, the goal is to run much faster than that so that a mirror node can bootstrap from genesis to current time as quickly as possible. And good news, the potential looks great! _Do keep in mind, the performance indicated here only entails downloading the required files to the local file system. Signature validation does not occur, nor are the data files parsed and the database updated._

Using `testnet`, I made several runs to download a 1/2 day, 2 days and then a week's worth of files to tune a few parameters. Download speeds varied from 154 - 2050 files/second or extrapolated out, 13,305,600 - 177,120,000 files/day. Even the slowest result far outstrips the normal production rate. After final tuning I downloaded a week's worth of files from `testnet`, which took just over 14 minutes. This is a rate of 1427 files/second or 123,292,800 files/day.

Therefore 123,292,800 / 475,200 = 259.5 days of `mainnet` data can be downloaded per day. `mainnet` has been producing  these files for about four years, or 365 * 4 = 1460 days worth. So, 1460 / 259.5 = 5.6, which is the number of days it would take to download all of `mainnet`. This does not account for the varying address book over the years, where fewer files would need to be downloaded at genesis where 1/3 of stake results = `n=5` of 13 nodes and then increasing over time.

Further improvements can be made to the code to increase performance, as well as the runtime environment being in the cloud with high network bandwidth, co-located with the data (AWS, GCP) will only make things faster.

### My Runtime Environment

- `testnet` was used as the source of files, configured using the GCP bucket access credentials defined in the `mirrornode` 1Password vault.
- My ISP provides, quite consistently, around 100Mbps download and about 18Mbps upload. Not much else was going on in the home while testing. My laptop is connected via USB-C (5Gbps) to a Dell monitor which has 1 Gb ethernet port to my Netgate firewall via a 2.5 GbE port to ISP.
- My work laptop is a 2021 16" MacbookPro (MacBookPro18,2), M1 Max (10 cores: 8 perf, 2 efficiency), 64GB RAM, MacOS Ventura 13.5.1. Other major programs running at the time were IntelliJ IDEA, Docker Desktop, Slack, lots of Chrome windows and tabs. The system was not solely dedicated to this testing.
- Java is OpenJDK 64-Bit Server VM Temurin-17.0.8+7 (build 17.0.8+7, mixed mode). [Apple Silicon native]
- The new historical downloader is enabled and the S3 client/API is configured to download S3 objects directly to files. They are not read into memory any more than the extent of the `ByteBuffer`s streamed from the service to the file system.
- All other downloaders are disabled via properties.  Therefore, no resources are spent verifying signatures, parsing record files or updating the database.

### The Test Scenario
Being a PoC, some parameters are hardcoded, while others can be more easily manipulated via properties. See *Notes for reviewer* below for some of the choices I made.

`testnet`, was reset part way through 2023-07-27. The first file is `2023-07-27T17_41_10.354040297Z.rcd.gz`. Rather than deal with a partial day, `HistoricalDownloader.java:98`  hardcodes the value `2023-07-28T00_00_00Z.rcd` as the starting point for objects listed in the bucket.

`HistoricalDownloaderProperties` (`hedera.mirror.importer.downloader.historical`) defines two new properties of interest, which are configured to my test defaults in `application.yml`:
- `stopAtPrefix`: The filename prefix when encountered downloading stops. This is a simple `String.startsWith(stopAtKeyPrefix)` implementation. To download only one week's data (starting with `2023-07-28T00_00_00Z` above, I defined the stop prefix as `2023-08-04T`.
- `downloadConcurrency`: The number of files (includes both signature and data files), per node, to download concurrently. This is set to 100. This is referenced in `HistoricalDownloader.java:166`. If you choose to increase this further, or run in an environment with more nodes for which files are to be downloaded, then also check `HistoricalDownloader.java:61` to ensure the backing `ExecutorService` thread pool is large enough to accommodate.

### Running the Historical Downloader

Note that the new property `hedera.mirror.importer.downloadPath` defaults to `../../historical-downloads` because it suited my purposes. This can be overridden. The historical downloader will create this path if it does not already exist, as well as the stream type and node specific sub-directories.
```
historical-downloads
└── recordstreams
    ├── record0.0.3
    ├── record0.0.8
    └── record0.0.9
```
The historical downloader will also overwrite any existing files, so to get a true measure of the files downloaded per run, it is advised to remove the download path (`rm -rf`) before running the downloader again.

Within my runtime environment defined earlier, I used the following command to run the Importer:
```
java -Xms2g -Xmx10g -XX:+CrashOnOutOfMemoryError -jar hedera-mirror-importer/build/libs/hedera-mirror-importer-v0.88.0-SNAPSHOT.jar --spring.config.additional-location=file:/Users/user/Development/mirrornode/config/importer/testnet.yml
```
Do note that with signature verification and data file parsing disabled, a 10g max heap should not be necessary. I tried less (1, 2, and 4g), and while they do not OOM, they are significantly slower, such as 248 seconds for 2 days of files vs 208.  It could be internet variability as well. Dedicate what memory you can on the machine you are using.

Of course, before running it, you must first compile (from the base of the repo):

```
./gradlew clean build -x test
```
Verify the name of the jar file found in `hedera-mirror-importer/build/libs`.

*NOTE:* `-x test` skips the unit tests. Not only does this make building a lot faster, unit tests will fail since the PoC is a bit of a hack and the regular Downloaders are disabled.

When using the `java` command above, the referred to additional Spring configuration is a YAML file that contains my GCP credentials as well as allows me to override settings in `application.yml` without having to recompile.  This looks like:
```
hedera:
  mirror:
    importer:
      #downloadPath: /some/path
      network: testnet
      downloader:
        cloudProvider: GCP
        accessKey: xxx
        secretKey: yyy
        gcpProjectId: zzz
        historical:
          #downloadConcurrency: 100
          #stopAtPrefix: 2023-08-04T
```
I commented out the two `historical` properties that are now defined by default with those values in `application.yml` so you can easily customize them if needed.

Finally, some important information is logged while running. If a DB migration occurred on startup, these first couple of lines may be before that. Search if you need to.
```
2023-09-06T13:09:43.316+0000 INFO scheduling-2 c.h.m.i.d.h.HistoricalDownloader Starting download from 2023-07-28T00_00_00Z.rcd until prefix 2023-08-04T for stream type RECORD, per node download concurrency of 100
2023-09-06T13:09:43.563+0000 INFO scheduling-2 c.h.m.i.d.h.HistoricalDownloader 3 of 7 node downloaders required to meet downloadRatio 0.34
2023-09-06T13:09:43.564+0000 INFO pool-10-thread-1 c.h.m.i.d.h.HistoricalDownloader Downloading files for node 5 (0.0.8)
2023-09-06T13:09:43.564+0000 INFO pool-10-thread-2 c.h.m.i.d.h.HistoricalDownloader Downloading files for node 0 (0.0.3)
2023-09-06T13:09:43.563+0000 INFO pool-10-thread-3 c.h.m.i.d.h.HistoricalDownloader Downloading files for node 6 (0.0.9)
```
This confirms your settings of `stopAtPrefix` and `downloadConcurrency`, as well as indicates what constitutes 1/3 stake and the nodes for which files are going to be downloaded. The nodes selected will change from one run to the next.

The S3 async client is used and each node lists its specific bucket contents and paginates through 1000 objects per page. This is reflected by:
```
2023-09-07T17:35:14.301+0000 INFO sdk-async-response-1-2 c.h.m.i.d.p.S3StreamFileProvider Node 0 (0.0.3) loaded page 12 containing 1000 S3 objects, starting with: recordstreams/record0.0.3/2023-07-28T03_03_22.055194003Z.rcd.gz
2023-09-07T17:35:14.310+0000 INFO sdk-async-response-1-9 c.h.m.i.d.p.S3StreamFileProvider Node 6 (0.0.9) loaded page 18 containing 1000 S3 objects, starting with: recordstreams/record0.0.9/2023-07-28T04_43_22.268103768Z.rcd.gz
2023-09-07T17:35:14.331+0000 INFO sdk-async-response-1-4 c.h.m.i.d.p.S3StreamFileProvider Node 3 (0.0.6) loaded page 14 containing 1000 S3 objects, starting with: recordstreams/record0.0.6/2023-07-28T03_36_42.086753003Z.rcd.gz
```
Note the key for the first object on each page is output as an indication of progress. Keep in mind that listing bucket contents is asynchronous from downloading those objects, and you may well see many pages listed that go well beyond your `stopAtPrefix`. Those objects will not be downloaded, however.

For a given node, for every 1000 files downloaded, a progress indicator is given:
```
2023-09-07T17:35:16.894+0000 INFO sdk-async-response-1-7 c.h.m.i.d.h.HistoricalDownloader Node 0 (0.0.3) downloaded cumulative total of 6000 files
2023-09-07T17:35:17.101+0000 INFO sdk-async-response-1-3 c.h.m.i.d.h.HistoricalDownloader Node 6 (0.0.9) downloaded cumulative total of 5000 files
```
These are intermingled with the object list paging output, until the paging is paused by the S3 client.

When all downloads have completed you are given a summary:
```
2023-09-06T13:23:50.049+0000 INFO pool-10-thread-2 c.h.m.i.d.h.HistoricalDownloader Downloaded 397034 files for node: 0 (0.0.3) in 14.11 min
2023-09-06T13:23:50.069+0000 INFO pool-10-thread-3 c.h.m.i.d.h.HistoricalDownloader Downloaded 413278 files for node: 6 (0.0.9) in 14.11 min
2023-09-06T13:23:50.498+0000 INFO pool-10-thread-1 c.h.m.i.d.h.HistoricalDownloader Downloaded 398932 files for node: 5 (0.0.8) in 14.12 min
2023-09-06T13:23:50.534+0000 INFO scheduling-2 c.h.m.i.d.h.HistoricalDownloader Total download time 14.12 min, total number of files 1209244
```
Note the java process will not exit on its own. Hit ctrl-C to kill it at this point.

That last line is the total number of files downloaded and the time it took to do it. The per node results are also reported. You can confirm this via the file system as well:
```
$ find historical-downloads -name \*.rcd_sig | wc -l                                                                                                    
  906933
$ find historical-downloads -name \*.rcd.gz | wc -l
  302311
$ du -sk  historical-downloads
5229436	historical-downloads
```
That is a total of 906,933 signature files, or 302,311 per node. And, 302,311 data files for a total of 1,209,244, resulting in about 5GB of data. Recall only one data file is downloaded from one of the nodes. 

So, you might be wondering why the per node log messages all indicate different file totals. While all signature files are downloaded for a node, only the first one to reach the point of downloading the data file does so, and the others do not. This is not deterministic and those 302,311 data files got scattered around for the 3 nodes.

# Related issue(s)

Fixes #6413 

# Notes for reviewer
Some things to keep in mind regarding this PoC. There are a number of hacks that most likely will not remain in place if we move beyond PoC and work on integrating this functionality into main.

- The PoC is executed by running the Importer. All other downloaders have their `enable` property set to false. `HistoricalDownloader` is enabled.
- Like the other downloaders, `HistoricalDownloader` is triggered via Spring `@Scheduled`, though only to run once and not to repeat.
- At one point I got frustrated trying to get ahold of the `AsyncS3Client` instance used by `S3StreamFileProvider` to access S3. In the end, I chose to update `StreamFileProvider` and define two methods to do the work I required. This also means that `CompositeStreamFileProvider` and `S3StreamFileProvider` were modified to implement things. It is what it is for the PoC.
- Therefore, the main body of work is `HistoricalDownloader` and `S3StreamFileProvider`.
- Some code was cut and pasted into `HistoricalDownloader` to get things done w/o refactoring existing code etc. just for the PoC.
- Everything is reactor based. Objects are downloaded from S3 directly to files using `AsyncResponseTransformer.toFile()`. `MirrorProperties.downloadPath` defines the top-level directory in which files are created. The hierarchy follows the S3 key/prefix structure defined in the bucket. Directories are created if not present.
- No additional tests have been written for the PoC.


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
