### PR TITLE
Fix log rate dashboard

### DIFF
--- a/charts/hedera-mirror-common/dashboards/hedera-mirror-grpc.json
+++ b/charts/hedera-mirror-common/dashboards/hedera-mirror-grpc.json
@@ -1348,7 +1348,7 @@
           "datasource": {
             "uid": "${prometheus}"
           },
-          "expr": "sum(jvm_memory_used_bytes{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "avg(jvm_memory_used_bytes{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "hide": false,
           "interval": "1m",
           "legendFormat": "used",
@@ -1358,7 +1358,7 @@
           "datasource": {
             "uid": "${prometheus}"
           },
-          "expr": "sum(jvm_memory_max_bytes{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "avg(jvm_memory_max_bytes{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "hide": false,
           "interval": "1m",
           "legendFormat": "max",
@@ -1629,7 +1629,7 @@
             "uid": "${prometheus}"
           },
           "editorMode": "code",
-          "expr": "sum(jvm_threads_states_threads{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) by (state) > 0",
+          "expr": "avg(jvm_threads_states_threads{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) by (state) > 0",
           "interval": "1m",
           "legendFormat": "{{ state }}",
           "range": true,
@@ -1789,7 +1789,7 @@
           "datasource": {
             "uid": "${prometheus}"
           },
-          "expr": "sum(process_files_open_files{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "avg(process_files_open_files{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "interval": "1m",
           "legendFormat": "open",
           "refId": "B"
@@ -1798,7 +1798,7 @@
           "datasource": {
             "uid": "${prometheus}"
           },
-          "expr": "sum(process_files_max_files{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "avg(process_files_max_files{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "interval": "1m",
           "legendFormat": "max",
           "refId": "A"
@@ -1920,7 +1920,7 @@
             "uid": "${prometheus}"
           },
           "editorMode": "code",
-          "expr": "sum(hikaricp_connections_active{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "avg(hikaricp_connections_active{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "interval": "1m",
           "legendFormat": "active",
           "range": true,
@@ -1931,7 +1931,7 @@
             "uid": "${prometheus}"
           },
           "editorMode": "code",
-          "expr": "sum(hikaricp_connections_idle{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "avg(hikaricp_connections_idle{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "interval": "1m",
           "legendFormat": "idle",
           "range": true,
@@ -1942,7 +1942,7 @@
             "uid": "${prometheus}"
           },
           "editorMode": "code",
-          "expr": "sum(hikaricp_connections_max{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) > 0",
+          "expr": "avg(hikaricp_connections_max{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) > 0",
           "hide": false,
           "interval": "1m",
           "legendFormat": "max",
@@ -1954,7 +1954,7 @@
             "uid": "${prometheus}"
           },
           "editorMode": "code",
-          "expr": "sum(hikaricp_connections_pending{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\"}) > 0",
+          "expr": "avg(hikaricp_connections_pending{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\"}) > 0",
           "hide": false,
           "interval": "1m",
           "legendFormat": "pending",
@@ -2078,7 +2078,7 @@
             "uid": "${prometheus}"
           },
           "editorMode": "code",
-          "expr": "sum(jdbc_connections_active{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "avg(jdbc_connections_active{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "interval": "1m",
           "legendFormat": "active",
           "range": true,
@@ -2089,7 +2089,7 @@
             "uid": "${prometheus}"
           },
           "editorMode": "code",
-          "expr": "sum(jdbc_connections_idle{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "avg(jdbc_connections_idle{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "interval": "1m",
           "legendFormat": "idle",
           "range": true,
@@ -2099,7 +2099,7 @@
           "datasource": {
             "uid": "${prometheus}"
           },
-          "expr": "sum(jdbc_connections_max{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "avg(jdbc_connections_max{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "hide": false,
           "interval": "1m",
           "legendFormat": "max",
@@ -2109,7 +2109,7 @@
           "datasource": {
             "uid": "${prometheus}"
           },
-          "expr": "sum(jdbc_connections_min{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\"})",
+          "expr": "avg(jdbc_connections_min{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\"})",
           "hide": false,
           "interval": "1m",
           "legendFormat": "min",
@@ -2841,7 +2841,7 @@
             "uid": "${prometheus}"
           },
           "editorMode": "code",
-          "expr": "sum(cache_size{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) by (cache_manager, cache)",
+          "expr": "avg(cache_size{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) by (cache_manager, cache)",
           "hide": false,
           "interval": "1m",
           "legendFormat": "{{ cache_manager }}.{{ cache }}",
@@ -2948,7 +2948,7 @@
             "uid": "${prometheus}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(cache_gets_total{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (cache_manager, cache)",
+          "expr": "avg(rate(cache_gets_total{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (cache_manager, cache)",
           "hide": false,
           "interval": "1m",
           "legendFormat": "{{ cache_manager }}.{{ cache }}",
@@ -3055,7 +3055,7 @@
             "uid": "${prometheus}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(cache_puts_total{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (cache_manager, cache)",
+          "expr": "avg(rate(cache_puts_total{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (cache_manager, cache)",
           "hide": false,
           "interval": "1m",
           "legendFormat": "{{ cache_manager }}.{{ cache }}",
@@ -3271,7 +3271,7 @@
             "uid": "${prometheus}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(log4j2_events_total{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (level) > 0",
+          "expr": "avg(rate(logback_events_total{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (level) > 0",
           "interval": "1m",
           "legendFormat": "{{ level }}",
           "range": true,

--- a/charts/hedera-mirror-common/dashboards/hedera-mirror-importer.json
+++ b/charts/hedera-mirror-common/dashboards/hedera-mirror-importer.json
@@ -1038,7 +1038,7 @@
             "uid": "${prometheus}"
           },
           "editorMode": "code",
-          "expr": "sum(jvm_memory_committed_bytes{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) > 0",
+          "expr": "avg(jvm_memory_committed_bytes{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) > 0",
           "interval": "1m",
           "legendFormat": "committed",
           "range": true,
@@ -1049,7 +1049,7 @@
             "uid": "${prometheus}"
           },
           "editorMode": "code",
-          "expr": "sum(jvm_memory_used_bytes{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) > 0",
+          "expr": "avg(jvm_memory_used_bytes{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) > 0",
           "hide": false,
           "interval": "1m",
           "legendFormat": "used",
@@ -1061,7 +1061,7 @@
             "uid": "${prometheus}"
           },
           "editorMode": "code",
-          "expr": "sum(jvm_memory_max_bytes{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) > 0",
+          "expr": "avg(jvm_memory_max_bytes{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) > 0",
           "hide": false,
           "interval": "1m",
           "legendFormat": "max",
@@ -1161,7 +1161,7 @@
             "uid": "${prometheus}"
           },
           "editorMode": "code",
-          "expr": "sum(system_cpu_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "avg(system_cpu_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "hide": false,
           "interval": "1m",
           "legendFormat": "cores",
@@ -1335,7 +1335,7 @@
             "uid": "${prometheus}"
           },
           "editorMode": "code",
-          "expr": "sum(jvm_threads_states_threads{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) by (state) > 0",
+          "expr": "avg(jvm_threads_states_threads{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) by (state) > 0",
           "interval": "1m",
           "legendFormat": "{{ state }}",
           "range": true,
@@ -1557,7 +1557,7 @@
             "uid": "${prometheus}"
           },
           "editorMode": "code",
-          "expr": "sum(process_files_max_files{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "avg(process_files_max_files{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "hide": false,
           "interval": "1m",
           "legendFormat": "max",
@@ -1568,7 +1568,7 @@
           "datasource": {
             "uid": "${prometheus}"
           },
-          "expr": "sum(process_files_open_files{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "avg(process_files_open_files{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "hide": false,
           "interval": "1m",
           "legendFormat": "open",
@@ -2618,7 +2618,7 @@
             "uid": "${prometheus}"
           },
           "editorMode": "code",
-          "expr": "sum(hikaricp_connections_active{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) > 0",
+          "expr": "avg(hikaricp_connections_active{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) > 0",
           "interval": "1m",
           "legendFormat": "active",
           "range": true,
@@ -2629,7 +2629,7 @@
             "uid": "${prometheus}"
           },
           "editorMode": "code",
-          "expr": "sum(hikaricp_connections_idle{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) > 0",
+          "expr": "avg(hikaricp_connections_idle{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) > 0",
           "interval": "1m",
           "legendFormat": "idle",
           "range": true,
@@ -2640,7 +2640,7 @@
             "uid": "${prometheus}"
           },
           "editorMode": "code",
-          "expr": "sum(hikaricp_connections_max{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) > 0",
+          "expr": "avg(hikaricp_connections_max{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) > 0",
           "hide": false,
           "interval": "1m",
           "legendFormat": "max",
@@ -2652,7 +2652,7 @@
             "uid": "${prometheus}"
           },
           "editorMode": "code",
-          "expr": "sum(hikaricp_connections_pending{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) > 0",
+          "expr": "avg(hikaricp_connections_pending{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) > 0",
           "hide": false,
           "interval": "1m",
           "legendFormat": "pending",
@@ -2776,7 +2776,7 @@
             "uid": "${prometheus}"
           },
           "editorMode": "code",
-          "expr": "sum(jdbc_connections_active{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) > 0",
+          "expr": "avg(jdbc_connections_active{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) > 0",
           "interval": "1m",
           "legendFormat": "active",
           "range": true,
@@ -2787,7 +2787,7 @@
             "uid": "${prometheus}"
           },
           "editorMode": "code",
-          "expr": "sum(jdbc_connections_idle{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) > 0",
+          "expr": "avg(jdbc_connections_idle{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) > 0",
           "interval": "1m",
           "legendFormat": "idle",
           "range": true,
@@ -2798,7 +2798,7 @@
             "uid": "${prometheus}"
           },
           "editorMode": "code",
-          "expr": "sum(jdbc_connections_max{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) > 0",
+          "expr": "avg(jdbc_connections_max{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) > 0",
           "hide": false,
           "interval": "1m",
           "legendFormat": "max",
@@ -2810,7 +2810,7 @@
             "uid": "${prometheus}"
           },
           "editorMode": "code",
-          "expr": "sum(jdbc_connections_min{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) > 0",
+          "expr": "avg(jdbc_connections_min{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) > 0",
           "hide": false,
           "interval": "1m",
           "legendFormat": "min",
@@ -3037,7 +3037,7 @@
             "uid": "${prometheus}"
           },
           "editorMode": "code",
