### PR TITLE
Track balance of all entities

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,7 +25,7 @@ Boot [documentation](https://docs.spring.io/spring-boot/docs/current/reference/h
 for the location and order it loads configuration.
 
 The following table lists the available properties along with their default values. Unless you need to set a non-default
-value, it is recommended to only populate overridden properties in the custom `application.yml`. 1
+value, it is recommended to only populate overridden properties in the custom `application.yml`.
 
 | Name                                                                             | Default                                          | Description                                                                                                                                                                                                                                                        |
 |----------------------------------------------------------------------------------|--------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,7 +25,7 @@ Boot [documentation](https://docs.spring.io/spring-boot/docs/current/reference/h
 for the location and order it loads configuration.
 
 The following table lists the available properties along with their default values. Unless you need to set a non-default
-value, it is recommended to only populate overridden properties in the custom `application.yml`.
+value, it is recommended to only populate overridden properties in the custom `application.yml`. 1
 
 | Name                                                                             | Default                                          | Description                                                                                                                                                                                                                                                        |
 |----------------------------------------------------------------------------------|--------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/AbstractEntity.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/AbstractEntity.java
@@ -60,7 +60,7 @@ public abstract class AbstractEntity implements History {
             coalesce =
                     """
             case when coalesce(e_type, type) in (''ACCOUNT'', ''CONTRACT'') then coalesce(e_{0}, 0) + coalesce({0}, 0)
-                 else null
+                 when e_{0} is not null then e_{0} + coalesce({0}, 0)
             end""")
     private Long balance;
 

--- a/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/DomainBuilder.java
+++ b/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/DomainBuilder.java
@@ -920,6 +920,7 @@ public class DomainBuilder {
 
     public DomainWrapper<Entity, Entity.EntityBuilder<?, ?>> topic() {
         return entity().customize(e -> e.alias(null)
+                .balance(null)
                 .receiverSigRequired(null)
                 .ethereumNonce(null)
                 .evmAddress(null)

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/AccountBalanceRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/AccountBalanceRepository.java
@@ -36,7 +36,7 @@ public interface AccountBalanceRepository
         insert into account_balance (account_id, balance, consensus_timestamp)
         select id, balance, :consensusTimestamp
         from entity
-        where deleted is not true and balance is not null and type in ('ACCOUNT', 'CONTRACT')
+        where deleted is not true and balance is not null
         order by id
         """)
     @Transactional

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/historicalbalance/HistoricalBalanceServiceIntegrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/historicalbalance/HistoricalBalanceServiceIntegrationTest.java
@@ -18,7 +18,9 @@ package com.hedera.mirror.importer.parser.record.historicalbalance;
 
 import static com.hedera.mirror.common.domain.balance.AccountBalanceFile.INVALID_NODE_ID;
 import static com.hedera.mirror.common.domain.entity.EntityType.CONTRACT;
+import static com.hedera.mirror.common.domain.entity.EntityType.FILE;
 import static com.hedera.mirror.common.domain.entity.EntityType.TOPIC;
+import static com.hedera.mirror.common.domain.entity.EntityType.UNKNOWN;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
@@ -80,9 +82,13 @@ class HistoricalBalanceServiceIntegrationTest extends IntegrationTest {
                 .entity()
                 .customize(e -> e.deleted(null).type(CONTRACT))
                 .persist();
+        var fileWithBalance =
+                domainBuilder.entity().customize(e -> e.type(FILE)).persist();
+        var unknownWithBalance =
+                domainBuilder.entity().customize(e -> e.type(UNKNOWN)).persist();
         domainBuilder.entity().customize(e -> e.deleted(true)).persist();
         domainBuilder.entity().customize(e -> e.balance(null)).persist();
-        domainBuilder.entity().customize(e -> e.type(TOPIC)).persist();
+        domainBuilder.entity().customize(e -> e.balance(null).type(TOPIC)).persist();
         tokenAccount = domainBuilder
                 .tokenAccount()
                 .customize(ta -> ta.accountId(account.getId()))
@@ -90,7 +96,7 @@ class HistoricalBalanceServiceIntegrationTest extends IntegrationTest {
         domainBuilder.tokenAccount().customize(ta -> ta.associated(false)).persist();
 
         // Only entities with valid balance
-        entities = Lists.newArrayList(account, contract);
+        entities = Lists.newArrayList(account, contract, fileWithBalance, unknownWithBalance);
         tokenAccounts = Lists.newArrayList(tokenAccount);
     }
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/AccountBalanceRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/AccountBalanceRepositoryTest.java
@@ -38,6 +38,7 @@ class AccountBalanceRepositoryTest extends AbstractRepositoryTest {
     void balanceSnapshot() {
         long timestamp = 100;
         assertThat(accountBalanceRepository.balanceSnapshot(timestamp)).isZero();
+        assertThat(accountBalanceRepository.findAll()).isEmpty();
 
         var account = domainBuilder.entity().persist();
         var contract = domainBuilder
@@ -46,10 +47,18 @@ class AccountBalanceRepositoryTest extends AbstractRepositoryTest {
                 .persist();
         domainBuilder.entity().customize(e -> e.balance(null)).persist();
         domainBuilder.entity().customize(e -> e.deleted(true)).persist();
-        domainBuilder.entity().customize(e -> e.type(EntityType.TOPIC)).persist();
-        domainBuilder.tokenAccount().customize(ta -> ta.associated(false)).persist();
+        var fileWithBalance =
+                domainBuilder.entity().customize(e -> e.type(EntityType.FILE)).persist();
+        var unknownWithBalance = domainBuilder
+                .entity()
+                .customize(e -> e.type(EntityType.UNKNOWN))
+                .persist();
+        domainBuilder
+                .entity()
+                .customize(e -> e.balance(null).type(EntityType.TOPIC))
+                .persist();
 
-        var expected = Stream.of(account, contract)
+        var expected = Stream.of(account, contract, fileWithBalance, unknownWithBalance)
                 .map(e -> AccountBalance.builder()
                         .balance(e.getBalance())
                         .id(new AccountBalance.Id(timestamp, e.toEntityId()))

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/GenericUpsertQueryGeneratorTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/GenericUpsertQueryGeneratorTest.java
@@ -150,7 +150,7 @@ class GenericUpsertQueryGeneratorTest extends IntegrationTest {
                           coalesce(auto_renew_period, e_auto_renew_period, null),
                           case
                             when coalesce(e_type, type) in ('ACCOUNT', 'CONTRACT') then coalesce(e_balance, 0) + coalesce(balance, 0)
-                            else null
+                            when e_balance is not null then e_balance + coalesce(balance, 0)
                           end,
                           coalesce(created_timestamp, e_created_timestamp, null),
                           coalesce(decline_reward, e_decline_reward, false),
@@ -361,7 +361,7 @@ class GenericUpsertQueryGeneratorTest extends IntegrationTest {
                             coalesce(auto_renew_period, e_auto_renew_period, null),
                             case
                               when coalesce(e_type, type) in ('ACCOUNT', 'CONTRACT') then coalesce(e_balance, 0) + coalesce(balance, 0)
-                              else null
+                              when e_balance is not null then e_balance + coalesce(balance, 0)
                             end,
                             coalesce(e_created_timestamp, created_timestamp, null),
                             coalesce(decline_reward, e_decline_reward, false),
@@ -444,7 +444,7 @@ class GenericUpsertQueryGeneratorTest extends IntegrationTest {
                           coalesce(auto_renew_period, e_auto_renew_period, null),
                           case
                             when coalesce(e_type, type) in ('ACCOUNT', 'CONTRACT') then coalesce(e_balance, 0) + coalesce(balance, 0)
-                            else null
+                            when e_balance is not null then e_balance + coalesce(balance, 0)
                           end,
                           coalesce(created_timestamp, e_created_timestamp, null),
                           coalesce(decline_reward, e_decline_reward, false),


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR changes importer to track balance of all entities

- Track balance on non-payable entities when there's already balance info in entity table
- Change HistoricalBalanceService to include all entities' balance info if the value in db is not null

**Related issue(s)**:

Relates to #6700 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
Currently, non-payable entity's balance is only set in `InitializeEntityBalanceMigration` and the previous PR has already bumped up that migration's checksum.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
