### PR TITLE
Set entity balance timestamp in the migration

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/InitializeEntityBalanceMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/InitializeEntityBalanceMigration.java
@@ -91,7 +91,7 @@ public class InitializeEntityBalanceMigration extends TimeSensitiveBalanceMigrat
 
     @Override
     protected MigrationVersion getMinimumVersion() {
-        return MigrationVersion.fromVersion("1.86.0");
+        return MigrationVersion.fromVersion("1.87.2"); // The version entity.balance_timestamp is added
     }
 
     @Override

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/InitializeEntityBalanceMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/InitializeEntityBalanceMigration.java
@@ -30,15 +30,18 @@ public class InitializeEntityBalanceMigration extends TimeSensitiveBalanceMigrat
 
     private static final String INITIALIZE_ENTITY_BALANCE_SQL =
             """
-            with timestamp_range as (
+            with last_record_file as (
+              select consensus_end
+              from record_file
+              order by consensus_end desc
+              limit 1
+            ), timestamp_range as (
               select
                 consensus_timestamp as snapshot_timestamp,
                 consensus_timestamp + time_offset as from_timestamp,
                 consensus_end as to_timestamp
-              from account_balance_file
-              join (select consensus_end from record_file order by consensus_end desc limit 1) last_record_file
-                on consensus_timestamp + time_offset <= consensus_end
-              where synthetic is false
+              from account_balance_file, last_record_file
+              where synthetic is false and consensus_timestamp + time_offset <= consensus_end
               order by consensus_timestamp desc
               limit 1
             ), snapshot as (
@@ -55,15 +58,18 @@ public class InitializeEntityBalanceMigration extends TimeSensitiveBalanceMigrat
               select
                 coalesce(account_id, entity_id) as account_id,
                 coalesce(balance, 0) + coalesce(amount, 0) as balance,
+                consensus_end as balance_timestamp,
                 case when balance is not null then false end as deleted
               from snapshot
-              full outer join change on account_id = entity_id
+                full outer join change on account_id = entity_id,
+                last_record_file
             )
-            insert into entity (balance, deleted, id, num, realm, shard, timestamp_range)
-            select s.balance, s.deleted, s.account_id, (s.account_id & 4294967295), ((s.account_id >> 32) & 65535), (s.account_id  >> 48), '[0,)'
+            insert into entity (balance, balance_timestamp, deleted, id, num, realm, shard, timestamp_range)
+            select s.balance, s.balance_timestamp, s.deleted, s.account_id, (s.account_id & 4294967295), ((s.account_id >> 32) & 65535), (s.account_id  >> 48), '[0,)'
             from state s
             on conflict (id) do update
-            set balance = excluded.balance;
+            set balance = excluded.balance,
+                balance_timestamp = coalesce(entity.balance_timestamp, excluded.balance_timestamp);
             """;
 
     private final JdbcOperations jdbcOperations;

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/InitializeEntityBalanceMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/InitializeEntityBalanceMigrationTest.java
@@ -117,6 +117,7 @@ class InitializeEntityBalanceMigrationTest extends IntegrationTest {
         migration.doMigrate();
 
         // then
+        setExpectedBalance();
         assertThat(entityRepository.findAll()).containsExactlyInAnyOrder(account, accountDeleted, contract, topic);
     }
 
@@ -136,6 +137,7 @@ class InitializeEntityBalanceMigrationTest extends IntegrationTest {
         migration.doMigrate();
 
         // then
+        setExpectedBalance();
         assertThat(entityRepository.findAll()).containsExactlyInAnyOrder(account, accountDeleted, contract, topic);
     }
 
@@ -150,9 +152,6 @@ class InitializeEntityBalanceMigrationTest extends IntegrationTest {
         migration.doMigrate();
 
         // then
-        account.setBalance(0L);
-        accountDeleted.setBalance(0L);
-        contract.setBalance(0L);
         assertThat(entityRepository.findAll()).containsExactlyInAnyOrder(account, accountDeleted, contract, topic);
     }
 
@@ -167,9 +166,6 @@ class InitializeEntityBalanceMigrationTest extends IntegrationTest {
         migration.doMigrate();
 
         // then
-        account.setBalance(0L);
-        accountDeleted.setBalance(0L);
-        contract.setBalance(0L);
         assertThat(entityRepository.findAll()).containsExactlyInAnyOrder(account, accountDeleted, contract, topic);
     }
 
