### PR TITLE
Refactor test suites to use headlong function encoding

### DIFF
--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AbstractEstimateFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AbstractEstimateFeature.java
@@ -19,11 +19,9 @@ package com.hedera.mirror.test.e2e.acceptance.steps;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.esaulpaugh.headlong.util.Strings;
 import com.hedera.mirror.test.e2e.acceptance.client.MirrorNodeClient;
 import com.hedera.mirror.test.e2e.acceptance.props.ContractCallRequest;
 import com.hedera.mirror.test.e2e.acceptance.response.ContractCallResponse;
-import java.nio.ByteBuffer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 
@@ -70,10 +68,9 @@ abstract class AbstractEstimateFeature extends AbstractFeature {
      * @param solidityAddress The address of the solidity contract.
      * @throws AssertionError If the actual gas used is not within the acceptable deviation range.
      */
-    protected void validateGasEstimation(
-            ByteBuffer data, ContractMethodInterface actualGasUsed, String solidityAddress) {
+    protected void validateGasEstimation(String data, ContractMethodInterface actualGasUsed, String solidityAddress) {
         var contractCallRequestBody = ContractCallRequest.builder()
-                .data(Strings.encode(data))
+                .data(data)
                 .to(solidityAddress)
                 .estimate(true)
                 .build();
@@ -90,13 +87,13 @@ abstract class AbstractEstimateFeature extends AbstractFeature {
      * then sends the request. It expects the call to result in a "400 Bad Request" response, and will throw an
      * assertion error if the response is anything other than that.
      *
-     * @param encodedFunctionCall The encoded function data to be sent.
+     * @param data The encoded function data to be sent.
      * @param contractAddress     The address of the contract.
      * @throws AssertionError If the response from the contract call does not contain "400 Bad Request from POST".
      */
-    protected void assertContractCallReturnsBadRequest(ByteBuffer encodedFunctionCall, String contractAddress) {
+    protected void assertContractCallReturnsBadRequest(String data, String contractAddress) {
         var contractCallRequestBody = ContractCallRequest.builder()
-                .data(Strings.encode(encodedFunctionCall))
+                .data(data)
                 .to(contractAddress)
                 .estimate(true)
                 .build();

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AbstractEstimateFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AbstractEstimateFeature.java
@@ -25,8 +25,6 @@ import com.hedera.mirror.test.e2e.acceptance.props.ContractCallRequest;
 import com.hedera.mirror.test.e2e.acceptance.response.ContractCallResponse;
 import java.nio.ByteBuffer;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.io.Resource;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 
 abstract class AbstractEstimateFeature extends AbstractFeature {
@@ -36,18 +34,6 @@ abstract class AbstractEstimateFeature extends AbstractFeature {
 
     @Autowired
     protected MirrorNodeClient mirrorClient;
-
-    @Value("classpath:solidity/artifacts/contracts/EstimatePrecompileContract.sol/EstimatePrecompileContract.json")
-    protected Resource estimatePrecompileTestContract;
-
-    @Value("classpath:solidity/artifacts/contracts/ERCTestContract.sol/ERCTestContract.json")
-    protected Resource ercTestContract;
-
-    @Value("classpath:solidity/artifacts/contracts/PrecompileTestContract.sol/PrecompileTestContract.json")
-    protected Resource precompileTestContract;
-
-    @Value("classpath:solidity/artifacts/contracts/EstimateGasContract.sol/EstimateGasContract.json")
-    protected Resource estimateGasTestContract;
 
     /**
      * Checks if the estimatedGas is within the specified range of the actualGas.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AbstractEstimateFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AbstractEstimateFeature.java
@@ -70,16 +70,17 @@ abstract class AbstractEstimateFeature extends AbstractFeature {
      * @param solidityAddress The address of the solidity contract.
      * @throws AssertionError If the actual gas used is not within the acceptable deviation range.
      */
-    protected void validateGasEstimation(String data, int actualGasUsed, String solidityAddress) {
+    protected void validateGasEstimation(
+            ByteBuffer data, ContractMethodInterface actualGasUsed, String solidityAddress) {
         var contractCallRequestBody = ContractCallRequest.builder()
-                .data(data)
+                .data(Strings.encode(data))
                 .to(solidityAddress)
                 .estimate(true)
                 .build();
         ContractCallResponse msgSenderResponse = mirrorClient.contractsCall(contractCallRequestBody);
         int estimatedGas = msgSenderResponse.getResultAsNumber().intValue();
 
-        assertTrue(isWithinDeviation(actualGasUsed, estimatedGas, lowerDeviation, upperDeviation));
+        assertTrue(isWithinDeviation(actualGasUsed.getActualGas(), estimatedGas, lowerDeviation, upperDeviation));
     }
 
     /**

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/CallFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/CallFeature.java
@@ -16,9 +16,9 @@
 
 package com.hedera.mirror.test.e2e.acceptance.steps;
 
-import static com.hedera.mirror.test.e2e.acceptance.steps.AbstractFeature.ContractResource.ERC_TEST_CONTRACT;
-import static com.hedera.mirror.test.e2e.acceptance.steps.AbstractFeature.ContractResource.ESTIMATE_GAS_TEST_CONTRACT;
-import static com.hedera.mirror.test.e2e.acceptance.steps.AbstractFeature.ContractResource.PRECOMPILE_TEST_CONTRACT;
+import static com.hedera.mirror.test.e2e.acceptance.steps.AbstractFeature.ContractResource.ERC;
+import static com.hedera.mirror.test.e2e.acceptance.steps.AbstractFeature.ContractResource.ESTIMATE_GAS;
+import static com.hedera.mirror.test.e2e.acceptance.steps.AbstractFeature.ContractResource.PRECOMPILE;
 import static com.hedera.mirror.test.e2e.acceptance.steps.CallFeature.ContractMethods.DEPLOY_NESTED_CONTRACT_CONTRACT_VIA_CREATE2_SELECTOR;
 import static com.hedera.mirror.test.e2e.acceptance.steps.CallFeature.ContractMethods.DEPLOY_NESTED_CONTRACT_CONTRACT_VIA_CREATE_SELECTOR;
 import static com.hedera.mirror.test.e2e.acceptance.steps.CallFeature.ContractMethods.HTS_GET_DEFAULT_FREEZE_STATUS_SELECTOR;
@@ -46,7 +46,6 @@ import com.hedera.mirror.test.e2e.acceptance.client.MirrorNodeClient;
 import com.hedera.mirror.test.e2e.acceptance.client.TokenClient;
 import com.hedera.mirror.test.e2e.acceptance.props.ExpandedAccountId;
 import com.hedera.mirror.test.e2e.acceptance.props.MirrorAccountBalance;
-import com.hedera.mirror.test.e2e.acceptance.response.ContractCallResponse;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import java.io.IOException;
@@ -93,19 +92,19 @@ public class CallFeature extends AbstractFeature {
 
     @Given("I successfully create ERC contract")
     public void createNewERCtestContract() throws IOException {
-        deployedContract = getContract(ERC_TEST_CONTRACT);
+        deployedContract = getContract(ERC);
         ercContractAddress = deployedContract.contractId().toSolidityAddress();
     }
 
     @Given("I successfully create Precompile contract")
     public void createNewPrecompileTestContract() throws IOException {
-        deployedContract = getContract(PRECOMPILE_TEST_CONTRACT);
+        deployedContract = getContract(PRECOMPILE);
         precompileContractAddress = deployedContract.contractId().toSolidityAddress();
     }
 
     @Given("I successfully create EstimateGas contract")
     public void createNewEstimateTestContract() throws IOException {
-        deployedContract = getContract(ESTIMATE_GAS_TEST_CONTRACT);
+        deployedContract = getContract(ESTIMATE_GAS);
         estimateContractAddress = deployedContract.contractId().toSolidityAddress();
         receiverAccountId = accountClient.getAccount(AccountNameEnum.BOB);
     }
@@ -117,8 +116,8 @@ public class CallFeature extends AbstractFeature {
         var tokenNameEnum = TokenClient.TokenNameEnum.valueOf(tokenName);
         var tokenId = tokenClient.getToken(tokenNameEnum).tokenId();
 
-        var data = encodeData(ERC_TEST_CONTRACT, IERC721_TOKEN_NAME_SELECTOR, asAddress(tokenId));
-        ContractCallResponse response = callContract(data, ercContractAddress);
+        var data = encodeData(ERC, IERC721_TOKEN_NAME_SELECTOR, asAddress(tokenId));
+        var response = callContract(data, ercContractAddress);
 
         assertThat(response.getResultAsText()).isEqualTo(tokenNameEnum.getSymbol() + "_name");
     }
@@ -130,8 +129,8 @@ public class CallFeature extends AbstractFeature {
         var tokenNameEnum = TokenClient.TokenNameEnum.valueOf(tokenName);
         var tokenId = tokenClient.getToken(tokenNameEnum).tokenId();
 
-        var data = encodeData(ERC_TEST_CONTRACT, IERC721_TOKEN_SYMBOL_SELECTOR, asAddress(tokenId));
-        ContractCallResponse response = callContract(data, ercContractAddress);
+        var data = encodeData(ERC, IERC721_TOKEN_SYMBOL_SELECTOR, asAddress(tokenId));
+        var response = callContract(data, ercContractAddress);
 
         assertThat(response.getResultAsText()).isEqualTo(tokenNameEnum.getSymbol());
     }
@@ -145,8 +144,8 @@ public class CallFeature extends AbstractFeature {
                 .tokenId();
         var totalSupplyOfNft = mirrorClient.getTokenInfo(tokenId.toString()).getTotalSupply();
 
-        var data = encodeData(ERC_TEST_CONTRACT, IERC721_TOKEN_TOTAL_SUPPLY_SELECTOR, asAddress(tokenId));
-        ContractCallResponse response = callContract(data, ercContractAddress);
+        var data = encodeData(ERC, IERC721_TOKEN_TOTAL_SUPPLY_SELECTOR, asAddress(tokenId));
+        var response = callContract(data, ercContractAddress);
 
         assertThat(response.getResultAsNumber()).isEqualTo(totalSupplyOfNft);
     }
@@ -167,9 +166,8 @@ public class CallFeature extends AbstractFeature {
                 .mapToLong(MirrorAccountBalance.Token::getBalance)
                 .findFirst();
 
-        var data = encodeData(
-                ERC_TEST_CONTRACT, IERC721_TOKEN_BALANCE_OF_SELECTOR, asAddress(tokenId), asAddress(contractClient));
-        ContractCallResponse response = callContract(data, ercContractAddress);
+        var data = encodeData(ERC, IERC721_TOKEN_BALANCE_OF_SELECTOR, asAddress(tokenId), asAddress(contractClient));
+        var response = callContract(data, ercContractAddress);
 
         assertThat(response.getResultAsNumber()).isEqualTo(balanceOfNft.getAsLong());
     }
@@ -182,8 +180,8 @@ public class CallFeature extends AbstractFeature {
                 .getToken(TokenClient.TokenNameEnum.valueOf(tokenName))
                 .tokenId();
 
-        var data = encodeData(PRECOMPILE_TEST_CONTRACT, HTS_IS_TOKEN_SELECTOR, asAddress(tokenId));
-        ContractCallResponse response = callContract(data, precompileContractAddress);
+        var data = encodeData(PRECOMPILE, HTS_IS_TOKEN_SELECTOR, asAddress(tokenId));
+        var response = callContract(data, precompileContractAddress);
 
         assertThat(response.getResultAsBoolean()).isTrue();
     }
@@ -196,9 +194,8 @@ public class CallFeature extends AbstractFeature {
                 .getToken(TokenClient.TokenNameEnum.valueOf(tokenName))
                 .tokenId();
 
-        var data = encodeData(
-                PRECOMPILE_TEST_CONTRACT, HTS_IS_FROZEN_SELECTOR, asAddress(tokenId), asAddress(contractClient));
-        ContractCallResponse response = callContract(data, precompileContractAddress);
+        var data = encodeData(PRECOMPILE, HTS_IS_FROZEN_SELECTOR, asAddress(tokenId), asAddress(contractClient));
+        var response = callContract(data, precompileContractAddress);
 
         assertThat(response.getResultAsBoolean()).isFalse();
     }
@@ -211,9 +208,8 @@ public class CallFeature extends AbstractFeature {
                 .getToken(TokenClient.TokenNameEnum.valueOf(tokenName))
                 .tokenId();
 
-        var data = encodeData(
-                PRECOMPILE_TEST_CONTRACT, HTS_IS_KYC_GRANTED_SELECTOR, asAddress(tokenId), asAddress(contractClient));
-        ContractCallResponse response = callContract(data, precompileContractAddress);
+        var data = encodeData(PRECOMPILE, HTS_IS_KYC_GRANTED_SELECTOR, asAddress(tokenId), asAddress(contractClient));
+        var response = callContract(data, precompileContractAddress);
 
         assertThat(response.getResultAsBoolean()).isTrue();
     }
@@ -226,8 +222,8 @@ public class CallFeature extends AbstractFeature {
                 .getToken(TokenClient.TokenNameEnum.valueOf(tokenName))
                 .tokenId();
 
-        var data = encodeData(PRECOMPILE_TEST_CONTRACT, HTS_GET_DEFAULT_FREEZE_STATUS_SELECTOR, asAddress(tokenId));
-        ContractCallResponse response = callContract(data, precompileContractAddress);
+        var data = encodeData(PRECOMPILE, HTS_GET_DEFAULT_FREEZE_STATUS_SELECTOR, asAddress(tokenId));
+        var response = callContract(data, precompileContractAddress);
 
         assertThat(response.getResultAsBoolean()).isFalse();
     }
@@ -240,8 +236,8 @@ public class CallFeature extends AbstractFeature {
                 .getToken(TokenClient.TokenNameEnum.valueOf(tokenName))
                 .tokenId();
 
-        var data = encodeData(PRECOMPILE_TEST_CONTRACT, HTS_GET_TOKEN_DEFAULT_KYC_STATUS_SELECTOR, asAddress(tokenId));
-        ContractCallResponse response = callContract(data, precompileContractAddress);
+        var data = encodeData(PRECOMPILE, HTS_GET_TOKEN_DEFAULT_KYC_STATUS_SELECTOR, asAddress(tokenId));
+        var response = callContract(data, precompileContractAddress);
 
         assertThat(response.getResultAsBoolean()).isFalse();
     }
@@ -249,24 +245,24 @@ public class CallFeature extends AbstractFeature {
     @Then("I call function with update and I expect return of the updated value")
     public void ethCallUpdateFunction() {
         var updateValue = new BigInteger("5");
-        var data = encodeData(ESTIMATE_GAS_TEST_CONTRACT, UPDATE_COUNTER_SELECTOR, updateValue);
-        ContractCallResponse response = callContract(data, estimateContractAddress);
+        var data = encodeData(ESTIMATE_GAS, UPDATE_COUNTER_SELECTOR, updateValue);
+        var response = callContract(data, estimateContractAddress);
 
         assertEquals(response.getResultAsNumber(), updateValue);
     }
 
     @Then("I call function that makes N times state update")
     public void ethCallStateUpdateNTimesFunction() {
-        var data = encodeData(ESTIMATE_GAS_TEST_CONTRACT, STATE_UPDATE_N_TIMES_SELECTOR, new BigInteger("15"));
-        ContractCallResponse response = callContract(data, estimateContractAddress);
+        var data = encodeData(ESTIMATE_GAS, STATE_UPDATE_N_TIMES_SELECTOR, new BigInteger("15"));
+        var response = callContract(data, estimateContractAddress);
 
         assertEquals(String.valueOf(response.getResultAsNumber()), "14");
     }
 
     @Then("I call function with nested deploy using create function")
     public void ethCallNestedDeployViaCreateFunction() {
-        var data = encodeData(ESTIMATE_GAS_TEST_CONTRACT, DEPLOY_NESTED_CONTRACT_CONTRACT_VIA_CREATE_SELECTOR);
-        ContractCallResponse response = callContract(data, estimateContractAddress);
+        var data = encodeData(ESTIMATE_GAS, DEPLOY_NESTED_CONTRACT_CONTRACT_VIA_CREATE_SELECTOR);
+        var response = callContract(data, estimateContractAddress);
         String[] addresses = splitAddresses(response.getResult());
 
         validateAddresses(addresses);
@@ -274,8 +270,8 @@ public class CallFeature extends AbstractFeature {
 
     @Then("I call function with nested deploy using create2 function")
     public void ethCallNestedDeployViaCreate2Function() {
-        var data = encodeData(ESTIMATE_GAS_TEST_CONTRACT, DEPLOY_NESTED_CONTRACT_CONTRACT_VIA_CREATE2_SELECTOR);
-        ContractCallResponse response = callContract(data, estimateContractAddress);
+        var data = encodeData(ESTIMATE_GAS, DEPLOY_NESTED_CONTRACT_CONTRACT_VIA_CREATE2_SELECTOR);
+        var response = callContract(data, estimateContractAddress);
 
         String[] addresses = splitAddresses(response.getResult());
 
@@ -286,11 +282,8 @@ public class CallFeature extends AbstractFeature {
     @Then("I call function with transfer that returns the balance")
     public void ethCallReentrancyCallFunction() {
         var data = encodeData(
-                ESTIMATE_GAS_TEST_CONTRACT,
-                REENTRANCY_CALL_WITH_GAS,
-                asAddress(receiverAccountId),
-                new BigInteger("10000"));
-        ContractCallResponse response = callContract(data, estimateContractAddress);
+                ESTIMATE_GAS, REENTRANCY_CALL_WITH_GAS, asAddress(receiverAccountId), new BigInteger("10000"));
+        var response = callContract(data, estimateContractAddress);
         String[] balances = splitAddresses(response.getResult());
         // verify initial balance
         assertEquals(Integer.parseInt(balances[0], 16), 1000000);

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ERCContractFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ERCContractFeature.java
@@ -44,7 +44,6 @@ import com.hedera.mirror.test.e2e.acceptance.client.AccountClient;
 import com.hedera.mirror.test.e2e.acceptance.client.MirrorNodeClient;
 import com.hedera.mirror.test.e2e.acceptance.client.TokenClient;
 import com.hedera.mirror.test.e2e.acceptance.props.ExpandedAccountId;
-import com.hedera.mirror.test.e2e.acceptance.response.ContractCallResponse;
 import io.cucumber.java.After;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
@@ -98,7 +97,7 @@ public class ERCContractFeature extends AbstractFeature {
     @Then("I call the erc contract via the mirror node REST API for token name")
     public void nameContractCall() {
         var data = encodeData(ERC, NAME_SELECTOR, asAddress(tokenIds.get(0)));
-        ContractCallResponse getNameResponse = callContract(data, ercTestContractSolidityAddress);
+        var getNameResponse = callContract(data, ercTestContractSolidityAddress);
 
         assertThat(getNameResponse.getResultAsText()).isEqualTo("TEST_name");
     }
@@ -107,7 +106,7 @@ public class ERCContractFeature extends AbstractFeature {
     @Then("I call the erc contract via the mirror node REST API for token symbol")
     public void symbolContractCall() {
         var data = encodeData(ERC, SYMBOL_SELECTOR, asAddress(tokenIds.get(0)));
-        ContractCallResponse getSymbolResponse = callContract(data, ercTestContractSolidityAddress);
+        var getSymbolResponse = callContract(data, ercTestContractSolidityAddress);
 
         assertThat(getSymbolResponse.getResultAsText()).isEqualTo("TEST");
     }
@@ -116,7 +115,7 @@ public class ERCContractFeature extends AbstractFeature {
     @Then("I call the erc contract via the mirror node REST API for token decimals")
     public void decimalsContractCall() {
         var data = encodeData(ERC, DECIMALS_SELECTOR, asAddress(tokenIds.get(0)));
-        ContractCallResponse getDecimalsResponse = callContract(data, ercTestContractSolidityAddress);
+        var getDecimalsResponse = callContract(data, ercTestContractSolidityAddress);
 
         assertThat(getDecimalsResponse.getResultAsNumber()).isEqualTo(10L);
     }
@@ -125,7 +124,7 @@ public class ERCContractFeature extends AbstractFeature {
     @Then("I call the erc contract via the mirror node REST API for token totalSupply")
     public void totalSupplyContractCall() {
         var data = encodeData(ERC, TOTAL_SUPPLY_SELECTOR, asAddress(tokenIds.get(0)));
-        ContractCallResponse getTotalSupplyResponse = callContract(data, ercTestContractSolidityAddress);
+        var getTotalSupplyResponse = callContract(data, ercTestContractSolidityAddress);
 
         assertThat(getTotalSupplyResponse.getResultAsNumber()).isEqualTo(1_000_000L);
     }
@@ -134,7 +133,7 @@ public class ERCContractFeature extends AbstractFeature {
     @Then("I call the erc contract via the mirror node REST API for token ownerOf")
     public void ownerOfContractCall() {
         var data = encodeData(ERC, GET_OWNER_OF_SELECTOR, asAddress(tokenIds.get(1)), new BigInteger("1"));
-        ContractCallResponse getOwnerOfResponse = callContract(data, ercTestContractSolidityAddress);
+        var getOwnerOfResponse = callContract(data, ercTestContractSolidityAddress);
         tokenClient.validateAddress(getOwnerOfResponse.getResultAsAddress());
     }
 
@@ -142,7 +141,7 @@ public class ERCContractFeature extends AbstractFeature {
     @Then("I call the erc contract via the mirror node REST API for token tokenUri")
     public void tokenURIContractCall() {
         var data = encodeData(ERC, TOKEN_URI_SELECTOR, asAddress(tokenIds.get(1)), new BigInteger("1"));
-        ContractCallResponse getTokenURIResponse = callContract(data, ercTestContractSolidityAddress);
+        var getTokenURIResponse = callContract(data, ercTestContractSolidityAddress);
 
         assertThat(getTokenURIResponse.getResultAsText()).isEqualTo("TEST_metadata");
     }
@@ -151,7 +150,7 @@ public class ERCContractFeature extends AbstractFeature {
     @Then("I call the erc contract via the mirror node REST API for token getApproved")
     public void getApprovedContractCall() {
         var data = encodeData(ERC, GET_APPROVED_SELECTOR, asAddress(tokenIds.get(1)), new BigInteger("1"));
-        ContractCallResponse getApprovedResponse = callContract(data, ercTestContractSolidityAddress);
+        var getApprovedResponse = callContract(data, ercTestContractSolidityAddress);
 
         assertThat(getApprovedResponse.getResultAsAddress()).isEqualTo("0000000000000000000000000000000000000000");
     }
@@ -161,7 +160,7 @@ public class ERCContractFeature extends AbstractFeature {
     public void allowanceContractCall() {
         var data = encodeData(
                 ERC, ALLOWANCE_SELECTOR, asAddress(tokenIds.get(0)), asAddress(tokenClient), asAddress(contractClient));
-        ContractCallResponse getAllowanceResponse = callContract(data, ercTestContractSolidityAddress);
+        var getAllowanceResponse = callContract(data, ercTestContractSolidityAddress);
 
         assertThat(getAllowanceResponse.getResultAsNumber()).isZero();
     }
@@ -175,7 +174,7 @@ public class ERCContractFeature extends AbstractFeature {
                 asAddress(tokenIds.get(0)),
                 asAddress(tokenClient),
                 asAddress(allowanceSpenderAccountId));
-        ContractCallResponse getAllowanceResponse = callContract(data, ercTestContractSolidityAddress);
+        var getAllowanceResponse = callContract(data, ercTestContractSolidityAddress);
 
         assertThat(getAllowanceResponse.getResultAsNumber()).isEqualTo(2);
     }
@@ -189,7 +188,7 @@ public class ERCContractFeature extends AbstractFeature {
                 asAddress(tokenIds.get(1)),
                 asAddress(tokenClient),
                 asAddress(contractClient));
-        ContractCallResponse getIsApproveForAllResponse = callContract(data, ercTestContractSolidityAddress);
+        var getIsApproveForAllResponse = callContract(data, ercTestContractSolidityAddress);
 
         assertThat(getIsApproveForAllResponse.getResultAsBoolean()).isFalse();
     }
@@ -203,7 +202,7 @@ public class ERCContractFeature extends AbstractFeature {
                 asAddress(tokenIds.get(1)),
                 asAddress(tokenClient),
                 asAddress(spenderAccountIdForAllSerials));
-        ContractCallResponse getIsApproveForAllResponse = callContract(data, ercTestContractSolidityAddress);
+        var getIsApproveForAllResponse = callContract(data, ercTestContractSolidityAddress);
 
         assertThat(getIsApproveForAllResponse.getResultAsBoolean()).isTrue();
     }
@@ -212,7 +211,7 @@ public class ERCContractFeature extends AbstractFeature {
     @Then("I call the erc contract via the mirror node REST API for token balance")
     public void balanceOfContractCall() {
         var data = encodeData(ERC, BALANCE_OF_SELECTOR, asAddress(tokenIds.get(0)), asAddress(contractClient));
-        ContractCallResponse getBalanceOfResponse = callContract(data, ercTestContractSolidityAddress);
+        var getBalanceOfResponse = callContract(data, ercTestContractSolidityAddress);
 
         assertThat(getBalanceOfResponse.getResultAsNumber()).isEqualTo(1000000);
     }
@@ -221,7 +220,7 @@ public class ERCContractFeature extends AbstractFeature {
     @Then("I call the erc contract via the mirror node REST API for token getApproved with response BOB")
     public void verifyNftAllowance() {
         var data = encodeData(ERC, GET_APPROVED_SELECTOR, asAddress(tokenIds.get(1)), new BigInteger("1"));
-        ContractCallResponse getApprovedResponse = callContract(data, ercTestContractSolidityAddress);
+        var getApprovedResponse = callContract(data, ercTestContractSolidityAddress);
         assertThat(getApprovedResponse.getResultAsAddress()).isEqualTo(spenderAccountAlias);
     }
 
@@ -319,7 +318,7 @@ public class ERCContractFeature extends AbstractFeature {
                 asAddress(mirrorClient
                         .getAccountDetailsByAccountId(ecdsaAccount.getAccountId())
                         .getEvmAddress()));
-        ContractCallResponse getIsApproveForAllResponse = callContract(data, ercTestContractSolidityAddress);
+        var getIsApproveForAllResponse = callContract(data, ercTestContractSolidityAddress);
         assertThat(getIsApproveForAllResponse.getResultAsBoolean()).isTrue();
     }
 
@@ -344,7 +343,7 @@ public class ERCContractFeature extends AbstractFeature {
                 asAddress(mirrorClient
                         .getAccountDetailsByAccountId(ecdsaAccount.getAccountId())
                         .getEvmAddress()));
-        ContractCallResponse getAllowanceResponse = callContract(data, ercTestContractSolidityAddress);
+        var getAllowanceResponse = callContract(data, ercTestContractSolidityAddress);
 
         assertThat(getAllowanceResponse.getResultAsNumber()).isEqualTo(1000);
     }
@@ -359,7 +358,7 @@ public class ERCContractFeature extends AbstractFeature {
                 asAddress(mirrorClient
                         .getAccountDetailsByAccountId(ecdsaAccount.getAccountId())
                         .getEvmAddress()));
-        ContractCallResponse getBalanceOfResponse = callContract(data, ercTestContractSolidityAddress);
+        var getBalanceOfResponse = callContract(data, ercTestContractSolidityAddress);
 
         assertThat(getBalanceOfResponse.getResultAsNumber()).isEqualTo(500);
     }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ERCContractFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ERCContractFeature.java
@@ -17,11 +17,21 @@
 package com.hedera.mirror.test.e2e.acceptance.steps;
 
 import static com.hedera.mirror.test.e2e.acceptance.client.AccountClient.AccountNameEnum.BOB;
+import static com.hedera.mirror.test.e2e.acceptance.steps.AbstractFeature.ContractResource.ERC_TEST_CONTRACT;
+import static com.hedera.mirror.test.e2e.acceptance.steps.ERCContractFeature.ContractMethods.ALLOWANCE_SELECTOR;
+import static com.hedera.mirror.test.e2e.acceptance.steps.ERCContractFeature.ContractMethods.BALANCE_OF_SELECTOR;
+import static com.hedera.mirror.test.e2e.acceptance.steps.ERCContractFeature.ContractMethods.DECIMALS_SELECTOR;
+import static com.hedera.mirror.test.e2e.acceptance.steps.ERCContractFeature.ContractMethods.GET_APPROVED_SELECTOR;
+import static com.hedera.mirror.test.e2e.acceptance.steps.ERCContractFeature.ContractMethods.GET_OWNER_OF_SELECTOR;
+import static com.hedera.mirror.test.e2e.acceptance.steps.ERCContractFeature.ContractMethods.IS_APPROVED_FOR_ALL_SELECTOR;
+import static com.hedera.mirror.test.e2e.acceptance.steps.ERCContractFeature.ContractMethods.NAME_SELECTOR;
+import static com.hedera.mirror.test.e2e.acceptance.steps.ERCContractFeature.ContractMethods.SYMBOL_SELECTOR;
+import static com.hedera.mirror.test.e2e.acceptance.steps.ERCContractFeature.ContractMethods.TOKEN_URI_SELECTOR;
+import static com.hedera.mirror.test.e2e.acceptance.steps.ERCContractFeature.ContractMethods.TOTAL_SUPPLY_SELECTOR;
 import static com.hedera.mirror.test.e2e.acceptance.util.TestUtil.asAddress;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import com.esaulpaugh.headlong.util.Strings;
 import com.hedera.hashgraph.sdk.CustomFee;
 import com.hedera.hashgraph.sdk.NftId;
 import com.hedera.hashgraph.sdk.TokenId;
@@ -40,7 +50,6 @@ import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import java.io.IOException;
 import java.math.BigInteger;
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -88,11 +97,8 @@ public class ERCContractFeature extends AbstractFeature {
     @RetryAsserts
     @Then("I call the erc contract via the mirror node REST API for token name")
     public void nameContractCall() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.NAME_SELECTOR, ContractResource.ERC_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(tokenIds.get(0).toSolidityAddress()));
-        ContractCallResponse getNameResponse =
-                callContract(Strings.encode(encodedFunctionCall), ercTestContractSolidityAddress);
+        var data = encodeData(ERC_TEST_CONTRACT, NAME_SELECTOR, asAddress(tokenIds.get(0)));
+        ContractCallResponse getNameResponse = callContract(data, ercTestContractSolidityAddress);
 
         assertThat(getNameResponse.getResultAsText()).isEqualTo("TEST_name");
     }
@@ -100,11 +106,8 @@ public class ERCContractFeature extends AbstractFeature {
     @RetryAsserts
     @Then("I call the erc contract via the mirror node REST API for token symbol")
     public void symbolContractCall() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.SYMBOL_SELECTOR, ContractResource.ERC_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(tokenIds.get(0).toSolidityAddress()));
-        ContractCallResponse getSymbolResponse =
-                callContract(Strings.encode(encodedFunctionCall), ercTestContractSolidityAddress);
+        var data = encodeData(ERC_TEST_CONTRACT, SYMBOL_SELECTOR, asAddress(tokenIds.get(0)));
+        ContractCallResponse getSymbolResponse = callContract(data, ercTestContractSolidityAddress);
 
         assertThat(getSymbolResponse.getResultAsText()).isEqualTo("TEST");
     }
@@ -112,11 +115,8 @@ public class ERCContractFeature extends AbstractFeature {
     @RetryAsserts
     @Then("I call the erc contract via the mirror node REST API for token decimals")
     public void decimalsContractCall() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.DECIMALS_SELECTOR, ContractResource.ERC_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(tokenIds.get(0).toSolidityAddress()));
-        ContractCallResponse getDecimalsResponse =
-                callContract(Strings.encode(encodedFunctionCall), ercTestContractSolidityAddress);
+        var data = encodeData(ERC_TEST_CONTRACT, DECIMALS_SELECTOR, asAddress(tokenIds.get(0)));
+        ContractCallResponse getDecimalsResponse = callContract(data, ercTestContractSolidityAddress);
 
         assertThat(getDecimalsResponse.getResultAsNumber()).isEqualTo(10L);
     }
@@ -124,11 +124,8 @@ public class ERCContractFeature extends AbstractFeature {
     @RetryAsserts
     @Then("I call the erc contract via the mirror node REST API for token totalSupply")
     public void totalSupplyContractCall() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.TOTAL_SUPPLY_SELECTOR, ContractResource.ERC_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(tokenIds.get(0).toSolidityAddress()));
-        ContractCallResponse getTotalSupplyResponse =
-                callContract(Strings.encode(encodedFunctionCall), ercTestContractSolidityAddress);
+        var data = encodeData(ERC_TEST_CONTRACT, TOTAL_SUPPLY_SELECTOR, asAddress(tokenIds.get(0)));
+        ContractCallResponse getTotalSupplyResponse = callContract(data, ercTestContractSolidityAddress);
 
         assertThat(getTotalSupplyResponse.getResultAsNumber()).isEqualTo(1_000_000L);
     }
@@ -136,22 +133,17 @@ public class ERCContractFeature extends AbstractFeature {
     @RetryAsserts
     @Then("I call the erc contract via the mirror node REST API for token ownerOf")
     public void ownerOfContractCall() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.GET_OWNER_OF_SELECTOR, ContractResource.ERC_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(tokenIds.get(1).toSolidityAddress()), new BigInteger("1"));
-        ContractCallResponse getOwnerOfResponse =
-                callContract(Strings.encode(encodedFunctionCall), ercTestContractSolidityAddress);
+        var data =
+                encodeData(ERC_TEST_CONTRACT, GET_OWNER_OF_SELECTOR, asAddress(tokenIds.get(1)), new BigInteger("1"));
+        ContractCallResponse getOwnerOfResponse = callContract(data, ercTestContractSolidityAddress);
         tokenClient.validateAddress(getOwnerOfResponse.getResultAsAddress());
     }
 
     @RetryAsserts
     @Then("I call the erc contract via the mirror node REST API for token tokenUri")
     public void tokenURIContractCall() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.TOKEN_URI_SELECTOR, ContractResource.ERC_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(tokenIds.get(1).toSolidityAddress()), new BigInteger("1"));
-        ContractCallResponse getTokenURIResponse =
-                callContract(Strings.encode(encodedFunctionCall), ercTestContractSolidityAddress);
+        var data = encodeData(ERC_TEST_CONTRACT, TOKEN_URI_SELECTOR, asAddress(tokenIds.get(1)), new BigInteger("1"));
+        ContractCallResponse getTokenURIResponse = callContract(data, ercTestContractSolidityAddress);
 
         assertThat(getTokenURIResponse.getResultAsText()).isEqualTo("TEST_metadata");
     }
@@ -159,11 +151,9 @@ public class ERCContractFeature extends AbstractFeature {
     @RetryAsserts
     @Then("I call the erc contract via the mirror node REST API for token getApproved")
     public void getApprovedContractCall() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.GET_APPROVED_SELECTOR, ContractResource.ERC_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(tokenIds.get(1).toSolidityAddress()), new BigInteger("1"));
-        ContractCallResponse getApprovedResponse =
-                callContract(Strings.encode(encodedFunctionCall), ercTestContractSolidityAddress);
+        var data =
+                encodeData(ERC_TEST_CONTRACT, GET_APPROVED_SELECTOR, asAddress(tokenIds.get(1)), new BigInteger("1"));
+        ContractCallResponse getApprovedResponse = callContract(data, ercTestContractSolidityAddress);
 
         assertThat(getApprovedResponse.getResultAsAddress()).isEqualTo("0000000000000000000000000000000000000000");
     }
@@ -171,18 +161,13 @@ public class ERCContractFeature extends AbstractFeature {
     @RetryAsserts
     @Then("I call the erc contract via the mirror node REST API for token allowance")
     public void allowanceContractCall() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.ALLOWANCE_SELECTOR, ContractResource.ERC_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(tokenIds.get(0).toSolidityAddress()),
-                        asAddress(tokenClient
-                                .getSdkClient()
-                                .getExpandedOperatorAccountId()
-                                .getAccountId()
-                                .toSolidityAddress()),
-                        asAddress(contractClient.getClientAddress()));
-        ContractCallResponse getAllowanceResponse =
-                callContract(Strings.encode(encodedFunctionCall), ercTestContractSolidityAddress);
+        var data = encodeData(
+                ERC_TEST_CONTRACT,
+                ALLOWANCE_SELECTOR,
+                asAddress(tokenIds.get(0)),
+                asAddress(tokenClient),
+                asAddress(contractClient));
+        ContractCallResponse getAllowanceResponse = callContract(data, ercTestContractSolidityAddress);
 
         assertThat(getAllowanceResponse.getResultAsNumber()).isZero();
     }
@@ -190,18 +175,13 @@ public class ERCContractFeature extends AbstractFeature {
     @RetryAsserts
     @Then("I call the erc contract via the mirror node REST API for token allowance with allowances")
     public void allowanceSecondContractCall() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.ALLOWANCE_SELECTOR, ContractResource.ERC_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(tokenIds.get(0).toSolidityAddress()),
-                        asAddress(tokenClient
-                                .getSdkClient()
-                                .getExpandedOperatorAccountId()
-                                .getAccountId()
-                                .toSolidityAddress()),
-                        asAddress(allowanceSpenderAccountId.getAccountId().toSolidityAddress()));
-        ContractCallResponse getAllowanceResponse =
-                callContract(Strings.encode(encodedFunctionCall), ercTestContractSolidityAddress);
+        var data = encodeData(
+                ERC_TEST_CONTRACT,
+                ALLOWANCE_SELECTOR,
+                asAddress(tokenIds.get(0)),
+                asAddress(tokenClient),
+                asAddress(allowanceSpenderAccountId));
+        ContractCallResponse getAllowanceResponse = callContract(data, ercTestContractSolidityAddress);
 
         assertThat(getAllowanceResponse.getResultAsNumber()).isEqualTo(2);
     }
@@ -209,18 +189,13 @@ public class ERCContractFeature extends AbstractFeature {
     @RetryAsserts
     @Then("I call the erc contract via the mirror node REST API for token isApprovedForAll")
     public void isApprovedForAllContractCall() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.IS_APPROVED_FOR_ALL_SELECTOR, ContractResource.ERC_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(tokenIds.get(1).toSolidityAddress()),
-                        asAddress(tokenClient
-                                .getSdkClient()
-                                .getExpandedOperatorAccountId()
-                                .getAccountId()
-                                .toSolidityAddress()),
-                        asAddress(contractClient.getClientAddress()));
-        ContractCallResponse getIsApproveForAllResponse =
-                callContract(Strings.encode(encodedFunctionCall), ercTestContractSolidityAddress);
+        var data = encodeData(
+                ERC_TEST_CONTRACT,
+                IS_APPROVED_FOR_ALL_SELECTOR,
+                asAddress(tokenIds.get(1)),
+                asAddress(tokenClient),
+                asAddress(contractClient));
+        ContractCallResponse getIsApproveForAllResponse = callContract(data, ercTestContractSolidityAddress);
 
         assertThat(getIsApproveForAllResponse.getResultAsBoolean()).isFalse();
     }
@@ -228,18 +203,13 @@ public class ERCContractFeature extends AbstractFeature {
     @RetryAsserts
     @Then("I call the erc contract via the mirror node REST API for token isApprovedForAll with response true")
     public void isApprovedForAllSecondContractCall() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.IS_APPROVED_FOR_ALL_SELECTOR, ContractResource.ERC_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(tokenIds.get(1).toSolidityAddress()),
-                        asAddress(tokenClient
-                                .getSdkClient()
-                                .getExpandedOperatorAccountId()
-                                .getAccountId()
-                                .toSolidityAddress()),
-                        asAddress(spenderAccountIdForAllSerials.getAccountId().toSolidityAddress()));
-        ContractCallResponse getIsApproveForAllResponse =
-                callContract(Strings.encode(encodedFunctionCall), ercTestContractSolidityAddress);
+        var data = encodeData(
+                ERC_TEST_CONTRACT,
+                IS_APPROVED_FOR_ALL_SELECTOR,
+                asAddress(tokenIds.get(1)),
+                asAddress(tokenClient),
+                asAddress(spenderAccountIdForAllSerials));
+        ContractCallResponse getIsApproveForAllResponse = callContract(data, ercTestContractSolidityAddress);
 
         assertThat(getIsApproveForAllResponse.getResultAsBoolean()).isTrue();
     }
@@ -247,12 +217,9 @@ public class ERCContractFeature extends AbstractFeature {
     @RetryAsserts
     @Then("I call the erc contract via the mirror node REST API for token balance")
     public void balanceOfContractCall() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.BALANCE_OF_SELECTOR, ContractResource.ERC_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(tokenIds.get(0).toSolidityAddress()), asAddress(contractClient.getClientAddress()));
-        ContractCallResponse getBalanceOfResponse =
-                callContract(Strings.encode(encodedFunctionCall), ercTestContractSolidityAddress);
+        var data = encodeData(
+                ERC_TEST_CONTRACT, BALANCE_OF_SELECTOR, asAddress(tokenIds.get(0)), asAddress(contractClient));
+        ContractCallResponse getBalanceOfResponse = callContract(data, ercTestContractSolidityAddress);
 
         assertThat(getBalanceOfResponse.getResultAsNumber()).isEqualTo(1000000);
     }
@@ -260,17 +227,15 @@ public class ERCContractFeature extends AbstractFeature {
     @RetryAsserts
     @Then("I call the erc contract via the mirror node REST API for token getApproved with response BOB")
     public void verifyNftAllowance() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.GET_APPROVED_SELECTOR, ContractResource.ERC_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(tokenIds.get(1).toSolidityAddress()), new BigInteger("1"));
-        ContractCallResponse getApprovedResponse =
-                callContract(Strings.encode(encodedFunctionCall), ercTestContractSolidityAddress);
+        var data =
+                encodeData(ERC_TEST_CONTRACT, GET_APPROVED_SELECTOR, asAddress(tokenIds.get(1)), new BigInteger("1"));
+        ContractCallResponse getApprovedResponse = callContract(data, ercTestContractSolidityAddress);
         assertThat(getApprovedResponse.getResultAsAddress()).isEqualTo(spenderAccountAlias);
     }
 
     @Given("I successfully create an erc contract from contract bytes with balance 0")
     public void createNewContract() throws IOException {
-        deployedErcContract = getContract(ContractResource.ERC_TEST_CONTRACT);
+        deployedErcContract = getContract(ERC_TEST_CONTRACT);
         ercTestContractSolidityAddress = deployedErcContract.contractId().toSolidityAddress();
     }
 
@@ -354,20 +319,15 @@ public class ERCContractFeature extends AbstractFeature {
         networkTransactionResponse = accountClient.approveNftAllSerials(tokenIds.get(1), ecdsaAccount.getAccountId());
         verifyMirrorTransactionsResponse(mirrorClient, 200);
 
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.IS_APPROVED_FOR_ALL_SELECTOR, ContractResource.ERC_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(tokenIds.get(1).toSolidityAddress()),
-                        asAddress(tokenClient
-                                .getSdkClient()
-                                .getExpandedOperatorAccountId()
-                                .getAccountId()
-                                .toSolidityAddress()),
-                        asAddress(mirrorClient
-                                .getAccountDetailsByAccountId(ecdsaAccount.getAccountId())
-                                .getEvmAddress()));
-        ContractCallResponse getIsApproveForAllResponse =
-                callContract(Strings.encode(encodedFunctionCall), ercTestContractSolidityAddress);
+        var data = encodeData(
+                ERC_TEST_CONTRACT,
+                IS_APPROVED_FOR_ALL_SELECTOR,
+                asAddress(tokenIds.get(1)),
+                asAddress(tokenClient),
+                asAddress(mirrorClient
+                        .getAccountDetailsByAccountId(ecdsaAccount.getAccountId())
+                        .getEvmAddress()));
+        ContractCallResponse getIsApproveForAllResponse = callContract(data, ercTestContractSolidityAddress);
         assertThat(getIsApproveForAllResponse.getResultAsBoolean()).isTrue();
     }
 
@@ -384,20 +344,15 @@ public class ERCContractFeature extends AbstractFeature {
                 500);
         verifyMirrorTransactionsResponse(mirrorClient, 200);
 
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.ALLOWANCE_SELECTOR, ContractResource.ERC_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(tokenIds.get(0).toSolidityAddress()),
-                        asAddress(tokenClient
-                                .getSdkClient()
-                                .getExpandedOperatorAccountId()
-                                .getAccountId()
-                                .toSolidityAddress()),
-                        asAddress(mirrorClient
-                                .getAccountDetailsByAccountId(ecdsaAccount.getAccountId())
-                                .getEvmAddress()));
-        ContractCallResponse getAllowanceResponse =
-                callContract(Strings.encode(encodedFunctionCall), ercTestContractSolidityAddress);
+        var data = encodeData(
+                ERC_TEST_CONTRACT,
+                ALLOWANCE_SELECTOR,
+                asAddress(tokenIds.get(0)),
+                asAddress(tokenClient),
+                asAddress(mirrorClient
+                        .getAccountDetailsByAccountId(ecdsaAccount.getAccountId())
+                        .getEvmAddress()));
+        ContractCallResponse getAllowanceResponse = callContract(data, ercTestContractSolidityAddress);
 
         assertThat(getAllowanceResponse.getResultAsNumber()).isEqualTo(1000);
     }
@@ -405,15 +360,14 @@ public class ERCContractFeature extends AbstractFeature {
     @RetryAsserts
     @Then("I call the erc contract via the mirror node REST API for token balance with alias account")
     public void balanceOfAliasAccountContractCall() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.BALANCE_OF_SELECTOR, ContractResource.ERC_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(tokenIds.get(0).toSolidityAddress()),
-                        asAddress(mirrorClient
-                                .getAccountDetailsByAccountId(ecdsaAccount.getAccountId())
-                                .getEvmAddress()));
-        ContractCallResponse getBalanceOfResponse =
-                callContract(Strings.encode(encodedFunctionCall), ercTestContractSolidityAddress);
+        var data = encodeData(
+                ERC_TEST_CONTRACT,
+                BALANCE_OF_SELECTOR,
+                asAddress(tokenIds.get(0)),
+                asAddress(mirrorClient
+                        .getAccountDetailsByAccountId(ecdsaAccount.getAccountId())
+                        .getEvmAddress()));
+        ContractCallResponse getBalanceOfResponse = callContract(data, ercTestContractSolidityAddress);
 
         assertThat(getBalanceOfResponse.getResultAsNumber()).isEqualTo(500);
     }
@@ -448,7 +402,7 @@ public class ERCContractFeature extends AbstractFeature {
 
     @Getter
     @RequiredArgsConstructor
-    private enum ContractMethods implements SelectorInterface {
+    enum ContractMethods implements SelectorInterface {
         ALLOWANCE_SELECTOR("allowance"),
         BALANCE_OF_SELECTOR("balanceOf"),
         DECIMALS_SELECTOR("decimals"),

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ERCContractFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ERCContractFeature.java
@@ -17,7 +17,7 @@
 package com.hedera.mirror.test.e2e.acceptance.steps;
 
 import static com.hedera.mirror.test.e2e.acceptance.client.AccountClient.AccountNameEnum.BOB;
-import static com.hedera.mirror.test.e2e.acceptance.steps.AbstractFeature.ContractResource.ERC_TEST_CONTRACT;
+import static com.hedera.mirror.test.e2e.acceptance.steps.AbstractFeature.ContractResource.ERC;
 import static com.hedera.mirror.test.e2e.acceptance.steps.ERCContractFeature.ContractMethods.ALLOWANCE_SELECTOR;
 import static com.hedera.mirror.test.e2e.acceptance.steps.ERCContractFeature.ContractMethods.BALANCE_OF_SELECTOR;
 import static com.hedera.mirror.test.e2e.acceptance.steps.ERCContractFeature.ContractMethods.DECIMALS_SELECTOR;
@@ -97,7 +97,7 @@ public class ERCContractFeature extends AbstractFeature {
     @RetryAsserts
     @Then("I call the erc contract via the mirror node REST API for token name")
     public void nameContractCall() {
-        var data = encodeData(ERC_TEST_CONTRACT, NAME_SELECTOR, asAddress(tokenIds.get(0)));
+        var data = encodeData(ERC, NAME_SELECTOR, asAddress(tokenIds.get(0)));
         ContractCallResponse getNameResponse = callContract(data, ercTestContractSolidityAddress);
 
         assertThat(getNameResponse.getResultAsText()).isEqualTo("TEST_name");
@@ -106,7 +106,7 @@ public class ERCContractFeature extends AbstractFeature {
     @RetryAsserts
     @Then("I call the erc contract via the mirror node REST API for token symbol")
     public void symbolContractCall() {
-        var data = encodeData(ERC_TEST_CONTRACT, SYMBOL_SELECTOR, asAddress(tokenIds.get(0)));
+        var data = encodeData(ERC, SYMBOL_SELECTOR, asAddress(tokenIds.get(0)));
         ContractCallResponse getSymbolResponse = callContract(data, ercTestContractSolidityAddress);
 
         assertThat(getSymbolResponse.getResultAsText()).isEqualTo("TEST");
@@ -115,7 +115,7 @@ public class ERCContractFeature extends AbstractFeature {
     @RetryAsserts
     @Then("I call the erc contract via the mirror node REST API for token decimals")
     public void decimalsContractCall() {
-        var data = encodeData(ERC_TEST_CONTRACT, DECIMALS_SELECTOR, asAddress(tokenIds.get(0)));
+        var data = encodeData(ERC, DECIMALS_SELECTOR, asAddress(tokenIds.get(0)));
         ContractCallResponse getDecimalsResponse = callContract(data, ercTestContractSolidityAddress);
 
         assertThat(getDecimalsResponse.getResultAsNumber()).isEqualTo(10L);
@@ -124,7 +124,7 @@ public class ERCContractFeature extends AbstractFeature {
     @RetryAsserts
     @Then("I call the erc contract via the mirror node REST API for token totalSupply")
     public void totalSupplyContractCall() {
-        var data = encodeData(ERC_TEST_CONTRACT, TOTAL_SUPPLY_SELECTOR, asAddress(tokenIds.get(0)));
+        var data = encodeData(ERC, TOTAL_SUPPLY_SELECTOR, asAddress(tokenIds.get(0)));
         ContractCallResponse getTotalSupplyResponse = callContract(data, ercTestContractSolidityAddress);
 
         assertThat(getTotalSupplyResponse.getResultAsNumber()).isEqualTo(1_000_000L);
@@ -133,8 +133,7 @@ public class ERCContractFeature extends AbstractFeature {
     @RetryAsserts
     @Then("I call the erc contract via the mirror node REST API for token ownerOf")
     public void ownerOfContractCall() {
-        var data =
-                encodeData(ERC_TEST_CONTRACT, GET_OWNER_OF_SELECTOR, asAddress(tokenIds.get(1)), new BigInteger("1"));
+        var data = encodeData(ERC, GET_OWNER_OF_SELECTOR, asAddress(tokenIds.get(1)), new BigInteger("1"));
         ContractCallResponse getOwnerOfResponse = callContract(data, ercTestContractSolidityAddress);
         tokenClient.validateAddress(getOwnerOfResponse.getResultAsAddress());
     }
@@ -142,7 +141,7 @@ public class ERCContractFeature extends AbstractFeature {
     @RetryAsserts
     @Then("I call the erc contract via the mirror node REST API for token tokenUri")
     public void tokenURIContractCall() {
-        var data = encodeData(ERC_TEST_CONTRACT, TOKEN_URI_SELECTOR, asAddress(tokenIds.get(1)), new BigInteger("1"));
+        var data = encodeData(ERC, TOKEN_URI_SELECTOR, asAddress(tokenIds.get(1)), new BigInteger("1"));
         ContractCallResponse getTokenURIResponse = callContract(data, ercTestContractSolidityAddress);
 
         assertThat(getTokenURIResponse.getResultAsText()).isEqualTo("TEST_metadata");
@@ -151,8 +150,7 @@ public class ERCContractFeature extends AbstractFeature {
     @RetryAsserts
     @Then("I call the erc contract via the mirror node REST API for token getApproved")
     public void getApprovedContractCall() {
-        var data =
-                encodeData(ERC_TEST_CONTRACT, GET_APPROVED_SELECTOR, asAddress(tokenIds.get(1)), new BigInteger("1"));
+        var data = encodeData(ERC, GET_APPROVED_SELECTOR, asAddress(tokenIds.get(1)), new BigInteger("1"));
         ContractCallResponse getApprovedResponse = callContract(data, ercTestContractSolidityAddress);
 
         assertThat(getApprovedResponse.getResultAsAddress()).isEqualTo("0000000000000000000000000000000000000000");
@@ -162,11 +160,7 @@ public class ERCContractFeature extends AbstractFeature {
     @Then("I call the erc contract via the mirror node REST API for token allowance")
     public void allowanceContractCall() {
         var data = encodeData(
-                ERC_TEST_CONTRACT,
-                ALLOWANCE_SELECTOR,
-                asAddress(tokenIds.get(0)),
-                asAddress(tokenClient),
-                asAddress(contractClient));
+                ERC, ALLOWANCE_SELECTOR, asAddress(tokenIds.get(0)), asAddress(tokenClient), asAddress(contractClient));
         ContractCallResponse getAllowanceResponse = callContract(data, ercTestContractSolidityAddress);
 
         assertThat(getAllowanceResponse.getResultAsNumber()).isZero();
@@ -176,7 +170,7 @@ public class ERCContractFeature extends AbstractFeature {
     @Then("I call the erc contract via the mirror node REST API for token allowance with allowances")
     public void allowanceSecondContractCall() {
         var data = encodeData(
-                ERC_TEST_CONTRACT,
+                ERC,
                 ALLOWANCE_SELECTOR,
                 asAddress(tokenIds.get(0)),
                 asAddress(tokenClient),
@@ -190,7 +184,7 @@ public class ERCContractFeature extends AbstractFeature {
     @Then("I call the erc contract via the mirror node REST API for token isApprovedForAll")
     public void isApprovedForAllContractCall() {
         var data = encodeData(
-                ERC_TEST_CONTRACT,
+                ERC,
                 IS_APPROVED_FOR_ALL_SELECTOR,
                 asAddress(tokenIds.get(1)),
                 asAddress(tokenClient),
@@ -204,7 +198,7 @@ public class ERCContractFeature extends AbstractFeature {
     @Then("I call the erc contract via the mirror node REST API for token isApprovedForAll with response true")
     public void isApprovedForAllSecondContractCall() {
         var data = encodeData(
-                ERC_TEST_CONTRACT,
+                ERC,
                 IS_APPROVED_FOR_ALL_SELECTOR,
                 asAddress(tokenIds.get(1)),
                 asAddress(tokenClient),
@@ -217,8 +211,7 @@ public class ERCContractFeature extends AbstractFeature {
     @RetryAsserts
     @Then("I call the erc contract via the mirror node REST API for token balance")
     public void balanceOfContractCall() {
-        var data = encodeData(
-                ERC_TEST_CONTRACT, BALANCE_OF_SELECTOR, asAddress(tokenIds.get(0)), asAddress(contractClient));
+        var data = encodeData(ERC, BALANCE_OF_SELECTOR, asAddress(tokenIds.get(0)), asAddress(contractClient));
         ContractCallResponse getBalanceOfResponse = callContract(data, ercTestContractSolidityAddress);
 
         assertThat(getBalanceOfResponse.getResultAsNumber()).isEqualTo(1000000);
@@ -227,15 +220,14 @@ public class ERCContractFeature extends AbstractFeature {
     @RetryAsserts
     @Then("I call the erc contract via the mirror node REST API for token getApproved with response BOB")
     public void verifyNftAllowance() {
-        var data =
-                encodeData(ERC_TEST_CONTRACT, GET_APPROVED_SELECTOR, asAddress(tokenIds.get(1)), new BigInteger("1"));
+        var data = encodeData(ERC, GET_APPROVED_SELECTOR, asAddress(tokenIds.get(1)), new BigInteger("1"));
         ContractCallResponse getApprovedResponse = callContract(data, ercTestContractSolidityAddress);
         assertThat(getApprovedResponse.getResultAsAddress()).isEqualTo(spenderAccountAlias);
     }
 
     @Given("I successfully create an erc contract from contract bytes with balance 0")
     public void createNewContract() throws IOException {
-        deployedErcContract = getContract(ERC_TEST_CONTRACT);
+        deployedErcContract = getContract(ERC);
         ercTestContractSolidityAddress = deployedErcContract.contractId().toSolidityAddress();
     }
 
@@ -320,7 +312,7 @@ public class ERCContractFeature extends AbstractFeature {
         verifyMirrorTransactionsResponse(mirrorClient, 200);
 
         var data = encodeData(
-                ERC_TEST_CONTRACT,
+                ERC,
                 IS_APPROVED_FOR_ALL_SELECTOR,
                 asAddress(tokenIds.get(1)),
                 asAddress(tokenClient),
@@ -345,7 +337,7 @@ public class ERCContractFeature extends AbstractFeature {
         verifyMirrorTransactionsResponse(mirrorClient, 200);
 
         var data = encodeData(
-                ERC_TEST_CONTRACT,
+                ERC,
                 ALLOWANCE_SELECTOR,
                 asAddress(tokenIds.get(0)),
                 asAddress(tokenClient),
@@ -361,7 +353,7 @@ public class ERCContractFeature extends AbstractFeature {
     @Then("I call the erc contract via the mirror node REST API for token balance with alias account")
     public void balanceOfAliasAccountContractCall() {
         var data = encodeData(
-                ERC_TEST_CONTRACT,
+                ERC,
                 BALANCE_OF_SELECTOR,
                 asAddress(tokenIds.get(0)),
                 asAddress(mirrorClient

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/EstimateFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/EstimateFeature.java
@@ -17,6 +17,39 @@
 package com.hedera.mirror.test.e2e.acceptance.steps;
 
 import static com.hedera.mirror.test.e2e.acceptance.client.TokenClient.TokenNameEnum.FUNGIBLE;
+import static com.hedera.mirror.test.e2e.acceptance.steps.AbstractFeature.ContractResource.ESTIMATE_GAS_TEST_CONTRACT;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimateFeature.ContractMethods.ADDRESS_BALANCE;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimateFeature.ContractMethods.CALL_CODE_TO_CONTRACT;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimateFeature.ContractMethods.CALL_CODE_TO_EXTERNAL_CONTRACT_FUNCTION;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimateFeature.ContractMethods.CALL_CODE_TO_EXTERNAL_CONTRACT_FUNCTION_VIEW;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimateFeature.ContractMethods.CALL_CODE_TO_INVALID_CONTRACT;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimateFeature.ContractMethods.CALL_TO_INVALID_CONTRACT;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimateFeature.ContractMethods.DELEGATE_CALL_CODE_TO_EXTERNAL_CONTRACT_FUNCTION;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimateFeature.ContractMethods.DELEGATE_CALL_TO_CONTRACT;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimateFeature.ContractMethods.DELEGATE_CALL_TO_INVALID_CONTRACT;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimateFeature.ContractMethods.DEPLOY_CONTRACT_VIA_CREATE_OPCODE;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimateFeature.ContractMethods.DEPLOY_CONTRACT_VIA_CREATE_TWO_OPCODE;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimateFeature.ContractMethods.DESTROY;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimateFeature.ContractMethods.GET_GAS_LEFT;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimateFeature.ContractMethods.GET_MOCK_ADDRESS;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimateFeature.ContractMethods.IERC20_TOKEN_APPROVE;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimateFeature.ContractMethods.IERC20_TOKEN_ASSOCIATE;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimateFeature.ContractMethods.IERC20_TOKEN_DISSOCIATE;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimateFeature.ContractMethods.IERC20_TOKEN_TRANSFER;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimateFeature.ContractMethods.LOGS;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimateFeature.ContractMethods.MESSAGE_SENDER;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimateFeature.ContractMethods.MESSAGE_SIGNER;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimateFeature.ContractMethods.MESSAGE_VALUE;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimateFeature.ContractMethods.MULTIPLY_SIMPLE_NUMBERS;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimateFeature.ContractMethods.NESTED_CALLS_LIMITED;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimateFeature.ContractMethods.NESTED_CALLS_POSITIVE;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimateFeature.ContractMethods.REENTRANCY_CALL_ATTACK;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimateFeature.ContractMethods.STATE_UPDATE_OF_CONTRACT;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimateFeature.ContractMethods.STATIC_CALL_TO_CONTRACT;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimateFeature.ContractMethods.STATIC_CALL_TO_INVALID_CONTRACT;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimateFeature.ContractMethods.TX_ORIGIN;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimateFeature.ContractMethods.UPDATE_COUNTER;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimateFeature.ContractMethods.WRONG_METHOD_SIGNATURE;
 import static com.hedera.mirror.test.e2e.acceptance.util.TestUtil.asAddress;
 import static com.hedera.mirror.test.e2e.acceptance.util.TestUtil.to32BytesString;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -60,7 +93,7 @@ public class EstimateFeature extends AbstractEstimateFeature {
 
     @Given("I successfully create EstimateGas contract from contract bytes")
     public void createNewEstimateContract() throws IOException {
-        deployedContract = getContract(ContractResource.ESTIMATE_GAS_TEST_CONTRACT);
+        deployedContract = getContract(ESTIMATE_GAS_TEST_CONTRACT);
         contractSolidityAddress = deployedContract.contractId().toSolidityAddress();
         newAccountEvmAddress =
                 PrivateKey.generateECDSA().getPublicKey().toEvmAddress().toString();
@@ -81,61 +114,40 @@ public class EstimateFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas without arguments that multiplies two numbers")
     public void multiplyEstimateCall() {
         validateGasEstimation(
-                Strings.encode(getFunctionFromArtifact(
-                                ContractMethods.MULTIPLY_SIMPLE_NUMBERS, ContractResource.ESTIMATE_GAS_TEST_CONTRACT)
-                        .encodeCallWithArgs()),
-                ContractMethods.MULTIPLY_SIMPLE_NUMBERS.getActualGas(),
+                encodeData(ESTIMATE_GAS_TEST_CONTRACT, MULTIPLY_SIMPLE_NUMBERS),
+                MULTIPLY_SIMPLE_NUMBERS,
                 contractSolidityAddress);
     }
 
     @Then("I call estimateGas with function msgSender")
     public void msgSenderEstimateCall() {
         validateGasEstimation(
-                Strings.encode(getFunctionFromArtifact(
-                                ContractMethods.MESSAGE_SENDER, ContractResource.ESTIMATE_GAS_TEST_CONTRACT)
-                        .encodeCallWithArgs()),
-                ContractMethods.MESSAGE_SENDER.getActualGas(),
-                contractSolidityAddress);
+                encodeData(ESTIMATE_GAS_TEST_CONTRACT, MESSAGE_SENDER), MESSAGE_SENDER, contractSolidityAddress);
     }
 
     @Then("I call estimateGas with function tx origin")
     public void txOriginEstimateCall() {
-        validateGasEstimation(
-                Strings.encode(
-                        getFunctionFromArtifact(ContractMethods.TX_ORIGIN, ContractResource.ESTIMATE_GAS_TEST_CONTRACT)
-                                .encodeCallWithArgs()),
-                ContractMethods.TX_ORIGIN.getActualGas(),
-                contractSolidityAddress);
+        validateGasEstimation(encodeData(ESTIMATE_GAS_TEST_CONTRACT, TX_ORIGIN), TX_ORIGIN, contractSolidityAddress);
     }
 
     @Then("I call estimateGas with function messageValue")
     public void msgValueEstimateCall() {
         validateGasEstimation(
-                Strings.encode(getFunctionFromArtifact(
-                                ContractMethods.MESSAGE_VALUE, ContractResource.ESTIMATE_GAS_TEST_CONTRACT)
-                        .encodeCallWithArgs()),
-                ContractMethods.MESSAGE_VALUE.getActualGas(),
-                contractSolidityAddress);
+                encodeData(ESTIMATE_GAS_TEST_CONTRACT, MESSAGE_VALUE), MESSAGE_VALUE, contractSolidityAddress);
     }
 
     @Then("I call estimateGas with function messageSigner")
     public void msgSignerEstimateCall() {
         validateGasEstimation(
-                Strings.encode(getFunctionFromArtifact(
-                                ContractMethods.MESSAGE_SIGNER, ContractResource.ESTIMATE_GAS_TEST_CONTRACT)
-                        .encodeCallWithArgs()),
-                ContractMethods.MESSAGE_SIGNER.getActualGas(),
-                contractSolidityAddress);
+                encodeData(ESTIMATE_GAS_TEST_CONTRACT, MESSAGE_SIGNER), MESSAGE_SIGNER, contractSolidityAddress);
     }
 
     @RetryAsserts
     @Then("I call estimateGas with function balance of address")
     public void addressBalanceEstimateCall() {
         validateGasEstimation(
-                Strings.encode(getFunctionFromArtifact(
-                                ContractMethods.ADDRESS_BALANCE, ContractResource.ESTIMATE_GAS_TEST_CONTRACT)
-                        .encodeCallWithArgs(asAddress(RANDOM_ADDRESS))),
-                ContractMethods.ADDRESS_BALANCE.getActualGas(),
+                encodeData(ESTIMATE_GAS_TEST_CONTRACT, ADDRESS_BALANCE, asAddress(RANDOM_ADDRESS)),
+                ADDRESS_BALANCE,
                 contractSolidityAddress);
     }
 
@@ -143,41 +155,31 @@ public class EstimateFeature extends AbstractEstimateFeature {
             + " by updating global contract field with the passed argument")
     public void updateCounterEstimateCall() {
         validateGasEstimation(
-                Strings.encode(getFunctionFromArtifact(
-                                ContractMethods.UPDATE_COUNTER, ContractResource.ESTIMATE_GAS_TEST_CONTRACT)
-                        .encodeCallWithArgs(new BigInteger("5"))),
-                ContractMethods.UPDATE_COUNTER.getActualGas(),
+                encodeData(ESTIMATE_GAS_TEST_CONTRACT, UPDATE_COUNTER, new BigInteger("5")),
+                UPDATE_COUNTER,
                 contractSolidityAddress);
     }
 
     @Then("I call estimateGas with function that successfully deploys a new smart contract via CREATE op code")
     public void deployContractViaCreateOpcodeEstimateCall() {
         validateGasEstimation(
-                Strings.encode(getFunctionFromArtifact(
-                                ContractMethods.DEPLOY_CONTRACT_VIA_CREATE_OPCODE,
-                                ContractResource.ESTIMATE_GAS_TEST_CONTRACT)
-                        .encodeCallWithArgs()),
-                ContractMethods.DEPLOY_CONTRACT_VIA_CREATE_OPCODE.getActualGas(),
+                encodeData(ESTIMATE_GAS_TEST_CONTRACT, DEPLOY_CONTRACT_VIA_CREATE_OPCODE),
+                DEPLOY_CONTRACT_VIA_CREATE_OPCODE,
                 contractSolidityAddress);
     }
 
     @Then("I call estimateGas with function that successfully deploys a new smart contract via CREATE2 op code")
     public void deployContractViaCreateTwoOpcodeEstimateCall() {
         validateGasEstimation(
-                Strings.encode(getFunctionFromArtifact(
-                                ContractMethods.DEPLOY_CONTRACT_VIA_CREATE_TWO_OPCODE,
-                                ContractResource.ESTIMATE_GAS_TEST_CONTRACT)
-                        .encodeCallWithArgs()),
-                ContractMethods.DEPLOY_CONTRACT_VIA_CREATE_TWO_OPCODE.getActualGas(),
+                encodeData(ESTIMATE_GAS_TEST_CONTRACT, DEPLOY_CONTRACT_VIA_CREATE_TWO_OPCODE),
+                DEPLOY_CONTRACT_VIA_CREATE_TWO_OPCODE,
                 contractSolidityAddress);
     }
 
     @Then("I get mock contract address and getAddress selector")
     public void getMockAddress() {
         var contractCallGetMockAddress = ContractCallRequest.builder()
-                .data(Strings.encode(getFunctionFromArtifact(
-                                ContractMethods.GET_MOCK_ADDRESS, ContractResource.ESTIMATE_GAS_TEST_CONTRACT)
-                        .encodeCallWithArgs()))
+                .data(Strings.encode(encodeData(ESTIMATE_GAS_TEST_CONTRACT, GET_MOCK_ADDRESS)))
                 .to(contractSolidityAddress)
                 .estimate(false)
                 .build();
@@ -188,66 +190,62 @@ public class EstimateFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with function that makes a static call to a method from a different contract")
     public void staticCallToContractEstimateCall() {
         validateGasEstimation(
-                Strings.encode(getFunctionFromArtifact(
-                                ContractMethods.STATIC_CALL_TO_CONTRACT, ContractResource.ESTIMATE_GAS_TEST_CONTRACT)
-                        .encodeCallWithArgs(asAddress(mockAddress), getAddressSelectorByteArray)),
-                ContractMethods.STATIC_CALL_TO_CONTRACT.getActualGas(),
+                encodeData(
+                        ESTIMATE_GAS_TEST_CONTRACT,
+                        STATIC_CALL_TO_CONTRACT,
+                        asAddress(mockAddress),
+                        getAddressSelectorByteArray),
+                STATIC_CALL_TO_CONTRACT,
                 contractSolidityAddress);
     }
 
     @Then("I call estimateGas with function that makes a delegate call to a method from a different contract")
     public void delegateCallToContractEstimateCall() {
         validateGasEstimation(
-                Strings.encode(getFunctionFromArtifact(
-                                ContractMethods.DELEGATE_CALL_TO_CONTRACT, ContractResource.ESTIMATE_GAS_TEST_CONTRACT)
-                        .encodeCallWithArgs(asAddress(mockAddress), getAddressSelectorByteArray)),
-                ContractMethods.DELEGATE_CALL_TO_CONTRACT.getActualGas(),
+                encodeData(
+                        ESTIMATE_GAS_TEST_CONTRACT,
+                        DELEGATE_CALL_TO_CONTRACT,
+                        asAddress(mockAddress),
+                        getAddressSelectorByteArray),
+                DELEGATE_CALL_TO_CONTRACT,
                 contractSolidityAddress);
     }
 
     @Then("I call estimateGas with function that makes a call code to a method from a different contract")
     public void callCodeToContractEstimateCall() {
         validateGasEstimation(
-                Strings.encode(getFunctionFromArtifact(
-                                ContractMethods.CALL_CODE_TO_CONTRACT, ContractResource.ESTIMATE_GAS_TEST_CONTRACT)
-                        .encodeCallWithArgs(asAddress(mockAddress), getAddressSelectorByteArray)),
-                ContractMethods.CALL_CODE_TO_CONTRACT.getActualGas(),
+                encodeData(
+                        ESTIMATE_GAS_TEST_CONTRACT,
+                        CALL_CODE_TO_CONTRACT,
+                        asAddress(mockAddress),
+                        getAddressSelectorByteArray),
+                CALL_CODE_TO_CONTRACT,
                 contractSolidityAddress);
     }
 
     @Then("I call estimateGas with function that performs LOG0, LOG1, LOG2, LOG3, LOG4 operations")
     public void logsEstimateCall() {
-        validateGasEstimation(
-                Strings.encode(
-                        getFunctionFromArtifact(ContractMethods.LOGS, ContractResource.ESTIMATE_GAS_TEST_CONTRACT)
-                                .encodeCallWithArgs()),
-                ContractMethods.LOGS.getActualGas(),
-                contractSolidityAddress);
+        validateGasEstimation(encodeData(ESTIMATE_GAS_TEST_CONTRACT, LOGS), LOGS, contractSolidityAddress);
     }
 
     @Then("I call estimateGas with function that performs self destruct")
     public void destroyEstimateCall() {
-        validateGasEstimation(
-                Strings.encode(
-                        getFunctionFromArtifact(ContractMethods.DESTROY, ContractResource.ESTIMATE_GAS_TEST_CONTRACT)
-                                .encodeCallWithArgs()),
-                ContractMethods.DESTROY.getActualGas(),
-                contractSolidityAddress);
+        validateGasEstimation(encodeData(ESTIMATE_GAS_TEST_CONTRACT, DESTROY), DESTROY, contractSolidityAddress);
     }
 
     @Then("I call estimateGas with request body that contains wrong method signature")
     public void wrongMethodSignatureEstimateCall() {
         assertContractCallReturnsBadRequest(
-                new Function(ContractMethods.WRONG_METHOD_SIGNATURE.getSelector()).encodeCallWithArgs(),
-                contractSolidityAddress);
+                new Function(WRONG_METHOD_SIGNATURE.getSelector()).encodeCallWithArgs(), contractSolidityAddress);
     }
 
     @Then("I call estimateGas with wrong encoded parameter")
     public void wrongEncodedParameterEstimateCall() {
         // wrong encoded address -> it should contain leading zero's equal to 64 characters
         String wrongEncodedAddress = "5642";
+        // 3ec4de35 is the address balance signature, we cant send wrong encoded parameter with headlong
         var contractCallRequestBody = ContractCallRequest.builder()
-                .data(ContractMethods.ADDRESS_BALANCE.getSelector() + wrongEncodedAddress)
+                .data("3ec4de35" + wrongEncodedAddress)
                 .to(contractSolidityAddress)
                 .estimate(true)
                 .build();
@@ -259,9 +257,7 @@ public class EstimateFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with non-existing from address in the request body")
     public void wrongFromParameterEstimateCall() {
         var contractCallRequestBody = ContractCallRequest.builder()
-                .data(Strings.encode(getFunctionFromArtifact(
-                                ContractMethods.MESSAGE_SIGNER, ContractResource.ESTIMATE_GAS_TEST_CONTRACT)
-                        .encodeCallWithArgs()))
+                .data(Strings.encode(encodeData(ESTIMATE_GAS_TEST_CONTRACT, MESSAGE_SIGNER)))
                 .to(contractSolidityAddress)
                 .from(newAccountEvmAddress)
                 .estimate(true)
@@ -269,83 +265,74 @@ public class EstimateFeature extends AbstractEstimateFeature {
         ContractCallResponse msgSignerResponse = mirrorClient.contractsCall(contractCallRequestBody);
         int estimatedGas = msgSignerResponse.getResultAsNumber().intValue();
 
-        assertTrue(isWithinDeviation(
-                ContractMethods.MESSAGE_SIGNER.getActualGas(), estimatedGas, lowerDeviation, upperDeviation));
+        assertTrue(isWithinDeviation(MESSAGE_SIGNER.getActualGas(), estimatedGas, lowerDeviation, upperDeviation));
     }
 
     @Then("I call estimateGas with function that makes a call to invalid smart contract")
     public void callToInvalidSmartContractEstimateCall() {
         validateGasEstimation(
-                Strings.encode(getFunctionFromArtifact(
-                                ContractMethods.CALL_TO_INVALID_CONTRACT, ContractResource.ESTIMATE_GAS_TEST_CONTRACT)
-                        .encodeCallWithArgs(asAddress(RANDOM_ADDRESS))),
-                ContractMethods.CALL_TO_INVALID_CONTRACT.getActualGas(),
+                encodeData(ESTIMATE_GAS_TEST_CONTRACT, CALL_TO_INVALID_CONTRACT, asAddress(RANDOM_ADDRESS)),
+                CALL_TO_INVALID_CONTRACT,
                 contractSolidityAddress);
     }
 
     @Then("I call estimateGas with function that makes a delegate call to invalid smart contract")
     public void delegateCallToInvalidSmartContractEstimateCall() {
         validateGasEstimation(
-                Strings.encode(getFunctionFromArtifact(
-                                ContractMethods.DELEGATE_CALL_TO_INVALID_CONTRACT,
-                                ContractResource.ESTIMATE_GAS_TEST_CONTRACT)
-                        .encodeCallWithArgs(asAddress(RANDOM_ADDRESS))),
-                ContractMethods.DELEGATE_CALL_TO_INVALID_CONTRACT.getActualGas(),
+                encodeData(ESTIMATE_GAS_TEST_CONTRACT, DELEGATE_CALL_TO_INVALID_CONTRACT, asAddress(RANDOM_ADDRESS)),
+                DELEGATE_CALL_TO_INVALID_CONTRACT,
                 contractSolidityAddress);
     }
 
     @Then("I call estimateGas with function that makes a static call to invalid smart contract")
     public void staticCallToInvalidSmartContractEstimateCall() {
         validateGasEstimation(
-                Strings.encode(getFunctionFromArtifact(
-                                ContractMethods.STATIC_CALL_TO_INVALID_CONTRACT,
-                                ContractResource.ESTIMATE_GAS_TEST_CONTRACT)
-                        .encodeCallWithArgs(asAddress(RANDOM_ADDRESS))),
-                ContractMethods.STATIC_CALL_TO_INVALID_CONTRACT.getActualGas(),
+                encodeData(ESTIMATE_GAS_TEST_CONTRACT, STATIC_CALL_TO_INVALID_CONTRACT, asAddress(RANDOM_ADDRESS)),
+                STATIC_CALL_TO_INVALID_CONTRACT,
                 contractSolidityAddress);
     }
 
     @Then("I call estimateGas with function that makes a call code to invalid smart contract")
     public void callCodeToInvalidSmartContractEstimateCall() {
         validateGasEstimation(
-                Strings.encode(getFunctionFromArtifact(
-                                ContractMethods.CALL_CODE_TO_INVALID_CONTRACT,
-                                ContractResource.ESTIMATE_GAS_TEST_CONTRACT)
-                        .encodeCallWithArgs(asAddress(RANDOM_ADDRESS))),
-                ContractMethods.CALL_CODE_TO_INVALID_CONTRACT.getActualGas(),
+                encodeData(ESTIMATE_GAS_TEST_CONTRACT, CALL_CODE_TO_INVALID_CONTRACT, asAddress(RANDOM_ADDRESS)),
+                CALL_CODE_TO_INVALID_CONTRACT,
                 contractSolidityAddress);
     }
 
     @Then("I call estimateGas with function that makes call to an external contract function")
     public void callCodeToExternalContractFunction() {
         validateGasEstimation(
-                Strings.encode(getFunctionFromArtifact(
-                                ContractMethods.CALL_CODE_TO_EXTERNAL_CONTRACT_FUNCTION,
-                                ContractResource.ESTIMATE_GAS_TEST_CONTRACT)
-                        .encodeCallWithArgs(new BigInteger("1"), asAddress(contractSolidityAddress))),
-                ContractMethods.CALL_CODE_TO_EXTERNAL_CONTRACT_FUNCTION.getActualGas(),
+                encodeData(
+                        ESTIMATE_GAS_TEST_CONTRACT,
+                        CALL_CODE_TO_EXTERNAL_CONTRACT_FUNCTION,
+                        new BigInteger("1"),
+                        asAddress(contractSolidityAddress)),
+                CALL_CODE_TO_EXTERNAL_CONTRACT_FUNCTION,
                 contractSolidityAddress);
     }
 
     @Then("I call estimateGas with function that makes delegate call to an external contract function")
     public void delegateCallCodeToExternalContractFunction() {
         validateGasEstimation(
-                Strings.encode(getFunctionFromArtifact(
-                                ContractMethods.DELEGATE_CALL_CODE_TO_EXTERNAL_CONTRACT_FUNCTION,
-                                ContractResource.ESTIMATE_GAS_TEST_CONTRACT)
-                        .encodeCallWithArgs(new BigInteger("1"), asAddress(contractSolidityAddress))),
-                ContractMethods.DELEGATE_CALL_CODE_TO_EXTERNAL_CONTRACT_FUNCTION.getActualGas(),
+                encodeData(
+                        ESTIMATE_GAS_TEST_CONTRACT,
+                        DELEGATE_CALL_CODE_TO_EXTERNAL_CONTRACT_FUNCTION,
+                        new BigInteger("1"),
+                        asAddress(contractSolidityAddress)),
+                DELEGATE_CALL_CODE_TO_EXTERNAL_CONTRACT_FUNCTION,
                 contractSolidityAddress);
     }
 
     @Then("I call estimateGas with function that makes call to an external contract view function")
     public void callCodeToExternalContractViewFunction() {
         validateGasEstimation(
-                Strings.encode(getFunctionFromArtifact(
-                                ContractMethods.CALL_CODE_TO_EXTERNAL_CONTRACT_FUNCTION_VIEW,
-                                ContractResource.ESTIMATE_GAS_TEST_CONTRACT)
-                        .encodeCallWithArgs(new BigInteger("1"), asAddress(contractSolidityAddress))),
-                ContractMethods.CALL_CODE_TO_EXTERNAL_CONTRACT_FUNCTION_VIEW.getActualGas(),
+                encodeData(
+                        ESTIMATE_GAS_TEST_CONTRACT,
+                        CALL_CODE_TO_EXTERNAL_CONTRACT_FUNCTION_VIEW,
+                        new BigInteger("1"),
+                        asAddress(contractSolidityAddress)),
+                CALL_CODE_TO_EXTERNAL_CONTRACT_FUNCTION_VIEW,
                 contractSolidityAddress);
     }
 
@@ -353,10 +340,8 @@ public class EstimateFeature extends AbstractEstimateFeature {
     public void stateUpdateContractFunction() {
         // making 5 times to state update
         validateGasEstimation(
-                Strings.encode(getFunctionFromArtifact(
-                                ContractMethods.STATE_UPDATE_OF_CONTRACT, ContractResource.ESTIMATE_GAS_TEST_CONTRACT)
-                        .encodeCallWithArgs(new BigInteger("5"))),
-                ContractMethods.STATE_UPDATE_OF_CONTRACT.getActualGas(),
+                encodeData(ESTIMATE_GAS_TEST_CONTRACT, STATE_UPDATE_OF_CONTRACT, new BigInteger("5")),
+                STATE_UPDATE_OF_CONTRACT,
                 contractSolidityAddress);
     }
 
@@ -365,9 +350,8 @@ public class EstimateFeature extends AbstractEstimateFeature {
     public void progressiveStateUpdateContractFunction() {
         // making 5 times to state update
         var contractCallRequestStateUpdateWithFive = ContractCallRequest.builder()
-                .data(Strings.encode(getFunctionFromArtifact(
-                                ContractMethods.STATE_UPDATE_OF_CONTRACT, ContractResource.ESTIMATE_GAS_TEST_CONTRACT)
-                        .encodeCallWithArgs(new BigInteger("5"))))
+                .data(Strings.encode(
+                        encodeData(ESTIMATE_GAS_TEST_CONTRACT, STATE_UPDATE_OF_CONTRACT, new BigInteger("5"))))
                 .to(contractSolidityAddress)
                 .estimate(true)
                 .build();
@@ -377,9 +361,8 @@ public class EstimateFeature extends AbstractEstimateFeature {
                 fiveStateUpdatesResponse.getResultAsNumber().intValue();
         // making 10 times to state update
         var contractCallRequestStateUpdateWithTen = ContractCallRequest.builder()
-                .data(Strings.encode(getFunctionFromArtifact(
-                                ContractMethods.STATE_UPDATE_OF_CONTRACT, ContractResource.ESTIMATE_GAS_TEST_CONTRACT)
-                        .encodeCallWithArgs(new BigInteger("10"))))
+                .data(Strings.encode(
+                        encodeData(ESTIMATE_GAS_TEST_CONTRACT, STATE_UPDATE_OF_CONTRACT, new BigInteger("10"))))
                 .to(contractSolidityAddress)
                 .estimate(true)
                 .build();
@@ -394,31 +377,31 @@ public class EstimateFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with function that executes reentrancy attack with call")
     public void reentrancyCallAttackFunction() {
         validateGasEstimation(
-                Strings.encode(getFunctionFromArtifact(
-                                ContractMethods.REENTRANCY_CALL_ATTACK, ContractResource.ESTIMATE_GAS_TEST_CONTRACT)
-                        .encodeCallWithArgs(asAddress(RANDOM_ADDRESS), new BigInteger("10000000000"))),
-                ContractMethods.REENTRANCY_CALL_ATTACK.getActualGas(),
+                encodeData(
+                        ESTIMATE_GAS_TEST_CONTRACT,
+                        REENTRANCY_CALL_ATTACK,
+                        asAddress(RANDOM_ADDRESS),
+                        new BigInteger("10000000000")),
+                REENTRANCY_CALL_ATTACK,
                 contractSolidityAddress);
     }
 
     @Then("I call estimateGas with function that executes gasLeft")
     public void getGasLeftContractFunction() {
         validateGasEstimation(
-                Strings.encode(getFunctionFromArtifact(
-                                ContractMethods.GET_GAS_LEFT, ContractResource.ESTIMATE_GAS_TEST_CONTRACT)
-                        .encodeCallWithArgs()),
-                ContractMethods.GET_GAS_LEFT.getActualGas(),
-                contractSolidityAddress);
+                encodeData(ESTIMATE_GAS_TEST_CONTRACT, GET_GAS_LEFT), GET_GAS_LEFT, contractSolidityAddress);
     }
 
     @Then("I call estimateGas with function that executes positive nested calls")
     public void positiveNestedCallsFunction() {
         validateGasEstimation(
-                Strings.encode(getFunctionFromArtifact(
-                                ContractMethods.NESTED_CALLS_POSITIVE, ContractResource.ESTIMATE_GAS_TEST_CONTRACT)
-                        .encodeCallWithArgs(
-                                new BigInteger("1"), new BigInteger("10"), asAddress(contractSolidityAddress))),
-                ContractMethods.NESTED_CALLS_POSITIVE.getActualGas(),
+                encodeData(
+                        ESTIMATE_GAS_TEST_CONTRACT,
+                        NESTED_CALLS_POSITIVE,
+                        new BigInteger("1"),
+                        new BigInteger("10"),
+                        asAddress(contractSolidityAddress)),
+                NESTED_CALLS_POSITIVE,
                 contractSolidityAddress);
     }
 
@@ -427,35 +410,40 @@ public class EstimateFeature extends AbstractEstimateFeature {
         // verify that after exceeding a number of nested calls that the estimated gas would return the same
         // we will execute with 500, 1024 and 1025, and it should return the same estimatedGas
         validateGasEstimation(
-                Strings.encode(getFunctionFromArtifact(
-                                ContractMethods.NESTED_CALLS_LIMITED, ContractResource.ESTIMATE_GAS_TEST_CONTRACT)
-                        .encodeCallWithArgs(
-                                new BigInteger("1"), new BigInteger("500"), asAddress(contractSolidityAddress))),
-                ContractMethods.NESTED_CALLS_LIMITED.getActualGas(),
+                encodeData(
+                        ESTIMATE_GAS_TEST_CONTRACT,
+                        NESTED_CALLS_LIMITED,
+                        new BigInteger("1"),
+                        new BigInteger("500"),
+                        asAddress(contractSolidityAddress)),
+                NESTED_CALLS_LIMITED,
                 contractSolidityAddress);
         validateGasEstimation(
-                Strings.encode(getFunctionFromArtifact(
-                                ContractMethods.NESTED_CALLS_LIMITED, ContractResource.ESTIMATE_GAS_TEST_CONTRACT)
-                        .encodeCallWithArgs(
-                                new BigInteger("1"), new BigInteger("1024"), asAddress(contractSolidityAddress))),
-                ContractMethods.NESTED_CALLS_LIMITED.getActualGas(),
+                encodeData(
+                        ESTIMATE_GAS_TEST_CONTRACT,
+                        NESTED_CALLS_LIMITED,
+                        new BigInteger("1"),
+                        new BigInteger("1024"),
+                        asAddress(contractSolidityAddress)),
+                NESTED_CALLS_LIMITED,
                 contractSolidityAddress);
         validateGasEstimation(
-                Strings.encode(getFunctionFromArtifact(
-                                ContractMethods.NESTED_CALLS_LIMITED, ContractResource.ESTIMATE_GAS_TEST_CONTRACT)
-                        .encodeCallWithArgs(
-                                new BigInteger("1"), new BigInteger("1025"), asAddress(contractSolidityAddress))),
-                ContractMethods.NESTED_CALLS_LIMITED.getActualGas(),
+                encodeData(
+                        ESTIMATE_GAS_TEST_CONTRACT,
+                        NESTED_CALLS_LIMITED,
+                        new BigInteger("1"),
+                        new BigInteger("1025"),
+                        asAddress(contractSolidityAddress)),
+                NESTED_CALLS_LIMITED,
                 contractSolidityAddress);
     }
 
     @Then("I call estimateGas with IERC20 token transfer using long zero address as receiver")
     public void ierc20TransferWithLongZeroAddressForReceiver() {
         validateGasEstimation(
-                Strings.encode(new Function(ContractMethods.IERC20_TOKEN_TRANSFER.getSelector())
-                        .encodeCallWithArgs(
-                                asAddress(receiverAccountId.getAccountId().toSolidityAddress()), new BigInteger("1"))),
-                ContractMethods.IERC20_TOKEN_TRANSFER.getActualGas(),
+                new Function(IERC20_TOKEN_TRANSFER.getSelector())
+                        .encodeCallWithArgs(asAddress(receiverAccountId), new BigInteger("1")),
+                IERC20_TOKEN_TRANSFER,
                 fungibleTokenId.toSolidityAddress());
     }
 
@@ -463,10 +451,10 @@ public class EstimateFeature extends AbstractEstimateFeature {
     public void ierc20TransferWithEvmAddressForReceiver() {
         var accountInfo = mirrorClient.getAccountDetailsByAccountId(receiverAccountId.getAccountId());
         validateGasEstimation(
-                Strings.encode(new Function(ContractMethods.IERC20_TOKEN_TRANSFER.getSelector())
+                new Function(IERC20_TOKEN_TRANSFER.getSelector())
                         .encodeCallWithArgs(
-                                asAddress(accountInfo.getEvmAddress().replace("0x", "")), new BigInteger("1"))),
-                ContractMethods.IERC20_TOKEN_TRANSFER.getActualGas(),
+                                asAddress(accountInfo.getEvmAddress().replace("0x", "")), new BigInteger("1")),
+                IERC20_TOKEN_TRANSFER,
                 fungibleTokenId.toSolidityAddress());
     }
 
@@ -474,27 +462,26 @@ public class EstimateFeature extends AbstractEstimateFeature {
     public void ierc20ApproveWithEvmAddressForReceiver() {
         var accountInfo = mirrorClient.getAccountDetailsByAccountId(receiverAccountId.getAccountId());
         validateGasEstimation(
-                (Strings.encode(new Function(ContractMethods.IERC20_TOKEN_APPROVE.getSelector())
+                new Function(IERC20_TOKEN_APPROVE.getSelector())
                         .encodeCallWithArgs(
-                                asAddress(accountInfo.getEvmAddress().replace("0x", "")), new BigInteger("1")))),
-                ContractMethods.IERC20_TOKEN_APPROVE.getActualGas(),
+                                asAddress(accountInfo.getEvmAddress().replace("0x", "")), new BigInteger("1")),
+                IERC20_TOKEN_APPROVE,
                 fungibleTokenId.toSolidityAddress());
     }
 
     @Then("I call estimateGas with IERC20 token associate using evm address as receiver")
     public void ierc20AssociateWithEvmAddressForReceiver() {
         validateGasEstimation(
-                Strings.encode(new Function(ContractMethods.IERC20_TOKEN_ASSOCIATE.getSelector()).encodeCallWithArgs()),
-                ContractMethods.IERC20_TOKEN_ASSOCIATE.getActualGas(),
+                new Function(IERC20_TOKEN_ASSOCIATE.getSelector()).encodeCallWithArgs(),
+                IERC20_TOKEN_ASSOCIATE,
                 fungibleTokenId.toSolidityAddress());
     }
 
     @Then("I call estimateGas with IERC20 token dissociate using evm address as receiver")
     public void ierc20DissociateWithEvmAddressForReceiver() {
         validateGasEstimation(
-                (Strings.encode(
-                        new Function(ContractMethods.IERC20_TOKEN_DISSOCIATE.getSelector()).encodeCallWithArgs())),
-                ContractMethods.IERC20_TOKEN_DISSOCIATE.getActualGas(),
+                new Function(IERC20_TOKEN_DISSOCIATE.getSelector()).encodeCallWithArgs(),
+                IERC20_TOKEN_DISSOCIATE,
                 fungibleTokenId.toSolidityAddress());
     }
 
@@ -504,7 +491,7 @@ public class EstimateFeature extends AbstractEstimateFeature {
      */
     @Getter
     @RequiredArgsConstructor
-    private enum ContractMethods implements ContractMethodInterface {
+    enum ContractMethods implements ContractMethodInterface {
         ADDRESS_BALANCE("addressBalance", 24041),
         CALL_CODE_TO_CONTRACT("callCodeToContract", 26398),
         CALL_CODE_TO_EXTERNAL_CONTRACT_FUNCTION("callExternalFunctionNTimes", 26100),

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/EstimatePrecompileFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/EstimatePrecompileFeature.java
@@ -20,9 +20,9 @@ import static com.hedera.mirror.test.e2e.acceptance.client.TokenClient.TokenName
 import static com.hedera.mirror.test.e2e.acceptance.client.TokenClient.TokenNameEnum.FUNGIBLE_KYC_UNFROZEN;
 import static com.hedera.mirror.test.e2e.acceptance.client.TokenClient.TokenNameEnum.NFT;
 import static com.hedera.mirror.test.e2e.acceptance.client.TokenClient.TokenNameEnum.NFT_KYC_UNFROZEN;
-import static com.hedera.mirror.test.e2e.acceptance.steps.AbstractFeature.ContractResource.ERC_TEST_CONTRACT;
-import static com.hedera.mirror.test.e2e.acceptance.steps.AbstractFeature.ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT;
-import static com.hedera.mirror.test.e2e.acceptance.steps.AbstractFeature.ContractResource.PRECOMPILE_TEST_CONTRACT;
+import static com.hedera.mirror.test.e2e.acceptance.steps.AbstractFeature.ContractResource.ERC;
+import static com.hedera.mirror.test.e2e.acceptance.steps.AbstractFeature.ContractResource.ESTIMATE_PRECOMPILE;
+import static com.hedera.mirror.test.e2e.acceptance.steps.AbstractFeature.ContractResource.PRECOMPILE;
 import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.ALLOWANCE;
 import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.ALLOWANCE_ERC;
 import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.APPROVE;
@@ -123,7 +123,6 @@ import static com.hedera.mirror.test.e2e.acceptance.util.TestUtil.to32BytesStrin
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.esaulpaugh.headlong.abi.Tuple;
-import com.esaulpaugh.headlong.util.Strings;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.hashgraph.sdk.AccountId;
 import com.hedera.hashgraph.sdk.NftId;
@@ -139,7 +138,6 @@ import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import java.io.IOException;
 import java.math.BigInteger;
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -180,7 +178,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Given("I create estimate precompile contract with 0 balance")
     public void createNewEstimateContract() throws IOException {
-        deployedEstimatePrecompileContract = getContract(ESTIMATE_PRECOMPILE_TEST_CONTRACT);
+        deployedEstimatePrecompileContract = getContract(ESTIMATE_PRECOMPILE);
         estimatePrecompileContractSolidityAddress =
                 deployedEstimatePrecompileContract.contractId().toSolidityAddress();
         admin = tokenClient.getSdkClient().getExpandedOperatorAccountId();
@@ -191,7 +189,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Given("I create erc test contract with 0 balance")
     public void createNewERCContract() throws IOException {
-        deployedErcTestContract = getContract(ERC_TEST_CONTRACT);
+        deployedErcTestContract = getContract(ERC);
         ercTestContractSolidityAddress = deployedErcTestContract.contractId().toSolidityAddress();
     }
 
@@ -202,7 +200,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Given("I successfully create Precompile contract with 0 balance")
     public void createNewPrecompileTestContract() throws IOException {
-        deployedPrecompileContract = getContract(PRECOMPILE_TEST_CONTRACT);
+        deployedPrecompileContract = getContract(PRECOMPILE);
         precompileTestContractSolidityAddress =
                 deployedPrecompileContract.contractId().toSolidityAddress();
     }
@@ -239,20 +237,14 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with associate function for fungible token")
     public void associateFunctionEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
-                ASSOCIATE_TOKEN,
-                asAddress(receiverAccountAlias),
-                asAddress(fungibleTokenId));
+                ESTIMATE_PRECOMPILE, ASSOCIATE_TOKEN, asAddress(receiverAccountAlias), asAddress(fungibleTokenId));
         validateGasEstimation(data, ASSOCIATE_TOKEN, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with associate function for NFT")
     public void associateFunctionNFTEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
-                ASSOCIATE_TOKEN,
-                asAddress(receiverAccountAlias),
-                asAddress(nonFungibleTokenId));
+                ESTIMATE_PRECOMPILE, ASSOCIATE_TOKEN, asAddress(receiverAccountAlias), asAddress(nonFungibleTokenId));
         validateGasEstimation(data, ASSOCIATE_TOKEN, estimatePrecompileContractSolidityAddress);
     }
 
@@ -261,10 +253,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
         // attempt to call dissociate function without having association
         // expecting status 400/revert
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
-                DISSOCIATE_TOKEN,
-                asAddress(receiverAccountAlias),
-                asAddress(fungibleTokenId));
+                ESTIMATE_PRECOMPILE, DISSOCIATE_TOKEN, asAddress(receiverAccountAlias), asAddress(fungibleTokenId));
 
         assertContractCallReturnsBadRequest(data, estimatePrecompileContractSolidityAddress);
     }
@@ -274,10 +263,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
         // attempt to call dissociate function without having association
         // expecting status 400/revert
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
-                DISSOCIATE_TOKEN,
-                asAddress(receiverAccountAlias),
-                asAddress(nonFungibleTokenId));
+                ESTIMATE_PRECOMPILE, DISSOCIATE_TOKEN, asAddress(receiverAccountAlias), asAddress(nonFungibleTokenId));
 
         assertContractCallReturnsBadRequest(data, estimatePrecompileContractSolidityAddress);
     }
@@ -287,10 +273,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
         // attempt to call associate function twice
         // expecting a revert
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
-                NESTED_ASSOCIATE,
-                asAddress(receiverAccountAlias),
-                asAddress(fungibleTokenId));
+                ESTIMATE_PRECOMPILE, NESTED_ASSOCIATE, asAddress(receiverAccountAlias), asAddress(fungibleTokenId));
 
         assertContractCallReturnsBadRequest(data, estimatePrecompileContractSolidityAddress);
     }
