### PR TITLE
HIP-584: Estimated gas under expected range

### DIFF
--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/EstimateFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/EstimateFeature.java
@@ -96,6 +96,11 @@ public class EstimateFeature extends AbstractEstimateFeature {
         receiverAccountId = accountClient.getAccount(AccountClient.AccountNameEnum.BOB);
     }
 
+    @Then("the mirror node REST API should return status {int} for the estimate contract creation")
+    public void verifyMirrorAPIResponses(int status) {
+        verifyMirrorTransactionsResponse(mirrorClient, status);
+    }
+
     @Given("I successfully create fungible token")
     public void createFungibleToken() {
         fungibleTokenId = tokenClient.getToken(FUNGIBLE).tokenId();

--- a/hedera-mirror-test/src/test/resources/features/contract/estimate.feature
+++ b/hedera-mirror-test/src/test/resources/features/contract/estimate.feature
@@ -3,6 +3,7 @@ Feature: EstimateGas Contract Base Coverage Feature
 
   Scenario Outline: Validate EstimateGas
     Given I successfully create EstimateGas contract from contract bytes
+    Then the mirror node REST API should return status 200 for the estimate contract creation
     Given I successfully create fungible token
     And lower deviation is 5% and upper deviation is 20%
     Then I call estimateGas without arguments that multiplies two numbers

--- a/hedera-mirror-test/src/test/resources/features/contract/estimate.feature
+++ b/hedera-mirror-test/src/test/resources/features/contract/estimate.feature
@@ -3,8 +3,8 @@ Feature: EstimateGas Contract Base Coverage Feature
 
   Scenario Outline: Validate EstimateGas
     Given I successfully create EstimateGas contract from contract bytes
-    Then the mirror node REST API should return status 200 for the estimate contract creation
     Given I successfully create fungible token
+    Then the mirror node REST API should return status 200 for the estimate contract creation
     And lower deviation is 5% and upper deviation is 20%
     Then I call estimateGas without arguments that multiplies two numbers
     Then I call estimateGas with function msgSender


### PR DESCRIPTION
**Description**:
When running the acceptance tests in `estimate.feature` sometimes some of them (such as `I call estimateGas with function that changes contract slot information by updating global contract field with the passed argument`) fail because the estimated gas is below the lower expected range. After debugging it seems that in some cases the contract's bytecode could not be fetched from the repository and the initial gas estimation is 21000 which is the minimum gas cost and this affects the further gas calculations.

This PR adds check in estimate gas acceptance tests to ensure that the contract is deployed and that the bytecode will be fetched successfully in web3. As a result the gas estimation will be within the expected range.

Fixes https://github.com/hashgraph/hedera-mirror-node/issues/7040