### PR TITLE
Find entity from evm address recovered from EC public key alias 

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/EntityIdService.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/EntityIdService.java
@@ -63,9 +63,9 @@ public interface EntityIdService {
     Optional<EntityId> lookup(ContractID... contractIds);
 
     /**
-     * Used to notify the system of new aliases for potential use in future lookups.
+     * Used to notify the system of new aliases / evm addresses for potential use in future lookups.
      *
-     * @param aliasable Represents a mapping of alias to entity ID.
+     * @param entity The entity which may have alias or evm address
      */
     void notify(Entity entity);
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/IntegrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/IntegrationTest.java
@@ -146,13 +146,16 @@ public abstract class IntegrationTest {
     }
 
     protected void reset() {
-        cacheManagers.forEach(
-                c -> c.getCacheNames().forEach(name -> c.getCache(name).clear()));
+        cacheManagers.forEach(this::resetCacheManager);
         mirrorDateRangePropertiesProcessor.clear();
         mirrorProperties.setNetwork(MirrorProperties.HederaNetwork.TESTNET);
         mirrorProperties.setStartDate(Instant.EPOCH);
         jdbcOperations.execute(cleanupSql);
         retryRecorder.reset();
+    }
+
+    protected void resetCacheManager(CacheManager cacheManager) {
+        cacheManager.getCacheNames().forEach(name -> cacheManager.getCache(name).clear());
     }
 
     private String getDefaultIdColumns(Class<?> entityClass) {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/EntityIdServiceImplTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/EntityIdServiceImplTest.java
@@ -167,6 +167,14 @@ class EntityIdServiceImplTest extends IntegrationTest {
     }
 
     @Test
+    void lookupAccountAliasToEvmAddressNotFound() {
+        var accountId = AccountID.newBuilder()
+                .setAlias(DomainUtils.fromBytes(ALIAS_ECDSA_SECP256K1))
+                .build();
+        assertThat(entityIdService.lookup(accountId)).isEmpty();
+    }
+
+    @Test
     void lookupAccountsReturnsFirst() {
         AccountID accountId1 = AccountID.newBuilder().setAccountNum(100).build();
         AccountID accountId2 = AccountID.newBuilder().setAccountNum(101).build();

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/EntityIdServiceImplTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/EntityIdServiceImplTest.java
@@ -18,8 +18,10 @@ package com.hedera.mirror.importer.domain;
 
 import static com.hedera.mirror.common.domain.entity.EntityType.CONTRACT;
 import static com.hedera.mirror.common.domain.entity.EntityType.UNKNOWN;
+import static com.hedera.mirror.importer.util.UtilityTest.ALIAS_ECDSA_SECP256K1;
+import static com.hedera.mirror.importer.util.UtilityTest.EVM_ADDRESS;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import com.hedera.mirror.common.domain.entity.Entity;
 import com.hedera.mirror.common.domain.entity.EntityId;
@@ -133,6 +135,35 @@ class EntityIdServiceImplTest extends IntegrationTest {
                 accountId);
 
         assertThat(entityId).hasValue(EntityId.of(accountId));
+    }
+
+    @Test
+    void lookupAccountAliasToEvmAddressFromCache() {
+        // given
+        var entity = domainBuilder
+                .entity()
+                .customize(e -> e.alias(EVM_ADDRESS).evmAddress(EVM_ADDRESS))
+                .get();
+        entityIdService.notify(entity);
+        var accountId = AccountID.newBuilder()
+                .setAlias(DomainUtils.fromBytes(ALIAS_ECDSA_SECP256K1))
+                .build();
+        // when, then
+        assertThat(entityIdService.lookup(accountId)).hasValue(entity.toEntityId());
+    }
+
+    @Test
+    void lookupAccountAliasToEvmAddressFromDb() {
+        // given
+        var entity = domainBuilder
+                .entity()
+                .customize(e -> e.alias(EVM_ADDRESS).evmAddress(EVM_ADDRESS))
+                .persist();
+        var accountId = AccountID.newBuilder()
+                .setAlias(DomainUtils.fromBytes(ALIAS_ECDSA_SECP256K1))
+                .build();
+        // when, then
+        assertThat(entityIdService.lookup(accountId)).hasValue(entity.toEntityId());
     }
 
     @Test

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerCryptoTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerCryptoTest.java
@@ -18,7 +18,10 @@ package com.hedera.mirror.importer.parser.record.entity;
 
 import static com.hedera.mirror.importer.TestUtils.toEntityTransaction;
 import static com.hedera.mirror.importer.TestUtils.toEntityTransactions;
+import static com.hedera.mirror.importer.config.CacheConfiguration.CACHE_MANAGER_ALIAS;
 import static com.hedera.mirror.importer.parser.domain.RecordItemBuilder.STAKING_REWARD_ACCOUNT;
+import static com.hedera.mirror.importer.util.UtilityTest.ALIAS_ECDSA_SECP256K1;
+import static com.hedera.mirror.importer.util.UtilityTest.EVM_ADDRESS;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -98,6 +101,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.cache.CacheManager;
 
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
 class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItemListenerTest {
@@ -108,6 +113,7 @@ class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItemListene
     private static final long[] additionalTransferAmounts = {1001, 1002};
     private static final ByteString ALIAS_KEY = DomainUtils.fromBytes(UtilityTest.ALIAS_ECDSA_SECP256K1);
 
+    private final @Qualifier(CACHE_MANAGER_ALIAS) CacheManager cacheManager;
     private final ContractRepository contractRepository;
     private final CryptoAllowanceRepository cryptoAllowanceRepository;
     private final NftAllowanceRepository nftAllowanceRepository;
@@ -332,6 +338,136 @@ class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItemListene
                 () -> assertThat(entityRepository.findByAlias(ALIAS_KEY.toByteArray()))
                         .get()
                         .isEqualTo(accountEntityId.getId()));
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+            textBlock =
+                    """
+            false, true
+            false, false
+            # clear cache after the first record file to test the scenario the evm address is looked up from db
+            true, false
+            """)
+    void cryptoCreateHollowAccountThenTransferToPublicKeyAlias(boolean clearCache, boolean singleRecordFile) {
+        entityProperties.getPersist().setCryptoTransferAmounts(true);
+        entityProperties.getPersist().setItemizedTransfers(true);
+
+        var evmAddress = DomainUtils.fromBytes(EVM_ADDRESS);
+        var cryptoCreate = recordItemBuilder
+                .cryptoCreate()
+                .transactionBody(b -> b.setAlias(evmAddress).setInitialBalance(0))
+                .transactionBodyWrapper(w -> {
+                    var transactionId =
+                            w.getTransactionID().toBuilder().setNonce(1).build();
+                    w.setTransactionID(transactionId);
+                })
+                .record(r -> {
+                    var transactionId =
+                            r.getTransactionID().toBuilder().setNonce(1).build();
+                    r.setEvmAddress(evmAddress).setTransactionID(transactionId);
+                })
+                .build();
+        var transactionRecord = cryptoCreate.getTransactionRecord();
+        var hollowAccountId = transactionRecord.getReceipt().getAccountID();
+        // The triggering crypto transfer tx's transaction id has nonce 0
+        var transactionId =
+                transactionRecord.getTransactionID().toBuilder().setNonce(0).build();
+        var payerAccountId = transactionId.getAccountID();
+        var cryptoTransfer = recordItemBuilder
+                .cryptoTransfer()
+                .transactionBody(b -> b.setTransfers(TransferList.newBuilder()
+                        .addAccountAmounts(AccountAmount.newBuilder()
+                                .setAccountID(payerAccountId)
+                                .setAmount(-1000))
+                        .addAccountAmounts(AccountAmount.newBuilder()
+                                .setAccountID(AccountID.newBuilder().setAlias(evmAddress))
+                                .setAmount(1000))))
+                .transactionBodyWrapper(w -> w.setTransactionID(transactionId))
+                .record(r -> r.setTransactionID(transactionId)
+                        // For simplicity, only add transfer from payer to hollow account in transaction record
+                        .setTransferList(TransferList.newBuilder()
+                                .addAccountAmounts(AccountAmount.newBuilder()
+                                        .setAccountID(payerAccountId)
+                                        .setAmount(-1000))
+                                .addAccountAmounts(AccountAmount.newBuilder()
+                                        .setAccountID(hollowAccountId)
+                                        .setAmount(1000L))))
+                .build();
+        var recordItems = new ArrayList<RecordItem>();
+        // crypto transfer to evm address and hollow account create always happen in the same record file
+        recordItems.add(cryptoCreate);
+        recordItems.add(cryptoTransfer);
+
+        if (!singleRecordFile) {
+            parseRecordItemsAndCommit(recordItems);
+            recordItems.clear();
+        }
+
+        if (clearCache) {
+            resetCacheManager(cacheManager);
+        }
+
+        // Crypto transfer to public key alias
+        var cryptoTransferToAlias = recordItemBuilder
+                .cryptoTransfer()
+                .transactionBody(b -> b.setTransfers(TransferList.newBuilder()
+                        .addAccountAmounts(AccountAmount.newBuilder()
+                                .setAccountID(payerAccountId)
+                                .setAmount(-200))
+                        .addAccountAmounts(AccountAmount.newBuilder()
+                                .setAccountID(
+                                        AccountID.newBuilder().setAlias(DomainUtils.fromBytes(ALIAS_ECDSA_SECP256K1)))
+                                .setAmount(200))))
+                .record(r -> r.setTransferList(TransferList.newBuilder()
+                        .addAccountAmounts(AccountAmount.newBuilder()
+                                .setAccountID(payerAccountId)
+                                .setAmount(-200))
+                        .addAccountAmounts(AccountAmount.newBuilder()
+                                .setAccountID(hollowAccountId)
+                                .setAmount(200))))
+                .build();
+        recordItems.add(cryptoTransferToAlias);
+        parseRecordItemsAndCommit(recordItems);
+
+        // then
+        var hollowAccount = EntityId.of(hollowAccountId);
+        var payerAccount = EntityId.of(payerAccountId);
+        var expectedItemizedTransfers = new ArrayList<List<ItemizedTransfer>>();
+        // From hollow account create tx
+        expectedItemizedTransfers.add(null);
+        // From crypto transfer tx which triggers hollow account creation
+        expectedItemizedTransfers.add(List.of(
+                ItemizedTransfer.builder()
+                        .amount(-1000L)
+                        .entityId(payerAccount)
+                        .isApproval(false)
+                        .build(),
+                ItemizedTransfer.builder()
+                        .amount(1000L)
+                        .entityId(hollowAccount)
+                        .isApproval(false)
+                        .build()));
+        // From the last crypto transfer to public key alias
+        expectedItemizedTransfers.add(List.of(
+                ItemizedTransfer.builder()
+                        .amount(-200L)
+                        .entityId(payerAccount)
+                        .isApproval(false)
+                        .build(),
+                ItemizedTransfer.builder()
+                        .amount(200L)
+                        .entityId(hollowAccount)
+                        .isApproval(false)
+                        .build()));
+        assertAll(
+                () -> assertEquals(3, transactionRepository.count()),
+                () -> assertEntities(hollowAccount),
+                () -> assertCryptoTransfers(7),
+                () -> assertThat(entityRepository.findByAlias(EVM_ADDRESS)).hasValue(hollowAccount.getId()),
+                () -> assertThat(transactionRepository.findAll())
+                        .map(com.hedera.mirror.common.domain.transaction.Transaction::getItemizedTransfer)
+                        .containsExactlyInAnyOrderElementsOf(expectedItemizedTransfers));
     }
 
     @Test
@@ -1384,12 +1520,6 @@ class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItemListene
                         }));
     }
 