@@ -300,10 +283,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
         // attempt to call associate function twice
         // expecting a revert
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
-                NESTED_ASSOCIATE,
-                asAddress(receiverAccountAlias),
-                asAddress(nonFungibleTokenId));
+                ESTIMATE_PRECOMPILE, NESTED_ASSOCIATE, asAddress(receiverAccountAlias), asAddress(nonFungibleTokenId));
 
         assertContractCallReturnsBadRequest(data, estimatePrecompileContractSolidityAddress);
     }
@@ -317,10 +297,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with dissociate token function for fungible token")
     public void dissociateFunctionEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
-                DISSOCIATE_TOKEN,
-                asAddress(receiverAccountAlias),
-                asAddress(fungibleTokenId));
+                ESTIMATE_PRECOMPILE, DISSOCIATE_TOKEN, asAddress(receiverAccountAlias), asAddress(fungibleTokenId));
 
         validateGasEstimation(data, DISSOCIATE_TOKEN, estimatePrecompileContractSolidityAddress);
     }
@@ -334,10 +311,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with dissociate token function for NFT")
     public void dissociateFunctionNFTEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
-                DISSOCIATE_TOKEN,
-                asAddress(receiverAccountAlias),
-                asAddress(nonFungibleTokenId));
+                ESTIMATE_PRECOMPILE, DISSOCIATE_TOKEN, asAddress(receiverAccountAlias), asAddress(nonFungibleTokenId));
 
         validateGasEstimation(data, DISSOCIATE_TOKEN, estimatePrecompileContractSolidityAddress);
     }
