### PR TITLE
Use deduped token balance data in historical token balance distribution REST API (0.93)

### DIFF
--- a/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.90.0__add_token_balance_index.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.90.0__add_token_balance_index.sql
@@ -1,0 +1,3 @@
+-- add an index to speed up the query for a specific token's balance distribution
+create index if not exists token_balance__token_account_timestamp
+    on token_balance (token_id, account_id, consensus_timestamp);

--- a/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.3__index_init.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.0.3__index_init.sql
@@ -240,6 +240,8 @@ create index if not exists token_allowance_history__owner_spender_token_lower_ti
 -- token_balance
 alter table if exists token_balance
     add constraint token_balance__pk primary key (account_id, token_id, consensus_timestamp);
+create index if not exists token_balance__token_account_timestamp
+    on token_balance (token_id, account_id, consensus_timestamp);
 
 -- token_transfer
 create index if not exists token_transfer__token_account_timestamp

--- a/hedera-mirror-rest/__tests__/balances.test.js
+++ b/hedera-mirror-rest/__tests__/balances.test.js
@@ -15,10 +15,14 @@
  */
 
 import request from 'supertest';
+import sinon from 'sinon';
 
+import balances from '../balances';
+import {MAX_LONG} from '../constants';
 import EntityId from '../entityId';
 import server from '../server';
 import * as testutils from './testutils';
