### PR TITLE
Add table disk size metrics & graphs

### DIFF
--- a/charts/hedera-mirror-common/dashboards/hedera-mirror-grpc.json
+++ b/charts/hedera-mirror-common/dashboards/hedera-mirror-grpc.json
@@ -24,7 +24,7 @@
   "editable": false,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 60,
+  "id": 112,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -112,7 +112,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "10.2.0-59422pre",
+      "pluginVersion": "10.2.0-61469",
       "targets": [
         {
           "datasource": {
@@ -190,7 +190,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "10.2.0-59422pre",
+      "pluginVersion": "10.2.0-61469",
       "targets": [
         {
           "datasource": {
@@ -267,7 +267,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "10.2.0-59422pre",
+      "pluginVersion": "10.2.0-61469",
       "targets": [
         {
           "datasource": {
@@ -345,7 +345,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "10.2.0-59422pre",
+      "pluginVersion": "10.2.0-61469",
       "targets": [
         {
           "datasource": {
@@ -427,7 +427,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "10.2.0-59422pre",
+      "pluginVersion": "10.2.0-61469",
       "targets": [
         {
           "datasource": {
@@ -502,7 +502,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "10.2.0-59422pre",
+      "pluginVersion": "10.2.0-61469",
       "targets": [
         {
           "datasource": {
@@ -530,6 +530,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
@@ -664,6 +665,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
@@ -800,6 +802,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
@@ -902,6 +905,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
@@ -1018,6 +1022,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
@@ -1133,6 +1138,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
@@ -1257,6 +1263,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
@@ -1373,6 +1380,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
@@ -1482,6 +1490,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
@@ -1641,6 +1650,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
@@ -1809,6 +1819,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
@@ -1966,6 +1977,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
@@ -2119,6 +2131,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
@@ -2224,6 +2237,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
@@ -2327,6 +2341,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
@@ -2426,6 +2441,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
@@ -2525,6 +2541,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
@@ -2610,6 +2627,447 @@
     },
     {
       "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 128
+      },
+      "id": 91,
+      "panels": [],
+      "title": "Cache",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheus}"
+      },
+      "description": "The percent of time the value is retrieved from the cache",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisGridShow": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 250
+              },
+              {
+                "color": "red",
+                "value": 500
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 129
+      },
+      "id": 92,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Mean",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.1.0-cloud.3.2a3062e8",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${prometheus}"
+          },
+          "editorMode": "code",
+          "expr": "sum(cache_gets_total{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\",result=\"hit\"}) by (cache_manager, cache) / sum (cache_gets_total{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) by (cache_manager, cache)",
+          "hide": false,
+          "interval": "1m",
+          "legendFormat": "{{ cache_manager }}.{{ cache }}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Cache Hit",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheus}"
+      },
+      "description": "The number of entries in the cache",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisGridShow": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 250
+              },
+              {
+                "color": "red",
+                "value": 500
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 129
+      },
+      "id": 93,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Mean",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.1.0-cloud.3.2a3062e8",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${prometheus}"
+          },
+          "editorMode": "code",
+          "expr": "sum(cache_size{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) by (cache_manager, cache)",
+          "hide": false,
+          "interval": "1m",
+          "legendFormat": "{{ cache_manager }}.{{ cache }}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Cache Size",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheus}"
+      },
+      "description": "The number of cache gets per second",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisGridShow": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 250
+              },
+              {
+                "color": "red",
+                "value": 500
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 137
+      },
+      "id": 94,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Mean",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.1.0-cloud.3.2a3062e8",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${prometheus}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(cache_gets_total{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (cache_manager, cache)",
+          "hide": false,
+          "interval": "1m",
+          "legendFormat": "{{ cache_manager }}.{{ cache }}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Cache Get Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheus}"
+      },
+      "description": "The number of cache puts per second",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisGridShow": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 250
+              },
+              {
+                "color": "red",
+                "value": 500
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 137
+      },
+      "id": 95,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Mean",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.1.0-cloud.3.2a3062e8",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${prometheus}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(cache_puts_total{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (cache_manager, cache)",
+          "hide": false,
+          "interval": "1m",
+          "legendFormat": "{{ cache_manager }}.{{ cache }}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Cache Put Rate",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
       "datasource": {
         "uid": "${prometheus}"
       },
@@ -2617,7 +3075,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 128
+        "y": 145
       },
       "id": 35,
       "panels": [],
@@ -2644,6 +3102,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
@@ -2790,7 +3249,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 129
+        "y": 146
       },
       "id": 5,
       "options": {
@@ -2831,7 +3290,7 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 137
+        "y": 154
       },
       "id": 54,
       "links": [
@@ -2873,7 +3332,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 147
+        "y": 164
       },
       "id": 61,
       "panels": [],
@@ -2900,6 +3359,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
@@ -2953,7 +3413,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 148
+        "y": 165
       },
       "id": 81,
       "options": {
@@ -3002,6 +3462,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
@@ -3055,7 +3516,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 156
+        "y": 173
       },
       "id": 84,
       "options": {
@@ -3104,6 +3565,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
@@ -3157,7 +3619,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 164
+        "y": 181
       },
       "id": 83,
       "options": {
@@ -3206,6 +3668,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
@@ -3259,7 +3722,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 172
+        "y": 189
       },
       "id": 85,
       "options": {
@@ -3299,7 +3762,6 @@
   ],
   "refresh": "1m",
   "schemaVersion": 38,
-  "style": "dark",
   "tags": [
     "hedera",
     "mirror",
@@ -3467,6 +3929,6 @@
   "timezone": "",
   "title": "Hedera / Mirror / gRPC API",
   "uid": "26rjapg7z",
-  "version": 11,
+  "version": 12,
   "weekStart": ""
 }

--- a/charts/hedera-mirror-common/dashboards/hedera-mirror-importer.json
+++ b/charts/hedera-mirror-common/dashboards/hedera-mirror-importer.json
@@ -24,7 +24,7 @@
   "editable": false,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 99,
+  "id": 109,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -88,7 +88,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "10.2.0-59422pre",
+      "pluginVersion": "10.2.0-61469",
       "targets": [
         {
           "datasource": {
@@ -173,7 +173,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "10.2.0-59422pre",
+      "pluginVersion": "10.2.0-61469",
       "targets": [
         {
           "datasource": {
@@ -252,7 +252,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "10.2.0-59422pre",
+      "pluginVersion": "10.2.0-61469",
       "targets": [
         {
           "datasource": {
@@ -331,7 +331,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "10.2.0-59422pre",
+      "pluginVersion": "10.2.0-61469",
       "targets": [
         {
           "datasource": {
@@ -412,7 +412,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "10.2.0-59422pre",
+      "pluginVersion": "10.2.0-61469",
       "targets": [
         {
           "datasource": {
@@ -492,7 +492,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "10.2.0-59422pre",
+      "pluginVersion": "10.2.0-61469",
       "targets": [
         {
           "datasource": {
@@ -548,6 +548,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
@@ -679,6 +680,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
@@ -796,6 +798,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
@@ -958,6 +961,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
@@ -1080,6 +1084,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
@@ -1191,6 +1196,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
@@ -1351,6 +1357,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
@@ -1454,6 +1461,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
@@ -1608,6 +1616,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
@@ -1689,14 +1698,326 @@
             "uid": "${prometheus}"
           },
           "editorMode": "code",
-          "expr": "avg(db_table_size_rows{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) by (table) > 0",
+          "expr": "avg(db_table_rows{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) by (table) > 0",
           "interval": "1m",
           "legendFormat": "{{ table }}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Table size",
+      "title": "Table Rows",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheus}"
+      },
+      "description": "The size of the table and indexes on disk",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisGridShow": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 64
+      },
+      "id": 247,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Last",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.2.0-59422pre",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${prometheus}"
+          },
+          "editorMode": "code",
+          "expr": "sum(db_table_bytes{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) by (table) + sum(db_index_bytes{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) by (table) > 0",
+          "interval": "1m",
+          "legendFormat": "{{ table }}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Total Size",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheus}"
+      },
+      "description": "The size of the table on disk",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisGridShow": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 72
+      },
+      "id": 268,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Last",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.2.0-59422pre",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${prometheus}"
+          },
+          "editorMode": "code",
+          "expr": "sum(db_table_bytes{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) by (table) > 0",
+          "interval": "1m",
+          "legendFormat": "{{ table }}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Table Size",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheus}"
+      },
+      "description": "The size of the indexes on disk",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisGridShow": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 80
+      },
+      "id": 267,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Last",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.2.0-59422pre",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${prometheus}"
+          },
+          "editorMode": "code",
+          "expr": "sum(db_index_bytes{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) by (table) > 0",
+          "interval": "1m",
+          "legendFormat": "{{ table }}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Index Size",
       "type": "timeseries"
     },
     {
@@ -1711,6 +2032,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
@@ -1766,7 +2088,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 64
+        "y": 88
       },
       "id": 19,
       "interval": "1m",
@@ -1854,6 +2176,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
@@ -1913,7 +2236,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 72
+        "y": 96
       },
       "id": 187,
       "options": {
@@ -1976,6 +2299,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
@@ -2035,7 +2359,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 80
+        "y": 104
       },
       "id": 207,
       "options": {
@@ -2098,6 +2422,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
@@ -2157,7 +2482,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 88
+        "y": 112
       },
       "id": 227,
       "options": {
@@ -2208,6 +2533,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
@@ -2263,7 +2589,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 96
+        "y": 120
       },
       "id": 15,
       "interval": "1m",
@@ -2349,6 +2675,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
@@ -2420,7 +2747,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 96
+        "y": 120
       },
       "id": 110,
       "interval": "1m",
@@ -2496,6 +2823,447 @@
     },
     {
       "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 128
+      },
+      "id": 273,
+      "panels": [],
+      "title": "Cache",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheus}"
+      },
+      "description": "The percent of time the value is retrieved from the cache",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisGridShow": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 250
+              },
+              {
+                "color": "red",
+                "value": 500
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 129
+      },
+      "id": 269,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Mean",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.1.0-cloud.3.2a3062e8",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${prometheus}"
+          },
+          "editorMode": "code",
+          "expr": "sum (cache_gets_total{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\",result=\"hit\"}) by (cache_manager, cache) / sum (cache_gets_total{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) by (cache_manager, cache)",
+          "hide": false,
+          "interval": "1m",
+          "legendFormat": "{{ cache_manager }}.{{ cache }}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Cache Hit",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheus}"
+      },
+      "description": "The number of entries in the cache",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisGridShow": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 250
+              },
+              {
+                "color": "red",
+                "value": 500
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 129
+      },
+      "id": 270,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Mean",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.1.0-cloud.3.2a3062e8",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${prometheus}"
+          },
+          "editorMode": "code",
+          "expr": "sum(cache_size{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) by (cache_manager, cache)",
+          "hide": false,
+          "interval": "1m",
+          "legendFormat": "{{ cache_manager }}.{{ cache }}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Cache Size",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheus}"
+      },
+      "description": "The number of cache gets per second",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisGridShow": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 250
+              },
+              {
+                "color": "red",
+                "value": 500
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 137
+      },
+      "id": 271,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Mean",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.1.0-cloud.3.2a3062e8",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${prometheus}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(cache_gets_total{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (cache_manager, cache)",
+          "hide": false,
+          "interval": "1m",
+          "legendFormat": "{{ cache_manager }}.{{ cache }}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Cache Get Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheus}"
+      },
+      "description": "The number of cache puts per second",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisGridShow": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 250
+              },
+              {
+                "color": "red",
+                "value": 500
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 137
+      },
+      "id": 272,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Mean",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.1.0-cloud.3.2a3062e8",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${prometheus}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(cache_puts_total{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (cache_manager, cache)",
+          "hide": false,
+          "interval": "1m",
+          "legendFormat": "{{ cache_manager }}.{{ cache }}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Cache Put Rate",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
       "datasource": {
         "type": "prometheus",
         "uid": "${prometheus}"
@@ -2504,7 +3272,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 104
+        "y": 161
       },
       "id": 35,
       "panels": [],
@@ -2532,6 +3300,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
@@ -2678,7 +3447,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 105
+        "y": 162
       },
       "id": 5,
       "options": {
@@ -2726,7 +3495,7 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 113
+        "y": 170
       },
       "id": 54,
       "links": [
@@ -2769,7 +3538,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 123
+        "y": 180
       },
       "id": 37,
       "panels": [
@@ -2823,8 +3592,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -2928,8 +3696,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -3033,8 +3800,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -3139,8 +3905,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -3244,8 +4009,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -3349,8 +4113,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -3454,8 +4217,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -3559,8 +4321,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -3664,8 +4425,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -3769,8 +4529,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -3872,8 +4631,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -3977,8 +4735,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4082,8 +4839,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4187,8 +4943,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4292,8 +5047,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4397,8 +5151,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4502,8 +5255,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4607,8 +5359,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4874,6 +5625,6 @@
   "timezone": "",
   "title": "Hedera / Mirror / Importer",
   "uid": "dfca62a1-9d6c-4f21-9933-b60e8cdac7d2",
-  "version": 2,
+  "version": 3,
   "weekStart": ""
 }

--- a/charts/hedera-mirror-common/dashboards/hedera-mirror-web3.json
+++ b/charts/hedera-mirror-common/dashboards/hedera-mirror-web3.json
@@ -24,7 +24,7 @@
   "editable": false,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 100,
+  "id": 113,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -88,7 +88,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "10.2.0-59542pre",
+      "pluginVersion": "10.2.0-61469",
       "targets": [
         {
           "datasource": {
@@ -169,7 +169,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "10.2.0-59542pre",
+      "pluginVersion": "10.2.0-61469",
       "targets": [
         {
           "datasource": {
@@ -252,7 +252,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "10.2.0-59542pre",
+      "pluginVersion": "10.2.0-61469",
       "targets": [
         {
           "datasource": {
@@ -376,6 +376,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
@@ -480,6 +481,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
@@ -611,6 +613,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
@@ -717,6 +720,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
@@ -824,6 +828,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
@@ -930,6 +935,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
@@ -1036,6 +1042,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
@@ -1167,6 +1174,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
@@ -1290,6 +1298,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
@@ -1394,6 +1403,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
@@ -1551,6 +1561,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
@@ -1718,6 +1729,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
@@ -1866,6 +1878,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
@@ -2015,6 +2028,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
@@ -2118,6 +2132,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
@@ -2205,6 +2220,447 @@
     },
     {
       "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 129
+      },
+      "id": 88,
+      "panels": [],
+      "title": "Cache",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheus}"
+      },
+      "description": "The percent of time the value is retrieved from the cache",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisGridShow": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 250
+              },
+              {
+                "color": "red",
+                "value": 500
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 130
+      },
+      "id": 89,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Mean",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.1.0-cloud.3.2a3062e8",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${prometheus}"
+          },
+          "editorMode": "code",
+          "expr": "sum (cache_gets_total{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\",result=\"hit\"}) by (cache_manager, cache) / sum (cache_gets_total{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) by (cache_manager, cache)",
+          "hide": false,
+          "interval": "1m",
+          "legendFormat": "{{ cache_manager }}.{{ cache }}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Cache Hit %",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheus}"
+      },
+      "description": "The number of entries in the cache",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisGridShow": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 250
+              },
+              {
+                "color": "red",
+                "value": 500
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 130
+      },
+      "id": 90,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Mean",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.1.0-cloud.3.2a3062e8",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${prometheus}"
+          },
+          "editorMode": "code",
+          "expr": "sum(cache_size{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) by (cache_manager, cache)",
+          "hide": false,
+          "interval": "1m",
+          "legendFormat": "{{ cache_manager }}.{{ cache }}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Cache Size",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheus}"
+      },
+      "description": "The number of cache gets per second",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisGridShow": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 250
+              },
+              {
+                "color": "red",
+                "value": 500
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 138
+      },
+      "id": 91,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Mean",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.1.0-cloud.3.2a3062e8",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${prometheus}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(cache_gets_total{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (cache_manager, cache)",
+          "hide": false,
+          "interval": "1m",
+          "legendFormat": "{{ cache_manager }}.{{ cache }}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Cache Get Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheus}"
+      },
+      "description": "The number of cache puts per second",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisGridShow": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 250
+              },
+              {
+                "color": "red",
+                "value": 500
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 138
+      },
+      "id": 92,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Mean",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.1.0-cloud.3.2a3062e8",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${prometheus}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(cache_puts_total{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (cache_manager, cache)",
+          "hide": false,
+          "interval": "1m",
+          "legendFormat": "{{ cache_manager }}.{{ cache }}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Cache Put Rate",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
       "datasource": {
         "type": "prometheus",
         "uid": "${prometheus}"
@@ -2213,7 +2669,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 129
+        "y": 146
       },
       "id": 35,
       "panels": [],
@@ -2241,6 +2697,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
@@ -2387,7 +2844,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 130
+        "y": 147
       },
       "id": 5,
       "options": {
@@ -2428,7 +2885,7 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 138
+        "y": 155
       },
       "id": 54,
       "links": [
@@ -2464,7 +2921,6 @@
   ],
   "refresh": "1m",
   "schemaVersion": 38,
-  "style": "dark",
   "tags": [
     "hedera",
     "mirror",
@@ -2635,6 +3091,6 @@
   "timezone": "",
   "title": "Hedera / Mirror / Web3 API",
   "uid": "Si3C9zAnk",
-  "version": 2,
+  "version": 3,
   "weekStart": ""
 }

--- a/charts/hedera-mirror-rest/templates/monitor/deployment.yaml
+++ b/charts/hedera-mirror-rest/templates/monitor/deployment.yaml
@@ -59,6 +59,9 @@ spec:
               mountPath: /config
             - name: pm2
               mountPath: /home/node/.pm2
+      imagePullSecrets: {{ toYaml .Values.monitor.imagePullSecrets | nindent 8 }}
+      nodeSelector: {{ toYaml .Values.monitor.nodeSelector | nindent 8 }}
+      priorityClassName: {{ .Values.monitor.priorityClassName }}
       securityContext:
         fsGroup: 1000
         runAsGroup: 1000
@@ -67,6 +70,7 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: {{ include "hedera-mirror-rest.serviceAccountName" . }}
+      tolerations: {{ toYaml .Values.monitor.tolerations | nindent 8 }}
       volumes:
         - name: config
           secret:

--- a/charts/hedera-mirror-rest/values.yaml
+++ b/charts/hedera-mirror-rest/values.yaml
@@ -121,6 +121,9 @@ monitor:
     registry: gcr.io
     repository: mirrornode/hedera-mirror-rest-monitor
     tag: ""  # Defaults to the chart's app version
+  imagePullSecrets: []
+  nodeSelector: {}
+  priorityClassName: ""
   resources:
     limits:
       cpu: 250m
@@ -136,6 +139,7 @@ monitor:
       pullPolicy: IfNotPresent
       repository: busybox
       tag: latest
+  tolerations: []
 
 nameOverride: ""
 

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/repository/AddressBookEntryRepository.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/repository/AddressBookEntryRepository.java
@@ -16,8 +16,10 @@
 
 package com.hedera.mirror.grpc.repository;
 
+import static com.hedera.mirror.grpc.config.CacheConfiguration.ADDRESS_BOOK_ENTRY_CACHE;
+import static com.hedera.mirror.grpc.config.CacheConfiguration.CACHE_NAME;
+
 import com.hedera.mirror.common.domain.addressbook.AddressBookEntry;
-import com.hedera.mirror.grpc.config.CacheConfiguration;
 import java.util.List;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.jpa.repository.Query;
@@ -26,8 +28,8 @@ import org.springframework.data.repository.CrudRepository;
 public interface AddressBookEntryRepository extends CrudRepository<AddressBookEntry, AddressBookEntry.Id> {
 
     @Cacheable(
-            cacheManager = CacheConfiguration.ADDRESS_BOOK_ENTRY_CACHE,
-            cacheNames = "address_book_entry",
+            cacheManager = ADDRESS_BOOK_ENTRY_CACHE,
+            cacheNames = CACHE_NAME,
             unless = "#result == null or #result.size() == 0")
     @Query(
             value = "select * from address_book_entry where consensus_timestamp = ? and node_id >= ? "

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/repository/EntityRepository.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/repository/EntityRepository.java
@@ -16,13 +16,15 @@
 
 package com.hedera.mirror.grpc.repository;
 
+import static com.hedera.mirror.grpc.config.CacheConfiguration.CACHE_NAME;
+import static com.hedera.mirror.grpc.config.CacheConfiguration.ENTITY_CACHE;
+
 import com.hedera.mirror.common.domain.entity.Entity;
-import com.hedera.mirror.grpc.config.CacheConfiguration;
 import java.util.Optional;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.repository.CrudRepository;
 
 public interface EntityRepository extends CrudRepository<Entity, Long> {
-    @Cacheable(cacheNames = "entity", cacheManager = CacheConfiguration.ENTITY_CACHE, unless = "#result == null")
+    @Cacheable(cacheNames = CACHE_NAME, cacheManager = ENTITY_CACHE, unless = "#result == null")
     Optional<Entity> findById(long entityId);
 }

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/repository/NodeStakeRepository.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/repository/NodeStakeRepository.java
@@ -16,8 +16,10 @@
 
 package com.hedera.mirror.grpc.repository;
 
+import static com.hedera.mirror.grpc.config.CacheConfiguration.CACHE_NAME;
+import static com.hedera.mirror.grpc.config.CacheConfiguration.NODE_STAKE_CACHE;
+
 import com.hedera.mirror.common.domain.addressbook.NodeStake;
-import com.hedera.mirror.grpc.config.CacheConfiguration;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -33,7 +35,7 @@ public interface NodeStakeRepository extends CrudRepository<NodeStake, NodeStake
     List<NodeStake> findAllByConsensusTimestamp(long consensusTimestamp);
 
     // An empty map may be cached, indicating the node_stake table is empty
-    @Cacheable(cacheManager = CacheConfiguration.NODE_STAKE_CACHE, cacheNames = "node_stake")
+    @Cacheable(cacheManager = NODE_STAKE_CACHE, cacheNames = CACHE_NAME)
     default Map<Long, Long> findAllStakeByConsensusTimestamp(long consensusTimestamp) {
         return findAllByConsensusTimestamp(consensusTimestamp).stream()
                 .collect(Collectors.toUnmodifiableMap(NodeStake::getNodeId, NodeStake::getStake));

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/addressbook/AddressBookServiceImpl.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/addressbook/AddressBookServiceImpl.java
@@ -16,8 +16,8 @@
 
 package com.hedera.mirror.importer.addressbook;
 
-import static com.hedera.mirror.importer.addressbook.AddressBookServiceImpl.CACHE_NAME;
-import static com.hedera.mirror.importer.config.CacheConfiguration.EXPIRE_AFTER_5M;
+import static com.hedera.mirror.importer.config.CacheConfiguration.CACHE_ADDRESS_BOOK;
+import static com.hedera.mirror.importer.config.CacheConfiguration.CACHE_NAME;
 
 import com.hedera.mirror.common.domain.addressbook.AddressBook;
 import com.hedera.mirror.common.domain.addressbook.AddressBookEntry;
@@ -70,11 +70,10 @@ import org.springframework.util.CollectionUtils;
 
 @CustomLog
 @Named
-@CacheConfig(cacheNames = CACHE_NAME, cacheManager = EXPIRE_AFTER_5M)
+@CacheConfig(cacheNames = CACHE_NAME, cacheManager = CACHE_ADDRESS_BOOK)
 @RequiredArgsConstructor
 public class AddressBookServiceImpl implements AddressBookService {
 
-    public static final String CACHE_NAME = "nodes";
     public static final EntityId FILE_101 = EntityId.of(0, 0, 101);
     public static final EntityId FILE_102 = EntityId.of(0, 0, 102);
     public static final int INITIAL_NODE_ID_ACCOUNT_ID_OFFSET = 3;
@@ -534,7 +533,7 @@ public class AddressBookServiceImpl implements AddressBookService {
         try {
             Path initialAddressBook = mirrorProperties.getInitialAddressBook();
             if (initialAddressBook != null) {
-                log.info("Loading bootstrap address book from {}", initialAddressBook.toString());
+                log.info("Loading bootstrap address book from {}", initialAddressBook);
                 addressBookBytes = Files.readAllBytes(initialAddressBook);
             } else {
                 var resourcePath = String.format("/addressbook/%s", mirrorProperties.getNetwork());

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/CacheConfiguration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/CacheConfiguration.java
@@ -16,6 +16,7 @@
 
 package com.hedera.mirror.importer.config;
 
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cache.CacheManager;
@@ -32,29 +33,38 @@ import org.springframework.context.annotation.Primary;
 @RequiredArgsConstructor
 public class CacheConfiguration {
 
-    public static final String EXPIRE_AFTER_5M = "cacheManagerExpireAfter5m";
-    public static final String CACHE_MANAGER_ALIAS = "cacheManagerAlias";
-    public static final String CACHE_MANAGER_TABLE_TIME_PARTITION = "cacheManagerTableTimePartition";
+    public static final String CACHE_ADDRESS_BOOK = "addressBook";
+    public static final String CACHE_ALIAS = "alias";
+    public static final String CACHE_OVERLAPPING_TIME_PARTITION = "overlappingTimePartition";
+    public static final String CACHE_TIME_PARTITION = "timePartition";
+    public static final String CACHE_NAME = "default";
 
-    @Bean(EXPIRE_AFTER_5M)
+    @Bean(CACHE_ADDRESS_BOOK)
     @Primary
-    CacheManager cacheManager5m() {
-        var caffeineCacheManager = new CaffeineCacheManager();
-        caffeineCacheManager.setCacheSpecification("maximumSize=100,expireAfterWrite=5m");
-        return new TransactionAwareCacheManagerProxy(caffeineCacheManager);
+    CacheManager cacheManagerAddressBook() {
+        var cacheManager = cacheManager("maximumSize=100,expireAfterWrite=5m,recordStats");
+        return new TransactionAwareCacheManagerProxy(cacheManager);
     }
 
-    @Bean(CACHE_MANAGER_ALIAS)
+    @Bean(CACHE_ALIAS)
     CacheManager cacheManagerAlias() {
-        var caffeineCacheManager = new CaffeineCacheManager();
-        caffeineCacheManager.setCacheSpecification("maximumSize=100000,expireAfterWrite=30m");
-        return caffeineCacheManager;
+        return cacheManager("maximumSize=100000,expireAfterWrite=30m,recordStats");
     }
 
-    @Bean(CACHE_MANAGER_TABLE_TIME_PARTITION)
-    CacheManager cacheManagerTableTimePartition() {
-        var caffeineCacheManager = new CaffeineCacheManager();
-        caffeineCacheManager.setCacheSpecification("maximumSize=50,expireAfterWrite=1d");
-        return caffeineCacheManager;
+    @Bean(CACHE_OVERLAPPING_TIME_PARTITION)
+    CacheManager cacheManagerOverlappingTimePartition() {
+        return cacheManager("maximumSize=50,expireAfterWrite=1d,recordStats");
+    }
+
+    @Bean(CACHE_TIME_PARTITION)
+    CacheManager cacheManagerTimePartition() {
+        return cacheManager("maximumSize=50,expireAfterWrite=1d,recordStats");
+    }
+
+    private CacheManager cacheManager(String specification) {
+        var cacheManager = new CaffeineCacheManager();
+        cacheManager.setCacheNames(Set.of(CACHE_NAME));
+        cacheManager.setCacheSpecification(specification);
+        return cacheManager;
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/MetricsConfiguration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/MetricsConfiguration.java
@@ -43,6 +43,7 @@ class MetricsConfiguration {
 
     private final DataSource dataSource;
     private final DBProperties dbProperties;
+    private final @Lazy JdbcOperations jdbcOperations;
 
     @Bean
     MeterBinder processMemoryMetrics() {
@@ -65,22 +66,22 @@ class MetricsConfiguration {
             name = "enabled",
             havingValue = "true",
             matchIfMissing = true)
-    MeterBinder tableMetrics(@Lazy JdbcOperations jdbcOperations) {
-        return registry -> getTablesNames().forEach(t -> registerTableMetric(jdbcOperations, registry, t));
+    MeterBinder tableMetrics() {
+        return registry -> getTablesNames().forEach(t -> registerTableMetrics(registry, t));
     }
 
-    // select count(*) is very slow on large tables, so we use the stats table to provide an estimate
-    private void registerTableMetric(JdbcOperations jdbcOperations, MeterRegistry registry, String tableName) {
-        final String query = "select n_live_tup from pg_stat_all_tables where schemaname = ? and relname = ?";
-        ToDoubleFunction<DataSource> totalRows =
-                ds -> jdbcOperations.queryForObject(query, Long.class, dbProperties.getSchema(), tableName);
-
-        Gauge.builder("db.table.size", dataSource, totalRows)
-                .tag("db", dbProperties.getName())
-                .tag("table", tableName)
-                .description("Number of rows in a database table")
-                .baseUnit(BaseUnits.ROWS)
-                .register(registry);
+    private void registerTableMetrics(MeterRegistry registry, String tableName) {
+        for (TableMetric tableMetric : TableMetric.values()) {
+            ToDoubleFunction<DataSource> func = dataSource ->
+                    jdbcOperations.queryForObject(tableMetric.query, Long.class, dbProperties.getSchema(), tableName);
+            Gauge.builder(tableMetric.metricName, dataSource, func)
+                    .tag("database", dbProperties.getName())
+                    .tag("schema", dbProperties.getSchema())
+                    .tag("table", tableName)
+                    .description(tableMetric.description)
+                    .baseUnit(tableMetric.baseUnits)
+                    .register(registry);
+        }
     }
 
     private Collection<String> getTablesNames() {
@@ -102,5 +103,29 @@ class MetricsConfiguration {
 
         log.info("Collecting {} table metrics: {}", tableNames.size(), tableNames);
         return tableNames;
+    }
+
+    @RequiredArgsConstructor
+    private enum TableMetric {
+        INDEX_BYTES(
+                BaseUnits.BYTES,
+                "db.index.bytes",
+                "The size of the indexes on disk",
+                "select pg_indexes_size('\"' || ? || '\".\"' || ? || '\"')"),
+        TABLE_BYTES(
+                BaseUnits.BYTES,
+                "db.table.bytes",
+                "The size of the table on disk",
+                "select pg_table_size('\"' || ? || '\".\"' || ? || '\"')"),
+        TABLE_SIZE(
+                BaseUnits.ROWS,
+                "db.table.rows",
+                "The number of rows in the table",
+                "select n_live_tup from pg_stat_all_tables where schemaname = ? and relname = ?");
+
+        private final String baseUnits;
+        private final String metricName;
+        private final String description;
+        private final String query;
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/MetricsConfiguration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/MetricsConfiguration.java
@@ -72,7 +72,7 @@ class MetricsConfiguration {
 
     private void registerTableMetrics(MeterRegistry registry, String tableName) {
         for (TableMetric tableMetric : TableMetric.values()) {
-            ToDoubleFunction<DataSource> func = dataSource ->
+            ToDoubleFunction<DataSource> func = ds ->
                     jdbcOperations.queryForObject(tableMetric.query, Long.class, dbProperties.getSchema(), tableName);
             Gauge.builder(tableMetric.metricName, dataSource, func)
                     .tag("database", dbProperties.getName())

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/EntityIdServiceImpl.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/EntityIdServiceImpl.java
@@ -16,7 +16,8 @@
 
 package com.hedera.mirror.importer.domain;
 
-import static com.hedera.mirror.importer.config.CacheConfiguration.CACHE_MANAGER_ALIAS;
+import static com.hedera.mirror.importer.config.CacheConfiguration.CACHE_ALIAS;
+import static com.hedera.mirror.importer.config.CacheConfiguration.CACHE_NAME;
 import static com.hedera.mirror.importer.util.Utility.aliasToEvmAddress;
 
 import com.google.protobuf.ByteString;
@@ -35,6 +36,7 @@ import java.util.concurrent.Callable;
 import java.util.function.Function;
 import lombok.CustomLog;
 import org.apache.commons.codec.binary.Hex;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 
@@ -45,9 +47,8 @@ public class EntityIdServiceImpl implements EntityIdService {
     private final Cache cache;
     private final EntityRepository entityRepository;
 
-    public EntityIdServiceImpl(
-            @Named(CACHE_MANAGER_ALIAS) CacheManager cacheManager, EntityRepository entityRepository) {
-        this.cache = cacheManager.getCache("entityId");
+    public EntityIdServiceImpl(@Qualifier(CACHE_ALIAS) CacheManager cacheManager, EntityRepository entityRepository) {
+        this.cache = cacheManager.getCache(CACHE_NAME);
         this.entityRepository = entityRepository;
     }
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/addressbook/AddressBookServiceImplTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/addressbook/AddressBookServiceImplTest.java
@@ -16,7 +16,7 @@
 
 package com.hedera.mirror.importer.addressbook;
 
-import static com.hedera.mirror.importer.addressbook.AddressBookServiceImpl.CACHE_NAME;
+import static com.hedera.mirror.importer.config.CacheConfiguration.CACHE_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -89,7 +89,7 @@ class AddressBookServiceImplTest extends IntegrationTest {
     private final AddressBookService addressBookService;
     private final AddressBookServiceEndpointRepository addressBookServiceEndpointRepository;
 
-    @Qualifier(CacheConfiguration.EXPIRE_AFTER_5M)
+    @Qualifier(CacheConfiguration.CACHE_ADDRESS_BOOK)
     private final CacheManager cacheManager;
 
     private final FileDataRepository fileDataRepository;

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerCryptoTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerCryptoTest.java
@@ -18,7 +18,7 @@ package com.hedera.mirror.importer.parser.record.entity;
 
 import static com.hedera.mirror.importer.TestUtils.toEntityTransaction;
 import static com.hedera.mirror.importer.TestUtils.toEntityTransactions;
-import static com.hedera.mirror.importer.config.CacheConfiguration.CACHE_MANAGER_ALIAS;
+import static com.hedera.mirror.importer.config.CacheConfiguration.CACHE_ALIAS;
 import static com.hedera.mirror.importer.parser.domain.RecordItemBuilder.STAKING_REWARD_ACCOUNT;
 import static com.hedera.mirror.importer.util.UtilityTest.ALIAS_ECDSA_SECP256K1;
 import static com.hedera.mirror.importer.util.UtilityTest.EVM_ADDRESS;
@@ -114,7 +114,7 @@ class EntityRecordItemListenerCryptoTest extends AbstractEntityRecordItemListene
     private static final long[] additionalTransferAmounts = {1001, 1002};
     private static final ByteString ALIAS_KEY = DomainUtils.fromBytes(UtilityTest.ALIAS_ECDSA_SECP256K1);
 
-    private final @Qualifier(CACHE_MANAGER_ALIAS) CacheManager cacheManager;
+    private final @Qualifier(CACHE_ALIAS) CacheManager cacheManager;
     private final ContractRepository contractRepository;
     private final CryptoAllowanceRepository cryptoAllowanceRepository;
     private final NftAllowanceRepository nftAllowanceRepository;

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/config/EvmConfiguration.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/config/EvmConfiguration.java
@@ -18,6 +18,7 @@ package com.hedera.mirror.web3.evm.config;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.hedera.mirror.web3.repository.properties.CacheProperties;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.CacheManager;
@@ -32,17 +33,28 @@ import org.springframework.context.annotation.Primary;
 @RequiredArgsConstructor
 public class EvmConfiguration {
 
-    public static final String CACHE_MANAGER_FEE = "cacheManagerFee";
-    public static final String CACHE_MANAGER_10MIN = "cacheManager10Min";
-    public static final String CACHE_MANAGER_500MS = "cacheManager500Ms";
-    public static final String CACHE_MANAGER_STATE = "cacheManagerState";
-    public static final String CACHE_MANAGER_ENTITY = "cacheManagerEntity";
-    public static final String CACHE_MANAGER_TOKEN = "cacheManagerToken";
+    public static final String CACHE_MANAGER_ENTITY = "entity";
+    public static final String CACHE_MANAGER_RECORD_FILE_LATEST = "recordFileLatest";
+    public static final String CACHE_MANAGER_RECORD_FILE_INDEX = "recordFileIndex";
+    public static final String CACHE_MANAGER_CONTRACT_STATE = "contractState";
+    public static final String CACHE_MANAGER_SYSTEM_FILE = "systemFile";
+    public static final String CACHE_MANAGER_TOKEN = "token";
+    public static final String CACHE_NAME = "default";
+    public static final String CACHE_NAME_EXCHANGE_RATE = "exchangeRate";
+    public static final String CACHE_NAME_FEE_SCHEDULE = "fee_schedule";
+    public static final String CACHE_NAME_NFT = "nft";
+    public static final String CACHE_NAME_NFT_ALLOWANCE = "nftAllowance";
+    public static final String CACHE_NAME_RECORD_FILE_LATEST = "latest";
+    public static final String CACHE_NAME_RECORD_FILE_LATEST_INDEX = "latestIndex";
+    public static final String CACHE_NAME_TOKEN = "token";
+    public static final String CACHE_NAME_TOKEN_ACCOUNT = "tokenAccount";
+    public static final String CACHE_NAME_TOKEN_ALLOWANCE = "tokenAllowance";
     private final CacheProperties cacheProperties;
 
-    @Bean(CACHE_MANAGER_STATE)
+    @Bean(CACHE_MANAGER_CONTRACT_STATE)
     CacheManager cacheManagerState() {
         final CaffeineCacheManager caffeineCacheManager = new CaffeineCacheManager();
+        caffeineCacheManager.setCacheNames(Set.of(CACHE_NAME));
         caffeineCacheManager.setCacheSpecification(cacheProperties.getContractState());
         return caffeineCacheManager;
     }
@@ -50,6 +62,7 @@ public class EvmConfiguration {
     @Bean(CACHE_MANAGER_ENTITY)
     CacheManager cacheManagerEntity() {
         final CaffeineCacheManager caffeineCacheManager = new CaffeineCacheManager();
+        caffeineCacheManager.setCacheNames(Set.of(CACHE_NAME));
         caffeineCacheManager.setCacheSpecification(cacheProperties.getEntity());
         return caffeineCacheManager;
     }
@@ -57,33 +70,45 @@ public class EvmConfiguration {
     @Bean(CACHE_MANAGER_TOKEN)
     CacheManager cacheManagerToken() {
         final CaffeineCacheManager caffeineCacheManager = new CaffeineCacheManager();
+        caffeineCacheManager.setCacheNames(Set.of(
+                CACHE_NAME_NFT,
+                CACHE_NAME_NFT_ALLOWANCE,
+                CACHE_NAME_TOKEN,
+                CACHE_NAME_TOKEN_ACCOUNT,
+                CACHE_NAME_TOKEN_ALLOWANCE));
         caffeineCacheManager.setCacheSpecification(cacheProperties.getToken());
         return caffeineCacheManager;
     }
 
-    @Bean(CACHE_MANAGER_FEE)
-    CacheManager cacheManagerFee() {
+    @Bean(CACHE_MANAGER_SYSTEM_FILE)
+    CacheManager cacheManagerSystemFile() {
         final CaffeineCacheManager caffeineCacheManager = new CaffeineCacheManager();
+        caffeineCacheManager.setCacheNames(Set.of(CACHE_NAME_EXCHANGE_RATE, CACHE_NAME_FEE_SCHEDULE));
         caffeineCacheManager.setCacheSpecification(cacheProperties.getFee());
         return caffeineCacheManager;
     }
 
-    @Bean(CACHE_MANAGER_10MIN)
+    @Bean(CACHE_MANAGER_RECORD_FILE_INDEX)
     @Primary
-    CacheManager cacheManager10Min() {
-        final var caffeine =
-                Caffeine.newBuilder().expireAfterWrite(10, TimeUnit.MINUTES).maximumSize(10000);
+    CacheManager cacheManagerRecordFileIndex() {
+        final var caffeine = Caffeine.newBuilder()
+                .expireAfterWrite(10, TimeUnit.MINUTES)
+                .maximumSize(10000)
+                .recordStats();
         final CaffeineCacheManager caffeineCacheManager = new CaffeineCacheManager();
+        caffeineCacheManager.setCacheNames(Set.of(CACHE_NAME));
         caffeineCacheManager.setCaffeine(caffeine);
         return caffeineCacheManager;
     }
 
-    @Bean(CACHE_MANAGER_500MS)
-    CacheManager cacheManager500MS() {
+    @Bean(CACHE_MANAGER_RECORD_FILE_LATEST)
+    CacheManager cacheManagerRecordFileLatest() {
         final var caffeine = Caffeine.newBuilder()
                 .expireAfterWrite(500, TimeUnit.MILLISECONDS)
-                .maximumSize(1);
+                .maximumSize(1)
+                .recordStats();
         final CaffeineCacheManager caffeineCacheManager = new CaffeineCacheManager();
+        caffeineCacheManager.setCacheNames(Set.of(CACHE_NAME_RECORD_FILE_LATEST, CACHE_NAME_RECORD_FILE_LATEST_INDEX));
         caffeineCacheManager.setCaffeine(caffeine);
         return caffeineCacheManager;
     }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/ContractStateRepository.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/ContractStateRepository.java
@@ -16,7 +16,8 @@
 
 package com.hedera.mirror.web3.repository;
 
-import static com.hedera.mirror.web3.evm.config.EvmConfiguration.CACHE_MANAGER_STATE;
+import static com.hedera.mirror.web3.evm.config.EvmConfiguration.CACHE_MANAGER_CONTRACT_STATE;
+import static com.hedera.mirror.web3.evm.config.EvmConfiguration.CACHE_NAME;
 
 import com.hedera.mirror.common.domain.contract.ContractState;
 import java.util.Optional;
@@ -27,6 +28,6 @@ import org.springframework.data.repository.CrudRepository;
 public interface ContractStateRepository extends CrudRepository<ContractState, Long> {
 
     @Query(value = "select value from contract_state where contract_id = ?1 and slot =?2", nativeQuery = true)
-    @Cacheable(cacheNames = "contract_state.storage", cacheManager = CACHE_MANAGER_STATE, unless = "#result == null")
+    @Cacheable(cacheNames = CACHE_NAME, cacheManager = CACHE_MANAGER_CONTRACT_STATE, unless = "#result == null")
     Optional<byte[]> findStorage(final Long contractId, final byte[] key);
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/EntityRepository.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/EntityRepository.java
@@ -17,6 +17,7 @@
 package com.hedera.mirror.web3.repository;
 
 import static com.hedera.mirror.web3.evm.config.EvmConfiguration.CACHE_MANAGER_ENTITY;
+import static com.hedera.mirror.web3.evm.config.EvmConfiguration.CACHE_NAME;
 
 import com.hedera.mirror.common.domain.entity.Entity;
 import java.util.Optional;
@@ -25,10 +26,7 @@ import org.springframework.data.repository.CrudRepository;
 
 public interface EntityRepository extends CrudRepository<Entity, Long> {
 
-    @Cacheable(
-            cacheNames = "entity.id_and_deleted_is_false",
-            cacheManager = CACHE_MANAGER_ENTITY,
-            unless = "#result == null")
+    @Cacheable(cacheNames = CACHE_NAME, cacheManager = CACHE_MANAGER_ENTITY, unless = "#result == null")
     Optional<Entity> findByIdAndDeletedIsFalse(Long entityId);
 
     Optional<Entity> findByEvmAddressAndDeletedIsFalse(byte[] alias);

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/NftAllowanceRepository.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/NftAllowanceRepository.java
@@ -17,6 +17,7 @@
 package com.hedera.mirror.web3.repository;
 
 import static com.hedera.mirror.web3.evm.config.EvmConfiguration.CACHE_MANAGER_TOKEN;
+import static com.hedera.mirror.web3.evm.config.EvmConfiguration.CACHE_NAME_NFT_ALLOWANCE;
 
 import com.hedera.mirror.common.domain.entity.AbstractNftAllowance.Id;
 import com.hedera.mirror.common.domain.entity.NftAllowance;
@@ -28,7 +29,7 @@ import org.springframework.data.repository.CrudRepository;
 public interface NftAllowanceRepository extends CrudRepository<NftAllowance, Id> {
 
     @Override
-    @Cacheable(cacheNames = "nft_allowance", cacheManager = CACHE_MANAGER_TOKEN, unless = "#result == null")
+    @Cacheable(cacheNames = CACHE_NAME_NFT_ALLOWANCE, cacheManager = CACHE_MANAGER_TOKEN, unless = "#result == null")
     Optional<NftAllowance> findById(Id id);
 
     List<NftAllowance> findByOwnerAndApprovedForAllIsTrue(long owner);

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/NftRepository.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/NftRepository.java
@@ -17,6 +17,7 @@
 package com.hedera.mirror.web3.repository;
 
 import static com.hedera.mirror.web3.evm.config.EvmConfiguration.CACHE_MANAGER_TOKEN;
+import static com.hedera.mirror.web3.evm.config.EvmConfiguration.CACHE_NAME_NFT;
 
 import com.hedera.mirror.common.domain.token.AbstractNft;
 import com.hedera.mirror.common.domain.token.Nft;
@@ -28,7 +29,7 @@ import org.springframework.data.repository.CrudRepository;
 public interface NftRepository extends CrudRepository<Nft, AbstractNft.Id> {
 
     @Override
-    @Cacheable(cacheNames = "nft", cacheManager = CACHE_MANAGER_TOKEN, unless = "#result == null")
+    @Cacheable(cacheNames = CACHE_NAME_NFT, cacheManager = CACHE_MANAGER_TOKEN, unless = "#result == null")
     Optional<Nft> findById(AbstractNft.Id id);
 
     @Query(

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/RecordFileRepository.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/RecordFileRepository.java
@@ -16,8 +16,11 @@
 
 package com.hedera.mirror.web3.repository;
 
-import static com.hedera.mirror.web3.evm.config.EvmConfiguration.CACHE_MANAGER_10MIN;
-import static com.hedera.mirror.web3.evm.config.EvmConfiguration.CACHE_MANAGER_500MS;
+import static com.hedera.mirror.web3.evm.config.EvmConfiguration.CACHE_MANAGER_RECORD_FILE_INDEX;
+import static com.hedera.mirror.web3.evm.config.EvmConfiguration.CACHE_MANAGER_RECORD_FILE_LATEST;
+import static com.hedera.mirror.web3.evm.config.EvmConfiguration.CACHE_NAME;
+import static com.hedera.mirror.web3.evm.config.EvmConfiguration.CACHE_NAME_RECORD_FILE_LATEST;
+import static com.hedera.mirror.web3.evm.config.EvmConfiguration.CACHE_NAME_RECORD_FILE_LATEST_INDEX;
 
 import com.hedera.mirror.common.domain.transaction.RecordFile;
 import java.util.Optional;
@@ -27,15 +30,21 @@ import org.springframework.data.repository.PagingAndSortingRepository;
 
 public interface RecordFileRepository extends PagingAndSortingRepository<RecordFile, Long> {
 
-    @Cacheable(cacheNames = "record_file.latest_index", cacheManager = CACHE_MANAGER_500MS, unless = "#result == null")
+    @Cacheable(
+            cacheNames = CACHE_NAME_RECORD_FILE_LATEST_INDEX,
+            cacheManager = CACHE_MANAGER_RECORD_FILE_LATEST,
+            unless = "#result == null")
     @Query("select max(r.index) from RecordFile r")
     Optional<Long> findLatestIndex();
 
-    @Cacheable(cacheNames = "record_file.index", cacheManager = CACHE_MANAGER_10MIN, unless = "#result == null")
+    @Cacheable(cacheNames = CACHE_NAME, cacheManager = CACHE_MANAGER_RECORD_FILE_INDEX, unless = "#result == null")
     @Query("select r.hash from RecordFile r where r.index = ?1")
     Optional<String> findHashByIndex(long index);
 
-    @Cacheable(cacheNames = "record_file.latest", cacheManager = CACHE_MANAGER_500MS, unless = "#result == null")
+    @Cacheable(
+            cacheNames = CACHE_NAME_RECORD_FILE_LATEST,
+            cacheManager = CACHE_MANAGER_RECORD_FILE_LATEST,
+            unless = "#result == null")
     @Query(value = "select * from record_file order by consensus_end desc limit 1", nativeQuery = true)
     Optional<RecordFile> findLatest();
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/TokenAccountRepository.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/TokenAccountRepository.java
@@ -17,6 +17,7 @@
 package com.hedera.mirror.web3.repository;
 
 import static com.hedera.mirror.web3.evm.config.EvmConfiguration.CACHE_MANAGER_TOKEN;
+import static com.hedera.mirror.web3.evm.config.EvmConfiguration.CACHE_NAME_TOKEN_ACCOUNT;
 
 import com.hedera.mirror.common.domain.token.AbstractTokenAccount;
 import com.hedera.mirror.common.domain.token.TokenAccount;
@@ -30,7 +31,7 @@ import org.springframework.data.repository.CrudRepository;
 public interface TokenAccountRepository extends CrudRepository<TokenAccount, AbstractTokenAccount.Id> {
 
     @Override
-    @Cacheable(cacheNames = "token_account", cacheManager = CACHE_MANAGER_TOKEN, unless = "#result == null")
+    @Cacheable(cacheNames = CACHE_NAME_TOKEN_ACCOUNT, cacheManager = CACHE_MANAGER_TOKEN, unless = "#result == null")
     Optional<TokenAccount> findById(AbstractTokenAccount.Id id);
 
     @Query(

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/TokenAllowanceRepository.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/TokenAllowanceRepository.java
@@ -17,6 +17,7 @@
 package com.hedera.mirror.web3.repository;
 
 import static com.hedera.mirror.web3.evm.config.EvmConfiguration.CACHE_MANAGER_TOKEN;
+import static com.hedera.mirror.web3.evm.config.EvmConfiguration.CACHE_NAME_TOKEN_ALLOWANCE;
 
 import com.hedera.mirror.common.domain.entity.AbstractTokenAllowance;
 import com.hedera.mirror.common.domain.entity.AbstractTokenAllowance.Id;
@@ -29,7 +30,7 @@ import org.springframework.data.repository.CrudRepository;
 public interface TokenAllowanceRepository extends CrudRepository<TokenAllowance, AbstractTokenAllowance.Id> {
 
     @Override
-    @Cacheable(cacheNames = "token_allowance", cacheManager = CACHE_MANAGER_TOKEN, unless = "#result == null")
+    @Cacheable(cacheNames = CACHE_NAME_TOKEN_ALLOWANCE, cacheManager = CACHE_MANAGER_TOKEN, unless = "#result == null")
     Optional<TokenAllowance> findById(Id id);
 
     List<TokenAllowance> findByOwner(long owner);

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/TokenRepository.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/TokenRepository.java
@@ -17,6 +17,7 @@
 package com.hedera.mirror.web3.repository;
 
 import static com.hedera.mirror.web3.evm.config.EvmConfiguration.CACHE_MANAGER_TOKEN;
+import static com.hedera.mirror.web3.evm.config.EvmConfiguration.CACHE_NAME_TOKEN;
 
 import com.hedera.mirror.common.domain.token.Token;
 import java.util.Optional;
@@ -26,6 +27,6 @@ import org.springframework.data.repository.CrudRepository;
 public interface TokenRepository extends CrudRepository<Token, Long> {
 
     @Override
-    @Cacheable(cacheNames = "token", cacheManager = CACHE_MANAGER_TOKEN, unless = "#result == null")
+    @Cacheable(cacheNames = CACHE_NAME_TOKEN, cacheManager = CACHE_MANAGER_TOKEN, unless = "#result == null")
     Optional<Token> findById(Long tokenId);
 }


### PR DESCRIPTION
**Description**:

* Add a `database.index.bytes` metric
* Add a `database.table.bytes` metric
* Add `imagePullSecrets`, `nodeSelector`, `priorityClassName`, and `tolerations` to monitor deployment
* Add `Table Size`, `Index Size`, and `Total Size` graphs to the importer dashboard
* Add `Cache Hit`, `Cache Size`, `Cache Get Rate` and `Cache Put Rate` graphs to grpc, importer, and web3 dashboards
* Add `recordStats` option to all Caffeine caches
* Fix cache metrics not being registered by using static cache names
* Rename `database.table.size` to `database.table.rows` to disambiguate with new metrics

**Related issue(s)**:

Fixes: #7016

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