@@ -347,7 +321,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
         // token is already associated
         // attempting to execute nested dissociate and associate function
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                ESTIMATE_PRECOMPILE,
                 DISSOCIATE_AND_ASSOCIATE,
                 asAddress(receiverAccountAlias),
                 asAddress(fungibleTokenId));
@@ -360,7 +334,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
         // token is already associated
         // attempting to execute nested dissociate and associate function
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                ESTIMATE_PRECOMPILE,
                 DISSOCIATE_AND_ASSOCIATE,
                 asAddress(receiverAccountAlias),
                 asAddress(nonFungibleTokenId));
@@ -371,7 +345,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with approve function without association")
     public void approveWithoutAssociationEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                ESTIMATE_PRECOMPILE,
                 APPROVE,
                 asAddress(fungibleTokenId),
                 asAddress(receiverAccountAlias),
@@ -383,7 +357,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with setApprovalForAll function without association")
     public void setApprovalForAllWithoutAssociationEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                ESTIMATE_PRECOMPILE,
                 SET_APPROVAL_FOR_ALL,
                 asAddress(nonFungibleTokenId),
                 asAddress(receiverAccountAlias),
@@ -395,7 +369,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with approveNFT function without association")
     public void approveNonFungibleWithoutAssociationEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                ESTIMATE_PRECOMPILE,
                 APPROVE_NFT,
                 asAddress(nonFungibleTokenId),
                 asAddress(receiverAccountAlias),
@@ -421,7 +395,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with approve function")
     public void approveEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                ESTIMATE_PRECOMPILE,
                 APPROVE,
                 asAddress(fungibleTokenId),
                 asAddress(receiverAccountAlias),
@@ -433,7 +407,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with approveNFT function")
     public void approveNftEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                ESTIMATE_PRECOMPILE,
                 APPROVE_NFT,
                 asAddress(nonFungibleKycUnfrozenTokenId),
                 asAddress(receiverAccountAlias),
@@ -445,11 +419,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with ERC approve function")
     public void ercApproveEstimateGas() {
         var data = encodeData(
-                ERC_TEST_CONTRACT,
-                APPROVE_ERC,
-                asAddress(fungibleTokenId),
-                asAddress(receiverAccountAlias),
-                new BigInteger("10"));
+                ERC, APPROVE_ERC, asAddress(fungibleTokenId), asAddress(receiverAccountAlias), new BigInteger("10"));
 
         validateGasEstimation(data, APPROVE_ERC, ercTestContractSolidityAddress);
     }
@@ -457,7 +427,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with setApprovalForAll function")
     public void setApprovalForAllEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                ESTIMATE_PRECOMPILE,
                 SET_APPROVAL_FOR_ALL,
                 asAddress(nonFungibleKycUnfrozenTokenId),
                 asAddress(receiverAccountAlias),
@@ -469,7 +439,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with transferFrom function without approval")
     public void transferFromEstimateGasWithoutApproval() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                ESTIMATE_PRECOMPILE,
                 TRANSFER_FROM,
                 asAddress(fungibleKycUnfrozenTokenId),
                 asAddress(admin),
@@ -482,7 +452,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with ERC transferFrom function without approval")
     public void ercTransferFromEstimateGasWithoutApproval() {
         var data = encodeData(
-                ERC_TEST_CONTRACT,
+                ERC,
                 TRANSFER_FROM_ERC,
                 asAddress(fungibleKycUnfrozenTokenId),
                 asAddress(admin),
@@ -500,7 +470,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with transferFrom function")
     public void transferFromEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                ESTIMATE_PRECOMPILE,
                 TRANSFER_FROM,
                 asAddress(fungibleTokenId),
                 asAddress(admin),
@@ -513,7 +483,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with ERC transferFrom function")
     public void ercTransferFromEstimateGas() {
         var data = encodeData(
-                ERC_TEST_CONTRACT,
+                ERC,
                 TRANSFER_FROM_ERC,
                 asAddress(fungibleTokenId),
                 asAddress(admin),
@@ -526,7 +496,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with transferFrom function with more than the approved allowance")
     public void transferFromExceedAllowanceEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                ESTIMATE_PRECOMPILE,
                 TRANSFER_FROM,
                 asAddress(fungibleKycUnfrozenTokenId),
                 asAddress(admin),
@@ -539,7 +509,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with ERC transferFrom function with more than the approved allowance")
     public void ercTransferFromExceedsAllowanceEstimateGas() {
         var data = encodeData(
-                ERC_TEST_CONTRACT,
+                ERC,
                 TRANSFER_FROM_ERC,
                 asAddress(fungibleKycUnfrozenTokenId),
                 asAddress(admin),
@@ -558,7 +528,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with transferFromNFT function")
     public void transferFromNFTEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                ESTIMATE_PRECOMPILE,
                 TRANSFER_FROM_NFT,
                 asAddress(nonFungibleTokenId),
                 asAddress(admin),
@@ -571,7 +541,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with transferFromNFT with invalid serial number")
     public void transferFromNFTInvalidSerialEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                ESTIMATE_PRECOMPILE,
                 TRANSFER_FROM_NFT,
                 asAddress(nonFungibleKycUnfrozenTokenId),
                 asAddress(admin),
@@ -584,7 +554,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with transferToken function")
     public void transferTokenEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                ESTIMATE_PRECOMPILE,
                 TRANSFER_TOKEN,
                 asAddress(fungibleTokenId),
                 asAddress(admin),
@@ -597,7 +567,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with transferNFT function")
     public void transferNFTEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                ESTIMATE_PRECOMPILE,
                 TRANSFER_NFT,
                 asAddress(nonFungibleTokenId),
                 asAddress(admin),
@@ -621,11 +591,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with ERC transfer function")
     public void ercTransferEstimateGas() {
         var data = encodeData(
-                ERC_TEST_CONTRACT,
-                TRANSFER_ERC,
-                asAddress(fungibleTokenId),
-                asAddress(receiverAccountAlias),
-                new BigInteger("5"));
+                ERC, TRANSFER_ERC, asAddress(fungibleTokenId), asAddress(receiverAccountAlias), new BigInteger("5"));
 
         validateGasEstimation(data, TRANSFER_ERC, ercTestContractSolidityAddress);
     }
@@ -633,7 +599,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with associateTokens function for fungible tokens")
     public void associateTokensEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                ESTIMATE_PRECOMPILE,
                 ASSOCIATE_TOKENS,
                 asAddress(secondReceiverAccount),
                 asAddressArray(Arrays.asList(
@@ -645,7 +611,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with associateTokens function for NFTs")
     public void associateNFTEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                ESTIMATE_PRECOMPILE,
                 ASSOCIATE_TOKENS,
                 asAddress(secondReceiverAccount),
                 asAddressArray(Arrays.asList(
@@ -662,7 +628,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with dissociateTokens function for fungible tokens")
     public void dissociateTokensEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                ESTIMATE_PRECOMPILE,
                 DISSOCIATE_TOKENS,
                 asAddress(receiverAccountAlias),
                 asAddressArray(Arrays.asList(
@@ -679,7 +645,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with dissociateTokens function for NFTs")
     public void dissociateNFTEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                ESTIMATE_PRECOMPILE,
                 DISSOCIATE_TOKENS,
                 asAddress(receiverAccountAlias),
                 asAddressArray(Arrays.asList(
@@ -698,7 +664,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with transferTokens function")
     public void transferTokensEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                ESTIMATE_PRECOMPILE,
                 TRANSFER_TOKENS,
                 asAddress(fungibleTokenId),
                 asAddressArray(Arrays.asList(
@@ -721,7 +687,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with transferNFTs function")
     public void transferNFTsEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                ESTIMATE_PRECOMPILE,
                 TRANSFER_NFTS,
                 asAddress(nonFungibleTokenId),
                 asAddressArray(Arrays.asList(admin.getAccountId().toSolidityAddress())),
@@ -738,7 +704,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
         var senderTransfer = accountAmount(admin.getAccountId().toSolidityAddress(), -10L, false);
         var receiverTransfer = accountAmount(receiverAccountAlias, 10L, false);
         var args = Tuple.of((Object) new Tuple[] {senderTransfer, receiverTransfer});
-        var data = encodeData(ESTIMATE_PRECOMPILE_TEST_CONTRACT, CRYPTO_TRANSFER_HBARS, args, EMPTY_TUPLE_ARRAY);
+        var data = encodeData(ESTIMATE_PRECOMPILE, CRYPTO_TRANSFER_HBARS, args, EMPTY_TUPLE_ARRAY);
         validateGasEstimation(data, CRYPTO_TRANSFER_HBARS, estimatePrecompileContractSolidityAddress);
     }
 
@@ -756,10 +722,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
                     .build()
         };
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
-                CRYPTO_TRANSFER_NFT,
-                Tuple.of((Object) EMPTY_TUPLE_ARRAY),
-                tokenTransferList);
+                ESTIMATE_PRECOMPILE, CRYPTO_TRANSFER_NFT, Tuple.of((Object) EMPTY_TUPLE_ARRAY), tokenTransferList);
         validateGasEstimation(data, CRYPTO_TRANSFER_NFT, estimatePrecompileContractSolidityAddress);
     }
 
@@ -774,17 +737,14 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
                     .build()
         };
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
-                CRYPTO_TRANSFER,
-                Tuple.of((Object) EMPTY_TUPLE_ARRAY),
-                tokenTransferList);
+                ESTIMATE_PRECOMPILE, CRYPTO_TRANSFER, Tuple.of((Object) EMPTY_TUPLE_ARRAY), tokenTransferList);
         validateGasEstimation(data, CRYPTO_TRANSFER, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with mintToken function for fungible token")
     public void mintFungibleTokenEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                ESTIMATE_PRECOMPILE,
                 MINT_TOKEN,
                 asAddress(fungibleKycUnfrozenTokenId),
                 1L,
@@ -796,11 +756,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with mintToken function for NFT")
     public void mintNFTEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
-                MINT_NFT,
-                asAddress(nonFungibleTokenId),
-                0L,
-                asByteArray(Arrays.asList("0x02")));
+                ESTIMATE_PRECOMPILE, MINT_NFT, asAddress(nonFungibleTokenId), 0L, asByteArray(Arrays.asList("0x02")));
 
         validateGasEstimation(data, MINT_NFT, estimatePrecompileContractSolidityAddress);
     }
@@ -808,7 +764,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with burnToken function for fungible token")
     public void burnFungibleTokenEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                ESTIMATE_PRECOMPILE,
                 BURN_TOKEN,
                 asAddress(fungibleKycUnfrozenTokenId),
                 1L,
@@ -820,7 +776,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with burnToken function for NFT")
     public void burnNFTEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                ESTIMATE_PRECOMPILE,
                 BURN_TOKEN,
                 asAddress(nonFungibleKycUnfrozenTokenId),
                 0L,
@@ -831,7 +787,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with CreateFungibleToken function")
     public void createFungibleTokenEstimateGas() {
-        var data = encodeData(ESTIMATE_PRECOMPILE_TEST_CONTRACT, CREATE_FUNGIBLE_TOKEN, asAddress(admin));
+        var data = encodeData(ESTIMATE_PRECOMPILE, CREATE_FUNGIBLE_TOKEN, asAddress(admin));
 
         Consumer<Boolean> estimateFunction = current -> validateGasEstimationForCreateToken(
                 data, CREATE_FUNGIBLE_TOKEN.getActualGas(), calculateCreateTokenFee(1, current));
@@ -840,7 +796,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with CreateNFT function")
     public void createNFTEstimateGas() {
-        var data = encodeData(ESTIMATE_PRECOMPILE_TEST_CONTRACT, CREATE_NFT, asAddress(admin));
+        var data = encodeData(ESTIMATE_PRECOMPILE, CREATE_NFT, asAddress(admin));
 
         Consumer<Boolean> estimateFunction = current -> validateGasEstimationForCreateToken(
                 data, CREATE_FUNGIBLE_TOKEN.getActualGas(), calculateCreateTokenFee(1, current));
@@ -850,7 +806,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with CreateFungibleToken function with custom fees")
     public void createFungibleTokenWithCustomFeesEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                ESTIMATE_PRECOMPILE,
                 CREATE_FUNGIBLE_TOKEN_WITH_CUSTOM_FEES,
                 asAddress(admin),
                 asAddress(fungibleKycUnfrozenTokenId));
@@ -863,7 +819,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with CreateNFT function with custom fees")
     public void createNFTWithCustomFeesEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                ESTIMATE_PRECOMPILE,
                 CREATE_NFT_WITH_CUSTOM_FEES,
                 asAddress(admin),
                 asAddress(nonFungibleKycUnfrozenTokenId));
@@ -883,7 +839,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with WipeTokenAccount function")
     public void wipeTokenAccountEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                ESTIMATE_PRECOMPILE,
                 WIPE_TOKEN_ACCOUNT,
                 asAddress(fungibleTokenId),
                 asAddress(receiverAccountAlias),
@@ -895,7 +851,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with WipeTokenAccount function with invalid amount")
     public void wipeTokenAccountInvalidAmountEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                ESTIMATE_PRECOMPILE,
                 WIPE_TOKEN_ACCOUNT,
                 asAddress(fungibleKycUnfrozenTokenId),
                 asAddress(receiverAccountAlias),
@@ -917,7 +873,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with WipeNFTAccount function")
     public void wipeNFTAccountEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                ESTIMATE_PRECOMPILE,
                 WIPE_NFT_ACCOUNT,
                 asAddress(nonFungibleTokenId),
                 asAddress(receiverAccountAlias),
@@ -929,7 +885,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with WipeNFTAccount function with invalid serial number")
     public void wipeNFTAccountInvalidSerialNumberEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                ESTIMATE_PRECOMPILE,
                 WIPE_NFT_ACCOUNT,
                 asAddress(nonFungibleKycUnfrozenTokenId),
                 asAddress(receiverAccountAlias),
@@ -941,10 +897,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with GrantKYC function for fungible token")
     public void grantKYCFungibleEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
-                GRANT_KYC,
-                asAddress(fungibleKycUnfrozenTokenId),
-                asAddress(receiverAccountAlias));
+                ESTIMATE_PRECOMPILE, GRANT_KYC, asAddress(fungibleKycUnfrozenTokenId), asAddress(receiverAccountAlias));
 
         validateGasEstimation(data, GRANT_KYC, estimatePrecompileContractSolidityAddress);
     }
@@ -952,7 +905,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with GrantKYC function for NFT")
     public void grantKYCNonFungibleEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                ESTIMATE_PRECOMPILE,
                 GRANT_KYC,
                 asAddress(nonFungibleKycUnfrozenTokenId),
                 asAddress(receiverAccountAlias));
@@ -963,7 +916,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with RevokeTokenKYC function for fungible token")
     public void revokeTokenKYCEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                ESTIMATE_PRECOMPILE,
                 REVOKE_KYC,
                 asAddress(fungibleKycUnfrozenTokenId),
                 asAddress(receiverAccountAlias));
