### PR TITLE
HIP-584: Return BAD_REQUEST if invalid method signature is used

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/HTSPrecompiledContract.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/HTSPrecompiledContract.java
@@ -21,7 +21,6 @@ import static com.hedera.node.app.service.evm.store.contracts.HederaEvmWorldStat
 import static com.hedera.node.app.service.evm.store.contracts.utils.DescriptorUtils.isTokenProxyRedirect;
 import static com.hedera.node.app.service.evm.store.contracts.utils.DescriptorUtils.isViewFunction;
 import static com.hedera.node.app.service.evm.utils.ValidationUtils.validateTrue;
-import static com.hedera.services.store.contracts.precompile.PrecompileMapper.UNSUPPORTED_ERROR;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FAIL_INVALID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_GAS;
 
@@ -93,6 +92,7 @@ public class HTSPrecompiledContract implements HTSPrecompiledContractAdapter {
             null, true, MessageFrame.State.COMPLETED_FAILED, Optional.of(ExceptionalHaltReason.PRECOMPILE_ERROR));
     private static final Logger log = LogManager.getLogger(HTSPrecompiledContract.class);
     private static final Bytes STATIC_CALL_REVERT_REASON = Bytes.of("HTS precompiles are not static".getBytes());
+    private static final String PRECOMPILE_RESULT_IS_NULL = "Precompile result is null";
 
     private final MirrorNodeEvmProperties evmProperties;
     private final EvmInfrastructureFactory infrastructureFactory;
