### PR TITLE
Update citus version to  12.1.0

### DIFF
--- a/charts/hedera-mirror/values.yaml
+++ b/charts/hedera-mirror/values.yaml
@@ -286,7 +286,7 @@ stackgres:
   enabled: false
   extensions:
     - name: citus
-      version: "12.0-1"
+      version: "12.1.0"
     - name: btree_gist
       version: stable
   nameOverride: citus

--- a/charts/hedera-mirror/values.yaml
+++ b/charts/hedera-mirror/values.yaml
@@ -72,9 +72,9 @@ fullnameOverride: ""
 
 global:
   hostname: ""
-  image: { }
+  image: {}
   namespaceOverride: ""
-  podAnnotations: { }
+  podAnnotations: {}
   useReleaseForNameLabel: false  # Set the name label to the release name for Marketplace
 
 graphql:
@@ -108,7 +108,7 @@ importer:
     - secretRef:
         name: "{{ .Release.Name }}-redis"
 
-labels: { }
+labels: {}
 
 monitor:
   enabled: true
@@ -286,7 +286,7 @@ stackgres:
   enabled: false
   extensions:
     - name: citus
-      version: "12.0.1"
+      version: "12.0-1"
     - name: btree_gist
       version: stable
   nameOverride: citus
@@ -337,7 +337,7 @@ test:
               baseUrl: "http://{{ .Release.Name }}-web3"
   cucumberTags: "@acceptance"
   enabled: false
-  env: { }
+  env: {}
   args:
     - -Dcucumber.ansi-colors.disabled=true
     - -Dcucumber.filter.tags={{ .Values.test.cucumberTags }}

--- a/charts/hedera-mirror/values.yaml
+++ b/charts/hedera-mirror/values.yaml
@@ -72,9 +72,9 @@ fullnameOverride: ""
 
 global:
   hostname: ""
-  image: {}
+  image: { }
   namespaceOverride: ""
-  podAnnotations: {}
+  podAnnotations: { }
   useReleaseForNameLabel: false  # Set the name label to the release name for Marketplace
 
 graphql:
@@ -108,7 +108,7 @@ importer:
     - secretRef:
         name: "{{ .Release.Name }}-redis"
 
-labels: {}
+labels: { }
 
 monitor:
   enabled: true
@@ -286,7 +286,7 @@ stackgres:
   enabled: false
   extensions:
     - name: citus
-      version: "12.0-1"
+      version: "12.0.1"
     - name: btree_gist
       version: stable
   nameOverride: citus
@@ -337,7 +337,7 @@ test:
               baseUrl: "http://{{ .Release.Name }}-web3"
   cucumberTags: "@acceptance"
   enabled: false