@@ -974,7 +927,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with RevokeTokenKYC function for NFT")
     public void revokeTokenKYCNonFungibleEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                ESTIMATE_PRECOMPILE,
                 REVOKE_KYC,
                 asAddress(nonFungibleKycUnfrozenTokenId),
                 asAddress(receiverAccountAlias));
@@ -985,7 +938,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with Grant and Revoke KYC nested function")
     public void nestedGrantRevokeKYCEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                ESTIMATE_PRECOMPILE,
                 NESTED_GRANT_REVOKE_KYC,
                 asAddress(fungibleKycUnfrozenTokenId),
                 asAddress(receiverAccountAlias));
@@ -996,7 +949,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with Freeze function for fungible token")
     public void freezeFungibleEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                ESTIMATE_PRECOMPILE,
                 FREEZE_TOKEN,
                 asAddress(fungibleKycUnfrozenTokenId),
                 asAddress(receiverAccountAlias));
@@ -1007,7 +960,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with Freeze function for NFT")
     public void freezeNonFungibleEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                ESTIMATE_PRECOMPILE,
                 FREEZE_TOKEN,
                 asAddress(nonFungibleKycUnfrozenTokenId),
                 asAddress(receiverAccountAlias));
@@ -1018,7 +971,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with Unfreeze function for fungible token")
     public void unfreezeFungibleEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                ESTIMATE_PRECOMPILE,
                 UNFREEZE_TOKEN,
                 asAddress(fungibleKycUnfrozenTokenId),
                 asAddress(receiverAccountAlias));
@@ -1029,7 +982,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with Unfreeze function for NFT")
     public void unfreezeNonFungibleEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                ESTIMATE_PRECOMPILE,
                 UNFREEZE_TOKEN,
                 asAddress(nonFungibleKycUnfrozenTokenId),
                 asAddress(receiverAccountAlias));
@@ -1040,7 +993,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with nested Freeze and Unfreeze function for fungible token")
     public void nestedFreezeAndUnfreezeEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                ESTIMATE_PRECOMPILE,
                 NESTED_FREEZE_UNFREEZE,
                 asAddress(fungibleKycUnfrozenTokenId),
                 asAddress(receiverAccountAlias));
@@ -1051,7 +1004,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with nested Freeze and Unfreeze function for NFT")
     public void nestedFreezeAndUnfreezeNFTEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                ESTIMATE_PRECOMPILE,
                 NESTED_FREEZE_UNFREEZE,
                 asAddress(nonFungibleKycUnfrozenTokenId),
                 asAddress(receiverAccountAlias));
@@ -1061,69 +1014,64 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with delete function for Fungible token")
     public void deleteFungibleEstimateGas() {
-        var data = encodeData(ESTIMATE_PRECOMPILE_TEST_CONTRACT, DELETE_TOKEN, asAddress(fungibleKycUnfrozenTokenId));
+        var data = encodeData(ESTIMATE_PRECOMPILE, DELETE_TOKEN, asAddress(fungibleKycUnfrozenTokenId));
 
         validateGasEstimation(data, DELETE_TOKEN, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with delete function for NFT")
     public void deleteNFTEstimateGas() {
-        var data =
-                encodeData(ESTIMATE_PRECOMPILE_TEST_CONTRACT, DELETE_TOKEN, asAddress(nonFungibleKycUnfrozenTokenId));
+        var data = encodeData(ESTIMATE_PRECOMPILE, DELETE_TOKEN, asAddress(nonFungibleKycUnfrozenTokenId));
 
         validateGasEstimation(data, DELETE_TOKEN, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with delete function for invalid token address")
     public void deleteTokenRandomAddressEstimateGas() {
-        var data = encodeData(ESTIMATE_PRECOMPILE_TEST_CONTRACT, DELETE_TOKEN, asAddress(RANDOM_ADDRESS));
+        var data = encodeData(ESTIMATE_PRECOMPILE, DELETE_TOKEN, asAddress(RANDOM_ADDRESS));
 
         assertContractCallReturnsBadRequest(data, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with pause function for fungible token")
     public void pauseFungibleTokenPositiveEstimateGas() {
-        var data = encodeData(ESTIMATE_PRECOMPILE_TEST_CONTRACT, PAUSE_TOKEN, asAddress(fungibleKycUnfrozenTokenId));
+        var data = encodeData(ESTIMATE_PRECOMPILE, PAUSE_TOKEN, asAddress(fungibleKycUnfrozenTokenId));
 
         validateGasEstimation(data, PAUSE_TOKEN, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with pause function for NFT")
     public void pauseNFTPositiveEstimateGas() {
-        var data = encodeData(ESTIMATE_PRECOMPILE_TEST_CONTRACT, PAUSE_TOKEN, asAddress(nonFungibleKycUnfrozenTokenId));
+        var data = encodeData(ESTIMATE_PRECOMPILE, PAUSE_TOKEN, asAddress(nonFungibleKycUnfrozenTokenId));
 
         validateGasEstimation(data, PAUSE_TOKEN, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with unpause function for fungible token")
     public void unpauseFungibleTokenPositiveEstimateGas() {
-        var data = encodeData(ESTIMATE_PRECOMPILE_TEST_CONTRACT, UNPAUSE_TOKEN, asAddress(fungibleKycUnfrozenTokenId));
+        var data = encodeData(ESTIMATE_PRECOMPILE, UNPAUSE_TOKEN, asAddress(fungibleKycUnfrozenTokenId));
 
         validateGasEstimation(data, UNPAUSE_TOKEN, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with unpause function for NFT")
     public void unpauseNFTPositiveEstimateGas() {
-        var data =
-                encodeData(ESTIMATE_PRECOMPILE_TEST_CONTRACT, UNPAUSE_TOKEN, asAddress(nonFungibleKycUnfrozenTokenId));
+        var data = encodeData(ESTIMATE_PRECOMPILE, UNPAUSE_TOKEN, asAddress(nonFungibleKycUnfrozenTokenId));
 
         validateGasEstimation(data, UNPAUSE_TOKEN, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas for nested pause and unpause function")
     public void pauseUnpauseFungibleTokenNestedCallEstimateGas() {
-        var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT, PAUSE_UNPAUSE_NESTED_TOKEN, asAddress(fungibleKycUnfrozenTokenId));
+        var data = encodeData(ESTIMATE_PRECOMPILE, PAUSE_UNPAUSE_NESTED_TOKEN, asAddress(fungibleKycUnfrozenTokenId));
 
         validateGasEstimation(data, PAUSE_UNPAUSE_NESTED_TOKEN, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas for nested pause, unpause NFT function")
     public void pauseUnpauseNFTNestedCallEstimateGas() {
-        var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
-                PAUSE_UNPAUSE_NESTED_TOKEN,
-                asAddress(nonFungibleKycUnfrozenTokenId));
+        var data =
+                encodeData(ESTIMATE_PRECOMPILE, PAUSE_UNPAUSE_NESTED_TOKEN, asAddress(nonFungibleKycUnfrozenTokenId));
 
         validateGasEstimation(data, PAUSE_UNPAUSE_NESTED_TOKEN, estimatePrecompileContractSolidityAddress);
     }
@@ -1131,10 +1079,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with updateTokenExpiryInfo function")
     public void updateTokenExpiryInfoEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
-                UPDATE_TOKEN_EXPIRY,
-                asAddress(fungibleKycUnfrozenTokenId),
-                asAddress(admin));
+                ESTIMATE_PRECOMPILE, UPDATE_TOKEN_EXPIRY, asAddress(fungibleKycUnfrozenTokenId), asAddress(admin));
 
         validateGasEstimation(data, UPDATE_TOKEN_EXPIRY, estimatePrecompileContractSolidityAddress);
     }
@@ -1142,33 +1087,28 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with updateTokenInfo function")
     public void updateTokenInfoEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
-                UPDATE_TOKEN_INFO,
-                asAddress(fungibleKycUnfrozenTokenId),
-                asAddress(admin));
+                ESTIMATE_PRECOMPILE, UPDATE_TOKEN_INFO, asAddress(fungibleKycUnfrozenTokenId), asAddress(admin));
 
         validateGasEstimation(data, UPDATE_TOKEN_INFO, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with updateTokenKeys function")
     public void updateTokenKeysEstimateGas() {
-        var data =
-                encodeData(ESTIMATE_PRECOMPILE_TEST_CONTRACT, UPDATE_TOKEN_KEYS, asAddress(fungibleKycUnfrozenTokenId));
+        var data = encodeData(ESTIMATE_PRECOMPILE, UPDATE_TOKEN_KEYS, asAddress(fungibleKycUnfrozenTokenId));
 
         validateGasEstimation(data, UPDATE_TOKEN_KEYS, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with getTokenExpiryInfo function")
     public void getTokenExpiryInfoEstimateGas() {
-        var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT, GET_TOKEN_EXPIRY_INFO, asAddress(fungibleKycUnfrozenTokenId));
+        var data = encodeData(ESTIMATE_PRECOMPILE, GET_TOKEN_EXPIRY_INFO, asAddress(fungibleKycUnfrozenTokenId));
 
         validateGasEstimation(data, GET_TOKEN_EXPIRY_INFO, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with isToken function")
     public void isTokenEstimateGas() {
-        var data = encodeData(ESTIMATE_PRECOMPILE_TEST_CONTRACT, IS_TOKEN, asAddress(fungibleKycUnfrozenTokenId));
+        var data = encodeData(ESTIMATE_PRECOMPILE, IS_TOKEN, asAddress(fungibleKycUnfrozenTokenId));
 
         validateGasEstimation(data, IS_TOKEN, estimatePrecompileContractSolidityAddress);
     }
@@ -1176,10 +1116,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with getTokenKey function for supply")
     public void getTokenKeySupplyEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
-                GET_TOKEN_KEY,
-                asAddress(fungibleKycUnfrozenTokenId),
-                new BigInteger("16"));
+                ESTIMATE_PRECOMPILE, GET_TOKEN_KEY, asAddress(fungibleKycUnfrozenTokenId), new BigInteger("16"));
 
         validateGasEstimation(data, GET_TOKEN_KEY, estimatePrecompileContractSolidityAddress);
     }
@@ -1187,10 +1124,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with getTokenKey function for KYC")
     public void getTokenKeyKYCEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
-                GET_TOKEN_KEY,
-                asAddress(fungibleKycUnfrozenTokenId),
-                new BigInteger("2"));
+                ESTIMATE_PRECOMPILE, GET_TOKEN_KEY, asAddress(fungibleKycUnfrozenTokenId), new BigInteger("2"));
 
         validateGasEstimation(data, GET_TOKEN_KEY, estimatePrecompileContractSolidityAddress);
     }
@@ -1198,10 +1132,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with getTokenKey function for freeze")
     public void getTokenKeyFreezeEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
-                GET_TOKEN_KEY,
-                asAddress(fungibleKycUnfrozenTokenId),
-                new BigInteger("4"));
+                ESTIMATE_PRECOMPILE, GET_TOKEN_KEY, asAddress(fungibleKycUnfrozenTokenId), new BigInteger("4"));
 
         validateGasEstimation(data, GET_TOKEN_KEY, estimatePrecompileContractSolidityAddress);
     }
@@ -1209,10 +1140,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with getTokenKey function for admin")
     public void getTokenKeyAdminEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
-                GET_TOKEN_KEY,
-                asAddress(fungibleKycUnfrozenTokenId),
-                new BigInteger("1"));
+                ESTIMATE_PRECOMPILE, GET_TOKEN_KEY, asAddress(fungibleKycUnfrozenTokenId), new BigInteger("1"));
 
         validateGasEstimation(data, GET_TOKEN_KEY, estimatePrecompileContractSolidityAddress);
     }
@@ -1220,10 +1148,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with getTokenKey function for wipe")
     public void getTokenKeyWipeEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
-                GET_TOKEN_KEY,
-                asAddress(fungibleKycUnfrozenTokenId),
-                new BigInteger("8"));
+                ESTIMATE_PRECOMPILE, GET_TOKEN_KEY, asAddress(fungibleKycUnfrozenTokenId), new BigInteger("8"));
 
         validateGasEstimation(data, GET_TOKEN_KEY, estimatePrecompileContractSolidityAddress);
     }
@@ -1231,10 +1156,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with getTokenKey function for fee")
     public void getTokenKeyFeeEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
-                GET_TOKEN_KEY,
-                asAddress(fungibleKycUnfrozenTokenId),
-                new BigInteger("32"));
+                ESTIMATE_PRECOMPILE, GET_TOKEN_KEY, asAddress(fungibleKycUnfrozenTokenId), new BigInteger("32"));
 
         validateGasEstimation(data, GET_TOKEN_KEY, estimatePrecompileContractSolidityAddress);
     }
@@ -1242,10 +1164,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with getTokenKey function for pause")
     public void getTokenKeyPauseEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
-                GET_TOKEN_KEY,
-                asAddress(fungibleKycUnfrozenTokenId),
-                new BigInteger("64"));
+                ESTIMATE_PRECOMPILE, GET_TOKEN_KEY, asAddress(fungibleKycUnfrozenTokenId), new BigInteger("64"));
 
         validateGasEstimation(data, GET_TOKEN_KEY, estimatePrecompileContractSolidityAddress);
     }
@@ -1253,7 +1172,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with allowance function for fungible token")
     public void allowanceFungibleEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                ESTIMATE_PRECOMPILE,
                 ALLOWANCE,
                 asAddress(fungibleKycUnfrozenTokenId),
                 asAddress(admin),
@@ -1265,7 +1184,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with allowance function for NFT")
     public void allowanceNonFungibleEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                ESTIMATE_PRECOMPILE,
                 ALLOWANCE,
                 asAddress(nonFungibleKycUnfrozenTokenId),
                 asAddress(admin),
@@ -1277,7 +1196,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with ERC allowance function for fungible token")
     public void ercAllowanceFungibleEstimateGas() {
         var data = encodeData(
-                ERC_TEST_CONTRACT,
+                ERC,
                 ALLOWANCE_ERC,
                 asAddress(fungibleKycUnfrozenTokenId),
                 asAddress(admin),
@@ -1289,18 +1208,14 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with getApproved function for NFT")
     public void getApprovedNonFungibleEstimateGas() {
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
-                GET_APPROVED,
-                asAddress(nonFungibleKycUnfrozenTokenId),
-                new BigInteger("1"));
+                ESTIMATE_PRECOMPILE, GET_APPROVED, asAddress(nonFungibleKycUnfrozenTokenId), new BigInteger("1"));
 
         validateGasEstimation(data, GET_APPROVED, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with ERC getApproved function for NFT")
     public void ercGetApprovedNonFungibleEstimateGas() {
-        var data = encodeData(
-                ERC_TEST_CONTRACT, GET_APPROVED_ERC, asAddress(nonFungibleKycUnfrozenTokenId), new BigInteger("1"));
+        var data = encodeData(ERC, GET_APPROVED_ERC, asAddress(nonFungibleKycUnfrozenTokenId), new BigInteger("1"));
 
         validateGasEstimation(data, GET_APPROVED_ERC, ercTestContractSolidityAddress);
     }
@@ -1309,7 +1224,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     public void isApprovedForAllEstimateGas() {
         // reminder: check with setApprovalForAll test-> there we have the contract associated so the test can work
         var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                ESTIMATE_PRECOMPILE,
                 IS_APPROVED_FOR_ALL,
                 asAddress(nonFungibleKycUnfrozenTokenId),
                 asAddress(admin),
@@ -1322,7 +1237,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     public void ercIsApprovedForAllEstimateGas() {
         // reminder: check with setApprovalForAll test-> there we have the contract associated so the test can work
         var data = encodeData(
-                ERC_TEST_CONTRACT,
+                ERC,
                 IS_APPROVED_FOR_ALL_ERC,
                 asAddress(nonFungibleKycUnfrozenTokenId),
                 asAddress(admin),
@@ -1333,152 +1248,141 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with name function for fungible token")
     public void nameEstimateGas() {
-        var data = encodeData(ERC_TEST_CONTRACT, NAME, asAddress(fungibleKycUnfrozenTokenId));
+        var data = encodeData(ERC, NAME, asAddress(fungibleKycUnfrozenTokenId));
 
         validateGasEstimation(data, NAME, ercTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with name function for NFT")
     public void nameNonFungibleEstimateGas() {
-        var data = encodeData(ERC_TEST_CONTRACT, NAME_NFT, asAddress(nonFungibleKycUnfrozenTokenId));
+        var data = encodeData(ERC, NAME_NFT, asAddress(nonFungibleKycUnfrozenTokenId));
 
         validateGasEstimation(data, NAME_NFT, ercTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with symbol function for fungible token")
     public void symbolEstimateGas() {
-        var data = encodeData(ERC_TEST_CONTRACT, SYMBOL, asAddress(fungibleKycUnfrozenTokenId));
+        var data = encodeData(ERC, SYMBOL, asAddress(fungibleKycUnfrozenTokenId));
 
         validateGasEstimation(data, SYMBOL, ercTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with symbol function for NFT")
     public void symbolNonFungibleEstimateGas() {
-        var data = encodeData(ERC_TEST_CONTRACT, SYMBOL_NFT, asAddress(nonFungibleKycUnfrozenTokenId));
+        var data = encodeData(ERC, SYMBOL_NFT, asAddress(nonFungibleKycUnfrozenTokenId));
 
         validateGasEstimation(data, SYMBOL_NFT, ercTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with decimals function for fungible token")
     public void decimalsEstimateGas() {
-        var data = encodeData(ERC_TEST_CONTRACT, DECIMALS, asAddress(fungibleKycUnfrozenTokenId));
+        var data = encodeData(ERC, DECIMALS, asAddress(fungibleKycUnfrozenTokenId));
 
         validateGasEstimation(data, DECIMALS, ercTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with totalSupply function for fungible token")
     public void totalSupplyEstimateGas() {
-        var data = encodeData(ERC_TEST_CONTRACT, TOTAL_SUPPLY, asAddress(fungibleKycUnfrozenTokenId));
+        var data = encodeData(ERC, TOTAL_SUPPLY, asAddress(fungibleKycUnfrozenTokenId));
 
         validateGasEstimation(data, TOTAL_SUPPLY, ercTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with totalSupply function for NFT")
     public void totalSupplyNonFungibleEstimateGas() {
-        var data = encodeData(ERC_TEST_CONTRACT, TOTAL_SUPPLY_NFT, asAddress(nonFungibleKycUnfrozenTokenId));
+        var data = encodeData(ERC, TOTAL_SUPPLY_NFT, asAddress(nonFungibleKycUnfrozenTokenId));
 
         validateGasEstimation(data, TOTAL_SUPPLY_NFT, ercTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with balanceOf function for fungible token")
     public void balanceOfEstimateGas() {
-        var data = encodeData(ERC_TEST_CONTRACT, BALANCE_OF, asAddress(fungibleKycUnfrozenTokenId), asAddress(admin));
+        var data = encodeData(ERC, BALANCE_OF, asAddress(fungibleKycUnfrozenTokenId), asAddress(admin));
 
         validateGasEstimation(data, BALANCE_OF, ercTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with balanceOf function for NFT")
     public void balanceOfNFTEstimateGas() {
-        var data = encodeData(
-                ERC_TEST_CONTRACT, BALANCE_OF_NFT, asAddress(nonFungibleKycUnfrozenTokenId), asAddress(admin));
+        var data = encodeData(ERC, BALANCE_OF_NFT, asAddress(nonFungibleKycUnfrozenTokenId), asAddress(admin));
 
         validateGasEstimation(data, BALANCE_OF_NFT, ercTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with ownerOf function for NFT")
     public void ownerOfEstimateGas() {
-        var data =
-                encodeData(ERC_TEST_CONTRACT, OWNER_OF, asAddress(nonFungibleKycUnfrozenTokenId), new BigInteger("1"));
+        var data = encodeData(ERC, OWNER_OF, asAddress(nonFungibleKycUnfrozenTokenId), new BigInteger("1"));
 
         validateGasEstimation(data, OWNER_OF, ercTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with tokenURI function for NFT")
     public void tokenURIEstimateGas() {
-        var data =
-                encodeData(ERC_TEST_CONTRACT, TOKEN_URI, asAddress(nonFungibleKycUnfrozenTokenId), new BigInteger("1"));
+        var data = encodeData(ERC, TOKEN_URI, asAddress(nonFungibleKycUnfrozenTokenId), new BigInteger("1"));
 
         validateGasEstimation(data, TOKEN_URI, ercTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with getFungibleTokenInfo function")
     public void getFungibleTokenInfoEstimateGas() {
-        var data = encodeData(PRECOMPILE_TEST_CONTRACT, GET_FUNGIBLE_TOKEN_INFO, asAddress(fungibleKycUnfrozenTokenId));
+        var data = encodeData(PRECOMPILE, GET_FUNGIBLE_TOKEN_INFO, asAddress(fungibleKycUnfrozenTokenId));
 
         validateGasEstimation(data, GET_FUNGIBLE_TOKEN_INFO, precompileTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with getNonFungibleTokenInfo function")
     public void getNonFungibleTokenInfoEstimateGas() {
-        var data = encodeData(
-                PRECOMPILE_TEST_CONTRACT, GET_NON_FUNGIBLE_TOKEN_INFO, asAddress(nonFungibleKycUnfrozenTokenId), 1L);
+        var data = encodeData(PRECOMPILE, GET_NON_FUNGIBLE_TOKEN_INFO, asAddress(nonFungibleKycUnfrozenTokenId), 1L);
 
         validateGasEstimation(data, GET_NON_FUNGIBLE_TOKEN_INFO, precompileTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with getTokenInfo function for fungible")
     public void getTokenInfoEstimateGas() {
-        var data = encodeData(PRECOMPILE_TEST_CONTRACT, GET_TOKEN_INFO, asAddress(fungibleKycUnfrozenTokenId));
+        var data = encodeData(PRECOMPILE, GET_TOKEN_INFO, asAddress(fungibleKycUnfrozenTokenId));
 
         validateGasEstimation(data, GET_TOKEN_INFO, precompileTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with getTokenInfo function for NFT")
     public void getTokenInfoNonFungibleEstimateGas() {
-        var data = encodeData(PRECOMPILE_TEST_CONTRACT, GET_TOKEN_INFO_NFT, asAddress(nonFungibleKycUnfrozenTokenId));
+        var data = encodeData(PRECOMPILE, GET_TOKEN_INFO_NFT, asAddress(nonFungibleKycUnfrozenTokenId));
 
         validateGasEstimation(data, GET_TOKEN_INFO_NFT, precompileTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with getTokenDefaultFreezeStatus function for fungible token")
     public void getTokenDefaultFreezeStatusFungibleEstimateGas() {
-        var data = encodeData(
-                PRECOMPILE_TEST_CONTRACT, GET_TOKEN_DEFAULT_FREEZE_STATUS, asAddress(fungibleKycUnfrozenTokenId));
+        var data = encodeData(PRECOMPILE, GET_TOKEN_DEFAULT_FREEZE_STATUS, asAddress(fungibleKycUnfrozenTokenId));
 
         validateGasEstimation(data, GET_TOKEN_DEFAULT_FREEZE_STATUS, precompileTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with getTokenDefaultFreezeStatus function for NFT")
     public void getTokenDefaultFreezeStatusNonFungibleEstimateGas() {
-        var data = encodeData(
-                PRECOMPILE_TEST_CONTRACT, GET_TOKEN_DEFAULT_FREEZE_STATUS, asAddress(nonFungibleKycUnfrozenTokenId));
+        var data = encodeData(PRECOMPILE, GET_TOKEN_DEFAULT_FREEZE_STATUS, asAddress(nonFungibleKycUnfrozenTokenId));
 
         validateGasEstimation(data, GET_TOKEN_DEFAULT_FREEZE_STATUS, precompileTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with getTokenDefaultKycStatus function for fungible token")
     public void getTokenDefaultKycStatusFungibleEstimateGas() {
-        var data = encodeData(
-                PRECOMPILE_TEST_CONTRACT, GET_TOKEN_DEFAULT_KYC_STATUS, asAddress(fungibleKycUnfrozenTokenId));
+        var data = encodeData(PRECOMPILE, GET_TOKEN_DEFAULT_KYC_STATUS, asAddress(fungibleKycUnfrozenTokenId));
 
         validateGasEstimation(data, GET_TOKEN_DEFAULT_KYC_STATUS, precompileTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with getTokenDefaultKycStatus function for NFT")
     public void getTokenDefaultKycStatusNonFungibleEstimateGas() {
-        var data = encodeData(
-                PRECOMPILE_TEST_CONTRACT, GET_TOKEN_DEFAULT_KYC_STATUS, asAddress(nonFungibleKycUnfrozenTokenId));
+        var data = encodeData(PRECOMPILE, GET_TOKEN_DEFAULT_KYC_STATUS, asAddress(nonFungibleKycUnfrozenTokenId));
 
         validateGasEstimation(data, GET_TOKEN_DEFAULT_KYC_STATUS, precompileTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with isKyc function for fungible token")
     public void isKycFungibleEstimateGas() {
-        var data = encodeData(
-                PRECOMPILE_TEST_CONTRACT,
-                IS_KYC,
-                asAddress(fungibleKycUnfrozenTokenId),
-                asAddress(receiverAccountAlias));
+        var data =
+                encodeData(PRECOMPILE, IS_KYC, asAddress(fungibleKycUnfrozenTokenId), asAddress(receiverAccountAlias));
 
         validateGasEstimation(data, IS_KYC, precompileTestContractSolidityAddress);
     }
@@ -1486,10 +1390,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with isKyc function for NFT")
     public void isKycNonFungibleEstimateGas() {
         var data = encodeData(
-                PRECOMPILE_TEST_CONTRACT,
-                IS_KYC,
-                asAddress(nonFungibleKycUnfrozenTokenId),
-                asAddress(receiverAccountAlias));
+                PRECOMPILE, IS_KYC, asAddress(nonFungibleKycUnfrozenTokenId), asAddress(receiverAccountAlias));
 
         validateGasEstimation(data, IS_KYC, precompileTestContractSolidityAddress);
     }
@@ -1497,10 +1398,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with isFrozen function for fungible token")
     public void isFrozenFungibleEstimateGas() {
         var data = encodeData(
-                PRECOMPILE_TEST_CONTRACT,
-                IS_FROZEN,
-                asAddress(fungibleKycUnfrozenTokenId),
-                asAddress(receiverAccountAlias));
+                PRECOMPILE, IS_FROZEN, asAddress(fungibleKycUnfrozenTokenId), asAddress(receiverAccountAlias));
 
         validateGasEstimation(data, IS_FROZEN, precompileTestContractSolidityAddress);
     }
@@ -1508,24 +1406,21 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with isFrozen function for NFT")
     public void isFrozenNonFungibleEstimateGas() {
         var data = encodeData(
-                PRECOMPILE_TEST_CONTRACT,
-                IS_FROZEN,
-                asAddress(nonFungibleKycUnfrozenTokenId),
-                asAddress(receiverAccountAlias));
+                PRECOMPILE, IS_FROZEN, asAddress(nonFungibleKycUnfrozenTokenId), asAddress(receiverAccountAlias));
 
         validateGasEstimation(data, IS_FROZEN, precompileTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with getTokenType function for fungible token")
     public void getTokenTypeFungibleEstimateGas() {
-        var data = encodeData(PRECOMPILE_TEST_CONTRACT, GET_TOKEN_TYPE, asAddress(fungibleKycUnfrozenTokenId));
+        var data = encodeData(PRECOMPILE, GET_TOKEN_TYPE, asAddress(fungibleKycUnfrozenTokenId));
 
         validateGasEstimation(data, GET_TOKEN_TYPE, precompileTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with getTokenType function for NFT")
     public void getTokenTypeNonFungibleEstimateGas() {
-        var data = encodeData(PRECOMPILE_TEST_CONTRACT, GET_TOKEN_TYPE, asAddress(nonFungibleKycUnfrozenTokenId));
+        var data = encodeData(PRECOMPILE, GET_TOKEN_TYPE, asAddress(nonFungibleKycUnfrozenTokenId));
 
         validateGasEstimation(data, GET_TOKEN_TYPE, precompileTestContractSolidityAddress);
     }
@@ -1533,49 +1428,42 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with redirect balanceOf function")
     public void redirectBalanceOfEstimateGas() {
         var data = encodeData(
-                PRECOMPILE_TEST_CONTRACT,
-                REDIRECT_FOR_TOKEN_BALANCE_OF,
-                asAddress(fungibleKycUnfrozenTokenId),
-                asAddress(admin));
+                PRECOMPILE, REDIRECT_FOR_TOKEN_BALANCE_OF, asAddress(fungibleKycUnfrozenTokenId), asAddress(admin));
 
         validateGasEstimation(data, REDIRECT_FOR_TOKEN_BALANCE_OF, precompileTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with redirect name function")
     public void redirectNameEstimateGas() {
-        var data = encodeData(PRECOMPILE_TEST_CONTRACT, REDIRECT_FOR_TOKEN_NAME, asAddress(fungibleKycUnfrozenTokenId));
+        var data = encodeData(PRECOMPILE, REDIRECT_FOR_TOKEN_NAME, asAddress(fungibleKycUnfrozenTokenId));
 
         validateGasEstimation(data, REDIRECT_FOR_TOKEN_NAME, precompileTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with redirect symbol function")
     public void redirectSymbolEstimateGas() {
-        var data =
-                encodeData(PRECOMPILE_TEST_CONTRACT, REDIRECT_FOR_TOKEN_SYMBOL, asAddress(fungibleKycUnfrozenTokenId));
+        var data = encodeData(PRECOMPILE, REDIRECT_FOR_TOKEN_SYMBOL, asAddress(fungibleKycUnfrozenTokenId));
 
         validateGasEstimation(data, REDIRECT_FOR_TOKEN_SYMBOL, precompileTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with redirect name function for NFT")
     public void redirectNameNonFungibleEstimateGas() {
-        var data =
-                encodeData(PRECOMPILE_TEST_CONTRACT, REDIRECT_FOR_TOKEN_NAME, asAddress(nonFungibleKycUnfrozenTokenId));
+        var data = encodeData(PRECOMPILE, REDIRECT_FOR_TOKEN_NAME, asAddress(nonFungibleKycUnfrozenTokenId));
 
         validateGasEstimation(data, REDIRECT_FOR_TOKEN_NAME, precompileTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with redirect symbol function for NFT")
     public void redirectSymbolNonFungibleEstimateGas() {
-        var data = encodeData(
-                PRECOMPILE_TEST_CONTRACT, REDIRECT_FOR_TOKEN_SYMBOL, asAddress(nonFungibleKycUnfrozenTokenId));
+        var data = encodeData(PRECOMPILE, REDIRECT_FOR_TOKEN_SYMBOL, asAddress(nonFungibleKycUnfrozenTokenId));
 
         validateGasEstimation(data, REDIRECT_FOR_TOKEN_SYMBOL, precompileTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with redirect decimals function")
     public void redirectDecimalsEstimateGas() {
-        var data = encodeData(
-                PRECOMPILE_TEST_CONTRACT, REDIRECT_FOR_TOKEN_DECIMALS, asAddress(fungibleKycUnfrozenTokenId));
+        var data = encodeData(PRECOMPILE, REDIRECT_FOR_TOKEN_DECIMALS, asAddress(fungibleKycUnfrozenTokenId));
 
         validateGasEstimation(data, REDIRECT_FOR_TOKEN_DECIMALS, precompileTestContractSolidityAddress);
     }
@@ -1583,7 +1471,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with redirect allowance function")
     public void redirectAllowanceEstimateGas() {
         var data = encodeData(
-                PRECOMPILE_TEST_CONTRACT,
+                PRECOMPILE,
                 REDIRECT_FOR_TOKEN_ALLOWANCE,
                 asAddress(fungibleKycUnfrozenTokenId),
                 asAddress(admin),
@@ -1595,7 +1483,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with redirect getOwnerOf function")
     public void redirectGetOwnerOfEstimateGas() {
         var data = encodeData(
-                PRECOMPILE_TEST_CONTRACT,
+                PRECOMPILE,
                 REDIRECT_FOR_TOKEN_GET_OWNER_OF,
                 asAddress(nonFungibleKycUnfrozenTokenId),
                 new BigInteger("1"));
@@ -1606,7 +1494,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with redirect tokenURI function")
     public void redirectTokenURIEstimateGas() {
         var data = encodeData(
-                PRECOMPILE_TEST_CONTRACT,
+                PRECOMPILE,
                 REDIRECT_FOR_TOKEN_TOKEN_URI,
                 asAddress(nonFungibleKycUnfrozenTokenId),
                 new BigInteger("1"));
@@ -1617,7 +1505,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with redirect isApprovedForAll function")
     public void redirectIsApprovedForAllEstimateGas() {
         var data = encodeData(
-                PRECOMPILE_TEST_CONTRACT,
+                PRECOMPILE,
                 REDIRECT_FOR_TOKEN_IS_APPROVED_FOR_ALL,
                 asAddress(nonFungibleKycUnfrozenTokenId),
                 asAddress(admin),
@@ -1639,7 +1527,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with redirect transfer function")
     public void redirectTransferEstimateGas() {
         var data = encodeData(
-                PRECOMPILE_TEST_CONTRACT,
+                PRECOMPILE,
                 REDIRECT_FOR_TOKEN_TRANSFER,
                 asAddress(fungibleTokenId),
                 asAddress(receiverAccountAlias),
@@ -1651,7 +1539,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with redirect transferFrom function")
     public void redirectTransferFromEstimateGas() {
         var data = encodeData(
-                PRECOMPILE_TEST_CONTRACT,
+                PRECOMPILE,
                 REDIRECT_FOR_TOKEN_TRANSFER_FROM,
                 asAddress(fungibleTokenId),
                 asAddress(admin),
@@ -1664,7 +1552,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with redirect approve function")
     public void redirectApproveEstimateGas() {
         var data = encodeData(
-                PRECOMPILE_TEST_CONTRACT,
+                PRECOMPILE,
                 REDIRECT_FOR_TOKEN_APPROVE,
                 asAddress(fungibleTokenId),
                 asAddress(receiverAccountAlias),
@@ -1676,7 +1564,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with redirect transferFrom NFT function")
     public void redirectTransferFromNonFungibleEstimateGas() {
         var data = encodeData(
-                PRECOMPILE_TEST_CONTRACT,
+                PRECOMPILE,
                 REDIRECT_FOR_TOKEN_TRANSFER_FROM_NFT,
                 asAddress(nonFungibleTokenId),
                 asAddress(admin),
@@ -1689,7 +1577,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with redirect setApprovalForAll function")
     public void redirectSetApprovalForAllEstimateGas() {
         var data = encodeData(
-                PRECOMPILE_TEST_CONTRACT,
+                PRECOMPILE,
                 REDIRECT_FOR_TOKEN_SET_APPROVAL_FOR_ALL,
                 asAddress(nonFungibleKycUnfrozenTokenId),
                 asAddress(receiverAccountAlias),
@@ -1700,37 +1588,35 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with pseudo random seed")
     public void pseudoRandomSeedEstimateGas() {
-        var data = encodeData(ESTIMATE_PRECOMPILE_TEST_CONTRACT, PSEUDO_RANDOM_SEED);
+        var data = encodeData(ESTIMATE_PRECOMPILE, PSEUDO_RANDOM_SEED);
 
         validateGasEstimation(data, PSEUDO_RANDOM_SEED, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with pseudo random number")
     public void pseudoRandomNumberEstimateGas() {
-        var data = encodeData(ESTIMATE_PRECOMPILE_TEST_CONTRACT, PSEUDO_RANDOM_NUMBER, 500L, 1000L);
+        var data = encodeData(ESTIMATE_PRECOMPILE, PSEUDO_RANDOM_NUMBER, 500L, 1000L);
 
         validateGasEstimation(data, PSEUDO_RANDOM_NUMBER, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with exchange rate tinycents to tinybars")
     public void exchangeRateTinyCentsToTinyBarsEstimateGas() {
-        var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT, EXCHANGE_RATE_TINYCENTS_TO_TINYBARS, new BigInteger("100"));
+        var data = encodeData(ESTIMATE_PRECOMPILE, EXCHANGE_RATE_TINYCENTS_TO_TINYBARS, new BigInteger("100"));
 
         validateGasEstimation(data, EXCHANGE_RATE_TINYCENTS_TO_TINYBARS, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with exchange rate tinybars to tinycents")
     public void exchangeRateTinyBarsToTinyCentsEstimateGas() {
-        var data = encodeData(
-                ESTIMATE_PRECOMPILE_TEST_CONTRACT, EXCHANGE_RATE_TINYBARS_TO_TINYCENTS, new BigInteger("100"));
+        var data = encodeData(ESTIMATE_PRECOMPILE, EXCHANGE_RATE_TINYBARS_TO_TINYCENTS, new BigInteger("100"));
 
         validateGasEstimation(data, EXCHANGE_RATE_TINYBARS_TO_TINYCENTS, estimatePrecompileContractSolidityAddress);
     }
 
-    private void validateGasEstimationForCreateToken(ByteBuffer data, int actualGasUsed, long value) {
+    private void validateGasEstimationForCreateToken(String data, int actualGasUsed, long value) {
         var contractCallRequestBody = ContractCallRequest.builder()
-                .data(Strings.encode(data))
+                .data(data)
                 .to(estimatePrecompileContractSolidityAddress)
                 .from(contractClient.getClientAddress())
                 .estimate(true)

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/EstimatePrecompileFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/EstimatePrecompileFeature.java
@@ -26,12 +26,10 @@ import static com.hedera.mirror.test.e2e.acceptance.util.TestUtil.asAddress;
 import static com.hedera.mirror.test.e2e.acceptance.util.TestUtil.asAddressArray;
 import static com.hedera.mirror.test.e2e.acceptance.util.TestUtil.asByteArray;
 import static com.hedera.mirror.test.e2e.acceptance.util.TestUtil.asLongArray;
-import static com.hedera.mirror.test.e2e.acceptance.util.TestUtil.getAbiFunctionAsJsonString;
 import static com.hedera.mirror.test.e2e.acceptance.util.TestUtil.nftAmount;
 import static com.hedera.mirror.test.e2e.acceptance.util.TestUtil.to32BytesString;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.esaulpaugh.headlong.abi.Function;
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.esaulpaugh.headlong.util.Strings;
 import com.google.protobuf.InvalidProtocolBufferException;
@@ -148,7 +146,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with associate function for fungible token")
     public void associateFunctionEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.ASSOCIATE_TOKEN)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.ASSOCIATE_TOKEN, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(receiverAccountAlias), asAddress(fungibleTokenId.toSolidityAddress()));
         validateGasEstimation(
                 Strings.encode(encodedFunctionCall),
@@ -158,7 +157,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with associate function for NFT")
     public void associateFunctionNFTEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.ASSOCIATE_TOKEN)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.ASSOCIATE_TOKEN, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(receiverAccountAlias), asAddress(nonFungibleTokenId.toSolidityAddress()));
         validateGasEstimation(
                 Strings.encode(encodedFunctionCall),
@@ -170,7 +170,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     public void dissociateFunctionEstimateGasNegative() {
         // attempt to call dissociate function without having association
         // expecting status 400/revert
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.DISSOCIATE_TOKEN)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.DISSOCIATE_TOKEN, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(receiverAccountAlias), asAddress(fungibleTokenId.toSolidityAddress()));
 
         assertContractCallReturnsBadRequest(encodedFunctionCall, estimatePrecompileContractSolidityAddress);
@@ -180,7 +181,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     public void dissociateFunctionNFTEstimateGasNegative() {
         // attempt to call dissociate function without having association
         // expecting status 400/revert
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.DISSOCIATE_TOKEN)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.DISSOCIATE_TOKEN, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(receiverAccountAlias), asAddress(nonFungibleTokenId.toSolidityAddress()));
 
         assertContractCallReturnsBadRequest(encodedFunctionCall, estimatePrecompileContractSolidityAddress);
@@ -190,7 +192,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     public void nestedAssociateFunctionEstimateGas() {
         // attempt to call associate function twice
         // expecting a revert
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.NESTED_ASSOCIATE)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.NESTED_ASSOCIATE, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(receiverAccountAlias), asAddress(fungibleTokenId.toSolidityAddress()));
 
         assertContractCallReturnsBadRequest(encodedFunctionCall, estimatePrecompileContractSolidityAddress);
@@ -200,7 +203,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     public void nestedAssociateFunctionNFTEstimateGas() {
         // attempt to call associate function twice
         // expecting a revert
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.NESTED_ASSOCIATE)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.NESTED_ASSOCIATE, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(receiverAccountAlias), asAddress(nonFungibleTokenId.toSolidityAddress()));
 
         assertContractCallReturnsBadRequest(encodedFunctionCall, estimatePrecompileContractSolidityAddress);
@@ -214,7 +218,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with dissociate token function for fungible token")
     public void dissociateFunctionEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.DISSOCIATE_TOKEN)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.DISSOCIATE_TOKEN, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(receiverAccountAlias), asAddress(fungibleTokenId.toSolidityAddress()));
 
         validateGasEstimation(
@@ -231,7 +236,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with dissociate token function for NFT")
     public void dissociateFunctionNFTEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.DISSOCIATE_TOKEN)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.DISSOCIATE_TOKEN, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(receiverAccountAlias), asAddress(nonFungibleTokenId.toSolidityAddress()));
 
         validateGasEstimation(
@@ -244,7 +250,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     public void dissociateAndAssociatedEstimateGas() {
         // token is already associated
         // attempting to execute nested dissociate and associate function
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.DISSOCIATE_AND_ASSOCIATE)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.DISSOCIATE_AND_ASSOCIATE, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(receiverAccountAlias), asAddress(fungibleTokenId.toSolidityAddress()));
 
         validateGasEstimation(
@@ -257,7 +264,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     public void dissociateAndAssociatedNFTEstimateGas() {
         // token is already associated
         // attempting to execute nested dissociate and associate function
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.DISSOCIATE_AND_ASSOCIATE)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.DISSOCIATE_AND_ASSOCIATE, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(receiverAccountAlias), asAddress(nonFungibleTokenId.toSolidityAddress()));
 
         validateGasEstimation(
@@ -268,7 +276,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with approve function without association")
     public void approveWithoutAssociationEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.APPROVE)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.APPROVE, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(fungibleTokenId.toSolidityAddress()),
                         asAddress(receiverAccountAlias),
@@ -279,7 +288,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with setApprovalForAll function without association")
     public void setApprovalForAllWithoutAssociationEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.SET_APPROVAL_FOR_ALL)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.SET_APPROVAL_FOR_ALL, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(nonFungibleTokenId.toSolidityAddress()), asAddress(receiverAccountAlias), true);
 
@@ -288,7 +298,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with approveNFT function without association")
     public void approveNonFungibleWithoutAssociationEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.APPROVE_NFT)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.APPROVE_NFT, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(nonFungibleTokenId.toSolidityAddress()),
                         asAddress(receiverAccountAlias),
@@ -313,7 +324,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with approve function")
     public void approveEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.APPROVE)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.APPROVE, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(fungibleTokenId.toSolidityAddress()),
                         asAddress(receiverAccountAlias),
@@ -327,7 +339,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with approveNFT function")
     public void approveNftEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.APPROVE_NFT)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.APPROVE_NFT, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()),
                         asAddress(receiverAccountAlias),
@@ -341,7 +354,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with ERC approve function")
     public void ercApproveEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromErcArtifact(ContractMethods.APPROVE_ERC)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.APPROVE_ERC, ContractResource.ERC_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(fungibleTokenId.toSolidityAddress()),
                         asAddress(receiverAccountAlias),
@@ -355,7 +369,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with setApprovalForAll function")
     public void setApprovalForAllEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.SET_APPROVAL_FOR_ALL)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.SET_APPROVAL_FOR_ALL, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()),
                         asAddress(receiverAccountAlias),
@@ -369,7 +384,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with transferFrom function without approval")
     public void transferFromEstimateGasWithoutApproval() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.TRANSFER_FROM)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.TRANSFER_FROM, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()),
                         asAddress(admin.getAccountId().toSolidityAddress()),
@@ -381,7 +397,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with ERC transferFrom function without approval")
     public void ercTransferFromEstimateGasWithoutApproval() {
-        ByteBuffer encodedFunctionCall = getFunctionFromErcArtifact(ContractMethods.TRANSFER_FROM_ERC)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.TRANSFER_FROM_ERC, ContractResource.ERC_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()),
                         asAddress(admin.getAccountId().toSolidityAddress()),
@@ -398,7 +415,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with transferFrom function")
     public void transferFromEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.TRANSFER_FROM)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.TRANSFER_FROM, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(fungibleTokenId.toSolidityAddress()),
                         asAddress(admin.getAccountId().toSolidityAddress()),
@@ -413,7 +431,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with ERC transferFrom function")
     public void ercTransferFromEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromErcArtifact(ContractMethods.TRANSFER_FROM_ERC)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.TRANSFER_FROM_ERC, ContractResource.ERC_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(fungibleTokenId.toSolidityAddress()),
                         asAddress(admin.getAccountId().toSolidityAddress()),
@@ -428,7 +447,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with transferFrom function with more than the approved allowance")
     public void transferFromExceedAllowanceEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.TRANSFER_FROM)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.TRANSFER_FROM, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()),
                         asAddress(admin.getAccountId().toSolidityAddress()),
@@ -440,7 +460,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with ERC transferFrom function with more than the approved allowance")
     public void ercTransferFromExceedsAllowanceEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromErcArtifact(ContractMethods.TRANSFER_FROM_ERC)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.TRANSFER_FROM_ERC, ContractResource.ERC_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()),
                         asAddress(admin.getAccountId().toSolidityAddress()),
@@ -458,7 +479,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with transferFromNFT function")
     public void transferFromNFTEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.TRANSFER_FROM_NFT)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.TRANSFER_FROM_NFT, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(nonFungibleTokenId.toSolidityAddress()),
                         asAddress(admin.getAccountId().toSolidityAddress()),
@@ -473,7 +495,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with transferFromNFT with invalid serial number")
     public void transferFromNFTInvalidSerialEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.TRANSFER_FROM_NFT)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.TRANSFER_FROM_NFT, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()),
                         asAddress(admin.getAccountId().toSolidityAddress()),
@@ -485,7 +508,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with transferToken function")
     public void transferTokenEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.TRANSFER_TOKEN)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.TRANSFER_TOKEN, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(fungibleTokenId.toSolidityAddress()),
                         asAddress(admin.getAccountId().toSolidityAddress()),
@@ -500,7 +524,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with transferNFT function")
     public void transferNFTEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.TRANSFER_NFT)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.TRANSFER_NFT, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(nonFungibleTokenId.toSolidityAddress()),
                         asAddress(admin.getAccountId().toSolidityAddress()),
@@ -526,7 +551,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with ERC transfer function")
     public void ercTransferEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromErcArtifact(ContractMethods.TRANSFER_ERC)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.TRANSFER_ERC, ContractResource.ERC_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(fungibleTokenId.toSolidityAddress()),
                         asAddress(receiverAccountAlias),
@@ -540,7 +566,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with associateTokens function for fungible tokens")
     public void associateTokensEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.ASSOCIATE_TOKENS)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.ASSOCIATE_TOKENS, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(secondReceiverAccount.getAccountId().toSolidityAddress()),
                         asAddressArray(Arrays.asList(
@@ -554,7 +581,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with associateTokens function for NFTs")
     public void associateNFTEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.ASSOCIATE_TOKENS)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.ASSOCIATE_TOKENS, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(secondReceiverAccount.getAccountId().toSolidityAddress()),
                         asAddressArray(Arrays.asList(
@@ -574,7 +602,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with dissociateTokens function for fungible tokens")
     public void dissociateTokensEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.DISSOCIATE_TOKENS)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.DISSOCIATE_TOKENS, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(receiverAccountAlias),
                         asAddressArray(Arrays.asList(
@@ -593,7 +622,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with dissociateTokens function for NFTs")
     public void dissociateNFTEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.DISSOCIATE_TOKENS)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.DISSOCIATE_TOKENS, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(receiverAccountAlias),
                         asAddressArray(Arrays.asList(
@@ -615,7 +645,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with transferTokens function")
     public void transferTokensEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.TRANSFER_TOKENS)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.TRANSFER_TOKENS, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(fungibleTokenId.toSolidityAddress()),
                         asAddressArray(Arrays.asList(
@@ -640,7 +671,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with transferNFTs function")
     public void transferNFTsEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.TRANSFER_NFTS)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.TRANSFER_NFTS, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(nonFungibleTokenId.toSolidityAddress()),
                         asAddressArray(Arrays.asList(admin.getAccountId().toSolidityAddress())),
@@ -660,7 +692,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
         var senderTransfer = accountAmount(admin.getAccountId().toSolidityAddress(), -10L, false);
         var receiverTransfer = accountAmount(receiverAccountAlias, 10L, false);
         var args = Tuple.of((Object) new Tuple[] {senderTransfer, receiverTransfer});
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.CRYPTO_TRANSFER_HBARS)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.CRYPTO_TRANSFER_HBARS, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(args, EMPTY_TUPLE_ARRAY);
         validateGasEstimation(
                 Strings.encode(encodedFunctionCall),
@@ -681,7 +714,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
                             nftAmount(admin.getAccountId().toSolidityAddress(), receiverAccountAlias, 1L, false))
                     .build()
         };
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.CRYPTO_TRANSFER_NFT)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.CRYPTO_TRANSFER_NFT, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(Tuple.of((Object) EMPTY_TUPLE_ARRAY), tokenTransferList);
         validateGasEstimation(
                 Strings.encode(encodedFunctionCall),
@@ -699,7 +733,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
                             accountAmount(secondReceiverAccount.getAccountId().toSolidityAddress(), 3L, false))
                     .build()
         };
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.CRYPTO_TRANSFER)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.CRYPTO_TRANSFER, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(Tuple.of((Object) EMPTY_TUPLE_ARRAY), tokenTransferList);
         validateGasEstimation(
                 Strings.encode(encodedFunctionCall),
@@ -709,7 +744,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with mintToken function for fungible token")
     public void mintFungibleTokenEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.MINT_TOKEN)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.MINT_TOKEN, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()), 1L, asByteArray(new ArrayList<>()));
 
@@ -721,7 +757,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with mintToken function for NFT")
     public void mintNFTEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.MINT_NFT)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.MINT_NFT, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(nonFungibleTokenId.toSolidityAddress()), 0L, asByteArray(Arrays.asList("0x02")));
 
@@ -733,7 +770,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with burnToken function for fungible token")
     public void burnFungibleTokenEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.BURN_TOKEN)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.BURN_TOKEN, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()), 1L, asLongArray(new ArrayList<>()));
 
@@ -745,7 +783,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with burnToken function for NFT")
     public void burnNFTEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.BURN_TOKEN)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.BURN_TOKEN, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()), 0L, asLongArray(List.of(1L)));
 
@@ -757,7 +796,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with CreateFungibleToken function")
     public void createFungibleTokenEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.CREATE_FUNGIBLE_TOKEN)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.CREATE_FUNGIBLE_TOKEN, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(admin.getAccountId().toSolidityAddress()));
 
         Consumer<Boolean> estimateFunction = current -> validateGasEstimationForCreateToken(
@@ -769,7 +809,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with CreateNFT function")
     public void createNFTEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.CREATE_NFT)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.CREATE_NFT, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(admin.getAccountId().toSolidityAddress()));
 
         Consumer<Boolean> estimateFunction = current -> validateGasEstimationForCreateToken(
@@ -781,8 +822,9 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with CreateFungibleToken function with custom fees")
     public void createFungibleTokenWithCustomFeesEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(
-                        ContractMethods.CREATE_FUNGIBLE_TOKEN_WITH_CUSTOM_FEES)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.CREATE_FUNGIBLE_TOKEN_WITH_CUSTOM_FEES,
+                        ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(admin.getAccountId().toSolidityAddress()),
                         asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()));
@@ -796,7 +838,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with CreateNFT function with custom fees")
     public void createNFTWithCustomFeesEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.CREATE_NFT_WITH_CUSTOM_FEES)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.CREATE_NFT_WITH_CUSTOM_FEES, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(admin.getAccountId().toSolidityAddress()),
                         asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()));
@@ -817,7 +860,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with WipeTokenAccount function")
     public void wipeTokenAccountEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.WIPE_TOKEN_ACCOUNT)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.WIPE_TOKEN_ACCOUNT, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(fungibleTokenId.toSolidityAddress()), asAddress(receiverAccountAlias), 1L);
 
@@ -829,7 +873,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with WipeTokenAccount function with invalid amount")
     public void wipeTokenAccountInvalidAmountEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.WIPE_TOKEN_ACCOUNT)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.WIPE_TOKEN_ACCOUNT, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()),
                         asAddress(receiverAccountAlias),
@@ -850,7 +895,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with WipeNFTAccount function")
     public void wipeNFTAccountEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.WIPE_NFT_ACCOUNT)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.WIPE_NFT_ACCOUNT, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(nonFungibleTokenId.toSolidityAddress()),
                         asAddress(receiverAccountAlias),
@@ -864,7 +910,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with WipeNFTAccount function with invalid serial number")
     public void wipeNFTAccountInvalidSerialNumberEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.WIPE_NFT_ACCOUNT)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.WIPE_NFT_ACCOUNT, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()),
                         asAddress(receiverAccountAlias),
@@ -875,7 +922,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with GrantKYC function for fungible token")
     public void grantKYCFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.GRANT_KYC)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.GRANT_KYC, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()), asAddress(receiverAccountAlias));
 
@@ -887,7 +935,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with GrantKYC function for NFT")
     public void grantKYCNonFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.GRANT_KYC)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.GRANT_KYC, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()), asAddress(receiverAccountAlias));
 
@@ -899,7 +948,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with RevokeTokenKYC function for fungible token")
     public void revokeTokenKYCEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.REVOKE_KYC)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.REVOKE_KYC, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()), asAddress(receiverAccountAlias));
 
@@ -911,7 +961,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with RevokeTokenKYC function for NFT")
     public void revokeTokenKYCNonFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.REVOKE_KYC)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.REVOKE_KYC, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()), asAddress(receiverAccountAlias));
 
@@ -923,7 +974,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with Grant and Revoke KYC nested function")
     public void nestedGrantRevokeKYCEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.NESTED_GRANT_REVOKE_KYC)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.NESTED_GRANT_REVOKE_KYC, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()), asAddress(receiverAccountAlias));
 
@@ -935,7 +987,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with Freeze function for fungible token")
     public void freezeFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.FREEZE_TOKEN)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.FREEZE_TOKEN, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()), asAddress(receiverAccountAlias));
 
@@ -947,7 +1000,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with Freeze function for NFT")
     public void freezeNonFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.FREEZE_TOKEN)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.FREEZE_TOKEN, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()), asAddress(receiverAccountAlias));
 
@@ -959,7 +1013,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with Unfreeze function for fungible token")
     public void unfreezeFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.UNFREEZE_TOKEN)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.UNFREEZE_TOKEN, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()), asAddress(receiverAccountAlias));
 
