### PR TITLE
HIP-584: Remove unneeded store.wrap() call in ApproveAllowanceLogic

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/services/txns/crypto/ApproveAllowanceLogic.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/txns/crypto/ApproveAllowanceLogic.java
@@ -180,7 +180,6 @@ public class ApproveAllowanceLogic {
         if (nftAllowances.isEmpty()) {
             return;
         }
-        Account modifiedAccount = null;
         for (final var allowance : nftAllowances) {
             final var owner = allowance.getOwner();
             var approvingAccount = fetchOwnerAccount(owner, payerAccount, store, accountsChanged);
@@ -201,7 +200,7 @@ public class ApproveAllowanceLogic {
                 final var accountWithUpdatedApproveForAllNfts =
                         approvingAccount.setApproveForAllNfts(approveForAllNfts);
                 if (!accountWithUpdatedApproveForAllNfts.equals(approvingAccount)) {
-                    modifiedAccount = accountWithUpdatedApproveForAllNfts;
+                    accountsChanged.put(approvingAccount.getId().num(), approvingAccount);
                 }
             }
 
@@ -214,9 +213,6 @@ public class ApproveAllowanceLogic {
                     store, approvingAccount.getId(), spenderId, tokenId, allowance.getSerialNumbersList());
             for (final var nft : nfts) {
                 nftsTouched.put(nft.getNftId(), nft);
-            }
-            if (modifiedAccount != null) {
-                accountsChanged.put(approvingAccount.getId().num(), approvingAccount);
             }
         }
     }

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/txns/crypto/ApproveAllowanceLogic.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/txns/crypto/ApproveAllowanceLogic.java
@@ -180,6 +180,7 @@ public class ApproveAllowanceLogic {
         if (nftAllowances.isEmpty()) {
             return;
         }
+        Account modifiedAccount = null;
         for (final var allowance : nftAllowances) {
             final var owner = allowance.getOwner();
             var approvingAccount = fetchOwnerAccount(owner, payerAccount, store, accountsChanged);
@@ -197,7 +198,11 @@ public class ApproveAllowanceLogic {
                     // Need not validate anything here to revoke the approval
                     approveForAllNfts.remove(key);
                 }
-                approvingAccount = approvingAccount.setApproveForAllNfts(approveForAllNfts);
+                final var accountWithUpdatedApproveForAllNfts =
+                        approvingAccount.setApproveForAllNfts(approveForAllNfts);
+                if (!accountWithUpdatedApproveForAllNfts.equals(approvingAccount)) {
+                    modifiedAccount = accountWithUpdatedApproveForAllNfts;
+                }
             }
 
             if (allowance.getSerialNumbersCount() > 0) {
@@ -207,11 +212,12 @@ public class ApproveAllowanceLogic {
 
             final var nfts = updateSpender(
                     store, approvingAccount.getId(), spenderId, tokenId, allowance.getSerialNumbersList());
-            store.wrap();
             for (final var nft : nfts) {
                 nftsTouched.put(nft.getNftId(), nft);
             }
-            accountsChanged.put(approvingAccount.getId().num(), approvingAccount);
+            if (modifiedAccount != null) {
+                accountsChanged.put(approvingAccount.getId().num(), approvingAccount);
+            }
         }
     }
 


### PR DESCRIPTION
**Description**:
In ApproveAllowanceLogic#applyNftAllowances() there is an extra store.wrap() call and the stack frames grow unnecessary. This call is now removed.

Fixes https://github.com/hashgraph/hedera-mirror-node/issues/6963
