### PR TITLE
Regression on `contract/results/<transactionHash>` address to field as 0x

### DIFF
--- a/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/ethereum-transaction-contract-create-with-null-to-address.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/ethereum-transaction-contract-create-with-null-to-address.json
@@ -1,0 +1,105 @@
+{
+  "description": "Contract results api call using transactionId or an ethereum transaction hash for contract creation with null to address in ethereum transaction table",
+  "setup": {
+    "entities": [
+      {
+        "num": 5001,
+        "evm_address": "0xd856bd1c30f1bbb64c4bd1f94668f85e4b23267c"
+      }
+    ],
+    "contractresults": [
+      {
+        "amount": 30,
+        "bloom": [5, 5],
+        "call_result": [6, 6],
+        "consensus_timestamp": "167654000123456",
+        "contract_id": 5001,
+        "created_contract_ids": [8001],
+        "error_message": "",
+        "function_parameters": [],
+        "function_result": [],
+        "gas_limit": 1000000,
+        "gas_used": 123,
+        "payer_account_id": 8001,
+        "sender_id": 8001,
+        "transaction_result": 22,
+        "transaction_hash": "4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6392",
+        "transaction_index": 1,
+        "transaction_nonce": 0,
+        "evmAddress": "d856bd1c30f1bbb64c4bd1f94668f85e4b23267c"
+      }
+    ],
+    "recordFiles": [
+      {
+        "index": 17,
+        "gas_used": 50000000,
+        "consensus_start": 167654000123450,
+        "consensus_end": 167654000123460,
+        "hash": "6ceecd8bb224da491"
+      }
+    ],
+    "transactions": [
+      {
+        "consensus_timestamp": 167654000123456,
+        "payerAccountId": "8001",
+        "transaction_hash": "519a008fabde4d",
+        "type": 50,
+        "valid_start_timestamp": 167654000123400
+      }
+    ],
+    "ethereumtransactions": [
+      {
+        "call_data": "0x0707",
+        "consensus_timestamp": 167654000123456,
+        "hash": "4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6392",
+        "payer_account_id": "8001",
+        "value": "0x0077359400",
+        "_value_description": "2000000000 tinybars, in importer java BigInteger.toByteArray always adds extra 0x00",
+        "to_address": null
+      }
+    ]
+  },
+  "urls": [
+    "/api/v1/contracts/results/0.0.8001-167654-000123400",
+    "/api/v1/contracts/results/0.0.8001-167654-000123400?nonce=0",
+    "/api/v1/contracts/results/0.0.8001-167654-000123400?nonce=1&nonce=0",
+    "/api/v1/contracts/results/4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6392",
+    "/api/v1/contracts/results/0x4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6392"
+  ],
+  "responseStatus": 200,
+  "responseJson": {
+    "access_list": "0x",
+    "amount": 2000000000,
+    "block_gas_used": 50000000,
+    "block_hash": "0x6ceecd8bb224da491",
+    "block_number": 17,
+    "bloom": "0x0505",
+    "call_result": "0x0606",
+    "chain_id": "0x",
+    "contract_id": "0.0.5001",
+    "created_contract_ids": ["0.0.8001"],
+    "error_message": null,
+    "address": "0xd856bd1c30f1bbb64c4bd1f94668f85e4b23267c",
+    "failed_initcode": null,
+    "from": "0x0000000000000000000000000000000000001f41",
+    "function_parameters": "0x0707",
+    "gas_limit": 1000000,
+    "gas_price": "0x4a817c80",
+    "gas_used": 123,
+    "hash": "0x4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6392",
+    "logs": [],
+    "max_fee_per_gas": "0x",
+    "max_priority_fee_per_gas": "0x",
+    "nonce": 1,
+    "r": "0xd693b532a80fed6392b428604171fb32fdbf953728a3a7ecc7d4062b1652c042",
+    "result": "SUCCESS",
+    "s": "0x24e9c602ac800b983b035700a14b23f78a253ab762deab5dc27e3555a750b354",
+    "state_changes": [],
+    "status": "0x1",
+    "timestamp": "167654.000123456",
+    "to": "0xd856bd1c30f1bbb64c4bd1f94668f85e4b23267c",
+    "transaction_index": 1,
+    "type": 2,
+    "v": 1
+  }
+}

