### PR TITLE
Modify `Token` model to make it immutable

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/models/Token.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/models/Token.java
@@ -939,7 +939,7 @@ public class Token {
      * @param removedUniqueTokens
      * @return new instance of {@link Token} with updated {@link #removedUniqueTokens} property
      */
-    private Token createNewTokenWithRemoveddUniqueTokens(Token oldToken, List<UniqueToken> removedUniqueTokens) {
+    private Token createNewTokenWithRemovedUniqueTokens(Token oldToken, List<UniqueToken> removedUniqueTokens) {
         return new Token(
                 oldToken.entityId,
                 oldToken.id,
@@ -1738,16 +1738,8 @@ public class Token {
         return createNewTokenWithMintedUniqueTokens(this, mintedUniqueTokens);
     }
 
-    public List<UniqueToken> getMintedUniqueTokens() {
-        return mintedUniqueTokens;
-    }
-
-    public List<UniqueToken> getRemovedUniqueTokens() {
-        return removedUniqueTokens;
-    }
-
     public Token setRemovedUniqueTokens(final List<UniqueToken> removedUniqueTokens) {
-        return createNewTokenWithRemoveddUniqueTokens(this, removedUniqueTokens);
+        return createNewTokenWithRemovedUniqueTokens(this, removedUniqueTokens);
     }
 
     public boolean hasFreezeKey() {

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/models/TokenTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/models/TokenTest.java
@@ -326,14 +326,16 @@ class TokenTest {
         final long serialNumber1 = 11L;
 
         var tokenModificationResult = subject.burn(treasuryRel, List.of(serialNumber0, serialNumber1));
-        subject = tokenModificationResult.token();
+        var newToken = tokenModificationResult.token();
         treasuryRel = tokenModificationResult.tokenRelationship();
         treasuryAccount = treasuryRel.getAccount();
 
-        assertEquals(initialSupply - 2, subject.getTotalSupply());
+        assertEquals(initialSupply - 2, newToken.getTotalSupply());
+        assertEquals(initialSupply, subject.getTotalSupply());
         assertEquals(-2, treasuryRel.getBalanceChange());
-        assertTrue(subject.hasRemovedUniqueTokens());
-        final var removedUniqueTokens = subject.removedUniqueTokens();
+        assertFalse(subject.hasRemovedUniqueTokens());
+        assertTrue(newToken.hasRemovedUniqueTokens());
+        final var removedUniqueTokens = newToken.removedUniqueTokens();
         assertEquals(2, removedUniqueTokens.size());
         assertEquals(serialNumber0, removedUniqueTokens.get(0).getSerialNumber());
         assertEquals(serialNumber1, removedUniqueTokens.get(1).getSerialNumber());
@@ -348,15 +350,17 @@ class TokenTest {
 
         var tokenModificationResult = subject.mint(
                 treasuryRel, List.of(ByteString.copyFromUtf8("memo")), RichInstant.fromJava(Instant.now()));
-        subject = tokenModificationResult.token();
+        var newToken = tokenModificationResult.token();
         treasuryRel = tokenModificationResult.tokenRelationship();
         treasuryAccount = treasuryRel.getAccount();
 
-        assertEquals(initialSupply + 1, subject.getTotalSupply());
+        assertEquals(initialSupply + 1, newToken.getTotalSupply());
+        assertEquals(initialSupply, subject.getTotalSupply());
         assertEquals(1, treasuryRel.getBalanceChange());
-        assertTrue(subject.hasMintedUniqueTokens());
-        assertEquals(1, subject.mintedUniqueTokens().get(0).getSerialNumber());
-        assertEquals(1, subject.getLastUsedSerialNumber());
+        assertTrue(newToken.hasMintedUniqueTokens());
+        assertFalse(subject.hasMintedUniqueTokens());
+        assertEquals(1, newToken.mintedUniqueTokens().get(0).getSerialNumber());
+        assertEquals(1, newToken.getLastUsedSerialNumber());
         assertEquals(TokenType.NON_FUNGIBLE_UNIQUE, subject.getType());
         assertEquals(numPositiveBalances + 1, treasuryAccount.getNumPositiveBalances());
     }
@@ -481,16 +485,18 @@ class TokenTest {
         nonTreasuryRel = nonTreasuryRel.setBalance(100);
 
         var tokenModificationResult = subject.wipe(nonTreasuryRel, List.of(1L));
-        subject = tokenModificationResult.token();
+        var newToken = tokenModificationResult.token();
         nonTreasuryRel = tokenModificationResult.tokenRelationship();
 
-        assertEquals(initialSupply - 1, subject.getTotalSupply());
+        assertEquals(initialSupply - 1, newToken.getTotalSupply());
+        assertEquals(initialSupply, subject.getTotalSupply());
         assertEquals(99, nonTreasuryRel.getBalanceChange());
         assertEquals(99, nonTreasuryRel.getBalance());
-        assertTrue(subject.hasRemovedUniqueTokens());
-        assertEquals(1, subject.removedUniqueTokens().get(0).getSerialNumber());
-        assertTrue(subject.hasChangedSupply());
-        assertEquals(21_000_000, subject.getMaxSupply());
+        assertTrue(newToken.hasRemovedUniqueTokens());
+        assertFalse(subject.hasRemovedUniqueTokens());
+        assertEquals(1, newToken.removedUniqueTokens().get(0).getSerialNumber());
+        assertTrue(newToken.hasChangedSupply());
+        assertEquals(21_000_000, newToken.getMaxSupply());
         assertEquals(numPositiveBalances, nonTreasuryAccount.getNumPositiveBalances());
     }
 


### PR DESCRIPTION
**Description**:
We need to modify the store models to not modify the state of the collections they hold. This breaks the immutability and causes issues for estimateGas, where we call doProcessCall multiple times in one transaction.
This is currently not a problem but is seen in https://github.com/hashgraph/hedera-mirror-node/pull/6676 as potential bug

**Related issue(s)**:

Fixes #6918

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
