### PR TITLE
Fix `TokenAccessorImpl` to return canonical address

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/token/TokenAccessorImpl.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/token/TokenAccessorImpl.java
@@ -182,7 +182,7 @@ public class TokenAccessorImpl implements TokenAccessor {
         if (spender == null) {
             return Address.ZERO;
         }
-        return spender.asEvmAddress();
+        return canonicalAddress(spender.asEvmAddress());
     }
 
     @Override
@@ -209,7 +209,7 @@ public class TokenAccessorImpl implements TokenAccessor {
         if (owner == null) {
             return Address.ZERO;
         }
-        return owner.asEvmAddress();
+        return canonicalAddress(owner.asEvmAddress());
     }
 
     @Override

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileTest.java
@@ -322,7 +322,7 @@ class ContractCallServicePrecompileTest extends ContractCallTestSetup {
         GET_TOKEN_EXPIRY("getExpiryInfoForToken", new Object[] {FUNGIBLE_TOKEN_ADDRESS_WITH_EXPIRY}, new Object[] {
             1000L, AUTO_RENEW_ACCOUNT_ADDRESS, 1800L
         }),
-        HTS_GET_APPROVED("htsGetApproved", new Object[] {NFT_ADDRESS, 1L}, new Object[] {SPENDER_ADDRESS}),
+        HTS_GET_APPROVED("htsGetApproved", new Object[] {NFT_ADDRESS, 1L}, new Object[] {SPENDER_ALIAS}),
         HTS_ALLOWANCE(
                 "htsAllowance",
                 new Object[] {FUNGIBLE_TOKEN_ADDRESS, SENDER_ADDRESS, SPENDER_ADDRESS},


### PR DESCRIPTION
**Description**:
Currently `TokenAccessorImpl` to returns long zero address instead of canonical address.
This PR provides the needed changes

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
