### PR TITLE
HIP-584: Properly extract error messages when making ContractCallQuery

### DIFF
--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/ContractClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/ContractClient.java
@@ -28,14 +28,15 @@ import com.hedera.hashgraph.sdk.ContractId;
 import com.hedera.hashgraph.sdk.ContractUpdateTransaction;
 import com.hedera.hashgraph.sdk.FileId;
 import com.hedera.hashgraph.sdk.Hbar;
+import com.hedera.hashgraph.sdk.PrecheckStatusException;
 import com.hedera.hashgraph.sdk.TransactionRecord;
 import com.hedera.mirror.test.e2e.acceptance.response.NetworkTransactionResponse;
 import jakarta.inject.Named;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeoutException;
 import lombok.RequiredArgsConstructor;
-import lombok.SneakyThrows;
 import org.springframework.retry.support.RetryTemplate;
 
 @Named
@@ -173,9 +174,9 @@ public class ContractClient extends AbstractNetworkClient {
         return new ExecuteContractResult(transactionRecord.contractFunctionResult, response);
     }
 
-    @SneakyThrows
     public ContractFunctionResult executeContractQuery(
-            ContractId contractId, String functionName, Long gas, byte[] data) {
+            ContractId contractId, String functionName, Long gas, byte[] data)
+            throws PrecheckStatusException, TimeoutException {
         ContractCallQuery contractCallQuery =
                 new ContractCallQuery().setContractId(contractId).setGas(gas);
 
@@ -188,33 +189,10 @@ public class ContractClient extends AbstractNetworkClient {
 
         contractCallQuery.setQueryPayment(Hbar.fromTinybars(totalPaymentInTinybars));
 
-        ContractFunctionResult functionResult = retryTemplate.execute(x -> contractCallQuery.execute(client));
+        ContractFunctionResult functionResult = contractCallQuery.execute(client);
 
         log.info("Executed query on contract {} function {}, result: {}", contractId, functionName, functionResult);
-        return functionResult;
-    }
 
-    @SneakyThrows
-    public ContractFunctionResult executeContractQuery(
-            ContractId contractId, String functionName, Long gas, ContractFunctionParameters parameters) {
-        ContractCallQuery contractCallQuery =
-                new ContractCallQuery().setContractId(contractId).setGas(gas);
-        if (parameters == null) {
-            contractCallQuery.setFunction(functionName);
-        } else {
-            contractCallQuery.setFunction(functionName, parameters);
-        }
-
-        long costInTinybars = contractCallQuery.getCost(client).toTinybars();
-
-        long additionalTinybars = 10000;
-        long totalPaymentInTinybars = costInTinybars + additionalTinybars;
-
-        contractCallQuery.setQueryPayment(Hbar.fromTinybars(totalPaymentInTinybars));
-
-        ContractFunctionResult functionResult = retryTemplate.execute(x -> contractCallQuery.execute(client));
-
-        log.info("Executed query on contract {} function {}, result: {}", contractId, functionName, functionResult);
         return functionResult;
     }
 

--- a/hedera-mirror-test/src/test/resources/features/contract/equivalence.feature
+++ b/hedera-mirror-test/src/test/resources/features/contract/equivalence.feature
@@ -7,7 +7,7 @@ Feature: in-equivalence tests
     Given I successfully create equivalence call contract
     Then the mirror node REST API should return status 200 for the contracts creation
     Then I execute balance opcode against a contract with balance with call to <node>
-    Then I execute selfdestruct and set beneficiary to <account> address
+    Then I execute selfdestruct and set beneficiary to <account> address with call to <node>
     Then I execute balance opcode to system account <account> address would return 0 with call to <node>
     Then I verify extcodesize opcode against a system account <account> address returns 0 with call to <node>
     Then I verify extcodecopy opcode against a system account <account> address returns empty bytes with call to <node>


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
It seems when we want to test a negative scenario with contract call queries to the consensus node, we face a problem, since we are using a spring retry mechanism to send calls to consensus via the Java SDK. If the first request fails, we then attempt to send the same transaction object (having the same TransactionID) and eventually we receive DUPLICATE_TRANSACTION pre-check failures, which is normal, since we send the same transaction to the consensus node.

This PR changes the behaviour by sending a single query only and extract the error reason like INVALID_SOLIDITY_ADDRESS or CONTRACT_REVERT_EXECUTED.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
