### PR TITLE
Remove temporary workarounds

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,11 +31,9 @@ plugins {
 extra.apply {
     set("grpcVersion", "1.60.0")
     set("gson.version", "2.8.9") // Temporary until Apache jclouds supports gson 2.9
-    set("logback.version", "1.4.14") // Temporary until next Spring Boot version
     set("mapStructVersion", "1.5.5.Final")
     set("protobufVersion", "3.25.1")
     set("reactorGrpcVersion", "1.2.4")
-    set("snakeyaml.version", "2.0")
     set("vertxVersion", "4.5.1")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,6 +31,7 @@ plugins {
 extra.apply {
     set("grpcVersion", "1.60.0")
     set("gson.version", "2.8.9") // Temporary until Apache jclouds supports gson 2.9
+    set("logback.version", "1.4.14") // Temporary until next Spring Boot version
     set("mapStructVersion", "1.5.5.Final")
     set("protobufVersion", "3.25.1")
     set("reactorGrpcVersion", "1.2.4")
@@ -70,7 +71,7 @@ dependencies {
         api("io.cucumber:cucumber-bom:7.15.0")
         api("io.github.mweirauch:micrometer-jvm-extras:0.2.2")
         api("io.grpc:grpc-bom:$grpcVersion")
-        api("io.hypersistence:hypersistence-utils-hibernate-62:3.6.1")
+        api("io.hypersistence:hypersistence-utils-hibernate-63:3.7.0")
         api("io.projectreactor:reactor-core-micrometer:1.1.1")
         api("io.swagger:swagger-annotations:1.6.12")
         api("io.vertx:vertx-pg-client:$vertxVersion")

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
     implementation("org.openapitools:openapi-generator-gradle-plugin:7.1.0")
     implementation("org.owasp:dependency-check-gradle:8.4.3")
     implementation("org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:4.4.1.3373")
-    implementation("org.springframework.boot:spring-boot-gradle-plugin:3.2.1")
+    implementation("org.springframework.boot:spring-boot-gradle-plugin:3.2.0")
 }
 
 val gitHook = tasks.register<Exec>("gitHook") {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
     implementation("org.openapitools:openapi-generator-gradle-plugin:7.1.0")
     implementation("org.owasp:dependency-check-gradle:8.4.3")
     implementation("org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:4.4.1.3373")
-    implementation("org.springframework.boot:spring-boot-gradle-plugin:3.2.0")
+    implementation("org.springframework.boot:spring-boot-gradle-plugin:3.2.1")
 }
 
 val gitHook = tasks.register<Exec>("gitHook") {

--- a/hedera-mirror-common/build.gradle.kts
+++ b/hedera-mirror-common/build.gradle.kts
@@ -26,7 +26,7 @@ dependencies {
     api("com.google.guava:guava")
     api("com.google.protobuf:protobuf-java")
     api("com.hedera.hashgraph:hedera-protobuf-java-api") { isTransitive = false }
-    api("io.hypersistence:hypersistence-utils-hibernate-62")
+    api("io.hypersistence:hypersistence-utils-hibernate-63")
     api("commons-codec:commons-codec")
     api("io.projectreactor:reactor-core")
     api("org.apache.commons:commons-lang3")

--- a/hedera-mirror-rest/__tests__/model/transactionType.test.js
+++ b/hedera-mirror-rest/__tests__/model/transactionType.test.js
@@ -48,7 +48,7 @@ describe('getProtoId', () => {
     expect(TransactionType.getProtoId('CRYPTOCREATEACCOUNT')).toEqual(`${cryptoCreateAccountProtoId}`);
   });
   test('Return valid custom proto id', () => {
-    expect(TransactionType.getProtoId('UTILPRNG')).toEqual(52);
+    expect(TransactionType.getProtoId('UTILPRNG')).toEqual('52');
   });
   test('Return valid proto id for camel case', () => {
     expect(TransactionType.getProtoId('cryptoCreateAccount')).toEqual(`${cryptoCreateAccountProtoId}`);
@@ -103,7 +103,6 @@ describe('transactionType constants are up to date', () => {
   // There isn't a dedicated enum for TransactionBody values, so just check that no new HederaFunctionality exists. If
   // this test fails, ensure that new transaction types are added and update this test with the new HederaFunctionality.
   test('transactionType have new values been added', () => {
-    // Last entry is TokenUnpause: 80
     expect(Object.keys(proto.HederaFunctionality).length).toEqual(hederaFunctionalityLength);
   });
 });

--- a/hedera-mirror-rest/model/transactionType.js
+++ b/hedera-mirror-rest/model/transactionType.js
@@ -62,13 +62,11 @@ const protoToName = {
   49: 'CRYPTODELETEALLOWANCE',
   50: 'ETHEREUMTRANSACTION',
   51: 'NODESTAKEUPDATE',
-  52: 'PRNG',
+  52: 'UTILPRNG',
 };
 
 // Temporary extra mappings until we can update the hashgraph proto dependency with the latest types
-const custom = {
-  UTILPRNG: 52,
-};
+const custom = {};
 
 const UNKNOWN = 'UNKNOWN';
 


### PR DESCRIPTION
**Description**:

* Change `hypersistence-utils-hibernate` to `6.3` variant and bump it to `3.7.0`
* Remove temporary `snakeyaml` version override
* Remove temporary `PRNG` transaction type name override in favor of `UTILPRNG`

**Related issue(s)**:

**Notes for reviewer**:

Originally bumped Spring Boot to 3.2.1 but realized it upgraded to Hibernate 6.4 in a bugfix release and hyperpersistenceutils does not yet have [support](https://github.com/vladmihalcea/hypersistence-utils/issues/685) for it.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