@@ -184,9 +180,6 @@ class InitializeEntityBalanceMigrationTest extends IntegrationTest {
         migration.doMigrate();
 
         // then
-        account.setBalance(0L);
-        accountDeleted.setBalance(0L);
-        contract.setBalance(0L);
         assertThat(entityRepository.findAll()).containsExactlyInAnyOrder(account, accountDeleted, contract, topic);
     }
 
@@ -200,6 +193,7 @@ class InitializeEntityBalanceMigrationTest extends IntegrationTest {
         migration.doMigrate();
 
         // then
+        setExpectedBalance();
         account.setDeleted(false); // We only know for sure that entities in the balance file are not deleted
         accountDeleted.setDeleted(null);
         contract.setDeleted(null);
@@ -221,9 +215,6 @@ class InitializeEntityBalanceMigrationTest extends IntegrationTest {
         migration.onEnd(accountBalanceFile2);
 
         // then
-        account.setBalance(0L);
-        accountDeleted.setBalance(0L);
-        contract.setBalance(0L);
         assertThat(entityRepository.findAll()).containsExactlyInAnyOrder(account, accountDeleted, contract, topic);
     }
 
@@ -251,9 +242,6 @@ class InitializeEntityBalanceMigrationTest extends IntegrationTest {
         migration.onEnd(accountBalanceFile3);
 
         // then
-        account.setBalance(0L);
-        accountDeleted.setBalance(0L);
-        contract.setBalance(0L);
         assertThat(entityRepository.findAll()).containsExactlyInAnyOrder(account, accountDeleted, contract, topic);
     }
 
@@ -268,9 +256,6 @@ class InitializeEntityBalanceMigrationTest extends IntegrationTest {
         migration.onEnd(accountBalanceFile2);
 
         // then
-        account.setBalance(0L);
-        accountDeleted.setBalance(0L);
-        contract.setBalance(0L);
         assertThat(entityRepository.findAll()).containsExactlyInAnyOrder(account, accountDeleted, contract, topic);
     }
 
@@ -305,6 +290,13 @@ class InitializeEntityBalanceMigrationTest extends IntegrationTest {
                 .persist();
     }
 
+    private void setExpectedBalance() {
+        account.setBalance(505L);
+        account.setBalanceTimestamp(recordFile2.getConsensusEnd());
+        accountDeleted.setBalance(20L);
+        contract.setBalance(25L);
+    }
+
     private void setup() {
         setupForFirstAccountBalanceFile();
 
@@ -329,17 +321,15 @@ class InitializeEntityBalanceMigrationTest extends IntegrationTest {
                 .persist();
         persistAccountBalance(750L, account.toEntityId(), accountBalanceTimestamp2);
         persistAccountBalance(450L, contract.toEntityId(), accountBalanceTimestamp2);
-
-        // Set expected balances
-        account.setBalance(505L);
-        accountDeleted.setBalance(20L);
-        contract.setBalance(25L);
     }
 
     private void setupForFirstAccountBalanceFile() {
         account = domainBuilder
                 .entity()
-                .customize(e -> e.balance(0L).deleted(null).createdTimestamp(timestamp(Duration.ofSeconds(1L))))
+                .customize(e -> e.balance(0L)
+                        .balanceTimestamp(null)
+                        .deleted(null)
+                        .createdTimestamp(timestamp(Duration.ofSeconds(1L))))
                 .persist();
         accountDeleted = domainBuilder
                 .entity()
@@ -348,6 +338,7 @@ class InitializeEntityBalanceMigrationTest extends IntegrationTest {
         topic = domainBuilder
                 .entity()
                 .customize(e -> e.balance(null)
+                        .balanceTimestamp(null)
                         .createdTimestamp(timestamp(Duration.ofSeconds(1)))
                         .type(TOPIC))
                 .persist();
@@ -375,6 +366,7 @@ class InitializeEntityBalanceMigrationTest extends IntegrationTest {
         contract = domainBuilder
                 .entity()
                 .customize(e -> e.balance(0L)
+                        .balanceTimestamp(accountBalanceTimestamp1 + 10)
                         .createdTimestamp(timestamp(Duration.ofSeconds(1)))
                         .type(CONTRACT))
                 .persist();


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR fix the issue.

- set entity balance_timestamp to consensus_end of the last record file if it's null

**Related issue(s)**:

Fixes #7328 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

Note, I didn't bump up the migration's checksum since
- migration V1.87.2 does set balance_timestamp properly if there's already data ingested
- there is no entity with non-null balance and null balance timestamp in mainnet db
- rerun the migration will be really slow with our mainnet db since the last non-synthetic account balance file is more than 1 months ago, there are a lot of transactions thus crypto transfers to reconcile and get the correct balance
 
**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
