### PR TITLE
HIP-584: 0x returned when contract's runtime bytecode is not available yet

### DIFF
--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/CallFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/CallFeature.java
@@ -62,7 +62,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 public class CallFeature extends AbstractFeature {
 
     private static final String HEX_REGEX = "^[0-9a-fA-F]+$";
-    private static DeployedContract deployedContract;
     private final AccountClient accountClient;
     private final MirrorNodeClient mirrorClient;
     private final TokenClient tokenClient;
@@ -88,19 +87,19 @@ public class CallFeature extends AbstractFeature {
 
     @Given("I successfully create ERC contract")
     public void createNewERCtestContract() throws IOException {
-        deployedContract = getContract(ERC);
+        var deployedContract = getContract(ERC);
         ercContractAddress = deployedContract.contractId().toSolidityAddress();
     }
 
     @Given("I successfully create Precompile contract")
     public void createNewPrecompileTestContract() throws IOException {
-        deployedContract = getContract(PRECOMPILE);
+        var deployedContract = getContract(PRECOMPILE);
         precompileContractAddress = deployedContract.contractId().toSolidityAddress();
     }
 
     @Given("I successfully create EstimateGas contract")
     public void createNewEstimateTestContract() throws IOException {
-        deployedContract = getContract(ESTIMATE_GAS);
+        var deployedContract = getContract(ESTIMATE_GAS);
         estimateContractAddress = deployedContract.contractId().toSolidityAddress();
         receiverAccountId = accountClient.getAccount(AccountNameEnum.BOB);
     }
@@ -168,6 +167,14 @@ public class CallFeature extends AbstractFeature {
         assertThat(response.getResultAsNumber()).isEqualTo(balanceOfNft.getAsLong());
     }
 
+    @RetryAsserts
+    @Then("I verify the precompile contract bytecode is deployed")
+    public void contractDeployed() {
+        var response = mirrorClient.getContractInfo(precompileContractAddress);
+        assertThat(response.getBytecode()).isNotBlank();
+        assertThat(response.getRuntimeBytecode()).isNotBlank();
+    }
+
     // ETHCALL-025
     @RetryAsserts
     @Then("I call function with HederaTokenService isToken token {string}")
@@ -178,7 +185,6 @@ public class CallFeature extends AbstractFeature {
 
         var data = encodeData(PRECOMPILE, HTS_IS_TOKEN_SELECTOR, asAddress(tokenId));
         var response = callContract(data, precompileContractAddress);
-
         assertThat(response.getResultAsBoolean()).isTrue();
     }
 

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/CallFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/CallFeature.java
@@ -185,6 +185,7 @@ public class CallFeature extends AbstractFeature {
 
         var data = encodeData(PRECOMPILE, HTS_IS_TOKEN_SELECTOR, asAddress(tokenId));
         var response = callContract(data, precompileContractAddress);
+
         assertThat(response.getResultAsBoolean()).isTrue();
     }
 

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/EstimatePrecompileFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/EstimatePrecompileFeature.java
@@ -942,7 +942,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with delete function for Fungible token")
     public void deleteFungibleEstimateGas() {
         var data = encodeData(ESTIMATE_PRECOMPILE, DELETE_TOKEN, asAddress(fungibleKycUnfrozenTokenId));
-        System.out.println(Thread.currentThread().getName() + "| Delete token data: " + data);
+
         validateGasEstimation(data, DELETE_TOKEN, estimatePrecompileContractSolidityAddress);
     }
 

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/EstimatePrecompileFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/EstimatePrecompileFeature.java
@@ -942,7 +942,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     @Then("I call estimateGas with delete function for Fungible token")
     public void deleteFungibleEstimateGas() {
         var data = encodeData(ESTIMATE_PRECOMPILE, DELETE_TOKEN, asAddress(fungibleKycUnfrozenTokenId));
-
+        System.out.println(Thread.currentThread().getName() + "| Delete token data: " + data);
         validateGasEstimation(data, DELETE_TOKEN, estimatePrecompileContractSolidityAddress);
     }
 

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/PrecompileContractFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/PrecompileContractFeature.java
@@ -188,6 +188,7 @@ public class PrecompileContractFeature extends AbstractFeature {
         var data = encodeData(PRECOMPILE, IS_TOKEN_SELECTOR, asAddress(tokenIds.get(0)));
 
         var response = callContract(data, precompileTestContractSolidityAddress);
+
         assertTrue(response.getResultAsBoolean());
     }
 

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/PrecompileContractFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/PrecompileContractFeature.java
@@ -175,12 +175,19 @@ public class PrecompileContractFeature extends AbstractFeature {
         verifyMirrorTransactionsResponse(mirrorClient, status);
     }
 
+    @RetryAsserts
+    @Then("I verify the precompile contract bytecode is deployed successfully")
+    public void contractDeployed() {
+        var response = mirrorClient.getContractInfo(precompileTestContractSolidityAddress);
+        assertThat(response.getBytecode()).isNotBlank();
+        assertThat(response.getRuntimeBytecode()).isNotBlank();
+    }
+
     @Then("check if fungible token is token")
     public void checkIfFungibleTokenIsToken() {
         var data = encodeData(PRECOMPILE, IS_TOKEN_SELECTOR, asAddress(tokenIds.get(0)));
 
         var response = callContract(data, precompileTestContractSolidityAddress);
-
         assertTrue(response.getResultAsBoolean());
     }
 

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TokenFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TokenFeature.java
@@ -100,6 +100,8 @@ public class TokenFeature extends AbstractFeature {
             this.networkTransactionResponse = tokenAndResponse.response();
             verifyMirrorTransactionsResponse(mirrorClient, 200);
         }
+        var tokenInfo = mirrorClient.getTokenInfo(tokenAndResponse.tokenId().toString());
+        log.info("Get token info for token {}: {}", tokenId, tokenInfo);
     }
 
     @Given("I associate account {account} with token {token}")

--- a/hedera-mirror-test/src/test/resources/features/contract/call.feature
+++ b/hedera-mirror-test/src/test/resources/features/contract/call.feature
@@ -4,6 +4,7 @@ Feature: eth_call Contract Base Coverage Feature
   Scenario Outline: Validate eth_call
     Given I successfully create ERC contract
     Given I successfully create Precompile contract
+    Then I verify the precompile contract bytecode is deployed
     Given I successfully create EstimateGas contract
     Given I ensure token "NFT" has been created
     And I ensure token "FUNGIBLE" has been created

--- a/hedera-mirror-test/src/test/resources/features/contract/precompile.feature
+++ b/hedera-mirror-test/src/test/resources/features/contract/precompile.feature
@@ -3,6 +3,7 @@ Feature: Precompile Contract Base Coverage Feature
 
   Scenario Outline: Validate Precompile Contract
     Given I successfully create and verify a precompile contract from contract bytes
+    Then I verify the precompile contract bytecode is deployed successfully
     Given I successfully create and verify a fungible token for precompile contract tests
     Given I create an ecdsa account and associate it to the tokens
     Then check if fungible token is token

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/controller/ContractController.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/controller/ContractController.java
@@ -37,7 +37,6 @@ import com.hedera.mirror.web3.service.model.CallServiceParameters;
 import com.hedera.mirror.web3.viewmodel.ContractCallRequest;
 import com.hedera.mirror.web3.viewmodel.ContractCallResponse;
 import com.hedera.mirror.web3.viewmodel.GenericErrorResponse;
-import com.hedera.node.app.service.evm.exceptions.InvalidTransactionException;
 import com.hedera.node.app.service.evm.store.models.HederaEvmAccount;
 import io.github.bucket4j.Bucket;
 import jakarta.validation.Valid;
@@ -147,13 +146,6 @@ class ContractController {
     private Mono<GenericErrorResponse> mirrorEvmTransactionException(final MirrorEvmTransactionException e) {
         log.warn("Mirror EVM transaction error: {}", e.getMessage());
         return errorResponse(e.getMessage(), e.getDetail(), e.getData());
-    }
-
-    @ExceptionHandler
-    @ResponseStatus(BAD_REQUEST)
-    private Mono<GenericErrorResponse> invalidTransactionException(final InvalidTransactionException e) {
-        log.warn("Invalid transaction error: {}", e.getMessage());
-        return errorResponse(e.getMessage(), e.getResponseCode().name(), StringUtils.EMPTY);
     }
 
     @ExceptionHandler

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/controller/ContractController.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/controller/ContractController.java
@@ -37,6 +37,7 @@ import com.hedera.mirror.web3.service.model.CallServiceParameters;
 import com.hedera.mirror.web3.viewmodel.ContractCallRequest;
 import com.hedera.mirror.web3.viewmodel.ContractCallResponse;
 import com.hedera.mirror.web3.viewmodel.GenericErrorResponse;
+import com.hedera.node.app.service.evm.exceptions.InvalidTransactionException;
 import com.hedera.node.app.service.evm.store.models.HederaEvmAccount;
 import io.github.bucket4j.Bucket;
 import jakarta.validation.Valid;
@@ -143,9 +144,16 @@ class ContractController {
 
     @ExceptionHandler
     @ResponseStatus(BAD_REQUEST)
-    private Mono<GenericErrorResponse> invalidTxnError(final MirrorEvmTransactionException e) {
-        log.warn("Transaction error: {}", e.getMessage());
+    private Mono<GenericErrorResponse> mirrorEvmTransactionException(final MirrorEvmTransactionException e) {
+        log.warn("Mirror EVM transaction error: {}", e.getMessage());
         return errorResponse(e.getMessage(), e.getDetail(), e.getData());
+    }
+
+    @ExceptionHandler
+    @ResponseStatus(BAD_REQUEST)
+    private Mono<GenericErrorResponse> invalidTransactionException(final InvalidTransactionException e) {
+        log.warn("Invalid transaction error: {}", e.getMessage());
+        return errorResponse(e.getMessage(), e.getResponseCode().name(), StringUtils.EMPTY);
     }
 
     @ExceptionHandler

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccess.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccess.java
@@ -127,11 +127,11 @@ public class MirrorEntityAccess implements HederaEvmEntityAccess {
         final var entityId = fetchEntityId(address);
 
         if (entityId == 0) {
-            return Bytes.EMPTY;
+            return null;
         }
 
         final var runtimeCode = contractRepository.findRuntimeBytecode(entityId);
-        return runtimeCode.map(Bytes::wrap).orElse(Bytes.EMPTY);
+        return runtimeCode.map(Bytes::wrap).orElse(null);
     }
 
     private Long fetchEntityId(final Address address) {

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessorTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessorTest.java
@@ -146,6 +146,9 @@ class MirrorEvmTxProcessorTest {
     @Mock
     private HederaPrngSeedOperation prngSeedOperation;
 
+    @Mock
+    private AbstractCodeCache codeCache;
+
     private MirrorEvmTxProcessorImpl mirrorEvmTxProcessor;
 
     private Pair<ResponseCodeEnum, Long> result;
@@ -193,7 +196,6 @@ class MirrorEvmTxProcessorTest {
     void assertSuccessExecution(boolean isEstimate) {
         givenValidMockWithoutGetOrCreate();
         given(autoCreationLogic.create(any(), any(), any(), any(), any())).willReturn(result);
-        given(hederaEvmEntityAccess.fetchCodeIfPresent(any())).willReturn(Bytes.EMPTY);
         given(evmProperties.fundingAccountAddress()).willReturn(Address.ALTBN128_PAIRING);
         given(hederaEvmContractAliases.resolveForEvm(receiverAddress)).willReturn(receiverAddress);
         given(pricesAndFeesProvider.currentGasPrice(any(), any())).willReturn(10L);
@@ -232,8 +234,7 @@ class MirrorEvmTxProcessorTest {
                 .blockHashLookup(hash -> null);
 
         assertThatExceptionOfType(MirrorEvmTransactionException.class)
-                .isThrownBy(
-                        () -> mirrorEvmTxProcessor.buildInitialFrame(protoFrame, receiverAddress, Bytes.EMPTY, 33L));
+                .isThrownBy(() -> mirrorEvmTxProcessor.buildInitialFrame(protoFrame, receiverAddress, Bytes.EMPTY, 0L));
     }
 
     @Test
@@ -246,6 +247,7 @@ class MirrorEvmTxProcessorTest {
         // setup:
         given(hederaEvmContractAliases.resolveForEvm(receiverAddress)).willReturn(receiverAddress);
         given(hederaEvmEntityAccess.fetchCodeIfPresent(any())).willReturn(Bytes.EMPTY);
+        given(hederaEvmContractAliases.isMirror(receiverAddress)).willReturn(true);
         final long GAS_LIMIT = 300_000L;
         final Wei oneWei = Wei.of(1L);
         final MessageFrame.Builder commonInitialFrame = MessageFrame.builder()

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccessTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccessTest.java
@@ -262,9 +262,9 @@ class MirrorEntityAccessTest {
     }
 
     @Test
-    void fetchCodeIfPresentReturnsEmpty() {
+    void fetchCodeIfPresentReturnsNull() {
         when(contractRepository.findRuntimeBytecode(ENTITY_ID)).thenReturn(Optional.empty());
         final var result = mirrorEntityAccess.fetchCodeIfPresent(ADDRESS);
-        assertThat(result).isEqualTo(Bytes.EMPTY);
+        assertThat(result).isNull();
     }
 }


### PR DESCRIPTION
**Description**:
Some of the acceptance tests for isToken and getTokenInfo scenarios were failing randomly. The response was HTTP 200 and a body with content "0x". After further investigation it seems that if a contract is not fully deployed (it has an address but the runtime bytecode is not imported yet) then we get this ambiguos response.

In this PR the following changes were made:
- `MirrorEntityAccess#fetchCodeIfPresent` is changed to return null if the entity is not found. This change was necessary because the AbstractCodeCache depends on this value in order to function correctly. Otherwise, the cache would contain addresses as keys and null values for some time even when the code is available at a later point. 
- `MirrorEvmTxProcessorImpl#buildInitialFrame` was changed to correspond to the implementation in services.
- As a result from the other two bullet points in case the runtime bytecode of a contract is not available yet in buildInitialFrame a `MirrorEvmTransactionException` will be thrown and the user will get HTTP 400 with error code "INVALID_TRANSACTION".

The acceptance tests are now enhanced to verify that a contract's runtime bytecode is available and that the token exists before executing the other tests for isToken and getTokenInfo. 

Fixes https://github.com/hashgraph/hedera-mirror-node/issues/7147
