### PR TITLE
HIP-584: Historical support - 6970 map block number to timestamp

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/common/ContractCallContext.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/common/ContractCallContext.java
@@ -32,6 +32,11 @@ public class ContractCallContext implements AutoCloseable {
 
     private static final ThreadLocal<ContractCallContext> THREAD_LOCAL = ThreadLocal.withInitial(() -> null);
 
+    /**
+     * Constant for representing an unset or disabled timestamp for filtering.
+     */
+    public static final long UNSET_TIMESTAMP = -1L;
+
     /** Map of account aliases that were committed */
     private final Map<Address, Address> aliases = new HashMap<>();
 
@@ -40,6 +45,15 @@ public class ContractCallContext implements AutoCloseable {
 
     /** Set of account aliases that are deleted by the current frame and are not yet committed */
     private final Set<Address> pendingRemovals = new HashSet<>();
+
+    /**
+     * Long value which stores the block timestamp used for filtering of historical data.
+     * A value of UNSET_TIMESTAMP indicates that the timestamp is unset or disabled for filtering.
+     * Any value other than UNSET_TIMESTAMP that is a valid timestamp should be considered for filtering operations.
+     */
+    @SuppressWarnings("java:S1068")
+    @Setter
+    private long blockTimestamp = UNSET_TIMESTAMP;
 
     /** Boolean flag which determines whether we should make a contract call or contract init transaction simulation */
     @Setter
@@ -90,6 +104,7 @@ public class ContractCallContext implements AutoCloseable {
         estimate = false;
         pendingAliases.clear();
         pendingRemovals.clear();
+        blockTimestamp = UNSET_TIMESTAMP;
         stack = stackBase;
     }
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/controller/ContractController.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/controller/ContractController.java
@@ -89,6 +89,7 @@ class ContractController {
         final var data = request.getData() != null ? Bytes.fromHexString(request.getData()) : EMPTY;
         final var isStaticCall = false;
         final var callType = request.isEstimate() ? ETH_ESTIMATE_GAS : ETH_CALL;
+        final var block = request.getBlock();
 
         return CallServiceParameters.builder()
                 .sender(sender)
@@ -99,6 +100,7 @@ class ContractController {
                 .isStatic(isStaticCall)
                 .callType(callType)
                 .isEstimate(request.isEstimate())
+                .block(block)
                 .build();
     }
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/config/EvmConfiguration.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/config/EvmConfiguration.java
@@ -29,6 +29,7 @@ import com.hedera.mirror.web3.evm.properties.StaticBlockMetaSource;
 import com.hedera.mirror.web3.evm.store.Store;
 import com.hedera.mirror.web3.evm.store.contract.EntityAddressSequencer;
 import com.hedera.mirror.web3.evm.store.contract.HederaEvmWorldState;
+import com.hedera.mirror.web3.repository.RecordFileRepository;
 import com.hedera.mirror.web3.repository.properties.CacheProperties;
 import com.hedera.node.app.service.evm.store.contracts.AbstractCodeCache;
 import com.hedera.services.contracts.execution.LivePricesSource;
@@ -153,7 +154,8 @@ public class EvmConfiguration {
             final BasicHbarCentExchange basicHbarCentExchange,
             final PrngSystemPrecompiledContract prngSystemPrecompiledContract,
             final HederaPrngSeedOperation prngSeedOperation,
-            final Store store) {
+            final Store store,
+            final RecordFileRepository recordFileRepository) {
         return new MirrorEvmTxProcessorImpl(
                 worldState,
                 pricesAndFees,
@@ -174,6 +176,7 @@ public class EvmConfiguration {
                 mirrorEvmContractAliases,
                 abstractCodeCache,
                 mirrorOperationTracer,
-                store);
+                store,
+                recordFileRepository);
     }
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessor.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessor.java
@@ -16,6 +16,7 @@
 
 package com.hedera.mirror.web3.evm.contracts.execution;
 
+import com.hedera.mirror.web3.viewmodel.BlockType;
 import com.hedera.node.app.service.evm.contracts.execution.HederaEvmTransactionProcessingResult;
 import com.hedera.node.app.service.evm.store.models.HederaEvmAccount;
 import java.time.Instant;
@@ -33,5 +34,6 @@ public interface MirrorEvmTxProcessor {
             Bytes callData,
             Instant consensusTime,
             boolean isStatic,
-            boolean isEstimate);
+            boolean isEstimate,
+            final BlockType blockType);
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/RecordFileRepository.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/RecordFileRepository.java
@@ -47,4 +47,7 @@ public interface RecordFileRepository extends PagingAndSortingRepository<RecordF
             unless = "#result == null")
     @Query(value = "select * from record_file order by consensus_end desc limit 1", nativeQuery = true)
     Optional<RecordFile> findLatest();
+
+    @Query(value = "select consensus_end from record_file where index = ?1", nativeQuery = true)
+    Optional<Long> findConsensusEndByBlockNumber(long blockNumber);
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/ContractCallService.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/ContractCallService.java
@@ -119,7 +119,8 @@ public class ContractCallService {
                     params.getCallData(),
                     Instant.now(),
                     params.isStatic(),
-                    isEstimate);
+                    isEstimate,
+                    params.getBlock());
         } catch (IllegalStateException | IllegalArgumentException e) {
             throw new MirrorEvmTransactionException(e.getMessage(), EMPTY, EMPTY);
         }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/model/CallServiceParameters.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/model/CallServiceParameters.java
@@ -16,6 +16,7 @@
 
 package com.hedera.mirror.web3.service.model;
 
+import com.hedera.mirror.web3.viewmodel.BlockType;
 import com.hedera.node.app.service.evm.store.models.HederaEvmAccount;
 import lombok.Builder;
 import lombok.Value;
