### PR TITLE
Switch tests to use OutputCaptureExtension

### DIFF
--- a/buildSrc/src/main/kotlin/java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-conventions.gradle.kts
@@ -31,6 +31,7 @@ plugins {
 
 configurations.all {
     exclude(group = "ch.qos.logback", module = "logback-classic")
+    exclude(group = "org.slf4j", module = "slf4j-nop")
     exclude(group = "org.springframework.boot", module = "spring-boot-starter-logging")
 }
 

--- a/hedera-mirror-graphql/src/test/java/com/hedera/mirror/graphql/config/LoggingFilterTest.java
+++ b/hedera-mirror-graphql/src/test/java/com/hedera/mirror/graphql/config/LoggingFilterTest.java
@@ -18,59 +18,38 @@ package com.hedera.mirror.graphql.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.StringWriter;
 import java.time.Duration;
-import lombok.CustomLog;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.Logger;
-import org.apache.logging.log4j.core.appender.WriterAppender;
-import org.apache.logging.log4j.core.layout.PatternLayout;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.mock.web.server.MockServerWebExchange;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
-@CustomLog
+@ExtendWith(OutputCaptureExtension.class)
 class LoggingFilterTest {
 
-    private static final Duration WAIT = Duration.ofSeconds(10);
+    private static final Duration WAIT = Duration.ofSeconds(10L);
 
-    private LoggingFilter loggingFilter;
-    private StringWriter logOutput;
-    private WriterAppender appender;
+    private final LoggingFilter loggingFilter = new LoggingFilter();
 
-    @BeforeEach
-    void setup() {
-        loggingFilter = new LoggingFilter();
-        logOutput = new StringWriter();
-        appender = WriterAppender.newBuilder()
-                .setLayout(PatternLayout.newBuilder().withPattern("%p|%m%n").build())
-                .setName("stringAppender")
-                .setTarget(logOutput)
-                .build();
-        Logger logger = (Logger) LogManager.getLogger(loggingFilter);
-        logger.addAppender(appender);
-        logger.setLevel(org.apache.logging.log4j.Level.DEBUG);
-        appender.start();
-    }
-
-    @AfterEach
-    void cleanup() {
-        appender.stop();
-        org.apache.logging.log4j.core.Logger logger =
-                (org.apache.logging.log4j.core.Logger) LogManager.getLogger(loggingFilter);
-        logger.removeAppender(appender);
+    @BeforeAll
+    static void setup() {
+        var logger = (Logger) LogManager.getLogger(LoggingFilter.class);
+        logger.setLevel(Level.DEBUG);
     }
 
     @CsvSource({"/, 200, INFO", "/actuator/, 200, DEBUG"})
     @ParameterizedTest
-    void filterOnSuccess(String path, int code, String level) {
+    void filterOnSuccess(String path, int code, String level, CapturedOutput output) {
         MockServerWebExchange exchange =
                 MockServerWebExchange.from(MockServerHttpRequest.get(path).build());
         exchange.getResponse().setRawStatusCode(code);
@@ -83,13 +62,13 @@ class LoggingFilterTest {
                 .expectComplete()
                 .verify(WAIT);
 
-        assertLog(Level.toLevel(level), "\\w+ GET " + path + " in \\d+ ms: " + code);
+        assertLog(output, level, "\\w+ GET " + path + " in \\d+ ms: " + code);
     }
 
     @Test
-    void filterXForwardedFor() {
+    void filterXForwardedFor(CapturedOutput output) {
         String clientIp = "10.0.0.100";
-        MockServerWebExchange exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/")
+        var exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/")
                 .header(LoggingFilter.X_FORWARDED_FOR, clientIp)
                 .build());
         exchange.getResponse().setRawStatusCode(200);
@@ -102,29 +81,27 @@ class LoggingFilterTest {
                 .expectComplete()
                 .verify(WAIT);
 
-        assertLog(Level.INFO, clientIp + " GET / in \\d+ ms: 200");
+        assertLog(output, "INFO", clientIp + " GET / in \\d+ ms: 200");
     }
 
     @Test
-    void filterOnCancel() {
-        MockServerWebExchange exchange =
-                MockServerWebExchange.from(MockServerHttpRequest.get("/").build());
+    void filterOnCancel(CapturedOutput output) {
+        var exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/").build());
 
         StepVerifier.withVirtualTime(() -> loggingFilter.filter(
                         exchange, serverWebExchange -> exchange.getResponse().setComplete()))
                 .thenCancel()
                 .verify(WAIT);
 
-        assertLog(Level.WARN, "\\w+ GET / in \\d+ ms: cancelled");
+        assertLog(output, "WARN", "\\w+ GET / in \\d+ ms: cancelled");
     }
 
     @Test
-    void filterOnError() {
-        MockServerWebExchange exchange =
-                MockServerWebExchange.from(MockServerHttpRequest.get("/").build());
+    void filterOnError(CapturedOutput output) {
+        var exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/").build());
         exchange.getResponse().setRawStatusCode(500);
 
-        var exception = new RuntimeException("error");
+        var exception = new IllegalArgumentException("error");
         StepVerifier.withVirtualTime(() -> loggingFilter
                         .filter(exchange, serverWebExchange -> Mono.error(exception))
                         .onErrorResume((t) -> exchange.getResponse().setComplete()))
@@ -132,14 +109,10 @@ class LoggingFilterTest {
                 .expectComplete()
                 .verify(WAIT);
 
-        assertLog(Level.WARN, "\\w+ GET / in \\d+ ms: " + exception.getMessage());
+        assertLog(output, "WARN", "\\w+ GET / in \\d+ ms: " + exception.getMessage());
     }
 
-    private void assertLog(Level level, String pattern) {
-        assertThat(logOutput)
-                .asString()
-                .hasLineCount(1)
-                .contains(level.toString())
-                .containsPattern(pattern);
+    private void assertLog(CapturedOutput logOutput, String level, String pattern) {
+        assertThat(logOutput).asString().hasLineCount(1).contains(level).containsPattern(pattern);
     }
 }

--- a/hedera-mirror-graphql/src/test/resources/log4j2-test.xml
+++ b/hedera-mirror-graphql/src/test/resources/log4j2-test.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="WARN">
   <Appenders>
-    <Console name="console" target="SYSTEM_OUT">
+    <Console follow="true" name="console" target="SYSTEM_OUT">
       <PatternLayout>
         <alwaysWriteExceptions>false</alwaysWriteExceptions>
         <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}{UTC} %p %t %c{1.} %m %ex%n</pattern>

--- a/hedera-mirror-grpc/src/test/resources/log4j2-test.xml
+++ b/hedera-mirror-grpc/src/test/resources/log4j2-test.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="WARN">
   <Appenders>
-    <Console name="console" target="SYSTEM_OUT">
+    <Console follow="true" name="console" target="SYSTEM_OUT">
       <PatternLayout>
         <alwaysWriteExceptions>false</alwaysWriteExceptions>
         <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}{UTC} %p %t %c{1.} %m %ex%n</pattern>

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/config/LoggingFilterTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/config/LoggingFilterTest.java
@@ -18,56 +18,38 @@ package com.hedera.mirror.monitor.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.StringWriter;
 import java.time.Duration;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.Logger;
-import org.apache.logging.log4j.core.appender.WriterAppender;
-import org.apache.logging.log4j.core.layout.PatternLayout;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.mock.web.server.MockServerWebExchange;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
+@ExtendWith(OutputCaptureExtension.class)
 class LoggingFilterTest {
 
     private static final Duration WAIT = Duration.ofSeconds(10L);
 
-    private LoggingFilter loggingFilter;
-    private StringWriter logOutput;
-    private WriterAppender appender;
+    private final LoggingFilter loggingFilter = new LoggingFilter();
 
-    @BeforeEach
-    void setup() {
-        loggingFilter = new LoggingFilter();
-        logOutput = new StringWriter();
-        appender = WriterAppender.newBuilder()
-                .setLayout(PatternLayout.newBuilder().withPattern("%p|%m%n").build())
-                .setName("stringAppender")
-                .setTarget(logOutput)
-                .build();
-        Logger logger = (Logger) LogManager.getLogger(loggingFilter);
-        logger.addAppender(appender);
+    @BeforeAll
+    static void setup() {
+        var logger = (Logger) LogManager.getLogger(LoggingFilter.class);
         logger.setLevel(Level.DEBUG);
-        appender.start();
-    }
-
-    @AfterEach
-    void cleanup() {
-        appender.stop();
-        Logger logger = (Logger) LogManager.getLogger(loggingFilter);
-        logger.removeAppender(appender);
     }
 
     @CsvSource({"/, 200, INFO", "/actuator/, 200, DEBUG"})
     @ParameterizedTest
-    void filterOnSuccess(String path, int code, String level) {
+    void filterOnSuccess(String path, int code, String level, CapturedOutput output) {
         MockServerWebExchange exchange =
                 MockServerWebExchange.from(MockServerHttpRequest.get(path).build());
         exchange.getResponse().setRawStatusCode(code);
@@ -80,13 +62,13 @@ class LoggingFilterTest {
                 .expectComplete()
                 .verify(WAIT);
 
-        assertLog(Level.getLevel(level), "\\w+ GET " + path + " in \\d+ ms: " + code);
+        assertLog(output, level, "\\w+ GET " + path + " in \\d+ ms: " + code);
     }
 
     @Test
-    void filterXForwardedFor() {
+    void filterXForwardedFor(CapturedOutput output) {
         String clientIp = "10.0.0.100";
-        MockServerWebExchange exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/")
+        var exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/")
                 .header(LoggingFilter.X_FORWARDED_FOR, clientIp)
                 .build());
         exchange.getResponse().setRawStatusCode(200);
@@ -99,26 +81,24 @@ class LoggingFilterTest {
                 .expectComplete()
                 .verify(WAIT);
 
-        assertLog(Level.INFO, clientIp + " GET / in \\d+ ms: 200");
+        assertLog(output, "INFO", clientIp + " GET / in \\d+ ms: 200");
     }
 
     @Test
-    void filterOnCancel() {
-        MockServerWebExchange exchange =
-                MockServerWebExchange.from(MockServerHttpRequest.get("/").build());
+    void filterOnCancel(CapturedOutput output) {
+        var exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/").build());
 
         StepVerifier.withVirtualTime(() -> loggingFilter.filter(
                         exchange, serverWebExchange -> exchange.getResponse().setComplete()))
                 .thenCancel()
                 .verify(WAIT);
 
-        assertLog(Level.WARN, "\\w+ GET / in \\d+ ms: cancelled");
+        assertLog(output, "WARN", "\\w+ GET / in \\d+ ms: cancelled");
     }
 
     @Test
-    void filterOnError() {
-        MockServerWebExchange exchange =
-                MockServerWebExchange.from(MockServerHttpRequest.get("/").build());
+    void filterOnError(CapturedOutput output) {
+        var exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/").build());
         exchange.getResponse().setRawStatusCode(500);
 
         var exception = new IllegalArgumentException("error");
@@ -129,14 +109,10 @@ class LoggingFilterTest {
                 .expectComplete()
                 .verify(WAIT);
 
-        assertLog(Level.WARN, "\\w+ GET / in \\d+ ms: " + exception.getMessage());
+        assertLog(output, "WARN", "\\w+ GET / in \\d+ ms: " + exception.getMessage());
     }
 
-    private void assertLog(Level level, String pattern) {
-        assertThat(logOutput)
-                .asString()
-                .hasLineCount(1)
-                .contains(level.toString())
-                .containsPattern(pattern);
+    private void assertLog(CapturedOutput logOutput, String level, String pattern) {
+        assertThat(logOutput).asString().hasLineCount(1).contains(level).containsPattern(pattern);
     }
 }

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/SubscribeMetricsTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/SubscribeMetricsTest.java
@@ -27,24 +27,21 @@ import com.hedera.mirror.monitor.ScenarioStatus;
 import com.hedera.mirror.monitor.subscribe.grpc.GrpcSubscriberProperties;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import java.io.StringWriter;
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.core.Logger;
-import org.apache.logging.log4j.core.appender.WriterAppender;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 
+@ExtendWith(OutputCaptureExtension.class)
 class SubscribeMetricsTest {
 
     private MeterRegistry meterRegistry;
     private SubscribeProperties subscribeProperties;
     private SubscribeMetrics subscribeMetrics;
     private AbstractSubscriberProperties properties;
-    private StringWriter logOutput;
-    private WriterAppender writerAppender;
 
     @BeforeEach
     void setup() {
@@ -53,22 +50,6 @@ class SubscribeMetricsTest {
         meterRegistry = new SimpleMeterRegistry();
         subscribeProperties = new SubscribeProperties();
         subscribeMetrics = new SubscribeMetrics(meterRegistry, subscribeProperties);
-
-        logOutput = new StringWriter();
-        writerAppender = WriterAppender.newBuilder()
-                .setName("stringAppender")
-                .setTarget(logOutput)
-                .build();
-        Logger logger = (Logger) LogManager.getLogger(subscribeMetrics);
-        logger.addAppender(writerAppender);
-        writerAppender.start();
-    }
-
-    @AfterEach
-    void after() {
-        writerAppender.stop();
-        Logger logger = (Logger) LogManager.getLogger(subscribeMetrics);
-        logger.removeAppender(writerAppender);
     }
 
     @Test
@@ -120,7 +101,7 @@ class SubscribeMetricsTest {
     }
 
     @Test
-    void status() {
+    void status(CapturedOutput logOutput) {
         TestScenario testSubscription1 = new TestScenario();
         TestScenario testSubscription2 = new TestScenario();
         testSubscription2.setName("Test2");
@@ -137,7 +118,7 @@ class SubscribeMetricsTest {
     }
 
     @Test
-    void statusDisabled() {
+    void statusDisabled(CapturedOutput logOutput) {
         subscribeProperties.setEnabled(false);
 
         subscribeMetrics.onNext(response(new TestScenario()));
@@ -147,7 +128,7 @@ class SubscribeMetricsTest {
     }
 
     @Test
-    void statusNotRunning() {
+    void statusNotRunning(CapturedOutput logOutput) {
         TestScenario testSubscription = new TestScenario();
         testSubscription.setStatus(ScenarioStatus.COMPLETED);
 

--- a/hedera-mirror-monitor/src/test/resources/log4j2-test.xml
+++ b/hedera-mirror-monitor/src/test/resources/log4j2-test.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="WARN">
   <Appenders>
-    <Console name="console" target="SYSTEM_OUT">
+    <Console follow="true" name="console" target="SYSTEM_OUT">
       <PatternLayout>
         <alwaysWriteExceptions>false</alwaysWriteExceptions>
         <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}{UTC} %p %t %c{1.} %m %ex%n</pattern>

--- a/hedera-mirror-rest-java/build.gradle.kts
+++ b/hedera-mirror-rest-java/build.gradle.kts
@@ -33,7 +33,7 @@ dependencies {
     implementation("org.springframework:spring-context-support")
     implementation("org.springframework.boot:spring-boot-actuator-autoconfigure")
     implementation("org.springframework.boot:spring-boot-configuration-processor")
-    implementation("org.springframework.boot:spring-boot-starter-logging")
+    implementation("org.springframework.boot:spring-boot-starter-log4j2")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-webflux")
     implementation("org.springframework.cloud:spring-cloud-starter-bootstrap")

--- a/hedera-mirror-rest-java/src/test/java/com/hedera/mirror/restjava/config/LoggingFilterTest.java
+++ b/hedera-mirror-rest-java/src/test/java/com/hedera/mirror/restjava/config/LoggingFilterTest.java
@@ -18,58 +18,38 @@ package com.hedera.mirror.restjava.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.StringWriter;
 import java.time.Duration;
-import lombok.CustomLog;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.Logger;
-import org.apache.logging.log4j.core.appender.WriterAppender;
-import org.apache.logging.log4j.core.layout.PatternLayout;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.mock.web.server.MockServerWebExchange;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
-@CustomLog
+@ExtendWith(OutputCaptureExtension.class)
 class LoggingFilterTest {
 
-    private static final Duration WAIT = Duration.ofSeconds(10);
+    private static final Duration WAIT = Duration.ofSeconds(10L);
 
-    private LoggingFilter loggingFilter;
-    private StringWriter logOutput;
-    private WriterAppender appender;
+    private final LoggingFilter loggingFilter = new LoggingFilter();
 
-    @BeforeEach
-    void setup() {
-        loggingFilter = new LoggingFilter();
-        logOutput = new StringWriter();
-        appender = WriterAppender.newBuilder()
-                .setLayout(PatternLayout.newBuilder().withPattern("%p|%m%n").build())
-                .setName("stringAppender")
-                .setTarget(logOutput)
-                .build();
-        Logger logger = (Logger) LogManager.getLogger(loggingFilter);
-        logger.addAppender(appender);
+    @BeforeAll
+    static void setup() {
+        var logger = (Logger) LogManager.getLogger(LoggingFilter.class);
         logger.setLevel(Level.DEBUG);
-        appender.start();
-    }
-
-    @AfterEach
-    void cleanup() {
-        appender.stop();
-        Logger logger = (Logger) LogManager.getLogger(loggingFilter);
-        logger.removeAppender(appender);
     }
 
     @CsvSource({"/, 200, INFO", "/actuator/, 200, DEBUG"})
     @ParameterizedTest
-    void filterOnSuccess(String path, int code, String level) {
+    void filterOnSuccess(String path, int code, String level, CapturedOutput output) {
         MockServerWebExchange exchange =
                 MockServerWebExchange.from(MockServerHttpRequest.get(path).build());
         exchange.getResponse().setRawStatusCode(code);
@@ -82,13 +62,13 @@ class LoggingFilterTest {
                 .expectComplete()
                 .verify(WAIT);
 
-        assertLog(Level.toLevel(level), "\\w+ GET " + path + " in \\d+ ms: " + code);
+        assertLog(output, level, "\\w+ GET " + path + " in \\d+ ms: " + code);
     }
 
     @Test
-    void filterXForwardedFor() {
+    void filterXForwardedFor(CapturedOutput output) {
         String clientIp = "10.0.0.100";
-        MockServerWebExchange exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/")
+        var exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/")
                 .header(LoggingFilter.X_FORWARDED_FOR, clientIp)
                 .build());
         exchange.getResponse().setRawStatusCode(200);
@@ -101,29 +81,27 @@ class LoggingFilterTest {
                 .expectComplete()
                 .verify(WAIT);
 
-        assertLog(Level.INFO, clientIp + " GET / in \\d+ ms: 200");
+        assertLog(output, "INFO", clientIp + " GET / in \\d+ ms: 200");
     }
 
     @Test
-    void filterOnCancel() {
-        MockServerWebExchange exchange =
-                MockServerWebExchange.from(MockServerHttpRequest.get("/").build());
+    void filterOnCancel(CapturedOutput output) {
+        var exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/").build());
 
         StepVerifier.withVirtualTime(() -> loggingFilter.filter(
                         exchange, serverWebExchange -> exchange.getResponse().setComplete()))
                 .thenCancel()
                 .verify(WAIT);
 
-        assertLog(Level.WARN, "\\w+ GET / in \\d+ ms: cancelled");
+        assertLog(output, "WARN", "\\w+ GET / in \\d+ ms: cancelled");
     }
 
     @Test
-    void filterOnError() {
-        MockServerWebExchange exchange =
-                MockServerWebExchange.from(MockServerHttpRequest.get("/").build());
+    void filterOnError(CapturedOutput output) {
+        var exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/").build());
         exchange.getResponse().setRawStatusCode(500);
 
-        var exception = new RuntimeException("error");
+        var exception = new IllegalArgumentException("error");
         StepVerifier.withVirtualTime(() -> loggingFilter
                         .filter(exchange, serverWebExchange -> Mono.error(exception))
                         .onErrorResume((t) -> exchange.getResponse().setComplete()))
@@ -131,14 +109,10 @@ class LoggingFilterTest {
                 .expectComplete()
                 .verify(WAIT);
 
-        assertLog(Level.WARN, "\\w+ GET / in \\d+ ms: " + exception.getMessage());
+        assertLog(output, "WARN", "\\w+ GET / in \\d+ ms: " + exception.getMessage());
     }
 
-    private void assertLog(Level level, String pattern) {
-        assertThat(logOutput)
-                .asString()
-                .hasLineCount(1)
-                .contains(level.toString())
-                .containsPattern(pattern);
+    private void assertLog(CapturedOutput logOutput, String level, String pattern) {
+        assertThat(logOutput).asString().hasLineCount(1).contains(level).containsPattern(pattern);
     }
 }

--- a/hedera-mirror-web3/build.gradle.kts
+++ b/hedera-mirror-web3/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
     implementation("org.springframework:spring-context-support")
     implementation("org.springframework.boot:spring-boot-actuator-autoconfigure")
     implementation("org.springframework.boot:spring-boot-configuration-processor")
-    implementation("org.springframework.boot:spring-boot-starter-logging")
+    implementation("org.springframework.boot:spring-boot-starter-log4j2")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-webflux")
     implementation("org.springframework.cloud:spring-cloud-starter-bootstrap")

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/config/LoggingFilterTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/config/LoggingFilterTest.java
@@ -18,60 +18,38 @@ package com.hedera.mirror.web3.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.hedera.mirror.web3.exception.InvalidParametersException;
-import java.io.StringWriter;
 import java.time.Duration;
-import lombok.CustomLog;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.Logger;
-import org.apache.logging.log4j.core.appender.WriterAppender;
-import org.apache.logging.log4j.core.layout.PatternLayout;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.mock.web.server.MockServerWebExchange;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
-@CustomLog
+@ExtendWith(OutputCaptureExtension.class)
 class LoggingFilterTest {
 
-    private static final Duration WAIT = Duration.ofSeconds(10);
+    private static final Duration WAIT = Duration.ofSeconds(10L);
 
-    private LoggingFilter loggingFilter;
-    private StringWriter logOutput;
-    private WriterAppender appender;
+    private final LoggingFilter loggingFilter = new LoggingFilter();
 
-    @BeforeEach
-    void setup() {
-        loggingFilter = new LoggingFilter();
-        logOutput = new StringWriter();
-        appender = WriterAppender.newBuilder()
-                .setLayout(PatternLayout.newBuilder().withPattern("%p|%m%n").build())
-                .setName("stringAppender")
-                .setTarget(logOutput)
-                .build();
-        Logger logger = (Logger) LogManager.getLogger(loggingFilter);
-        logger.addAppender(appender);
-        logger.setLevel(org.apache.logging.log4j.Level.DEBUG);
-        appender.start();
-    }
-
-    @AfterEach
-    void cleanup() {
-        appender.stop();
-        org.apache.logging.log4j.core.Logger logger =
-                (org.apache.logging.log4j.core.Logger) LogManager.getLogger(loggingFilter);
-        logger.removeAppender(appender);
+    @BeforeAll
+    static void setup() {
+        var logger = (Logger) LogManager.getLogger(LoggingFilter.class);
+        logger.setLevel(Level.DEBUG);
     }
 
     @CsvSource({"/, 200, INFO", "/actuator/, 200, DEBUG"})
     @ParameterizedTest
-    void filterOnSuccess(String path, int code, String level) {
+    void filterOnSuccess(String path, int code, String level, CapturedOutput output) {
         MockServerWebExchange exchange =
                 MockServerWebExchange.from(MockServerHttpRequest.get(path).build());
         exchange.getResponse().setRawStatusCode(code);
@@ -84,13 +62,13 @@ class LoggingFilterTest {
                 .expectComplete()
                 .verify(WAIT);
 
-        assertLog(Level.toLevel(level), "\\w+ GET " + path + " in \\d+ ms: " + code);
+        assertLog(output, level, "\\w+ GET " + path + " in \\d+ ms: " + code);
     }
 
     @Test
-    void filterXForwardedFor() {
+    void filterXForwardedFor(CapturedOutput output) {
         String clientIp = "10.0.0.100";
-        MockServerWebExchange exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/")
+        var exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/")
                 .header(LoggingFilter.X_FORWARDED_FOR, clientIp)
                 .build());
         exchange.getResponse().setRawStatusCode(200);
@@ -103,29 +81,27 @@ class LoggingFilterTest {
                 .expectComplete()
                 .verify(WAIT);
 
-        assertLog(Level.INFO, clientIp + " GET / in \\d+ ms: 200");
+        assertLog(output, "INFO", clientIp + " GET / in \\d+ ms: 200");
     }
 
     @Test
-    void filterOnCancel() {
-        MockServerWebExchange exchange =
-                MockServerWebExchange.from(MockServerHttpRequest.get("/").build());
+    void filterOnCancel(CapturedOutput output) {
+        var exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/").build());
 
         StepVerifier.withVirtualTime(() -> loggingFilter.filter(
                         exchange, serverWebExchange -> exchange.getResponse().setComplete()))
                 .thenCancel()
                 .verify(WAIT);
 
-        assertLog(Level.WARN, "\\w+ GET / in \\d+ ms: cancelled");
+        assertLog(output, "WARN", "\\w+ GET / in \\d+ ms: cancelled");
     }
 
     @Test
-    void filterOnError() {
-        MockServerWebExchange exchange =
-                MockServerWebExchange.from(MockServerHttpRequest.get("/").build());
+    void filterOnError(CapturedOutput output) {
+        var exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/").build());
         exchange.getResponse().setRawStatusCode(500);
 
-        var exception = new InvalidParametersException("error");
+        var exception = new IllegalArgumentException("error");
         StepVerifier.withVirtualTime(() -> loggingFilter
                         .filter(exchange, serverWebExchange -> Mono.error(exception))
                         .onErrorResume((t) -> exchange.getResponse().setComplete()))
@@ -133,14 +109,10 @@ class LoggingFilterTest {
                 .expectComplete()
                 .verify(WAIT);
 
-        assertLog(Level.WARN, "\\w+ GET / in \\d+ ms: " + exception.getMessage());
+        assertLog(output, "WARN", "\\w+ GET / in \\d+ ms: " + exception.getMessage());
     }
 
-    private void assertLog(Level level, String pattern) {
-        assertThat(logOutput)
-                .asString()
-                .hasLineCount(1)
-                .contains(level.toString())
-                .containsPattern(pattern);
+    private void assertLog(CapturedOutput logOutput, String level, String pattern) {
+        assertThat(logOutput).asString().hasLineCount(1).contains(level).containsPattern(pattern);
     }
 }


### PR DESCRIPTION
**Description**:

* Change tests to use Spring's logging framework agnostic `OutputCaptureExtension`
* Fix monitor and web3 including sl4fj implementations on the classpath

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