@@ -454,7 +454,7 @@ public class HTSPrecompiledContract implements HTSPrecompiledContractAdapter {
         final var result = executor.computeCosted();
 
         if (result.getRight() == null) {
-            throw new UnsupportedOperationException(UNSUPPORTED_ERROR);
+            throw new InvalidTransactionException(PRECOMPILE_RESULT_IS_NULL, FAIL_INVALID);
         }
 
         return result;

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/PrecompileMapper.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/PrecompileMapper.java
@@ -25,86 +25,6 @@ public class PrecompileMapper {
 
     public static final String UNSUPPORTED_ERROR = "Precompile not supported for non-static frames";
     private static final Map<Integer, Precompile> abiConstantToPrecompile = new HashMap<>();
-    private static final Set<Integer> precompileSelectors = Set.of(
-            AbiConstants.ABI_ID_CRYPTO_TRANSFER,
-            AbiConstants.ABI_ID_CRYPTO_TRANSFER_V2,
-            AbiConstants.ABI_ID_TRANSFER_TOKENS,
-            AbiConstants.ABI_ID_TRANSFER_TOKEN,
-            AbiConstants.ABI_ID_TRANSFER_NFTS,
-            AbiConstants.ABI_ID_TRANSFER_NFT,
-            AbiConstants.ABI_ID_MINT_TOKEN,
-            AbiConstants.ABI_ID_MINT_TOKEN_V2,
-            AbiConstants.ABI_ID_BURN_TOKEN,
-            AbiConstants.ABI_ID_BURN_TOKEN_V2,
-            AbiConstants.ABI_ID_DELETE_TOKEN,
-            AbiConstants.ABI_ID_ASSOCIATE_TOKENS,
-            AbiConstants.ABI_ID_ASSOCIATE_TOKEN,
-            AbiConstants.ABI_ID_DISSOCIATE_TOKENS,
-            AbiConstants.ABI_ID_DISSOCIATE_TOKEN,
-            AbiConstants.ABI_ID_PAUSE_TOKEN,
-            AbiConstants.ABI_ID_UNPAUSE_TOKEN,
-            AbiConstants.ABI_ID_ALLOWANCE,
-            AbiConstants.ABI_ID_APPROVE,
-            AbiConstants.ABI_ID_APPROVE_NFT,
-            AbiConstants.ABI_ID_SET_APPROVAL_FOR_ALL,
-            AbiConstants.ABI_ID_GET_APPROVED,
-            AbiConstants.ABI_ID_IS_APPROVED_FOR_ALL,
-            AbiConstants.ABI_ID_TRANSFER_FROM,
-            AbiConstants.ABI_ID_TRANSFER_FROM_NFT,
-            AbiConstants.ABI_ID_REDIRECT_FOR_TOKEN,
-            AbiConstants.ABI_ID_ERC_NAME,
-            AbiConstants.ABI_ID_ERC_SYMBOL,
-            AbiConstants.ABI_ID_ERC_DECIMALS,
-            AbiConstants.ABI_ID_ERC_TOTAL_SUPPLY_TOKEN,
-            AbiConstants.ABI_ID_ERC_BALANCE_OF_TOKEN,
-            AbiConstants.ABI_ID_ERC_TRANSFER,
-            AbiConstants.ABI_ID_ERC_TRANSFER_FROM,
-            AbiConstants.ABI_ID_ERC_ALLOWANCE,
-            AbiConstants.ABI_ID_ERC_APPROVE,
-            AbiConstants.ABI_ID_ERC_SET_APPROVAL_FOR_ALL,
-            AbiConstants.ABI_ID_ERC_GET_APPROVED,
-            AbiConstants.ABI_ID_ERC_IS_APPROVED_FOR_ALL,
-            AbiConstants.ABI_ID_ERC_OWNER_OF_NFT,
-            AbiConstants.ABI_ID_ERC_TOKEN_URI_NFT,
-            AbiConstants.ABI_ID_HRC_ASSOCIATE,
-            AbiConstants.ABI_ID_HRC_DISSOCIATE,
-            AbiConstants.ABI_WIPE_TOKEN_ACCOUNT_FUNGIBLE,
-            AbiConstants.ABI_WIPE_TOKEN_ACCOUNT_FUNGIBLE_V2,
-            AbiConstants.ABI_WIPE_TOKEN_ACCOUNT_NFT,
-            AbiConstants.ABI_ID_IS_FROZEN,
-            AbiConstants.ABI_ID_FREEZE,
-            AbiConstants.ABI_ID_UNFREEZE,
-            AbiConstants.ABI_ID_UPDATE_TOKEN_INFO,
-            AbiConstants.ABI_ID_UPDATE_TOKEN_INFO_V2,
-            AbiConstants.ABI_ID_UPDATE_TOKEN_INFO_V3,
-            AbiConstants.ABI_ID_UPDATE_TOKEN_KEYS,
-            AbiConstants.ABI_ID_GET_TOKEN_KEY,
-            AbiConstants.ABI_ID_CREATE_FUNGIBLE_TOKEN,
-            AbiConstants.ABI_ID_CREATE_FUNGIBLE_TOKEN_V2,
-            AbiConstants.ABI_ID_CREATE_FUNGIBLE_TOKEN_V3,
-            AbiConstants.ABI_ID_CREATE_FUNGIBLE_TOKEN_WITH_FEES,
-            AbiConstants.ABI_ID_CREATE_FUNGIBLE_TOKEN_WITH_FEES_V2,
-            AbiConstants.ABI_ID_CREATE_FUNGIBLE_TOKEN_WITH_FEES_V3,
-            AbiConstants.ABI_ID_CREATE_NON_FUNGIBLE_TOKEN,
-            AbiConstants.ABI_ID_CREATE_NON_FUNGIBLE_TOKEN_V2,
-            AbiConstants.ABI_ID_CREATE_NON_FUNGIBLE_TOKEN_V3,
-            AbiConstants.ABI_ID_CREATE_NON_FUNGIBLE_TOKEN_WITH_FEES,
-            AbiConstants.ABI_ID_CREATE_NON_FUNGIBLE_TOKEN_WITH_FEES_V2,
-            AbiConstants.ABI_ID_CREATE_NON_FUNGIBLE_TOKEN_WITH_FEES_V3,
-            AbiConstants.ABI_ID_GET_FUNGIBLE_TOKEN_INFO,
-            AbiConstants.ABI_ID_GET_TOKEN_INFO,
-            AbiConstants.ABI_ID_GET_NON_FUNGIBLE_TOKEN_INFO,
-            AbiConstants.ABI_ID_GET_TOKEN_DEFAULT_FREEZE_STATUS,
-            AbiConstants.ABI_ID_GET_TOKEN_DEFAULT_KYC_STATUS,
-            AbiConstants.ABI_ID_IS_KYC,
-            AbiConstants.ABI_ID_GRANT_TOKEN_KYC,
-            AbiConstants.ABI_ID_REVOKE_TOKEN_KYC,
-            AbiConstants.ABI_ID_GET_TOKEN_CUSTOM_FEES,
-            AbiConstants.ABI_ID_IS_TOKEN,
-            AbiConstants.ABI_ID_GET_TOKEN_TYPE,
-            AbiConstants.ABI_ID_GET_TOKEN_EXPIRY_INFO,
-            AbiConstants.ABI_ID_UPDATE_TOKEN_EXPIRY_INFO,
-            AbiConstants.ABI_ID_UPDATE_TOKEN_EXPIRY_INFO_V2);
 
     public PrecompileMapper(final Set<Precompile> precompiles) {
         for (final Precompile precompile : precompiles) {
@@ -116,16 +36,6 @@ public class PrecompileMapper {
 
     public Optional<Precompile> lookup(final int functionSelector) {
         final var precompile = abiConstantToPrecompile.get(functionSelector);
-
-        if (precompile != null) {
-            return Optional.of(precompile);
-        }
-        // TODO If the function selector is not mapped but is from the list of HTS precompiles, throw an exception until
-        // the given precompile is supported
-        else if (precompileSelectors.contains(functionSelector)) {
-            throw new UnsupportedOperationException(UNSUPPORTED_ERROR);
-        } else {
-            return Optional.empty();
-        }
+        return Optional.ofNullable(precompile);
     }
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/PrecompileMapper.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/PrecompileMapper.java
@@ -23,7 +23,6 @@ import java.util.Set;
 
 public class PrecompileMapper {
 
-    public static final String UNSUPPORTED_ERROR = "Precompile not supported for non-static frames";
     private static final Map<Integer, Precompile> abiConstantToPrecompile = new HashMap<>();
 
     public PrecompileMapper(final Set<Precompile> precompiles) {

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileTest.java
@@ -27,6 +27,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import com.google.protobuf.ByteString;
 import com.hedera.mirror.web3.exception.MirrorEvmTransactionException;
 import com.hedera.mirror.web3.viewmodel.BlockType;
+import com.hedera.node.app.service.evm.exceptions.InvalidTransactionException;
 import lombok.RequiredArgsConstructor;
 import org.hyperledger.besu.datatypes.Address;
 import org.junit.jupiter.api.Test;
@@ -35,7 +36,6 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.EnumSource.Mode;
 
 class ContractCallServicePrecompileTest extends ContractCallTestSetup {
-    private static final String ERROR_MESSAGE = "Precompile not supported for non-static frames";
 
     @ParameterizedTest
     @EnumSource(ContractReadFunctions.class)
@@ -163,8 +163,8 @@ class ContractCallServicePrecompileTest extends ContractCallTestSetup {
                 functionHash, MODIFICATION_CONTRACT_ADDRESS, ETH_ESTIMATE_GAS, 0L, BlockType.LATEST);
 
         assertThatThrownBy(() -> contractCallService.processCall(serviceParameters))
-                .isInstanceOf(UnsupportedOperationException.class)
-                .hasMessage(ERROR_MESSAGE);
+                .isInstanceOf(InvalidTransactionException.class)
+                .hasMessage("Precompile result is null");
     }
 
     private static long getValue(SupportedContractModificationFunctions contractFunc) {


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
Currently if we try to invoke invalid precompile method we get `501 NOT_IMPLEMENTED` response. The correct behaviour would be to get `400 BAD_REQUEST`. This PR fixes this behaviour.
**Related issue(s)**:

Fixes #7318 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