@@ -971,7 +1026,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with Unfreeze function for NFT")
     public void unfreezeNonFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.UNFREEZE_TOKEN)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.UNFREEZE_TOKEN, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()), asAddress(receiverAccountAlias));
 
@@ -983,7 +1039,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with nested Freeze and Unfreeze function for fungible token")
     public void nestedFreezeAndUnfreezeEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.NESTED_FREEZE_UNFREEZE)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.NESTED_FREEZE_UNFREEZE, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()), asAddress(receiverAccountAlias));
 
@@ -995,7 +1052,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with nested Freeze and Unfreeze function for NFT")
     public void nestedFreezeAndUnfreezeNFTEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.NESTED_FREEZE_UNFREEZE)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.NESTED_FREEZE_UNFREEZE, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()), asAddress(receiverAccountAlias));
 
@@ -1007,7 +1065,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with delete function for Fungible token")
     public void deleteFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.DELETE_TOKEN)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.DELETE_TOKEN, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()));
 
         validateGasEstimation(
@@ -1018,7 +1077,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with delete function for NFT")
     public void deleteNFTEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.DELETE_TOKEN)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.DELETE_TOKEN, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()));
 
         validateGasEstimation(
@@ -1029,7 +1089,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with delete function for invalid token address")
     public void deleteTokenRandomAddressEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.DELETE_TOKEN)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.DELETE_TOKEN, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(RANDOM_ADDRESS));
 
         assertContractCallReturnsBadRequest(encodedFunctionCall, estimatePrecompileContractSolidityAddress);
@@ -1037,7 +1098,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with pause function for fungible token")
     public void pauseFungibleTokenPositiveEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.PAUSE_TOKEN)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.PAUSE_TOKEN, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()));
 
         validateGasEstimation(
@@ -1048,7 +1110,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with pause function for NFT")
     public void pauseNFTPositiveEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.PAUSE_TOKEN)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.PAUSE_TOKEN, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()));
 
         validateGasEstimation(
@@ -1059,7 +1122,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with unpause function for fungible token")
     public void unpauseFungibleTokenPositiveEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.UNPAUSE_TOKEN)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.UNPAUSE_TOKEN, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()));
 
         validateGasEstimation(
@@ -1070,7 +1134,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with unpause function for NFT")
     public void unpauseNFTPositiveEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.UNPAUSE_TOKEN)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.UNPAUSE_TOKEN, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()));
 
         validateGasEstimation(
@@ -1081,7 +1146,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas for nested pause and unpause function")
     public void pauseUnpauseFungibleTokenNestedCallEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.PAUSE_UNPAUSE_NESTED_TOKEN)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.PAUSE_UNPAUSE_NESTED_TOKEN, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()));
 
         validateGasEstimation(
@@ -1092,7 +1158,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas for nested pause, unpause NFT function")
     public void pauseUnpauseNFTNestedCallEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.PAUSE_UNPAUSE_NESTED_TOKEN)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.PAUSE_UNPAUSE_NESTED_TOKEN, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()));
 
         validateGasEstimation(
@@ -1103,7 +1170,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with updateTokenExpiryInfo function")
     public void updateTokenExpiryInfoEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.UPDATE_TOKEN_EXPIRY)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.UPDATE_TOKEN_EXPIRY, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()),
                         asAddress(admin.getAccountId().toSolidityAddress()));
@@ -1116,7 +1184,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with updateTokenInfo function")
     public void updateTokenInfoEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.UPDATE_TOKEN_INFO)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.UPDATE_TOKEN_INFO, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()),
                         asAddress(admin.getAccountId().toSolidityAddress()));
@@ -1129,7 +1198,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with updateTokenKeys function")
     public void updateTokenKeysEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.UPDATE_TOKEN_KEYS)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.UPDATE_TOKEN_KEYS, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()));
 
         validateGasEstimation(
@@ -1140,7 +1210,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with getTokenExpiryInfo function")
     public void getTokenExpiryInfoEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.GET_TOKEN_EXPIRY_INFO)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.GET_TOKEN_EXPIRY_INFO, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()));
 
         validateGasEstimation(
@@ -1151,7 +1222,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with isToken function")
     public void isTokenEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.IS_TOKEN)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.IS_TOKEN, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()));
 
         validateGasEstimation(
@@ -1162,7 +1234,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with getTokenKey function for supply")
     public void getTokenKeySupplyEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.GET_TOKEN_KEY)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.GET_TOKEN_KEY, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()), new BigInteger("16"));
 
         validateGasEstimation(
@@ -1173,7 +1246,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with getTokenKey function for KYC")
     public void getTokenKeyKYCEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.GET_TOKEN_KEY)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.GET_TOKEN_KEY, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()), new BigInteger("2"));
 
         validateGasEstimation(
@@ -1184,7 +1258,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with getTokenKey function for freeze")
     public void getTokenKeyFreezeEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.GET_TOKEN_KEY)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.GET_TOKEN_KEY, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()), new BigInteger("4"));
 
         validateGasEstimation(
@@ -1195,7 +1270,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with getTokenKey function for admin")
     public void getTokenKeyAdminEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.GET_TOKEN_KEY)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.GET_TOKEN_KEY, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()), new BigInteger("1"));
 
         validateGasEstimation(
@@ -1206,7 +1282,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with getTokenKey function for wipe")
     public void getTokenKeyWipeEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.GET_TOKEN_KEY)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.GET_TOKEN_KEY, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()), new BigInteger("8"));
 
         validateGasEstimation(
@@ -1217,7 +1294,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with getTokenKey function for fee")
     public void getTokenKeyFeeEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.GET_TOKEN_KEY)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.GET_TOKEN_KEY, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()), new BigInteger("32"));
 
         validateGasEstimation(
@@ -1228,7 +1306,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with getTokenKey function for pause")
     public void getTokenKeyPauseEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.GET_TOKEN_KEY)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.GET_TOKEN_KEY, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()), new BigInteger("64"));
 
         validateGasEstimation(
@@ -1239,7 +1318,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with allowance function for fungible token")
     public void allowanceFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.ALLOWANCE)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.ALLOWANCE, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()),
                         asAddress(admin.getAccountId().toSolidityAddress()),
@@ -1253,7 +1333,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with allowance function for NFT")
     public void allowanceNonFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.ALLOWANCE)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.ALLOWANCE, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()),
                         asAddress(admin.getAccountId().toSolidityAddress()),
@@ -1267,7 +1348,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with ERC allowance function for fungible token")
     public void ercAllowanceFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromErcArtifact(ContractMethods.ALLOWANCE_ERC)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.ALLOWANCE_ERC, ContractResource.ERC_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()),
                         asAddress(admin.getAccountId().toSolidityAddress()),
@@ -1281,7 +1363,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with getApproved function for NFT")
     public void getApprovedNonFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.GET_APPROVED)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.GET_APPROVED, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()), new BigInteger("1"));
 
         validateGasEstimation(
@@ -1292,7 +1375,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with ERC getApproved function for NFT")
     public void ercGetApprovedNonFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromErcArtifact(ContractMethods.GET_APPROVED_ERC)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.GET_APPROVED_ERC, ContractResource.ERC_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()), new BigInteger("1"));
 
         validateGasEstimation(
@@ -1304,7 +1388,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with isApprovedForAll function")
     public void isApprovedForAllEstimateGas() {
         // reminder: check with setApprovalForAll test-> there we have the contract associated so the test can work
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.IS_APPROVED_FOR_ALL)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.IS_APPROVED_FOR_ALL, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()),
                         asAddress(admin.getAccountId().toSolidityAddress()),
@@ -1319,7 +1404,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with ERC isApprovedForAll function")
     public void ercIsApprovedForAllEstimateGas() {
         // reminder: check with setApprovalForAll test-> there we have the contract associated so the test can work
-        ByteBuffer encodedFunctionCall = getFunctionFromErcArtifact(ContractMethods.IS_APPROVED_FOR_ALL_ERC)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.IS_APPROVED_FOR_ALL_ERC, ContractResource.ERC_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()),
                         asAddress(admin.getAccountId().toSolidityAddress()),
@@ -1333,7 +1419,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with name function for fungible token")
     public void nameEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromErcArtifact(ContractMethods.NAME)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.NAME, ContractResource.ERC_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()));
 
         validateGasEstimation(
@@ -1344,7 +1431,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with name function for NFT")
     public void nameNonFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromErcArtifact(ContractMethods.NAME_NFT)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.NAME_NFT, ContractResource.ERC_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()));
 
         validateGasEstimation(
@@ -1355,7 +1443,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with symbol function for fungible token")
     public void symbolEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromErcArtifact(ContractMethods.SYMBOL)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.SYMBOL, ContractResource.ERC_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()));
 
         validateGasEstimation(
@@ -1366,7 +1455,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with symbol function for NFT")
     public void symbolNonFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromErcArtifact(ContractMethods.SYMBOL_NFT)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.SYMBOL_NFT, ContractResource.ERC_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()));
 
         validateGasEstimation(
@@ -1377,7 +1467,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with decimals function for fungible token")
     public void decimalsEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromErcArtifact(ContractMethods.DECIMALS)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.DECIMALS, ContractResource.ERC_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()));
 
         validateGasEstimation(
@@ -1388,7 +1479,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with totalSupply function for fungible token")
     public void totalSupplyEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromErcArtifact(ContractMethods.TOTAL_SUPPLY)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.TOTAL_SUPPLY, ContractResource.ERC_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()));
 
         validateGasEstimation(
@@ -1399,7 +1491,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with totalSupply function for NFT")
     public void totalSupplyNonFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromErcArtifact(ContractMethods.TOTAL_SUPPLY_NFT)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.TOTAL_SUPPLY_NFT, ContractResource.ERC_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()));
 
         validateGasEstimation(
@@ -1410,7 +1503,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with balanceOf function for fungible token")
     public void balanceOfEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromErcArtifact(ContractMethods.BALANCE_OF)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.BALANCE_OF, ContractResource.ERC_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()),
                         asAddress(admin.getAccountId().toSolidityAddress()));
@@ -1423,7 +1517,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with balanceOf function for NFT")
     public void balanceOfNFTEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromErcArtifact(ContractMethods.BALANCE_OF_NFT)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.BALANCE_OF_NFT, ContractResource.ERC_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()),
                         asAddress(admin.getAccountId().toSolidityAddress()));
@@ -1436,7 +1531,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with ownerOf function for NFT")
     public void ownerOfEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromErcArtifact(ContractMethods.OWNER_OF)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.OWNER_OF, ContractResource.ERC_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()), new BigInteger("1"));
 
         validateGasEstimation(
@@ -1447,7 +1543,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with tokenURI function for NFT")
     public void tokenURIEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromErcArtifact(ContractMethods.TOKEN_URI)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.TOKEN_URI, ContractResource.ERC_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()), new BigInteger("1"));
 
         validateGasEstimation(
@@ -1458,7 +1555,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with getFungibleTokenInfo function")
     public void getFungibleTokenInfoEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromPrecompileArtifact(ContractMethods.GET_FUNGIBLE_TOKEN_INFO)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.GET_FUNGIBLE_TOKEN_INFO, ContractResource.PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()));
 
         validateGasEstimation(
@@ -1469,7 +1567,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with getNonFungibleTokenInfo function")
     public void getNonFungibleTokenInfoEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromPrecompileArtifact(ContractMethods.GET_NON_FUNGIBLE_TOKEN_INFO)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.GET_NON_FUNGIBLE_TOKEN_INFO, ContractResource.PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()), 1L);
 
         validateGasEstimation(
@@ -1480,7 +1579,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with getTokenInfo function for fungible")
     public void getTokenInfoEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromPrecompileArtifact(ContractMethods.GET_TOKEN_INFO)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.GET_TOKEN_INFO, ContractResource.PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()));
 
         validateGasEstimation(
@@ -1491,7 +1591,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with getTokenInfo function for NFT")
     public void getTokenInfoNonFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromPrecompileArtifact(ContractMethods.GET_TOKEN_INFO_NFT)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.GET_TOKEN_INFO_NFT, ContractResource.PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()));
 
         validateGasEstimation(
@@ -1502,8 +1603,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with getTokenDefaultFreezeStatus function for fungible token")
     public void getTokenDefaultFreezeStatusFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromPrecompileArtifact(
-                        ContractMethods.GET_TOKEN_DEFAULT_FREEZE_STATUS)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.GET_TOKEN_DEFAULT_FREEZE_STATUS, ContractResource.PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()));
 
         validateGasEstimation(
@@ -1514,8 +1615,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with getTokenDefaultFreezeStatus function for NFT")
     public void getTokenDefaultFreezeStatusNonFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromPrecompileArtifact(
-                        ContractMethods.GET_TOKEN_DEFAULT_FREEZE_STATUS)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.GET_TOKEN_DEFAULT_FREEZE_STATUS, ContractResource.PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()));
 
         validateGasEstimation(
@@ -1526,7 +1627,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with getTokenDefaultKycStatus function for fungible token")
     public void getTokenDefaultKycStatusFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromPrecompileArtifact(ContractMethods.GET_TOKEN_DEFAULT_KYC_STATUS)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.GET_TOKEN_DEFAULT_KYC_STATUS, ContractResource.PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()));
 
         validateGasEstimation(
@@ -1537,7 +1639,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with getTokenDefaultKycStatus function for NFT")
     public void getTokenDefaultKycStatusNonFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromPrecompileArtifact(ContractMethods.GET_TOKEN_DEFAULT_KYC_STATUS)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.GET_TOKEN_DEFAULT_KYC_STATUS, ContractResource.PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()));
 
         validateGasEstimation(
@@ -1548,7 +1651,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with isKyc function for fungible token")
     public void isKycFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromPrecompileArtifact(ContractMethods.IS_KYC)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.IS_KYC, ContractResource.PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()), asAddress(receiverAccountAlias));
 
@@ -1560,7 +1664,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with isKyc function for NFT")
     public void isKycNonFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromPrecompileArtifact(ContractMethods.IS_KYC)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.IS_KYC, ContractResource.PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()), asAddress(receiverAccountAlias));
 
@@ -1572,7 +1677,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with isFrozen function for fungible token")
     public void isFrozenFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromPrecompileArtifact(ContractMethods.IS_FROZEN)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.IS_FROZEN, ContractResource.PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()), asAddress(receiverAccountAlias));
 
@@ -1584,7 +1690,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with isFrozen function for NFT")
     public void isFrozenNonFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromPrecompileArtifact(ContractMethods.IS_FROZEN)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.IS_FROZEN, ContractResource.PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()), asAddress(receiverAccountAlias));
 
@@ -1596,7 +1703,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with getTokenType function for fungible token")
     public void getTokenTypeFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromPrecompileArtifact(ContractMethods.GET_TOKEN_TYPE)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.GET_TOKEN_TYPE, ContractResource.PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()));
 
         validateGasEstimation(
@@ -1607,7 +1715,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with getTokenType function for NFT")
     public void getTokenTypeNonFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromPrecompileArtifact(ContractMethods.GET_TOKEN_TYPE)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.GET_TOKEN_TYPE, ContractResource.PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()));
 
         validateGasEstimation(
@@ -1618,8 +1727,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with redirect balanceOf function")
     public void redirectBalanceOfEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromPrecompileArtifact(
-                        ContractMethods.REDIRECT_FOR_TOKEN_BALANCE_OF)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.REDIRECT_FOR_TOKEN_BALANCE_OF, ContractResource.PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()),
                         asAddress(admin.getAccountId().toSolidityAddress()));
@@ -1632,7 +1741,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with redirect name function")
     public void redirectNameEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromPrecompileArtifact(ContractMethods.REDIRECT_FOR_TOKEN_NAME)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.REDIRECT_FOR_TOKEN_NAME, ContractResource.PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()));
 
         validateGasEstimation(
@@ -1643,7 +1753,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with redirect symbol function")
     public void redirectSymbolEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromPrecompileArtifact(ContractMethods.REDIRECT_FOR_TOKEN_SYMBOL)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.REDIRECT_FOR_TOKEN_SYMBOL, ContractResource.PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()));
 
         validateGasEstimation(
@@ -1654,7 +1765,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with redirect name function for NFT")
     public void redirectNameNonFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromPrecompileArtifact(ContractMethods.REDIRECT_FOR_TOKEN_NAME)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.REDIRECT_FOR_TOKEN_NAME, ContractResource.PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()));
 
         validateGasEstimation(
@@ -1665,7 +1777,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with redirect symbol function for NFT")
     public void redirectSymbolNonFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromPrecompileArtifact(ContractMethods.REDIRECT_FOR_TOKEN_SYMBOL)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.REDIRECT_FOR_TOKEN_SYMBOL, ContractResource.PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()));
 
         validateGasEstimation(
@@ -1676,7 +1789,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with redirect decimals function")
     public void redirectDecimalsEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromPrecompileArtifact(ContractMethods.REDIRECT_FOR_TOKEN_DECIMALS)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.REDIRECT_FOR_TOKEN_DECIMALS, ContractResource.PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()));
 
         validateGasEstimation(
@@ -1687,7 +1801,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with redirect allowance function")
     public void redirectAllowanceEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromPrecompileArtifact(ContractMethods.REDIRECT_FOR_TOKEN_ALLOWANCE)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.REDIRECT_FOR_TOKEN_ALLOWANCE, ContractResource.PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()),
                         asAddress(admin.getAccountId().toSolidityAddress()),
