### PR TITLE
Set daemonsets to a higher priority class

### DIFF
--- a/charts/hedera-mirror-common/templates/priorityclass.yaml
+++ b/charts/hedera-mirror-common/templates/priorityclass.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.priorityClass.enabled -}}
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
@@ -30,4 +29,3 @@ metadata:
 value: 250
 globalDefault: false
 description: "Used for low priority workloads that no workloads depend upon"
-{{- end -}}

--- a/charts/hedera-mirror-common/templates/zfs/daemonset.yaml
+++ b/charts/hedera-mirror-common/templates/zfs/daemonset.yaml
@@ -17,7 +17,6 @@ spec:
       labels: {{ include "hedera-mirror-common.selectorLabels" . | nindent 8 }}
         app: zfs-init
     spec:
-      serviceAccount: {{ .Values.zfs.init.serviceAccount.name }}
       containers:
         - image: registry.k8s.io/pause:latest
           imagePullPolicy: {{ .Values.zfs.init.image.pullPolicy }}
@@ -48,6 +47,8 @@ spec:
             - name: scripts
               mountPath: /scripts
       nodeSelector: {{ toYaml .Values.zfs.zfsNode.nodeSelector | nindent 8 }}
+      priorityClassName: {{ .Values.zfs.priorityClassName }}
+      serviceAccountName: {{ .Values.zfs.init.serviceAccount.name }}
       terminationGracePeriodSeconds: 1
       tolerations: {{ toYaml .Values.zfs.zfsNode.tolerations | nindent 8 }}
       volumes:

--- a/charts/hedera-mirror-common/values.yaml
+++ b/charts/hedera-mirror-common/values.yaml
@@ -152,9 +152,6 @@ loki:
 networkPolicy:
   enabled: false
 
-priorityClass:
-  enabled: true
-
 prometheus-adapter:
   enabled: true
   priorityClassName: low
@@ -286,6 +283,7 @@ prometheus:
     enabled: false
   prometheus-node-exporter:
     hostNetwork: false
+    priorityClassName: critical
     resources:
       limits:
         cpu: 100m
@@ -343,6 +341,7 @@ promtail:
         - multiline:
             firstline: '^\d{4}-\d{2}-\d{2}T\d{1,2}:\d{2}:\d{2}\.\d+(Z|[+-]\d{4}) '
   enabled: true
+  priorityClassName: critical
   resources:
     limits:
       cpu: 125m
@@ -435,16 +434,13 @@ zfs:
     fstype: zfs
     poolname: zfspv-pool
     recordsize: 32k
+  priorityClassName: critical
   worker:
     diskSize: 3200GB
+  zfsController:
+    priorityClass:
+      create: true
   zfsNode:
-    nodeSelector:
-      csi-type: zfs
-    tolerations:
-      - effect: NoSchedule
-        key: zfs
-        operator: Equal
-        value: "true"
     additionalVolumes:
       node:
         hostPath:
@@ -468,6 +464,15 @@ zfs:
             mountPath: /node
           - name: scripts
             mountPath: /scripts
+    nodeSelector:
+      csi-type: zfs
+    priorityClass:
+      create: true
+    tolerations:
+      - effect: NoSchedule
+        key: zfs
+        operator: Equal
+        value: "true"
   zfsPlugin:
     image:
       registry: gcr.io/


### PR DESCRIPTION
**Description**:

* Add `priorityClassName` to zfs-init daemonset
* Change all daemon sets to a higher priority class
* Fix use of deprecated `serviceAccount` field
* Remove global `priorityClass.enabled` since it's required elsewhere

**Related issue(s)**:

Fixes #6835

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
