### PR TITLE
Fix acceptance test regression in estimate gas w/ bytecode

### DIFF
--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AbstractEstimateFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AbstractEstimateFeature.java
@@ -52,8 +52,8 @@ abstract class AbstractEstimateFeature extends AbstractFeature {
         int lowerBound = actualUsedGas + lowerDeviation;
         int upperBound = actualUsedGas + upperDeviation;
 
-        assertThat(estimatedGas).as("Estimated gas is below lower bound").isGreaterThanOrEqualTo(lowerBound);
-        assertThat(estimatedGas).as("Estimated gas is above upper bound").isLessThanOrEqualTo(upperBound);
+        assertThat(estimatedGas).as("Estimated gas is above lower bound").isGreaterThanOrEqualTo(lowerBound);
+        assertThat(estimatedGas).as("Estimated gas is below upper bound").isLessThanOrEqualTo(upperBound);
     }
 
     /**

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AbstractEstimateFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AbstractEstimateFeature.java
@@ -16,8 +16,8 @@
 
 package com.hedera.mirror.test.e2e.acceptance.steps;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.hedera.mirror.test.e2e.acceptance.client.MirrorNodeClient;
 import com.hedera.mirror.test.e2e.acceptance.props.ContractCallRequest;
@@ -37,15 +37,14 @@ abstract class AbstractEstimateFeature extends AbstractFeature {
      * Checks if the estimatedGas is within the specified range of the actualGas.
      * <p>
      * The method calculates the lower and upper bounds as percentages of the actualUsedGas, then checks if the
-     * estimatedGas is within the range (inclusive) and returns true if it is, otherwise returns false.
+     * estimatedGas is within the range (inclusive).
      *
      * @param actualUsedGas     the integer value that represents the actualGas used value
      * @param estimatedGas      the integer value to be checked
      * @param lowerBoundPercent the integer percentage value for the lower bound of the acceptable range
      * @param upperBoundPercent the integer percentage value for the upper bound of the acceptable range
-     * @return true if the actualUsedGas is within the specified range, false otherwise
      */
-    protected static boolean isWithinDeviation(
+    protected static void assertWithinDeviation(
             int actualUsedGas, int estimatedGas, int lowerBoundPercent, int upperBoundPercent) {
         int lowerDeviation = actualUsedGas * lowerBoundPercent / 100;
         int upperDeviation = actualUsedGas * upperBoundPercent / 100;
@@ -53,7 +52,8 @@ abstract class AbstractEstimateFeature extends AbstractFeature {
         int lowerBound = actualUsedGas + lowerDeviation;
         int upperBound = actualUsedGas + upperDeviation;
 
-        return (estimatedGas >= lowerBound) && (estimatedGas <= upperBound);
+        assertThat(estimatedGas).as("Estimated gas is below lower bound").isGreaterThanOrEqualTo(lowerBound);
+        assertThat(estimatedGas).as("Estimated gas is above upper bound").isLessThanOrEqualTo(upperBound);
     }
 
     /**
@@ -77,7 +77,7 @@ abstract class AbstractEstimateFeature extends AbstractFeature {
         ContractCallResponse msgSenderResponse = mirrorClient.contractsCall(contractCallRequestBody);
         int estimatedGas = msgSenderResponse.getResultAsNumber().intValue();
 
-        assertTrue(isWithinDeviation(actualGasUsed.getActualGas(), estimatedGas, lowerDeviation, upperDeviation));
+        assertWithinDeviation(actualGasUsed.getActualGas(), estimatedGas, lowerDeviation, upperDeviation);
     }
 
     /**

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/EstimateFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/EstimateFeature.java
@@ -230,7 +230,7 @@ public class EstimateFeature extends AbstractEstimateFeature {
         ContractCallResponse msgSignerResponse = mirrorClient.contractsCall(contractCallRequestBody);
         int estimatedGas = msgSignerResponse.getResultAsNumber().intValue();
 
-        assertTrue(isWithinDeviation(MESSAGE_SIGNER.getActualGas(), estimatedGas, lowerDeviation, upperDeviation));
+        assertWithinDeviation(MESSAGE_SIGNER.getActualGas(), estimatedGas, lowerDeviation, upperDeviation);
     }
 
     @Then("I call estimateGas with function that makes a call to invalid smart contract")
@@ -419,7 +419,7 @@ public class EstimateFeature extends AbstractEstimateFeature {
         DELEGATE_CALL_TO_INVALID_CONTRACT("delegateCallToInvalidContract", 24350),
         DEPLOY_CONTRACT_VIA_CREATE_OPCODE("deployViaCreate", 53477),
         DEPLOY_CONTRACT_VIA_CREATE_TWO_OPCODE("deployViaCreate2", 55693),
-        DEPLOY_CONTRACT_VIA_BYTECODE_DATA("", 174704),
+        DEPLOY_CONTRACT_VIA_BYTECODE_DATA("", 254007),
         DESTROY("destroy", 26171),
         GET_GAS_LEFT("getGasLeft", 21326),
         GET_MOCK_ADDRESS("getMockContractAddress", 0),

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/EstimatePrecompileFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/EstimatePrecompileFeature.java
@@ -120,7 +120,6 @@ import static com.hedera.mirror.test.e2e.acceptance.util.TestUtil.asLongArray;
 import static com.hedera.mirror.test.e2e.acceptance.util.TestUtil.nextBytes;
 import static com.hedera.mirror.test.e2e.acceptance.util.TestUtil.nftAmount;
 import static com.hedera.mirror.test.e2e.acceptance.util.TestUtil.to32BytesString;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.esaulpaugh.headlong.util.Strings;
@@ -1520,7 +1519,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
         var encodedData = Strings.encode(ByteBuffer.wrap(data));
         var response = estimateContract(encodedData, contractAddress);
         var estimateGasValue = response.getResultAsNumber().intValue();
-        assertTrue(isWithinDeviation(contractMethods.getActualGas(), estimateGasValue, lowerDeviation, upperDeviation));
+        assertWithinDeviation(contractMethods.getActualGas(), estimateGasValue, lowerDeviation, upperDeviation);
         return estimateGasValue;
     }
 
@@ -1700,7 +1699,7 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
                 .build();
         ContractCallResponse msgSenderResponse = mirrorClient.contractsCall(contractCallRequestBody);
         int estimatedGas = msgSenderResponse.getResultAsNumber().intValue();
-        assertTrue(isWithinDeviation(actualGasUsed, estimatedGas, lowerDeviation, upperDeviation));
+        assertWithinDeviation(actualGasUsed, estimatedGas, lowerDeviation, upperDeviation);
     }
 
     /**


### PR DESCRIPTION
**Description**:

* Fix acceptance test regression in estimate gas w/ bytecode caused by change in #7327 
* Refactor `isWithinDeviation` to directly assert so it displays input in case of failure

**Related issue(s)**:

Fixes #7329

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
