### PR TITLE
Add a transaction hash pivot timestamp

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityProperties.java
@@ -83,6 +83,7 @@ public class EntityProperties {
         private boolean trackNonce = true;
 
         private boolean transactionHash = false;
+        private long transactionHashPivotTimestamp = -1;
 
         /**
          * A set of transaction types to persist transaction hash for. If empty and transactionHash is true, transaction
@@ -108,8 +109,9 @@ public class EntityProperties {
             return entityTransactions && !EntityId.isEmpty(entityId) && !entityTransactionExclusion.contains(entityId);
         }
 
-        public boolean shouldPersistTransactionHash(TransactionType transactionType) {
+        public boolean shouldPersistTransactionHash(TransactionType transactionType, long consensusTimestamp) {
             return transactionHash
+                    && consensusTimestamp > transactionHashPivotTimestamp
                     && (transactionHashTypes.isEmpty() || transactionHashTypes.contains(transactionType));
         }
     }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListener.java
@@ -475,7 +475,10 @@ public class SqlEntityListener implements EntityListener, RecordStreamFileListen
     public void onTransaction(Transaction transaction) throws ImporterException {
         transactions.add(transaction);
 
-        if (entityProperties.getPersist().shouldPersistTransactionHash(TransactionType.of(transaction.getType()))) {
+        if (entityProperties
+                .getPersist()
+                .shouldPersistTransactionHash(
+                        TransactionType.of(transaction.getType()), transaction.getConsensusTimestamp())) {
             transactionHashes.add(transaction.toTransactionHash());
         }
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/PersistPropertiesTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/PersistPropertiesTest.java
@@ -81,18 +81,25 @@ class PersistPropertiesTest {
     @CsvSource(
             textBlock =
                     """
-            true, CRYPTOTRANSFER, true,
-            true, CONSENSUSSUBMITMESSAGE, false,
-            false, CRYPTOTRANSFER, false,
-            false, CONSENSUSSUBMITMESSAGE, false,
+            true, CRYPTOTRANSFER, 0, 1, true,
+            true, CRYPTOTRANSFER, 5, 1, false,
+            true, CONSENSUSSUBMITMESSAGE, 0, 1, false,
+            false, CRYPTOTRANSFER, 0, 1, false,
+            false, CONSENSUSSUBMITMESSAGE, 0, 1, false,
             """)
-    void shouldPersistTransactionHash(boolean transactionHash, TransactionType transactionType, boolean expected) {
+    void shouldPersistTransactionHash(
+            boolean transactionHash,
+            TransactionType transactionType,
+            long transactionHashPivot,
+            long consensusTimestamp,
+            boolean expected) {
         var persistProperties = new EntityProperties.PersistProperties();
         persistProperties.setTransactionHash(transactionHash);
         persistProperties.setTransactionHashTypes(Set.of(transactionType));
-        assertThat(persistProperties.shouldPersistTransactionHash(TransactionType.CRYPTOTRANSFER))
+        persistProperties.setTransactionHashPivotTimestamp(transactionHashPivot);
+        assertThat(persistProperties.shouldPersistTransactionHash(TransactionType.CRYPTOTRANSFER, consensusTimestamp))
                 .isEqualTo(expected);
-        assertThat(persistProperties.shouldPersistTransactionHash(TransactionType.CONTRACTCALL))
+        assertThat(persistProperties.shouldPersistTransactionHash(TransactionType.CONTRACTCALL, consensusTimestamp))
                 .isFalse();
     }
 
@@ -102,9 +109,9 @@ class PersistPropertiesTest {
         var persistProperties = new EntityProperties.PersistProperties();
         persistProperties.setTransactionHash(transactionHash);
         persistProperties.setTransactionHashTypes(Collections.emptySet());
-        assertThat(persistProperties.shouldPersistTransactionHash(TransactionType.CRYPTOTRANSFER))
+        assertThat(persistProperties.shouldPersistTransactionHash(TransactionType.CRYPTOTRANSFER, 0))
                 .isEqualTo(transactionHash);
-        assertThat(persistProperties.shouldPersistTransactionHash(TransactionType.CONTRACTCALL))
+        assertThat(persistProperties.shouldPersistTransactionHash(TransactionType.CONTRACTCALL, 0))
                 .isEqualTo(transactionHash);
     }
 }


### PR DESCRIPTION
**Description**:

Add `hedera.mirror.importer.parser.record.entity.persist.transactionHashPivotTimestamp ` property to indicate transaction hash migration

**Related issue(s)**:

Fixes #6793 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
