### PR TITLE
Fix GCP Marketplace workflow

### DIFF
--- a/charts/marketplace/gcp/Dockerfile
+++ b/charts/marketplace/gcp/Dockerfile
@@ -2,7 +2,7 @@
 FROM gcr.io/cloud-marketplace-tools/k8s/deployer_helm AS build
 
 # Install yq
-RUN wget https://github.com/mikefarah/yq/releases/download/v4.25.3/yq_linux_amd64 \
+RUN wget https://github.com/mikefarah/yq/releases/download/v4.35.2/yq_linux_amd64 \
     && mv yq_linux_amd64 /usr/local/bin/yq \
     && chmod +x /usr/local/bin/yq
 

--- a/charts/marketplace/gcp/values.yaml
+++ b/charts/marketplace/gcp/values.yaml
@@ -58,6 +58,10 @@ importer:
   rbac:
     enabled: false
   replicas: 1
+  resources:
+    requests:
+      cpu: 200m
+      memory: 512Mi
   serviceAccount:
     create: false
 


### PR DESCRIPTION
**Description**:

* Bump yq from 4.25.3 to 4.35.2
* Fix workflow failure due to importer resources

**Related issue(s)**:

Fixes #6961

**Notes for reviewer**:

You can see a "working" workflow [here](https://github.com/hashgraph/hedera-mirror-node/actions/runs/6384105951/job/17326061640). The demo bucket does not currently work so it gets past the previous scheduling error but still fails.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
