### PR TITLE
Update web3 module README with contracts/call API support (0.89)

### DIFF
--- a/docs/web3/README.md
+++ b/docs/web3/README.md
@@ -37,3 +37,31 @@ docker run --rm -v "${PWD}/charts/hedera-mirror-web3/postman.json:/tmp/postman.j
 ```
 
 _Note:_ To test against an instance running on the same machine as Docker use your local IP instead of 127.0.0.1.
+
+### Supported/unsupported operations
+
+
+| Estimate | Static | Operation Type                                                                            | Supported | Historical data support | Reads | Modifications |
+|----------|--------|-------------------------------------------------------------------------------------------|-----------|-------------------------|-------|---------------|
+|    Y     |   Y    | non precompile functions                                                                  |     Y     |           N             |   Y   | Y             |
+|    Y     |   N    | operations for Hts system contract AssociatePrecompile                                    |     Y     |           N             |   Y   | Y             |
+|    Y     |   N    | non precompile functions with lazy account creation                                       |     Y     |           N             |   Y   | Y             |
+|    Y     |   Y    | operations for ERC precompile functions (balance, symbol, tokenURI, name, decimals, etc.) |     Y     |           N             |   Y   | N             |
+|    Y     |   N    | operations for HTS system contract MintPrecompile                                         |     Y     |           N             |   Y   | Y             |
+|    Y     |   N    | operations for HTS system contract GrantKycPrecompile                                     |     Y     |           N             |   Y   | Y             |
+|    Y     |   N    | operations for HTS system contract WipePrecompile                                         |     Y     |           N             |   Y   | Y             |
+|    Y     |   N    | operations for HTS system contract BurnPrecompile                                         |     Y     |           N             |   Y   | Y             |
+|    Y     |   N    | operations for HTS system contract DissociatePrecompile                                   |     Y     |           N             |   Y   | Y             |
+|    Y     |   N    | operations for HTS system contract SetApprovalForAllPrecompile                            |     Y     |           N             |   Y   | Y             |
+|    Y     |   N    | operations for HTS system contract ApprovePrecompile                                      |     Y     |           N             |   Y   | Y             |
+|    Y     |   N    | operations for HTS system contract RevokeKycPrecompile                                    |     Y     |           N             |   Y   | Y             |
+|    Y     |   N    | operations for HTS system contract UnpausePrecompile                                      |     Y     |           N             |   Y   | Y             |
+|    Y     |   N    | operations for HTS system contract PausePrecompile                                        |     Y     |           N             |   Y   | Y             |
+|    Y     |   N    | operations for HTS system contract DeleteTokenPrecompile                                  |     Y     |           N             |   Y   | Y             |
+|    Y     |   N    | operations for HTS system contract PausePrecompile                                        |     Y     |           N             |   Y   | Y             |
+|    Y     |   N    | operations for HTS system contract FreezePrecompile                                       |     Y     |           N             |   Y   | Y             |
+|    Y     |   N    | operations for HTS system contract UnfreezePrecompile                                     |     Y     |           N             |   Y   | Y             |
+|    Y     |   N    | operations for IsApprovedForAllPrecompile                                                 |     Y     |           N             |   Y   | N             |
+|    Y     |   N    | operations for AllowancePrecompile                                                        |     Y     |           N             |   Y   | N             |
+|    Y     |   N    | operations for GetApprovedPrecompile                                                      |     Y     |           N             |   Y   | N             |
+|    Y     |   N    | operations for HTS system contract UpdateTokenKeysPrecompile                              |     Y     |           N             |   Y   | Y             |

--- a/hedera-mirror-rest/api/v1/openapi.yml
+++ b/hedera-mirror-rest/api/v1/openapi.yml
@@ -306,21 +306,7 @@ paths:
       description: |
 
         Returns a result from EVM execution such as cost-free execution of read-only smart contract queries, gas estimation, and transient simulation of read-write operations. If `estimate` field is set to true gas estimation is executed. Currently we support only `latest` block.
-
-        **The table below defines the restrictions and support for the endpoint**
-
-        | Estimate         | Operation Type                                                                                               | Mirror Node Version                     |
-        | -------------    | -----------------------------------------------------------------------------------------------------------  | ----------------------------------------|
-        | false            | static contract state reads for non precompile functions                                                     | 0.78+                                   |
-        |                  | static contract state reads for precompile functions except allowance/isApprovedForAll                       | 0.78+                                   |
-        |                  | static contract state reads for precompile functions with allowance                                          | 0.79+                                   |
-        |                  | static contract state reads for precompile functions with isApprovedForAll                                   | 0.81+                                   |
-        |                  | non-static contract state reads for non precompile functions                                                 | 0.83+                                   |
-        |                  | non-static contract state reads for precompile read only functions                                           | 0.83+                                   |
-        | true             | non-static contract state reads and modifications for non precompile functions except lazy account creation  | 0.83+                                   |
-        |                  | non-static contract state reads and modifications for associate precompile functions                         | 0.83+                                   |
-        |                  | non-static contract state reads and modifications for non precompile functions with lazy account creation    | 0.84+                                   |
-        |                  | non-static contract state reads and modifications for precompile functions except associate                  | Not supported                           |
+        [Link to Supported/Unsupported Operations Table](https://github.com/hashgraph/hedera-mirror-node/blob/main/docs/web3/README.md#supported/unsupported-operations)
 
         The operations types which are not currently supported should return 501 error status.
 


### PR DESCRIPTION
**Description**:

Cherry pick of #6865 to `release/0.89`:

Currently the openAPI docs under api/v1/docs give a summary of what the contracts/call POST method supports across call and estimate scenarios. But some of the operations are missing.

**Related issue(s)**:

Fixes #6726

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
