### PR TITLE
Bump logback from 1.4.13 to 1.4.14

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ plugins {
 // Can't use typed variable syntax due to Dependabot limitations
 extra.apply {
     set("gson.version", "2.8.9") // Temporary until Apache jclouds supports gson 2.9
-    set("logback.version", "1.4.13") // Temporary until next Spring Boot version
+    set("logback.version", "1.4.14") // Temporary until next Spring Boot version
     set("mapStructVersion", "1.5.5.Final")
     set("protobufVersion", "3.25.1")
     set("reactorGrpcVersion", "1.2.4")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -41,7 +41,9 @@ shortenProjectName(rootProject)
 
 // Shorten project name to remove verbose "hedera-mirror-" prefix
 fun shortenProjectName(project: ProjectDescriptor) {
-    project.name = project.name.removePrefix("hedera-mirror-")
+    if (project != rootProject) {
+        project.name = project.name.removePrefix("hedera-mirror-")
+    }
     project.children.forEach(this::shortenProjectName)
 }
 


### PR DESCRIPTION
**Description**:

* Bump logback from 1.4.13 to 1.4.14
* Fix root Gradle project named as `node` instead of `hedera-mirror-node`

**Related issue(s)**:


**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
