### PR TITLE
Bump org.json:json

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,9 @@ extra.apply {
     set("reactorGrpcVersion", "1.2.4")
     set("vertxVersion", "4.5.1")
 }
+
+// Temporarily override json version until snyk/gradle-plugin has an update with a fix
+configurations["dataFiles"].dependencies.add(dependencies.create("org.json:json:20231013"))
 
 // Creates a platform/BOM with specific versions so subprojects don't need to specify a version when
 // using a dependency


### PR DESCRIPTION
**Description**:

* Bump `org.json:json` from `20230227` to `20231013` to address a vulnerability
* Remove use of `org.json` in acceptance tests

**Related issue(s)**:

**Notes for reviewer**:

Example of a failing job: https://github.com/hashgraph/hedera-mirror-node/actions/runs/7484513903/job/20371498300?pr=7511

`org.json:json` is only used by snyk gradle plugin but there's no release [available](https://github.com/snyk/gradle-plugin/pull/30) with a fix.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