--- a/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/ethereum-transaction-contract-create.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/{id}/ethereum-transaction-contract-create.json
@@ -1,0 +1,105 @@
+{
+  "description": "Contract results api call using transactionId or an ethereum transaction hash for contract creation",
+  "setup": {
+    "entities": [
+      {
+        "num": 5001,
+        "evm_address": "0x867623472bd7c14e5b5ad0b17f7e810490d07718"
+      }
+    ],
+    "contractresults": [
+      {
+        "amount": 30,
+        "bloom": [5, 5],
+        "call_result": [6, 6],
+        "consensus_timestamp": "167654000123456",
+        "contract_id": 5001,
+        "created_contract_ids": [8001],
+        "error_message": "",
+        "function_parameters": [],
+        "function_result": [],
+        "gas_limit": 1000000,
+        "gas_used": 123,
+        "payer_account_id": 8001,
+        "sender_id": 8001,
+        "transaction_result": 22,
+        "transaction_hash": "4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6392",
+        "transaction_index": 1,
+        "transaction_nonce": 0,
+        "evmAddress": "867623472bd7c14e5b5ad0b17f7e810490d07718"
+      }
+    ],
+    "recordFiles": [
+      {
+        "index": 17,
+        "gas_used": 50000000,
+        "consensus_start": 167654000123450,
+        "consensus_end": 167654000123460,
+        "hash": "6ceecd8bb224da491"
+      }
+    ],
+    "transactions": [
+      {
+        "consensus_timestamp": 167654000123456,
+        "payerAccountId": "8001",
+        "transaction_hash": "519a008fabde4d",
+        "type": 50,
+        "valid_start_timestamp": 167654000123400
+      }
+    ],
+    "ethereumtransactions": [
+      {
+        "call_data": "0x0707",
+        "consensus_timestamp": 167654000123456,
+        "hash": "4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6392",
+        "payer_account_id": "8001",
+        "value": "0x0077359400",
+        "_value_description": "2000000000 tinybars, in importer java BigInteger.toByteArray always adds extra 0x00",
+        "to_address": []
+      }
+    ]
+  },
+  "urls": [
+    "/api/v1/contracts/results/0.0.8001-167654-000123400",
+    "/api/v1/contracts/results/0.0.8001-167654-000123400?nonce=0",
+    "/api/v1/contracts/results/0.0.8001-167654-000123400?nonce=1&nonce=0",
+    "/api/v1/contracts/results/4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6392",
+    "/api/v1/contracts/results/0x4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6392"
+  ],
+  "responseStatus": 200,
+  "responseJson": {
+    "access_list": "0x",
+    "amount": 2000000000,
+    "block_gas_used": 50000000,
+    "block_hash": "0x6ceecd8bb224da491",
+    "block_number": 17,
+    "bloom": "0x0505",
+    "call_result": "0x0606",
+    "chain_id": "0x",
+    "contract_id": "0.0.5001",
+    "created_contract_ids": ["0.0.8001"],
+    "error_message": null,
+    "address": "0x867623472bd7c14e5b5ad0b17f7e810490d07718",
+    "failed_initcode": null,
+    "from": "0x0000000000000000000000000000000000001f41",
+    "function_parameters": "0x0707",
+    "gas_limit": 1000000,
+    "gas_price": "0x4a817c80",
+    "gas_used": 123,
+    "hash": "0x4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6392",
+    "logs": [],
+    "max_fee_per_gas": "0x",
+    "max_priority_fee_per_gas": "0x",
+    "nonce": 1,
+    "r": "0xd693b532a80fed6392b428604171fb32fdbf953728a3a7ecc7d4062b1652c042",
+    "result": "SUCCESS",
+    "s": "0x24e9c602ac800b983b035700a14b23f78a253ab762deab5dc27e3555a750b354",
+    "state_changes": [],
+    "status": "0x1",
+    "timestamp": "167654.000123456",
+    "to": "0x867623472bd7c14e5b5ad0b17f7e810490d07718",
+    "transaction_index": 1,
+    "type": 2,
+    "v": 1
+  }
+}

