### PR TITLE
Remove transaction_hash_old table

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/batch/TransactionHashBatchInserter.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/batch/TransactionHashBatchInserter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ import reactor.core.scheduler.Schedulers;
 @Profile("!v2")
 public class TransactionHashBatchInserter implements BatchPersister {
     private final Map<Integer, BatchInserter> shardBatchInserters;
-    private final String shardedTableName;
+    private final String tableName;
     private final Scheduler scheduler;
     private final TransactionHashTxManager transactionManager;
 
@@ -55,9 +55,8 @@ public class TransactionHashBatchInserter implements BatchPersister {
             MeterRegistry meterRegistry,
             CommonParserProperties commonParserProperties,
             TransactionHashTxManager transactionHashTxManager) {
-        this.shardedTableName = CaseFormat.UPPER_CAMEL.to(
-                CaseFormat.LOWER_UNDERSCORE, TransactionHash.class.getSimpleName() + "_sharded");
-        this.scheduler = Schedulers.newParallel(this.shardedTableName, 8);
+        this.tableName = CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, TransactionHash.class.getSimpleName());
+        this.scheduler = Schedulers.newParallel(this.tableName, 8);
         this.transactionManager = transactionHashTxManager;
 
         this.shardBatchInserters = IntStream.range(0, V1_SHARD_COUNT)
@@ -69,7 +68,7 @@ public class TransactionHashBatchInserter implements BatchPersister {
                                 dataSource,
                                 meterRegistry,
                                 commonParserProperties,
-                                String.format("%s_%02d", shardedTableName, shard))));
+                                String.format("%s_%02d", tableName, shard))));
     }
 
     @Override
