### PR TITLE
Add Health check on Rest Network Stake

### DIFF
--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/rest/RestApiClient.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/rest/RestApiClient.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import lombok.CustomLog;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Flux;
@@ -64,5 +65,9 @@ public class RestApiClient {
                                 next.set(r.getLinks() != null ? r.getLinks().getNext() : null))
                         .flatMapIterable(NetworkNodesResponse::getNodes))
                 .repeat(() -> StringUtils.isNotBlank(next.get()));
+    }
+
+    public Mono<HttpStatusCode> getNetworkStakeStatusCode() {
+        return webClient.get().uri("/network/stake").exchangeToMono(r -> Mono.just(r.statusCode()));
     }
 }

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/health/ClusterHealthIndicatorTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/health/ClusterHealthIndicatorTest.java
@@ -25,22 +25,32 @@ import com.hedera.mirror.monitor.publish.generator.TransactionGenerator;
 import com.hedera.mirror.monitor.subscribe.MirrorSubscriber;
 import com.hedera.mirror.monitor.subscribe.Scenario;
 import com.hedera.mirror.monitor.subscribe.TestScenario;
+import com.hedera.mirror.monitor.subscribe.rest.RestApiClient;
 import lombok.Getter;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.Status;
+import org.springframework.http.HttpStatusCode;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class ClusterHealthIndicatorTest {
 
     @Mock
     private MirrorSubscriber mirrorSubscriber;
+
+    @Mock
+    private RestApiClient restApiClient;
 
     @Mock
     private TransactionGenerator transactionGenerator;
@@ -50,17 +60,29 @@ class ClusterHealthIndicatorTest {
 
     @ParameterizedTest
     @CsvSource({
-        "1.0, 1.0, UP", // healthy
-        "0.0, 1.0, UNKNOWN", // publishing inactive
-        "1.0, 0.0, UNKNOWN", // subscribing inactive
-        "0.0, 0.0, UNKNOWN", // publishing and subscribing inactive
+        "1.0, 1.0, 200, UP", // healthy
+        "0.0, 1.0, 200, UNKNOWN", // publishing inactive
+        "1.0, 0.0, 200, UNKNOWN", // subscribing inactive
+        "0.0, 0.0, 200, UNKNOWN", // publishing and subscribing inactive
+        "1.0, 1.0, 400, UNKNOWN", // unknown network stake
+        "1.0, 1.0, 500, DOWN", // network stake down
     })
-    void health(double publishRate, double subscribeRate, Status status) {
+    void health(double publishRate, double subscribeRate, int networkStatusCode, Status status) {
         when(transactionGenerator.scenarios()).thenReturn(Flux.just(publishScenario(publishRate)));
         when(mirrorSubscriber.getSubscriptions()).thenReturn(Flux.just(subscribeScenario(subscribeRate)));
+        when(restApiClient.getNetworkStakeStatusCode())
+                .thenReturn(Mono.just(HttpStatusCode.valueOf(networkStatusCode)));
         assertThat(clusterHealthIndicator.health().block())
                 .extracting(Health::getStatus)
                 .isEqualTo(status);
+    }
+
+    @Test
+    void restNetworkStakeError() {
+        when(restApiClient.getNetworkStakeStatusCode()).thenReturn(Mono.error(new RuntimeException()));
+        assertThat(clusterHealthIndicator.health().block())
+                .extracting(Health::getStatus)
+                .isEqualTo(Status.UNKNOWN);
     }
 
     private PublishScenario publishScenario(double rate) {

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/health/ClusterHealthIndicatorTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/health/ClusterHealthIndicatorTest.java
@@ -66,6 +66,9 @@ class ClusterHealthIndicatorTest {
         "0.0, 0.0, 200, UNKNOWN", // publishing and subscribing inactive
         "1.0, 1.0, 400, UNKNOWN", // unknown network stake
         "1.0, 1.0, 500, DOWN", // network stake down
+        "0.0, 0.0, 500, DOWN", // publishing and subscribing inactive and network stake down
+        "0.0, 1.0, 500, DOWN", // network stake down and publishing inactive
+        "1.0, 0.0, 500, DOWN", // network stake down and subscribing inactive
     })
     void health(double publishRate, double subscribeRate, int networkStatusCode, Status status) {
         when(transactionGenerator.scenarios()).thenReturn(Flux.just(publishScenario(publishRate)));
@@ -79,7 +82,7 @@ class ClusterHealthIndicatorTest {
 
     @Test
     void restNetworkStakeError() {
-        when(restApiClient.getNetworkStakeStatusCode()).thenReturn(Mono.error(new RuntimeException()));
+        when(restApiClient.getNetworkStakeStatusCode()).thenReturn(Mono.error(new RuntimeException("Test exception")));
         assertThat(clusterHealthIndicator.health().block())
                 .extracting(Health::getStatus)
                 .isEqualTo(Status.UNKNOWN);

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/rest/RestApiClientTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/rest/RestApiClientTest.java
@@ -37,6 +37,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.web.reactive.function.client.ClientRequest;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.ExchangeFunction;
@@ -126,6 +127,21 @@ class RestApiClientTest {
                 .thenAwait(WAIT)
                 .expectErrorMatches(t -> t.getCause() instanceof ConnectException)
                 .verify(WAIT);
+    }
+
+    @Test
+    void getNetworkStakeStatusCode() {
+        when(exchangeFunction.exchange(isA(ClientRequest.class)))
+                .thenReturn(Mono.just(
+                        ClientResponse.create(HttpStatus.SERVICE_UNAVAILABLE).build()));
+
+        StepVerifier.withVirtualTime(() -> restApiClient.getNetworkStakeStatusCode())
+                .thenAwait(WAIT)
+                .expectNext(HttpStatusCode.valueOf(503))
+                .expectComplete()
+                .verify(WAIT);
+
+        verify(exchangeFunction).exchange(isA(ClientRequest.class));
     }
 
     private Mono<ClientResponse> response(Object response) {


### PR DESCRIPTION
**Description**:
Add a health check on the Rest Network Stake endpoint. If this endpoint is down it may be indicative of a database problem.

**Related issue(s)**:

Fixes #7141 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
