### PR TITLE
Add contract caching mechanism for acceptance tests

### DIFF
--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/CallFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/CallFeature.java
@@ -88,19 +88,19 @@ public class CallFeature extends AbstractFeature {
 
     @Given("I successfully create ERC contract")
     public void createNewERCtestContract() throws IOException {
-        deployedContract = createContract(ercTestContract, 0);
+        deployedContract = getContract(ContractResource.ERC_TEST_CONTRACT);
         ercContractAddress = deployedContract.contractId().toSolidityAddress();
     }
 
     @Given("I successfully create Precompile contract")
     public void createNewPrecompileTestContract() throws IOException {
-        deployedContract = createContract(precompileTestContract, 0);
+        deployedContract = getContract(ContractResource.PRECOMPILE_TEST_CONTRACT);
         precompileContractAddress = deployedContract.contractId().toSolidityAddress();
     }
 
     @Given("I successfully create EstimateGas contract")
     public void createNewEstimateTestContract() throws IOException {
-        deployedContract = createContract(estimateGasTestContract, 1000000);
+        deployedContract = getContract(ContractResource.ESTIMATE_GAS_TEST_CONTRACT);
         estimateContractAddress = deployedContract.contractId().toSolidityAddress();
         receiverAccountId = accountClient.getAccount(AccountNameEnum.BOB);
     }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ContractFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ContractFeature.java
@@ -77,9 +77,9 @@ public class ContractFeature extends AbstractFeature {
 
     private byte[] childContractBytecodeFromParent;
 
-    @Given("I successfully create a contract from the parent contract bytes with {int} balance")
-    public void createNewContract(int initialBalance) throws IOException {
-        deployedParentContract = createContract(parentContract, initialBalance);
+    @Given("I successfully create a contract from the parent contract bytes with 10000000 balance")
+    public void createNewContract() throws IOException {
+        deployedParentContract = getContract(ContractResource.PARENT_CONTRACT);
     }
 
     @Given("I successfully call the contract")

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ERCContractFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ERCContractFeature.java
@@ -321,7 +321,7 @@ public class ERCContractFeature extends AbstractFeature {
 
     @Given("I successfully create an erc contract from contract bytes with balance 0")
     public void createNewContract() throws IOException {
-        deployedErcContract = createContract(ercContract, 0);
+        deployedErcContract = getContract(ContractResource.ERC_TEST_CONTRACT);
         ercTestContractSolidityAddress = deployedErcContract.contractId().toSolidityAddress();
     }
 

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/EstimateFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/EstimateFeature.java
@@ -54,9 +54,9 @@ public class EstimateFeature extends AbstractEstimateFeature {
     private String newAccountEvmAddress;
     private ExpandedAccountId receiverAccountId;
 
-    @Given("I successfully create contract from contract bytes with {int} balance")
-    public void createNewEstimateContract(int supply) throws IOException {
-        deployedContract = createContract(estimateGasTestContract, supply);
+    @Given("I successfully create EstimateGas contract from contract bytes")
+    public void createNewEstimateContract() throws IOException {
+        deployedContract = getContract(ContractResource.ESTIMATE_GAS_TEST_CONTRACT);
         contractSolidityAddress = deployedContract.contractId().toSolidityAddress();
         newAccountEvmAddress =
                 PrivateKey.generateECDSA().getPublicKey().toEvmAddress().toString();

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/EstimatePrecompileFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/EstimatePrecompileFeature.java
@@ -88,9 +88,9 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     private String ercTestContractSolidityAddress;
     private String precompileTestContractSolidityAddress;
 
-    @Given("I create estimate precompile contract with {int} balance")
-    public void createNewEstimateContract(int supply) throws IOException {
-        deployedEstimatePrecompileContract = createContract(estimatePrecompileTestContract, supply);
+    @Given("I create estimate precompile contract with 0 balance")
+    public void createNewEstimateContract() throws IOException {
+        deployedEstimatePrecompileContract = getContract(ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT);
         estimatePrecompileContractSolidityAddress =
                 deployedEstimatePrecompileContract.contractId().toSolidityAddress();
         admin = tokenClient.getSdkClient().getExpandedOperatorAccountId();
@@ -99,9 +99,9 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
         receiverAccountAlias = receiverAccount.getPublicKey().toEvmAddress().toString();
     }
 
-    @Given("I create erc test contract with {int} balance")
-    public void createNewERCContract(int supply) throws IOException {
-        deployedErcTestContract = createContract(ercTestContract, supply);
+    @Given("I create erc test contract with 0 balance")
+    public void createNewERCContract() throws IOException {
+        deployedErcTestContract = getContract(ContractResource.ERC_TEST_CONTRACT);
         ercTestContractSolidityAddress = deployedErcTestContract.contractId().toSolidityAddress();
     }
 
@@ -110,9 +110,9 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
         exchangeRates = mirrorClient.getExchangeRates();
     }
 
-    @Given("I successfully create Precompile contract with {int} balance")
-    public void createNewPrecompileTestContract(int supply) throws IOException {
-        deployedPrecompileContract = createContract(precompileTestContract, supply);
+    @Given("I successfully create Precompile contract with 0 balance")
+    public void createNewPrecompileTestContract() throws IOException {
+        deployedPrecompileContract = getContract(ContractResource.PRECOMPILE_TEST_CONTRACT);
         precompileTestContractSolidityAddress =
                 deployedPrecompileContract.contractId().toSolidityAddress();
     }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/PrecompileContractFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/PrecompileContractFeature.java
@@ -91,7 +91,7 @@ public class PrecompileContractFeature extends AbstractFeature {
 
     @Given("I successfully create and verify a precompile contract from contract bytes")
     public void createNewContract() throws IOException {
-        deployedPrecompileContract = createContract(precompileTestContract, 0);
+        deployedPrecompileContract = getContract(ContractResource.PRECOMPILE_TEST_CONTRACT);
         precompileTestContractSolidityAddress =
                 deployedPrecompileContract.contractId().toSolidityAddress();
     }

--- a/hedera-mirror-test/src/test/resources/features/contract/contract.feature
+++ b/hedera-mirror-test/src/test/resources/features/contract/contract.feature
@@ -18,7 +18,7 @@ Feature: Contract Base Coverage Feature
         to cause its self destruction, vacating the EVM address for future use. Also, Finally, delete the original parent
         contract and its underlying bytecode file.
 
-        Given I successfully create a contract from the parent contract bytes with <initialBalance> balance
+        Given I successfully create a contract from the parent contract bytes with 10000000 balance
         Then the mirror node REST API should return status <httpStatusCode> for the contract transaction
         And the mirror node REST API should verify the deployed contract entity
         When I successfully update the contract
@@ -47,5 +47,5 @@ Feature: Contract Base Coverage Feature
         And the mirror node REST API should verify the deleted contract entity
         Then I successfully delete the parent contract bytecode file
         Examples:
-            | httpStatusCode | initialBalance | transferAmount |
-            | 200            | 10000000       | 1000           |
+            | httpStatusCode | transferAmount |
+            | 200            | 1000           |

--- a/hedera-mirror-test/src/test/resources/features/contract/estimate.feature
+++ b/hedera-mirror-test/src/test/resources/features/contract/estimate.feature
@@ -2,7 +2,7 @@
 Feature: EstimateGas Contract Base Coverage Feature
 
   Scenario Outline: Validate EstimateGas
-    Given I successfully create contract from contract bytes with 10000000 balance
+    Given I successfully create EstimateGas contract from contract bytes
     Given I successfully create fungible token
     And lower deviation is 5% and upper deviation is 20%
     Then I call estimateGas without arguments that multiplies two numbers


### PR DESCRIPTION
**Description**: This PR introduces a caching mechanism to retrieve already created contracts, reducing the cost and redundancy of deploying the same contract in multiple test suites. 
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #6789

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
