### PR TITLE
Fix custom fee schedule not updated properly

### DIFF
--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/UpsertColumn.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/UpsertColumn.java
@@ -39,4 +39,12 @@ public @interface UpsertColumn {
      * @return the SQL clause
      */
     String coalesce() default "";
+
+    /**
+     * Specify if the column should coalesce with existing and default value. If false, {@link #coalesce()} is ignored.
+     * The default is true.
+     *
+     * @return Whether to coalesce the column
+     */
+    boolean shouldCoalesce() default true;
 }

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/AbstractCustomFee.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/AbstractCustomFee.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.collect.Range;
 import com.hedera.mirror.common.converter.ObjectToStringSerializer;
 import com.hedera.mirror.common.domain.History;
+import com.hedera.mirror.common.domain.UpsertColumn;
 import com.hedera.mirror.common.domain.Upsertable;
 import io.hypersistence.utils.hibernate.type.json.JsonBinaryType;
 import jakarta.persistence.Id;
@@ -43,14 +44,17 @@ public abstract class AbstractCustomFee implements History {
 
     @JsonSerialize(using = ObjectToStringSerializer.class)
     @Type(JsonBinaryType.class)
+    @UpsertColumn(shouldCoalesce = false)
     private List<FixedFee> fixedFees;
 
     @JsonSerialize(using = ObjectToStringSerializer.class)
     @Type(JsonBinaryType.class)
+    @UpsertColumn(shouldCoalesce = false)
     private List<FractionalFee> fractionalFees;
 
     @JsonSerialize(using = ObjectToStringSerializer.class)
     @Type(JsonBinaryType.class)
+    @UpsertColumn(shouldCoalesce = false)
     private List<RoyaltyFee> royaltyFees;
 
     private Range<Long> timestampRange;

--- a/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/DomainBuilder.java
+++ b/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/DomainBuilder.java
@@ -368,7 +368,7 @@ public class DomainBuilder {
                 .fixedFees(List.of(fixedFee()))
                 .fractionalFees(List.of(fractionalFee()))
                 .royaltyFees(List.of(royaltyFee()))
-                .timestampRange(Range.closedOpen(timestamp(), timestamp()))
+                .timestampRange(Range.atLeast(timestamp()))
                 .tokenId(entityId().getId());
         return new DomainWrapperImpl<>(builder, builder::build);
     }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/ColumnMetadata.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/ColumnMetadata.java
@@ -50,10 +50,15 @@ class ColumnMetadata implements Comparable<ColumnMetadata> {
     }
 
     String format(String pattern) {
-        var coalesce = upsertColumn != null ? upsertColumn.coalesce() : null;
+        if (pattern.contains("coalesce") && upsertColumn != null) {
+            if (!upsertColumn.shouldCoalesce()) {
+                return name;
+            }
 
-        if (pattern.contains("coalesce") && StringUtils.isNotBlank(coalesce)) {
-            pattern = coalesce;
+            var coalesce = upsertColumn.coalesce();
+            if (StringUtils.isNotBlank(coalesce)) {
+                pattern = coalesce;
+            }
         }
 
         return MessageFormat.format(pattern, name, defaultValue);

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/AbstractEntityRecordItemListenerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/AbstractEntityRecordItemListenerTest.java
@@ -43,7 +43,6 @@ import com.hedera.mirror.importer.parser.record.RecordStreamFileListener;
 import com.hedera.mirror.importer.repository.ContractRepository;
 import com.hedera.mirror.importer.repository.ContractResultRepository;
 import com.hedera.mirror.importer.repository.CryptoTransferRepository;
-import com.hedera.mirror.importer.repository.CustomFeeHistoryRepository;
 import com.hedera.mirror.importer.repository.CustomFeeRepository;
 import com.hedera.mirror.importer.repository.EntityHistoryRepository;
 import com.hedera.mirror.importer.repository.EntityRepository;
@@ -119,9 +118,6 @@ public abstract class AbstractEntityRecordItemListenerTest extends IntegrationTe
 
     @Resource
     protected CustomFeeRepository customFeeRepository;
-
-    @Resource
-    protected CustomFeeHistoryRepository customFeeHistoryRepository;
 
     @Resource
     protected DomainBuilder domainBuilder;

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerTokenTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerTokenTest.java
@@ -983,10 +983,7 @@ class EntityRecordItemListenerTokenTest extends AbstractEntityRecordItemListener
         assertTokenInRepository(TOKEN_ID, true, CREATE_TIMESTAMP, CREATE_TIMESTAMP, SYMBOL, expectedSupply);
 
         secondCustomFee.setTimestampUpper(updateTimestamp);
-        var lastCustomFee = CustomFee.builder()
-                .timestampRange(Range.atLeast(updateTimestamp))
-                .tokenId(secondCustomFee.getTokenId())
-                .build();
+        var lastCustomFee = emptyCustomFees(updateTimestamp, DOMAIN_TOKEN_ID);
         assertCustomFeesInDb(List.of(lastCustomFee), List.of(initialCustomFee, secondCustomFee));
     }
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerTokenTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerTokenTest.java
@@ -3629,46 +3629,6 @@ class EntityRecordItemListenerTokenTest extends AbstractEntityRecordItemListener
     private void assertCustomFeesInDb(List<CustomFee> expected, List<CustomFee> expectedHistory) {
         assertThat(customFeeRepository.findAll()).containsExactlyInAnyOrderElementsOf(expected);
         assertThat(findHistory(CustomFee.class)).containsExactlyInAnyOrderElementsOf(expectedHistory);
-        //        var listAssert = assertThat(customFeeRepository.findAll()).hasSize(expected.size());
-        //        for (var result : expected) {
-        //            listAssert.anySatisfy(fee -> {
-        //                if (result.getFixedFees() != null) {
-        //                    assertThat(fee.getFixedFees()).containsExactlyInAnyOrderElementsOf(result.getFixedFees());
-        //                }
-        //                if (result.getFractionalFees() != null) {
-        //
-        // assertThat(fee.getFractionalFees()).containsExactlyInAnyOrderElementsOf(result.getFractionalFees());
-        //                }
-        //                if (result.getRoyaltyFees() != null) {
-        //
-        // assertThat(fee.getRoyaltyFees()).containsExactlyInAnyOrderElementsOf(result.getRoyaltyFees());
-        //                }
-        //                assertThat(fee.getTimestampRange()).isEqualTo(result.getTimestampRange());
-        //                assertThat(fee.getTokenId()).isEqualTo(result.getTokenId());
-        //                assertThat(fee.getTimestampRange()).isEqualTo(result.getTimestampRange());
-        //            });
-        //        }
-
-        //        findHistory()
-        //        var historyAssert = assertThat(customFeeHistoryRepository.findAll()).hasSize(expectedHistory.size());
-        //        for (var result : expectedHistory) {
-        //            historyAssert.anySatisfy(fee -> {
-        //                if (result.getFixedFees() != null) {
-        //                    assertThat(fee.getFixedFees()).containsExactlyInAnyOrderElementsOf(result.getFixedFees());
-        //                }
-        //                if (result.getFractionalFees() != null) {
-        //
-        // assertThat(fee.getFractionalFees()).containsExactlyInAnyOrderElementsOf(result.getFractionalFees());
-        //                }
-        //                if (result.getRoyaltyFees() != null) {
-        //
-        // assertThat(fee.getRoyaltyFees()).containsExactlyInAnyOrderElementsOf(result.getRoyaltyFees());
-        //                }
-        //                assertThat(fee.getTimestampRange()).isEqualTo(result.getTimestampRange());
-        //                assertThat(fee.getTokenId()).isEqualTo(result.getTokenId());
-        //                assertThat(fee.getTimestampRange()).isEqualTo(result.getTimestampRange());
-        //            });
-        //        }
     }
 
     private void assertAssessedCustomFeesInDb(List<AssessedCustomFee> expected) {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/EntityMetadataRegistryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/EntityMetadataRegistryTest.java
@@ -23,9 +23,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.hedera.mirror.common.domain.UpsertColumn;
 import com.hedera.mirror.common.domain.Upsertable;
 import com.hedera.mirror.common.domain.entity.Entity;
+import com.hedera.mirror.common.domain.token.CustomFee;
 import com.hedera.mirror.common.domain.token.Token;
 import com.hedera.mirror.importer.IntegrationTest;
 import jakarta.persistence.Id;
+import java.util.Objects;
 import java.util.stream.Stream;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
@@ -134,6 +136,17 @@ class EntityMetadataRegistryTest extends IntegrationTest {
                 .isNotNull()
                 .extracting(UpsertColumn::coalesce)
                 .isNotNull();
+    }
+
+    @Test
+    void upsertColumnNoCoalesce() {
+        var metadata = registry.lookup(CustomFee.class);
+        assertThat(metadata)
+                .isNotNull()
+                .returns(
+                        "fixed_fees",
+                        m -> m.column(c -> Objects.equals(c.getName(), "fixed_fees"), "coalesce(e_{0}, {0})"))
+                .returns("e_fixed_fees", m -> m.column(c -> Objects.equals(c.getName(), "fixed_fees"), "e_{0}"));
     }
 
     @Upsertable


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR fixes the bug that custom fee schedule isn't updated properly

- Add `shouldCoalesce()` flag to `UpsertColumn` annotation and skip any coalesce when false
- Annotate `fixedFees`, `fractionalFees`, and `royaltyFees` with `shouldCoalesce = false`
- Add integration tests

**Related issue(s)**:

Fixes #6908 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

The migration is left out from the PR, since we want to think about if there's way to fix the existing data without re-downloading and parsing record stream files.

Also want to point out, unable to clear the whole custom fee schedule is a special case of the issue. Generally, if any type of fee is not present in the token fee schedule update tx being processed and the previous such tx has that type of fee, importer will end up copying the old type fee instead of clearing it.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