@@ -1701,8 +1816,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with redirect getOwnerOf function")
     public void redirectGetOwnerOfEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromPrecompileArtifact(
-                        ContractMethods.REDIRECT_FOR_TOKEN_GET_OWNER_OF)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.REDIRECT_FOR_TOKEN_GET_OWNER_OF, ContractResource.PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()), new BigInteger("1"));
 
         validateGasEstimation(
@@ -1713,7 +1828,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with redirect tokenURI function")
     public void redirectTokenURIEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromPrecompileArtifact(ContractMethods.REDIRECT_FOR_TOKEN_TOKEN_URI)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.REDIRECT_FOR_TOKEN_TOKEN_URI, ContractResource.PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()), new BigInteger("1"));
 
         validateGasEstimation(
@@ -1724,8 +1840,9 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with redirect isApprovedForAll function")
     public void redirectIsApprovedForAllEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromPrecompileArtifact(
-                        ContractMethods.REDIRECT_FOR_TOKEN_IS_APPROVED_FOR_ALL)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.REDIRECT_FOR_TOKEN_IS_APPROVED_FOR_ALL,
+                        ContractResource.PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()),
                         asAddress(admin.getAccountId().toSolidityAddress()),
@@ -1749,7 +1866,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with redirect transfer function")
     public void redirectTransferEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromPrecompileArtifact(ContractMethods.REDIRECT_FOR_TOKEN_TRANSFER)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.REDIRECT_FOR_TOKEN_TRANSFER, ContractResource.PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(fungibleTokenId.toSolidityAddress()),
                         asAddress(receiverAccountAlias),
@@ -1763,8 +1881,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with redirect transferFrom function")
     public void redirectTransferFromEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromPrecompileArtifact(
-                        ContractMethods.REDIRECT_FOR_TOKEN_TRANSFER_FROM)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.REDIRECT_FOR_TOKEN_TRANSFER_FROM, ContractResource.PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(fungibleTokenId.toSolidityAddress()),
                         asAddress(admin.getAccountId().toSolidityAddress()),
@@ -1779,7 +1897,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with redirect approve function")
     public void redirectApproveEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromPrecompileArtifact(ContractMethods.REDIRECT_FOR_TOKEN_APPROVE)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.REDIRECT_FOR_TOKEN_APPROVE, ContractResource.PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(fungibleTokenId.toSolidityAddress()),
                         asAddress(receiverAccountAlias),
@@ -1793,8 +1912,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with redirect transferFrom NFT function")
     public void redirectTransferFromNonFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromPrecompileArtifact(
-                        ContractMethods.REDIRECT_FOR_TOKEN_TRANSFER_FROM_NFT)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.REDIRECT_FOR_TOKEN_TRANSFER_FROM_NFT, ContractResource.PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(nonFungibleTokenId.toSolidityAddress()),
                         asAddress(admin.getAccountId().toSolidityAddress()),
@@ -1809,8 +1928,9 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with redirect setApprovalForAll function")
     public void redirectSetApprovalForAllEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromPrecompileArtifact(
-                        ContractMethods.REDIRECT_FOR_TOKEN_SET_APPROVAL_FOR_ALL)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.REDIRECT_FOR_TOKEN_SET_APPROVAL_FOR_ALL,
+                        ContractResource.PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(
                         asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()),
                         asAddress(receiverAccountAlias),
@@ -1824,7 +1944,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with pseudo random seed")
     public void pseudoRandomSeedEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.PSEUDO_RANDOM_SEED)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.PSEUDO_RANDOM_SEED, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs();
 
         validateGasEstimation(
@@ -1835,7 +1956,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with pseudo random number")
     public void pseudoRandomNumberEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(ContractMethods.PSEUDO_RANDOM_NUMBER)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.PSEUDO_RANDOM_NUMBER, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(500L, 1000L);
 
         validateGasEstimation(
@@ -1846,8 +1968,9 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with exchange rate tinycents to tinybars")
     public void exchangeRateTinyCentsToTinyBarsEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(
-                        ContractMethods.EXCHANGE_RATE_TINYCENTS_TO_TINYBARS)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.EXCHANGE_RATE_TINYCENTS_TO_TINYBARS,
+                        ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(new BigInteger("100"));
 
         validateGasEstimation(
@@ -1858,8 +1981,9 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with exchange rate tinybars to tinycents")
     public void exchangeRateTinyBarsToTinyCentsEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromEstimateArtifact(
-                        ContractMethods.EXCHANGE_RATE_TINYBARS_TO_TINYCENTS)
+        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
+                        ContractMethods.EXCHANGE_RATE_TINYBARS_TO_TINYCENTS,
+                        ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
                 .encodeCallWithArgs(new BigInteger("100"));
 
         validateGasEstimation(
@@ -1903,39 +2027,9 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
         validationFunction.accept(false);
     }
 
-    public Function getFunctionFromEstimateArtifact(ContractMethods contractMethod) {
-        String json;
-        try (var in = estimatePrecompileTestContract.getInputStream()) {
-            json = getAbiFunctionAsJsonString(readCompiledArtifact(in), contractMethod.getFunctionName());
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-        return Function.fromJson(json);
-    }
-
-    public Function getFunctionFromErcArtifact(ContractMethods contractMethod) {
-        String json;
-        try (var in = ercTestContract.getInputStream()) {
-            json = getAbiFunctionAsJsonString(readCompiledArtifact(in), contractMethod.getFunctionName());
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-        return Function.fromJson(json);
-    }
-
-    public Function getFunctionFromPrecompileArtifact(ContractMethods contractMethod) {
-        String json;
-        try (var in = precompileTestContract.getInputStream()) {
-            json = getAbiFunctionAsJsonString(readCompiledArtifact(in), contractMethod.getFunctionName());
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-        return Function.fromJson(json);
-    }
-
     @Getter
     @RequiredArgsConstructor
-    private enum ContractMethods {
+    private enum ContractMethods implements ContractMethodInterface {
         ALLOWANCE("allowanceExternal", 25399),
         ALLOWANCE_ERC("allowance", 27481),
         APPROVE("approveExternal", 729571),
@@ -2030,7 +2124,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
         UPDATE_TOKEN_INFO("updateTokenInfoExternal", 74920),
         UPDATE_TOKEN_KEYS("updateTokenKeysExternal", 60427);
 
-        private final String functionName;
+        private final String selector;
         private final int actualGas;
     }
 }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/EstimatePrecompileFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/EstimatePrecompileFeature.java
@@ -20,6 +20,98 @@ import static com.hedera.mirror.test.e2e.acceptance.client.TokenClient.TokenName
 import static com.hedera.mirror.test.e2e.acceptance.client.TokenClient.TokenNameEnum.FUNGIBLE_KYC_UNFROZEN;
 import static com.hedera.mirror.test.e2e.acceptance.client.TokenClient.TokenNameEnum.NFT;
 import static com.hedera.mirror.test.e2e.acceptance.client.TokenClient.TokenNameEnum.NFT_KYC_UNFROZEN;
+import static com.hedera.mirror.test.e2e.acceptance.steps.AbstractFeature.ContractResource.ERC_TEST_CONTRACT;
+import static com.hedera.mirror.test.e2e.acceptance.steps.AbstractFeature.ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT;
+import static com.hedera.mirror.test.e2e.acceptance.steps.AbstractFeature.ContractResource.PRECOMPILE_TEST_CONTRACT;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.ALLOWANCE;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.ALLOWANCE_ERC;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.APPROVE;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.APPROVE_ERC;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.APPROVE_NFT;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.ASSOCIATE_TOKEN;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.ASSOCIATE_TOKENS;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.BALANCE_OF;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.BALANCE_OF_NFT;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.BURN_TOKEN;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.CREATE_FUNGIBLE_TOKEN;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.CREATE_FUNGIBLE_TOKEN_WITH_CUSTOM_FEES;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.CREATE_NFT;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.CREATE_NFT_WITH_CUSTOM_FEES;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.CRYPTO_TRANSFER;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.CRYPTO_TRANSFER_HBARS;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.CRYPTO_TRANSFER_NFT;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.DECIMALS;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.DELETE_TOKEN;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.DISSOCIATE_AND_ASSOCIATE;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.DISSOCIATE_TOKEN;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.DISSOCIATE_TOKENS;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.EXCHANGE_RATE_TINYBARS_TO_TINYCENTS;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.EXCHANGE_RATE_TINYCENTS_TO_TINYBARS;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.FREEZE_TOKEN;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.GET_APPROVED;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.GET_APPROVED_ERC;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.GET_FUNGIBLE_TOKEN_INFO;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.GET_NON_FUNGIBLE_TOKEN_INFO;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.GET_TOKEN_DEFAULT_FREEZE_STATUS;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.GET_TOKEN_DEFAULT_KYC_STATUS;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.GET_TOKEN_EXPIRY_INFO;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.GET_TOKEN_INFO;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.GET_TOKEN_INFO_NFT;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.GET_TOKEN_KEY;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.GET_TOKEN_TYPE;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.GRANT_KYC;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.IS_APPROVED_FOR_ALL;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.IS_APPROVED_FOR_ALL_ERC;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.IS_FROZEN;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.IS_KYC;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.IS_TOKEN;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.MINT_NFT;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.MINT_TOKEN;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.NAME;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.NAME_NFT;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.NESTED_ASSOCIATE;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.NESTED_FREEZE_UNFREEZE;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.NESTED_GRANT_REVOKE_KYC;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.OWNER_OF;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.PAUSE_TOKEN;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.PAUSE_UNPAUSE_NESTED_TOKEN;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.PSEUDO_RANDOM_NUMBER;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.PSEUDO_RANDOM_SEED;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.REDIRECT_FOR_TOKEN_ALLOWANCE;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.REDIRECT_FOR_TOKEN_APPROVE;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.REDIRECT_FOR_TOKEN_BALANCE_OF;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.REDIRECT_FOR_TOKEN_DECIMALS;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.REDIRECT_FOR_TOKEN_GET_OWNER_OF;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.REDIRECT_FOR_TOKEN_IS_APPROVED_FOR_ALL;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.REDIRECT_FOR_TOKEN_NAME;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.REDIRECT_FOR_TOKEN_SET_APPROVAL_FOR_ALL;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.REDIRECT_FOR_TOKEN_SYMBOL;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.REDIRECT_FOR_TOKEN_TOKEN_URI;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.REDIRECT_FOR_TOKEN_TRANSFER;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.REDIRECT_FOR_TOKEN_TRANSFER_FROM;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.REDIRECT_FOR_TOKEN_TRANSFER_FROM_NFT;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.REVOKE_KYC;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.SET_APPROVAL_FOR_ALL;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.SYMBOL;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.SYMBOL_NFT;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.TOKEN_URI;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.TOTAL_SUPPLY;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.TOTAL_SUPPLY_NFT;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.TRANSFER_ERC;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.TRANSFER_FROM;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.TRANSFER_FROM_ERC;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.TRANSFER_FROM_NFT;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.TRANSFER_NFT;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.TRANSFER_NFTS;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.TRANSFER_TOKEN;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.TRANSFER_TOKENS;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.UNFREEZE_TOKEN;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.UNPAUSE_TOKEN;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.UPDATE_TOKEN_EXPIRY;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.UPDATE_TOKEN_INFO;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.UPDATE_TOKEN_KEYS;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.WIPE_NFT_ACCOUNT;
+import static com.hedera.mirror.test.e2e.acceptance.steps.EstimatePrecompileFeature.ContractMethods.WIPE_TOKEN_ACCOUNT;
 import static com.hedera.mirror.test.e2e.acceptance.util.TestUtil.TokenTransferListBuilder;
 import static com.hedera.mirror.test.e2e.acceptance.util.TestUtil.accountAmount;
 import static com.hedera.mirror.test.e2e.acceptance.util.TestUtil.asAddress;
@@ -88,7 +180,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Given("I create estimate precompile contract with 0 balance")
     public void createNewEstimateContract() throws IOException {
-        deployedEstimatePrecompileContract = getContract(ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT);
+        deployedEstimatePrecompileContract = getContract(ESTIMATE_PRECOMPILE_TEST_CONTRACT);
         estimatePrecompileContractSolidityAddress =
                 deployedEstimatePrecompileContract.contractId().toSolidityAddress();
         admin = tokenClient.getSdkClient().getExpandedOperatorAccountId();
@@ -99,7 +191,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Given("I create erc test contract with 0 balance")
     public void createNewERCContract() throws IOException {
-        deployedErcTestContract = getContract(ContractResource.ERC_TEST_CONTRACT);
+        deployedErcTestContract = getContract(ERC_TEST_CONTRACT);
         ercTestContractSolidityAddress = deployedErcTestContract.contractId().toSolidityAddress();
     }
 
@@ -110,7 +202,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Given("I successfully create Precompile contract with 0 balance")
     public void createNewPrecompileTestContract() throws IOException {
-        deployedPrecompileContract = getContract(ContractResource.PRECOMPILE_TEST_CONTRACT);
+        deployedPrecompileContract = getContract(PRECOMPILE_TEST_CONTRACT);
         precompileTestContractSolidityAddress =
                 deployedPrecompileContract.contractId().toSolidityAddress();
     }
@@ -146,68 +238,74 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with associate function for fungible token")
     public void associateFunctionEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.ASSOCIATE_TOKEN, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(receiverAccountAlias), asAddress(fungibleTokenId.toSolidityAddress()));
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.ASSOCIATE_TOKEN.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                ASSOCIATE_TOKEN,
+                asAddress(receiverAccountAlias),
+                asAddress(fungibleTokenId));
+        validateGasEstimation(data, ASSOCIATE_TOKEN, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with associate function for NFT")
     public void associateFunctionNFTEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.ASSOCIATE_TOKEN, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(receiverAccountAlias), asAddress(nonFungibleTokenId.toSolidityAddress()));
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.ASSOCIATE_TOKEN.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                ASSOCIATE_TOKEN,
+                asAddress(receiverAccountAlias),
+                asAddress(nonFungibleTokenId));
+        validateGasEstimation(data, ASSOCIATE_TOKEN, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with dissociate token function without association for fungible token")
     public void dissociateFunctionEstimateGasNegative() {
         // attempt to call dissociate function without having association
         // expecting status 400/revert
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.DISSOCIATE_TOKEN, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(receiverAccountAlias), asAddress(fungibleTokenId.toSolidityAddress()));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                DISSOCIATE_TOKEN,
+                asAddress(receiverAccountAlias),
+                asAddress(fungibleTokenId));
 
-        assertContractCallReturnsBadRequest(encodedFunctionCall, estimatePrecompileContractSolidityAddress);
+        assertContractCallReturnsBadRequest(data, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with dissociate token function without association for NFT")
     public void dissociateFunctionNFTEstimateGasNegative() {
         // attempt to call dissociate function without having association
         // expecting status 400/revert
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.DISSOCIATE_TOKEN, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(receiverAccountAlias), asAddress(nonFungibleTokenId.toSolidityAddress()));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                DISSOCIATE_TOKEN,
+                asAddress(receiverAccountAlias),
+                asAddress(nonFungibleTokenId));
 
-        assertContractCallReturnsBadRequest(encodedFunctionCall, estimatePrecompileContractSolidityAddress);
+        assertContractCallReturnsBadRequest(data, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with nested associate function that executes it twice for fungible token")
     public void nestedAssociateFunctionEstimateGas() {
         // attempt to call associate function twice
         // expecting a revert
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.NESTED_ASSOCIATE, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(receiverAccountAlias), asAddress(fungibleTokenId.toSolidityAddress()));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                NESTED_ASSOCIATE,
+                asAddress(receiverAccountAlias),
+                asAddress(fungibleTokenId));
 
-        assertContractCallReturnsBadRequest(encodedFunctionCall, estimatePrecompileContractSolidityAddress);
+        assertContractCallReturnsBadRequest(data, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with nested associate function that executes it twice for NFT")
     public void nestedAssociateFunctionNFTEstimateGas() {
         // attempt to call associate function twice
         // expecting a revert
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.NESTED_ASSOCIATE, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(receiverAccountAlias), asAddress(nonFungibleTokenId.toSolidityAddress()));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                NESTED_ASSOCIATE,
+                asAddress(receiverAccountAlias),
+                asAddress(nonFungibleTokenId));
 
-        assertContractCallReturnsBadRequest(encodedFunctionCall, estimatePrecompileContractSolidityAddress);
+        assertContractCallReturnsBadRequest(data, estimatePrecompileContractSolidityAddress);
     }
 
     @And("I associate the receiver account with the fungible token")
@@ -218,14 +316,13 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with dissociate token function for fungible token")
     public void dissociateFunctionEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.DISSOCIATE_TOKEN, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(receiverAccountAlias), asAddress(fungibleTokenId.toSolidityAddress()));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                DISSOCIATE_TOKEN,
+                asAddress(receiverAccountAlias),
+                asAddress(fungibleTokenId));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.DISSOCIATE_TOKEN.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, DISSOCIATE_TOKEN, estimatePrecompileContractSolidityAddress);
     }
 
     @And("I associate the receiver account with the NFT")
@@ -236,76 +333,75 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with dissociate token function for NFT")
     public void dissociateFunctionNFTEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.DISSOCIATE_TOKEN, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(receiverAccountAlias), asAddress(nonFungibleTokenId.toSolidityAddress()));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                DISSOCIATE_TOKEN,
+                asAddress(receiverAccountAlias),
+                asAddress(nonFungibleTokenId));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.DISSOCIATE_TOKEN.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, DISSOCIATE_TOKEN, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with dissociate and associate nested function for fungible token")
     public void dissociateAndAssociatedEstimateGas() {
         // token is already associated
         // attempting to execute nested dissociate and associate function
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.DISSOCIATE_AND_ASSOCIATE, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(receiverAccountAlias), asAddress(fungibleTokenId.toSolidityAddress()));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                DISSOCIATE_AND_ASSOCIATE,
+                asAddress(receiverAccountAlias),
+                asAddress(fungibleTokenId));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.DISSOCIATE_AND_ASSOCIATE.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, DISSOCIATE_AND_ASSOCIATE, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with dissociate and associate nested function for NFT")
     public void dissociateAndAssociatedNFTEstimateGas() {
         // token is already associated
         // attempting to execute nested dissociate and associate function
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.DISSOCIATE_AND_ASSOCIATE, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(receiverAccountAlias), asAddress(nonFungibleTokenId.toSolidityAddress()));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                DISSOCIATE_AND_ASSOCIATE,
+                asAddress(receiverAccountAlias),
+                asAddress(nonFungibleTokenId));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.DISSOCIATE_AND_ASSOCIATE.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, DISSOCIATE_AND_ASSOCIATE, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with approve function without association")
     public void approveWithoutAssociationEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.APPROVE, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(fungibleTokenId.toSolidityAddress()),
-                        asAddress(receiverAccountAlias),
-                        new BigInteger("10"));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                APPROVE,
+                asAddress(fungibleTokenId),
+                asAddress(receiverAccountAlias),
+                new BigInteger("10"));
 
-        assertContractCallReturnsBadRequest(encodedFunctionCall, estimatePrecompileContractSolidityAddress);
+        assertContractCallReturnsBadRequest(data, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with setApprovalForAll function without association")
     public void setApprovalForAllWithoutAssociationEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.SET_APPROVAL_FOR_ALL, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(nonFungibleTokenId.toSolidityAddress()), asAddress(receiverAccountAlias), true);
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                SET_APPROVAL_FOR_ALL,
+                asAddress(nonFungibleTokenId),
+                asAddress(receiverAccountAlias),
+                true);
 
-        assertContractCallReturnsBadRequest(encodedFunctionCall, estimatePrecompileContractSolidityAddress);
+        assertContractCallReturnsBadRequest(data, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with approveNFT function without association")
     public void approveNonFungibleWithoutAssociationEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.APPROVE_NFT, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(nonFungibleTokenId.toSolidityAddress()),
-                        asAddress(receiverAccountAlias),
-                        new BigInteger("1"));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                APPROVE_NFT,
+                asAddress(nonFungibleTokenId),
+                asAddress(receiverAccountAlias),
+                new BigInteger("1"));
 
-        assertContractCallReturnsBadRequest(encodedFunctionCall, estimatePrecompileContractSolidityAddress);
+        assertContractCallReturnsBadRequest(data, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I associate contracts with the tokens and approve all nft serials")
@@ -324,88 +420,76 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with approve function")
     public void approveEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.APPROVE, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(fungibleTokenId.toSolidityAddress()),
-                        asAddress(receiverAccountAlias),
-                        new BigInteger("10"));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                APPROVE,
+                asAddress(fungibleTokenId),
+                asAddress(receiverAccountAlias),
+                new BigInteger("10"));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.APPROVE.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, APPROVE, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with approveNFT function")
     public void approveNftEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.APPROVE_NFT, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()),
-                        asAddress(receiverAccountAlias),
-                        new BigInteger("1"));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                APPROVE_NFT,
+                asAddress(nonFungibleKycUnfrozenTokenId),
+                asAddress(receiverAccountAlias),
+                new BigInteger("1"));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.APPROVE_NFT.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, APPROVE_NFT, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with ERC approve function")
     public void ercApproveEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.APPROVE_ERC, ContractResource.ERC_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(fungibleTokenId.toSolidityAddress()),
-                        asAddress(receiverAccountAlias),
-                        new BigInteger("10"));
+        var data = encodeData(
+                ERC_TEST_CONTRACT,
+                APPROVE_ERC,
+                asAddress(fungibleTokenId),
+                asAddress(receiverAccountAlias),
+                new BigInteger("10"));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.APPROVE_ERC.getActualGas(),
-                ercTestContractSolidityAddress);
+        validateGasEstimation(data, APPROVE_ERC, ercTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with setApprovalForAll function")
     public void setApprovalForAllEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.SET_APPROVAL_FOR_ALL, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()),
-                        asAddress(receiverAccountAlias),
-                        true);
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                SET_APPROVAL_FOR_ALL,
+                asAddress(nonFungibleKycUnfrozenTokenId),
+                asAddress(receiverAccountAlias),
+                true);
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.SET_APPROVAL_FOR_ALL.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, SET_APPROVAL_FOR_ALL, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with transferFrom function without approval")
     public void transferFromEstimateGasWithoutApproval() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.TRANSFER_FROM, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()),
-                        asAddress(admin.getAccountId().toSolidityAddress()),
-                        asAddress(receiverAccountAlias),
-                        new BigInteger("5"));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                TRANSFER_FROM,
+                asAddress(fungibleKycUnfrozenTokenId),
+                asAddress(admin),
+                asAddress(receiverAccountAlias),
+                new BigInteger("5"));
 
-        assertContractCallReturnsBadRequest(encodedFunctionCall, estimatePrecompileContractSolidityAddress);
+        assertContractCallReturnsBadRequest(data, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with ERC transferFrom function without approval")
     public void ercTransferFromEstimateGasWithoutApproval() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.TRANSFER_FROM_ERC, ContractResource.ERC_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()),
-                        asAddress(admin.getAccountId().toSolidityAddress()),
-                        asAddress(receiverAccountAlias),
-                        new BigInteger("10"));
+        var data = encodeData(
+                ERC_TEST_CONTRACT,
+                TRANSFER_FROM_ERC,
+                asAddress(fungibleKycUnfrozenTokenId),
+                asAddress(admin),
+                asAddress(receiverAccountAlias),
+                new BigInteger("10"));
 
-        assertContractCallReturnsBadRequest(encodedFunctionCall, ercTestContractSolidityAddress);
+        assertContractCallReturnsBadRequest(data, ercTestContractSolidityAddress);
     }
 
     @And("I approve receiver account to use fungible token")
@@ -415,60 +499,54 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with transferFrom function")
     public void transferFromEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.TRANSFER_FROM, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(fungibleTokenId.toSolidityAddress()),
-                        asAddress(admin.getAccountId().toSolidityAddress()),
-                        asAddress(receiverAccountAlias),
-                        new BigInteger("5"));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                TRANSFER_FROM,
+                asAddress(fungibleTokenId),
+                asAddress(admin),
+                asAddress(receiverAccountAlias),
+                new BigInteger("5"));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.TRANSFER_FROM.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, TRANSFER_FROM, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with ERC transferFrom function")
     public void ercTransferFromEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.TRANSFER_FROM_ERC, ContractResource.ERC_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(fungibleTokenId.toSolidityAddress()),
-                        asAddress(admin.getAccountId().toSolidityAddress()),
-                        asAddress(receiverAccountAlias),
-                        new BigInteger("5"));
+        var data = encodeData(
+                ERC_TEST_CONTRACT,
+                TRANSFER_FROM_ERC,
+                asAddress(fungibleTokenId),
+                asAddress(admin),
+                asAddress(receiverAccountAlias),
+                new BigInteger("5"));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.TRANSFER_FROM_ERC.getActualGas(),
-                ercTestContractSolidityAddress);
+        validateGasEstimation(data, TRANSFER_FROM_ERC, ercTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with transferFrom function with more than the approved allowance")
     public void transferFromExceedAllowanceEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.TRANSFER_FROM, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()),
-                        asAddress(admin.getAccountId().toSolidityAddress()),
-                        asAddress(receiverAccountAlias),
-                        new BigInteger("500"));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                TRANSFER_FROM,
+                asAddress(fungibleKycUnfrozenTokenId),
+                asAddress(admin),
+                asAddress(receiverAccountAlias),
+                new BigInteger("500"));
 
-        assertContractCallReturnsBadRequest(encodedFunctionCall, estimatePrecompileContractSolidityAddress);
+        assertContractCallReturnsBadRequest(data, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with ERC transferFrom function with more than the approved allowance")
     public void ercTransferFromExceedsAllowanceEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.TRANSFER_FROM_ERC, ContractResource.ERC_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()),
-                        asAddress(admin.getAccountId().toSolidityAddress()),
-                        asAddress(receiverAccountAlias),
-                        new BigInteger("500"));
+        var data = encodeData(
+                ERC_TEST_CONTRACT,
+                TRANSFER_FROM_ERC,
+                asAddress(fungibleKycUnfrozenTokenId),
+                asAddress(admin),
+                asAddress(receiverAccountAlias),
+                new BigInteger("500"));
 
-        assertContractCallReturnsBadRequest(encodedFunctionCall, ercTestContractSolidityAddress);
+        assertContractCallReturnsBadRequest(data, ercTestContractSolidityAddress);
     }
 
     @And("I approve receiver account to use the NFT with id 1")
@@ -479,63 +557,54 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with transferFromNFT function")
     public void transferFromNFTEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.TRANSFER_FROM_NFT, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(nonFungibleTokenId.toSolidityAddress()),
-                        asAddress(admin.getAccountId().toSolidityAddress()),
-                        asAddress(receiverAccountAlias),
-                        new BigInteger("1"));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                TRANSFER_FROM_NFT,
+                asAddress(nonFungibleTokenId),
+                asAddress(admin),
+                asAddress(receiverAccountAlias),
+                new BigInteger("1"));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.TRANSFER_FROM_NFT.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, TRANSFER_FROM_NFT, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with transferFromNFT with invalid serial number")
     public void transferFromNFTInvalidSerialEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.TRANSFER_FROM_NFT, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()),
-                        asAddress(admin.getAccountId().toSolidityAddress()),
-                        asAddress(receiverAccountAlias),
-                        new BigInteger("50"));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                TRANSFER_FROM_NFT,
+                asAddress(nonFungibleKycUnfrozenTokenId),
+                asAddress(admin),
+                asAddress(receiverAccountAlias),
+                new BigInteger("50"));
 
-        assertContractCallReturnsBadRequest(encodedFunctionCall, estimatePrecompileContractSolidityAddress);
+        assertContractCallReturnsBadRequest(data, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with transferToken function")
     public void transferTokenEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.TRANSFER_TOKEN, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(fungibleTokenId.toSolidityAddress()),
-                        asAddress(admin.getAccountId().toSolidityAddress()),
-                        asAddress(receiverAccountAlias),
-                        5L);
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                TRANSFER_TOKEN,
+                asAddress(fungibleTokenId),
+                asAddress(admin),
+                asAddress(receiverAccountAlias),
+                5L);
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.TRANSFER_TOKEN.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, TRANSFER_TOKEN, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with transferNFT function")
     public void transferNFTEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.TRANSFER_NFT, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(nonFungibleTokenId.toSolidityAddress()),
-                        asAddress(admin.getAccountId().toSolidityAddress()),
-                        asAddress(receiverAccountAlias),
-                        1L);
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                TRANSFER_NFT,
+                asAddress(nonFungibleTokenId),
+                asAddress(admin),
+                asAddress(receiverAccountAlias),
+                1L);
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.TRANSFER_NFT.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, TRANSFER_NFT, estimatePrecompileContractSolidityAddress);
     }
 
     @And("I approve receiver account to use fungible token and transfer fungible token to the erc contract")
@@ -551,48 +620,38 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with ERC transfer function")
     public void ercTransferEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.TRANSFER_ERC, ContractResource.ERC_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(fungibleTokenId.toSolidityAddress()),
-                        asAddress(receiverAccountAlias),
-                        new BigInteger("5"));
+        var data = encodeData(
+                ERC_TEST_CONTRACT,
+                TRANSFER_ERC,
+                asAddress(fungibleTokenId),
+                asAddress(receiverAccountAlias),
+                new BigInteger("5"));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.TRANSFER_ERC.getActualGas(),
-                ercTestContractSolidityAddress);
+        validateGasEstimation(data, TRANSFER_ERC, ercTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with associateTokens function for fungible tokens")
     public void associateTokensEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.ASSOCIATE_TOKENS, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(secondReceiverAccount.getAccountId().toSolidityAddress()),
-                        asAddressArray(Arrays.asList(
-                                fungibleTokenId.toSolidityAddress(), fungibleKycUnfrozenTokenId.toSolidityAddress())));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                ASSOCIATE_TOKENS,
+                asAddress(secondReceiverAccount),
+                asAddressArray(Arrays.asList(
+                        fungibleTokenId.toSolidityAddress(), fungibleKycUnfrozenTokenId.toSolidityAddress())));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.ASSOCIATE_TOKENS.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, ASSOCIATE_TOKENS, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with associateTokens function for NFTs")
     public void associateNFTEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.ASSOCIATE_TOKENS, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(secondReceiverAccount.getAccountId().toSolidityAddress()),
-                        asAddressArray(Arrays.asList(
-                                nonFungibleKycUnfrozenTokenId.toSolidityAddress(),
-                                nonFungibleTokenId.toSolidityAddress())));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                ASSOCIATE_TOKENS,
+                asAddress(secondReceiverAccount),
+                asAddressArray(Arrays.asList(
+                        nonFungibleKycUnfrozenTokenId.toSolidityAddress(), nonFungibleTokenId.toSolidityAddress())));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.ASSOCIATE_TOKENS.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, ASSOCIATE_TOKENS, estimatePrecompileContractSolidityAddress);
     }
 
     @And("I associate the fungible_kyc_unfrozen token with the receiver account")
@@ -602,17 +661,14 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with dissociateTokens function for fungible tokens")
     public void dissociateTokensEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.DISSOCIATE_TOKENS, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(receiverAccountAlias),
-                        asAddressArray(Arrays.asList(
-                                fungibleTokenId.toSolidityAddress(), fungibleKycUnfrozenTokenId.toSolidityAddress())));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                DISSOCIATE_TOKENS,
+                asAddress(receiverAccountAlias),
+                asAddressArray(Arrays.asList(
+                        fungibleTokenId.toSolidityAddress(), fungibleKycUnfrozenTokenId.toSolidityAddress())));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.DISSOCIATE_TOKENS.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, DISSOCIATE_TOKENS, estimatePrecompileContractSolidityAddress);
     }
 
     @And("I associate the nft_kyc_unfrozen with the receiver account")
@@ -622,18 +678,14 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with dissociateTokens function for NFTs")
     public void dissociateNFTEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.DISSOCIATE_TOKENS, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(receiverAccountAlias),
-                        asAddressArray(Arrays.asList(
-                                nonFungibleKycUnfrozenTokenId.toSolidityAddress(),
-                                nonFungibleTokenId.toSolidityAddress())));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                DISSOCIATE_TOKENS,
+                asAddress(receiverAccountAlias),
+                asAddressArray(Arrays.asList(
+                        nonFungibleKycUnfrozenTokenId.toSolidityAddress(), nonFungibleTokenId.toSolidityAddress())));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.DISSOCIATE_TOKENS.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, DISSOCIATE_TOKENS, estimatePrecompileContractSolidityAddress);
     }
 
     @And("I associate and approve the second receiver to use the fungible_kyc_unfrozen token")
@@ -645,20 +697,17 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with transferTokens function")
     public void transferTokensEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.TRANSFER_TOKENS, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(fungibleTokenId.toSolidityAddress()),
-                        asAddressArray(Arrays.asList(
-                                admin.getAccountId().toSolidityAddress(),
-                                receiverAccountAlias,
-                                secondReceiverAccount.getAccountId().toSolidityAddress())),
-                        new long[] {-6L, 3L, 3L});
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                TRANSFER_TOKENS,
+                asAddress(fungibleTokenId),
+                asAddressArray(Arrays.asList(
+                        admin.getAccountId().toSolidityAddress(),
+                        receiverAccountAlias,
+                        secondReceiverAccount.getAccountId().toSolidityAddress())),
+                new long[] {-6L, 3L, 3L});
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.TRANSFER_TOKENS.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, TRANSFER_TOKENS, estimatePrecompileContractSolidityAddress);
     }
 
     @And("I mint a new NFT and approve second receiver account to all serial numbers")
@@ -671,20 +720,17 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with transferNFTs function")
     public void transferNFTsEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.TRANSFER_NFTS, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(nonFungibleTokenId.toSolidityAddress()),
-                        asAddressArray(Arrays.asList(admin.getAccountId().toSolidityAddress())),
-                        asAddressArray(Arrays.asList(
-                                receiverAccountAlias,
-                                secondReceiverAccount.getAccountId().toSolidityAddress())),
-                        new long[] {1, 2});
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                TRANSFER_NFTS,
+                asAddress(nonFungibleTokenId),
+                asAddressArray(Arrays.asList(admin.getAccountId().toSolidityAddress())),
+                asAddressArray(Arrays.asList(
+                        receiverAccountAlias,
+                        secondReceiverAccount.getAccountId().toSolidityAddress())),
+                new long[] {1, 2});
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.TRANSFER_NFTS.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, TRANSFER_NFTS, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with cryptoTransfer function for hbars")
@@ -692,13 +738,8 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
         var senderTransfer = accountAmount(admin.getAccountId().toSolidityAddress(), -10L, false);
         var receiverTransfer = accountAmount(receiverAccountAlias, 10L, false);
         var args = Tuple.of((Object) new Tuple[] {senderTransfer, receiverTransfer});
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.CRYPTO_TRANSFER_HBARS, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(args, EMPTY_TUPLE_ARRAY);
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.CRYPTO_TRANSFER_HBARS.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        var data = encodeData(ESTIMATE_PRECOMPILE_TEST_CONTRACT, CRYPTO_TRANSFER_HBARS, args, EMPTY_TUPLE_ARRAY);
+        validateGasEstimation(data, CRYPTO_TRANSFER_HBARS, estimatePrecompileContractSolidityAddress);
     }
 
     private TokenTransferListBuilder tokenTransferList() {
@@ -714,13 +755,12 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
                             nftAmount(admin.getAccountId().toSolidityAddress(), receiverAccountAlias, 1L, false))
                     .build()
         };
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.CRYPTO_TRANSFER_NFT, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(Tuple.of((Object) EMPTY_TUPLE_ARRAY), tokenTransferList);
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.CRYPTO_TRANSFER_NFT.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                CRYPTO_TRANSFER_NFT,
+                Tuple.of((Object) EMPTY_TUPLE_ARRAY),
+                tokenTransferList);
+        validateGasEstimation(data, CRYPTO_TRANSFER_NFT, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with cryptoTransfer function for fungible tokens")
@@ -733,121 +773,103 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
                             accountAmount(secondReceiverAccount.getAccountId().toSolidityAddress(), 3L, false))
                     .build()
         };
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.CRYPTO_TRANSFER, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(Tuple.of((Object) EMPTY_TUPLE_ARRAY), tokenTransferList);
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.CRYPTO_TRANSFER.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                CRYPTO_TRANSFER,
+                Tuple.of((Object) EMPTY_TUPLE_ARRAY),
+                tokenTransferList);
+        validateGasEstimation(data, CRYPTO_TRANSFER, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with mintToken function for fungible token")
     public void mintFungibleTokenEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.MINT_TOKEN, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()), 1L, asByteArray(new ArrayList<>()));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                MINT_TOKEN,
+                asAddress(fungibleKycUnfrozenTokenId),
+                1L,
+                asByteArray(new ArrayList<>()));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.MINT_TOKEN.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, MINT_TOKEN, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with mintToken function for NFT")
     public void mintNFTEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.MINT_NFT, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(nonFungibleTokenId.toSolidityAddress()), 0L, asByteArray(Arrays.asList("0x02")));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                MINT_NFT,
