### PR TITLE
Upgrade to Java 21

### DIFF
--- a/.github/workflows/charts.yml
+++ b/.github/workflows/charts.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: 21
 
       - name: Install Python
         uses: actions/setup-python@v4

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
 
       - name: Execute Gradle
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -65,7 +65,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: 21
 
       - name: Create and Switch to Release Branch
         run: |
@@ -153,7 +153,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: 21
 
       - name: Reset main to release branch
         run: |

--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: 21
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: 21
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: 21
 
       - name: Vulnerability check
         uses: gradle/gradle-build-action@v2
@@ -68,7 +68,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: 21
 
       - name: Cache SonarCloud dependencies
         uses: actions/cache@v3
@@ -97,7 +97,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: "temurin"
-          java-version: 17
+          java-version: 21
 
       - name: Setup Snyk
         run: npm install -g snyk-to-html @wcj/html-to-markdown-cli
@@ -133,7 +133,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: "temurin"
-          java-version: 17
+          java-version: 21
 
       - name: Setup Snyk
         run: npm install -g snyk-to-html @wcj/html-to-markdown-cli
@@ -169,7 +169,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: "temurin"
-          java-version: 17
+          java-version: 21
 
       - name: Execute Gradle Snyk Monitor
         uses: gradle/gradle-build-action@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Compiled class file
 *.class