@@ -33,6 +34,7 @@ public class CallServiceParameters {
     boolean isStatic;
     CallType callType;
     boolean isEstimate;
+    BlockType block;
 
     public enum CallType {
         ETH_CALL,

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/common/ContractCallContextTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/common/ContractCallContextTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.web3.common;
+
+import static com.hedera.mirror.web3.common.ContractCallContext.UNSET_TIMESTAMP;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class ContractCallContextTest {
+
+    @Test
+    void testGet() {
+        ContractCallContext context = ContractCallContext.init(null);
+        assertThat(ContractCallContext.get()).isEqualTo(context);
+        context.close();
+    }
+
+    @Test
+    void testReset() {
+        ContractCallContext context = ContractCallContext.init(null);
+        ContractCallContext.get().setEstimate(true);
+        ContractCallContext.get().setCreate(true);
+
+        context.reset();
+
+        assertThat(context.isEstimate()).isEqualTo(false);
+        assertThat(context.isCreate()).isEqualTo(false);
+        context.close();
+    }
+
+    @Test
+    void testClose() {
+        ContractCallContext context = ContractCallContext.init(null);
+
+        context.close();
+
+        assertThat(ContractCallContext.get()).isNull();
+    }
+
+    @Test
+    void testBlockTimestampIsClearedOnReset() {
+        ContractCallContext context = ContractCallContext.init(null);
+
+        long blockTimestamp = 1234567890L;
+        context.setBlockTimestamp(blockTimestamp);
+        assertThat(context.getBlockTimestamp()).isEqualTo(blockTimestamp);
+
+        context.reset();
+        assertThat(context.getBlockTimestamp()).isEqualTo(UNSET_TIMESTAMP);
+
+        context.close();
+    }
+}

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/controller/ContractControllerTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/controller/ContractControllerTest.java
@@ -452,6 +452,7 @@ class ContractControllerTest {
         request.setTo("0x00000000000000000000000000000000000004e4");
         request.setValue(23);
         request.setData("0x1079023a");
+        request.setBlock(BlockType.LATEST);
         return request;
     }
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/RecordFileRepositoryTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/RecordFileRepositoryTest.java
@@ -52,4 +52,22 @@ class RecordFileRepositoryTest extends Web3IntegrationTest {
 
         assertThat(recordFileRepository.findLatest()).get().isEqualTo(latest);
     }
+
+    @Test
+    void findConsensusEndByBlockNumber() {
+        domainBuilder.recordFile().persist();
+        var latest = domainBuilder.recordFile().persist();
+        long blockNumber = latest.getIndex();
+
+        assertThat(recordFileRepository.findConsensusEndByBlockNumber(blockNumber))
+                .get()
+                .isEqualTo(latest.getConsensusEnd());
+    }
+
+    @Test
+    void findConsensusEndByBlockNumberNotExists() {
+        long nonExistentBlockNumber = 1L;
+        assertThat(recordFileRepository.findConsensusEndByBlockNumber(nonExistentBlockNumber))
+                .isEmpty();
+    }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallDynamicCallsTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallDynamicCallsTest.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.google.protobuf.ByteString;
 import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.web3.exception.MirrorEvmTransactionException;
+import com.hedera.mirror.web3.viewmodel.BlockType;
 import java.math.BigInteger;
 import lombok.RequiredArgsConstructor;
 import org.assertj.core.data.Percentage;
@@ -39,8 +40,8 @@ class ContractCallDynamicCallsTest extends ContractCallTestSetup {
     void dynamicCallsTestWithAliasSenderForEthCall(DynamicCallsContractFunctions contractFunctions) {
         final var functionHash = functionEncodeDecoder.functionHashFor(
                 contractFunctions.name, DYNAMIC_ETH_CALLS_ABI_PATH, contractFunctions.functionParameters);
-        final var serviceParameters =
-                serviceParametersForExecution(functionHash, DYNAMIC_ETH_CALLS_CONTRACT_ALIAS, ETH_CALL, 0L);
+        final var serviceParameters = serviceParametersForExecution(
+                functionHash, DYNAMIC_ETH_CALLS_CONTRACT_ALIAS, ETH_CALL, 0L, BlockType.LATEST);
         if (contractFunctions.expectedErrorMessage != null) {
             assertThatThrownBy(() -> contractCallService.processCall(serviceParameters))
                     .isInstanceOf(MirrorEvmTransactionException.class)
@@ -58,8 +59,8 @@ class ContractCallDynamicCallsTest extends ContractCallTestSetup {
     void dynamicCallsTestWithAliasSenderForEstimateGas(DynamicCallsContractFunctions contractFunctions) {
         final var functionHash = functionEncodeDecoder.functionHashFor(
                 contractFunctions.name, DYNAMIC_ETH_CALLS_ABI_PATH, contractFunctions.functionParameters);
-        final var serviceParameters =
-                serviceParametersForExecution(functionHash, DYNAMIC_ETH_CALLS_CONTRACT_ALIAS, ETH_ESTIMATE_GAS, 0L);
+        final var serviceParameters = serviceParametersForExecution(
+                functionHash, DYNAMIC_ETH_CALLS_CONTRACT_ALIAS, ETH_ESTIMATE_GAS, 0L, BlockType.LATEST);
         if (contractFunctions.expectedErrorMessage != null) {
             assertThatThrownBy(() -> contractCallService.processCall(serviceParameters))
                     .isInstanceOf(MirrorEvmTransactionException.class)

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallEvmCodesTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallEvmCodesTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.hedera.mirror.web3.service.model.CallServiceParameters;
+import com.hedera.mirror.web3.viewmodel.BlockType;
 import com.hedera.node.app.service.evm.store.models.HederaEvmAccount;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
@@ -150,6 +151,7 @@ class ContractCallEvmCodesTest extends ContractCallTestSetup {
                 .gas(15_000_000L)
                 .isStatic(true)
                 .callType(ETH_CALL)
+                .block(BlockType.LATEST)
                 .build();
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallNestedCallsTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallNestedCallsTest.java
@@ -20,6 +20,7 @@ import static com.hedera.mirror.web3.service.model.CallServiceParameters.CallTyp
 import static com.hedera.mirror.web3.service.model.CallServiceParameters.CallType.ETH_ESTIMATE_GAS;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
+import com.hedera.mirror.web3.viewmodel.BlockType;
 import com.hedera.services.store.contracts.precompile.codec.TokenExpiryWrapper;
 import com.hedera.services.utils.EntityIdUtils;
 import lombok.RequiredArgsConstructor;
@@ -45,8 +46,8 @@ class ContractCallNestedCallsTest extends ContractCallTestSetup {
                             CREATE_NON_FUNGIBLE_TOKEN_INHERIT_KEYS -> 10000 * 100_000_000L;
                     default -> 0L;
                 };
-        final var serviceParameters =
-                serviceParametersForExecution(functionHash, NESTED_ETH_CALLS_CONTRACT_ADDRESS, ETH_CALL, value);
+        final var serviceParameters = serviceParametersForExecution(
+                functionHash, NESTED_ETH_CALLS_CONTRACT_ADDRESS, ETH_CALL, value, BlockType.LATEST);
         final var successfulResponse = functionEncodeDecoder.encodedResultFor(
                 contractFunc.name, NESTED_CALLS_ABI_PATH, contractFunc.expectedResultFields);
 
@@ -68,8 +69,8 @@ class ContractCallNestedCallsTest extends ContractCallTestSetup {
                             CREATE_NON_FUNGIBLE_TOKEN_INHERIT_KEYS -> 3050 * 100_000_000L;
                     default -> 0L;
                 };
-        final var serviceParameters =
-                serviceParametersForExecution(functionHash, NESTED_ETH_CALLS_CONTRACT_ADDRESS, ETH_ESTIMATE_GAS, value);
+        final var serviceParameters = serviceParametersForExecution(
+                functionHash, NESTED_ETH_CALLS_CONTRACT_ADDRESS, ETH_ESTIMATE_GAS, value, BlockType.LATEST);
 
         final var expectedGasUsed = gasUsedAfterExecution(serviceParameters);
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceERCTokenTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceERCTokenTest.java
@@ -20,6 +20,7 @@ import static com.hedera.mirror.web3.service.model.CallServiceParameters.CallTyp
 import static com.hedera.mirror.web3.service.model.CallServiceParameters.CallType.ETH_ESTIMATE_GAS;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
+import com.hedera.mirror.web3.viewmodel.BlockType;
 import java.util.Arrays;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
@@ -46,7 +47,8 @@ class ContractCallServiceERCTokenTest extends ContractCallTestSetup {
         final var functionName = ercFunction.getName(isStatic);
         final var functionHash =
                 functionEncodeDecoder.functionHashFor(functionName, ERC_ABI_PATH, ercFunction.functionParameters);
-        final var serviceParameters = serviceParametersForExecution(functionHash, ERC_CONTRACT_ADDRESS, ETH_CALL, 0L);
+        final var serviceParameters =
+                serviceParametersForExecution(functionHash, ERC_CONTRACT_ADDRESS, ETH_CALL, 0L, BlockType.LATEST);
 
         final var successfulResponse = functionEncodeDecoder.encodedResultFor(
                 ercFunction.name, ERC_ABI_PATH, ercFunction.expectedResultFields);
@@ -61,8 +63,8 @@ class ContractCallServiceERCTokenTest extends ContractCallTestSetup {
         final var functionName = ercFunction.getName(isStatic);
         final var functionHash =
                 functionEncodeDecoder.functionHashFor(functionName, ERC_ABI_PATH, ercFunction.functionParameters);
-        final var serviceParameters =
-                serviceParametersForExecution(functionHash, ERC_CONTRACT_ADDRESS, ETH_ESTIMATE_GAS, 0L);
+        final var serviceParameters = serviceParametersForExecution(
+                functionHash, ERC_CONTRACT_ADDRESS, ETH_ESTIMATE_GAS, 0L, BlockType.LATEST);
 
         final var expectedGasUsed = gasUsedAfterExecution(serviceParameters);
 
@@ -76,8 +78,8 @@ class ContractCallServiceERCTokenTest extends ContractCallTestSetup {
     void supportedErcModificationPrecompileOperationsTest(final ErcContractModificationFunctions ercFunction) {
         final var functionHash =
                 functionEncodeDecoder.functionHashFor(ercFunction.name, ERC_ABI_PATH, ercFunction.functionParameters);
-        final var serviceParameters =
-                serviceParametersForExecution(functionHash, ERC_CONTRACT_ADDRESS, ETH_ESTIMATE_GAS, 0L);
+        final var serviceParameters = serviceParametersForExecution(
+                functionHash, ERC_CONTRACT_ADDRESS, ETH_ESTIMATE_GAS, 0L, BlockType.LATEST);
 
         final var expectedGasUsed = gasUsedAfterExecution(serviceParameters);
 
@@ -92,8 +94,8 @@ class ContractCallServiceERCTokenTest extends ContractCallTestSetup {
         final var functionName = ercFunction.name + REDIRECT_SUFFIX;
         final var functionHash = functionEncodeDecoder.functionHashFor(
                 functionName, REDIRECT_CONTRACT_ABI_PATH, ercFunction.functionParameters);
-        final var serviceParameters =
-                serviceParametersForExecution(functionHash, REDIRECT_CONTRACT_ADDRESS, ETH_ESTIMATE_GAS, 0L);
+        final var serviceParameters = serviceParametersForExecution(
+                functionHash, REDIRECT_CONTRACT_ADDRESS, ETH_ESTIMATE_GAS, 0L, BlockType.LATEST);
 
         final var expectedGasUsed = gasUsedAfterExecution(serviceParameters);
 
@@ -108,8 +110,8 @@ class ContractCallServiceERCTokenTest extends ContractCallTestSetup {
         final var functionName = ercFunction.name + "Redirect";
         final var functionHash = functionEncodeDecoder.functionHashFor(
                 functionName, REDIRECT_CONTRACT_ABI_PATH, ercFunction.functionParameters);
-        final var serviceParameters =
-                serviceParametersForExecution(functionHash, REDIRECT_CONTRACT_ADDRESS, ETH_ESTIMATE_GAS, 0L);
+        final var serviceParameters = serviceParametersForExecution(
+                functionHash, REDIRECT_CONTRACT_ADDRESS, ETH_ESTIMATE_GAS, 0L, BlockType.LATEST);
 
         final var expectedGasUsed = gasUsedAfterExecution(serviceParameters);
 
@@ -122,7 +124,8 @@ class ContractCallServiceERCTokenTest extends ContractCallTestSetup {
     void delegateTransferDoesNotExecuteAndReturnEmpty() {
         final var functionHash = functionEncodeDecoder.functionHashFor(
                 "delegateTransfer", ERC_ABI_PATH, FUNGIBLE_TOKEN_ADDRESS, SPENDER_ADDRESS, 2L);
-        final var serviceParameters = serviceParametersForExecution(functionHash, ERC_CONTRACT_ADDRESS, ETH_CALL, 0L);
+        final var serviceParameters =
+                serviceParametersForExecution(functionHash, ERC_CONTRACT_ADDRESS, ETH_CALL, 0L, BlockType.LATEST);
         assertThat(contractCallService.processCall(serviceParameters)).isEqualTo("0x");
     }
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileTest.java
@@ -26,6 +26,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 import com.google.protobuf.ByteString;
 import com.hedera.mirror.web3.exception.MirrorEvmTransactionException;
+import com.hedera.mirror.web3.viewmodel.BlockType;
 import lombok.RequiredArgsConstructor;
 import org.hyperledger.besu.datatypes.Address;
 import org.junit.jupiter.api.Test;
@@ -41,8 +42,8 @@ class ContractCallServicePrecompileTest extends ContractCallTestSetup {
     void evmPrecompileReadOnlyTokenFunctionsTestEthCall(final ContractReadFunctions contractFunc) {
         final var functionHash = functionEncodeDecoder.functionHashFor(
                 contractFunc.name, PRECOMPILE_TEST_CONTRACT_ABI_PATH, contractFunc.functionParameters);
-        final var serviceParameters =
-                serviceParametersForExecution(functionHash, PRECOMPILE_TEST_CONTRACT_ADDRESS, ETH_CALL, 0L);
+        final var serviceParameters = serviceParametersForExecution(
+                functionHash, PRECOMPILE_TEST_CONTRACT_ADDRESS, ETH_CALL, 0L, BlockType.LATEST);
         switch (contractFunc) {
             case GET_CUSTOM_FEES_FOR_TOKEN_WITH_FIXED_FEE -> customFeePersist(FIXED_FEE);
             case GET_CUSTOM_FEES_FOR_TOKEN_WITH_FRACTIONAL_FEE,
@@ -63,8 +64,8 @@ class ContractCallServicePrecompileTest extends ContractCallTestSetup {
     void evmPrecompileReadOnlyTokenFunctionsTestEthEstimateGas(final ContractReadFunctions contractFunc) {
         final var functionHash = functionEncodeDecoder.functionHashFor(
                 contractFunc.name, PRECOMPILE_TEST_CONTRACT_ABI_PATH, contractFunc.functionParameters);
-        final var serviceParameters =
-                serviceParametersForExecution(functionHash, PRECOMPILE_TEST_CONTRACT_ADDRESS, ETH_ESTIMATE_GAS, 0L);
+        final var serviceParameters = serviceParametersForExecution(
+                functionHash, PRECOMPILE_TEST_CONTRACT_ADDRESS, ETH_ESTIMATE_GAS, 0L, BlockType.LATEST);
 
         final var expectedGasUsed = gasUsedAfterExecution(serviceParameters);
 
@@ -80,8 +81,8 @@ class ContractCallServicePrecompileTest extends ContractCallTestSetup {
         final var functionHash = functionEncodeDecoder.functionHashFor(
                 contractFunc.name, MODIFICATION_CONTRACT_ABI_PATH, contractFunc.functionParameters);
         final long value = getValue(contractFunc);
-        final var serviceParameters =
-                serviceParametersForExecution(functionHash, MODIFICATION_CONTRACT_ADDRESS, ETH_ESTIMATE_GAS, value);
+        final var serviceParameters = serviceParametersForExecution(
+                functionHash, MODIFICATION_CONTRACT_ADDRESS, ETH_ESTIMATE_GAS, value, BlockType.LATEST);
 
         final var expectedGasUsed = gasUsedAfterExecution(serviceParameters);
 
@@ -95,8 +96,8 @@ class ContractCallServicePrecompileTest extends ContractCallTestSetup {
     void nestedContractModificationFunctionsTest(final NestedContractModificationFunctions contractFunc) {
         final var functionHash = functionEncodeDecoder.functionHashFor(
                 contractFunc.name, MODIFICATION_CONTRACT_ABI_PATH, contractFunc.functionParameters);
-        final var serviceParameters =
-                serviceParametersForExecution(functionHash, MODIFICATION_CONTRACT_ADDRESS, ETH_ESTIMATE_GAS, 0L);
+        final var serviceParameters = serviceParametersForExecution(
+                functionHash, MODIFICATION_CONTRACT_ADDRESS, ETH_ESTIMATE_GAS, 0L, BlockType.LATEST);
 
         final var expectedGasUsed = gasUsedAfterExecution(serviceParameters);
 
@@ -124,8 +125,8 @@ class ContractCallServicePrecompileTest extends ContractCallTestSetup {
         final var functionHash = functionEncodeDecoder.functionHashFor(
                 contractFunc.name, MODIFICATION_CONTRACT_ABI_PATH, contractFunc.functionParameters);
         final long value = getValue(contractFunc);
-        final var serviceParameters =
-                serviceParametersForExecution(functionHash, MODIFICATION_CONTRACT_ADDRESS, ETH_CALL, value);
+        final var serviceParameters = serviceParametersForExecution(
+                functionHash, MODIFICATION_CONTRACT_ADDRESS, ETH_CALL, value, BlockType.LATEST);
         final var expectedResult = functionEncodeDecoder.encodedResultFor(
                 contractFunc.name, MODIFICATION_CONTRACT_ABI_PATH, contractFunc.expectedResult);
         final var result = contractCallService.processCall(serviceParameters);
@@ -136,8 +137,8 @@ class ContractCallServicePrecompileTest extends ContractCallTestSetup {
     void nftInfoForInvalidSerialNo() {
         final var functionHash = functionEncodeDecoder.functionHashFor(
                 "getInformationForNonFungibleToken", PRECOMPILE_TEST_CONTRACT_ABI_PATH, NFT_ADDRESS, 4L);
-        final var serviceParameters =
-                serviceParametersForExecution(functionHash, PRECOMPILE_TEST_CONTRACT_ADDRESS, ETH_CALL, 0L);
+        final var serviceParameters = serviceParametersForExecution(
+                functionHash, PRECOMPILE_TEST_CONTRACT_ADDRESS, ETH_CALL, 0L, BlockType.LATEST);
 
         assertThatThrownBy(() -> contractCallService.processCall(serviceParameters))
                 .isInstanceOf(MirrorEvmTransactionException.class);
@@ -147,8 +148,8 @@ class ContractCallServicePrecompileTest extends ContractCallTestSetup {
     void tokenInfoForNonTokenAccount() {
         final var functionHash = functionEncodeDecoder.functionHashFor(
                 "getInformationForFungibleToken", PRECOMPILE_TEST_CONTRACT_ABI_PATH, SENDER_ADDRESS);
-        final var serviceParameters =
-                serviceParametersForExecution(functionHash, PRECOMPILE_TEST_CONTRACT_ADDRESS, ETH_CALL, 0L);
+        final var serviceParameters = serviceParametersForExecution(
+                functionHash, PRECOMPILE_TEST_CONTRACT_ADDRESS, ETH_CALL, 0L, BlockType.LATEST);
 
         assertThatThrownBy(() -> contractCallService.processCall(serviceParameters))
                 .isInstanceOf(MirrorEvmTransactionException.class);
@@ -158,8 +159,8 @@ class ContractCallServicePrecompileTest extends ContractCallTestSetup {
     void notExistingPrecompileCallFails() {
         final var functionHash = functionEncodeDecoder.functionHashFor(
                 "callNotExistingPrecompile", MODIFICATION_CONTRACT_ABI_PATH, FUNGIBLE_TOKEN_ADDRESS);
-        final var serviceParameters =
-                serviceParametersForExecution(functionHash, MODIFICATION_CONTRACT_ADDRESS, ETH_ESTIMATE_GAS, 0L);
+        final var serviceParameters = serviceParametersForExecution(
+                functionHash, MODIFICATION_CONTRACT_ADDRESS, ETH_ESTIMATE_GAS, 0L, BlockType.LATEST);
 
         assertThatThrownBy(() -> contractCallService.processCall(serviceParameters))
                 .isInstanceOf(UnsupportedOperationException.class)

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.params.provider.EnumSource;
 
 class ContractCallServiceTest extends ContractCallTestSetup {
 
+    // add tests in this class
     private static final String GAS_METRICS = "hedera.mirror.web3.call.gas";
 
     @BeforeEach

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
@@ -26,6 +26,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 import com.hedera.mirror.web3.exception.MirrorEvmTransactionException;
 import com.hedera.mirror.web3.service.model.CallServiceParameters.CallType;
+import com.hedera.mirror.web3.viewmodel.BlockType;
 import lombok.RequiredArgsConstructor;
 import org.apache.tuweni.bytes.Bytes;
 import org.assertj.core.data.Percentage;
@@ -37,7 +38,6 @@ import org.junit.jupiter.params.provider.EnumSource;
 
 class ContractCallServiceTest extends ContractCallTestSetup {
 
-    // add tests in this class
     private static final String GAS_METRICS = "hedera.mirror.web3.call.gas";
 
     @BeforeEach
@@ -54,7 +54,27 @@ class ContractCallServiceTest extends ContractCallTestSetup {
         final var pureFuncHash = "8070450f";
         final var successfulReadResponse = "0x0000000000000000000000000000000000000000000000000000000000000004";
         final var serviceParameters = serviceParametersForExecution(
-                Bytes.fromHexString(pureFuncHash), ETH_CALL_CONTRACT_ADDRESS, ETH_CALL, 0L);
+                Bytes.fromHexString(pureFuncHash), ETH_CALL_CONTRACT_ADDRESS, ETH_CALL, 0L, BlockType.LATEST);
+
+        assertThat(contractCallService.processCall(serviceParameters)).isEqualTo(successfulReadResponse);
+
+        assertGasUsedIsPositive(gasUsedBeforeExecution, ETH_CALL);
+    }
+
+    @Test
+    void pureCallWithCustomBlock() {
+        domainBuilder
+                .recordFile()
+                .customize(recordFileBuilder -> recordFileBuilder.index(1L))
+                .persist();
+
+        final var gasUsedBeforeExecution = getGasUsedBeforeExecution(ETH_CALL);
+
+        final var pureFuncHash = "8070450f";
+        final var successfulReadResponse = "0x0000000000000000000000000000000000000000000000000000000000000004";
+
+        final var serviceParameters = serviceParametersForExecution(
+                Bytes.fromHexString(pureFuncHash), ETH_CALL_CONTRACT_ADDRESS, ETH_CALL, 0L, BlockType.of("0x1"));
 
         assertThat(contractCallService.processCall(serviceParameters)).isEqualTo(successfulReadResponse);
 
@@ -66,7 +86,7 @@ class ContractCallServiceTest extends ContractCallTestSetup {
         final var pureFuncHash = "8070450f";
         final var gasUsedBeforeExecution = getGasUsedBeforeExecution(ETH_ESTIMATE_GAS);
         final var serviceParameters = serviceParametersForExecution(
-                Bytes.fromHexString(pureFuncHash), ETH_CALL_CONTRACT_ADDRESS, ETH_ESTIMATE_GAS, 0L);
+                Bytes.fromHexString(pureFuncHash), ETH_CALL_CONTRACT_ADDRESS, ETH_ESTIMATE_GAS, 0L, BlockType.LATEST);
 
         final var expectedGasUsed = gasUsedAfterExecution(serviceParameters);
 
@@ -79,8 +99,8 @@ class ContractCallServiceTest extends ContractCallTestSetup {
 
     @Test
     void estimateGasWithoutReceiver() {
-        final var serviceParameters =
-                serviceParametersForExecution(Bytes.fromHexString("0x"), Address.ZERO, ETH_ESTIMATE_GAS, 0L);
+        final var serviceParameters = serviceParametersForExecution(
+                Bytes.fromHexString("0x"), Address.ZERO, ETH_ESTIMATE_GAS, 0L, BlockType.LATEST);
 
         final var expectedGasUsed = gasUsedAfterExecution(serviceParameters);
 
@@ -99,7 +119,7 @@ class ContractCallServiceTest extends ContractCallTestSetup {
         final var successfulReadResponse =
                 "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000047465737400000000000000000000000000000000000000000000000000000000";
         final var serviceParameters = serviceParametersForExecution(
-                Bytes.fromHexString(viewFuncHash), ETH_CALL_CONTRACT_ADDRESS, ETH_CALL, 0L);
+                Bytes.fromHexString(viewFuncHash), ETH_CALL_CONTRACT_ADDRESS, ETH_CALL, 0L, BlockType.LATEST);
 
         assertThat(contractCallService.processCall(serviceParameters)).isEqualTo(successfulReadResponse);
 
@@ -111,7 +131,7 @@ class ContractCallServiceTest extends ContractCallTestSetup {
         final var viewFuncHash =
                 "0x6601c296000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000036b75720000000000000000000000000000000000000000000000000000000000";
         final var serviceParameters = serviceParametersForExecution(
-                Bytes.fromHexString(viewFuncHash), ETH_CALL_CONTRACT_ADDRESS, ETH_ESTIMATE_GAS, 0L);
+                Bytes.fromHexString(viewFuncHash), ETH_CALL_CONTRACT_ADDRESS, ETH_ESTIMATE_GAS, 0L, BlockType.LATEST);
 
         final var expectedGasUsed = gasUsedAfterExecution(serviceParameters);
 
@@ -124,8 +144,8 @@ class ContractCallServiceTest extends ContractCallTestSetup {
     void transferFunds() {
         final var gasUsedBeforeExecution = getGasUsedBeforeExecution(ETH_CALL);
 
-        final var serviceParameters =
-                serviceParametersForExecution(Bytes.fromHexString("0x"), RECEIVER_ADDRESS, ETH_CALL, 7L);
+        final var serviceParameters = serviceParametersForExecution(
+                Bytes.fromHexString("0x"), RECEIVER_ADDRESS, ETH_CALL, 7L, BlockType.LATEST);
 
         assertThatCode(() -> contractCallService.processCall(serviceParameters)).doesNotThrowAnyException();
 
@@ -141,7 +161,7 @@ class ContractCallServiceTest extends ContractCallTestSetup {
         final var balanceCall = "0x93423e9c000000000000000000000000" + SENDER_ALIAS.toUnprefixedHexString();
         final var expectedBalance = "0x000000000000000000000000000000000000000000000000000000e8d4a51000";
         final var serviceParameters = serviceParametersForExecution(
-                Bytes.fromHexString(balanceCall), ETH_CALL_CONTRACT_ADDRESS, ETH_CALL, 0L);
+                Bytes.fromHexString(balanceCall), ETH_CALL_CONTRACT_ADDRESS, ETH_CALL, 0L, BlockType.LATEST);
 
         final var isSuccessful = contractCallService.processCall(serviceParameters);
         assertThat(isSuccessful).isEqualTo(expectedBalance);
@@ -153,7 +173,7 @@ class ContractCallServiceTest extends ContractCallTestSetup {
     void estimateGasForBalanceCall() {
         final var balanceCall = "0x93423e9c00000000000000000000000000000000000000000000000000000000000003e6";
         final var serviceParameters = serviceParametersForExecution(
-                Bytes.fromHexString(balanceCall), ETH_CALL_CONTRACT_ADDRESS, ETH_ESTIMATE_GAS, 0L);
+                Bytes.fromHexString(balanceCall), ETH_CALL_CONTRACT_ADDRESS, ETH_ESTIMATE_GAS, 0L, BlockType.LATEST);
 
         final var expectedGasUsed = gasUsedAfterExecution(serviceParameters);
 
@@ -166,7 +186,11 @@ class ContractCallServiceTest extends ContractCallTestSetup {
     void testRevertDetailMessage() {
         final var revertFunctionSignature = "0xa26388bb";
         final var serviceParameters = serviceParametersForExecution(
-                Bytes.fromHexString(revertFunctionSignature), ETH_CALL_CONTRACT_ADDRESS, ETH_CALL, 0L);
+                Bytes.fromHexString(revertFunctionSignature),
+                ETH_CALL_CONTRACT_ADDRESS,
+                ETH_CALL,
+                0L,
+                BlockType.LATEST);
 
         assertThatThrownBy(() -> contractCallService.processCall(serviceParameters))
                 .isInstanceOf(MirrorEvmTransactionException.class)
@@ -181,7 +205,11 @@ class ContractCallServiceTest extends ContractCallTestSetup {
     @EnumSource(RevertFunctions.class)
     void testReverts(final RevertFunctions revertFunctions) {
         final var serviceParameters = serviceParametersForExecution(
-                Bytes.fromHexString(revertFunctions.functionSignature), REVERTER_CONTRACT_ADDRESS, ETH_CALL, 0L);
+                Bytes.fromHexString(revertFunctions.functionSignature),
+                REVERTER_CONTRACT_ADDRESS,
+                ETH_CALL,
+                0L,
+                BlockType.LATEST);
 
         assertThatThrownBy(() -> contractCallService.processCall(serviceParameters))
                 .isInstanceOf(MirrorEvmTransactionException.class)
@@ -196,7 +224,7 @@ class ContractCallServiceTest extends ContractCallTestSetup {
 
         final var wrongFunctionSignature = "0x542ec32e";
         final var serviceParameters = serviceParametersForExecution(
-                Bytes.fromHexString(wrongFunctionSignature), ETH_CALL_CONTRACT_ADDRESS, ETH_CALL, 0L);
+                Bytes.fromHexString(wrongFunctionSignature), ETH_CALL_CONTRACT_ADDRESS, ETH_CALL, 0L, BlockType.LATEST);
 
         assertThatThrownBy(() -> contractCallService.processCall(serviceParameters))
                 .isInstanceOf(MirrorEvmTransactionException.class)
@@ -208,8 +236,8 @@ class ContractCallServiceTest extends ContractCallTestSetup {
 
     @Test
     void transferNegative() {
-        final var serviceParameters =
-                serviceParametersForExecution(Bytes.fromHexString("0x"), RECEIVER_ADDRESS, ETH_CALL, -5L);
+        final var serviceParameters = serviceParametersForExecution(
+                Bytes.fromHexString("0x"), RECEIVER_ADDRESS, ETH_CALL, -5L, BlockType.LATEST);
 
         assertThatThrownBy(() -> contractCallService.processCall(serviceParameters))
                 .isInstanceOf(MirrorEvmTransactionException.class);
@@ -218,7 +246,7 @@ class ContractCallServiceTest extends ContractCallTestSetup {
     @Test
     void transferExceedsBalance() {
         final var serviceParameters = serviceParametersForExecution(
-                Bytes.fromHexString("0x"), RECEIVER_ADDRESS, ETH_CALL, 1500000000000000000L);
+                Bytes.fromHexString("0x"), RECEIVER_ADDRESS, ETH_CALL, 1500000000000000000L, BlockType.LATEST);
 
         assertThatThrownBy(() -> contractCallService.processCall(serviceParameters))
                 .isInstanceOf(MirrorEvmTransactionException.class);
@@ -229,7 +257,7 @@ class ContractCallServiceTest extends ContractCallTestSetup {
         // transferHbarsToAddress(address)
         final var transferHbarsInput = "0x80b9f03c00000000000000000000000000000000000000000000000000000000000004e9";
         final var serviceParameters = serviceParametersForExecution(
-                Bytes.fromHexString(transferHbarsInput), ETH_CALL_CONTRACT_ADDRESS, ETH_CALL, 90L);
+                Bytes.fromHexString(transferHbarsInput), ETH_CALL_CONTRACT_ADDRESS, ETH_CALL, 90L, BlockType.LATEST);
 
         assertThat(contractCallService.processCall(serviceParameters)).isEqualTo("0x");
     }
@@ -240,7 +268,11 @@ class ContractCallServiceTest extends ContractCallTestSetup {
         final var gasUsedBeforeExecution = getGasUsedBeforeExecution(ETH_ESTIMATE_GAS);
         final var transferHbarsInput = "0x80b9f03c00000000000000000000000000a94f5374fce5edbc8e2a8697c15331677e6ebf0b";
         final var serviceParameters = serviceParametersForExecution(
-                Bytes.fromHexString(transferHbarsInput), ETH_CALL_CONTRACT_ADDRESS, ETH_ESTIMATE_GAS, 90L);
+                Bytes.fromHexString(transferHbarsInput),
+                ETH_CALL_CONTRACT_ADDRESS,
+                ETH_ESTIMATE_GAS,
+                90L,
+                BlockType.LATEST);
 
         final var expectedGasUsed = gasUsedAfterExecution(serviceParameters);
 
@@ -257,7 +289,7 @@ class ContractCallServiceTest extends ContractCallTestSetup {
         final var stateChangeHash =
                 "0x9ac27b62000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000033233320000000000000000000000000000000000000000000000000000000000";
         final var serviceParameters = serviceParametersForExecution(
-                Bytes.fromHexString(stateChangeHash), ETH_CALL_CONTRACT_ADDRESS, ETH_ESTIMATE_GAS, 0);
+                Bytes.fromHexString(stateChangeHash), ETH_CALL_CONTRACT_ADDRESS, ETH_ESTIMATE_GAS, 0, BlockType.LATEST);
 
         final var expectedGasUsed = gasUsedAfterExecution(serviceParameters);
 
@@ -275,7 +307,11 @@ class ContractCallServiceTest extends ContractCallTestSetup {
         // deployViaCreate2()
         final var deployViaCreate2Hash = "0xdbb6f04a";
         final var serviceParameters = serviceParametersForExecution(
-                Bytes.fromHexString(deployViaCreate2Hash), ETH_CALL_CONTRACT_ADDRESS, ETH_ESTIMATE_GAS, 0);
+                Bytes.fromHexString(deployViaCreate2Hash),
+                ETH_CALL_CONTRACT_ADDRESS,
+                ETH_ESTIMATE_GAS,
+                0,
+                BlockType.LATEST);
 
         final var expectedGasUsed = gasUsedAfterExecution(serviceParameters);
 
@@ -322,7 +358,7 @@ class ContractCallServiceTest extends ContractCallTestSetup {
         final var stateChangeHash =
                 "0x51fecdca000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000004ed00000000000000000000000000000000000000000000000000000000000000046976616e00000000000000000000000000000000000000000000000000000000";
         final var serviceParameters = serviceParametersForExecution(
-                Bytes.fromHexString(stateChangeHash), ETH_CALL_CONTRACT_ADDRESS, ETH_CALL, 0);
+                Bytes.fromHexString(stateChangeHash), ETH_CALL_CONTRACT_ADDRESS, ETH_CALL, 0, BlockType.LATEST);
 
         assertThat(contractCallService.processCall(serviceParameters))
                 .isEqualTo(
@@ -333,8 +369,8 @@ class ContractCallServiceTest extends ContractCallTestSetup {
     void contractCreationWork() {
         final var deployHash =
                 "0xc32723ed000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000046976616e00000000000000000000000000000000000000000000000000000000";
-        final var serviceParameters =
-                serviceParametersForExecution(Bytes.fromHexString(deployHash), ETH_CALL_CONTRACT_ADDRESS, ETH_CALL, 0);
+        final var serviceParameters = serviceParametersForExecution(
+                Bytes.fromHexString(deployHash), ETH_CALL_CONTRACT_ADDRESS, ETH_CALL, 0, BlockType.LATEST);
 
         assertThat(contractCallService.processCall(serviceParameters))
                 .isEqualTo(
@@ -350,7 +386,7 @@ class ContractCallServiceTest extends ContractCallTestSetup {
                 "000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000033233320000000000000000000000000000000000000000000000000000000000";
         final var stateChangeHash = "0x9ac27b62" + stateChange;
         final var serviceParameters = serviceParametersForExecution(
-                Bytes.fromHexString(stateChangeHash), ETH_CALL_CONTRACT_ADDRESS, ETH_CALL, 0);
+                Bytes.fromHexString(stateChangeHash), ETH_CALL_CONTRACT_ADDRESS, ETH_CALL, 0, BlockType.LATEST);
 
         assertThat(contractCallService.processCall(serviceParameters)).isEqualTo("0x" + stateChange);
 
@@ -362,7 +398,7 @@ class ContractCallServiceTest extends ContractCallTestSetup {
         final var tokenNameCall = "0x6f0fccab0000000000000000000000000000000000000000000000000000000000000416";
         final var gasUsedBeforeExecution = getGasUsedBeforeExecution(ETH_ESTIMATE_GAS);
         final var serviceParameters = serviceParametersForExecution(
-                Bytes.fromHexString(tokenNameCall), ETH_CALL_CONTRACT_ADDRESS, ETH_ESTIMATE_GAS, 0);
+                Bytes.fromHexString(tokenNameCall), ETH_CALL_CONTRACT_ADDRESS, ETH_ESTIMATE_GAS, 0, BlockType.LATEST);
 
         final var expectedGasUsed = gasUsedAfterExecution(serviceParameters);
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallSystemPrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallSystemPrecompileTest.java
@@ -21,6 +21,7 @@ import static com.hedera.mirror.web3.service.model.CallServiceParameters.CallTyp
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.hedera.mirror.web3.viewmodel.BlockType;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -33,8 +34,8 @@ class ContractCallSystemPrecompileTest extends ContractCallTestSetup {
     void systemPrecompileFunctionsTestEthCall(final SystemContractFunctions contractFunc) {
         final var functionHash = functionEncodeDecoder.functionHashFor(
                 contractFunc.name, EXCHANGE_RATE_PRECOMPILE_ABI_PATH, contractFunc.functionParameters);
-        final var serviceParameters =
-                serviceParametersForExecution(functionHash, EXCHANGE_RATE_PRECOMPILE_CONTRACT_ADDRESS, ETH_CALL, 0L);
+        final var serviceParameters = serviceParametersForExecution(
+                functionHash, EXCHANGE_RATE_PRECOMPILE_CONTRACT_ADDRESS, ETH_CALL, 0L, BlockType.LATEST);
         final var successfulResponse = functionEncodeDecoder.encodedResultFor(
                 contractFunc.name, EXCHANGE_RATE_PRECOMPILE_ABI_PATH, contractFunc.expectedResultFields);
 
@@ -47,7 +48,7 @@ class ContractCallSystemPrecompileTest extends ContractCallTestSetup {
         final var functionHash = functionEncodeDecoder.functionHashFor(
                 contractFunc.name, EXCHANGE_RATE_PRECOMPILE_ABI_PATH, contractFunc.functionParameters);
         final var serviceParameters = serviceParametersForExecution(
-                functionHash, EXCHANGE_RATE_PRECOMPILE_CONTRACT_ADDRESS, ETH_ESTIMATE_GAS, 0L);
+                functionHash, EXCHANGE_RATE_PRECOMPILE_CONTRACT_ADDRESS, ETH_ESTIMATE_GAS, 0L, BlockType.LATEST);
 
         final var expectedGasUsed = gasUsedAfterExecution(serviceParameters);
 
@@ -60,8 +61,8 @@ class ContractCallSystemPrecompileTest extends ContractCallTestSetup {
     void pseudoRandomGeneratorPrecompileFunctionsTestEthEstimateGas() {
         final var functionName = "getPseudorandomSeed";
         final var functionHash = functionEncodeDecoder.functionHashFor(functionName, PRNG_PRECOMPILE_ABI_PATH);
-        final var serviceParameters =
-                serviceParametersForExecution(functionHash, PRNG_CONTRACT_ADDRESS, ETH_ESTIMATE_GAS, 0L);
+        final var serviceParameters = serviceParametersForExecution(
+                functionHash, PRNG_CONTRACT_ADDRESS, ETH_ESTIMATE_GAS, 0L, BlockType.LATEST);
 
         final var expectedGasUsed = gasUsedAfterExecution(serviceParameters);
 
@@ -74,7 +75,8 @@ class ContractCallSystemPrecompileTest extends ContractCallTestSetup {
     void pseudoRandomGeneratorPrecompileFunctionsTestEthCall() {
         final var functionName = "getPseudorandomSeed";
         final var functionHash = functionEncodeDecoder.functionHashFor(functionName, PRNG_PRECOMPILE_ABI_PATH);
-        final var serviceParameters = serviceParametersForExecution(functionHash, PRNG_CONTRACT_ADDRESS, ETH_CALL, 0L);
+        final var serviceParameters =
+                serviceParametersForExecution(functionHash, PRNG_CONTRACT_ADDRESS, ETH_CALL, 0L, BlockType.LATEST);
 
         final var result = contractCallService.processCall(serviceParameters);
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallTestSetup.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallTestSetup.java
@@ -751,7 +751,11 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
     }
 
     protected CallServiceParameters serviceParametersForExecution(
-            final Bytes callData, final Address contractAddress, final CallType callType, final long value) {
+            final Bytes callData,
+            final Address contractAddress,
+            final CallType callType,
+            final long value,
+            BlockType block) {
         final var sender = new HederaEvmAccount(SENDER_ADDRESS);
         persistEntities();
 
@@ -764,7 +768,7 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
                 .isStatic(false)
                 .callType(callType)
                 .isEstimate(ETH_ESTIMATE_GAS == callType)
-                .block(BlockType.LATEST)
+                .block(block)
                 .build();
     }
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallTestSetup.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallTestSetup.java
@@ -54,6 +54,7 @@ import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
 import com.hedera.mirror.web3.service.model.CallServiceParameters;
 import com.hedera.mirror.web3.service.model.CallServiceParameters.CallType;
 import com.hedera.mirror.web3.utils.FunctionEncodeDecoder;
+import com.hedera.mirror.web3.viewmodel.BlockType;
 import com.hedera.node.app.service.evm.store.models.HederaEvmAccount;
 import com.hedera.services.hapi.utils.ByteStringUtils;
 import com.hedera.services.store.contracts.precompile.TokenCreateWrapper;
@@ -763,6 +764,7 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
                 .isStatic(false)
                 .callType(callType)
                 .isEstimate(ETH_ESTIMATE_GAS == callType)
+                .block(BlockType.LATEST)
                 .build();
     }
 
@@ -780,6 +782,7 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
                 .isStatic(false)
                 .callType(callType)
                 .isEstimate(ETH_ESTIMATE_GAS == callType)
+                .block(BlockType.LATEST)
                 .build();
     }
 
@@ -796,7 +799,8 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
                             serviceParameters.getCallData(),
                             Instant.now(),
                             serviceParameters.isStatic(),
-                            true)
+                            true,
+                            BlockType.LATEST)
                     .getGasUsed();
 
             assertThat(store.getStackedStateFrames().height()).isEqualTo(1);


### PR DESCRIPTION
**Description**:
This PR fixes the following two issues: 

#6895 - Since the timestamp field was deleted at some point in [PR](https://github.com/hashgraph/hedera-mirror-node/pull/6676) - the same change is introduced here

#6970 - When a block number is passed in contracts/call request body for eth_call, we need to map the block passed
to a certain timestamp which we will be using to later query historical data in db.


Modifications in this **PR**

Added new timestamp field in **ContractCallContext** which will be used for filtering.
Added new method in **RecordFileRepository** that will query to find consensus_end timestamp for record file based on block number 

Added a logic in MirrorEvmTxProcessorImpl that checks if we are in eth_call context. Then gets the block passed in request and finds the record file with that number and gets its consensus_end timestamp and sets in the **ContractCallContext**( later on this value will be read and used for filtering in db queries).
 If no value is found for that block number the timestamp field will be left with default value and this will be treated as if **BlockType.LATEST** is passed.

Added unit tests for ContractCallContext -> **ContractCallContextTest**

Modified **MirrorEvmTxProcessorTest** where we pass different combinations of is estimate gas or eth call with different block number values 

Modified **RecordFileRepositoryTest** - added test for the new query 

Modified **ContractCallServiceTest** - added a test for eth call where custom block number is passed

Modified shared method used to build service parameters for **processCall** - now we can pass **block** parameter to it.



**Related issue(s)**:

Fixes #6970, #6895 


**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