@@ -82,7 +81,7 @@ public class TransactionHashBatchInserter implements BatchPersister {
             Stopwatch stopwatch = Stopwatch.createStarted();
 
             // After parser transaction completes, process all transactions for shards
-            transactionManager.initialize(items, this.shardedTableName);
+            transactionManager.initialize(items, this.tableName);
 
             Map<Integer, List<TransactionHash>> shardedItems = items.stream()
                     .map(TransactionHash.class::cast)
@@ -96,11 +95,11 @@ public class TransactionHashBatchInserter implements BatchPersister {
                     "Copied {} rows from {} shards to {} table in {}",
                     items.size(),
                     shardedItems.size(),
-                    this.shardedTableName,
+                    this.tableName,
                     stopwatch);
         } catch (Exception e) {
             throw new ParserException(
-                    String.format("Error copying %d items to table %s", items.size(), this.shardedTableName));
+                    String.format("Error copying %d items to table %s", items.size(), this.tableName));
         }
     }
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/batch/TransactionHashTxManager.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/batch/TransactionHashTxManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ public class TransactionHashTxManager implements TransactionSynchronization {
     private final DataSource dataSource;
     private long itemCount;
     private long recordTimestamp;
-    private String shardedTableName;
+    private String tableName;
 
     @Override
     public void afterCompletion(int status) {
@@ -88,14 +88,14 @@ public class TransactionHashTxManager implements TransactionSynchronization {
                     "Successfully {} {} items in {} shards {} in file containing timestamp {}",
                     statusString,
                     itemCount,
-                    shardedTableName,
+                    tableName,
                     successfulShards,
                     recordTimestamp);
         } else {
             log.error(
                     "Errors occurred processing sharded table {}. parent status {} successful shards {} "
                             + "failed shards {} in file containing timestamp {}",
-                    shardedTableName,
+                    tableName,
                     statusString,
                     successfulShards,
                     failedShards,
@@ -104,7 +104,7 @@ public class TransactionHashTxManager implements TransactionSynchronization {
         threadConnections.clear();
     }
 
-    public void initialize(Collection<?> items, String shardedTableName) {
+    public void initialize(Collection<?> items, String tableName) {
         // This will be non-empty when there are multiple calls to persist
         // in the same parent transaction which is the case if batch limit is reached
         if (!threadConnections.isEmpty()) {
@@ -112,7 +112,7 @@ public class TransactionHashTxManager implements TransactionSynchronization {
             return;
         }
 
-        this.shardedTableName = shardedTableName;
+        this.tableName = tableName;
         this.itemCount = items.size();
         this.recordTimestamp = ((TransactionHash) items.iterator().next()).getConsensusTimestamp();
         TransactionSynchronizationManager.registerSynchronization(this);

--- a/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.92.0__transaction_hash_old_cleanup.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.92.0__transaction_hash_old_cleanup.sql
@@ -1,12 +1,5 @@
 drop view if exists transaction_hash;
 
-insert into transaction_hash_sharded
-select tho.*
-from transaction_hash_old tho
-where not exists (select 1 from transaction_hash_sharded ths where ths.hash = tho.hash);
-
-drop table transaction_hash_old;
-
 alter table transaction_hash_sharded rename to transaction_hash;
 
 alter table transaction_hash_sharded_00 rename to transaction_hash_00;
@@ -61,4 +54,10 @@ RETURN QUERY EXECUTE 'SELECT * from ' || shard || ' WHERE hash = $1'
 END
 $$ LANGUAGE plpgsql;
 
+insert into transaction_hash
+select *
+from transaction_hash_old tho
+where not exists (select get_transaction_info_by_hash(tho.hash));
+
+drop table transaction_hash_old;
 

--- a/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.92.0__transaction_hash_old_cleanup.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.92.0__transaction_hash_old_cleanup.sql
@@ -1,0 +1,64 @@
+drop view if exists transaction_hash;
+
+insert into transaction_hash_sharded
+select tho.*
+from transaction_hash_old tho
+where not exists (select 1 from transaction_hash_sharded ths where ths.hash = tho.hash);
+
+drop table transaction_hash_old;
+
+alter table transaction_hash_sharded rename to transaction_hash;
+
+alter table transaction_hash_sharded_00 rename to transaction_hash_00;
+alter table transaction_hash_sharded_01 rename to transaction_hash_01;
+alter table transaction_hash_sharded_02 rename to transaction_hash_02;
+alter table transaction_hash_sharded_03 rename to transaction_hash_03;
+alter table transaction_hash_sharded_04 rename to transaction_hash_04;
+alter table transaction_hash_sharded_05 rename to transaction_hash_05;
+alter table transaction_hash_sharded_06 rename to transaction_hash_06;
+alter table transaction_hash_sharded_07 rename to transaction_hash_07;
+alter table transaction_hash_sharded_08 rename to transaction_hash_08;
+alter table transaction_hash_sharded_09 rename to transaction_hash_09;
+alter table transaction_hash_sharded_10 rename to transaction_hash_10;
+alter table transaction_hash_sharded_11 rename to transaction_hash_11;
+alter table transaction_hash_sharded_12 rename to transaction_hash_12;
+alter table transaction_hash_sharded_13 rename to transaction_hash_13;
+alter table transaction_hash_sharded_14 rename to transaction_hash_14;
+alter table transaction_hash_sharded_15 rename to transaction_hash_15;
+alter table transaction_hash_sharded_16 rename to transaction_hash_16;
+alter table transaction_hash_sharded_17 rename to transaction_hash_17;
+alter table transaction_hash_sharded_18 rename to transaction_hash_18;
+alter table transaction_hash_sharded_19 rename to transaction_hash_19;
+alter table transaction_hash_sharded_20 rename to transaction_hash_20;
+alter table transaction_hash_sharded_21 rename to transaction_hash_21;
+alter table transaction_hash_sharded_22 rename to transaction_hash_22;
+alter table transaction_hash_sharded_23 rename to transaction_hash_23;
+alter table transaction_hash_sharded_24 rename to transaction_hash_24;
+alter table transaction_hash_sharded_25 rename to transaction_hash_25;
+alter table transaction_hash_sharded_26 rename to transaction_hash_26;
+alter table transaction_hash_sharded_27 rename to transaction_hash_27;
+alter table transaction_hash_sharded_28 rename to transaction_hash_28;
+alter table transaction_hash_sharded_29 rename to transaction_hash_29;
+alter table transaction_hash_sharded_30 rename to transaction_hash_30;
+alter table transaction_hash_sharded_31 rename to transaction_hash_31;
+
+CREATE OR REPLACE FUNCTION get_transaction_info_by_hash(bytea)
+    returns TABLE
+            (
+                consensus_timestamp bigint,
+                hash                bytea,
+                payer_account_id    bigint
+            )
+AS
+$$
+DECLARE
+shard varchar;
+BEGIN
+    shard
+:= concat('transaction_hash_', to_char(mod(get_byte($1, 0), 32), 'fm00'));
+RETURN QUERY EXECUTE 'SELECT * from ' || shard || ' WHERE hash = $1'
+        USING $1;
+END
+$$ LANGUAGE plpgsql;
+
+

--- a/hedera-mirror-importer/src/main/resources/db/scripts/v2/migration.config
+++ b/hedera-mirror-importer/src/main/resources/db/scripts/v2/migration.config
@@ -1,5 +1,5 @@
 CONCURRENCY=
-EXCLUDED_TABLES=("'entity_state_start'","'flyway_schema_history'","'transaction_hash'","'transaction_hash_old'","'transaction_hash_sharded'")
+EXCLUDED_TABLES=("'entity_state_start'","'flyway_schema_history'","'transaction_hash'")
 FLYWAY_URL=https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/9.22.3/flyway-commandline-9.22.3-linux-x64.tar.gz
 MAX_TIMESTAMP=
 SOURCE_DB_HOST=

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/TestUtils.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/TestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -168,7 +168,7 @@ public class TestUtils {
     }
 
     public Collection<TransactionHash> getShardTransactionHashes(int shard, JdbcTemplate jdbcTemplate) {
-        var sql = String.format("SELECT * from transaction_hash_sharded_%02d", shard);
+        var sql = String.format("SELECT * from transaction_hash_%02d", shard);
         return jdbcTemplate.query(sql, new DataClassRowMapper<>(TransactionHash.class));
     }
 
@@ -178,8 +178,8 @@ public class TestUtils {
         return results.iterator().hasNext() ? results.iterator().next() : null;
     }
 
-    public void insertIntoTransactionHashSharded(JdbcTemplate jdbcTemplate, TransactionHash hash) {
-        var sql = "INSERT INTO transaction_hash_sharded(consensus_timestamp,hash,payer_account_id) VALUES (?,?,?)";
+    public void insertIntoTransactionHash(JdbcTemplate jdbcTemplate, TransactionHash hash) {
+        var sql = "INSERT INTO transaction_hash(consensus_timestamp,hash,payer_account_id) VALUES (?,?,?)";
         jdbcTemplate.update(sql, hash.getConsensusTimestamp(), hash.getHash(), hash.getPayerAccountId());
     }
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/BackfillTransactionHashMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/BackfillTransactionHashMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.env.Environment;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 @RequiredArgsConstructor
@@ -55,7 +54,6 @@ class BackfillTransactionHashMigrationTest extends ImporterIntegrationTest {
     private final @Owner JdbcTemplate jdbcTemplate;
     private final ImporterProperties importerProperties;
     private final TransactionHashRepository transactionHashRepository;
-    private final Environment environment;
 
     private Set<TransactionType> defaultTransactionHashTypes;
     private BackfillTransactionHashMigration migration;
@@ -73,8 +71,7 @@ class BackfillTransactionHashMigrationTest extends ImporterIntegrationTest {
                 .getParams()
                 .put("startTimestamp", Long.valueOf(DEFAULT_START_TIMESTAMP).toString());
         importerProperties.getMigration().put(MIGRATION_NAME, migrationProperties);
-        migration =
-                new BackfillTransactionHashMigration(entityProperties, jdbcTemplate, importerProperties, environment);
+        migration = new BackfillTransactionHashMigration(entityProperties, jdbcTemplate, importerProperties);
     }
 
     @AfterEach
@@ -250,7 +247,7 @@ class BackfillTransactionHashMigrationTest extends ImporterIntegrationTest {
             hashWrapper.persist();
         } else {
             var hash = hashWrapper.get();
-            TestUtils.insertIntoTransactionHashSharded(jdbcTemplate, hash);
+            TestUtils.insertIntoTransactionHash(jdbcTemplate, hash);
         }
     }
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/batch/TransactionHashTxManagerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/batch/TransactionHashTxManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,13 +63,13 @@ class TransactionHashTxManagerTest extends ImporterIntegrationTest {
             var threadState = transactionHashTxManager.updateAndGetThreadState(hash1.calculateV1Shard());
             assertThat(threadState.getStatus()).isEqualTo(-1);
             assertThat(threadState.getProcessedShards()).containsExactly(1);
-            TestUtils.insertIntoTransactionHashSharded(jdbcTemplate, hash1);
+            TestUtils.insertIntoTransactionHash(jdbcTemplate, hash1);
 
             var threadState2 = transactionHashTxManager.updateAndGetThreadState(2);
             assertThat(threadState2).isEqualTo(threadState);
             assertThat(threadState.getProcessedShards()).containsExactly(1, 2);
             assertThat(threadState2.getStatus()).isEqualTo(-1);
-            TestUtils.insertIntoTransactionHashSharded(jdbcTemplate, hash2);
+            TestUtils.insertIntoTransactionHash(jdbcTemplate, hash2);
         });
 
         var hash3 = domainBuilder.transactionHash().get();
@@ -81,25 +81,25 @@ class TransactionHashTxManagerTest extends ImporterIntegrationTest {
             var threadState = transactionHashTxManager.updateAndGetThreadState(3);
             assertThat(threadState.getStatus()).isEqualTo(-1);
             assertThat(threadState.getProcessedShards()).containsExactly(3);
-            TestUtils.insertIntoTransactionHashSharded(jdbcTemplate, hash3);
+            TestUtils.insertIntoTransactionHash(jdbcTemplate, hash3);
 
             var threadState2 = transactionHashTxManager.updateAndGetThreadState(4);
             assertThat(threadState2).isEqualTo(threadState);
             assertThat(threadState.getProcessedShards()).containsExactly(3, 4);
             assertThat(threadState.getStatus()).isEqualTo(-1);
-            TestUtils.insertIntoTransactionHashSharded(jdbcTemplate, hash4);
+            TestUtils.insertIntoTransactionHash(jdbcTemplate, hash4);
         });
 
         transactionTemplate.executeWithoutResult((status) -> {
             try {
-                transactionHashTxManager.initialize(Collections.singleton(hash1), "transaction_hash_sharded");
+                transactionHashTxManager.initialize(Collections.singleton(hash1), "transaction_hash");
                 assertThat(transactionHashTxManager.getItemCount()).isEqualTo(1);
                 thread1.start();
                 thread1.join();
 
                 assertThat(transactionHashTxManager.getThreadConnections()).hasSize(1);
 
-                transactionHashTxManager.initialize(Collections.singleton(hash2), "transaction_hash_sharded");
+                transactionHashTxManager.initialize(Collections.singleton(hash2), "transaction_hash");
                 assertThat(transactionHashTxManager.getItemCount()).isEqualTo(2);
                 thread2.start();
                 thread2.join();

--- a/hedera-mirror-rest/__tests__/integration/transactionHashV1Matrix.js
+++ b/hedera-mirror-rest/__tests__/integration/transactionHashV1Matrix.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,7 @@
 
 import {isV2Schema} from '../testutils.js';
 
-const nullifyPayerAccountId = async () =>
-  pool.queryQuietly('update transaction_hash_sharded set payer_account_id = null');
-const putHashInOldTable = async () =>
-  pool.queryQuietly(
-    `with deleted as (DELETE from transaction_hash_sharded RETURNING *)
-                    INSERT into transaction_hash_old(consensus_timestamp, hash, payer_account_id)
-                       SELECT consensus_timestamp, hash, payer_account_id from deleted`
-  );
+const nullifyPayerAccountId = async () => pool.queryQuietly('update transaction_hash set payer_account_id = null');
 
 const applyMatrix = (spec) => {
   if (isV2Schema()) {
@@ -38,11 +31,7 @@ const applyMatrix = (spec) => {
   nullPayerAccountIdSpec.name = `${nullPayerAccountIdSpec.name} - null transaction_hash.payer_account_id`;
   nullPayerAccountIdSpec.postSetup = nullifyPayerAccountId;
 
-  const transactionHashOldSpec = {...spec};
-  transactionHashOldSpec.name = `${transactionHashOldSpec.name} - in old transaction_hash table`;
-  transactionHashOldSpec.postSetup = putHashInOldTable;
-
-  return [defaultSpec, transactionHashOldSpec, nullPayerAccountIdSpec];
+  return [defaultSpec, nullPayerAccountIdSpec];
 };
 
 export default applyMatrix;

--- a/hedera-mirror-rest/__tests__/integrationDomainOps.js
+++ b/hedera-mirror-rest/__tests__/integrationDomainOps.js
@@ -22,7 +22,7 @@ import base32 from '../base32';
 import config from '../config';
 import * as constants from '../constants';
 import EntityId from '../entityId';
-import {isV2Schema, valueToBuffer} from './testutils';
+import {valueToBuffer} from './testutils';
 import {JSONStringify} from '../utils';
 
 const NETWORK_FEE = 1n;
@@ -913,11 +913,7 @@ const addTransaction = async (transaction) => {
 
 const addTransactionHash = async (transactionHash) => {
   transactionHash.hash = valueToBuffer(transactionHash.hash);
-  let table = 'transaction_hash';
-  if (!isV2Schema()) {
-    table = 'transaction_hash_sharded';
-  }
-  await insertDomainObject(table, Object.keys(transactionHash), transactionHash);
+  await insertDomainObject('transaction_hash', Object.keys(transactionHash), transactionHash);
 };
 
 const insertTransfers = async (


### PR DESCRIPTION
**Description**:
* drop transaction_hash view
* migrate any data in transaction_hash_old to transaction_hash_sharded
* rename transaction_hash_sharded to transaction_hash
* update udf to lookup transaction hashes

**Related issue(s)**:

Fixes #6929 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
