### PR TITLE
Fix incorrect string in k6 performance test report

### DIFF
--- a/hedera-mirror-test/k6/src/lib/common.js
+++ b/hedera-mirror-test/k6/src/lib/common.js
@@ -225,9 +225,9 @@ function satisfyParameters(available, required) {
 
 function markdownReport(data, includeUrlColumn, funcs, scenarios, getUrlFuncs = {}) {
   const header = `| Scenario ${
-    includeUrlColumn && '| URL'
+    includeUrlColumn ? '| URL' : ''
   } | VUS | Pass% | RPS | Pass RPS | Avg. Req Duration | Skipped? | Comment |
-|----------${includeUrlColumn && '|----------'}|-----|-------|-----|----------|-------------------|--------|---------|`;
+|----------${includeUrlColumn ? '|----------' : ''}|-----|-------|-----|----------|-------------------|--------|---------|`;
 
   // collect the metrics
   const {setup_data: availableParams} = data;
@@ -274,7 +274,7 @@ function markdownReport(data, includeUrlColumn, funcs, scenarios, getUrlFuncs = 
       const httpReqDuration = scenarioMetric['http_req_duration'].values.avg.toFixed(2);
       const skipped = satisfyParameters(availableParams, funcs[scenario].requiredParameters || []) ? 'No' : 'Yes';
 
-      markdown += `| ${scenario} ${includeUrlColumn && '| ' + scenarioUrls[scenario]} | ${
+      markdown += `| ${scenario} ${includeUrlColumn ? '| ' + scenarioUrls[scenario] : ''} | ${
         __ENV.DEFAULT_VUS
       } | ${passPercentage} | ${rps}/s | ${passRps}/s | ${httpReqDuration}ms | ${skipped} | |\n`;
     } catch (err) {


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

This PR fixes the incorrect string in k6 performance test report.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

The bug would generate the following string if `includeUrlColumn` is false:

```
| Scenario false | VUS | Pass% | RPS | Pass RPS | Avg. Req Duration | Skipped? | Comment |
|----------false|-----|-------|-----|----------|-------------------|--------|---------|
| contractCallAllowance false | 500 | 98.33 | 1209.89/s | 1189.68/s | 409.93ms | No | |
```
 
**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
