### PR TITLE
Add grpc inprocess dependency in hedera-mirror-test project

### DIFF
--- a/hedera-mirror-test/build.gradle.kts
+++ b/hedera-mirror-test/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-autoconfigure")
     implementation("org.springframework.boot:spring-boot-configuration-processor")
     implementation("org.springframework.boot:spring-boot-starter-logging")
+    testImplementation("io.grpc:grpc-inprocess")
     testImplementation("com.esaulpaugh:headlong")
     testImplementation("com.google.guava:guava")
     testImplementation("com.hedera.hashgraph:sdk")


### PR DESCRIPTION
**Description**: Upon upgrading to gRPC version 1.58.0, a `NoClassDefFoundError` for `io.grpc.inprocess.InProcessChannelBuilder` was encountered, causing a `BeanCreationException` when initializing SDKClient in the hedera-mirror-test project.
Adding `testImplementation("io.grpc:grpc-inprocess")` to the Gradle build file resolved the issue.
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #7111

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
