### PR TITLE
Fix acceptance test cleanup

### DIFF
--- a/charts/hedera-mirror-common/values.yaml
+++ b/charts/hedera-mirror-common/values.yaml
@@ -28,7 +28,7 @@ loki:
             directory: /rules
       table_manager:
         retention_deletes_enabled: true
-        retention_period: 2184h
+        retention_period: 1440h
   monitoring:
     lokiCanary:
       enabled: false

--- a/hedera-mirror-grpc/src/main/resources/application.yml
+++ b/hedera-mirror-grpc/src/main/resources/application.yml
@@ -20,6 +20,7 @@ logging:
   level:
     root: warn
     com.hedera.mirror.grpc: info
+    io.grpc.netty.shaded.io.grpc.netty.NettyServerHandler: error
     org.springframework.cloud.kubernetes.fabric8.config: error
     # io.grpc: debug
     # org.hibernate.SQL: debug

--- a/hedera-mirror-test/README.md
+++ b/hedera-mirror-test/README.md
@@ -133,9 +133,9 @@ Test Suite Tags
 Feature based Tags
 
 - `@accounts` - Crypto account focused tests.
-- `@topicmessagesbase` - Simple HCS focused tests.
+- `@topic` - Simple HCS focused tests.
 - `@topicmessagesfilter` - HCS focused tests wth varied subscription filters.
-- `@tokenbase` - HTS focused tests.
+- `@token` - HTS focused tests.
 - `@schedulebase` - Scheduled transactions focused tests.
 
 To execute run
