### PR TITLE
Bump chart dependencies

### DIFF
--- a/charts/hedera-mirror-common/Chart.yaml
+++ b/charts/hedera-mirror-common/Chart.yaml
@@ -3,20 +3,20 @@ appVersion: 0.92.0-SNAPSHOT
 dependencies:
   - name: loki
     condition: loki.enabled
-    version: 5.9.2
+    version: 5.36.0
     repository: https://grafana.github.io/helm-charts
   - condition: prometheus-adapter.enabled
     name: prometheus-adapter
     repository: https://prometheus-community.github.io/helm-charts
-    version: 4.3.1
+    version: 4.7.1
   - alias: prometheus
     condition: prometheus.enabled
     name: kube-prometheus-stack
     repository: https://prometheus-community.github.io/helm-charts
-    version: 48.2.3
+    version: 52.1.0
   - name: promtail
     condition: promtail.enabled
-    version: 6.14.1
+    version: 6.15.3
     repository: https://grafana.github.io/helm-charts
   - alias: stackgres
     condition: stackgres.enabled
@@ -26,12 +26,12 @@ dependencies:
   - condition: traefik.enabled
     name: traefik
     repository: https://helm.traefik.io/traefik
-    version: 24.0.0
+    version: 25.0.0
   - alias: zfs
     condition: zfs.enabled
     name: zfs-localpv
     repository: https://openebs.github.io/zfs-localpv
-    version: 2.3.0
+    version: 2.3.1
 description: Hedera Mirror Node common components installed globally for use across namespaces
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067

--- a/charts/hedera-mirror-graphql/templates/middleware.yaml
+++ b/charts/hedera-mirror-graphql/templates/middleware.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.global.middleware .Values.middleware -}}
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   labels: {{ include "hedera-mirror-graphql.labels" . | nindent 4 }}
@@ -14,7 +14,7 @@ spec:
 
 {{- range .Values.middleware }}
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   labels: {{ include "hedera-mirror-graphql.labels" $ | nindent 4 }}

--- a/charts/hedera-mirror-grpc/templates/middleware.yaml
+++ b/charts/hedera-mirror-grpc/templates/middleware.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.global.middleware .Values.middleware -}}
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   labels: {{ include "hedera-mirror-grpc.labels" . | nindent 4 }}
@@ -14,7 +14,7 @@ spec:
 
 {{- range .Values.middleware }}
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   labels: {{ include "hedera-mirror-grpc.labels" $ | nindent 4 }}

--- a/charts/hedera-mirror-rest/templates/middleware.yaml
+++ b/charts/hedera-mirror-rest/templates/middleware.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.global.middleware .Values.middleware -}}
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   labels: {{ include "hedera-mirror-rest.labels" . | nindent 4 }}
@@ -14,7 +14,7 @@ spec:
 
 {{- range .Values.middleware }}
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   labels: {{ include "hedera-mirror-rest.labels" $ | nindent 4 }}

--- a/charts/hedera-mirror-rosetta/templates/middleware.yaml
+++ b/charts/hedera-mirror-rosetta/templates/middleware.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.global.middleware .Values.middleware -}}
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   labels: {{ include "hedera-mirror-rosetta.labels" . | nindent 4 }}
@@ -14,7 +14,7 @@ spec:
 
 {{- range .Values.middleware }}
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   labels: {{ include "hedera-mirror-rosetta.labels" $ | nindent 4 }}

--- a/charts/hedera-mirror-web3/templates/middleware.yaml
+++ b/charts/hedera-mirror-web3/templates/middleware.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.global.middleware .Values.middleware -}}
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   labels: {{ include "hedera-mirror-web3.labels" . | nindent 4 }}
@@ -14,7 +14,7 @@ spec:
 
 {{- range .Values.middleware }}
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   labels: {{ include "hedera-mirror-web3.labels" $ | nindent 4 }}

--- a/charts/hedera-mirror/Chart.yaml
+++ b/charts/hedera-mirror/Chart.yaml
@@ -29,11 +29,11 @@ dependencies:
     condition: postgresql.enabled
     name: postgresql-ha
     repository: https://charts.bitnami.com/bitnami
-    version: 11.8.1
+    version: 12.0.4
   - condition: redis.enabled
     name: redis
     repository: https://charts.bitnami.com/bitnami
-    version: 17.14.5
+    version: 18.2.0
   - alias: rest
     condition: rest.enabled
     name: hedera-mirror-rest

--- a/charts/hedera-mirror/values.yaml
+++ b/charts/hedera-mirror/values.yaml
@@ -174,7 +174,7 @@ postgresql:
     extraEnvVarsSecret: mirror-passwords
     image:
       debug: true
-      tag: 14.9.0-debian-11-r25
+      tag: 14.9.0-debian-11-r54
     initdbScriptsCM: "{{ .Release.Name }}-init"
     maxConnections: 200
     password: ""  # Randomly generated if left blank

--- a/charts/marketplace/gcp/release.sh
+++ b/charts/marketplace/gcp/release.sh
@@ -21,7 +21,7 @@ fi
 target_tag="${target_tag#v}" # Strip v prefix if present
 target_tag_minor="${target_tag%\.*}"
 bats_tag="v1.10.0"
-postgresql_tag="14.9.0-debian-11-r25"
+postgresql_tag="14.9.0-debian-11-r54"
 registry="gcr.io/mirror-node-public/hedera-mirror-node"
 
 function retag() {


### PR DESCRIPTION
**Description**:

* Bump chart dependencies
* Update Traefik `apiVersion` from deprecated `traefik.containo.us` to `traefik.io`

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
