### PR TITLE
HIP-584 Historical: Add integration tests for custom fees and HTS calls - part 4

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/token/TokenAccessorImpl.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/token/TokenAccessorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -274,7 +274,7 @@ public class TokenAccessorImpl implements TokenAccessor {
 
     @SuppressWarnings("unchecked")
     private List<CustomFee> getCustomFees(final Address address) {
-        return store.getToken(address, OnMissing.DONT_THROW).getCustomFees();
+        return store.getToken(address, OnMissing.THROW).getCustomFees();
     }
 
     private void setEvmKeys(final Token token, final EvmTokenInfo evmTokenInfo) {

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/AllowancePrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/AllowancePrecompile.java
@@ -70,7 +70,7 @@ public class AllowancePrecompile extends AbstractReadOnlyPrecompile {
         final var updater = (HederaEvmStackedWorldStateUpdater) frame.getWorldUpdater();
         final var inputData = frame.getInputData();
         final var wrapper = decodeTokenAllowance(inputData);
-        final var store = ((HederaEvmStackedWorldStateUpdater) frame.getWorldUpdater()).getStore();
+        final var store = updater.getStore();
         final var account = store.getAccount(addressFromBytes(wrapper.owner()), OnMissing.THROW);
         validateFalseOrRevert(account.isEmptyAccount(), INVALID_ACCOUNT_ID);
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/AllowancePrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/AllowancePrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,12 +19,15 @@ package com.hedera.services.store.contracts.precompile.impl;
 import static com.hedera.node.app.service.evm.store.contracts.precompile.codec.EvmDecodingFacade.decodeFunctionCall;
 import static com.hedera.node.app.service.evm.store.contracts.utils.DescriptorUtils.addressFromBytes;
 import static com.hedera.node.app.service.evm.store.contracts.utils.EvmParsingConstants.ADDRESS_TRIO_RAW_TYPE;
+import static com.hedera.node.app.service.evm.utils.ValidationUtils.validateFalseOrRevert;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 
 import com.esaulpaugh.headlong.abi.ABIType;
 import com.esaulpaugh.headlong.abi.Function;
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.esaulpaugh.headlong.abi.TypeFactory;
+import com.hedera.mirror.web3.evm.store.Store.OnMissing;
 import com.hedera.mirror.web3.evm.store.contract.HederaEvmStackedWorldStateUpdater;
 import com.hedera.node.app.service.evm.store.contracts.precompile.codec.TokenAllowanceWrapper;
 import com.hedera.services.store.contracts.precompile.AbiConstants;
@@ -67,6 +70,10 @@ public class AllowancePrecompile extends AbstractReadOnlyPrecompile {
         final var updater = (HederaEvmStackedWorldStateUpdater) frame.getWorldUpdater();
         final var inputData = frame.getInputData();
         final var wrapper = decodeTokenAllowance(inputData);
+        final var store = ((HederaEvmStackedWorldStateUpdater) frame.getWorldUpdater()).getStore();
+        final var account = store.getAccount(addressFromBytes(wrapper.owner()), OnMissing.THROW);
+        validateFalseOrRevert(account.isEmptyAccount(), INVALID_ACCOUNT_ID);
+
         final var allowances = updater.tokenAccessor()
                 .staticAllowanceOf(
                         addressFromBytes(wrapper.owner()),

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/GetApprovedPrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/GetApprovedPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@ package com.hedera.services.store.contracts.precompile.impl;
 import static com.hedera.node.app.service.evm.store.contracts.precompile.codec.EvmDecodingFacade.decodeFunctionCall;
 import static com.hedera.node.app.service.evm.store.contracts.utils.DescriptorUtils.addressFromBytes;
 import static com.hedera.node.app.service.evm.store.contracts.utils.EvmParsingConstants.ADDRESS_UINT256_RAW_TYPE;
+import static com.hedera.node.app.service.evm.utils.ValidationUtils.validateTrueOrRevert;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_NFT_SERIAL_NUMBER;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 
 import com.esaulpaugh.headlong.abi.ABIType;
@@ -69,6 +71,9 @@ public class GetApprovedPrecompile extends AbstractReadOnlyPrecompile {
         final var updater = (HederaEvmStackedWorldStateUpdater) frame.getWorldUpdater();
         final var inputData = frame.getInputData();
         final var wrapper = decodeGetApproved(inputData);
+        validateTrueOrRevert(
+                updater.tokenAccessor().isTokenAddress(addressFromBytes(wrapper.token())),
+                INVALID_TOKEN_NFT_SERIAL_NUMBER);
         final var spender =
                 updater.tokenAccessor().staticApprovedSpenderOf(addressFromBytes(wrapper.token()), wrapper.serialNo());
         return new GetApprovedResult(spender);

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/IsApprovedForAllPrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/IsApprovedForAllPrecompile.java
@@ -70,7 +70,7 @@ public class IsApprovedForAllPrecompile extends AbstractReadOnlyPrecompile {
         final var updater = (HederaEvmStackedWorldStateUpdater) frame.getWorldUpdater();
         final var inputData = frame.getInputData();
         final var wrapper = decodeIsApprovedForAll(inputData);
-        final var store = ((HederaEvmStackedWorldStateUpdater) frame.getWorldUpdater()).getStore();
+        final var store = updater.getStore();
         final var account = store.getAccount(addressFromBytes(wrapper.owner()), OnMissing.THROW);
         validateFalseOrRevert(account.isEmptyAccount(), INVALID_ACCOUNT_ID);
 


### PR DESCRIPTION
**Description**:
In this PR test cases for the previously failing custom fees tests and tests for HTS_GET_APPROVED, HTS_ALLOWANCE, HTS_IS_APPROVED_FOR_ALL are added. The latter are the only scenarios where an exception is not thrown when the data is not found for the passed historical block. The returned result is zeroes. The reason for this inconsistency is because the top frame in the stack overrides the output with zeroes and this behaviour comes from the Besu EVM. These cases should be improved in the future to behave like all the other scenarios where an exception is thrown.

Fixes https://github.com/hashgraph/hedera-mirror-node/issues/7054
