### PR TITLE
HIP-584 Historical: fix slot parameter in `MirrorEntityAccess`

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccess.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccess.java
@@ -119,7 +119,8 @@ public class MirrorEntityAccess implements HederaEvmEntityAccess {
         }
 
         return store.getHistoricalTimestamp()
-                .map(t -> contractStateRepository.findStorageByBlockTimestamp(entityId, key.toArrayUnsafe(), t))
+                .map(t -> contractStateRepository.findStorageByBlockTimestamp(
+                        entityId, trimLeadingZeros(key.toArrayUnsafe()), t))
                 .orElseGet(() -> contractStateRepository.findStorage(entityId, key.toArrayUnsafe()))
                 .map(Bytes::wrap)
                 .orElse(Bytes.EMPTY);
@@ -146,5 +147,28 @@ public class MirrorEntityAccess implements HederaEvmEntityAccess {
             entityId = store.getToken(address, OnMissing.DONT_THROW).getEntityId();
         }
         return entityId;
+    }
+
+    static byte[] trimLeadingZeros(byte[] inputArray) {
+        int leadingZeros = 0;
+        int length = inputArray.length;
+
+        // Count the number of leading zeros
+        for (int i = 0; i < length; i++) {
+            if (inputArray[i] == 0) {
+                leadingZeros++;
+            } else {
+                break;
+            }
+        }
+
+        // Create a new array with the trimmed length
+        int trimmedLength = length - leadingZeros;
+        byte[] trimmedArray = new byte[trimmedLength];
+
+        // Copy the non-zero elements to the new array
+        System.arraycopy(inputArray, leadingZeros, trimmedArray, 0, trimmedLength);
+
+        return trimmedArray;
     }
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccess.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccess.java
@@ -120,7 +120,7 @@ public class MirrorEntityAccess implements HederaEvmEntityAccess {
 
         return store.getHistoricalTimestamp()
                 .map(t -> contractStateRepository.findStorageByBlockTimestamp(
-                        entityId, trimLeadingZeros(key.toArrayUnsafe()), t))
+                        entityId, key.trimLeadingZeros().toArrayUnsafe(), t))
                 .orElseGet(() -> contractStateRepository.findStorage(entityId, key.toArrayUnsafe()))
                 .map(Bytes::wrap)
                 .orElse(Bytes.EMPTY);
@@ -147,28 +147,5 @@ public class MirrorEntityAccess implements HederaEvmEntityAccess {
             entityId = store.getToken(address, OnMissing.DONT_THROW).getEntityId();
         }
         return entityId;
