### PR TITLE
Set dynamic value for create token in acceptance tests

### DIFF
--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/MirrorNodeClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/MirrorNodeClient.java
@@ -212,7 +212,7 @@ public class MirrorNodeClient {
     }
 
     public ExchangeRateResponse getExchangeRates() {
-        log.debug("Verify contract result '{}' is returned by Mirror Node");
+        log.debug("Get exchange rates by Mirror Node");
         return callRestEndpoint("/network/exchangerate", ExchangeRateResponse.class);
     }
 

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/MirrorNodeClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/MirrorNodeClient.java
@@ -30,6 +30,7 @@ import com.hedera.mirror.test.e2e.acceptance.props.MirrorNetworkNode;
 import com.hedera.mirror.test.e2e.acceptance.props.MirrorNetworkNodes;
 import com.hedera.mirror.test.e2e.acceptance.props.MirrorNetworkStake;
 import com.hedera.mirror.test.e2e.acceptance.response.ContractCallResponse;
+import com.hedera.mirror.test.e2e.acceptance.response.ExchangeRateResponse;
 import com.hedera.mirror.test.e2e.acceptance.response.MirrorAccountResponse;
 import com.hedera.mirror.test.e2e.acceptance.response.MirrorContractResponse;
 import com.hedera.mirror.test.e2e.acceptance.response.MirrorContractResultResponse;
