### PR TITLE
Bump chart-testing-action from 2.4.0 to 2.6.0

### DIFF
--- a/.github/workflows/charts.yml
+++ b/.github/workflows/charts.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install ct
-        uses: helm/chart-testing-action@v2.4.0
+        uses: helm/chart-testing-action@v2.6.0
 
       - name: Run lint
         run: ct lint --config .github/ct.yaml --all
@@ -50,7 +50,7 @@ jobs:
           helm install stackgres stackgres/stackgres-operator --version 1.5.0 --create-namespace -n stackgres
 
       - name: Install ct
-        uses: helm/chart-testing-action@v2.4.0
+        uses: helm/chart-testing-action@v2.6.0
 
       - name: Install chart
         run: ct install --config .github/ct.yaml --charts=charts/hedera-mirror --helm-extra-args="--timeout 10m"

--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -117,7 +117,7 @@ jobs:
         with:
           bodyFile: ${{ env.RELEASE_NOTES_FILENAME }}.md
           commit: ${{ env.RELEASE_BRANCH }}
-          draft: true
+          draft: ${{ steps.version_parser.outputs.prerelease == '' }}
           name: ${{ env.RELEASE_TAG }}
           omitBody: ${{ steps.milestone.outputs.milestone_id == '' }}
           prerelease: ${{ steps.version_parser.outputs.prerelease != '' }}

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -111,7 +111,7 @@ jobs:
         run: curl --retry 3 -fsL https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
 
       - name: Create k3d cluster
-        run: k3d cluster create mirror --agents 1 --wait --image rancher/k3s:v1.27.4-k3s1
+        run: k3d cluster create mirror --agents 1 --wait --image rancher/k3s:v1.27.7-k3s1
 
       - name: Get tag
         run: echo "TAG=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV


### PR DESCRIPTION
**Description**:

* Bump chart-testing-action from `2.4.0` to `2.6.0`
* Bump k3s from `v1.24.7-k3s1` to `v1.27.7-k3s1`
* Change release automation to always publish pre-release GitHub releases

**Related issue(s)**:

**Notes for reviewer**:

Successful run: https://github.com/hashgraph/hedera-mirror-node/actions/runs/6723436361

Will cherry pick to `release/0.92` to unblock Marketplace release

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