-  env: {}
+  env: { }
   args:
     - -Dcucumber.ansi-colors.disabled=true
     - -Dcucumber.filter.tags={{ .Values.test.cucumberTags }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
   citus:
-    image: gcr.io/mirrornode/citus:12.0.0
+    image: gcr.io/mirrornode/citus:12.0.1
     deploy:
       replicas: 0
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
   citus:
-    image: gcr.io/mirrornode/citus:12.0.1
+    image: gcr.io/mirrornode/citus:12.1.0
     deploy:
       replicas: 0
     environment:

--- a/docs/importer/README.md
+++ b/docs/importer/README.md
@@ -78,35 +78,28 @@ For local testing the importer can be run using the following command:
 ```
 
 ## Building the Citus docker image
-
 The citus image is built and then pushed to our [Google Cloud Registry](https://gcr.io/mirrornode).
 A multi-platform alpine linux image is built in order to be used for local testing (arm64 on M-series Macs).
 This image will need to be maintained until the [upstream builder](https://github.com/citusdata/docker/tree/master)
 provides a multi-platform build supporting arm64.
 
-In production and ci environments, citus is enabled through stackgres SGShardedCluster and doesn't use the custom image.
+In production and ci environments, citus is enabled through stackgres SGShardedCluster and doesn't use the custom image. 
 
-`DockerFile` to build a custom image to be used in v2 testing is located
-in [Citus's upstream repository](https://github.com/citusdata/docker). To build this image:
+`DockerFile` to build a custom image to be used in v2 testing is located in [Citus's upstream repository](https://github.com/citusdata/docker). To build this image:
 
 ### GCR details
-
 You authenticate with the registry via gcloud:
 
 ```console
 gcloud auth configure-docker gcr.io
 ```
-
 You should see output similar to:
-
 ```console
 Adding credentials for: gcr.io
 ```
 
 ### Build
-
-The instructions here pertain to building the multi-platform alpine image on an M-series Mac using Docker Desktop.
-Please refer to
+The instructions here pertain to building the multi-platform alpine image on an M-series Mac using Docker Desktop. Please refer to
 [Multi-platform images](https://docs.docker.com/build/building/multi-platform/) for an overview on how to use Docker
 Desktop to do this.
 
@@ -122,13 +115,11 @@ mybuilder
 ```
 
 Switch to the new builder:
-
 ```console
 docker buildx use mybuilder
 ```
 
 Checkout the upstream project containing the docker file
-
 ```
 git clone git@github.com:citusdata/docker.git
 cd docker
@@ -136,7 +127,6 @@ cd docker
 
 Build the image for both amd64 (Github CI) and arm64 (local testing). Don't forget the '.' at the end of the line. This
 can take some time depending on your internet speed. You will see activity around both arm64 and amd64.
-
 ```console
 $ docker buildx build --platform linux/arm64,linux/amd64 -t gcr.io/mirrornode/citus:12.1.0 --file alpine/Dockerfile  .
 [+] Building 351.1s (28/28) FINISHED
@@ -150,19 +140,14 @@ $ docker buildx build --platform linux/arm64,linux/amd64 -t gcr.io/mirrornode/ci
  => [linux/arm64  1/11] FROM docker.io/library/postgres:15.1-alpine@sha256:f19eede5a214c0933dce30c2e734b787b4c09193e874cce3b26c5d54b8b77ec7              28.0s
  WARNING: No output specified with docker-container driver. Build result will only remain in the build cache. To push result image into registry use --push or to load image into docker use --load
 ```
-
-Again, this does not push the image. If you prefer, you can add `--push` to the command above and push the image at this
-time
+Again, this does not push the image. If you prefer, you can add `--push` to the command above and push the image at this time
 rather than as a separate step below.
 
 ## Publishing the Citus docker images
 
 If you did not utilize `--push` with `docker buildx` when building the alpine image, push it now to Docker Hub.
-
 ```console
 docker push gcr.io/mirrornode/citus:12.1.0
 ```
-
-You can then see that the images have been updated
-in [the repository](https://hub.docker.com/repository/docker/mirrornodeswirldslabs/citus/general).
+You can then see that the images have been updated in [the repository](https://hub.docker.com/repository/docker/mirrornodeswirldslabs/citus/general).
 If you click on the tags you can see the OS/ARCH supported by each.

--- a/docs/importer/README.md
+++ b/docs/importer/README.md
@@ -78,28 +78,35 @@ For local testing the importer can be run using the following command:
 ```
 
 ## Building the Citus docker image
+
 The citus image is built and then pushed to our [Google Cloud Registry](https://gcr.io/mirrornode).
 A multi-platform alpine linux image is built in order to be used for local testing (arm64 on M-series Macs).
 This image will need to be maintained until the [upstream builder](https://github.com/citusdata/docker/tree/master)
 provides a multi-platform build supporting arm64.
 
-In production and ci environments, citus is enabled through stackgres SGShardedCluster and doesn't use the custom image. 
+In production and ci environments, citus is enabled through stackgres SGShardedCluster and doesn't use the custom image.
 
-`DockerFile` to build a custom image to be used in v2 testing is located in [Citus's upstream repository](https://github.com/citusdata/docker). To build this image:
+`DockerFile` to build a custom image to be used in v2 testing is located
+in [Citus's upstream repository](https://github.com/citusdata/docker). To build this image:
 
 ### GCR details
+
 You authenticate with the registry via gcloud:
 
 ```console
 gcloud auth configure-docker gcr.io
 ```
+
 You should see output similar to:
+
 ```console
 Adding credentials for: gcr.io
 ```
 
 ### Build
-The instructions here pertain to building the multi-platform alpine image on an M-series Mac using Docker Desktop. Please refer to
+
+The instructions here pertain to building the multi-platform alpine image on an M-series Mac using Docker Desktop.
+Please refer to
 [Multi-platform images](https://docs.docker.com/build/building/multi-platform/) for an overview on how to use Docker
 Desktop to do this.
 
@@ -115,11 +122,13 @@ mybuilder
 ```
 
 Switch to the new builder:
+
 ```console
 docker buildx use mybuilder
 ```
 
 Checkout the upstream project containing the docker file
+
 ```
 git clone git@github.com:citusdata/docker.git
 cd docker
@@ -127,8 +136,9 @@ cd docker
 
 Build the image for both amd64 (Github CI) and arm64 (local testing). Don't forget the '.' at the end of the line. This
 can take some time depending on your internet speed. You will see activity around both arm64 and amd64.
+
 ```console
-$ docker buildx build --platform linux/arm64,linux/amd64 -t gcr.io/mirrornode/citus:12.0.0 --file alpine/Dockerfile  .
+$ docker buildx build --platform linux/arm64,linux/amd64 -t gcr.io/mirrornode/citus:12.0.1 --file alpine/Dockerfile  .
 [+] Building 351.1s (28/28) FINISHED
  => [internal] load .dockerignore                                                                                                                         0.0s
  => => transferring context: 2B                                                                                                                           0.0s
@@ -140,14 +150,19 @@ $ docker buildx build --platform linux/arm64,linux/amd64 -t gcr.io/mirrornode/ci
  => [linux/arm64  1/11] FROM docker.io/library/postgres:15.1-alpine@sha256:f19eede5a214c0933dce30c2e734b787b4c09193e874cce3b26c5d54b8b77ec7              28.0s
  WARNING: No output specified with docker-container driver. Build result will only remain in the build cache. To push result image into registry use --push or to load image into docker use --load
 ```
-Again, this does not push the image. If you prefer, you can add `--push` to the command above and push the image at this time
+
+Again, this does not push the image. If you prefer, you can add `--push` to the command above and push the image at this
+time
 rather than as a separate step below.
 
 ## Publishing the Citus docker images
 
 If you did not utilize `--push` with `docker buildx` when building the alpine image, push it now to Docker Hub.
+
 ```console
 docker push gcr.io/mirrornode/citus:12.0.0
 ```
-You can then see that the images have been updated in [the repository](https://hub.docker.com/repository/docker/mirrornodeswirldslabs/citus/general).
+
+You can then see that the images have been updated
+in [the repository](https://hub.docker.com/repository/docker/mirrornodeswirldslabs/citus/general).
 If you click on the tags you can see the OS/ARCH supported by each.

--- a/docs/importer/README.md
+++ b/docs/importer/README.md
@@ -138,7 +138,7 @@ Build the image for both amd64 (Github CI) and arm64 (local testing). Don't forg
 can take some time depending on your internet speed. You will see activity around both arm64 and amd64.
 
 ```console
-$ docker buildx build --platform linux/arm64,linux/amd64 -t gcr.io/mirrornode/citus:12.0.1 --file alpine/Dockerfile  .
+$ docker buildx build --platform linux/arm64,linux/amd64 -t gcr.io/mirrornode/citus:12.1.0 --file alpine/Dockerfile  .
 [+] Building 351.1s (28/28) FINISHED
  => [internal] load .dockerignore                                                                                                                         0.0s
  => => transferring context: 2B                                                                                                                           0.0s
@@ -160,7 +160,7 @@ rather than as a separate step below.
 If you did not utilize `--push` with `docker buildx` when building the alpine image, push it now to Docker Hub.
 
 ```console
-docker push gcr.io/mirrornode/citus:12.0.0
+docker push gcr.io/mirrornode/citus:12.1.0
 ```
 
 You can then see that the images have been updated

--- a/hedera-mirror-graphql/src/test/resources/bootstrap-v2.yml
+++ b/hedera-mirror-graphql/src/test/resources/bootstrap-v2.yml
@@ -1,6 +1,6 @@
 embedded:
   postgresql:
-    docker-image: gcr.io/mirrornode/citus:12.0.1
+    docker-image: gcr.io/mirrornode/citus:12.1.0
     initScriptPath: db/init-v2.sql
 spring:
   flyway:

--- a/hedera-mirror-graphql/src/test/resources/bootstrap-v2.yml
+++ b/hedera-mirror-graphql/src/test/resources/bootstrap-v2.yml
@@ -1,6 +1,6 @@
 embedded:
   postgresql:
-    docker-image: gcr.io/mirrornode/citus:12.0.0
+    docker-image: gcr.io/mirrornode/citus:12.0.1
     initScriptPath: db/init-v2.sql
 spring:
   flyway:

--- a/hedera-mirror-grpc/src/test/resources/config/bootstrap-v2.yml
+++ b/hedera-mirror-grpc/src/test/resources/config/bootstrap-v2.yml
@@ -1,6 +1,6 @@
 embedded:
   postgresql:
-    docker-image: gcr.io/mirrornode/citus:12.0.0
+    docker-image: gcr.io/mirrornode/citus:12.0.1
     initScriptPath: db/scripts/init-v2.sql
 spring:
   flyway:

--- a/hedera-mirror-grpc/src/test/resources/config/bootstrap-v2.yml
+++ b/hedera-mirror-grpc/src/test/resources/config/bootstrap-v2.yml
@@ -1,6 +1,6 @@
 embedded:
   postgresql:
-    docker-image: gcr.io/mirrornode/citus:12.0.1
+    docker-image: gcr.io/mirrornode/citus:12.1.0
     initScriptPath: db/scripts/init-v2.sql
 spring:
   flyway:

--- a/hedera-mirror-importer/src/test/resources/config/bootstrap-v2.yml
+++ b/hedera-mirror-importer/src/test/resources/config/bootstrap-v2.yml
@@ -1,4 +1,4 @@
 embedded:
   postgresql:
-    docker-image: gcr.io/mirrornode/citus:12.0.0
+    docker-image: gcr.io/mirrornode/citus:12.0.1
     initScriptPath: db/scripts/init-v2.sql

--- a/hedera-mirror-importer/src/test/resources/config/bootstrap-v2.yml
+++ b/hedera-mirror-importer/src/test/resources/config/bootstrap-v2.yml
@@ -1,4 +1,4 @@
 embedded:
   postgresql:
-    docker-image: gcr.io/mirrornode/citus:12.0.1
+    docker-image: gcr.io/mirrornode/citus:12.1.0
     initScriptPath: db/scripts/init-v2.sql

--- a/hedera-mirror-rest-java/src/test/resources/bootstrap-v2.yml
+++ b/hedera-mirror-rest-java/src/test/resources/bootstrap-v2.yml
@@ -1,6 +1,6 @@
 embedded:
   postgresql:
-    docker-image: gcr.io/mirrornode/citus:12.0.0
+    docker-image: gcr.io/mirrornode/citus:12.0.1
     initScriptPath: db/scripts/init-v2.sql
 spring:
   flyway:

--- a/hedera-mirror-rest-java/src/test/resources/bootstrap-v2.yml
+++ b/hedera-mirror-rest-java/src/test/resources/bootstrap-v2.yml
@@ -1,6 +1,6 @@
 embedded:
   postgresql:
-    docker-image: gcr.io/mirrornode/citus:12.0.1
+    docker-image: gcr.io/mirrornode/citus:12.1.0
     initScriptPath: db/scripts/init-v2.sql
 spring:
   flyway:

--- a/hedera-mirror-rest/__tests__/globalSetup.js
+++ b/hedera-mirror-rest/__tests__/globalSetup.js
@@ -58,10 +58,7 @@ const createDbContainer = async (maxWorkers) => {
         grant temporary on database ${dbName} to ${poolConfig.user};
         alter type timestamptz owner to ${poolConfig.user}`;
 
-      const workerPool = new pg.Pool({
-        ...poolConfig,
-        database: dbName,
-      });
+      const workerPool = new pg.Pool({...poolConfig, database: dbName});
       await workerPool.query(query);
       await workerPool.end();
     }

--- a/hedera-mirror-rest/__tests__/globalSetup.js
+++ b/hedera-mirror-rest/__tests__/globalSetup.js
@@ -22,7 +22,7 @@ import {PostgreSqlContainer} from '@testcontainers/postgresql';
 
 const dbNamePrefix = 'test';
 const v1DatabaseImage = 'postgres:14-alpine';
-const v2DatabaseImage = 'gcr.io/mirrornode/citus:12.0.1';
+const v2DatabaseImage = 'gcr.io/mirrornode/citus:12.1.0';
 
 const isV2Schema = () => process.env.MIRROR_NODE_SCHEMA === 'v2';
 

--- a/hedera-mirror-rest/__tests__/globalSetup.js
+++ b/hedera-mirror-rest/__tests__/globalSetup.js
@@ -22,7 +22,7 @@ import {PostgreSqlContainer} from '@testcontainers/postgresql';
 
 const dbNamePrefix = 'test';
 const v1DatabaseImage = 'postgres:14-alpine';
-const v2DatabaseImage = 'gcr.io/mirrornode/citus:12.0.0';
+const v2DatabaseImage = 'gcr.io/mirrornode/citus:12.0.1';
 
 const isV2Schema = () => process.env.MIRROR_NODE_SCHEMA === 'v2';
 
@@ -58,7 +58,10 @@ const createDbContainer = async (maxWorkers) => {
         grant temporary on database ${dbName} to ${poolConfig.user};
         alter type timestamptz owner to ${poolConfig.user}`;
 
-      const workerPool = new pg.Pool({...poolConfig, database: dbName});
+      const workerPool = new pg.Pool({
+        ...poolConfig,
+        database: dbName,
+      });
       await workerPool.query(query);
       await workerPool.end();
     }

--- a/hedera-mirror-web3/src/test/resources/bootstrap-v2.yml
+++ b/hedera-mirror-web3/src/test/resources/bootstrap-v2.yml
@@ -1,6 +1,6 @@
 embedded:
   postgresql:
-    docker-image: gcr.io/mirrornode/citus:12.0.0
+    docker-image: gcr.io/mirrornode/citus:12.0.1
     initScriptPath: db/scripts/init-v2.sql
 spring:
   flyway:

--- a/hedera-mirror-web3/src/test/resources/bootstrap-v2.yml
+++ b/hedera-mirror-web3/src/test/resources/bootstrap-v2.yml
@@ -1,6 +1,6 @@
 embedded:
   postgresql:
-    docker-image: gcr.io/mirrornode/citus:12.0.1
+    docker-image: gcr.io/mirrornode/citus:12.1.0
     initScriptPath: db/scripts/init-v2.sql
 spring:
   flyway:


### PR DESCRIPTION
**Description**:

Citus 12.1 was released and this is an upgrade in our v2 schema.

This PR modifies 
* Citus version for all modules for v2
* Adds documentation to build citus 12.1.0 to gcr.io/mirrornode/citus


**Related issue(s)**:

Fixes #6886

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
