### PR TITLE
Bump Node.js from 18.17.1 to 18.18.2

### DIFF
--- a/buildSrc/src/main/kotlin/common-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/common-conventions.gradle.kts
@@ -63,7 +63,7 @@ dependencyCheck {
 // Spotless uses Prettier and it requires Node.js
 node {
     download = true
-    version = "18.17.1"
+    version = "18.18.2"
     workDir = rootDir.resolve(".gradle").resolve("nodejs")
 }
 

--- a/charts/hedera-mirror-common/Chart.yaml
+++ b/charts/hedera-mirror-common/Chart.yaml
@@ -26,7 +26,7 @@ dependencies:
   - condition: traefik.enabled
     name: traefik
     repository: https://helm.traefik.io/traefik
-    version: 23.2.0
+    version: 24.0.0
   - alias: zfs
     condition: zfs.enabled
     name: zfs-localpv

--- a/hedera-mirror-rest/Dockerfile
+++ b/hedera-mirror-rest/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.17.1-bullseye-slim
+FROM node:18.18.2-bullseye-slim
 LABEL maintainer="mirrornode@hedera.com"
 
 # Setup

--- a/hedera-mirror-rest/monitoring/Dockerfile
+++ b/hedera-mirror-rest/monitoring/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.17.1-bullseye-slim
+FROM node:18.18.2-bullseye-slim
 LABEL maintainer="mirrornode@hedera.com"
 
 # Setup


### PR DESCRIPTION
**Description**:

* Bump Node.js from 18.17.1 to 18.18.2
* Bump Traefik from v2.10.4 to v2.10.5

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