@@ -208,6 +209,11 @@ public class MirrorNodeClient {
         log.debug("Verify contract result '{}' is returned by Mirror Node", transactionId);
         return callRestEndpoint(
                 "/contracts/results/{transactionId}", MirrorContractResultResponse.class, transactionId);
+    }
+
+    public ExchangeRateResponse getExchangeRates() {
+        log.debug("Verify contract result '{}' is returned by Mirror Node");
+        return callRestEndpoint("/network/exchangerate", ExchangeRateResponse.class);
     }
 
     public ContractCallResponse contractsCall(ContractCallRequest request) {

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/response/ExchangeRateResponse.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/response/ExchangeRateResponse.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.test.e2e.acceptance.response;
+
+import lombok.Data;
+
+@Data
+public class ExchangeRateResponse {
+    private Rate currentRate;
+
+    private Rate nextRate;
+
+    private String timestamp;
+
+    @Data
+    public static class Rate {
+        private int centEquivalent;
+
+        private long expirationTime;
+
+        private int hbarEquivalent;
+    }
+}

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AbstractFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AbstractFeature.java
@@ -61,7 +61,7 @@ abstract class AbstractFeature {
             throw new RuntimeException("Exchange rates are not initialized.");
         }
         final var fee = useCurrentFee ? exchangeRates.getCurrentRate() : exchangeRates.getNextRate();
-        final long hbarPriceInCents = fee.getCentEquivalent() / fee.getHbarEquivalent();
+        final double hbarPriceInCents = (double) fee.getCentEquivalent() / fee.getHbarEquivalent();
         final int usdInCents = 100;
         // create token requires 1 usd in fees
         // create token with custom fees requires 2 usd in fees

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AbstractFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AbstractFeature.java
@@ -120,6 +120,8 @@ abstract class AbstractFeature {
     protected record DeployedContract(
             FileId fileId, ContractId contractId, CompiledSolidityArtifact compiledSolidityArtifact) {}
 
+    protected record ExchangeRate(int centEquivalent, int hbarEquivalent) {}
+
     protected CompiledSolidityArtifact readCompiledArtifact(InputStream in) throws IOException {
         return mapper.readValue(in, CompiledSolidityArtifact.class);
     }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AbstractFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AbstractFeature.java
@@ -137,8 +137,6 @@ abstract class AbstractFeature {
     protected record DeployedContract(
             FileId fileId, ContractId contractId, CompiledSolidityArtifact compiledSolidityArtifact) {}
 
-    //    protected record ExchangeRate(int centEquivalent, int hbarEquivalent) {}
-
     protected CompiledSolidityArtifact readCompiledArtifact(InputStream in) throws IOException {
         return mapper.readValue(in, CompiledSolidityArtifact.class);
     }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/EstimatePrecompileFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/EstimatePrecompileFeature.java
@@ -114,8 +114,13 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
                 exchangeRates.getCurrentRate().getCentEquivalent(),
                 exchangeRates.getCurrentRate().getHbarEquivalent());
         final long hbarPriceInCents = currentExchangeRate.centEquivalent() / currentExchangeRate.hbarEquivalent();
-        createTokenValue = ((100 / hbarPriceInCents + 1) * 100000000);
-        createTokenValueWithCustomFees = ((200 / hbarPriceInCents + 1) * 100000000);
+        final int usdInCents = 100;
+        // create token requires 1 usd in fees
+        // create token with custom fees requires 2 usd in fees
+        // usdInCents / hbarPriceInCents = amount of hbars equal to 1 usd. Increment that number with 1 for safety and
+        // multiply that number with 10 ^ 8 to convert hbar to tinybar
+        createTokenValue = (usdInCents / hbarPriceInCents + 1) * 100000000;
+        createTokenValueWithCustomFees = (usdInCents * 2 / hbarPriceInCents + 1) * 100000000;
     }
 
     @Given("I successfully create Precompile contract with {int} balance")

--- a/hedera-mirror-test/src/test/resources/features/contract/estimatePrecompile.feature
+++ b/hedera-mirror-test/src/test/resources/features/contract/estimatePrecompile.feature
@@ -4,6 +4,7 @@ Feature: EstimateGas Contract Base Coverage Feature
   Scenario Outline: Validate EstimateGas with precompile
     Given I create estimate precompile contract with 0 balance
     Given I create erc test contract with 0 balance
+    Given I get exchange rates
     Given I successfully create Precompile contract with 0 balance
     Given I successfully create fungible tokens
     Given I successfully create non fungible tokens
@@ -71,10 +72,10 @@ Feature: EstimateGas Contract Base Coverage Feature
     Then I call estimateGas with mintToken function for NFT
     Then I call estimateGas with burnToken function for fungible token
     Then I call estimateGas with burnToken function for NFT
-    #Then I call estimateGas with CreateFungibleToken function
-    #Then I call estimateGas with CreateNFT function
-    #Then I call estimateGas with CreateFungibleToken function with custom fees
-    #Then I call estimateGas with CreateNFT function with custom fees
+    Then I call estimateGas with CreateFungibleToken function
+    Then I call estimateGas with CreateNFT function
+    Then I call estimateGas with CreateFungibleToken function with custom fees
+    Then I call estimateGas with CreateNFT function with custom fees
     And I approve and transfer fungible tokens to receiver account
     Then the mirror node REST API should return status 200 for the HAPI transaction
     Then I call estimateGas with WipeTokenAccount function
@@ -166,5 +167,5 @@ Feature: EstimateGas Contract Base Coverage Feature
     Then I call estimateGas with redirect setApprovalForAll function
     Then I call estimateGas with exchange rate tinycents to tinybars
     Then I call estimateGas with exchange rate tinybars to tinycents
-    #Then I call estimateGas with pseudo random seed
-    #Then I call estimateGas with pseudo random number
+    Then I call estimateGas with pseudo random seed
+    Then I call estimateGas with pseudo random number

--- a/hedera-mirror-test/src/test/resources/features/contract/estimatePrecompile.feature
+++ b/hedera-mirror-test/src/test/resources/features/contract/estimatePrecompile.feature
@@ -167,5 +167,5 @@ Feature: EstimateGas Contract Base Coverage Feature
     Then I call estimateGas with redirect setApprovalForAll function
     Then I call estimateGas with exchange rate tinycents to tinybars
     Then I call estimateGas with exchange rate tinybars to tinycents
-    Then I call estimateGas with pseudo random seed
-    Then I call estimateGas with pseudo random number
+    #Then I call estimateGas with pseudo random seed
+    #Then I call estimateGas with pseudo random number


### PR DESCRIPTION
**Description**:  

Exchange rates in local / testnet / previewnet envs are different and token create operations cost 1 usd and 2 usd for custom fees.
Currently the value passed in the create token tests are hardcoded and work only in local environment.
This PR implements dynamic setting of the hbars sent to the create token call, so the fee is sufficient.

**Related issue(s)**:

Fixes #6905

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
