### PR TITLE
Update web3 module README with contracts/call API support

### DIFF
--- a/docs/web3/README.md
+++ b/docs/web3/README.md
@@ -37,3 +37,31 @@ docker run --rm -v "${PWD}/charts/hedera-mirror-web3/postman.json:/tmp/postman.j
 ```
 
 _Note:_ To test against an instance running on the same machine as Docker use your local IP instead of 127.0.0.1.
+
+### Supported/unsupported operations
+
+
+| Estimate | Static | Operation Type                                                                            | Supported | Historical data support | Reads | Modifications |
+|----------|--------|-------------------------------------------------------------------------------------------|-----------|-------------------------|-------|---------------|
+|    Y     |   Y    | non precompile functions                                                                  |     Y     |           N             |   Y   | Y             |
+|    Y     |   N    | operations for Hts system contract AssociatePrecompile                                    |     Y     |           N             |   Y   | Y             |
+|    Y     |   N    | non precompile functions with lazy account creation                                       |     Y     |           N             |   Y   | Y             |
+|    Y     |   Y    | operations for ERC precompile functions (balance, symbol, tokenURI, name, decimals, etc.) |     Y     |           N             |   Y   | N             |
+|    Y     |   N    | operations for HTS system contract MintPrecompile                                         |     Y     |           N             |   Y   | Y             |
+|    Y     |   N    | operations for HTS system contract GrantKycPrecompile                                     |     Y     |           N             |   Y   | Y             |
+|    Y     |   N    | operations for HTS system contract WipePrecompile                                         |     Y     |           N             |   Y   | Y             |
+|    Y     |   N    | operations for HTS system contract BurnPrecompile                                         |     Y     |           N             |   Y   | Y             |
+|    Y     |   N    | operations for HTS system contract DissociatePrecompile                                   |     Y     |           N             |   Y   | Y             |
+|    Y     |   N    | operations for HTS system contract SetApprovalForAllPrecompile                            |     Y     |           N             |   Y   | Y             |
+|    Y     |   N    | operations for HTS system contract ApprovePrecompile                                      |     Y     |           N             |   Y   | Y             |
+|    Y     |   N    | operations for HTS system contract RevokeKycPrecompile                                    |     Y     |           N             |   Y   | Y             |
+|    Y     |   N    | operations for HTS system contract UnpausePrecompile                                      |     Y     |           N             |   Y   | Y             |
+|    Y     |   N    | operations for HTS system contract PausePrecompile                                        |     Y     |           N             |   Y   | Y             |
+|    Y     |   N    | operations for HTS system contract DeleteTokenPrecompile                                  |     Y     |           N             |   Y   | Y             |
+|    Y     |   N    | operations for HTS system contract PausePrecompile                                        |     Y     |           N             |   Y   | Y             |
+|    Y     |   N    | operations for HTS system contract FreezePrecompile                                       |     Y     |           N             |   Y   | Y             |
+|    Y     |   N    | operations for HTS system contract UnfreezePrecompile                                     |     Y     |           N             |   Y   | Y             |
+|    Y     |   N    | operations for IsApprovedForAllPrecompile                                                 |     Y     |           N             |   Y   | N             |
+|    Y     |   N    | operations for AllowancePrecompile                                                        |     Y     |           N             |   Y   | N             |
+|    Y     |   N    | operations for GetApprovedPrecompile                                                      |     Y     |           N             |   Y   | N             |
+|    Y     |   N    | operations for HTS system contract UpdateTokenKeysPrecompile                              |     Y     |           N             |   Y   | Y             |

--- a/hedera-mirror-rest/api/v1/openapi.yml
+++ b/hedera-mirror-rest/api/v1/openapi.yml
@@ -321,27 +321,27 @@ paths:
         |                  | non-static contract state reads and modifications for associate precompile functions                         | 0.83+                                   |
         |                  | non-static contract state reads and modifications for non precompile functions with lazy account creation    | 0.84+                                   |
         |                  | static contract state reads for ERC precompile functions (balance, symbol, tokenURI, name, decimals, etc. )  | 0.84+                                   |
-        |                  | HTS system contract MintPrecompile                                                                           | 0.84+                                   |
-        |                  | HTS system contract GrantKycPrecompile                                                                       | 0.85+                                   |
-        |                  | HTS system contract WipePrecompile                                                                           | 0.85+                                   |
-        |                  | HTS system contract BurnPrecompile                                                                           | 0.85+                                   |
-        |                  | HTS system contract DissociatePrecompile                                                                     | 0.85+                                   |
-        |                  | HTS system contract SetApprovalForAllPrecompile                                                              | 0.86+                                   |
-        |                  | HTS system contract ApprovePrecompile                                                                        | 0.86+                                   |
-        |                  | HTS system contract RevokeKycPrecompile                                                                      | 0.86+                                   |
-        |                  | HTS system contract UnpausePrecompile                                                                        | 0.86+                                   |
-        |                  | HTS system contract PausePrecompile                                                                          | 0.86+                                   |
-        |                  | HTS system contract DeleteTokenPrecompile                                                                    | 0.86+                                   |
-        |                  | HTS system contract PausePrecompile                                                                          | 0.86+                                   |
-        |                  | HTS system contract FreezePrecompile                                                                         | 0.86+                                   |
-        |                  | HTS system contract UnfreezePrecompile                                                                       | 0.86+                                   |
+        |                  | non-static contract state reads and modifications for HTS system contract MintPrecompile                     | 0.84+                                   |
+        |                  | non-static contract state reads and modifications for HTS system contract GrantKycPrecompile                 | 0.85+                                   |
+        |                  | non-static contract state reads and modifications for HTS system contract WipePrecompile                     | 0.85+                                   |
+        |                  | non-static contract state reads and modifications for HTS system contract BurnPrecompile                     | 0.85+                                   |
+        |                  | non-static contract state reads and modifications for HTS system contract DissociatePrecompile               | 0.85+                                   |
+        |                  | non-static contract state reads and modifications for HTS system contract SetApprovalForAllPrecompile        | 0.86+                                   |
+        |                  | non-static contract state reads and modifications for HTS system contract ApprovePrecompile                  | 0.86+                                   |
+        |                  | non-static contract state reads and modifications for HTS system contract RevokeKycPrecompile                | 0.86+                                   |
+        |                  | non-static contract state reads and modifications for HTS system contract UnpausePrecompile                  | 0.86+                                   |
+        |                  | non-static contract state reads and modifications for HTS system contract PausePrecompile                    | 0.86+                                   |
+        |                  | non-static contract state reads and modifications for HTS system contract DeleteTokenPrecompile              | 0.86+                                   |
+        |                  | non-static contract state reads and modifications for HTS system contract PausePrecompile                    | 0.86+                                   |
+        |                  | non-static contract state reads and modifications for HTS system contract FreezePrecompile                   | 0.86+                                   |
+        |                  | non-static contract state reads and modifications for HTS system contract UnfreezePrecompile                 | 0.86+                                   |
         |                  | static contract state reads for IsApprovedForAllPrecompile                                                   | 0.87+                                   |
         |                  | static contract state reads for AllowancePrecompile                                                          | 0.87+                                   |
         |                  | static contract state reads for GetApprovedPrecompile                                                        | 0.87+                                   |
         |                  | HTS system contract UpdateTokenKeysPrecompile                                                                | 0.87+                                   |
         |                  | HTS system contract UpdateTokenExpiryInfoPrecompile                                                          | 0.87+                                   |
-        |                  | HTS system contract ExchangeRatePrecompiledContract                                                          | 0.88+                                   |
-        |                  | HTS system contract PrngSystemPrecompiledContract                                                            | 0.89+                                   |
+        |                  | non-static contract state reads and modifications for system contract ExchangeRatePrecompiledContract        | 0.88+                                   |
+        |                  | non-static contract state reads and modifications for system contract PrngSystemPrecompiledContract          | 0.89+                                   |
 
         The operations types which are not currently supported should return 501 error status.
 

--- a/hedera-mirror-rest/api/v1/openapi.yml
+++ b/hedera-mirror-rest/api/v1/openapi.yml
@@ -338,8 +338,8 @@ paths:
         |                  | static contract state reads for IsApprovedForAllPrecompile                                                   | 0.87+                                   |
         |                  | static contract state reads for AllowancePrecompile                                                          | 0.87+                                   |
         |                  | static contract state reads for GetApprovedPrecompile                                                        | 0.87+                                   |
-        |                  | HTS system contract UpdateTokenKeysPrecompile                                                                | 0.87+                                   |
-        |                  | HTS system contract UpdateTokenExpiryInfoPrecompile                                                          | 0.87+                                   |
+        |                  | non-static contract state reads and modifications for HTS system contract UpdateTokenKeysPrecompile          | 0.87+                                   |
+        |                  | non-static contract state reads and modifications for HTS system contract UpdateTokenExpiryInfoPrecompile    | 0.87+                                   |
         |                  | non-static contract state reads and modifications for system contract ExchangeRatePrecompiledContract        | 0.88+                                   |
         |                  | non-static contract state reads and modifications for system contract PrngSystemPrecompiledContract          | 0.89+                                   |
 

--- a/hedera-mirror-rest/api/v1/openapi.yml
+++ b/hedera-mirror-rest/api/v1/openapi.yml
@@ -320,7 +320,28 @@ paths:
         | true             | non-static contract state reads and modifications for non precompile functions except lazy account creation  | 0.83+                                   |
         |                  | non-static contract state reads and modifications for associate precompile functions                         | 0.83+                                   |
         |                  | non-static contract state reads and modifications for non precompile functions with lazy account creation    | 0.84+                                   |
-        |                  | non-static contract state reads and modifications for precompile functions except associate                  | Not supported                           |
+        |                  | static contract state reads for ERC precompile functions (balance, symbol, tokenURI, name, decimals, etc. )  | 0.84+                                   |
+        |                  | HTS system contract MintPrecompile                                                                           | 0.84+                                   |
+        |                  | HTS system contract GrantKycPrecompile                                                                       | 0.85+                                   |
+        |                  | HTS system contract WipePrecompile                                                                           | 0.85+                                   |
+        |                  | HTS system contract BurnPrecompile                                                                           | 0.85+                                   |
+        |                  | HTS system contract DissociatePrecompile                                                                     | 0.85+                                   |
+        |                  | HTS system contract SetApprovalForAllPrecompile                                                              | 0.86+                                   |
+        |                  | HTS system contract ApprovePrecompile                                                                        | 0.86+                                   |
+        |                  | HTS system contract RevokeKycPrecompile                                                                      | 0.86+                                   |
+        |                  | HTS system contract UnpausePrecompile                                                                        | 0.86+                                   |
+        |                  | HTS system contract PausePrecompile                                                                          | 0.86+                                   |
+        |                  | HTS system contract DeleteTokenPrecompile                                                                    | 0.86+                                   |
+        |                  | HTS system contract PausePrecompile                                                                          | 0.86+                                   |
+        |                  | HTS system contract FreezePrecompile                                                                         | 0.86+                                   |
+        |                  | HTS system contract UnfreezePrecompile                                                                       | 0.86+                                   |
+        |                  | static contract state reads for IsApprovedForAllPrecompile                                                   | 0.87+                                   |
+        |                  | static contract state reads for AllowancePrecompile                                                          | 0.87+                                   |
+        |                  | static contract state reads for GetApprovedPrecompile                                                        | 0.87+                                   |
+        |                  | HTS system contract UpdateTokenKeysPrecompile                                                                | 0.87+                                   |
+        |                  | HTS system contract UpdateTokenExpiryInfoPrecompile                                                          | 0.87+                                   |
+        |                  | HTS system contract ExchangeRatePrecompiledContract                                                          | 0.88+                                   |
+        |                  | HTS system contract PrngSystemPrecompiledContract                                                            | 0.89+                                   |
 
         The operations types which are not currently supported should return 501 error status.
 

--- a/hedera-mirror-rest/api/v1/openapi.yml
+++ b/hedera-mirror-rest/api/v1/openapi.yml
@@ -335,9 +335,9 @@ paths:
         |                  | non-static contract state reads and modifications for HTS system contract PausePrecompile                    | 0.86+                                   |
         |                  | non-static contract state reads and modifications for HTS system contract FreezePrecompile                   | 0.86+                                   |
         |                  | non-static contract state reads and modifications for HTS system contract UnfreezePrecompile                 | 0.86+                                   |
-        |                  | static contract state reads for IsApprovedForAllPrecompile                                                   | 0.87+                                   |
-        |                  | static contract state reads for AllowancePrecompile                                                          | 0.87+                                   |
-        |                  | static contract state reads for GetApprovedPrecompile                                                        | 0.87+                                   |
+        |                  | non-static contract state reads for IsApprovedForAllPrecompile                                               | 0.87+                                   |
+        |                  | non-static contract state reads for AllowancePrecompile                                                      | 0.87+                                   |
+        |                  | non-static contract state reads for GetApprovedPrecompile                                                    | 0.87+                                   |
         |                  | non-static contract state reads and modifications for HTS system contract UpdateTokenKeysPrecompile          | 0.87+                                   |
         |                  | non-static contract state reads and modifications for HTS system contract UpdateTokenExpiryInfoPrecompile    | 0.87+                                   |
         |                  | non-static contract state reads and modifications for system contract ExchangeRatePrecompiledContract        | 0.88+                                   |

--- a/hedera-mirror-rest/api/v1/openapi.yml
+++ b/hedera-mirror-rest/api/v1/openapi.yml
@@ -306,42 +306,7 @@ paths:
       description: |
 
         Returns a result from EVM execution such as cost-free execution of read-only smart contract queries, gas estimation, and transient simulation of read-write operations. If `estimate` field is set to true gas estimation is executed. Currently we support only `latest` block.
-
-        **The table below defines the restrictions and support for the endpoint**
-
-        | Estimate         | Operation Type                                                                                               | Mirror Node Version                     |
-        | -------------    | -----------------------------------------------------------------------------------------------------------  | ----------------------------------------|
-        | false            | static contract state reads for non precompile functions                                                     | 0.78+                                   |
-        |                  | static contract state reads for precompile functions except allowance/isApprovedForAll                       | 0.78+                                   |
-        |                  | static contract state reads for precompile functions with allowance                                          | 0.79+                                   |
-        |                  | static contract state reads for precompile functions with isApprovedForAll                                   | 0.81+                                   |
-        |                  | non-static contract state reads for non precompile functions                                                 | 0.83+                                   |
-        |                  | non-static contract state reads for precompile read only functions                                           | 0.83+                                   |
-        | true             | non-static contract state reads and modifications for non precompile functions except lazy account creation  | 0.83+                                   |
-        |                  | non-static contract state reads and modifications for associate precompile functions                         | 0.83+                                   |
-        |                  | non-static contract state reads and modifications for non precompile functions with lazy account creation    | 0.84+                                   |
-        |                  | static contract state reads for ERC precompile functions (balance, symbol, tokenURI, name, decimals, etc. )  | 0.84+                                   |
-        |                  | non-static contract state reads and modifications for HTS system contract MintPrecompile                     | 0.84+                                   |
-        |                  | non-static contract state reads and modifications for HTS system contract GrantKycPrecompile                 | 0.85+                                   |
-        |                  | non-static contract state reads and modifications for HTS system contract WipePrecompile                     | 0.85+                                   |
-        |                  | non-static contract state reads and modifications for HTS system contract BurnPrecompile                     | 0.85+                                   |
-        |                  | non-static contract state reads and modifications for HTS system contract DissociatePrecompile               | 0.85+                                   |
-        |                  | non-static contract state reads and modifications for HTS system contract SetApprovalForAllPrecompile        | 0.86+                                   |
-        |                  | non-static contract state reads and modifications for HTS system contract ApprovePrecompile                  | 0.86+                                   |
-        |                  | non-static contract state reads and modifications for HTS system contract RevokeKycPrecompile                | 0.86+                                   |
-        |                  | non-static contract state reads and modifications for HTS system contract UnpausePrecompile                  | 0.86+                                   |
-        |                  | non-static contract state reads and modifications for HTS system contract PausePrecompile                    | 0.86+                                   |
-        |                  | non-static contract state reads and modifications for HTS system contract DeleteTokenPrecompile              | 0.86+                                   |
-        |                  | non-static contract state reads and modifications for HTS system contract PausePrecompile                    | 0.86+                                   |
-        |                  | non-static contract state reads and modifications for HTS system contract FreezePrecompile                   | 0.86+                                   |
-        |                  | non-static contract state reads and modifications for HTS system contract UnfreezePrecompile                 | 0.86+                                   |
-        |                  | non-static contract state reads for IsApprovedForAllPrecompile                                               | 0.87+                                   |
-        |                  | non-static contract state reads for AllowancePrecompile                                                      | 0.87+                                   |
-        |                  | non-static contract state reads for GetApprovedPrecompile                                                    | 0.87+                                   |
-        |                  | non-static contract state reads and modifications for HTS system contract UpdateTokenKeysPrecompile          | 0.87+                                   |
-        |                  | non-static contract state reads and modifications for HTS system contract UpdateTokenExpiryInfoPrecompile    | 0.87+                                   |
-        |                  | non-static contract state reads and modifications for system contract ExchangeRatePrecompiledContract        | 0.88+                                   |
-        |                  | non-static contract state reads and modifications for system contract PrngSystemPrecompiledContract          | 0.89+                                   |
+        [Link to Supported/Unsupported Operations Table](https://github.com/hashgraph/hedera-mirror-node/blob/main/docs/web3/README.md)
 
         The operations types which are not currently supported should return 501 error status.
 

--- a/hedera-mirror-rest/api/v1/openapi.yml
+++ b/hedera-mirror-rest/api/v1/openapi.yml
@@ -306,7 +306,7 @@ paths:
       description: |
 
         Returns a result from EVM execution such as cost-free execution of read-only smart contract queries, gas estimation, and transient simulation of read-write operations. If `estimate` field is set to true gas estimation is executed. Currently we support only `latest` block.
-        [Link to Supported/Unsupported Operations Table](https://github.com/hashgraph/hedera-mirror-node/blob/main/docs/web3/README.md)
+        [Link to Supported/Unsupported Operations Table](https://github.com/hashgraph/hedera-mirror-node/blob/main/docs/web3/README.md#supported/unsupported-operations)
 
         The operations types which are not currently supported should return 501 error status.
 


### PR DESCRIPTION
**Description**:  

Currently the openAPI docs under api/v1/docs give a summary of what the contracts/call POST method supports across call and estimate scenarios. But some of the operations are missing.

**Solution**:
Update the openApi spec with the newest supported precompile calls.

**Related issue(s)**:

Fixes #6726

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
