### PR TITLE
HIP-584 Historical: Fix historical crypto balance

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/accessor/AccountDatabaseAccessor.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/accessor/AccountDatabaseAccessor.java
@@ -121,7 +121,8 @@ public class AccountDatabaseAccessor extends DatabaseAccessor<Object, Account> {
 
     private Long getAccountBalance(Entity entity, final Optional<Long> timestamp) {
         return timestamp
-                .map(t -> accountBalanceRepository.findHistoricalAccountBalanceUpToTimestamp(entity.getId(), t))
+                .map(t -> accountBalanceRepository.findHistoricalAccountBalanceUpToTimestamp(
+                        entity.getId(), t, entity.getCreatedTimestamp()))
                 .orElseGet(() -> Optional.ofNullable(entity.getBalance()))
                 .orElse(0L);
     }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/AccountBalanceRepository.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/AccountBalanceRepository.java
@@ -54,7 +54,6 @@ public interface AccountBalanceRepository extends CrudRepository<AccountBalance,
      *
      * @param accountId       the ID of the account.
      * @param blockTimestamp  the block timestamp used to filter the results.
-     * @param accountCreatedTimestamp the block timestamp when the account is created
      * @return an Optional containing the historical balance at the specified timestamp.
      *         If there are no crypto transfers between the consensus_timestamp of account_balance and the block timestamp,
      *         the method will return the balance present at consensus_timestamp.
@@ -62,27 +61,32 @@ public interface AccountBalanceRepository extends CrudRepository<AccountBalance,
     @Query(
             value =
                     """
-                    with balance_snapshot as (
-                        select balance, consensus_timestamp
-                        from account_balance
-                            where
-                            account_id = ?1 and
-                            consensus_timestamp <= ?2
-                            order by consensus_timestamp desc
-                        limit 1
-                    ),
-                    change as (
-                        select sum(amount) as amount
-                        from crypto_transfer as ct
-                            where
-                            ct.entity_id = ?1 and
-                            ct.consensus_timestamp >= coalesce((select consensus_timestamp from balance_snapshot), ?3) and
-                            ct.consensus_timestamp <= ?2 and
-                            (ct.errata is null or ct.errata <> 'DELETE')
-                    )
-                    select coalesce((select balance from balance_snapshot), 0) + coalesce((select amount from change), 0)
-                    """,
+                with balance_timestamp as (
+                    select consensus_timestamp
+                    from account_balance
+                    where account_id = 2 and
+                        consensus_timestamp > ?2 - 2678400000000000 and
+                        consensus_timestamp <= ?2
+                    order by consensus_timestamp desc
+                    limit 1
+                ), balance_snapshot as (
+                    select balance
+                    from account_balance as ab, balance_timestamp as bt
+                    where account_id = ?1 and
+                        ab.consensus_timestamp > bt.consensus_timestamp - 2678400000000000 and
+                        ab.consensus_timestamp <= bt.consensus_timestamp
+                    order by ab.consensus_timestamp desc
+                    limit 1
+                ), change as (
+                    select sum(amount) as amount
+                    from crypto_transfer as ct, balance_timestamp as bt
+                    where ct.entity_id = ?1 and
+                        ct.consensus_timestamp > bt.consensus_timestamp and
+                        ct.consensus_timestamp <= ?2 and
+                        (ct.errata is null or ct.errata <> 'DELETE')
+                )
+                select coalesce((select balance from balance_snapshot), 0) + coalesce((select amount from change), 0)
+                """,
             nativeQuery = true)
-    Optional<Long> findHistoricalAccountBalanceUpToTimestamp(
-            long accountId, long blockTimestamp, long accountCreatedTimestamp);
+    Optional<Long> findHistoricalAccountBalanceUpToTimestamp(long accountId, long blockTimestamp);
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/StoreImplTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/StoreImplTest.java
@@ -39,6 +39,7 @@ import com.hedera.mirror.web3.evm.store.accessor.TokenDatabaseAccessor;
 import com.hedera.mirror.web3.evm.store.accessor.TokenRelationshipDatabaseAccessor;
 import com.hedera.mirror.web3.evm.store.accessor.UniqueTokenDatabaseAccessor;
 import com.hedera.mirror.web3.evm.store.accessor.model.TokenRelationshipKey;
+import com.hedera.mirror.web3.repository.AccountBalanceRepository;
 import com.hedera.mirror.web3.repository.CryptoAllowanceRepository;
 import com.hedera.mirror.web3.repository.EntityRepository;
 import com.hedera.mirror.web3.repository.NftAllowanceRepository;
@@ -130,6 +131,9 @@ class StoreImplTest {
     private CryptoAllowanceRepository cryptoAllowanceRepository;
 
     @Mock
+    private AccountBalanceRepository accountBalanceRepository;
+
+    @Mock
     private Entity tokenModel;
 
     @Mock
@@ -154,7 +158,8 @@ class StoreImplTest {
                 nftRepository,
                 tokenAllowanceRepository,
                 cryptoAllowanceRepository,
-                tokenAccountRepository);
+                tokenAccountRepository,
+                accountBalanceRepository);
         final var tokenDatabaseAccessor = new TokenDatabaseAccessor(
                 tokenRepository, entityDatabaseAccessor, entityRepository, customFeeDatabaseAccessor);
         final var tokenRelationshipDatabaseAccessor = new TokenRelationshipDatabaseAccessor(

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/accessor/AccountDatabaseAccessorTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/accessor/AccountDatabaseAccessorTest.java
@@ -124,6 +124,7 @@ class AccountDatabaseAccessorTest {
         final var entityNum = entityIdNumFromEvmAddress(ADDRESS);
         entity = new Entity();
         entity.setId(entityNum);
+        entity.setCreatedTimestamp(timestamp.get());
         entity.setShard(SHARD);
         entity.setRealm(REALM);
         entity.setNum(entityNum);
@@ -214,7 +215,8 @@ class AccountDatabaseAccessorTest {
     void accountBalanceMatchesValueFromRepositoryHistorical() {
         when(entityDatabaseAccessor.get(ADDRESS, timestamp)).thenReturn(Optional.ofNullable(entity));
         long balance = 20;
-        when(accountBalanceRepository.findHistoricalAccountBalanceUpToTimestamp(entity.getId(), timestamp.get()))
+        when(accountBalanceRepository.findHistoricalAccountBalanceUpToTimestamp(
+                        entity.getId(), timestamp.get(), entity.getCreatedTimestamp()))
                 .thenReturn(Optional.of(balance));
 
         assertThat(accountAccessor.get(ADDRESS, timestamp))

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/accessor/AccountDatabaseAccessorTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/accessor/AccountDatabaseAccessorTest.java
@@ -234,9 +234,22 @@ class AccountDatabaseAccessorTest {
 
     @Test
     void accountBalanceIsZeroHistorical() {
+        entity.setCreatedTimestamp(timestamp.get() - 1);
         when(entityDatabaseAccessor.get(ADDRESS, timestamp)).thenReturn(Optional.ofNullable(entity));
         long balance = 0;
-        entity.setCreatedTimestamp(timestamp.get() + 1);
+        when(accountBalanceRepository.findHistoricalAccountBalanceUpToTimestamp(entity.getId(), timestamp.get()))
+                .thenReturn(Optional.of(balance));
+        assertThat(accountAccessor.get(ADDRESS, timestamp))
+                .hasValueSatisfying(account -> assertThat(account).returns(balance, Account::getBalance));
+    }
+
+    @Test
+    void accountBalanceWhenCreatedTimestampIsNull() {
+        when(entityDatabaseAccessor.get(ADDRESS, timestamp)).thenReturn(Optional.ofNullable(entity));
+        long balance = 20;
+        entity.setCreatedTimestamp(null);
+        when(accountBalanceRepository.findHistoricalAccountBalanceUpToTimestamp(entity.getId(), timestamp.get()))
+                .thenReturn(Optional.of(balance));
         assertThat(accountAccessor.get(ADDRESS, timestamp))
                 .hasValueSatisfying(account -> assertThat(account).returns(balance, Account::getBalance));
     }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/accessor/AccountDatabaseAccessorTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/accessor/AccountDatabaseAccessorTest.java
@@ -29,6 +29,7 @@ import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.entity.EntityType;
 import com.hedera.mirror.common.domain.entity.NftAllowance;
 import com.hedera.mirror.common.domain.entity.TokenAllowance;
+import com.hedera.mirror.web3.repository.AccountBalanceRepository;
 import com.hedera.mirror.web3.repository.CryptoAllowanceRepository;
 import com.hedera.mirror.web3.repository.NftAllowanceRepository;
 import com.hedera.mirror.web3.repository.NftRepository;
@@ -111,6 +112,9 @@ class AccountDatabaseAccessorTest {
 
     @Mock
     private CryptoAllowanceRepository cryptoAllowanceRepository;
+
+    @Mock
+    private AccountBalanceRepository accountBalanceRepository;
 
     @Mock
     private TokenAccountRepository tokenAccountRepository;
@@ -204,6 +208,17 @@ class AccountDatabaseAccessorTest {
 
         assertThat(accountAccessor.get(ADDRESS, timestamp))
                 .hasValueSatisfying(account -> assertThat(account).returns(ownedNfts, Account::getOwnedNfts));
+    }
+
+    @Test
+    void accountBalanceMatchesValueFromRepositoryHistorical() {
+        when(entityDatabaseAccessor.get(ADDRESS, timestamp)).thenReturn(Optional.ofNullable(entity));
+        long balance = 20;
+        when(accountBalanceRepository.findHistoricalAccountBalanceUpToTimestamp(entity.getId(), timestamp.get()))
+                .thenReturn(Optional.of(balance));
+
+        assertThat(accountAccessor.get(ADDRESS, timestamp))
+                .hasValueSatisfying(account -> assertThat(account).returns(balance, Account::getBalance));
     }
 
     @Test

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/accessor/AccountDatabaseAccessorTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/accessor/AccountDatabaseAccessorTest.java
@@ -215,10 +215,18 @@ class AccountDatabaseAccessorTest {
     void accountBalanceMatchesValueFromRepositoryHistorical() {
         when(entityDatabaseAccessor.get(ADDRESS, timestamp)).thenReturn(Optional.ofNullable(entity));
         long balance = 20;
-        when(accountBalanceRepository.findHistoricalAccountBalanceUpToTimestamp(
-                        entity.getId(), timestamp.get(), entity.getCreatedTimestamp()))
+        when(accountBalanceRepository.findHistoricalAccountBalanceUpToTimestamp(entity.getId(), timestamp.get()))
                 .thenReturn(Optional.of(balance));
 
+        assertThat(accountAccessor.get(ADDRESS, timestamp))
+                .hasValueSatisfying(account -> assertThat(account).returns(balance, Account::getBalance));
+    }
+
+    @Test
+    void accountBalanceIsZeroHistorical() {
+        when(entityDatabaseAccessor.get(ADDRESS, timestamp)).thenReturn(Optional.ofNullable(entity));
+        long balance = 0;
+        entity.setCreatedTimestamp(timestamp.get() + 1);
         assertThat(accountAccessor.get(ADDRESS, timestamp))
                 .hasValueSatisfying(account -> assertThat(account).returns(balance, Account::getBalance));
     }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/accessor/AccountDatabaseAccessorTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/accessor/AccountDatabaseAccessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -217,6 +217,16 @@ class AccountDatabaseAccessorTest {
         long balance = 20;
         when(accountBalanceRepository.findHistoricalAccountBalanceUpToTimestamp(entity.getId(), timestamp.get()))
                 .thenReturn(Optional.of(balance));
+
+        assertThat(accountAccessor.get(ADDRESS, timestamp))
+                .hasValueSatisfying(account -> assertThat(account).returns(balance, Account::getBalance));
+    }
+
+    @Test
+    void accountBalanceBeforeAccountCreation() {
+        entity.setCreatedTimestamp(timestamp.get() + 1);
+        when(entityDatabaseAccessor.get(ADDRESS, timestamp)).thenReturn(Optional.ofNullable(entity));
+        long balance = 0;
 
         assertThat(accountAccessor.get(ADDRESS, timestamp))
                 .hasValueSatisfying(account -> assertThat(account).returns(balance, Account::getBalance));

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/HederaEvmStackedWorldStateUpdaterTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/HederaEvmStackedWorldStateUpdaterTest.java
@@ -97,7 +97,7 @@ class HederaEvmStackedWorldStateUpdaterTest {
         final var entityDatabaseAccessor = new EntityDatabaseAccessor(entityRepository);
         final List<DatabaseAccessor<Object, ?>> accessors = List.of(
                 entityDatabaseAccessor,
-                new AccountDatabaseAccessor(entityDatabaseAccessor, null, null, null, null, null));
+                new AccountDatabaseAccessor(entityDatabaseAccessor, null, null, null, null, null, null));
         final var stackedStateFrames = new StackedStateFrames(accessors);
         store = new StoreImpl(stackedStateFrames);
         subject = new HederaEvmStackedWorldStateUpdater(

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/HederaEvmWorldStateTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/HederaEvmWorldStateTest.java
@@ -109,7 +109,7 @@ class HederaEvmWorldStateTest {
     @BeforeEach
     void setUp() {
         final var accountDatabaseAccessor =
-                new AccountDatabaseAccessor(entityDatabaseAccessor, null, null, null, null, null);
+                new AccountDatabaseAccessor(entityDatabaseAccessor, null, null, null, null, null, null);
         final var tokenDatabaseAccessor = new TokenDatabaseAccessor(
                 tokenRepository, entityDatabaseAccessor, entityRepository, customFeeDatabaseAccessor);
         final var tokenRelationshipDatabaseAccessor = new TokenRelationshipDatabaseAccessor(

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/token/TokenAccessorImplTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/token/TokenAccessorImplTest.java
@@ -52,6 +52,7 @@ import com.hedera.mirror.web3.evm.store.accessor.EntityDatabaseAccessor;
 import com.hedera.mirror.web3.evm.store.accessor.TokenDatabaseAccessor;
 import com.hedera.mirror.web3.evm.store.accessor.TokenRelationshipDatabaseAccessor;
 import com.hedera.mirror.web3.evm.store.accessor.UniqueTokenDatabaseAccessor;
+import com.hedera.mirror.web3.repository.AccountBalanceRepository;
 import com.hedera.mirror.web3.repository.CryptoAllowanceRepository;
 import com.hedera.mirror.web3.repository.CustomFeeRepository;
 import com.hedera.mirror.web3.repository.EntityRepository;
@@ -113,6 +114,9 @@ class TokenAccessorImplTest {
     private NftAllowanceRepository nftAllowanceRepository;
 
     @Mock
+    private AccountBalanceRepository accountBalanceRepository;
+
+    @Mock
     private MirrorEvmContractAliases mirrorEvmContractAliases;
 
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
@@ -139,7 +143,8 @@ class TokenAccessorImplTest {
                 nftRepository,
                 tokenAllowanceRepository,
                 cryptoAllowanceRepository,
-                tokenAccountRepository);
+                tokenAccountRepository,
+                accountBalanceRepository);
         accessors = List.of(
                 entityAccessor,
                 customFeeAccessor,

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/AccountBalanceRepositoryTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/AccountBalanceRepositoryTest.java
@@ -69,7 +69,7 @@ class AccountBalanceRepositoryTest extends Web3IntegrationTest {
         persistCryptoTransfersBefore(3, consensusTimestamp, accountBalance1);
 
         assertThat(accountBalanceRepository.findHistoricalAccountBalanceUpToTimestamp(
-                        accountBalance1.getId().getAccountId().getId(), consensusTimestamp + 10L, 0L))
+                        accountBalance1.getId().getAccountId().getId(), consensusTimestamp + 10L))
                 .get()
                 .isEqualTo(accountBalance1.getBalance());
     }
@@ -85,7 +85,7 @@ class AccountBalanceRepositoryTest extends Web3IntegrationTest {
         historicalAccountBalance += TRANSFER_AMOUNT * 3;
 
         assertThat(accountBalanceRepository.findHistoricalAccountBalanceUpToTimestamp(
-                        accountBalance1.getId().getAccountId().getId(), consensusTimestamp + 10L, 0L))
+                        accountBalance1.getId().getAccountId().getId(), consensusTimestamp + 10L))
                 .get()
                 .isEqualTo(historicalAccountBalance);
     }
@@ -102,7 +102,7 @@ class AccountBalanceRepositoryTest extends Web3IntegrationTest {
         persistCryptoTransfers(3, consensusTimestamp + 10, accountBalance1);
 
         assertThat(accountBalanceRepository.findHistoricalAccountBalanceUpToTimestamp(
-                        accountBalance1.getId().getAccountId().getId(), consensusTimestamp + 10l, 0L))
+                        accountBalance1.getId().getAccountId().getId(), consensusTimestamp + 10l))
                 .get()
                 .isEqualTo(historicalAccountBalance);
     }
@@ -133,7 +133,7 @@ class AccountBalanceRepositoryTest extends Web3IntegrationTest {
                 .persist();
 
         assertThat(accountBalanceRepository.findHistoricalAccountBalanceUpToTimestamp(
-                        accountId, accountCreationTimestamp - 1, accountCreationTimestamp))
+                        accountId, accountCreationTimestamp - 1))
                 .get()
                 .isEqualTo(0L);
     }
@@ -165,7 +165,7 @@ class AccountBalanceRepositoryTest extends Web3IntegrationTest {
         long timestampBetweenTheTransfers = initialTransfer.getConsensusTimestamp() + 1L;
 
         assertThat(accountBalanceRepository.findHistoricalAccountBalanceUpToTimestamp(
-                        accountId, timestampBetweenTheTransfers, accountCreationTimestamp))
+                        accountId, timestampBetweenTheTransfers))
                 .get()
                 .isEqualTo(initialBalance);
 
@@ -178,7 +178,7 @@ class AccountBalanceRepositoryTest extends Web3IntegrationTest {
         long timestampBetweenSecondAndThirdTheTransfers = secondTransfer.getConsensusTimestamp() + 1L;
 
         assertThat(accountBalanceRepository.findHistoricalAccountBalanceUpToTimestamp(
-                        accountId, timestampBetweenSecondAndThirdTheTransfers, accountCreationTimestamp + 1))
+                        accountId, timestampBetweenSecondAndThirdTheTransfers))
                 .get()
                 .isEqualTo(TRANSFER_AMOUNT);
     }
@@ -211,7 +211,7 @@ class AccountBalanceRepositoryTest extends Web3IntegrationTest {
         long timestampBetweenTheTransfers = initialTransfer.getConsensusTimestamp() + 1L;
 
         assertThat(accountBalanceRepository.findHistoricalAccountBalanceUpToTimestamp(
-                        accountId, timestampBetweenTheTransfers, accountCreationTimestamp))
+                        accountId, timestampBetweenTheTransfers))
                 .get()
                 .isEqualTo(initialBalance);
 
@@ -224,7 +224,7 @@ class AccountBalanceRepositoryTest extends Web3IntegrationTest {
         long timestampBetweenSecondAndThirdTheTransfers = secondTransfer.getConsensusTimestamp() + 1L;
 
         assertThat(accountBalanceRepository.findHistoricalAccountBalanceUpToTimestamp(
-                        accountId, timestampBetweenSecondAndThirdTheTransfers, accountCreationTimestamp))
+                        accountId, timestampBetweenSecondAndThirdTheTransfers))
                 .get()
                 .isEqualTo(TRANSFER_AMOUNT + initialBalance);
     }

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/txns/crypto/AutoCreationLogicTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/txns/crypto/AutoCreationLogicTest.java
@@ -107,7 +107,7 @@ class AutoCreationLogicTest {
     @BeforeEach
     void setUp() {
         final List<DatabaseAccessor<Object, ?>> accessors =
-                List.of(new AccountDatabaseAccessor(entityDatabaseAccessor, null, null, null, null, null));
+                List.of(new AccountDatabaseAccessor(entityDatabaseAccessor, null, null, null, null, null, null));
         final var stackedStateFrames = new StackedStateFrames(accessors);
         store = new StoreImpl(stackedStateFrames);
         subject = new AutoCreationLogic(feeCalculator, evmProperties, syntheticTxnFactory, aliasManager);


### PR DESCRIPTION
**Description**:
This PR includes the following fixes:

- get historical entity balance from `AccountBalanceRepository`
- fix `findHistoricalAccountBalanceUpToTimestamp` in edge case where `balance_snapshot` query does not match anything in the db. Currently reproducible in acceptance tests:
1. create account with initial balance 50
2. make crypto transfer +50 
3. make historical call with timestamp before the crypto transfer, expected balance is 50, but returns 0

I have observed that the state in db after these operations is the following:
`account_balance` - no entry for this accountId
`crypto_transfers` - 2 entries for this accountId, one for initial balance (50) and one for the crypto transfer (50)

`balance_snapshot` matches nothing because there is no entry for this accountId in `account_balance` before the given timestamp.
This causes the statement `ct.consensus_timestamp > s.consensus_timestamp` to be false and cannot match any crypto transfers, always returning 0 due to the `coalesce` at the end of the query.
NB. `account_balance` entry  gets persisted ~8 minutes after the account creation

Current solution:
If `balance_snapshot` does not match anything, find crypto transfers that occured after the account creation and before the given timestamp:
```sql
ct.consensus_timestamp >= coalesce((select consensus_timestamp from balance_snapshot), accountCreatedTimestamp)
```
Changed `>` to `>=` in order to match the initial balance transfer (in this case 50) if there is one.

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
