### PR TITLE
HIP-584 Historical: Added new query for contract state to return historical contract state storage value

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/ContractStateRepository.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/ContractStateRepository.java
@@ -32,6 +32,22 @@ public interface ContractStateRepository extends CrudRepository<ContractState, L
     Optional<byte[]> findStorage(final Long contractId, final byte[] key);
 
 
+    /**
+     * This method retrieves the most recent contract state storage value up to given block timestamp.
+     *
+     * <p>The method first queries the contract_state table for the most recent contract state storage value
+     * before or equal the specified block timestamp. If no matching record is found there,
+     * it then checks the contract_state_change table for the most recent contract state storage value
+     * before or equal to the specified block timestamp.
+     *
+     * <p>The combined result of these two queries is then ordered by their respective timestamps in descending order
+     * to get the most recent value.
+     *
+     * @param id             The ID of the contract.
+     * @param slot           The slot in the contract's storage.
+     * @param blockTimestamp The block timestamp up to which to retrieve the storage value.
+     * @return An {@code Optional} containing the byte array of the storage value if found, or an empty {@code Optional} if not.
+     */
     @Query(value =
             """
             select value

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/ContractStateRepositoryTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/ContractStateRepositoryTest.java
@@ -40,14 +40,40 @@ class ContractStateRepositoryTest extends Web3IntegrationTest {
 
     @Test
     void findStorageOfContractStateChangeByBlockTimestampSuccessfulCall() {
-        ContractStateChange contractStateChange =
+        ContractStateChange olderContractState =
                 domainBuilder.contractStateChange().persist();
+        ContractStateChange contractStateChange = domainBuilder
+                .contractStateChange()
+                .customize(
+                        cs -> cs.contractId(olderContractState.getContractId())
+                                .slot(olderContractState.getSlot()))
+                .persist();
+
         assertThat(contractStateRepository.findStorageByBlockTimestamp(
                         contractStateChange.getContractId(),
                         contractStateChange.getSlot(),
                         contractStateChange.getConsensusTimestamp()))
                 .get()
                 .isEqualTo(contractStateChange.getValueWritten());
+    }
+
+    @Test
+    void findStorageOfContractStateChangeWithEmptyValueWrittenByBlockTimestampSuccessfulCall() {
+        ContractStateChange olderContractState =
+                domainBuilder.contractStateChange().persist();
+        ContractStateChange contractStateChange = domainBuilder
+                .contractStateChange()
+                .customize(cs -> cs.contractId(olderContractState.getContractId())
+                        .slot(olderContractState.getSlot())
+                        .valueWritten(null))
+                .persist();
+
+        assertThat(contractStateRepository.findStorageByBlockTimestamp(
+                        contractStateChange.getContractId(),
+                        contractStateChange.getSlot(),
+                        contractStateChange.getConsensusTimestamp()))
+                .get()
+                .isEqualTo(contractStateChange.getValueRead());
     }
 
     @Test

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/ContractStateRepositoryTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/ContractStateRepositoryTest.java
@@ -39,54 +39,26 @@ class ContractStateRepositoryTest extends Web3IntegrationTest {
     }
 
     @Test
-    void findStorageOfContractStateByBlockTimestampSuccessfulCall() {
-        ContractState contractState = domainBuilder.contractState().persist();
-        assertThat(contractStateRepository.findStorageByBlockTimestamp(contractState.getContractId(),
-                contractState.getSlot(),
-                contractState.getCreatedTimestamp()))
-                .get()
-                .isEqualTo(contractState.getValue());
-    }
-
-    @Test
     void findStorageOfContractStateChangeByBlockTimestampSuccessfulCall() {
-        ContractStateChange contractStateChange = domainBuilder.contractStateChange().persist();
-        assertThat(contractStateRepository.findStorageByBlockTimestamp(contractStateChange.getContractId(),
-                contractStateChange.getSlot(),
-                contractStateChange.getConsensusTimestamp()))
+        ContractStateChange contractStateChange =
+                domainBuilder.contractStateChange().persist();
+        assertThat(contractStateRepository.findStorageByBlockTimestamp(
+                        contractStateChange.getContractId(),
+                        contractStateChange.getSlot(),
+                        contractStateChange.getConsensusTimestamp()))
                 .get()
                 .isEqualTo(contractStateChange.getValueWritten());
     }
 
     @Test
-    void findLatestStorageByBlockTimestampSuccessfulCall() {
-        domainBuilder.contractStateChange().persist();
-        ContractState contractState = domainBuilder.contractState().persist();
-
-        assertThat(contractStateRepository.findStorageByBlockTimestamp(contractState.getContractId(),
-                contractState.getSlot(),
-                contractState.getCreatedTimestamp()))
-                .get()
-                .isEqualTo(contractState.getValue());
-    }
-
-    @Test
-    void findStorageOfContractStateByBlockTimestampFailCall() {
-        ContractState contractState = domainBuilder.contractState().persist();
-
-        assertThat(contractStateRepository.findStorageByBlockTimestamp(contractState.getContractId(),
-                contractState.getSlot(),
-                contractState.getCreatedTimestamp() - 1))
-                .isEmpty();
-    }
-
-    @Test
     void findStorageOfContractStateChangeByBlockTimestampFailCall() {
-        ContractStateChange contractStateChange = domainBuilder.contractStateChange().persist();
+        ContractStateChange contractStateChange =
+                domainBuilder.contractStateChange().persist();
 
-        assertThat(contractStateRepository.findStorageByBlockTimestamp(contractStateChange.getContractId(),
-                contractStateChange.getSlot(),
-                contractStateChange.getConsensusTimestamp() - 1))
+        assertThat(contractStateRepository.findStorageByBlockTimestamp(
+                        contractStateChange.getContractId(),
+                        contractStateChange.getSlot(),
+                        contractStateChange.getConsensusTimestamp() - 1))
                 .isEmpty();
     }
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/ContractStateRepositoryTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/ContractStateRepositoryTest.java
@@ -19,6 +19,7 @@ package com.hedera.mirror.web3.repository;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.hedera.mirror.common.domain.contract.ContractState;
+import com.hedera.mirror.common.domain.contract.ContractStateChange;
 import com.hedera.mirror.web3.Web3IntegrationTest;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.Test;
@@ -35,6 +36,58 @@ class ContractStateRepositoryTest extends Web3IntegrationTest {
         assertThat(contractStateRepository.findStorage(contractState.getContractId(), contractState.getSlot()))
                 .get()
                 .isEqualTo(contractState.getValue());
+    }
+
+    @Test
+    void findStorageOfContractStateByBlockTimestampSuccessfulCall() {
+        ContractState contractState = domainBuilder.contractState().persist();
+        assertThat(contractStateRepository.findStorageByBlockTimestamp(contractState.getContractId(),
+                contractState.getSlot(),
+                contractState.getCreatedTimestamp()))
+                .get()
+                .isEqualTo(contractState.getValue());
+    }
+
+    @Test
+    void findStorageOfContractStateChangeByBlockTimestampSuccessfulCall() {
+        ContractStateChange contractStateChange = domainBuilder.contractStateChange().persist();
+        assertThat(contractStateRepository.findStorageByBlockTimestamp(contractStateChange.getContractId(),
+                contractStateChange.getSlot(),
+                contractStateChange.getConsensusTimestamp()))
+                .get()
+                .isEqualTo(contractStateChange.getValueWritten());
+    }
+
+    @Test
+    void findLatestStorageByBlockTimestampSuccessfulCall() {
+        domainBuilder.contractStateChange().persist();
+        ContractState contractState = domainBuilder.contractState().persist();
+
+        assertThat(contractStateRepository.findStorageByBlockTimestamp(contractState.getContractId(),
+                contractState.getSlot(),
+                contractState.getCreatedTimestamp()))
+                .get()
+                .isEqualTo(contractState.getValue());
+    }
+
+    @Test
+    void findStorageOfContractStateByBlockTimestampFailCall() {
+        ContractState contractState = domainBuilder.contractState().persist();
+
+        assertThat(contractStateRepository.findStorageByBlockTimestamp(contractState.getContractId(),
+                contractState.getSlot(),
+                contractState.getCreatedTimestamp() - 1))
+                .isEmpty();
+    }
+
+    @Test
+    void findStorageOfContractStateChangeByBlockTimestampFailCall() {
+        ContractStateChange contractStateChange = domainBuilder.contractStateChange().persist();
+
+        assertThat(contractStateRepository.findStorageByBlockTimestamp(contractStateChange.getContractId(),
+                contractStateChange.getSlot(),
+                contractStateChange.getConsensusTimestamp() - 1))
+                .isEmpty();
     }
 
     @Test


### PR DESCRIPTION
Description:

This PR fixes part of the following [issue](https://github.com/hashgraph/hedera-mirror-node/issues/6812)

**Description**:
For historical support we need to be able to get historical snapshot of the contract state.
To do this we need to add new method to retrieve a historical contract state storage value based on a timestamp filter.

This PR modifies:
Added new method in **ContractStateRepository** to retrieve historical contract state storage value.
Added new unit tests in **ContractStateRepositoryTest** to test all the possible scenarios for the newly added repository method.


**Related issue(s)**:

Fixes #6812

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