-          "expr": "sum(cache_size{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) by (cache_manager, cache)",
+          "expr": "avg(cache_size{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) by (cache_manager, cache)",
           "hide": false,
           "interval": "1m",
           "legendFormat": "{{ cache_manager }}.{{ cache }}",
@@ -3144,7 +3144,7 @@
             "uid": "${prometheus}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(cache_gets_total{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (cache_manager, cache)",
+          "expr": "avg(rate(cache_gets_total{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (cache_manager, cache)",
           "hide": false,
           "interval": "1m",
           "legendFormat": "{{ cache_manager }}.{{ cache }}",
@@ -3251,7 +3251,7 @@
             "uid": "${prometheus}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(cache_puts_total{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (cache_manager, cache)",
+          "expr": "avg(rate(cache_puts_total{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (cache_manager, cache)",
           "hide": false,
           "interval": "1m",
           "legendFormat": "{{ cache_manager }}.{{ cache }}",
@@ -3475,7 +3475,7 @@
             "uid": "${prometheus}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(log4j2_events_total{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (level) > 0",
+          "expr": "avg(rate(logback_events_total{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (level) > 0",
           "interval": "1m",
           "legendFormat": "{{ level }}",
           "range": true,

--- a/charts/hedera-mirror-common/dashboards/hedera-mirror-monitor.json
+++ b/charts/hedera-mirror-common/dashboards/hedera-mirror-monitor.json
@@ -1960,7 +1960,7 @@
           "datasource": {
             "uid": "${prometheus}"
           },
