### PR TITLE
Option to halt importer on recoverable error

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/record/RecordFileDownloader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/record/RecordFileDownloader.java
@@ -16,8 +16,6 @@
 
 package com.hedera.mirror.importer.downloader.record;
 
-import static com.hedera.mirror.importer.util.Utility.RECOVERABLE_ERROR;
-
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimaps;
 import com.hedera.mirror.common.domain.transaction.RecordFile;
@@ -39,6 +37,7 @@ import com.hedera.mirror.importer.reader.record.ProtoRecordFileReader;
 import com.hedera.mirror.importer.reader.record.RecordFileReader;
 import com.hedera.mirror.importer.reader.record.sidecar.SidecarFileReader;
 import com.hedera.mirror.importer.reader.signature.SignatureFileReader;
+import com.hedera.mirror.importer.util.Utility;
 import com.hedera.services.stream.proto.SidecarType;
 import com.hedera.services.stream.proto.TransactionSidecarRecord;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -162,8 +161,8 @@ public class RecordFileDownloader extends Downloader<RecordFile, RecordItem> {
             case BYTECODE -> SidecarType.CONTRACT_BYTECODE_VALUE;
             case STATE_CHANGES -> SidecarType.CONTRACT_STATE_CHANGE_VALUE;
             default -> {
-                log.error(
-                        RECOVERABLE_ERROR + "Unknown sidecar transaction record type at {}: {}",
+                Utility.handleRecoverableError(
+                        "Unknown sidecar transaction record type at {}: {}",
                         transactionSidecarRecord.getConsensusTimestamp(),
                         transactionSidecarRecord.getSidecarRecordsCase());
                 yield SidecarType.SIDECAR_TYPE_UNKNOWN_VALUE;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListener.java
@@ -17,7 +17,6 @@
 package com.hedera.mirror.importer.parser.record.entity;
 
 import static com.hedera.mirror.common.domain.token.NftTransfer.WILDCARD_SERIAL_NUMBER;
-import static com.hedera.mirror.importer.util.Utility.RECOVERABLE_ERROR;
 
 import com.google.common.collect.Range;
 import com.google.protobuf.ByteString;
@@ -54,6 +53,7 @@ import com.hedera.mirror.importer.parser.contractresult.TransferContractResult;
 import com.hedera.mirror.importer.parser.record.RecordItemListener;
 import com.hedera.mirror.importer.parser.record.transactionhandler.TransactionHandler;
 import com.hedera.mirror.importer.parser.record.transactionhandler.TransactionHandlerFactory;
+import com.hedera.mirror.importer.util.Utility;
 import com.hederahashgraph.api.proto.java.AccountAmount;
 import com.hederahashgraph.api.proto.java.NftTransfer;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
@@ -101,10 +101,8 @@ public class EntityRecordItemListener implements RecordItemListener {
         try {
             entityId = transactionHandler.getEntity(recordItem);
         } catch (InvalidEntityException e) { // transaction can have invalid topic/contract/file id
-            log.error(
-                    RECOVERABLE_ERROR + "Invalid entity encountered for consensusTimestamp {} : {}",
-                    consensusTimestamp,
-                    e.getMessage());
+            Utility.handleRecoverableError(
+                    "Invalid entity encountered for consensusTimestamp {} : {}", consensusTimestamp, e.getMessage());
             entityId = EntityId.EMPTY;
         }
 
@@ -231,9 +229,8 @@ public class EntityRecordItemListener implements RecordItemListener {
         for (var aa : transfers) {
             var entityId = entityIdService.lookup(aa.getAccountID()).orElse(EntityId.EMPTY);
             if (EntityId.isEmpty(entityId)) {
-                log.error(
-                        RECOVERABLE_ERROR + "Invalid itemizedTransfer entity id at {}",
-                        recordItem.getConsensusTimestamp());
+                Utility.handleRecoverableError(
+                        "Invalid itemizedTransfer entity id at {}", recordItem.getConsensusTimestamp());
                 continue;
             }
 
@@ -678,16 +675,14 @@ public class EntityRecordItemListener implements RecordItemListener {
                     }
 
                     if (signature == null) {
-                        log.error(
-                                RECOVERABLE_ERROR + "Unsupported signature at {}: {}",
-                                consensusTimestamp,
-                                unknownFields);
+                        Utility.handleRecoverableError(
+                                "Unsupported signature at {}: {}", consensusTimestamp, unknownFields);
                         continue;
                     }
                     break;
                 default:
-                    log.error(
-                            RECOVERABLE_ERROR + "Unsupported signature case at {}: {}",
+                    Utility.handleRecoverableError(
+                            "Unsupported signature case at {}: {}",
                             consensusTimestamp,
                             signaturePair.getSignatureCase());
                     continue;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/notify/NotifyingEntityListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/notify/NotifyingEntityListener.java
@@ -17,7 +17,6 @@
 package com.hedera.mirror.importer.parser.record.entity.notify;
 
 import static com.hedera.mirror.common.converter.ObjectToStringSerializer.OBJECT_MAPPER;
-import static com.hedera.mirror.importer.util.Utility.RECOVERABLE_ERROR;
 
 import com.google.common.base.Stopwatch;
 import com.hedera.mirror.common.domain.topic.TopicMessage;
@@ -26,6 +25,7 @@ import com.hedera.mirror.importer.parser.record.entity.BatchEntityListener;
 import com.hedera.mirror.importer.parser.record.entity.ConditionOnEntityRecordParser;
 import com.hedera.mirror.importer.parser.record.entity.EntityBatchCleanupEvent;
 import com.hedera.mirror.importer.parser.record.entity.EntityBatchSaveEvent;
+import com.hedera.mirror.importer.util.Utility;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import jakarta.annotation.PostConstruct;
@@ -116,7 +116,7 @@ public class NotifyingEntityListener implements BatchEntityListener {
 
             return json;
         } catch (Exception e) {
-            log.error(RECOVERABLE_ERROR + "Error serializing topicMessage to json", topicMessage, e);
+            Utility.handleRecoverableError("Error serializing topicMessage to json", topicMessage, e);
             return null;
         }
     }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/pubsub/PubSubRecordItemListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/pubsub/PubSubRecordItemListener.java
@@ -16,8 +16,6 @@
 
 package com.hedera.mirror.importer.parser.record.pubsub;
 
-import static com.hedera.mirror.importer.util.Utility.RECOVERABLE_ERROR;
-
 import com.google.cloud.spring.pubsub.core.PubSubTemplate;
 import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.file.FileData;
@@ -70,10 +68,8 @@ public class PubSubRecordItemListener implements RecordItemListener {
         try {
             entityId = transactionHandler.getEntity(recordItem);
         } catch (InvalidEntityException e) { // transaction can have invalid topic/contract/file id
-            log.error(
-                    RECOVERABLE_ERROR + "Invalid entity encountered for consensusTimestamp {} : {}",
-                    consensusTimestamp,
-                    e.getMessage());
+            Utility.handleRecoverableError(
+                    "Invalid entity encountered for consensusTimestamp {} : {}", consensusTimestamp, e.getMessage());
             entityId = EntityId.EMPTY;
         }
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ConsensusUpdateTopicTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ConsensusUpdateTopicTransactionHandler.java
@@ -16,8 +16,6 @@
 
 package com.hedera.mirror.importer.parser.record.transactionhandler;
 
-import static com.hedera.mirror.importer.util.Utility.RECOVERABLE_ERROR;
-
 import com.hedera.mirror.common.domain.entity.Entity;
 import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.entity.EntityType;
@@ -26,6 +24,7 @@ import com.hedera.mirror.common.domain.transaction.TransactionType;
 import com.hedera.mirror.common.util.DomainUtils;
 import com.hedera.mirror.importer.domain.EntityIdService;
 import com.hedera.mirror.importer.parser.record.entity.EntityListener;
+import com.hedera.mirror.importer.util.Utility;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import jakarta.inject.Named;
 import lombok.CustomLog;
@@ -57,9 +56,8 @@ class ConsensusUpdateTopicTransactionHandler extends AbstractEntityCrudTransacti
                                 entity.setAutoRenewAccountId(entityId.getId());
                                 recordItem.addEntityId(entityId);
                             },
-                            () -> log.error(
-                                    RECOVERABLE_ERROR + "Invalid autoRenewAccountId at {}",
-                                    recordItem.getConsensusTimestamp()));
+                            () -> Utility.handleRecoverableError(
+                                    "Invalid autoRenewAccountId at {}", recordItem.getConsensusTimestamp()));
         }
 
         if (transactionBody.hasAutoRenewPeriod()) {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractCreateTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractCreateTransactionHandler.java
@@ -16,7 +16,6 @@
 
 package com.hedera.mirror.importer.parser.record.transactionhandler;
 
-import static com.hedera.mirror.importer.util.Utility.RECOVERABLE_ERROR;
 import static com.hederahashgraph.api.proto.java.ContractCreateTransactionBody.InitcodeSourceCase.INITCODE;
 
 import com.hedera.mirror.common.domain.contract.Contract;
@@ -82,7 +81,7 @@ class ContractCreateTransactionHandler extends AbstractEntityCrudTransactionHand
                 entity.setAutoRenewAccountId(autoRenewAccount.getId());
                 recordItem.addEntityId(autoRenewAccount);
             } else {
-                log.error(RECOVERABLE_ERROR + "Invalid autoRenewAccountId at {}", recordItem.getConsensusTimestamp());
+                Utility.handleRecoverableError("Invalid autoRenewAccountId at {}", recordItem.getConsensusTimestamp());
             }
         }
 
@@ -224,8 +223,8 @@ class ContractCreateTransactionHandler extends AbstractEntityCrudTransactionHand
                 }
                 break;
             default:
-                log.error(
-                        RECOVERABLE_ERROR + "Invalid InitcodeSourceCase {} at {}",
+                Utility.handleRecoverableError(
+                        "Invalid InitcodeSourceCase {} at {}",
                         transactionBody.getInitcodeSourceCase(),
                         recordItem.getConsensusTimestamp());
                 break;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractUpdateTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractUpdateTransactionHandler.java
@@ -16,7 +16,6 @@
 
 package com.hedera.mirror.importer.parser.record.transactionhandler;
 
-import static com.hedera.mirror.importer.util.Utility.RECOVERABLE_ERROR;
 import static com.hederahashgraph.api.proto.java.ContractUpdateTransactionBody.StakedIdCase.STAKEDID_NOT_SET;
 
 import com.hedera.mirror.common.domain.entity.AbstractEntity;
@@ -78,9 +77,8 @@ class ContractUpdateTransactionHandler extends AbstractEntityCrudTransactionHand
                                 entity.setAutoRenewAccountId(accountId.getId());
                                 recordItem.addEntityId(accountId);
                             },
-                            () -> log.error(
-                                    RECOVERABLE_ERROR + "Invalid autoRenewAccountId at {}",
-                                    recordItem.getConsensusTimestamp()));
+                            () -> Utility.handleRecoverableError(
+                                    "Invalid autoRenewAccountId at {}", recordItem.getConsensusTimestamp()));
         }
 
         if (transactionBody.hasAutoRenewPeriod()) {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoApproveAllowanceTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoApproveAllowanceTransactionHandler.java
@@ -16,8 +16,6 @@
 
 package com.hedera.mirror.importer.parser.record.transactionhandler;
 
-import static com.hedera.mirror.importer.util.Utility.RECOVERABLE_ERROR;
-
 import com.google.common.collect.Range;
 import com.hedera.mirror.common.domain.entity.AbstractCryptoAllowance;
 import com.hedera.mirror.common.domain.entity.AbstractNftAllowance;
@@ -39,6 +37,7 @@ import com.hedera.mirror.importer.parser.contractlog.SyntheticContractLogService
 import com.hedera.mirror.importer.parser.contractresult.ApproveAllowanceContractResult;
 import com.hedera.mirror.importer.parser.contractresult.SyntheticContractResultService;
 import com.hedera.mirror.importer.parser.record.entity.EntityListener;
+import com.hedera.mirror.importer.util.Utility;
 import com.hederahashgraph.api.proto.java.AccountID;
 import jakarta.inject.Named;
 import java.util.HashMap;
@@ -91,7 +90,7 @@ class CryptoApproveAllowanceTransactionHandler extends AbstractTransactionHandle
             var cryptoApproval = iterator.previous();
             var ownerAccountId = getOwnerAccountId(cryptoApproval.getOwner(), payerAccountId);
             if (EntityId.isEmpty(ownerAccountId)) {
-                log.error(RECOVERABLE_ERROR + "Empty ownerAccountId at consensusTimestamp {}", consensusTimestamp);
+                Utility.handleRecoverableError("Empty ownerAccountId at consensusTimestamp {}", consensusTimestamp);
                 continue;
             }
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoDeleteTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoDeleteTransactionHandler.java
@@ -16,8 +16,6 @@
 
 package com.hedera.mirror.importer.parser.record.transactionhandler;
 
-import static com.hedera.mirror.importer.util.Utility.RECOVERABLE_ERROR;
-
 import com.hedera.mirror.common.domain.entity.Entity;
 import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.entity.EntityType;
@@ -25,6 +23,7 @@ import com.hedera.mirror.common.domain.transaction.RecordItem;
 import com.hedera.mirror.common.domain.transaction.TransactionType;
 import com.hedera.mirror.importer.domain.EntityIdService;
 import com.hedera.mirror.importer.parser.record.entity.EntityListener;
+import com.hedera.mirror.importer.util.Utility;
 import jakarta.inject.Named;
 import lombok.CustomLog;
 
@@ -47,9 +46,8 @@ class CryptoDeleteTransactionHandler extends AbstractEntityCrudTransactionHandle
         var obtainerId =
                 entityIdService.lookup(transactionBody.getTransferAccountID()).orElse(EntityId.EMPTY);
         if (EntityId.isEmpty(obtainerId)) {
-            log.error(
-                    RECOVERABLE_ERROR + "Unable to lookup ObtainerId at consensusTimestamp {}",
-                    recordItem.getConsensusTimestamp());
+            Utility.handleRecoverableError(
+                    "Unable to lookup ObtainerId at consensusTimestamp {}", recordItem.getConsensusTimestamp());
         } else {
             entity.setObtainerId(obtainerId);
         }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenCreateTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenCreateTransactionHandler.java
@@ -18,7 +18,6 @@ package com.hedera.mirror.importer.parser.record.transactionhandler;
 
 import static com.hedera.mirror.common.domain.token.TokenFreezeStatusEnum.NOT_APPLICABLE;
 import static com.hedera.mirror.common.domain.token.TokenFreezeStatusEnum.UNFROZEN;
-import static com.hedera.mirror.importer.util.Utility.RECOVERABLE_ERROR;
 
 import com.hedera.mirror.common.domain.entity.Entity;
 import com.hedera.mirror.common.domain.entity.EntityId;
@@ -36,6 +35,7 @@ import com.hedera.mirror.common.util.DomainUtils;
 import com.hedera.mirror.importer.domain.EntityIdService;
 import com.hedera.mirror.importer.parser.record.entity.EntityListener;
 import com.hedera.mirror.importer.parser.record.entity.EntityProperties;
+import com.hedera.mirror.importer.util.Utility;
 import com.hederahashgraph.api.proto.java.TokenAssociation;
 import jakarta.inject.Named;
 import lombok.CustomLog;
@@ -75,7 +75,7 @@ class TokenCreateTransactionHandler extends AbstractEntityCrudTransactionHandler
                     .lookup(transactionBody.getAutoRenewAccount())
                     .orElse(EntityId.EMPTY);
             if (EntityId.isEmpty(autoRenewAccountId)) {
-                log.error(RECOVERABLE_ERROR + "Invalid autoRenewAccountId at {}", recordItem.getConsensusTimestamp());
+                Utility.handleRecoverableError("Invalid autoRenewAccountId at {}", recordItem.getConsensusTimestamp());
             } else {
                 entity.setAutoRenewAccountId(autoRenewAccountId.getId());
                 recordItem.addEntityId(autoRenewAccountId);

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenFeeScheduleUpdateTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenFeeScheduleUpdateTransactionHandler.java
@@ -17,7 +17,6 @@
 package com.hedera.mirror.importer.parser.record.transactionhandler;
 
 import static com.hedera.mirror.common.domain.transaction.TransactionType.TOKENCREATION;
-import static com.hedera.mirror.importer.util.Utility.RECOVERABLE_ERROR;
 
 import com.google.common.collect.Range;
 import com.hedera.mirror.common.domain.entity.EntityId;
@@ -32,6 +31,7 @@ import com.hedera.mirror.common.domain.transaction.Transaction;
 import com.hedera.mirror.common.domain.transaction.TransactionType;
 import com.hedera.mirror.importer.parser.record.entity.EntityListener;
 import com.hedera.mirror.importer.parser.record.entity.EntityProperties;
+import com.hedera.mirror.importer.util.Utility;
 import jakarta.inject.Named;
 import java.util.Collection;
 import java.util.HashSet;
@@ -123,7 +123,7 @@ class TokenFeeScheduleUpdateTransactionHandler extends AbstractTransactionHandle
                     fee = royaltyFee;
                     break;
                 default:
-                    log.error(RECOVERABLE_ERROR + "Invalid CustomFee FeeCase at {}: {}", consensusTimestamp, feeCase);
+                    Utility.handleRecoverableError("Invalid CustomFee FeeCase at {}: {}", consensusTimestamp, feeCase);
                     continue;
             }
 
@@ -152,8 +152,8 @@ class TokenFeeScheduleUpdateTransactionHandler extends AbstractTransactionHandle
     /**
      * Parse protobuf FixedFee object to domain FixedFee object.
      *
-     * @param protoFixedFee  the protobuf FixedFee object
-     * @param tokenId   the attached token id
+     * @param protoFixedFee the protobuf FixedFee object
+     * @param tokenId       the attached token id
      * @return whether the fee is paid in the attached token
      */
     private FixedFee parseFixedFee(com.hederahashgraph.api.proto.java.FixedFee protoFixedFee, EntityId tokenId) {
@@ -171,7 +171,7 @@ class TokenFeeScheduleUpdateTransactionHandler extends AbstractTransactionHandle
     /**
      * Parse protobuf FractionalFee object to domain FractionalFee object.
      *
-     * @param protoFractionalFee  the protobuf FractionalFee object
+     * @param protoFractionalFee the protobuf FractionalFee object
      */
     private FractionalFee parseFractionalFee(com.hederahashgraph.api.proto.java.FractionalFee protoFractionalFee) {
         var fractionalFee = new FractionalFee();
@@ -189,7 +189,7 @@ class TokenFeeScheduleUpdateTransactionHandler extends AbstractTransactionHandle
     /**
      * Parse protobuf RoyaltyFee object to domain RoyaltyFee object.
      *
-     * @param protoRoyaltyFee  the protobuf RoyaltyFee object
+     * @param protoRoyaltyFee the protobuf RoyaltyFee object
      */
     private RoyaltyFee parseRoyaltyFee(
             com.hederahashgraph.api.proto.java.RoyaltyFee protoRoyaltyFee, EntityId tokenId) {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenMintTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenMintTransactionHandler.java
@@ -17,7 +17,6 @@
 package com.hedera.mirror.importer.parser.record.transactionhandler;
 
 import static com.hedera.mirror.common.util.DomainUtils.toBytes;
-import static com.hedera.mirror.importer.util.Utility.RECOVERABLE_ERROR;
 
 import com.google.common.collect.Range;
 import com.hedera.mirror.common.domain.entity.EntityId;
@@ -28,6 +27,7 @@ import com.hedera.mirror.common.domain.transaction.Transaction;
 import com.hedera.mirror.common.domain.transaction.TransactionType;
 import com.hedera.mirror.importer.parser.record.entity.EntityListener;
 import com.hedera.mirror.importer.parser.record.entity.EntityProperties;
+import com.hedera.mirror.importer.util.Utility;
 import jakarta.inject.Named;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
@@ -70,8 +70,8 @@ class TokenMintTransactionHandler extends AbstractTransactionHandler {
         var serialNumbers = recordItem.getTransactionRecord().getReceipt().getSerialNumbersList();
         for (int i = 0; i < serialNumbers.size(); i++) {
             if (i >= transactionBody.getMetadataCount()) {
-                log.warn(
-                        RECOVERABLE_ERROR + "Mismatch between {} metadata and {} serial numbers at {}",
+                Utility.handleRecoverableError(
+                        "Mismatch between {} metadata and {} serial numbers at {}",
                         transactionBody.getMetadataCount(),
                         serialNumbers,
                         consensusTimestamp);

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenUpdateTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenUpdateTransactionHandler.java
@@ -16,8 +16,6 @@
 
 package com.hedera.mirror.importer.parser.record.transactionhandler;
 
-import static com.hedera.mirror.importer.util.Utility.RECOVERABLE_ERROR;
-
 import com.hedera.mirror.common.domain.entity.Entity;
 import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.entity.EntityType;
@@ -28,6 +26,7 @@ import com.hedera.mirror.common.util.DomainUtils;
 import com.hedera.mirror.importer.domain.EntityIdService;
 import com.hedera.mirror.importer.parser.record.entity.EntityListener;
 import com.hedera.mirror.importer.parser.record.entity.EntityProperties;
+import com.hedera.mirror.importer.util.Utility;
 import jakarta.inject.Named;
 import lombok.CustomLog;
 
@@ -65,9 +64,8 @@ class TokenUpdateTransactionHandler extends AbstractEntityCrudTransactionHandler
                                 entity.setAutoRenewAccountId(accountId.getId());
                                 recordItem.addEntityId(accountId);
                             },
-                            () -> log.error(
-                                    RECOVERABLE_ERROR + "Invalid autoRenewAccountId at {}",
-                                    recordItem.getConsensusTimestamp()));
+                            () -> Utility.handleRecoverableError(
+                                    "Invalid autoRenewAccountId at {}", recordItem.getConsensusTimestamp()));
         }
 
         if (transactionBody.hasAutoRenewPeriod()) {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/util/Utility.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/util/Utility.java
@@ -90,7 +90,7 @@ public class Utility {
             }
         } catch (Exception e) {
             var aliasHex = Hex.encodeHexString(alias);
-            log.error(RECOVERABLE_ERROR + "Unable to decode alias to EVM address: {}", aliasHex, e);
+            handleRecoverableError("Unable to decode alias to EVM address: {}", aliasHex, e);
         }
 
         return evmAddress;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/util/Utility.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/util/Utility.java
@@ -210,16 +210,13 @@ public class Utility {
      *                the cause of the thrown ParserException.
      */
     public static void handleRecoverableError(String message, Object... args) {
-        var haltOnError = Boolean.parseBoolean(System.getProperty(HALT_ON_ERROR_PROPERTY, HALT_ON_ERROR_DEFAULT));
+        var haltOnError = Boolean.parseBoolean(System.getProperty(HALT_ON_ERROR_PROPERTY));
 
         if (haltOnError) {
             var formattingTuple = MessageFormatter.arrayFormat(message, args);
             var throwable = formattingTuple.getThrowable();
             var formattedMessage = formattingTuple.getMessage();
-
-            throw throwable == null
-                    ? new ParserException(formattedMessage)
-                    : new ParserException(formattedMessage, throwable);
+            throw new ParserException(formattedMessage, throwable);
         } else {
             log.error(RECOVERABLE_ERROR + message, args);
         }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/util/Utility.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/util/Utility.java
@@ -53,7 +53,7 @@ public class Utility {
 
     public static final Instant MAX_INSTANT_LONG = Instant.ofEpochSecond(0, Long.MAX_VALUE);
 
-    public static final String RECOVERABLE_ERROR = "Recoverable error. ";
+    static final String RECOVERABLE_ERROR = "Recoverable error. ";
     static final String HALT_ON_ERROR_PROPERTY = "HEDERA_MIRROR_IMPORTER_PARSER_HALTONERROR";
     static final String HALT_ON_ERROR_DEFAULT = "false";
     private static final int ECDSA_SECP256K1_COMPRESSED_KEY_LENGTH = 33;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/util/Utility.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/util/Utility.java
@@ -193,6 +193,22 @@ public class Utility {
         return CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, text);
     }
 
+    /**
+     * Handle a parser recoverable error. Depending on the value of the system property
+     * HEDERA_MIRROR_IMPORTER_PARSER_HALTONERROR, when false (default), the provided message and arguments are logged at
+     * ERROR level, with the message prepended with the String defined by Utility.RECOVERABLE_ERROR, identifying it as a
+     * recoverable error.
+     * <p/>
+     * When the system property is set to true, then ParserException is thrown, and the provided message and arguments
+     * are used for generating the exception message string. Nothing is logged in this mode.
+     *
+     * @param message The message string to be logged. This may contain ordered placeholders in the format of {} just
+     *                like the rest of the logging in Mirror Node.
+     * @param args    the variable arguments list to match each placeholder. Simply omit this if there are no mess
+     *                placeholders. The final, or only, argument may be a reference to a Throwable, in which case it is
+     *                identified as the cause of the error; either logged in the stacktrace following the message, or as
+     *                the cause of the thrown ParserException.
+     */
     public static void handleRecoverableError(String message, Object... args) {
         var haltOnError = Boolean.parseBoolean(System.getProperty(HALT_ON_ERROR_PROPERTY, HALT_ON_ERROR_DEFAULT));
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/util/Utility.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/util/Utility.java
@@ -204,7 +204,7 @@ public class Utility {
      *
      * @param message The message string to be logged. This may contain ordered placeholders in the format of {} just
      *                like the rest of the logging in Mirror Node.
-     * @param args    the variable arguments list to match each placeholder. Simply omit this if there are no mess
+     * @param args    the variable arguments list to match each placeholder. Simply omit this if there are no message
      *                placeholders. The final, or only, argument may be a reference to a Throwable, in which case it is
      *                identified as the cause of the error; either logged in the stacktrace following the message, or as
      *                the cause of the thrown ParserException.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/util/UtilityTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/util/UtilityTest.java
@@ -195,13 +195,13 @@ public class UtilityTest {
          * With halt on error set, ensure ParserException is thrown with expected information.
          */
         System.setProperty(HALT_ON_ERROR_PROPERTY, "true");
-        ParserException parserException = assertThrows(ParserException.class, () -> {
-            if (logArgs == null) {
-                Utility.handleRecoverableError(format);
-            } else {
-                Utility.handleRecoverableError(format, logArgs);
-            }
-        });
+        ParserException parserException;
+        if (logArgs == null) {
+            parserException = assertThrows(ParserException.class, () -> Utility.handleRecoverableError(format));
+        } else {
+            parserException =
+                    assertThrows(ParserException.class, () -> Utility.handleRecoverableError(format, logArgs));
+        }
         assertThat(parserException.getMessage()).isEqualTo(formatted);
         if (addCause) {
             assertThat(parserException.getCause()).isSameAs(cause);

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/util/UtilityTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/util/UtilityTest.java
@@ -151,11 +151,11 @@ public class UtilityTest {
     @CsvSource(
             textBlock =
                     """
-                plain message, plain message, false,
-                {} arg message, one arg message, true, one
-                {} {} message, a b message, false, 'a, b'
-                {} {} {} {}, a b c d, true, 'a, b, c, d'
-            """)
+                                plain message, plain message, false,
+                                {} arg message, one arg message, true, one
+                                {} {} message, a b message, false, 'a, b'
+                                {} {} {} {}, a b c d, true, 'a, b, c, d'
+                            """)
     void handleRecoverableErrorLogOrThrow(
             String format,
             String formatted,
@@ -195,16 +195,16 @@ public class UtilityTest {
          * With halt on error set, ensure ParserException is thrown with expected information.
          */
         System.setProperty(HALT_ON_ERROR_PROPERTY, "true");
-        ParserException parserException2 = assertThrows(ParserException.class, () -> {
+        ParserException parserException = assertThrows(ParserException.class, () -> {
             if (logArgs == null) {
                 Utility.handleRecoverableError(format);
             } else {
                 Utility.handleRecoverableError(format, logArgs);
             }
         });
-        assertThat(parserException2.getMessage()).isEqualTo(formatted);
+        assertThat(parserException.getMessage()).isEqualTo(formatted);
         if (addCause) {
-            assertThat(parserException2.getCause()).isSameAs(cause);
+            assertThat(parserException.getCause()).isSameAs(cause);
         }
     }
 


### PR DESCRIPTION
**Description**:
Mirror node importer prioritizes availability over finding issues in the record stream. It would be useful to prefer the latter in pre-production environments to catch issues earlier in the lifecycle.

This PR modifies:

* Utilize the `HEDERA_MIRROR_IMPORTER_PARSER_HALTONERROR=false` system property (can't be regular property since we'll use it in a static utility)
* Add a `Utility.handleRecoverableError(String message, String... args)` that either logs the message with the prefix or throws a `ParserException`
* Change everywhere that logs uses `Utility.RECOVERABLE_ERROR` to use the new utility

**Related issue(s)**:

Fixes #6860

**Notes for reviewer**:
- I'm still working on that final bullet item regarding environment specific property setting, but otherwise this PR defines the implementation of this feature. By default, the system will behave as previous releases.
- Issue calls for **not** documenting the new property.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
