### PR TITLE
Fix flaky acceptance tests

### DIFF
--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AccountClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AccountClient.java
@@ -309,6 +309,7 @@ public class AccountClient extends AbstractNetworkClient {
     public enum AccountNameEnum {
         ALICE(false, Key.KeyCase.ED25519),
         BOB(true, Key.KeyCase.ECDSA_SECP256K1),
+        // used in token.feature
         CAROL(false, Key.KeyCase.ED25519),
         DAVE(false, Key.KeyCase.ED25519),
         OPERATOR(false, Key.KeyCase.ED25519); // These may not be accurate for operator

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TokenClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TokenClient.java
@@ -619,6 +619,11 @@ public class TokenClient extends AbstractNetworkClient {
                 TokenType.NON_FUNGIBLE_UNIQUE,
                 TokenKycStatus.KycNotApplicable,
                 TokenFreezeStatus.FreezeNotApplicable),
+        NFT_ERC(
+                "non_fungible_erc",
+                TokenType.NON_FUNGIBLE_UNIQUE,
+                TokenKycStatus.KycNotApplicable,
+                TokenFreezeStatus.FreezeNotApplicable),
         NFT_DELETABLE(
                 "non_fungible_deletable",
                 TokenType.NON_FUNGIBLE_UNIQUE,

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ERCContractFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ERCContractFeature.java
@@ -282,16 +282,29 @@ public class ERCContractFeature extends AbstractFeature {
         assertNotNull(networkTransactionResponse.getReceipt());
     }
 
-    @RetryAsserts
-    @Then(
-            "I call the erc contract via the mirror node REST API for token isApprovedForAll with response true with alias accounts")
-    public void isApprovedForAllWithAliasSecondContractCall() {
+    @Then("I associate and approve the tokens")
+    public void associateAndApproveTokens() {
         ecdsaAccount = accountClient.getAccount(BOB);
         tokenClient.associate(ecdsaAccount, nonFungibleTokenId);
         networkTransactionResponse =
                 accountClient.approveNftAllSerials(nonFungibleTokenId, ecdsaAccount.getAccountId());
         verifyMirrorTransactionsResponse(mirrorClient, 200);
 
+        tokenClient.associate(ecdsaAccount, fungibleTokenId);
+        accountClient.approveToken(fungibleTokenId, ecdsaAccount.getAccountId(), 1_000);
+        networkTransactionResponse = tokenClient.transferFungibleToken(
+                fungibleTokenId,
+                tokenClient.getSdkClient().getExpandedOperatorAccountId(),
+                ecdsaAccount.getAccountId(),
+                ecdsaAccount.getPrivateKey(),
+                500);
+        verifyMirrorTransactionsResponse(mirrorClient, 200);
+    }
+
+    @RetryAsserts
+    @Then(
+            "I call the erc contract via the mirror node REST API for token isApprovedForAll with response true with alias accounts")
+    public void isApprovedForAllWithAliasSecondContractCall() {
         var data = encodeData(
                 ERC,
                 IS_APPROVED_FOR_ALL_SELECTOR,
@@ -307,16 +320,6 @@ public class ERCContractFeature extends AbstractFeature {
     @RetryAsserts
     @Then("I call the erc contract via the mirror node REST API for token allowance with alias accounts")
     public void allowanceAliasAccountsCall() {
-        tokenClient.associate(ecdsaAccount, fungibleTokenId);
-        accountClient.approveToken(fungibleTokenId, ecdsaAccount.getAccountId(), 1_000);
-        networkTransactionResponse = tokenClient.transferFungibleToken(
-                fungibleTokenId,
-                tokenClient.getSdkClient().getExpandedOperatorAccountId(),
-                ecdsaAccount.getAccountId(),
-                ecdsaAccount.getPrivateKey(),
-                500);
-        verifyMirrorTransactionsResponse(mirrorClient, 200);
-
         var data = encodeData(
                 ERC,
                 ALLOWANCE_SELECTOR,

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ERCContractFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ERCContractFeature.java
@@ -57,8 +57,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 @CustomLog
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
 public class ERCContractFeature extends AbstractFeature {
-    private static final int INITIAL_SUPPLY = 1_000_000;
-    private static final int MAX_SUPPLY = 1;
 
     private final AccountClient accountClient;
     private final Map<TokenId, List<Long>> tokenSerialNumbers = new ConcurrentHashMap<>();
@@ -232,7 +230,7 @@ public class ERCContractFeature extends AbstractFeature {
 
     @Then("I create a new nft with infinite supplyType")
     public void createNewNft() {
-        final var tokenId = tokenClient.getToken(TokenNameEnum.NFT_DELETABLE).tokenId();
+        final var tokenId = tokenClient.getToken(TokenNameEnum.NFT_ERC).tokenId();
         tokenSerialNumbers.put(tokenId, new ArrayList<>());
         nonFungibleTokenId = tokenId;
     }

--- a/hedera-mirror-test/src/test/resources/features/contract/erc.feature
+++ b/hedera-mirror-test/src/test/resources/features/contract/erc.feature
@@ -26,6 +26,7 @@ Feature: ERC Contract Base Coverage Feature
     When I approve <tokenAllowanceSpender> with <allowances>
     Then the mirror node REST API should return status 200 for the erc contract transaction
     And I call the erc contract via the mirror node REST API for token allowance with allowances
+    Then I associate and approve the tokens
     Then I call the erc contract via the mirror node REST API for token isApprovedForAll with response true with alias accounts
     Then I call the erc contract via the mirror node REST API for token allowance with alias accounts
     Then I call the erc contract via the mirror node REST API for token balance with alias account


### PR DESCRIPTION
**Description**:

`token.feature` and `erc.feature` share the same cached token - `NFT_DELETABLE`. Sometimes the token feature deletes the token before erc feature is executed.

Created new token and fixed `@RetryAsserts` method that sometimes tries to make multiple associate operations. This makes the mirror node to return error `TOKEN_ALREADY_ASSOCIATED_TO_ACCOUNT` after the first execution.

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
