### PR TITLE
Fix flaky RedisEntityListenerIntegrationTest

### DIFF
--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/redis/RedisEntityListenerIntegrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/redis/RedisEntityListenerIntegrationTest.java
@@ -16,6 +16,7 @@
 
 package com.hedera.mirror.importer.parser.record.entity.redis;
 
+import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.topic.TopicMessage;
 import com.hedera.mirror.importer.parser.record.entity.BatchEntityListenerTest;
 import org.junit.jupiter.api.TestInstance;
@@ -46,7 +47,7 @@ class RedisEntityListenerIntegrationTest extends BatchEntityListenerTest {
     }
 
     @Override
-    protected Flux<TopicMessage> subscribe(long topicId) {
-        return redisOperations.listenToChannel("topic." + topicId).map(m -> m.getMessage());
+    protected Flux<TopicMessage> subscribe(EntityId topicId) {
+        return redisOperations.listenToChannel("topic." + topicId.getId()).map(m -> m.getMessage());
     }
 }


### PR DESCRIPTION
**Description**:

* Fix flaky `RedisEntityListenerIntegrationTest` by moving publish after subscribing
* Fix flaky `NotifyingEntityListenerTest` by subscribing on different thread and not prematurely closing connection.

**Related issue(s)**:

Fixes #7187

**Notes for reviewer**:

Tested 5 [times](https://github.com/hashgraph/hedera-mirror-node/actions/runs/6803660662) successfully with retry disabled. Fixing this flaky test uncovered [another](https://github.com/hashgraph/hedera-mirror-node/issues/7188) flaky test that sometimes cause these tests to fail.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
