### PR TITLE
Suppress Snyk static analysis false positive

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -5,4 +5,4 @@ patch: {}
 exclude:
   global:
     - hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/OperatorProperties.java
-
+    - hedera-mirror-rest/tokens.js


### PR DESCRIPTION
**Description**:

Fix security snyk-code workflow [failing](https://github.com/hashgraph/hedera-mirror-node/actions/runs/6644857333/job/18054903115) by suppressing false positive `token` hardcoded secret

**Related issue(s)**:

**Notes for reviewer**:

Snyk currently has no way to exclude specific rules on specific files for static analysis. So we're forced to ignore the entire file for now.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
