### PR TITLE
HIP-786: Finalize protobuf artifact to persist new staking properties

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,7 +58,7 @@ dependencies {
         api("com.graphql-java:graphql-java-extended-scalars:21.0")
         api("com.graphql-java:graphql-java-extended-validation:21.0")
         api("com.hedera.evm:hedera-evm:0.39.0")
-        api("com.hedera.hashgraph:hedera-protobuf-java-api:0.43.0-HIP-786-SNAPSHOT")
+        api("com.hedera.hashgraph:hedera-protobuf-java-api:0.43.0")
         api("com.hedera.hashgraph:sdk:2.28.0")
         api("com.ongres.scram:client:2.1")
         api("com.playtika.testcontainers:embedded-google-pubsub:$testcontainersSpringBootVersion")
@@ -134,14 +134,14 @@ idea {
 fun replaceVersion(files: String, match: String) {
     ant.withGroovyBuilder {
         "replaceregexp"(
-                "match" to match,
-                "replace" to project.version,
-                "flags" to "gm"
+            "match" to match,
+            "replace" to project.version,
+            "flags" to "gm"
         ) {
             "fileset"(
-                    "dir" to rootProject.projectDir,
-                    "includes" to files,
-                    "excludes" to "**/node_modules/"
+                "dir" to rootProject.projectDir,
+                "includes" to files,
+                "excludes" to "**/node_modules/"
             )
         }
     }
@@ -154,8 +154,8 @@ project.tasks.register("release") {
         replaceVersion("docker-compose.yml", "(?<=gcr.io/mirrornode/hedera-mirror-.+:).+")
         replaceVersion("gradle.properties", "(?<=^version=).+")
         replaceVersion(
-                "hedera-mirror-rest/**/package*.json",
-                "(?<=\"@hashgraph/(check-state-proof|mirror-rest|mirror-monitor)\",\\s{3,7}\"version\": \")[^\"]+"
+            "hedera-mirror-rest/**/package*.json",
+            "(?<=\"@hashgraph/(check-state-proof|mirror-rest|mirror-monitor)\",\\s{3,7}\"version\": \")[^\"]+"
         )
         replaceVersion("hedera-mirror-rest/**/openapi.yml", "(?<=^  version: ).+")
     }

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/models/NftId.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/models/NftId.java
@@ -23,7 +23,7 @@ import java.util.Comparator;
 
 /**
  * Copied NftId type from hedera-services.
- *
+ * <p>
  * Represents the id of a UniqueToken model
  */
 public record NftId(long shard, long realm, long num, long serialNo) implements Comparable<NftId> {
@@ -36,6 +36,14 @@ public record NftId(long shard, long realm, long num, long serialNo) implements 
         return new NftId(0, 0, num, serialNo);
     }
 
+    public static NftId fromGrpc(final TokenID tokenId, final long serialNo) {
+        return new NftId(tokenId.getShardNum(), tokenId.getRealmNum(), tokenId.getTokenNum(), serialNo);
+    }
+
+    public static NftId fromGrpc(final NftID nftId) {
+        return fromGrpc(nftId.getTokenID(), nftId.getSerialNumber());
+    }
+
     public TokenID tokenId() {
         return TokenID.newBuilder()
                 .setShardNum(shard)
@@ -44,16 +52,8 @@ public record NftId(long shard, long realm, long num, long serialNo) implements 
                 .build();
     }
 
-    public static NftId fromGrpc(final TokenID tokenId, final long serialNo) {
-        return new NftId(tokenId.getShardNum(), tokenId.getRealmNum(), tokenId.getTokenNum(), serialNo);
-    }
-
     @Override
     public int compareTo(final @NonNull NftId that) {
         return NATURAL_ORDER.compare(this, that);
-    }
-
-    public static NftId fromGrpc(final NftID nftId) {
-        return fromGrpc(nftId.getTokenId(), nftId.getSerialNumber());
     }
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/utils/EntityIdUtils.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/utils/EntityIdUtils.java
@@ -206,7 +206,7 @@ public final class EntityIdUtils {
             return String.format(ENTITY_ID_FORMAT, id.getShardNum(), id.getRealmNum(), id.getTokenNum());
         }
         if (o instanceof NftID id) {
-            final var tokenID = id.getTokenId();
+            final var tokenID = id.getTokenID();
             return String.format(
                     ENTITY_ID_FORMAT + ".%d",
                     tokenID.getShardNum(),


### PR DESCRIPTION
**Description**:
Utilize new, non-SNAPSHOT, version of `com.hedera.hashgraph:hedera-protobuf-java-api` and undo `NftID` method name case changes required with the previous SNAPSHOT.

**Related issue(s)**:

Related to #6791

**Notes for reviewer**:
- Looks like IDEA/Spotless has reformatted more than necessary.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
