### PR TITLE
Update to no longer log recoverable error when transaction receipt contains invalid entity id

### DIFF
--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/RecordItem.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/RecordItem.java
@@ -159,6 +159,18 @@ public class RecordItem implements StreamItem {
         return transactionRecord.hasParentConsensusTimestamp();
     }
 
+    public boolean isInvalidIdError() {
+        return switch (transactionRecord.getReceipt().getStatus()) {
+            case INVALID_ACCOUNT_ID,
+                    INVALID_CONTRACT_ID,
+                    INVALID_FILE_ID,
+                    INVALID_SCHEDULE_ID,
+                    INVALID_TOKEN_ID,
+                    INVALID_TOPIC_ID -> true;
+            default -> false;
+        };
+    }
+
     // Whether this is a top level, user submitted transaction that could possibly trigger other internal transactions.
     public boolean isTopLevel() {
         return transactionRecord.getTransactionID().getNonce() == 0;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordItemListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordItemListener.java
@@ -18,5 +18,19 @@ package com.hedera.mirror.importer.parser.record;
 
 import com.hedera.mirror.common.domain.transaction.RecordItem;
 import com.hedera.mirror.importer.parser.StreamItemListener;
+import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 
-public interface RecordItemListener extends StreamItemListener<RecordItem> {}
+public interface RecordItemListener extends StreamItemListener<RecordItem> {
+
+    default boolean receiptStatusContainsInvalidId(ResponseCodeEnum receiptStatus) {
+        return switch (receiptStatus) {
+            case INVALID_ACCOUNT_ID,
+                    INVALID_CONTRACT_ID,
+                    INVALID_FILE_ID,
+                    INVALID_TOPIC_ID,
+                    INVALID_TOKEN_ID,
+                    INVALID_SCHEDULE_ID -> true;
+            default -> false;
+        };
+    }
+}

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordItemListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordItemListener.java
@@ -18,19 +18,5 @@ package com.hedera.mirror.importer.parser.record;
 
 import com.hedera.mirror.common.domain.transaction.RecordItem;
 import com.hedera.mirror.importer.parser.StreamItemListener;
-import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 
-public interface RecordItemListener extends StreamItemListener<RecordItem> {
-
-    default boolean receiptStatusContainsInvalidId(ResponseCodeEnum receiptStatus) {
-        return switch (receiptStatus) {
-            case INVALID_ACCOUNT_ID,
-                    INVALID_CONTRACT_ID,
-                    INVALID_FILE_ID,
-                    INVALID_SCHEDULE_ID,
-                    INVALID_TOKEN_ID,
-                    INVALID_TOPIC_ID -> true;
-            default -> false;
-        };
-    }
-}
+public interface RecordItemListener extends StreamItemListener<RecordItem> {}

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordItemListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordItemListener.java
@@ -27,9 +27,9 @@ public interface RecordItemListener extends StreamItemListener<RecordItem> {
             case INVALID_ACCOUNT_ID,
                     INVALID_CONTRACT_ID,
                     INVALID_FILE_ID,
-                    INVALID_TOPIC_ID,
+                    INVALID_SCHEDULE_ID,
                     INVALID_TOKEN_ID,
-                    INVALID_SCHEDULE_ID -> true;
+                    INVALID_TOPIC_ID -> true;
             default -> false;
         };
     }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListener.java
@@ -103,8 +103,7 @@ public class EntityRecordItemListener implements RecordItemListener {
         try {
             entityId = transactionHandler.getEntity(recordItem);
         } catch (InvalidEntityException e) { // transaction can have invalid topic/contract/file id
-            if (!receiptStatusContainsInvalidId(
-                    recordItem.getTransactionRecord().getReceipt().getStatus())) {
+            if (!recordItem.isInvalidIdError()) {
                 Utility.handleRecoverableError(
                         "Invalid entity encountered for consensusTimestamp {} : {}",
                         consensusTimestamp,

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListener.java
@@ -103,8 +103,13 @@ public class EntityRecordItemListener implements RecordItemListener {
         try {
             entityId = transactionHandler.getEntity(recordItem);
         } catch (InvalidEntityException e) { // transaction can have invalid topic/contract/file id
-            Utility.handleRecoverableError(
-                    "Invalid entity encountered for consensusTimestamp {} : {}", consensusTimestamp, e.getMessage());
+            if (!receiptStatusContainsInvalidId(
+                    recordItem.getTransactionRecord().getReceipt().getStatus())) {
+                Utility.handleRecoverableError(
+                        "Invalid entity encountered for consensusTimestamp {} : {}",
+                        consensusTimestamp,
+                        e.getMessage());
+            }
             entityId = EntityId.EMPTY;
         }
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/pubsub/PubSubRecordItemListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/pubsub/PubSubRecordItemListener.java
@@ -68,8 +68,13 @@ public class PubSubRecordItemListener implements RecordItemListener {
         try {
             entityId = transactionHandler.getEntity(recordItem);
         } catch (InvalidEntityException e) { // transaction can have invalid topic/contract/file id
-            Utility.handleRecoverableError(
-                    "Invalid entity encountered for consensusTimestamp {} : {}", consensusTimestamp, e.getMessage());
+            if (!receiptStatusContainsInvalidId(
+                    recordItem.getTransactionRecord().getReceipt().getStatus())) {
+                Utility.handleRecoverableError(
+                        "Invalid entity encountered for consensusTimestamp {} : {}",
+                        consensusTimestamp,
+                        e.getMessage());
+            }
             entityId = EntityId.EMPTY;
         }
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/pubsub/PubSubRecordItemListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/pubsub/PubSubRecordItemListener.java
@@ -68,8 +68,7 @@ public class PubSubRecordItemListener implements RecordItemListener {
         try {
             entityId = transactionHandler.getEntity(recordItem);
         } catch (InvalidEntityException e) { // transaction can have invalid topic/contract/file id
-            if (!receiptStatusContainsInvalidId(
-                    recordItem.getTransactionRecord().getReceipt().getStatus())) {
+            if (!recordItem.isInvalidIdError()) {
                 Utility.handleRecoverableError(
                         "Invalid entity encountered for consensusTimestamp {} : {}",
                         consensusTimestamp,

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/pubsub/PubSubRecordItemListenerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/pubsub/PubSubRecordItemListenerTest.java
@@ -365,9 +365,9 @@ class PubSubRecordItemListenerTest {
         "INVALID_ACCOUNT_ID, false",
         "INVALID_CONTRACT_ID, false",
         "INVALID_FILE_ID, false",
-        "INVALID_TOPIC_ID, false",
-        "INVALID_TOKEN_ID, false",
         "INVALID_SCHEDULE_ID, false",
+        "INVALID_TOKEN_ID, false",
+        "INVALID_TOPIC_ID, false",
     })
     @ParameterizedTest
     void testRecoverableErrorWithInvalidEntityId(ResponseCodeEnum receiptStatus, boolean expected) {


### PR DESCRIPTION
**Description**:

Will no longer throw Recoverable errors for invalid entity ids when the protobuf receipt status contains one of the invalid id status'.

**Related issue(s)**:

Fixes #7077

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
