### PR TITLE
Re-truncate some tables not in use by rosetta

### DIFF
--- a/hedera-mirror-rosetta/container/importer/sql/V1.86.99__truncate_tables_for_rosetta.sql
+++ b/hedera-mirror-rosetta/container/importer/sql/V1.86.99__truncate_tables_for_rosetta.sql
@@ -1,0 +1,24 @@
+-- truncate tables not needed by rosetta
+truncate assessed_custom_fee;
+truncate contract;
+truncate contract_action;
+truncate contract_log;
+truncate contract_result;
+truncate contract_state;
+truncate contract_state_change;
+truncate custom_fee;
+truncate ethereum_transaction;
+truncate file_data;
+truncate nft;
+truncate nft_allowance;
+truncate nft_allowance_history;
+truncate schedule;
+truncate token;
+truncate token_account;
+truncate token_account_history;
+truncate token_allowance;
+truncate token_allowance_history;
+truncate token_balance;
+truncate token_transfer;
+truncate topic_message;
+truncate transaction_signature;


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR adds a database migration to truncate some tables not in use by rosetta

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
As mentioned in scrum, we need to truncate these tables again since it was missed in last upgrade. Will cherry-pick it to release 0.88 branch.

The only difference v.s. V1.78.99 is the removal of `truncate nft_transfer` since the table no longer exists.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
