### PR TITLE
Replace TimePartitionService Cacheable annotation with caches

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/db/TimePartitionServiceImpl.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/db/TimePartitionServiceImpl.java
@@ -21,7 +21,6 @@ import static com.hedera.mirror.importer.config.CacheConfiguration.CACHE_TIME_PA
 import static com.hedera.mirror.importer.config.CacheConfiguration.CACHE_TIME_PARTITION_OVERLAP;
 
 import com.google.common.collect.Range;
-import com.hedera.mirror.importer.util.Utility;
 import jakarta.inject.Named;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -60,24 +59,13 @@ public class TimePartitionServiceImpl implements TimePartitionService {
     @Override
     public List<TimePartition> getOverlappingTimePartitions(String tableName, long fromTimestamp, long toTimestamp) {
         String cacheKey = tableName + "-" + fromTimestamp + "-" + toTimestamp;
-        try {
-            return cacheTimePartitionOverlap.get(
-                    cacheKey, () -> queryForOverlappingTimePartitions(tableName, fromTimestamp, toTimestamp));
-        } catch (Cache.ValueRetrievalException e) {
-            Utility.handleRecoverableError(
-                    "Error looking up timePartition {} from cacheTimePartitionOverlap", cacheKey, e);
-            return Collections.emptyList();
-        }
+        return cacheTimePartitionOverlap.get(
+                cacheKey, () -> queryForOverlappingTimePartitions(tableName, fromTimestamp, toTimestamp));
     }
 
     @Override
     public List<TimePartition> getTimePartitions(String tableName) {
-        try {
-            return cacheTimePartition.get(tableName, () -> queryForTimePartitions(tableName));
-        } catch (Cache.ValueRetrievalException e) {
-            Utility.handleRecoverableError("Error looking up timePartition {} from cacheTimePartition", tableName, e);
-            return Collections.emptyList();
-        }
+        return cacheTimePartition.get(tableName, () -> queryForTimePartitions(tableName));
     }
 
     private List<TimePartition> queryForOverlappingTimePartitions(

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/db/TimePartitionServiceImpl.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/db/TimePartitionServiceImpl.java
@@ -27,7 +27,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import lombok.CustomLog;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
@@ -38,15 +37,16 @@ import org.springframework.jdbc.core.RowMapper;
 @Named
 public class TimePartitionServiceImpl implements TimePartitionService {
 
-    private final Cache cacheTimePartitionOverlap;
-    private final Cache cacheTimePartition;
-    private final JdbcTemplate jdbcTemplate;
     private static final String GET_TIME_PARTITIONS_SQL = "select * from mirror_node_time_partitions where parent = ?";
     private static final RowMapper<TimePartition> ROW_MAPPER = (rs, rowNum) -> TimePartition.builder()
             .name(rs.getString("name"))
             .parent(rs.getString("parent"))
             .timestampRange(Range.closedOpen(rs.getLong("from_timestamp"), rs.getLong("to_timestamp")))
             .build();
+
+    private final Cache cacheTimePartitionOverlap;
+    private final Cache cacheTimePartition;
+    private final JdbcTemplate jdbcTemplate;
 
     TimePartitionServiceImpl(
             @Qualifier(CACHE_TIME_PARTITION_OVERLAP) CacheManager cacheManagerOverlapTimePartition,
@@ -59,7 +59,7 @@ public class TimePartitionServiceImpl implements TimePartitionService {
 
     @Override
     public List<TimePartition> getOverlappingTimePartitions(String tableName, long fromTimestamp, long toTimestamp) {
-        String cacheKey = StringUtils.joinWith("-", tableName, fromTimestamp, toTimestamp);
+        String cacheKey = tableName + "-" + fromTimestamp + "-" + toTimestamp;
         try {
             return cacheTimePartitionOverlap.get(
                     cacheKey, () -> queryForOverlappingTimePartitions(tableName, fromTimestamp, toTimestamp));


### PR DESCRIPTION
**Description**:
This replaces the `@Cacheable` annotation in `TimePartitionServiceImpl` with caches. In testing this has shown to improve performance.

**Related issue(s)**:

Fixes #7393 

**Notes for reviewer**:
Multiple runs of a unit test where ran comparing the performance of the unaltered @Cacheable methods and the non-Cacheable methods. The unit test was of a loop that performed 100 million identical requests to the methods. The non-Cacheable methods demonstrated a marked performance improvement, performing roughly twice as fast for getOverlappingTimePartitions and four times faster for getTimePartitions: 


@Cacheable measurements:
2024-01-08T19:37:18.006Z  INFO Test worker c.h.m.i.d.TimePartitionServiceTest getOverlappingTimePartitions took 41282 ms for 100,000,000 iterations
2024-01-08T19:40:32.382Z  INFO Test worker c.h.m.i.d.TimePartitionServiceTest getTimePartitions took 33759 ms for 100,000,000 iterations


Non @Cacheable measurements:
2024-01-08T19:15:34.405Z  INFO Test worker c.h.m.i.d.TimePartitionServiceTest getOverlappingTimePartitions took 21869 ms for 100,000,000 iterations
2024-01-08T19:28:26.697Z  INFO Test worker c.h.m.i.d.TimePartitionServiceTest getTimePartitions took 7704 ms for 100,000,000 iterations


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