@@ -145,8 +145,8 @@ To execute run
 > **_NOTE:_** Feature tags can be combined - See [Tag expressions](https://cucumber.io/docs/cucumber/api/). To run a
 > subset of tags
 >
-> - `@acceptance and @topicmessagesbase` - all token acceptance scenarios
-> - `@acceptance and not @tokenbase` - all acceptance except token scenarios
+> - `@acceptance and @topic` - all topic acceptance scenarios
+> - `@acceptance and not @token` - all acceptance except token scenarios
 
 ### Test Layout
 

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/AcceptanceTest.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/AcceptanceTest.java
@@ -16,6 +16,9 @@
 
 package com.hedera.mirror.test.e2e.acceptance;
 
+import com.hedera.mirror.test.e2e.acceptance.client.AccountClient.AccountNameEnum;
+import com.hedera.mirror.test.e2e.acceptance.client.TokenClient.TokenNameEnum;
+import io.cucumber.java.ParameterType;
 import io.cucumber.spring.CucumberContextConfiguration;
 import org.junit.jupiter.api.Tag;
 import org.junit.platform.suite.api.IncludeEngines;
@@ -30,4 +33,15 @@ import org.springframework.boot.test.context.SpringBootTest;
 @CucumberContextConfiguration
 @SuppressWarnings("java:S2187") // Ignore no tests in file warning
 @Tag("acceptance")
-public class AcceptanceTest {}
+public class AcceptanceTest {
+
+    @ParameterType("\"?([A-Z]+)\"?")
+    public AccountNameEnum account(String name) {
+        return AccountNameEnum.valueOf(name);
+    }
+
+    @ParameterType("\"?([A-Z]+)\"?")
+    public TokenNameEnum token(String name) {
+        return TokenNameEnum.valueOf(name);
+    }
+}

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AbstractNetworkClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AbstractNetworkClient.java
@@ -37,6 +37,8 @@ import com.hedera.hashgraph.sdk.TransactionRecordQuery;
 import com.hedera.mirror.test.e2e.acceptance.props.ExpandedAccountId;
 import com.hedera.mirror.test.e2e.acceptance.response.NetworkTransactionResponse;
 import java.time.Instant;
+import java.util.Collection;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import lombok.Data;
 import lombok.SneakyThrows;
@@ -64,6 +66,18 @@ public abstract class AbstractNetworkClient implements Cleanable {
     @Override
     public void clean() {
         // Nothing to clean up
+    }
+
+    protected final <T> void deleteAll(Collection<T> ids, Consumer<T> deleteAction) {
+        ids.forEach(id -> {
+            try {
+                deleteAction.accept(id);
+            } catch (Exception e) {
+                log.warn("Unable to delete {}: {}", id, e.getMessage());
+            }
+        });
+
+        ids.clear();
     }
 
     @SneakyThrows

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TokenClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TokenClient.java
@@ -76,17 +76,8 @@ public class TokenClient extends AbstractNetworkClient {
     public void clean() {
         var admin = sdkClient.getExpandedOperatorAccountId();
         log.info("Deleting {} tokens and dissociating {} token relationships", tokenIds.size(), tokenAccounts.size());
-
-        for (var tokenId : tokenIds) {
-            delete(admin, tokenId);
-        }
-
-        for (var tokenAccount : tokenAccounts) {
-            dissociate(tokenAccount.accountId, tokenAccount.tokenId);
-        }
-
-        tokenIds.clear();
-        tokenAccounts.clear();
+        deleteAll(tokenIds, tokenId -> delete(admin, tokenId));
+        deleteAll(tokenAccounts, tokenAccount -> dissociate(tokenAccount.accountId, tokenAccount.tokenId));
     }
 
     @Override
@@ -301,6 +292,11 @@ public class TokenClient extends AbstractNetworkClient {
                 .setTransactionMemo(getMemo("Associate w token"));
         var response = executeTransactionAndRetrieveReceipt(tokenAssociateTransaction);
         log.info("Associated contract {} with token {} via {}", contractId, token, response.getTransactionId());
+        tokenAccounts.add(new TokenAccount(
+                token,
+                new ExpandedAccountId(
+                        AccountId.fromString(contractId.toString()),
+                        sdkClient.getExpandedOperatorAccountId().getPrivateKey())));
         return response;
     }
 

--- a/hedera-mirror-test/src/test/resources/features/schedule/schedule.feature
+++ b/hedera-mirror-test/src/test/resources/features/schedule/schedule.feature
@@ -14,4 +14,4 @@ Feature: Schedule Base Coverage Feature
     And the mirror node REST API should verify the executed schedule entity
     Examples:
       | accountName | httpStatusCode |
-      | "CAROL"     | 200            |
+      | "BOB"       | 200            |

--- a/hedera-mirror-test/src/test/resources/features/token/token.feature
+++ b/hedera-mirror-test/src/test/resources/features/token/token.feature
@@ -1,7 +1,7 @@
-@fullsuite @acceptance @critical @release @token
+@fullsuite @acceptance @token
 Feature: HTS Base Coverage Feature
 
-  @fungible
+  @fungible @critical @release
   Scenario Outline: Validate Token Flow - Create, Associate, Freeze, GrantKyc, Fund, Update, Burn, Mint, Wipe, Pause, Unpause, Dissociate, Delete
     Given I successfully create a new token with freeze status 2 and kyc status 1
     Then the mirror node REST API should return the transaction
@@ -36,7 +36,7 @@ Feature: HTS Base Coverage Feature
       | amount | freezeStatus | kycStatus | modifySupplyAmount |
       | 2350   | 2            | 1         | 100                |
 
-  @nft
+  @nft @critical @release
   Scenario Outline: Validate Full NFT Flow - Create, Associate, Mint, Transfer, Burn, Wipe, Update Treasury, Delete
     Given I successfully create a new nft with supplyType <supplyType>
     Then the mirror node REST API should return the transaction
@@ -62,7 +62,7 @@ Feature: HTS Base Coverage Feature
       | supplyType |
       | "INFINITE" |
 
-  @acceptance @customfees
+  @customfees
   Scenario Outline: Validate Base Token Flow with Custom Fees Schedule - Create, Associate, Fund, Transfer
     Given I successfully create a new token with custom fees schedule
       | amount | numerator | denominator | collector | maximum | minimum | token |

--- a/hedera-mirror-test/src/test/resources/features/token/token.feature
+++ b/hedera-mirror-test/src/test/resources/features/token/token.feature
@@ -1,113 +1,93 @@
-@tokenbase @fullsuite
+@fullsuite @acceptance @critical @release @token
 Feature: HTS Base Coverage Feature
 
-    @critical @release @acceptance
-    Scenario Outline: Validate Token Flow - Create, Associate, Freeze, GrantKyc, Fund, Update, Burn, Mint, Wipe, Pause, Unpause, Dissociate, Delete
-        Given I successfully create a new token with freeze status 2 and kyc status 1
-        Then the mirror node REST API should return the transaction
-        When I associate a new recipient account with token
-        Then the mirror node REST API should return the transaction
-        Then the mirror node REST API should return the token relationship for token
-        And I set new account freeze status to <freezeStatus>
-        Then the mirror node REST API should return the transaction
-        And I set new account kyc status to <kycStatus>
-        Then the mirror node REST API should return the transaction
-        Then I transfer <amount> tokens to recipient
-        Then the mirror node REST API should return the transaction for token fund flow
-        Then I update the token
-        And the mirror node REST API should confirm token update
-        Then I burn <modifySupplyAmount> from the token
-        And the mirror node REST API should return the transaction
-        Then I mint <modifySupplyAmount> from the token
-        And the mirror node REST API should return the transaction
-        Then I wipe <amount> from the token
-        And the mirror node REST API should return the transaction
-        Then I pause the token
-        And the mirror node REST API should return the transaction
-        And the mirror node Token Info REST API should return pause status "PAUSED"
-        Then I unpause the token
-        And the mirror node REST API should return the transaction
-        And the mirror node Token Info REST API should return pause status "UNPAUSED"
-        Then I dissociate the account from the token
-        And the mirror node REST API should return the transaction
-        Then I delete the token
-        And the mirror node REST API should return the transaction
-        Examples:
-            | amount | freezeStatus | kycStatus | modifySupplyAmount |
-            | 2350   | 2            | 1         | 100                |
+  @fungible
+  Scenario Outline: Validate Token Flow - Create, Associate, Freeze, GrantKyc, Fund, Update, Burn, Mint, Wipe, Pause, Unpause, Dissociate, Delete
+    Given I successfully create a new token with freeze status 2 and kyc status 1
+    Then the mirror node REST API should return the transaction
+    When I associate ALICE with token
+    Then the mirror node REST API should return the transaction
+    Then the mirror node REST API should return the token relationship for token
+    And I set account freeze status to <freezeStatus>
+    Then the mirror node REST API should return the transaction
+    And I set account kyc status to <kycStatus>
+    Then the mirror node REST API should return the transaction
+    Then I transfer <amount> tokens to ALICE
+    Then the mirror node REST API should return the transaction for token fund flow
+    Then I update the token
+    And the mirror node REST API should confirm token update
+    Then I burn <modifySupplyAmount> from the token
+    And the mirror node REST API should return the transaction
+    Then I mint <modifySupplyAmount> from the token
+    And the mirror node REST API should return the transaction
+    Then I wipe <amount> from the token
+    And the mirror node REST API should return the transaction
+    Then I pause the token
+    And the mirror node REST API should return the transaction
+    And the mirror node Token Info REST API should return pause status "PAUSED"
+    Then I unpause the token
+    And the mirror node REST API should return the transaction
+    And the mirror node Token Info REST API should return pause status "UNPAUSED"
+    Then I dissociate the account from the token
+    And the mirror node REST API should return the transaction
+    Then I delete the token
+    And the mirror node REST API should return the transaction
+    Examples:
+      | amount | freezeStatus | kycStatus | modifySupplyAmount |
+      | 2350   | 2            | 1         | 100                |
 
-    @acceptance @nft @critical @release
-    Scenario Outline: Validate Full NFT Flow - Create, Associate, Mint, Transfer, Burn, Wipe, Update Treasury, Delete
-        Given I successfully create a new nft with supplyType <supplyType>
-        Then the mirror node REST API should return the transaction
-        When I associate a new recipient account with token
-        And the mirror node REST API should return the transaction
-        Then the mirror node REST API should return the token relationship for nft
-        Then I mint a serial number from the token
-        And the mirror node REST API should return the transaction for token 0 serial number 0 transaction flow
-        Then I transfer serial number of token to recipient
-        And the mirror node REST API should return the transaction for token 0 serial number 0 full flow
-        Then I wipe serial number 0 from token 0
-        And the mirror node REST API should return the transaction for token 0 serial number 0 transaction flow
-        Then I mint a serial number from the token
-        And the mirror node REST API should return the transaction for token 0 serial number 1 transaction flow
-        Then I burn serial number 1 from token 0
-        And the mirror node REST API should return the transaction for token 0 serial number 1 transaction flow
+  @nft
+  Scenario Outline: Validate Full NFT Flow - Create, Associate, Mint, Transfer, Burn, Wipe, Update Treasury, Delete
+    Given I successfully create a new nft with supplyType <supplyType>
+    Then the mirror node REST API should return the transaction
+    When I associate ALICE with token
+    And the mirror node REST API should return the transaction
+    Then the mirror node REST API should return the token relationship for nft
+    Then I mint a serial number from the token
+    And the mirror node REST API should return the transaction for token serial number 0 transaction flow
+    Then I transfer serial number 0 to ALICE
+    And the mirror node REST API should return the transaction for token serial number 0 full flow
+    Then I wipe serial number 0 from token
+    And the mirror node REST API should return the transaction for token serial number 0 transaction flow
+    Then I mint a serial number from the token
+    And the mirror node REST API should return the transaction for token serial number 1 transaction flow
+    Then I burn serial number 1 from token
+    And the mirror node REST API should return the transaction for token serial number 1 transaction flow
         #TODO This test should be updated when services enables the ability to change NFT treasury accounts.
-        Then I update the treasury of token 0 to recipient 0
-        And the mirror node REST API should return the transaction
-        Then I delete the token
-        And the mirror node REST API should return the transaction for token 0 serial number 1 transaction flow
-        Examples:
-            | supplyType |
-            | "INFINITE" |
+    Then I update the treasury of token to ALICE
+    And the mirror node REST API should return the transaction
+    Then I delete the token
+    And the mirror node REST API should return the transaction for token serial number 1 transaction flow
+    Examples:
+      | supplyType |
+      | "INFINITE" |
 
-    @acceptance @customfees
-    Scenario Outline: Validate Base Token Flow with Custom Fees Schedule - Create, Associate, Fund, Transfer
-        # create the first token for fixed fee paid in token
-        Given I successfully create a new token
-        And the mirror node REST API should return the transaction
-        Given I associate a new recipient account with token 0
-        And the mirror node REST API should return the transaction
-        # create the second token with empty custom fees so we can associate recipient accounts
-        And I successfully create a new token with custom fees schedule
-            | amount | numerator | denominator | collector | maximum | minimum | token |
-            | 50     |           |             | 0         |         |         |       |
-            | 20     |           |             | 0         |         |         | 0     |
-        Then the mirror node REST API should confirm token 1 with custom fees schedule
-        # create 4 recipients, 0 as hbar fee collector, 1 as fixed fee token collector, 2 as fractional fee collector,
-        # and the last as token transfer recipient
-        Given I associate a new recipient account with token 0
-        And the mirror node REST API should return the transaction
-        Given I associate a new recipient account with token 1
-        And the mirror node REST API should return the transaction
-        Given I associate a new recipient account with token 1
-        And the mirror node REST API should return the transaction
-        # create a sender account, the sender account needs to associate with both tokens
-        Given I associate a new sender account with token 0
-        And the mirror node REST API should return the transaction
-        Given I associate an existing sender account 0 with token 1
-        And the mirror node REST API should return the transaction
-        # fund the sender account with both tokens
-        Given I transfer <fundAmount> tokens 0 to sender
-        And the mirror node REST API should return the transaction for token 0 fund flow
-        Given I transfer <fundAmount> tokens 1 to sender
-        And the mirror node REST API should return the transaction for token 1 fund flow
-        # update token 1's custom fees schedule
-        Given I update token 1 with new custom fees schedule
-            | amount | numerator | denominator | collector | maximum | minimum | token |
-            | 100    |           |             | 0         |         |         |       |
-            | 10     |           |             | 1         |         |         | 0     |
-            |        | 1         | 10          | 2         |         |         |       |
-        And the mirror node REST API should return the transaction
-        # make a transfer from sender 0 to the last recipient and verify the assessed custom fees
-        When Sender 0 transfers 200 tokens 1 to recipient 3 with fractional fee 20
-        Then the mirror node REST API should return the transaction for token 1 fund flow with assessed custom fees
-            | amount | collector | token |
-            | 100    | 0         |       |
-            | 10     | 1         | 0     |
-            | 20     | 2         | 1     |
+  @acceptance @customfees
+  Scenario Outline: Validate Base Token Flow with Custom Fees Schedule - Create, Associate, Fund, Transfer
+    Given I successfully create a new token with custom fees schedule
+      | amount | numerator | denominator | collector | maximum | minimum | token |
+      | 50     |           |             | ALICE     |         |         |       |
+      | 20     |           |             | CAROL     |         |         |       |
+    Then the mirror node REST API should confirm token with custom fees schedule
+    # Create ALICE as hbar fee collector, CAROL as fractional fee collector, and DAVE as token transfer recipient
+    Given I associate ALICE with token
+    And the mirror node REST API should return the transaction
+    Given I associate CAROL with token
+    And the mirror node REST API should return the transaction
+    Given I associate DAVE with token
+    Given I transfer <fundAmount> tokens to DAVE
+    And the mirror node REST API should return the transaction for token fund flow
+    Given I update token with new custom fees schedule
+      | amount | numerator | denominator | collector | maximum | minimum | token |
+      | 100    |           |             | ALICE     |         |         |       |
+      |        | 1         | 10          | CAROL     |         |         |       |
+    And the mirror node REST API should return the transaction
+    When DAVE transfers 200 tokens to ALICE with fractional fee 20
+    Then the mirror node REST API should return the transaction for token fund flow with assessed custom fees
+      | amount | collector | token |
+      | 100    | ALICE     |       |
+      | 20     | CAROL     | 0     |
 
-        Examples:
-            | fundAmount |
-            | 3000       |
+    Examples:
+      | fundAmount |
+      | 3000       |

--- a/hedera-mirror-test/src/test/resources/features/topic/topic.feature
+++ b/hedera-mirror-test/src/test/resources/features/topic/topic.feature
@@ -1,46 +1,23 @@
-@topicmessagesbase @fullsuite
+@topic @fullsuite @acceptance
 Feature: HCS Base Coverage Feature
 
-  @critical @release @acceptance @basicsubscribe
+  @critical @release @basicsubscribe
   Scenario Outline: Validate Topic message submission
     Given I successfully create a new topic id
     And I publish and verify <numMessages> messages sent
     Then the mirror node should successfully observe the transaction
+    When I successfully update an existing topic
+    Then the mirror node should successfully observe the transaction
     When I provide a number of messages <numMessages> I want to receive
     And I subscribe with a filter to retrieve messages
     Then the network should successfully observe these messages
+    When I successfully delete the topic
+    Then the mirror node should successfully observe the transaction
     Examples:
       | numMessages |
       | 10          |
 
-  @release @acceptance @updatetopic
-  Scenario: Validate Topic Updates
-    Given I successfully create a new topic id
-    Then the mirror node should successfully observe the transaction
-    When I successfully update an existing topic
-    Then the mirror node should successfully observe the transaction
-
-  @acceptance @deletetopic
-  Scenario: Validate topic deletion
-    Given I successfully create a new topic id
-    Then the mirror node should successfully observe the transaction
-    When I successfully delete the topic
-    Then the mirror node should successfully observe the transaction
-
-  @acceptance @latency
-  Scenario Outline: Validate Topic message listener latency
-    Given I successfully create a new topic id
-    And I publish and verify <numMessages> messages sent
-    Then the mirror node should successfully observe the transaction
-    When I provide a number of messages <numMessages> I want to receive within <latency> seconds
-    And I subscribe with a filter to retrieve messages
-    Then the network should successfully observe these messages
-    Examples:
-      | numMessages | latency |
-      | 2           | 30      |
-      | 5           | 30      |
-
-  @acceptance @negative
+  @negative
   Scenario Outline: Validate topic subscription with missing topic id
     Given I provide a topic id <topicId>
     Then the network should observe an error <errorCode>

--- a/hedera-mirror-test/src/test/resources/features/topic/topicfilter.feature
+++ b/hedera-mirror-test/src/test/resources/features/topic/topicfilter.feature
@@ -1,4 +1,4 @@
-@topicmessagesfilter @fullsuite
+@topic @topicmessagesfilter @fullsuite
 Feature: HCS Message Filter Coverage Feature
 
   @critical @release @acceptance @filter

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/traceability/MirrorOperationTracer.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/traceability/MirrorOperationTracer.java
@@ -49,15 +49,17 @@ public class MirrorOperationTracer implements HederaEvmOperationTracer {
         }
 
         log.info(
-                "{} messageFrame={}, callDepth={}, remainingGas={}, sender={}, recipient={}, contract={}, revertReason={}, inputData={}",
+                "type={} operation={}, callDepth={}, contract={}, sender={}, recipient={}, remainingGas={}, revertReason={}, input={}, output={}, return={}",
                 currentFrame.getType(),
-                currentFrame.toString(),
+                currentFrame.getCurrentOperation().getName(),
                 currentFrame.getMessageStackDepth(),
+                currentFrame.getContractAddress().toShortHexString(),
+                currentFrame.getSenderAddress().toShortHexString(),
+                currentFrame.getRecipientAddress().toShortHexString(),
                 currentFrame.getRemainingGas(),
-                currentFrame.getSenderAddress(),
-                currentFrame.getRecipientAddress(),
-                currentFrame.getContractAddress(),
                 currentFrame.getRevertReason().orElse(Bytes.EMPTY).toHexString(),
-                currentFrame.getInputData());
+                currentFrame.getInputData().toShortHexString(),
+                currentFrame.getOutputData().toShortHexString(),
+                currentFrame.getReturnData().toShortHexString());
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/contracts/execution/traceability/MirrorOperationTracerTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/contracts/execution/traceability/MirrorOperationTracerTest.java
@@ -28,6 +28,8 @@ import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.frame.MessageFrame.State;
 import org.hyperledger.besu.evm.frame.MessageFrame.Type;
+import org.hyperledger.besu.evm.operation.BalanceOperation;
+import org.hyperledger.besu.evm.operation.Operation;
 import org.hyperledger.besu.evm.operation.Operation.OperationResult;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -39,6 +41,15 @@ import org.springframework.boot.test.system.OutputCaptureExtension;
 
 @ExtendWith({MockitoExtension.class, OutputCaptureExtension.class})
 class MirrorOperationTracerTest {
+
+    private static final Address contract = Address.fromHexString("0x2");
+    private static final Address recipient = Address.fromHexString("0x3");
+    private static final Address sender = Address.fromHexString("0x4");
+    private static final long initialGas = 1000L;
+    private static final Bytes input = Bytes.of("inputData".getBytes());
+    private static final Operation operation = new BalanceOperation(null);
+    private static final Bytes outputData = Bytes.of("outputData".getBytes());
+    private static final Bytes returnData = Bytes.of("returnData".getBytes());
 
     @Mock
     private OperationResult operationResult;
@@ -52,12 +63,6 @@ class MirrorOperationTracerTest {
     private MirrorEvmContractAliases mirrorEvmContractAliases;
 
     private MirrorOperationTracer mirrorOperationTracer;
-
-    private static final Address contract = Address.fromHexString("0x2");
-    private static final Address recipient = Address.fromHexString("0x3");
-    private static final Address sender = Address.fromHexString("0x4");
-    private static final long initialGas = 1000L;
-    private static final Bytes input = Bytes.of("inputData".getBytes());
 
     @BeforeEach
     void setup() {
@@ -92,9 +97,12 @@ class MirrorOperationTracerTest {
         given(messageFrame.getState()).willReturn(State.CODE_SUSPENDED);
         given(messageFrame.getType()).willReturn(Type.MESSAGE_CALL);
         given(messageFrame.getContractAddress()).willReturn(contract);
+        given(messageFrame.getCurrentOperation()).willReturn(operation);
         given(messageFrame.getRemainingGas()).willReturn(initialGas);
         given(messageFrame.getInputData()).willReturn(input);
+        given(messageFrame.getOutputData()).willReturn(outputData);
         given(messageFrame.getRecipientAddress()).willReturn(recipient);
+        given(messageFrame.getReturnData()).willReturn(returnData);
         given(messageFrame.getSenderAddress()).willReturn(sender);
         given(messageFrame.getState()).willReturn(State.CODE_SUSPENDED);
         given(messageFrame.getMessageStackDepth()).willReturn(1);
@@ -104,14 +112,16 @@ class MirrorOperationTracerTest {
 
         assertThat(output)
                 .contains(
-                        "MESSAGE_CALL",
+                        "type=MESSAGE_CALL",
                         "callDepth=1",
-                        "recipient=0x0000000000000000000000000000000000000003",
-                        "messageFrame=messageFrame",
-                        "inputData=0x696e70757444617461",
+                        "recipient=0x3",
+                        "input=0x696e70757444617461",
+                        "operation=BALANCE",
+                        "output=0x6f757470757444617461",
                         "remainingGas=1000",
-                        "sender=0x0000000000000000000000000000000000000004",
-                        "revertReason=");
+                        "return=0x72657475726e44617461",
+                        "revertReason=",
+                        "sender=0x4");
     }
 
     @Test
@@ -134,9 +144,12 @@ class MirrorOperationTracerTest {
         given(messageFrame.getState()).willReturn(State.CODE_SUSPENDED);
         given(messageFrame.getType()).willReturn(Type.MESSAGE_CALL);
         given(messageFrame.getContractAddress()).willReturn(contract);
+        given(messageFrame.getCurrentOperation()).willReturn(operation);
         given(messageFrame.getRemainingGas()).willReturn(initialGas);
         given(messageFrame.getInputData()).willReturn(input);
+        given(messageFrame.getOutputData()).willReturn(outputData);
         given(messageFrame.getRecipientAddress()).willReturn(recipient);
+        given(messageFrame.getReturnData()).willReturn(returnData);
         given(messageFrame.getSenderAddress()).willReturn(sender);
         given(messageFrame.getState()).willReturn(State.CODE_SUSPENDED);
         given(messageFrame.getMessageStackDepth()).willReturn(1);
@@ -146,14 +159,16 @@ class MirrorOperationTracerTest {
 
         assertThat(output)
                 .contains(
-                        "MESSAGE_CALL",
+                        "type=MESSAGE_CALL",
                         "callDepth=1",
-                        "recipient=0x0000000000000000000000000000000000000003",
-                        "messageFrame=messageFrame",
-                        "inputData=0x696e70757444617461",
+                        "recipient=0x3",
+                        "input=0x696e70757444617461",
+                        "operation=BALANCE",
+                        "output=0x6f757470757444617461",
                         "remainingGas=1000",
-                        "sender=0x0000000000000000000000000000000000000004",
-                        "revertReason=");
+                        "revertReason=",
+                        "return=0x72657475726e44617461",
+                        "sender=0x4");
     }
 
     @Test
@@ -162,18 +177,24 @@ class MirrorOperationTracerTest {
 
         given(messageFrame.getType()).willReturn(Type.MESSAGE_CALL);
         given(messageFrame.getContractAddress()).willReturn(contract);
+        given(messageFrame.getCurrentOperation()).willReturn(operation);
         given(messageFrame.getRemainingGas()).willReturn(initialGas);
         given(messageFrame.getInputData()).willReturn(input);
+        given(messageFrame.getOutputData()).willReturn(outputData);
         given(messageFrame.getRecipientAddress()).willReturn(recipient);
+        given(messageFrame.getReturnData()).willReturn(returnData);
         given(messageFrame.getSenderAddress()).willReturn(sender);
         given(mirrorEvmContractAliases.resolveForEvm(recipient)).willReturn(recipient);
         mirrorOperationTracer.tracePostExecution(messageFrame, operationResult);
 
         given(messageFrame.getType()).willReturn(Type.MESSAGE_CALL);
         given(messageFrame.getContractAddress()).willReturn(contract);
+        given(messageFrame.getCurrentOperation()).willReturn(operation);
         given(messageFrame.getRemainingGas()).willReturn(initialGas);
         given(messageFrame.getInputData()).willReturn(input);
+        given(messageFrame.getOutputData()).willReturn(outputData);
         given(messageFrame.getRecipientAddress()).willReturn(recipient);
+        given(messageFrame.getReturnData()).willReturn(returnData);
         given(messageFrame.getSenderAddress()).willReturn(sender);
         given(messageFrame.getState()).willReturn(State.CODE_SUSPENDED);
         given(messageFrame.getMessageStackDepth()).willReturn(1);
@@ -182,22 +203,26 @@ class MirrorOperationTracerTest {
         mirrorOperationTracer.tracePostExecution(messageFrame, operationResult);
         assertThat(output)
                 .contains(
-                        "MESSAGE_CALL",
+                        "type=MESSAGE_CALL",
                         "callDepth=0",
-                        "recipient=0x0000000000000000000000000000000000000003",
-                        "messageFrame=messageFrame",
-                        "inputData=0x696e70757444617461",
+                        "recipient=0x3",
+                        "input=0x696e70757444617461",
+                        "operation=BALANCE",
+                        "output=0x6f757470757444617461",
                         "remainingGas=1000",
-                        "sender=0x0000000000000000000000000000000000000004",
-                        "revertReason=")
+                        "revertReason=",
+                        "return=0x72657475726e44617461",
+                        "sender=0x4")
                 .contains(
-                        "MESSAGE_CALL",
+                        "type=MESSAGE_CALL",
                         "callDepth=1",
-                        "recipient=0x0000000000000000000000000000000000000003",
-                        "messageFrame=messageFrame",
-                        "inputData=0x696e70757444617461",
+                        "recipient=0x3",
+                        "input=0x696e70757444617461",
+                        "operation=BALANCE",
+                        "output=0x6f757470757444617461",
                         "remainingGas=1000",
-                        "sender=0x0000000000000000000000000000000000000004",
-                        "revertReason=");
+                        "return=0x72657475726e44617461",
+                        "revertReason=",
+                        "sender=0x4");
     }
 }


### PR DESCRIPTION
**Description**:

* Add an `AccountNameEnum.OPERATOR`
* Add cleanup of contracts, files, schedules and topic entities
* Add more info to contract call tracer logs
* Add support for `AccountNameEnum` and `TokenNameEnum` method parameters
* Add well known account name to account creation log statement
* Combine create/update/delete topic flows to reduce costs
* Fix `GrpcErrors` log level alert by suppressing max connections `NettyServerHandler` warnings
* Fix not cleaning up contract token associations
* Reduce Loki log retention period from 90 to 60 days
* Remove ad-hoc account creation in token feature in favor of `AccountNameEnum`
* Remove extra token creation in custom fee scenario to reduce costs
* Rename `@tokenbase` to `@token`
* Rename `@topicmessagebase` tag to `@topic`

**Related issue(s)**:

Fixes #6959

**Notes for reviewer**:

Cleanup after changes:
```
2023-09-25T16:03:01.917Z  INFO ForkJoinPool-1-worker-1 c.h.m.t.e.a.c.TokenClient Deleting 9 tokens and dissociating 29 token relationships 
2023-09-25T16:04:18.609Z  INFO ForkJoinPool-1-worker-1 c.h.m.t.e.a.c.ContractClient Deleting 7 contracts 
2023-09-25T16:04:33.172Z  INFO ForkJoinPool-1-worker-1 c.h.m.t.e.a.c.FileClient Deleting 8 files 
2023-09-25T16:04:49.520Z  INFO ForkJoinPool-1-worker-1 c.h.m.t.e.a.c.ScheduleClient Deleting 1 schedules 
2023-09-25T16:04:51.588Z  INFO ForkJoinPool-1-worker-1 c.h.m.t.e.a.c.TopicClient Deleting 3 topics 
2023-09-25T16:04:57.711Z  INFO ForkJoinPool-1-worker-1 c.h.m.t.e.a.c.AccountClient Deleting 5 accounts 
2023-09-25T16:05:07.963Z  WARN ForkJoinPool-1-worker-1 c.h.m.t.e.a.c.AccountClient Tests cost 697.85130818 ℏ to run 
```

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
