### PR TITLE
Revert "Bump quick-lru from 6.1.2 to 7.0.0"

### DIFF
--- a/hedera-mirror-rest/package-lock.json
+++ b/hedera-mirror-rest/package-lock.json
@@ -68,7 +68,7 @@
         "pg-range": "^1.1.2",
         "prom-client": "^14.2.0",
         "qs": "^6.11.2",
-        "quick-lru": "^7.0.0",
+        "quick-lru": "^6.1.2",
         "rfc4648": "^1.5.2",
         "swagger-stats": "^0.99.7",
         "swagger-ui-express": "^5.0.0",
@@ -9756,12 +9756,12 @@
       "dev": true
     },
     "node_modules/quick-lru": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-7.0.0.tgz",
-      "integrity": "sha512-MX8gB7cVYTrYcFfAnfLlhRd0+Toyl8yX8uBx1MrX7K0jegiz9TumwOK27ldXrgDlHRdVi+MqU9Ssw6dr4BNreg==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.2.tgz",
+      "integrity": "sha512-AAFUA5O1d83pIHEhJwWCq/RQcRukCkn/NSm2QsTEMle5f2hP0ChI2+3Xb051PZCkLryI/Ir1MVKviT2FIloaTQ==",
       "inBundle": true,
       "engines": {
-        "node": ">=18"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/hedera-mirror-rest/package.json
+++ b/hedera-mirror-rest/package.json
@@ -44,7 +44,7 @@
     "pg-range": "^1.1.2",
     "prom-client": "^14.2.0",
     "qs": "^6.11.2",
-    "quick-lru": "^7.0.0",
+    "quick-lru": "^6.1.2",
     "rfc4648": "^1.5.2",
     "swagger-stats": "^0.99.7",
     "swagger-ui-express": "^5.0.0",


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR reverts "Bump quick-lru from 6.1.2 to 7.0.0" since some of our envs are still on nodejs v16 while quick-lru 7.0.0 requires minimum nodejs 18.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