+                asAddress(nonFungibleTokenId),
+                0L,
+                asByteArray(Arrays.asList("0x02")));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.MINT_NFT.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, MINT_NFT, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with burnToken function for fungible token")
     public void burnFungibleTokenEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.BURN_TOKEN, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()), 1L, asLongArray(new ArrayList<>()));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                BURN_TOKEN,
+                asAddress(fungibleKycUnfrozenTokenId),
+                1L,
+                asLongArray(new ArrayList<>()));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.BURN_TOKEN.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, BURN_TOKEN, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with burnToken function for NFT")
     public void burnNFTEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.BURN_TOKEN, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()), 0L, asLongArray(List.of(1L)));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                BURN_TOKEN,
+                asAddress(nonFungibleKycUnfrozenTokenId),
+                0L,
+                asLongArray(List.of(1L)));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.BURN_TOKEN.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, BURN_TOKEN, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with CreateFungibleToken function")
     public void createFungibleTokenEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.CREATE_FUNGIBLE_TOKEN, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(admin.getAccountId().toSolidityAddress()));
+        var data = encodeData(ESTIMATE_PRECOMPILE_TEST_CONTRACT, CREATE_FUNGIBLE_TOKEN, asAddress(admin));
 
         Consumer<Boolean> estimateFunction = current -> validateGasEstimationForCreateToken(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.CREATE_FUNGIBLE_TOKEN.getActualGas(),
-                calculateCreateTokenFee(1, current));
+                data, CREATE_FUNGIBLE_TOKEN.getActualGas(), calculateCreateTokenFee(1, current));
         executeAndRetryWithNextExchangeRates(estimateFunction);
     }
 
     @Then("I call estimateGas with CreateNFT function")
     public void createNFTEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.CREATE_NFT, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(admin.getAccountId().toSolidityAddress()));
+        var data = encodeData(ESTIMATE_PRECOMPILE_TEST_CONTRACT, CREATE_NFT, asAddress(admin));
 
         Consumer<Boolean> estimateFunction = current -> validateGasEstimationForCreateToken(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.CREATE_FUNGIBLE_TOKEN.getActualGas(),
-                calculateCreateTokenFee(1, current));
+                data, CREATE_FUNGIBLE_TOKEN.getActualGas(), calculateCreateTokenFee(1, current));
         executeAndRetryWithNextExchangeRates(estimateFunction);
     }
 
     @Then("I call estimateGas with CreateFungibleToken function with custom fees")
     public void createFungibleTokenWithCustomFeesEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.CREATE_FUNGIBLE_TOKEN_WITH_CUSTOM_FEES,
-                        ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(admin.getAccountId().toSolidityAddress()),
-                        asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                CREATE_FUNGIBLE_TOKEN_WITH_CUSTOM_FEES,
+                asAddress(admin),
+                asAddress(fungibleKycUnfrozenTokenId));
 
         Consumer<Boolean> estimateFunction = current -> validateGasEstimationForCreateToken(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.CREATE_FUNGIBLE_TOKEN_WITH_CUSTOM_FEES.getActualGas(),
-                calculateCreateTokenFee(2, current));
+                data, CREATE_FUNGIBLE_TOKEN_WITH_CUSTOM_FEES.getActualGas(), calculateCreateTokenFee(2, current));
         executeAndRetryWithNextExchangeRates(estimateFunction);
     }
 
     @Then("I call estimateGas with CreateNFT function with custom fees")
     public void createNFTWithCustomFeesEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.CREATE_NFT_WITH_CUSTOM_FEES, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(admin.getAccountId().toSolidityAddress()),
-                        asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                CREATE_NFT_WITH_CUSTOM_FEES,
+                asAddress(admin),
+                asAddress(nonFungibleKycUnfrozenTokenId));
 
         Consumer<Boolean> estimateFunction = current -> validateGasEstimationForCreateToken(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.CREATE_NFT_WITH_CUSTOM_FEES.getActualGas(),
-                calculateCreateTokenFee(2, current));
+                data, CREATE_NFT_WITH_CUSTOM_FEES.getActualGas(), calculateCreateTokenFee(2, current));
         executeAndRetryWithNextExchangeRates(estimateFunction);
     }
 
@@ -860,27 +882,26 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with WipeTokenAccount function")
     public void wipeTokenAccountEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.WIPE_TOKEN_ACCOUNT, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(fungibleTokenId.toSolidityAddress()), asAddress(receiverAccountAlias), 1L);
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                WIPE_TOKEN_ACCOUNT,
+                asAddress(fungibleTokenId),
+                asAddress(receiverAccountAlias),
+                1L);
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.WIPE_TOKEN_ACCOUNT.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, WIPE_TOKEN_ACCOUNT, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with WipeTokenAccount function with invalid amount")
     public void wipeTokenAccountInvalidAmountEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.WIPE_TOKEN_ACCOUNT, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()),
-                        asAddress(receiverAccountAlias),
-                        100000000000000000L);
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                WIPE_TOKEN_ACCOUNT,
+                asAddress(fungibleKycUnfrozenTokenId),
+                asAddress(receiverAccountAlias),
+                100000000000000000L);
 
-        assertContractCallReturnsBadRequest(encodedFunctionCall, estimatePrecompileContractSolidityAddress);
+        assertContractCallReturnsBadRequest(data, estimatePrecompileContractSolidityAddress);
     }
 
     @And("I transfer NFT to receiver account")
@@ -895,963 +916,714 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with WipeNFTAccount function")
     public void wipeNFTAccountEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.WIPE_NFT_ACCOUNT, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(nonFungibleTokenId.toSolidityAddress()),
-                        asAddress(receiverAccountAlias),
-                        asLongArray(List.of(1L)));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                WIPE_NFT_ACCOUNT,
+                asAddress(nonFungibleTokenId),
+                asAddress(receiverAccountAlias),
+                asLongArray(List.of(1L)));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.WIPE_NFT_ACCOUNT.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, WIPE_NFT_ACCOUNT, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with WipeNFTAccount function with invalid serial number")
     public void wipeNFTAccountInvalidSerialNumberEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.WIPE_NFT_ACCOUNT, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()),
-                        asAddress(receiverAccountAlias),
-                        asLongArray(List.of(66L)));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                WIPE_NFT_ACCOUNT,
+                asAddress(nonFungibleKycUnfrozenTokenId),
+                asAddress(receiverAccountAlias),
+                asLongArray(List.of(66L)));
 
-        assertContractCallReturnsBadRequest(encodedFunctionCall, estimatePrecompileContractSolidityAddress);
+        assertContractCallReturnsBadRequest(data, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with GrantKYC function for fungible token")
     public void grantKYCFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.GRANT_KYC, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()), asAddress(receiverAccountAlias));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                GRANT_KYC,
+                asAddress(fungibleKycUnfrozenTokenId),
+                asAddress(receiverAccountAlias));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.GRANT_KYC.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, GRANT_KYC, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with GrantKYC function for NFT")
     public void grantKYCNonFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.GRANT_KYC, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()), asAddress(receiverAccountAlias));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                GRANT_KYC,
+                asAddress(nonFungibleKycUnfrozenTokenId),
+                asAddress(receiverAccountAlias));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.GRANT_KYC.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, GRANT_KYC, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with RevokeTokenKYC function for fungible token")
     public void revokeTokenKYCEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.REVOKE_KYC, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()), asAddress(receiverAccountAlias));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                REVOKE_KYC,
+                asAddress(fungibleKycUnfrozenTokenId),
+                asAddress(receiverAccountAlias));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.REVOKE_KYC.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, REVOKE_KYC, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with RevokeTokenKYC function for NFT")
     public void revokeTokenKYCNonFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.REVOKE_KYC, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()), asAddress(receiverAccountAlias));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                REVOKE_KYC,
+                asAddress(nonFungibleKycUnfrozenTokenId),
+                asAddress(receiverAccountAlias));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.REVOKE_KYC.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, REVOKE_KYC, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with Grant and Revoke KYC nested function")
     public void nestedGrantRevokeKYCEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.NESTED_GRANT_REVOKE_KYC, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()), asAddress(receiverAccountAlias));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                NESTED_GRANT_REVOKE_KYC,
+                asAddress(fungibleKycUnfrozenTokenId),
+                asAddress(receiverAccountAlias));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.NESTED_GRANT_REVOKE_KYC.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, NESTED_GRANT_REVOKE_KYC, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with Freeze function for fungible token")
     public void freezeFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.FREEZE_TOKEN, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()), asAddress(receiverAccountAlias));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                FREEZE_TOKEN,
+                asAddress(fungibleKycUnfrozenTokenId),
+                asAddress(receiverAccountAlias));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.FREEZE_TOKEN.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, FREEZE_TOKEN, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with Freeze function for NFT")
     public void freezeNonFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.FREEZE_TOKEN, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()), asAddress(receiverAccountAlias));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                FREEZE_TOKEN,
+                asAddress(nonFungibleKycUnfrozenTokenId),
+                asAddress(receiverAccountAlias));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.FREEZE_TOKEN.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, FREEZE_TOKEN, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with Unfreeze function for fungible token")
     public void unfreezeFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.UNFREEZE_TOKEN, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()), asAddress(receiverAccountAlias));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                UNFREEZE_TOKEN,
+                asAddress(fungibleKycUnfrozenTokenId),
+                asAddress(receiverAccountAlias));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.UNFREEZE_TOKEN.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, UNFREEZE_TOKEN, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with Unfreeze function for NFT")
     public void unfreezeNonFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.UNFREEZE_TOKEN, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()), asAddress(receiverAccountAlias));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                UNFREEZE_TOKEN,
+                asAddress(nonFungibleKycUnfrozenTokenId),
+                asAddress(receiverAccountAlias));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.UNFREEZE_TOKEN.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, UNFREEZE_TOKEN, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with nested Freeze and Unfreeze function for fungible token")
     public void nestedFreezeAndUnfreezeEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.NESTED_FREEZE_UNFREEZE, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()), asAddress(receiverAccountAlias));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                NESTED_FREEZE_UNFREEZE,
+                asAddress(fungibleKycUnfrozenTokenId),
+                asAddress(receiverAccountAlias));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.NESTED_FREEZE_UNFREEZE.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, NESTED_FREEZE_UNFREEZE, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with nested Freeze and Unfreeze function for NFT")
     public void nestedFreezeAndUnfreezeNFTEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.NESTED_FREEZE_UNFREEZE, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()), asAddress(receiverAccountAlias));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                NESTED_FREEZE_UNFREEZE,
+                asAddress(nonFungibleKycUnfrozenTokenId),
+                asAddress(receiverAccountAlias));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.NESTED_FREEZE_UNFREEZE.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, NESTED_FREEZE_UNFREEZE, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with delete function for Fungible token")
     public void deleteFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.DELETE_TOKEN, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()));
+        var data = encodeData(ESTIMATE_PRECOMPILE_TEST_CONTRACT, DELETE_TOKEN, asAddress(fungibleKycUnfrozenTokenId));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.DELETE_TOKEN.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, DELETE_TOKEN, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with delete function for NFT")
     public void deleteNFTEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.DELETE_TOKEN, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()));
+        var data =
+                encodeData(ESTIMATE_PRECOMPILE_TEST_CONTRACT, DELETE_TOKEN, asAddress(nonFungibleKycUnfrozenTokenId));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.DELETE_TOKEN.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, DELETE_TOKEN, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with delete function for invalid token address")
     public void deleteTokenRandomAddressEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.DELETE_TOKEN, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(RANDOM_ADDRESS));
+        var data = encodeData(ESTIMATE_PRECOMPILE_TEST_CONTRACT, DELETE_TOKEN, asAddress(RANDOM_ADDRESS));
 
-        assertContractCallReturnsBadRequest(encodedFunctionCall, estimatePrecompileContractSolidityAddress);
+        assertContractCallReturnsBadRequest(data, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with pause function for fungible token")
     public void pauseFungibleTokenPositiveEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.PAUSE_TOKEN, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()));
+        var data = encodeData(ESTIMATE_PRECOMPILE_TEST_CONTRACT, PAUSE_TOKEN, asAddress(fungibleKycUnfrozenTokenId));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.PAUSE_TOKEN.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, PAUSE_TOKEN, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with pause function for NFT")
     public void pauseNFTPositiveEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.PAUSE_TOKEN, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()));
+        var data = encodeData(ESTIMATE_PRECOMPILE_TEST_CONTRACT, PAUSE_TOKEN, asAddress(nonFungibleKycUnfrozenTokenId));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.PAUSE_TOKEN.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, PAUSE_TOKEN, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with unpause function for fungible token")
     public void unpauseFungibleTokenPositiveEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.UNPAUSE_TOKEN, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()));
+        var data = encodeData(ESTIMATE_PRECOMPILE_TEST_CONTRACT, UNPAUSE_TOKEN, asAddress(fungibleKycUnfrozenTokenId));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.UNPAUSE_TOKEN.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, UNPAUSE_TOKEN, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with unpause function for NFT")
     public void unpauseNFTPositiveEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.UNPAUSE_TOKEN, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()));
+        var data =
+                encodeData(ESTIMATE_PRECOMPILE_TEST_CONTRACT, UNPAUSE_TOKEN, asAddress(nonFungibleKycUnfrozenTokenId));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.UNPAUSE_TOKEN.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, UNPAUSE_TOKEN, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas for nested pause and unpause function")
     public void pauseUnpauseFungibleTokenNestedCallEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.PAUSE_UNPAUSE_NESTED_TOKEN, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT, PAUSE_UNPAUSE_NESTED_TOKEN, asAddress(fungibleKycUnfrozenTokenId));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.PAUSE_UNPAUSE_NESTED_TOKEN.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, PAUSE_UNPAUSE_NESTED_TOKEN, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas for nested pause, unpause NFT function")
     public void pauseUnpauseNFTNestedCallEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.PAUSE_UNPAUSE_NESTED_TOKEN, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                PAUSE_UNPAUSE_NESTED_TOKEN,
+                asAddress(nonFungibleKycUnfrozenTokenId));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.PAUSE_UNPAUSE_NESTED_TOKEN.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, PAUSE_UNPAUSE_NESTED_TOKEN, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with updateTokenExpiryInfo function")
     public void updateTokenExpiryInfoEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.UPDATE_TOKEN_EXPIRY, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()),
-                        asAddress(admin.getAccountId().toSolidityAddress()));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                UPDATE_TOKEN_EXPIRY,
+                asAddress(fungibleKycUnfrozenTokenId),
+                asAddress(admin));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.UPDATE_TOKEN_EXPIRY.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, UPDATE_TOKEN_EXPIRY, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with updateTokenInfo function")
     public void updateTokenInfoEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.UPDATE_TOKEN_INFO, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()),
-                        asAddress(admin.getAccountId().toSolidityAddress()));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                UPDATE_TOKEN_INFO,
+                asAddress(fungibleKycUnfrozenTokenId),
+                asAddress(admin));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.UPDATE_TOKEN_INFO.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, UPDATE_TOKEN_INFO, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with updateTokenKeys function")
     public void updateTokenKeysEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.UPDATE_TOKEN_KEYS, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()));
+        var data =
+                encodeData(ESTIMATE_PRECOMPILE_TEST_CONTRACT, UPDATE_TOKEN_KEYS, asAddress(fungibleKycUnfrozenTokenId));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.UPDATE_TOKEN_KEYS.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, UPDATE_TOKEN_KEYS, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with getTokenExpiryInfo function")
     public void getTokenExpiryInfoEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.GET_TOKEN_EXPIRY_INFO, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT, GET_TOKEN_EXPIRY_INFO, asAddress(fungibleKycUnfrozenTokenId));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.GET_TOKEN_EXPIRY_INFO.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, GET_TOKEN_EXPIRY_INFO, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with isToken function")
     public void isTokenEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.IS_TOKEN, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()));
+        var data = encodeData(ESTIMATE_PRECOMPILE_TEST_CONTRACT, IS_TOKEN, asAddress(fungibleKycUnfrozenTokenId));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.IS_TOKEN.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, IS_TOKEN, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with getTokenKey function for supply")
     public void getTokenKeySupplyEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.GET_TOKEN_KEY, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()), new BigInteger("16"));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                GET_TOKEN_KEY,
+                asAddress(fungibleKycUnfrozenTokenId),
+                new BigInteger("16"));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.GET_TOKEN_KEY.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, GET_TOKEN_KEY, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with getTokenKey function for KYC")
     public void getTokenKeyKYCEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.GET_TOKEN_KEY, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()), new BigInteger("2"));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                GET_TOKEN_KEY,
+                asAddress(fungibleKycUnfrozenTokenId),
+                new BigInteger("2"));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.GET_TOKEN_KEY.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, GET_TOKEN_KEY, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with getTokenKey function for freeze")
     public void getTokenKeyFreezeEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.GET_TOKEN_KEY, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()), new BigInteger("4"));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                GET_TOKEN_KEY,
+                asAddress(fungibleKycUnfrozenTokenId),
+                new BigInteger("4"));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.GET_TOKEN_KEY.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, GET_TOKEN_KEY, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with getTokenKey function for admin")
     public void getTokenKeyAdminEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.GET_TOKEN_KEY, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()), new BigInteger("1"));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                GET_TOKEN_KEY,
+                asAddress(fungibleKycUnfrozenTokenId),
+                new BigInteger("1"));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.GET_TOKEN_KEY.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, GET_TOKEN_KEY, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with getTokenKey function for wipe")
     public void getTokenKeyWipeEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.GET_TOKEN_KEY, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()), new BigInteger("8"));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                GET_TOKEN_KEY,
+                asAddress(fungibleKycUnfrozenTokenId),
+                new BigInteger("8"));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.GET_TOKEN_KEY.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, GET_TOKEN_KEY, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with getTokenKey function for fee")
     public void getTokenKeyFeeEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.GET_TOKEN_KEY, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()), new BigInteger("32"));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                GET_TOKEN_KEY,
+                asAddress(fungibleKycUnfrozenTokenId),
+                new BigInteger("32"));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.GET_TOKEN_KEY.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, GET_TOKEN_KEY, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with getTokenKey function for pause")
     public void getTokenKeyPauseEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.GET_TOKEN_KEY, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()), new BigInteger("64"));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                GET_TOKEN_KEY,
+                asAddress(fungibleKycUnfrozenTokenId),
+                new BigInteger("64"));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.GET_TOKEN_KEY.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, GET_TOKEN_KEY, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with allowance function for fungible token")
     public void allowanceFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.ALLOWANCE, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()),
-                        asAddress(admin.getAccountId().toSolidityAddress()),
-                        asAddress(receiverAccountAlias));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                ALLOWANCE,
+                asAddress(fungibleKycUnfrozenTokenId),
+                asAddress(admin),
+                asAddress(receiverAccountAlias));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.ALLOWANCE.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, ALLOWANCE, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with allowance function for NFT")
     public void allowanceNonFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.ALLOWANCE, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()),
-                        asAddress(admin.getAccountId().toSolidityAddress()),
-                        asAddress(receiverAccountAlias));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                ALLOWANCE,
+                asAddress(nonFungibleKycUnfrozenTokenId),
+                asAddress(admin),
+                asAddress(receiverAccountAlias));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.ALLOWANCE.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, ALLOWANCE, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with ERC allowance function for fungible token")
     public void ercAllowanceFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.ALLOWANCE_ERC, ContractResource.ERC_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()),
-                        asAddress(admin.getAccountId().toSolidityAddress()),
-                        asAddress(receiverAccountAlias));
+        var data = encodeData(
+                ERC_TEST_CONTRACT,
+                ALLOWANCE_ERC,
+                asAddress(fungibleKycUnfrozenTokenId),
+                asAddress(admin),
+                asAddress(receiverAccountAlias));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.ALLOWANCE_ERC.getActualGas(),
-                ercTestContractSolidityAddress);
+        validateGasEstimation(data, ALLOWANCE_ERC, ercTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with getApproved function for NFT")
     public void getApprovedNonFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.GET_APPROVED, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()), new BigInteger("1"));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                GET_APPROVED,
+                asAddress(nonFungibleKycUnfrozenTokenId),
+                new BigInteger("1"));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.GET_APPROVED.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, GET_APPROVED, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with ERC getApproved function for NFT")
     public void ercGetApprovedNonFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.GET_APPROVED_ERC, ContractResource.ERC_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()), new BigInteger("1"));
+        var data = encodeData(
+                ERC_TEST_CONTRACT, GET_APPROVED_ERC, asAddress(nonFungibleKycUnfrozenTokenId), new BigInteger("1"));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.GET_APPROVED_ERC.getActualGas(),
-                ercTestContractSolidityAddress);
+        validateGasEstimation(data, GET_APPROVED_ERC, ercTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with isApprovedForAll function")
     public void isApprovedForAllEstimateGas() {
         // reminder: check with setApprovalForAll test-> there we have the contract associated so the test can work
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.IS_APPROVED_FOR_ALL, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()),
-                        asAddress(admin.getAccountId().toSolidityAddress()),
-                        asAddress(receiverAccountAlias));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT,
+                IS_APPROVED_FOR_ALL,
+                asAddress(nonFungibleKycUnfrozenTokenId),
+                asAddress(admin),
+                asAddress(receiverAccountAlias));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.IS_APPROVED_FOR_ALL.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, IS_APPROVED_FOR_ALL, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with ERC isApprovedForAll function")
     public void ercIsApprovedForAllEstimateGas() {
         // reminder: check with setApprovalForAll test-> there we have the contract associated so the test can work
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.IS_APPROVED_FOR_ALL_ERC, ContractResource.ERC_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()),
-                        asAddress(admin.getAccountId().toSolidityAddress()),
-                        asAddress(receiverAccountAlias));
+        var data = encodeData(
+                ERC_TEST_CONTRACT,
+                IS_APPROVED_FOR_ALL_ERC,
+                asAddress(nonFungibleKycUnfrozenTokenId),
+                asAddress(admin),
+                asAddress(receiverAccountAlias));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.IS_APPROVED_FOR_ALL_ERC.getActualGas(),
-                ercTestContractSolidityAddress);
+        validateGasEstimation(data, IS_APPROVED_FOR_ALL_ERC, ercTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with name function for fungible token")
     public void nameEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.NAME, ContractResource.ERC_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()));
+        var data = encodeData(ERC_TEST_CONTRACT, NAME, asAddress(fungibleKycUnfrozenTokenId));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.NAME.getActualGas(),
-                ercTestContractSolidityAddress);
+        validateGasEstimation(data, NAME, ercTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with name function for NFT")
     public void nameNonFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.NAME_NFT, ContractResource.ERC_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()));
+        var data = encodeData(ERC_TEST_CONTRACT, NAME_NFT, asAddress(nonFungibleKycUnfrozenTokenId));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.NAME_NFT.getActualGas(),
-                ercTestContractSolidityAddress);
+        validateGasEstimation(data, NAME_NFT, ercTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with symbol function for fungible token")
     public void symbolEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.SYMBOL, ContractResource.ERC_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()));
+        var data = encodeData(ERC_TEST_CONTRACT, SYMBOL, asAddress(fungibleKycUnfrozenTokenId));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.SYMBOL.getActualGas(),
-                ercTestContractSolidityAddress);
+        validateGasEstimation(data, SYMBOL, ercTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with symbol function for NFT")
     public void symbolNonFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.SYMBOL_NFT, ContractResource.ERC_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()));
+        var data = encodeData(ERC_TEST_CONTRACT, SYMBOL_NFT, asAddress(nonFungibleKycUnfrozenTokenId));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.SYMBOL_NFT.getActualGas(),
-                ercTestContractSolidityAddress);
+        validateGasEstimation(data, SYMBOL_NFT, ercTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with decimals function for fungible token")
     public void decimalsEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.DECIMALS, ContractResource.ERC_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()));
+        var data = encodeData(ERC_TEST_CONTRACT, DECIMALS, asAddress(fungibleKycUnfrozenTokenId));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.DECIMALS.getActualGas(),
-                ercTestContractSolidityAddress);
+        validateGasEstimation(data, DECIMALS, ercTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with totalSupply function for fungible token")
     public void totalSupplyEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.TOTAL_SUPPLY, ContractResource.ERC_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()));
+        var data = encodeData(ERC_TEST_CONTRACT, TOTAL_SUPPLY, asAddress(fungibleKycUnfrozenTokenId));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.TOTAL_SUPPLY.getActualGas(),
-                ercTestContractSolidityAddress);
+        validateGasEstimation(data, TOTAL_SUPPLY, ercTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with totalSupply function for NFT")
     public void totalSupplyNonFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.TOTAL_SUPPLY_NFT, ContractResource.ERC_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()));
+        var data = encodeData(ERC_TEST_CONTRACT, TOTAL_SUPPLY_NFT, asAddress(nonFungibleKycUnfrozenTokenId));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.TOTAL_SUPPLY_NFT.getActualGas(),
-                ercTestContractSolidityAddress);
+        validateGasEstimation(data, TOTAL_SUPPLY_NFT, ercTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with balanceOf function for fungible token")
     public void balanceOfEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.BALANCE_OF, ContractResource.ERC_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()),
-                        asAddress(admin.getAccountId().toSolidityAddress()));
+        var data = encodeData(ERC_TEST_CONTRACT, BALANCE_OF, asAddress(fungibleKycUnfrozenTokenId), asAddress(admin));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.BALANCE_OF.getActualGas(),
-                ercTestContractSolidityAddress);
+        validateGasEstimation(data, BALANCE_OF, ercTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with balanceOf function for NFT")
     public void balanceOfNFTEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.BALANCE_OF_NFT, ContractResource.ERC_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()),
-                        asAddress(admin.getAccountId().toSolidityAddress()));
+        var data = encodeData(
+                ERC_TEST_CONTRACT, BALANCE_OF_NFT, asAddress(nonFungibleKycUnfrozenTokenId), asAddress(admin));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.BALANCE_OF_NFT.getActualGas(),
-                ercTestContractSolidityAddress);
+        validateGasEstimation(data, BALANCE_OF_NFT, ercTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with ownerOf function for NFT")
     public void ownerOfEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.OWNER_OF, ContractResource.ERC_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()), new BigInteger("1"));
+        var data =
+                encodeData(ERC_TEST_CONTRACT, OWNER_OF, asAddress(nonFungibleKycUnfrozenTokenId), new BigInteger("1"));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.OWNER_OF.getActualGas(),
-                ercTestContractSolidityAddress);
+        validateGasEstimation(data, OWNER_OF, ercTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with tokenURI function for NFT")
     public void tokenURIEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.TOKEN_URI, ContractResource.ERC_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()), new BigInteger("1"));
+        var data =
+                encodeData(ERC_TEST_CONTRACT, TOKEN_URI, asAddress(nonFungibleKycUnfrozenTokenId), new BigInteger("1"));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.TOKEN_URI.getActualGas(),
-                ercTestContractSolidityAddress);
+        validateGasEstimation(data, TOKEN_URI, ercTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with getFungibleTokenInfo function")
     public void getFungibleTokenInfoEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.GET_FUNGIBLE_TOKEN_INFO, ContractResource.PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()));
+        var data = encodeData(PRECOMPILE_TEST_CONTRACT, GET_FUNGIBLE_TOKEN_INFO, asAddress(fungibleKycUnfrozenTokenId));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.GET_FUNGIBLE_TOKEN_INFO.getActualGas(),
-                precompileTestContractSolidityAddress);
+        validateGasEstimation(data, GET_FUNGIBLE_TOKEN_INFO, precompileTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with getNonFungibleTokenInfo function")
     public void getNonFungibleTokenInfoEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.GET_NON_FUNGIBLE_TOKEN_INFO, ContractResource.PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()), 1L);
+        var data = encodeData(
+                PRECOMPILE_TEST_CONTRACT, GET_NON_FUNGIBLE_TOKEN_INFO, asAddress(nonFungibleKycUnfrozenTokenId), 1L);
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.GET_NON_FUNGIBLE_TOKEN_INFO.getActualGas(),
-                precompileTestContractSolidityAddress);
+        validateGasEstimation(data, GET_NON_FUNGIBLE_TOKEN_INFO, precompileTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with getTokenInfo function for fungible")
     public void getTokenInfoEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.GET_TOKEN_INFO, ContractResource.PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()));
+        var data = encodeData(PRECOMPILE_TEST_CONTRACT, GET_TOKEN_INFO, asAddress(fungibleKycUnfrozenTokenId));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.GET_TOKEN_INFO.getActualGas(),
-                precompileTestContractSolidityAddress);
+        validateGasEstimation(data, GET_TOKEN_INFO, precompileTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with getTokenInfo function for NFT")
     public void getTokenInfoNonFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.GET_TOKEN_INFO_NFT, ContractResource.PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()));
+        var data = encodeData(PRECOMPILE_TEST_CONTRACT, GET_TOKEN_INFO_NFT, asAddress(nonFungibleKycUnfrozenTokenId));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.GET_TOKEN_INFO_NFT.getActualGas(),
-                precompileTestContractSolidityAddress);
+        validateGasEstimation(data, GET_TOKEN_INFO_NFT, precompileTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with getTokenDefaultFreezeStatus function for fungible token")
     public void getTokenDefaultFreezeStatusFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.GET_TOKEN_DEFAULT_FREEZE_STATUS, ContractResource.PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()));
+        var data = encodeData(
+                PRECOMPILE_TEST_CONTRACT, GET_TOKEN_DEFAULT_FREEZE_STATUS, asAddress(fungibleKycUnfrozenTokenId));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.GET_TOKEN_DEFAULT_FREEZE_STATUS.getActualGas(),
-                precompileTestContractSolidityAddress);
+        validateGasEstimation(data, GET_TOKEN_DEFAULT_FREEZE_STATUS, precompileTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with getTokenDefaultFreezeStatus function for NFT")
     public void getTokenDefaultFreezeStatusNonFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.GET_TOKEN_DEFAULT_FREEZE_STATUS, ContractResource.PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()));
+        var data = encodeData(
+                PRECOMPILE_TEST_CONTRACT, GET_TOKEN_DEFAULT_FREEZE_STATUS, asAddress(nonFungibleKycUnfrozenTokenId));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.GET_TOKEN_DEFAULT_FREEZE_STATUS.getActualGas(),
-                precompileTestContractSolidityAddress);
+        validateGasEstimation(data, GET_TOKEN_DEFAULT_FREEZE_STATUS, precompileTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with getTokenDefaultKycStatus function for fungible token")
     public void getTokenDefaultKycStatusFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.GET_TOKEN_DEFAULT_KYC_STATUS, ContractResource.PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()));
+        var data = encodeData(
+                PRECOMPILE_TEST_CONTRACT, GET_TOKEN_DEFAULT_KYC_STATUS, asAddress(fungibleKycUnfrozenTokenId));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.GET_TOKEN_DEFAULT_KYC_STATUS.getActualGas(),
-                precompileTestContractSolidityAddress);
+        validateGasEstimation(data, GET_TOKEN_DEFAULT_KYC_STATUS, precompileTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with getTokenDefaultKycStatus function for NFT")
     public void getTokenDefaultKycStatusNonFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.GET_TOKEN_DEFAULT_KYC_STATUS, ContractResource.PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()));
+        var data = encodeData(
+                PRECOMPILE_TEST_CONTRACT, GET_TOKEN_DEFAULT_KYC_STATUS, asAddress(nonFungibleKycUnfrozenTokenId));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.GET_TOKEN_DEFAULT_KYC_STATUS.getActualGas(),
-                precompileTestContractSolidityAddress);
+        validateGasEstimation(data, GET_TOKEN_DEFAULT_KYC_STATUS, precompileTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with isKyc function for fungible token")
     public void isKycFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.IS_KYC, ContractResource.PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()), asAddress(receiverAccountAlias));
+        var data = encodeData(
+                PRECOMPILE_TEST_CONTRACT,
+                IS_KYC,
+                asAddress(fungibleKycUnfrozenTokenId),
+                asAddress(receiverAccountAlias));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.IS_KYC.getActualGas(),
-                precompileTestContractSolidityAddress);
+        validateGasEstimation(data, IS_KYC, precompileTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with isKyc function for NFT")
     public void isKycNonFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.IS_KYC, ContractResource.PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()), asAddress(receiverAccountAlias));
+        var data = encodeData(
+                PRECOMPILE_TEST_CONTRACT,
+                IS_KYC,
+                asAddress(nonFungibleKycUnfrozenTokenId),
+                asAddress(receiverAccountAlias));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.IS_KYC.getActualGas(),
-                precompileTestContractSolidityAddress);
+        validateGasEstimation(data, IS_KYC, precompileTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with isFrozen function for fungible token")
     public void isFrozenFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.IS_FROZEN, ContractResource.PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()), asAddress(receiverAccountAlias));
+        var data = encodeData(
+                PRECOMPILE_TEST_CONTRACT,
+                IS_FROZEN,
+                asAddress(fungibleKycUnfrozenTokenId),
+                asAddress(receiverAccountAlias));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.IS_FROZEN.getActualGas(),
-                precompileTestContractSolidityAddress);
+        validateGasEstimation(data, IS_FROZEN, precompileTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with isFrozen function for NFT")
     public void isFrozenNonFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.IS_FROZEN, ContractResource.PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()), asAddress(receiverAccountAlias));
+        var data = encodeData(
+                PRECOMPILE_TEST_CONTRACT,
+                IS_FROZEN,
+                asAddress(nonFungibleKycUnfrozenTokenId),
+                asAddress(receiverAccountAlias));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.IS_FROZEN.getActualGas(),
-                precompileTestContractSolidityAddress);
+        validateGasEstimation(data, IS_FROZEN, precompileTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with getTokenType function for fungible token")
     public void getTokenTypeFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.GET_TOKEN_TYPE, ContractResource.PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()));
+        var data = encodeData(PRECOMPILE_TEST_CONTRACT, GET_TOKEN_TYPE, asAddress(fungibleKycUnfrozenTokenId));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.GET_TOKEN_TYPE.getActualGas(),
-                precompileTestContractSolidityAddress);
+        validateGasEstimation(data, GET_TOKEN_TYPE, precompileTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with getTokenType function for NFT")
     public void getTokenTypeNonFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.GET_TOKEN_TYPE, ContractResource.PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()));
+        var data = encodeData(PRECOMPILE_TEST_CONTRACT, GET_TOKEN_TYPE, asAddress(nonFungibleKycUnfrozenTokenId));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.GET_TOKEN_TYPE.getActualGas(),
-                precompileTestContractSolidityAddress);
+        validateGasEstimation(data, GET_TOKEN_TYPE, precompileTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with redirect balanceOf function")
     public void redirectBalanceOfEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.REDIRECT_FOR_TOKEN_BALANCE_OF, ContractResource.PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()),
-                        asAddress(admin.getAccountId().toSolidityAddress()));
+        var data = encodeData(
+                PRECOMPILE_TEST_CONTRACT,
+                REDIRECT_FOR_TOKEN_BALANCE_OF,
+                asAddress(fungibleKycUnfrozenTokenId),
+                asAddress(admin));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.REDIRECT_FOR_TOKEN_BALANCE_OF.getActualGas(),
-                precompileTestContractSolidityAddress);
+        validateGasEstimation(data, REDIRECT_FOR_TOKEN_BALANCE_OF, precompileTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with redirect name function")
     public void redirectNameEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.REDIRECT_FOR_TOKEN_NAME, ContractResource.PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()));
+        var data = encodeData(PRECOMPILE_TEST_CONTRACT, REDIRECT_FOR_TOKEN_NAME, asAddress(fungibleKycUnfrozenTokenId));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.REDIRECT_FOR_TOKEN_NAME.getActualGas(),
-                precompileTestContractSolidityAddress);
+        validateGasEstimation(data, REDIRECT_FOR_TOKEN_NAME, precompileTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with redirect symbol function")
     public void redirectSymbolEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.REDIRECT_FOR_TOKEN_SYMBOL, ContractResource.PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()));
+        var data =
+                encodeData(PRECOMPILE_TEST_CONTRACT, REDIRECT_FOR_TOKEN_SYMBOL, asAddress(fungibleKycUnfrozenTokenId));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.REDIRECT_FOR_TOKEN_SYMBOL.getActualGas(),
-                precompileTestContractSolidityAddress);
+        validateGasEstimation(data, REDIRECT_FOR_TOKEN_SYMBOL, precompileTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with redirect name function for NFT")
     public void redirectNameNonFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.REDIRECT_FOR_TOKEN_NAME, ContractResource.PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()));
+        var data =
+                encodeData(PRECOMPILE_TEST_CONTRACT, REDIRECT_FOR_TOKEN_NAME, asAddress(nonFungibleKycUnfrozenTokenId));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.REDIRECT_FOR_TOKEN_NAME.getActualGas(),
-                precompileTestContractSolidityAddress);
+        validateGasEstimation(data, REDIRECT_FOR_TOKEN_NAME, precompileTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with redirect symbol function for NFT")
     public void redirectSymbolNonFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.REDIRECT_FOR_TOKEN_SYMBOL, ContractResource.PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()));
+        var data = encodeData(
+                PRECOMPILE_TEST_CONTRACT, REDIRECT_FOR_TOKEN_SYMBOL, asAddress(nonFungibleKycUnfrozenTokenId));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.REDIRECT_FOR_TOKEN_SYMBOL.getActualGas(),
-                precompileTestContractSolidityAddress);
+        validateGasEstimation(data, REDIRECT_FOR_TOKEN_SYMBOL, precompileTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with redirect decimals function")
     public void redirectDecimalsEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.REDIRECT_FOR_TOKEN_DECIMALS, ContractResource.PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()));
