### PR TITLE
Improve MirrorEvmTxProcessor execute method

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessor.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessor.java
@@ -21,6 +21,5 @@ import com.hedera.node.app.service.evm.contracts.execution.HederaEvmTransactionP
 
 public interface MirrorEvmTxProcessor {
 
-    @SuppressWarnings("java:S107")
     HederaEvmTransactionProcessingResult execute(CallServiceParameters params, long estimatedGas);
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessor.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessor.java
@@ -16,22 +16,11 @@
 
 package com.hedera.mirror.web3.evm.contracts.execution;
 
+import com.hedera.mirror.web3.service.model.CallServiceParameters;
 import com.hedera.node.app.service.evm.contracts.execution.HederaEvmTransactionProcessingResult;
-import com.hedera.node.app.service.evm.store.models.HederaEvmAccount;
-import java.time.Instant;
-import org.apache.tuweni.bytes.Bytes;
-import org.hyperledger.besu.datatypes.Address;
 
 public interface MirrorEvmTxProcessor {
 
     @SuppressWarnings("java:S107")
-    HederaEvmTransactionProcessingResult execute(
-            HederaEvmAccount sender,
-            Address receiver,
-            long providedGasLimit,
-            long value,
-            Bytes callData,
-            Instant consensusTime,
-            boolean isStatic,
-            boolean isEstimate);
+    HederaEvmTransactionProcessingResult execute(CallServiceParameters params, long estimatedGas);
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/ContractCallService.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/ContractCallService.java
@@ -82,7 +82,7 @@ public class ContractCallService {
                     }
                 }
 
-                final var ethCallTxnResult = doProcessCall(params, params.getGas(), false);
+                final var ethCallTxnResult = doProcessCall(params, params.getGas());
 
                 validateResult(ethCallTxnResult, params.getCallType());
 
@@ -106,7 +106,7 @@ public class ContractCallService {
      * gas used in the first step, while the upper bound is the inputted gas parameter.
      */
     private Bytes estimateGas(final CallServiceParameters params) {
-        HederaEvmTransactionProcessingResult processingResult = doProcessCall(params, params.getGas(), true);
+        HederaEvmTransactionProcessingResult processingResult = doProcessCall(params, params.getGas());
         validateResult(processingResult, ETH_ESTIMATE_GAS);
 
         final var gasUsedByInitialCall = processingResult.getGasUsed();
@@ -118,7 +118,7 @@ public class ContractCallService {
 
         final var estimatedGas = binaryGasEstimator.search(
                 (totalGas, iterations) -> updateGasMetric(ETH_ESTIMATE_GAS, totalGas, iterations),
-                gas -> doProcessCall(params, gas, true),
+                gas -> doProcessCall(params, gas),
                 gasUsedByInitialCall,
                 params.getGas());
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/ContractCallService.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/ContractCallService.java
@@ -39,7 +39,6 @@ import com.hedera.node.app.service.evm.contracts.execution.HederaEvmTransactionP
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.inject.Named;
-import java.time.Instant;
 import java.util.Objects;
 import java.util.Optional;
 import lombok.CustomLog;
@@ -130,15 +129,7 @@ public class ContractCallService {
             final CallServiceParameters params, final long estimatedGas, final boolean isEstimate) {
         HederaEvmTransactionProcessingResult transactionResult;
         try {
-            transactionResult = mirrorEvmTxProcessor.execute(
-                    params.getSender(),
-                    params.getReceiver(),
-                    params.isEstimate() ? estimatedGas : params.getGas(),
-                    params.getValue(),
-                    params.getCallData(),
-                    Instant.now(),
-                    params.isStatic(),
-                    isEstimate);
+            transactionResult = mirrorEvmTxProcessor.execute(params, estimatedGas);
         } catch (IllegalStateException | IllegalArgumentException e) {
             throw new MirrorEvmTransactionException(e.getMessage(), EMPTY, EMPTY);
         }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/ContractCallService.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/ContractCallService.java
@@ -126,7 +126,7 @@ public class ContractCallService {
     }
 
     private HederaEvmTransactionProcessingResult doProcessCall(
-            final CallServiceParameters params, final long estimatedGas, final boolean isEstimate) {
+            final CallServiceParameters params, final long estimatedGas) {
         HederaEvmTransactionProcessingResult transactionResult;
         try {
             transactionResult = mirrorEvmTxProcessor.execute(params, estimatedGas);

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallTestSetup.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallTestSetup.java
@@ -80,7 +80,6 @@ import com.hederahashgraph.api.proto.java.TimestampSeconds;
 import com.hederahashgraph.api.proto.java.TransactionFeeSchedule;
 import java.math.BigInteger;
 import java.nio.file.Path;
-import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.ToLongFunction;
@@ -797,16 +796,9 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
     protected long gasUsedAfterExecution(final CallServiceParameters serviceParameters) {
         long result;
         try (ContractCallContext ctx = init(store.getStackedStateFrames())) {
+
             result = processor
-                    .execute(
-                            serviceParameters.getSender(),
-                            serviceParameters.getReceiver(),
-                            serviceParameters.getGas(),
-                            serviceParameters.getValue(),
-                            serviceParameters.getCallData(),
-                            Instant.now(),
-                            serviceParameters.isStatic(),
-                            true)
+                    .execute(serviceParameters, serviceParameters.getGas())
                     .getGasUsed();
 
             assertThat(store.getStackedStateFrames().height()).isEqualTo(1);


### PR DESCRIPTION
**Description**:
This issue is raised based on the following https://github.com/hashgraph/hedera-mirror-node/pull/7090#discussion_r1365837436.

In MirrorEvmTxProcessor interface we pass many arguments in the execute method.

These are mostly taken from CallServiceParameters object and then passed one by one to the execute method.

The main problem here is that any new parameter that can be added in the future or modified existing parameter will cause unnecessary modifications in MirrorEvmTxProcessor and ContractCallService.
**Related issue(s)**:

Fixes #7113

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
