### PR TITLE
Make `MirrorEntityAccess.isUsable` not consider expiry (0.88)

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccess.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccess.java
@@ -25,7 +25,6 @@ import com.hedera.mirror.web3.evm.store.Store.OnMissing;
 import com.hedera.mirror.web3.repository.ContractRepository;
 import com.hedera.mirror.web3.repository.ContractStateRepository;
 import com.hedera.node.app.service.evm.store.contracts.HederaEvmEntityAccess;
-import java.time.Instant;
 import lombok.RequiredArgsConstructor;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
@@ -36,9 +35,16 @@ public class MirrorEntityAccess implements HederaEvmEntityAccess {
     private final ContractRepository contractRepository;
     private final Store store;
 
-    // We should check only accounts usability
+    // An account is usable if it isn't deleted or if it has balance==0 but is not the 0-address
+    // or the empty account.  (This allows the special case where a synthetic 0-address account
+    // is used in eth_estimateGas.)
+    @SuppressWarnings("java:S1126") // "replace this if-then-else statement by a single return"
     @Override
     public boolean isUsable(final Address address) {
+        // Do not consider expiry/renewal at this time.  It is not enabled in the network.
+        // When it is handled it must be gated on (already existing) mirror node feature flags
+        // (properties).
+
         final var account = store.getAccount(address, OnMissing.DONT_THROW);
 
         final var balance = account.getBalance();
@@ -56,7 +62,11 @@ public class MirrorEntityAccess implements HederaEvmEntityAccess {
             return false;
         }
 
-        return account.getExpiry() >= Instant.now().getEpochSecond();
+        if (account.isEmptyAccount()) {
+            return false;
+        }
+
+        return true;
     }
 
     @Override

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccessTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccessTest.java
@@ -37,6 +37,7 @@ import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.hyperledger.besu.datatypes.Address;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -86,22 +87,14 @@ class MirrorEntityAccessTest {
     }
 
     @Test
-    void isNotUsableWithNegativeBalance() {
-        final long balance = -1L;
-        when(store.getAccount(ADDRESS, OnMissing.DONT_THROW)).thenReturn(account);
-        when(account.getBalance()).thenReturn(balance);
-        final var result = mirrorEntityAccess.isUsable(ADDRESS);
-        assertThat(result).isFalse();
-    }
-
-    @Test
     void isNotUsableWithWrongAlias() {
-        final var address = Address.fromHexString("0x3232134567785444e");
+        final var address = Address.fromHexString("0x0");
         when(store.getAccount(address, OnMissing.DONT_THROW)).thenReturn(Account.getEmptyAccount());
         final var result = mirrorEntityAccess.isUsable(address);
         assertThat(result).isFalse();
     }
 
+    @Disabled("Expiry not enabled on network; these tests need to account for feature flags; see #6941")
     @Test
     void isNotUsableWithExpiredTimestamp() {
         when(store.getAccount(ADDRESS, OnMissing.DONT_THROW)).thenReturn(Account.getEmptyAccount());
@@ -109,6 +102,7 @@ class MirrorEntityAccessTest {
         assertThat(result).isFalse();
     }
 
+    @Disabled("Expiry not enabled on network; these tests need to account for feature flags; see #6941")
     @Test
     void isNotUsableWithExpiredTimestampAndNullBalance() {
         when(store.getAccount(ADDRESS, OnMissing.DONT_THROW)).thenReturn(Account.getEmptyAccount());
@@ -116,6 +110,7 @@ class MirrorEntityAccessTest {
         assertThat(result).isFalse();
     }
 
+    @Disabled("Expiry not enabled on network; these tests need to account for feature flags; see #6941")
     @Test
     void isUsableWithNotExpiredTimestamp() {
         final long expiredTimestamp = Instant.MAX.getEpochSecond();
@@ -125,6 +120,7 @@ class MirrorEntityAccessTest {
         assertThat(result).isTrue();
     }
 
+    @Disabled("Expiry not enabled on network; these tests need to account for feature flags; see #6941")
     @Test
     void isNotUsableWithExpiredAutoRenewTimestamp() {
         final long autoRenewPeriod = Instant.MAX.getEpochSecond();
@@ -133,6 +129,7 @@ class MirrorEntityAccessTest {
         assertThat(result).isFalse();
     }
 
+    @Disabled("Expiry not enabled on network; these tests need to account for feature flags; see #6941")
     @Test
     void isUsableWithNotExpiredAutoRenewTimestamp() {
         when(store.getAccount(ADDRESS, OnMissing.DONT_THROW)).thenReturn(account);
@@ -141,6 +138,7 @@ class MirrorEntityAccessTest {
         assertThat(result).isTrue();
     }
 
+    @Disabled("Expiry not enabled on network; these tests need to account for feature flags; see #6941")
     @Test
     void isUsableWithEmptyExpiry() {
         when(store.getAccount(ADDRESS, OnMissing.DONT_THROW)).thenReturn(account);


### PR DESCRIPTION
**Description**:
Cherry pick #6940 to 0.88

MirrorEntityAccess is using expiry as a gate for isUsable for accounts, incl contracts

Should be gated on feature flags - but isn't. Expiry isn't enabled now but this code thought it was.

Solution for now is to simply not check for expiry as that is the network behavior right now.

**Related issue(s)**:

Fixes #6928 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
