### PR TITLE
HIP-584: Fix nested contract deploy fail

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccess.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccess.java
@@ -81,6 +81,15 @@ public class MirrorEntityAccess implements HederaEvmEntityAccess {
     }
 
     @Override
+    public long getNonce(Address address) {
+        var account = store.getAccount(address, OnMissing.DONT_THROW);
+        if (account.isEmptyAccount()) {
+            return 0L;
+        }
+        return account.getEthereumNonce();
+    }
+
+    @Override
     public boolean isExtant(final Address address) {
         var account = store.getAccount(address, OnMissing.DONT_THROW);
         return !account.isEmptyAccount();

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccessTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccessTest.java
@@ -164,6 +164,22 @@ class MirrorEntityAccessTest {
     }
 
     @Test
+    void getNonce() {
+        final long nonce = 2;
+        when(store.getAccount(ADDRESS, OnMissing.DONT_THROW)).thenReturn(account);
+        when(account.getEthereumNonce()).thenReturn(nonce);
+        final var result = mirrorEntityAccess.getNonce(ADDRESS);
+        assertThat(result).isEqualTo(nonce);
+    }
+
+    @Test
+    void getNonceForEmptyAccount() {
+        when(store.getAccount(ADDRESS, OnMissing.DONT_THROW)).thenReturn(account);
+        final var result = mirrorEntityAccess.getNonce(ADDRESS);
+        assertThat(result).isZero();
+    }
+
+    @Test
     void isExtant() {
         when(store.getAccount(ADDRESS, OnMissing.DONT_THROW)).thenReturn(account);
         final var result = mirrorEntityAccess.isExtant(ADDRESS);


### PR DESCRIPTION
**Description**:
When deploying nested contracts after the Besu upgrade to 23.10.0 (and hedera-evm upgrade to 0.43.0) the target addresses of the created contracts are now created as address aliases based on the sender address and the account nonce. The account nonce was returned always as 0 from the default getNonce(Address) method from HederaEvmEntityAccess and this caused collisions in the generated aliases for the created contracts. This method is now overriden in MirrorEntityAccess to return the correct nonce value from the DB.

Fixes https://github.com/hashgraph/hedera-mirror-node/issues/7123