-    }
-
-    static byte[] trimLeadingZeros(byte[] inputArray) {
-        int leadingZeros = 0;
-        int length = inputArray.length;
-
-        // Count the number of leading zeros
-        for (int i = 0; i < length; i++) {
-            if (inputArray[i] == 0) {
-                leadingZeros++;
-            } else {
-                break;
-            }
-        }
-
-        // Create a new array with the trimmed length
-        int trimmedLength = length - leadingZeros;
-        byte[] trimmedArray = new byte[trimmedLength];
-
-        // Copy the non-zero elements to the new array
-        System.arraycopy(inputArray, leadingZeros, trimmedArray, 0, trimmedLength);
-
-        return trimmedArray;
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccessTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccessTest.java
@@ -18,10 +18,8 @@ package com.hedera.mirror.web3.evm.store.contract;
 
 import static com.google.protobuf.ByteString.EMPTY;
 import static com.hedera.mirror.common.domain.entity.AbstractEntity.DEFAULT_EXPIRY_TIMESTAMP;
-import static com.hedera.mirror.web3.evm.store.contract.MirrorEntityAccess.trimLeadingZeros;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.hyperledger.besu.datatypes.Address.ZERO;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.mockito.Mockito.when;
 
 import com.google.protobuf.ByteString;
@@ -238,7 +236,7 @@ class MirrorEntityAccessTest {
     void getStorageHistorical() {
         when(store.getHistoricalTimestamp()).thenReturn(timestamp);
         when(contractStateRepository.findStorageByBlockTimestamp(
-                        ENTITY_ID, trimLeadingZeros(BYTES.toArrayUnsafe()), timestamp.get()))
+                        ENTITY_ID, BYTES.trimLeadingZeros().toArrayUnsafe(), timestamp.get()))
                 .thenReturn(Optional.of(DATA));
         final var result = UInt256.fromBytes(mirrorEntityAccess.getStorage(ADDRESS, BYTES));
         assertThat(result).isEqualTo(UInt256.fromHexString(HEX));
@@ -280,28 +278,5 @@ class MirrorEntityAccessTest {
         when(contractRepository.findRuntimeBytecode(ENTITY_ID)).thenReturn(Optional.empty());
         final var result = mirrorEntityAccess.fetchCodeIfPresent(ADDRESS);
         assertThat(result).isNull();
-    }
-
-    @Test
-    void testTrimLeadingZeros() {
-        // Test case 1: Array with leading zeros
-        byte[] inputArray1 = {0, 0, 0, 1, 2, 3};
-        byte[] expectedArray1 = {1, 2, 3};
-        assertArrayEquals(expectedArray1, trimLeadingZeros(inputArray1));
-
-        // Test case 2: Array with no leading zeros
-        byte[] inputArray2 = {1, 2, 3};
-        byte[] expectedArray2 = {1, 2, 3};
-        assertArrayEquals(expectedArray2, trimLeadingZeros(inputArray2));
-
-        // Test case 3: Array with all zeros
-        byte[] inputArray3 = {0, 0, 0, 0};
-        byte[] expectedArray3 = {};
-        assertArrayEquals(expectedArray3, trimLeadingZeros(inputArray3));
-
-        // Test case 4: Empty array
-        byte[] inputArray4 = {};
-        byte[] expectedArray4 = {};
-        assertArrayEquals(expectedArray4, trimLeadingZeros(inputArray4));
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccessTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccessTest.java
@@ -236,7 +236,7 @@ class MirrorEntityAccessTest {
     void getStorageHistorical() {
         when(store.getHistoricalTimestamp()).thenReturn(timestamp);
         when(contractStateRepository.findStorageByBlockTimestamp(
-                        ENTITY_ID, BYTES.trimLeadingZeros().toArrayUnsafe(), timestamp.get()))
+                        ENTITY_ID, new byte[] {(byte) 0x04, (byte) 0xE4}, timestamp.get()))
                 .thenReturn(Optional.of(DATA));
         final var result = UInt256.fromBytes(mirrorEntityAccess.getStorage(ADDRESS, BYTES));
         assertThat(result).isEqualTo(UInt256.fromHexString(HEX));

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccessTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccessTest.java
@@ -18,8 +18,10 @@ package com.hedera.mirror.web3.evm.store.contract;
 
 import static com.google.protobuf.ByteString.EMPTY;
 import static com.hedera.mirror.common.domain.entity.AbstractEntity.DEFAULT_EXPIRY_TIMESTAMP;
+import static com.hedera.mirror.web3.evm.store.contract.MirrorEntityAccess.trimLeadingZeros;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.hyperledger.besu.datatypes.Address.ZERO;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.mockito.Mockito.when;
 
 import com.google.protobuf.ByteString;
@@ -225,8 +227,18 @@ class MirrorEntityAccessTest {
 
     @Test
     void getStorage() {
+        when(store.getHistoricalTimestamp()).thenReturn(Optional.empty());
+        when(contractStateRepository.findStorage(ENTITY_ID, BYTES.toArrayUnsafe()))
+                .thenReturn(Optional.of(DATA));
+        final var result = UInt256.fromBytes(mirrorEntityAccess.getStorage(ADDRESS, BYTES));
+        assertThat(result).isEqualTo(UInt256.fromHexString(HEX));
+    }
+
+    @Test
+    void getStorageHistorical() {
         when(store.getHistoricalTimestamp()).thenReturn(timestamp);
-        when(contractStateRepository.findStorageByBlockTimestamp(ENTITY_ID, BYTES.toArrayUnsafe(), timestamp.get()))
+        when(contractStateRepository.findStorageByBlockTimestamp(
+                        ENTITY_ID, trimLeadingZeros(BYTES.toArrayUnsafe()), timestamp.get()))
                 .thenReturn(Optional.of(DATA));
         final var result = UInt256.fromBytes(mirrorEntityAccess.getStorage(ADDRESS, BYTES));
         assertThat(result).isEqualTo(UInt256.fromHexString(HEX));
@@ -268,5 +280,28 @@ class MirrorEntityAccessTest {
         when(contractRepository.findRuntimeBytecode(ENTITY_ID)).thenReturn(Optional.empty());
         final var result = mirrorEntityAccess.fetchCodeIfPresent(ADDRESS);
         assertThat(result).isNull();
+    }
+
+    @Test
+    void testTrimLeadingZeros() {
+        // Test case 1: Array with leading zeros
+        byte[] inputArray1 = {0, 0, 0, 1, 2, 3};
+        byte[] expectedArray1 = {1, 2, 3};
+        assertArrayEquals(expectedArray1, trimLeadingZeros(inputArray1));
+
+        // Test case 2: Array with no leading zeros
+        byte[] inputArray2 = {1, 2, 3};
+        byte[] expectedArray2 = {1, 2, 3};
+        assertArrayEquals(expectedArray2, trimLeadingZeros(inputArray2));
+
+        // Test case 3: Array with all zeros
+        byte[] inputArray3 = {0, 0, 0, 0};
+        byte[] expectedArray3 = {};
+        assertArrayEquals(expectedArray3, trimLeadingZeros(inputArray3));
+
+        // Test case 4: Empty array
+        byte[] inputArray4 = {};
+        byte[] expectedArray4 = {};
+        assertArrayEquals(expectedArray4, trimLeadingZeros(inputArray4));
     }
 }


### PR DESCRIPTION
**Description**:

After conducting both manual and integration testing, it was determined that the `contract_state_change table` is capable of storing values for the slot column ranging from 0 bytes to 32 bytes. This is in contrast to the `contract_state` table, where the slot is consistently represented as a 32-byte array.

`contract_state_change`:  

![image](https://github.com/hashgraph/hedera-mirror-node/assets/56980328/fd135078-25a5-4674-90e8-d79b039ac64e)

`contract_state`:  

![image](https://github.com/hashgraph/hedera-mirror-node/assets/56980328/0c1e883b-fe03-4b3b-bc01-4a59f4a71d97)



Solution:
Trim the leading zeros from the key if we are doing historical call.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
