### PR TITLE
Update config limit max test

### DIFF
--- a/hedera-mirror-rest/__tests__/config.test.js
+++ b/hedera-mirror-rest/__tests__/config.test.js
@@ -30,7 +30,7 @@ const custom = {
         response: {
           compression: false,
           limit: {
-            max: 30,
+            max: 101,
           },
         },
         shard: 1,


### PR DESCRIPTION
**Description**:
Update the config limit max test; this could remove the possibility of a problem with the limits of other tests being set too high.

**Related issue(s)**:

Fixes #7315 

**Notes for reviewer**:
Setting the limit max to below 99 yields errors identical to those seen in the build logs for this issue. Perhaps there is a problem with the rest test infrastructure where the custom config from `config.test.js` is sometimes in use for other tests. The custom config reduced the max limit to 30, so that would cause the other tests to fail. This change assures that even if the custom config is used the tests will not fail.

The REST tests have been ran through the CI build process 5 times in this PR and have not been able to recreate the problem, so it could be that this change solves it.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