--- a/hedera-mirror-rest/viewmodel/contractResultDetailsViewModel.js
+++ b/hedera-mirror-rest/viewmodel/contractResultDetailsViewModel.js
@@ -118,7 +118,7 @@ class ContractResultDetailsViewModel extends ContractResultViewModel {
       this.nonce = ethTransaction.nonce;
       this.r = utils.toHexStringNonQuantity(ethTransaction.signatureR);
       this.s = utils.toHexStringNonQuantity(ethTransaction.signatureS);
-      this.to = utils.toHexStringNonQuantity(ethTransaction.toAddress.length ? ethTransaction.toAddress : contractResult.evmAddress);
+      this.to = utils.toHexStringNonQuantity(ethTransaction.toAddress?.length ? ethTransaction.toAddress : contractResult.evmAddress);
       this.type = ethTransaction.type;
       this.v = ethTransaction.recoveryId;
 

--- a/hedera-mirror-rest/viewmodel/contractResultDetailsViewModel.js
+++ b/hedera-mirror-rest/viewmodel/contractResultDetailsViewModel.js
@@ -118,7 +118,7 @@ class ContractResultDetailsViewModel extends ContractResultViewModel {
       this.nonce = ethTransaction.nonce;
       this.r = utils.toHexStringNonQuantity(ethTransaction.signatureR);
       this.s = utils.toHexStringNonQuantity(ethTransaction.signatureS);
-      this.to = ethTransaction.toAddress ? utils.toHexStringNonQuantity(ethTransaction.toAddress) : null;
+      this.to = utils.toHexStringNonQuantity(ethTransaction.toAddress.length ? ethTransaction.toAddress : contractResult.evmAddress);
       this.type = ethTransaction.type;
       this.v = ethTransaction.recoveryId;
 


### PR DESCRIPTION
### Description

After version `0.89.0-rc1` there is a regression on `contracts/results/<transactionHash>` rest API.

Example on `previewnet` with regression:

https://previewnet.mirrornode.hedera.com/api/v1/contracts/results/0xdd6e0683c742a3fd126ec8d3f8e7e3743e4250e84c6ad5e144d92f885895db32

Notice on the response the field `to` is showing just `0x`

<img width="1345" alt="image" src="https://github.com/hashgraph/hedera-mirror-node/assets/123040664/a79731cf-dedc-437c-bdd8-f433b4c0d959">


Example of a similar transaction (Contract Create on a EVM Transaction) on `testnet`:

https://testnet.mirrornode.hedera.com/api/v1/contracts/results/0x521d88048ae1e08e7fe503f16d2a32ffaa6ce4af0d9799a1348f994e8ed15909

<img width="1412" alt="image" src="https://github.com/hashgraph/hedera-mirror-node/assets/123040664/90b54e63-07a1-4e92-90ff-1c0dce8cdb00">



### Steps to reproduce

Use the provided link:

With regression on `0.89.0-rc1` deployed on `previewnet`

https://previewnet.mirrornode.hedera.com/api/v1/contracts/results/0xdd6e0683c742a3fd126ec8d3f8e7e3743e4250e84c6ad5e144d92f885895db32


Without, on `0.88.0` version on `testnet

https://testnet.mirrornode.hedera.com/api/v1/contracts/results/0x521d88048ae1e08e7fe503f16d2a32ffaa6ce4af0d9799a1348f994e8ed15909

Notice that the field `to` does show the `contractAddress` that was created as a result of the transaction.

### Additional context

Preliminary research made by @xin-hedera indicates that the regression was introduced via PR: 
https://github.com/hashgraph/hedera-mirror-node/pull/6827

### Hedera network

previewnet

### Version

v0.89.0-rc1

**Related issue(s)**:

Fixes #6903 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
