### PR TITLE
HIP-584: Throw exception only on populated `data` and missing bytecode (0.93)

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessorImpl.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessorImpl.java
@@ -133,7 +133,7 @@ public class MirrorEvmTxProcessorImpl extends HederaEvmTxProcessor implements Mi
 
             // If there is no bytecode, it means we have a non-token and non-contract account,
             // hence the code should be null and there must be a value transfer.
-            if (code == null && value <= 0) {
+            if (code == null && value <= 0 && !payload.isEmpty()) {
                 throw new MirrorEvmTransactionException(
                         ResponseCodeEnum.INVALID_TRANSACTION, StringUtils.EMPTY, StringUtils.EMPTY);
             }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessorTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessorTest.java
@@ -145,6 +145,7 @@ class MirrorEvmTxProcessorTest {
 
     private String mcpVersion;
     private String ccpVersion;
+    private static final String FUNCTION_HASH = "0x8070450f";
 
     @BeforeEach
     void setup() {
@@ -236,7 +237,8 @@ class MirrorEvmTxProcessorTest {
                 .blockHashLookup(hash -> null);
 
         assertThatExceptionOfType(MirrorEvmTransactionException.class)
-                .isThrownBy(() -> mirrorEvmTxProcessor.buildInitialFrame(protoFrame, receiverAddress, Bytes.EMPTY, 0L));
+                .isThrownBy(() -> mirrorEvmTxProcessor.buildInitialFrame(
+                        protoFrame, receiverAddress, Bytes.fromHexString(FUNCTION_HASH), 0L));
     }
 
     @Test

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
@@ -52,6 +52,18 @@ class ContractCallServiceTest extends ContractCallTestSetup {
     }
 
     @Test
+    void callWithoutDataToAddressWithNoBytecodeReturnsEmptyResult() {
+        final var gasUsedBeforeExecution = getGasUsedBeforeExecution(ETH_CALL);
+
+        final var serviceParameters =
+                serviceParametersForExecution(Bytes.EMPTY, ETH_ADDRESS, ETH_CALL, 0L, BlockType.LATEST);
+
+        assertThat(contractCallService.processCall(serviceParameters)).isEqualTo("0x");
+
+        assertGasUsedIsPositive(gasUsedBeforeExecution, ETH_CALL);
+    }
+
+    @Test
     void pureCall() {
         final var gasUsedBeforeExecution = getGasUsedBeforeExecution(ETH_CALL);
 


### PR DESCRIPTION
**Description**:

If we don't pass a data and don't want to call a given method during `eth_call`, we shouldn't throw exception but return empty result. This case was broken after a previous fix in #7203 

**Related issue(s)**:

Fixes #7284

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