-    private Condition<CryptoTransfer> isAccountAmountReceiverAccountAmount(AccountAmount receiver) {
-        return new Condition<>(
-                cryptoTransfer -> isAccountAmountReceiverAccountAmount(cryptoTransfer, receiver),
-                format("Is %s the receiver account amount.", receiver));
-    }
-
     @Test
     void cryptoTransferWithUnknownAlias() {
         // given
@@ -1435,24 +1565,6 @@ class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItemListene
     }
 
     @Test
-    void unknownTransactionResult() {
-        int unknownResult = -1000;
-        Transaction transaction = cryptoCreateTransaction();
-        TransactionBody transactionBody = getTransactionBody(transaction);
-        TransactionRecord record = transactionRecord(transactionBody, unknownResult);
-
-        parseRecordItemAndCommit(RecordItem.builder()
-                .transactionRecord(record)
-                .transaction(transaction)
-                .build());
-
-        assertThat(transactionRepository.findAll())
-                .hasSize(1)
-                .extracting(com.hedera.mirror.common.domain.transaction.Transaction::getResult)
-                .containsOnly(unknownResult);
-    }
-
-    @Test
     void cryptoTransferPersistRawBytesDefault() {
         // Use the default properties for record parsing - the raw bytes should NOT be stored in the db
         Transaction transaction = cryptoTransferTransaction();
@@ -1473,24 +1585,6 @@ class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItemListene
         entityProperties.getPersist().setTransactionBytes(false);
         Transaction transaction = cryptoTransferTransaction();
         testRawBytes(transaction, null);
-    }
-
-    @ParameterizedTest
-    @ValueSource(booleans = {true, false})
-    void persistTransactionRecordBytes(boolean persist) {
-        // given
-        entityProperties.getPersist().setTransactionRecordBytes(persist);
-        var recordItem = recordItemBuilder.cryptoTransfer().build();
-        var transactionRecordBytes = persist ? recordItem.getRecordBytes() : null;
-
-        // when
-        parseRecordItemAndCommit(recordItem);
-
-        // then
-        assertThat(transactionRepository.findAll())
-                .hasSize(1)
-                .extracting(com.hedera.mirror.common.domain.transaction.Transaction::getTransactionRecordBytes)
-                .containsOnly(transactionRecordBytes);
     }
 
     @SuppressWarnings("deprecation")
