### PR TITLE
Enable previously commented out tests

### DIFF
--- a/hedera-mirror-test/src/test/resources/features/contract/call.feature
+++ b/hedera-mirror-test/src/test/resources/features/contract/call.feature
@@ -18,6 +18,6 @@ Feature: eth_call Contract Base Coverage Feature
     Then I call function with HederaTokenService getTokenDefaultKycStatus token "FUNGIBLE"
     Then I call function with update and I expect return of the updated value
     Then I call function that makes N times state update
-#    Then I call function with nested deploy using create function
-#    Then I call function with nested deploy using create2 function
+    Then I call function with nested deploy using create function
+    Then I call function with nested deploy using create2 function
     Then I call function with transfer that returns the balance

--- a/hedera-mirror-test/src/test/resources/features/contract/estimatePrecompile.feature
+++ b/hedera-mirror-test/src/test/resources/features/contract/estimatePrecompile.feature
@@ -156,8 +156,8 @@ Feature: EstimateGas Contract Base Coverage Feature
     Then I call estimateGas with redirect setApprovalForAll function
     Then I call estimateGas with exchange rate tinycents to tinybars
     Then I call estimateGas with exchange rate tinybars to tinycents
-    #Then I call estimateGas with pseudo random seed
-    #Then I call estimateGas with pseudo random number
+    Then I call estimateGas with pseudo random seed
+    Then I call estimateGas with pseudo random number
     #### These tests below are recommended to be kept at the end as they change the state #####
     Then I call estimateGas with balanceOf function for "FUNGIBLE" and verify the estimated gas against HAPI
     Then I call estimateGas with balanceOf function for "NFT" and verify the estimated gas against HAPI


### PR DESCRIPTION
**Description**: Enabling previously commented out tests.
call.feature-> Tested against local and integration environment.
Then I call function with nested deploy using create function
Then I call function with nested deploy using create2 function

estimatePrecompile.feature-> Tested against local, preview and integration environment.
Then I call estimateGas with pseudo random seed
Then I call estimateGas with pseudo random number

<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #7154

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