+import {opsMap} from '../utils';
 
 // Validation functions
 /**
@@ -319,4 +323,99 @@ describe('Balances tests', () => {
   testutils.testBadParams(request, server, api, 'account.publickey', testutils.badParamsList());
   testutils.testBadParams(request, server, api, 'limit', testutils.badParamsList());
   testutils.testBadParams(request, server, api, 'order', testutils.badParamsList());
+});
+
+describe('getOptimizedTimestampRange', () => {
+  let clock;
+  // Set now, so Date.now() returns the expected epoch millis
+  const now = Date.parse('2022-10-15T08:10:15.333Z');
+
+  beforeAll(() => {
+    clock = sinon.useFakeTimers({now});
+  });
+
+  afterAll(() => {
+    clock.restore();
+  });
+
+  const toNs = (value) => {
+    if (typeof value !== 'string') {
+      return value;
+    }
+
+    return BigInt(Date.parse(value)) * 10n ** 6n;
+  };
+
+  const convertBound = (bound) => {
+    if (typeof bound !== 'object') {
+      return toNs(bound);
+    }
+
+    const {value, delta} = bound;
+    return toNs(value) + (delta ?? 0n);
+  };
+
+  const {lt, lte, gt, gte, ne} = opsMap;
+  const spec = [
+    {operators: [], params: [], expected: {lowerBound: '2022-09-01Z', upperBound: MAX_LONG, neParams: []}},
+    {operators: [gt, lt], params: ['2022-10-11Z', '2022-10-10Z'], expected: {}},
+    {
+      operators: [gte, lte],
+      params: ['2022-01-05Z', '2022-07-12Z'],
+      expected: {lowerBound: '2022-01-05Z', upperBound: '2022-07-12Z', neParams: []},
+    },
+    {
+      operators: [gt],
+      params: ['2022-10-10Z'],
+      expected: {lowerBound: {value: '2022-10-10Z', delta: 1n}, upperBound: MAX_LONG, neParams: []},
+    },
+    {
+      operators: [gt],
+      params: ['2022-01-01Z'],
+      expected: {lowerBound: '2022-09-01Z', upperBound: MAX_LONG, neParams: []},
+    },
+    {
+      operators: [gte],
+      params: ['2022-10-10Z'],
+      expected: {lowerBound: '2022-10-10Z', upperBound: MAX_LONG, neParams: []},
+    },
+    {
+      operators: [lt],
+      params: ['2022-12-15Z'],
+      expected: {lowerBound: '2022-09-01Z', upperBound: {value: '2022-12-15Z', delta: -1n}, neParams: []},
+    },
+    {
+      operators: [lt, ne],
+      params: ['2022-10-10Z', '2022-10-02Z'],
+      expected: {lowerBound: '2022-09-01Z', upperBound: {value: '2022-10-10Z', delta: -1n}, neParams: ['2022-10-02Z']},
+    },
+    {
+      operators: [lte],
+      params: ['2022-10-10Z'],
+      expected: {lowerBound: '2022-09-01Z', upperBound: '2022-10-10Z', neParams: []},
+    },
+    {
+      operators: [lte],
+      params: ['2022-09-20Z'],
+      expected: {lowerBound: '2022-08-01Z', upperBound: '2022-09-20Z', neParams: []},
+    },
+    {
+      operators: [gt, gte, lt, lte],
+      params: ['2022-01-05Z', '2022-02-10Z', '2022-10-02Z', '2022-09-20Z'],
+      expected: {lowerBound: '2022-02-10Z', upperBound: '2022-09-20Z', neParams: []},
+    },
+  ].map((s) => ({
+    query: s.operators.map((op) => `consensus_timestamp ${op} ?`).join(' and '),
+    params: s.params.map(toNs),
+    expected: {
+      lowerBound: convertBound(s.expected.lowerBound),
+      upperBound: convertBound(s.expected.upperBound),
+      neParams: s.expected.neParams?.map(toNs),
+    },
+  }));
+
+  test.each(spec)('$query', ({query, params, expected}) => {
+    const actual = balances.getOptimizedTimestampRange(query, params);
+    expect(actual).toEqual(expected);
+  });
 });

--- a/hedera-mirror-rest/__tests__/specs/accounts/{id}/timestamp.json
+++ b/hedera-mirror-rest/__tests__/specs/accounts/{id}/timestamp.json
@@ -9,7 +9,7 @@
         "num": 7
       },
       {
-        "balance": 80,
+        "balance": 88,
         "balance_timestamp": "1234567890300123456",
         "num": 8,
         "alias": "KGNABD5L3ZGSRVUCSPDR7TONZSRY3D5OMEBKQMVTD2AC6JL72HMQ",
@@ -285,18 +285,9 @@
       }
     ],
     "balance": {
-      "timestamp": "1234567890.300000010",
-      "balance": 80,
-      "tokens": [
-        {
-          "token_id": "0.0.99998",
-          "balance": 98
-        },
-        {
-          "token_id": "0.0.99999",
-          "balance": 88
-        }
-      ]
+      "timestamp": "1234567890.300123456",
+      "balance": 88,
+      "tokens": []
     },
     "account": "0.0.8",
     "alias": "KGNABD5L3ZGSRVUCSPDR7TONZSRY3D5OMEBKQMVTD2AC6JL72HMQ",

--- a/hedera-mirror-rest/__tests__/specs/tokens/{id}/balances/all-params.json
+++ b/hedera-mirror-rest/__tests__/specs/tokens/{id}/balances/all-params.json
@@ -33,7 +33,7 @@
         "num": 20,
         "realm": 1,
         "shard": 0,
-        "public_key": "c7e81a0c1444c6e5b5c1bfb1a02ae5faae44c11e621f286d21242cc584280692",
+        "public_key": "3c3d546321ff6f63d701d2ec5c277095874e19f4a235bee1e6bb19258bf362be",
         "expiration_timestamp": 123456784,
         "auto_renew_period": 44444,
         "key": [4, 4, 4]
@@ -81,6 +81,16 @@
       }
     ],
     "balances": [
+      {
+        "timestamp": 1566560001000000000,
+        "id": 2,
+        "balance": 180
+      },
+      {
+        "timestamp": 1566560003000000000,
+        "id": 2,
+        "balance": 200
+      },
       {
         "timestamp": 1566560001000000000,
         "id": 17,
@@ -144,7 +154,7 @@
           {
             "token_realm": 20,
             "token_num": 1,
-            "balance": 20
+            "balance": 46
           },
           {
             "token_realm": 20,
@@ -206,48 +216,12 @@
             "balance": 190190
           }
         ]
-      },
-      {
-        "timestamp": 1566560003000000000,
-        "id": 20,
-        "realm_num": 1,
-        "balance": 1000,
-        "tokens": [
-          {
-            "token_realm": 20,
-            "token_num": 1,
-            "balance": 200
-          },
-          {
-            "token_realm": 20,
-            "token_num": 2,
-            "balance": 200200
-          }
-        ]
-      },
-      {
-        "timestamp": 1566560009000000000,
-        "id": 19,
-        "realm_num": 1,
-        "balance": 999,
-        "tokens": [
-          {
-            "token_realm": 20,
-            "token_num": 1,
-            "balance": 1900
-          },
-          {
-            "token_realm": 20,
-            "token_num": 2,
-            "balance": 19001900
-          }
-        ]
       }
     ],
     "transactions": [],
     "cryptotransfers": []
   },
-  "url": "/api/v1/tokens/0.20.1/balances?account.id=gte:0.1.18&account.id=lt:0.1.20&account.balance=gt:45&account.publicKey=3c3d546321ff6f63d701d2ec5c277095874e19f4a235bee1e6bb19258bf362be&timestamp=1566560003.000000000&order=asc",
+  "url": "/api/v1/tokens/0.20.1/balances?account.id=gte:0.1.18&account.id=lt:0.1.21&account.balance=gt:45&account.publicKey=3c3d546321ff6f63d701d2ec5c277095874e19f4a235bee1e6bb19258bf362be&timestamp=1566560003.000000000&order=asc",
   "responseStatus": 200,
   "responseJson": {
     "timestamp": "1566560003.000000000",
@@ -255,6 +229,10 @@
       {
         "account": "0.1.19",
         "balance": 190
+      },
+      {
+        "account": "0.1.20",
+        "balance": 46
       }
     ],
     "links": {

--- a/hedera-mirror-rest/__tests__/specs/tokens/{id}/balances/timestamp-range-not-found.json
+++ b/hedera-mirror-rest/__tests__/specs/tokens/{id}/balances/timestamp-range-not-found.json
@@ -1,20 +1,6 @@
 {
   "description": "Token balances api calls with a timestamp range. Results in no timestamp found in range",
   "setup": {
-    "accounts": [
-      {
-        "num": 4
-      },
-      {
-        "num": 5
-      },
-      {
-        "num": 6
-      },
-      {
-        "num": 7
-      }
-    ],
     "tokens": [
       {
         "token_id": "0.20.1",
@@ -48,6 +34,21 @@
       }
     ],
     "balances": [
+      {
+        "timestamp": 1566560001000000000,
+        "id": 2,
+        "balance": 20
+      },
+      {
+        "timestamp": 1566560003000000000,
+        "id": 2,
+        "balance": 21
+      },
+      {
+        "timestamp": 1566560007000000000,
+        "id": 2,
+        "balance": 22
+      },
       {
         "timestamp": 1566560001000000000,
         "id": 4,
@@ -135,9 +136,7 @@
           }
         ]
       }
-    ],
-    "transactions": [],
-    "cryptotransfers": []
+    ]
   },
   "url": "/api/v1/tokens/0.20.1/balances?timestamp=gt:1566560003.000000000&timestamp=lt:1566560004.000000000",
   "responseStatus": 200,

--- a/hedera-mirror-rest/__tests__/specs/tokens/{id}/balances/timestamp-range.json
+++ b/hedera-mirror-rest/__tests__/specs/tokens/{id}/balances/timestamp-range.json
@@ -1,20 +1,6 @@
 {
   "description": "Token balances api calls for all account balances referencing the latest snapshot in a timestamp range",
   "setup": {
-    "accounts": [
-      {
-        "num": 4
-      },
-      {
-        "num": 5
-      },
-      {
-        "num": 6
-      },
-      {
-        "num": 7
-      }
-    ],
     "tokens": [
       {
         "token_id": "0.20.1",
@@ -48,6 +34,26 @@
       }
     ],
     "balances": [
+      {
+        "timestamp": 1566560001000000000,
+        "id": 2,
+        "balance": 20
+      },
+      {
+        "timestamp": 1566560003000000000,
+        "id": 2,
+        "balance": 21
+      },
+      {
+        "timestamp": 1566560007000000000,
+        "id": 2,
+        "balance": 22
+      },
+      {
+        "timestamp": 1566560008000000000,
+        "id": 4,
+        "balance": 23
+      },
       {
         "timestamp": 1566560001000000000,
         "id": 4,
@@ -147,11 +153,9 @@
           }
         ]
       }
-    ],
-    "transactions": [],
-    "cryptotransfers": []
+    ]
   },
-  "url": "/api/v1/tokens/0.20.1/balances?timestamp=gt:1566560001.000000000&timestamp=lt:1566560007.000000001",
+  "url": "/api/v1/tokens/0.20.1/balances?timestamp=gt:1566560003.000000000&timestamp=lt:1566560007.000000001",
   "responseStatus": 200,
   "responseJson": {
     "timestamp": "1566560007.000000000",
@@ -159,6 +163,14 @@
       {
         "account": "0.0.6",
         "balance": 662
+      },
+      {
+        "account": "0.0.5",
+        "balance": 5
+      },
+      {
+        "account": "0.0.4",
+        "balance": 4
       }
     ],
     "links": {

--- a/hedera-mirror-rest/__tests__/specs/tokens/{id}/balances/timestamp.json
+++ b/hedera-mirror-rest/__tests__/specs/tokens/{id}/balances/timestamp.json
@@ -5,15 +5,6 @@
       {
         "num": 4,
         "public_key": "6ceecd8bb224da4914d53f292e5624f6f4cf8c134c920e1cac8d06f879df5819"
-      },
-      {
-        "num": 5
-      },
-      {
-        "num": 6
-      },
-      {
-        "num": 7
       }
     ],
     "tokens": [
@@ -49,6 +40,16 @@
       }
     ],
     "balances": [
+      {
+        "timestamp": 1566560001000000000,
+        "id": 2,
+        "balance": 20
+      },
+      {
+        "timestamp": 1566560003000000000,
+        "id": 2,
+        "balance": 21
+      },
       {
         "timestamp": 1566560001000000000,
         "id": 4,

--- a/hedera-mirror-rest/balances.js
+++ b/hedera-mirror-rest/balances.js
@@ -108,7 +108,7 @@ const getBalances = async (req, res) => {
   let sqlQuery;
   if (tsQuery) {
     const tsQueryResult = await getTsQuery(tsQuery, tsParams);
-    if (!tsQueryResult.consensusTsQuery) {
+    if (!tsQueryResult.query) {
       return;
     }
 
@@ -118,8 +118,8 @@ const getBalances = async (req, res) => {
       limitQuery,
       order,
       pubKeyQuery,
-      tsQueryResult.tsParams,
-      tsQueryResult.consensusTsQuery
+      tsQueryResult.params,
+      tsQueryResult.query
     );
   } else {
     // use current balance from entity table when there's no timestamp query filter
@@ -146,7 +146,6 @@ const getBalances = async (req, res) => {
     logger.trace(`getBalance query: ${pgSqlQuery} ${utils.JSONStringify(sqlParams)}`);
   }
 
-  // Execute query
   const result = await pool.queryQuietly(pgSqlQuery, sqlParams);
   res.locals[constants.responseDataLabel] = formatBalancesResult(req, result, limit, order);
   logger.debug(`getBalances returning ${result.rows.length} entries`);
@@ -162,24 +161,32 @@ const getBalances = async (req, res) => {
  * @returns {Promise<{lower: BigInt|Number, upper: BigInt|Number}|{}>}
  */
 const getAccountBalanceTimestampRange = async (tsQuery, tsParams) => {
+  const {lowerBound, upperBound, neParams} = getOptimizedTimestampRange(tsQuery, tsParams);
+  if (lowerBound === undefined) {
+    return {};
+  }
+
   // Add the treasury account to the query as it will always be in the balance snapshot and account_id is the first
   // column of the primary key
-  tsQuery = tsQuery ? tsQuery.concat(' and account_id = ?') : ' account_id = ?';
-  tsParams.push(2);
+  let condition = 'account_id = 2 and consensus_timestamp >= $1 and consensus_timestamp <= $2';
+  const params = [lowerBound, upperBound];
+  if (neParams.length) {
+    condition += ' and not consensus_timestamp = any ($3)';
+    params.push(neParams);
+  }
 
   const query = `
     select consensus_timestamp
     from account_balance
-    where ${tsQuery}
+    where ${condition}
     order by consensus_timestamp desc
     limit 1`;
 
-  const pgSqlQuery = utils.convertMySqlStyleQueryToPostgres(query);
   if (logger.isTraceEnabled()) {
-    logger.trace(`getAccountBalanceTimestampRange query: ${pgSqlQuery} ${utils.JSONStringify(tsParams)}`);
+    logger.trace(`getAccountBalanceTimestampRange query: ${query} ${utils.JSONStringify(params)}`);
   }
 
-  const {rows} = await pool.queryQuietly(pgSqlQuery, tsParams);
+  const {rows} = await pool.queryQuietly(query, params);
   if (rows.length === 0) {
     return {};
   }
@@ -205,12 +212,21 @@ const getBalancesQuery = async (accountQuery, balanceQuery, limitQuery, order, p
   return [sqlQuery, tsParams];
 };
 
-const getTsQuery = async (tsQuery, tsParams) => {
-  let upperBound = constants.MAX_LONG;
-  let gteParam = 0n;
+/**
+ * Optimize the timestamp range based on the query built from the timestamp parameters in the request URL. With the
+ * assumption that the importer has synced up and the balance data close to NOW in wall clock should exist in db,
+ * adjust the lower bound and upper bound timestamps so the range will cover at most two monthly time partitions.
+ *
+ * @param tsQuery
+ * @param tsParams
+ * @returns {{}|{upperBound: bigint, lowerBound: bigint, neParams: *[]}}
+ */
+const getOptimizedTimestampRange = (tsQuery, tsParams) => {
+  let lowerBound = 0n;
   const neParams = [];
+  let upperBound = constants.MAX_LONG;
 
-  // Combine the tsParams into a single upperBound and gteParam if present
+  // Find the lower bound and the upper bound from tsParams if present
   tsQuery
     .split('?')
     .filter(Boolean)
@@ -226,64 +242,58 @@ const getTsQuery = async (tsQuery, tsParams) => {
         upperBound = upperBound < ltValue ? upperBound : ltValue;
       } else if (query.includes(utils.opsMap.gte)) {
         // gte operator includes the gt operator, so this clause must come before the gt clause
-        gteParam = gteParam > value ? gteParam : value;
+        lowerBound = lowerBound > value ? lowerBound : value;
       } else if (query.includes(utils.opsMap.gt)) {
         // Convert gt to gte to simplify query
         const gtValue = value + 1n;
-        gteParam = gteParam > gtValue ? gteParam : gtValue;
+        lowerBound = lowerBound > gtValue ? lowerBound : gtValue;
       } else if (query.includes(utils.opsMap.ne)) {
         neParams.push(value);
       }
     });
 
-  if (gteParam > upperBound) {
+  if (lowerBound > upperBound) {
     return {};
   }
 
-  let lowerBound = gteParam;
   const nowInNs = BigInt(Date.now()) * constants.NANOSECONDS_PER_MILLISECOND;
   if (upperBound !== constants.MAX_LONG) {
-    if (gteParam === 0n) {
+    if (lowerBound === 0n) {
       // There is an upper bound but no lowerBound
       const firstDayOfUpperBoundMonth = utils.getFirstDayOfMonth(upperBound);
       const firstDayOfCurrentMonth = utils.getFirstDayOfMonth(nowInNs);
       lowerBound =
         firstDayOfUpperBoundMonth < firstDayOfCurrentMonth
-          ? // if the upper bound is in a month prior to the current month, the lower bound is the beginning of the month prior to the month the upper bound is in.
-            // For example if the upper bound month is November 2022, the lower bound timestamp is the beginning of October 2022.
+          ? // if the upper bound is in a month prior to the current month, the lower bound is the beginning of
+            // the month prior to the month the upper bound is in. For example if the upper bound month is November
+            // 2022, the lower bound timestamp is the beginning of October 2022.
             utils.getFirstDayOfMonth(firstDayOfUpperBoundMonth - 1n)
-          : // If upper bound is in the current or later month the lower bound is the beginning of the month before current month.
-            // For example if the current month is November, the lower bound timestamp is the beginning of October.
+          : // If upper bound is in the current or later month the lower bound is the beginning of the month before
+            // current month. For example if the current month is November, the lower bound timestamp is
+            // the beginning of October.
             utils.getFirstDayOfMonth(firstDayOfCurrentMonth - 1n);
     }
   } else {
-    // There is only a lower bound, set the lower bound to the maximum of (gteParam, the first day of the month before the current month)
+    // There is only a lower bound, set the lower bound to the maximum of (gteParam, the first day of the month
+    // before the current month)
     const firstDayOfCurrentMonth = utils.getFirstDayOfMonth(nowInNs);
     const firstDayOfPreviousMonth = utils.getFirstDayOfMonth(firstDayOfCurrentMonth - 1n);
-    lowerBound = gteParam > firstDayOfPreviousMonth ? gteParam : firstDayOfPreviousMonth;
+    lowerBound = lowerBound > firstDayOfPreviousMonth ? lowerBound : firstDayOfPreviousMonth;
   }
 
-  return getPartitionedTsQuery(lowerBound, upperBound, neParams);
+  return {lowerBound, upperBound, neParams};
 };
 
-const getPartitionedTsQuery = async (lowerBound, upperBound, neParams) => {
-  let query = `consensus_timestamp >= ? and consensus_timestamp <= ?`;
-  const params = [lowerBound, upperBound];
-  const neQuery = Array.from(neParams, (v) => '?').join(', ');
-  if (neQuery) {
-    query = query.concat(` and consensus_timestamp not in (${neQuery})`);
-    params.push(...neParams);
-  }
-
-  const {lower, upper} = await getAccountBalanceTimestampRange(query, params);
-  if (upper === undefined) {
+const getTsQuery = async (tsQuery, tsParams) => {
+  const {lower, upper} = await getAccountBalanceTimestampRange(tsQuery, tsParams);
+  if (lower === undefined) {
     return {};
   }
 
-  const consensusTsQuery = `ab.consensus_timestamp >= ? and ab.consensus_timestamp <= ?`;
+  const query = 'ab.consensus_timestamp >= ? and ab.consensus_timestamp <= ?';
   // Double the params to account for the query values for account_balance and token_balance together
-  const tsParams = [lower, upper, lower, upper];
-  return {consensusTsQuery, tsParams};
+  const params = [lower, upper, lower, upper];
+  return {query, params};
 };
 
 const getTokenBalanceSubQuery = (order, consensusTsQuery) => {
@@ -366,7 +376,15 @@ const acceptedBalancesParameters = new Set([
   constants.filterKeys.TIMESTAMP,
 ]);
 
-export default {
+const balances = {
   getAccountBalanceTimestampRange,
   getBalances,
 };
+
+if (utils.isTestEnv()) {
+  Object.assign(balances, {
+    getOptimizedTimestampRange,
+  });
+}
+
+export default balances;

--- a/hedera-mirror-rest/utils.js
+++ b/hedera-mirror-rest/utils.js
@@ -922,7 +922,7 @@ const getFirstDayOfMonth = (secNs) => {
     return null;
   }
 
-  if (typeof secNs !== 'BigInt') {
+  if (typeof secNs !== 'bigint') {
     secNs = BigInt(secNs);
   }
 
@@ -932,10 +932,6 @@ const getFirstDayOfMonth = (secNs) => {
   const firstDayMs = Date.UTC(timestampDate.getUTCFullYear(), timestampDate.getUTCMonth());
   // Convert milliseconds to nanoseconds
   return BigInt(firstDayMs) * constants.NANOSECONDS_PER_MILLISECOND;
-};
-
-const secNsToSeconds = (secNs) => {
-  return math.floor(Number(secNs));
 };
 
 /**
@@ -1742,7 +1738,6 @@ export {
   parseTransactionTypeParam,
   randomString,
   resultSuccess,
-  secNsToSeconds,
   toHexString,
   toHexStringNonQuantity,
   toHexStringQuantity,


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

This PR ports the changes to `release/0.93`

- Change historical token balance distribution SQL query to use deduped token_balance table
- Refactor some functions in balances.js for better testability
- Change balances.getAccountBalanceTimestampRange to include the optimization logic

**Related issue(s)**:

Relates to #7281 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