@@ -1606,6 +1700,42 @@ class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItemListene
         assertThat(contractRepository.findById(expectedContract.getId()))
                 .get()
                 .returns(expectedFileId, Contract::getFileId);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void persistTransactionRecordBytes(boolean persist) {
+        // given
+        entityProperties.getPersist().setTransactionRecordBytes(persist);
+        var recordItem = recordItemBuilder.cryptoTransfer().build();
+        var transactionRecordBytes = persist ? recordItem.getRecordBytes() : null;
+
+        // when
+        parseRecordItemAndCommit(recordItem);
+
+        // then
+        assertThat(transactionRepository.findAll())
+                .hasSize(1)
+                .extracting(com.hedera.mirror.common.domain.transaction.Transaction::getTransactionRecordBytes)
+                .containsOnly(transactionRecordBytes);
+    }
+
+    @Test
+    void unknownTransactionResult() {
+        int unknownResult = -1000;
+        Transaction transaction = cryptoCreateTransaction();
+        TransactionBody transactionBody = getTransactionBody(transaction);
+        TransactionRecord record = transactionRecord(transactionBody, unknownResult);
+
+        parseRecordItemAndCommit(RecordItem.builder()
+                .transactionRecord(record)
+                .transaction(transaction)
+                .build());
+
+        assertThat(transactionRepository.findAll())
+                .hasSize(1)
+                .extracting(com.hedera.mirror.common.domain.transaction.Transaction::getResult)
+                .containsOnly(unknownResult);
     }
 
     private void assertAllowances(RecordItem recordItem, Collection<Nft> expectedNfts) {
@@ -1866,6 +1996,12 @@ class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItemListene
             transferListBuilder.addAccountAmounts(accountAmount);
         });
         recordBuilder.setTransferList(transferListBuilder);
+    }
+
+    private Condition<CryptoTransfer> isAccountAmountReceiverAccountAmount(AccountAmount receiver) {
+        return new Condition<>(
+                cryptoTransfer -> isAccountAmountReceiverAccountAmount(cryptoTransfer, receiver),
+                format("Is %s the receiver account amount.", receiver));
     }
 
     private void testRawBytes(Transaction transaction, byte[] expectedBytes) {


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR fixes the bug that importer fails to find entity id from evm address recovered from EC public key alias

- Fall back to look up entity by the 20-byte EVM address recovered from EC public key alias 

**Related issue(s)**:

Fixes #6833 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

tested against testnet bucket:

| consensus_timestamp | type |                                                             itemized_transfer                                                             |
|---------------------|------|-------------------------------------------------------------------------------------------------------------------------------------------|
| 1693551103588458308 |   11 |                                                                                                                                           |
| 1693551103588458309 |   50 |                                                                                                                                           |
| 1693564170736327003 |   14 | [{"amount": 1000000000000, "entity_id": 1149886, "is_approval": false}, {"amount": -1000000000000, "entity_id": 2, "is_approval": false}] |
| 1693566283798793002 |   15 |                                                                                                                                           |

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
