### PR TITLE
Fix incorrect usage of k6 VU execution context in web3 tests

### DIFF
--- a/hedera-mirror-test/k6/README.md
+++ b/hedera-mirror-test/k6/README.md
@@ -100,7 +100,7 @@ The following parameters can be used to configure a rosetta test:
 The following parameters can be used to configure a web3 test:
 
 - ACCOUNT_ADDRESS - 64 character hex encoded account address without `0x` prefix
-- DEFAULT_ACCOUNT_ADDRESS - 64 character hex encoded account address without `0x` prefix
+- DEFAULT_ACCOUNT_ADDRESS - 40 character hex encoded account address without `0x` prefix
 - DEFAULT_CONTRACT_ADDRESS - 40 character hex encoded contract address without `0x` prefix (Parent contract should be deployed)
 - ERC_CONTRACT_ADDRESS - 40 character hex encoded contract address without `0x` prefix (ErcTestContract contract in hedera-mirror-test/src/test/resources/solidity/contracts/ErcTestContract.sol should be deployed)
 - HTS_CONTRACT_ADDRESS - 40 character hex encoded contract address without `0x` prefix (PrecompileTestContract contract in hedera-mirror-test/src/test/resources/solidity/contracts/PrecompileTestContract.sol should be deployed)

--- a/hedera-mirror-test/k6/src/web3/test/common.js
+++ b/hedera-mirror-test/k6/src/web3/test/common.js
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
+import {check, sleep} from 'k6';
+import {vu} from 'k6/execution';
 import http from 'k6/http';
-import {check} from 'k6';
 import * as utils from '../../lib/common.js';
-import {sleep} from 'k6';
 
 const resultField = 'result';
 
@@ -44,20 +44,20 @@ const jsonPost = (url, payload) =>
   });
 
 function ContractCallTestScenarioBuilder() {
+  this._args = null;
   this._name = null;
   this._selector = null;
-  this._args = null;
-  this._to = null;
   this._scenario = null;
   this._tags = {};
-  this._sleep = 0;
+  this._to = null;
+  this._vuData = null;
 
   this._block = 'latest';
   this._data = null;
-  this._gas = 15000000;
-  this._from = null;
-  this._value = null;
   this._estimate = null;
+  this._from = null;
+  this._gas = 15000000;
+  this._value = null;
 
   this._url = `${__ENV.BASE_URL_PREFIX}/contracts/call`;
 
@@ -66,6 +66,7 @@ function ContractCallTestScenarioBuilder() {
     return {
       options: utils.getOptionsWithScenario(that._name, that._scenario, that._tags),
       run: function (testParameters) {
+        let sleepSecs = 0;
         const payload = {
           to: that._to,
           estimate: that._estimate || false, // Set default to false
@@ -74,18 +75,26 @@ function ContractCallTestScenarioBuilder() {
         if (that._selector && that._args) {
           payload.data = that._selector + that._args;
         } else {
-          Object.assign(payload, {
-            block: that._block,
-            data: that._data,
-            gas: that._gas,
-            from: that._from,
-            value: that._value,
-          });
+          const {_vuData: vuData} = that;
+          const data = vuData
+            ? Object.assign({}, vuData[vu.idInTest % vuData.length])
+            : {
+                block: that._block,
+                data: that._data,
+                gas: that._gas,
+                from: that._from,
+                value: that._value,
+              };
+          sleepSecs = data.sleep;
+          delete data.sleep;
+
+          Object.assign(payload, data);
         }
+
         const response = jsonPost(that._url, JSON.stringify(payload));
         check(response, {[`${that._name}`]: (r) => isNonErrorResponse(r)});
-        if (that._sleep > 0) {
-          sleep(that._sleep);
+        if (sleepSecs > 0) {
+          sleep(sleepSecs);
         }
       },
     };
@@ -154,8 +163,8 @@ function ContractCallTestScenarioBuilder() {
     return this;
   };
 
-  this.sleep = function (sleep) {
-    this._sleep = sleep;
+  this.vuData = function (vuData) {
+    this._vuData = vuData;
     return this;
   };
 

--- a/hedera-mirror-test/k6/src/web3/test/commonContractCallEstimateTemplate.js
+++ b/hedera-mirror-test/k6/src/web3/test/commonContractCallEstimateTemplate.js
@@ -15,27 +15,14 @@
  */
 
 import {SharedArray} from 'k6/data';
-import {vu} from 'k6/execution';
 import {ContractCallTestScenarioBuilder} from './common.js';
 
 function ContractCallEstimateTestTemplate(key) {
-  const allData = new SharedArray(key, () => {
+  const data = new SharedArray(key, () => {
     return JSON.parse(open('./resources/estimate.json'))[key];
   });
 
-  const data = allData[vu.idInTest % allData.length];
-
-  const {options, run} = new ContractCallTestScenarioBuilder()
-    .name(key)
-    .estimate(true)
-    .block(data.block)
-    .data(data.data)
-    .gas(data.gas)
-    .from(data.from)
-    .value(data.value)
-    .to(data.to)
-    .sleep(data.sleep)
-    .build();
+  const {options, run} = new ContractCallTestScenarioBuilder().name(key).estimate(true).vuData(data).build();
 
   return {options, run};
 }


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

- Use k6 vu execution context in VU code

**Related issue(s)**:

Relates to #6811

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

`VU code` is a part of k6 test lifecycle: https://k6.io/docs/using-k6/test-lifecycle/
 
**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
