### PR TITLE
Bump graphql-java-generator from 2.2 to 2.3.1

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
     implementation("com.github.node-gradle:gradle-node-plugin:7.0.0")
     implementation("com.google.protobuf:protobuf-gradle-plugin:0.9.4")
     implementation("com.gorylenko.gradle-git-properties:gradle-git-properties:2.4.1")
-    implementation("com.graphql-java-generator:graphql-gradle-plugin3:2.2")
+    implementation("com.graphql-java-generator:graphql-gradle-plugin3:2.3.1")
     implementation("gradle.plugin.io.snyk.gradle.plugin:snyk:0.5")
     implementation("io.freefair.gradle:lombok-plugin:8.3")
     implementation("io.spring.gradle:dependency-management-plugin:1.1.3")

--- a/buildSrc/src/main/kotlin/java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-conventions.gradle.kts
@@ -62,8 +62,7 @@ dependencies {
 
 tasks.compileJava {
     dependsOn("generateEffectiveLombokConfig")
-    // Can remove -Xlint:-cast after https://github.com/graphql-java-generator/graphql-gradle-plugin-project/issues/15
-    options.compilerArgs.addAll(listOf("-Werror", "-Xlint:all", "-Xlint:-cast"))
+    options.compilerArgs.addAll(listOf("-Werror", "-Xlint:all"))
     options.encoding = "UTF-8"
     sourceCompatibility = "17"
     targetCompatibility = "17"


### PR DESCRIPTION
**Description**:

* Bump graphql-java-generator from 2.2 to 2.3.1
* Drop `-Xlint:-cast` workaround

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
