### PR TITLE
Rename `MirrorProperties` to `ImporterProperties`

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/ImporterProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/ImporterProperties.java
@@ -36,7 +36,7 @@ import org.springframework.validation.annotation.Validated;
 @Data
 @Validated
 @ConfigurationProperties("hedera.mirror.importer")
-public class MirrorProperties {
+public class ImporterProperties {
 
     public static final String STREAMS = "streams";
     static final String NETWORK_PREFIX_DELIMITER = "-";

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/addressbook/AddressBookServiceImpl.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/addressbook/AddressBookServiceImpl.java
@@ -27,8 +27,8 @@ import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.file.FileData;
 import com.hedera.mirror.common.domain.transaction.TransactionType;
 import com.hedera.mirror.common.util.DomainUtils;
-import com.hedera.mirror.importer.MirrorProperties;
-import com.hedera.mirror.importer.MirrorProperties.ConsensusMode;
+import com.hedera.mirror.importer.ImporterProperties;
+import com.hedera.mirror.importer.ImporterProperties.ConsensusMode;
 import com.hedera.mirror.importer.exception.InvalidDatasetException;
 import com.hedera.mirror.importer.repository.AddressBookRepository;
 import com.hedera.mirror.importer.repository.FileDataRepository;
@@ -80,7 +80,7 @@ public class AddressBookServiceImpl implements AddressBookService {
 
     private final AddressBookRepository addressBookRepository;
     private final FileDataRepository fileDataRepository;
-    private final MirrorProperties mirrorProperties;
+    private final ImporterProperties importerProperties;
     private final NodeStakeRepository nodeStakeRepository;
     private final TransactionTemplate transactionTemplate;
 
@@ -135,7 +135,7 @@ public class AddressBookServiceImpl implements AddressBookService {
         var totalStake = new AtomicLong(0L);
         var nodes = new TreeSet<ConsensusNode>();
         var nodeStakes = new HashMap<Long, NodeStake>();
-        var consensusMode = mirrorProperties.getConsensusMode();
+        var consensusMode = importerProperties.getConsensusMode();
         var nodesInAddressBook = addressBook.getEntries().stream()
                 .map(AddressBookEntry::getNodeId)
                 .collect(Collectors.toSet());
@@ -531,12 +531,12 @@ public class AddressBookServiceImpl implements AddressBookService {
 
         // retrieve bootstrap address book from filesystem or classpath
         try {
-            Path initialAddressBook = mirrorProperties.getInitialAddressBook();
+            Path initialAddressBook = importerProperties.getInitialAddressBook();
             if (initialAddressBook != null) {
                 log.info("Loading bootstrap address book from {}", initialAddressBook);
                 addressBookBytes = Files.readAllBytes(initialAddressBook);
             } else {
-                var resourcePath = String.format("/addressbook/%s", mirrorProperties.getNetwork());
+                var resourcePath = String.format("/addressbook/%s", importerProperties.getNetwork());
                 log.info("Loading bootstrap address book from {}", resourcePath);
                 Resource resource = new ClassPathResource(resourcePath, getClass());
                 addressBookBytes = resource.getInputStream().readAllBytes();

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/DateRangeCalculator.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/DateRangeCalculator.java
@@ -22,7 +22,7 @@ import static org.apache.commons.lang3.ObjectUtils.max;
 import com.hedera.mirror.common.domain.StreamFile;
 import com.hedera.mirror.common.domain.StreamType;
 import com.hedera.mirror.common.util.DomainUtils;
-import com.hedera.mirror.importer.MirrorProperties;
+import com.hedera.mirror.importer.ImporterProperties;
 import com.hedera.mirror.importer.domain.StreamFilename;
 import com.hedera.mirror.importer.exception.InvalidConfigurationException;
 import com.hedera.mirror.importer.repository.AccountBalanceFileRepository;
@@ -46,7 +46,7 @@ public class DateRangeCalculator {
 
     static final Instant STARTUP_TIME = Instant.now();
 
-    private final MirrorProperties mirrorProperties;
+    private final ImporterProperties importerProperties;
     private final AccountBalanceFileRepository accountBalanceFileRepository;
     private final EventFileRepository eventFileRepository;
     private final RecordFileRepository recordFileRepository;
@@ -69,8 +69,8 @@ public class DateRangeCalculator {
     }
 
     private DateRangeFilter newDateRangeFilter(StreamType streamType) {
-        Instant startDate = mirrorProperties.getStartDate();
-        Instant endDate = mirrorProperties.getEndDate();
+        Instant startDate = importerProperties.getStartDate();
+        Instant endDate = importerProperties.getEndDate();
         Instant lastFileInstant = findLatest(streamType)
                 .map(StreamFile::getConsensusStart)
                 .map(nanos -> Instant.ofEpochSecond(0, nanos))
@@ -85,7 +85,7 @@ public class DateRangeCalculator {
         if (startDate != null) {
             filterStartDate = max(startDate, lastFileInstant);
         } else {
-            if (!MirrorProperties.HederaNetwork.DEMO.equalsIgnoreCase(mirrorProperties.getNetwork())
+            if (!ImporterProperties.HederaNetwork.DEMO.equalsIgnoreCase(importerProperties.getNetwork())
                     && lastFileInstant == null) {
                 filterStartDate = STARTUP_TIME;
             }
@@ -98,7 +98,7 @@ public class DateRangeCalculator {
     }
 
     /**
-     * Gets the latest stream file for downloader based on startDate in MirrorProperties, the startDateAdjustment and
+     * Gets the latest stream file for downloader based on startDate in ImporterProperties, the startDateAdjustment and
      * last valid downloaded stream file.
      *
      * @param streamType What type of stream to retrieve
@@ -106,7 +106,7 @@ public class DateRangeCalculator {
      * start date
      */
     public <T extends StreamFile<?>> Optional<T> getLastStreamFile(StreamType streamType) {
-        Instant startDate = mirrorProperties.getStartDate();
+        Instant startDate = importerProperties.getStartDate();
         Optional<T> streamFile = findLatest(streamType);
         Instant lastFileInstant = streamFile
                 .map(StreamFile::getConsensusStart)
@@ -120,11 +120,11 @@ public class DateRangeCalculator {
             effectiveStartDate = max(startDate, hasStreamFile ? lastFileInstant : Instant.EPOCH);
         } else if (hasStreamFile) {
             effectiveStartDate = lastFileInstant;
-        } else if (MirrorProperties.HederaNetwork.DEMO.equalsIgnoreCase(mirrorProperties.getNetwork())) {
+        } else if (ImporterProperties.HederaNetwork.DEMO.equalsIgnoreCase(importerProperties.getNetwork())) {
             effectiveStartDate = Instant.EPOCH; // Demo network contains only data in the past, so don't default to now
         }
 
-        Instant endDate = mirrorProperties.getEndDate();
+        Instant endDate = importerProperties.getEndDate();
         if (startDate != null && startDate.compareTo(endDate) > 0) {
             throw new InvalidConfigurationException(String.format(
                     "Date range constraint violation: " + "startDate (%s) > endDate (%s)", startDate, endDate));
@@ -149,7 +149,7 @@ public class DateRangeCalculator {
                 "{}: downloader will download files in time range ({}, {}]",
                 streamType,
                 effectiveStartDate,
-                mirrorProperties.getEndDate());
+                importerProperties.getEndDate());
         return streamFile;
     }
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/HealthCheckConfiguration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/HealthCheckConfiguration.java
@@ -16,7 +16,7 @@
 
 package com.hedera.mirror.importer.config;
 
-import com.hedera.mirror.importer.MirrorProperties;
+import com.hedera.mirror.importer.ImporterProperties;
 import com.hedera.mirror.importer.leader.LeaderService;
 import com.hedera.mirror.importer.parser.ParserProperties;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -36,7 +36,7 @@ import org.springframework.context.annotation.Configuration;
 class HealthCheckConfiguration {
 
     private final LeaderService leaderService;
-    private final MirrorProperties mirrorProperties;
+    private final ImporterProperties importerProperties;
     private final Collection<ParserProperties> parserProperties;
 
     @Bean
@@ -45,7 +45,7 @@ class HealthCheckConfiguration {
         Map<String, HealthIndicator> healthIndicators = parserProperties.stream()
                 .collect(Collectors.toMap(
                         k -> k.getStreamType().toString(),
-                        v -> new StreamFileHealthIndicator(leaderService, registry, mirrorProperties, v)));
+                        v -> new StreamFileHealthIndicator(leaderService, registry, importerProperties, v)));
 
         return CompositeHealthContributor.fromMap(healthIndicators);
     }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/ImporterConfiguration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/ImporterConfiguration.java
@@ -16,7 +16,7 @@
 
 package com.hedera.mirror.importer.config;
 
-import com.hedera.mirror.importer.MirrorProperties;
+import com.hedera.mirror.importer.ImporterProperties;
 import com.hedera.mirror.importer.leader.LeaderAspect;
 import com.hedera.mirror.importer.leader.LeaderService;
 import lombok.CustomLog;
@@ -43,7 +43,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @AutoConfigureBefore(FlywayAutoConfiguration.class) // Since this configuration creates FlywayConfigurationCustomizer
 class ImporterConfiguration {
 
-    private final MirrorProperties mirrorProperties;
+    private final ImporterProperties importerProperties;
 
     @Bean
     @ConditionalOnCloudPlatform(CloudPlatform.KUBERNETES)
@@ -61,9 +61,9 @@ class ImporterConfiguration {
     @Bean
     FlywayConfigurationCustomizer flywayConfigurationCustomizer() {
         return configuration -> {
-            Long timestamp = mirrorProperties.getTopicRunningHashV2AddedTimestamp();
+            Long timestamp = importerProperties.getTopicRunningHashV2AddedTimestamp();
             if (timestamp == null) {
-                if (MirrorProperties.HederaNetwork.MAINNET.equalsIgnoreCase(mirrorProperties.getNetwork())) {
+                if (ImporterProperties.HederaNetwork.MAINNET.equalsIgnoreCase(importerProperties.getNetwork())) {
                     timestamp = 1592499600000000000L;
                 } else {
                     timestamp = 1588706343553042000L;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/StreamFileHealthIndicator.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/StreamFileHealthIndicator.java
@@ -19,7 +19,7 @@ package com.hedera.mirror.importer.config;
 import static com.hedera.mirror.importer.downloader.Downloader.STREAM_CLOSE_LATENCY_METRIC_NAME;
 import static com.hedera.mirror.importer.parser.AbstractStreamFileParser.STREAM_PARSE_DURATION_METRIC_NAME;
 
-import com.hedera.mirror.importer.MirrorProperties;
+import com.hedera.mirror.importer.ImporterProperties;
 import com.hedera.mirror.importer.leader.LeaderService;
 import com.hedera.mirror.importer.parser.ParserProperties;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -60,7 +60,7 @@ public class StreamFileHealthIndicator implements HealthIndicator {
 
     private final LeaderService leaderService;
     private final MeterRegistry meterRegistry;
-    private final MirrorProperties mirrorProperties;
+    private final ImporterProperties importerProperties;
     private final ParserProperties parserProperty;
 
     @Override
@@ -73,7 +73,7 @@ public class StreamFileHealthIndicator implements HealthIndicator {
         }
 
         // consider case where endTime has been passed
-        if (mirrorProperties.getEndDate().isBefore(currentInstant)) {
+        if (importerProperties.getEndDate().isBefore(currentInstant)) {
             return endDateInPastHealth;
         }
 
@@ -111,9 +111,9 @@ public class StreamFileHealthIndicator implements HealthIndicator {
     }
 
     private Instant getStartTime() {
-        return mirrorProperties.getStartDate() == null
+        return importerProperties.getStartDate() == null
                 ? DateRangeCalculator.STARTUP_TIME
-                : mirrorProperties.getStartDate();
+                : importerProperties.getStartDate();
     }
 
     private Health getResolvedHealthWhenNoStreamFilesParsed(Instant currentInstant, Instant lastCheck) {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/CommonDownloaderProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/CommonDownloaderProperties.java
@@ -16,8 +16,8 @@
 
 package com.hedera.mirror.importer.downloader;
 
-import com.hedera.mirror.importer.MirrorProperties;
-import com.hedera.mirror.importer.MirrorProperties.HederaNetwork;
+import com.hedera.mirror.importer.ImporterProperties;
+import com.hedera.mirror.importer.ImporterProperties.HederaNetwork;
 import jakarta.annotation.PostConstruct;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -46,7 +46,7 @@ public class CommonDownloaderProperties {
 
     private static final MathContext MATH_CONTEXT = new MathContext(19, RoundingMode.DOWN);
 
-    private final MirrorProperties mirrorProperties;
+    private final ImporterProperties importerProperties;
 
     private String accessKey;
 
@@ -92,9 +92,9 @@ public class CommonDownloaderProperties {
     @PostConstruct
     public void init() {
         if (StringUtils.isBlank(bucketName)
-                && StringUtils.isBlank(HederaNetwork.getBucketName(mirrorProperties.getNetwork()))) {
+                && StringUtils.isBlank(HederaNetwork.getBucketName(importerProperties.getNetwork()))) {
             throw new IllegalArgumentException(
-                    "Must define bucketName for network named '%s'".formatted(mirrorProperties.getNetwork()));
+                    "Must define bucketName for network named '%s'".formatted(importerProperties.getNetwork()));
         }
 
         StreamSourceProperties.SourceCredentials credentials = null;
@@ -134,13 +134,13 @@ public class CommonDownloaderProperties {
     public String getBucketName() {
         return StringUtils.isNotBlank(bucketName)
                 ? bucketName
-                : HederaNetwork.getBucketName(mirrorProperties.getNetwork());
+                : HederaNetwork.getBucketName(importerProperties.getNetwork());
     }
 
     public boolean isAnonymousCredentials() {
         return allowAnonymousAccess != null
                 ? allowAnonymousAccess
-                : HederaNetwork.isAllowAnonymousAccess(mirrorProperties.getNetwork());
+                : HederaNetwork.isAllowAnonymousAccess(importerProperties.getNetwork());
     }
 
     public enum PathType {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/Downloader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/Downloader.java
@@ -27,7 +27,7 @@ import com.google.common.collect.TreeMultimap;
 import com.hedera.mirror.common.domain.StreamFile;
 import com.hedera.mirror.common.domain.StreamItem;
 import com.hedera.mirror.common.domain.StreamType;
-import com.hedera.mirror.importer.MirrorProperties;
+import com.hedera.mirror.importer.ImporterProperties;
 import com.hedera.mirror.importer.addressbook.ConsensusNode;
 import com.hedera.mirror.importer.addressbook.ConsensusNodeService;
 import com.hedera.mirror.importer.config.DateRangeCalculator;
@@ -89,6 +89,7 @@ public abstract class Downloader<T extends StreamFile<I>, I extends StreamItem> 
 
     protected final Logger log = LoggerFactory.getLogger(getClass());
     protected final DownloaderProperties downloaderProperties;
+    protected final ImporterProperties importerProperties;
     protected final NodeSignatureVerifier nodeSignatureVerifier;
     protected final SignatureFileReader signatureFileReader;
     protected final StreamFileProvider streamFileProvider;
@@ -98,7 +99,6 @@ public abstract class Downloader<T extends StreamFile<I>, I extends StreamItem> 
     protected final AtomicReference<Optional<T>> lastStreamFile = new AtomicReference<>(Optional.empty());
 
     private final ConsensusNodeService consensusNodeService;
-    private final MirrorProperties mirrorProperties;
     private final StreamType streamType;
 
     // Metrics
@@ -113,6 +113,7 @@ public abstract class Downloader<T extends StreamFile<I>, I extends StreamItem> 
     protected Downloader(
             ConsensusNodeService consensusNodeService,
             DownloaderProperties downloaderProperties,
+            ImporterProperties importerProperties,
             MeterRegistry meterRegistry,
             DateRangeCalculator dateRangeCalculator,
             NodeSignatureVerifier nodeSignatureVerifier,
@@ -122,6 +123,7 @@ public abstract class Downloader<T extends StreamFile<I>, I extends StreamItem> 
             StreamFileReader<T, ?> streamFileReader) {
         this.consensusNodeService = consensusNodeService;
         this.downloaderProperties = downloaderProperties;
+        this.importerProperties = importerProperties;
         this.meterRegistry = meterRegistry;
         this.dateRangeCalculator = dateRangeCalculator;
         this.nodeSignatureVerifier = nodeSignatureVerifier;
@@ -129,7 +131,6 @@ public abstract class Downloader<T extends StreamFile<I>, I extends StreamItem> 
         this.streamFileProvider = streamFileProvider;
         this.streamFileReader = streamFileReader;
         this.streamFileNotifier = streamFileNotifier;
-        this.mirrorProperties = downloaderProperties.getMirrorProperties();
         this.streamType = downloaderProperties.getStreamType();
 
         // Metrics
@@ -167,7 +168,7 @@ public abstract class Downloader<T extends StreamFile<I>, I extends StreamItem> 
 
             // Following is a cost optimization to not unnecessarily list the public demo bucket once complete
             if (sigFilesMap.isEmpty()
-                    && MirrorProperties.HederaNetwork.DEMO.equalsIgnoreCase(mirrorProperties.getNetwork())) {
+                    && ImporterProperties.HederaNetwork.DEMO.equalsIgnoreCase(importerProperties.getNetwork())) {
                 downloaderProperties.setEnabled(false);
                 log.warn("Disabled polling after downloading all files in demo bucket");
             }
@@ -191,7 +192,7 @@ public abstract class Downloader<T extends StreamFile<I>, I extends StreamItem> 
                 .get()
                 .map(StreamFile::getIndex)
                 .map(v -> v + 1)
-                .or(() -> Optional.ofNullable(mirrorProperties.getStartBlockNumber()))
+                .or(() -> Optional.ofNullable(importerProperties.getStartBlockNumber()))
                 .orElse(0L);
         streamFile.setIndex(index);
     }
@@ -338,7 +339,7 @@ public abstract class Downloader<T extends StreamFile<I>, I extends StreamItem> 
     }
 
     private boolean verifySignatures(Collection<StreamFileSignature> signatures) {
-        Instant endDate = mirrorProperties.getEndDate();
+        Instant endDate = importerProperties.getEndDate();
 
         for (var signature : signatures) {
             // Ignore signatures that didn't validate or weren't in the majority
@@ -360,11 +361,11 @@ public abstract class Downloader<T extends StreamFile<I>, I extends StreamItem> 
 
                 if (downloaderProperties.isWriteFiles()) {
                     Utility.archiveFile(
-                            streamFileData.getFilePath(), streamFile.getBytes(), mirrorProperties.getStreamPath());
+                            streamFileData.getFilePath(), streamFile.getBytes(), importerProperties.getStreamPath());
                 }
 
                 if (downloaderProperties.isWriteSignatures()) {
-                    var destination = mirrorProperties.getStreamPath();
+                    var destination = importerProperties.getStreamPath();
                     signatures.forEach(
                             s -> Utility.archiveFile(s.getFilename().getFilePath(), s.getBytes(), destination));
                 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/DownloaderProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/DownloaderProperties.java
@@ -17,7 +17,6 @@
 package com.hedera.mirror.importer.downloader;
 
 import com.hedera.mirror.common.domain.StreamType;
-import com.hedera.mirror.importer.MirrorProperties;
 import java.time.Duration;
 
 public interface DownloaderProperties {
@@ -25,8 +24,6 @@ public interface DownloaderProperties {
     CommonDownloaderProperties getCommon();
 
     Duration getFrequency();
-
-    MirrorProperties getMirrorProperties();
 
     StreamType getStreamType();
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/balance/AccountBalancesDownloader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/balance/AccountBalancesDownloader.java
@@ -18,6 +18,7 @@ package com.hedera.mirror.importer.downloader.balance;
 
 import com.hedera.mirror.common.domain.balance.AccountBalance;
 import com.hedera.mirror.common.domain.balance.AccountBalanceFile;
+import com.hedera.mirror.importer.ImporterProperties;
 import com.hedera.mirror.importer.addressbook.ConsensusNode;
 import com.hedera.mirror.importer.addressbook.ConsensusNodeService;
 import com.hedera.mirror.importer.config.DateRangeCalculator;
@@ -46,6 +47,7 @@ public class AccountBalancesDownloader extends Downloader<AccountBalanceFile, Ac
             AccountBalanceFileRepository accountBalanceFileRepository,
             ConsensusNodeService consensusNodeService,
             BalanceDownloaderProperties downloaderProperties,
+            ImporterProperties importerProperties,
             MeterRegistry meterRegistry,
             DateRangeCalculator dateRangeCalculator,
             NodeSignatureVerifier nodeSignatureVerifier,
@@ -56,6 +58,7 @@ public class AccountBalancesDownloader extends Downloader<AccountBalanceFile, Ac
         super(
                 consensusNodeService,
                 downloaderProperties,
+                importerProperties,
                 meterRegistry,
                 dateRangeCalculator,
                 nodeSignatureVerifier,

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/balance/BalanceDownloaderProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/balance/BalanceDownloaderProperties.java
@@ -17,7 +17,6 @@
 package com.hedera.mirror.importer.downloader.balance;
 
 import com.hedera.mirror.common.domain.StreamType;
-import com.hedera.mirror.importer.MirrorProperties;
 import com.hedera.mirror.importer.downloader.CommonDownloaderProperties;
 import com.hedera.mirror.importer.downloader.DownloaderProperties;
 import jakarta.validation.constraints.NotNull;
@@ -35,7 +34,6 @@ import org.springframework.validation.annotation.Validated;
 @Validated
 public class BalanceDownloaderProperties implements DownloaderProperties {
 
-    private final MirrorProperties mirrorProperties;
     private final CommonDownloaderProperties common;
 
     private boolean enabled = false;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/event/EventDownloaderProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/event/EventDownloaderProperties.java
@@ -17,7 +17,6 @@
 package com.hedera.mirror.importer.downloader.event;
 
 import com.hedera.mirror.common.domain.StreamType;
-import com.hedera.mirror.importer.MirrorProperties;
 import com.hedera.mirror.importer.downloader.CommonDownloaderProperties;
 import com.hedera.mirror.importer.downloader.DownloaderProperties;
 import jakarta.validation.constraints.NotNull;
@@ -35,7 +34,6 @@ import org.springframework.validation.annotation.Validated;
 @Validated
 public class EventDownloaderProperties implements DownloaderProperties {
 
-    private final MirrorProperties mirrorProperties;
     private final CommonDownloaderProperties common;
 
     private boolean enabled = false;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/event/EventFileDownloader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/event/EventFileDownloader.java
@@ -18,6 +18,7 @@ package com.hedera.mirror.importer.downloader.event;
 
 import com.hedera.mirror.common.domain.event.EventFile;
 import com.hedera.mirror.common.domain.event.EventItem;
+import com.hedera.mirror.importer.ImporterProperties;
 import com.hedera.mirror.importer.addressbook.ConsensusNodeService;
 import com.hedera.mirror.importer.config.DateRangeCalculator;
 import com.hedera.mirror.importer.downloader.Downloader;
@@ -38,6 +39,7 @@ public class EventFileDownloader extends Downloader<EventFile, EventItem> {
     public EventFileDownloader(
             ConsensusNodeService consensusNodeService,
             EventDownloaderProperties downloaderProperties,
+            ImporterProperties importerProperties,
             MeterRegistry meterRegistry,
             DateRangeCalculator dateRangeCalculator,
             NodeSignatureVerifier nodeSignatureVerifier,
@@ -48,6 +50,7 @@ public class EventFileDownloader extends Downloader<EventFile, EventItem> {
         super(
                 consensusNodeService,
                 downloaderProperties,
+                importerProperties,
                 meterRegistry,
                 dateRangeCalculator,
                 nodeSignatureVerifier,

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/LocalStreamFileProvider.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/LocalStreamFileProvider.java
@@ -48,7 +48,7 @@ public class LocalStreamFileProvider implements StreamFileProvider {
 
     @Override
     public Mono<StreamFileData> get(ConsensusNode node, StreamFilename streamFilename) {
-        var basePath = properties.getMirrorProperties().getStreamPath();
+        var basePath = properties.getImporterProperties().getStreamPath();
         return Mono.fromSupplier(() -> StreamFileData.from(basePath, streamFilename))
                 .timeout(properties.getTimeout())
                 .onErrorMap(FileOperationException.class, TransientProviderException::new);
@@ -87,9 +87,10 @@ public class LocalStreamFileProvider implements StreamFileProvider {
                                 case ACCOUNT_ID, AUTO -> Path.of(
                                         streamType.getPath(), streamType.getNodePrefix() + node.getNodeAccountId());
                                 case NODE_ID -> Path.of(
-                                        properties.getMirrorProperties().getNetwork(),
-                                        String.valueOf(
-                                                properties.getMirrorProperties().getShard()),
+                                        properties.getImporterProperties().getNetwork(),
+                                        String.valueOf(properties
+                                                .getImporterProperties()
+                                                .getShard()),
                                         String.valueOf(node.getNodeId()),
                                         streamType.getNodeIdBasedSuffix());
                             };
@@ -106,7 +107,7 @@ public class LocalStreamFileProvider implements StreamFileProvider {
      * Search YYYY-MM-DD sub-folders if present, otherwise just search streams directory.
      */
     private Flux<Path> getBasePaths(StreamFilename streamFilename) {
-        var basePath = properties.getMirrorProperties().getStreamPath();
+        var basePath = properties.getImporterProperties().getStreamPath();
         basePath.toFile().mkdirs();
 
         try (var subDirs = Files.list(basePath)) {
@@ -154,7 +155,7 @@ public class LocalStreamFileProvider implements StreamFileProvider {
     }
 
     private StreamFileData toStreamFileData(File file) {
-        var basePath = properties.getMirrorProperties().getStreamPath();
+        var basePath = properties.getImporterProperties().getStreamPath();
         var filename = StreamFilename.from(basePath.relativize(file.toPath()).toString());
         return StreamFileData.from(basePath, filename);
     }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/S3StreamFileProvider.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/S3StreamFileProvider.java
@@ -116,8 +116,8 @@ public final class S3StreamFileProvider implements StreamFileProvider {
     }
 
     private String getNodeIdPrefix(PathKey key) {
-        var network = properties.getMirrorProperties().getNetwork();
-        var shard = properties.getMirrorProperties().getShard();
+        var network = properties.getImporterProperties().getNetwork();
+        var shard = properties.getImporterProperties().getShard();
         var streamFolder = key.type().getNodeIdBasedSuffix();
         return TEMPLATE_NODE_ID_PREFIX.formatted(network, shard, key.node().getNodeId(), streamFolder);
     }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/record/RecordDownloaderProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/record/RecordDownloaderProperties.java
@@ -17,7 +17,6 @@
 package com.hedera.mirror.importer.downloader.record;
 
 import com.hedera.mirror.common.domain.StreamType;
-import com.hedera.mirror.importer.MirrorProperties;
 import com.hedera.mirror.importer.downloader.CommonDownloaderProperties;
 import com.hedera.mirror.importer.downloader.DownloaderProperties;
 import jakarta.validation.constraints.NotNull;
@@ -34,8 +33,6 @@ import org.springframework.validation.annotation.Validated;
 @RequiredArgsConstructor
 @Validated
 public class RecordDownloaderProperties implements DownloaderProperties {
-
-    private final MirrorProperties mirrorProperties;
 
     private final CommonDownloaderProperties common;
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/record/RecordFileDownloader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/record/RecordFileDownloader.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Multimaps;
 import com.hedera.mirror.common.domain.transaction.RecordFile;
 import com.hedera.mirror.common.domain.transaction.RecordItem;
 import com.hedera.mirror.common.domain.transaction.SidecarFile;
+import com.hedera.mirror.importer.ImporterProperties;
 import com.hedera.mirror.importer.addressbook.ConsensusNode;
 import com.hedera.mirror.importer.addressbook.ConsensusNodeService;
 import com.hedera.mirror.importer.config.DateRangeCalculator;
@@ -61,6 +62,7 @@ public class RecordFileDownloader extends Downloader<RecordFile, RecordItem> {
     public RecordFileDownloader(
             ConsensusNodeService consensusNodeService,
             RecordDownloaderProperties downloaderProperties,
+            ImporterProperties importerProperties,
             MeterRegistry meterRegistry,
             DateRangeCalculator dateRangeCalculator,
             NodeSignatureVerifier nodeSignatureVerifier,
@@ -73,6 +75,7 @@ public class RecordFileDownloader extends Downloader<RecordFile, RecordItem> {
         super(
                 consensusNodeService,
                 downloaderProperties,
+                importerProperties,
                 meterRegistry,
                 dateRangeCalculator,
                 nodeSignatureVerifier,
@@ -148,7 +151,7 @@ public class RecordFileDownloader extends Downloader<RecordFile, RecordItem> {
             }
 
             if (downloaderProperties.isWriteFiles()) {
-                var streamPath = downloaderProperties.getMirrorProperties().getStreamPath();
+                var streamPath = importerProperties.getStreamPath();
                 Utility.archiveFile(streamFileData.getFilePath(), sidecar.getBytes(), streamPath);
             }
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/AccountEvmAddressMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/AccountEvmAddressMigration.java
@@ -16,7 +16,7 @@
 
 package com.hedera.mirror.importer.migration;
 
-import com.hedera.mirror.importer.MirrorProperties;
+import com.hedera.mirror.importer.ImporterProperties;
 import com.hedera.mirror.importer.util.Utility;
 import jakarta.inject.Named;
 import java.io.IOException;
@@ -31,8 +31,9 @@ public class AccountEvmAddressMigration extends RepeatableMigration {
     private final NamedParameterJdbcOperations jdbcOperations;
 
     @Lazy
-    public AccountEvmAddressMigration(NamedParameterJdbcOperations jdbcOperations, MirrorProperties mirrorProperties) {
-        super(mirrorProperties.getMigration());
+    public AccountEvmAddressMigration(
+            NamedParameterJdbcOperations jdbcOperations, ImporterProperties importerProperties) {
+        super(importerProperties.getMigration());
         this.jdbcOperations = jdbcOperations;
     }
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/BackfillAndDeduplicateBalanceMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/BackfillAndDeduplicateBalanceMigration.java
@@ -17,7 +17,7 @@
 package com.hedera.mirror.importer.migration;
 
 import com.google.common.base.Stopwatch;
-import com.hedera.mirror.importer.MirrorProperties;
+import com.hedera.mirror.importer.ImporterProperties;
 import com.hedera.mirror.importer.config.Owner;
 import com.hedera.mirror.importer.db.DBProperties;
 import com.hedera.mirror.importer.db.TimePartitionService;
@@ -155,10 +155,13 @@ public class BackfillAndDeduplicateBalanceMigration extends AsyncJavaMigration<L
     @Lazy
     public BackfillAndDeduplicateBalanceMigration(
             DBProperties dbProperties,
-            MirrorProperties mirrorProperties,
+            ImporterProperties importerProperties,
             @Owner JdbcTemplate jdbcTemplate,
             TimePartitionService timePartitionService) {
-        super(mirrorProperties.getMigration(), new NamedParameterJdbcTemplate(jdbcTemplate), dbProperties.getSchema());
+        super(
+                importerProperties.getMigration(),
+                new NamedParameterJdbcTemplate(jdbcTemplate),
+                dbProperties.getSchema());
         this.jdbcTemplate = jdbcTemplate;
         this.timePartitionService = timePartitionService;
     }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/BackfillBlockMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/BackfillBlockMigration.java
@@ -17,7 +17,7 @@
 package com.hedera.mirror.importer.migration;
 
 import com.hedera.mirror.common.aggregator.LogsBloomAggregator;
-import com.hedera.mirror.importer.MirrorProperties;
+import com.hedera.mirror.importer.ImporterProperties;
 import com.hedera.mirror.importer.db.DBProperties;
 import com.hedera.mirror.importer.repository.RecordFileRepository;
 import jakarta.annotation.Nonnull;
@@ -59,11 +59,11 @@ public class BackfillBlockMigration extends AsyncJavaMigration<Long> {
     @Lazy
     public BackfillBlockMigration(
             DBProperties dbProperties,
-            MirrorProperties mirrorProperties,
+            ImporterProperties importerProperties,
             NamedParameterJdbcTemplate jdbcTemplate,
             RecordFileRepository recordFileRepository,
             TransactionOperations transactionOperations) {
-        super(mirrorProperties.getMigration(), jdbcTemplate, dbProperties.getSchema());
+        super(importerProperties.getMigration(), jdbcTemplate, dbProperties.getSchema());
         this.recordFileRepository = recordFileRepository;
         this.transactionOperations = transactionOperations;
     }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/BackfillTransactionHashMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/BackfillTransactionHashMigration.java
@@ -20,7 +20,7 @@ import static java.util.stream.Collectors.joining;
 
 import com.google.common.base.Stopwatch;
 import com.hedera.mirror.common.domain.transaction.TransactionType;
-import com.hedera.mirror.importer.MirrorProperties;
+import com.hedera.mirror.importer.ImporterProperties;
 import com.hedera.mirror.importer.config.Owner;
 import com.hedera.mirror.importer.parser.record.entity.EntityProperties;
 import jakarta.inject.Named;
@@ -55,9 +55,9 @@ public class BackfillTransactionHashMigration extends RepeatableMigration {
     public BackfillTransactionHashMigration(
             EntityProperties entityProperties,
             @Owner JdbcTemplate jdbcTemplate,
-            MirrorProperties mirrorProperties,
+            ImporterProperties importerProperties,
             Environment environment) {
-        super(mirrorProperties.getMigration());
+        super(importerProperties.getMigration());
         this.entityProperties = entityProperties;
         this.jdbcTemplate = jdbcTemplate;
         this.isV2 = environment.acceptsProfiles(Profiles.of("v2"));

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/BlockNumberMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/BlockNumberMigration.java
@@ -16,12 +16,12 @@
 
 package com.hedera.mirror.importer.migration;
 
-import static com.hedera.mirror.importer.MirrorProperties.HederaNetwork.MAINNET;
-import static com.hedera.mirror.importer.MirrorProperties.HederaNetwork.TESTNET;
+import static com.hedera.mirror.importer.ImporterProperties.HederaNetwork.MAINNET;
+import static com.hedera.mirror.importer.ImporterProperties.HederaNetwork.TESTNET;
 
 import com.google.common.base.Stopwatch;
 import com.hedera.mirror.common.domain.transaction.RecordFile;
-import com.hedera.mirror.importer.MirrorProperties;
+import com.hedera.mirror.importer.ImporterProperties;
 import com.hedera.mirror.importer.repository.RecordFileRepository;
 import jakarta.inject.Named;
 import java.util.Map;
@@ -36,13 +36,13 @@ public class BlockNumberMigration extends RepeatableMigration {
             TESTNET, Pair.of(1656461617493248000L, 22384256L),
             MAINNET, Pair.of(1656461547557609267L, 34305852L));
 
-    private final MirrorProperties mirrorProperties;
+    private final ImporterProperties importerProperties;
     private final RecordFileRepository recordFileRepository;
 
     @Lazy
-    public BlockNumberMigration(MirrorProperties mirrorProperties, RecordFileRepository recordFileRepository) {
-        super(mirrorProperties.getMigration());
-        this.mirrorProperties = mirrorProperties;
+    public BlockNumberMigration(ImporterProperties importerProperties, RecordFileRepository recordFileRepository) {
+        super(importerProperties.getMigration());
+        this.importerProperties = importerProperties;
         this.recordFileRepository = recordFileRepository;
     }
 
@@ -58,7 +58,7 @@ public class BlockNumberMigration extends RepeatableMigration {
 
     @Override
     protected void doMigrate() {
-        var hederaNetwork = mirrorProperties.getNetwork();
+        var hederaNetwork = importerProperties.getNetwork();
         var consensusEndAndBlockNumber = BLOCK_NUMBER_MAPPING.get(hederaNetwork);
 
         if (consensusEndAndBlockNumber == null) {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/ErrataMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/ErrataMigration.java
@@ -22,7 +22,7 @@ import com.hedera.mirror.common.domain.balance.AccountBalanceFile;
 import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.token.TokenTransfer;
 import com.hedera.mirror.common.domain.transaction.RecordItem;
-import com.hedera.mirror.importer.MirrorProperties;
+import com.hedera.mirror.importer.ImporterProperties;
 import com.hedera.mirror.importer.config.DateRangeCalculator.DateRangeFilter;
 import com.hedera.mirror.importer.exception.FileOperationException;
 import com.hedera.mirror.importer.parser.balance.BalanceStreamFileListener;
@@ -74,7 +74,7 @@ public class ErrataMigration extends RepeatableMigration implements BalanceStrea
     private final EntityRecordItemListener entityRecordItemListener;
     private final EntityProperties entityProperties;
     private final NamedParameterJdbcOperations jdbcOperations;
-    private final MirrorProperties mirrorProperties;
+    private final ImporterProperties importerProperties;
     private final RecordStreamFileListener recordStreamFileListener;
     private final TokenTransferRepository tokenTransferRepository;
     private final TransactionOperations transactionOperations;
@@ -89,18 +89,18 @@ public class ErrataMigration extends RepeatableMigration implements BalanceStrea
             EntityRecordItemListener entityRecordItemListener,
             EntityProperties entityProperties,
             NamedParameterJdbcOperations jdbcOperations,
-            MirrorProperties mirrorProperties,
+            ImporterProperties importerProperties,
             RecordStreamFileListener recordStreamFileListener,
             TokenTransferRepository tokenTransferRepository,
             TransactionOperations transactionOperations,
             TransactionRepository transactionRepository) {
-        super(mirrorProperties.getMigration());
+        super(importerProperties.getMigration());
         this.balanceOffsets = balanceOffsets;
         this.accountBalanceFileRepository = accountBalanceFileRepository;
         this.entityRecordItemListener = entityRecordItemListener;
         this.entityProperties = entityProperties;
         this.jdbcOperations = jdbcOperations;
-        this.mirrorProperties = mirrorProperties;
+        this.importerProperties = importerProperties;
         this.recordStreamFileListener = recordStreamFileListener;
         this.tokenTransferRepository = tokenTransferRepository;
         this.transactionOperations = transactionOperations;
@@ -221,7 +221,7 @@ public class ErrataMigration extends RepeatableMigration implements BalanceStrea
         Resource[] resources = resourceResolver.getResources("classpath*:errata/mainnet/missingtransactions/*.bin");
         Arrays.sort(resources, Comparator.comparing(Resource::getFilename));
         recordStreamFileListener.onStart();
-        var dateRangeFilter = new DateRangeFilter(mirrorProperties.getStartDate(), mirrorProperties.getEndDate());
+        var dateRangeFilter = new DateRangeFilter(importerProperties.getStartDate(), importerProperties.getEndDate());
 
         for (Resource resource : resources) {
             String name = resource.getFilename();
@@ -325,7 +325,7 @@ public class ErrataMigration extends RepeatableMigration implements BalanceStrea
     }
 
     private boolean isMainnet() {
-        return MirrorProperties.HederaNetwork.MAINNET.equalsIgnoreCase(mirrorProperties.getNetwork());
+        return ImporterProperties.HederaNetwork.MAINNET.equalsIgnoreCase(importerProperties.getNetwork());
     }
 
     private boolean shouldApplyFixedTimeOffset(long consensusTimestamp) {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/FixCryptoAllowanceAmountMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/FixCryptoAllowanceAmountMigration.java
@@ -16,7 +16,7 @@
 
 package com.hedera.mirror.importer.migration;
 
-import com.hedera.mirror.importer.MirrorProperties;
+import com.hedera.mirror.importer.ImporterProperties;
 import com.hedera.mirror.importer.config.Owner;
 import com.hedera.mirror.importer.db.DBProperties;
 import com.hedera.mirror.importer.parser.record.entity.EntityProperties;
@@ -140,9 +140,12 @@ public class FixCryptoAllowanceAmountMigration extends AsyncJavaMigration<Long> 
     public FixCryptoAllowanceAmountMigration(
             DBProperties dbProperties,
             EntityProperties entityProperties,
-            MirrorProperties mirrorProperties,
+            ImporterProperties importerProperties,
             @Owner JdbcTemplate jdbcTemplate) {
-        super(mirrorProperties.getMigration(), new NamedParameterJdbcTemplate(jdbcTemplate), dbProperties.getSchema());
+        super(
+                importerProperties.getMigration(),
+                new NamedParameterJdbcTemplate(jdbcTemplate),
+                dbProperties.getSchema());
         this.entityProperties = entityProperties;
         this.jdbcTemplate = jdbcTemplate;
     }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/FixFungibleTokenTotalSupplyMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/FixFungibleTokenTotalSupplyMigration.java
@@ -17,7 +17,7 @@
 package com.hedera.mirror.importer.migration;
 
 import com.google.common.base.Stopwatch;
-import com.hedera.mirror.importer.MirrorProperties;
+import com.hedera.mirror.importer.ImporterProperties;
 import jakarta.inject.Named;
 import java.io.IOException;
 import lombok.CustomLog;
@@ -65,8 +65,8 @@ public class FixFungibleTokenTotalSupplyMigration extends RepeatableMigration {
     private final JdbcTemplate jdbcTemplate;
 
     @Lazy
-    public FixFungibleTokenTotalSupplyMigration(JdbcTemplate jdbcTemplate, MirrorProperties mirrorProperties) {
-        super(mirrorProperties.getMigration());
+    public FixFungibleTokenTotalSupplyMigration(JdbcTemplate jdbcTemplate, ImporterProperties importerProperties) {
+        super(importerProperties.getMigration());
         this.jdbcTemplate = jdbcTemplate;
     }
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/FixStakedBeforeEnabledMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/FixStakedBeforeEnabledMigration.java
@@ -17,7 +17,7 @@
 package com.hedera.mirror.importer.migration;
 
 import com.google.common.base.Stopwatch;
-import com.hedera.mirror.importer.MirrorProperties;
+import com.hedera.mirror.importer.ImporterProperties;
 import com.hedera.mirror.importer.util.Utility;
 import jakarta.inject.Named;
 import lombok.RequiredArgsConstructor;
@@ -77,7 +77,7 @@ public class FixStakedBeforeEnabledMigration extends AbstractJavaMigration {
     private static final MigrationVersion VERSION = MigrationVersion.fromVersion("1.68.3");
 
     private final NamedParameterJdbcOperations jdbcOperations;
-    private final MirrorProperties mirrorProperties;
+    private final ImporterProperties importerProperties;
 
     @Override
     public MigrationVersion getVersion() {
@@ -91,8 +91,8 @@ public class FixStakedBeforeEnabledMigration extends AbstractJavaMigration {
 
     @Override
     protected void doMigrate() {
-        var hederaNetwork = mirrorProperties.getNetwork();
-        if (!MirrorProperties.HederaNetwork.MAINNET.equalsIgnoreCase(hederaNetwork)) {
+        var hederaNetwork = importerProperties.getNetwork();
+        if (!ImporterProperties.HederaNetwork.MAINNET.equalsIgnoreCase(hederaNetwork)) {
             return;
         }
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/HistoricalAccountInfoMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/HistoricalAccountInfoMigration.java
@@ -21,7 +21,7 @@ import com.hedera.mirror.common.domain.entity.Entity;
 import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.entity.EntityType;
 import com.hedera.mirror.common.util.DomainUtils;
-import com.hedera.mirror.importer.MirrorProperties;
+import com.hedera.mirror.importer.ImporterProperties;
 import com.hedera.mirror.importer.repository.EntityRepository;
 import com.hederahashgraph.api.proto.java.CryptoGetInfoResponse.AccountInfo;
 import jakarta.inject.Named;
@@ -54,7 +54,7 @@ public class HistoricalAccountInfoMigration extends RepeatableMigration {
     private final Set<Long> contractIds = new HashSet<>();
     private final EntityRepository entityRepository;
     private final NamedParameterJdbcTemplate jdbcOperations;
-    private final MirrorProperties mirrorProperties;
+    private final ImporterProperties importerProperties;
 
     @Value("classpath:accountInfoContracts.txt")
     private Resource accountInfoContracts;
@@ -66,11 +66,11 @@ public class HistoricalAccountInfoMigration extends RepeatableMigration {
     public HistoricalAccountInfoMigration(
             EntityRepository entityRepository,
             NamedParameterJdbcTemplate jdbcTemplate,
-            MirrorProperties mirrorProperties) {
-        super(mirrorProperties.getMigration());
+            ImporterProperties importerProperties) {
+        super(importerProperties.getMigration());
         this.entityRepository = entityRepository;
         this.jdbcOperations = jdbcTemplate;
-        this.mirrorProperties = mirrorProperties;
+        this.importerProperties = importerProperties;
     }
 
     @Override
@@ -90,17 +90,17 @@ public class HistoricalAccountInfoMigration extends RepeatableMigration {
 
     @Override
     protected void doMigrate() throws IOException {
-        if (!mirrorProperties.isImportHistoricalAccountInfo()) {
+        if (!importerProperties.isImportHistoricalAccountInfo()) {
             log.info("Skipping migration since importing historical account information is disabled");
             return;
         }
 
-        if (!MirrorProperties.HederaNetwork.MAINNET.equalsIgnoreCase(mirrorProperties.getNetwork())) {
+        if (!ImporterProperties.HederaNetwork.MAINNET.equalsIgnoreCase(importerProperties.getNetwork())) {
             log.info("Skipping migration since it only applies to mainnet");
             return;
         }
 
-        Instant startDate = Objects.requireNonNullElseGet(mirrorProperties.getStartDate(), Instant::now);
+        Instant startDate = Objects.requireNonNullElseGet(importerProperties.getStartDate(), Instant::now);
         if (startDate.isAfter(EXPORT_DATE)) {
             log.info("Skipping migration since start date {} is after the export date {}", startDate, EXPORT_DATE);
             return;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/InitializeEntityBalanceMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/InitializeEntityBalanceMigration.java
@@ -17,7 +17,7 @@
 package com.hedera.mirror.importer.migration;
 
 import com.google.common.base.Stopwatch;
-import com.hedera.mirror.importer.MirrorProperties;
+import com.hedera.mirror.importer.ImporterProperties;
 import com.hedera.mirror.importer.repository.AccountBalanceFileRepository;
 import com.hedera.mirror.importer.repository.RecordFileRepository;
 import jakarta.inject.Named;
@@ -77,10 +77,10 @@ public class InitializeEntityBalanceMigration extends TimeSensitiveBalanceMigrat
     @Lazy
     public InitializeEntityBalanceMigration(
             JdbcOperations jdbcOperations,
-            MirrorProperties mirrorProperties,
+            ImporterProperties importerProperties,
             AccountBalanceFileRepository accountBalanceFileRepository,
             RecordFileRepository recordFileRepository) {
-        super(mirrorProperties.getMigration(), accountBalanceFileRepository, recordFileRepository);
+        super(importerProperties.getMigration(), accountBalanceFileRepository, recordFileRepository);
         this.jdbcOperations = jdbcOperations;
     }
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/MergeDuplicateBlocksMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/MergeDuplicateBlocksMigration.java
@@ -17,7 +17,7 @@
 package com.hedera.mirror.importer.migration;
 
 import com.google.common.base.Stopwatch;
-import com.hedera.mirror.importer.MirrorProperties;
+import com.hedera.mirror.importer.ImporterProperties;
 import com.hedera.mirror.importer.config.Owner;
 import jakarta.inject.Named;
 import java.io.IOException;
@@ -55,18 +55,18 @@ class MergeDuplicateBlocksMigration extends RepeatableMigration {
                     """;
 
     private final JdbcTemplate jdbcTemplate;
-    private final MirrorProperties mirrorProperties;
+    private final ImporterProperties importerProperties;
 
     @Lazy
-    protected MergeDuplicateBlocksMigration(@Owner JdbcTemplate jdbcTemplate, MirrorProperties mirrorProperties) {
-        super(mirrorProperties.getMigration());
+    protected MergeDuplicateBlocksMigration(@Owner JdbcTemplate jdbcTemplate, ImporterProperties importerProperties) {
+        super(importerProperties.getMigration());
         this.jdbcTemplate = jdbcTemplate;
-        this.mirrorProperties = mirrorProperties;
+        this.importerProperties = importerProperties;
     }
 
     @Override
     protected void doMigrate() throws IOException {
-        if (!MirrorProperties.HederaNetwork.MAINNET.equalsIgnoreCase(mirrorProperties.getNetwork())) {
+        if (!ImporterProperties.HederaNetwork.MAINNET.equalsIgnoreCase(importerProperties.getNetwork())) {
             return;
         }
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/MissingAddressBooksMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/MissingAddressBooksMigration.java
@@ -16,7 +16,7 @@
 
 package com.hedera.mirror.importer.migration;
 
-import com.hedera.mirror.importer.MirrorProperties;
+import com.hedera.mirror.importer.ImporterProperties;
 import com.hedera.mirror.importer.addressbook.AddressBookService;
 import com.hedera.mirror.importer.repository.AddressBookServiceEndpointRepository;
 import jakarta.inject.Named;
@@ -33,8 +33,8 @@ public class MissingAddressBooksMigration extends RepeatableMigration {
     public MissingAddressBooksMigration(
             AddressBookService addressBookService,
             AddressBookServiceEndpointRepository addressBookServiceEndpointRepository,
-            MirrorProperties mirrorProperties) {
-        super(mirrorProperties.getMigration());
+            ImporterProperties importerProperties) {
+        super(importerProperties.getMigration());
         this.addressBookService = addressBookService;
         this.addressBookServiceEndpointRepository = addressBookServiceEndpointRepository;
     }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/RecalculatePendingRewardMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/RecalculatePendingRewardMigration.java
@@ -17,8 +17,8 @@
 package com.hedera.mirror.importer.migration;
 
 import com.google.common.base.Stopwatch;
-import com.hedera.mirror.importer.MirrorProperties;
-import com.hedera.mirror.importer.MirrorProperties.HederaNetwork;
+import com.hedera.mirror.importer.ImporterProperties;
+import com.hedera.mirror.importer.ImporterProperties.HederaNetwork;
 import jakarta.inject.Named;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -87,7 +87,7 @@ public class RecalculatePendingRewardMigration extends AbstractJavaMigration {
     private static final MigrationVersion VERSION = MigrationVersion.fromVersion("1.68.4");
 
     private final NamedParameterJdbcOperations jdbcOperations;
-    private final MirrorProperties mirrorProperties;
+    private final ImporterProperties importerProperties;
 
     @Override
     public String getDescription() {
@@ -101,7 +101,7 @@ public class RecalculatePendingRewardMigration extends AbstractJavaMigration {
 
     @Override
     protected void doMigrate() {
-        var hederaNetwork = mirrorProperties.getNetwork();
+        var hederaNetwork = importerProperties.getNetwork();
         Long consensusTimestamp = FIRST_NONZERO_REWARD_RATE_TIMESTAMP.get(hederaNetwork);
         if (consensusTimestamp == null) {
             return;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/SyntheticCryptoTransferApprovalMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/SyntheticCryptoTransferApprovalMigration.java
@@ -19,7 +19,7 @@ package com.hedera.mirror.importer.migration;
 import com.google.common.annotations.VisibleForTesting;
 import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.transaction.RecordFile;
-import com.hedera.mirror.importer.MirrorProperties;
+import com.hedera.mirror.importer.ImporterProperties;
 import com.hedera.mirror.importer.db.DBProperties;
 import com.hedera.mirror.importer.exception.ImporterException;
 import com.hedera.mirror.importer.parser.record.RecordStreamFileListener;
@@ -186,7 +186,7 @@ public class SyntheticCryptoTransferApprovalMigration extends AsyncJavaMigration
     private static final DataClassRowMapper<SyntheticCryptoTransferApprovalMigration.ApprovalTransfer> resultRowMapper =
             new DataClassRowMapper<>(ApprovalTransfer.class);
 
-    private final MirrorProperties mirrorProperties;
+    private final ImporterProperties importerProperties;
     private final NamedParameterJdbcTemplate transferJdbcTemplate;
 
     @Getter
@@ -196,12 +196,12 @@ public class SyntheticCryptoTransferApprovalMigration extends AsyncJavaMigration
     public SyntheticCryptoTransferApprovalMigration(
             DBProperties dbProperties,
             RecordFileRepository recordFileRepository,
-            MirrorProperties mirrorProperties,
+            ImporterProperties importerProperties,
             NamedParameterJdbcTemplate transferJdbcTemplate,
             TransactionOperations transactionOperations) {
-        super(mirrorProperties.getMigration(), transferJdbcTemplate, dbProperties.getSchema());
+        super(importerProperties.getMigration(), transferJdbcTemplate, dbProperties.getSchema());
         this.recordFileRepository = recordFileRepository;
-        this.mirrorProperties = mirrorProperties;
+        this.importerProperties = importerProperties;
         this.transferJdbcTemplate = transferJdbcTemplate;
         this.transactionOperations = transactionOperations;
     }
@@ -224,7 +224,7 @@ public class SyntheticCryptoTransferApprovalMigration extends AsyncJavaMigration
 
     @Override
     protected Optional<Long> migratePartial(Long lowerBound) {
-        if (!MirrorProperties.HederaNetwork.MAINNET.equalsIgnoreCase(mirrorProperties.getNetwork())) {
+        if (!ImporterProperties.HederaNetwork.MAINNET.equalsIgnoreCase(importerProperties.getNetwork())) {
             log.info("Skipping migration since it only applies to mainnet");
             return Optional.empty();
         }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/SyntheticNftAllowanceOwnerMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/SyntheticNftAllowanceOwnerMigration.java
@@ -18,7 +18,7 @@ package com.hedera.mirror.importer.migration;
 
 import com.google.common.base.Stopwatch;
 import com.hedera.mirror.common.domain.transaction.RecordFile;
-import com.hedera.mirror.importer.MirrorProperties;
+import com.hedera.mirror.importer.ImporterProperties;
 import com.hedera.mirror.importer.config.Owner;
 import com.hedera.mirror.importer.exception.ImporterException;
 import com.hedera.mirror.importer.parser.record.RecordStreamFileListener;
@@ -119,9 +119,9 @@ public class SyntheticNftAllowanceOwnerMigration extends RepeatableMigration imp
     @Lazy
     public SyntheticNftAllowanceOwnerMigration(
             @Owner JdbcTemplate jdbcTemplate,
-            MirrorProperties mirrorProperties,
+            ImporterProperties importerProperties,
             RecordFileRepository recordFileRepository) {
-        super(mirrorProperties.getMigration());
+        super(importerProperties.getMigration());
         this.jdbcTemplate = jdbcTemplate;
         this.recordFileRepository = recordFileRepository;
     }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/SyntheticTokenAllowanceOwnerMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/SyntheticTokenAllowanceOwnerMigration.java
@@ -18,7 +18,7 @@ package com.hedera.mirror.importer.migration;
 
 import com.google.common.base.Stopwatch;
 import com.hedera.mirror.common.domain.transaction.RecordFile;
-import com.hedera.mirror.importer.MirrorProperties;
+import com.hedera.mirror.importer.ImporterProperties;
 import com.hedera.mirror.importer.config.Owner;
 import com.hedera.mirror.importer.exception.ImporterException;
 import com.hedera.mirror.importer.parser.record.RecordStreamFileListener;
@@ -122,9 +122,9 @@ public class SyntheticTokenAllowanceOwnerMigration extends RepeatableMigration i
     @Lazy
     public SyntheticTokenAllowanceOwnerMigration(
             @Owner JdbcTemplate jdbcTemplate,
-            MirrorProperties mirrorProperties,
+            ImporterProperties importerProperties,
             RecordFileRepository recordFileRepository) {
-        super(mirrorProperties.getMigration());
+        super(importerProperties.getMigration());
         this.jdbcTemplate = jdbcTemplate;
         this.recordFileRepository = recordFileRepository;
     }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/TokenAccountBalanceMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/TokenAccountBalanceMigration.java
@@ -17,7 +17,7 @@
 package com.hedera.mirror.importer.migration;
 
 import com.google.common.base.Stopwatch;
-import com.hedera.mirror.importer.MirrorProperties;
+import com.hedera.mirror.importer.ImporterProperties;
 import com.hedera.mirror.importer.repository.AccountBalanceFileRepository;
 import com.hedera.mirror.importer.repository.RecordFileRepository;
 import jakarta.inject.Named;
@@ -76,10 +76,10 @@ public class TokenAccountBalanceMigration extends TimeSensitiveBalanceMigration 
     @Lazy
     public TokenAccountBalanceMigration(
             JdbcOperations jdbcOperations,
-            MirrorProperties mirrorProperties,
+            ImporterProperties importerProperties,
             AccountBalanceFileRepository accountBalanceFileRepository,
             RecordFileRepository recordFileRepository) {
-        super(mirrorProperties.getMigration(), accountBalanceFileRepository, recordFileRepository);
+        super(importerProperties.getMigration(), accountBalanceFileRepository, recordFileRepository);
         this.jdbcOperations = jdbcOperations;
     }
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/TopicMessageLookupMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/TopicMessageLookupMigration.java
@@ -17,7 +17,7 @@
 package com.hedera.mirror.importer.migration;
 
 import com.google.common.base.Stopwatch;
-import com.hedera.mirror.importer.MirrorProperties;
+import com.hedera.mirror.importer.ImporterProperties;
 import com.hedera.mirror.importer.config.Owner;
 import com.hedera.mirror.importer.db.TimePartitionService;
 import com.hedera.mirror.importer.parser.record.entity.EntityProperties;
@@ -57,10 +57,10 @@ public class TopicMessageLookupMigration extends RepeatableMigration {
     protected TopicMessageLookupMigration(
             EntityProperties entityProperties,
             @Owner JdbcTemplate jdbcTemplate,
-            MirrorProperties mirrorProperties,
+            ImporterProperties importerProperties,
             RecordFileRepository recordFileRepository,
             TimePartitionService timePartitionService) {
-        super(mirrorProperties.getMigration());
+        super(importerProperties.getMigration());
         this.entityProperties = entityProperties;
         this.jdbcTemplate = jdbcTemplate;
         this.recordFileRepository = recordFileRepository;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/balance/line/AccountBalanceLineParserV1.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/balance/line/AccountBalanceLineParserV1.java
@@ -19,7 +19,7 @@ package com.hedera.mirror.importer.reader.balance.line;
 import com.google.common.base.Splitter;
 import com.hedera.mirror.common.domain.balance.AccountBalance;
 import com.hedera.mirror.common.domain.entity.EntityId;
-import com.hedera.mirror.importer.MirrorProperties;
+import com.hedera.mirror.importer.ImporterProperties;
 import com.hedera.mirror.importer.exception.InvalidDatasetException;
 import jakarta.inject.Named;
 import java.util.Collections;
@@ -32,7 +32,7 @@ public class AccountBalanceLineParserV1 implements AccountBalanceLineParser {
 
     private static final Splitter SPLITTER = Splitter.on(',').trimResults().omitEmptyStrings();
 
-    private final MirrorProperties mirrorProperties;
+    private final ImporterProperties importerProperties;
 
     /**
      * Parses an account balance line to extract shard, realm, account, and balance. If the shard matches
@@ -63,10 +63,10 @@ public class AccountBalanceLineParserV1 implements AccountBalanceLineParser {
                 throw new InvalidDatasetException(INVALID_BALANCE + line);
             }
 
-            if (shardNum != mirrorProperties.getShard()) {
+            if (shardNum != importerProperties.getShard()) {
                 throw new InvalidDatasetException(String.format(
                         "Invalid account balance line: %s. Expect " + "shard (%d), got shard (%d)",
-                        line, mirrorProperties.getShard(), shardNum));
+                        line, importerProperties.getShard(), shardNum));
             }
 
             return new AccountBalance(

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/balance/line/AccountBalanceLineParserV2.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/balance/line/AccountBalanceLineParserV2.java
@@ -21,7 +21,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.mirror.common.domain.balance.AccountBalance;
 import com.hedera.mirror.common.domain.balance.TokenBalance;
 import com.hedera.mirror.common.domain.entity.EntityId;
-import com.hedera.mirror.importer.MirrorProperties;
+import com.hedera.mirror.importer.ImporterProperties;
 import com.hedera.mirror.importer.exception.InvalidDatasetException;
 import com.hederahashgraph.api.proto.java.TokenBalances;
 import com.hederahashgraph.api.proto.java.TokenID;
@@ -38,7 +38,7 @@ public class AccountBalanceLineParserV2 implements AccountBalanceLineParser {
 
     private static final Splitter SPLITTER = Splitter.on(',').trimResults().omitEmptyStrings();
 
-    private final MirrorProperties mirrorProperties;
+    private final ImporterProperties importerProperties;
 
     /**
      * Parses an account balance line to extract shard, realm, account, balance, and token balances. If the shard
@@ -75,10 +75,10 @@ public class AccountBalanceLineParserV2 implements AccountBalanceLineParser {
                 throw new InvalidDatasetException(INVALID_BALANCE + line);
             }
 
-            if (shardNum != mirrorProperties.getShard()) {
+            if (shardNum != importerProperties.getShard()) {
                 throw new InvalidDatasetException(String.format(
                         "Invalid account balance line: %s. Expect " + "shard (%d), got shard (%d)",
-                        line, mirrorProperties.getShard(), shardNum));
+                        line, importerProperties.getShard(), shardNum));
             }
 
             EntityId accountId = EntityId.of(shardNum, realmNum, accountNum);

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/ImporterIntegrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/ImporterIntegrationTest.java
@@ -82,7 +82,7 @@ public abstract class ImporterIntegrationTest extends CommonIntegrationTest {
     private DateRangeCalculator dateRangeCalculator;
 
     @Resource
-    private MirrorProperties mirrorProperties;
+    private ImporterProperties importerProperties;
 
     @Getter
     @Value("#{environment.matchesProfiles('!v2')}")
@@ -132,8 +132,8 @@ public abstract class ImporterIntegrationTest extends CommonIntegrationTest {
     protected void reset() {
         super.reset();
         dateRangeCalculator.clear();
-        mirrorProperties.setNetwork(MirrorProperties.HederaNetwork.TESTNET);
-        mirrorProperties.setStartDate(Instant.EPOCH);
+        importerProperties.setNetwork(ImporterProperties.HederaNetwork.TESTNET);
+        importerProperties.setStartDate(Instant.EPOCH);
         retryRecorder.reset();
     }
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/ImporterPropertiesTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/ImporterPropertiesTest.java
@@ -19,12 +19,12 @@ package com.hedera.mirror.importer;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.hedera.mirror.importer.MirrorProperties.HederaNetwork;
+import com.hedera.mirror.importer.ImporterProperties.HederaNetwork;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
-class MirrorPropertiesTest {
+class ImporterPropertiesTest {
 
     @ParameterizedTest(name = "Network {2} is canonical network {0}, with prefix {1}")
     @CsvSource({
@@ -47,7 +47,7 @@ class MirrorPropertiesTest {
     })
     void verifyCanonicalNetworkWithPrefix(String expectedHederaNetwork, String expectedPrefix, String networkName) {
 
-        var properties = new MirrorProperties();
+        var properties = new ImporterProperties();
         properties.setNetwork(networkName);
         assertThat(properties.getNetwork()).isEqualTo(expectedHederaNetwork);
         assertThat(properties.getNetworkPrefix()).isEqualTo(expectedPrefix);
@@ -62,7 +62,7 @@ class MirrorPropertiesTest {
     })
     void verifyNonCanonicalNetworkWithPrefix(String expectedNetwork, String expectedPrefix, String networkName) {
 
-        var properties = new MirrorProperties();
+        var properties = new ImporterProperties();
         properties.setNetwork(networkName);
         assertThat(properties.getNetwork()).isEqualTo(expectedNetwork);
         assertThat(properties.getNetworkPrefix()).isEqualTo(expectedPrefix);
@@ -70,7 +70,7 @@ class MirrorPropertiesTest {
 
     @Test
     void verifySetNetworkPropertyValidation() {
-        var properties = new MirrorProperties();
+        var properties = new ImporterProperties();
         assertThat(properties.getNetwork()).isEqualTo(HederaNetwork.DEMO); // Default
         assertThat(properties.getNetworkPrefix()).isNull();
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/addressbook/AddressBookServiceImplTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/addressbook/AddressBookServiceImplTest.java
@@ -33,8 +33,8 @@ import com.hedera.mirror.common.domain.file.FileData;
 import com.hedera.mirror.common.domain.transaction.TransactionType;
 import com.hedera.mirror.importer.FileCopier;
 import com.hedera.mirror.importer.ImporterIntegrationTest;
-import com.hedera.mirror.importer.MirrorProperties;
-import com.hedera.mirror.importer.MirrorProperties.ConsensusMode;
+import com.hedera.mirror.importer.ImporterProperties;
+import com.hedera.mirror.importer.ImporterProperties.ConsensusMode;
 import com.hedera.mirror.importer.config.CacheConfiguration;
 import com.hedera.mirror.importer.repository.AddressBookEntryRepository;
 import com.hedera.mirror.importer.repository.AddressBookRepository;
@@ -92,7 +92,7 @@ class AddressBookServiceImplTest extends ImporterIntegrationTest {
     private final CacheManager cacheManager;
 
     private final FileDataRepository fileDataRepository;
-    private final MirrorProperties mirrorProperties;
+    private final ImporterProperties importerProperties;
     private final NodeStakeRepository nodeStakeRepository;
     private final TransactionTemplate transactionTemplate;
 
@@ -162,14 +162,14 @@ class AddressBookServiceImplTest extends ImporterIntegrationTest {
 
     @Test
     void startupWithOtherNetworkIncorrectInitialAddressBookPath() {
-        MirrorProperties otherNetworkMirrorProperties = new MirrorProperties();
-        otherNetworkMirrorProperties.setDataPath(dataPath);
-        otherNetworkMirrorProperties.setInitialAddressBook(dataPath.resolve("test-v1"));
-        otherNetworkMirrorProperties.setNetwork(MirrorProperties.HederaNetwork.OTHER);
+        ImporterProperties otherNetworkImporterProperties = new ImporterProperties();
+        otherNetworkImporterProperties.setDataPath(dataPath);
+        otherNetworkImporterProperties.setInitialAddressBook(dataPath.resolve("test-v1"));
+        otherNetworkImporterProperties.setNetwork(ImporterProperties.HederaNetwork.OTHER);
         AddressBookService customAddressBookService = new AddressBookServiceImpl(
                 addressBookRepository,
                 fileDataRepository,
-                otherNetworkMirrorProperties,
+                otherNetworkImporterProperties,
                 nodeStakeRepository,
                 transactionTemplate);
         assertThrows(IllegalStateException.class, () -> {
@@ -200,14 +200,14 @@ class AddressBookServiceImplTest extends ImporterIntegrationTest {
                 .to("");
         fileCopier.copy();
 
-        MirrorProperties otherNetworkMirrorProperties = new MirrorProperties();
-        otherNetworkMirrorProperties.setDataPath(dataPath);
-        otherNetworkMirrorProperties.setInitialAddressBook(dataPath.resolve("test-v1"));
-        otherNetworkMirrorProperties.setNetwork(MirrorProperties.HederaNetwork.OTHER);
+        ImporterProperties otherNetworkImporterProperties = new ImporterProperties();
+        otherNetworkImporterProperties.setDataPath(dataPath);
+        otherNetworkImporterProperties.setInitialAddressBook(dataPath.resolve("test-v1"));
+        otherNetworkImporterProperties.setNetwork(ImporterProperties.HederaNetwork.OTHER);
         AddressBookService customAddressBookService = new AddressBookServiceImpl(
                 addressBookRepository,
                 fileDataRepository,
-                otherNetworkMirrorProperties,
+                otherNetworkImporterProperties,
                 nodeStakeRepository,
                 transactionTemplate);
         AddressBook addressBook = customAddressBookService.getCurrent();
@@ -969,7 +969,7 @@ class AddressBookServiceImplTest extends ImporterIntegrationTest {
                             .stake(stake))
                     .persist();
         }
-        mirrorProperties.setConsensusMode(mode);
+        importerProperties.setConsensusMode(mode);
 
         assertThat(addressBookService.getNodes())
                 .hasSize(TEST_INITIAL_ADDRESS_BOOK_NODE_COUNT)
@@ -1001,7 +1001,7 @@ class AddressBookServiceImplTest extends ImporterIntegrationTest {
                             .stake(10000L))
                     .persist();
         }
-        mirrorProperties.setConsensusMode(mode);
+        importerProperties.setConsensusMode(mode);
 
         assertThat(addressBookService.getNodes())
                 .hasSize(TEST_INITIAL_ADDRESS_BOOK_NODE_COUNT)

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/CommonDownloaderPropertiesTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/CommonDownloaderPropertiesTest.java
@@ -21,8 +21,8 @@ import static com.hedera.mirror.importer.downloader.StreamSourceProperties.Sourc
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.hedera.mirror.importer.MirrorProperties;
-import com.hedera.mirror.importer.MirrorProperties.HederaNetwork;
+import com.hedera.mirror.importer.ImporterProperties;
+import com.hedera.mirror.importer.ImporterProperties.HederaNetwork;
 import java.net.URI;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -32,7 +32,7 @@ class CommonDownloaderPropertiesTest {
 
     @Test
     void getBucketName() {
-        var mirrorProperties = new MirrorProperties();
+        var mirrorProperties = new ImporterProperties();
         var properties = new CommonDownloaderProperties(mirrorProperties);
         assertThat(properties.getBucketName()).isEqualTo(HederaNetwork.getBucketName(mirrorProperties.getNetwork()));
 
@@ -43,7 +43,7 @@ class CommonDownloaderPropertiesTest {
 
     @Test
     void initNoNetworkDefaultBucketName() {
-        var mirrorProperties = new MirrorProperties();
+        var mirrorProperties = new ImporterProperties();
         var properties = new CommonDownloaderProperties(mirrorProperties);
 
         mirrorProperties.setNetwork(HederaNetwork.OTHER);
@@ -55,7 +55,7 @@ class CommonDownloaderPropertiesTest {
 
     @Test
     void isAnonymousCredentials() {
-        var mirrorProperties = new MirrorProperties();
+        var mirrorProperties = new ImporterProperties();
         var properties = new CommonDownloaderProperties(mirrorProperties);
 
         // Default network is DEMO, which is the only network allowing anonymous access
@@ -72,7 +72,7 @@ class CommonDownloaderPropertiesTest {
 
     @Test
     void initNoSources() {
-        var properties = new CommonDownloaderProperties(new MirrorProperties());
+        var properties = new CommonDownloaderProperties(new ImporterProperties());
         properties.setCloudProvider(SourceType.S3);
         properties.setEndpointOverride("http://localhost");
         properties.setGcpProjectId("project1");
@@ -95,7 +95,7 @@ class CommonDownloaderPropertiesTest {
         sourceProperties.setUri(URI.create("http://localhost"));
         sourceProperties.setType(SourceType.GCP);
         sourceProperties.setProjectId("project1");
-        var properties = new CommonDownloaderProperties(new MirrorProperties());
+        var properties = new CommonDownloaderProperties(new ImporterProperties());
         properties.getSources().add(sourceProperties);
         properties.init();
 
@@ -117,7 +117,7 @@ class CommonDownloaderPropertiesTest {
         sourceProperties.setType(SourceType.GCP);
         sourceProperties.setProjectId("project1");
 
-        var properties = new CommonDownloaderProperties(new MirrorProperties());
+        var properties = new CommonDownloaderProperties(new ImporterProperties());
         properties.setAccessKey("foo");
         properties.setCloudProvider(SourceType.S3);
         properties.setEndpointOverride("http://localhost");

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/ConsensusValidatorImplTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/ConsensusValidatorImplTest.java
@@ -45,7 +45,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.hedera.mirror.common.domain.DomainBuilder;
 import com.hedera.mirror.common.domain.StreamType;
-import com.hedera.mirror.importer.MirrorProperties;
+import com.hedera.mirror.importer.ImporterProperties;
 import com.hedera.mirror.importer.domain.ConsensusNodeStub;
 import com.hedera.mirror.importer.domain.StreamFileSignature;
 import com.hedera.mirror.importer.domain.StreamFileSignature.SignatureType;
@@ -74,7 +74,7 @@ class ConsensusValidatorImplTest {
 
     @BeforeEach
     void setup() {
-        commonDownloaderProperties = new CommonDownloaderProperties(new MirrorProperties());
+        commonDownloaderProperties = new CommonDownloaderProperties(new ImporterProperties());
         commonDownloaderProperties.setConsensusRatio(
                 BigDecimal.ONE.divide(BigDecimal.valueOf(3), 19, RoundingMode.DOWN));
         consensusValidator = new ConsensusValidatorImpl(commonDownloaderProperties);

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/NodeSignatureVerifierTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/NodeSignatureVerifierTest.java
@@ -43,7 +43,7 @@ import static org.mockito.ArgumentMatchers.any;
 
 import com.hedera.mirror.common.domain.StreamType;
 import com.hedera.mirror.common.domain.entity.EntityId;
-import com.hedera.mirror.importer.MirrorProperties;
+import com.hedera.mirror.importer.ImporterProperties;
 import com.hedera.mirror.importer.TestUtils;
 import com.hedera.mirror.importer.domain.ConsensusNodeStub;
 import com.hedera.mirror.importer.domain.StreamFileSignature;
@@ -92,7 +92,7 @@ class NodeSignatureVerifierTest {
     @BeforeEach
     @SneakyThrows
     void setup() {
-        commonDownloaderProperties = new CommonDownloaderProperties(new MirrorProperties());
+        commonDownloaderProperties = new CommonDownloaderProperties(new ImporterProperties());
         commonDownloaderProperties.setConsensusRatio(
                 BigDecimal.ONE.divide(BigDecimal.valueOf(3), 19, RoundingMode.DOWN));
         nodeSignatureVerifier = new NodeSignatureVerifier(consensusValidator);

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/balance/AccountBalancesDownloaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/balance/AccountBalancesDownloaderTest.java
@@ -55,7 +55,7 @@ class AccountBalancesDownloaderTest extends AbstractDownloaderTest<AccountBalanc
 
     @Override
     protected DownloaderProperties getDownloaderProperties() {
-        var properties = new BalanceDownloaderProperties(mirrorProperties, commonDownloaderProperties);
+        var properties = new BalanceDownloaderProperties(commonDownloaderProperties);
         properties.setEnabled(true);
         return properties;
     }
@@ -63,12 +63,13 @@ class AccountBalancesDownloaderTest extends AbstractDownloaderTest<AccountBalanc
     @Override
     protected Downloader<AccountBalanceFile, AccountBalance> getDownloader() {
         BalanceFileReader balanceFileReader = new BalanceFileReaderImplV1(
-                new BalanceParserProperties(), new AccountBalanceLineParserV1(mirrorProperties));
+                new BalanceParserProperties(), new AccountBalanceLineParserV1(importerProperties));
         var streamFileProvider = new S3StreamFileProvider(commonDownloaderProperties, s3AsyncClient);
         return new AccountBalancesDownloader(
                 accountBalanceFileRepository,
                 consensusNodeService,
                 (BalanceDownloaderProperties) downloaderProperties,
+                importerProperties,
                 meterRegistry,
                 dateRangeProcessor,
                 nodeSignatureVerifier,
@@ -107,6 +108,7 @@ class AccountBalancesDownloaderTest extends AbstractDownloaderTest<AccountBalanc
                 accountBalanceFileRepository,
                 consensusNodeService,
                 (BalanceDownloaderProperties) downloaderProperties,
+                importerProperties,
                 meterRegistry,
                 dateRangeProcessor,
                 nodeSignatureVerifier,
@@ -125,7 +127,7 @@ class AccountBalancesDownloaderTest extends AbstractDownloaderTest<AccountBalanc
         downloader.download();
 
         verifyForSuccess();
-        assertThat(mirrorProperties.getDataPath()).isEmptyDirectory();
+        assertThat(importerProperties.getDataPath()).isEmptyDirectory();
     }
 
     @Test

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/event/EventFileDownloaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/event/EventFileDownloaderTest.java
@@ -40,7 +40,7 @@ class EventFileDownloaderTest extends AbstractLinkedStreamDownloaderTest<EventFi
 
     @Override
     protected DownloaderProperties getDownloaderProperties() {
-        var eventDownloaderProperties = new EventDownloaderProperties(mirrorProperties, commonDownloaderProperties);
+        var eventDownloaderProperties = new EventDownloaderProperties(commonDownloaderProperties);
         eventDownloaderProperties.setEnabled(true);
         return eventDownloaderProperties;
     }
@@ -51,6 +51,7 @@ class EventFileDownloaderTest extends AbstractLinkedStreamDownloaderTest<EventFi
         return new EventFileDownloader(
                 consensusNodeService,
                 (EventDownloaderProperties) downloaderProperties,
+                importerProperties,
                 meterRegistry,
                 dateRangeProcessor,
                 nodeSignatureVerifier,

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/AbstractStreamFileProviderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/AbstractStreamFileProviderTest.java
@@ -21,7 +21,7 @@ import static com.hedera.mirror.importer.domain.StreamFilename.SIDECAR_FOLDER;
 
 import com.hedera.mirror.common.domain.StreamType;
 import com.hedera.mirror.importer.FileCopier;
-import com.hedera.mirror.importer.MirrorProperties;
+import com.hedera.mirror.importer.ImporterProperties;
 import com.hedera.mirror.importer.TestUtils;
 import com.hedera.mirror.importer.addressbook.ConsensusNode;
 import com.hedera.mirror.importer.domain.StreamFileData;
@@ -50,7 +50,7 @@ abstract class AbstractStreamFileProviderTest {
 
     @BeforeEach
     void setup() throws Exception {
-        var mirrorProperties = new MirrorProperties();
+        var mirrorProperties = new ImporterProperties();
         mirrorProperties.setDataPath(dataPath);
         properties = new CommonDownloaderProperties(mirrorProperties);
         customizeProperties(properties);

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/AutoS3StreamFileProviderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/AutoS3StreamFileProviderTest.java
@@ -49,7 +49,7 @@ class AutoS3StreamFileProviderTest extends S3StreamFileProviderTest {
                 .to(properties.getBucketName(), StreamType.RECORD.getPath());
 
         var nodeIdFromPath = Path.of("data", "hip679", "provider-auto", "demo");
-        var network = properties.getMirrorProperties().getNetwork();
+        var network = properties.getImporterProperties().getNetwork();
         var nodeIdFileCopier = FileCopier.create(
                         TestUtils.getResource(nodeIdFromPath.toString()).toPath(), dataPath)
                 .to(properties.getBucketName(), network);
@@ -93,7 +93,7 @@ class AutoS3StreamFileProviderTest extends S3StreamFileProviderTest {
                         node,
                         StreamType.RECORD,
                         fileName,
-                        properties.getMirrorProperties().getNetwork());
+                        properties.getImporterProperties().getNetwork());
     }
 
     @Test
@@ -106,7 +106,7 @@ class AutoS3StreamFileProviderTest extends S3StreamFileProviderTest {
                 .to(properties.getBucketName(), StreamType.RECORD.getPath());
 
         var nodeIdFromPath = Path.of("data", "hip679", "provider-auto-transition", "demo");
-        var network = properties.getMirrorProperties().getNetwork();
+        var network = properties.getImporterProperties().getNetwork();
         var nodeIdFileCopier = FileCopier.create(
                         TestUtils.getResource(nodeIdFromPath.toString()).toPath(), dataPath)
                 .to(properties.getBucketName(), network);

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/CompositeStreamFileProviderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/CompositeStreamFileProviderTest.java
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.when;
 
-import com.hedera.mirror.importer.MirrorProperties;
+import com.hedera.mirror.importer.ImporterProperties;
 import com.hedera.mirror.importer.addressbook.ConsensusNode;
 import com.hedera.mirror.importer.domain.ConsensusNodeStub;
 import com.hedera.mirror.importer.domain.StreamFileData;
@@ -59,7 +59,7 @@ class CompositeStreamFileProviderTest {
 
     @BeforeEach
     void setup() {
-        properties = new CommonDownloaderProperties(new MirrorProperties());
+        properties = new CommonDownloaderProperties(new ImporterProperties());
         properties.getSources().add(new StreamSourceProperties());
         properties.getSources().add(new StreamSourceProperties());
         compositeStreamFileProvider =

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/LocalStreamFileProviderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/LocalStreamFileProviderTest.java
@@ -16,7 +16,7 @@
 
 package com.hedera.mirror.importer.downloader.provider;
 
-import static com.hedera.mirror.importer.MirrorProperties.STREAMS;
+import static com.hedera.mirror.importer.ImporterProperties.STREAMS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.hedera.mirror.common.domain.StreamType;
@@ -178,7 +178,7 @@ class LocalStreamFileProviderTest extends AbstractStreamFileProviderTest {
             fileCopier.copy();
         } else {
             fileCopier.copyAsNodeIdStructure(
-                    Path::getParent, properties.getMirrorProperties().getNetwork());
+                    Path::getParent, properties.getImporterProperties().getNetwork());
         }
 
         var accountId = "0.0.3";
@@ -196,7 +196,7 @@ class LocalStreamFileProviderTest extends AbstractStreamFileProviderTest {
     @SneakyThrows
     private File createSignature(String... paths) {
         var subPath = Path.of("", paths);
-        var streamsDir = properties.getMirrorProperties().getStreamPath();
+        var streamsDir = properties.getImporterProperties().getStreamPath();
         var file = streamsDir.resolve(subPath).toFile();
         file.getParentFile().mkdirs();
         file.createNewFile();

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/NodeIdS3StreamProviderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/NodeIdS3StreamProviderTest.java
@@ -33,7 +33,7 @@ public class NodeIdS3StreamProviderTest extends S3StreamFileProviderTest {
 
     @Override
     protected FileCopier createFileCopier(Path dataPath) {
-        String network = properties.getMirrorProperties().getNetwork();
+        String network = properties.getImporterProperties().getNetwork();
         var fromPath = Path.of("data", "hip679", "provider-node-id");
 
         return FileCopier.create(TestUtils.getResource(fromPath.toString()).toPath(), dataPath)
@@ -58,6 +58,6 @@ public class NodeIdS3StreamProviderTest extends S3StreamFileProviderTest {
                 node,
                 StreamType.RECORD,
                 fileName,
-                properties.getMirrorProperties().getNetwork());
+                properties.getImporterProperties().getNetwork());
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/record/AbstractRecordFileDownloaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/record/AbstractRecordFileDownloaderTest.java
@@ -64,7 +64,7 @@ abstract class AbstractRecordFileDownloaderTest extends AbstractLinkedStreamDown
 
     @Override
     protected DownloaderProperties getDownloaderProperties() {
-        return new RecordDownloaderProperties(mirrorProperties, commonDownloaderProperties);
+        return new RecordDownloaderProperties(commonDownloaderProperties);
     }
 
     @Override
@@ -85,6 +85,7 @@ abstract class AbstractRecordFileDownloaderTest extends AbstractLinkedStreamDown
         return new RecordFileDownloader(
                 consensusNodeService,
                 (RecordDownloaderProperties) downloaderProperties,
+                importerProperties,
                 meterRegistry,
                 dateRangeProcessor,
                 nodeSignatureVerifier,

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/record/ProtoRecordFileDownloaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/record/ProtoRecordFileDownloaderTest.java
@@ -72,7 +72,7 @@ class ProtoRecordFileDownloaderTest extends AbstractRecordFileDownloaderTest {
         downloader.download();
 
         super.verifyStreamFiles(List.of(file1, file2), s -> {});
-        assertThat(mirrorProperties.getDataPath()).isEmptyDirectory();
+        assertThat(importerProperties.getDataPath()).isEmptyDirectory();
     }
 
     @Test
@@ -98,7 +98,7 @@ class ProtoRecordFileDownloaderTest extends AbstractRecordFileDownloaderTest {
                     .block();
             assertThat(transactionSidecarRecords).isEmpty();
         });
-        assertThat(mirrorProperties.getDataPath()).isEmptyDirectory();
+        assertThat(importerProperties.getDataPath()).isEmptyDirectory();
     }
 
     @Test
@@ -122,7 +122,7 @@ class ProtoRecordFileDownloaderTest extends AbstractRecordFileDownloaderTest {
                 assertThat(sidecarTypes).isEmpty();
             }
         });
-        assertThat(mirrorProperties.getDataPath()).isEmptyDirectory();
+        assertThat(importerProperties.getDataPath()).isEmptyDirectory();
     }
 
     @Test
@@ -132,7 +132,7 @@ class ProtoRecordFileDownloaderTest extends AbstractRecordFileDownloaderTest {
         expectLastStreamFile(Instant.EPOCH);
         downloader.download();
 
-        assertThat(mirrorProperties.getDataPath())
+        assertThat(importerProperties.getDataPath())
                 .isNotEmptyDirectory()
                 .isDirectoryRecursivelyContaining(
                         "glob:**/streams/recordstreams/record*/sidecar/2022-07-13T08_46_11.304284003Z_01.rcd.gz");
@@ -146,7 +146,7 @@ class ProtoRecordFileDownloaderTest extends AbstractRecordFileDownloaderTest {
         downloader.download();
 
         verifyForSuccess(List.of(file1));
-        assertThat(mirrorProperties.getDataPath()).isEmptyDirectory();
+        assertThat(importerProperties.getDataPath()).isEmptyDirectory();
     }
 
     @Test
@@ -169,7 +169,7 @@ class ProtoRecordFileDownloaderTest extends AbstractRecordFileDownloaderTest {
             downloader.download();
 
             verifyForSuccess(List.of(file1));
-            assertThat(mirrorProperties.getDataPath()).isEmptyDirectory();
+            assertThat(importerProperties.getDataPath()).isEmptyDirectory();
         }
     }
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/record/RecordFileV2DownloaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/record/RecordFileV2DownloaderTest.java
@@ -51,7 +51,7 @@ class RecordFileV2DownloaderTest extends AbstractRecordFileDownloaderTest {
     @Test
     @DisplayName("Download and verify V1 files")
     void downloadV1() {
-        mirrorProperties.setStartBlockNumber(null);
+        importerProperties.setStartBlockNumber(null);
         loadAddressBook("test-v1");
         var allRecordFiles = TestRecordFiles.getAll();
         var testRecordFiles = Map.of(

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/BackfillAndDeduplicateBalanceMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/BackfillAndDeduplicateBalanceMigrationTest.java
@@ -25,7 +25,7 @@ import com.hedera.mirror.common.domain.balance.AccountBalance;
 import com.hedera.mirror.common.domain.balance.TokenBalance;
 import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.importer.EnabledIfV1;
-import com.hedera.mirror.importer.MirrorProperties;
+import com.hedera.mirror.importer.ImporterProperties;
 import com.hedera.mirror.importer.config.Owner;
 import com.hedera.mirror.importer.repository.AccountBalanceRepository;
 import com.hedera.mirror.importer.repository.TokenBalanceRepository;
@@ -77,7 +77,7 @@ class BackfillAndDeduplicateBalanceMigrationTest
     private final @Getter BackfillAndDeduplicateBalanceMigration migration;
     private final @Getter Class<BackfillAndDeduplicateBalanceMigration> migrationClass =
             BackfillAndDeduplicateBalanceMigration.class;
-    private final MirrorProperties mirrorProperties;
+    private final ImporterProperties importerProperties;
 
     @Value("classpath:db/migration/v1/V1.89.1__add_balance_deduplicate_functions.sql")
     private final Resource migrationSql;
@@ -608,7 +608,7 @@ class BackfillAndDeduplicateBalanceMigrationTest
     }
 
     private MigrationProperties getMigrationProperties() {
-        return mirrorProperties.getMigration().get("backfillAndDeduplicateBalanceMigration");
+        return importerProperties.getMigration().get("backfillAndDeduplicateBalanceMigration");
     }
 
     @SneakyThrows

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/BackfillTransactionHashMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/BackfillTransactionHashMigrationTest.java
@@ -22,7 +22,7 @@ import com.hedera.mirror.common.domain.transaction.Transaction;
 import com.hedera.mirror.common.domain.transaction.TransactionHash;
 import com.hedera.mirror.common.domain.transaction.TransactionType;
 import com.hedera.mirror.importer.ImporterIntegrationTest;
-import com.hedera.mirror.importer.MirrorProperties;
+import com.hedera.mirror.importer.ImporterProperties;
 import com.hedera.mirror.importer.TestUtils;
 import com.hedera.mirror.importer.config.Owner;
 import com.hedera.mirror.importer.parser.record.entity.EntityProperties;
@@ -53,7 +53,7 @@ class BackfillTransactionHashMigrationTest extends ImporterIntegrationTest {
 
     private final EntityProperties entityProperties;
     private final @Owner JdbcTemplate jdbcTemplate;
-    private final MirrorProperties mirrorProperties;
+    private final ImporterProperties importerProperties;
     private final TransactionHashRepository transactionHashRepository;
     private final Environment environment;
 
@@ -72,8 +72,9 @@ class BackfillTransactionHashMigrationTest extends ImporterIntegrationTest {
         migrationProperties
                 .getParams()
                 .put("startTimestamp", Long.valueOf(DEFAULT_START_TIMESTAMP).toString());
-        mirrorProperties.getMigration().put(MIGRATION_NAME, migrationProperties);
-        migration = new BackfillTransactionHashMigration(entityProperties, jdbcTemplate, mirrorProperties, environment);
+        importerProperties.getMigration().put(MIGRATION_NAME, migrationProperties);
+        migration =
+                new BackfillTransactionHashMigration(entityProperties, jdbcTemplate, importerProperties, environment);
     }
 
     @AfterEach

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/BlockNumberMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/BlockNumberMigrationTest.java
@@ -16,14 +16,14 @@
 
 package com.hedera.mirror.importer.migration;
 
-import static com.hedera.mirror.importer.MirrorProperties.HederaNetwork.PREVIEWNET;
-import static com.hedera.mirror.importer.MirrorProperties.HederaNetwork.TESTNET;
+import static com.hedera.mirror.importer.ImporterProperties.HederaNetwork.PREVIEWNET;
+import static com.hedera.mirror.importer.ImporterProperties.HederaNetwork.TESTNET;
 import static com.hedera.mirror.importer.migration.BlockNumberMigration.BLOCK_NUMBER_MAPPING;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.hedera.mirror.common.domain.transaction.RecordFile;
 import com.hedera.mirror.importer.ImporterIntegrationTest;
-import com.hedera.mirror.importer.MirrorProperties;
+import com.hedera.mirror.importer.ImporterProperties;
 import com.hedera.mirror.importer.repository.RecordFileRepository;
 import java.util.ArrayList;
 import java.util.List;
@@ -45,12 +45,12 @@ class BlockNumberMigrationTest extends ImporterIntegrationTest {
             BLOCK_NUMBER_MAPPING.get(TESTNET).getValue();
 
     private final BlockNumberMigration blockNumberMigration;
-    private final MirrorProperties mirrorProperties;
+    private final ImporterProperties importerProperties;
     private final RecordFileRepository recordFileRepository;
 
     @BeforeEach
     void setup() {
-        mirrorProperties.setNetwork(TESTNET);
+        importerProperties.setNetwork(TESTNET);
     }
 
     @Test
@@ -60,8 +60,8 @@ class BlockNumberMigrationTest extends ImporterIntegrationTest {
 
     @Test
     void unsupportedNetwork() {
-        var previousNetwork = mirrorProperties.getNetwork();
-        mirrorProperties.setNetwork(PREVIEWNET);
+        var previousNetwork = importerProperties.getNetwork();
+        importerProperties.setNetwork(PREVIEWNET);
         List<Tuple> expectedBlockNumbersAndConsensusEnd =
                 insertDefaultRecordFiles(Set.of(CORRECT_CONSENSUS_END)).stream()
                         .map(recordFile -> Tuple.tuple(recordFile.getConsensusEnd(), recordFile.getIndex()))
@@ -70,7 +70,7 @@ class BlockNumberMigrationTest extends ImporterIntegrationTest {
         blockNumberMigration.doMigrate();
 
         assertConsensusEndAndBlockNumber(expectedBlockNumbersAndConsensusEnd);
-        mirrorProperties.setNetwork(previousNetwork);
+        importerProperties.setNetwork(previousNetwork);
     }
 
     @Test

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/CleanupEntityMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/CleanupEntityMigrationTest.java
@@ -28,7 +28,7 @@ import com.hedera.mirror.common.domain.transaction.TransactionType;
 import com.hedera.mirror.importer.DisableRepeatableSqlMigration;
 import com.hedera.mirror.importer.EnabledIfV1;
 import com.hedera.mirror.importer.ImporterIntegrationTest;
-import com.hedera.mirror.importer.MirrorProperties;
+import com.hedera.mirror.importer.ImporterProperties;
 import com.hedera.mirror.importer.config.Owner;
 import com.hedera.mirror.importer.repository.EntityRepository;
 import com.hedera.mirror.importer.repository.TransactionRepository;
@@ -62,13 +62,13 @@ class CleanupEntityMigrationTest extends ImporterIntegrationTest {
     private final File migrationSql;
 
     private final EntityRepository entityRepository;
-    private final MirrorProperties mirrorProperties;
+    private final ImporterProperties importerProperties;
     private final TransactionRepository transactionRepository;
 
     @BeforeEach
     void before() {
-        mirrorProperties.setStartDate(Instant.EPOCH);
-        mirrorProperties.setEndDate(Instant.EPOCH.plusSeconds(1));
+        importerProperties.setStartDate(Instant.EPOCH);
+        importerProperties.setEndDate(Instant.EPOCH.plusSeconds(1));
         setEntityTablesPreV_1_36();
     }
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/DummyMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/DummyMigrationTest.java
@@ -19,7 +19,7 @@ package com.hedera.mirror.importer.migration;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.hedera.mirror.importer.ImporterIntegrationTest;
-import com.hedera.mirror.importer.MirrorProperties;
+import com.hedera.mirror.importer.ImporterProperties;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.Tag;
@@ -30,11 +30,11 @@ import org.springframework.context.annotation.Lazy;
 @Tag("migration")
 class DummyMigrationTest extends ImporterIntegrationTest {
 
-    private final MirrorProperties mirrorProperties;
+    private final ImporterProperties importerProperties;
 
     @Test
     void checksum() {
-        var dummyMigration = new DummyMigration(mirrorProperties);
+        var dummyMigration = new DummyMigration(importerProperties);
         assertThat(dummyMigration.getChecksum()).isEqualTo(5);
     }
 
@@ -44,8 +44,8 @@ class DummyMigrationTest extends ImporterIntegrationTest {
         private boolean migrated = false;
 
         @Lazy
-        public DummyMigration(MirrorProperties mirrorProperties) {
-            super(mirrorProperties.getMigration());
+        public DummyMigration(ImporterProperties importerProperties) {
+            super(importerProperties.getMigration());
         }
 
         @Override

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/ErrataMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/ErrataMigrationTest.java
@@ -25,7 +25,7 @@ import com.hedera.mirror.common.domain.transaction.Transaction;
 import com.hedera.mirror.common.domain.transaction.TransactionType;
 import com.hedera.mirror.common.util.DomainUtils;
 import com.hedera.mirror.importer.ImporterIntegrationTest;
-import com.hedera.mirror.importer.MirrorProperties;
+import com.hedera.mirror.importer.ImporterProperties;
 import com.hedera.mirror.importer.repository.AccountBalanceFileRepository;
 import com.hedera.mirror.importer.repository.ContractResultRepository;
 import com.hedera.mirror.importer.repository.CryptoTransferRepository;
@@ -72,19 +72,19 @@ public class ErrataMigrationTest extends ImporterIntegrationTest {
     private final CryptoTransferRepository cryptoTransferRepository;
     private final TokenTransferRepository tokenTransferRepository;
     private final ErrataMigration errataMigration;
-    private final MirrorProperties mirrorProperties;
+    private final ImporterProperties importerProperties;
     private final TransactionRepository transactionRepository;
 
     @BeforeEach
     void setup() {
-        mirrorProperties.setNetwork(MirrorProperties.HederaNetwork.MAINNET);
+        importerProperties.setNetwork(ImporterProperties.HederaNetwork.MAINNET);
     }
 
     @AfterEach
     void teardown() {
-        mirrorProperties.setEndDate(Utility.MAX_INSTANT_LONG);
-        mirrorProperties.setNetwork(MirrorProperties.HederaNetwork.TESTNET);
-        mirrorProperties.setStartDate(Instant.EPOCH);
+        importerProperties.setEndDate(Utility.MAX_INSTANT_LONG);
+        importerProperties.setNetwork(ImporterProperties.HederaNetwork.TESTNET);
+        importerProperties.setStartDate(Instant.EPOCH);
     }
 
     @Test
@@ -94,7 +94,7 @@ public class ErrataMigrationTest extends ImporterIntegrationTest {
 
     @Test
     void migrateNotMainnet() throws Exception {
-        mirrorProperties.setNetwork(MirrorProperties.HederaNetwork.TESTNET);
+        importerProperties.setNetwork(ImporterProperties.HederaNetwork.TESTNET);
         domainBuilder.accountBalanceFile().persist();
         domainBuilder
                 .accountBalanceFile()
@@ -115,8 +115,8 @@ public class ErrataMigrationTest extends ImporterIntegrationTest {
     @Test
     void migrateOutsideDateRange() throws Exception {
         Instant now = Instant.now();
-        mirrorProperties.setStartDate(now);
-        mirrorProperties.setEndDate(now.plusSeconds(1L));
+        importerProperties.setStartDate(now);
+        importerProperties.setEndDate(now.plusSeconds(1L));
 
         errataMigration.doMigrate();
 
@@ -220,7 +220,7 @@ public class ErrataMigrationTest extends ImporterIntegrationTest {
 
     @Test
     void onEndNotMainnet() {
-        mirrorProperties.setNetwork(MirrorProperties.HederaNetwork.TESTNET);
+        importerProperties.setNetwork(ImporterProperties.HederaNetwork.TESTNET);
         AccountBalanceFile accountBalanceFile = new AccountBalanceFile();
         accountBalanceFile.setConsensusTimestamp(BAD_TIMESTAMP1);
         errataMigration.onStart(); // Call to increase test coverage of no-op methods

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/FixCryptoAllowanceAmountMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/FixCryptoAllowanceAmountMigrationTest.java
@@ -24,7 +24,7 @@ import com.hedera.mirror.common.domain.entity.CryptoAllowanceHistory;
 import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.transaction.CryptoTransfer;
 import com.hedera.mirror.importer.EnabledIfV1;
-import com.hedera.mirror.importer.MirrorProperties;
+import com.hedera.mirror.importer.ImporterProperties;
 import com.hedera.mirror.importer.TestUtils;
 import com.hedera.mirror.importer.config.Owner;
 import com.hedera.mirror.importer.db.DBProperties;
@@ -69,7 +69,7 @@ class FixCryptoAllowanceAmountMigrationTest extends AbstractAsyncJavaMigrationTe
     @BeforeEach
     void setup() {
         // Create migration object for each test case due to the cached earliestTimestamp
-        var mirrorProperties = new MirrorProperties();
+        var mirrorProperties = new ImporterProperties();
         migration =
                 new FixCryptoAllowanceAmountMigration(dbProperties, entityProperties, mirrorProperties, jdbcTemplate);
     }
@@ -279,7 +279,7 @@ class FixCryptoAllowanceAmountMigrationTest extends AbstractAsyncJavaMigrationTe
         var entityProperties = new EntityProperties();
         entityProperties.getPersist().setTrackAllowance(trackAllowance);
         var migration = new FixCryptoAllowanceAmountMigration(
-                dbProperties, entityProperties, new MirrorProperties(), jdbcTemplate);
+                dbProperties, entityProperties, new ImporterProperties(), jdbcTemplate);
         var configuration = new FluentConfiguration().target(migration.getMinimumVersion());
 
         // when, then

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/FixStakedBeforeEnabledMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/FixStakedBeforeEnabledMigrationTest.java
@@ -22,8 +22,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.google.common.collect.Range;
 import com.hedera.mirror.common.domain.entity.Entity;
 import com.hedera.mirror.importer.EnabledIfV1;
-import com.hedera.mirror.importer.MirrorProperties;
-import com.hedera.mirror.importer.MirrorProperties.HederaNetwork;
+import com.hedera.mirror.importer.ImporterProperties;
+import com.hedera.mirror.importer.ImporterProperties.HederaNetwork;
 import com.hedera.mirror.importer.util.Utility;
 import lombok.RequiredArgsConstructor;
 import org.assertj.core.api.IterableAssert;
@@ -41,14 +41,14 @@ class FixStakedBeforeEnabledMigrationTest extends AbstractStakingMigrationTest {
 
     private static final String[] ENTITY_FIELDS =
             new String[] {"id", "declineReward", "stakedNodeId", "stakePeriodStart"};
-    private final MirrorProperties mirrorProperties;
+    private final ImporterProperties importerProperties;
     private final FixStakedBeforeEnabledMigration migration;
 
     private long lastHapi26EpochDay;
 
     @AfterEach
     void teardown() {
-        mirrorProperties.setNetwork(HederaNetwork.TESTNET);
+        importerProperties.setNetwork(HederaNetwork.TESTNET);
     }
 
     @Test
@@ -82,7 +82,7 @@ class FixStakedBeforeEnabledMigrationTest extends AbstractStakingMigrationTest {
     void otherNetwork() {
         // given
         setupForMainnet();
-        mirrorProperties.setNetwork(HederaNetwork.OTHER);
+        importerProperties.setNetwork(HederaNetwork.OTHER);
         var entity = domainBuilder
                 .entity()
                 .customize(e -> e.stakedNodeId(0L)
@@ -257,7 +257,7 @@ class FixStakedBeforeEnabledMigrationTest extends AbstractStakingMigrationTest {
     }
 
     private void setupForMainnet() {
-        mirrorProperties.setNetwork(HederaNetwork.MAINNET);
+        importerProperties.setNetwork(HederaNetwork.MAINNET);
         lastHapi26EpochDay = Utility.getEpochDay(LAST_HAPI_26_RECORD_FILE_CONSENSUS_END_MAINNET);
         // Persist last Hapi version 26 RecordFile
         domainBuilder

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/HistoricalAccountInfoMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/HistoricalAccountInfoMigrationTest.java
@@ -26,7 +26,7 @@ import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.entity.EntityType;
 import com.hedera.mirror.common.util.DomainUtils;
 import com.hedera.mirror.importer.ImporterIntegrationTest;
-import com.hedera.mirror.importer.MirrorProperties;
+import com.hedera.mirror.importer.ImporterProperties;
 import com.hedera.mirror.importer.repository.EntityRepository;
 import com.hedera.mirror.importer.util.Utility;
 import com.hederahashgraph.api.proto.java.AccountID;
@@ -53,21 +53,21 @@ class HistoricalAccountInfoMigrationTest extends ImporterIntegrationTest {
 
     private final HistoricalAccountInfoMigration historicalAccountInfoMigration;
     private final EntityRepository entityRepository;
-    private final MirrorProperties mirrorProperties;
+    private final ImporterProperties importerProperties;
 
     private String network;
 
     @BeforeEach
     void before() {
-        network = mirrorProperties.getNetwork();
-        mirrorProperties.setImportHistoricalAccountInfo(true);
-        mirrorProperties.setNetwork(MirrorProperties.HederaNetwork.MAINNET);
+        network = importerProperties.getNetwork();
+        importerProperties.setImportHistoricalAccountInfo(true);
+        importerProperties.setNetwork(ImporterProperties.HederaNetwork.MAINNET);
     }
 
     @AfterEach
     void after() {
-        mirrorProperties.setImportHistoricalAccountInfo(false);
-        mirrorProperties.setNetwork(network);
+        importerProperties.setImportHistoricalAccountInfo(false);
+        importerProperties.setNetwork(network);
     }
 
     @Test
@@ -138,42 +138,42 @@ class HistoricalAccountInfoMigrationTest extends ImporterIntegrationTest {
 
     @Test
     void disabled() throws Exception {
-        mirrorProperties.setImportHistoricalAccountInfo(false);
+        importerProperties.setImportHistoricalAccountInfo(false);
         historicalAccountInfoMigration.doMigrate();
         assertThat(entityRepository.count()).isZero();
     }
 
     @Test
     void notMainnet() throws Exception {
-        mirrorProperties.setNetwork(MirrorProperties.HederaNetwork.DEMO);
+        importerProperties.setNetwork(ImporterProperties.HederaNetwork.DEMO);
         historicalAccountInfoMigration.doMigrate();
         assertThat(entityRepository.count()).isZero();
     }
 
     @Test
     void startDateAfter() throws Exception {
-        mirrorProperties.setStartDate(Instant.now());
+        importerProperties.setStartDate(Instant.now());
         historicalAccountInfoMigration.doMigrate();
         assertThat(entityRepository.count()).isZero();
     }
 
     @Test
     void startDateBefore() throws Exception {
-        mirrorProperties.setStartDate(HistoricalAccountInfoMigration.EXPORT_DATE.minusNanos(1));
+        importerProperties.setStartDate(HistoricalAccountInfoMigration.EXPORT_DATE.minusNanos(1));
         historicalAccountInfoMigration.doMigrate();
         assertThat(entityRepository.count()).isEqualTo(ENTITY_COUNT + CONTRACT_COUNT);
     }
 
     @Test
     void startDateEquals() throws Exception {
-        mirrorProperties.setStartDate(HistoricalAccountInfoMigration.EXPORT_DATE);
+        importerProperties.setStartDate(HistoricalAccountInfoMigration.EXPORT_DATE);
         historicalAccountInfoMigration.doMigrate();
         assertThat(entityRepository.count()).isEqualTo(ENTITY_COUNT + CONTRACT_COUNT);
     }
 
     @Test
     void startDateNull() throws Exception {
-        mirrorProperties.setStartDate(null);
+        importerProperties.setStartDate(null);
         historicalAccountInfoMigration.doMigrate();
         assertThat(entityRepository.count()).isZero();
     }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/InitializeEntityBalanceMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/InitializeEntityBalanceMigrationTest.java
@@ -29,7 +29,7 @@ import com.hedera.mirror.common.domain.entity.EntityType;
 import com.hedera.mirror.common.domain.transaction.ErrataType;
 import com.hedera.mirror.common.domain.transaction.RecordFile;
 import com.hedera.mirror.importer.ImporterIntegrationTest;
-import com.hedera.mirror.importer.MirrorProperties;
+import com.hedera.mirror.importer.ImporterProperties;
 import com.hedera.mirror.importer.config.Owner;
 import com.hedera.mirror.importer.repository.AccountBalanceFileRepository;
 import com.hedera.mirror.importer.repository.AccountBalanceRepository;
@@ -64,7 +64,7 @@ class InitializeEntityBalanceMigrationTest extends ImporterIntegrationTest {
     private final CryptoTransferRepository cryptoTransferRepository;
     private final EntityRepository entityRepository;
     private final @Owner JdbcTemplate jdbcTemplate;
-    private final MirrorProperties mirrorProperties;
+    private final ImporterProperties importerProperties;
     private final RecordFileRepository recordFileRepository;
     private InitializeEntityBalanceMigration migration;
     private Entity account;
@@ -80,7 +80,7 @@ class InitializeEntityBalanceMigrationTest extends ImporterIntegrationTest {
     void beforeEach() {
         timestamp = new AtomicLong(0L);
         migration = new InitializeEntityBalanceMigration(
-                jdbcOperations, mirrorProperties, accountBalanceFileRepository, recordFileRepository);
+                jdbcOperations, importerProperties, accountBalanceFileRepository, recordFileRepository);
     }
 
     @Test

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/MergeDuplicateBlocksMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/MergeDuplicateBlocksMigrationTest.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.hedera.mirror.common.domain.transaction.RecordFile;
 import com.hedera.mirror.common.domain.transaction.Transaction;
 import com.hedera.mirror.importer.ImporterIntegrationTest;
-import com.hedera.mirror.importer.MirrorProperties;
+import com.hedera.mirror.importer.ImporterProperties;
 import com.hedera.mirror.importer.repository.RecordFileRepository;
 import com.hedera.mirror.importer.repository.TransactionRepository;
 import lombok.RequiredArgsConstructor;
@@ -36,7 +36,7 @@ class MergeDuplicateBlocksMigrationTest extends ImporterIntegrationTest {
     private static final long TIMESTAMP2 = 1675962001984524003L;
 
     private final MergeDuplicateBlocksMigration migration;
-    private final MirrorProperties mirrorProperties;
+    private final ImporterProperties importerProperties;
     private final RecordFileRepository recordFileRepository;
     private final TransactionRepository transactionRepository;
 
@@ -57,7 +57,7 @@ class MergeDuplicateBlocksMigrationTest extends ImporterIntegrationTest {
     @Test
     void notMainnet() throws Exception {
         // Given
-        mirrorProperties.setNetwork(MirrorProperties.HederaNetwork.TESTNET);
+        importerProperties.setNetwork(ImporterProperties.HederaNetwork.TESTNET);
 
         // When
         migration.doMigrate();
@@ -74,7 +74,7 @@ class MergeDuplicateBlocksMigrationTest extends ImporterIntegrationTest {
     @Test
     void mainnet() throws Exception {
         // Given
-        mirrorProperties.setNetwork(MirrorProperties.HederaNetwork.MAINNET);
+        importerProperties.setNetwork(ImporterProperties.HederaNetwork.MAINNET);
 
         // When
         migration.doMigrate();

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/RecalculatePendingRewardMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/RecalculatePendingRewardMigrationTest.java
@@ -23,8 +23,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.hedera.mirror.common.domain.entity.Entity;
 import com.hedera.mirror.common.util.DomainUtils;
 import com.hedera.mirror.importer.EnabledIfV1;
-import com.hedera.mirror.importer.MirrorProperties;
-import com.hedera.mirror.importer.MirrorProperties.HederaNetwork;
+import com.hedera.mirror.importer.ImporterProperties;
+import com.hedera.mirror.importer.ImporterProperties.HederaNetwork;
 import com.hedera.mirror.importer.TestUtils;
 import com.hedera.mirror.importer.util.Utility;
 import lombok.RequiredArgsConstructor;
@@ -41,7 +41,7 @@ import org.springframework.test.context.TestPropertySource;
 @TestPropertySource(properties = "spring.flyway.target=1.68.3")
 class RecalculatePendingRewardMigrationTest extends AbstractStakingMigrationTest {
 
-    private final MirrorProperties mirrorProperties;
+    private final ImporterProperties importerProperties;
     private final RecalculatePendingRewardMigration migration;
 
     private long firstEpochDay;
@@ -49,7 +49,7 @@ class RecalculatePendingRewardMigrationTest extends AbstractStakingMigrationTest
 
     @AfterEach
     void teardown() {
-        mirrorProperties.setNetwork(HederaNetwork.TESTNET);
+        importerProperties.setNetwork(HederaNetwork.TESTNET);
     }
 
     @Test
@@ -62,7 +62,7 @@ class RecalculatePendingRewardMigrationTest extends AbstractStakingMigrationTest
     void otherNetwork() {
         // given
         setupNodeStakeForNetwork(HederaNetwork.MAINNET);
-        mirrorProperties.setNetwork(HederaNetwork.OTHER);
+        importerProperties.setNetwork(HederaNetwork.OTHER);
         var entity = domainBuilder
                 .entity()
                 .customize(e -> e.stakedNodeId(0L).stakePeriodStart(firstEpochDay))
@@ -349,7 +349,7 @@ class RecalculatePendingRewardMigrationTest extends AbstractStakingMigrationTest
     }
 
     private void setupNodeStakeForNetwork(String network) {
-        mirrorProperties.setNetwork(network);
+        importerProperties.setNetwork(network);
 
         long firstNonZeroRewardTimestamp = FIRST_NONZERO_REWARD_RATE_TIMESTAMP.get(network);
         firstNonZeroRewardEpochDay = Utility.getEpochDay(firstNonZeroRewardTimestamp);

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/RemoveInvalidEntityMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/RemoveInvalidEntityMigrationTest.java
@@ -28,7 +28,7 @@ import com.hedera.mirror.common.domain.transaction.TransactionType;
 import com.hedera.mirror.importer.DisableRepeatableSqlMigration;
 import com.hedera.mirror.importer.EnabledIfV1;
 import com.hedera.mirror.importer.ImporterIntegrationTest;
-import com.hedera.mirror.importer.MirrorProperties;
+import com.hedera.mirror.importer.ImporterProperties;
 import com.hedera.mirror.importer.config.Owner;
 import com.hedera.mirror.importer.repository.TransactionRepository;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
@@ -60,13 +60,13 @@ class RemoveInvalidEntityMigrationTest extends ImporterIntegrationTest {
     @Value("classpath:db/migration/v1/V1.31.2__remove_invalid_entities.sql")
     private final File migrationSql;
 
-    private final MirrorProperties mirrorProperties;
+    private final ImporterProperties importerProperties;
     private final TransactionRepository transactionRepository;
 
     @BeforeEach
     void before() {
-        mirrorProperties.setStartDate(Instant.EPOCH);
-        mirrorProperties.setEndDate(Instant.EPOCH.plusSeconds(1));
+        importerProperties.setStartDate(Instant.EPOCH);
+        importerProperties.setEndDate(Instant.EPOCH.plusSeconds(1));
     }
 
     @Test

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/SyntheticCryptoTransferApprovalMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/SyntheticCryptoTransferApprovalMigrationTest.java
@@ -16,8 +16,8 @@
 
 package com.hedera.mirror.importer.migration;
 
-import static com.hedera.mirror.importer.MirrorProperties.HederaNetwork.MAINNET;
-import static com.hedera.mirror.importer.MirrorProperties.HederaNetwork.TESTNET;
+import static com.hedera.mirror.importer.ImporterProperties.HederaNetwork.MAINNET;
+import static com.hedera.mirror.importer.ImporterProperties.HederaNetwork.TESTNET;
 import static com.hedera.mirror.importer.migration.SyntheticCryptoTransferApprovalMigration.LOWER_BOUND_TIMESTAMP;
 import static com.hedera.mirror.importer.migration.SyntheticCryptoTransferApprovalMigration.UPPER_BOUND_TIMESTAMP;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -34,7 +34,7 @@ import com.hedera.mirror.common.domain.transaction.CryptoTransfer;
 import com.hedera.mirror.common.domain.transaction.RecordFile;
 import com.hedera.mirror.common.domain.transaction.Transaction;
 import com.hedera.mirror.importer.ImporterIntegrationTest;
-import com.hedera.mirror.importer.MirrorProperties;
+import com.hedera.mirror.importer.ImporterProperties;
 import com.hedera.mirror.importer.repository.CryptoTransferRepository;
 import com.hedera.mirror.importer.repository.TokenTransferRepository;
 import com.hedera.mirror.importer.repository.TransactionRepository;
@@ -78,7 +78,7 @@ class SyntheticCryptoTransferApprovalMigrationTest extends ImporterIntegrationTe
     private final CryptoTransferRepository cryptoTransferRepository;
     private final TransactionRepository transactionRepository;
     private final TokenTransferRepository tokenTransferRepository;
-    private final MirrorProperties mirrorProperties;
+    private final ImporterProperties importerProperties;
     private Entity currentKeyUnaffectedEntity;
     private Entity currentKeyAffectedEntity;
     private Entity noKeyEntity;
@@ -87,14 +87,14 @@ class SyntheticCryptoTransferApprovalMigrationTest extends ImporterIntegrationTe
     @BeforeEach
     @SneakyThrows
     void setup() {
-        mirrorProperties.setNetwork(MAINNET);
+        importerProperties.setNetwork(MAINNET);
         migration.setExecuted(false);
         migration.setComplete(false);
     }
 
     @AfterEach
     void teardown() {
-        mirrorProperties.setNetwork(TESTNET);
+        importerProperties.setNetwork(TESTNET);
     }
 
     @Test

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/TokenAccountBalanceMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/TokenAccountBalanceMigrationTest.java
@@ -29,7 +29,7 @@ import com.hedera.mirror.common.domain.token.TokenSupplyTypeEnum;
 import com.hedera.mirror.common.domain.token.TokenTransfer;
 import com.hedera.mirror.common.domain.token.TokenTypeEnum;
 import com.hedera.mirror.importer.ImporterIntegrationTest;
-import com.hedera.mirror.importer.MirrorProperties;
+import com.hedera.mirror.importer.ImporterProperties;
 import com.hedera.mirror.importer.config.Owner;
 import com.hedera.mirror.importer.repository.AccountBalanceFileRepository;
 import com.hedera.mirror.importer.repository.RecordFileRepository;
@@ -61,7 +61,7 @@ class TokenAccountBalanceMigrationTest extends ImporterIntegrationTest {
     private final TokenAccountRepository tokenAccountRepository;
     private final TokenAccountHistoryRepository tokenAccountHistoryRepository;
     private final TokenTransferRepository tokenTransferRepository;
-    private final MirrorProperties mirrorProperties;
+    private final ImporterProperties importerProperties;
 
     private TokenAccountBalanceMigration tokenAccountBalanceMigration;
     private AccountBalanceFile accountBalanceFile1;
@@ -78,7 +78,7 @@ class TokenAccountBalanceMigrationTest extends ImporterIntegrationTest {
     void beforeEach() {
         timestamp = new AtomicLong(domainBuilder.timestamp());
         tokenAccountBalanceMigration = new TokenAccountBalanceMigration(
-                jdbcOperations, mirrorProperties, accountBalanceFileRepository, recordFileRepository);
+                jdbcOperations, importerProperties, accountBalanceFileRepository, recordFileRepository);
     }
 
     @Test

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/balance/AccountBalanceFileParserTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/balance/AccountBalanceFileParserTest.java
@@ -23,7 +23,7 @@ import com.hedera.mirror.common.domain.balance.AccountBalance;
 import com.hedera.mirror.common.domain.balance.AccountBalanceFile;
 import com.hedera.mirror.common.domain.balance.TokenBalance;
 import com.hedera.mirror.importer.ImporterIntegrationTest;
-import com.hedera.mirror.importer.MirrorProperties;
+import com.hedera.mirror.importer.ImporterProperties;
 import com.hedera.mirror.importer.parser.StreamFileParser;
 import com.hedera.mirror.importer.repository.AccountBalanceFileRepository;
 import com.hedera.mirror.importer.repository.AccountBalanceRepository;
@@ -46,7 +46,7 @@ class AccountBalanceFileParserTest extends ImporterIntegrationTest {
     private final AccountBalanceRepository accountBalanceRepository;
     private final TokenBalanceRepository tokenBalanceRepository;
     private final BalanceParserProperties parserProperties;
-    private final MirrorProperties mirrorProperties;
+    private final ImporterProperties importerProperties;
 
     @BeforeEach
     void setup() {
@@ -127,8 +127,8 @@ class AccountBalanceFileParserTest extends ImporterIntegrationTest {
     @Test
     void errata() {
         // given
-        var network = mirrorProperties.getNetwork();
-        mirrorProperties.setNetwork(MirrorProperties.HederaNetwork.MAINNET);
+        var network = importerProperties.getNetwork();
+        importerProperties.setNetwork(ImporterProperties.HederaNetwork.MAINNET);
         AccountBalanceFile accountBalanceFile = accountBalanceFile(BAD_TIMESTAMP1);
         List<AccountBalance> items = accountBalanceFile.getItems().collectList().block();
 
@@ -138,7 +138,7 @@ class AccountBalanceFileParserTest extends ImporterIntegrationTest {
         // then
         assertAccountBalanceFile(accountBalanceFile, items);
         assertThat(accountBalanceFile.getTimeOffset()).isEqualTo(-1);
-        mirrorProperties.setNetwork(network);
+        importerProperties.setNetwork(network);
     }
 
     void assertAccountBalanceFile(AccountBalanceFile accountBalanceFile, List<AccountBalance> accountBalances) {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/balance/CsvBalanceFileReaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/balance/CsvBalanceFileReaderTest.java
@@ -24,7 +24,7 @@ import com.google.common.collect.Collections2;
 import com.hedera.mirror.common.domain.balance.AccountBalance;
 import com.hedera.mirror.common.domain.balance.AccountBalanceFile;
 import com.hedera.mirror.common.util.DomainUtils;
-import com.hedera.mirror.importer.MirrorProperties;
+import com.hedera.mirror.importer.ImporterProperties;
 import com.hedera.mirror.importer.TestUtils;
 import com.hedera.mirror.importer.domain.StreamFileData;
 import com.hedera.mirror.importer.domain.StreamFilename;
@@ -52,7 +52,7 @@ import org.springframework.util.StringUtils;
 
 abstract class CsvBalanceFileReaderTest {
 
-    protected final MirrorProperties mirrorProperties;
+    protected final ImporterProperties importerProperties;
     protected final BalanceParserProperties balanceParserProperties;
     protected final File balanceFile;
     protected final CsvBalanceFileReader balanceFileReader;
@@ -69,12 +69,13 @@ abstract class CsvBalanceFileReaderTest {
             Class<? extends AccountBalanceLineParser> accountBalanceLineParserClass,
             String balanceFilePath,
             long expectedCount) {
-        mirrorProperties = new MirrorProperties();
+        importerProperties = new ImporterProperties();
         balanceParserProperties = new BalanceParserProperties();
         balanceFile = TestUtils.getResource(balanceFilePath);
         parser = (AccountBalanceLineParser) ReflectUtils.newInstance(
-                accountBalanceLineParserClass, new Class<?>[] {MirrorProperties.class}, new Object[] {mirrorProperties
-                });
+                accountBalanceLineParserClass,
+                new Class<?>[] {ImporterProperties.class},
+                new Object[] {importerProperties});
         balanceFileReader = (CsvBalanceFileReader) ReflectUtils.newInstance(
                 balanceFileReaderClass,
                 new Class<?>[] {BalanceParserProperties.class, accountBalanceLineParserClass},
@@ -200,7 +201,7 @@ abstract class CsvBalanceFileReaderTest {
     void readValidWhenFileHasLinesWithDifferentShardNum() throws IOException {
         List<String> lines = FileUtils.readLines(balanceFile, CsvBalanceFileReader.CHARSET);
         FileUtils.writeLines(testFile, lines);
-        long otherShard = mirrorProperties.getShard() + 1;
+        long otherShard = importerProperties.getShard() + 1;
         FileUtils.writeStringToFile(
                 testFile,
                 String.format("\n%d,0,3,340\n%d,0,4,340\n", otherShard, otherShard),

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/balance/line/AccountBalanceLineParserV1Test.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/balance/line/AccountBalanceLineParserV1Test.java
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.hedera.mirror.common.domain.balance.AccountBalance;
-import com.hedera.mirror.importer.MirrorProperties;
+import com.hedera.mirror.importer.ImporterProperties;
 import com.hedera.mirror.importer.exception.InvalidDatasetException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -32,12 +32,12 @@ class AccountBalanceLineParserV1Test {
 
     private static final long timestamp = 1596340377922333444L;
     private AccountBalanceLineParserV1 parser;
-    private MirrorProperties mirrorProperties;
+    private ImporterProperties importerProperties;
 
     @BeforeEach
     void setup() {
-        mirrorProperties = new MirrorProperties();
-        parser = new AccountBalanceLineParserV1(mirrorProperties);
+        importerProperties = new ImporterProperties();
+        parser = new AccountBalanceLineParserV1(importerProperties);
     }
 
     @DisplayName("Parse account balance line")
@@ -75,7 +75,7 @@ class AccountBalanceLineParserV1Test {
 
             assertThat(accountBalance.getBalance()).isEqualTo(expectedBalance);
             assertThat(id).isNotNull();
-            assertThat(id.getAccountId().getShard()).isEqualTo(mirrorProperties.getShard());
+            assertThat(id.getAccountId().getShard()).isEqualTo(importerProperties.getShard());
             assertThat(id.getAccountId().getRealm()).isEqualTo(expectedRealm);
             assertThat(id.getAccountId().getNum()).isEqualTo(expectedAccount);
             assertThat(id.getConsensusTimestamp()).isEqualTo(timestamp);

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/balance/line/AccountBalanceLineParserV2Test.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/balance/line/AccountBalanceLineParserV2Test.java
@@ -22,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import com.google.common.base.Splitter;
 import com.hedera.mirror.common.domain.balance.AccountBalance;
 import com.hedera.mirror.common.domain.balance.TokenBalance;
-import com.hedera.mirror.importer.MirrorProperties;
+import com.hedera.mirror.importer.ImporterProperties;
 import com.hedera.mirror.importer.exception.InvalidDatasetException;
 import java.io.IOException;
 import java.util.List;
@@ -39,12 +39,12 @@ class AccountBalanceLineParserV2Test {
 
     private static final long timestamp = 1596340377922333444L;
     private AccountBalanceLineParserV2 parser;
-    private MirrorProperties mirrorProperties;
+    private ImporterProperties importerProperties;
 
     @BeforeEach
     void setup() {
-        mirrorProperties = new MirrorProperties();
-        parser = new AccountBalanceLineParserV2(mirrorProperties);
+        importerProperties = new ImporterProperties();
+        parser = new AccountBalanceLineParserV2(importerProperties);
     }
 
     @DisplayName("Parse account balance line")
@@ -122,11 +122,11 @@ class AccountBalanceLineParserV2Test {
                                     actualId.getTokenId().getNum()));
                     assertThat(actualId).isNotNull();
                     assertThat(actualId.getConsensusTimestamp()).isEqualTo(timestamp);
-                    assertThat(actualId.getAccountId().getShard()).isEqualTo(mirrorProperties.getShard());
+                    assertThat(actualId.getAccountId().getShard()).isEqualTo(importerProperties.getShard());
                     assertThat(actualId.getAccountId().getRealm()).isEqualTo(expectedRealm);
                     assertThat(actualId.getAccountId().getNum()).isEqualTo(expectedAccount);
 
-                    assertThat(actualId.getTokenId().getShard()).isEqualTo(mirrorProperties.getShard());
+                    assertThat(actualId.getTokenId().getShard()).isEqualTo(importerProperties.getShard());
                     assertThat(actualId.getTokenId().getRealm()).isEqualTo(expectedRealm);
                 }
             } else {


### PR DESCRIPTION
**Description**:

Follow up to #7380. Provide consistency in naming by renaming `Mirror` prefixed classes that are not common to all modules.

* Rename `MirrorProperties` to `ImporterProperties`
* Remove `DownloaderProperties.getMirrorProperties()`

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