-          "expr": "sum(jvm_memory_used_bytes{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "avg(jvm_memory_used_bytes{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "hide": false,
           "interval": "1m",
           "legendFormat": "used",
@@ -1970,7 +1970,7 @@
           "datasource": {
             "uid": "${prometheus}"
           },
-          "expr": "sum(jvm_memory_max_bytes{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "avg(jvm_memory_max_bytes{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "hide": false,
           "interval": "1m",
           "legendFormat": "max",
@@ -2066,7 +2066,7 @@
           "datasource": {
             "uid": "${prometheus}"
           },
-          "expr": "sum(system_cpu_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "avg(system_cpu_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "hide": false,
           "interval": "1m",
           "legendFormat": "max",
@@ -2236,7 +2236,7 @@
             "uid": "${prometheus}"
           },
           "editorMode": "code",
-          "expr": "sum(jvm_threads_states_threads{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) by (state) > 0",
+          "expr": "avg(jvm_threads_states_threads{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) by (state) > 0",
           "interval": "1m",
           "legendFormat": "{{ state }}",
           "range": true,
@@ -2395,7 +2395,7 @@
           "datasource": {
             "uid": "${prometheus}"
           },
-          "expr": "sum(process_files_open_files{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "avg(process_files_open_files{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "interval": "1m",
           "legendFormat": "open",
           "refId": "B"
@@ -2404,7 +2404,7 @@
           "datasource": {
             "uid": "${prometheus}"
           },
-          "expr": "sum(process_files_max_files{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "avg(process_files_max_files{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "interval": "1m",
           "legendFormat": "max",
           "refId": "A"
@@ -2724,7 +2724,7 @@
             "uid": "${prometheus}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(log4j2_events_total{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (level) > 0",
+          "expr": "avg(rate(logback_events_total{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (level) > 0",
           "interval": "1m",
           "legendFormat": "{{ level }}",
           "range": true,

--- a/charts/hedera-mirror-common/dashboards/hedera-mirror-web3.json
+++ b/charts/hedera-mirror-common/dashboards/hedera-mirror-web3.json
@@ -1266,7 +1266,7 @@
           "datasource": {
             "uid": "${prometheus}"
           },
-          "expr": "sum(jvm_memory_used_bytes{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "avg(jvm_memory_used_bytes{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "hide": false,
           "interval": "1m",
           "legendFormat": "used",
@@ -1276,7 +1276,7 @@
           "datasource": {
             "uid": "${prometheus}"
           },
-          "expr": "sum(jvm_memory_max_bytes{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "avg(jvm_memory_max_bytes{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "hide": false,
           "interval": "1m",
           "legendFormat": "max",
@@ -1541,7 +1541,7 @@
           "datasource": {
             "uid": "${prometheus}"
           },
-          "expr": "sum(jvm_threads_states_threads{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) by (state)",
+          "expr": "avg(jvm_threads_states_threads{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) by (state)",
           "interval": "1m",
           "legendFormat": "{{ state }}",
           "refId": "A"
@@ -1700,7 +1700,7 @@
           "datasource": {
             "uid": "${prometheus}"
           },
-          "expr": "sum(process_files_open_files{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "avg(process_files_open_files{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "interval": "1m",
           "legendFormat": "open",
           "refId": "B"
@@ -1709,7 +1709,7 @@
           "datasource": {
             "uid": "${prometheus}"
           },
-          "expr": "sum(process_files_max_files{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "avg(process_files_max_files{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "interval": "1m",
           "legendFormat": "max",
           "refId": "A"
@@ -1829,7 +1829,7 @@
           "datasource": {
             "uid": "${prometheus}"
           },
-          "expr": "sum(hikaricp_connections_active{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "avg(hikaricp_connections_active{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "interval": "1m",
           "legendFormat": "active",
           "refId": "A"
@@ -1838,7 +1838,7 @@
           "datasource": {
             "uid": "${prometheus}"
           },
-          "expr": "sum(hikaricp_connections_idle{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "avg(hikaricp_connections_idle{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "interval": "1m",
           "legendFormat": "idle",
           "refId": "B"
@@ -1847,7 +1847,7 @@
           "datasource": {
             "uid": "${prometheus}"
           },
-          "expr": "sum(hikaricp_connections_max{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "avg(hikaricp_connections_max{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "hide": false,
           "interval": "1m",
           "legendFormat": "max",
@@ -1857,7 +1857,7 @@
           "datasource": {
             "uid": "${prometheus}"
           },
-          "expr": "sum(hikaricp_connections_pending{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\"})",
+          "expr": "avg(hikaricp_connections_pending{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\"})",
           "hide": false,
           "interval": "1m",
           "legendFormat": "pending",
@@ -1978,7 +1978,7 @@
           "datasource": {
             "uid": "${prometheus}"
           },
-          "expr": "sum(jdbc_connections_active{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "avg(jdbc_connections_active{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "interval": "1m",
           "legendFormat": "active",
           "refId": "A"
@@ -1987,7 +1987,7 @@
           "datasource": {
             "uid": "${prometheus}"
           },
-          "expr": "sum(jdbc_connections_idle{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "avg(jdbc_connections_idle{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "interval": "1m",
           "legendFormat": "idle",
           "refId": "B"
@@ -1996,7 +1996,7 @@
           "datasource": {
             "uid": "${prometheus}"
           },
-          "expr": "sum(jdbc_connections_max{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+          "expr": "avg(jdbc_connections_max{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"})",
           "hide": false,
           "interval": "1m",
           "legendFormat": "max",
@@ -2006,7 +2006,7 @@
           "datasource": {
             "uid": "${prometheus}"
           },
-          "expr": "sum(jdbc_connections_min{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\"})",
+          "expr": "avg(jdbc_connections_min{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\"})",
           "hide": false,
           "interval": "1m",
           "legendFormat": "min",
@@ -2434,7 +2434,7 @@
             "uid": "${prometheus}"
           },
           "editorMode": "code",
-          "expr": "sum(cache_size{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) by (cache_manager, cache)",
+          "expr": "avg(cache_size{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}) by (cache_manager, cache)",
           "hide": false,
           "interval": "1m",
           "legendFormat": "{{ cache_manager }}.{{ cache }}",
@@ -2541,7 +2541,7 @@
             "uid": "${prometheus}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(cache_gets_total{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (cache_manager, cache)",
+          "expr": "avg(rate(cache_gets_total{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (cache_manager, cache)",
           "hide": false,
           "interval": "1m",
           "legendFormat": "{{ cache_manager }}.{{ cache }}",
@@ -2648,7 +2648,7 @@
             "uid": "${prometheus}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(cache_puts_total{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (cache_manager, cache)",
+          "expr": "avg(rate(cache_puts_total{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (cache_manager, cache)",
           "hide": false,
           "interval": "1m",
           "legendFormat": "{{ cache_manager }}.{{ cache }}",
@@ -2866,7 +2866,7 @@
             "uid": "${prometheus}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(log4j2_events_total{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (level) > 0",
+          "expr": "avg(rate(logback_events_total{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (level) > 0",
           "interval": "1m",
           "legendFormat": "{{ level }}",
           "range": true,

--- a/charts/hedera-mirror-common/dashboards/jvm-micrometer-rev9.json
+++ b/charts/hedera-mirror-common/dashboards/jvm-micrometer-rev9.json
@@ -2052,7 +2052,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(log4j2_events_total{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\"}[5m])) by (level)",
+          "expr": "sum(rate(logback_events_total{application=\"$application\", cluster=~\"$cluster\",namespace=~\"$namespace\",pod=\"$pod\"}[5m])) by (level)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,

--- a/charts/hedera-mirror-graphql/values.yaml
+++ b/charts/hedera-mirror-graphql/values.yaml
@@ -203,7 +203,7 @@ prometheusRules:
       description: "Logs for {{ $labels.namespace }}/{{ $labels.pod }} have reached {{ $value }} error messages/s in a 3m period"
       summary: "High rate of log errors"
     enabled: true
-    expr: sum(increase(log4j2_events_total{application="hedera-mirror-graphql", level="error"}[1m])) by (namespace, pod) >= 2
+    expr: sum(increase(logback_events_total{application="hedera-mirror-graphql", level="error"}[1m])) by (namespace, pod) >= 2
     for: 3m
     labels:
       application: hedera-mirror-graphql

--- a/charts/hedera-mirror-grpc/values.yaml
+++ b/charts/hedera-mirror-grpc/values.yaml
@@ -213,7 +213,7 @@ prometheusRules:
       description: "Logs for {{ $labels.namespace }}/{{ $labels.pod }} have reached {{ $value }} error messages/s in a 3m period"
       summary: "High rate of log errors"
     enabled: true
-    expr: sum(increase(log4j2_events_total{application="hedera-mirror-grpc", level="error"}[1m])) by (namespace, pod) >= 2
+    expr: sum(increase(logback_events_total{application="hedera-mirror-grpc", level="error"}[1m])) by (namespace, pod) >= 2
     for: 3m
     labels:
       severity: critical

--- a/charts/hedera-mirror-importer/values.yaml
+++ b/charts/hedera-mirror-importer/values.yaml
@@ -294,7 +294,7 @@ prometheusRules:
       description: "Logs for {{ $labels.namespace }}/{{ $labels.pod }} have reached {{ $value }} error messages/s in a 3m period"
       summary: High rate of log errors
     enabled: true
-    expr: sum(increase(log4j2_events_total{application="hedera-mirror-importer", level="error"}[2m])) by (namespace, pod) >= 2
+    expr: sum(increase(logback_events_total{application="hedera-mirror-importer", level="error"}[2m])) by (namespace, pod) >= 2
     for: 3m
     labels:
       severity: critical

--- a/charts/hedera-mirror-monitor/values.yaml
+++ b/charts/hedera-mirror-monitor/values.yaml
@@ -152,7 +152,7 @@ prometheusRules:
       description: "Logs for {{ $labels.namespace }}/{{ $labels.pod }} have reached {{ $value }} error messages/s in a 3m period"
       summary: "High rate of log errors"
     enabled: true
-    expr: sum(increase(log4j2_events_total{application="hedera-mirror-monitor", level="error"}[2m])) by (namespace, pod) >= 2
+    expr: sum(increase(logback_events_total{application="hedera-mirror-monitor", level="error"}[2m])) by (namespace, pod) >= 2
     for: 3m
     labels:
       severity: critical

--- a/charts/hedera-mirror-web3/values.yaml
+++ b/charts/hedera-mirror-web3/values.yaml
@@ -187,7 +187,7 @@ prometheusRules:
       description: "Logs for {{ $labels.namespace }}/{{ $labels.pod }} have reached {{ $value }} error messages/s in a 3m period"
       summary: "High rate of log errors"
     enabled: true
-    expr: sum(increase(log4j2_events_total{application="hedera-mirror-web3", level="error"}[1m])) by (namespace, pod) >= 2
+    expr: sum(increase(logback_events_total{application="hedera-mirror-web3", level="error"}[1m])) by (namespace, pod) >= 2
     for: 3m
     labels:
       application: hedera-mirror-web3


### PR DESCRIPTION
**Description**:

Showing the sum of resources metrics like memory across many pods is not very useful. Switching these to an average provides more meaningful graphs.

* Change resource graphs to use average instead of sum
* Fix log rate metrics still using log4j2

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
