### PR TITLE
HIP-584: Extract precompile fields from ThreadLocal context

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/common/ContractCallContext.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/common/ContractCallContext.java
@@ -19,12 +19,9 @@ package com.hedera.mirror.web3.common;
 import com.hedera.mirror.common.domain.transaction.RecordFile;
 import com.hedera.mirror.web3.evm.store.CachingStateFrame;
 import com.hedera.mirror.web3.evm.store.StackedStateFrames;
-import com.hedera.services.store.contracts.precompile.Precompile;
-import com.hederahashgraph.api.proto.java.TransactionBody;
 import java.util.EmptyStackException;
 import lombok.Getter;
 import lombok.Setter;
-import org.hyperledger.besu.datatypes.Address;
 
 @Getter
 public class ContractCallContext implements AutoCloseable {
@@ -40,35 +37,11 @@ public class ContractCallContext implements AutoCloseable {
     @Setter
     private RecordFile recordFile;
 
-    /** Boolean flag which determines whether we should make a contract call or contract init transaction simulation */
-    @Setter
-    private boolean create = false;
-
-    /** Boolean flag which determines whether the transaction is estimate gas or not */
-    @Setter
-    private boolean estimate = false;
-
     /** Current top of stack (which is all linked together) */
     private CachingStateFrame<Object> stack;
 
     /** Fixed "base" of stack: a R/O cache frame on top of the DB-backed cache frame */
     private CachingStateFrame<Object> stackBase;
-
-    /** HTS Precompile field keeping the precompile which is going to be executed at a given point in time */
-    @Setter
-    private Precompile precompile;
-
-    /** HTS Precompile field keeping the gas amount, which is going to be charged for a given precompile execution */
-    @Setter
-    private long gasRequirement = 0L;
-
-    /** HTS Precompile field keeping the transactionBody needed for a given precompile execution */
-    @Setter
-    private TransactionBody.Builder transactionBody;
-
-    /** HTS Precompile field keeping the sender address of the account that initiated a given precompile execution */
-    @Setter
-    private Address senderAddress;
 
     private ContractCallContext() {}
 
@@ -95,14 +68,8 @@ public class ContractCallContext implements AutoCloseable {
     }
 
     public void reset() {
-        create = false;
-        estimate = false;
         recordFile = null;
-        senderAddress = null;
         stack = stackBase;
-        precompile = null;
-        gasRequirement = 0L;
-        transactionBody = TransactionBody.getDefaultInstance().toBuilder();
     }
 
     @Override

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/common/PrecompileContext.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/common/PrecompileContext.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.web3.common;
+
+import com.hedera.services.store.contracts.precompile.Precompile;
+import com.hederahashgraph.api.proto.java.TransactionBody;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import org.hyperledger.besu.datatypes.Address;
+
+@Getter
+@AllArgsConstructor
+public class PrecompileContext {
+    public static final String PRECOMPILE_CONTEXT = "PrecompileContext";
+
+    /** Boolean flag which determines whether the transaction is estimate gas or not */
+    @Setter
+    private boolean estimate = false;
+
+    /** HTS Precompile field keeping the precompile which is going to be executed at a given point in time */
+    @Setter
+    private Precompile precompile;
+
+    /** HTS Precompile field keeping the gas amount, which is going to be charged for a given precompile execution */
+    @Setter
+    private long gasRequirement = 0L;
+
+    /** HTS Precompile field keeping the transactionBody needed for a given precompile execution */
+    @Setter
+    private TransactionBody.Builder transactionBody;
+
+    /** HTS Precompile field keeping the sender address of the account that initiated a given precompile execution */
+    @Setter
+    private Address senderAddress;
+}

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/Precompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/Precompile.java
@@ -25,6 +25,7 @@ import com.hedera.node.app.service.evm.exceptions.InvalidTransactionException;
 import com.hedera.services.store.contracts.precompile.codec.BodyParams;
 import com.hedera.services.store.contracts.precompile.codec.EncodingFacade;
 import com.hedera.services.store.contracts.precompile.codec.RunResult;
+import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TransactionBody;
@@ -41,7 +42,8 @@ import org.hyperledger.besu.evm.frame.MessageFrame;
  *
  * Differences from the original:
  *  1. Added record types for input arguments and return types, so that the Precompile implementation could achieve statless behaviour
- *  2. Added dependency to a {@link Store} interface that will hide the details of the state used for read/write operations
+ *  2. Added senderAccount to the getMinimumFeeInTinybars and getGasRequirement methods, so that the Precompile implementation could achieve statless behaviour
+ *  3. Added dependency to a {@link Store} interface that will hide the details of the state used for read/write operations
  */
 public interface Precompile {
 
@@ -49,12 +51,12 @@ public interface Precompile {
     TransactionBody.Builder body(Bytes input, UnaryOperator<byte[]> aliasResolver, BodyParams bodyParams);
 
     // Customize fee charging
-    long getMinimumFeeInTinybars(Timestamp consensusTime, TransactionBody transactionBody);
+    long getMinimumFeeInTinybars(Timestamp consensusTime, TransactionBody transactionBody, AccountID senderAccount);
 
     // Change the world state through the given frame
     RunResult run(MessageFrame frame, TransactionBody transactionBody);
 
-    long getGasRequirement(long blockTimestamp, TransactionBody.Builder transactionBody);
+    long getGasRequirement(long blockTimestamp, TransactionBody.Builder transactionBody, AccountID senderAccount);
 
     Set<Integer> getFunctionSelectors();
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/AbstractAssociatePrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/AbstractAssociatePrecompile.java
@@ -30,6 +30,7 @@ import com.hedera.services.store.contracts.precompile.utils.PrecompilePricingUti
 import com.hedera.services.store.models.Id;
 import com.hedera.services.txn.token.AssociateLogic;
 import com.hedera.services.utils.EntityIdUtils;
+import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import java.util.Objects;
@@ -61,7 +62,8 @@ public abstract class AbstractAssociatePrecompile implements Precompile {
     }
 
     @Override
-    public long getMinimumFeeInTinybars(Timestamp consensusTime, final TransactionBody transactionBody) {
+    public long getMinimumFeeInTinybars(
+            Timestamp consensusTime, final TransactionBody transactionBody, final AccountID sender) {
         return pricingUtils.getMinimumPriceInTinybars(ASSOCIATE, consensusTime);
     }
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/AbstractDissociatePrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/AbstractDissociatePrecompile.java
@@ -28,6 +28,7 @@ import com.hedera.services.store.contracts.precompile.utils.PrecompilePricingUti
 import com.hedera.services.store.models.Id;
 import com.hedera.services.txn.token.DissociateLogic;
 import com.hedera.services.utils.EntityIdUtils;
+import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import java.util.Objects;
@@ -46,7 +47,8 @@ public abstract class AbstractDissociatePrecompile implements Precompile {
     }
 
     @Override
-    public long getMinimumFeeInTinybars(Timestamp consensusTime, TransactionBody transactionBody) {
+    public long getMinimumFeeInTinybars(
+            Timestamp consensusTime, TransactionBody transactionBody, final AccountID sender) {
         return pricingUtils.getMinimumPriceInTinybars(DISSOCIATE, consensusTime);
     }
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/AbstractReadOnlyPrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/AbstractReadOnlyPrecompile.java
@@ -23,6 +23,7 @@ import com.hedera.services.store.contracts.precompile.codec.EmptyRunResult;
 import com.hedera.services.store.contracts.precompile.codec.EncodingFacade;
 import com.hedera.services.store.contracts.precompile.codec.RunResult;
 import com.hedera.services.store.contracts.precompile.utils.PrecompilePricingUtils;
+import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionBody.Builder;
@@ -52,7 +53,8 @@ public abstract class AbstractReadOnlyPrecompile implements Precompile {
     }
 
     @Override
-    public long getMinimumFeeInTinybars(Timestamp consensusTime, TransactionBody transactionBody) {
+    public long getMinimumFeeInTinybars(
+            Timestamp consensusTime, TransactionBody transactionBody, final AccountID sender) {
         return MINIMUM_GAS_COST;
     }
 
@@ -62,7 +64,7 @@ public abstract class AbstractReadOnlyPrecompile implements Precompile {
     }
 
     @Override
-    public long getGasRequirement(long blockTimestamp, Builder transactionBody) {
+    public long getGasRequirement(long blockTimestamp, Builder transactionBody, final AccountID sender) {
         final var now = Timestamp.newBuilder().setSeconds(blockTimestamp).build();
         return pricingUtils.computeViewFunctionGas(now, MINIMUM_GAS_COST);
     }

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/AbstractTokenUpdatePrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/AbstractTokenUpdatePrecompile.java
@@ -32,6 +32,7 @@ import com.hedera.services.store.contracts.precompile.codec.RunResult;
 import com.hedera.services.store.contracts.precompile.utils.PrecompilePricingUtils;
 import com.hedera.services.store.tokens.HederaTokenStore;
 import com.hedera.services.txns.validation.OptionValidator;
+import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import java.util.Objects;
@@ -65,7 +66,7 @@ public abstract class AbstractTokenUpdatePrecompile extends AbstractWritePrecomp
     }
 
     @Override
-    public long getMinimumFeeInTinybars(Timestamp consensusTime, TransactionBody transactionBody) {
+    public long getMinimumFeeInTinybars(Timestamp consensusTime, TransactionBody transactionBody, AccountID sender) {
         return pricingUtils.getMinimumPriceInTinybars(UPDATE, consensusTime);
     }
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/AbstractWritePrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/AbstractWritePrecompile.java
@@ -20,6 +20,7 @@ import com.hedera.mirror.web3.evm.store.contract.HederaEvmStackedWorldStateUpdat
 import com.hedera.services.store.contracts.precompile.Precompile;
 import com.hedera.services.store.contracts.precompile.SyntheticTxnFactory;
 import com.hedera.services.store.contracts.precompile.utils.PrecompilePricingUtils;
+import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
@@ -43,8 +44,9 @@ public abstract class AbstractWritePrecompile implements Precompile {
     }
 
     @Override
-    public long getGasRequirement(long blockTimestamp, final TransactionBody.Builder transactionBody) {
-        return pricingUtils.computeGasRequirement(blockTimestamp, this, transactionBody);
+    public long getGasRequirement(
+            long blockTimestamp, final TransactionBody.Builder transactionBody, final AccountID sender) {
+        return pricingUtils.computeGasRequirement(blockTimestamp, this, transactionBody, sender);
     }
 
     protected Address unalias(Address addressOrAlias, HederaEvmStackedWorldStateUpdater updater) {

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/ApprovePrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/ApprovePrecompile.java
@@ -270,7 +270,8 @@ public class ApprovePrecompile extends AbstractWritePrecompile {
     }
 
     @Override
-    public long getMinimumFeeInTinybars(final Timestamp consensusTime, final TransactionBody transactionBody) {
+    public long getMinimumFeeInTinybars(
+            final Timestamp consensusTime, final TransactionBody transactionBody, final AccountID sender) {
         final var deleteAllowanceBody = transactionBody.getCryptoDeleteAllowance();
         final var isNftApprovalRevocation = deleteAllowanceBody.isInitialized();
         if (isNftApprovalRevocation) {

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/AssociatePrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/AssociatePrecompile.java
@@ -96,8 +96,9 @@ public class AssociatePrecompile extends AbstractAssociatePrecompile {
     }
 
     @Override
-    public long getGasRequirement(final long blockTimestamp, final TransactionBody.Builder transactionBody) {
-        return pricingUtils.computeGasRequirement(blockTimestamp, this, transactionBody);
+    public long getGasRequirement(
+            final long blockTimestamp, final TransactionBody.Builder transactionBody, final AccountID sender) {
+        return pricingUtils.computeGasRequirement(blockTimestamp, this, transactionBody, sender);
     }
 
     @Override

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/BurnPrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/BurnPrecompile.java
@@ -40,6 +40,7 @@ import com.hedera.services.store.models.Id;
 import com.hedera.services.store.models.TokenModificationResult;
 import com.hedera.services.store.models.UniqueToken;
 import com.hedera.services.txn.token.BurnLogic;
+import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TransactionBody;
@@ -95,7 +96,8 @@ public class BurnPrecompile extends AbstractWritePrecompile {
     }
 
     @Override
-    public long getMinimumFeeInTinybars(final Timestamp consensusTime, final TransactionBody transactionBody) {
+    public long getMinimumFeeInTinybars(
+            final Timestamp consensusTime, final TransactionBody transactionBody, final AccountID sender) {
         final var isNftBurn = transactionBody.getTokenBurn().getSerialNumbersCount() > 0;
         return pricingUtils.getMinimumPriceInTinybars(isNftBurn ? BURN_NFT : BURN_FUNGIBLE, consensusTime);
     }

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/DeleteTokenPrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/DeleteTokenPrecompile.java
@@ -38,6 +38,7 @@ import com.hedera.services.store.contracts.precompile.codec.EmptyRunResult;
 import com.hedera.services.store.contracts.precompile.codec.RunResult;
 import com.hedera.services.store.contracts.precompile.utils.PrecompilePricingUtils;
 import com.hedera.services.txn.token.DeleteLogic;
+import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import java.util.Objects;
@@ -83,7 +84,8 @@ public class DeleteTokenPrecompile extends AbstractWritePrecompile {
     }
 
     @Override
-    public long getMinimumFeeInTinybars(Timestamp consensusTime, final TransactionBody transactionBody) {
+    public long getMinimumFeeInTinybars(
+            Timestamp consensusTime, final TransactionBody transactionBody, final AccountID sender) {
         Objects.requireNonNull(transactionBody, "`body` method should be called before `getMinimumFeeInTinybars`");
         return pricingUtils.getMinimumPriceInTinybars(DELETE, consensusTime);
     }

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/DissociatePrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/DissociatePrecompile.java
@@ -81,8 +81,8 @@ public class DissociatePrecompile extends AbstractDissociatePrecompile {
     }
 
     @Override
-    public long getGasRequirement(final long blockTimestamp, final Builder transactionBody) {
-        return pricingUtils.computeGasRequirement(blockTimestamp, this, transactionBody);
+    public long getGasRequirement(final long blockTimestamp, final Builder transactionBody, final AccountID sender) {
+        return pricingUtils.computeGasRequirement(blockTimestamp, this, transactionBody, sender);
     }
 
     @Override

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/FreezeTokenPrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/FreezeTokenPrecompile.java
@@ -73,7 +73,8 @@ public class FreezeTokenPrecompile extends AbstractFreezeUnfreezePrecompile {
     }
 
     @Override
-    public long getMinimumFeeInTinybars(final Timestamp consensusTime, final TransactionBody transactionBody) {
+    public long getMinimumFeeInTinybars(
+            final Timestamp consensusTime, final TransactionBody transactionBody, final AccountID sender) {
         Objects.requireNonNull(transactionBody, "`body` method should be called before `getMinimumFeeInTinybars`");
         return pricingUtils.getMinimumPriceInTinybars(FREEZE, consensusTime);
     }

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/GrantKycPrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/GrantKycPrecompile.java
@@ -101,7 +101,8 @@ public class GrantKycPrecompile extends AbstractGrantRevokeKycPrecompile {
     }
 
     @Override
-    public long getMinimumFeeInTinybars(Timestamp consensusTime, TransactionBody transactionBody) {
+    public long getMinimumFeeInTinybars(
+            Timestamp consensusTime, TransactionBody transactionBody, final AccountID sender) {
         requireNonNull(transactionBody, "`body` method should be called before `getMinimumFeeInTinybars`");
         return pricingUtils.getMinimumPriceInTinybars(GRANT_KYC, consensusTime);
     }

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/MintPrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/MintPrecompile.java
@@ -43,6 +43,7 @@ import com.hedera.services.store.models.Id;
 import com.hedera.services.store.models.TokenModificationResult;
 import com.hedera.services.store.models.UniqueToken;
 import com.hedera.services.txn.token.MintLogic;
+import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TransactionBody;
@@ -116,7 +117,8 @@ public class MintPrecompile extends AbstractWritePrecompile {
     }
 
     @Override
-    public long getMinimumFeeInTinybars(final Timestamp consensusTime, final TransactionBody transactionBody) {
+    public long getMinimumFeeInTinybars(
+            final Timestamp consensusTime, final TransactionBody transactionBody, final AccountID sender) {
         final var isNftMint = transactionBody.getTokenMint().getMetadataCount() > 0;
         return pricingUtils.getMinimumPriceInTinybars(isNftMint ? MINT_NFT : MINT_FUNGIBLE, consensusTime);
     }

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/MultiAssociatePrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/MultiAssociatePrecompile.java
@@ -31,6 +31,7 @@ import com.hedera.services.store.contracts.precompile.codec.Association;
 import com.hedera.services.store.contracts.precompile.codec.BodyParams;
 import com.hedera.services.store.contracts.precompile.utils.PrecompilePricingUtils;
 import com.hedera.services.txn.token.AssociateLogic;
+import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import java.util.Set;
 import java.util.function.UnaryOperator;
@@ -72,8 +73,9 @@ public class MultiAssociatePrecompile extends AbstractAssociatePrecompile {
     }
 
     @Override
-    public long getGasRequirement(final long blockTimestamp, final TransactionBody.Builder transactionBody) {
-        return pricingUtils.computeGasRequirement(blockTimestamp, this, transactionBody);
+    public long getGasRequirement(
+            final long blockTimestamp, final TransactionBody.Builder transactionBody, final AccountID sender) {
+        return pricingUtils.computeGasRequirement(blockTimestamp, this, transactionBody, sender);
     }
 
     @Override

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/MultiDissociatePrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/MultiDissociatePrecompile.java
@@ -31,6 +31,7 @@ import com.hedera.services.store.contracts.precompile.codec.BodyParams;
 import com.hedera.services.store.contracts.precompile.codec.Dissociation;
 import com.hedera.services.store.contracts.precompile.utils.PrecompilePricingUtils;
 import com.hedera.services.txn.token.DissociateLogic;
+import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.TransactionBody.Builder;
 import java.util.Set;
 import java.util.function.UnaryOperator;
@@ -65,8 +66,8 @@ public class MultiDissociatePrecompile extends AbstractDissociatePrecompile {
     }
 
     @Override
-    public long getGasRequirement(long blockTimestamp, Builder transactionBody) {
-        return pricingUtils.computeGasRequirement(blockTimestamp, this, transactionBody);
+    public long getGasRequirement(long blockTimestamp, Builder transactionBody, final AccountID sender) {
+        return pricingUtils.computeGasRequirement(blockTimestamp, this, transactionBody, sender);
     }
 
     @Override

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/PausePrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/PausePrecompile.java
@@ -39,6 +39,7 @@ import com.hedera.services.store.contracts.precompile.codec.RunResult;
 import com.hedera.services.store.contracts.precompile.utils.PrecompilePricingUtils;
 import com.hedera.services.store.models.Id;
 import com.hedera.services.txn.token.PauseLogic;
+import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import java.util.Objects;
@@ -78,7 +79,8 @@ public class PausePrecompile extends AbstractWritePrecompile {
     }
 
     @Override
-    public long getMinimumFeeInTinybars(final Timestamp consensusTime, final TransactionBody transactionBody) {
+    public long getMinimumFeeInTinybars(
+            final Timestamp consensusTime, final TransactionBody transactionBody, final AccountID sender) {
         Objects.requireNonNull(transactionBody, "`body` method should be called before `getMinimumFeeInTinybars`");
         return pricingUtils.getMinimumPriceInTinybars(PAUSE, consensusTime);
     }

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/RevokeKycPrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/RevokeKycPrecompile.java
@@ -79,7 +79,8 @@ public class RevokeKycPrecompile extends AbstractGrantRevokeKycPrecompile {
     }
 
     @Override
-    public long getMinimumFeeInTinybars(Timestamp consensusTime, TransactionBody transactionBody) {
+    public long getMinimumFeeInTinybars(
+            Timestamp consensusTime, TransactionBody transactionBody, final AccountID sender) {
         requireNonNull(transactionBody, "`body` method should be called before `getMinimumFeeInTinybars`");
         return pricingUtils.getMinimumPriceInTinybars(REVOKE_KYC, consensusTime);
     }

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/SetApprovalForAllPrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/SetApprovalForAllPrecompile.java
@@ -48,6 +48,7 @@ import com.hedera.services.store.models.Id;
 import com.hedera.services.txns.crypto.ApproveAllowanceLogic;
 import com.hedera.services.txns.crypto.validators.ApproveAllowanceChecks;
 import com.hedera.services.utils.EntityIdUtils;
+import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TokenID;
 import com.hederahashgraph.api.proto.java.TransactionBody;
@@ -148,7 +149,8 @@ public class SetApprovalForAllPrecompile extends AbstractWritePrecompile {
     }
 
     @Override
-    public long getMinimumFeeInTinybars(final Timestamp consensusTime, final TransactionBody transactionBody) {
+    public long getMinimumFeeInTinybars(
+            final Timestamp consensusTime, final TransactionBody transactionBody, final AccountID sender) {
         return pricingUtils.getMinimumPriceInTinybars(APPROVE, consensusTime);
     }
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/TokenCreatePrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/TokenCreatePrecompile.java
@@ -68,6 +68,7 @@ import com.hedera.services.store.models.Account;
 import com.hedera.services.txn.token.CreateLogic;
 import com.hedera.services.txns.validation.OptionValidator;
 import com.hedera.services.utils.EntityIdUtils;
+import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TransactionBody;
@@ -271,7 +272,8 @@ public class TokenCreatePrecompile extends AbstractWritePrecompile {
     }
 
     @Override
-    public long getMinimumFeeInTinybars(Timestamp consensusTime, TransactionBody transactionBody) {
+    public long getMinimumFeeInTinybars(
+            Timestamp consensusTime, TransactionBody transactionBody, final AccountID sender) {
         return 100_000L;
     }
 
@@ -333,7 +335,7 @@ public class TokenCreatePrecompile extends AbstractWritePrecompile {
 
         final var tinybarsRequirement = calculatedFeeInTinybars
                 + (calculatedFeeInTinybars / 5)
-                - getMinimumFeeInTinybars(timestamp, transactionBody.build()) * gasPriceInTinybars;
+                - getMinimumFeeInTinybars(timestamp, transactionBody.build(), null) * gasPriceInTinybars;
 
         validateTrue(frame.getValue().greaterOrEqualThan(Wei.of(tinybarsRequirement)), INSUFFICIENT_TX_FEE);
 
@@ -344,9 +346,9 @@ public class TokenCreatePrecompile extends AbstractWritePrecompile {
     }
 
     @Override
-    public long getGasRequirement(long blockTimestamp, Builder transactionBody) {
+    public long getGasRequirement(long blockTimestamp, Builder transactionBody, final AccountID sender) {
         return getMinimumFeeInTinybars(
-                Timestamp.newBuilder().setSeconds(blockTimestamp).build(), transactionBody.build());
+                Timestamp.newBuilder().setSeconds(blockTimestamp).build(), transactionBody.build(), sender);
     }
 
     /**

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/UnfreezeTokenPrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/UnfreezeTokenPrecompile.java
@@ -74,7 +74,8 @@ public class UnfreezeTokenPrecompile extends AbstractFreezeUnfreezePrecompile {
     }
 
     @Override
-    public long getMinimumFeeInTinybars(final Timestamp consensusTime, final TransactionBody transactionBody) {
+    public long getMinimumFeeInTinybars(
+            final Timestamp consensusTime, final TransactionBody transactionBody, final AccountID sender) {
         Objects.requireNonNull(transactionBody, "`body` method should be called before `getMinimumFeeInTinybars`");
         return pricingUtils.getMinimumPriceInTinybars(UNFREEZE, consensusTime);
     }

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/UnpausePrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/UnpausePrecompile.java
@@ -39,6 +39,7 @@ import com.hedera.services.store.contracts.precompile.codec.UnpauseWrapper;
 import com.hedera.services.store.contracts.precompile.utils.PrecompilePricingUtils;
 import com.hedera.services.store.models.Id;
 import com.hedera.services.txn.token.UnpauseLogic;
+import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import java.util.Objects;
@@ -78,7 +79,8 @@ public class UnpausePrecompile extends AbstractWritePrecompile {
     }
 
     @Override
-    public long getMinimumFeeInTinybars(final Timestamp consensusTime, final TransactionBody transactionBody) {
+    public long getMinimumFeeInTinybars(
+            final Timestamp consensusTime, final TransactionBody transactionBody, final AccountID sender) {
         Objects.requireNonNull(transactionBody, "`body` method should be called before `getMinimumFeeInTinybars`");
         return pricingUtils.getMinimumPriceInTinybars(UNPAUSE, consensusTime);
     }

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/WipeFungiblePrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/WipeFungiblePrecompile.java
@@ -30,6 +30,7 @@ import com.hedera.services.store.contracts.precompile.codec.FunctionParam;
 import com.hedera.services.store.contracts.precompile.codec.WipeWrapper;
 import com.hedera.services.store.contracts.precompile.utils.PrecompilePricingUtils;
 import com.hedera.services.txn.token.WipeLogic;
+import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -81,7 +82,8 @@ public class WipeFungiblePrecompile extends AbstractWipePrecompile {
     }
 
     @Override
-    public long getMinimumFeeInTinybars(final Timestamp consensusTime, final TransactionBody transactionBody) {
+    public long getMinimumFeeInTinybars(
+            final Timestamp consensusTime, final TransactionBody transactionBody, final AccountID sender) {
         Objects.requireNonNull(transactionBody, "`body` method should be called before `getMinimumFeeInTinybars`");
         return pricingUtils.getMinimumPriceInTinybars(WIPE_FUNGIBLE, consensusTime);
     }

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/WipeNonFungiblePrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/WipeNonFungiblePrecompile.java
@@ -32,6 +32,7 @@ import com.hedera.services.store.contracts.precompile.codec.BodyParams;
 import com.hedera.services.store.contracts.precompile.codec.WipeWrapper;
 import com.hedera.services.store.contracts.precompile.utils.PrecompilePricingUtils;
 import com.hedera.services.txn.token.WipeLogic;
+import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import java.util.Arrays;
@@ -71,7 +72,8 @@ public class WipeNonFungiblePrecompile extends AbstractWipePrecompile {
     }
 
     @Override
-    public long getMinimumFeeInTinybars(Timestamp consensusTime, final TransactionBody transactionBody) {
+    public long getMinimumFeeInTinybars(
+            Timestamp consensusTime, final TransactionBody transactionBody, final AccountID sender) {
         Objects.requireNonNull(transactionBody, "`body` method should be called before `getMinimumFeeInTinybars`");
         return pricingUtils.getMinimumPriceInTinybars(WIPE_NFT, consensusTime);
     }

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/utils/PrecompilePricingUtils.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/utils/PrecompilePricingUtils.java
@@ -53,6 +53,7 @@ import com.hedera.services.hapi.utils.fees.FeeBuilder;
 import com.hedera.services.jproto.JKey;
 import com.hedera.services.store.contracts.precompile.Precompile;
 import com.hedera.services.utils.accessors.AccessorFactory;
+import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.HederaFunctionality;
 import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.KeyList;
@@ -168,7 +169,10 @@ public class PrecompilePricingUtils {
     }
 
     public long computeGasRequirement(
-            final long blockTimestamp, final Precompile precompile, final TransactionBody.Builder transactionBody) {
+            final long blockTimestamp,
+            final Precompile precompile,
+            final TransactionBody.Builder transactionBody,
+            final AccountID sender) {
         final Timestamp timestamp =
                 Timestamp.newBuilder().setSeconds(blockTimestamp).build();
         final long gasPriceInTinybars = feeCalculator.estimatedGasPriceInTinybars(ContractCall, timestamp);
@@ -179,7 +183,8 @@ public class PrecompilePricingUtils {
                         .build()),
                 timestamp);
 
-        final long minimumFeeInTinybars = precompile.getMinimumFeeInTinybars(timestamp, transactionBody.build());
+        final long minimumFeeInTinybars =
+                precompile.getMinimumFeeInTinybars(timestamp, transactionBody.build(), sender);
         final long actualFeeInTinybars = Math.max(minimumFeeInTinybars, calculatedFeeInTinybars);
 
         // convert to gas cost

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/common/ContractCallContextTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/common/ContractCallContextTest.java
@@ -19,30 +19,28 @@ package com.hedera.mirror.web3.common;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.hedera.mirror.common.domain.DomainBuilder;
-import org.hyperledger.besu.datatypes.Address;
+import com.hedera.mirror.common.domain.transaction.RecordFile;
+import com.hedera.mirror.web3.evm.store.StackedStateFrames;
+import com.hedera.mirror.web3.evm.store.StackedStateFramesTest.BareDatabaseAccessor;
+import com.hedera.mirror.web3.evm.store.accessor.DatabaseAccessor;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class ContractCallContextTest {
 
+    private final StackedStateFrames stackedStateFrames;
+
     private final DomainBuilder domainBuilder = new DomainBuilder();
+
+    public ContractCallContextTest() {
+        stackedStateFrames = new StackedStateFrames(List.<DatabaseAccessor<Object, ?>>of(
+                new BareDatabaseAccessor<Object, Character>() {}, new BareDatabaseAccessor<Object, String>() {}));
+    }
 
     @Test
     void testGet() {
         ContractCallContext context = ContractCallContext.init(null);
         assertThat(ContractCallContext.get()).isEqualTo(context);
-        context.close();
-    }
-
-    @Test
-    void testReset() {
-        ContractCallContext context = ContractCallContext.init(null);
-        ContractCallContext.get().setEstimate(true);
-        ContractCallContext.get().setCreate(true);
-
-        context.reset();
-
-        assertThat(context.isEstimate()).isFalse();
-        assertThat(context.isCreate()).isFalse();
         context.close();
     }
 
@@ -69,13 +67,15 @@ class ContractCallContextTest {
     }
 
     @Test
-    void testSenderIsClearedOnReset() {
-        ContractCallContext context = ContractCallContext.init(null);
-        context.setSenderAddress(Address.ALTBN128_ADD);
-        assertThat(context.getSenderAddress()).isEqualTo(Address.ALTBN128_ADD);
+    void testReset() {
+        ContractCallContext context = ContractCallContext.init(stackedStateFrames);
+        context.setRecordFile(new RecordFile());
+        stackedStateFrames.push();
+        context.setStack(stackedStateFrames.top());
 
         context.reset();
-        assertThat(context.getSenderAddress()).isNull();
+        assertThat(context.getRecordFile()).isNull();
+        assertThat(context.getStack()).isEqualTo(context.getStackBase());
 
         context.close();
     }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessorTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessorTest.java
@@ -42,10 +42,6 @@ import com.hedera.node.app.service.evm.contracts.execution.PricesAndFeesProvider
 import com.hedera.node.app.service.evm.store.contracts.AbstractCodeCache;
 import com.hedera.node.app.service.evm.store.contracts.HederaEvmEntityAccess;
 import com.hedera.node.app.service.evm.store.models.HederaEvmAccount;
-import com.hedera.services.evm.contracts.operations.HederaPrngSeedOperation;
-import com.hedera.services.store.contracts.precompile.PrngSystemPrecompiledContract;
-import com.hedera.services.txns.crypto.AbstractAutoCreationLogic;
-import com.hederahashgraph.api.proto.java.HederaFunctionality;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import java.math.BigInteger;
 import java.util.List;
@@ -127,18 +123,6 @@ class MirrorEvmTxProcessorTest {
 
     @Mock
     private StoreImpl store;
-
-    @Mock
-    private PrngSystemPrecompiledContract prngSystemPrecompiledContract;
-
-    @Mock
-    private HederaPrngSeedOperation prngSeedOperation;
-
-    @Mock
-    private AbstractCodeCache codeCache;
-
-    @Mock
-    private AbstractAutoCreationLogic autoCreationLogic;
 
     private MirrorEvmTxProcessorImpl mirrorEvmTxProcessor;
     private Pair<ResponseCodeEnum, Long> result;
@@ -237,11 +221,6 @@ class MirrorEvmTxProcessorTest {
 
         assertThatExceptionOfType(MirrorEvmTransactionException.class)
                 .isThrownBy(() -> mirrorEvmTxProcessor.buildInitialFrame(protoFrame, receiverAddress, Bytes.EMPTY, 0L));
-    }
-
-    @Test
-    void assertIsContractCallFunctionality() {
-        assertThat(mirrorEvmTxProcessor.getFunctionType()).isEqualTo(HederaFunctionality.ContractCall);
     }
 
     @Test

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/StackedStateFramesTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/StackedStateFramesTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(ContextExtension.class)
-class StackedStateFramesTest {
+public class StackedStateFramesTest {
 
     @Test
     void constructionHappyPath() {
@@ -122,7 +122,7 @@ class StackedStateFramesTest {
         assertThatIllegalArgumentException().isThrownBy(() -> sut.push(newTos));
     }
 
-    static class BareDatabaseAccessor<K, V> extends DatabaseAccessor<K, V> {
+    public static class BareDatabaseAccessor<K, V> extends DatabaseAccessor<K, V> {
         @NonNull
         @Override
         public Optional<V> get(@NonNull final K key) {

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/precompile/MirrorHTSPrecompiledContractTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/precompile/MirrorHTSPrecompiledContractTest.java
@@ -16,17 +16,22 @@
 
 package com.hedera.mirror.web3.evm.store.contract.precompile;
 
+import static com.hedera.mirror.web3.common.PrecompileContext.PRECOMPILE_CONTEXT;
 import static com.hedera.node.app.service.evm.store.contracts.precompile.AbiConstants.ABI_ID_ERC_NAME;
 import static com.hedera.services.store.contracts.precompile.AbiConstants.ABI_ID_REDIRECT_FOR_TOKEN;
+import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.contractAddress;
 import static com.hedera.services.store.contracts.precompile.codec.EncodingFacade.SUCCESS_RESULT;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.hyperledger.besu.datatypes.Address.ALTBN128_ADD;
+import static org.hyperledger.besu.datatypes.Address.ALTBN128_MUL;
+import static org.hyperledger.besu.datatypes.Address.BLS12_G1ADD;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
 import com.esaulpaugh.headlong.util.Integers;
 import com.hedera.mirror.web3.ContextExtension;
 import com.hedera.mirror.web3.common.ContractCallContext;
+import com.hedera.mirror.web3.common.PrecompileContext;
 import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
 import com.hedera.mirror.web3.evm.store.StackedStateFrames;
 import com.hedera.mirror.web3.evm.store.Store;
@@ -45,6 +50,7 @@ import com.hedera.services.store.contracts.precompile.PrecompileMapper;
 import com.hedera.services.store.contracts.precompile.codec.EncodingFacade;
 import com.hedera.services.store.contracts.precompile.utils.PrecompilePricingUtils;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
+import com.hederahashgraph.api.proto.java.TransactionBody;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.ArrayDeque;
 import java.util.Deque;
@@ -80,6 +86,18 @@ class MirrorHTSPrecompiledContractTest {
 
     @Mock
     private MessageFrame parentMessageFrame;
+
+    @Mock
+    private MessageFrame lastFrame;
+
+    @Mock
+    private Deque<MessageFrame> stack;
+
+    @Mock
+    private TransactionBody.Builder transactionBodyBuilder;
+
+    @Mock
+    private PrecompileContext precompileContext;
 
     @Mock
     private BlockValues blockValues;
@@ -126,6 +144,7 @@ class MirrorHTSPrecompiledContractTest {
 
         store = new StoreImpl(stackedStateFrames);
         messageFrameStack = new ArrayDeque<>();
+        messageFrameStack.push(lastFrame);
         messageFrameStack.push(messageFrame);
 
         precompileMapper = new PrecompileMapper(Set.of(mockPrecompile));
@@ -195,12 +214,17 @@ class MirrorHTSPrecompiledContractTest {
     void nonStaticCallToPrecompileWorks() {
         given(messageFrame.getContractAddress()).willReturn(ALTBN128_ADD);
         given(messageFrame.getRecipientAddress()).willReturn(ALTBN128_ADD);
-        given(messageFrame.getSenderAddress()).willReturn(Address.ALTBN128_MUL);
+        given(messageFrame.getSenderAddress()).willReturn(ALTBN128_MUL);
         given(messageFrame.isStatic()).willReturn(false);
         given(messageFrame.getValue()).willReturn(Wei.ZERO);
         given(messageFrame.getBlockValues()).willReturn(blockValues);
         given(blockValues.getTimestamp()).willReturn(10L);
         given(messageFrame.getWorldUpdater()).willReturn(worldUpdater);
+        given(messageFrame.getMessageFrameStack()).willReturn(messageFrameStack);
+        given(lastFrame.getContextVariable(PRECOMPILE_CONTEXT)).willReturn(precompileContext);
+        given(precompileContext.getSenderAddress()).willReturn(contractAddress);
+        given(precompileContext.getPrecompile()).willReturn(mockPrecompile);
+        given(precompileContext.getTransactionBody()).willReturn(transactionBodyBuilder);
         given(worldUpdater.permissivelyUnaliased(any()))
                 .willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
         final var precompileResult =
@@ -213,9 +237,11 @@ class MirrorHTSPrecompiledContractTest {
     @Test
     void unqualifiedDelegateCallFails() {
         given(messageFrame.getContractAddress()).willReturn(ALTBN128_ADD);
-        given(messageFrame.getRecipientAddress()).willReturn(Address.BLS12_G1ADD);
+        given(messageFrame.getRecipientAddress()).willReturn(BLS12_G1ADD);
         given(messageFrame.isStatic()).willReturn(false);
         given(messageFrame.getWorldUpdater()).willReturn(worldUpdater);
+        given(messageFrame.getMessageFrameStack()).willReturn(messageFrameStack);
+        given(lastFrame.getContextVariable(PRECOMPILE_CONTEXT)).willReturn(precompileContext);
         final var precompileResult =
                 subject.computeCosted(MOCK_PRECOMPILE_FUNCTION_HASH, messageFrame, gasCalculator, tokenAccessor);
 
@@ -225,14 +251,20 @@ class MirrorHTSPrecompiledContractTest {
     @Test
     void invalidFeeSentFails() {
         given(messageFrame.getContractAddress()).willReturn(ALTBN128_ADD);
-        given(messageFrame.getRecipientAddress()).willReturn(Address.BLS12_G1ADD);
-        given(messageFrame.getSenderAddress()).willReturn(Address.ALTBN128_MUL);
+        given(messageFrame.getRecipientAddress()).willReturn(BLS12_G1ADD);
+        given(messageFrame.getSenderAddress()).willReturn(ALTBN128_MUL);
+        given(lastFrame.getContractAddress()).willReturn(ALTBN128_MUL);
+        given(lastFrame.getRecipientAddress()).willReturn(ALTBN128_MUL);
         given(messageFrame.isStatic()).willReturn(false);
         given(messageFrame.getWorldUpdater()).willReturn(worldUpdater);
-        given(worldUpdater.get(Address.BLS12_G1ADD)).willReturn(account);
+        given(worldUpdater.get(BLS12_G1ADD)).willReturn(account);
         given(account.getNonce()).willReturn(-1L);
         given(messageFrame.getMessageFrameStack()).willReturn(messageFrameStack);
         given(messageFrame.getBlockValues()).willReturn(blockValues);
+        given(lastFrame.getContextVariable(PRECOMPILE_CONTEXT)).willReturn(precompileContext);
+        given(precompileContext.getSenderAddress()).willReturn(contractAddress);
+        given(precompileContext.getPrecompile()).willReturn(mockPrecompile);
+        given(precompileContext.getTransactionBody()).willReturn(transactionBodyBuilder);
         given(blockValues.getTimestamp()).willReturn(10L);
         given(worldUpdater.permissivelyUnaliased(any()))
                 .willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
@@ -249,12 +281,13 @@ class MirrorHTSPrecompiledContractTest {
         messageFrameStack.push(parentMessageFrame);
 
         given(messageFrame.getContractAddress()).willReturn(ALTBN128_ADD);
-        given(messageFrame.getRecipientAddress()).willReturn(Address.BLS12_G1ADD);
+        given(messageFrame.getRecipientAddress()).willReturn(BLS12_G1ADD);
         given(messageFrame.isStatic()).willReturn(false);
         given(messageFrame.getWorldUpdater()).willReturn(worldUpdater);
-        given(worldUpdater.get(Address.BLS12_G1ADD)).willReturn(account);
+        given(worldUpdater.get(BLS12_G1ADD)).willReturn(account);
         given(account.getNonce()).willReturn(-1L);
         given(messageFrame.getMessageFrameStack()).willReturn(messageFrameStack);
+        given(lastFrame.getContextVariable(PRECOMPILE_CONTEXT)).willReturn(precompileContext);
         final var precompileResult =
                 subject.computeCosted(MOCK_PRECOMPILE_FUNCTION_HASH, messageFrame, gasCalculator, tokenAccessor);
 
@@ -267,13 +300,17 @@ class MirrorHTSPrecompiledContractTest {
         final var functionHash = Bytes.fromHexString("0x11111111");
 
         given(messageFrame.getContractAddress()).willReturn(ALTBN128_ADD);
-        given(messageFrame.getRecipientAddress()).willReturn(Address.BLS12_G1ADD);
-        given(messageFrame.getSenderAddress()).willReturn(Address.ALTBN128_MUL);
+        given(lastFrame.getContractAddress()).willReturn(ALTBN128_ADD);
+        given(lastFrame.getRecipientAddress()).willReturn(ALTBN128_ADD);
+        given(messageFrame.getRecipientAddress()).willReturn(BLS12_G1ADD);
+        given(messageFrame.getSenderAddress()).willReturn(ALTBN128_MUL);
         given(messageFrame.isStatic()).willReturn(false);
         given(messageFrame.getWorldUpdater()).willReturn(worldUpdater);
-        given(worldUpdater.get(Address.BLS12_G1ADD)).willReturn(account);
+        given(worldUpdater.get(BLS12_G1ADD)).willReturn(account);
         given(account.getNonce()).willReturn(-1L);
         given(messageFrame.getMessageFrameStack()).willReturn(messageFrameStack);
+        given(lastFrame.getContextVariable(PRECOMPILE_CONTEXT)).willReturn(precompileContext);
+        given(precompileContext.getSenderAddress()).willReturn(contractAddress);
         given(worldUpdater.permissivelyUnaliased(any()))
                 .willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
         given(messageFrame.getMessageFrameStack()).willReturn(messageFrameStack);
@@ -288,12 +325,14 @@ class MirrorHTSPrecompiledContractTest {
         final var functionHash = Bytes.fromHexString("0x000000000000000000000000000000000000000000000000");
 
         given(messageFrame.getContractAddress()).willReturn(ALTBN128_ADD);
-        given(messageFrame.getRecipientAddress()).willReturn(Address.BLS12_G1ADD);
+        given(lastFrame.getContractAddress()).willReturn(ALTBN128_ADD);
+        given(lastFrame.getRecipientAddress()).willReturn(ALTBN128_ADD);
+        given(messageFrame.getRecipientAddress()).willReturn(BLS12_G1ADD);
         given(messageFrame.getSenderAddress()).willReturn(Address.ECREC);
         given(messageFrame.isStatic()).willReturn(false);
         given(messageFrame.getWorldUpdater()).willReturn(worldUpdater);
         given(messageFrame.getValue()).willReturn(Wei.ZERO);
-        given(worldUpdater.get(Address.BLS12_G1ADD)).willReturn(account);
+        given(worldUpdater.get(BLS12_G1ADD)).willReturn(account);
         given(account.getNonce()).willReturn(-1L);
         given(messageFrame.getMessageFrameStack()).willReturn(messageFrameStack);
         given(messageFrame.getBlockValues()).willReturn(blockValues);
@@ -301,6 +340,10 @@ class MirrorHTSPrecompiledContractTest {
         given(worldUpdater.permissivelyUnaliased(any()))
                 .willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
         given(messageFrame.getMessageFrameStack()).willReturn(messageFrameStack);
+        given(lastFrame.getContextVariable(PRECOMPILE_CONTEXT)).willReturn(precompileContext);
+        given(precompileContext.getSenderAddress()).willReturn(contractAddress);
+        given(precompileContext.getPrecompile()).willReturn(mockPrecompile);
+        given(precompileContext.getTransactionBody()).willReturn(transactionBodyBuilder);
 
         final var precompileResult = subject.computeCosted(functionHash, messageFrame, gasCalculator, tokenAccessor);
 
@@ -310,14 +353,20 @@ class MirrorHTSPrecompiledContractTest {
     @Test
     void delegateCallWithNoParent() {
         given(messageFrame.getContractAddress()).willReturn(ALTBN128_ADD);
-        given(messageFrame.getRecipientAddress()).willReturn(Address.BLS12_G1ADD);
-        given(messageFrame.getSenderAddress()).willReturn(Address.ALTBN128_MUL);
+        given(lastFrame.getContractAddress()).willReturn(ALTBN128_ADD);
+        given(lastFrame.getRecipientAddress()).willReturn(ALTBN128_ADD);
+        given(messageFrame.getRecipientAddress()).willReturn(BLS12_G1ADD);
+        given(messageFrame.getSenderAddress()).willReturn(ALTBN128_MUL);
         given(messageFrame.isStatic()).willReturn(false);
         given(messageFrame.getWorldUpdater()).willReturn(worldUpdater);
-        given(worldUpdater.get(Address.BLS12_G1ADD)).willReturn(account);
+        given(worldUpdater.get(BLS12_G1ADD)).willReturn(account);
         given(messageFrame.getValue()).willReturn(Wei.ZERO);
         given(account.getNonce()).willReturn(-1L);
         given(messageFrame.getMessageFrameStack()).willReturn(messageFrameStack);
+        given(lastFrame.getContextVariable(PRECOMPILE_CONTEXT)).willReturn(precompileContext);
+        given(precompileContext.getSenderAddress()).willReturn(contractAddress);
+        given(precompileContext.getPrecompile()).willReturn(mockPrecompile);
+        given(precompileContext.getTransactionBody()).willReturn(transactionBodyBuilder);
         given(messageFrame.getBlockValues()).willReturn(blockValues);
         given(blockValues.getTimestamp()).willReturn(10L);
         given(worldUpdater.permissivelyUnaliased(any()))
@@ -341,6 +390,13 @@ class MirrorHTSPrecompiledContractTest {
         given(messageFrame.getWorldUpdater()).willReturn(worldUpdater);
         given(worldUpdater.permissivelyUnaliased(any()))
                 .willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
+        given(messageFrame.getMessageFrameStack()).willReturn(stack);
+        given(stack.getLast()).willReturn(lastFrame);
+        given(lastFrame.getContextVariable(PRECOMPILE_CONTEXT)).willReturn(precompileContext);
+        given(precompileContext.getSenderAddress()).willReturn(contractAddress);
+        given(precompileContext.getPrecompile()).willReturn(mockPrecompile);
+        given(precompileContext.getTransactionBody()).willReturn(transactionBodyBuilder);
+
         final var precompileResult =
                 subject.computeCosted(MOCK_PRECOMPILE_FUNCTION_HASH, messageFrame, gasCalculator, tokenAccessor);
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/precompile/MockPrecompile.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/precompile/MockPrecompile.java
@@ -23,6 +23,7 @@ import com.hedera.services.store.contracts.precompile.Precompile;
 import com.hedera.services.store.contracts.precompile.codec.BodyParams;
 import com.hedera.services.store.contracts.precompile.codec.EmptyRunResult;
 import com.hedera.services.store.contracts.precompile.codec.RunResult;
+import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TransactionBody;
@@ -43,7 +44,8 @@ public class MockPrecompile implements Precompile {
     }
 
     @Override
-    public long getMinimumFeeInTinybars(final Timestamp consensusTime, final TransactionBody transactionBody) {
+    public long getMinimumFeeInTinybars(
+            final Timestamp consensusTime, final TransactionBody transactionBody, final AccountID sender) {
         return 0;
     }
 
@@ -60,7 +62,8 @@ public class MockPrecompile implements Precompile {
     }
 
     @Override
-    public long getGasRequirement(final long blockTimestamp, final TransactionBody.Builder transactionBody) {
+    public long getGasRequirement(
+            final long blockTimestamp, final TransactionBody.Builder transactionBody, final AccountID sender) {
         return 0;
     }
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/AssociatePrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/AssociatePrecompileTest.java
@@ -16,6 +16,11 @@
 
 package com.hedera.services.store.contracts.precompile;
 
+import static com.hedera.mirror.web3.common.PrecompileContext.PRECOMPILE_CONTEXT;
+import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.secondSender;
+import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.sender;
+import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.senderAddress;
+import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.tokenAddress;
 import static com.hedera.services.store.contracts.precompile.impl.AssociatePrecompile.decodeAssociation;
 import static com.hedera.services.store.contracts.precompile.impl.MultiAssociatePrecompile.decodeMultipleAssociations;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.TokenAssociateToAccount;
@@ -25,12 +30,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
-import com.hedera.mirror.web3.common.ContractCallContext;
+import com.hedera.mirror.web3.common.PrecompileContext;
 import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
 import com.hedera.mirror.web3.evm.store.Store;
 import com.hedera.mirror.web3.evm.store.Store.OnMissing;
 import com.hedera.mirror.web3.evm.store.contract.HederaEvmStackedWorldStateUpdater;
-import com.hedera.node.app.service.evm.accounts.HederaEvmContractAliases;
 import com.hedera.node.app.service.evm.store.contracts.precompile.EvmHTSPrecompiledContract;
 import com.hedera.node.app.service.evm.store.contracts.precompile.EvmInfrastructureFactory;
 import com.hedera.node.app.service.evm.store.tokens.TokenAccessor;
@@ -89,8 +93,10 @@ class AssociatePrecompileTest {
             "0x49146bde00000000000000000000000000000000000000000000000000000000000004820000000000000000000000000000000000000000000000000000000000000480");
     private static final Bytes MULTIPLE_ASSOCIATE_INPUT = Bytes.fromHexString(
             "0x2e63879b00000000000000000000000000000000000000000000000000000000000004880000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000004860000000000000000000000000000000000000000000000000000000000000486");
-    private final TransactionBody.Builder transactionBody =
-            TransactionBody.newBuilder().setTokenAssociate(TokenAssociateTransactionBody.newBuilder());
+    private final TransactionBody.Builder transactionBody = TransactionBody.newBuilder()
+            .setTokenAssociate(TokenAssociateTransactionBody.newBuilder()
+                    .setAccount(secondSender)
+                    .addTokens(HTSTestsUtil.token));
 
     @Mock
     private MirrorNodeEvmProperties evmProperties;
@@ -112,9 +118,6 @@ class AssociatePrecompileTest {
 
     @Mock
     private Store store;
-
-    @Mock
-    private HederaEvmContractAliases hederaEvmContractAliases;
 
     @Mock
     private EvmInfrastructureFactory infrastructureFactory;
@@ -156,6 +159,9 @@ class AssociatePrecompileTest {
     private Deque<MessageFrame> stack;
 
     @Mock
+    private PrecompileContext precompileContext;
+
+    @Mock
     private TokenAccessor tokenAccessor;
 
     private HTSPrecompiledContract subject;
@@ -185,8 +191,6 @@ class AssociatePrecompileTest {
                 store,
                 tokenAccessor,
                 precompilePricingUtils);
-
-        ContractCallContext.init(store.getStackedStateFrames());
     }
 
     @Test
@@ -207,10 +211,17 @@ class AssociatePrecompileTest {
         given(feeCalculator.computeFee(any(), any(), any())).willReturn(mockFeeObject);
         given(mockFeeObject.getServiceFee()).willReturn(1L);
 
+        given(frame.getMessageFrameStack()).willReturn(stack);
+        given(stack.getLast()).willReturn(lastFrame);
+        given(lastFrame.getContextVariable(PRECOMPILE_CONTEXT)).willReturn(precompileContext);
+        given(precompileContext.getPrecompile()).willReturn(associatePrecompile);
+        given(precompileContext.getSenderAddress()).willReturn(senderAddress);
+        given(precompileContext.getTransactionBody()).willReturn(transactionBody);
+
         // when:
         subject.prepareFields(frame);
-        subject.prepareComputation(ASSOCIATE_INPUT, a -> a);
-        subject.getPrecompile().getGasRequirement(HTSTestsUtil.TEST_CONSENSUS_TIME, transactionBody);
+        subject.prepareComputation(ASSOCIATE_INPUT, a -> a, precompileContext);
+        subject.getPrecompile(frame).getGasRequirement(HTSTestsUtil.TEST_CONSENSUS_TIME, transactionBody, sender);
         final var result = subject.computeInternal(frame);
 
         // then:
@@ -235,11 +246,17 @@ class AssociatePrecompileTest {
                 .willReturn(1L);
         given(feeCalculator.computeFee(any(), any(), any())).willReturn(mockFeeObject);
         given(mockFeeObject.getServiceFee()).willReturn(1L);
+        given(frame.getMessageFrameStack()).willReturn(stack);
+        given(stack.getLast()).willReturn(lastFrame);
+        given(lastFrame.getContextVariable(PRECOMPILE_CONTEXT)).willReturn(precompileContext);
+        given(precompileContext.getPrecompile()).willReturn(associatePrecompile);
+        given(precompileContext.getSenderAddress()).willReturn(senderAddress);
+        given(precompileContext.getTransactionBody()).willReturn(transactionBody);
 
         // when:
         subject.prepareFields(frame);
-        subject.prepareComputation(ASSOCIATE_INPUT, a -> a);
-        subject.getPrecompile().getGasRequirement(HTSTestsUtil.TEST_CONSENSUS_TIME, transactionBody);
+        subject.prepareComputation(ASSOCIATE_INPUT, a -> a, precompileContext);
+        subject.getPrecompile(frame).getGasRequirement(HTSTestsUtil.TEST_CONSENSUS_TIME, transactionBody, sender);
         final var result = subject.computeInternal(frame);
 
         // then:
@@ -264,11 +281,17 @@ class AssociatePrecompileTest {
                 .willReturn(1L);
         given(feeCalculator.computeFee(any(), any(), any())).willReturn(mockFeeObject);
         given(mockFeeObject.getServiceFee()).willReturn(1L);
+        given(frame.getMessageFrameStack()).willReturn(stack);
+        given(stack.getLast()).willReturn(lastFrame);
+        given(lastFrame.getContextVariable(PRECOMPILE_CONTEXT)).willReturn(precompileContext);
+        given(precompileContext.getPrecompile()).willReturn(associatePrecompile);
+        given(precompileContext.getSenderAddress()).willReturn(senderAddress);
+        given(precompileContext.getTransactionBody()).willReturn(transactionBody);
 
         // when:
         subject.prepareFields(frame);
-        subject.prepareComputation(ASSOCIATE_INPUT, a -> a);
-        subject.getPrecompile().getGasRequirement(HTSTestsUtil.TEST_CONSENSUS_TIME, transactionBody);
+        subject.prepareComputation(ASSOCIATE_INPUT, a -> a, precompileContext);
+        subject.getPrecompile(frame).getGasRequirement(HTSTestsUtil.TEST_CONSENSUS_TIME, transactionBody, sender);
         final var result = subject.computeInternal(frame);
 
         // then:
@@ -291,11 +314,16 @@ class AssociatePrecompileTest {
         given(frame.getWorldUpdater()).willReturn(worldUpdater);
         given(worldUpdater.permissivelyUnaliased(any()))
                 .willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
+        given(frame.getMessageFrameStack()).willReturn(stack);
+        given(stack.getLast()).willReturn(lastFrame);
+        given(lastFrame.getContextVariable(PRECOMPILE_CONTEXT)).willReturn(precompileContext);
+        given(precompileContext.getPrecompile()).willReturn(associatePrecompile);
+        given(precompileContext.getSenderAddress()).willReturn(senderAddress);
 
         subject.prepareFields(frame);
-        subject.prepareComputation(ASSOCIATE_INPUT, a -> a);
-        final long result =
-                subject.getPrecompile().getGasRequirement(HTSTestsUtil.TEST_CONSENSUS_TIME, transactionBody);
+        subject.prepareComputation(ASSOCIATE_INPUT, a -> a, precompileContext);
+        final long result = subject.getPrecompile(frame)
+                .getGasRequirement(HTSTestsUtil.TEST_CONSENSUS_TIME, transactionBody, sender);
 
         // then
         assertEquals(EXPECTED_GAS_PRICE, result);
@@ -319,10 +347,16 @@ class AssociatePrecompileTest {
         given(worldUpdater.permissivelyUnaliased(any()))
                 .willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
 
+        given(frame.getMessageFrameStack()).willReturn(stack);
+        given(stack.getLast()).willReturn(lastFrame);
+        given(lastFrame.getContextVariable(PRECOMPILE_CONTEXT)).willReturn(precompileContext);
+        given(precompileContext.getPrecompile()).willReturn(associatePrecompile);
+        given(precompileContext.getSenderAddress()).willReturn(senderAddress);
+
         subject.prepareFields(frame);
-        subject.prepareComputation(ASSOCIATE_INPUT, a -> a);
-        final long result =
-                subject.getPrecompile().getGasRequirement(HTSTestsUtil.TEST_CONSENSUS_TIME, transactionBody);
+        subject.prepareComputation(ASSOCIATE_INPUT, a -> a, precompileContext);
+        final long result = subject.getPrecompile(frame)
+                .getGasRequirement(HTSTestsUtil.TEST_CONSENSUS_TIME, transactionBody, sender);
 
         // then
         assertEquals(EXPECTED_GAS_PRICE, result);
@@ -359,7 +393,7 @@ class AssociatePrecompileTest {
     private void givenTokenAssociate() {
         given(store.getAccount(Address.fromHexString("0x0000000000000000000000000000000000000482"), OnMissing.THROW))
                 .willReturn(account);
-        given(store.getToken(Address.fromHexString("0x0000000000000000000000000000000000000480"), OnMissing.THROW))
+        given(store.getToken(Address.fromHexString(tokenAddress.toHexString()), OnMissing.THROW))
                 .willReturn(token);
         given(account.getAccountAddress())
                 .willReturn(Address.fromHexString("0x0000000000000000000000000000000000000482"));

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/BurnPrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/BurnPrecompileTest.java
@@ -16,9 +16,11 @@
 
 package com.hedera.services.store.contracts.precompile;
 
+import static com.hedera.mirror.web3.common.PrecompileContext.PRECOMPILE_CONTEXT;
 import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.DEFAULT_GAS_PRICE;
 import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.TEST_CONSENSUS_TIME;
 import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.contractAddress;
+import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.sender;
 import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.senderAddress;
 import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.timestamp;
 import static com.hedera.services.store.contracts.precompile.impl.BurnPrecompile.getBurnWrapper;
@@ -31,8 +33,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.when;
 
-import com.hedera.mirror.web3.common.ContractCallContext;
-import com.hedera.mirror.web3.evm.account.MirrorEvmContractAliases;
+import com.hedera.mirror.web3.common.PrecompileContext;
 import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
 import com.hedera.mirror.web3.evm.store.Store;
 import com.hedera.mirror.web3.evm.store.Store.OnMissing;
@@ -69,6 +70,7 @@ import com.hederahashgraph.api.proto.java.TransactionBody;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -156,8 +158,8 @@ class BurnPrecompileTest {
     private static final Bytes RETURN_NON_FUNGIBLE_BURN =
             Bytes.fromHexString("0x" + SUCCESS_RESPONSE_CODE + convertToPaddedHex(EMPTY_ARGUMENT));
 
-    private final TransactionBody.Builder transactionBody =
-            TransactionBody.newBuilder().setTokenBurn(TokenBurnTransactionBody.newBuilder());
+    private final TransactionBody.Builder transactionBody = TransactionBody.newBuilder()
+            .setTokenBurn(TokenBurnTransactionBody.newBuilder().setToken(HTSTestsUtil.token2));
 
     @Mock
     private com.hedera.services.store.models.Account account;
@@ -179,6 +181,15 @@ class BurnPrecompileTest {
 
     @Mock
     private MessageFrame frame;
+
+    @Mock
+    private MessageFrame lastFrame;
+
+    @Mock
+    private Deque<MessageFrame> stack;
+
+    @Mock
+    private PrecompileContext precompileContext;
 
     @Mock
     private EncodingFacade encoder;
@@ -220,9 +231,6 @@ class BurnPrecompileTest {
     private Store store;
 
     @Mock
-    private MirrorEvmContractAliases mirrorEvmContractAliases;
-
-    @Mock
     private ContextOptionValidator contextOptionValidator;
 
     @Mock
@@ -257,8 +265,6 @@ class BurnPrecompileTest {
                 store,
                 tokenAccessor,
                 precompilePricingUtils);
-
-        ContractCallContext.init(store.getStackedStateFrames());
     }
 
     @Test
@@ -274,11 +280,17 @@ class BurnPrecompileTest {
                 .willReturn(1L);
         given(feeCalculator.computeFee(any(), any(), any())).willReturn(mockFeeObject);
         given(mockFeeObject.getServiceFee()).willReturn(1L);
+        given(frame.getMessageFrameStack()).willReturn(stack);
+        given(stack.getLast()).willReturn(lastFrame);
+        given(lastFrame.getContextVariable(PRECOMPILE_CONTEXT)).willReturn(precompileContext);
+        given(precompileContext.getPrecompile()).willReturn(burnPrecompile);
+        given(precompileContext.getSenderAddress()).willReturn(senderAddress);
+        given(precompileContext.getTransactionBody()).willReturn(transactionBody);
 
         // when:
         subject.prepareFields(frame);
-        subject.prepareComputation(pretendArguments, a -> a);
-        subject.getPrecompile().getGasRequirement(TEST_CONSENSUS_TIME, transactionBody);
+        subject.prepareComputation(pretendArguments, a -> a, precompileContext);
+        subject.getPrecompile(frame).getGasRequirement(TEST_CONSENSUS_TIME, transactionBody, sender);
         final var result = subject.computeInternal(frame);
 
         // then:
@@ -289,7 +301,12 @@ class BurnPrecompileTest {
     void fungibleBurnHappyPathWorks() {
         // given:
         final Bytes pretendArguments = givenFungibleFrameContext();
-        prepareStoreForFungibleBurn(67);
+        final var tokenID = TokenID.newBuilder()
+                .setShardNum(0)
+                .setRealmNum(0)
+                .setTokenNum(TOKEN_ID_TO_BURN)
+                .build();
+        prepareStoreForFungibleBurn(tokenID);
         givenPricingUtilsContext();
 
         given(worldUpdater.permissivelyUnaliased(any()))
@@ -298,11 +315,22 @@ class BurnPrecompileTest {
                 .willReturn(1L);
         given(feeCalculator.computeFee(any(), any(), any())).willReturn(mockFeeObject);
         given(mockFeeObject.getServiceFee()).willReturn(1L);
+        given(frame.getMessageFrameStack()).willReturn(stack);
+        given(stack.getLast()).willReturn(lastFrame);
+        given(lastFrame.getContextVariable(PRECOMPILE_CONTEXT)).willReturn(precompileContext);
+        given(precompileContext.getPrecompile()).willReturn(burnPrecompile);
+        given(precompileContext.getSenderAddress()).willReturn(senderAddress);
+
+        final var transactionBody = TransactionBody.newBuilder()
+                .setTokenBurn(
+                        TokenBurnTransactionBody.newBuilder().setToken(tokenID).setAmount(33L));
+
+        given(precompileContext.getTransactionBody()).willReturn(transactionBody);
 
         // when:
         subject.prepareFields(frame);
-        subject.prepareComputation(pretendArguments, a -> a);
-        subject.getPrecompile().getGasRequirement(TEST_CONSENSUS_TIME, transactionBody);
+        subject.prepareComputation(pretendArguments, a -> a, precompileContext);
+        subject.getPrecompile(frame).getGasRequirement(TEST_CONSENSUS_TIME, transactionBody, sender);
         final var result = subject.computeInternal(frame);
 
         // then:
@@ -324,10 +352,16 @@ class BurnPrecompileTest {
         given(frame.getWorldUpdater()).willReturn(worldUpdater);
         given(worldUpdater.permissivelyUnaliased(any()))
                 .willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
+        given(frame.getMessageFrameStack()).willReturn(stack);
+        given(stack.getLast()).willReturn(lastFrame);
+        given(lastFrame.getContextVariable(PRECOMPILE_CONTEXT)).willReturn(precompileContext);
+        given(precompileContext.getPrecompile()).willReturn(burnPrecompile);
+        given(precompileContext.getSenderAddress()).willReturn(senderAddress);
 
         subject.prepareFields(frame);
-        subject.prepareComputation(FUNGIBLE_BURN_INPUT_V1, a -> a);
-        final long result = subject.getPrecompile().getGasRequirement(TEST_CONSENSUS_TIME, transactionBody);
+        subject.prepareComputation(FUNGIBLE_BURN_INPUT_V1, a -> a, precompileContext);
+        final long result =
+                subject.getPrecompile(frame).getGasRequirement(TEST_CONSENSUS_TIME, transactionBody, sender);
 
         // then
         assertEquals(EXPECTED_GAS_PRICE, result);
@@ -430,12 +464,7 @@ class BurnPrecompileTest {
         when(token.burn(tokenRelationship, EMPTY_ARGUMENT)).thenReturn(tokenModificationResult);
     }
 
-    private void prepareStoreForFungibleBurn(final long newTotalSupply) {
-        final var tokenID = TokenID.newBuilder()
-                .setShardNum(0)
-                .setRealmNum(0)
-                .setTokenNum(TOKEN_ID_TO_BURN)
-                .build();
+    private void prepareStoreForFungibleBurn(final TokenID tokenID) {
         final var tokenAddress = Id.fromGrpcToken(tokenID).asEvmAddress();
         final var treasuryAddress = senderAddress;
         when(token.getTreasury()).thenReturn(account);

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/DeleteTokenPrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/DeleteTokenPrecompileTest.java
@@ -16,10 +16,13 @@
 
 package com.hedera.services.store.contracts.precompile;
 
+import static com.hedera.mirror.web3.common.PrecompileContext.PRECOMPILE_CONTEXT;
 import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.DEFAULT_GAS_PRICE;
 import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.TEST_CONSENSUS_TIME;
 import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.contractAddress;
 import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.fungible;
+import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.sender;
+import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.senderAddress;
 import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.successResult;
 import static com.hedera.services.store.contracts.precompile.impl.DeleteTokenPrecompile.decodeDelete;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.TokenDelete;
@@ -27,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
-import com.hedera.mirror.web3.common.ContractCallContext;
+import com.hedera.mirror.web3.common.PrecompileContext;
 import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
 import com.hedera.mirror.web3.evm.store.Store;
 import com.hedera.mirror.web3.evm.store.contract.HederaEvmStackedWorldStateUpdater;
@@ -132,10 +135,14 @@ class DeleteTokenPrecompileTest {
     @Mock
     private TokenAccessor tokenAccessor;
 
+    @Mock
+    private PrecompileContext precompileContext;
+
     @InjectMocks
     private MirrorNodeEvmProperties evmProperties;
 
     private HTSPrecompiledContract subject;
+    private DeleteTokenPrecompile deletePrecompile;
 
     @BeforeEach
     void setUp() throws IOException {
@@ -147,8 +154,7 @@ class DeleteTokenPrecompileTest {
 
         SyntheticTxnFactory syntheticTxnFactory = new SyntheticTxnFactory();
         DeleteLogic deleteLogic = new DeleteLogic();
-        final var deletePrecompile =
-                new DeleteTokenPrecompile(precompilePricingUtils, syntheticTxnFactory, deleteLogic);
+        deletePrecompile = new DeleteTokenPrecompile(precompilePricingUtils, syntheticTxnFactory, deleteLogic);
         PrecompileMapper precompileMapper = new PrecompileMapper(Set.of(deletePrecompile));
         subject = new HTSPrecompiledContract(
                 infrastructureFactory,
@@ -158,8 +164,6 @@ class DeleteTokenPrecompileTest {
                 store,
                 tokenAccessor,
                 precompilePricingUtils);
-
-        ContractCallContext.init(store.getStackedStateFrames());
     }
 
     @Test
@@ -168,10 +172,16 @@ class DeleteTokenPrecompileTest {
         givenFrameContext();
         givenMinimalContextForSuccessfulCall();
         given(frame.getWorldUpdater()).willReturn(worldUpdater);
+        given(frame.getMessageFrameStack()).willReturn(stack);
+        given(stack.getLast()).willReturn(lastFrame);
+        given(lastFrame.getContextVariable(PRECOMPILE_CONTEXT)).willReturn(precompileContext);
+        given(precompileContext.getPrecompile()).willReturn(deletePrecompile);
+        given(precompileContext.getSenderAddress()).willReturn(senderAddress);
+        given(precompileContext.getTransactionBody()).willReturn(transactionBody);
 
         // when
         subject.prepareFields(frame);
-        subject.prepareComputation(DELETE_INPUT, a -> a);
+        subject.prepareComputation(DELETE_INPUT, a -> a, precompileContext);
         final var result = subject.computeInternal(frame);
 
         // then
@@ -189,10 +199,16 @@ class DeleteTokenPrecompileTest {
         given(feeCalculator.computeFee(any(), any(), any()))
                 .willReturn(new FeeObject(TEST_NODE_FEE, TEST_NETWORK_FEE, TEST_SERVICE_FEE));
         given(feeCalculator.estimatedGasPriceInTinybars(any(), any())).willReturn(DEFAULT_GAS_PRICE);
+        given(frame.getMessageFrameStack()).willReturn(stack);
+        given(stack.getLast()).willReturn(lastFrame);
+        given(lastFrame.getContextVariable(PRECOMPILE_CONTEXT)).willReturn(precompileContext);
+        given(precompileContext.getPrecompile()).willReturn(deletePrecompile);
+        given(precompileContext.getSenderAddress()).willReturn(senderAddress);
+
         // when
         subject.prepareFields(frame);
-        subject.prepareComputation(DELETE_INPUT, a -> a);
-        final var result = subject.getPrecompile().getGasRequirement(TEST_CONSENSUS_TIME, transactionBody);
+        subject.prepareComputation(DELETE_INPUT, a -> a, precompileContext);
+        final var result = subject.getPrecompile(frame).getGasRequirement(TEST_CONSENSUS_TIME, transactionBody, sender);
         // then
         assertEquals(EXPECTED_GAS_PRICE, result);
     }

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/FreezeTokenPrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/FreezeTokenPrecompileTest.java
@@ -16,6 +16,7 @@
 
 package com.hedera.services.store.contracts.precompile;
 
+import static com.hedera.mirror.web3.common.PrecompileContext.PRECOMPILE_CONTEXT;
 import static com.hedera.services.store.contracts.precompile.AbiConstants.ABI_ID_FREEZE;
 import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.*;
 import static com.hedera.services.store.contracts.precompile.impl.FreezeTokenPrecompile.decodeFreeze;
@@ -26,7 +27,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
 import com.esaulpaugh.headlong.util.Integers;
-import com.hedera.mirror.web3.common.ContractCallContext;
+import com.hedera.mirror.web3.common.PrecompileContext;
 import com.hedera.mirror.web3.evm.account.MirrorEvmContractAliases;
 import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
 import com.hedera.mirror.web3.evm.store.Store;
@@ -120,6 +121,9 @@ class FreezeTokenPrecompileTest {
     @Mock
     private TokenAccessor tokenAccessor;
 
+    @Mock
+    private PrecompileContext precompileContext;
+
     private HTSPrecompiledContract subject;
     private MockedStatic<FreezeTokenPrecompile> staticFreezeTokenPrecompile;
 
@@ -135,6 +139,7 @@ class FreezeTokenPrecompileTest {
 
     private final TransactionBody.Builder transactionBody =
             TransactionBody.newBuilder().setTokenFreeze(TokenFreezeAccountTransactionBody.newBuilder());
+    private FreezeTokenPrecompile freezeTokenPrecompile;
 
     @BeforeEach
     void setUp() throws IOException {
@@ -144,8 +149,7 @@ class FreezeTokenPrecompileTest {
         final PrecompilePricingUtils precompilePricingUtils =
                 new PrecompilePricingUtils(assetLoader, exchange, feeCalculator, resourceCosts, accessorFactory);
 
-        FreezeTokenPrecompile freezeTokenPrecompile =
-                new FreezeTokenPrecompile(precompilePricingUtils, syntheticTxnFactory, freezeLogic);
+        freezeTokenPrecompile = new FreezeTokenPrecompile(precompilePricingUtils, syntheticTxnFactory, freezeLogic);
         PrecompileMapper precompileMapper = new PrecompileMapper(Set.of(freezeTokenPrecompile));
         staticFreezeTokenPrecompile = Mockito.mockStatic(FreezeTokenPrecompile.class);
 
@@ -157,8 +161,6 @@ class FreezeTokenPrecompileTest {
                 store,
                 tokenAccessor,
                 precompilePricingUtils);
-
-        ContractCallContext.init(store.getStackedStateFrames());
     }
 
     @AfterEach
@@ -174,10 +176,16 @@ class FreezeTokenPrecompileTest {
         givenMinimalContextForSuccessfulCall();
         givenFreezeUnfreezeContext();
         given(frame.getWorldUpdater()).willReturn(worldUpdater);
+        given(frame.getMessageFrameStack()).willReturn(stack);
+        given(stack.getLast()).willReturn(lastFrame);
+        given(lastFrame.getContextVariable(PRECOMPILE_CONTEXT)).willReturn(precompileContext);
+        given(precompileContext.getPrecompile()).willReturn(freezeTokenPrecompile);
+        given(precompileContext.getSenderAddress()).willReturn(senderAddress);
+        given(precompileContext.getTransactionBody()).willReturn(transactionBody);
 
         // when
         subject.prepareFields(frame);
-        subject.prepareComputation(input, a -> a);
+        subject.prepareComputation(input, a -> a, precompileContext);
         final var result = subject.computeInternal(frame);
 
         // then
@@ -196,11 +204,16 @@ class FreezeTokenPrecompileTest {
                 .willReturn(new FeeObject(TEST_NODE_FEE, TEST_NETWORK_FEE, TEST_SERVICE_FEE));
         given(feeCalculator.estimatedGasPriceInTinybars(any(), any())).willReturn(DEFAULT_GAS_PRICE);
         given(frame.getWorldUpdater()).willReturn(worldUpdater);
+        given(frame.getMessageFrameStack()).willReturn(stack);
+        given(stack.getLast()).willReturn(lastFrame);
+        given(lastFrame.getContextVariable(PRECOMPILE_CONTEXT)).willReturn(precompileContext);
+        given(precompileContext.getPrecompile()).willReturn(freezeTokenPrecompile);
+        given(precompileContext.getSenderAddress()).willReturn(senderAddress);
 
         // when
         subject.prepareFields(frame);
-        subject.prepareComputation(input, a -> a);
-        final var result = subject.getPrecompile().getGasRequirement(TEST_CONSENSUS_TIME, transactionBody);
+        subject.prepareComputation(input, a -> a, precompileContext);
+        final var result = subject.getPrecompile(frame).getGasRequirement(TEST_CONSENSUS_TIME, transactionBody, sender);
         // then
         assertEquals(EXPECTED_GAS_PRICE, result);
     }

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/HTSTestsUtil.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/HTSTestsUtil.java
@@ -63,6 +63,7 @@ public class HTSTestsUtil {
     public static final long DEFAULT_GAS_PRICE = 10_000L;
     public static final long TEST_CONSENSUS_TIME = 1_640_000_000L; // Monday, December 20, 2021 11:33:20 AM UTC
     public static final TokenID token = asToken("0.0.1");
+    public static final TokenID token2 = asToken("0.0.1176");
     public static final AccountID payer = asAccount("0.0.12345");
     public static final AccountID sender = asAccount("0.0.2");
     public static final AccountID receiver = asAccount("0.0.3");
@@ -73,6 +74,8 @@ public class HTSTestsUtil {
             .build();
     public static final AccountID feeCollector = asAccount("0.0.4");
     public static final AccountID account = asAccount("0.0.3");
+    public static final AccountID contract = asAccount("0.0.7");
+    public static final AccountID secondSender = asAccount("0.0.1154");
     public static final AccountID accountMerkleId = asAccount("0.0.999");
     public static final ContractID precompiledContract = asContract(asAccount("0.0.359"));
     public static final TokenID nonFungible = asToken("0.0.777");

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/PausePrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/PausePrecompileTest.java
@@ -16,6 +16,7 @@
 
 package com.hedera.services.store.contracts.precompile;
 
+import static com.hedera.mirror.web3.common.PrecompileContext.PRECOMPILE_CONTEXT;
 import static com.hedera.services.store.contracts.precompile.AbiConstants.ABI_ID_PAUSE_TOKEN;
 import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.*;
 import static com.hedera.services.store.contracts.precompile.impl.PausePrecompile.decodePause;
@@ -27,8 +28,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
 import com.esaulpaugh.headlong.util.Integers;
-import com.hedera.mirror.web3.common.ContractCallContext;
-import com.hedera.mirror.web3.evm.account.MirrorEvmContractAliases;
+import com.hedera.mirror.web3.common.PrecompileContext;
 import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
 import com.hedera.mirror.web3.evm.store.Store;
 import com.hedera.mirror.web3.evm.store.contract.HederaEvmStackedWorldStateUpdater;
@@ -116,9 +116,6 @@ class PausePrecompileTest {
     private Store store;
 
     @Mock
-    private MirrorEvmContractAliases contractAliases;
-
-    @Mock
     private BodyParams bodyParams;
 
     @Mock
@@ -132,6 +129,9 @@ class PausePrecompileTest {
 
     @Mock
     private TokenAccessor tokenAccessor;
+
+    @Mock
+    private PrecompileContext precompileContext;
 
     private static final long TEST_SERVICE_FEE = 5_000_000;
     private static final long TEST_NETWORK_FEE = 400_000;
@@ -172,8 +172,6 @@ class PausePrecompileTest {
                 store,
                 tokenAccessor,
                 precompilePricingUtils);
-
-        ContractCallContext.init(store.getStackedStateFrames());
     }
 
     @AfterEach
@@ -193,10 +191,16 @@ class PausePrecompileTest {
         given(feeCalculator.computeFee(any(), any(), any())).willReturn(mockFeeObject);
         given(pauseLogic.validateSyntax(any())).willReturn(OK);
         given(pausePrecompile.body(pretendArguments, aliasResolver, bodyParams)).willReturn(transactionBody);
+        given(frame.getMessageFrameStack()).willReturn(stack);
+        given(stack.getLast()).willReturn(lastFrame);
+        given(lastFrame.getContextVariable(PRECOMPILE_CONTEXT)).willReturn(precompileContext);
+        given(precompileContext.getPrecompile()).willReturn(pausePrecompile);
+        given(precompileContext.getSenderAddress()).willReturn(senderAddress);
+        given(precompileContext.getTransactionBody()).willReturn(transactionBody);
 
         subject.prepareFields(frame);
-        subject.prepareComputation(pretendArguments, a -> a);
-        subject.getPrecompile().getGasRequirement(TEST_CONSENSUS_TIME, transactionBody);
+        subject.prepareComputation(pretendArguments, a -> a, precompileContext);
+        subject.getPrecompile(frame).getGasRequirement(TEST_CONSENSUS_TIME, transactionBody, sender);
         final var result = subject.computeInternal(frame);
 
         assertEquals(successResult, result);
@@ -218,10 +222,16 @@ class PausePrecompileTest {
         given(feeCalculator.estimatedGasPriceInTinybars(any(), any())).willReturn(DEFAULT_GAS_PRICE);
         given(worldUpdater.permissivelyUnaliased(any()))
                 .willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
+        given(frame.getMessageFrameStack()).willReturn(stack);
+        given(stack.getLast()).willReturn(lastFrame);
+        given(lastFrame.getContextVariable(PRECOMPILE_CONTEXT)).willReturn(precompileContext);
+        given(precompileContext.getPrecompile()).willReturn(pausePrecompile);
+        given(precompileContext.getSenderAddress()).willReturn(senderAddress);
 
         subject.prepareFields(frame);
-        subject.prepareComputation(input, a -> a);
-        final long result = subject.getPrecompile().getGasRequirement(TEST_CONSENSUS_TIME, transactionBody);
+        subject.prepareComputation(input, a -> a, precompileContext);
+        final long result =
+                subject.getPrecompile(frame).getGasRequirement(TEST_CONSENSUS_TIME, transactionBody, sender);
 
         // then
         assertEquals(EXPECTED_GAS_PRICE, result);

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/RevokeKycPrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/RevokeKycPrecompileTest.java
@@ -16,6 +16,7 @@
 
 package com.hedera.services.store.contracts.precompile;
 
+import static com.hedera.mirror.web3.common.PrecompileContext.PRECOMPILE_CONTEXT;
 import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.*;
 import static com.hedera.services.store.contracts.precompile.impl.RevokeKycPrecompile.decodeRevokeTokenKyc;
 import static java.util.function.UnaryOperator.identity;
@@ -24,8 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
-import com.hedera.mirror.web3.common.ContractCallContext;
-import com.hedera.mirror.web3.evm.account.MirrorEvmContractAliases;
+import com.hedera.mirror.web3.common.PrecompileContext;
 import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
 import com.hedera.mirror.web3.evm.store.Store;
 import com.hedera.mirror.web3.evm.store.contract.HederaEvmStackedWorldStateUpdater;
@@ -75,8 +75,9 @@ class RevokeKycPrecompileTest {
     private static final Bytes REVOKE_TOKEN_KYC_INPUT = Bytes.fromHexString(
             "0xaf99c63300000000000000000000000000000000000000000000000000000000000004b200000000000000000000000000000000000000000000000000000000000004b0");
 
-    private final TransactionBody.Builder transactionBody =
-            TransactionBody.newBuilder().setTokenRevokeKyc(TokenRevokeKycTransactionBody.newBuilder());
+    private final TransactionBody.Builder transactionBody = TransactionBody.newBuilder()
+            .setTokenRevokeKyc(
+                    TokenRevokeKycTransactionBody.newBuilder().setToken(token).setAccount(account));
 
     @Mock
     private AccessorFactory accessorFactory;
@@ -109,9 +110,6 @@ class RevokeKycPrecompileTest {
     private MessageFrame frame;
 
     @Mock
-    private MirrorEvmContractAliases contractAliases;
-
-    @Mock
     private MirrorNodeEvmProperties evmProperties;
 
     @Mock
@@ -131,6 +129,9 @@ class RevokeKycPrecompileTest {
 
     @Mock
     private TokenAccessor tokenAccessor;
+
+    @Mock
+    private PrecompileContext precompileContext;
 
     private HTSPrecompiledContract subject;
     private PrecompileMapper precompileMapper;
@@ -160,8 +161,6 @@ class RevokeKycPrecompileTest {
                 store,
                 tokenAccessor,
                 precompilePricingUtils);
-
-        ContractCallContext.init(store.getStackedStateFrames());
     }
 
     @Test
@@ -178,10 +177,16 @@ class RevokeKycPrecompileTest {
                 .willReturn(1L);
         given(feeCalculator.computeFee(any(), any(), any())).willReturn(mockFeeObject);
         given(frame.getWorldUpdater()).willReturn(worldUpdater);
+        given(frame.getMessageFrameStack()).willReturn(stack);
+        given(stack.getLast()).willReturn(lastFrame);
+        given(lastFrame.getContextVariable(PRECOMPILE_CONTEXT)).willReturn(precompileContext);
+        given(precompileContext.getPrecompile()).willReturn(revokeKycPrecompile);
+        given(precompileContext.getSenderAddress()).willReturn(senderAddress);
+        given(precompileContext.getTransactionBody()).willReturn(transactionBody);
         // when
         subject.prepareFields(frame);
-        subject.prepareComputation(REVOKE_TOKEN_KYC_INPUT, a -> a);
-        subject.getPrecompile().getGasRequirement(HTSTestsUtil.TEST_CONSENSUS_TIME, transactionBody);
+        subject.prepareComputation(REVOKE_TOKEN_KYC_INPUT, a -> a, precompileContext);
+        subject.getPrecompile(frame).getGasRequirement(HTSTestsUtil.TEST_CONSENSUS_TIME, transactionBody, sender);
         final var result = subject.computeInternal(frame);
 
         // then
@@ -199,10 +204,15 @@ class RevokeKycPrecompileTest {
         given(feeCalculator.computeFee(any(), any(), any()))
                 .willReturn(new FeeObject(TEST_NODE_FEE, TEST_NETWORK_FEE, TEST_SERVICE_FEE));
         given(feeCalculator.estimatedGasPriceInTinybars(any(), any())).willReturn(DEFAULT_GAS_PRICE);
+        given(frame.getMessageFrameStack()).willReturn(stack);
+        given(stack.getLast()).willReturn(lastFrame);
+        given(lastFrame.getContextVariable(PRECOMPILE_CONTEXT)).willReturn(precompileContext);
+        given(precompileContext.getPrecompile()).willReturn(revokeKycPrecompile);
+        given(precompileContext.getSenderAddress()).willReturn(senderAddress);
         // when
         subject.prepareFields(frame);
-        subject.prepareComputation(REVOKE_TOKEN_KYC_INPUT, a -> a);
-        final var result = subject.getPrecompile().getGasRequirement(TEST_CONSENSUS_TIME, transactionBody);
+        subject.prepareComputation(REVOKE_TOKEN_KYC_INPUT, a -> a, precompileContext);
+        final var result = subject.getPrecompile(frame).getGasRequirement(TEST_CONSENSUS_TIME, transactionBody, sender);
         // then
         assertEquals(EXPECTED_GAS_PRICE, result);
     }

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/TokenUpdateKeysPrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/TokenUpdateKeysPrecompileTest.java
@@ -16,9 +16,12 @@
 
 package com.hedera.services.store.contracts.precompile;
 
+import static com.hedera.mirror.web3.common.PrecompileContext.PRECOMPILE_CONTEXT;
 import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.contractAddress;
 import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.failResult;
 import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.fungible;
+import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.sender;
+import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.senderAddress;
 import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.successResult;
 import static com.hedera.services.store.contracts.precompile.impl.TokenUpdateKeysPrecompile.decodeUpdateTokenKeys;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FAIL_INVALID;
@@ -30,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
-import com.hedera.mirror.web3.common.ContractCallContext;
+import com.hedera.mirror.web3.common.PrecompileContext;
 import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
 import com.hedera.mirror.web3.evm.store.Store;
 import com.hedera.mirror.web3.evm.store.contract.HederaEvmStackedWorldStateUpdater;
@@ -52,6 +55,7 @@ import com.hedera.services.utils.EntityIdUtils;
 import com.hedera.services.utils.accessors.AccessorFactory;
 import com.hederahashgraph.api.proto.java.ExchangeRate;
 import com.hederahashgraph.api.proto.java.Timestamp;
+import com.hederahashgraph.api.proto.java.TokenUpdateTransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import java.util.Deque;
 import java.util.List;
@@ -109,8 +113,8 @@ class TokenUpdateKeysPrecompileTest {
     @Mock
     private OptionValidator optionValidator;
 
-    @Mock
-    private TransactionBody.Builder transactionBodyBuilder;
+    private TransactionBody.Builder transactionBodyBuilder =
+            TransactionBody.newBuilder().setTokenUpdate(TokenUpdateTransactionBody.newBuilder());
 
     @Mock
     private Store store;
@@ -123,6 +127,11 @@ class TokenUpdateKeysPrecompileTest {
 
     @Mock
     private TokenAccessor tokenAccessor;
+
+    @Mock
+    private PrecompileContext precompileContext;
+
+    private TokenUpdateKeysPrecompile tokenUpdateKeysPrecompile;
 
     private static final int CENTS_RATE = 12;
     private static final int HBAR_RATE = 1;
@@ -192,7 +201,7 @@ class TokenUpdateKeysPrecompileTest {
                 new PrecompilePricingUtils(assetLoader, exchange, feeCalculator, resourceCosts, accessorFactory);
 
         SyntheticTxnFactory syntheticTxnFactory = new SyntheticTxnFactory();
-        final var tokenUpdateKeysPrecompile = new TokenUpdateKeysPrecompile(
+        tokenUpdateKeysPrecompile = new TokenUpdateKeysPrecompile(
                 syntheticTxnFactory, precompilePricingUtils, updateLogic, optionValidator, evmProperties);
         PrecompileMapper precompileMapper = new PrecompileMapper(Set.of(tokenUpdateKeysPrecompile));
 
@@ -204,8 +213,6 @@ class TokenUpdateKeysPrecompileTest {
                 store,
                 tokenAccessor,
                 precompilePricingUtils);
-
-        ContractCallContext.init(store.getStackedStateFrames());
     }
 
     @Test
@@ -217,10 +224,18 @@ class TokenUpdateKeysPrecompileTest {
         givenPricingUtilsContext();
         given(updateLogic.validate(any())).willReturn(OK);
         given(frame.getWorldUpdater()).willReturn(worldUpdater);
+        given(frame.getMessageFrameStack()).willReturn(stack);
+        given(stack.getLast()).willReturn(lastFrame);
+        given(lastFrame.getContextVariable(PRECOMPILE_CONTEXT)).willReturn(precompileContext);
+        given(precompileContext.getPrecompile()).willReturn(tokenUpdateKeysPrecompile);
+        given(precompileContext.getSenderAddress()).willReturn(senderAddress);
+        given(precompileContext.getTransactionBody()).willReturn(transactionBodyBuilder);
+
         // when
         subject.prepareFields(frame);
-        subject.prepareComputation(UPDATE_FUNGIBLE_TOKEN_KEYS, a -> a);
-        subject.getPrecompile().getMinimumFeeInTinybars(Timestamp.getDefaultInstance(), transactionBodyBuilder.build());
+        subject.prepareComputation(UPDATE_FUNGIBLE_TOKEN_KEYS, a -> a, precompileContext);
+        subject.getPrecompile(frame)
+                .getMinimumFeeInTinybars(Timestamp.getDefaultInstance(), transactionBodyBuilder.build(), sender);
         final var result = subject.computeInternal(frame);
         // then
         assertEquals(successResult, result);
@@ -235,9 +250,15 @@ class TokenUpdateKeysPrecompileTest {
         given(worldUpdater.permissivelyUnaliased(any()))
                 .willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
         given(updateLogic.validate(any())).willReturn(FAIL_INVALID);
+        given(frame.getMessageFrameStack()).willReturn(stack);
+        given(stack.getLast()).willReturn(lastFrame);
+        given(lastFrame.getContextVariable(PRECOMPILE_CONTEXT)).willReturn(precompileContext);
+        given(precompileContext.getPrecompile()).willReturn(tokenUpdateKeysPrecompile);
+        given(precompileContext.getSenderAddress()).willReturn(senderAddress);
+        given(precompileContext.getTransactionBody()).willReturn(transactionBodyBuilder);
         // when
         subject.prepareFields(frame);
-        subject.prepareComputation(UPDATE_FUNGIBLE_TOKEN_KEYS, a -> a);
+        subject.prepareComputation(UPDATE_FUNGIBLE_TOKEN_KEYS, a -> a, precompileContext);
         final var result = subject.computeInternal(frame);
         // then
         assertEquals(failResult, result);

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/TokenUpdatePrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/TokenUpdatePrecompileTest.java
@@ -16,7 +16,10 @@
 
 package com.hedera.services.store.contracts.precompile;
 
+import static com.hedera.mirror.web3.common.PrecompileContext.PRECOMPILE_CONTEXT;
 import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.failResult;
+import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.sender;
+import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.senderAddress;
 import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.successResult;
 import static com.hedera.services.store.contracts.precompile.impl.TokenUpdatePrecompile.decodeUpdateTokenInfo;
 import static com.hedera.services.store.contracts.precompile.impl.TokenUpdatePrecompile.decodeUpdateTokenInfoV2;
@@ -29,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
-import com.hedera.mirror.web3.common.ContractCallContext;
+import com.hedera.mirror.web3.common.PrecompileContext;
 import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
 import com.hedera.mirror.web3.evm.store.Store;
 import com.hedera.mirror.web3.evm.store.contract.HederaEvmStackedWorldStateUpdater;
@@ -142,15 +145,18 @@ class TokenUpdatePrecompileTest {
     @Mock
     private HederaEvmContractAliases hederaEvmContractAliases;
 
+    @Mock
+    private PrecompileContext precompileContext;
+
     private final TokenUpdateWrapper updateWrapper = HTSTestsUtil.createFungibleTokenUpdateWrapperWithKeys(null);
 
-    private final TransactionBody transactionBody = TransactionBody.newBuilder()
-            .setTokenUpdate(TokenUpdateTransactionBody.newBuilder())
-            .build();
+    private final TransactionBody.Builder transactionBody =
+            TransactionBody.newBuilder().setTokenUpdate(TokenUpdateTransactionBody.newBuilder());
 
     private HTSPrecompiledContract subject;
 
     private MockedStatic<TokenUpdatePrecompile> tokenUpdatePrecompileStatic;
+    private TokenUpdatePrecompile tokenUpdatePrecompile;
 
     @Mock
     private PrecompileMapper precompileMapper;
@@ -162,7 +168,7 @@ class TokenUpdatePrecompileTest {
 
         tokenUpdatePrecompileStatic = Mockito.mockStatic(TokenUpdatePrecompile.class);
 
-        TokenUpdatePrecompile tokenUpdatePrecompile = new TokenUpdatePrecompile(
+        tokenUpdatePrecompile = new TokenUpdatePrecompile(
                 pricingUtils, updateLogic, syntheticTxnFactory, mirrorNodeEvmProperties, contextOptionValidator);
 
         precompileMapper = new PrecompileMapper(Set.of(tokenUpdatePrecompile));
@@ -175,8 +181,6 @@ class TokenUpdatePrecompileTest {
                 store,
                 tokenAccessor,
                 pricingUtils);
-
-        ContractCallContext.init(store.getStackedStateFrames());
     }
 
     @AfterEach
@@ -204,8 +208,9 @@ class TokenUpdatePrecompileTest {
         given(frame.getWorldUpdater()).willReturn(worldUpdater);
         // when
         subject.prepareFields(frame);
-        subject.prepareComputation(UPDATE_FUNGIBLE_TOKEN_INPUT, a -> a);
-        subject.getPrecompile().getMinimumFeeInTinybars(Timestamp.getDefaultInstance(), transactionBody);
+        subject.prepareComputation(UPDATE_FUNGIBLE_TOKEN_INPUT, a -> a, precompileContext);
+        subject.getPrecompile(frame)
+                .getMinimumFeeInTinybars(Timestamp.getDefaultInstance(), transactionBody.build(), sender);
         final var result = subject.computeInternal(frame);
         // then
         assertEquals(successResult, result);
@@ -230,8 +235,9 @@ class TokenUpdatePrecompileTest {
         given(frame.getWorldUpdater()).willReturn(worldUpdater);
         // when
         subject.prepareFields(frame);
-        subject.prepareComputation(UPDATE_FUNGIBLE_TOKEN_INPUT_V2, a -> a);
-        subject.getPrecompile().getMinimumFeeInTinybars(Timestamp.getDefaultInstance(), transactionBody);
+        subject.prepareComputation(UPDATE_FUNGIBLE_TOKEN_INPUT_V2, a -> a, precompileContext);
+        subject.getPrecompile(frame)
+                .getMinimumFeeInTinybars(Timestamp.getDefaultInstance(), transactionBody.build(), sender);
         final var result = subject.computeInternal(frame);
         // then
         assertEquals(successResult, result);
@@ -256,8 +262,9 @@ class TokenUpdatePrecompileTest {
         given(frame.getWorldUpdater()).willReturn(worldUpdater);
         // when
         subject.prepareFields(frame);
-        subject.prepareComputation(UPDATE_FUNGIBLE_TOKEN_INPUT_V3, a -> a);
-        subject.getPrecompile().getMinimumFeeInTinybars(Timestamp.getDefaultInstance(), transactionBody);
+        subject.prepareComputation(UPDATE_FUNGIBLE_TOKEN_INPUT_V3, a -> a, precompileContext);
+        subject.getPrecompile(frame)
+                .getMinimumFeeInTinybars(Timestamp.getDefaultInstance(), transactionBody.build(), sender);
         final var result = subject.computeInternal(frame);
         // then
         assertEquals(successResult, result);
@@ -281,7 +288,7 @@ class TokenUpdatePrecompileTest {
                 .willReturn(TransactionBody.newBuilder().setTokenUpdate(TokenUpdateTransactionBody.newBuilder()));
         // when
         subject.prepareFields(frame);
-        subject.prepareComputation(UPDATE_FUNGIBLE_TOKEN_INPUT, a -> a);
+        subject.prepareComputation(UPDATE_FUNGIBLE_TOKEN_INPUT, a -> a, precompileContext);
         final var result = subject.computeInternal(frame);
         // then
         assertEquals(failResult, result);
@@ -301,9 +308,10 @@ class TokenUpdatePrecompileTest {
                 .thenReturn(updateWrapper);
         given(syntheticTxnFactory.createTokenUpdate(updateWrapper))
                 .willReturn(TransactionBody.newBuilder().setTokenUpdate(TokenUpdateTransactionBody.newBuilder()));
+
         // when
         subject.prepareFields(frame);
-        subject.prepareComputation(UPDATE_FUNGIBLE_TOKEN_INPUT_V2, a -> a);
+        subject.prepareComputation(UPDATE_FUNGIBLE_TOKEN_INPUT_V2, a -> a, precompileContext);
         final var result = subject.computeInternal(frame);
         // then
         assertEquals(failResult, result);
@@ -369,6 +377,12 @@ class TokenUpdatePrecompileTest {
         givenMinimalFrameContext();
         given(frame.getRemainingGas()).willReturn(300L);
         given(frame.getValue()).willReturn(Wei.ZERO);
+        given(frame.getMessageFrameStack()).willReturn(stack);
+        given(stack.getLast()).willReturn(lastFrame);
+        given(lastFrame.getContextVariable(PRECOMPILE_CONTEXT)).willReturn(precompileContext);
+        given(precompileContext.getPrecompile()).willReturn(tokenUpdatePrecompile);
+        given(precompileContext.getSenderAddress()).willReturn(senderAddress);
+        given(precompileContext.getTransactionBody()).willReturn(transactionBody);
     }
 
     private void givenMinimalContextForSuccessfulCall() {

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/TransferPrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/TransferPrecompileTest.java
@@ -16,6 +16,7 @@
 
 package com.hedera.services.store.contracts.precompile;
 
+import static com.hedera.mirror.web3.common.PrecompileContext.PRECOMPILE_CONTEXT;
 import static com.hedera.services.store.contracts.precompile.AbiConstants.ABI_ID_CRYPTO_TRANSFER;
 import static com.hedera.services.store.contracts.precompile.AbiConstants.ABI_ID_CRYPTO_TRANSFER_V2;
 import static com.hedera.services.store.contracts.precompile.AbiConstants.ABI_ID_TRANSFER_NFTS;
@@ -70,6 +71,7 @@ import static org.mockito.Mockito.when;
 
 import com.esaulpaugh.headlong.util.Integers;
 import com.hedera.mirror.web3.common.ContractCallContext;
+import com.hedera.mirror.web3.common.PrecompileContext;
 import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
 import com.hedera.mirror.web3.evm.store.Store;
 import com.hedera.mirror.web3.evm.store.contract.EntityAddressSequencer;
@@ -173,7 +175,7 @@ class TransferPrecompileTest {
     private TransferPrecompile transferPrecompile;
 
     @Mock
-    private ContractCallContext contractCallContext;
+    private PrecompileContext precompileContext;
 
     private BodyParams transferParams;
 
@@ -236,8 +238,6 @@ class TransferPrecompileTest {
 
     @BeforeEach
     void setup() {
-        staticMock = mockStatic(ContractCallContext.class);
-        staticMock.when(ContractCallContext::get).thenReturn(contractCallContext);
         syntheticTxnFactory = new SyntheticTxnFactory();
 
         transferPrecompile = new TransferPrecompile(
@@ -259,14 +259,11 @@ class TransferPrecompileTest {
                 pricingUtils);
 
         staticTransferPrecompile = mockStatic(TransferPrecompile.class);
-
-        ContractCallContext.init(store.getStackedStateFrames());
     }
 
     @AfterEach
     void closeMocks() {
         staticTransferPrecompile.close();
-        staticMock.close();
     }
 
     @Test
@@ -294,18 +291,20 @@ class TransferPrecompileTest {
         given(worldUpdater.getStore()).willReturn(store);
         given(frame.getWorldUpdater()).willReturn(worldUpdater);
         given(frame.getValue()).willReturn(Wei.ZERO);
-        given(contractCallContext.getPrecompile()).willReturn(transferPrecompile);
-        given(contractCallContext.getTransactionBody()).willReturn(transactionBody);
-        given(contractCallContext.getSenderAddress()).willReturn(contractAddress);
-        ContractCallContext.get().setSenderAddress(contractAddress);
+        given(frame.getMessageFrameStack()).willReturn(stack);
+        given(stack.getLast()).willReturn(lastFrame);
+        given(lastFrame.getContextVariable(PRECOMPILE_CONTEXT)).willReturn(precompileContext);
+        given(precompileContext.getPrecompile()).willReturn(transferPrecompile);
+        given(precompileContext.getTransactionBody()).willReturn(transactionBody);
+        given(precompileContext.getSenderAddress()).willReturn(contractAddress);
         given(worldUpdater.permissivelyUnaliased(any()))
                 .willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
         given(frame.getSenderAddress()).willReturn(contractAddress);
 
         // when:
         subject.prepareFields(frame);
-        subject.prepareComputation(pretendArguments, a -> a);
-        subject.getPrecompile().getGasRequirement(TEST_CONSENSUS_TIME, transactionBodyBuilder);
+        subject.prepareComputation(pretendArguments, a -> a, precompileContext);
+        subject.getPrecompile(frame).getGasRequirement(TEST_CONSENSUS_TIME, transactionBodyBuilder, sender);
         final var result = subject.computeInternal(frame);
 
         Assertions.assertEquals(UInt256.valueOf(ResponseCodeEnum.ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS_VALUE), result);
@@ -317,7 +316,7 @@ class TransferPrecompileTest {
         givenMinimalFrameContext();
         given(worldUpdater.permissivelyUnaliased(any()))
                 .willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
-        when(contractCallContext.getSenderAddress()).thenReturn(senderAddress);
+        when(precompileContext.getSenderAddress()).thenReturn(senderAddress);
 
         staticTransferPrecompile
                 .when(() -> decodeTransferTokens(eq(pretendArguments), any()))
@@ -326,14 +325,16 @@ class TransferPrecompileTest {
         given(frame.getRemainingGas()).willReturn(10000L);
         given(frame.getSenderAddress()).willReturn(contractAddress);
         given(frame.getWorldUpdater()).willReturn(worldUpdater);
+        given(frame.getMessageFrameStack()).willReturn(stack);
+        given(stack.getLast()).willReturn(lastFrame);
+        given(lastFrame.getContextVariable(PRECOMPILE_CONTEXT)).willReturn(precompileContext);
         given(worldUpdater.getStore()).willReturn(store);
-        given(contractCallContext.getPrecompile()).willReturn(transferPrecompile);
-        given(contractCallContext.getTransactionBody()).willReturn(transactionBody);
-        ContractCallContext.get().setSenderAddress(contractAddress);
+        given(precompileContext.getPrecompile()).willReturn(transferPrecompile);
+        given(precompileContext.getTransactionBody()).willReturn(transactionBody);
         // when:
         subject.prepareFields(frame);
-        subject.prepareComputation(pretendArguments, a -> a);
-        subject.getPrecompile().getGasRequirement(TEST_CONSENSUS_TIME, transactionBodyBuilder);
+        subject.prepareComputation(pretendArguments, a -> a, precompileContext);
+        subject.getPrecompile(frame).getGasRequirement(TEST_CONSENSUS_TIME, transactionBodyBuilder, sender);
 
         final var result = subject.computeInternal(frame);
 
@@ -347,7 +348,7 @@ class TransferPrecompileTest {
         givenMinimalFrameContext();
         given(worldUpdater.permissivelyUnaliased(any()))
                 .willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
-        when(contractCallContext.getSenderAddress()).thenReturn(senderAddress);
+        when(precompileContext.getSenderAddress()).thenReturn(senderAddress);
 
         staticTransferPrecompile
                 .when(() -> decodeTransferNFTs(eq(pretendArguments), any()))
@@ -356,14 +357,16 @@ class TransferPrecompileTest {
         given(frame.getRemainingGas()).willReturn(10000L);
         given(frame.getSenderAddress()).willReturn(contractAddress);
         given(frame.getWorldUpdater()).willReturn(worldUpdater);
+        given(frame.getMessageFrameStack()).willReturn(stack);
+        given(stack.getLast()).willReturn(lastFrame);
+        given(lastFrame.getContextVariable(PRECOMPILE_CONTEXT)).willReturn(precompileContext);
         given(worldUpdater.getStore()).willReturn(store);
-        given(contractCallContext.getPrecompile()).willReturn(transferPrecompile);
-        given(contractCallContext.getTransactionBody()).willReturn(transactionBody);
-        ContractCallContext.get().setSenderAddress(contractAddress);
+        given(precompileContext.getPrecompile()).willReturn(transferPrecompile);
+        given(precompileContext.getTransactionBody()).willReturn(transactionBody);
         // when:
         subject.prepareFields(frame);
-        subject.prepareComputation(pretendArguments, a -> a);
-        subject.getPrecompile().getGasRequirement(TEST_CONSENSUS_TIME, transactionBodyBuilder);
+        subject.prepareComputation(pretendArguments, a -> a, precompileContext);
+        subject.getPrecompile(frame).getGasRequirement(TEST_CONSENSUS_TIME, transactionBodyBuilder, sender);
         final var result = subject.computeInternal(frame);
 
         // then:
@@ -376,7 +379,7 @@ class TransferPrecompileTest {
         givenMinimalFrameContext();
         given(worldUpdater.permissivelyUnaliased(any()))
                 .willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
-        when(contractCallContext.getSenderAddress()).thenReturn(senderAddress);
+        when(precompileContext.getSenderAddress()).thenReturn(senderAddress);
 
         staticTransferPrecompile
                 .when(() -> decodeCryptoTransfer(eq(pretendArguments), any(), any()))
@@ -385,14 +388,16 @@ class TransferPrecompileTest {
         given(frame.getRemainingGas()).willReturn(10000L);
         given(frame.getSenderAddress()).willReturn(contractAddress);
         given(frame.getWorldUpdater()).willReturn(worldUpdater);
+        given(frame.getMessageFrameStack()).willReturn(stack);
+        given(stack.getLast()).willReturn(lastFrame);
+        given(lastFrame.getContextVariable(PRECOMPILE_CONTEXT)).willReturn(precompileContext);
         given(worldUpdater.getStore()).willReturn(store);
-        given(contractCallContext.getPrecompile()).willReturn(transferPrecompile);
-        given(contractCallContext.getTransactionBody()).willReturn(transactionBody);
-        ContractCallContext.get().setSenderAddress(contractAddress);
+        given(precompileContext.getPrecompile()).willReturn(transferPrecompile);
+        given(precompileContext.getTransactionBody()).willReturn(transactionBody);
         // when:
         subject.prepareFields(frame);
-        subject.prepareComputation(pretendArguments, a -> a);
-        subject.getPrecompile().getGasRequirement(TEST_CONSENSUS_TIME, transactionBodyBuilder);
+        subject.prepareComputation(pretendArguments, a -> a, precompileContext);
+        subject.getPrecompile(frame).getGasRequirement(TEST_CONSENSUS_TIME, transactionBodyBuilder, sender);
         final var result = subject.computeInternal(frame);
 
         // then:
@@ -405,7 +410,7 @@ class TransferPrecompileTest {
         givenMinimalFrameContext();
         given(worldUpdater.permissivelyUnaliased(any()))
                 .willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
-        when(contractCallContext.getSenderAddress()).thenReturn(senderAddress);
+        when(precompileContext.getSenderAddress()).thenReturn(senderAddress);
 
         staticTransferPrecompile
                 .when(() -> decodeCryptoTransferV2(eq(pretendArguments), any(), any()))
@@ -414,14 +419,16 @@ class TransferPrecompileTest {
         given(frame.getRemainingGas()).willReturn(10000L);
         given(frame.getSenderAddress()).willReturn(contractAddress);
         given(frame.getWorldUpdater()).willReturn(worldUpdater);
+        given(frame.getMessageFrameStack()).willReturn(stack);
+        given(stack.getLast()).willReturn(lastFrame);
+        given(lastFrame.getContextVariable(PRECOMPILE_CONTEXT)).willReturn(precompileContext);
         given(worldUpdater.getStore()).willReturn(store);
-        given(contractCallContext.getPrecompile()).willReturn(transferPrecompile);
-        given(contractCallContext.getTransactionBody()).willReturn(transactionBody);
-        ContractCallContext.get().setSenderAddress(contractAddress);
+        given(precompileContext.getPrecompile()).willReturn(transferPrecompile);
+        given(precompileContext.getTransactionBody()).willReturn(transactionBody);
         // when:
         subject.prepareFields(frame);
-        subject.prepareComputation(pretendArguments, a -> a);
-        subject.getPrecompile().getGasRequirement(TEST_CONSENSUS_TIME, transactionBodyBuilder);
+        subject.prepareComputation(pretendArguments, a -> a, precompileContext);
+        subject.getPrecompile(frame).getGasRequirement(TEST_CONSENSUS_TIME, transactionBodyBuilder, sender);
         final var result = subject.computeInternal(frame);
 
         // then:
@@ -434,7 +441,7 @@ class TransferPrecompileTest {
         givenMinimalFrameContext();
         given(worldUpdater.permissivelyUnaliased(any()))
                 .willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
-        when(contractCallContext.getSenderAddress()).thenReturn(senderAddress);
+        when(precompileContext.getSenderAddress()).thenReturn(senderAddress);
 
         staticTransferPrecompile
                 .when(() -> decodeCryptoTransferV2(eq(pretendArguments), any(), any()))
@@ -443,14 +450,16 @@ class TransferPrecompileTest {
         given(frame.getRemainingGas()).willReturn(10000L);
         given(frame.getSenderAddress()).willReturn(contractAddress);
         given(frame.getWorldUpdater()).willReturn(worldUpdater);
+        given(frame.getMessageFrameStack()).willReturn(stack);
+        given(stack.getLast()).willReturn(lastFrame);
+        given(lastFrame.getContextVariable(PRECOMPILE_CONTEXT)).willReturn(precompileContext);
         given(worldUpdater.getStore()).willReturn(store);
-        given(contractCallContext.getPrecompile()).willReturn(transferPrecompile);
-        given(contractCallContext.getTransactionBody()).willReturn(transactionBody);
-        ContractCallContext.get().setSenderAddress(contractAddress);
+        given(precompileContext.getPrecompile()).willReturn(transferPrecompile);
+        given(precompileContext.getTransactionBody()).willReturn(transactionBody);
         // when:
         subject.prepareFields(frame);
-        subject.prepareComputation(pretendArguments, a -> a);
-        subject.getPrecompile().getGasRequirement(TEST_CONSENSUS_TIME, transactionBodyBuilder);
+        subject.prepareComputation(pretendArguments, a -> a, precompileContext);
+        subject.getPrecompile(frame).getGasRequirement(TEST_CONSENSUS_TIME, transactionBodyBuilder, sender);
 
         final var result = subject.computeInternal(frame);
 
@@ -464,7 +473,7 @@ class TransferPrecompileTest {
         givenMinimalFrameContext();
         given(worldUpdater.permissivelyUnaliased(any()))
                 .willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
-        when(contractCallContext.getSenderAddress()).thenReturn(senderAddress);
+        when(precompileContext.getSenderAddress()).thenReturn(senderAddress);
 
         staticTransferPrecompile
                 .when(() -> decodeCryptoTransferV2(eq(pretendArguments), any(), any()))
@@ -473,14 +482,15 @@ class TransferPrecompileTest {
         given(frame.getRemainingGas()).willReturn(10000L);
         given(frame.getSenderAddress()).willReturn(contractAddress);
         given(frame.getWorldUpdater()).willReturn(worldUpdater);
+        given(frame.getMessageFrameStack()).willReturn(stack);
+        given(stack.getLast()).willReturn(lastFrame);
+        given(lastFrame.getContextVariable(PRECOMPILE_CONTEXT)).willReturn(precompileContext);
         given(worldUpdater.getStore()).willReturn(store);
-        given(contractCallContext.getPrecompile()).willReturn(transferPrecompile);
-        given(contractCallContext.getTransactionBody()).willReturn(transactionBody);
-        ContractCallContext.get().setSenderAddress(contractAddress);
-
+        given(precompileContext.getPrecompile()).willReturn(transferPrecompile);
+        given(precompileContext.getTransactionBody()).willReturn(transactionBody);
         // when:
         subject.prepareFields(frame);
-        subject.prepareComputation(pretendArguments, a -> a);
+        subject.prepareComputation(pretendArguments, a -> a, precompileContext);
         final var result = subject.computeInternal(frame);
 
         // then:
@@ -493,7 +503,7 @@ class TransferPrecompileTest {
         givenMinimalFrameContext();
         given(worldUpdater.permissivelyUnaliased(any()))
                 .willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
-        when(contractCallContext.getSenderAddress()).thenReturn(senderAddress);
+        when(precompileContext.getSenderAddress()).thenReturn(senderAddress);
 
         staticTransferPrecompile
                 .when(() -> decodeCryptoTransferV2(eq(pretendArguments), any(), any()))
@@ -502,14 +512,16 @@ class TransferPrecompileTest {
         given(frame.getRemainingGas()).willReturn(10000L);
         given(frame.getSenderAddress()).willReturn(contractAddress);
         given(frame.getWorldUpdater()).willReturn(worldUpdater);
-        given(contractCallContext.getPrecompile()).willReturn(transferPrecompile);
-        given(contractCallContext.getTransactionBody()).willReturn(transactionBody);
-        ContractCallContext.get().setSenderAddress(contractAddress);
+        given(frame.getMessageFrameStack()).willReturn(stack);
+        given(stack.getLast()).willReturn(lastFrame);
+        given(lastFrame.getContextVariable(PRECOMPILE_CONTEXT)).willReturn(precompileContext);
+        given(precompileContext.getPrecompile()).willReturn(transferPrecompile);
+        given(precompileContext.getTransactionBody()).willReturn(transactionBody);
         given(worldUpdater.getStore()).willReturn(store);
 
         // when:
         subject.prepareFields(frame);
-        subject.prepareComputation(pretendArguments, a -> a);
+        subject.prepareComputation(pretendArguments, a -> a, precompileContext);
         final var result = subject.computeInternal(frame);
 
         // then:
@@ -522,7 +534,6 @@ class TransferPrecompileTest {
         givenMinimalFrameContext();
         given(worldUpdater.permissivelyUnaliased(any()))
                 .willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
-        when(contractCallContext.getSenderAddress()).thenReturn(senderAddress);
 
         staticTransferPrecompile
                 .when(() -> decodeCryptoTransferV2(eq(pretendArguments), any(), any()))
@@ -547,17 +558,20 @@ class TransferPrecompileTest {
         given(frame.getRemainingGas()).willReturn(10000L);
         given(frame.getSenderAddress()).willReturn(contractAddress);
         given(frame.getWorldUpdater()).willReturn(worldUpdater);
+        given(frame.getMessageFrameStack()).willReturn(stack);
+        given(stack.getLast()).willReturn(lastFrame);
+        given(lastFrame.getContextVariable(PRECOMPILE_CONTEXT)).willReturn(precompileContext);
+        given(precompileContext.getPrecompile()).willReturn(transferPrecompile);
+        given(precompileContext.getTransactionBody()).willReturn(transactionBody);
+        given(precompileContext.getSenderAddress()).willReturn(contractAddress);
         given(worldUpdater.getStore()).willReturn(store);
         final var lazyCreationFee = 500L;
         when(autoCreationLogic.create(any(), any(), any(), any()))
                 .thenReturn(Pair.of(MAX_ENTITIES_IN_PRICE_REGIME_HAVE_BEEN_CREATED, lazyCreationFee));
-        given(contractCallContext.getPrecompile()).willReturn(transferPrecompile);
-        given(contractCallContext.getTransactionBody()).willReturn(transactionBody);
-        given(contractCallContext.getSenderAddress()).willReturn(contractAddress);
 
         // when:
         subject.prepareFields(frame);
-        subject.prepareComputation(pretendArguments, a -> a);
+        subject.prepareComputation(pretendArguments, a -> a, precompileContext);
         final var result = subject.computeInternal(frame);
 
         // then:
@@ -571,11 +585,11 @@ class TransferPrecompileTest {
         staticTransferPrecompile
                 .when(() -> decodeTransferToken(eq(input), any()))
                 .thenReturn(CRYPTO_TRANSFER_EMPTY_WRAPPER);
-        when(pricingUtils.computeGasRequirement(anyLong(), any(), any())).thenReturn(EXPECTED_GAS_PRICE);
+        when(pricingUtils.computeGasRequirement(anyLong(), any(), any(), any())).thenReturn(EXPECTED_GAS_PRICE);
 
         transferPrecompile.body(input, a -> a, null);
 
-        final long result = transferPrecompile.getGasRequirement(TEST_CONSENSUS_TIME, transactionBodyBuilder);
+        final long result = transferPrecompile.getGasRequirement(TEST_CONSENSUS_TIME, transactionBodyBuilder, sender);
 
         // then
         assertEquals(EXPECTED_GAS_PRICE, result);
@@ -590,10 +604,10 @@ class TransferPrecompileTest {
                 .when(() -> decodeCryptoTransferV2(eq(input), any(), any()))
                 .thenReturn(CRYPTO_TRANSFER_HBAR_ONLY_WRAPPER);
         when(pricingUtils.getMinimumPriceInTinybars(any(), any())).thenReturn(TEST_CRYPTO_TRANSFER_MIN_FEE);
-        given(contractCallContext.getSenderAddress()).willReturn(contractAddress);
 
         final var transactionBody = transferPrecompile.body(input, a -> a, transferParams);
-        final var minimumFeeInTinybars = transferPrecompile.getMinimumFeeInTinybars(timestamp, transactionBody.build());
+        final var minimumFeeInTinybars =
+                transferPrecompile.getMinimumFeeInTinybars(timestamp, transactionBody.build(), sender);
 
         // then
         assertEquals(TEST_CRYPTO_TRANSFER_MIN_FEE, minimumFeeInTinybars);
@@ -610,10 +624,10 @@ class TransferPrecompileTest {
                 .when(() -> decodeCryptoTransferV2(eq(input), any(), any()))
                 .thenReturn(CRYPTO_TRANSFER_TWO_HBAR_ONLY_WRAPPER);
         when(pricingUtils.getMinimumPriceInTinybars(any(), any())).thenReturn(TEST_CRYPTO_TRANSFER_MIN_FEE);
-        given(contractCallContext.getSenderAddress()).willReturn(contractAddress);
 
         final var transactionBody = transferPrecompile.body(input, a -> a, transferParams);
-        final var minimumFeeInTinybars = transferPrecompile.getMinimumFeeInTinybars(timestamp, transactionBody.build());
+        final var minimumFeeInTinybars =
+                transferPrecompile.getMinimumFeeInTinybars(timestamp, transactionBody.build(), sender);
 
         // then
         // expect 2 times the fee as there are two transfers
@@ -631,10 +645,10 @@ class TransferPrecompileTest {
                 .when(() -> decodeCryptoTransferV2(eq(input), any(), any()))
                 .thenReturn(CRYPTO_TRANSFER_HBAR_FUNGIBLE_WRAPPER);
         when(pricingUtils.getMinimumPriceInTinybars(any(), any())).thenReturn(TEST_CRYPTO_TRANSFER_MIN_FEE);
-        given(contractCallContext.getSenderAddress()).willReturn(contractAddress);
 
         final var transactionBody = transferPrecompile.body(input, a -> a, transferParams);
-        final var minimumFeeInTinybars = transferPrecompile.getMinimumFeeInTinybars(timestamp, transactionBody.build());
+        final var minimumFeeInTinybars =
+                transferPrecompile.getMinimumFeeInTinybars(timestamp, transactionBody.build(), sender);
 
         // then
         // 1 for hbars and 1 for fungible tokens
@@ -651,10 +665,10 @@ class TransferPrecompileTest {
                 .when(() -> decodeCryptoTransferV2(eq(input), any(), any()))
                 .thenReturn(CRYPTO_TRANSFER_HBAR_NFT_WRAPPER);
         when(pricingUtils.getMinimumPriceInTinybars(any(), any())).thenReturn(TEST_CRYPTO_TRANSFER_MIN_FEE);
-        given(contractCallContext.getSenderAddress()).willReturn(contractAddress);
 
         final var transactionBody = transferPrecompile.body(input, a -> a, transferParams);
-        final var minimumFeeInTinybars = transferPrecompile.getMinimumFeeInTinybars(timestamp, transactionBody.build());
+        final var minimumFeeInTinybars =
+                transferPrecompile.getMinimumFeeInTinybars(timestamp, transactionBody.build(), sender);
 
         // then
         // 2 for nfts transfers and 1 for hbars
@@ -670,11 +684,10 @@ class TransferPrecompileTest {
                 .when(() -> decodeCryptoTransferV2(eq(input), any(), any()))
                 .thenReturn(CRYPTO_TRANSFER_HBAR_FUNGIBLE_NFT_WRAPPER);
         when(pricingUtils.getMinimumPriceInTinybars(any(), any())).thenReturn(TEST_CRYPTO_TRANSFER_MIN_FEE);
-        given(contractCallContext.getSenderAddress()).willReturn(contractAddress);
-        ContractCallContext.get().setSenderAddress(contractAddress);
 
         final var transactionBody = transferPrecompile.body(input, a -> a, transferParams);
-        final var minimumFeeInTinybars = transferPrecompile.getMinimumFeeInTinybars(timestamp, transactionBody.build());
+        final var minimumFeeInTinybars =
+                transferPrecompile.getMinimumFeeInTinybars(timestamp, transactionBody.build(), sender);
 
         // then
         // 1 for fungible + 2 for nfts transfers + 1 for hbars

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/UnfreezeTokenPrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/UnfreezeTokenPrecompileTest.java
@@ -16,6 +16,7 @@
 
 package com.hedera.services.store.contracts.precompile;
 
+import static com.hedera.mirror.web3.common.PrecompileContext.PRECOMPILE_CONTEXT;
 import static com.hedera.services.store.contracts.precompile.AbiConstants.ABI_ID_UNFREEZE;
 import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.*;
 import static com.hedera.services.store.contracts.precompile.impl.UnfreezeTokenPrecompile.decodeUnfreeze;
@@ -26,8 +27,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
 import com.esaulpaugh.headlong.util.Integers;
-import com.hedera.mirror.web3.common.ContractCallContext;
-import com.hedera.mirror.web3.evm.account.MirrorEvmContractAliases;
+import com.hedera.mirror.web3.common.PrecompileContext;
 import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
 import com.hedera.mirror.web3.evm.store.Store;
 import com.hedera.mirror.web3.evm.store.contract.HederaEvmStackedWorldStateUpdater;
@@ -106,9 +106,6 @@ class UnfreezeTokenPrecompileTest {
     private EvmHTSPrecompiledContract evmHTSPrecompiledContract;
 
     @Mock
-    private MirrorEvmContractAliases contractAliases;
-
-    @Mock
     private Store store;
 
     @Mock
@@ -119,6 +116,10 @@ class UnfreezeTokenPrecompileTest {
 
     @Mock
     private TokenAccessor tokenAccessor;
+
+    private PrecompileContext precompileContext;
+
+    private UnfreezeTokenPrecompile unfreezeTokenPrecompile;
 
     private HTSPrecompiledContract subject;
     private MockedStatic<UnfreezeTokenPrecompile> staticUnfreezeTokenPrecompile;
@@ -144,10 +145,11 @@ class UnfreezeTokenPrecompileTest {
         final PrecompilePricingUtils precompilePricingUtils =
                 new PrecompilePricingUtils(assetLoader, exchange, feeCalculator, resourceCosts, accessorFactory);
 
-        UnfreezeTokenPrecompile unfreezeTokenPrecompile =
+        unfreezeTokenPrecompile =
                 new UnfreezeTokenPrecompile(precompilePricingUtils, syntheticTxnFactory, unfreezeLogic);
         PrecompileMapper precompileMapper = new PrecompileMapper(Set.of(unfreezeTokenPrecompile));
         staticUnfreezeTokenPrecompile = Mockito.mockStatic(UnfreezeTokenPrecompile.class);
+        precompileContext = new PrecompileContext(false, unfreezeTokenPrecompile, 0L, transactionBody, senderAddress);
 
         subject = new HTSPrecompiledContract(
                 infrastructureFactory,
@@ -157,8 +159,6 @@ class UnfreezeTokenPrecompileTest {
                 store,
                 tokenAccessor,
                 precompilePricingUtils);
-
-        ContractCallContext.init(store.getStackedStateFrames());
     }
 
     @AfterEach
@@ -174,10 +174,13 @@ class UnfreezeTokenPrecompileTest {
         givenMinimalContextForSuccessfulCall();
         givenFreezeUnfreezeContext();
         given(frame.getWorldUpdater()).willReturn(worldUpdater);
+        given(frame.getMessageFrameStack()).willReturn(stack);
+        given(stack.getLast()).willReturn(lastFrame);
+        given(lastFrame.getContextVariable(PRECOMPILE_CONTEXT)).willReturn(precompileContext);
 
         // when
         subject.prepareFields(frame);
-        subject.prepareComputation(input, a -> a);
+        subject.prepareComputation(input, a -> a, precompileContext);
         final var result = subject.computeInternal(frame);
 
         // then
@@ -190,6 +193,9 @@ class UnfreezeTokenPrecompileTest {
         final var input = Bytes.of(Integers.toBytes(ABI_ID_UNFREEZE));
         givenMinimalFrameContext();
         given(frame.getWorldUpdater()).willReturn(worldUpdater);
+        given(frame.getMessageFrameStack()).willReturn(stack);
+        given(stack.getLast()).willReturn(lastFrame);
+        given(lastFrame.getContextVariable(PRECOMPILE_CONTEXT)).willReturn(precompileContext);
         given(worldUpdater.permissivelyUnaliased(any()))
                 .willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
         givenPricingUtilsContext();
@@ -199,8 +205,8 @@ class UnfreezeTokenPrecompileTest {
 
         // when
         subject.prepareFields(frame);
-        subject.prepareComputation(input, a -> a);
-        final var result = subject.getPrecompile().getGasRequirement(TEST_CONSENSUS_TIME, transactionBody);
+        subject.prepareComputation(input, a -> a, precompileContext);
+        final var result = subject.getPrecompile(frame).getGasRequirement(TEST_CONSENSUS_TIME, transactionBody, sender);
         // then
         assertEquals(EXPECTED_GAS_PRICE, result);
     }

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/UpdateTokenExpiryInfoPrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/UpdateTokenExpiryInfoPrecompileTest.java
@@ -16,7 +16,9 @@
 
 package com.hedera.services.store.contracts.precompile;
 
+import static com.hedera.mirror.web3.common.PrecompileContext.PRECOMPILE_CONTEXT;
 import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.contractAddress;
+import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.senderAddress;
 import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.successResult;
 import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.tokenUpdateExpiryInfoWrapper;
 import static com.hedera.services.store.contracts.precompile.impl.UpdateTokenExpiryInfoPrecompile.getTokenUpdateExpiryInfoWrapper;
@@ -28,8 +30,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mockStatic;
 
-import com.hedera.mirror.web3.common.ContractCallContext;
-import com.hedera.mirror.web3.evm.account.MirrorEvmContractAliases;
+import com.hedera.mirror.web3.common.PrecompileContext;
 import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
 import com.hedera.mirror.web3.evm.store.Store;
 import com.hedera.mirror.web3.evm.store.contract.HederaEvmStackedWorldStateUpdater;
@@ -119,7 +120,10 @@ class UpdateTokenExpiryInfoPrecompileTest {
     private TokenAccessor tokenAccessor;
 
     @Mock
-    private MirrorEvmContractAliases contractAliases;
+    private PrecompileContext precompileContext;
+
+    private final TransactionBody.Builder transactionBody =
+            TransactionBody.newBuilder().setTokenUpdate(TokenUpdateTransactionBody.newBuilder());
 
     public static final Bytes UPDATE_EXPIRY_INFO_FOR_TOKEN_INPUT = Bytes.fromHexString(
             "0x593d6e8200000000000000000000000000000000000000000000000000000000000008d300000000000000000000000000000000000000000000000000000000bbf7edc700000000000000000000000000000000000000000000000000000000000008d000000000000000000000000000000000000000000000000000000000002820a8");
@@ -127,6 +131,7 @@ class UpdateTokenExpiryInfoPrecompileTest {
             "0xd27be6cd00000000000000000000000000000000000000000000000000000000000008d3000000000000000000000000000000000000000000000000000000000bf7edc700000000000000000000000000000000000000000000000000000000000008d00000000000000000000000000000000000000000000000000000000000000008");
 
     private HTSPrecompiledContract subject;
+    private UpdateTokenExpiryInfoPrecompile updateTokenExpiryInfoPrecompile;
     private MockedStatic<UpdateTokenExpiryInfoPrecompile> staticUpdateTokenExpiryInfoPrecompile;
 
     @BeforeEach
@@ -137,7 +142,7 @@ class UpdateTokenExpiryInfoPrecompileTest {
         staticUpdateTokenExpiryInfoPrecompile = mockStatic(UpdateTokenExpiryInfoPrecompile.class);
 
         optionValidator = new ContextOptionValidator(evmProperties);
-        final var updateTokenExpiryInfoPrecompile = new UpdateTokenExpiryInfoPrecompile(
+        updateTokenExpiryInfoPrecompile = new UpdateTokenExpiryInfoPrecompile(
                 tokenUpdateLogic, evmProperties, optionValidator, syntheticTxnFactory, precompilePricingUtils);
 
         precompileMapper = new PrecompileMapper(Set.of(updateTokenExpiryInfoPrecompile));
@@ -150,8 +155,6 @@ class UpdateTokenExpiryInfoPrecompileTest {
                 store,
                 tokenAccessor,
                 precompilePricingUtils);
-
-        ContractCallContext.init(store.getStackedStateFrames());
     }
 
     @AfterEach
@@ -176,10 +179,16 @@ class UpdateTokenExpiryInfoPrecompileTest {
         // givenPricingUtilsContext
         given(worldUpdater.permissivelyUnaliased(any()))
                 .willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
+        given(frame.getMessageFrameStack()).willReturn(stack);
+        given(stack.getLast()).willReturn(lastFrame);
+        given(lastFrame.getContextVariable(PRECOMPILE_CONTEXT)).willReturn(precompileContext);
+        given(precompileContext.getPrecompile()).willReturn(updateTokenExpiryInfoPrecompile);
+        given(precompileContext.getTransactionBody()).willReturn(transactionBody);
+        given(precompileContext.getSenderAddress()).willReturn(senderAddress);
 
         // when
         subject.prepareFields(frame);
-        subject.prepareComputation(UPDATE_EXPIRY_INFO_FOR_TOKEN_INPUT, a -> a);
+        subject.prepareComputation(UPDATE_EXPIRY_INFO_FOR_TOKEN_INPUT, a -> a, precompileContext);
         final var result = subject.computeInternal(frame);
 
         // then
@@ -201,10 +210,16 @@ class UpdateTokenExpiryInfoPrecompileTest {
         // givenPricingUtilsContext
         given(worldUpdater.permissivelyUnaliased(any()))
                 .willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
+        given(frame.getMessageFrameStack()).willReturn(stack);
+        given(stack.getLast()).willReturn(lastFrame);
+        given(lastFrame.getContextVariable(PRECOMPILE_CONTEXT)).willReturn(precompileContext);
+        given(precompileContext.getPrecompile()).willReturn(updateTokenExpiryInfoPrecompile);
+        given(precompileContext.getTransactionBody()).willReturn(transactionBody);
+        given(precompileContext.getSenderAddress()).willReturn(senderAddress);
 
         // when
         subject.prepareFields(frame);
-        subject.prepareComputation(UPDATE_EXPIRY_INFO_FOR_TOKEN_INPUT_V2, a -> a);
+        subject.prepareComputation(UPDATE_EXPIRY_INFO_FOR_TOKEN_INPUT_V2, a -> a, precompileContext);
         final var result = subject.computeInternal(frame);
 
         // then

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/WipeFungiblePrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/WipeFungiblePrecompileTest.java
@@ -16,10 +16,13 @@
 
 package com.hedera.services.store.contracts.precompile;
 
+import static com.hedera.mirror.web3.common.PrecompileContext.PRECOMPILE_CONTEXT;
 import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.DEFAULT_GAS_PRICE;
 import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.TEST_CONSENSUS_TIME;
 import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.contractAddress;
 import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.fungible;
+import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.sender;
+import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.senderAddress;
 import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.successResult;
 import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.timestamp;
 import static com.hedera.services.store.contracts.precompile.impl.WipeFungiblePrecompile.getWipeWrapper;
@@ -31,11 +34,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 
-import com.hedera.mirror.web3.common.ContractCallContext;
+import com.hedera.mirror.web3.common.PrecompileContext;
 import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
 import com.hedera.mirror.web3.evm.store.Store;
 import com.hedera.mirror.web3.evm.store.contract.HederaEvmStackedWorldStateUpdater;
-import com.hedera.node.app.service.evm.accounts.HederaEvmContractAliases;
 import com.hedera.node.app.service.evm.store.contracts.precompile.EvmHTSPrecompiledContract;
 import com.hedera.node.app.service.evm.store.contracts.precompile.EvmInfrastructureFactory;
 import com.hedera.node.app.service.evm.store.tokens.TokenAccessor;
@@ -90,7 +92,9 @@ class WipeFungiblePrecompileTest {
     private static final Bytes FUNGIBLE_WIPE_INPUT_V2 = Bytes.fromHexString(
             "0xefef57f900000000000000000000000000000000000000000000000000000000000006aa00000000000000000000000000000000000000000000000000000000000006a8000000000000000000000000000000000000000000000000000000000000000a");
     private final TransactionBody.Builder transactionBody = TransactionBody.newBuilder()
-            .setTokenWipe(TokenWipeAccountTransactionBody.newBuilder().setToken(fungible));
+            .setTokenWipe(TokenWipeAccountTransactionBody.newBuilder()
+                    .setToken(fungible)
+                    .setAccount(HTSTestsUtil.contract));
 
     @Mock
     private MessageFrame frame;
@@ -129,9 +133,6 @@ class WipeFungiblePrecompileTest {
     private Store store;
 
     @Mock
-    private HederaEvmContractAliases hederaEvmContractAliases;
-
-    @Mock
     private Token token;
 
     @Mock
@@ -155,10 +156,14 @@ class WipeFungiblePrecompileTest {
     @Mock
     private TokenAccessor tokenAccessor;
 
+    @Mock
+    private PrecompileContext precompileContext;
+
     @InjectMocks
     private MirrorNodeEvmProperties evmProperties;
 
     private HTSPrecompiledContract subject;
+    private WipeFungiblePrecompile wipeFungiblePrecompile;
 
     @BeforeEach
     void setUp() throws IOException {
@@ -171,8 +176,8 @@ class WipeFungiblePrecompileTest {
 
         SyntheticTxnFactory syntheticTxnFactory = new SyntheticTxnFactory();
         WipeLogic wipeLogic = new WipeLogic(evmProperties);
-        final var wipePrecompile = new WipeFungiblePrecompile(precompilePricingUtils, syntheticTxnFactory, wipeLogic);
-        PrecompileMapper precompileMapper = new PrecompileMapper(Set.of(wipePrecompile));
+        wipeFungiblePrecompile = new WipeFungiblePrecompile(precompilePricingUtils, syntheticTxnFactory, wipeLogic);
+        PrecompileMapper precompileMapper = new PrecompileMapper(Set.of(wipeFungiblePrecompile));
 
         subject = new HTSPrecompiledContract(
                 infrastructureFactory,
@@ -182,8 +187,6 @@ class WipeFungiblePrecompileTest {
                 store,
                 tokenAccessor,
                 precompilePricingUtils);
-
-        ContractCallContext.init(store.getStackedStateFrames());
     }
 
     @Test
@@ -198,9 +201,16 @@ class WipeFungiblePrecompileTest {
         given(feeCalculator.computeFee(any(), any(), any())).willReturn(mockFeeObject);
         given(mockFeeObject.getServiceFee()).willReturn(1L);
 
+        given(frame.getMessageFrameStack()).willReturn(stack);
+        given(stack.getLast()).willReturn(lastFrame);
+        given(lastFrame.getContextVariable(PRECOMPILE_CONTEXT)).willReturn(precompileContext);
+        given(precompileContext.getPrecompile()).willReturn(wipeFungiblePrecompile);
+        given(precompileContext.getTransactionBody()).willReturn(transactionBody);
+        given(precompileContext.getSenderAddress()).willReturn(senderAddress);
+
         subject.prepareFields(frame);
-        subject.prepareComputation(FUNGIBLE_WIPE_INPUT, a -> a);
-        subject.getPrecompile().getGasRequirement(TEST_CONSENSUS_TIME, transactionBody);
+        subject.prepareComputation(FUNGIBLE_WIPE_INPUT, a -> a, precompileContext);
+        subject.getPrecompile(frame).getGasRequirement(TEST_CONSENSUS_TIME, transactionBody, sender);
         final var result = subject.computeInternal(frame);
 
         assertEquals(successResult, result);
@@ -218,9 +228,16 @@ class WipeFungiblePrecompileTest {
         given(feeCalculator.computeFee(any(), any(), any())).willReturn(mockFeeObject);
         given(mockFeeObject.getServiceFee()).willReturn(1L);
 
+        given(frame.getMessageFrameStack()).willReturn(stack);
+        given(stack.getLast()).willReturn(lastFrame);
+        given(lastFrame.getContextVariable(PRECOMPILE_CONTEXT)).willReturn(precompileContext);
+        given(precompileContext.getPrecompile()).willReturn(wipeFungiblePrecompile);
+        given(precompileContext.getTransactionBody()).willReturn(transactionBody);
+        given(precompileContext.getSenderAddress()).willReturn(senderAddress);
+
         subject.prepareFields(frame);
-        subject.prepareComputation(FUNGIBLE_WIPE_INPUT, a -> a);
-        subject.getPrecompile().getGasRequirement(TEST_CONSENSUS_TIME, transactionBody);
+        subject.prepareComputation(FUNGIBLE_WIPE_INPUT, a -> a, precompileContext);
+        subject.getPrecompile(frame).getGasRequirement(TEST_CONSENSUS_TIME, transactionBody, sender);
         final var result = subject.computeInternal(frame);
 
         assertEquals(successResult, result);
@@ -240,9 +257,16 @@ class WipeFungiblePrecompileTest {
         given(worldUpdater.permissivelyUnaliased(any()))
                 .willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
 
+        given(frame.getMessageFrameStack()).willReturn(stack);
+        given(stack.getLast()).willReturn(lastFrame);
+        given(lastFrame.getContextVariable(PRECOMPILE_CONTEXT)).willReturn(precompileContext);
+        given(precompileContext.getPrecompile()).willReturn(wipeFungiblePrecompile);
+        given(precompileContext.getSenderAddress()).willReturn(senderAddress);
+
         subject.prepareFields(frame);
-        subject.prepareComputation(FUNGIBLE_WIPE_INPUT, a -> a);
-        final long result = subject.getPrecompile().getGasRequirement(TEST_CONSENSUS_TIME, transactionBody);
+        subject.prepareComputation(FUNGIBLE_WIPE_INPUT, a -> a, precompileContext);
+        final long result =
+                subject.getPrecompile(frame).getGasRequirement(TEST_CONSENSUS_TIME, transactionBody, sender);
 
         // then
         assertEquals(EXPECTED_GAS_PRICE, result);

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/WipeNonFungiblePrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/WipeNonFungiblePrecompileTest.java
@@ -16,11 +16,13 @@
 
 package com.hedera.services.store.contracts.precompile;
 
+import static com.hedera.mirror.web3.common.PrecompileContext.PRECOMPILE_CONTEXT;
 import static com.hedera.services.store.contracts.precompile.AbiConstants.ABI_WIPE_TOKEN_ACCOUNT_NFT;
 import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.DEFAULT_GAS_PRICE;
 import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.TEST_CONSENSUS_TIME;
 import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.contractAddress;
 import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.nonFungible;
+import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.sender;
 import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.successResult;
 import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.timestamp;
 import static com.hedera.services.store.contracts.precompile.impl.WipeNonFungiblePrecompile.decodeWipeNFT;
@@ -33,11 +35,10 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.BDDMockito.given;
 
 import com.esaulpaugh.headlong.util.Integers;
-import com.hedera.mirror.web3.common.ContractCallContext;
+import com.hedera.mirror.web3.common.PrecompileContext;
 import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
 import com.hedera.mirror.web3.evm.store.Store;
 import com.hedera.mirror.web3.evm.store.contract.HederaEvmStackedWorldStateUpdater;
-import com.hedera.node.app.service.evm.accounts.HederaEvmContractAliases;
 import com.hedera.node.app.service.evm.store.contracts.precompile.EvmHTSPrecompiledContract;
 import com.hedera.node.app.service.evm.store.contracts.precompile.EvmInfrastructureFactory;
 import com.hedera.node.app.service.evm.store.tokens.TokenAccessor;
@@ -89,7 +90,9 @@ class WipeNonFungiblePrecompileTest {
     private static final Bytes NON_FUNGIBLE_WIPE_INPUT = Bytes.fromHexString(
             "0xf7f38e2600000000000000000000000000000000000000000000000000000000000006b000000000000000000000000000000000000000000000000000000000000006ae000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001");
     private final TransactionBody.Builder transactionBody = TransactionBody.newBuilder()
-            .setTokenWipe(TokenWipeAccountTransactionBody.newBuilder().setToken(nonFungible));
+            .setTokenWipe(TokenWipeAccountTransactionBody.newBuilder()
+                    .setToken(nonFungible)
+                    .setAccount(HTSTestsUtil.contract));
 
     @InjectMocks
     private MirrorNodeEvmProperties evmProperties;
@@ -131,9 +134,6 @@ class WipeNonFungiblePrecompileTest {
     private Store store;
 
     @Mock
-    private HederaEvmContractAliases hederaEvmContractAliases;
-
-    @Mock
     private Token token;
 
     @Mock
@@ -157,7 +157,11 @@ class WipeNonFungiblePrecompileTest {
     @Mock
     private TokenAccessor tokenAccessor;
 
+    @Mock
+    private PrecompileContext precompileContext;
+
     private HTSPrecompiledContract subject;
+    private WipeNonFungiblePrecompile wipePrecompile;
 
     @BeforeEach
     void setUp() throws IOException {
@@ -170,8 +174,7 @@ class WipeNonFungiblePrecompileTest {
 
         SyntheticTxnFactory syntheticTxnFactory = new SyntheticTxnFactory();
         WipeLogic wipeLogic = new WipeLogic(evmProperties);
-        final var wipePrecompile =
-                new WipeNonFungiblePrecompile(precompilePricingUtils, syntheticTxnFactory, wipeLogic);
+        wipePrecompile = new WipeNonFungiblePrecompile(precompilePricingUtils, syntheticTxnFactory, wipeLogic);
         PrecompileMapper precompileMapper = new PrecompileMapper(Set.of(wipePrecompile));
         subject = new HTSPrecompiledContract(
                 infrastructureFactory,
@@ -181,8 +184,6 @@ class WipeNonFungiblePrecompileTest {
                 store,
                 tokenAccessor,
                 precompilePricingUtils);
-
-        ContractCallContext.init(store.getStackedStateFrames());
     }
 
     @Test
@@ -196,10 +197,16 @@ class WipeNonFungiblePrecompileTest {
                 .willReturn(1L);
         given(feeCalculator.computeFee(any(), any(), any())).willReturn(mockFeeObject);
         given(mockFeeObject.getServiceFee()).willReturn(1L);
+        given(frame.getMessageFrameStack()).willReturn(stack);
+        given(stack.getLast()).willReturn(lastFrame);
+        given(lastFrame.getContextVariable(PRECOMPILE_CONTEXT)).willReturn(precompileContext);
+        given(precompileContext.getPrecompile()).willReturn(wipePrecompile);
+        given(precompileContext.getTransactionBody()).willReturn(transactionBody);
+        given(precompileContext.getSenderAddress()).willReturn(contractAddress);
 
         subject.prepareFields(frame);
-        subject.prepareComputation(NON_FUNGIBLE_WIPE_INPUT, a -> a);
-        subject.getPrecompile().getGasRequirement(TEST_CONSENSUS_TIME, transactionBody);
+        subject.prepareComputation(NON_FUNGIBLE_WIPE_INPUT, a -> a, precompileContext);
+        subject.getPrecompile(frame).getGasRequirement(TEST_CONSENSUS_TIME, transactionBody, sender);
         final var result = subject.computeInternal(frame);
 
         assertEquals(successResult, result);
@@ -219,10 +226,16 @@ class WipeNonFungiblePrecompileTest {
         given(feeCalculator.estimatedGasPriceInTinybars(any(), any())).willReturn(DEFAULT_GAS_PRICE);
         given(worldUpdater.permissivelyUnaliased(any()))
                 .willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
+        given(frame.getMessageFrameStack()).willReturn(stack);
+        given(stack.getLast()).willReturn(lastFrame);
+        given(lastFrame.getContextVariable(PRECOMPILE_CONTEXT)).willReturn(precompileContext);
+        given(precompileContext.getPrecompile()).willReturn(wipePrecompile);
+        given(precompileContext.getSenderAddress()).willReturn(contractAddress);
 
         subject.prepareFields(frame);
-        subject.prepareComputation(NON_FUNGIBLE_WIPE_INPUT, a -> a);
-        final long result = subject.getPrecompile().getGasRequirement(TEST_CONSENSUS_TIME, transactionBody);
+        subject.prepareComputation(NON_FUNGIBLE_WIPE_INPUT, a -> a, precompileContext);
+        final long result =
+                subject.getPrecompile(frame).getGasRequirement(TEST_CONSENSUS_TIME, transactionBody, sender);
 
         // then
         assertEquals(EXPECTED_GAS_PRICE, result);


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR extracts precompile related fields from ThreadLocal context to a new PrecompileContext, which is attached to the context variables of the initial root MessageFrame.

This reduces ThreadLocal context size and additionally would reduce calls to the ThreadLocal context itself.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
