### PR TITLE
Fix acceptance tests race condition

### DIFF
--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorAccountBalance.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorAccountBalance.java
@@ -16,10 +16,21 @@
 
 package com.hedera.mirror.test.e2e.acceptance.props;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
 import lombok.Data;
 
 @Data
 public class MirrorAccountBalance {
     private String timestamp;
     private Long balance;
+    private List<Token> tokens;
+
+    @Data
+    public static class Token {
+        @JsonProperty("token_id")
+        private String tokenId;
+
+        private Long balance;
+    }
 }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/response/MirrorTokenResponse.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/response/MirrorTokenResponse.java
@@ -17,6 +17,7 @@
 package com.hedera.mirror.test.e2e.acceptance.response;
 
 import com.hedera.mirror.test.e2e.acceptance.props.MirrorCustomFees;
+import java.math.BigInteger;
 import lombok.Data;
 
 @Data
@@ -31,4 +32,6 @@ public class MirrorTokenResponse {
     private String pauseStatus;
 
     private String tokenId;
+
+    private BigInteger totalSupply;
 }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/EstimatePrecompileFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/EstimatePrecompileFeature.java
@@ -39,6 +39,7 @@ import com.hedera.hashgraph.sdk.AccountId;
 import com.hedera.hashgraph.sdk.NftId;
 import com.hedera.hashgraph.sdk.TokenId;
 import com.hedera.mirror.test.e2e.acceptance.client.AccountClient;
+import com.hedera.mirror.test.e2e.acceptance.client.AccountClient.AccountNameEnum;
 import com.hedera.mirror.test.e2e.acceptance.client.TokenClient;
 import com.hedera.mirror.test.e2e.acceptance.props.ContractCallRequest;
 import com.hedera.mirror.test.e2e.acceptance.props.ExpandedAccountId;
@@ -92,7 +93,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
                 deployedEstimatePrecompileContract.contractId().toSolidityAddress();
         admin = tokenClient.getSdkClient().getExpandedOperatorAccountId();
         receiverAccount = accountClient.getAccount(AccountClient.AccountNameEnum.BOB);
-        secondReceiverAccount = accountClient.getAccount(AccountClient.AccountNameEnum.ALICE);
+        secondReceiverAccount = accountClient.getAccount(AccountNameEnum.DAVE);
     }
 
     @Given("I create erc test contract with {int} balance")


### PR DESCRIPTION
**Description**: After the addition of the estimateGas+precompile tests, we observed a race condition when running the tests with the @acceptance tag in parallel.

Changes in this PR:

- Modified getTokenInfo to fetch totalSupply for use in the eth_call tests.
- Updated getAccountDetail to fetch tokens and their respective balances for the eth_call tests.
- Updated secondReceiver account in estimateGas+precompile tests to "Dave"

Benefits:

- When running acceptance tests in parallel (like the NFT TotalSupply test), even if other suites modify the totalSupply, our test will now dynamically pick up the correct amount and assert it.
- This dynamic approach also ensures that if the test is run individually, it will still pass due to the accurate amount fetched.

<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #6807

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
