### PR TITLE
Revert "Add a transaction hash pivot timestamp (0.89)"

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityProperties.java
@@ -83,7 +83,6 @@ public class EntityProperties {
         private boolean trackNonce = true;
 
         private boolean transactionHash = false;
-        private long transactionHashPivotTimestamp = -1;
 
         /**
          * A set of transaction types to persist transaction hash for. If empty and transactionHash is true, transaction
@@ -109,9 +108,8 @@ public class EntityProperties {
             return entityTransactions && !EntityId.isEmpty(entityId) && !entityTransactionExclusion.contains(entityId);
         }
 
-        public boolean shouldPersistTransactionHash(TransactionType transactionType, long consensusTimestamp) {
+        public boolean shouldPersistTransactionHash(TransactionType transactionType) {
             return transactionHash
-                    && consensusTimestamp > transactionHashPivotTimestamp
                     && (transactionHashTypes.isEmpty() || transactionHashTypes.contains(transactionType));
         }
     }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListener.java
@@ -475,10 +475,7 @@ public class SqlEntityListener implements EntityListener, RecordStreamFileListen
     public void onTransaction(Transaction transaction) throws ImporterException {
         transactions.add(transaction);
 
-        if (entityProperties
-                .getPersist()
-                .shouldPersistTransactionHash(
-                        TransactionType.of(transaction.getType()), transaction.getConsensusTimestamp())) {
+        if (entityProperties.getPersist().shouldPersistTransactionHash(TransactionType.of(transaction.getType()))) {
             transactionHashes.add(transaction.toTransactionHash());
         }
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/PersistPropertiesTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/PersistPropertiesTest.java
@@ -81,25 +81,18 @@ class PersistPropertiesTest {
     @CsvSource(
             textBlock =
                     """
-            true, CRYPTOTRANSFER, 0, 1, true,
-            true, CRYPTOTRANSFER, 5, 1, false,
-            true, CONSENSUSSUBMITMESSAGE, 0, 1, false,
-            false, CRYPTOTRANSFER, 0, 1, false,
-            false, CONSENSUSSUBMITMESSAGE, 0, 1, false,
+            true, CRYPTOTRANSFER, true,
+            true, CONSENSUSSUBMITMESSAGE, false,
+            false, CRYPTOTRANSFER, false,
+            false, CONSENSUSSUBMITMESSAGE, false,
             """)
-    void shouldPersistTransactionHash(
-            boolean transactionHash,
-            TransactionType transactionType,
-            long transactionHashPivot,
-            long consensusTimestamp,
-            boolean expected) {
+    void shouldPersistTransactionHash(boolean transactionHash, TransactionType transactionType, boolean expected) {
         var persistProperties = new EntityProperties.PersistProperties();
         persistProperties.setTransactionHash(transactionHash);
         persistProperties.setTransactionHashTypes(Set.of(transactionType));
-        persistProperties.setTransactionHashPivotTimestamp(transactionHashPivot);
-        assertThat(persistProperties.shouldPersistTransactionHash(TransactionType.CRYPTOTRANSFER, consensusTimestamp))
+        assertThat(persistProperties.shouldPersistTransactionHash(TransactionType.CRYPTOTRANSFER))
                 .isEqualTo(expected);
-        assertThat(persistProperties.shouldPersistTransactionHash(TransactionType.CONTRACTCALL, consensusTimestamp))
+        assertThat(persistProperties.shouldPersistTransactionHash(TransactionType.CONTRACTCALL))
                 .isFalse();
     }
 
@@ -109,9 +102,9 @@ class PersistPropertiesTest {
         var persistProperties = new EntityProperties.PersistProperties();
         persistProperties.setTransactionHash(transactionHash);
         persistProperties.setTransactionHashTypes(Collections.emptySet());
-        assertThat(persistProperties.shouldPersistTransactionHash(TransactionType.CRYPTOTRANSFER, 0))
+        assertThat(persistProperties.shouldPersistTransactionHash(TransactionType.CRYPTOTRANSFER))
                 .isEqualTo(transactionHash);
-        assertThat(persistProperties.shouldPersistTransactionHash(TransactionType.CONTRACTCALL, 0))
+        assertThat(persistProperties.shouldPersistTransactionHash(TransactionType.CONTRACTCALL))
                 .isEqualTo(transactionHash);
     }
 }


### PR DESCRIPTION
**Description**:

Revert adding `hedera.mirror.importer.parser.record.entity.persist.transactionHashPivotTimestamp`

**Related issue(s)**:

Related To #6793 

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