+        var data = encodeData(
+                PRECOMPILE_TEST_CONTRACT, REDIRECT_FOR_TOKEN_DECIMALS, asAddress(fungibleKycUnfrozenTokenId));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.REDIRECT_FOR_TOKEN_DECIMALS.getActualGas(),
-                precompileTestContractSolidityAddress);
+        validateGasEstimation(data, REDIRECT_FOR_TOKEN_DECIMALS, precompileTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with redirect allowance function")
     public void redirectAllowanceEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.REDIRECT_FOR_TOKEN_ALLOWANCE, ContractResource.PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(fungibleKycUnfrozenTokenId.toSolidityAddress()),
-                        asAddress(admin.getAccountId().toSolidityAddress()),
-                        asAddress(receiverAccountAlias));
+        var data = encodeData(
+                PRECOMPILE_TEST_CONTRACT,
+                REDIRECT_FOR_TOKEN_ALLOWANCE,
+                asAddress(fungibleKycUnfrozenTokenId),
+                asAddress(admin),
+                asAddress(receiverAccountAlias));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.REDIRECT_FOR_TOKEN_ALLOWANCE.getActualGas(),
-                precompileTestContractSolidityAddress);
+        validateGasEstimation(data, REDIRECT_FOR_TOKEN_ALLOWANCE, precompileTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with redirect getOwnerOf function")
     public void redirectGetOwnerOfEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.REDIRECT_FOR_TOKEN_GET_OWNER_OF, ContractResource.PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()), new BigInteger("1"));
+        var data = encodeData(
+                PRECOMPILE_TEST_CONTRACT,
+                REDIRECT_FOR_TOKEN_GET_OWNER_OF,
+                asAddress(nonFungibleKycUnfrozenTokenId),
+                new BigInteger("1"));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.REDIRECT_FOR_TOKEN_GET_OWNER_OF.getActualGas(),
-                precompileTestContractSolidityAddress);
+        validateGasEstimation(data, REDIRECT_FOR_TOKEN_GET_OWNER_OF, precompileTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with redirect tokenURI function")
     public void redirectTokenURIEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.REDIRECT_FOR_TOKEN_TOKEN_URI, ContractResource.PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()), new BigInteger("1"));
+        var data = encodeData(
+                PRECOMPILE_TEST_CONTRACT,
+                REDIRECT_FOR_TOKEN_TOKEN_URI,
+                asAddress(nonFungibleKycUnfrozenTokenId),
+                new BigInteger("1"));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.REDIRECT_FOR_TOKEN_TOKEN_URI.getActualGas(),
-                precompileTestContractSolidityAddress);
+        validateGasEstimation(data, REDIRECT_FOR_TOKEN_TOKEN_URI, precompileTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with redirect isApprovedForAll function")
     public void redirectIsApprovedForAllEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.REDIRECT_FOR_TOKEN_IS_APPROVED_FOR_ALL,
-                        ContractResource.PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()),
-                        asAddress(admin.getAccountId().toSolidityAddress()),
-                        asAddress(receiverAccountAlias));
+        var data = encodeData(
+                PRECOMPILE_TEST_CONTRACT,
+                REDIRECT_FOR_TOKEN_IS_APPROVED_FOR_ALL,
+                asAddress(nonFungibleKycUnfrozenTokenId),
+                asAddress(admin),
+                asAddress(receiverAccountAlias));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.REDIRECT_FOR_TOKEN_IS_APPROVED_FOR_ALL.getActualGas(),
-                precompileTestContractSolidityAddress);
+        validateGasEstimation(data, REDIRECT_FOR_TOKEN_IS_APPROVED_FOR_ALL, precompileTestContractSolidityAddress);
     }
 
     @And("I transfer fungible token to the precompile contract")
@@ -1866,135 +1638,99 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with redirect transfer function")
     public void redirectTransferEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.REDIRECT_FOR_TOKEN_TRANSFER, ContractResource.PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(fungibleTokenId.toSolidityAddress()),
-                        asAddress(receiverAccountAlias),
-                        new BigInteger("5"));
+        var data = encodeData(
+                PRECOMPILE_TEST_CONTRACT,
+                REDIRECT_FOR_TOKEN_TRANSFER,
+                asAddress(fungibleTokenId),
+                asAddress(receiverAccountAlias),
+                new BigInteger("5"));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.REDIRECT_FOR_TOKEN_TRANSFER.getActualGas(),
-                precompileTestContractSolidityAddress);
+        validateGasEstimation(data, REDIRECT_FOR_TOKEN_TRANSFER, precompileTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with redirect transferFrom function")
     public void redirectTransferFromEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.REDIRECT_FOR_TOKEN_TRANSFER_FROM, ContractResource.PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(fungibleTokenId.toSolidityAddress()),
-                        asAddress(admin.getAccountId().toSolidityAddress()),
-                        asAddress(receiverAccountAlias),
-                        new BigInteger("5"));
+        var data = encodeData(
+                PRECOMPILE_TEST_CONTRACT,
+                REDIRECT_FOR_TOKEN_TRANSFER_FROM,
+                asAddress(fungibleTokenId),
+                asAddress(admin),
+                asAddress(receiverAccountAlias),
+                new BigInteger("5"));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.REDIRECT_FOR_TOKEN_TRANSFER_FROM.getActualGas(),
-                precompileTestContractSolidityAddress);
+        validateGasEstimation(data, REDIRECT_FOR_TOKEN_TRANSFER_FROM, precompileTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with redirect approve function")
     public void redirectApproveEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.REDIRECT_FOR_TOKEN_APPROVE, ContractResource.PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(fungibleTokenId.toSolidityAddress()),
-                        asAddress(receiverAccountAlias),
-                        new BigInteger("10"));
+        var data = encodeData(
+                PRECOMPILE_TEST_CONTRACT,
+                REDIRECT_FOR_TOKEN_APPROVE,
+                asAddress(fungibleTokenId),
+                asAddress(receiverAccountAlias),
+                new BigInteger("10"));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.REDIRECT_FOR_TOKEN_APPROVE.getActualGas(),
-                precompileTestContractSolidityAddress);
+        validateGasEstimation(data, REDIRECT_FOR_TOKEN_APPROVE, precompileTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with redirect transferFrom NFT function")
     public void redirectTransferFromNonFungibleEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.REDIRECT_FOR_TOKEN_TRANSFER_FROM_NFT, ContractResource.PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(nonFungibleTokenId.toSolidityAddress()),
-                        asAddress(admin.getAccountId().toSolidityAddress()),
-                        asAddress(receiverAccountAlias),
-                        new BigInteger("2"));
+        var data = encodeData(
+                PRECOMPILE_TEST_CONTRACT,
+                REDIRECT_FOR_TOKEN_TRANSFER_FROM_NFT,
+                asAddress(nonFungibleTokenId),
+                asAddress(admin),
+                asAddress(receiverAccountAlias),
+                new BigInteger("2"));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.REDIRECT_FOR_TOKEN_TRANSFER_FROM_NFT.getActualGas(),
-                precompileTestContractSolidityAddress);
+        validateGasEstimation(data, REDIRECT_FOR_TOKEN_TRANSFER_FROM_NFT, precompileTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with redirect setApprovalForAll function")
     public void redirectSetApprovalForAllEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.REDIRECT_FOR_TOKEN_SET_APPROVAL_FOR_ALL,
-                        ContractResource.PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(
-                        asAddress(nonFungibleKycUnfrozenTokenId.toSolidityAddress()),
-                        asAddress(receiverAccountAlias),
-                        true);
+        var data = encodeData(
+                PRECOMPILE_TEST_CONTRACT,
+                REDIRECT_FOR_TOKEN_SET_APPROVAL_FOR_ALL,
+                asAddress(nonFungibleKycUnfrozenTokenId),
+                asAddress(receiverAccountAlias),
+                true);
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.REDIRECT_FOR_TOKEN_SET_APPROVAL_FOR_ALL.getActualGas(),
-                precompileTestContractSolidityAddress);
+        validateGasEstimation(data, REDIRECT_FOR_TOKEN_SET_APPROVAL_FOR_ALL, precompileTestContractSolidityAddress);
     }
 
     @Then("I call estimateGas with pseudo random seed")
     public void pseudoRandomSeedEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.PSEUDO_RANDOM_SEED, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs();
+        var data = encodeData(ESTIMATE_PRECOMPILE_TEST_CONTRACT, PSEUDO_RANDOM_SEED);
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.PSEUDO_RANDOM_SEED.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, PSEUDO_RANDOM_SEED, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with pseudo random number")
     public void pseudoRandomNumberEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.PSEUDO_RANDOM_NUMBER, ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(500L, 1000L);
+        var data = encodeData(ESTIMATE_PRECOMPILE_TEST_CONTRACT, PSEUDO_RANDOM_NUMBER, 500L, 1000L);
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.PSEUDO_RANDOM_NUMBER.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, PSEUDO_RANDOM_NUMBER, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with exchange rate tinycents to tinybars")
     public void exchangeRateTinyCentsToTinyBarsEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.EXCHANGE_RATE_TINYCENTS_TO_TINYBARS,
-                        ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(new BigInteger("100"));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT, EXCHANGE_RATE_TINYCENTS_TO_TINYBARS, new BigInteger("100"));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.EXCHANGE_RATE_TINYCENTS_TO_TINYBARS.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, EXCHANGE_RATE_TINYCENTS_TO_TINYBARS, estimatePrecompileContractSolidityAddress);
     }
 
     @Then("I call estimateGas with exchange rate tinybars to tinycents")
     public void exchangeRateTinyBarsToTinyCentsEstimateGas() {
-        ByteBuffer encodedFunctionCall = getFunctionFromArtifact(
-                        ContractMethods.EXCHANGE_RATE_TINYBARS_TO_TINYCENTS,
-                        ContractResource.ESTIMATE_PRECOMPILE_TEST_CONTRACT)
-                .encodeCallWithArgs(new BigInteger("100"));
+        var data = encodeData(
+                ESTIMATE_PRECOMPILE_TEST_CONTRACT, EXCHANGE_RATE_TINYBARS_TO_TINYCENTS, new BigInteger("100"));
 
-        validateGasEstimation(
-                Strings.encode(encodedFunctionCall),
-                ContractMethods.EXCHANGE_RATE_TINYBARS_TO_TINYCENTS.getActualGas(),
-                estimatePrecompileContractSolidityAddress);
+        validateGasEstimation(data, EXCHANGE_RATE_TINYBARS_TO_TINYCENTS, estimatePrecompileContractSolidityAddress);
     }
 
-    private void validateGasEstimationForCreateToken(String selector, int actualGasUsed, long value) {
+    private void validateGasEstimationForCreateToken(ByteBuffer data, int actualGasUsed, long value) {
         var contractCallRequestBody = ContractCallRequest.builder()
-                .data(selector)
+                .data(Strings.encode(data))
                 .to(estimatePrecompileContractSolidityAddress)
                 .from(contractClient.getClientAddress())
                 .estimate(true)
@@ -2029,7 +1765,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
 
     @Getter
     @RequiredArgsConstructor
-    private enum ContractMethods implements ContractMethodInterface {
+    enum ContractMethods implements ContractMethodInterface {
         ALLOWANCE("allowanceExternal", 25399),
         ALLOWANCE_ERC("allowance", 27481),
         APPROVE("approveExternal", 729571),

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/PrecompileContractFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/PrecompileContractFeature.java
@@ -179,7 +179,7 @@ public class PrecompileContractFeature extends AbstractFeature {
     public void checkIfFungibleTokenIsToken() {
         var data = encodeData(PRECOMPILE, IS_TOKEN_SELECTOR, asAddress(tokenIds.get(0)));
 
-        ContractCallResponse response = callContract(data, precompileTestContractSolidityAddress);
+        var response = callContract(data, precompileTestContractSolidityAddress);
 
         assertTrue(response.getResultAsBoolean());
     }
@@ -188,7 +188,7 @@ public class PrecompileContractFeature extends AbstractFeature {
     public void checkIfNonFungibleTokenIsToken() {
         var data = encodeData(PRECOMPILE, IS_TOKEN_SELECTOR, asAddress(tokenIds.get(1)));
 
-        ContractCallResponse response = callContract(data, precompileTestContractSolidityAddress);
+        var response = callContract(data, precompileTestContractSolidityAddress);
 
         assertTrue(response.getResultAsBoolean());
     }
@@ -217,7 +217,7 @@ public class PrecompileContractFeature extends AbstractFeature {
         var data =
                 encodeData(PRECOMPILE, IS_TOKEN_FROZEN_SELECTOR, asAddress(tokenIds.get(0)), asAddress(contractClient));
 
-        ContractCallResponse response = callContract(data, precompileTestContractSolidityAddress);
+        var response = callContract(data, precompileTestContractSolidityAddress);
 
         assertFalse(response.getResultAsBoolean());
     }
@@ -227,7 +227,7 @@ public class PrecompileContractFeature extends AbstractFeature {
         var data =
                 encodeData(PRECOMPILE, IS_TOKEN_FROZEN_SELECTOR, asAddress(tokenIds.get(1)), asAddress(contractClient));
 
-        ContractCallResponse response = callContract(data, precompileTestContractSolidityAddress);
+        var response = callContract(data, precompileTestContractSolidityAddress);
 
         assertFalse(response.getResultAsBoolean());
     }
@@ -248,7 +248,7 @@ public class PrecompileContractFeature extends AbstractFeature {
         var data =
                 encodeData(PRECOMPILE, IS_TOKEN_FROZEN_SELECTOR, asAddress(tokenIds.get(1)), asAddress(contractClient));
 
-        ContractCallResponse response = callContract(data, precompileTestContractSolidityAddress);
+        var response = callContract(data, precompileTestContractSolidityAddress);
 
         assertTrue(response.getResultAsBoolean());
     }
@@ -269,7 +269,7 @@ public class PrecompileContractFeature extends AbstractFeature {
         var data =
                 encodeData(PRECOMPILE, IS_TOKEN_FROZEN_SELECTOR, asAddress(tokenIds.get(1)), asAddress(contractClient));
 
-        ContractCallResponse response = callContract(data, precompileTestContractSolidityAddress);
+        var response = callContract(data, precompileTestContractSolidityAddress);
 
         assertFalse(response.getResultAsBoolean());
     }
@@ -293,7 +293,7 @@ public class PrecompileContractFeature extends AbstractFeature {
                 asAddress(tokenIds.get(0)),
                 asAddress(accountInfo.getEvmAddress()));
 
-        ContractCallResponse response = callContract(data, precompileTestContractSolidityAddress);
+        var response = callContract(data, precompileTestContractSolidityAddress);
 
         assertTrue(response.getResultAsBoolean());
     }
@@ -317,7 +317,7 @@ public class PrecompileContractFeature extends AbstractFeature {
                 asAddress(tokenIds.get(0)),
                 asAddress(accountInfo.getEvmAddress()));
 
-        ContractCallResponse response = callContract(data, precompileTestContractSolidityAddress);
+        var response = callContract(data, precompileTestContractSolidityAddress);
 
         assertFalse(response.getResultAsBoolean());
     }
@@ -336,7 +336,7 @@ public class PrecompileContractFeature extends AbstractFeature {
         var data =
                 encodeData(PRECOMPILE, IS_KYC_GRANTED_SELECTOR, asAddress(tokenIds.get(0)), asAddress(contractClient));
 
-        ContractCallResponse response = callContract(data, precompileTestContractSolidityAddress);
+        var response = callContract(data, precompileTestContractSolidityAddress);
 
         assertTrue(response.getResultAsBoolean());
     }
@@ -346,7 +346,7 @@ public class PrecompileContractFeature extends AbstractFeature {
         var data =
                 encodeData(PRECOMPILE, IS_KYC_GRANTED_SELECTOR, asAddress(tokenIds.get(1)), asAddress(contractClient));
 
-        ContractCallResponse response = callContract(data, precompileTestContractSolidityAddress);
+        var response = callContract(data, precompileTestContractSolidityAddress);
 
         assertTrue(response.getResultAsBoolean());
     }
@@ -355,7 +355,7 @@ public class PrecompileContractFeature extends AbstractFeature {
     public void getDefaultFreezeOfFungibleToken() {
         var data = encodeData(PRECOMPILE, GET_TOKEN_DEFAULT_FREEZE_SELECTOR, asAddress(tokenIds.get(0)));
 
-        ContractCallResponse response = callContract(data, precompileTestContractSolidityAddress);
+        var response = callContract(data, precompileTestContractSolidityAddress);
 
         assertFalse(response.getResultAsBoolean());
     }
@@ -364,7 +364,7 @@ public class PrecompileContractFeature extends AbstractFeature {
     public void getDefaultFreezeOfNonFungibleToken() {
         var data = encodeData(PRECOMPILE, GET_TOKEN_DEFAULT_FREEZE_SELECTOR, asAddress(tokenIds.get(1)));
 
-        ContractCallResponse response = callContract(data, precompileTestContractSolidityAddress);
+        var response = callContract(data, precompileTestContractSolidityAddress);
 
         assertFalse(response.getResultAsBoolean());
     }
@@ -373,7 +373,7 @@ public class PrecompileContractFeature extends AbstractFeature {
     public void getDefaultKycOfFungibleToken() {
         var data = encodeData(PRECOMPILE, GET_TOKEN_DEFAULT_KYC_SELECTOR, asAddress(tokenIds.get(0)));
 
-        ContractCallResponse response = callContract(data, precompileTestContractSolidityAddress);
+        var response = callContract(data, precompileTestContractSolidityAddress);
 
         assertFalse(response.getResultAsBoolean());
     }
@@ -382,7 +382,7 @@ public class PrecompileContractFeature extends AbstractFeature {
     public void getDefaultKycOfNonFungibleToken() {
         var data = encodeData(PRECOMPILE, GET_TOKEN_DEFAULT_KYC_SELECTOR, asAddress(tokenIds.get(1)));
 
-        ContractCallResponse response = callContract(data, precompileTestContractSolidityAddress);
+        var response = callContract(data, precompileTestContractSolidityAddress);
 
         assertFalse(response.getResultAsBoolean());
     }
@@ -390,7 +390,7 @@ public class PrecompileContractFeature extends AbstractFeature {
     @And("the contract call REST API should return the information for token for a fungible token")
     public void getInformationForTokenOfFungibleToken() throws Exception {
         var data = encodeData(PRECOMPILE, GET_INFORMATION_FOR_TOKEN_SELECTOR, asAddress(tokenIds.get(0)));
-        ContractCallResponse response = callContract(data, precompileTestContractSolidityAddress);
+        var response = callContract(data, precompileTestContractSolidityAddress);
 
         Tuple tokenInfo = baseGetInformationForTokenChecks(response);
         Long totalSupply = tokenInfo.get(1);
@@ -404,7 +404,7 @@ public class PrecompileContractFeature extends AbstractFeature {
     @And("the contract call REST API should return the information for token for a non fungible token")
     public void getInformationForTokenOfNonFungibleToken() throws Exception {
         var data = encodeData(PRECOMPILE, GET_INFORMATION_FOR_TOKEN_SELECTOR, asAddress(tokenIds.get(1)));
-        ContractCallResponse response = callContract(data, precompileTestContractSolidityAddress);
+        var response = callContract(data, precompileTestContractSolidityAddress);
 
         Tuple tokenInfo = baseGetInformationForTokenChecks(response);
         Long totalSupply = tokenInfo.get(1);
@@ -414,7 +414,7 @@ public class PrecompileContractFeature extends AbstractFeature {
     @And("the contract call REST API should return the information for a fungible token")
     public void getInformationForFungibleToken() throws Exception {
         var data = encodeData(PRECOMPILE, GET_INFORMATION_FOR_FUNGIBLE_TOKEN_SELECTOR, asAddress(tokenIds.get(0)));
-        ContractCallResponse response = callContract(data, precompileTestContractSolidityAddress);
+        var response = callContract(data, precompileTestContractSolidityAddress);
 
         Tuple result = decodeFunctionResult("getInformationForFungibleToken", response);
         assertThat(result).isNotEmpty();
@@ -434,7 +434,7 @@ public class PrecompileContractFeature extends AbstractFeature {
                 GET_INFORMATION_FOR_NON_FUNGIBLE_TOKEN_SELECTOR,
                 asAddress(tokenIds.get(1)),
                 firstNftSerialNumber);
-        ContractCallResponse response = callContract(data, precompileTestContractSolidityAddress);
+        var response = callContract(data, precompileTestContractSolidityAddress);
 
         Tuple result = decodeFunctionResult("getInformationForNonFungibleToken", response);
         assertThat(result).isNotEmpty();
@@ -458,7 +458,7 @@ public class PrecompileContractFeature extends AbstractFeature {
     @And("the contract call REST API should return the type for a fungible token")
     public void getTypeForFungibleToken() {
         var data = encodeData(PRECOMPILE, GET_TYPE_SELECTOR, asAddress(tokenIds.get(0)));
-        ContractCallResponse response = callContract(data, precompileTestContractSolidityAddress);
+        var response = callContract(data, precompileTestContractSolidityAddress);
 
         assertThat(response.getResultAsNumber()).isZero();
     }
@@ -466,7 +466,7 @@ public class PrecompileContractFeature extends AbstractFeature {
     @And("the contract call REST API should return the type for a non fungible token")
     public void getTypeForNonFungibleToken() {
         var data = encodeData(PRECOMPILE, GET_TYPE_SELECTOR, asAddress(tokenIds.get(1)));
-        ContractCallResponse response = callContract(data, precompileTestContractSolidityAddress);
+        var response = callContract(data, precompileTestContractSolidityAddress);
 
         assertThat(response.getResultAsNumber()).isEqualTo(1);
     }
@@ -474,7 +474,7 @@ public class PrecompileContractFeature extends AbstractFeature {
     @And("the contract call REST API should return the expiry token info for a fungible token")
     public void getExpiryTokenInfoForFungibleToken() throws Exception {
         var data = encodeData(PRECOMPILE, GET_EXPIRY_INFO_FOR_TOKEN_SELECTOR, asAddress(tokenIds.get(0)));
-        ContractCallResponse response = callContract(data, precompileTestContractSolidityAddress);
+        var response = callContract(data, precompileTestContractSolidityAddress);
 
         baseExpiryInfoChecks(response);
     }
@@ -482,7 +482,7 @@ public class PrecompileContractFeature extends AbstractFeature {
     @And("the contract call REST API should return the expiry token info for a non fungible token")
     public void getExpiryTokenInfoForNonFungibleToken() throws Exception {
         var data = encodeData(PRECOMPILE, GET_EXPIRY_INFO_FOR_TOKEN_SELECTOR, asAddress(tokenIds.get(1)));
-        ContractCallResponse response = callContract(data, precompileTestContractSolidityAddress);
+        var response = callContract(data, precompileTestContractSolidityAddress);
 
         baseExpiryInfoChecks(response);
     }
@@ -491,7 +491,7 @@ public class PrecompileContractFeature extends AbstractFeature {
     public void getTokenKeyForFungibleToken() throws Exception {
         var data =
                 encodeData(PRECOMPILE, GET_TOKEN_KEY_PUBLIC_SELECTOR, asAddress(tokenIds.get(0)), new BigInteger("1"));
-        ContractCallResponse response = callContract(data, precompileTestContractSolidityAddress);
+        var response = callContract(data, precompileTestContractSolidityAddress);
 
         Tuple result = decodeFunctionResult("getTokenKeyPublic", response);
         assertThat(result).isNotEmpty();
@@ -503,7 +503,7 @@ public class PrecompileContractFeature extends AbstractFeature {
     public void getTokenKeyForNonFungibleToken() throws Exception {
         var data =
                 encodeData(PRECOMPILE, GET_TOKEN_KEY_PUBLIC_SELECTOR, asAddress(tokenIds.get(1)), new BigInteger("1"));
-        ContractCallResponse response = callContract(data, precompileTestContractSolidityAddress);
+        var response = callContract(data, precompileTestContractSolidityAddress);
 
         Tuple result = decodeFunctionResult("getTokenKeyPublic", response);
         assertThat(result).isNotEmpty();
@@ -537,91 +537,91 @@ public class PrecompileContractFeature extends AbstractFeature {
     @And("the contract call REST API should return the name by direct call for a fungible token")
     public void getFungibleTokenNameByDirectCall() {
         var data = encodeData(NAME_SELECTOR);
-        ContractCallResponse response = callContract(data, tokenIds.get(0).toSolidityAddress());
+        var response = callContract(data, tokenIds.get(0).toSolidityAddress());
         assertThat(response.getResultAsAsciiString()).contains("_name");
     }
 
     @And("the contract call REST API should return the symbol by direct call for a fungible token")
     public void getFungibleTokenSymbolByDirectCall() {
         var data = encodeData(SYMBOL_SELECTOR);
-        ContractCallResponse response = callContract(data, tokenIds.get(0).toSolidityAddress());
+        var response = callContract(data, tokenIds.get(0).toSolidityAddress());
         assertThat(response.getResultAsAsciiString()).isNotEmpty();
     }
 
     @And("the contract call REST API should return the decimals by direct call for a  fungible token")
     public void getFungibleTokenDecimalsByDirectCall() {
         var data = encodeData(DECIMALS_SELECTOR);
-        ContractCallResponse response = callContract(data, tokenIds.get(0).toSolidityAddress());
+        var response = callContract(data, tokenIds.get(0).toSolidityAddress());
         assertThat(response.getResultAsNumber()).isEqualTo(10);
     }
 
     @And("the contract call REST API should return the total supply by direct call for a  fungible token")
     public void getFungibleTokenTotalSupplyByDirectCall() {
         var data = encodeData(TOTAL_SUPPLY_SELECTOR);
-        ContractCallResponse response = callContract(data, tokenIds.get(0).toSolidityAddress());
+        var response = callContract(data, tokenIds.get(0).toSolidityAddress());
         assertThat(response.getResultAsNumber()).isEqualTo(1000000);
     }
 
     @And("the contract call REST API should return the balanceOf by direct call for a fungible token")
     public void getFungibleTokenBalanceOfByDirectCall() {
         var data = encodeData(BALANCE_OF_SELECTOR, asAddress(contractClient));
-        ContractCallResponse response = callContract(data, tokenIds.get(0).toSolidityAddress());
+        var response = callContract(data, tokenIds.get(0).toSolidityAddress());
         assertThat(response.getResultAsNumber()).isEqualTo(1000000);
     }
 
     @And("the contract call REST API should return the allowance by direct call for a fungible token")
     public void getFungibleTokenAllowanceByDirectCall() {
         var data = encodeData(ALLOWANCE_SELECTOR, asAddress(contractClient), asAddress(ecdsaEaId));
-        ContractCallResponse response = callContract(data, tokenIds.get(0).toSolidityAddress());
+        var response = callContract(data, tokenIds.get(0).toSolidityAddress());
         assertThat(response.getResultAsNumber()).isZero();
     }
 
     @And("the contract call REST API should return the name by direct call for a non fungible token")
     public void getNonFungibleTokenNameByDirectCall() {
         var data = encodeData(NAME_SELECTOR);
-        ContractCallResponse response = callContract(data, tokenIds.get(1).toSolidityAddress());
+        var response = callContract(data, tokenIds.get(1).toSolidityAddress());
         assertThat(response.getResultAsAsciiString()).contains("_name");
     }
 
     @And("the contract call REST API should return the symbol by direct call for a non fungible token")
     public void getNonFungibleTokenSymbolByDirectCall() {
         var data = encodeData(SYMBOL_SELECTOR);
-        ContractCallResponse response = callContract(data, tokenIds.get(1).toSolidityAddress());
+        var response = callContract(data, tokenIds.get(1).toSolidityAddress());
         assertThat(response.getResultAsAsciiString()).isNotEmpty();
     }
 
     @And("the contract call REST API should return the total supply by direct call for a non fungible token")
     public void getNonFungibleTokenTotalSupplyByDirectCall() {
         var data = encodeData(TOTAL_SUPPLY_SELECTOR);
-        ContractCallResponse response = callContract(data, tokenIds.get(1).toSolidityAddress());
+        var response = callContract(data, tokenIds.get(1).toSolidityAddress());
         assertThat(response.getResultAsNumber()).isEqualTo(1);
     }
 
     @And("the contract call REST API should return the ownerOf by direct call for a non fungible token")
     public void getNonFungibleTokenOwnerOfByDirectCall() {
         var data = encodeData(OWNER_OF_SELECTOR, new BigInteger("1"));
-        ContractCallResponse response = callContract(data, tokenIds.get(1).toSolidityAddress());
+        var response = callContract(data, tokenIds.get(1).toSolidityAddress());
         tokenClient.validateAddress(response.getResultAsAddress());
     }
 
     @And("the contract call REST API should return the getApproved by direct call for a non fungible token")
     public void getNonFungibleTokenGetApprovedByDirectCall() {
         var data = encodeData(GET_APPROVED_SELECTOR, new BigInteger("1"));
-        ContractCallResponse response = callContract(data, tokenIds.get(0).toSolidityAddress());
+        var response = callContract(data, tokenIds.get(0).toSolidityAddress());
         assertFalse(response.getResultAsBoolean());
     }
 
     @And("the contract call REST API should return the isApprovedForAll by direct call for a non fungible token")
     public void getNonFungibleTokenIsApprovedForAllByDirectCallOwner() {
         var data = encodeData(IS_APPROVED_FOR_ALL_SELECTOR, asAddress(contractClient), asAddress(ecdsaEaId));
-        ContractCallResponse response = callContract(data, tokenIds.get(0).toSolidityAddress());
+        var response = callContract(data, tokenIds.get(0).toSolidityAddress());
         assertFalse(response.getResultAsBoolean());
     }
 
     @And("the contract call REST API should return the custom fees for a fungible token")
     public void getCustomFeesForFungibleToken() throws Exception {
         var data = encodeData(PRECOMPILE, GET_CUSTOM_FEES_FOR_TOKEN_SELECTOR, asAddress(tokenIds.get(0)));
-        ContractCallResponse response = callContract(data, precompileTestContractSolidityAddress);
+        var response = callContract(data, precompileTestContractSolidityAddress);
 
         Tuple result = decodeFunctionResult("getCustomFeesForToken", response);
         assertThat(result).isNotEmpty();
@@ -641,7 +641,7 @@ public class PrecompileContractFeature extends AbstractFeature {
     @And("the contract call REST API should return the custom fees for a non fungible token")
     public void getCustomFeesForNonFungibleToken() throws Exception {
         var data = encodeData(PRECOMPILE, GET_CUSTOM_FEES_FOR_TOKEN_SELECTOR, asAddress(tokenIds.get(1)));
-        ContractCallResponse response = callContract(data, precompileTestContractSolidityAddress);
+        var response = callContract(data, precompileTestContractSolidityAddress);
         Tuple result = decodeFunctionResult("getCustomFeesForToken", response);
         assertThat(result).isNotEmpty();
         baseFixedFeeCheck(result.get(0));
@@ -656,7 +656,7 @@ public class PrecompileContractFeature extends AbstractFeature {
             "I call function with HederaTokenService getTokenCustomFees token - fractional fee and fixed fee - fungible token")
     public void getCustomFeesForFungibleTokenFractionalAndFixedFees() throws Exception {
         var data = encodeData(PRECOMPILE, GET_CUSTOM_FEES_FOR_TOKEN_SELECTOR, asAddress(tokenIds.get(0)));
-        ContractCallResponse response = callContract(data, precompileTestContractSolidityAddress);
+        var response = callContract(data, precompileTestContractSolidityAddress);
 
         Tuple result = decodeFunctionResult("getCustomFeesForToken", response);
         assertThat(result).isNotEmpty();
@@ -677,7 +677,7 @@ public class PrecompileContractFeature extends AbstractFeature {
     @And("I call function with HederaTokenService getTokenCustomFees token - royalty fee")
     public void getCustomFeesForFungibleTokenRoyaltyFee() throws Exception {
         var data = encodeData(PRECOMPILE, GET_CUSTOM_FEES_FOR_TOKEN_SELECTOR, asAddress(tokenIds.get(1)));
-        ContractCallResponse response = callContract(data, precompileTestContractSolidityAddress);
+        var response = callContract(data, precompileTestContractSolidityAddress);
 
         Tuple result = decodeFunctionResult("getCustomFeesForToken", response);
         assertThat(result).isNotEmpty();
@@ -698,7 +698,7 @@ public class PrecompileContractFeature extends AbstractFeature {
     @And("I call function with HederaTokenService getTokenCustomFees token - royalty fee + fallback")
     public void getCustomFeesForFungibleTokenRoyaltyFeeAndFallback() throws Exception {
         var data = encodeData(PRECOMPILE, GET_CUSTOM_FEES_FOR_TOKEN_SELECTOR, asAddress(tokenIds.get(1)));
-        ContractCallResponse response = callContract(data, precompileTestContractSolidityAddress);
+        var response = callContract(data, precompileTestContractSolidityAddress);
 
         Tuple result = decodeFunctionResult("getCustomFeesForToken", response);
         assertThat(result).isNotEmpty();

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/util/TestUtil.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/util/TestUtil.java
@@ -21,8 +21,12 @@ import com.esaulpaugh.headlong.abi.Tuple;
 import com.google.common.io.BaseEncoding;
 import com.google.protobuf.ByteString;
 import com.hedera.hashgraph.sdk.PublicKey;
+import com.hedera.hashgraph.sdk.TokenId;
 import com.hedera.hashgraph.sdk.proto.Key;
+import com.hedera.mirror.test.e2e.acceptance.client.ContractClient;
+import com.hedera.mirror.test.e2e.acceptance.client.TokenClient;
 import com.hedera.mirror.test.e2e.acceptance.props.CompiledSolidityArtifact;
+import com.hedera.mirror.test.e2e.acceptance.props.ExpandedAccountId;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -73,6 +77,38 @@ public class TestUtil {
     }
 
     public static Address asAddress(String address) {
+        final var addressBytes = Bytes.fromHexString(address.startsWith("0x") ? address : "0x" + address);
+        final var addressAsInteger = addressBytes.toUnsignedBigInteger();
+        return Address.wrap(Address.toChecksumAddress(addressAsInteger));
+    }
+
+    public static Address asAddress(ExpandedAccountId accountId) {
+        final var address = accountId.getAccountId().toSolidityAddress();
+        final var addressBytes = Bytes.fromHexString(address.startsWith("0x") ? address : "0x" + address);
+        final var addressAsInteger = addressBytes.toUnsignedBigInteger();
+        return Address.wrap(Address.toChecksumAddress(addressAsInteger));
+    }
+
+    public static Address asAddress(TokenId tokenId) {
+        final var address = tokenId.toSolidityAddress();
+        final var addressBytes = Bytes.fromHexString(address.startsWith("0x") ? address : "0x" + address);
+        final var addressAsInteger = addressBytes.toUnsignedBigInteger();
+        return Address.wrap(Address.toChecksumAddress(addressAsInteger));
+    }
+
+    public static Address asAddress(ContractClient contractClient) {
+        final var address = contractClient.getClientAddress();
+        final var addressBytes = Bytes.fromHexString(address.startsWith("0x") ? address : "0x" + address);
+        final var addressAsInteger = addressBytes.toUnsignedBigInteger();
+        return Address.wrap(Address.toChecksumAddress(addressAsInteger));
+    }
+
+    public static Address asAddress(TokenClient tokenClient) {
+        final var address = tokenClient
+                .getSdkClient()
+                .getExpandedOperatorAccountId()
+                .getAccountId()
+                .toSolidityAddress();
         final var addressBytes = Bytes.fromHexString(address.startsWith("0x") ? address : "0x" + address);
         final var addressAsInteger = addressBytes.toUnsignedBigInteger();
         return Address.wrap(Address.toChecksumAddress(addressAsInteger));

--- a/hedera-mirror-test/src/test/resources/features/contract/estimate.feature
+++ b/hedera-mirror-test/src/test/resources/features/contract/estimate.feature
@@ -14,6 +14,7 @@ Feature: EstimateGas Contract Base Coverage Feature
     Then I call estimateGas with function that changes contract slot information by updating global contract field with the passed argument
     Then I call estimateGas with function that successfully deploys a new smart contract via CREATE op code
     Then I call estimateGas with function that successfully deploys a new smart contract via CREATE2 op code
+    Then I get mock contract address and getAddress selector
     Then I call estimateGas with function that makes a static call to a method from a different contract
     Then I call estimateGas with function that makes a delegate call to a method from a different contract
     Then I call estimateGas with function that makes a call code to a method from a different contract


### PR DESCRIPTION
**Description**:

This PR addresses the need to bring better consistency and maintainability to our test suites by refactoring the encoding of function selectors and parameters using the Headlong library.

Changes:
* Refactored CallFeature, EstimateFeature, PrecompileContractFeature, ERCConctractFeature to leverage Headlong framework for function encoding;
* Added a new function `getFunctionFromArtifact` in `AbstractFeature` which facilitates extracting a Function object directly from a compiled artifact;
* Removed redundant resource declarations and centralized all necessary resource paths into the `ContractResource` enum within `AbstractFeature`, ensuring a more organized and maintainable approach to resource management. 
**Related issue(s)**:

Fixes #7006

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
