### PR TITLE
Revert REST API to Node.js 18

### DIFF
--- a/buildSrc/src/main/kotlin/common-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/common-conventions.gradle.kts
@@ -63,7 +63,7 @@ dependencyCheck {
 // Spotless uses Prettier and it requires Node.js
 node {
     download = true
-    version = "20.9.0"
+    version = "18.18.0"
     workDir = rootDir.resolve(".gradle").resolve("nodejs")
 }
 

--- a/hedera-mirror-rest/Dockerfile
+++ b/hedera-mirror-rest/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-bookworm-slim
+FROM node:18-bookworm-slim
 LABEL maintainer="mirrornode@hedera.com"
 
 # Setup
@@ -26,4 +26,4 @@ RUN apt-get update && \
 USER node
 
 # Run
-ENTRYPOINT ["node", "--import=extensionless/register", "server.js"]
+ENTRYPOINT ["node", "--experimental-specifier-resolution=node", "server.js"]

--- a/hedera-mirror-rest/package-lock.json
+++ b/hedera-mirror-rest/package-lock.json
@@ -21,7 +21,6 @@
         "express-http-context",
         "express-openapi-validator",
         "extend",
-        "extensionless",
         "ip-anonymize",
         "js-yaml",
         "json-bigint",
@@ -56,7 +55,6 @@
         "express-http-context": "^1.2.4",
         "express-openapi-validator": "^5.1.1",
         "extend": "^3.0.2",
-        "extensionless": "^1.7.3",
         "ip-anonymize": "^0.1.0",
         "js-yaml": "^4.1.0",
         "json-bigint": "^1.0.0",
@@ -6089,12 +6087,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "inBundle": true
-    },
-    "node_modules/extensionless": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/extensionless/-/extensionless-1.7.3.tgz",
-      "integrity": "sha512-XnabdmjuuRetGf4isqbDG5SyZTbeWvS1tE+Sba5UR4DJ9hAi3PRBYWnzxaqrghCF3q5hYrQ+L0w5TR+NqnznLA==",
       "inBundle": true
     },
     "node_modules/extract-zip": {

--- a/hedera-mirror-rest/package.json
+++ b/hedera-mirror-rest/package.json
@@ -6,13 +6,13 @@
   "main": "server.js",
   "private": true,
   "engines": {
-    "node": ">=16.13.0 < 21"
+    "node": ">=16.13.0 < 20"
   },
   "scripts": {
-    "dev": "HEDERA_MIRROR_REST_LOG_LEVEL=trace nodemon --import=extensionless/register server.js",
+    "dev": "HEDERA_MIRROR_REST_LOG_LEVEL=trace nodemon --experimental-specifier-resolution=node server.js",
     "lint": "eslint --ignore-pattern node_modules/ --fix .",
-    "start": "node --import=extensionless/register server.js",
-    "pretest": "node --import=extensionless/register __tests__/integration/generator.js",
+    "start": "node --experimental-specifier-resolution=node server.js",
+    "pretest": "node --experimental-specifier-resolution=node __tests__/integration/generator.js",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
   },
   "author": "Hedera Mirror Node Team",
@@ -31,7 +31,6 @@
     "express-http-context": "^1.2.4",
     "express-openapi-validator": "^5.1.1",
     "extend": "^3.0.2",
-    "extensionless": "^1.7.3",
     "ip-anonymize": "^0.1.0",
     "js-yaml": "^4.1.0",
     "json-bigint": "^1.0.0",


### PR DESCRIPTION
**Description**:

* Revert Node.js from 20 to 18 to address performance problem
* Remove extensionless in `hedera-mirror-rest` since it's not supported for < 20

**Related issue(s)**:

Fixes #7275

**Notes for reviewer**:

Will cherry pick to `release/0.93`.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
