### PR TITLE
HIP-584 Historical: Add integration tests for ERC and HTS precompiles - part 1

### DIFF
--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallEvmCodesTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallEvmCodesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallEvmCodesTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallEvmCodesTest.java
@@ -43,7 +43,7 @@ class ContractCallEvmCodesTest extends ContractCallTestSetup {
         final var serviceParameters = serviceParametersForEvmCodes(functionHash);
 
         assertThat(contractCallService.processCall(serviceParameters))
-                .isEqualTo(properties.chainIdBytes32().toHexString());
+                .isEqualTo(mirrorNodeEvmProperties.chainIdBytes32().toHexString());
     }
 
     @Test

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceERCTokenTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceERCTokenTest.java
@@ -86,7 +86,7 @@ class ContractCallServiceERCTokenTest extends ContractCallTestSetup {
                 ercFunction.name, ERC_ABI_PATH, ercFunction.expectedResultFields);
         final var emptyResponse = Bytes.EMPTY.toHexString();
 
-        // Before EVM_V_34_BLOCK the data did not exist.
+        // Before the block the data did not exist yet
         if (blockNumber.number() < PERSISTENCE_HISTORICAL_BLOCK) {
             assertThat(contractCallService.processCall(serviceParameters)).isEqualTo(emptyResponse);
         } else {

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceERCTokenTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceERCTokenTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ class ContractCallServiceERCTokenTest extends ContractCallTestSetup {
     }
 
     private static Stream<Arguments> ercContractFunctionArgumentsProviderHistoricalReadOnly() {
-        List<BlockType> blockNumbers = List.of(BlockType.of(String.valueOf(EVM_V_34_BLOCK)));
+        List<BlockType> blockNumbers = List.of(BlockType.of(String.valueOf(PERSISTENCE_HISTORICAL_BLOCK)));
 
         return Arrays.stream(ErcContractReadOnlyFunctionsHistorical.values())
                 .flatMap(ercFunction -> Stream.concat(
@@ -87,7 +87,7 @@ class ContractCallServiceERCTokenTest extends ContractCallTestSetup {
         final var emptyResponse = Bytes.EMPTY.toHexString();
 
         // Before EVM_V_34_BLOCK the data did not exist.
-        if (blockNumber.number() < EVM_V_34_BLOCK) {
+        if (blockNumber.number() < PERSISTENCE_HISTORICAL_BLOCK) {
             assertThat(contractCallService.processCall(serviceParameters)).isEqualTo(emptyResponse);
         } else {
             assertThat(contractCallService.processCall(serviceParameters)).isEqualTo(successfulResponse);
@@ -114,7 +114,7 @@ class ContractCallServiceERCTokenTest extends ContractCallTestSetup {
             assertThatThrownBy(() -> contractCallService.processCall(serviceParameters))
                     .isInstanceOf(BlockNumberOutOfRangeException.class);
         } else if (blockNumber == 51) {
-            // Block number 51 = (EVM_V_34_BLOCK + 1) does not exist in the DB but it before the latest
+            // Block number 51 = (EVM_V_34_BLOCK + 1) does not exist in the DB but is before the latest
             // block available in the DB => returning empty response
             assertThat(contractCallService.processCall(serviceParameters)).isEqualTo(emptyResponse);
         }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceERCTokenTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceERCTokenTest.java
@@ -44,7 +44,7 @@ class ContractCallServiceERCTokenTest extends ContractCallTestSetup {
     }
 
     private static Stream<Arguments> ercContractFunctionArgumentsProviderHistoricalReadOnly() {
-        List<BlockType> blockNumbers = List.of(BlockType.of(String.valueOf(PERSISTENCE_HISTORICAL_BLOCK)));
+        List<BlockType> blockNumbers = List.of(BlockType.of(String.valueOf(EVM_V_34_BLOCK)));
 
         return Arrays.stream(ErcContractReadOnlyFunctionsHistorical.values())
                 .flatMap(ercFunction -> Stream.concat(
@@ -87,7 +87,7 @@ class ContractCallServiceERCTokenTest extends ContractCallTestSetup {
         final var emptyResponse = Bytes.EMPTY.toHexString();
 
         // Before the block the data did not exist yet
-        if (blockNumber.number() < PERSISTENCE_HISTORICAL_BLOCK) {
+        if (blockNumber.number() < EVM_V_34_BLOCK) {
             assertThat(contractCallService.processCall(serviceParameters)).isEqualTo(emptyResponse);
         } else {
             assertThat(contractCallService.processCall(serviceParameters)).isEqualTo(successfulResponse);

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceERCTokenTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceERCTokenTest.java
@@ -19,23 +19,37 @@ package com.hedera.mirror.web3.service;
 import static com.hedera.mirror.web3.service.model.CallServiceParameters.CallType.ETH_CALL;
 import static com.hedera.mirror.web3.service.model.CallServiceParameters.CallType.ETH_ESTIMATE_GAS;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
+import com.hedera.mirror.web3.exception.BlockNumberOutOfRangeException;
 import com.hedera.mirror.web3.viewmodel.BlockType;
 import java.util.Arrays;
+import java.util.List;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
+import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class ContractCallServiceERCTokenTest extends ContractCallTestSetup {
 
     private static Stream<Arguments> ercContractFunctionArgumentsProvider() {
         return Arrays.stream(ErcContractReadOnlyFunctions.values())
                 .flatMap(ercFunction -> Stream.of(Arguments.of(ercFunction, true), Arguments.of(ercFunction, false)));
+    }
+
+    private static Stream<Arguments> ercContractFunctionArgumentsProviderHistoricalReadOnly() {
+        List<BlockType> blockNumbers = List.of(BlockType.of(String.valueOf(EVM_V_34_BLOCK)));
+
+        return Arrays.stream(ErcContractReadOnlyFunctionsHistorical.values())
+                .flatMap(ercFunction -> Stream.concat(
+                        blockNumbers.stream().map(blockNumber -> Arguments.of(ercFunction, true, blockNumber)),
+                        blockNumbers.stream().map(blockNumber -> Arguments.of(ercFunction, false, blockNumber))));
     }
 
     public static final String REDIRECT_SUFFIX = "Redirect";
@@ -54,6 +68,56 @@ class ContractCallServiceERCTokenTest extends ContractCallTestSetup {
                 ercFunction.name, ERC_ABI_PATH, ercFunction.expectedResultFields);
 
         assertThat(contractCallService.processCall(serviceParameters)).isEqualTo(successfulResponse);
+    }
+
+    @ParameterizedTest
+    @MethodSource("ercContractFunctionArgumentsProviderHistoricalReadOnly")
+    void ercReadOnlyPrecompileHistoricalOperationsTest(
+            final ErcContractReadOnlyFunctionsHistorical ercFunction,
+            final boolean isStatic,
+            final BlockType blockNumber) {
+        final var functionName = ercFunction.getName(isStatic);
+        final var functionHash =
+                functionEncodeDecoder.functionHashFor(functionName, ERC_ABI_PATH, ercFunction.functionParameters);
+        final var serviceParameters =
+                serviceParametersForExecution(functionHash, ERC_CONTRACT_ADDRESS, ETH_CALL, 0L, blockNumber);
+
+        final var successfulResponse = functionEncodeDecoder.encodedResultFor(
+                ercFunction.name, ERC_ABI_PATH, ercFunction.expectedResultFields);
+        final var emptyResponse = Bytes.EMPTY.toHexString();
+
+        // Before EVM_V_34_BLOCK the data did not exist.
+        if (blockNumber.number() < EVM_V_34_BLOCK) {
+            assertThat(contractCallService.processCall(serviceParameters)).isEqualTo(emptyResponse);
+        } else {
+            assertThat(contractCallService.processCall(serviceParameters)).isEqualTo(successfulResponse);
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = {51, Long.MAX_VALUE - 1})
+    void ercReadOnlyPrecompileHistoricalNotExistingBlockTest(final long blockNumber) {
+        final var functionHash = functionEncodeDecoder.functionHashFor(
+                "isApprovedForAll",
+                ERC_ABI_PATH,
+                NFT_ADDRESS_HISTORICAL,
+                SENDER_ADDRESS_HISTORICAL,
+                SPENDER_ADDRESS_HISTORICAL);
+        final var serviceParameters = serviceParametersForExecution(
+                functionHash, ERC_CONTRACT_ADDRESS, ETH_CALL, 0L, BlockType.of(String.valueOf(blockNumber)));
+        final var latestBlockNumber = recordFileRepository.findLatestIndex().orElse(Long.MAX_VALUE);
+        final var emptyResponse = Bytes.EMPTY.toHexString();
+
+        // Block number (Long.MAX_VALUE - 1) does not exist in the DB and is after the
+        // latest block available in the DB => returning error
+        if (blockNumber > latestBlockNumber) {
+            assertThatThrownBy(() -> contractCallService.processCall(serviceParameters))
+                    .isInstanceOf(BlockNumberOutOfRangeException.class);
+        } else if (blockNumber == 51) {
+            // Block number 51 = (EVM_V_34_BLOCK + 1) does not exist in the DB but it before the latest
+            // block available in the DB => returning empty response
+            assertThat(contractCallService.processCall(serviceParameters)).isEqualTo(emptyResponse);
+        }
     }
 
     @ParameterizedTest
@@ -161,6 +225,53 @@ class ContractCallServiceERCTokenTest extends ContractCallTestSetup {
     }
 
     @RequiredArgsConstructor
+    public enum ErcContractReadOnlyFunctionsHistorical {
+        GET_APPROVED_EMPTY_SPENDER(
+                "getApproved", new Object[] {NFT_ADDRESS_HISTORICAL, 2L}, new Address[] {Address.ZERO}),
+        IS_APPROVE_FOR_ALL(
+                "isApprovedForAll",
+                new Address[] {NFT_ADDRESS_HISTORICAL, SENDER_ADDRESS_HISTORICAL, SPENDER_ADDRESS_HISTORICAL},
+                new Boolean[] {true}),
+        IS_APPROVE_FOR_ALL_WITH_ALIAS(
+                "isApprovedForAll",
+                new Address[] {NFT_ADDRESS_HISTORICAL, SENDER_ALIAS_HISTORICAL, SPENDER_ALIAS_HISTORICAL},
+                new Boolean[] {true}),
+        ALLOWANCE_OF(
+                "allowance",
+                new Address[] {FUNGIBLE_TOKEN_ADDRESS_HISTORICAL, SENDER_ADDRESS_HISTORICAL, SPENDER_ADDRESS_HISTORICAL
+                },
+                new Long[] {13L}),
+        ALLOWANCE_OF_WITH_ALIAS(
+                "allowance",
+                new Address[] {FUNGIBLE_TOKEN_ADDRESS_HISTORICAL, SENDER_ALIAS_HISTORICAL, SPENDER_ALIAS_HISTORICAL},
+                new Long[] {13L}),
+        GET_APPROVED(
+                "getApproved", new Object[] {NFT_ADDRESS_HISTORICAL, 1L}, new Address[] {SPENDER_ALIAS_HISTORICAL}),
+        ERC_DECIMALS("decimals", new Address[] {FUNGIBLE_TOKEN_ADDRESS_HISTORICAL}, new Integer[] {12}),
+        TOTAL_SUPPLY("totalSupply", new Address[] {FUNGIBLE_TOKEN_ADDRESS_HISTORICAL}, new Long[] {12345L}),
+        ERC_SYMBOL("symbol", new Address[] {FUNGIBLE_TOKEN_ADDRESS_HISTORICAL}, new String[] {"HBAR"}),
+        BALANCE_OF(
+                "balanceOf",
+                new Address[] {FUNGIBLE_TOKEN_ADDRESS_HISTORICAL, SENDER_ADDRESS_HISTORICAL},
+                new Long[] {12L}),
+        BALANCE_OF_WITH_ALIAS(
+                "balanceOf", new Address[] {FUNGIBLE_TOKEN_ADDRESS_HISTORICAL, SENDER_ALIAS_HISTORICAL}, new Long[] {12L
+                }),
+        ERC_NAME("name", new Address[] {FUNGIBLE_TOKEN_ADDRESS_HISTORICAL}, new String[] {"Hbars"}),
+        OWNER_OF("getOwnerOf", new Object[] {NFT_ADDRESS_HISTORICAL, 1L}, new Address[] {OWNER_ADDRESS_HISTORICAL}),
+        EMPTY_OWNER_OF("getOwnerOf", new Object[] {NFT_ADDRESS_HISTORICAL, 2L}, new Address[] {Address.ZERO}),
+        TOKEN_URI("tokenURI", new Object[] {NFT_ADDRESS_HISTORICAL, 1L}, new String[] {"NFT_METADATA_URI"});
+
+        private final String name;
+        private final Object[] functionParameters;
+        private final Object[] expectedResultFields;
+
+        public String getName(final boolean isStatic) {
+            return isStatic ? name : name + NON_STATIC_SUFFIX;
+        }
+    }
+
+    @RequiredArgsConstructor
     public enum ErcContractModificationFunctions {
         APPROVE("approve", new Object[] {FUNGIBLE_TOKEN_ADDRESS, SPENDER_ALIAS, 2L}),
         DELETE_ALLOWANCE_NFT("approve", new Object[] {NFT_ADDRESS, Address.ZERO, 1L}),
@@ -174,6 +285,7 @@ class ContractCallServiceERCTokenTest extends ContractCallTestSetup {
                 "transferFrom", new Object[] {TREASURY_TOKEN_ADDRESS, SENDER_ALIAS, SPENDER_ALIAS, 2L}),
         TRANSFER_FROM_NFT_WITH_ALIAS(
                 "transferFromNFT", new Object[] {NFT_TRANSFER_ADDRESS, OWNER_ADDRESS, SPENDER_ALIAS, 1L});
+
         private final String name;
         private final Object[] functionParameters;
     }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileTest.java
@@ -48,7 +48,7 @@ class ContractCallServicePrecompileTest extends ContractCallTestSetup {
     private static final String ERROR_MESSAGE = "Precompile not supported for non-static frames";
 
     private static Stream<Arguments> htsContractFunctionArgumentsProviderHistoricalReadOnly() {
-        List<String> blockNumbers = List.of(String.valueOf(PERSISTENCE_HISTORICAL_BLOCK));
+        List<String> blockNumbers = List.of(String.valueOf(EVM_V_34_BLOCK));
 
         return Arrays.stream(ContractReadFunctionsHistorical.values()).flatMap(htsFunction -> blockNumbers.stream()
                 .map(blockNumber -> Arguments.of(htsFunction, blockNumber)));
@@ -106,7 +106,7 @@ class ContractCallServicePrecompileTest extends ContractCallTestSetup {
                 contractFunc.name, PRECOMPILE_TEST_CONTRACT_ABI_PATH, contractFunc.expectedResultFields);
         final var emptyResponse = Bytes.EMPTY.toHexString();
 
-        if (Long.parseLong(blockNumber) < PERSISTENCE_HISTORICAL_BLOCK) {
+        if (Long.parseLong(blockNumber) < EVM_V_34_BLOCK) {
             assertThat(contractCallService.processCall(serviceParameters)).isEqualTo(emptyResponse);
         } else {
             assertThat(contractCallService.processCall(serviceParameters)).isEqualTo(successfulResponse);

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ class ContractCallServicePrecompileTest extends ContractCallTestSetup {
     private static final String ERROR_MESSAGE = "Precompile not supported for non-static frames";
 
     private static Stream<Arguments> htsContractFunctionArgumentsProviderHistoricalReadOnly() {
-        List<String> blockNumbers = List.of(String.valueOf(EVM_V_34_BLOCK));
+        List<String> blockNumbers = List.of(String.valueOf(PERSISTENCE_HISTORICAL_BLOCK));
 
         return Arrays.stream(ContractReadFunctionsHistorical.values()).flatMap(htsFunction -> blockNumbers.stream()
                 .map(blockNumber -> Arguments.of(htsFunction, blockNumber)));
@@ -106,7 +106,7 @@ class ContractCallServicePrecompileTest extends ContractCallTestSetup {
                 contractFunc.name, PRECOMPILE_TEST_CONTRACT_ABI_PATH, contractFunc.expectedResultFields);
         final var emptyResponse = Bytes.EMPTY.toHexString();
 
-        if (Long.parseLong(blockNumber) < EVM_V_34_BLOCK) {
+        if (Long.parseLong(blockNumber) < PERSISTENCE_HISTORICAL_BLOCK) {
             assertThat(contractCallService.processCall(serviceParameters)).isEqualTo(emptyResponse);
         } else {
             assertThat(contractCallService.processCall(serviceParameters)).isEqualTo(successfulResponse);

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileTest.java
@@ -24,18 +24,35 @@ import static com.hederahashgraph.api.proto.java.CustomFee.FeeCase.ROYALTY_FEE;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
+import com.google.common.collect.Range;
 import com.google.protobuf.ByteString;
+import com.hedera.mirror.web3.exception.BlockNumberOutOfRangeException;
 import com.hedera.mirror.web3.exception.MirrorEvmTransactionException;
 import com.hedera.mirror.web3.viewmodel.BlockType;
 import com.hedera.node.app.service.evm.exceptions.InvalidTransactionException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
+import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.EnumSource.Mode;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class ContractCallServicePrecompileTest extends ContractCallTestSetup {
+    private static final String ERROR_MESSAGE = "Precompile not supported for non-static frames";
+
+    private static Stream<Arguments> htsContractFunctionArgumentsProviderHistoricalReadOnly() {
+        List<String> blockNumbers = List.of(String.valueOf(EVM_V_34_BLOCK));
+
+        return Arrays.stream(ContractReadFunctionsHistorical.values()).flatMap(htsFunction -> blockNumbers.stream()
+                .map(blockNumber -> Arguments.of(htsFunction, blockNumber)));
+    }
 
     @ParameterizedTest
     @EnumSource(ContractReadFunctions.class)
@@ -60,6 +77,73 @@ class ContractCallServicePrecompileTest extends ContractCallTestSetup {
     }
 
     @ParameterizedTest
+    @MethodSource("htsContractFunctionArgumentsProviderHistoricalReadOnly")
+    void evmPrecompileReadOnlyTokenFunctionsTestEthCallHistorical(
+            final ContractReadFunctionsHistorical contractFunc, final String blockNumber) {
+        final var functionHash = functionEncodeDecoder.functionHashFor(
+                contractFunc.name, PRECOMPILE_TEST_CONTRACT_ABI_PATH, contractFunc.functionParameters);
+        final var serviceParameters = serviceParametersForExecution(
+                functionHash, PRECOMPILE_TEST_CONTRACT_ADDRESS, ETH_CALL, 0L, BlockType.of(blockNumber));
+        switch (contractFunc) {
+            case GET_CUSTOM_FEES_FOR_TOKEN_WITH_FIXED_FEE -> customFeePersistHistorical(
+                    FIXED_FEE,
+                    Range.closedOpen(
+                            recordFileBeforeEvm34.getConsensusStart(), recordFileBeforeEvm34.getConsensusEnd()));
+            case GET_CUSTOM_FEES_FOR_TOKEN_WITH_FRACTIONAL_FEE,
+                    GET_INFORMATION_FOR_TOKEN_FUNGIBLE,
+                    GET_INFORMATION_FOR_TOKEN_NFT,
+                    GET_FUNGIBLE_TOKEN_INFO,
+                    GET_NFT_INFO -> customFeePersistHistorical(
+                    FRACTIONAL_FEE,
+                    Range.closedOpen(
+                            recordFileBeforeEvm34.getConsensusStart(), recordFileBeforeEvm34.getConsensusEnd()));
+            case GET_CUSTOM_FEES_FOR_TOKEN_WITH_ROYALTY_FEE -> customFeePersistHistorical(
+                    ROYALTY_FEE,
+                    Range.closedOpen(
+                            recordFileBeforeEvm34.getConsensusStart(), recordFileBeforeEvm34.getConsensusEnd()));
+        }
+        final var successfulResponse = functionEncodeDecoder.encodedResultFor(
+                contractFunc.name, PRECOMPILE_TEST_CONTRACT_ABI_PATH, contractFunc.expectedResultFields);
+        final var emptyResponse = Bytes.EMPTY.toHexString();
+
+        if (Long.parseLong(blockNumber) < EVM_V_34_BLOCK) {
+            assertThat(contractCallService.processCall(serviceParameters)).isEqualTo(emptyResponse);
+        } else {
+            assertThat(contractCallService.processCall(serviceParameters)).isEqualTo(successfulResponse);
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = {51, Long.MAX_VALUE - 1})
+    void evmPrecompileReadOnlyTokenFunctionsEthCallHistoricalNotExistingBlockTest(final long blockNumber) {
+        final var functionHash = functionEncodeDecoder.functionHashFor(
+                "isTokenFrozen",
+                PRECOMPILE_TEST_CONTRACT_ABI_PATH,
+                FUNGIBLE_TOKEN_ADDRESS_HISTORICAL,
+                SENDER_ADDRESS_HISTORICAL);
+        final var serviceParameters = serviceParametersForExecution(
+                functionHash,
+                PRECOMPILE_TEST_CONTRACT_ADDRESS,
+                ETH_CALL,
+                0L,
+                BlockType.of(String.valueOf(blockNumber)));
+
+        final var latestBlockNumber = recordFileRepository.findLatestIndex().orElse(Long.MAX_VALUE);
+        final var emptyResponse = Bytes.EMPTY.toHexString();
+
+        // Block number (Long.MAX_VALUE - 1) does not exist in the DB and is after the
+        // latest block available in the DB => returning error
+        if (blockNumber > latestBlockNumber) {
+            assertThatThrownBy(() -> contractCallService.processCall(serviceParameters))
+                    .isInstanceOf(BlockNumberOutOfRangeException.class);
+        } else if (blockNumber == 51) {
+            // Block number 51 = (EVM_V_34_BLOCK + 1) does not exist in the DB but it before the latest
+            // block available in the DB => returning empty response
+            assertThat(contractCallService.processCall(serviceParameters)).isEqualTo(emptyResponse);
+        }
+    }
+
+    @ParameterizedTest
     @EnumSource(ContractReadFunctions.class)
     void evmPrecompileReadOnlyTokenFunctionsTestEthEstimateGas(final ContractReadFunctions contractFunc) {
         final var functionHash = functionEncodeDecoder.functionHashFor(
@@ -76,7 +160,7 @@ class ContractCallServicePrecompileTest extends ContractCallTestSetup {
 
     @ParameterizedTest
     @EnumSource(SupportedContractModificationFunctions.class)
-    void evmPrecompileSupportedModificationTokenFunctionsTest(
+    void evmPrecompileSupportedModificationTokenFunctionsTestEstimateGas(
             final SupportedContractModificationFunctions contractFunc) {
         final var functionHash = functionEncodeDecoder.functionHashFor(
                 contractFunc.name, MODIFICATION_CONTRACT_ABI_PATH, contractFunc.functionParameters);
@@ -376,6 +460,236 @@ class ContractCallServicePrecompileTest extends ContractCallTestSetup {
             false,
             true,
             new Object[] {0L, 0L, 0L, 0L, false, SENDER_ALIAS},
+            "0x01"
+        });
+
+        private final String name;
+        private final Object[] functionParameters;
+        private final Object[] expectedResultFields;
+    }
+
+    @RequiredArgsConstructor
+    enum ContractReadFunctionsHistorical {
+        IS_FROZEN(
+                "isTokenFrozen",
+                new Address[] {FUNGIBLE_TOKEN_ADDRESS_HISTORICAL, SENDER_ADDRESS_HISTORICAL},
+                new Boolean[] {true}),
+        IS_FROZEN_WITH_ALIAS(
+                "isTokenFrozen",
+                new Address[] {FUNGIBLE_TOKEN_ADDRESS_HISTORICAL, SENDER_ALIAS_HISTORICAL},
+                new Boolean[] {true}),
+        IS_KYC(
+                "isKycGranted",
+                new Address[] {FUNGIBLE_TOKEN_ADDRESS_HISTORICAL, SENDER_ADDRESS_HISTORICAL},
+                new Boolean[] {true}),
+        IS_KYC_WITH_ALIAS(
+                "isKycGranted",
+                new Address[] {FUNGIBLE_TOKEN_ADDRESS_HISTORICAL, SENDER_ALIAS_HISTORICAL},
+                new Boolean[] {true}),
+        IS_KYC_FOR_NFT(
+                "isKycGranted", new Address[] {NFT_ADDRESS_HISTORICAL, SENDER_ADDRESS_HISTORICAL}, new Boolean[] {true
+                }),
+        IS_KYC_FOR_NFT_WITH_ALIAS(
+                "isKycGranted", new Address[] {NFT_ADDRESS_HISTORICAL, SENDER_ALIAS_HISTORICAL}, new Boolean[] {true}),
+        IS_TOKEN_PRECOMPILE("isTokenAddress", new Address[] {FUNGIBLE_TOKEN_ADDRESS_HISTORICAL}, new Boolean[] {true}),
+        IS_TOKEN_PRECOMPILE_NFT("isTokenAddress", new Address[] {NFT_ADDRESS_HISTORICAL}, new Boolean[] {true}),
+        GET_TOKEN_DEFAULT_KYC(
+                "getTokenDefaultKyc", new Address[] {FUNGIBLE_TOKEN_ADDRESS_HISTORICAL}, new Boolean[] {true}),
+        GET_TOKEN_DEFAULT_KYC_NFT("getTokenDefaultKyc", new Address[] {NFT_ADDRESS_HISTORICAL}, new Boolean[] {true}),
+        GET_TOKEN_TYPE("getType", new Address[] {FUNGIBLE_TOKEN_ADDRESS_HISTORICAL}, new Long[] {0L}),
+        GET_TOKEN_TYPE_FOR_NFT("getType", new Address[] {NFT_ADDRESS_HISTORICAL}, new Long[] {1L}),
+        GET_TOKEN_DEFAULT_FREEZE(
+                "getTokenDefaultFreeze", new Address[] {FUNGIBLE_TOKEN_ADDRESS_HISTORICAL}, new Boolean[] {true}),
+        GET_TOKEN_DEFAULT_FREEZE_FOR_NFT(
+                "getTokenDefaultFreeze", new Address[] {NFT_ADDRESS_HISTORICAL}, new Boolean[] {true}),
+        GET_TOKEN_ADMIN_KEY_WITH_CONTRACT_ADDRESS(
+                "getTokenKeyPublic",
+                new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_CONTRACT_ADDRESS_HISTORICAL, 1L},
+                new Object[] {false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
+        GET_TOKEN_FREEZE_KEY_WITH_CONTRACT_ADDRESS(
+                "getTokenKeyPublic",
+                new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_CONTRACT_ADDRESS_HISTORICAL, 4L},
+                new Object[] {false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
+        GET_TOKEN_WIPE_KEY_WITH_CONTRACT_ADDRESS(
+                "getTokenKeyPublic",
+                new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_CONTRACT_ADDRESS_HISTORICAL, 8L},
+                new Object[] {false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
+        GET_TOKEN_SUPPLY_KEY_WITH_CONTRACT_ADDRESS(
+                "getTokenKeyPublic",
+                new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_CONTRACT_ADDRESS_HISTORICAL, 16L},
+                new Object[] {false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
+        GET_TOKEN_ADMIN_KEY_WITH_ED25519_KEY(
+                "getTokenKeyPublic",
+                new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_ED25519_KEY_HISTORICAL, 1L},
+                new Object[] {false, Address.ZERO, ED25519_KEY, new byte[0], Address.ZERO}),
+        GET_TOKEN_FREEZE_KEY_WITH_ED25519_KEY(
+                "getTokenKeyPublic",
+                new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_ED25519_KEY_HISTORICAL, 4L},
+                new Object[] {false, Address.ZERO, ED25519_KEY, new byte[0], Address.ZERO}),
+        GET_TOKEN_WIPE_KEY_WITH_ED25519_KEY(
+                "getTokenKeyPublic",
+                new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_ED25519_KEY_HISTORICAL, 8L},
+                new Object[] {false, Address.ZERO, ED25519_KEY, new byte[0], Address.ZERO}),
+        GET_TOKEN_SUPPLY_KEY_WITH_ED25519_KEY(
+                "getTokenKeyPublic",
+                new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_ED25519_KEY_HISTORICAL, 16L},
+                new Object[] {false, Address.ZERO, ED25519_KEY, new byte[0], Address.ZERO}),
+        GET_TOKEN_ADMIN_KEY_WITH_ECDSA_KEY(
+                "getTokenKeyPublic",
+                new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_ECDSA_KEY_HISTORICAL, 1L},
+                new Object[] {false, Address.ZERO, new byte[0], ECDSA_KEY, Address.ZERO}),
+        GET_TOKEN_FREEZE_KEY_WITH_ECDSA_KEY(
+                "getTokenKeyPublic",
+                new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_ECDSA_KEY_HISTORICAL, 4L},
+                new Object[] {false, Address.ZERO, new byte[0], ECDSA_KEY, Address.ZERO}),
+        GET_TOKEN_WIPE_KEY_WITH_ECDSA_KEY(
+                "getTokenKeyPublic",
+                new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_ECDSA_KEY_HISTORICAL, 8L},
+                new Object[] {false, Address.ZERO, new byte[0], ECDSA_KEY, Address.ZERO}),
+        GET_TOKEN_SUPPLY_KEY_WITH_ECDSA_KEY(
+                "getTokenKeyPublic",
+                new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_ECDSA_KEY_HISTORICAL, 16L},
+                new Object[] {false, Address.ZERO, new byte[0], ECDSA_KEY, Address.ZERO}),
+        GET_TOKEN_ADMIN_KEY_WITH_DELEGATABLE_CONTRACT_ID(
+                "getTokenKeyPublic",
+                new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_DELEGATABLE_CONTRACT_ID_HISTORICAL, 1L},
+                new Object[] {false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
+        GET_TOKEN_FREEZE_KEY_WITH_DELEGATABLE_CONTRACT_ID(
+                "getTokenKeyPublic",
+                new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_DELEGATABLE_CONTRACT_ID_HISTORICAL, 4L},
+                new Object[] {false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
+        GET_TOKEN_WIPE_KEY_WITH_DELEGATABLE_CONTRACT_ID(
+                "getTokenKeyPublic",
+                new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_DELEGATABLE_CONTRACT_ID_HISTORICAL, 8L},
+                new Object[] {false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
+        GET_TOKEN_SUPPLY_KEY_WITH_DELEGATABLE_CONTRACT_ID(
+                "getTokenKeyPublic",
+                new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_DELEGATABLE_CONTRACT_ID_HISTORICAL, 16L},
+                new Object[] {false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
+        GET_TOKEN_KYC_KEY_FOR_NFT_WITH_CONTRACT_ADDRESS(
+                "getTokenKeyPublic",
+                new Object[] {NFT_ADDRESS_GET_KEY_WITH_CONTRACT_ADDRESS_HISTORICAL, 2L},
+                new Object[] {false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
+        GET_TOKEN_FEE_KEY_FOR_NFT_WITH_CONTRACT_ADDRESS(
+                "getTokenKeyPublic",
+                new Object[] {NFT_ADDRESS_GET_KEY_WITH_CONTRACT_ADDRESS_HISTORICAL, 32L},
+                new Object[] {false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
+        GET_TOKEN_PAUSE_KEY_FOR_NFT_WITH_CONTRACT_ADDRESS(
+                "getTokenKeyPublic",
+                new Object[] {NFT_ADDRESS_GET_KEY_WITH_CONTRACT_ADDRESS_HISTORICAL, 64L},
+                new Object[] {false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
+        GET_TOKEN_KYC_KEY_FOR_NFT_WITH_ED25519_KEY(
+                "getTokenKeyPublic",
+                new Object[] {NFT_ADDRESS_GET_KEY_WITH_ED25519_KEY_HISTORICAL, 2L},
+                new Object[] {false, Address.ZERO, ED25519_KEY, new byte[0], Address.ZERO}),
+        GET_TOKEN_FEE_KEY_FOR_NFT_WITH_ED25519_KEY(
+                "getTokenKeyPublic",
+                new Object[] {NFT_ADDRESS_GET_KEY_WITH_ED25519_KEY_HISTORICAL, 32L},
+                new Object[] {false, Address.ZERO, ED25519_KEY, new byte[0], Address.ZERO}),
+        GET_TOKEN_PAUSE_KEY_FOR_NFT_WITH_ED25519_KEY(
+                "getTokenKeyPublic",
+                new Object[] {NFT_ADDRESS_GET_KEY_WITH_ED25519_KEY_HISTORICAL, 64L},
+                new Object[] {false, Address.ZERO, ED25519_KEY, new byte[0], Address.ZERO}),
+        GET_TOKEN_KYC_KEY_FOR_NFT_WITH_ECDSA_KEY(
+                "getTokenKeyPublic",
+                new Object[] {NFT_ADDRESS_GET_KEY_WITH_ECDSA_KEY_HISTORICAL, 2L},
+                new Object[] {false, Address.ZERO, new byte[0], ECDSA_KEY, Address.ZERO}),
+        GET_TOKEN_FEE_KEY_FOR_NFT_WITH_ECDSA_KEY(
+                "getTokenKeyPublic",
+                new Object[] {NFT_ADDRESS_GET_KEY_WITH_ECDSA_KEY_HISTORICAL, 32L},
+                new Object[] {false, Address.ZERO, new byte[0], ECDSA_KEY, Address.ZERO}),
+        GET_TOKEN_PAUSE_KEY_FOR_NFT_WITH_ECDSA_KEY(
+                "getTokenKeyPublic",
+                new Object[] {NFT_ADDRESS_GET_KEY_WITH_ECDSA_KEY_HISTORICAL, 64L},
+                new Object[] {false, Address.ZERO, new byte[0], ECDSA_KEY, Address.ZERO}),
+        GET_TOKEN_KYC_KEY_FOR_NFT_WITH_DELEGATABLE_CONTRACT_ID(
+                "getTokenKeyPublic",
+                new Object[] {NFT_ADDRESS_GET_KEY_WITH_DELEGATABLE_CONTRACT_ID_HISTORICAL, 2L},
+                new Object[] {false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
+        GET_TOKEN_FEE_KEY_FOR_NFT_WITH_DELEGATABLE_CONTRACT_ID(
+                "getTokenKeyPublic",
+                new Object[] {NFT_ADDRESS_GET_KEY_WITH_DELEGATABLE_CONTRACT_ID_HISTORICAL, 32L},
+                new Object[] {false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
+        GET_TOKEN_PAUSE_KEY_FOR_NFT_WITH_DELEGATABLE_CONTRACT_ID(
+                "getTokenKeyPublic",
+                new Object[] {NFT_ADDRESS_GET_KEY_WITH_DELEGATABLE_CONTRACT_ID_HISTORICAL, 64L},
+                new Object[] {false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
+        GET_CUSTOM_FEES_FOR_TOKEN_WITH_FIXED_FEE(
+                "getCustomFeesForToken", new Object[] {FUNGIBLE_TOKEN_ADDRESS_HISTORICAL}, new Object[] {
+                    new Object[] {100L, FUNGIBLE_TOKEN_ADDRESS_HISTORICAL, false, false, SENDER_ALIAS_HISTORICAL},
+                    new Object[0],
+                    new Object[0]
+                }),
+        GET_CUSTOM_FEES_FOR_TOKEN_WITH_FRACTIONAL_FEE(
+                "getCustomFeesForToken", new Object[] {FUNGIBLE_TOKEN_ADDRESS_HISTORICAL}, new Object[] {
+                    new Object[0], new Object[] {100L, 10L, 1L, 1000L, true, SENDER_ALIAS_HISTORICAL}, new Object[0]
+                }),
+        GET_CUSTOM_FEES_FOR_TOKEN_WITH_ROYALTY_FEE(
+                "getCustomFeesForToken", new Object[] {FUNGIBLE_TOKEN_ADDRESS_HISTORICAL}, new Object[] {
+                    new Object[0],
+                    new Object[0],
+                    new Object[] {20L, 10L, 100L, FUNGIBLE_TOKEN_ADDRESS_HISTORICAL, SENDER_ALIAS_HISTORICAL}
+                }),
+        GET_TOKEN_EXPIRY(
+                "getExpiryInfoForToken",
+                new Object[] {FUNGIBLE_TOKEN_ADDRESS_WITH_EXPIRY_HISTORICAL},
+                new Object[] {1000L, AUTO_RENEW_ACCOUNT_ADDRESS_HISTORICAL, 1800L}),
+        HTS_GET_APPROVED(
+                "htsGetApproved", new Object[] {NFT_ADDRESS_HISTORICAL, 1L}, new Object[] {SPENDER_ALIAS_HISTORICAL}),
+        HTS_ALLOWANCE(
+                "htsAllowance",
+                new Object[] {FUNGIBLE_TOKEN_ADDRESS_HISTORICAL, SENDER_ADDRESS_HISTORICAL, SPENDER_ADDRESS_HISTORICAL},
+                new Object[] {13L}),
+        HTS_IS_APPROVED_FOR_ALL(
+                "htsIsApprovedForAll",
+                new Object[] {NFT_ADDRESS_HISTORICAL, SENDER_ADDRESS_HISTORICAL, SPENDER_ADDRESS_HISTORICAL},
+                new Object[] {true}),
+        GET_FUNGIBLE_TOKEN_INFO(
+                "getInformationForFungibleToken", new Object[] {FUNGIBLE_TOKEN_ADDRESS_HISTORICAL}, new Object[] {
+                    new Object[] {
+                        FUNGIBLE_HBAR_TOKEN_AND_KEYS_HISTORICAL,
+                        12345L,
+                        false,
+                        false,
+                        true,
+                        new Object[] {100L, 10L, 1L, 1000L, true, SENDER_ALIAS_HISTORICAL},
+                        "0x01"
+                    },
+                    12
+                }),
+        GET_NFT_INFO("getInformationForNonFungibleToken", new Object[] {NFT_ADDRESS_HISTORICAL, 1L}, new Object[] {
+            new Object[] {
+                NFT_HBAR_TOKEN_AND_KEYS_HISTORICAL,
+                1_000_000_000L,
+                false,
+                false,
+                true,
+                new Object[] {0L, 0L, 0L, 0L, false, SENDER_ALIAS_HISTORICAL},
+                "0x01"
+            },
+            1L,
+            OWNER_ADDRESS_HISTORICAL,
+            1475067194L,
+            "NFT_METADATA_URI".getBytes(),
+            SPENDER_ADDRESS_HISTORICAL
+        }),
+        GET_INFORMATION_FOR_TOKEN_FUNGIBLE(
+                "getInformationForToken", new Object[] {FUNGIBLE_TOKEN_ADDRESS_HISTORICAL}, new Object[] {
+                    FUNGIBLE_HBAR_TOKEN_AND_KEYS_HISTORICAL,
+                    12345L,
+                    false,
+                    false,
+                    true,
+                    new Object[] {100L, 10L, 1L, 1000L, true, SENDER_ALIAS_HISTORICAL},
+                    "0x01"
+                }),
+        GET_INFORMATION_FOR_TOKEN_NFT("getInformationForToken", new Object[] {NFT_ADDRESS_HISTORICAL}, new Object[] {
+            NFT_HBAR_TOKEN_AND_KEYS_HISTORICAL,
+            1_000_000_000L,
+            false,
+            false,
+            true,
+            new Object[] {0L, 0L, 0L, 0L, false, SENDER_ALIAS_HISTORICAL},
             "0x01"
         });
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
@@ -94,7 +94,7 @@ class ContractCallServiceTest extends ContractCallTestSetup {
         final var serviceParameters = serviceParametersForExecution(
                 Bytes.fromHexString(pureFuncHash), ETH_CALL_CONTRACT_ADDRESS, ETH_CALL, 0L, blockType);
 
-        if (blockType.number() < PERSISTENCE_HISTORICAL_BLOCK) { // Before the block the data did not exist yet
+        if (blockType.number() < EVM_V_34_BLOCK) { // Before the block the data did not exist yet
             assertThatThrownBy(() -> contractCallService.processCall(serviceParameters))
                     .isInstanceOf(MirrorEvmTransactionException.class);
         } else {
@@ -118,7 +118,7 @@ class ContractCallServiceTest extends ContractCallTestSetup {
         final var serviceParameters = serviceParametersForExecution(
                 Bytes.fromHexString(pureFuncHash), ETH_CALL_CONTRACT_ADDRESS, ETH_CALL, 0L, blockType);
 
-        if (blockType.number() < PERSISTENCE_HISTORICAL_BLOCK) { // Before the block the data did not exist yet
+        if (blockType.number() < EVM_V_34_BLOCK) { // Before the block the data did not exist yet
             assertThatThrownBy(() -> contractCallService.processCall(serviceParameters))
                     .isInstanceOf(MirrorEvmTransactionException.class);
         } else {

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
@@ -94,7 +94,7 @@ class ContractCallServiceTest extends ContractCallTestSetup {
         final var serviceParameters = serviceParametersForExecution(
                 Bytes.fromHexString(pureFuncHash), ETH_CALL_CONTRACT_ADDRESS, ETH_CALL, 0L, blockType);
 
-        if (blockType.number() < PERSISTENCE_HISTORICAL_BLOCK) { // EVM v0.30 is used and it does not support the call
+        if (blockType.number() < PERSISTENCE_HISTORICAL_BLOCK) { // Before the block the data did not exist yet
             assertThatThrownBy(() -> contractCallService.processCall(serviceParameters))
                     .isInstanceOf(MirrorEvmTransactionException.class);
         } else {
@@ -118,7 +118,7 @@ class ContractCallServiceTest extends ContractCallTestSetup {
         final var serviceParameters = serviceParametersForExecution(
                 Bytes.fromHexString(pureFuncHash), ETH_CALL_CONTRACT_ADDRESS, ETH_CALL, 0L, blockType);
 
-        if (blockType.number() < PERSISTENCE_HISTORICAL_BLOCK) { // EVM v0.30 is used and it does not support the call
+        if (blockType.number() < PERSISTENCE_HISTORICAL_BLOCK) { // Before the block the data did not exist yet
             assertThatThrownBy(() -> contractCallService.processCall(serviceParameters))
                     .isInstanceOf(MirrorEvmTransactionException.class);
         } else {

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -94,7 +94,7 @@ class ContractCallServiceTest extends ContractCallTestSetup {
         final var serviceParameters = serviceParametersForExecution(
                 Bytes.fromHexString(pureFuncHash), ETH_CALL_CONTRACT_ADDRESS, ETH_CALL, 0L, blockType);
 
-        if (blockType.number() < EVM_V_34_BLOCK) { // EVM v0.30 is used and it does not support the call
+        if (blockType.number() < PERSISTENCE_HISTORICAL_BLOCK) { // EVM v0.30 is used and it does not support the call
             assertThatThrownBy(() -> contractCallService.processCall(serviceParameters))
                     .isInstanceOf(MirrorEvmTransactionException.class);
         } else {
@@ -118,7 +118,7 @@ class ContractCallServiceTest extends ContractCallTestSetup {
         final var serviceParameters = serviceParametersForExecution(
                 Bytes.fromHexString(pureFuncHash), ETH_CALL_CONTRACT_ADDRESS, ETH_CALL, 0L, blockType);
 
-        if (blockType.number() < EVM_V_34_BLOCK) { // EVM v0.30 is used and it does not support the call
+        if (blockType.number() < PERSISTENCE_HISTORICAL_BLOCK) { // EVM v0.30 is used and it does not support the call
             assertThatThrownBy(() -> contractCallService.processCall(serviceParameters))
                     .isInstanceOf(MirrorEvmTransactionException.class);
         } else {

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
@@ -83,7 +83,7 @@ class ContractCallServiceTest extends ContractCallTestSetup {
     void pureCallWithCustomBlock(BlockType blockType) {
         domainBuilder
                 .recordFile()
-                .customize(recordFileBuilder -> recordFileBuilder.index(1L))
+                .customize(recordFileBuilder -> recordFileBuilder.index(blockType.number()))
                 .persist();
 
         final var gasUsedBeforeExecution = getGasUsedBeforeExecution(ETH_CALL);
@@ -94,9 +94,13 @@ class ContractCallServiceTest extends ContractCallTestSetup {
         final var serviceParameters = serviceParametersForExecution(
                 Bytes.fromHexString(pureFuncHash), ETH_CALL_CONTRACT_ADDRESS, ETH_CALL, 0L, blockType);
 
-        assertThat(contractCallService.processCall(serviceParameters)).isEqualTo(successfulReadResponse);
-
-        assertGasUsedIsPositive(gasUsedBeforeExecution, ETH_CALL);
+        if (blockType.number() < EVM_V_34_BLOCK) { // EVM v0.30 is used and it does not support the call
+            assertThatThrownBy(() -> contractCallService.processCall(serviceParameters))
+                    .isInstanceOf(MirrorEvmTransactionException.class);
+        } else {
+            assertThat(contractCallService.processCall(serviceParameters)).isEqualTo(successfulReadResponse);
+            assertGasUsedIsPositive(gasUsedBeforeExecution, ETH_CALL);
+        }
     }
 
     @ParameterizedTest
@@ -114,10 +118,15 @@ class ContractCallServiceTest extends ContractCallTestSetup {
         final var serviceParameters = serviceParametersForExecution(
                 Bytes.fromHexString(pureFuncHash), ETH_CALL_CONTRACT_ADDRESS, ETH_CALL, 0L, blockType);
 
-        assertThat(contractCallService.processCall(serviceParameters)).isEqualTo(expectedResponse);
+        if (blockType.number() < EVM_V_34_BLOCK) { // EVM v0.30 is used and it does not support the call
+            assertThatThrownBy(() -> contractCallService.processCall(serviceParameters))
+                    .isInstanceOf(MirrorEvmTransactionException.class);
+        } else {
+            assertThat(contractCallService.processCall(serviceParameters)).isEqualTo(expectedResponse);
 
-        if (checkGas) {
-            assertGasUsedIsPositive(gasUsedBeforeExecution, ETH_CALL);
+            if (checkGas) {
+                assertGasUsedIsPositive(gasUsedBeforeExecution, ETH_CALL);
+            }
         }
     }
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallSystemPrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallSystemPrecompileTest.java
@@ -36,8 +36,8 @@ class ContractCallSystemPrecompileTest extends ContractCallTestSetup {
 
     private static final List<BlockType> BLOCK_NUMBERS_FOR_EVM_VERSION = List.of(
             BlockType.of(String.valueOf(EVM_V_38_BLOCK)),
-            BlockType.of(String.valueOf(PERSISTENCE_HISTORICAL_BLOCK)),
-            BlockType.of(String.valueOf(PERSISTENCE_HISTORICAL_BLOCK - 1)));
+            BlockType.of(String.valueOf(EVM_V_34_BLOCK)),
+            BlockType.of(String.valueOf(EVM_V_34_BLOCK - 1)));
 
     private static Stream<Arguments> exchangeRateFunctionsProviderHistorical() {
         return Arrays.stream(SystemContractFunctions.values())

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallSystemPrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallSystemPrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,12 +22,32 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.hedera.mirror.web3.viewmodel.BlockType;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class ContractCallSystemPrecompileTest extends ContractCallTestSetup {
+
+    private static final List<BlockType> BLOCK_NUMBERS_FOR_EVM_VERSION = List.of(
+            BlockType.of(String.valueOf(EVM_V_38_BLOCK)),
+            BlockType.of(String.valueOf(PERSISTENCE_HISTORICAL_BLOCK)),
+            BlockType.of(String.valueOf(PERSISTENCE_HISTORICAL_BLOCK - 1)));
+
+    private static Stream<Arguments> exchangeRateFunctionsProviderHistorical() {
+        return Arrays.stream(SystemContractFunctions.values())
+                .flatMap(exchangeRateFunction -> BLOCK_NUMBERS_FOR_EVM_VERSION.stream()
+                        .map(blockNumber -> Arguments.of(exchangeRateFunction, blockNumber)));
+    }
+
+    private static Stream<Arguments> blockNumberForDifferentEvmVersionsProviderHistorical() {
+        return BLOCK_NUMBERS_FOR_EVM_VERSION.stream().map(Arguments::of);
+    }
 
     @ParameterizedTest
     @EnumSource(SystemContractFunctions.class)
@@ -36,6 +56,20 @@ class ContractCallSystemPrecompileTest extends ContractCallTestSetup {
                 contractFunc.name, EXCHANGE_RATE_PRECOMPILE_ABI_PATH, contractFunc.functionParameters);
         final var serviceParameters = serviceParametersForExecution(
                 functionHash, EXCHANGE_RATE_PRECOMPILE_CONTRACT_ADDRESS, ETH_CALL, 0L, BlockType.LATEST);
+        final var successfulResponse = functionEncodeDecoder.encodedResultFor(
+                contractFunc.name, EXCHANGE_RATE_PRECOMPILE_ABI_PATH, contractFunc.expectedResultFields);
+
+        assertThat(contractCallService.processCall(serviceParameters)).isEqualTo(successfulResponse);
+    }
+
+    @ParameterizedTest
+    @MethodSource("exchangeRateFunctionsProviderHistorical")
+    void systemPrecompileFunctionsTestEthCallHistorical(
+            final SystemContractFunctions contractFunc, BlockType blockNumber) {
+        final var functionHash = functionEncodeDecoder.functionHashFor(
+                contractFunc.name, EXCHANGE_RATE_PRECOMPILE_ABI_PATH, contractFunc.functionParameters);
+        final var serviceParameters = serviceParametersForExecution(
+                functionHash, EXCHANGE_RATE_PRECOMPILE_CONTRACT_ADDRESS, ETH_CALL, 0L, blockNumber);
         final var successfulResponse = functionEncodeDecoder.encodedResultFor(
                 contractFunc.name, EXCHANGE_RATE_PRECOMPILE_ABI_PATH, contractFunc.expectedResultFields);
 
@@ -77,6 +111,20 @@ class ContractCallSystemPrecompileTest extends ContractCallTestSetup {
         final var functionHash = functionEncodeDecoder.functionHashFor(functionName, PRNG_PRECOMPILE_ABI_PATH);
         final var serviceParameters =
                 serviceParametersForExecution(functionHash, PRNG_CONTRACT_ADDRESS, ETH_CALL, 0L, BlockType.LATEST);
+
+        final var result = contractCallService.processCall(serviceParameters);
+
+        // Length of "0x" + 64 hex characters (2 per byte * 32 bytes)
+        assertEquals(66, result.length(), "The string should represent a 32-byte long array");
+    }
+
+    @ParameterizedTest
+    @MethodSource("blockNumberForDifferentEvmVersionsProviderHistorical")
+    void pseudoRandomGeneratorPrecompileFunctionsTestEthCallHistorical(BlockType blockNumber) {
+        final var functionName = "getPseudorandomSeed";
+        final var functionHash = functionEncodeDecoder.functionHashFor(functionName, PRNG_PRECOMPILE_ABI_PATH);
+        final var serviceParameters =
+                serviceParametersForExecution(functionHash, PRNG_CONTRACT_ADDRESS, ETH_CALL, 0L, blockNumber);
 
         final var result = contractCallService.processCall(serviceParameters);
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallTestSetup.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallTestSetup.java
@@ -97,6 +97,7 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
 
     // The block numbers lower than EVM v0.34 are considered part of EVM v0.30 which includes all precompiles
     protected static final long PERSISTENCE_HISTORICAL_BLOCK = 50L;
+    protected static final long EVM_V_38_BLOCK = 100L;
     protected static final BigInteger SUCCESS_RESULT = BigInteger.valueOf(ResponseCodeEnum.SUCCESS_VALUE);
 
     // Exchange rates from local node.
@@ -474,6 +475,7 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
     protected static RecordFile genesisRecordFileForBlockHash;
     protected static RecordFile recordFileBeforeEvm34;
     protected static RecordFile recordFileAfterEvm34;
+    protected static RecordFile recordFileEvm38;
 
     @Autowired
     protected MirrorEvmTxProcessor processor;
@@ -1126,6 +1128,10 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
         recordFileAfterEvm34 = domainBuilder
                 .recordFile()
                 .customize(f -> f.index(PERSISTENCE_HISTORICAL_BLOCK))
+                .persist();
+        recordFileEvm38 = domainBuilder
+                .recordFile()
+                .customize(f -> f.index(EVM_V_38_BLOCK))
                 .persist();
     }
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallTestSetup.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallTestSetup.java
@@ -96,7 +96,7 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
     protected static final long expiry = 1_234_567_890L;
 
     // The block numbers lower than EVM v0.34 are considered part of EVM v0.30 which includes all precompiles
-    protected static final long PERSISTENCE_HISTORICAL_BLOCK = 50L;
+    protected static final long EVM_V_34_BLOCK = 50L;
     protected static final long EVM_V_38_BLOCK = 100L;
     protected static final BigInteger SUCCESS_RESULT = BigInteger.valueOf(ResponseCodeEnum.SUCCESS_VALUE);
 
@@ -1123,11 +1123,11 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
     private void historicalBlocksPersist() {
         recordFileBeforeEvm34 = domainBuilder
                 .recordFile()
-                .customize(f -> f.index(PERSISTENCE_HISTORICAL_BLOCK - 1))
+                .customize(f -> f.index(EVM_V_34_BLOCK - 1))
                 .persist();
         recordFileAfterEvm34 = domainBuilder
                 .recordFile()
-                .customize(f -> f.index(PERSISTENCE_HISTORICAL_BLOCK))
+                .customize(f -> f.index(EVM_V_34_BLOCK))
                 .persist();
         recordFileEvm38 = domainBuilder
                 .recordFile()

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallTestSetup.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallTestSetup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -96,7 +96,7 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
     protected static final long expiry = 1_234_567_890L;
 
     // The block numbers lower than EVM v0.34 are considered part of EVM v0.30 which includes all precompiles
-    protected static final long EVM_V_34_BLOCK = 50L;
+    protected static final long PERSISTENCE_HISTORICAL_BLOCK = 50L;
     protected static final BigInteger SUCCESS_RESULT = BigInteger.valueOf(ResponseCodeEnum.SUCCESS_VALUE);
 
     // Exchange rates from local node.
@@ -1121,11 +1121,11 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
     private void historicalBlocksPersist() {
         recordFileBeforeEvm34 = domainBuilder
                 .recordFile()
-                .customize(f -> f.index(EVM_V_34_BLOCK - 1))
+                .customize(f -> f.index(PERSISTENCE_HISTORICAL_BLOCK - 1))
                 .persist();
         recordFileAfterEvm34 = domainBuilder
                 .recordFile()
-                .customize(f -> f.index(EVM_V_34_BLOCK))
+                .customize(f -> f.index(PERSISTENCE_HISTORICAL_BLOCK))
                 .persist();
     }
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallTestSetup.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallTestSetup.java
@@ -52,6 +52,7 @@ import com.hedera.mirror.web3.Web3IntegrationTest;
 import com.hedera.mirror.web3.common.ContractCallContext;
 import com.hedera.mirror.web3.evm.contracts.execution.MirrorEvmTxProcessor;
 import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
+import com.hedera.mirror.web3.repository.RecordFileRepository;
 import com.hedera.mirror.web3.service.model.CallServiceParameters;
 import com.hedera.mirror.web3.service.model.CallServiceParameters.CallType;
 import com.hedera.mirror.web3.utils.FunctionEncodeDecoder;
@@ -93,6 +94,9 @@ import org.springframework.beans.factory.annotation.Value;
 public class ContractCallTestSetup extends Web3IntegrationTest {
 
     protected static final long expiry = 1_234_567_890L;
+
+    // The block numbers lower than EVM v0.34 are considered part of EVM v0.30 which includes all precompiles
+    protected static final long EVM_V_34_BLOCK = 50L;
     protected static final BigInteger SUCCESS_RESULT = BigInteger.valueOf(ResponseCodeEnum.SUCCESS_VALUE);
 
     // Exchange rates from local node.
@@ -132,16 +136,27 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
 
     // Account addresses
     protected static final Address AUTO_RENEW_ACCOUNT_ADDRESS = toAddress(EntityId.of(0, 0, 740));
+    protected static final Address AUTO_RENEW_ACCOUNT_ADDRESS_HISTORICAL = toAddress(EntityId.of(0, 0, 1078));
     protected static final Address SPENDER_ADDRESS = toAddress(EntityId.of(0, 0, 741));
+    protected static final Address SPENDER_ADDRESS_HISTORICAL = toAddress(EntityId.of(0, 0, 1016));
     protected static final ByteString SPENDER_PUBLIC_KEY =
             ByteString.fromHex("3a2102ff806fecbd31b4c377293cba8d2b78725965a4990e0ff1b1b29a1d2c61402310");
+    protected static final ByteString SPENDER_PUBLIC_KEY_HISTORICAL =
+            ByteString.fromHex("3a210398e17bcbd2926c4d8a31e32616b4754ac0a2fc71d7fb768e657db46202625f34");
     protected static final Address SPENDER_ALIAS = Address.wrap(
             Bytes.wrap(recoverAddressFromPubKey(SPENDER_PUBLIC_KEY.substring(2).toByteArray())));
+    protected static final Address SPENDER_ALIAS_HISTORICAL = Address.wrap(Bytes.wrap(
+            recoverAddressFromPubKey(SPENDER_PUBLIC_KEY_HISTORICAL.substring(2).toByteArray())));
     protected static final Address SENDER_ADDRESS = toAddress(EntityId.of(0, 0, 742));
+    protected static final Address SENDER_ADDRESS_HISTORICAL = toAddress(EntityId.of(0, 0, 1014));
     protected static final ByteString SENDER_PUBLIC_KEY =
             ByteString.copyFrom(Hex.decode("3a2103af80b90d25145da28c583359beb47b21796b2fe1a23c1511e443e7a64dfdb27d"));
+    protected static final ByteString SENDER_PUBLIC_KEY_HISTORICAL =
+            ByteString.copyFrom(Hex.decode("3a2102930a39a381a68d90afc8e8c82935bd93f89800e88ec29a18e8cc13d51947c6c8"));
     protected static final Address SENDER_ALIAS = Address.wrap(
             Bytes.wrap(recoverAddressFromPubKey(SENDER_PUBLIC_KEY.substring(2).toByteArray())));
+    protected static final Address SENDER_ALIAS_HISTORICAL = Address.wrap(Bytes.wrap(
+            recoverAddressFromPubKey(SENDER_PUBLIC_KEY_HISTORICAL.substring(2).toByteArray())));
     protected static final Address TREASURY_ADDRESS = toAddress(EntityId.of(0, 0, 743));
     protected static final Address NOT_ASSOCIATED_SPENDER_ADDRESS = toAddress(EntityId.of(0, 0, 744));
     protected static final ByteString NOT_ASSOCIATED_SPENDER_PUBLIC_KEY =
@@ -149,29 +164,48 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
     protected static final Address NOT_ASSOCIATED_SPENDER_ALIAS = Address.wrap(Bytes.wrap(recoverAddressFromPubKey(
             NOT_ASSOCIATED_SPENDER_PUBLIC_KEY.substring(2).toByteArray())));
     protected static final Address OWNER_ADDRESS = toAddress(EntityId.of(0, 0, 750));
+    protected static final Address OWNER_ADDRESS_HISTORICAL = toAddress(EntityId.of(0, 0, 751));
 
     // Token addresses
     protected static final Address FUNGIBLE_TOKEN_ADDRESS_WITH_EXPIRY = toAddress(EntityId.of(0, 0, 1042));
+    protected static final Address FUNGIBLE_TOKEN_ADDRESS_WITH_EXPIRY_HISTORICAL = toAddress(EntityId.of(0, 0, 1077));
     protected static final Address RECEIVER_ADDRESS = toAddress(EntityId.of(0, 0, 1045));
     protected static final Address FUNGIBLE_TOKEN_ADDRESS = toAddress(EntityId.of(0, 0, 1046));
+    protected static final Address FUNGIBLE_TOKEN_ADDRESS_HISTORICAL = toAddress(EntityId.of(0, 0, 1062));
     protected static final Address NFT_ADDRESS = toAddress(EntityId.of(0, 0, 1047));
+    protected static final Address NFT_ADDRESS_HISTORICAL = toAddress(EntityId.of(0, 0, 1063));
     protected static final Address NOT_FROZEN_FUNGIBLE_TOKEN_ADDRESS = toAddress(EntityId.of(0, 0, 1048));
     protected static final Address TREASURY_TOKEN_ADDRESS = toAddress(EntityId.of(0, 0, 1049));
     protected static final Address TRANSFRER_FROM_TOKEN_ADDRESS = toAddress(EntityId.of(0, 0, 1111));
     protected static final Address FROZEN_FUNGIBLE_TOKEN_ADDRESS = toAddress(EntityId.of(0, 0, 1050));
     protected static final Address NFT_TRANSFER_ADDRESS = toAddress(EntityId.of(0, 0, 1051));
+    protected static final Address NFT_TRANSFER_ADDRESS_HISTORICAL = toAddress(EntityId.of(0, 0, 1064));
     protected static final Address UNPAUSED_FUNGIBLE_TOKEN_ADDRESS = toAddress(EntityId.of(0, 0, 1052));
     protected static final Address NFT_ADDRESS_GET_KEY_WITH_CONTRACT_ADDRESS = toAddress(EntityId.of(0, 0, 1053));
+    protected static final Address NFT_ADDRESS_GET_KEY_WITH_CONTRACT_ADDRESS_HISTORICAL =
+            toAddress(EntityId.of(0, 0, 1073));
     protected static final Address FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_ED25519_KEY = toAddress(EntityId.of(0, 0, 1054));
+    protected static final Address FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_ED25519_KEY_HISTORICAL =
+            toAddress(EntityId.of(0, 0, 1069));
     protected static final Address FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_ECDSA_KEY = toAddress(EntityId.of(0, 0, 1055));
+    protected static final Address FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_ECDSA_KEY_HISTORICAL =
+            toAddress(EntityId.of(0, 0, 1070));
     protected static final Address FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_DELEGATABLE_CONTRACT_ID =
             toAddress(EntityId.of(0, 0, 1056));
+    protected static final Address FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_DELEGATABLE_CONTRACT_ID_HISTORICAL =
+            toAddress(EntityId.of(0, 0, 1072));
     protected static final Address NFT_ADDRESS_GET_KEY_WITH_ED25519_KEY = toAddress(EntityId.of(0, 0, 1057));
+    protected static final Address NFT_ADDRESS_GET_KEY_WITH_ED25519_KEY_HISTORICAL = toAddress(EntityId.of(0, 0, 1074));
     protected static final Address NFT_ADDRESS_GET_KEY_WITH_ECDSA_KEY = toAddress(EntityId.of(0, 0, 1058));
+    protected static final Address NFT_ADDRESS_GET_KEY_WITH_ECDSA_KEY_HISTORICAL = toAddress(EntityId.of(0, 0, 1075));
     protected static final Address NFT_ADDRESS_GET_KEY_WITH_DELEGATABLE_CONTRACT_ID =
             toAddress(EntityId.of(0, 0, 1059));
+    protected static final Address NFT_ADDRESS_GET_KEY_WITH_DELEGATABLE_CONTRACT_ID_HISTORICAL =
+            toAddress(EntityId.of(0, 0, 1076));
     protected static final Address FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_CONTRACT_ADDRESS =
             toAddress(EntityId.of(0, 0, 1060));
+    protected static final Address FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_CONTRACT_ADDRESS_HISTORICAL =
+            toAddress(EntityId.of(0, 0, 1068));
     protected static final Address FUNGIBLE_TOKEN_ADDRESS_NOT_ASSOCIATED = toAddress(EntityId.of(0, 0, 1061));
     protected static final Address NFT_ADDRESS_WITH_DIFFERENT_OWNER_AND_TREASURY = toAddress(EntityId.of(0, 0, 1067));
     protected static final Address NFT_TRANSFER_ADDRESS_WITHOUT_KYC_KEY = toAddress(EntityId.of(0, 0, 1071));
@@ -207,18 +241,27 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
     };
 
     // Token Wrappers
-    protected static final TokenCreateWrapper FUNGIBLE_TOKEN = getFungibleToken();
+    protected static final TokenCreateWrapper FUNGIBLE_TOKEN = getFungibleToken(OWNER_ADDRESS);
+    protected static final TokenCreateWrapper FUNGIBLE_TOKEN_HISTORICAL = getFungibleToken(OWNER_ADDRESS_HISTORICAL);
     protected static final TokenCreateWrapper FUNGIBLE_TOKEN2 = getFungibleToken2();
     protected static final TokenCreateWrapper FUNGIBLE_TOKEN_WITH_KEYS = getFungibleTokenWithKeys();
     protected static final TokenCreateWrapper FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE =
             getFungibleTokenExpiryInUint32Range();
-    protected static final TokenCreateWrapper FUNGIBLE_HBAR_TOKEN_AND_KEYS = getFungibleHbarsTokenWrapper();
+    protected static final TokenCreateWrapper FUNGIBLE_HBAR_TOKEN_AND_KEYS =
+            getFungibleHbarsTokenWrapper(OWNER_ADDRESS, AUTO_RENEW_ACCOUNT_ADDRESS);
+    protected static final TokenCreateWrapper FUNGIBLE_HBAR_TOKEN_AND_KEYS_HISTORICAL =
+            getFungibleHbarsTokenWrapper(OWNER_ADDRESS_HISTORICAL, AUTO_RENEW_ACCOUNT_ADDRESS_HISTORICAL);
     protected static final TokenCreateWrapper FUNGIBLE_TOKEN_INHERIT_KEYS = getFungibleTokenInheritKeys();
-    protected static final TokenCreateWrapper NON_FUNGIBLE_TOKEN = getNonFungibleToken();
+    protected static final TokenCreateWrapper NON_FUNGIBLE_TOKEN = getNonFungibleToken(OWNER_ADDRESS);
+    protected static final TokenCreateWrapper NON_FUNGIBLE_TOKEN_HISTORICAL =
+            getNonFungibleToken(OWNER_ADDRESS_HISTORICAL);
     protected static final TokenCreateWrapper NON_FUNGIBLE_TOKEN_WITH_KEYS = getNonFungibleTokenWithKeys();
     protected static final TokenCreateWrapper NON_FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE =
             getNonFungibleTokenExpiryInUint32Range();
-    protected static final TokenCreateWrapper NFT_HBAR_TOKEN_AND_KEYS = getNftHbarTokenAndKeysHbarsTokenWrapper();
+    protected static final TokenCreateWrapper NFT_HBAR_TOKEN_AND_KEYS =
+            getNftHbarTokenAndKeysHbarsTokenWrapper(OWNER_ADDRESS, AUTO_RENEW_ACCOUNT_ADDRESS);
+    protected static final TokenCreateWrapper NFT_HBAR_TOKEN_AND_KEYS_HISTORICAL =
+            getNftHbarTokenAndKeysHbarsTokenWrapper(OWNER_ADDRESS_HISTORICAL, AUTO_RENEW_ACCOUNT_ADDRESS_HISTORICAL);
     protected static final TokenCreateWrapper NON_FUNGIBLE_TOKEN_INHERIT_KEYS = getNonFungibleTokenInheritKeys();
 
     // Custom Fee wrappers
@@ -429,6 +472,8 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
 
     protected static RecordFile recordFileForBlockHash;
     protected static RecordFile genesisRecordFileForBlockHash;
+    protected static RecordFile recordFileBeforeEvm34;
+    protected static RecordFile recordFileAfterEvm34;
 
     @Autowired
     protected MirrorEvmTxProcessor processor;
@@ -440,7 +485,11 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
     protected ContractCallService contractCallService;
 
     @Autowired
-    protected MirrorNodeEvmProperties properties;
+    protected MirrorNodeEvmProperties mirrorNodeEvmProperties;
+
+    @Autowired
+    protected RecordFileRepository recordFileRepository;
+
     // The contract source `PrecompileTestContract.sol` is in test resources
     @Value("classpath:contracts/PrecompileTestContract/PrecompileTestContract.bin")
     protected Path CONTRACT_BYTES_PATH;
@@ -602,12 +651,12 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
                 new TokenExpiryWrapper(4_000_000_000L, EntityIdUtils.accountIdFromEvmAddress(SENDER_ADDRESS), 10_000L));
     }
 
-    private static TokenCreateWrapper getFungibleToken() {
+    private static TokenCreateWrapper getFungibleToken(Address ownerAddress) {
         return new TokenCreateWrapper(
                 true,
                 "Test",
                 "TST",
-                EntityIdUtils.accountIdFromEvmAddress(OWNER_ADDRESS),
+                EntityIdUtils.accountIdFromEvmAddress(ownerAddress),
                 "test",
                 true,
                 BigInteger.valueOf(10L),
@@ -615,7 +664,7 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
                 10_000_000L,
                 false,
                 List.of(),
-                new TokenExpiryWrapper(9_000_000_000L, EntityIdUtils.accountIdFromEvmAddress(OWNER_ADDRESS), 10_000L));
+                new TokenExpiryWrapper(9_000_000_000L, EntityIdUtils.accountIdFromEvmAddress(ownerAddress), 10_000L));
     }
 
     private static TokenCreateWrapper getFungibleToken2() {
@@ -634,12 +683,12 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
                 new TokenExpiryWrapper(9_000_000_000L, EntityIdUtils.accountIdFromEvmAddress(SENDER_ADDRESS), 10_000L));
     }
 
-    private static TokenCreateWrapper getNonFungibleToken() {
+    private static TokenCreateWrapper getNonFungibleToken(Address ownerAddress) {
         return new TokenCreateWrapper(
                 false,
                 "TestNFT",
                 "TFT",
-                EntityIdUtils.accountIdFromEvmAddress(OWNER_ADDRESS),
+                EntityIdUtils.accountIdFromEvmAddress(ownerAddress),
                 "test",
                 true,
                 BigInteger.valueOf(0L),
@@ -647,17 +696,18 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
                 0L,
                 false,
                 List.of(),
-                new TokenExpiryWrapper(9_000_000_000L, EntityIdUtils.accountIdFromEvmAddress(OWNER_ADDRESS), 10_000L));
+                new TokenExpiryWrapper(9_000_000_000L, EntityIdUtils.accountIdFromEvmAddress(ownerAddress), 10_000L));
     }
 
-    private static TokenCreateWrapper getFungibleHbarsTokenWrapper() {
+    private static TokenCreateWrapper getFungibleHbarsTokenWrapper(
+            final Address ownerAddress, final Address autoRenewAccountAddress) {
         final var keyValue =
                 new KeyValueWrapper(false, null, new byte[0], Arrays.copyOfRange(KEY_PROTO, 2, KEY_PROTO.length), null);
         return new TokenCreateWrapper(
                 true,
                 "Hbars",
                 "HBAR",
-                EntityIdUtils.accountIdFromEvmAddress(OWNER_ADDRESS),
+                EntityIdUtils.accountIdFromEvmAddress(ownerAddress),
                 "TestMemo",
                 false,
                 BigInteger.valueOf(10_000_000L),
@@ -672,8 +722,7 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
                         new TokenKeyWrapper(0b0010000, keyValue),
                         new TokenKeyWrapper(0b0100000, keyValue),
                         new TokenKeyWrapper(0b1000000, keyValue)),
-                new TokenExpiryWrapper(
-                        9_999L, EntityIdUtils.accountIdFromEvmAddress(AUTO_RENEW_ACCOUNT_ADDRESS), 1800L));
+                new TokenExpiryWrapper(9_999L, EntityIdUtils.accountIdFromEvmAddress(autoRenewAccountAddress), 1800L));
     }
 
     private static TokenCreateWrapper getFungibleTokenInheritKeys() {
@@ -693,14 +742,15 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
                 new TokenExpiryWrapper(9_000_000_000L, EntityIdUtils.accountIdFromEvmAddress(OWNER_ADDRESS), 10_000L));
     }
 
-    private static TokenCreateWrapper getNftHbarTokenAndKeysHbarsTokenWrapper() {
+    private static TokenCreateWrapper getNftHbarTokenAndKeysHbarsTokenWrapper(
+            final Address ownerAddress, final Address autoRenewAccountAddress) {
         final var keyValue =
                 new KeyValueWrapper(false, null, new byte[0], Arrays.copyOfRange(KEY_PROTO, 2, KEY_PROTO.length), null);
         return new TokenCreateWrapper(
                 false,
                 "Hbars",
                 "HBAR",
-                EntityIdUtils.accountIdFromEvmAddress(OWNER_ADDRESS),
+                EntityIdUtils.accountIdFromEvmAddress(ownerAddress),
                 "TestMemo",
                 true,
                 BigInteger.valueOf(0L),
@@ -715,8 +765,7 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
                         new TokenKeyWrapper(0b0010000, keyValue),
                         new TokenKeyWrapper(0b0100000, keyValue),
                         new TokenKeyWrapper(0b1000000, keyValue)),
-                new TokenExpiryWrapper(
-                        9999L, EntityIdUtils.accountIdFromEvmAddress(AUTO_RENEW_ACCOUNT_ADDRESS), 1800L));
+                new TokenExpiryWrapper(9999L, EntityIdUtils.accountIdFromEvmAddress(autoRenewAccountAddress), 1800L));
     }
 
     private static TokenCreateWrapper getNonFungibleTokenInheritKeys() {
@@ -758,8 +807,13 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
             final Address contractAddress,
             final CallType callType,
             final long value,
-            BlockType block) {
-        final var sender = new HederaEvmAccount(SENDER_ADDRESS);
+            final BlockType block) {
+        HederaEvmAccount sender;
+        if (block != BlockType.LATEST) {
+            sender = new HederaEvmAccount(SENDER_ADDRESS_HISTORICAL);
+        } else {
+            sender = new HederaEvmAccount(SENDER_ADDRESS);
+        }
         persistEntities();
 
         return CallServiceParameters.builder()
@@ -810,6 +864,7 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
 
     protected void persistEntities() {
         genesisBlockPersist();
+        historicalBlocksPersist();
         evmCodesContractPersist();
         ethCallContractPersist();
         reverterContractPersist();
@@ -1055,11 +1110,185 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
         contractAllowancesPersist(senderEntityId, REDIRECT_CONTRACT_ADDRESS, tokenTreasuryEntityId, nftEntityId3);
         exchangeRatesPersist();
         feeSchedulesPersist();
+        historicalDataPersist();
     }
 
     private void genesisBlockPersist() {
         genesisRecordFileForBlockHash =
                 domainBuilder.recordFile().customize(f -> f.index(0L)).persist();
+    }
+
+    private void historicalBlocksPersist() {
+        recordFileBeforeEvm34 = domainBuilder
+                .recordFile()
+                .customize(f -> f.index(EVM_V_34_BLOCK - 1))
+                .persist();
+        recordFileAfterEvm34 = domainBuilder
+                .recordFile()
+                .customize(f -> f.index(EVM_V_34_BLOCK))
+                .persist();
+    }
+
+    private void historicalDataPersist() {
+        // Accounts
+        final var ownerEntityId = ownerEntityPersistHistorical();
+        final var senderEntityId = senderEntityPersistHistorical();
+        final var spenderEntityId = spenderEntityPersistHistorical();
+        final var autoRenewEntityId = autoRenewAccountPersistHistorical();
+
+        // Fungible token
+        final var tokenEntityId = fromEvmAddress(FUNGIBLE_TOKEN_ADDRESS_HISTORICAL.toArrayUnsafe());
+        final var tokenEvmAddress = toEvmAddress(tokenEntityId);
+
+        fungibleTokenPersistHistorical(
+                ownerEntityId,
+                KEY_PROTO,
+                FUNGIBLE_TOKEN_ADDRESS_HISTORICAL,
+                AUTO_RENEW_ACCOUNT_ADDRESS_HISTORICAL,
+                9999999999999L,
+                TokenPauseStatusEnum.PAUSED,
+                true,
+                Range.closedOpen(recordFileAfterEvm34.getConsensusStart(), recordFileAfterEvm34.getConsensusEnd()));
+
+        // NFT
+        final var nftEntityId = fromEvmAddress(NFT_ADDRESS_HISTORICAL.toArrayUnsafe());
+        final var nftEvmAddress = toEvmAddress(nftEntityId);
+        nftPersistHistorical(
+                NFT_ADDRESS_HISTORICAL,
+                AUTO_RENEW_ACCOUNT_ADDRESS_HISTORICAL,
+                ownerEntityId,
+                spenderEntityId,
+                ownerEntityId,
+                KEY_PROTO,
+                TokenPauseStatusEnum.PAUSED,
+                true,
+                Range.closedOpen(recordFileAfterEvm34.getConsensusStart(), recordFileAfterEvm34.getConsensusEnd()));
+
+        // Token relationships
+        tokenAccountPersistHistorical(ownerEntityId, tokenEntityId, TokenFreezeStatusEnum.UNFROZEN);
+        tokenAccountPersistHistorical(senderEntityId, tokenEntityId, TokenFreezeStatusEnum.FROZEN);
+        tokenAccountPersistHistorical(ownerEntityId, nftEntityId, TokenFreezeStatusEnum.UNFROZEN);
+        tokenAccountPersistHistorical(senderEntityId, nftEntityId, TokenFreezeStatusEnum.FROZEN);
+
+        // Contracts
+        final var contractEntityId = fromEvmAddress(ERC_CONTRACT_ADDRESS.toArrayUnsafe());
+        final var precompileTestContractId = fromEvmAddress(PRECOMPILE_TEST_CONTRACT_ADDRESS.toArrayUnsafe());
+        final var precompileContractEvmAddress = toEvmAddress(precompileTestContractId);
+
+        // Token allowances
+        tokenAllowancePersistHistorical(tokenEntityId, senderEntityId, senderEntityId, spenderEntityId, 13L);
+        tokenAllowancePersistHistorical(tokenEntityId, senderEntityId, senderEntityId, contractEntityId, 20L);
+        tokenAllowancePersistHistorical(tokenEntityId, senderEntityId, senderEntityId, precompileTestContractId, 20L);
+
+        nftAllowancePersistHistorical(nftEntityId, senderEntityId, senderEntityId, spenderEntityId);
+        nftAllowancePersistHistorical(nftEntityId, senderEntityId, senderEntityId, contractEntityId);
+        nftAllowancePersistHistorical(nftEntityId, senderEntityId, senderEntityId, precompileTestContractId);
+
+        fungibleTokenPersistHistorical(
+                senderEntityId,
+                keyWithContractId.toByteArray(),
+                FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_CONTRACT_ADDRESS_HISTORICAL,
+                AUTO_RENEW_ACCOUNT_ADDRESS_HISTORICAL,
+                9999999999999L,
+                TokenPauseStatusEnum.PAUSED,
+                false,
+                Range.closedOpen(recordFileAfterEvm34.getConsensusStart(), recordFileAfterEvm34.getConsensusEnd()));
+
+        fungibleTokenPersistHistorical(
+                senderEntityId,
+                keyWithEd25519.toByteArray(),
+                FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_ED25519_KEY_HISTORICAL,
+                AUTO_RENEW_ACCOUNT_ADDRESS_HISTORICAL,
+                9999999999999L,
+                TokenPauseStatusEnum.PAUSED,
+                false,
+                Range.closedOpen(recordFileAfterEvm34.getConsensusStart(), recordFileAfterEvm34.getConsensusEnd()));
+
+        fungibleTokenPersistHistorical(
+                senderEntityId,
+                keyWithECDSASecp256K1.toByteArray(),
+                FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_ECDSA_KEY_HISTORICAL,
+                AUTO_RENEW_ACCOUNT_ADDRESS_HISTORICAL,
+                9999999999999L,
+                TokenPauseStatusEnum.PAUSED,
+                false,
+                Range.closedOpen(recordFileAfterEvm34.getConsensusStart(), recordFileAfterEvm34.getConsensusEnd()));
+
+        fungibleTokenPersistHistorical(
+                senderEntityId,
+                keyWithDelegatableContractId.toByteArray(),
+                FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_DELEGATABLE_CONTRACT_ID_HISTORICAL,
+                AUTO_RENEW_ACCOUNT_ADDRESS_HISTORICAL,
+                9999999999999L,
+                TokenPauseStatusEnum.PAUSED,
+                false,
+                Range.closedOpen(recordFileAfterEvm34.getConsensusStart(), recordFileAfterEvm34.getConsensusEnd()));
+
+        nftPersistHistorical(
+                NFT_ADDRESS_GET_KEY_WITH_CONTRACT_ADDRESS_HISTORICAL,
+                AUTO_RENEW_ACCOUNT_ADDRESS_HISTORICAL,
+                ownerEntityId,
+                spenderEntityId,
+                ownerEntityId,
+                keyWithContractId.toByteArray(),
+                TokenPauseStatusEnum.PAUSED,
+                true,
+                Range.closedOpen(recordFileAfterEvm34.getConsensusStart(), recordFileAfterEvm34.getConsensusEnd()));
+
+        nftPersistHistorical(
+                NFT_ADDRESS_GET_KEY_WITH_ED25519_KEY_HISTORICAL,
+                AUTO_RENEW_ACCOUNT_ADDRESS_HISTORICAL,
+                ownerEntityId,
+                spenderEntityId,
+                ownerEntityId,
+                keyWithEd25519.toByteArray(),
+                TokenPauseStatusEnum.PAUSED,
+                true,
+                Range.closedOpen(recordFileAfterEvm34.getConsensusStart(), recordFileAfterEvm34.getConsensusEnd()));
+
+        nftPersistHistorical(
+                NFT_ADDRESS_GET_KEY_WITH_ECDSA_KEY_HISTORICAL,
+                AUTO_RENEW_ACCOUNT_ADDRESS_HISTORICAL,
+                ownerEntityId,
+                spenderEntityId,
+                ownerEntityId,
+                keyWithECDSASecp256K1.toByteArray(),
+                TokenPauseStatusEnum.PAUSED,
+                true,
+                Range.closedOpen(recordFileAfterEvm34.getConsensusStart(), recordFileAfterEvm34.getConsensusEnd()));
+
+        nftPersistHistorical(
+                NFT_ADDRESS_GET_KEY_WITH_DELEGATABLE_CONTRACT_ID_HISTORICAL,
+                AUTO_RENEW_ACCOUNT_ADDRESS_HISTORICAL,
+                ownerEntityId,
+                spenderEntityId,
+                ownerEntityId,
+                keyWithDelegatableContractId.toByteArray(),
+                TokenPauseStatusEnum.PAUSED,
+                true,
+                Range.closedOpen(recordFileAfterEvm34.getConsensusStart(), recordFileAfterEvm34.getConsensusEnd()));
+
+        fungibleTokenPersistHistorical(
+                ownerEntityId,
+                KEY_PROTO,
+                FUNGIBLE_TOKEN_ADDRESS_WITH_EXPIRY_HISTORICAL,
+                AUTO_RENEW_ACCOUNT_ADDRESS_HISTORICAL,
+                1000000000000L,
+                TokenPauseStatusEnum.PAUSED,
+                false,
+                Range.closedOpen(recordFileAfterEvm34.getConsensusStart(), recordFileAfterEvm34.getConsensusEnd()));
+
+        domainBuilder
+                .customFeeHistory()
+                .customize(f -> f.tokenId(nftEntityId.getId())
+                        .fractionalFees(List.of(FractionalFee.builder()
+                                .collectorAccountId(senderEntityId)
+                                .build()))
+                        .royaltyFees(List.of())
+                        .fixedFees(List.of())
+                        .timestampRange(Range.closedOpen(
+                                recordFileAfterEvm34.getConsensusStart(), recordFileAfterEvm34.getConsensusEnd())))
+                .persist();
     }
 
     // Custom fees and rates persist
@@ -1119,6 +1348,69 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
             default -> domainBuilder
                     .customFee()
                     .customize(f -> f.tokenId(tokenEntityId.getId()))
+                    .persist();
+        }
+    }
+
+    protected void customFeePersistHistorical(final FeeCase feeCase, final Range<Long> historicalBlock) {
+        final var collectorAccountId = fromEvmAddress(SENDER_ADDRESS_HISTORICAL.toArrayUnsafe());
+        final var tokenEntityId = fromEvmAddress(FUNGIBLE_TOKEN_ADDRESS_HISTORICAL.toArrayUnsafe());
+        switch (feeCase) {
+            case ROYALTY_FEE -> {
+                final var royaltyFee = RoyaltyFee.builder()
+                        .collectorAccountId(collectorAccountId)
+                        .denominator(10L)
+                        .fallbackFee(FallbackFee.builder()
+                                .amount(100L)
+                                .denominatingTokenId(tokenEntityId)
+                                .build())
+                        .numerator(20L)
+                        .build();
+                domainBuilder
+                        .customFee()
+                        .customize(f -> f.royaltyFees(List.of(royaltyFee))
+                                .fixedFees(List.of())
+                                .fractionalFees(List.of())
+                                .tokenId(tokenEntityId.getId())
+                                .timestampRange(historicalBlock))
+                        .persist();
+            }
+            case FRACTIONAL_FEE -> {
+                final var fractionalFee = FractionalFee.builder()
+                        .collectorAccountId(collectorAccountId)
+                        .denominator(10L)
+                        .minimumAmount(1L)
+                        .maximumAmount(1000L)
+                        .netOfTransfers(true)
+                        .numerator(100L)
+                        .build();
+                domainBuilder
+                        .customFee()
+                        .customize(f -> f.fractionalFees(List.of(fractionalFee))
+                                .fixedFees(List.of())
+                                .royaltyFees(List.of())
+                                .tokenId(tokenEntityId.getId())
+                                .timestampRange(historicalBlock))
+                        .persist();
+            }
+            case FIXED_FEE -> {
+                final var fixedFee = FixedFee.builder()
+                        .amount(100L)
+                        .collectorAccountId(collectorAccountId)
+                        .denominatingTokenId(tokenEntityId)
+                        .build();
+                domainBuilder
+                        .customFee()
+                        .customize(f -> f.fixedFees(List.of(fixedFee))
+                                .fractionalFees(List.of())
+                                .royaltyFees(List.of())
+                                .tokenId(tokenEntityId.getId())
+                                .timestampRange(historicalBlock))
+                        .persist();
+            }
+            default -> domainBuilder
+                    .customFee()
+                    .customize(f -> f.tokenId(tokenEntityId.getId()).timestampRange(historicalBlock))
                     .persist();
         }
     }
@@ -1203,6 +1495,21 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
                 .persist();
     }
 
+    private void tokenAccountPersistHistorical(
+            final EntityId senderEntityId, final EntityId tokenEntityId, final TokenFreezeStatusEnum freezeStatus) {
+        domainBuilder
+                .tokenAccountHistory()
+                .customize(e -> e.freezeStatus(freezeStatus)
+                        .accountId(senderEntityId.getId())
+                        .tokenId(tokenEntityId.getId())
+                        .kycStatus(TokenKycStatusEnum.GRANTED)
+                        .associated(true)
+                        .balance(12L)
+                        .timestampRange(Range.closedOpen(
+                                recordFileAfterEvm34.getConsensusStart(), recordFileAfterEvm34.getConsensusEnd())))
+                .persist();
+    }
+
     private void ercContractTokenPersist(
             final Address contractAddress, final EntityId tokenEntityId, final TokenFreezeStatusEnum freezeStatusEnum) {
         final var contractEntityId = fromEvmAddress(contractAddress.toArrayUnsafe());
@@ -1245,6 +1552,24 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
         return spenderEntityId;
     }
 
+    @Nullable
+    private EntityId spenderEntityPersistHistorical() {
+        final var spenderEntityId = fromEvmAddress(SPENDER_ADDRESS_HISTORICAL.toArrayUnsafe());
+
+        domainBuilder
+                .entity()
+                .customize(e -> e.id(spenderEntityId.getId())
+                        .num(spenderEntityId.getNum())
+                        .evmAddress(SPENDER_ALIAS_HISTORICAL.toArray())
+                        .alias(SPENDER_PUBLIC_KEY_HISTORICAL.toByteArray())
+                        .deleted(false)
+                        .createdTimestamp(recordFileAfterEvm34.getConsensusStart())
+                        .timestampRange(Range.closedOpen(
+                                recordFileAfterEvm34.getConsensusStart(), recordFileAfterEvm34.getConsensusEnd())))
+                .persist();
+        return spenderEntityId;
+    }
+
     private long ethAccountPersist(final long ethAccount, final Address evmAddress) {
 
         domainBuilder
@@ -1275,6 +1600,26 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
     }
 
     @Nullable
+    private EntityId senderEntityPersistHistorical() {
+        final var senderEntityId = fromEvmAddress(SENDER_ADDRESS_HISTORICAL.toArrayUnsafe());
+
+        domainBuilder
+                .entity()
+                .customize(e -> e.id(senderEntityId.getId())
+                        .num(senderEntityId.getNum())
+                        .evmAddress(SENDER_ALIAS_HISTORICAL.toArray())
+                        .deleted(false)
+                        .alias(SENDER_PUBLIC_KEY_HISTORICAL.toByteArray())
+                        .balance(10000 * 100_000_000L)
+                        .createdTimestamp(recordFileAfterEvm34.getConsensusStart())
+                        .timestampRange(Range.closedOpen(
+                                recordFileAfterEvm34.getConsensusStart(), recordFileAfterEvm34.getConsensusEnd())))
+                .persist();
+
+        return senderEntityId;
+    }
+
+    @Nullable
     private EntityId ownerEntityPersist() {
         final var ownerEntityId = fromEvmAddress(OWNER_ADDRESS.toArrayUnsafe());
 
@@ -1290,6 +1635,24 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
     }
 
     @Nullable
+    private EntityId ownerEntityPersistHistorical() {
+        final var ownerEntityId = fromEvmAddress(OWNER_ADDRESS_HISTORICAL.toArrayUnsafe());
+
+        domainBuilder
+                .entity()
+                .customize(e -> e.id(ownerEntityId.getId())
+                        .num(ownerEntityId.getNum())
+                        .evmAddress(null)
+                        .alias(toEvmAddress(ownerEntityId))
+                        .balance(20000L)
+                        .timestampRange(Range.closedOpen(
+                                recordFileAfterEvm34.getConsensusStart(), recordFileAfterEvm34.getConsensusEnd())))
+                .persist();
+
+        return ownerEntityId;
+    }
+
+    @Nullable
     private EntityId autoRenewAccountPersist() {
         final var autoRenewEntityId = fromEvmAddress(AUTO_RENEW_ACCOUNT_ADDRESS.toArrayUnsafe());
 
@@ -1300,6 +1663,23 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
                         .evmAddress(null)
                         .alias(toEvmAddress(autoRenewEntityId)))
                 .persist();
+        return autoRenewEntityId;
+    }
+
+    @Nullable
+    private EntityId autoRenewAccountPersistHistorical() {
+        final var autoRenewEntityId = fromEvmAddress(AUTO_RENEW_ACCOUNT_ADDRESS_HISTORICAL.toArrayUnsafe());
+
+        domainBuilder
+                .entity()
+                .customize(e -> e.id(autoRenewEntityId.getId())
+                        .num(autoRenewEntityId.getNum())
+                        .evmAddress(null)
+                        .alias(toEvmAddress(autoRenewEntityId))
+                        .timestampRange(Range.closedOpen(
+                                recordFileAfterEvm34.getConsensusStart(), recordFileAfterEvm34.getConsensusEnd())))
+                .persist();
+
         return autoRenewEntityId;
     }
 
@@ -1381,6 +1761,60 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
         return tokenEntityId;
     }
 
+    private EntityId fungibleTokenPersistHistorical(
+            final EntityId treasuryId,
+            final byte[] key,
+            final Address tokenAddress,
+            final Address autoRenewAddress,
+            final long tokenExpiration,
+            final TokenPauseStatusEnum pauseStatus,
+            final boolean freezeDefault,
+            final Range<Long> historicalBlock) {
+        final var tokenEntityId = fromEvmAddress(tokenAddress.toArrayUnsafe());
+        final var autoRenewEntityId = fromEvmAddress(autoRenewAddress.toArrayUnsafe());
+        final var tokenEvmAddress = toEvmAddress(tokenEntityId);
+
+        domainBuilder
+                .entity()
+                .customize(e -> e.id(tokenEntityId.getId())
+                        .autoRenewAccountId(autoRenewEntityId.getId())
+                        .num(tokenEntityId.getNum())
+                        .evmAddress(tokenEvmAddress)
+                        .type(TOKEN)
+                        .balance(1500L)
+                        .key(key)
+                        .expirationTimestamp(tokenExpiration)
+                        .memo("TestMemo")
+                        .timestampRange(historicalBlock)
+                        .deleted(false))
+                .persist();
+
+        domainBuilder
+                .tokenHistory()
+                .customize(t -> t.tokenId(tokenEntityId.getId())
+                        .treasuryAccountId(EntityId.of(0, 0, treasuryId.getId()))
+                        .type(TokenTypeEnum.FUNGIBLE_COMMON)
+                        .kycKey(key)
+                        .freezeDefault(freezeDefault)
+                        .feeScheduleKey(key)
+                        .supplyType(TokenSupplyTypeEnum.INFINITE)
+                        .maxSupply(2525L)
+                        .initialSupply(10_000_000L)
+                        .name("Hbars")
+                        .totalSupply(12345L)
+                        .decimals(12)
+                        .wipeKey(key)
+                        .freezeKey(key)
+                        .pauseStatus(pauseStatus)
+                        .pauseKey(key)
+                        .supplyKey(key)
+                        .symbol("HBAR")
+                        .timestampRange(historicalBlock))
+                .persist();
+
+        return tokenEntityId;
+    }
+
     @Nullable
     private EntityId nftPersist(
             final Address nftAddress,
@@ -1441,6 +1875,75 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
                         .accountId(ownerEntity)
                         .timestampRange(Range.atLeast(1475067194949034022L))
                         .tokenId(nftEntityId.getId()))
+                .persist();
+        return nftEntityId;
+    }
+
+    @Nullable
+    private EntityId nftPersistHistorical(
+            final Address nftAddress,
+            final Address autoRenewAddress,
+            final EntityId ownerEntityId,
+            final EntityId spenderEntityId,
+            final EntityId treasuryId,
+            final byte[] key,
+            final TokenPauseStatusEnum pauseStatus,
+            final boolean freezeDefault,
+            final Range<Long> historicalBlock) {
+        final var nftEntityId = fromEvmAddress(nftAddress.toArrayUnsafe());
+        final var autoRenewEntityId = fromEvmAddress(autoRenewAddress.toArrayUnsafe());
+        final var nftEvmAddress = toEvmAddress(nftEntityId);
+        final var ownerEntity = EntityId.of(0, 0, ownerEntityId.getId());
+
+        domainBuilder
+                .entity()
+                .customize(e -> e.id(nftEntityId.getId())
+                        .autoRenewAccountId(autoRenewEntityId.getId())
+                        .num(nftEntityId.getNum())
+                        .evmAddress(nftEvmAddress)
+                        .type(TOKEN)
+                        .balance(1500L)
+                        .key(key)
+                        .expirationTimestamp(9999999999999L)
+                        .memo("TestMemo")
+                        .deleted(false)
+                        .timestampRange(historicalBlock))
+                .persist();
+
+        domainBuilder
+                .tokenHistory()
+                .customize(t -> t.tokenId(nftEntityId.getId())
+                        .treasuryAccountId(treasuryId)
+                        .type(TokenTypeEnum.NON_FUNGIBLE_UNIQUE)
+                        .kycKey(key)
+                        .freezeDefault(freezeDefault)
+                        .feeScheduleKey(key)
+                        .totalSupply(1_000_000_000L)
+                        .maxSupply(2_000_000_000L)
+                        .name("Hbars")
+                        .supplyType(TokenSupplyTypeEnum.FINITE)
+                        .freezeKey(key)
+                        .pauseKey(key)
+                        .pauseStatus(pauseStatus)
+                        .wipeKey(key)
+                        .supplyKey(key)
+                        .symbol("HBAR")
+                        .wipeKey(key)
+                        .decimals(0)
+                        .timestampRange(historicalBlock))
+                .persist();
+
+        domainBuilder
+                .nftHistory()
+                .customize(n -> n.accountId(spenderEntityId)
+                        .createdTimestamp(1475067194949034022L)
+                        .serialNumber(1L)
+                        .spender(spenderEntityId)
+                        .metadata("NFT_METADATA_URI".getBytes())
+                        .accountId(ownerEntity)
+                        .tokenId(nftEntityId.getId())
+                        .deleted(false)
+                        .timestampRange(historicalBlock))
                 .persist();
         return nftEntityId;
     }
@@ -1529,6 +2032,42 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
                         .owner(senderEntityId.getNum())
                         .approvedForAll(true)
                         .payerAccountId(senderEntityId))
+                .persist();
+    }
+
+    private void tokenAllowancePersistHistorical(
+            final EntityId tokenEntityId,
+            final EntityId payerAccountId,
+            final EntityId ownerEntityId,
+            final EntityId spenderEntityId,
+            final long amount) {
+        domainBuilder
+                .tokenAllowanceHistory()
+                .customize(a -> a.tokenId(tokenEntityId.getId())
+                        .payerAccountId(payerAccountId)
+                        .owner(ownerEntityId.getNum())
+                        .spender(spenderEntityId.getNum())
+                        .amount(amount)
+                        .amountGranted(amount)
+                        .timestampRange(Range.closedOpen(
+                                recordFileAfterEvm34.getConsensusStart(), recordFileAfterEvm34.getConsensusEnd())))
+                .persist();
+    }
+
+    private void nftAllowancePersistHistorical(
+            final EntityId tokenEntityId,
+            final EntityId payerAccountId,
+            final EntityId ownerEntityId,
+            final EntityId spenderEntityId) {
+        domainBuilder
+                .nftAllowanceHistory()
+                .customize(a -> a.tokenId(tokenEntityId.getId())
+                        .payerAccountId(payerAccountId)
+                        .owner(ownerEntityId.getNum())
+                        .spender(spenderEntityId.getNum())
+                        .approvedForAll(true)
+                        .timestampRange(Range.closedOpen(
+                                recordFileAfterEvm34.getConsensusStart(), recordFileAfterEvm34.getConsensusEnd())))
                 .persist();
     }
 

--- a/hedera-mirror-web3/src/test/resources/application.yml
+++ b/hedera-mirror-web3/src/test/resources/application.yml
@@ -1,3 +1,11 @@
+hedera:
+  mirror:
+    web3:
+      evm:
+        evm_versions:
+          0: v0.30
+          50: v0.34
+          100: v0.38
 spring:
   test:
     database:


### PR DESCRIPTION
**Description**:
This PR adds some of the integration tests needed after extending the DB queries and accessors. It is focused on the HTS and ERC precompiles for EVM v0.34.

In a separate PR more tests will be added for EVM v0.30 as some fixes will be needed there in order for the tests to pass.

Fixes https://github.com/hashgraph/hedera-mirror-node/issues/7054
