### PR TITLE
Bug Fix: REST API error

### DIFF
--- a/hedera-mirror-rest/health.js
+++ b/hedera-mirror-rest/health.js
@@ -23,7 +23,7 @@ const readinessQuery = 'select true from address_book limit 1';
  *
  * @returns {Promise<*>}
  */
-const beforeShutdown = async () => {
+const onShutdown = async () => {
   logger.info(`Closing connection pool`);
   return pool.end();
 };
@@ -54,7 +54,7 @@ const readinessCheck = async () => {
 const livenessCheck = async () => {};
 
 export default {
-  beforeShutdown,
+  onShutdown,
   livenessCheck,
   readinessCheck,
 };

--- a/hedera-mirror-rest/server.js
+++ b/hedera-mirror-rest/server.js
@@ -192,7 +192,7 @@ if (!isTestEnv()) {
       '/health/readiness': health.readinessCheck,
       '/health/liveness': health.livenessCheck,
     },
-    beforeShutdown: health.beforeShutdown,
+    onShutdown: health.beforeShutdown,
   });
 }
 

--- a/hedera-mirror-rest/server.js
+++ b/hedera-mirror-rest/server.js
@@ -192,7 +192,7 @@ if (!isTestEnv()) {
       '/health/readiness': health.readinessCheck,
       '/health/liveness': health.livenessCheck,
     },
-    onShutdown: health.beforeShutdown,
+    onShutdown: health.onShutdown,
   });
 }
 


### PR DESCRIPTION
**Description**:

This is a fix for Rest API error : Cannot use a pool after calling end on the pool

This PR modifies 
* beforeShutdown to register on onShutdown hook instead of beforeShutdown
* Renaming beforeShutdown to onShutdown

**Related issue(s)**:
Fixes #[7279](https://github.com/hashgraph/hedera-mirror-node/issues/7279)

**Notes for reviewer**:
This bug fix has been manually tested.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