+generated/
 
 # OS specific
 .DS_Store

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -29,7 +29,7 @@ repositories {
 
 dependencies {
     implementation("com.bmuschko:gradle-docker-plugin:9.4.0")
-    implementation("com.diffplug.spotless:spotless-plugin-gradle:6.23.2")
+    implementation("com.diffplug.spotless:spotless-plugin-gradle:6.23.3")
     implementation("com.github.johnrengelman:shadow:8.1.1")
     implementation("com.github.node-gradle:gradle-node-plugin:7.0.1")
     implementation("com.google.protobuf:protobuf-gradle-plugin:0.9.4")

--- a/buildSrc/src/main/kotlin/common-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/common-conventions.gradle.kts
@@ -97,7 +97,7 @@ spotless {
     })
     java {
         addStep(StripOldLicenseFormatterStep.create())
-        palantirJavaFormat()
+        palantirJavaFormat("2.39.0")
         licenseHeader(licenseHeader, "package").updateYearWithLatest(true)
         target("**/*.java")
         targetExclude("build/**")

--- a/buildSrc/src/main/kotlin/java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-conventions.gradle.kts
@@ -59,18 +59,19 @@ dependencies {
 
 tasks.compileJava {
     dependsOn("generateEffectiveLombokConfig")
-    options.compilerArgs.addAll(listOf("-Werror", "-Xlint:all"))
+    // Disable serial and this-escape warnings due to errors in generated code
+    options.compilerArgs.addAll(listOf("-Werror", "-Xlint:all", "-Xlint:-serial,-this-escape"))
     options.encoding = "UTF-8"
-    sourceCompatibility = "17"
-    targetCompatibility = "17"
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
 }
 
 tasks.compileTestJava {
     dependsOn("generateEffectiveLombokConfig")
-    options.compilerArgs.addAll(listOf("-Werror", "-Xlint:all"))
+    options.compilerArgs.addAll(listOf("-Werror", "-Xlint:all", "-Xlint:-this-escape"))
     options.encoding = "UTF-8"
-    sourceCompatibility = "17"
-    targetCompatibility = "17"
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
 }
 
 tasks.javadoc {

--- a/buildSrc/src/main/kotlin/plugin/go/GoSetup.kt
+++ b/buildSrc/src/main/kotlin/plugin/go/GoSetup.kt
@@ -22,13 +22,12 @@ package plugin.go
 
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream
 import org.gradle.api.DefaultTask
-import org.gradle.api.file.FileSystemOperations
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 import org.gradle.kotlin.dsl.getByName
 import java.io.File
 import java.io.FileInputStream
-import java.net.URL
+import java.net.URI
 import java.nio.file.Files
 import java.nio.file.Paths
 import java.nio.file.StandardCopyOption
@@ -43,7 +42,7 @@ open class GoSetup : DefaultTask() {
     @TaskAction
     fun prepare() {
         go.goRoot.mkdirs()
-        val url = URL("https://storage.googleapis.com/golang/go${go.version}.${go.os}-${go.arch}.tar.gz")
+        val url = URI.create("https://storage.googleapis.com/golang/go${go.version}.${go.os}-${go.arch}.tar.gz").toURL()
         val filename = Paths.get(url.path).fileName
         val targetFile = go.cacheDir.toPath().resolve(filename)
 

--- a/charts/README.md
+++ b/charts/README.md
@@ -86,12 +86,12 @@ a [Standalone NEG](https://cloud.google.com/kubernetes-engine/docs/how-to/standa
 
    This can be done by setting a unique name for the subnet in the UI or through the console with the following command
    ```shell script
-   gcloud container clusters create mirrornode-lb \
+   gcloud container clusters create mirror-node \
        --enable-ip-alias \
        --create-subnetwork="" \
        --network=default \
        --zone=us-central1-a \
-       --cluster-version=1.21.5-gke.1802 \
+       --cluster-version=1.27 \
        --machine-type=n1-standard-4
    ```
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,7 +4,7 @@ The Mirror Node can be run [locally](#running-locally) or via [Docker](#running-
 
 ## Building
 
-To run locally, first build the project using Java. Ensure you have OpenJDK 17 installed, then run the following command
+To run locally, first build the project using Java. Ensure you have Java 21 installed, then run the following command
 from the top level directory. This will compile a runnable mirror node JAR file in the `target` directory.
 
 ```console
@@ -15,7 +15,7 @@ from the top level directory. This will compile a runnable mirror node JAR file 
 
 ### Database Setup
 
-In addition to OpenJDK 17, you will need to install a [PostgreSQL](https://postgresql.org) database and initialize it.
+In addition to Java 21, you will need to install a [PostgreSQL](https://postgresql.org) database and initialize it.
 
 Since [Flyway](https://flywaydb.org) will manage the database schema, the only required step is to run the database
 initialization script. Locate the SQL script at `hedera-mirror-importer/src/main/resources/db/scripts/init.sh` and edit

--- a/hedera-mirror-common/build.gradle.kts
+++ b/hedera-mirror-common/build.gradle.kts
@@ -20,15 +20,12 @@ plugins { id("java-conventions") }
 
 dependencies {
     val testClasses by configurations.creating
-    annotationProcessor(group = "com.querydsl", name = "querydsl-apt", classifier = "jakarta")
     annotationProcessor("jakarta.persistence:jakarta.persistence-api")
     api("com.fasterxml.jackson.core:jackson-databind")
     api("com.github.ben-manes.caffeine:caffeine")
     api("com.google.guava:guava")
     api("com.google.protobuf:protobuf-java")
     api("com.hedera.hashgraph:hedera-protobuf-java-api") { isTransitive = false }
-    api("com.querydsl:querydsl-apt")
-    api("com.querydsl:querydsl-jpa")
     api("io.hypersistence:hypersistence-utils-hibernate-62")
     api("commons-codec:commons-codec")
     api("io.projectreactor:reactor-core")

--- a/hedera-mirror-graphql/Dockerfile
+++ b/hedera-mirror-graphql/Dockerfile
@@ -1,9 +1,9 @@
-FROM eclipse-temurin:17.0.8.1_1-jre-jammy as builder
+FROM eclipse-temurin:21-jre-jammy as builder
 WORKDIR /app
 COPY build/libs/*.jar ./
 RUN java -Djarmode=layertools -jar *.jar extract
 
-FROM eclipse-temurin:17.0.8.1_1-jre-jammy
+FROM eclipse-temurin:21-jre-jammy
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80"
 EXPOSE 8083
 HEALTHCHECK --interval=10s --retries=3 --start-period=50s --timeout=2s CMD curl -f http://localhost:8083/actuator/health/liveness

--- a/hedera-mirror-grpc/Dockerfile
+++ b/hedera-mirror-grpc/Dockerfile
@@ -1,9 +1,9 @@
-FROM eclipse-temurin:17.0.8.1_1-jre-jammy as builder
+FROM eclipse-temurin:21-jre-jammy as builder
 WORKDIR /app
 COPY build/libs/*.jar ./
 RUN java -Djarmode=layertools -jar *.jar extract
 
-FROM eclipse-temurin:17.0.8.1_1-jre-jammy
+FROM eclipse-temurin:21-jre-jammy
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80"
 EXPOSE 5600
 HEALTHCHECK --interval=10s --retries=3 --start-period=50s --timeout=2s CMD curl -f http://localhost:8081/actuator/health/liveness

--- a/hedera-mirror-importer/Dockerfile
+++ b/hedera-mirror-importer/Dockerfile
@@ -1,9 +1,9 @@
-FROM eclipse-temurin:17.0.8.1_1-jre-jammy as builder
+FROM eclipse-temurin:21-jre-jammy as builder
 WORKDIR /app
 COPY build/libs/*.jar ./
 RUN java -Djarmode=layertools -jar *.jar extract
 
-FROM eclipse-temurin:17.0.8.1_1-jre-jammy
+FROM eclipse-temurin:21-jre-jammy
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80"
 HEALTHCHECK --interval=30s --retries=3 --start-period=60s --timeout=2s CMD curl -f http://localhost:8080/actuator/health/liveness
 WORKDIR /app

--- a/hedera-mirror-monitor/Dockerfile
+++ b/hedera-mirror-monitor/Dockerfile
@@ -1,9 +1,9 @@
-FROM eclipse-temurin:17.0.8.1_1-jre-jammy as builder
+FROM eclipse-temurin:21-jre-jammy as builder
 WORKDIR /app
 COPY build/libs/*.jar ./
 RUN java -Djarmode=layertools -jar *.jar extract
 
-FROM eclipse-temurin:17.0.8.1_1-jre-jammy
+FROM eclipse-temurin:21-jre-jammy
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80"
 EXPOSE 8082
 HEALTHCHECK --interval=10s --retries=5 --start-period=60s --timeout=2s CMD curl -f http://localhost:8082/actuator/health/liveness

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishScenarioProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishScenarioProperties.java
@@ -61,7 +61,7 @@ public class PublishScenarioProperties extends ScenarioProperties {
     private TransactionType type;
 
     public PublishScenarioProperties() {
-        getRetry().setMaxAttempts(1L);
+        retry.setMaxAttempts(1L);
     }
 
     @Override

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/controller/SubscriberController.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/controller/SubscriberController.java
@@ -47,7 +47,8 @@ class SubscriberController {
 
     @GetMapping
     public <T extends ScenarioProperties> Flux<Scenario<T, Object>> subscriptions(
-            @RequestParam Optional<ScenarioProtocol> protocol, @RequestParam Optional<List<ScenarioStatus>> status) {
+            @RequestParam("protocol") Optional<ScenarioProtocol> protocol,
+            @RequestParam("status") Optional<List<ScenarioStatus>> status) {
         return mirrorSubscriber
                 .<Scenario<T, Object>>getSubscriptions()
                 .filter(s -> !protocol.isPresent() || protocol.get() == s.getProtocol())

--- a/hedera-mirror-rest-java/Dockerfile
+++ b/hedera-mirror-rest-java/Dockerfile
@@ -1,9 +1,9 @@
-FROM eclipse-temurin:17.0.8.1_1-jre-jammy as builder
+FROM eclipse-temurin:21-jre-jammy as builder
 WORKDIR /app
 COPY build/libs/*.jar ./
 RUN java -Djarmode=layertools -jar *.jar extract
 
-FROM eclipse-temurin:17.0.8.1_1-jre-jammy
+FROM eclipse-temurin:21-jre-jammy
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80"
 EXPOSE 8084
 HEALTHCHECK --interval=10s --retries=3 --start-period=50s --timeout=2s CMD curl -f http://localhost:8084/actuator/health/liveness

--- a/hedera-mirror-test/Dockerfile
+++ b/hedera-mirror-test/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17.0.8.1_1-jre-jammy
+FROM eclipse-temurin:21-jre-jammy
 
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80"
 WORKDIR /app

--- a/hedera-mirror-test/README.md
+++ b/hedera-mirror-test/README.md
@@ -24,7 +24,7 @@ complex code underneath.
 
 ### Requirements
 
-- OpenJDK 17+
+- Java 21
 
 ### Test Execution
 
@@ -39,7 +39,7 @@ uses [Spring Boot](https://spring.io/projects/spring-boot) properties to configu
 include:
 
 | Name                                                           | Default                                      | Description                                                                                               |
-| -------------------------------------------------------------- | -------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+|----------------------------------------------------------------|----------------------------------------------|-----------------------------------------------------------------------------------------------------------|
 | `hedera.mirror.test.acceptance.backOffPeriod`                  | 5s                                           | The amount of time the client will wait before retrying a retryable failure.                              |
 | `hedera.mirror.test.acceptance.createOperatorAccount`          | true                                         | Whether to create a separate operator account to run the acceptance tests.                                |
 | `hedera.mirror.test.acceptance.emitBackgroundMessages`         | false                                        | Whether background topic messages should be emitted.                                                      |

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/PrecompileContractFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/PrecompileContractFeature.java
@@ -252,7 +252,7 @@ public class PrecompileContractFeature extends AbstractFeature {
     }
 
     @Retryable(
-            value = {AssertionError.class, WebClientResponseException.class},
+            retryFor = {AssertionError.class, WebClientResponseException.class},
             backoff = @Backoff(delayExpression = "#{@restPollingProperties.minBackoff.toMillis()}"),
             maxAttemptsExpression = "#{@restPollingProperties.maxAttempts}")
     @And("check if non fungible token is frozen")
@@ -273,7 +273,7 @@ public class PrecompileContractFeature extends AbstractFeature {
     }
 
     @Retryable(
-            value = {AssertionError.class, WebClientResponseException.class},
+            retryFor = {AssertionError.class, WebClientResponseException.class},
             backoff = @Backoff(delayExpression = "#{@restPollingProperties.minBackoff.toMillis()}"),
             maxAttemptsExpression = "#{@restPollingProperties.maxAttempts}")
     @And("check if non fungible token is unfrozen")
@@ -293,7 +293,7 @@ public class PrecompileContractFeature extends AbstractFeature {
     }
 
     @Retryable(
-            value = {AssertionError.class, WebClientResponseException.class},
+            retryFor = {AssertionError.class, WebClientResponseException.class},
             backoff = @Backoff(delayExpression = "#{@restPollingProperties.minBackoff.toMillis()}"),
             maxAttemptsExpression = "#{@restPollingProperties.maxAttempts}")
     @And("check if fungible token is frozen for evm address")
@@ -317,7 +317,7 @@ public class PrecompileContractFeature extends AbstractFeature {
     }
 
     @Retryable(
-            value = {AssertionError.class, WebClientResponseException.class},
+            retryFor = {AssertionError.class, WebClientResponseException.class},
             backoff = @Backoff(delayExpression = "#{@restPollingProperties.minBackoff.toMillis()}"),
             maxAttemptsExpression = "#{@restPollingProperties.maxAttempts}")
     @And("check if fungible token is unfrozen for evm address")
@@ -335,7 +335,7 @@ public class PrecompileContractFeature extends AbstractFeature {
     }
 
     @Retryable(
-            value = {AssertionError.class, WebClientResponseException.class},
+            retryFor = {AssertionError.class, WebClientResponseException.class},
             backoff = @Backoff(delayExpression = "#{@restPollingProperties.minBackoff.toMillis()}"),
             maxAttemptsExpression = "#{@restPollingProperties.maxAttempts}")
     public void verifyTx(String txId) {
@@ -410,7 +410,7 @@ public class PrecompileContractFeature extends AbstractFeature {
     }
 
     @Retryable(
-            value = {AssertionError.class},
+            retryFor = {AssertionError.class},
             backoff = @Backoff(delayExpression = "#{@restPollingProperties.minBackoff.toMillis()}"),
             maxAttemptsExpression = "#{@restPollingProperties.maxAttempts}")
     @And("the contract call REST API should return the information for token for a non fungible token")
@@ -524,7 +524,7 @@ public class PrecompileContractFeature extends AbstractFeature {
     }
 
     @Retryable(
-            value = {AssertionError.class},
+            retryFor = {AssertionError.class},
             backoff = @Backoff(delayExpression = "#{@restPollingProperties.minBackoff.toMillis()}"),
             maxAttemptsExpression = "#{@restPollingProperties.maxAttempts}")
     public void verifyToken(TokenId tokenId) {
@@ -535,7 +535,7 @@ public class PrecompileContractFeature extends AbstractFeature {
     }
 
     @Retryable(
-            value = {AssertionError.class},
+            retryFor = {AssertionError.class},
             backoff = @Backoff(delayExpression = "#{@restPollingProperties.minBackoff.toMillis()}"),
             maxAttemptsExpression = "#{@restPollingProperties.maxAttempts}")
     public void verifyNft(TokenId tokenId, Long serialNumber) {
@@ -700,10 +700,10 @@ public class PrecompileContractFeature extends AbstractFeature {
         assertThat(royaltyFee.get(5).toString().toLowerCase())
                 .isEqualTo("0x"
                         + tokenClient
-                                .getSdkClient()
-                                .getExpandedOperatorAccountId()
-                                .getAccountId()
-                                .toSolidityAddress());
+                        .getSdkClient()
+                        .getExpandedOperatorAccountId()
+                        .getAccountId()
+                        .toSolidityAddress());
     }
 
     // ETHCALL-034
@@ -722,10 +722,10 @@ public class PrecompileContractFeature extends AbstractFeature {
         assertThat(royaltyFee.get(5).toString().toLowerCase())
                 .hasToString("0x"
                         + tokenClient
-                                .getSdkClient()
-                                .getExpandedOperatorAccountId()
-                                .getAccountId()
-                                .toSolidityAddress());
+                        .getSdkClient()
+                        .getExpandedOperatorAccountId()
+                        .getAccountId()
+                        .toSolidityAddress());
     }
 
     private void tokenKeyCheck(final Tuple result) {

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/RetryAsserts.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/RetryAsserts.java
@@ -31,8 +31,9 @@ import org.springframework.retry.annotation.Retryable;
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Retryable(
-        value = {AssertionError.class},
+        retryFor = {AssertionError.class},
         backoff = @Backoff(delayExpression = "#{@restPollingProperties.minBackoff.toMillis()}"),
         maxAttemptsExpression = "#{@restPollingProperties.maxAttempts}")
 @Target({ElementType.METHOD, ElementType.TYPE})
-public @interface RetryAsserts {}
+public @interface RetryAsserts {
+}

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TopicFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TopicFeature.java
@@ -213,7 +213,7 @@ public class TopicFeature {
 
     @When("I publish {int} batches of {int} messages every {long} milliseconds")
     @Retryable(
-            value = {PrecheckStatusException.class, ReceiptStatusException.class},
+            retryFor = {PrecheckStatusException.class, ReceiptStatusException.class},
             backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.backOffPeriod.toMillis()}"),
             maxAttemptsExpression = "#{@acceptanceTestProperties.maxRetries}")
     @SuppressWarnings("java:S2925")
@@ -233,7 +233,7 @@ public class TopicFeature {
     }
 
     @Retryable(
-            value = {PrecheckStatusException.class, ReceiptStatusException.class},
+            retryFor = {PrecheckStatusException.class, ReceiptStatusException.class},
             backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.backOffPeriod.toMillis()}"),
             maxAttemptsExpression = "#{@acceptanceTestProperties.maxRetries}")
     public void publishTopicMessages(int messageCount) {
@@ -243,7 +243,7 @@ public class TopicFeature {
 
     @When("I publish and verify {int} messages sent")
     @Retryable(
-            value = {AssertionError.class, PrecheckStatusException.class, ReceiptStatusException.class},
+            retryFor = {AssertionError.class, PrecheckStatusException.class, ReceiptStatusException.class},
             backoff = @Backoff(delayExpression = "#{@acceptanceTestProperties.backOffPeriod.toMillis()}"),
             maxAttemptsExpression = "#{@acceptanceTestProperties.maxRetries}")
     public void publishAndVerifyTopicMessages(int messageCount) {

--- a/hedera-mirror-web3/Dockerfile
+++ b/hedera-mirror-web3/Dockerfile
@@ -1,9 +1,9 @@
-FROM eclipse-temurin:17.0.8.1_1-jre-jammy as builder
+FROM eclipse-temurin:21-jre-jammy as builder
 WORKDIR /app
 COPY build/libs/*.jar ./
 RUN java -Djarmode=layertools -jar *.jar extract
 
-FROM eclipse-temurin:17.0.8.1_1-jre-jammy
+FROM eclipse-temurin:21-jre-jammy
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80"
 EXPOSE 8545
 HEALTHCHECK --interval=10s --retries=3 --start-period=50s --timeout=2s CMD curl -f http://localhost:8545/actuator/health/liveness

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/accessor/AccountDatabaseAccessor.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/accessor/AccountDatabaseAccessor.java
@@ -16,7 +16,8 @@
 
 package com.hedera.mirror.web3.evm.store.accessor;
 
-import static com.hedera.mirror.common.domain.entity.EntityType.*;
+import static com.hedera.mirror.common.domain.entity.EntityType.ACCOUNT;
+import static com.hedera.mirror.common.domain.entity.EntityType.CONTRACT;
 import static com.hedera.services.utils.EntityIdUtils.idFromEntityId;
 import static com.hedera.services.utils.MiscUtils.asFcKeyUnchecked;
 
@@ -27,7 +28,11 @@ import com.hedera.mirror.common.domain.entity.CryptoAllowance;
 import com.hedera.mirror.common.domain.entity.Entity;
 import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.web3.evm.exception.WrongTypeException;
-import com.hedera.mirror.web3.repository.*;
+import com.hedera.mirror.web3.repository.CryptoAllowanceRepository;
+import com.hedera.mirror.web3.repository.NftAllowanceRepository;
+import com.hedera.mirror.web3.repository.NftRepository;
+import com.hedera.mirror.web3.repository.TokenAccountRepository;
+import com.hedera.mirror.web3.repository.TokenAllowanceRepository;
 import com.hedera.mirror.web3.repository.projections.TokenAccountAssociationsCount;
 import com.hedera.services.jproto.JKey;
 import com.hedera.services.store.models.Account;
@@ -35,9 +40,12 @@ import com.hedera.services.store.models.FcTokenAllowanceId;
 import com.hedera.services.store.models.Id;
 import com.hedera.services.utils.EntityNum;
 import com.hederahashgraph.api.proto.java.Key;
-import com.mysema.commons.lang.Pair;
 import jakarta.inject.Named;
-import java.util.*;
+import java.util.Optional;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import java.util.TreeMap;
+import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BinaryOperator;
 import java.util.stream.Collectors;
@@ -87,8 +95,8 @@ public class AccountDatabaseAccessor extends DatabaseAccessor<Object, Account> {
                 getCryptoAllowances(entity.getId()),
                 getFungibleTokenAllowances(entity.getId()),
                 getApproveForAllNfts(entity.getId()),
-                tokenAssociationsCounts.getFirst(),
-                tokenAssociationsCounts.getSecond(),
+                tokenAssociationsCounts.all(),
+                tokenAssociationsCounts.positive(),
                 0,
                 Optional.ofNullable(entity.getEthereumNonce()).orElse(0L),
                 entity.getType().equals(CONTRACT),
@@ -134,7 +142,7 @@ public class AccountDatabaseAccessor extends DatabaseAccessor<Object, Account> {
         return EntityNum.fromLong(entityId.getNum());
     }
 
-    private Pair<Integer, Integer> getNumberOfAllAndPositiveBalanceTokenAssociations(long accountId) {
+    private TokenAccountBalances getNumberOfAllAndPositiveBalanceTokenAssociations(long accountId) {
         final var counts = tokenAccountRepository.countByAccountIdAndAssociatedGroupedByBalanceIsPositive(accountId);
         int all = 0;
         int positive = 0;
@@ -146,7 +154,7 @@ public class AccountDatabaseAccessor extends DatabaseAccessor<Object, Account> {
             all += count.getTokenCount();
         }
 
-        return new Pair<>(all, positive);
+        return new TokenAccountBalances(all, positive);
     }
 
     private JKey parseJkey(byte[] keyBytes) {
@@ -155,5 +163,8 @@ public class AccountDatabaseAccessor extends DatabaseAccessor<Object, Account> {
         } catch (InvalidProtocolBufferException | IllegalArgumentException e) {
             return null;
         }
+    }
+
+    private record TokenAccountBalances(int all, int positive) {
     }
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/fees/usage/token/TokenOpsUsageUtils.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/fees/usage/token/TokenOpsUsageUtils.java
@@ -190,7 +190,7 @@ public enum TokenOpsUsageUtils {
         return baseSize;
     }
 
-    public static <T> long keySizeIfPresent(final T op, final Predicate<T> check, final Function<T, Key> getter) {
-        return check.test(op) ? getAccountKeyStorageSize(getter.apply(op)) : 0L;
+    public static <T> int keySizeIfPresent(final T op, final Predicate<T> check, final Function<T, Key> getter) {
+        return check.test(op) ? getAccountKeyStorageSize(getter.apply(op)) : 0;
     }
 }


### PR DESCRIPTION
**Description**:

* Bump Java version from 17 to 21
* Change `@Retryable` to not use deprecated `value` attribute
* Fix compiler warnings
* Remove unused Query DSL dependency
* Suppress compiler warnings due to plugin generated code

**Related issue(s)**:

Fixes #7233

**Notes for reviewer**:

Requires IntelliJ IDEA 2023.3 and Java 21 installed locally. Recommended to use sdkman `sdk install java 21-tem`.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
