### PR TITLE
Fix REST API linux/arm64 image

### DIFF
--- a/hedera-mirror-rest/Dockerfile
+++ b/hedera-mirror-rest/Dockerfile
@@ -10,7 +10,8 @@ WORKDIR /home/node/app/
 
 # Install dependencies
 COPY package*.json ./
-RUN npm ci --omit=dev && \
+RUN npm config set update-notifier false && \
+    npm ci --omit=dev && \
     npm cache clean --force --loglevel=error && \
     chown -R node:node .
 COPY --chown=node:node . ./

--- a/hedera-mirror-rest/Dockerfile
+++ b/hedera-mirror-rest/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-bookworm-slim
+FROM node:18.18.2-bookworm-slim
 LABEL maintainer="mirrornode@hedera.com"
 
 # Setup
@@ -10,17 +10,15 @@ WORKDIR /home/node/app/
 
 # Install dependencies
 COPY package*.json ./
-RUN apt-get update && \
-    apt-get install -y wget && \
-    npm ci --only=production && \
+RUN npm ci --omit=dev && \
     npm cache clean --force --loglevel=error && \
-    chown -R node:node . && \
-    rm -rf /var/lib/apt/lists/*
+    chown -R node:node .
 COPY --chown=node:node . ./
 
 # Install OS updates
 RUN apt-get update && \
     apt-get upgrade -y --no-install-recommends && \
+    apt-get install -y wget && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
 USER node

--- a/hedera-mirror-rest/monitoring/Dockerfile
+++ b/hedera-mirror-rest/monitoring/Dockerfile
@@ -9,10 +9,8 @@ HEALTHCHECK --interval=10s --retries=3 --start-period=25s --timeout=2s CMD wget 
 WORKDIR /home/node/app/
 
 # Install dependencies
-COPY package*.json .
-RUN apt-get update && \
-    apt-get install -y wget && \
-    npm ci --only=production && \
+COPY package*.json ./
+RUN npm ci --omit=dev && \
     npm cache clean --force --loglevel=error && \
     chown -R node:node . && \
     rm -rf /var/lib/apt/lists/*
@@ -21,9 +19,10 @@ COPY --chown=node:node . ./
 # Install OS updates
 RUN apt-get update && \
     apt-get upgrade -y --no-install-recommends && \
+    apt-get install -y wget && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
 USER node
 
 # Run
-ENTRYPOINT ["npm", "start"]
+ENTRYPOINT ["node", "--import=extensionless/register", "server.js"]

--- a/hedera-mirror-rest/monitoring/Dockerfile
+++ b/hedera-mirror-rest/monitoring/Dockerfile
@@ -10,10 +10,10 @@ WORKDIR /home/node/app/
 
 # Install dependencies
 COPY package*.json ./
-RUN npm ci --omit=dev && \
+RUN npm config set update-notifier false && \
+    npm ci --omit=dev && \
     npm cache clean --force --loglevel=error && \
-    chown -R node:node . && \
-    rm -rf /var/lib/apt/lists/*
+    chown -R node:node .
 COPY --chown=node:node . ./
 
 # Install OS updates


### PR DESCRIPTION
**Description**:

* Disable npm upgrade check
* Fix rest monitor using npm to start since it ignores SIGTERM
* Fix warning `Use '--omit=dev' to omit dev dependencies`
* Optimize Node `Dockerfile` to do all apt commands in one place
* Revert node from `18.19.0` to `18.18.2` to fix NPM timeout issue on arm64


**Related issue(s)**:

Fixes #7322

**Notes for reviewer**:

Node 18.19 lands NPM 10 which apparently has some regressions. Successful run: https://github.com/hashgraph/hedera-mirror-node/actions/runs/7095028949

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
