### PR TITLE
Bump Spring Boot from 3.1.4 to 3.1.5

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,6 @@ plugins {
 extra.apply {
     set("gson.version", "2.8.9") // Temporary until Apache jclouds supports gson 2.9
     set("mapStructVersion", "1.5.5.Final")
-    set("netty.version", "4.1.100.Final") // Temporary until next Spring Boot
     set("protobufVersion", "3.24.4")
     set("reactorGrpcVersion", "1.2.4")
     set("snakeyaml.version", "2.0")

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
     implementation("org.openapitools:openapi-generator-gradle-plugin:7.0.1")
     implementation("org.owasp:dependency-check-gradle:8.4.0")
     implementation("org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:4.4.1.3373")
-    implementation("org.springframework.boot:spring-boot-gradle-plugin:3.1.4")
+    implementation("org.springframework.boot:spring-boot-gradle-plugin:3.1.5")
 }
 
 val gitHook = tasks.register<Exec>("gitHook") {


### PR DESCRIPTION
**Description**:

* Bump Spring Boot from 3.1.4 to 3.1.5
* Remove temporary netty override

**Related issue(s)**:


**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
