### PR TITLE
HIP-786: Include new staking properties in acceptance test

### DIFF
--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorNetworkStake.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorNetworkStake.java
@@ -20,8 +20,12 @@ import lombok.Data;
 
 @Data
 public class MirrorNetworkStake {
+    private long maxStakeRewarded;
     private long maxStakingRewardRatePerHbar;
+    private long maxTotalReward;
     private float nodeRewardFeeFraction;
+    private long reservedStakingRewards;
+    private long rewardBalanceThreshold;
     private long stakeTotal;
     private TimestampRange stakingPeriod;
     private long stakingPeriodDuration;
@@ -29,4 +33,5 @@ public class MirrorNetworkStake {
     private float stakingRewardFeeFraction;
     private long stakingRewardRate;
     private long stakingStartThreshold;
+    private long unreservedStakingRewardBalance;
 }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/NetworkFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/NetworkFeature.java
@@ -43,8 +43,12 @@ public class NetworkFeature {
 
     @Then("the mirror node REST API returns the network stake")
     public void verifyNetworkStakeResponse() {
+        assertThat(networkStake.getMaxStakeRewarded()).isNotNegative();
         assertThat(networkStake.getMaxStakingRewardRatePerHbar()).isPositive();
+        assertThat(networkStake.getMaxTotalReward()).isNotNegative();
         assertThat(networkStake.getNodeRewardFeeFraction()).isBetween(0.0F, 1.0F);
+        assertThat(networkStake.getReservedStakingRewards()).isNotNegative();
+        assertThat(networkStake.getRewardBalanceThreshold()).isNotNegative();
         assertThat(networkStake.getStakeTotal()).isNotNegative();
         assertNotNull(networkStake.getStakingPeriod());
         assertThat(networkStake.getStakingPeriodDuration()).isPositive();
@@ -52,5 +56,6 @@ public class NetworkFeature {
         assertThat(networkStake.getStakingRewardFeeFraction()).isBetween(0.0F, 1.0F);
         assertThat(networkStake.getStakingRewardRate()).isPositive();
         assertThat(networkStake.getStakingStartThreshold()).isPositive();
+        assertThat(networkStake.getUnreservedStakingRewardBalance()).isNotNegative();
     }
 }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/NetworkFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/NetworkFeature.java
@@ -44,7 +44,7 @@ public class NetworkFeature {
     @Then("the mirror node REST API returns the network stake")
     public void verifyNetworkStakeResponse() {
         assertThat(networkStake.getMaxStakeRewarded()).isNotNegative();
-        assertThat(networkStake.getMaxStakingRewardRatePerHbar()).isPositive();
+        assertThat(networkStake.getMaxStakingRewardRatePerHbar()).isNotNegative();
         assertThat(networkStake.getMaxTotalReward()).isNotNegative();
         assertThat(networkStake.getNodeRewardFeeFraction()).isBetween(0.0F, 1.0F);
         assertThat(networkStake.getReservedStakingRewards()).isNotNegative();
@@ -54,7 +54,7 @@ public class NetworkFeature {
         assertThat(networkStake.getStakingPeriodDuration()).isPositive();
         assertThat(networkStake.getStakingPeriodsStored()).isPositive();
         assertThat(networkStake.getStakingRewardFeeFraction()).isBetween(0.0F, 1.0F);
-        assertThat(networkStake.getStakingRewardRate()).isPositive();
+        assertThat(networkStake.getStakingRewardRate()).isNotNegative();
         assertThat(networkStake.getStakingStartThreshold()).isPositive();
         assertThat(networkStake.getUnreservedStakingRewardBalance()).isNotNegative();
     }

--- a/hedera-mirror-test/src/test/resources/features/network/networkstake.feature
+++ b/hedera-mirror-test/src/test/resources/features/network/networkstake.feature
@@ -1,7 +1,7 @@
 @network @fullsuite
 Feature: Account Coverage Feature
 
-    @networkstake
+    @networkstake @acceptance
     Scenario Outline: Get network stake
         When I query the network stake
         Then the mirror node REST API returns the network stake

--- a/hedera-mirror-test/src/test/resources/features/network/networkstake.feature
+++ b/hedera-mirror-test/src/test/resources/features/network/networkstake.feature
@@ -1,5 +1,5 @@
 @network @fullsuite
-Feature: Account Coverage Feature
+Feature: Network Stake Coverage Feature
 
     @networkstake @acceptance
     Scenario Outline: Get network stake


### PR DESCRIPTION
**Description**:
Adjust network stake API acceptance test to include the new fields provided by HIP-786, #6792, as well as valid assertion for even existing fields that could be zero depending on 0.0.800 account balance and staking configuration.
* Add assertions for new HIP-786 fields.
* Adjust assertions for existing fields allowing for zero values.
* Configure network stake test as `@acceptance` to run as acceptance tests suite.

**Related issue(s)**:

Fixes #6891 

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
