### PR TITLE
Make `MirrorEntityAccess.isUsable` **not** consider expiry

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccess.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccess.java
@@ -38,6 +38,10 @@ public class MirrorEntityAccess implements HederaEvmEntityAccess {
     // An account is usable if it isn't deleted, if it has a balance >0, or if it has balance==0
     // but is not the 0-address or the empty account.  (This allows the special case where
     // a synthetic 0-address account is used in eth_estimateGas.)
+    @SuppressWarnings("java:S1126") // "replace this if-then-else statement by a single return"
+    // ^ Complaining about the final if- before the `return true`. But it is clear that this
+    // method is a ladder of tests and merging the final `return true` into the last if- would
+    // impair readability, in this case.
     @Override
     public boolean isUsable(final Address address) {
         // Do not consider expiry/renewal at this time.  It is not enabled in the network.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccess.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccess.java
@@ -35,13 +35,10 @@ public class MirrorEntityAccess implements HederaEvmEntityAccess {
     private final ContractRepository contractRepository;
     private final Store store;
 
-    // An account is usable if it isn't deleted, if it has a balance >0, or if it has balance==0
-    // but is not the 0-address or the empty account.  (This allows the special case where
-    // a synthetic 0-address account is used in eth_estimateGas.)
+    // An account is usable if it isn't deleted or if it has balance==0 but is not the 0-address
+    // or the empty account.  (This allows the special case where a synthetic 0-address account
+    // is used in eth_estimateGas.)
     @SuppressWarnings("java:S1126") // "replace this if-then-else statement by a single return"
-    // ^ Complaining about the final if- before the `return true`. But it is clear that this
-    // method is a ladder of tests and merging the final `return true` into the last if- would
-    // impair readability, in this case.
     @Override
     public boolean isUsable(final Address address) {
         // Do not consider expiry/renewal at this time.  It is not enabled in the network.
@@ -61,15 +58,7 @@ public class MirrorEntityAccess implements HederaEvmEntityAccess {
             return true;
         }
 
-        if (balance < 0) {
-            return false;
-        }
-
         if (Address.ZERO.equals(address)) {
-            return false;
-        }
-
-        if (account.isEmptyAccount()) {
             return false;
         }
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccess.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccess.java
@@ -62,6 +62,10 @@ public class MirrorEntityAccess implements HederaEvmEntityAccess {
             return false;
         }
 
+        if (account.isEmptyAccount()) {
+            return false;
+        }
+
         return true;
     }
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccessTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccessTest.java
@@ -86,23 +86,6 @@ class MirrorEntityAccessTest {
         assertThat(result).isTrue();
     }
 
-    @Test
-    void isNotUsableWithNegativeBalance() {
-        final long balance = -1L;
-        when(store.getAccount(ADDRESS, OnMissing.DONT_THROW)).thenReturn(account);
-        when(account.getBalance()).thenReturn(balance);
-        final var result = mirrorEntityAccess.isUsable(ADDRESS);
-        assertThat(result).isFalse();
-    }
-
-    @Test
-    void isNotUsableWithWrongAlias() {
-        final var address = Address.fromHexString("0x3232134567785444e");
-        when(store.getAccount(address, OnMissing.DONT_THROW)).thenReturn(Account.getEmptyAccount());
-        final var result = mirrorEntityAccess.isUsable(address);
-        assertThat(result).isFalse();
-    }
-
     @Disabled("Expiry not enabled on network; these tests need to account for feature flags; see #6941")
     @Test
     void isNotUsableWithExpiredTimestamp() {

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccessTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccessTest.java
@@ -103,7 +103,7 @@ class MirrorEntityAccessTest {
         assertThat(result).isFalse();
     }
 
-    @Disabled
+    @Disabled("Expiry not enabled on network; these tests need to account for feature flags; see #6941")
     @Test
     void isNotUsableWithExpiredTimestamp() {
         when(store.getAccount(ADDRESS, OnMissing.DONT_THROW)).thenReturn(Account.getEmptyAccount());
@@ -111,7 +111,7 @@ class MirrorEntityAccessTest {
         assertThat(result).isFalse();
     }
 
-    @Disabled
+    @Disabled("Expiry not enabled on network; these tests need to account for feature flags; see #6941")
     @Test
     void isNotUsableWithExpiredTimestampAndNullBalance() {
         when(store.getAccount(ADDRESS, OnMissing.DONT_THROW)).thenReturn(Account.getEmptyAccount());
@@ -119,7 +119,7 @@ class MirrorEntityAccessTest {
         assertThat(result).isFalse();
     }
 
-    @Disabled
+    @Disabled("Expiry not enabled on network; these tests need to account for feature flags; see #6941")
     @Test
     void isUsableWithNotExpiredTimestamp() {
         final long expiredTimestamp = Instant.MAX.getEpochSecond();
@@ -129,7 +129,7 @@ class MirrorEntityAccessTest {
         assertThat(result).isTrue();
     }
 
-    @Disabled
+    @Disabled("Expiry not enabled on network; these tests need to account for feature flags; see #6941")
     @Test
     void isNotUsableWithExpiredAutoRenewTimestamp() {
         final long autoRenewPeriod = Instant.MAX.getEpochSecond();
@@ -138,7 +138,7 @@ class MirrorEntityAccessTest {
         assertThat(result).isFalse();
     }
 
-    @Disabled
+    @Disabled("Expiry not enabled on network; these tests need to account for feature flags; see #6941")
     @Test
     void isUsableWithNotExpiredAutoRenewTimestamp() {
         when(store.getAccount(ADDRESS, OnMissing.DONT_THROW)).thenReturn(account);
@@ -147,7 +147,7 @@ class MirrorEntityAccessTest {
         assertThat(result).isTrue();
     }
 
-    @Disabled
+    @Disabled("Expiry not enabled on network; these tests need to account for feature flags; see #6941")
     @Test
     void isUsableWithEmptyExpiry() {
         when(store.getAccount(ADDRESS, OnMissing.DONT_THROW)).thenReturn(account);

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccessTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccessTest.java
@@ -37,6 +37,7 @@ import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.hyperledger.besu.datatypes.Address;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -102,6 +103,7 @@ class MirrorEntityAccessTest {
         assertThat(result).isFalse();
     }
 
+    @Disabled
     @Test
     void isNotUsableWithExpiredTimestamp() {
         when(store.getAccount(ADDRESS, OnMissing.DONT_THROW)).thenReturn(Account.getEmptyAccount());
@@ -109,6 +111,7 @@ class MirrorEntityAccessTest {
         assertThat(result).isFalse();
     }
 
+    @Disabled
     @Test
     void isNotUsableWithExpiredTimestampAndNullBalance() {
         when(store.getAccount(ADDRESS, OnMissing.DONT_THROW)).thenReturn(Account.getEmptyAccount());
@@ -116,6 +119,7 @@ class MirrorEntityAccessTest {
         assertThat(result).isFalse();
     }
 
+    @Disabled
     @Test
     void isUsableWithNotExpiredTimestamp() {
         final long expiredTimestamp = Instant.MAX.getEpochSecond();
@@ -125,6 +129,7 @@ class MirrorEntityAccessTest {
         assertThat(result).isTrue();
     }
 
+    @Disabled
     @Test
     void isNotUsableWithExpiredAutoRenewTimestamp() {
         final long autoRenewPeriod = Instant.MAX.getEpochSecond();
@@ -133,6 +138,7 @@ class MirrorEntityAccessTest {
         assertThat(result).isFalse();
     }
 
+    @Disabled
     @Test
     void isUsableWithNotExpiredAutoRenewTimestamp() {
         when(store.getAccount(ADDRESS, OnMissing.DONT_THROW)).thenReturn(account);
@@ -141,6 +147,7 @@ class MirrorEntityAccessTest {
         assertThat(result).isTrue();
     }
 
+    @Disabled
     @Test
     void isUsableWithEmptyExpiry() {
         when(store.getAccount(ADDRESS, OnMissing.DONT_THROW)).thenReturn(account);

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccessTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccessTest.java
@@ -86,6 +86,14 @@ class MirrorEntityAccessTest {
         assertThat(result).isTrue();
     }
 
+    @Test
+    void isNotUsableWithWrongAlias() {
+        final var address = Address.fromHexString("0x0");
+        when(store.getAccount(address, OnMissing.DONT_THROW)).thenReturn(Account.getEmptyAccount());
+        final var result = mirrorEntityAccess.isUsable(address);
+        assertThat(result).isFalse();
+    }
+
     @Disabled("Expiry not enabled on network; these tests need to account for feature flags; see #6941")
     @Test
     void isNotUsableWithExpiredTimestamp() {


### PR DESCRIPTION
**Description**:

`MirrorEntityAccess` is using expiry as a gate for `isUsable` for accounts, incl contracts

Should be gated on feature flags - but isn't.  Expiry isn't enabled now but this code thought it was.

Solution for now is to simply _not_ check for expiry as that is the network behavior right now.

Also, make sure balance behaves properly: >0 balance means isUsable, <0 balance means _not_ isUsable, and ==0 balance is a special case.

**Related issue(s)**:

Fixes #6928

Will need #6941  to reimplement expiry here, properly


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit)
