### PR TITLE
Use ContractCallTestScenarioBuilder in web3 k6 test cases

### DIFF
--- a/hedera-mirror-test/k6/src/web3/test/common.js
+++ b/hedera-mirror-test/k6/src/web3/test/common.js
@@ -59,7 +59,7 @@ function ContractCallTestScenarioBuilder() {
   this._value = null;
   this._estimate = null;
 
-  this._url = `${__ENV.BASE_URL}/api/v1/contracts/call`;
+  this._url = `${__ENV.BASE_URL_PREFIX}/contracts/call`;
 
   this.build = function () {
     const that = this;

--- a/hedera-mirror-test/k6/src/web3/test/commonContractCallEstimateTemplate.js
+++ b/hedera-mirror-test/k6/src/web3/test/commonContractCallEstimateTemplate.js
@@ -15,6 +15,7 @@
  */
 
 import {SharedArray} from 'k6/data';
+import {vu} from 'k6/execution';
 import {ContractCallTestScenarioBuilder} from './common.js';
 
 function ContractCallEstimateTestTemplate(key) {
@@ -22,7 +23,7 @@ function ContractCallEstimateTestTemplate(key) {
     return JSON.parse(open('./resources/estimate.json'))[key];
   });
 
-  const data = allData[__VU % allData.length];
+  const data = allData[vu.idInTest % allData.length];
 
   const {options, run} = new ContractCallTestScenarioBuilder()
     .name(key)

--- a/hedera-mirror-test/k6/src/web3/test/contractCallBalance.js
+++ b/hedera-mirror-test/k6/src/web3/test/contractCallBalance.js
@@ -14,22 +14,15 @@
  * limitations under the License.
  */
 
-import {TestScenarioBuilder} from '../../lib/common.js';
-import {isNonErrorResponse} from './common.js';
-import {jsonPost} from './common.js';
+import {ContractCallTestScenarioBuilder} from './common.js';
 
-const url = __ENV.BASE_URL;
 const contract = __ENV.DEFAULT_CONTRACT_ADDRESS;
+const data = '0x6896fabf';
 
-const payload = JSON.stringify({
-  to: `${contract}`,
-  data: '0x6896fabf',
-});
-
-const {options, run} = new TestScenarioBuilder()
+const {options, run} = new ContractCallTestScenarioBuilder()
   .name('contractCallBalance') // use unique scenario name among all tests
-  .request(() => jsonPost(url, payload))
-  .check('contractCallBalance', (r) => isNonErrorResponse(r))
+  .data(data)
+  .to(contract)
   .build();
 
 export {options, run};

--- a/hedera-mirror-test/k6/src/web3/test/contractCallIdentifier.js
+++ b/hedera-mirror-test/k6/src/web3/test/contractCallIdentifier.js
@@ -14,22 +14,15 @@
  * limitations under the License.
  */
 
-import {TestScenarioBuilder} from '../../lib/common.js';
-import {isNonErrorResponse} from './common.js';
-import {jsonPost} from './common.js';
+import {ContractCallTestScenarioBuilder} from './common.js';
 
-const url = __ENV.BASE_URL;
 const contract = __ENV.DEFAULT_CONTRACT_ADDRESS;
+const data = '0x7998a1c4';
 
-const payload = JSON.stringify({
-  to: `${contract}`,
-  data: '0x7998a1c4',
-});
-
-const {options, run} = new TestScenarioBuilder()
+const {options, run} = new ContractCallTestScenarioBuilder()
   .name('contractCallIdentifier') // use unique scenario name among all tests
-  .request(() => jsonPost(url, payload))
-  .check('contractCallIdentifier', (r) => isNonErrorResponse(r))
+  .data(data)
+  .to(contract)
   .build();
 
 export {options, run};

--- a/hedera-mirror-test/k6/src/web3/test/contractCallMultiply.js
+++ b/hedera-mirror-test/k6/src/web3/test/contractCallMultiply.js
@@ -14,22 +14,15 @@
  * limitations under the License.
  */
 
-import {TestScenarioBuilder} from '../../lib/common.js';
-import {isNonErrorResponse} from './common.js';
-import {jsonPost} from './common.js';
+import {ContractCallTestScenarioBuilder} from './common.js';
 
-const url = __ENV.BASE_URL;
 const contract = __ENV.DEFAULT_CONTRACT_ADDRESS;
+const data = '0x8070450f';
 
-const payload = JSON.stringify({
-  to: `${contract}`,
-  data: '0x8070450f',
-});
-
-const {options, run} = new TestScenarioBuilder()
+const {options, run} = new ContractCallTestScenarioBuilder()
   .name('contractCallMultiply') // use unique scenario name among all tests
-  .request(() => jsonPost(url, payload))
-  .check('contractCallMultiply', (r) => isNonErrorResponse(r))
+  .data(data)
+  .to(contract)
   .build();
 
 export {options, run};

--- a/hedera-mirror-test/k6/src/web3/test/contractCallReceive.js
+++ b/hedera-mirror-test/k6/src/web3/test/contractCallReceive.js
@@ -14,23 +14,15 @@
  * limitations under the License.
  */
 
-import {TestScenarioBuilder} from '../../lib/common.js';
-import {isNonErrorResponse} from './common.js';
-import {jsonPost} from './common.js';
+import {ContractCallTestScenarioBuilder} from './common.js';
 
-const url = __ENV.BASE_URL;
 const contract = __ENV.DEFAULT_CONTRACT_ADDRESS;
 const account = __ENV.DEFAULT_ACCOUNT_ADDRESS;
 
-const payload = JSON.stringify({
-  from: `${account}`,
-  to: `${contract}`,
-});
-
-const {options, run} = new TestScenarioBuilder()
+const {options, run} = new ContractCallTestScenarioBuilder()
   .name('contractCallReceive') // use unique scenario name among all tests
-  .request(() => jsonPost(url, payload))
-  .check('contractCallReceive', (r) => isNonErrorResponse(r))
+  .from(account)
+  .to(contract)
   .build();
 
 export {options, run};

--- a/hedera-mirror-test/k6/src/web3/test/contractCallSender.js
+++ b/hedera-mirror-test/k6/src/web3/test/contractCallSender.js
@@ -14,22 +14,15 @@
  * limitations under the License.
  */
 
-import {TestScenarioBuilder} from '../../lib/common.js';
-import {isNonErrorResponse} from './common.js';
-import {jsonPost} from './common.js';
+import {ContractCallTestScenarioBuilder} from './common.js';
 
-const url = __ENV.BASE_URL;
 const contract = __ENV.DEFAULT_CONTRACT_ADDRESS;
+const data = '0x5e01eb5a';
 
-const payload = JSON.stringify({
-  to: `${contract}`,
-  data: '0x5e01eb5a',
-});
-
-const {options, run} = new TestScenarioBuilder()
+const {options, run} = new ContractCallTestScenarioBuilder()
   .name('contractCallSender') // use unique scenario name among all tests
-  .request(() => jsonPost(url, payload))
-  .check('contractCallSender', (r) => isNonErrorResponse(r))
+  .data(data)
+  .to(contract)
   .build();
 
 export {options, run};


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR mainly changes web3 k6 test cases to use `ContractCallTestScenarioBuilder`

- Change 5 web3 k6 tests cases to use `ContractCallTestScenarioBuilder`, also fix incorrect url
- Change to `__ENV.BASE_URL_PREFIX`
- Change to `vu.idInTest` from `k6/execution`

**Related issue(s)**:

Fixes #7012 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
