### PR TITLE
Bump Spring Boot from 3.2.0 to 3.2.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,6 @@ plugins {
 extra.apply {
     set("grpcVersion", "1.60.1")
     set("gson.version", "2.8.9") // Temporary until Apache jclouds supports gson 2.9
-    set("logback.version", "1.4.14") // Temporary until next Spring Boot version
     set("mapStructVersion", "1.5.5.Final")
     set("protobufVersion", "3.25.1")
     set("reactorGrpcVersion", "1.2.4")

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
     implementation("org.openapitools:openapi-generator-gradle-plugin:7.1.0")
     implementation("org.owasp:dependency-check-gradle:8.4.3")
     implementation("org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:4.4.1.3373")
-    implementation("org.springframework.boot:spring-boot-gradle-plugin:3.2.0")
+    implementation("org.springframework.boot:spring-boot-gradle-plugin:3.2.1")
 }
 
 val gitHook = tasks.register<Exec>("gitHook") {

--- a/charts/hedera-mirror-common/values.yaml
+++ b/charts/hedera-mirror-common/values.yaml
@@ -209,18 +209,13 @@ prometheus:
     templateFiles:
       slack.tmpl: |-
         {{- define "slack.title" -}}
-        {{- .Status | title }} {{ .CommonLabels.alertname }}{{ if .CommonLabels.namespace }} in {{ .CommonLabels.namespace }}{{ end }}
+        {{- .Status | title }} {{ .CommonLabels.alertname }}{{ if .CommonLabels.namespace }} in {{ with .CommonLabels.cluster }}{{ . }}/{{ end }}{{ .CommonLabels.namespace }}{{ end }}
         {{- end -}}
 
         {{- define "slack.text" -}}
         {{ range .Alerts -}}
-        *Summary:* {{ if .Annotations.summary }}{{ .Annotations.summary }}{{ else }}{{ .Annotations.message }}{{ end }}{{"\n"}}
-        {{- if .Annotations.description }} *Description:* {{ .Annotations.description }}{{"\n"}}{{ end }}
-        *Prometheus:* *<{{ .GeneratorURL }}|:fire:>* {{- if .Annotations.dashboard_url }}     *Grafana:* *<{{ .Annotations.dashboard_url }}|:chart_with_upwards_trend:>*{{ end }}{{- if .Annotations.runbook_url }}      *Runbook:* *<{{ .Annotations.runbook_url }}|:notebook:>*{{ end }}
-
-        *Labels:*
-          {{ range .Labels.SortedPairs }} • *{{ .Name }}:* `{{ .Value }}`
-          {{ end }}
+        *Summary:* {{ with .Annotations.summary }}{{ . }}{{ else }}{{ .Annotations.message }}{{ end }} <{{ .GeneratorURL }}|:fire:> {{- with .Annotations.dashboard_url }}<{{ . }}|:chart_with_upwards_trend:>{{ end }} {{- with .Annotations.runbook_url }}<{{ . }}|:notebook:>{{ end }}{{"\n"}}
+        {{- with .Annotations.description -}} *Description:* {{ . }}{{"\n"}}{{ end }}
         {{ end }}
         {{- end -}}
   coreDns:

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/converter/CustomJsonFormatMapper.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/converter/CustomJsonFormatMapper.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2024-2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.common.converter;
+
+import static com.hedera.mirror.common.converter.ObjectToStringSerializer.OBJECT_MAPPER;
+
+import org.hibernate.type.descriptor.WrapperOptions;
+import org.hibernate.type.descriptor.java.JavaType;
+import org.hibernate.type.format.FormatMapper;
+import org.hibernate.type.format.jackson.JacksonJsonFormatMapper;
+
+/*
+ * Used by Hibernate to handle JSON/JSONB columns. Set via the `hibernate.type.json_format_mapper` property.
+ */
+@SuppressWarnings("unused")
+public class CustomJsonFormatMapper implements FormatMapper {
+
+    private final JacksonJsonFormatMapper delegate = new JacksonJsonFormatMapper(OBJECT_MAPPER);
+
+    @Override
+    public <T> T fromString(CharSequence charSequence, JavaType<T> javaType, WrapperOptions wrapperOptions) {
+        return delegate.fromString(charSequence, javaType, wrapperOptions);
+    }
+
+    @Override
+    public <T> String toString(T value, JavaType<T> javaType, WrapperOptions wrapperOptions) {
+        return delegate.toString(value, javaType, wrapperOptions);
+    }
+}

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/converter/CustomJsonFormatMapper.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/converter/CustomJsonFormatMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,8 @@ import org.hibernate.type.format.FormatMapper;
 import org.hibernate.type.format.jackson.JacksonJsonFormatMapper;
 
 /*
- * Used by Hibernate to handle JSON/JSONB columns. Set via the `hibernate.type.json_format_mapper` property.
+ * Used by Hibernate to handle JSON/JSONB columns. We need this class since Hibernate doesn't provide a way to customize
+ * its default ObjectMapper. Set via the `hibernate.type.json_format_mapper` property.
  */
 @SuppressWarnings("unused")
 public class CustomJsonFormatMapper implements FormatMapper {

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/EntityId.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/EntityId.java
@@ -16,6 +16,7 @@
 
 package com.hedera.mirror.common.domain.entity;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.base.Splitter;
@@ -65,6 +66,7 @@ public final class EntityId implements Serializable, Comparable<EntityId> {
     @Serial
     private static final long serialVersionUID = 1427649605832330197L;
 
+    @JsonValue
     private final long id;
 
     private EntityId(long id) {

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/package-info.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/package-info.java
@@ -15,14 +15,11 @@
  */
 
 @ConverterRegistration(converter = EntityIdConverter.class)
-@TypeRegistration(basicClass = List.class, userType = ListArrayType.class)
 @TypeRegistration(basicClass = Range.class, userType = PostgreSQLGuavaRangeType.class)
 package com.hedera.mirror.common.domain;
 
 import com.google.common.collect.Range;
 import com.hedera.mirror.common.converter.EntityIdConverter;
-import io.hypersistence.utils.hibernate.type.array.ListArrayType;
 import io.hypersistence.utils.hibernate.type.range.guava.PostgreSQLGuavaRangeType;
-import java.util.List;
 import org.hibernate.annotations.ConverterRegistration;
 import org.hibernate.annotations.TypeRegistration;

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/AbstractCustomFee.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/AbstractCustomFee.java
@@ -23,7 +23,6 @@ import com.hedera.mirror.common.converter.ObjectToStringSerializer;
 import com.hedera.mirror.common.domain.History;
 import com.hedera.mirror.common.domain.UpsertColumn;
 import com.hedera.mirror.common.domain.Upsertable;
-import io.hypersistence.utils.hibernate.type.json.JsonBinaryType;
 import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
 import java.util.ArrayList;
@@ -32,7 +31,8 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.experimental.SuperBuilder;
-import org.hibernate.annotations.Type;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 import org.springframework.util.CollectionUtils;
 
 @Data
@@ -43,17 +43,17 @@ import org.springframework.util.CollectionUtils;
 public abstract class AbstractCustomFee implements History {
 
     @JsonSerialize(using = ObjectToStringSerializer.class)
-    @Type(JsonBinaryType.class)
+    @JdbcTypeCode(SqlTypes.JSON)
     @UpsertColumn(shouldCoalesce = false)
     private List<FixedFee> fixedFees;
 
     @JsonSerialize(using = ObjectToStringSerializer.class)
-    @Type(JsonBinaryType.class)
+    @JdbcTypeCode(SqlTypes.JSON)
     @UpsertColumn(shouldCoalesce = false)
     private List<FractionalFee> fractionalFees;
 
     @JsonSerialize(using = ObjectToStringSerializer.class)
-    @Type(JsonBinaryType.class)
+    @JdbcTypeCode(SqlTypes.JSON)
     @UpsertColumn(shouldCoalesce = false)
     private List<RoyaltyFee> royaltyFees;
 

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/Transaction.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/Transaction.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.hedera.mirror.common.converter.ObjectToStringSerializer;
 import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.token.NftTransfer;
-import io.hypersistence.utils.hibernate.type.json.JsonBinaryType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -36,7 +35,6 @@ import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.ToString;
 import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.annotations.Type;
 import org.hibernate.type.SqlTypes;
 import org.springframework.data.domain.Persistable;
 
@@ -63,7 +61,7 @@ public class Transaction implements Persistable<Long> {
     private Long initialBalance;
 
     @JsonSerialize(using = ObjectToStringSerializer.class)
-    @Type(JsonBinaryType.class)
+    @JdbcTypeCode(SqlTypes.JSON)
     private List<ItemizedTransfer> itemizedTransfer;
 
     @ToString.Exclude
@@ -72,7 +70,7 @@ public class Transaction implements Persistable<Long> {
     private Long maxFee;
 
     @JsonSerialize(using = ObjectToStringSerializer.class)
-    @Type(JsonBinaryType.class)
+    @JdbcTypeCode(SqlTypes.JSON)
     private List<NftTransfer> nftTransfer;
 
     private EntityId nodeAccountId;

--- a/hedera-mirror-graphql/src/main/resources/application.yml
+++ b/hedera-mirror-graphql/src/main/resources/application.yml
@@ -78,5 +78,6 @@ spring:
       hibernate.criteria.literal_handling_mode: BIND # Ensure Criteria API queries use bind parameters and not literals
       hibernate.generate_statistics: true
       hibernate.hbm2ddl.auto: none
+      hibernate.type.json_format_mapper: com.hedera.mirror.common.converter.CustomJsonFormatMapper
   lifecycle:
     timeout-per-shutdown-phase: 20s

--- a/hedera-mirror-grpc/src/main/resources/application.yml
+++ b/hedera-mirror-grpc/src/main/resources/application.yml
@@ -84,6 +84,7 @@ spring:
       hibernate.criteria.literal_handling_mode: BIND # Ensure Criteria API queries use bind parameters and not literals
       hibernate.generate_statistics: true
       hibernate.hbm2ddl.auto: none
+      hibernate.type.json_format_mapper: com.hedera.mirror.common.converter.CustomJsonFormatMapper
   lifecycle:
     timeout-per-shutdown-phase: 40s
   redis:

--- a/hedera-mirror-importer/src/main/resources/application.yml
+++ b/hedera-mirror-importer/src/main/resources/application.yml
@@ -128,6 +128,8 @@ spring:
           batch_size: 250
         order_inserts: true
         order_updates: true
+        type:
+          json_format_mapper: com.hedera.mirror.common.converter.CustomJsonFormatMapper
     show-sql: false
   lifecycle:
     timeout-per-shutdown-phase: 20s

--- a/hedera-mirror-importer/src/main/resources/db/scripts/cleanup.sql
+++ b/hedera-mirror-importer/src/main/resources/db/scripts/cleanup.sql
@@ -1,0 +1,13 @@
+do
+'
+declare
+    t record;
+begin
+    for t in select table_name
+             from information_schema.tables
+             where table_schema = ''public'' and table_name !~ ''.*(flyway|transaction_type|citus_|_\d+).*'' and table_type <> ''VIEW''
+        loop
+            execute format(''truncate %s restart identity cascade'', t.table_name);
+        end loop;
+end;
+';

--- a/hedera-mirror-rest-java/src/main/resources/application.yml
+++ b/hedera-mirror-rest-java/src/main/resources/application.yml
@@ -76,5 +76,6 @@ spring:
       hibernate.criteria.literal_handling_mode: BIND # Ensure Criteria API queries use bind parameters and not literals
       hibernate.generate_statistics: true
       hibernate.hbm2ddl.auto: none
+      hibernate.type.json_format_mapper: com.hedera.mirror.common.converter.CustomJsonFormatMapper
   lifecycle:
     timeout-per-shutdown-phase: 20s

--- a/hedera-mirror-web3/src/main/resources/application.yml
+++ b/hedera-mirror-web3/src/main/resources/application.yml
@@ -76,5 +76,6 @@ spring:
       hibernate.criteria.literal_handling_mode: BIND # Ensure Criteria API queries use bind parameters and not literals
       hibernate.generate_statistics: true
       hibernate.hbm2ddl.auto: none
+      hibernate.type.json_format_mapper: com.hedera.mirror.common.converter.CustomJsonFormatMapper
   lifecycle:
     timeout-per-shutdown-phase: 20s


### PR DESCRIPTION
**Description**:

* Bump Spring Boot from `3.2.0` to `3.2.1`
* Change jsonb columns to use new built-in Hibernate support
* Change Slack alerts to be more succinct
  * Add cluster name to title
  * Move links into Summary
  * Remove labels
* Re-add `cleanup.sql` used by ops
* Remove logback version override

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
