### PR TITLE
fix: Fix null pointer error on create fungible token with inherit account key

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/services/jproto/JKey.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/jproto/JKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -94,7 +94,9 @@ public abstract class JKey {
             throw new InvalidKeyException("Exceeding max expansion depth of " + MAX_KEY_DEPTH);
         }
 
-        if (!(jkey.hasThresholdKey() || jkey.hasKeyList())) {
+        if (jkey == null) {
+            return createEmptyKey();
+        } else if (!(jkey.hasThresholdKey() || jkey.hasKeyList())) {
             return convertJKeyBasic(jkey);
         } else {
             List<JKey> jKeys = jkey.getKeyList().getKeysList();
@@ -107,6 +109,14 @@ public abstract class JKey {
             Key result = Key.newBuilder().setKeyList(keys).build();
             return (result);
         }
+    }
+
+    /**
+     * Creates an empty key
+     * @return An empty Key.
+     */
+    static Key createEmptyKey() {
+        return Key.newBuilder().build();
     }
 
     /**

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/jproto/JKeyTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/jproto/JKeyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,6 +66,13 @@ class JKeyTest {
                 InvalidKeyException.class,
                 () -> JKey.convertJKey(jKeyTooDeep, 1),
                 "Exceeding max expansion depth of " + JKey.MAX_KEY_DEPTH);
+    }
+
+    @Test
+    void convertNullJKeyTest() {
+        // expect:
+        var result = assertDoesNotThrow(() -> JKey.convertJKey(null, 1));
+        assertEquals(JKey.createEmptyKey(), result);
     }
 
     @Test

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/TokenCreatePrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/TokenCreatePrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -987,6 +987,21 @@ class TokenCreatePrecompileTest {
                         validator,
                         store,
                         transactionBody.getTokenCreation());
+    }
+
+    @Test
+    void createFungibleTokenSuccessPathWithEmptySenderKeyWithInheritedKeyValueType() {
+        prepareStaticContext();
+        given(worldUpdater.permissivelyUnaliased(any()))
+                .willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
+        given(frame.getSenderAddress()).willReturn(HTSTestsUtil.senderAddress);
+        given(store.getAccount(frame.getSenderAddress(), OnMissing.DONT_THROW)).willReturn(senderAccount);
+        final var tokenCreateWrapper = HTSTestsUtil.createTokenCreateWrapperWithKeys(
+                List.of(new TokenKeyWrapper(2, new KeyValueWrapper(true, null, new byte[] {}, new byte[] {}, null))));
+        staticTokenCreatePrecompile
+                .when(() -> decodeFungibleCreate(any(), any()))
+                .thenReturn(tokenCreateWrapper);
+        prepareAndAssertCreateHappyPathSucceeds(CREATE_FUNGIBLE_NO_FEES_INPUT);
     }
 
     @Test


### PR DESCRIPTION
**Description**:

Currently **createFungibleToken** function fails with null pointer error 
when it is invoked from ethereum transaction deployed contract which has no admin key.
([Ethereum transaction deployed contract does not inherit sender key](https://github.com/hashgraph/hedera-services/pull/4110))

Function tested is - **Then I call estimateGas with CreateFungibleToken function** from test module.

`TokenCreateWrapper.setAllInheritedKeysTo() ` fails when the admin key is null and the function is called with keys with `KeyValueType.INHERIT_ACCOUNT_KEY`.

**Modifications done in this **PR****

Modify `JKey.convertJKey` method similar to hedera-services.

In case the key is missing return empty key
**hedera-services** logic - >

```
if (jkey.isEmpty()) {
     return jkey.convertJKeyEmpty();
}
```

Added similar logic in **mirror-node**
```
if (jkey == null) {
    return createEmptyKey();
}
```

Services obtains the key from ledger with empty value while mirror-node
store returns null in case the key is missing which is why the above conditions 
are not exactly the same.


Modified **JKey.java**

Added unit tests in **TokenCreatePrecompileTest** and **JKeyTest**


**Related issue(s)**:

Fixes #7508

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
